### PR TITLE
feat: homeboy cleanup — config health checks (Tier 2)

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,0 +1,127 @@
+use clap::Args;
+use serde::Serialize;
+
+use homeboy::cleanup::{self, CleanupResult};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct CleanupArgs {
+    /// Component to check (omit for all components)
+    pub component_id: Option<String>,
+
+    /// Show only issues of a specific severity: error, warning, info
+    #[arg(long)]
+    pub severity: Option<String>,
+
+    /// Show only issues in a specific category: local_path, remote_path, version_targets, modules
+    #[arg(long)]
+    pub category: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct CleanupOutput {
+    pub command: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    pub total_issues: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<CleanupResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub results: Vec<CleanupResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
+}
+
+pub fn run_json(args: CleanupArgs) -> CmdResult<CleanupOutput> {
+    let severity_filter = args.severity.as_deref();
+    let category_filter = args.category.as_deref();
+
+    if let Some(ref component_id) = args.component_id {
+        // Single component mode
+        let mut result = cleanup::cleanup_component(component_id)?;
+
+        // Apply filters
+        filter_issues(&mut result, severity_filter, category_filter);
+
+        let total_issues = result.summary.config_issues;
+
+        Ok((
+            CleanupOutput {
+                command: "cleanup",
+                component_id: Some(component_id.clone()),
+                total_issues,
+                result: Some(result),
+                results: Vec::new(),
+                hints: vec![
+                    "Full docs: homeboy docs commands/cleanup".to_string(),
+                ],
+            },
+            0,
+        ))
+    } else {
+        // All components mode
+        let mut results = cleanup::cleanup_all()?;
+
+        // Apply filters to each result
+        for result in &mut results {
+            filter_issues(result, severity_filter, category_filter);
+        }
+
+        let total_issues: usize = results.iter().map(|r| r.summary.config_issues).sum();
+
+        let mut hints = Vec::new();
+        if total_issues == 0 {
+            hints.push("All components passed config health checks.".to_string());
+        } else {
+            hints.push(format!(
+                "{} total issue(s) across {} component(s).",
+                total_issues,
+                results.iter().filter(|r| r.summary.config_issues > 0).count()
+            ));
+        }
+        hints.push("Full docs: homeboy docs commands/cleanup".to_string());
+
+        Ok((
+            CleanupOutput {
+                command: "cleanup",
+                component_id: None,
+                total_issues,
+                result: None,
+                results,
+                hints,
+            },
+            0,
+        ))
+    }
+}
+
+/// Filter issues in a CleanupResult by severity and/or category.
+fn filter_issues(
+    result: &mut CleanupResult,
+    severity_filter: Option<&str>,
+    category_filter: Option<&str>,
+) {
+    if severity_filter.is_none() && category_filter.is_none() {
+        return;
+    }
+
+    result.config_issues.retain(|issue| {
+        let severity_match = match severity_filter {
+            Some("error") => issue.severity == cleanup::config::IssueSeverity::Error,
+            Some("warning") => issue.severity == cleanup::config::IssueSeverity::Warning,
+            Some("info") => issue.severity == cleanup::config::IssueSeverity::Info,
+            _ => true,
+        };
+
+        let category_match = match category_filter {
+            Some(cat) => issue.category == cat,
+            None => true,
+        };
+
+        severity_match && category_match
+    });
+
+    // Update summary after filtering
+    result.summary.config_issues = result.config_issues.len();
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -208,6 +208,7 @@ pub mod auth;
 pub mod build;
 pub mod changelog;
 pub mod changes;
+pub mod cleanup;
 pub mod cli;
 pub mod component;
 pub mod config;
@@ -269,6 +270,7 @@ pub(crate) fn run_json(
         crate::Commands::Status(args) => dispatch!(args, status),
         crate::Commands::Test(args) => dispatch!(args, test),
         crate::Commands::Lint(args) => dispatch!(args, lint),
+        crate::Commands::Cleanup(args) => dispatch!(args, cleanup),
 
         // Commands with global context
         crate::Commands::Project(args) => dispatch!(args, global, project),

--- a/src/core/cleanup/config.rs
+++ b/src/core/cleanup/config.rs
@@ -1,0 +1,323 @@
+//! Config health checks for components.
+//!
+//! Identifies configuration drift: broken paths, dead version targets,
+//! unused module links, and other config-level issues that accumulate
+//! as projects evolve.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::component::Component;
+use crate::module;
+use crate::version;
+
+/// Severity of a config issue.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum IssueSeverity {
+    /// Will cause command failures.
+    Error,
+    /// Something is off but not blocking.
+    Warning,
+    /// Informational — could be cleaned up.
+    Info,
+}
+
+/// A single config health issue found on a component.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfigIssue {
+    pub severity: IssueSeverity,
+    pub category: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix_hint: Option<String>,
+}
+
+/// Run all config health checks on a component. Returns a list of issues found.
+pub fn check_config(component: &Component) -> Vec<ConfigIssue> {
+    let mut issues = Vec::new();
+
+    check_local_path(component, &mut issues);
+    check_remote_path(component, &mut issues);
+    check_version_targets(component, &mut issues);
+    check_modules(component, &mut issues);
+
+    issues
+}
+
+/// Check if local_path exists and is absolute.
+fn check_local_path(component: &Component, issues: &mut Vec<ConfigIssue>) {
+    if component.local_path.is_empty() {
+        issues.push(ConfigIssue {
+            severity: IssueSeverity::Error,
+            category: "local_path".to_string(),
+            message: "local_path is empty.".to_string(),
+            fix_hint: Some(format!(
+                "homeboy component set {} --local-path \"/path/to/component\"",
+                component.id
+            )),
+        });
+        return;
+    }
+
+    let expanded = shellexpand::tilde(&component.local_path);
+    let path = Path::new(expanded.as_ref());
+
+    if !path.is_absolute() {
+        issues.push(ConfigIssue {
+            severity: IssueSeverity::Error,
+            category: "local_path".to_string(),
+            message: format!(
+                "local_path '{}' is relative. Must be absolute.",
+                component.local_path
+            ),
+            fix_hint: Some(format!(
+                "homeboy component set {} --local-path \"/absolute/path/to/{}\"",
+                component.id, component.local_path
+            )),
+        });
+        return;
+    }
+
+    if !path.exists() {
+        issues.push(ConfigIssue {
+            severity: IssueSeverity::Error,
+            category: "local_path".to_string(),
+            message: format!("local_path does not exist: {}", path.display()),
+            fix_hint: Some(format!(
+                "homeboy component set {} --local-path \"/correct/path\"",
+                component.id
+            )),
+        });
+    }
+}
+
+/// Check if remote_path looks configured.
+fn check_remote_path(component: &Component, issues: &mut Vec<ConfigIssue>) {
+    if component.remote_path.is_empty() {
+        issues.push(ConfigIssue {
+            severity: IssueSeverity::Info,
+            category: "remote_path".to_string(),
+            message: "remote_path is empty. Deploy will not work.".to_string(),
+            fix_hint: Some(format!(
+                "homeboy component set {} --remote-path \"server:/path/to/deploy\"",
+                component.id
+            )),
+        });
+    }
+}
+
+/// Check that version targets point to real files with parseable versions.
+fn check_version_targets(component: &Component, issues: &mut Vec<ConfigIssue>) {
+    let targets = match &component.version_targets {
+        Some(t) if !t.is_empty() => t,
+        _ => return, // No version targets configured — not an issue by itself
+    };
+
+    // Only check if local_path exists (avoid cascading errors)
+    let expanded = shellexpand::tilde(&component.local_path);
+    let base = Path::new(expanded.as_ref());
+    if !base.exists() {
+        return;
+    }
+
+    for target in targets {
+        let file_path = base.join(&target.file);
+
+        if !file_path.exists() {
+            issues.push(ConfigIssue {
+                severity: IssueSeverity::Error,
+                category: "version_targets".to_string(),
+                message: format!(
+                    "Version target file '{}' does not exist at {}",
+                    target.file,
+                    file_path.display()
+                ),
+                fix_hint: Some(format!(
+                    "homeboy component set {} --replace version_targets --version-target \"correct-file.php::pattern\"",
+                    component.id
+                )),
+            });
+            continue;
+        }
+
+        // Try to read version using configured or module-default pattern
+        let pattern = target
+            .pattern
+            .clone()
+            .or_else(|| version::default_pattern_for_file(&target.file));
+
+        if let Some(ref pat) = pattern {
+            let content = match std::fs::read_to_string(&file_path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            if version::parse_version(&content, pat).is_none() {
+                issues.push(ConfigIssue {
+                    severity: IssueSeverity::Warning,
+                    category: "version_targets".to_string(),
+                    message: format!(
+                        "Version target '{}' exists but pattern '{}' doesn't match any version.",
+                        target.file, pat
+                    ),
+                    fix_hint: Some(format!(
+                        "Check pattern syntax. Test with: homeboy version read {}",
+                        component.id
+                    )),
+                });
+            }
+        } else {
+            issues.push(ConfigIssue {
+                severity: IssueSeverity::Warning,
+                category: "version_targets".to_string(),
+                message: format!(
+                    "Version target '{}' has no pattern and no module provides a default for this file type.",
+                    target.file
+                ),
+                fix_hint: Some(format!(
+                    "homeboy component set {} --replace version_targets --version-target \"{}::Version:\\\\s*(\\\\d+\\\\.\\\\d+\\\\.\\\\d+)\"",
+                    component.id, target.file
+                )),
+            });
+        }
+    }
+}
+
+/// Check that linked modules exist and have capabilities configured.
+fn check_modules(component: &Component, issues: &mut Vec<ConfigIssue>) {
+    let modules = match &component.modules {
+        Some(m) => m,
+        None => return,
+    };
+
+    for module_id in modules.keys() {
+        match module::load_module(module_id) {
+            Ok(manifest) => {
+                // Module exists — check if it provides any useful capabilities
+                let has_build = manifest.has_build();
+                let has_lint = manifest.has_lint();
+                let has_test = manifest.has_test();
+                let has_cli = manifest.has_cli();
+
+                if !has_build && !has_lint && !has_test && !has_cli {
+                    issues.push(ConfigIssue {
+                        severity: IssueSeverity::Info,
+                        category: "modules".to_string(),
+                        message: format!(
+                            "Module '{}' is linked but has no build, lint, test, or CLI capabilities.",
+                            module_id
+                        ),
+                        fix_hint: None,
+                    });
+                }
+            }
+            Err(_) => {
+                issues.push(ConfigIssue {
+                    severity: IssueSeverity::Error,
+                    category: "modules".to_string(),
+                    message: format!(
+                        "Module '{}' is linked but could not be loaded. Module may be missing or malformed.",
+                        module_id
+                    ),
+                    fix_hint: Some(format!(
+                        "Check installed modules: homeboy module list\nRemove dead link: homeboy component set {} --json '{{\"modules\": null}}'",
+                        component.id
+                    )),
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::Component;
+
+    fn make_component(id: &str, local_path: &str) -> Component {
+        Component::new(
+            id.to_string(),
+            local_path.to_string(),
+            String::new(),
+            None,
+        )
+    }
+
+    #[test]
+    fn empty_local_path_is_error() {
+        let comp = make_component("test", "");
+        let issues = check_config(&comp);
+        assert!(issues.iter().any(|i| i.category == "local_path"
+            && i.severity == IssueSeverity::Error
+            && i.message.contains("empty")));
+    }
+
+    #[test]
+    fn relative_local_path_is_error() {
+        let comp = make_component("test", "relative/path");
+        let issues = check_config(&comp);
+        assert!(issues.iter().any(|i| i.category == "local_path"
+            && i.severity == IssueSeverity::Error
+            && i.message.contains("relative")));
+    }
+
+    #[test]
+    fn nonexistent_local_path_is_error() {
+        let comp = make_component("test", "/definitely/does/not/exist/abc123");
+        let issues = check_config(&comp);
+        assert!(issues.iter().any(|i| i.category == "local_path"
+            && i.severity == IssueSeverity::Error
+            && i.message.contains("does not exist")));
+    }
+
+    #[test]
+    fn empty_remote_path_is_info() {
+        let comp = make_component("test", "/tmp");
+        let issues = check_config(&comp);
+        assert!(issues.iter().any(|i| i.category == "remote_path"
+            && i.severity == IssueSeverity::Info));
+    }
+
+    #[test]
+    fn missing_version_target_file_is_error() {
+        use crate::component::VersionTarget;
+        let mut comp = make_component("test", "/tmp");
+        comp.version_targets = Some(vec![VersionTarget {
+            file: "nonexistent-file.php".to_string(),
+            pattern: Some(r"Version:\s*(\d+\.\d+\.\d+)".to_string()),
+        }]);
+        let issues = check_config(&comp);
+        assert!(issues.iter().any(|i| i.category == "version_targets"
+            && i.severity == IssueSeverity::Error
+            && i.message.contains("does not exist")));
+    }
+
+    #[test]
+    fn missing_module_is_error() {
+        use crate::component::ScopedModuleConfig;
+        use std::collections::HashMap;
+        let mut comp = make_component("test", "/tmp");
+        let mut modules = HashMap::new();
+        modules.insert(
+            "nonexistent-module-xyz".to_string(),
+            ScopedModuleConfig::default(),
+        );
+        comp.modules = Some(modules);
+        let issues = check_config(&comp);
+        assert!(issues.iter().any(|i| i.category == "modules"
+            && i.severity == IssueSeverity::Error
+            && i.message.contains("could not be loaded")));
+    }
+
+    #[test]
+    fn valid_component_has_minimal_issues() {
+        // /tmp exists and is absolute, so local_path checks pass.
+        // Only remote_path (empty) should be flagged as info.
+        let comp = make_component("test", "/tmp");
+        let issues = check_config(&comp);
+        // Should only have the empty remote_path info
+        assert!(issues.iter().all(|i| i.severity == IssueSeverity::Info));
+    }
+}

--- a/src/core/cleanup/mod.rs
+++ b/src/core/cleanup/mod.rs
@@ -1,0 +1,85 @@
+//! Project cleanup system for identifying config drift, stale state, and hygiene issues.
+//!
+//! This module provides project-level health checks that only Homeboy can see:
+//! 1. Config health - broken paths, dead version targets, unused modules
+//! 2. Future: git staleness, orphan detection, unused registrations
+
+pub mod config;
+
+use serde::Serialize;
+
+use crate::component::Component;
+use crate::Result;
+
+/// Summary counts for the cleanup report.
+#[derive(Debug, Clone, Serialize)]
+pub struct CleanupSummary {
+    pub config_issues: usize,
+}
+
+/// Result of running cleanup checks on a component.
+#[derive(Debug, Clone, Serialize)]
+pub struct CleanupResult {
+    pub component_id: String,
+    pub summary: CleanupSummary,
+    pub config_issues: Vec<config::ConfigIssue>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
+}
+
+/// Run all cleanup checks on a component.
+pub fn cleanup_component(component_id: &str) -> Result<CleanupResult> {
+    let comp = crate::component::load(component_id)?;
+    let config_issues = config::check_config(&comp);
+
+    let mut hints = Vec::new();
+    if config_issues.is_empty() {
+        hints.push("No config issues found.".to_string());
+    } else {
+        hints.push(format!(
+            "{} config issue(s) found. Review and fix with `homeboy component set`.",
+            config_issues.len()
+        ));
+    }
+
+    Ok(CleanupResult {
+        component_id: component_id.to_string(),
+        summary: CleanupSummary {
+            config_issues: config_issues.len(),
+        },
+        config_issues,
+        hints,
+    })
+}
+
+/// Run cleanup checks across ALL registered components.
+pub fn cleanup_all() -> Result<Vec<CleanupResult>> {
+    let components: Vec<Component> = crate::component::list().unwrap_or_default();
+    let mut results = Vec::new();
+
+    for comp in &components {
+        let config_issues = config::check_config(comp);
+        let issue_count = config_issues.len();
+
+        let mut hints = Vec::new();
+        if config_issues.is_empty() {
+            hints.push("No config issues found.".to_string());
+        } else {
+            hints.push(format!(
+                "{} config issue(s) found. Review and fix with `homeboy component set`.",
+                issue_count
+            ));
+        }
+
+        results.push(CleanupResult {
+            component_id: comp.id.clone(),
+            summary: CleanupSummary {
+                config_issues: issue_count,
+            },
+            config_issues,
+            hints,
+        });
+    }
+
+    Ok(results)
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod auth;
 pub mod build;
 pub mod changelog;
+pub mod cleanup;
 pub mod cli_tool;
 pub mod component;
 pub mod context;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ mod output;
 mod tty;
 
 use commands::{
-    api, auth, build, changelog, changes, cli, component, config, db, deploy, file, fleet, git,
-    init, lint, logs, module, project, release, server, ssh, status, test, transfer, upgrade,
+    api, auth, build, changelog, changes, cleanup, cli, component, config, db, deploy, file, fleet,
+    git, init, lint, logs, module, project, release, server, ssh, status, test, transfer, upgrade,
     version,
 };
 use homeboy::module::load_all_modules;
@@ -54,6 +54,8 @@ enum Commands {
     Test(test::TestArgs),
     /// Lint a component
     Lint(lint::LintArgs),
+    /// Identify config drift, stale state, and hygiene issues
+    Cleanup(cleanup::CleanupArgs),
     /// Database operations
     Db(db::DbArgs),
     /// Remote file operations


### PR DESCRIPTION
## Summary

Adds `homeboy cleanup [component-id]` command that identifies config drift and hygiene issues across components.

- **Broken local_path** — missing, relative, or nonexistent paths (severity: error)
- **Empty remote_path** — deploy won't work (severity: info)
- **Dead version targets** — file doesn't exist, or pattern doesn't match (severity: error/warning)
- **Broken module links** — linked module can't be loaded (severity: error)
- **Unused module links** — module has no build/lint/test/CLI capabilities (severity: info)

## Architecture

Follows the `docs audit` pattern:

```
core/cleanup/
  mod.rs      — orchestrator, CleanupResult types, cleanup_component()
  config.rs   — config health checks (5 check functions)

commands/cleanup.rs — CLI layer, JSON output, severity/category filters
```

## CLI

```
homeboy cleanup                              # all components
homeboy cleanup my-plugin                    # single component
homeboy cleanup my-plugin --severity error   # errors only
homeboy cleanup --category version_targets   # specific category
```

## Tests

7 unit tests covering all config check categories:
- empty/relative/nonexistent local_path → error
- empty remote_path → info
- missing version target file → error
- missing module → error
- valid component → only info-level issues

All 279 existing tests continue to pass.

## Related

- Issue #156 — implements Tier 2 (config health checks)
- Future PRs will add Tier 3 (git staleness), Tier 1 (module dead code scripts), Tier 4 (orphan detection)