### PR TITLE
feat: add --path override for component commands

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -4,12 +4,28 @@
 
 ```sh
 homeboy build <component_id>
+homeboy build <component_id> --path /path/to/workspace/clone
 homeboy build --json '<spec>'
 ```
 
 ## Description
 
 Runs a build command for the component in the component's `local_path`.
+
+## Path Override
+
+Use `--path` to run the build against a different directory than the configured `local_path`:
+
+```sh
+homeboy build data-machine --path /var/lib/datamachine/workspace/data-machine
+```
+
+This is useful for:
+- **AI agent workflows** — agents working in workspace clones
+- **CI/CD** — running builds on a fresh checkout
+- **Multi-branch development** — testing different branches without swapping the installed plugin
+
+The override is transient — it does not modify the stored component config.
 
 Requires `build_command` to be configured on the component, or a module with build support. If neither is set, the command errors.
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -20,6 +20,10 @@ pub struct BuildArgs {
     /// Build all components in the project
     #[arg(long)]
     pub all: bool,
+
+    /// Override local_path for this build (use a workspace clone or temp checkout)
+    #[arg(long)]
+    pub path: Option<String>,
 }
 
 pub fn run(
@@ -123,5 +127,9 @@ pub fn run(
     }
 
     // Single target_id: treat as component ID
-    build::run(target_id)
+    if let Some(ref path) = args.path {
+        build::run_with_path(target_id, path)
+    } else {
+        build::run(target_id)
+    }
 }

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -108,6 +108,7 @@ pub fn run(args: ReleaseArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
     let options = release::ReleaseOptions {
         bump_type: bump_type.as_str().to_string(),
         dry_run: args.dry_run,
+        path_override: None,
     };
 
     if args.dry_run {

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -17,7 +17,10 @@ use super::types::{ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanSt
 pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
     let release_plan = plan(component_id, options)?;
 
-    let component = component::load(component_id)?;
+    let mut component = component::load(component_id)?;
+    if let Some(ref path) = options.path_override {
+        component.local_path = path.clone();
+    }
     let modules = resolve_modules(&component, None)?;
     let resolver = ReleaseCapabilityResolver::new(modules.clone());
     let executor = ReleaseStepExecutor::new(component_id.to_string(), modules);
@@ -63,7 +66,10 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
 /// - From component's modules that have `release.publish` action
 /// - Or explicit `release.publish` array if configured
 pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan> {
-    let component = component::load(component_id)?;
+    let mut component = component::load(component_id)?;
+    if let Some(ref path) = options.path_override {
+        component.local_path = path.clone();
+    }
     let modules = resolve_modules(&component, None)?;
 
     let mut v = ValidationCollector::new();

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -119,4 +119,7 @@ pub enum ReleasePlanStatus {
 pub struct ReleaseOptions {
     pub bump_type: String,
     pub dry_run: bool,
+    /// Override the component's `local_path` for this release.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_override: Option<String>,
 }


### PR DESCRIPTION
## Summary

Add `--path` flag to `build`, `lint`, `test`, and `version` commands that temporarily overrides the component's `local_path`. Enables agents and CI to run Homeboy operations on workspace clones without modifying stored config.

### Usage
```bash
homeboy build data-machine --path /var/lib/datamachine/workspace/data-machine
homeboy lint data-machine --path /workspace/data-machine
homeboy test data-machine --path /workspace/data-machine
homeboy version show data-machine --path /workspace/data-machine
homeboy version set data-machine 1.2.3 --path /workspace/data-machine
homeboy version bump data-machine patch --path /workspace/data-machine
```

### Implementation
- **ModuleRunner**: new `.path_override()` builder method, applied in `find_component()`
- **build core**: `execute_build()` accepts optional path override, new `run_with_path()` entry point
- **release pipeline**: `ReleaseOptions.path_override` threaded through `plan()` and `run()`
- **CLI layer**: `--path` added to BuildArgs, LintArgs, TestArgs, VersionCommand variants
- Override is transient — does not modify stored component config

Closes #151