### PR TITLE
feat: fire post:deploy hooks remotely via SSH

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -246,9 +246,51 @@ homeboy changes --project myproject
 homeboy changes --project myproject --git-diffs
 ```
 
+## Post-Deploy Hooks
+
+After a successful deploy, Homeboy runs `post:deploy` hooks remotely via SSH on the deployment target. Hooks are resolved from modules and components (see [hooks](../architecture/hooks.md)).
+
+Template variables available:
+
+| Variable | Description |
+|----------|-------------|
+| `{{component_id}}` | The component ID |
+| `{{install_dir}}` | Remote install directory |
+| `{{base_path}}` | Project base path on the remote server |
+
+### Module-level hooks
+
+Modules like WordPress define `post:deploy` hooks in their manifest. These run for every component using that module:
+
+```json
+{
+  "hooks": {
+    "post:deploy": [
+      "wp plugin is-installed {{component_id}} --path={{base_path}} --allow-root 2>/dev/null && wp plugin activate {{component_id}} --path={{base_path}} --allow-root 2>/dev/null || true",
+      "wp cache flush --path={{base_path}} --allow-root 2>/dev/null || true"
+    ]
+  }
+}
+```
+
+### Component-level hooks
+
+Components can add their own `post:deploy` hooks for custom automation:
+
+```json
+{
+  "hooks": {
+    "post:deploy": ["systemctl restart my-service"]
+  }
+}
+```
+
+Module hooks run first, then component hooks. All `post:deploy` hooks are non-fatal — failures are logged but do not affect the deploy result.
+
 ## Related
 
 - [build](build.md)
 - [changes](changes.md)
 - [component](component.md)
 - [fleet](fleet.md)
+- [hooks](../architecture/hooks.md)

--- a/docs/schemas/module-manifest-schema.md
+++ b/docs/schemas/module-manifest-schema.md
@@ -284,6 +284,37 @@ Release actions define steps for release pipelines.
 }
 ```
 
+## Hooks Configuration
+
+Modules can declare lifecycle hooks that run at named events. Module hooks execute before component hooks, providing platform-level behavior.
+
+```json
+{
+  "hooks": {
+    "pre:version:bump": ["cargo generate-lockfile"],
+    "post:deploy": [
+      "wp cache flush --path={{base_path}} --allow-root 2>/dev/null || true"
+    ]
+  }
+}
+```
+
+### Hooks Fields
+
+- **`hooks`** (object): Map of event names to command arrays
+  - Keys: event name (e.g., `pre:version:bump`, `post:version:bump`, `post:release`, `post:deploy`)
+  - Values: array of shell command strings
+
+Most hooks execute locally in the component's directory. `post:deploy` hooks execute **remotely via SSH** with template variable expansion:
+
+| Variable | Description |
+|----------|-------------|
+| `{{component_id}}` | The component ID |
+| `{{install_dir}}` | Remote install directory (base_path + remote_path) |
+| `{{base_path}}` | Project base path on the remote server |
+
+See [hooks architecture](../architecture/hooks.md) for details on execution order and failure modes.
+
 ## Documentation Configuration
 
 Modules can provide embedded documentation.

--- a/src/utils/template.rs
+++ b/src/utils/template.rs
@@ -20,6 +20,9 @@ impl TemplateVars {
     pub const DB_USER: &'static str = "db_user";
     pub const DB_PASSWORD: &'static str = "db_password";
     pub const MODULE_PATH: &'static str = "module_path";
+    pub const COMPONENT_ID: &'static str = "component_id";
+    pub const INSTALL_DIR: &'static str = "install_dir";
+    pub const BASE_PATH: &'static str = "base_path";
 }
 
 pub fn render(template: &str, variables: &[(&str, &str)]) -> String {


### PR DESCRIPTION
## Summary

Extends the hook system with remote execution support so `post:deploy` hooks run on the deployment target via SSH. This enables modules like WordPress to automate plugin activation and cache flushing after deploy.

## Changes

- **`src/core/hooks.rs`** — Add `run_hooks_remote()` and `run_commands_remote()` that resolve hooks, expand `{{template}}` variables, and execute via SSH
- **`src/core/deploy.rs`** — Wire `post:deploy` into both deploy success paths (git-deploy and standard). Add `run_post_deploy_hooks()` helper that builds template vars and calls the hook engine
- **`src/utils/template.rs`** — Add `COMPONENT_ID`, `INSTALL_DIR`, `BASE_PATH` template constants
- **Docs** — Update hooks architecture, deploy command, and module manifest schema docs

## Design

Uses the existing generic hook system rather than a separate mechanism:
- Module manifests declare `post:deploy` hooks in their `hooks` field (same as other events)
- `resolve_hooks()` merges module + component hooks as usual
- New `run_hooks_remote()` expands `{{component_id}}`, `{{install_dir}}`, `{{base_path}}` then executes via `SshClient`
- Hooks are non-fatal — failures are logged but don't affect the deploy result

## Template Variables

| Variable | Description |
|----------|-------------|
| `{{component_id}}` | The component ID |
| `{{install_dir}}` | Remote install directory (base_path + remote_path) |
| `{{base_path}}` | Project base path on the remote server |

Closes #165