### PR TITLE
feat: add git-based deployment strategy

### DIFF
--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -93,7 +93,35 @@ pub struct Component {
     pub build_command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extract_command: Option<String>,
+
+    /// Deployment strategy: "rsync" (default) or "git"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_strategy: Option<String>,
+    /// Git deploy configuration (used when deploy_strategy = "git")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_deploy: Option<GitDeployConfig>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GitDeployConfig {
+    /// Git remote to pull from (default: "origin")
+    #[serde(default = "default_git_remote", skip_serializing_if = "is_default_remote")]
+    pub remote: String,
+    /// Branch to pull (default: "main")
+    #[serde(default = "default_git_branch", skip_serializing_if = "is_default_branch")]
+    pub branch: String,
+    /// Commands to run after git pull (e.g., "composer install", "npm run build")
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_pull: Vec<String>,
+    /// Pull a specific tag instead of branch HEAD (e.g., "v{{version}}")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_pattern: Option<String>,
+}
+
+fn default_git_remote() -> String { "origin".to_string() }
+fn default_git_branch() -> String { "main".to_string() }
+fn is_default_remote(s: &str) -> bool { s == "origin" }
+fn is_default_branch(s: &str) -> bool { s == "main" }
 
 impl Component {
     pub fn new(
@@ -118,6 +146,8 @@ impl Component {
             post_release_commands: Vec::new(),
             build_command: None,
             extract_command: None,
+            deploy_strategy: None,
+            git_deploy: None,
         }
     }
 }


### PR DESCRIPTION
Adds configurable deployment strategy per component. Components can now deploy via `git pull` on the remote instead of local rsync.

**Config example:**
```json
{
  "deploy_strategy": "git",
  "git_deploy": {
    "remote": "origin",
    "branch": "main",
    "post_pull": ["composer install --no-dev", "npm run build"],
    "tag_pattern": "v{{version}}"
  }
}
```

**How it works:**
1. SSH to remote server
2. `git fetch <remote> --tags`
3. `git checkout <tag>` (if tag_pattern set) or `git pull <remote> <branch>`
4. Run each post_pull command in sequence

**Key behaviors:**
- Default strategy is `rsync` — zero changes to existing behavior
- Tag pattern supports `{{version}}` template (resolves to component version)
- Post-pull commands run in the remote_path directory
- Fails fast on any step failure with clear error messages

**Use case:** Agent A bumps version and merges on GitHub. Agent B (on a different server) can deploy without having the code locally — just `homeboy deploy <project>` and the remote does `git pull`.

Closes #52