### PR TITLE
fix: handle uncommitted changelog gracefully in version bump

### DIFF
--- a/src/core/changelog/sections.rs
+++ b/src/core/changelog/sections.rs
@@ -87,10 +87,13 @@ pub fn finalize_next_section(
     let start = validation::require_with_hints(
         find_next_section_start(&lines, next_section_aliases),
         "changelog",
-        "No changelog items found (cannot finalize)",
+        &format!(
+            "No unreleased changelog section found (looked for: {})",
+            next_section_aliases.iter().map(|a| format!("\"## {}\"", a)).collect::<Vec<_>>().join(", ")
+        ),
         vec![
-            "Commit all changes before running version bump (changelog auto-generates from commits).".to_string(),
-            "Or add entries manually: `homeboy changelog add <componentId> -m \"...\"`".to_string(),
+            "Add entries: `homeboy changelog add <componentId> -m \"...\"`".to_string(),
+            "Or create section manually: add a `## Unreleased` heading to your changelog".to_string(),
         ],
     )?;
 

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -124,6 +124,20 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
                         "hint": "Commit changes or stash before release"
                     })),
                 );
+            } else if uncommitted.has_changes {
+                // Only changelog/version files are uncommitted — auto-stage them
+                // so the release commit includes them (e.g., after `homeboy changelog add`)
+                eprintln!("[release] Auto-staging changelog/version files for release commit");
+                let all_files: Vec<&String> = uncommitted.staged.iter()
+                    .chain(uncommitted.unstaged.iter())
+                    .collect();
+                for file in all_files {
+                    let full_path = std::path::Path::new(&component.local_path).join(file);
+                    let _ = std::process::Command::new("git")
+                        .args(["add", &full_path.to_string_lossy()])
+                        .current_dir(&component.local_path)
+                        .output();
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes the workflow where \`homeboy changelog add\` → \`homeboy version bump\` fails because the changelog has uncommitted changes.

**Changes:**

1. **Auto-stage changelog/version files** — When the only uncommitted changes are changelog and version target files (which are expected during a release), the pipeline auto-stages them so they get included in the release commit. No more manual \`git add && git commit\` between \`changelog add\` and \`version bump\`.

2. **Better error message** — When the unreleased section heading is not found, the error now shows which headings were searched for (e.g. \`"## Unreleased", "## [Unreleased]"\`), making it easier to diagnose section label mismatches.

Closes #78