### PR TITLE
Add remote_owner chown support to deploy

### DIFF
--- a/skills/homeboy/SKILL.md
+++ b/skills/homeboy/SKILL.md
@@ -293,6 +293,7 @@ homeboy config path                        # show config file path
   "remote_path": "/usr/local/bin",
   "build_command": "cargo build --release",
   "build_artifact": "target/release/myapp",
+  "remote_owner": "www-data:www-data",
   "version_targets": [
     { "file": "Cargo.toml", "pattern": "^version = \"(\\d+\\.\\d+\\.\\d+)\"" }
   ],

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -95,6 +95,11 @@ pub struct Component {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extract_command: Option<String>,
 
+    /// Owner:group for deployed files (e.g., "www-data:www-data").
+    /// If not set, auto-detected from remote_path ownership.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_owner: Option<String>,
+
     /// Deployment strategy: "rsync" (default) or "git"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deploy_strategy: Option<String>,
@@ -150,6 +155,7 @@ impl Component {
             post_release_commands: Vec::new(),
             build_command: None,
             extract_command: None,
+            remote_owner: None,
             deploy_strategy: None,
             git_deploy: None,
             auto_cleanup: false,

--- a/src/core/deploy.rs
+++ b/src/core/deploy.rs
@@ -134,6 +134,7 @@ pub fn deploy_artifact(
     remote_path: &str,
     extract_command: Option<&str>,
     verification: Option<&DeployVerification>,
+    remote_owner: Option<&str>,
 ) -> Result<DeployResult> {
     // Step 1: Upload (directory or file)
     if local_path.is_dir() {
@@ -242,7 +243,7 @@ pub fn deploy_artifact(
 
             // Fix file permissions after extraction
             eprintln!("[deploy] Fixing file permissions");
-            permissions::fix_deployed_permissions(ssh_client, remote_path)?;
+            permissions::fix_deployed_permissions(ssh_client, remote_path, remote_owner)?;
         }
     }
 
@@ -881,6 +882,7 @@ pub fn deploy_components(
                     verification.as_ref(),
                     Some(base_path),
                     project.domain.as_deref(),
+                    component.remote_owner.as_deref(),
                 )
             } else {
                 // Standard deploy
@@ -890,6 +892,7 @@ pub fn deploy_components(
                     &install_dir,
                     component.extract_command.as_deref(),
                     verification.as_ref(),
+                    component.remote_owner.as_deref(),
                 )
             };
 
@@ -1347,6 +1350,7 @@ fn deploy_with_override(
     verification: Option<&DeployVerification>,
     site_root: Option<&str>,
     domain: Option<&str>,
+    remote_owner: Option<&str>,
 ) -> Result<DeployResult> {
     let artifact_filename = local_path
         .file_name()
@@ -1442,7 +1446,7 @@ fn deploy_with_override(
     // Step 5: Fix permissions unless skipped
     if !override_config.skip_permissions_fix {
         eprintln!("[deploy] Fixing file permissions");
-        permissions::fix_deployed_permissions(ssh_client, remote_path)?;
+        permissions::fix_deployed_permissions(ssh_client, remote_path, remote_owner)?;
     }
 
     // Step 6: Run verification if configured

--- a/src/core/permissions.rs
+++ b/src/core/permissions.rs
@@ -34,8 +34,13 @@ pub fn fix_local_permissions(local_path: &str) {
 }
 
 /// Fix file permissions after deployment.
-pub fn fix_deployed_permissions(ssh_client: &SshClient, remote_path: &str) -> Result<()> {
+pub fn fix_deployed_permissions(ssh_client: &SshClient, remote_path: &str, remote_owner: Option<&str>) -> Result<()> {
     let quoted_path = shell::quote_path(remote_path);
+
+    // Step 1: Fix ownership (chown before chmod)
+    fix_deployed_ownership(ssh_client, remote_path, remote_owner, &quoted_path);
+
+    // Step 2: Fix permissions
     let perms = defaults::load_defaults().permissions.remote;
 
     let dir_cmd = format!(
@@ -53,6 +58,36 @@ pub fn fix_deployed_permissions(ssh_client: &SshClient, remote_path: &str) -> Re
     ensure_remote_success(file_output, "chmod files", remote_path)?;
 
     Ok(())
+}
+
+/// Fix ownership of deployed files via chown.
+/// Uses configured remote_owner if provided, otherwise auto-detects from existing ownership.
+fn fix_deployed_ownership(ssh_client: &SshClient, remote_path: &str, remote_owner: Option<&str>, quoted_path: &str) {
+    let owner = if let Some(configured) = remote_owner {
+        configured.to_string()
+    } else {
+        // Auto-detect: stat the remote_path to get current owner:group
+        let stat_cmd = format!("stat -c '%U:%G' {} 2>/dev/null", quoted_path);
+        let stat_output = ssh_client.execute(&stat_cmd);
+        if !stat_output.success || stat_output.stdout.trim().is_empty() {
+            eprintln!("[deploy] Could not detect ownership of {}, skipping chown", remote_path);
+            return;
+        }
+        let detected = stat_output.stdout.trim().to_string();
+        // Skip chown if already root:root (no point changing to same)
+        if detected == "root:root" {
+            return;
+        }
+        detected
+    };
+
+    eprintln!("[deploy] Setting ownership to {} on {}", owner, remote_path);
+    let chown_cmd = format!("chown -R {} {} 2>/dev/null", shell::quote_arg(&owner), quoted_path);
+    let chown_output = ssh_client.execute(&chown_cmd);
+    if !chown_output.success {
+        eprintln!("[deploy] Warning: chown failed (exit {}): {}", chown_output.exit_code, chown_output.stderr);
+        // Don't fail the deploy - chown is best-effort
+    }
 }
 
 fn ensure_remote_success(output: CommandOutput, operation: &str, remote_path: &str) -> Result<()> {


### PR DESCRIPTION
## Summary

After extracting deployed files, chown them to match the configured `remote_owner` (e.g. `www-data:www-data`) or auto-detect from the target directory's existing ownership. Fixes root-owned files after SSH deploy.

## Changes

- **`src/core/component.rs`**: Added `remote_owner: Option<String>` field to Component struct
- **`src/core/permissions.rs`**: Added `fix_deployed_ownership()` — runs `chown -R` before chmod. Uses configured owner or auto-detects via `stat -c '%U:%G'`. Silently skips on failure.
- **`src/core/deploy.rs`**: Threaded `remote_owner` parameter through `deploy_artifact()` and `deploy_with_override()`
- **`skills/homeboy/SKILL.md`**: Added `remote_owner` to config example

## Usage

```bash
# Set owner for a component
homeboy component set my-plugin '{"remote_owner": "www-data:www-data"}'

# Deploy — will chown to www-data:www-data after extract
homeboy deploy my-plugin
```

If `remote_owner` is not configured, ownership is auto-detected from the target directory. If detection returns `root:root` or fails, chown is skipped.

Closes #110