### PR TITLE
fix: docs_audit absolute path bug + align docs for fleet sync deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Homeboy replaces scattered scripts, FTP clients, and manual SSH sessions with on
 | Deploy a plugin | `homeboy deploy my-site my-plugin` |
 | Deploy to all sites | `homeboy deploy my-plugin --shared` |
 | Fleet rollout | `homeboy deploy my-plugin --fleet production` |
-| Sync agent configs | `homeboy fleet sync fleet-servers` |
+| Deploy across fleet | `homeboy deploy my-plugin --fleet fleet-servers` |
 | Release a new version | `homeboy release run my-plugin` |
 | Check what's outdated | `homeboy deploy my-site --check --outdated` |
 | Tail remote logs | `homeboy logs show my-site error.log --follow` |

--- a/docs/commands/fleet.md
+++ b/docs/commands/fleet.md
@@ -131,81 +131,14 @@ Returns per-project status with:
 
 Summary includes counts for quick overview.
 
-### `sync`
+### `sync` (deprecated)
+
+> **Deprecated.** Use `homeboy deploy` to sync files across servers instead. Register shared configs as components and deploy them like any other component. See [#101](https://github.com/Extra-Chill/homeboy/issues/101).
 
 ```sh
-homeboy fleet sync <id> [--category <name>] [--dry-run] [--leader <project_id>]
-```
-
-Sync OpenClaw agent configurations across all servers in a fleet. Reads a `fleet-sync.json` manifest from `~/.config/homeboy/` that defines what to sync and where from.
-
-Options:
-- `--category <name>`: Only sync specific categories (repeatable, comma-separated)
-- `--dry-run`: Preview what would be synced without applying changes
-- `--leader <project_id>`: Override the leader server (source of truth)
-
-#### Sync Categories
-
-| Category | What it syncs | Method |
-|----------|--------------|--------|
-| `openclaw-config` | Specific JSON paths in `openclaw.json` (e.g., model fallbacks) | JSON merge |
-| `opencode-config` | OpenCode config files and prompts | File copy |
-| `opencode-auth` | GitHub Copilot auth tokens | File copy |
-| `skills` | Workspace skill directories | Directory tar stream |
-| `workspace-files` | Shared workspace files (CODING-STANDARDS.md, etc.) | File copy |
-
-#### Manifest Format (`~/.config/homeboy/fleet-sync.json`)
-
-```json
-{
-  "leader": "command-server",
-  "categories": {
-    "openclaw-config": {
-      "enabled": true,
-      "merge_paths": ["agents.defaults.model.fallbacks"]
-    },
-    "opencode-config": {
-      "enabled": true,
-      "files": [".config/opencode/opencode.json", ".config/opencode/prompts/"]
-    },
-    "opencode-auth": {
-      "enabled": true,
-      "files": [".local/share/opencode/auth.json"]
-    },
-    "skills": {
-      "enabled": true,
-      "items": ["skills/opencode/"]
-    },
-    "workspace-files": {
-      "enabled": false,
-      "items": ["CODING-STANDARDS.md", "TOOLS.md"]
-    }
-  }
-}
-```
-
-#### Key Behaviors
-
-- **Auto-detects OpenClaw home** on each server (handles `/root/.openclaw/` and `/home/openclaw/.openclaw/`)
-- **JSON merge** for `openclaw-config` — merges specific paths without overwriting the full config
-- **Skips the leader** — doesn't sync the source of truth to itself
-- **Fixes ownership** — automatically `chown`s files for non-root OpenClaw users
-- **Category filtering** — sync only what you need with `--category`
-
-#### Example
-
-```sh
-# Preview sync across the fleet
-homeboy fleet sync fleet-servers --dry-run
-
-# Sync everything
-homeboy fleet sync fleet-servers
-
-# Sync only model config
-homeboy fleet sync fleet-servers --category openclaw-config
-
-# Sync skills and opencode config
-homeboy fleet sync fleet-servers --category skills,opencode-config
+# Instead of: homeboy fleet sync fleet-servers
+# Use:
+homeboy deploy my-config --fleet fleet-servers
 ```
 
 ## Fleet Deployment


### PR DESCRIPTION
## Summary

Cleanup round: fixes the pre-existing test failure and aligns docs with the fleet sync deprecation.

### Bug fix: docs_audit absolute path verification

`verify_file_path` and `verify_directory_path` had a bug where `Path::join` with an absolute path would replace the base entirely, accidentally checking the real filesystem instead of the source tree. This caused `test_verify_absolute_path_needs_verification` to fail on any machine where `/var/lib/sweatpants/modules.yaml` existed.

Fix: check for absolute paths *before* the candidates loop and return `NeedsVerification` immediately.

**233 passed, 0 failed** (was 232 passed, 1 failed).

### Docs alignment

- Fleet sync docs replaced with deprecation notice pointing to `homeboy deploy`
- README quick reference updated (`fleet sync` → `deploy --fleet`)
- Changelog left as-is (historical record)