### PR TITLE
feat: add transfer command for server-to-server file transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -198,6 +198,7 @@ pub mod project;
 pub mod release;
 pub mod server;
 pub mod ssh;
+pub mod transfer;
 pub mod test;
 pub mod upgrade;
 pub mod version;
@@ -248,6 +249,7 @@ pub(crate) fn run_json(
         crate::Commands::File(args) => dispatch!(args, global, file),
         crate::Commands::Fleet(args) => dispatch!(args, global, fleet),
         crate::Commands::Logs(args) => dispatch!(args, global, logs),
+        crate::Commands::Transfer(args) => dispatch!(args, global, transfer),
         crate::Commands::Deploy(args) => dispatch!(args, global, deploy),
         crate::Commands::Component(args) => dispatch!(args, global, component),
         crate::Commands::Config(args) => dispatch!(args, global, config),

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -1,0 +1,234 @@
+use clap::Args;
+use homeboy::server;
+use homeboy::ssh::SshClient;
+use serde::Serialize;
+use std::process::{Command, Stdio};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct TransferArgs {
+    /// Source in format server_id:/path/to/file_or_dir
+    pub source: String,
+
+    /// Destination in format server_id:/path/to/file_or_dir
+    pub destination: String,
+
+    /// Transfer directories recursively
+    #[arg(short, long)]
+    pub recursive: bool,
+
+    /// Compress data during transfer
+    #[arg(short, long)]
+    pub compress: bool,
+
+    /// Show what would be transferred without doing it
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Exclude patterns (can be specified multiple times)
+    #[arg(long)]
+    pub exclude: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TransferOutput {
+    pub source_server: String,
+    pub source_path: String,
+    pub dest_server: String,
+    pub dest_path: String,
+    pub method: String,
+    pub recursive: bool,
+    pub compress: bool,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes_transferred: Option<String>,
+    pub dry_run: bool,
+}
+
+/// Parse a transfer target in format "server_id:/path"
+fn parse_target(target: &str) -> Result<(String, String), homeboy::Error> {
+    let parts: Vec<&str> = target.splitn(2, ':').collect();
+    if parts.len() != 2 || parts[1].is_empty() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "target",
+            "Must be in format server_id:/path/to/file",
+            Some(target.to_string()),
+            Some(vec![
+                "sarai:/var/www/site/backup.sql".to_string(),
+                "command:/tmp/data/".to_string(),
+            ]),
+        ));
+    }
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+/// Build SSH connection args for a server (for use in shell commands)
+fn build_ssh_args(client: &SshClient) -> String {
+    let mut args = Vec::new();
+    args.push("-o StrictHostKeyChecking=no".to_string());
+    args.push("-o BatchMode=yes".to_string());
+
+    if let Some(identity_file) = &client.identity_file {
+        args.push(format!("-i {}", identity_file));
+    }
+
+    if client.port != 22 {
+        args.push(format!("-p {}", client.port));
+    }
+
+    args.join(" ")
+}
+
+pub fn run(args: TransferArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<TransferOutput> {
+    // Parse source and destination
+    let (source_server_id, source_path) = parse_target(&args.source)?;
+    let (dest_server_id, dest_path) = parse_target(&args.destination)?;
+
+    // Load server configurations
+    let source_server = server::load(&source_server_id)?;
+    let dest_server = server::load(&dest_server_id)?;
+
+    let source_client = SshClient::from_server(&source_server, &source_server_id)?;
+    let dest_client = SshClient::from_server(&dest_server, &dest_server_id)?;
+
+    if args.dry_run {
+        let method = if args.recursive { "tar-pipe" } else { "scp-pipe" };
+        eprintln!(
+            "[dry-run] Would transfer {} -> {}",
+            args.source, args.destination
+        );
+        eprintln!("[dry-run] Method: {}", method);
+        if args.compress {
+            eprintln!("[dry-run] Compression: enabled");
+        }
+        if !args.exclude.is_empty() {
+            eprintln!("[dry-run] Excludes: {:?}", args.exclude);
+        }
+
+        return Ok((
+            TransferOutput {
+                source_server: source_server_id,
+                source_path,
+                dest_server: dest_server_id,
+                dest_path,
+                method: method.to_string(),
+                recursive: args.recursive,
+                compress: args.compress,
+                success: true,
+                error: None,
+                bytes_transferred: None,
+                dry_run: true,
+            },
+            0,
+        ));
+    }
+
+    // Build the transfer command
+    // Strategy: SSH pipe — ssh source "tar cf - /path" | ssh dest "tar xf - -C /dest"
+    let source_ssh_args = build_ssh_args(&source_client);
+    let dest_ssh_args = build_ssh_args(&dest_client);
+
+    let source_remote = format!("{}@{}", source_client.user, source_client.host);
+    let dest_remote = format!("{}@{}", dest_client.user, dest_client.host);
+
+    let (method, command) = if args.recursive || source_path.ends_with('/') {
+        // Directory transfer via tar pipe
+        let tar_compress_flag = if args.compress { "z" } else { "" };
+
+        // Build exclude args for tar
+        let exclude_args: String = args
+            .exclude
+            .iter()
+            .map(|e| format!(" --exclude='{}'", e))
+            .collect();
+
+        // For directory transfers, we tar from the parent and extract to dest
+        // This preserves the directory structure correctly
+        let cmd = format!(
+            "ssh {} {} 'tar c{}f - -C \"{}\" .{}' | ssh {} {} 'mkdir -p \"{}\" && tar x{}f - -C \"{}\"'",
+            source_ssh_args,
+            source_remote,
+            tar_compress_flag,
+            source_path.trim_end_matches('/'),
+            exclude_args,
+            dest_ssh_args,
+            dest_remote,
+            dest_path.trim_end_matches('/'),
+            tar_compress_flag,
+            dest_path.trim_end_matches('/'),
+        );
+
+        ("tar-pipe".to_string(), cmd)
+    } else {
+        // Single file transfer via cat pipe
+        let cmd = format!(
+            "ssh {} {} 'cat \"{}\"' | ssh {} {} 'cat > \"{}\"'",
+            source_ssh_args,
+            source_remote,
+            source_path,
+            dest_ssh_args,
+            dest_remote,
+            dest_path,
+        );
+
+        ("cat-pipe".to_string(), cmd)
+    };
+
+    eprintln!("Transferring {} -> {}", args.source, args.destination);
+    eprintln!("Method: {}", method);
+
+    // Execute the transfer
+    let output = Command::new("sh")
+        .args(["-c", &command])
+        .stdin(Stdio::null())
+        .output();
+
+    match output {
+        Ok(out) => {
+            let success = out.status.success();
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+
+            if !success {
+                eprintln!("Transfer failed: {}", stderr);
+            } else {
+                eprintln!("Transfer complete");
+            }
+
+            Ok((
+                TransferOutput {
+                    source_server: source_server_id,
+                    source_path,
+                    dest_server: dest_server_id,
+                    dest_path,
+                    method,
+                    recursive: args.recursive,
+                    compress: args.compress,
+                    success,
+                    error: if success { None } else { Some(stderr) },
+                    bytes_transferred: None,
+                    dry_run: false,
+                },
+                if success { 0 } else { 1 },
+            ))
+        }
+        Err(e) => Ok((
+            TransferOutput {
+                source_server: source_server_id,
+                source_path,
+                dest_server: dest_server_id,
+                dest_path,
+                method,
+                recursive: args.recursive,
+                compress: args.compress,
+                success: false,
+                error: Some(format!("Failed to execute transfer: {}", e)),
+                bytes_transferred: None,
+                dry_run: false,
+            },
+            1,
+        )),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod tty;
 
 use commands::{
     api, auth, build, changelog, changes, cli, component, config, db, deploy, file, fleet, git, init,
-    lint, logs, module, project, release, server, ssh, test, upgrade, version,
+    lint, logs, module, project, release, server, ssh, test, transfer, upgrade, version,
 };
 use homeboy::module::load_all_modules;
 use homeboy::utils::args;
@@ -62,6 +62,8 @@ enum Commands {
     Fleet(fleet::FleetArgs),
     /// Remote log viewing
     Logs(logs::LogsArgs),
+    /// Transfer files between servers
+    Transfer(transfer::TransferArgs),
     /// Deploy components to remote server
     Deploy(deploy::DeployArgs),
     /// Manage standalone component configurations


### PR DESCRIPTION
Closes #47

Adds `homeboy transfer` for moving files between configured servers via SSH pipe (no local intermediary needed).

## Usage

```bash
# Single file
homeboy transfer sarai:/tmp/backup.sql chubes-net:/tmp/backup.sql

# Recursive directory with compression
homeboy transfer -r -c sarai:/var/www/site/wp-content/uploads/ chubes-net:/var/www/site/wp-content/uploads/

# Dry run
homeboy transfer --dry-run sarai:/path chubes-net:/path

# With excludes
homeboy transfer -r sarai:/path chubes-net:/path --exclude '.git' --exclude 'node_modules'
```

## How it works

- Uses existing homeboy server configurations (host, user, identity_file, port)
- Single files: `ssh source 'cat file' | ssh dest 'cat > file'`
- Directories: `ssh source 'tar cf - dir' | ssh dest 'tar xf - -C dest'`
- No local intermediary — direct server-to-server via SSH pipe from the machine running homeboy
- Optional gzip compression for directory transfers

## Tested

- ✅ Single file transfer (sarai → chubes-net)
- ✅ Recursive directory transfer with compression (sarai → chubes-net)
- ✅ Dry run mode
- ✅ Clean build, no warnings