### PR TITLE
feat: support aliases for components, projects, and servers

### DIFF
--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -174,6 +174,7 @@ pub fn run(
 
                 let new_server = server::Server {
                     id,
+                    aliases: Vec::new(),
                     host,
                     user,
                     port: port.unwrap_or(22),

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -61,6 +61,8 @@ pub struct ScopedModuleConfig {
 pub struct Component {
     #[serde(skip_deserializing)]
     pub id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
     pub local_path: String,
     pub remote_path: String,
     #[serde(
@@ -102,6 +104,7 @@ impl Component {
     ) -> Self {
         Self {
             id,
+            aliases: Vec::new(),
             local_path,
             remote_path,
             build_artifact,
@@ -140,6 +143,9 @@ impl ConfigEntity for Component {
     }
     fn not_found_error(id: String, suggestions: Vec<String>) -> Error {
         Error::component_not_found(id, suggestions)
+    }
+    fn aliases(&self) -> &[String] {
+        &self.aliases
     }
 }
 

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -24,6 +24,9 @@ pub struct Project {
     #[serde(skip)]
     pub id: String,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
 
@@ -103,6 +106,9 @@ impl ConfigEntity for Project {
             }
         }
         Ok(())
+    }
+    fn aliases(&self) -> &[String] {
+        &self.aliases
     }
 }
 

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -13,6 +13,8 @@ use std::process::Command;
 pub struct Server {
     #[serde(skip_deserializing, default)]
     pub id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
     pub host: String,
     pub user: String,
     #[serde(default = "default_port")]
@@ -51,6 +53,9 @@ impl ConfigEntity for Server {
     }
     fn not_found_error(id: String, suggestions: Vec<String>) -> Error {
         Error::server_not_found(id, suggestions)
+    }
+    fn aliases(&self) -> &[String] {
+        &self.aliases
     }
 }
 


### PR DESCRIPTION
Adds an optional `aliases` array field to components, projects, and servers. Entities can be referenced by any of their aliases in addition to their primary ID.

**Changes:**
- `aliases: Vec<String>` field on Component, Project, and Server structs
- `config::load()` resolves aliases when exact ID match fails (scans all entities)
- `find_similar_ids()` searches aliases and shows hints like `extra-chill (alias: ec)`
- `check_id_collision()` prevents aliases from conflicting with IDs or other aliases

**Example:**
```json
{
  "id": "extra-chill",
  "aliases": ["extrachill", "ec"],
  "local_path": "/path/to/component",
  "remote_path": "wp-content/plugins/extra-chill"
}
```

All 227 existing tests pass (1 pre-existing failure in docs_audit unrelated to this change).

Closes #34