### PR TITLE
feat: configurable docs_dir for component audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.45.3"
+version = "0.45.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homeboy"
-version = "0.45.3"
+version = "0.45.4"
 edition = "2021"
 license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -47,6 +47,10 @@ pub enum DocsCommand {
     Audit {
         /// Component to audit
         component_id: String,
+
+        /// Docs directory relative to component root (overrides component config, default: docs)
+        #[arg(long)]
+        docs_dir: Option<String>,
     },
 
     /// Generate documentation files from JSON spec
@@ -156,7 +160,7 @@ pub fn run(args: DocsArgs, _global: &super::GlobalArgs) -> CmdResult<DocsOutput>
             source_extensions,
             detect_by_extension,
         ),
-        Some(DocsCommand::Audit { component_id }) => run_audit(&component_id),
+        Some(DocsCommand::Audit { component_id, docs_dir }) => run_audit(&component_id, docs_dir.as_deref()),
         Some(DocsCommand::Generate { spec, json }) => {
             let json_spec = json.as_deref().or(spec.as_deref());
             run_generate(json_spec)
@@ -255,8 +259,8 @@ fn run_scaffold(
 // Audit (Claim-Based Documentation Verification)
 // ============================================================================
 
-fn run_audit(component_id: &str) -> CmdResult<DocsOutput> {
-    let result = docs_audit::audit_component(component_id)?;
+fn run_audit(component_id: &str, docs_dir: Option<&str>) -> CmdResult<DocsOutput> {
+    let result = docs_audit::audit_component(component_id, docs_dir)?;
     Ok((DocsOutput::Audit(result), 0))
 }
 

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -109,6 +109,11 @@ pub struct Component {
     /// Enable post-deploy cleanup of build dependencies (default: false)
     #[serde(default)]
     pub auto_cleanup: bool,
+
+    /// Documentation directory relative to local_path (default: "docs").
+    /// Used by `docs audit` and `docs scaffold` to locate documentation files.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docs_dir: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -159,6 +164,7 @@ impl Component {
             deploy_strategy: None,
             git_deploy: None,
             auto_cleanup: false,
+            docs_dir: None,
         }
     }
 }

--- a/src/core/docs_audit/mod.rs
+++ b/src/core/docs_audit/mod.rs
@@ -74,10 +74,16 @@ pub struct AuditResult {
 }
 
 /// Audit a component's documentation and return an alignment report.
-pub fn audit_component(component_id: &str) -> Result<AuditResult> {
+///
+/// If `docs_dir_override` is provided, it's used instead of the component's
+/// configured `docs_dir` (which defaults to "docs").
+pub fn audit_component(component_id: &str, docs_dir_override: Option<&str>) -> Result<AuditResult> {
     let comp = component::load(component_id)?;
     let source_path = Path::new(&comp.local_path);
-    let docs_path = source_path.join("docs");
+    let docs_dir = docs_dir_override
+        .or(comp.docs_dir.as_deref())
+        .unwrap_or("docs");
+    let docs_path = source_path.join(docs_dir);
 
     // Get changelog target to exclude from audit (historical references are expected)
     let changelog_exclude = comp.changelog_target.as_deref();


### PR DESCRIPTION
## Problem

`docs audit` hardcodes `docs/` as the documentation directory. Projects that keep docs elsewhere (e.g. `documentation/`, `doc/`, or alongside source) can't be audited.

## Fix

Added `docs_dir` support at two levels:

1. **Component config** — persistent per-component setting:
   ```json
   { "docs_dir": "documentation" }
   ```

2. **CLI flag** — one-off override:
   ```
   homeboy docs audit my-component --docs-dir documentation
   ```

Resolution order: CLI flag > component config > default `docs`

## Changes

- `src/core/component.rs`: Added `docs_dir: Option<String>` field
- `src/core/docs_audit/mod.rs`: `audit_component()` accepts `docs_dir_override` param
- `src/commands/docs.rs`: Added `--docs-dir` flag to Audit subcommand

All 50 tests pass. Bumped to v0.45.4.