### PR TITLE
fix: expand {{module_path}} in project CLI command templates

### DIFF
--- a/src/core/cli_tool.rs
+++ b/src/core/cli_tool.rs
@@ -219,6 +219,15 @@ fn build_project_command(
     variables.insert(TemplateVars::SITE_PATH.to_string(), base_path);
     variables.insert(TemplateVars::CLI_PATH.to_string(), cli_path);
 
+    // Add module_path so {{module_path}} resolves in command templates
+    let module_dir = crate::module::module_path(module_id);
+    if module_dir.exists() {
+        variables.insert(
+            TemplateVars::MODULE_PATH.to_string(),
+            module_dir.to_string_lossy().to_string(),
+        );
+    }
+
     let mut rendered = render_map(&cli_config.command_template, &variables);
 
     // Append settings-based flags from module config

--- a/src/core/engine/executor.rs
+++ b/src/core/engine/executor.rs
@@ -203,6 +203,12 @@ fn parse_direct_template(
         .unwrap_or_else(|| cli_config.tool.clone());
     template = template.replace("{{cliPath}}", &cli_path);
 
+    // Expand {{module_path}}
+    let module_dir = crate::module::module_path(module_id);
+    if module_dir.exists() {
+        template = template.replace("{{module_path}}", &module_dir.to_string_lossy());
+    }
+
     // Expand {{domain}} in --url={{domain}}
     template = template.replace("--url={{domain}}", &format!("--url={}", target_domain));
 


### PR DESCRIPTION
`{{module_path}}` was only expanded in component commands (`build_component_command`) but not in project commands. This caused the literal string `{{module_path}}` to appear in executed commands when running CLI tools through projects.

**Root cause:** Two code paths build CLI commands:
1. `build_component_command` — had `module_path` ✅
2. `build_project_command` — missing `module_path` ❌
3. `parse_direct_template` (executor) — also missing ❌

**Fix:** Added `module_path` variable insertion to both `build_project_command` and `parse_direct_template`.

Closes #44