### PR TITLE
docs: Add entry point naming pattern for directories

### DIFF
--- a/docs/documentation/generation.md
+++ b/docs/documentation/generation.md
@@ -73,8 +73,9 @@ Never generate:
 ## File Naming
 
 - Use descriptive filenames that reflect functionality being documented
-- No generic names like `readme.md` in subdirectories
+- No generic names like `readme.md`, `index.md`, or `overview.md` in subdirectories
 - File names describe what the content covers
+- For directory entry points, use `{directory}/{directory}.md` pattern (see `homeboy docs documentation/structure`)
 
 ## Completion Criteria
 

--- a/docs/documentation/structure.md
+++ b/docs/documentation/structure.md
@@ -36,6 +36,24 @@ File names describe the functionality being documented:
 ### No Generic Names
 Never use generic names like `readme.md`, `index.md`, or `overview.md` in subdirectories. Each file should have a specific, descriptive name.
 
+### Directory Entry Points
+When a directory needs an introductory file (architecture overview, component listing, how pieces connect), name it after the directory:
+
+```
+blocks/
+├── blocks.md              # Entry point: "What is the blocks module?"
+├── class-wp-block.md      # Specific component
+├── functions.md           # Function reference
+└── hooks.md               # Hook reference
+```
+
+The pattern `{directory}/{directory}.md` serves as the natural entry point:
+- `api/api.md` — API module introduction
+- `cache/cache.md` — Cache system overview
+- `rest-api/rest-api.md` — REST API architecture
+
+This is descriptive (tells you it's THE blocks doc) while serving as an obvious starting point for navigation.
+
 ### Kebab-Case
 Use kebab-case for all file names: `user-authentication.md`, `api-reference.md`
 


### PR DESCRIPTION
When a directory needs an introductory file (architecture overview, component listing), use `{directory}/{directory}.md` instead of generic names like `overview.md` or `index.md`.

**Example:**
```
blocks/
├── blocks.md              # Entry point
├── class-wp-block.md
├── functions.md
└── hooks.md
```

**Why:**
- Descriptive (tells you it's THE blocks doc)
- Natural entry point (same name as directory)
- Follows existing 'no generic names' rule

Discovered while generating WordPress Core Docs - created 75 overview.md files before realizing the pattern violation, then renamed them all to `{dir}/{dir}.md`.