### PR TITLE
feat(docs): agnostic source directory detection for scaffold

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -196,14 +196,17 @@ fn run_scaffold(
         dirs
     } else if detect_by_extension {
         // Extension-based detection
-        let extensions = source_extensions.unwrap_or_else(default_source_extensions);
+        let extensions = source_extensions.clone().unwrap_or_else(default_source_extensions);
+        find_source_directories_by_extension(source_path, &extensions)
+    } else if let Some(extensions) = source_extensions {
+        // Custom extensions provided - use extension-based detection automatically
         find_source_directories_by_extension(source_path, &extensions)
     } else {
         // Try conventional directories first
         let conventional = find_source_directories(source_path);
         if conventional.is_empty() {
-            // Fallback to extension-based detection
-            let extensions = source_extensions.unwrap_or_else(default_source_extensions);
+            // Fallback to extension-based detection with defaults
+            let extensions = default_source_extensions();
             find_source_directories_by_extension(source_path, &extensions)
         } else {
             conventional


### PR DESCRIPTION
## Summary

Makes `homeboy docs scaffold` work with any codebase structure, not just projects using conventional `src/`, `lib/`, `inc/` directories.

## Changes

- Add fallback extension-based detection when no conventional dirs found
- Support `--source-dirs` for explicit override
- Support `--source-extensions` for custom file types
- Support `--detect-by-extension` to force extension detection
- Default extensions: php, rs, js, ts, jsx, tsx, py, go, java, rb, swift, kt

## Use Case

WordPress core uses a flat PHP structure:
```
wp-includes/
├── abilities-api.php
├── abilities-api/
├── blocks.php
├── blocks/
├── rest-api/
└── ...
```

Before: `homeboy docs scaffold wp-includes` → Found 0 source directories
After: `homeboy docs scaffold wp-includes` → Found 52 source directories

## Testing

```bash
# Auto-fallback to extension detection
homeboy docs scaffold wp-includes

# Explicit extension detection
homeboy docs scaffold wp-includes --detect-by-extension

# Custom directories
homeboy docs scaffold myproject --source-dirs abilities-api,rest-api,blocks

# Custom extensions (e.g., for a Ruby project)
homeboy docs scaffold myproject --source-extensions rb,erb
```

## Context

Discussion in WordPress AI Slack about regenerating/aligning WordPress documentation. This enables using Homeboy's docs workflow with WordPress core.