### PR TITLE
Extract shared DynamicSetArgs processing, migrate project set

### DIFF
--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -248,30 +248,15 @@ fn show(id: &str) -> CmdResult<FleetOutput> {
 }
 
 fn set(args: DynamicSetArgs) -> CmdResult<FleetOutput> {
-    let spec = args.json_spec()?;
-    let extra = args.effective_extra();
-    let has_input = spec.is_some() || !extra.is_empty();
-    if !has_input {
-        return Err(homeboy::Error::validation_invalid_argument(
+    let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
+        homeboy::Error::validation_invalid_argument(
             "spec",
             "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
             None,
             None,
-        ));
-    }
-
-    let merged = super::merge_json_sources(spec.as_deref(), &extra)?;
-    let json_string = serde_json::to_string(&merged).map_err(|e| {
-        homeboy::Error::internal_unexpected(format!("Failed to serialize merged JSON: {}", e))
+        )
     })?;
-
-    // Auto-replace array fields in set commands (see #154)
-    let mut replace_fields = args.replace.clone();
-    for field in homeboy::config::collect_array_fields(&merged) {
-        if !replace_fields.contains(&field) {
-            replace_fields.push(field);
-        }
-    }
+    let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;
 
     match fleet::merge(args.id.as_deref(), &json_string, &replace_fields)? {
         homeboy::MergeOutput::Single(result) => {


### PR DESCRIPTION
## Summary

Extracts the duplicated set-command processing into two shared helpers and migrates `project set` to use `DynamicSetArgs` for full feature parity with other entities.

### New helpers in `commands/mod.rs`

- **`merge_dynamic_args(args)`** — validates input exists, merges JSON/base64/key-value sources into a single `Value`
- **`finalize_set_spec(merged, replace)`** — serializes to string, computes auto-replace fields for arrays

### Refactored entity handlers

| Entity | Before | After |
|--------|--------|-------|
| `server set` | 15 lines of merge/serialize/replace logic | 3 lines using helpers |
| `fleet set` | 15 lines | 3 lines |
| `component set` | 25 lines (keeps extra flags logic) | 10 lines |
| `project set` | **No DynamicSetArgs** — inline args | **Full DynamicSetArgs** |

### Project set gains feature parity

Before this PR, `project set` was the only entity that didn't support:
- `--base64` flag (bypass shell escaping)
- `--key value` dynamic flags (e.g., `homeboy project set mysite -- --domain example.com`)
- Auto-replace array fields (arrays in set specs replace instead of merge)

Now it works identically to server/fleet/component set.

### Stats
- **5 files changed**, 64 insertions, 98 deletions (net **-34 lines**)
- All 307 tests pass

Closes #181