### PR TITLE
feat: multi-dir docs scanning + README auto-include for audit

### DIFF
--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -112,8 +112,15 @@ pub struct Component {
 
     /// Documentation directory relative to local_path (default: "docs").
     /// Used by `docs audit` and `docs scaffold` to locate documentation files.
+    /// Can be a single path or use `docs_dirs` for multiple paths.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docs_dir: Option<String>,
+
+    /// Multiple documentation directories relative to local_path.
+    /// When set, all directories are scanned for documentation.
+    /// Takes precedence over `docs_dir`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub docs_dirs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -165,6 +172,7 @@ impl Component {
             git_deploy: None,
             auto_cleanup: false,
             docs_dir: None,
+            docs_dirs: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Builds on #113 (merged).

## Changes

- **`docs_dirs` array** — component config can list multiple doc directories to scan
- **README auto-include** — README.md/README.txt from project root are always checked for feature mentions
- **Priority**: CLI `--docs-dir` > `docs_dirs` > `docs_dir` > default `docs`

## Why

Most repos document features in their README even without a `docs/` folder. Auto-including it means the audit works out of the box for simple projects. Multi-dir handles projects with split documentation (docs + wiki + guides).

## Tests

52 tests pass (+2 new: `test_detect_undocumented_features_reads_readme`, `test_detect_undocumented_features_multiple_dirs`)