### PR TITLE
fix: use non-existent path in docs audit test

### DIFF
--- a/src/core/docs_audit/verify.rs
+++ b/src/core/docs_audit/verify.rs
@@ -321,7 +321,7 @@ mod tests {
 
         let claim = Claim {
             claim_type: ClaimType::DirectoryPath,
-            value: "/var/lib/sweatpants/".to_string(),
+            value: "/opt/nonexistent-test-path-xyz/".to_string(),
             doc_file: "docs/test.md".to_string(),
             line: 1,
             context: None,


### PR DESCRIPTION
Test used `/var/lib/sweatpants/` as an example absolute path, but that exists on machines with sweatpants installed, making the test environment-dependent. Changed to `/opt/nonexistent-test-path-xyz/`.