### PR TITLE
fix(component): validate version target patterns at create time

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -298,6 +298,9 @@ fn set(args: DynamicSetArgs) -> CmdResult<ComponentOutput> {
 }
 
 fn add_version_target(id: &str, file: &str, pattern: &str) -> CmdResult<ComponentOutput> {
+    // Validate pattern is a valid regex with capture group
+    component::validate_version_pattern(pattern)?;
+
     // Load component to check existing targets
     let comp = component::load(id).map_err(|e| e.with_contextual_hint())?;
 


### PR DESCRIPTION
Rejects invalid version target patterns early (at `component create` / `add-version-target` time) instead of failing later during `version bump`.

**Catches:**
- `{version}` template syntax → clear error with correct regex example
- Invalid regex → shows parse error
- Missing capture group → explains parentheses requirement

**Tests added:** 5 new tests covering all validation paths.

Fixes #90