### PR TITLE
feat(deploy): post-deploy cleanup of build dependencies (#105)

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -57,6 +57,10 @@ pub struct DeployArgs {
     /// Deploy to all projects using the specified component(s)
     #[arg(long, short = 's')]
     pub shared: bool,
+
+    /// Keep build dependencies (skip post-deploy cleanup)
+    #[arg(long)]
+    pub keep_deps: bool,
 }
 
 #[derive(Serialize)]
@@ -225,6 +229,7 @@ pub fn run(
         check: args.check,
         force: args.force,
         skip_build: false,
+        keep_deps: args.keep_deps,
     };
 
     let result = deploy::run(&project_id, &config).map_err(|e| {
@@ -314,6 +319,7 @@ fn run_multi_project(
             check: args.check,
             force: args.force,
             skip_build: !first_project, // Build only on first project
+            keep_deps: args.keep_deps,
         };
 
         match deploy::run(project_id, &config) {

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -435,6 +435,7 @@ fn check(id: &str, only_outdated: bool) -> CmdResult<FleetOutput> {
             check: true,
             force: false,
             skip_build: true,
+            keep_deps: false, // Fleet checks don't support --keep-deps
         };
 
         match deploy::run(project_id, &config) {

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -237,6 +237,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
             check: false,
             force: false,
             skip_build: true,
+            keep_deps: false, // Release deploy doesn't support --keep-deps
         };
 
         match deploy::run(project_id, &config) {

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -101,6 +101,9 @@ pub struct Component {
     /// Git deploy configuration (used when deploy_strategy = "git")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_deploy: Option<GitDeployConfig>,
+    /// Enable post-deploy cleanup of build dependencies (default: false)
+    #[serde(default)]
+    pub auto_cleanup: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -149,6 +152,7 @@ impl Component {
             extract_command: None,
             deploy_strategy: None,
             git_deploy: None,
+            auto_cleanup: false,
         }
     }
 }

--- a/src/core/module/manifest.rs
+++ b/src/core/module/manifest.rs
@@ -304,6 +304,9 @@ pub struct BuildConfig {
     /// Supports: {component_id}, {local_path}
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifact_pattern: Option<String>,
+    /// Paths to clean up after successful deploy (e.g., node_modules, vendor, target)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cleanup_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Implements post-deploy cleanup of build dependencies as specified in issue #105.

## Changes

**1. Module manifest ( in ):**
- Added  field to allow modules to declare cleanable directories

**2. Component config ( in ):**
- Added  field (defaults to false) for components to opt-in

**3. Deploy config ( in ):**
- Added  flag to skip cleanup when needed

**4. CLI flag ():**
- Added  flag to the deploy command

**5. Cleanup logic ():**
- Implemented cleanup function that runs after successful deploys
- Only runs when component.auto_cleanup is true and --keep-deps is not set
- Collects cleanup paths from linked modules' BuildConfig
- Logs what was cleaned and bytes freed
- Best-effort operation - failures warn but don't fail deploy

## Key behavior

- {
  "success": false,
  "error": {
    "code": "validation.invalid_argument",
    "message": "Invalid argument",
    "details": {
      "field": "input",
      "problem": "Provide component ID, project ID with --all, or JSON spec",
      "tried": [
        "Build a single component: homeboy build <component-id>",
        "Build all project components: homeboy build <project-id> --all"
      ]
    }
  }
} NEVER cleans up
-  cleans up ONLY after successful deploy
- If deploy fails, deps remain for debugging  
-  flag skips cleanup even when opted in
- Cleanup is LOCAL only (component's local_path on build machine)

## Testing

- All existing tests pass ()
- New functionality follows existing code patterns
- No dead variables or wasteful instantiation