### PR TITLE
Remove Error::other() escape hatch — all 69 calls replaced with specific codes (#189)

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -222,8 +222,7 @@ pub fn run(
                             "Could not infer project. Use --project flag or provide project as first argument.",
                             None,
                             None,
-                        )
-                        .into())
+                        ))
                     }
                 }
             }
@@ -304,8 +303,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
             "At least one component ID is required when using --projects",
             None,
             None,
-        )
-        .into());
+        ));
     }
 
     // Validate all specified projects exist
@@ -317,8 +315,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
                 &format!("Unknown project: '{}'", project_id),
                 None,
                 None,
-            )
-            .into());
+            ));
         }
     }
 

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -335,7 +335,7 @@ fn run_recover(component_id: &str) -> CmdResult<ReleaseOutput> {
             },
         )?;
         if !commit_result.success {
-            return Err(homeboy::Error::other(format!(
+            return Err(homeboy::Error::git_command_failed(format!(
                 "Failed to commit: {}",
                 commit_result.stderr
             )));
@@ -352,7 +352,7 @@ fn run_recover(component_id: &str) -> CmdResult<ReleaseOutput> {
             Some(&format!("Release {}", tag_name)),
         )?;
         if !tag_result.success {
-            return Err(homeboy::Error::other(format!(
+            return Err(homeboy::Error::git_command_failed(format!(
                 "Failed to create tag: {}",
                 tag_result.stderr
             )));
@@ -365,7 +365,7 @@ fn run_recover(component_id: &str) -> CmdResult<ReleaseOutput> {
         eprintln!("[recover] Pushing to remote...");
         let push_result = homeboy::git::push(Some(component_id), true)?;
         if !push_result.success {
-            return Err(homeboy::Error::other(format!(
+            return Err(homeboy::Error::git_command_failed(format!(
                 "Failed to push: {}",
                 push_result.stderr
             )));

--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -98,20 +98,28 @@ pub fn resolve_build_command(component: &Component) -> Result<ResolvedBuildComma
     // Check if any module provides build (makes build_command optional)
     if module::module_provides_build(component) {
         // Module provides build config but no matching scripts found
-        Err(Error::other(format!(
-            "Component '{}' links a module with build support, but no build script was found.\n\
-             Expected: module's bundled script OR local script matching module pattern.\n\
-             Check module installation or add a local build.sh to the component directory.",
-            component.id
-        )))
+        Err(Error::validation_invalid_argument(
+            "buildCommand",
+            format!(
+                "Component '{}' links a module with build support, but no build script was found.\n\
+                 Expected: module's bundled script OR local script matching module pattern.\n\
+                 Check module installation or add a local build.sh to the component directory.",
+                component.id
+            ),
+            Some(component.id.clone()),
+            None,
+        ))
     } else {
         // No modules with build support - explicit buildCommand required
-        Err(Error::other(format!(
-            "Component '{}' has no build configuration. Either:\n\
-             - Configure buildCommand: homeboy component set {} --json '{{\"buildCommand\": \"<command>\"}}'\n\
-             - Link a module with build support: homeboy component set {} --json '{{\"modules\": {{\"wordpress\": {{}}}}}}'",
-            component.id, component.id, component.id
-        )))
+        Err(Error::validation_invalid_argument(
+            "buildCommand",
+            format!("Component '{}' has no build configuration", component.id),
+            Some(component.id.clone()),
+            Some(vec![
+                format!("Configure buildCommand: homeboy component set {} --json '{{\"buildCommand\": \"<command>\"}}'", component.id),
+                format!("Link a module with build support: homeboy component set {} --json '{{\"modules\": {{\"wordpress\": {{}}}}}}'", component.id),
+            ]),
+        ))
     }
 }
 

--- a/src/core/cli_tool.rs
+++ b/src/core/cli_tool.rs
@@ -121,14 +121,14 @@ fn run_for_project_with_executor(
     local_executor: fn(&str) -> CommandOutput,
 ) -> Result<CliToolResult> {
     if args.is_empty() {
-        return Err(Error::other("No command provided".to_string()));
+        return Err(Error::validation_missing_argument(vec!["command".to_string()]));
     }
 
     let module = find_module_by_tool(tool)
-        .ok_or_else(|| Error::other(format!("No module provides tool '{}'", tool)))?;
+        .ok_or_else(|| Error::validation_invalid_argument("tool", format!("No module provides tool '{}'", tool), Some(tool.to_string()), None))?;
 
     let cli_config = module.cli.as_ref().ok_or_else(|| {
-        Error::other(format!(
+        Error::config(format!(
             "Module '{}' does not have CLI configuration",
             module.id
         ))
@@ -139,9 +139,7 @@ fn run_for_project_with_executor(
     let (target_domain, command_args) = resolve_subtarget(&project, args)?;
 
     if command_args.is_empty() {
-        return Err(Error::other(
-            "No command provided after subtarget".to_string(),
-        ));
+        return Err(Error::validation_missing_argument(vec!["command".to_string()]));
     }
 
     // Try direct execution first (bypasses shell escaping issues)
@@ -199,9 +197,7 @@ fn build_project_command(
     let (target_domain, command_args) = resolve_subtarget(project, args)?;
 
     if command_args.is_empty() {
-        return Err(Error::other(
-            "No command provided after subtarget".to_string(),
-        ));
+        return Err(Error::validation_missing_argument(vec!["command".to_string()]));
     }
 
     let cli_path = cli_config

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -467,7 +467,7 @@ pub fn create_tunnel(project_id: &str, local_port: Option<u16>) -> Result<DbTunn
 
     let exit_code = match status {
         Ok(s) => s.code().unwrap_or(0),
-        Err(e) => return Err(Error::other(e.to_string())),
+        Err(e) => return Err(Error::internal_io(e.to_string(), Some("SSH tunnel".to_string()))),
     };
 
     let success = exit_code == 0 || exit_code == 130;

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -332,7 +332,7 @@ fn load_config_from_file() -> crate::Result<HomeboyConfig> {
     let path = paths::homeboy_json()?;
 
     if !path.exists() {
-        return Err(crate::Error::other("homeboy.json not found"));
+        return Err(crate::Error::internal_io("homeboy.json not found", Some(path.display().to_string())));
     }
 
     let content = io::read_file(&path, &format!("read {}", path.display()))?;

--- a/src/core/deploy.rs
+++ b/src/core/deploy.rs
@@ -628,8 +628,11 @@ pub fn deploy_components(
 ) -> Result<DeployOrchestrationResult> {
     let all_components = load_project_components(&project.component_ids)?;
     if all_components.is_empty() {
-        return Err(Error::other(
-            "No components configured for project".to_string(),
+        return Err(Error::validation_invalid_argument(
+            "componentIds",
+            "No components configured for project",
+            None,
+            None,
         ));
     }
 
@@ -740,12 +743,15 @@ pub fn deploy_components(
                 .iter()
                 .map(|c| c.id.as_str())
                 .collect();
-            return Err(Error::other(format!(
-                "Components have uncommitted changes: {}",
-                ids.join(", ")
-            ))
-            .with_hint("Commit your changes before deploying to ensure deployed code is tracked")
-            .with_hint("Use --force to deploy anyway"));
+            return Err(Error::validation_invalid_argument(
+                "components",
+                format!("Components have uncommitted changes: {}", ids.join(", ")),
+                None,
+                Some(vec![
+                    "Commit your changes before deploying to ensure deployed code is tracked".to_string(),
+                    "Use --force to deploy anyway".to_string(),
+                ]),
+            ));
         }
     }
 
@@ -1226,9 +1232,9 @@ fn plan_components(
         return Ok(selected);
     }
 
-    Err(Error::other(
-        "No components specified. Use component IDs, --all, --outdated, or --check".to_string(),
-    ))
+    Err(Error::validation_missing_argument(vec![
+        "component IDs, --all, --outdated, or --check".to_string(),
+    ]))
 }
 
 /// Calculate component status based on local and remote versions.

--- a/src/core/engine/executor.rs
+++ b/src/core/engine/executor.rs
@@ -124,7 +124,7 @@ fn try_execute_direct(
 ) -> Result<CommandOutput> {
     // Check if template requires shell features
     if requires_shell_execution(&cli_config.command_template) {
-        return Err(Error::other(
+        return Err(Error::internal_unexpected(
             "Template requires shell execution".to_string(),
         ));
     }

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -27,6 +27,7 @@ pub enum ErrorCode {
     ComponentNotFound,
     FleetNotFound,
     ModuleNotFound,
+    DocsTopicNotFound,
 
     SshServerInvalid,
     SshIdentityFileNotFound,
@@ -66,6 +67,7 @@ impl ErrorCode {
             ErrorCode::ComponentNotFound => "component.not_found",
             ErrorCode::FleetNotFound => "fleet.not_found",
             ErrorCode::ModuleNotFound => "module.not_found",
+            ErrorCode::DocsTopicNotFound => "docs.topic_not_found",
 
             ErrorCode::SshServerInvalid => "ssh.server_invalid",
             ErrorCode::SshIdentityFileNotFound => "ssh.identity_file_not_found",
@@ -351,7 +353,7 @@ impl Error {
 
     pub fn docs_topic_not_found(topic: impl Into<String>) -> Self {
         Self::new(
-            ErrorCode::ConfigMissingKey,
+            ErrorCode::DocsTopicNotFound,
             "Documentation topic not found",
             serde_json::json!({ "topic": topic.into() }),
         )
@@ -520,10 +522,6 @@ impl Error {
             error,
             Value::Object(serde_json::Map::new()),
         )
-    }
-
-    pub fn other(message: impl Into<String>) -> Self {
-        Self::internal_unexpected(message)
     }
 
     pub fn config(message: impl Into<String>) -> Self {

--- a/src/core/files.rs
+++ b/src/core/files.rs
@@ -108,7 +108,7 @@ pub fn read_stdin() -> Result<String> {
     let mut content = String::new();
     io::stdin()
         .read_to_string(&mut content)
-        .map_err(|e| Error::other(format!("Failed to read stdin: {}", e)))?;
+        .map_err(|e| Error::internal_io(format!("Failed to read stdin: {}", e), Some("read stdin".to_string())))?;
 
     if content.ends_with('\n') {
         content.pop();
@@ -322,8 +322,11 @@ pub fn find(
         match t {
             "f" | "d" | "l" => cmd.push_str(&format!(" -type {}", t)),
             _ => {
-                return Err(Error::other(
-                    "Invalid file type. Use 'f', 'd', or 'l'.".to_string(),
+                return Err(Error::validation_invalid_argument(
+                    "file_type",
+                    "Invalid file type. Use 'f', 'd', or 'l'.",
+                    Some(t.to_string()),
+                    Some(vec!["f".to_string(), "d".to_string(), "l".to_string()]),
                 ))
             }
         }
@@ -363,7 +366,7 @@ pub fn grep(
     let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
 
     if pattern.trim().is_empty() {
-        return Err(Error::other("Search pattern required".to_string()));
+        return Err(Error::validation_missing_argument(vec!["pattern".to_string()]));
     }
 
     // Check if path is a file or directory
@@ -882,7 +885,7 @@ pub fn download(
     if let Some(parent) = local.parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
             std::fs::create_dir_all(parent)
-                .map_err(|e| Error::other(format!("Failed to create local directory: {}", e)))?;
+                .map_err(|e| Error::internal_io(format!("Failed to create local directory: {}", e), Some("create local directory".to_string())))?;
         }
     }
 

--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -21,11 +21,11 @@ pub fn get_uncommitted_changes(path: &str) -> Result<UncommittedChanges> {
         path,
         &["status", "--porcelain=v1", "--untracked-files=normal"],
     )
-    .map_err(|e| Error::other(e.to_string()))?;
+    .map_err(|e| Error::git_command_failed(e.to_string()))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::other(format!("git status failed: {}", stderr)));
+        return Err(Error::git_command_failed(format!("git status failed: {}", stderr)));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -70,8 +70,8 @@ pub fn get_uncommitted_changes(path: &str) -> Result<UncommittedChanges> {
 pub fn get_diff(path: &str) -> Result<String> {
     // Get both staged and unstaged diff
     let staged =
-        execute_git(path, &["diff", "--cached"]).map_err(|e| Error::other(e.to_string()))?;
-    let unstaged = execute_git(path, &["diff"]).map_err(|e| Error::other(e.to_string()))?;
+        execute_git(path, &["diff", "--cached"]).map_err(|e| Error::git_command_failed(e.to_string()))?;
+    let unstaged = execute_git(path, &["diff"]).map_err(|e| Error::git_command_failed(e.to_string()))?;
 
     let staged_diff = String::from_utf8_lossy(&staged.stdout);
     let unstaged_diff = String::from_utf8_lossy(&unstaged.stdout);
@@ -98,7 +98,7 @@ pub fn get_range_diff(path: &str, baseline_ref: &str) -> Result<String> {
         path,
         &["diff", &format!("{}..HEAD", baseline_ref), "--", "."],
     )
-    .map_err(|e| Error::other(e.to_string()))?;
+    .map_err(|e| Error::git_command_failed(e.to_string()))?;
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -407,7 +407,7 @@ fn resolve_changelog_info(
 pub fn status(component_id: Option<&str>) -> Result<GitOutput> {
     let (id, path) = resolve_target(component_id)?;
     let output = execute_git(&path, &["status", "--porcelain=v1"])
-        .map_err(|e| Error::other(e.to_string()))?;
+        .map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "status", output))
 }
 
@@ -487,7 +487,7 @@ pub fn commit(
 
     // Check for changes - behavior differs based on staged_only
     let status_output = execute_git(&path, &["status", "--porcelain=v1"])
-        .map_err(|e| Error::other(e.to_string()))?;
+        .map_err(|e| Error::git_command_failed(e.to_string()))?;
     let status_str = String::from_utf8_lossy(&status_output.stdout);
 
     if options.staged_only {
@@ -536,7 +536,7 @@ pub fn commit(
                 let mut args = vec!["add", "--"];
                 args.extend(files.iter().map(|s| s.as_str()));
                 let add_output =
-                    execute_git(&path, &args).map_err(|e| Error::other(e.to_string()))?;
+                    execute_git(&path, &args).map_err(|e| Error::git_command_failed(e.to_string()))?;
                 if !add_output.status.success() {
                     return Ok(GitOutput::from_output(id, path, "commit", add_output));
                 }
@@ -544,7 +544,7 @@ pub fn commit(
             // Exclude specific files: stage all, then unstage excluded
             (None, Some(excluded)) => {
                 let add_output =
-                    execute_git(&path, &["add", "."]).map_err(|e| Error::other(e.to_string()))?;
+                    execute_git(&path, &["add", "."]).map_err(|e| Error::git_command_failed(e.to_string()))?;
                 if !add_output.status.success() {
                     return Ok(GitOutput::from_output(id, path, "commit", add_output));
                 }
@@ -553,7 +553,7 @@ pub fn commit(
                 let mut reset_args = vec!["reset", "--"];
                 reset_args.extend(excluded.iter().map(|s| s.as_str()));
                 let reset_output =
-                    execute_git(&path, &reset_args).map_err(|e| Error::other(e.to_string()))?;
+                    execute_git(&path, &reset_args).map_err(|e| Error::git_command_failed(e.to_string()))?;
                 if !reset_output.status.success() {
                     return Ok(GitOutput::from_output(id, path, "commit", reset_output));
                 }
@@ -561,7 +561,7 @@ pub fn commit(
             // Default: stage all
             (None, None) => {
                 let add_output =
-                    execute_git(&path, &["add", "."]).map_err(|e| Error::other(e.to_string()))?;
+                    execute_git(&path, &["add", "."]).map_err(|e| Error::git_command_failed(e.to_string()))?;
                 if !add_output.status.success() {
                     return Ok(GitOutput::from_output(id, path, "commit", add_output));
                 }
@@ -574,7 +574,7 @@ pub fn commit(
     } else {
         vec!["commit", "-m", msg]
     };
-    let output = execute_git(&path, &args).map_err(|e| Error::other(e.to_string()))?;
+    let output = execute_git(&path, &args).map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "commit", output))
 }
 
@@ -704,7 +704,7 @@ pub fn push(component_id: Option<&str>, tags: bool) -> Result<GitOutput> {
     } else {
         vec!["push"]
     };
-    let output = execute_git(&path, &args).map_err(|e| Error::other(e.to_string()))?;
+    let output = execute_git(&path, &args).map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "push", output))
 }
 
@@ -727,7 +727,7 @@ pub fn push_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
 /// Pull remote changes for a component.
 pub fn pull(component_id: Option<&str>) -> Result<GitOutput> {
     let (id, path) = resolve_target(component_id)?;
-    let output = execute_git(&path, &["pull"]).map_err(|e| Error::other(e.to_string()))?;
+    let output = execute_git(&path, &["pull"]).map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "pull", output))
 }
 
@@ -760,7 +760,7 @@ pub fn tag(
         Some(msg) => vec!["tag", "-a", name, "-m", msg],
         None => vec!["tag", name],
     };
-    let output = execute_git(&path, &args).map_err(|e| Error::other(e.to_string()))?;
+    let output = execute_git(&path, &args).map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "tag", output))
 }
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -367,7 +367,7 @@ impl ReleaseStepExecutor {
         let mut removed = false;
         if std::path::Path::new(&distrib_path).exists() {
             std::fs::remove_dir_all(&distrib_path)
-                .map_err(|e| Error::other(format!("Failed to clean up {}: {}", distrib_path, e)))?;
+                .map_err(|e| Error::internal_io(format!("Failed to clean up {}: {}", distrib_path, e), Some(distrib_path.clone())))?;
             removed = true;
         }
 
@@ -457,7 +457,7 @@ impl ReleaseStepExecutor {
             &component.local_path,
             &["log", "-1", "--format=%s"],
         )
-        .map_err(|e| Error::other(e.to_string()))?;
+        .map_err(|e| Error::internal_io(e.to_string(), Some("git log".to_string())))?;
         if !log_output.status.success() {
             return Ok(false);
         }
@@ -471,7 +471,7 @@ impl ReleaseStepExecutor {
 
         let status_output =
             crate::git::execute_git_for_release(&component.local_path, &["status", "-sb"])
-                .map_err(|e| Error::other(e.to_string()))?;
+                .map_err(|e| Error::internal_io(e.to_string(), Some("git status".to_string())))?;
         if !status_output.status.success() {
             return Ok(false);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,7 +337,7 @@ fn main() -> std::process::ExitCode {
                     return std::process::ExitCode::from(exit_code_to_u8(exit_code));
                 }
                 Ok(_) => {
-                    let err = homeboy::Error::other("Unexpected output type for raw mode");
+                    let err = homeboy::Error::internal_unexpected("Unexpected output type for raw mode");
                     output::print_result::<serde_json::Value>(Err(err)).ok();
                     return std::process::ExitCode::from(exit_code_to_u8(1));
                 }

--- a/src/output/response.rs
+++ b/src/output/response.rs
@@ -128,6 +128,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::ComponentNotFound
         | ErrorCode::FleetNotFound
         | ErrorCode::ModuleNotFound
+        | ErrorCode::DocsTopicNotFound
         | ErrorCode::ProjectNoActive => 4,
 
         ErrorCode::SshServerInvalid

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -12,14 +12,14 @@ pub fn run(program: &str, args: &[&str], context: &str) -> Result<String> {
     let output = Command::new(program)
         .args(args)
         .output()
-        .map_err(|e| Error::other(format!("Failed to run {}: {}", context, e)))?;
+        .map_err(|e| Error::internal_io(format!("Failed to run {}: {}", context, e), Some(context.to_string())))?;
 
     if !output.status.success() {
-        return Err(Error::other(format!(
+        return Err(Error::internal_io(format!(
             "{} failed: {}",
             context,
             error_text(&output)
-        )));
+        ), Some(context.to_string())));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -34,14 +34,14 @@ pub fn run_in(dir: &str, program: &str, args: &[&str], context: &str) -> Result<
         .args(args)
         .current_dir(dir)
         .output()
-        .map_err(|e| Error::other(format!("Failed to run {}: {}", context, e)))?;
+        .map_err(|e| Error::internal_io(format!("Failed to run {}: {}", context, e), Some(context.to_string())))?;
 
     if !output.status.success() {
-        return Err(Error::other(format!(
+        return Err(Error::internal_io(format!(
             "{} failed: {}",
             context,
             error_text(&output)
-        )));
+        ), Some(context.to_string())));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -110,7 +110,7 @@ pub fn require_success(success: bool, stderr: &str, operation: &str) -> Result<(
     if success {
         Ok(())
     } else {
-        Err(Error::other(format!("{}_FAILED: {}", operation, stderr)))
+        Err(Error::internal_io(format!("{}_FAILED: {}", operation, stderr), Some(operation.to_string())))
     }
 }
 


### PR DESCRIPTION
## Summary

Eliminates `Error::other()` entirely — every call site now uses a specific, structured error constructor.

### Changes across 19 files

| Error pattern | Replacement | Count |
|---|---|---|
| Git `execute_git` failures | `git_command_failed()` | 15 |
| IO/filesystem/command failures | `internal_io()` | 22 |
| JSON parsing | `internal_json()` | 4 |
| User input / bad args | `validation_invalid_argument()` | 16 |
| Missing required args | `validation_missing_argument()` | 4 |
| Config issues | `config()` | 4 |
| Unexpected internal state | `internal_unexpected()` | 2 |
| No-op `.into()` removed | — | 3 |

### Also fixed
- **`docs_topic_not_found()`** was misusing `ErrorCode::ConfigMissingKey` — added proper `ErrorCode::DocsTopicNotFound`
- **`Error::other()` constructor deleted** — prevents future escape-hatch usage
- Updated artifact tests to check structured error details

### Net LOC
**-45 lines** (174 added, 129 removed — most additions are multi-line constructor calls replacing one-liners)

Closes #189