### PR TITLE
feat: support homeboy.json portable config in repo root

### DIFF
--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -15,16 +15,18 @@ homeboy component [OPTIONS] <COMMAND>
 
 ```sh
 homeboy component create [OPTIONS] --local-path <path> --remote-path <path> --build-artifact <path>
+homeboy component create --from-repo <path> [--remote-path <path>]
 ```
 
-The component ID is derived from the `--local-path` directory name (lowercased). For example, `--local-path /path/to/extrachill-api` creates a component with ID `extrachill-api`.
+The component ID is derived from the `--local-path` (or `--from-repo`) directory name (lowercased). For example, `--local-path /path/to/extrachill-api` creates a component with ID `extrachill-api`.
 
 Options:
 
+- `--from-repo <path>`: create from a repo containing `homeboy.json` ([portable config](../schemas/portable-config.md)). Reads version targets, modules, changelog, etc. from the file. CLI flags override `homeboy.json` values.
 - `--json <spec>`: JSON input spec for create/update (supports single or bulk)
 - `--skip-existing`: skip items that already exist (JSON mode only)
-- `--local-path <path>`: absolute path to local **source / git checkout** directory (required; ID derived from directory name; `~` is expanded). Must be a git repo — not the production deploy target (see [component schema](../schemas/component-schema.md#local_path-vs-remote_path))
-- `--remote-path <path>`: remote path relative to project `base_path` (required)
+- `--local-path <path>`: absolute path to local **source / git checkout** directory (required unless `--from-repo`; ID derived from directory name; `~` is expanded). Must be a git repo — not the production deploy target (see [component schema](../schemas/component-schema.md#local_path-vs-remote_path))
+- `--remote-path <path>`: remote path relative to project `base_path` (required unless in `homeboy.json`)
 - `--build-artifact <path>`: build artifact path relative to `local_path` (required; must include a filename)
 - `--version-target <TARGET>`: version target in format `file` or `file::pattern` (repeatable)
 - `--build-command <command>`: build command to run in `local_path` (required for `homeboy build`)

--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -1,0 +1,91 @@
+# Portable Component Config (`homeboy.json`)
+
+A `homeboy.json` file in a repo root defines portable component configuration that travels with the code. Clone a repo, run one command, and homeboy knows how to build, test, version, and deploy it.
+
+## Schema
+
+```json
+{
+  "remote_path": "string",
+  "build_artifact": "string",
+  "build_command": "string",
+  "extract_command": "string",
+  "version_targets": [
+    {
+      "file": "string",
+      "pattern": "string"
+    }
+  ],
+  "changelog_target": "string",
+  "modules": {
+    "module_id": {}
+  }
+}
+```
+
+All fields are optional. The component `id` is derived from the directory name, and `local_path` is always machine-specific (provided at registration time).
+
+## Example
+
+```json
+{
+  "remote_path": "wp-content/plugins/data-machine",
+  "version_targets": [
+    {
+      "file": "data-machine.php",
+      "pattern": "Version:\\s*([0-9.]+)"
+    }
+  ],
+  "changelog_target": "docs/CHANGELOG.md",
+  "modules": {
+    "wordpress": {}
+  }
+}
+```
+
+## Usage
+
+### Register from repo
+
+```bash
+# Read config from homeboy.json, only need to provide machine-specific path
+homeboy component create --from-repo /path/to/repo --remote-path wp-content/plugins/my-plugin
+
+# If homeboy.json already includes remote_path:
+homeboy component create --from-repo /path/to/repo
+
+# Override any field from the CLI:
+homeboy component create --from-repo /path/to/repo --build-command "npm run build"
+```
+
+### What stays local (not in homeboy.json)
+
+| Field | Why |
+|-------|-----|
+| `local_path` | Absolute path, varies per machine |
+| `id` | Derived from directory name automatically |
+
+### What goes in homeboy.json
+
+| Field | Description |
+|-------|-------------|
+| `remote_path` | Deploy target relative to project `base_path` |
+| `build_artifact` | Build output path relative to repo root |
+| `build_command` | Shell command to build the component |
+| `extract_command` | Post-upload command (supports `{artifact}`, `{targetDir}`) |
+| `version_targets` | Version detection patterns |
+| `changelog_target` | Path to changelog file |
+| `modules` | Module configuration (e.g., `{"wordpress": {}}`) |
+
+## Precedence
+
+CLI flags override `homeboy.json` values. This lets teams share a base config while individuals customize for their environment:
+
+```
+homeboy.json (repo)  →  CLI flags (override)  →  ~/.config/homeboy/components/ (stored)
+```
+
+## Related
+
+- [Component schema](component-schema.md) - Full component configuration reference
+- [Component command](../commands/component.md) - CLI reference

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -26,6 +26,10 @@ enum ComponentCommand {
         #[arg(long)]
         skip_existing: bool,
 
+        /// Create from a repo containing homeboy.json (reads portable config)
+        #[arg(long, conflicts_with = "json")]
+        from_repo: Option<String>,
+
         /// Absolute path to local source directory (ID derived from directory name)
         #[arg(long)]
         local_path: Option<String>,
@@ -157,6 +161,7 @@ pub fn run(
         ComponentCommand::Create {
             json,
             skip_existing,
+            from_repo,
             local_path,
             remote_path,
             build_artifact,
@@ -169,13 +174,30 @@ pub fn run(
         } => {
             let json_spec = if let Some(spec) = json {
                 spec
+            } else if let Some(ref repo_path) = from_repo {
+                // --from-repo: read homeboy.json from repo, merge with CLI overrides
+                build_from_repo_spec(
+                    repo_path,
+                    local_path.as_deref(),
+                    remote_path.as_deref(),
+                    build_artifact.as_deref(),
+                    &version_targets,
+                    version_targets_json.as_deref(),
+                    build_command.as_deref(),
+                    extract_command.as_deref(),
+                    changelog_target.as_deref(),
+                    &modules,
+                )?
             } else {
                 let local_path = local_path.ok_or_else(|| {
                     homeboy::Error::validation_invalid_argument(
                         "local_path",
-                        "Missing required argument: --local-path",
+                        "Missing required argument: --local-path or --from-repo",
                         None,
-                        None,
+                        Some(vec![
+                            "Create from flags: homeboy component create --local-path <path> --remote-path <path>".to_string(),
+                            "Create from repo config: homeboy component create --from-repo <path>".to_string(),
+                        ]),
                     )
                 })?;
 
@@ -675,4 +697,123 @@ mod tests {
         assert_eq!(obj["local_path"], serde_json::json!("/override"));
         assert_eq!(obj["remote_path"], serde_json::json!("/keep-this"));
     }
+}
+
+/// Build a component JSON spec from a repo's `homeboy.json` with CLI overrides.
+///
+/// Reads the portable config from `{repo_path}/homeboy.json`, injects machine-specific
+/// fields (`id` from dir name, `local_path` from repo_path), and layers CLI flag
+/// overrides on top.
+#[allow(clippy::too_many_arguments)]
+fn build_from_repo_spec(
+    repo_path: &str,
+    local_path_override: Option<&str>,
+    remote_path_override: Option<&str>,
+    build_artifact_override: Option<&str>,
+    version_targets: &[String],
+    version_targets_json: Option<&str>,
+    build_command_override: Option<&str>,
+    extract_command_override: Option<&str>,
+    changelog_target_override: Option<&str>,
+    modules_override: &[String],
+) -> Result<String, homeboy::Error> {
+    let expanded = shellexpand::tilde(repo_path);
+    let repo = Path::new(expanded.as_ref());
+
+    if !repo.is_dir() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "from_repo",
+            format!("Directory not found: {}", repo_path),
+            Some(repo_path.to_string()),
+            None,
+        ));
+    }
+
+    // Read homeboy.json from repo root
+    let mut config = component::read_portable_config(repo)?.unwrap_or_else(|| {
+        serde_json::json!({})
+    });
+
+    let map = config
+        .as_object_mut()
+        .ok_or_else(|| {
+            homeboy::Error::validation_invalid_json(
+                serde_json::from_str::<serde_json::Value>("x").unwrap_err(),
+                Some("homeboy.json must be a JSON object".to_string()),
+                None,
+            )
+        })?;
+
+    // Derive ID from directory name
+    let dir_name = repo
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "from_repo",
+                "Could not derive component ID from repo path",
+                Some(repo_path.to_string()),
+                None,
+            )
+        })?;
+    let id = component::slugify_id(dir_name)?;
+    map.insert("id".to_string(), serde_json::json!(id));
+
+    // local_path: use --local-path override or the repo path itself
+    let local_path = local_path_override.unwrap_or(repo_path);
+    map.insert("local_path".to_string(), serde_json::json!(local_path));
+
+    // Apply CLI overrides (only if provided — don't clobber homeboy.json values)
+    if let Some(v) = remote_path_override {
+        map.insert("remote_path".to_string(), serde_json::json!(v));
+    }
+    if let Some(v) = build_artifact_override {
+        map.insert("build_artifact".to_string(), serde_json::json!(v));
+    }
+    if let Some(v) = build_command_override {
+        map.insert("build_command".to_string(), serde_json::json!(v));
+    }
+    if let Some(v) = extract_command_override {
+        map.insert("extract_command".to_string(), serde_json::json!(v));
+    }
+    if let Some(v) = changelog_target_override {
+        map.insert("changelog_target".to_string(), serde_json::json!(v));
+    }
+
+    // Version targets from CLI override homeboy.json
+    if let Some(json_spec) = version_targets_json {
+        let raw = homeboy::config::read_json_spec_to_string(json_spec)?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+            homeboy::Error::validation_invalid_json(
+                e,
+                Some("parse version targets JSON".to_string()),
+                Some(raw.chars().take(200).collect::<String>()),
+            )
+        })?;
+        map.insert("version_targets".to_string(), parsed);
+    } else if !version_targets.is_empty() {
+        let targets = component::parse_version_targets(version_targets)?;
+        let targets_value = serde_json::to_value(targets).map_err(|e| {
+            homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e))
+        })?;
+        map.insert("version_targets".to_string(), targets_value);
+    }
+
+    // Module overrides from CLI
+    if !modules_override.is_empty() {
+        let mut module_map = serde_json::Map::new();
+        for module_id in modules_override {
+            module_map.insert(module_id.clone(), serde_json::json!({}));
+        }
+        map.insert("modules".to_string(), serde_json::Value::Object(module_map));
+    }
+
+    // Ensure remote_path exists (required field, default to empty string)
+    if !map.contains_key("remote_path") {
+        map.insert("remote_path".to_string(), serde_json::json!(""));
+    }
+
+    serde_json::to_string(&config).map_err(|e| {
+        homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e))
+    })
 }


### PR DESCRIPTION
## Summary

- Add `--from-repo` flag to `component create` that reads `homeboy.json` from a repo directory
- Portable config defines version targets, modules, changelog, build settings — travels with the code
- Machine-specific fields (`id`, `local_path`) derived automatically from repo path
- CLI flags override `homeboy.json` values for per-machine customization
- New `docs/schemas/portable-config.md` schema documentation

### Usage
```bash
# Create component from repo with homeboy.json
homeboy component create --from-repo /path/to/data-machine --remote-path wp-content/plugins/data-machine

# If homeboy.json includes remote_path:
homeboy component create --from-repo /path/to/data-machine

# Override any field:
homeboy component create --from-repo /path/to/data-machine --build-command "npm run build"
```

### Example homeboy.json
```json
{
  "remote_path": "wp-content/plugins/data-machine",
  "version_targets": [{"file": "data-machine.php", "pattern": "Version:\\s*([0-9.]+)"}],
  "changelog_target": "docs/CHANGELOG.md",
  "modules": {"wordpress": {}}
}
```

Closes #150