### PR TITLE
docs: improve modules section and clarify local_path vs deploy target

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,24 +109,31 @@ homeboy docs audit my-component        # Verify docs match code
 
 ## Modules
 
-Extend Homeboy with platform-specific tools:
+Modules extend Homeboy with project-type support — WordPress, Node.js, Rust, and more. Browse all available modules at [homeboy-modules](https://github.com/Extra-Chill/homeboy-modules).
 
 | Module | Purpose |
 |--------|---------|
-| **wordpress** | WP-CLI integration |
+| **wordpress** | WP-CLI integration, build, test, lint |
 | **nodejs** | PM2 process management |
 | **rust** | Cargo CLI integration |
 | **github** | Issues, PRs, releases |
 | **homebrew** | Tap publishing |
 | **agent-hooks** | AI agent guardrails |
 
+Install from the [homeboy-modules](https://github.com/Extra-Chill/homeboy-modules) monorepo:
+
 ```bash
-homeboy module install <git-url>
+# Install a module by name
+homeboy module install https://github.com/Extra-Chill/homeboy-modules --id wordpress
+
+# List installed modules
 homeboy module list
+
+# Use a module's commands
 homeboy wp my-site plugin list         # WordPress via module
 ```
 
-See [homeboy-modules](https://github.com/Extra-Chill/homeboy-modules) for all available modules.
+Homeboy auto-detects monorepo layout — just pass `--id` with the module name. For single-module repos, `--id` is optional.
 
 ## Configuration
 

--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -23,7 +23,7 @@ Options:
 
 - `--json <spec>`: JSON input spec for create/update (supports single or bulk)
 - `--skip-existing`: skip items that already exist (JSON mode only)
-- `--local-path <path>`: absolute path to local source directory (required; ID derived from directory name; `~` is expanded)
+- `--local-path <path>`: absolute path to local **source / git checkout** directory (required; ID derived from directory name; `~` is expanded). Must be a git repo — not the production deploy target (see [component schema](../schemas/component-schema.md#local_path-vs-remote_path))
 - `--remote-path <path>`: remote path relative to project `base_path` (required)
 - `--build-artifact <path>`: build artifact path relative to `local_path` (required; must include a filename)
 - `--version-target <TARGET>`: version target in format `file` or `file::pattern` (repeatable)

--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -30,10 +30,12 @@ Component configuration defines buildable and deployable units stored in `compon
 ### Required Fields
 
 - **`id`** (string): Unique component identifier, derived from `local_path` directory name (lowercased)
-- **`local_path`** (string): Absolute path to local source directory, `~` is expanded
-- **`remote_path`** (string): Remote path relative to project `base_path`
+- **`local_path`** (string): Absolute path to local **source / git checkout** directory, `~` is expanded
+- **`remote_path`** (string): Remote path relative to project `base_path` (the **deploy target**)
 - **`build_artifact`** (string): Build artifact path relative to `local_path`, must include filename
 - **`build_command`** (string): Shell command to execute in `local_path` during builds
+
+> **Important:** `local_path` must point to a **git repository / source checkout**, not the production deploy target. The deploy target is derived from `project.base_path + component.remote_path`. If `local_path` points to the deployed directory, builds will run inside production and uncommitted-changes checks will fail (the directory isn't a git repo). This is a common misconfiguration after server migrations.
 
 ### Optional Fields
 
@@ -68,6 +70,22 @@ Component configuration defines buildable and deployable units stored in `compon
   - Execution: Sequential, runs in `local_path` directory
   - Failure behavior: **Non-fatal** - logs warnings but doesn't fail the release
   - Use case: Cleanup tasks, notifications, non-critical post-release actions
+
+## local_path vs remote_path
+
+```
+local_path (source)                          remote_path (deploy target)
+┌──────────────────────────┐                ┌──────────────────────────────────────────┐
+│ ~/repos/extrachill-api/  │  ── build ──▶  │ /var/www/site/wp-content/plugins/        │
+│ (git checkout, builds    │    deploy      │ extrachill-api/                          │
+│  run here)               │                │ (project.base_path + remote_path)        │
+└──────────────────────────┘                └──────────────────────────────────────────┘
+```
+
+- **`local_path`** — where the code lives on your dev machine (a git repo)
+- **`remote_path`** — where it gets deployed on the server (relative to the project's `base_path`)
+
+Setting `local_path` to the same directory as the deploy target is a misconfiguration — builds would run in production and `homeboy deploy` would fail uncommitted-changes checks.
 
 ## Example
 


### PR DESCRIPTION
## Summary

- **#172**: Update README Modules section with monorepo install syntax (`--id` flag), clearer descriptions
- **#169**: Add `local_path` vs `remote_path` diagram and explanation to component schema docs, clarify that `local_path` must be a git checkout (not the production deploy target), cross-reference from component command docs

Closes #172, closes #169