### PR TITLE
feat: detect and warn about outdated modules in homeboy init

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -657,6 +657,26 @@ fn build_actionable_next_steps(
         next_steps.push(format!("Suggestion: {}", suggestion));
     }
 
+    // Check for outdated modules (git-cloned only, skips linked)
+    let mut outdated_modules = Vec::new();
+    for module in all_modules {
+        if let Some(update) = homeboy::module::check_update_available(&module.id) {
+            outdated_modules.push(update);
+        }
+    }
+    if !outdated_modules.is_empty() {
+        for update in &outdated_modules {
+            next_steps.push(format!(
+                "Module '{}' is outdated (v{}, {} commit{} behind). Run: `homeboy module update {}`",
+                update.module_id,
+                update.installed_version,
+                update.behind_count,
+                if update.behind_count == 1 { "" } else { "s" },
+                update.module_id,
+            ));
+        }
+    }
+
     // Fallback for empty repos
     if components.is_empty() && !context_output.managed {
         next_steps.push(

--- a/src/core/module/mod.rs
+++ b/src/core/module/mod.rs
@@ -30,8 +30,8 @@ pub use scope::ModuleScope;
 
 // Re-export lifecycle types and functions
 pub use lifecycle::{
-    derive_id_from_url, install, is_git_url, slugify_id, uninstall, update,
-    InstallResult, UpdateResult,
+    check_update_available, derive_id_from_url, install, is_git_url, slugify_id, uninstall, update,
+    InstallResult, UpdateAvailable, UpdateResult,
 };
 
 // Module loader functions


### PR DESCRIPTION
Checks git-cloned modules for available updates during `homeboy init`. Fetches from remote and compares HEAD against the tracking branch. Shows warnings in `next_steps` like:

```
Module 'wordpress' is outdated (v1.2.0, 3 commits behind). Run: \`homeboy module update wordpress\`
```

- Skips linked modules (managed externally)
- Skips non-git modules
- Best-effort: if fetch fails, silently skips

Closes #26