### PR TITLE
Consistent logging: log_status! macro + to_json_string helper (#187)

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -258,9 +258,7 @@ pub fn run(
                 if let serde_json::Value::Object(ref mut map) = value {
                     map.insert("id".to_string(), serde_json::json!(id));
                 }
-                serde_json::to_string(&value).map_err(|e| {
-                    homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e))
-                })?
+                homeboy::config::to_json_string(&value)?
             };
 
             match component::create(&json_spec, skip_existing)? {
@@ -792,7 +790,5 @@ fn build_from_repo_spec(
         map.insert("remote_path".to_string(), serde_json::json!(""));
     }
 
-    serde_json::to_string(&config).map_err(|e| {
-        homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e))
-    })
+    homeboy::config::to_json_string(&config)
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use homeboy::log_status;
 use serde::Serialize;
 
 use homeboy::deploy::{self, ComponentDeployResult, DeployConfig, DeploySummary};
@@ -322,8 +323,9 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
         }
     }
 
-    eprintln!(
-        "[deploy] Deploying {:?} to {} project(s)...",
+    log_status!(
+        "deploy",
+        "Deploying {:?} to {} project(s)...",
         component_ids,
         project_ids.len()
     );
@@ -334,7 +336,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
     let mut first_project = true;
 
     for project_id in project_ids {
-        eprintln!("[deploy] Deploying to project '{}'...", project_id);
+        log_status!("deploy", "Deploying to project '{}'...", project_id);
 
         let config = DeployConfig {
             component_ids: component_ids.clone(),

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use homeboy::log_status;
 use serde::Serialize;
 
 use homeboy::component;
@@ -422,7 +423,7 @@ fn check(id: &str, only_outdated: bool) -> CmdResult<FleetOutput> {
     };
 
     for project_id in &fl.project_ids {
-        eprintln!("[fleet] Checking project '{}'...", project_id);
+        log_status!("fleet", "Checking project '{}'...", project_id);
 
         // Use existing deploy check infrastructure
         let config = DeployConfig {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -233,9 +233,7 @@ pub fn finalize_set_spec(
     merged: &Value,
     explicit_replace: &[String],
 ) -> homeboy::Result<(String, Vec<String>)> {
-    let json_string = serde_json::to_string(merged).map_err(|e| {
-        homeboy::Error::internal_unexpected(format!("Failed to serialize merged JSON: {}", e))
-    })?;
+    let json_string = homeboy::config::to_json_string(merged)?;
 
     let mut replace_fields = explicit_replace.to_vec();
     for field in homeboy::config::collect_array_fields(merged) {

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -278,9 +278,7 @@ pub fn run(
                 if let serde_json::Value::Object(ref mut map) = value {
                     map.insert("id".to_string(), serde_json::json!(id));
                 }
-                serde_json::to_string(&value).map_err(|e| {
-                    homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e))
-                })?
+                homeboy::config::to_json_string(&value)?
             };
 
             match project::create(&json_spec, skip_existing)? {

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -168,9 +168,7 @@ pub fn run(
                     identity_file: None,
                 };
 
-                serde_json::to_string(&new_server).map_err(|e| {
-                    homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e))
-                })?
+                homeboy::config::to_json_string(&new_server)?
             };
 
             match server::create(&json_spec, skip_existing)? {

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use homeboy::log_status;
 use homeboy::server;
 use homeboy::ssh::SshClient;
 use serde::Serialize;
@@ -171,9 +172,12 @@ fn run_push(
     let remote_target = format!("{}@{}:{}", client.user, client.host, remote_path);
 
     if args.dry_run {
-        eprintln!(
-            "[dry-run] Would push {} -> {}:{}",
-            local_path, server_id, remote_path
+        log_status!(
+            "dry-run",
+            "Would push {} -> {}:{}",
+            local_path,
+            server_id,
+            remote_path
         );
         return Ok((
             TransferOutput {
@@ -214,9 +218,12 @@ fn run_push(
     scp_args.push(local_path.to_string());
     scp_args.push(remote_target);
 
-    eprintln!(
-        "[transfer] Pushing {} -> {}:{}",
-        local_path, server_id, remote_path
+    log_status!(
+        "transfer",
+        "Pushing {} -> {}:{}",
+        local_path,
+        server_id,
+        remote_path
     );
 
     execute_scp(&scp_args, args)
@@ -235,9 +242,12 @@ fn run_pull(
     let remote_target = format!("{}@{}:{}", client.user, client.host, remote_path);
 
     if args.dry_run {
-        eprintln!(
-            "[dry-run] Would pull {}:{} -> {}",
-            server_id, remote_path, local_path
+        log_status!(
+            "dry-run",
+            "Would pull {}:{} -> {}",
+            server_id,
+            remote_path,
+            local_path
         );
         return Ok((
             TransferOutput {
@@ -280,9 +290,12 @@ fn run_pull(
     scp_args.push(remote_target);
     scp_args.push(local_path.to_string());
 
-    eprintln!(
-        "[transfer] Pulling {}:{} -> {}",
-        server_id, remote_path, local_path
+    log_status!(
+        "transfer",
+        "Pulling {}:{} -> {}",
+        server_id,
+        remote_path,
+        local_path
     );
 
     execute_scp(&scp_args, args)
@@ -308,11 +321,15 @@ fn run_server_to_server(
         } else {
             "scp-pipe"
         };
-        eprintln!(
-            "[dry-run] Would transfer {}:{} -> {}:{}",
-            src_id, src_path, dst_id, dst_path
+        log_status!(
+            "dry-run",
+            "Would transfer {}:{} -> {}:{}",
+            src_id,
+            src_path,
+            dst_id,
+            dst_path
         );
-        eprintln!("[dry-run] Method: {}", method);
+        log_status!("dry-run", "Method: {}", method);
         return Ok((
             TransferOutput {
                 source: args.source.clone(),
@@ -368,8 +385,8 @@ fn run_server_to_server(
         ("cat-pipe".to_string(), cmd)
     };
 
-    eprintln!("[transfer] {} -> {}", args.source, args.destination);
-    eprintln!("[transfer] Method: {}", method);
+    log_status!("transfer", "{} -> {}", args.source, args.destination);
+    log_status!("transfer", "Method: {}", method);
 
     let output = Command::new("sh")
         .args(["-c", &command])
@@ -384,7 +401,7 @@ fn run_server_to_server(
             if !success {
                 eprintln!("[transfer] Failed: {}", stderr);
             } else {
-                eprintln!("[transfer] Complete");
+                log_status!("transfer", "Complete");
             }
 
             Ok((
@@ -434,7 +451,7 @@ fn execute_scp(scp_args: &[String], args: &TransferArgs) -> CmdResult<TransferOu
             if !success {
                 eprintln!("[transfer] Failed: {}", stderr);
             } else {
-                eprintln!("[transfer] Complete");
+                log_status!("transfer", "Complete");
             }
 
             Ok((

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -73,7 +73,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         upgrade::restart_with_new_binary();
 
         #[cfg(not(unix))]
-        eprintln!("Please restart homeboy to use the new version.");
+        homeboy::log_status!("upgrade", "Please restart homeboy to use the new version.");
     }
 
     Ok((json, 0))

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use homeboy::log_status;
 use serde::Serialize;
 
 use homeboy::component;
@@ -316,8 +317,9 @@ fn create_version_commit(
                 match tag(component_id, Some(&tag_name), Some(&tag_message)) {
                     Ok(tag_output) => {
                         if tag_output.success {
-                            eprintln!(
-                                "[version] Tagged {}. For automated packaging/publishing, configure a release pipeline: homeboy docs release",
+                            log_status!(
+                                "version",
+                                "Tagged {}. For automated packaging/publishing, configure a release pipeline: homeboy docs release",
                                 tag_name
                             );
                         }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -28,6 +28,12 @@ pub(crate) fn to_string_pretty<T: Serialize>(data: &T) -> Result<String> {
         .map_err(|e| Error::internal_json(e.to_string(), Some("serialize json".to_string())))
 }
 
+/// Serialize value to compact JSON string with proper error handling.
+pub fn to_json_string<T: Serialize>(data: &T) -> Result<String> {
+    serde_json::to_string(data)
+        .map_err(|e| Error::internal_json(e.to_string(), Some("serialize json".to_string())))
+}
+
 /// Read JSON spec from string, file (@path), or stdin (-).
 pub fn read_json_spec_to_string(spec: &str) -> Result<String> {
     use std::io::IsTerminal;
@@ -734,8 +740,9 @@ pub(crate) fn list<T: ConfigEntity>() -> Result<Vec<T>> {
             let content = match local_files::local().read(&json_path) {
                 Ok(c) => c,
                 Err(err) => {
-                    eprintln!(
-                        "[config] Warning: failed to read {}: {}",
+                    log_status!(
+                        "config",
+                        "Warning: failed to read {}: {}",
                         json_path.display(),
                         err
                     );
@@ -745,8 +752,9 @@ pub(crate) fn list<T: ConfigEntity>() -> Result<Vec<T>> {
             let mut entity: T = match from_str(&content) {
                 Ok(e) => e,
                 Err(err) => {
-                    eprintln!(
-                        "[config] Warning: failed to parse {}: {}",
+                    log_status!(
+                        "config",
+                        "Warning: failed to parse {}: {}",
                         json_path.display(),
                         err
                     );

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -317,8 +317,9 @@ pub fn load_config() -> HomeboyConfig {
         Err(err) => {
             // Only warn if the file actually exists — missing file is expected
             if config_exists() {
-                eprintln!(
-                    "[config] Warning: failed to load homeboy.json ({}), using defaults",
+                log_status!(
+                    "config",
+                    "Warning: failed to load homeboy.json ({}), using defaults",
                     err.message
                 );
             }
@@ -359,9 +360,7 @@ pub fn save_config(config: &HomeboyConfig) -> crate::Result<()> {
         })?;
     }
 
-    let content = serde_json::to_string_pretty(config).map_err(|e| {
-        crate::Error::validation_invalid_json(e, Some("serialize homeboy.json".to_string()), None)
-    })?;
+    let content = crate::config::to_string_pretty(config)?;
 
     io::write_file_atomic(&path, &content, &format!("write {}", path.display()))?;
 

--- a/src/core/files.rs
+++ b/src/core/files.rs
@@ -911,9 +911,14 @@ pub fn download(
     scp_args.push(local_path.to_string());
 
     let label = if recursive { "directory" } else { "file" };
-    eprintln!(
-        "[download] Downloading {}: {}@{}:{} -> {}",
-        label, ctx.client.user, ctx.client.host, full_remote_path, local_path
+    log_status!(
+        "download",
+        "Downloading {}: {}@{}:{} -> {}",
+        label,
+        ctx.client.user,
+        ctx.client.host,
+        full_remote_path,
+        local_path
     );
 
     let output = Command::new("scp").args(&scp_args).output();

--- a/src/core/module/runner.rs
+++ b/src/core/module/runner.rs
@@ -269,9 +269,7 @@ impl ModuleRunner {
             }
         }
 
-        serde_json::to_string(&settings).map_err(|e| {
-            Error::internal_io(format!("Failed to serialize settings JSON: {}", e), None)
-        })
+        crate::config::to_json_string(&settings)
     }
 
     fn prepare_env_vars(

--- a/src/core/permissions.rs
+++ b/src/core/permissions.rs
@@ -13,9 +13,12 @@ pub fn fix_local_permissions(local_path: &str) {
     let quoted_path = shell::quote_path(local_path);
     let perms = defaults::load_defaults().permissions.local;
 
-    eprintln!(
-        "[build] Fixing local file permissions in {} (files: {}, dirs: {})",
-        local_path, perms.file_mode, perms.dir_mode
+    log_status!(
+        "build",
+        "Fixing local file permissions in {} (files: {}, dirs: {})",
+        local_path,
+        perms.file_mode,
+        perms.dir_mode
     );
 
     // Fix files (configurable mode, default: g+rw)
@@ -79,8 +82,9 @@ fn fix_deployed_ownership(
         let stat_cmd = format!("stat -c '%U:%G' {} 2>/dev/null", quoted_path);
         let stat_output = ssh_client.execute(&stat_cmd);
         if !stat_output.success || stat_output.stdout.trim().is_empty() {
-            eprintln!(
-                "[deploy] Could not detect ownership of {}, skipping chown",
+            log_status!(
+                "deploy",
+                "Could not detect ownership of {}, skipping chown",
                 remote_path
             );
             return;
@@ -93,7 +97,7 @@ fn fix_deployed_ownership(
         detected
     };
 
-    eprintln!("[deploy] Setting ownership to {} on {}", owner, remote_path);
+    log_status!("deploy", "Setting ownership to {} on {}", owner, remote_path);
     let chown_cmd = format!(
         "chown -R {} {} 2>/dev/null",
         shell::quote_arg(&owner),
@@ -101,9 +105,11 @@ fn fix_deployed_ownership(
     );
     let chown_output = ssh_client.execute(&chown_cmd);
     if !chown_output.success {
-        eprintln!(
-            "[deploy] Warning: chown failed (exit {}): {}",
-            chown_output.exit_code, chown_output.stderr
+        log_status!(
+            "deploy",
+            "Warning: chown failed (exit {}): {}",
+            chown_output.exit_code,
+            chown_output.stderr
         );
         // Don't fail the deploy - chown is best-effort
     }

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -133,7 +133,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
             } else if uncommitted.has_changes {
                 // Only changelog/version files are uncommitted — auto-stage them
                 // so the release commit includes them (e.g., after `homeboy changelog add`)
-                eprintln!("[release] Auto-staging changelog/version files for release commit");
+                log_status!("release", "Auto-staging changelog/version files for release commit");
                 let all_files: Vec<&String> = uncommitted
                     .staged
                     .iter()

--- a/src/core/ssh/client.rs
+++ b/src/core/ssh/client.rs
@@ -124,8 +124,9 @@ impl SshClient {
             }
 
             let delay = backoff_secs.get(attempt as usize + 1).copied().unwrap_or(5);
-            eprintln!(
-                "[ssh] Connection failed (attempt {}/{}), retrying in {}s...",
+            log_status!(
+                "ssh",
+                "Connection failed (attempt {}/{}), retrying in {}s...",
                 attempt + 1,
                 max_attempts,
                 delay

--- a/src/core/update_check.rs
+++ b/src/core/update_check.rs
@@ -67,9 +67,11 @@ fn is_disabled_by_config() -> bool {
 }
 
 fn print_hint(latest: &str, current: &str) {
-    eprintln!(
-        "hint: Homeboy {} is available (current: {}). Run `homeboy upgrade` to update.",
-        latest, current
+    log_status!(
+        "update",
+        "Homeboy {} is available (current: {}). Run `homeboy upgrade` to update.",
+        latest,
+        current
     );
 }
 

--- a/src/core/upgrade.rs
+++ b/src/core/upgrade.rs
@@ -386,7 +386,7 @@ pub fn restart_with_new_binary() -> ! {
 #[cfg(not(unix))]
 pub fn restart_with_new_binary() {
     // On Windows, just print a message
-    eprintln!("Please restart homeboy to use the new version.");
+    log_status!("upgrade", "Please restart homeboy to use the new version.");
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,19 @@
+/// Macro for prefixed status logging to stderr (only when stderr is a terminal).
+///
+/// Usage:
+/// ```ignore
+/// log_status!("deploy", "Uploading {} to {}", artifact, server);
+/// log_status!("release", "Version bumped to {}", version);
+/// ```
+#[macro_export]
+macro_rules! log_status {
+    ($prefix:expr, $($arg:tt)*) => {
+        if ::std::io::IsTerminal::is_terminal(&::std::io::stderr()) {
+            eprintln!(concat!("[", $prefix, "] {}"), format_args!($($arg)*));
+        }
+    };
+}
+
 pub mod core;
 pub mod utils;
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -43,3 +43,5 @@ pub fn status(message: &str) {
         eprintln!("{}", message);
     }
 }
+
+// log_status! macro is defined in lib.rs (#[macro_export]) and available crate-wide.

--- a/src/utils/artifact.rs
+++ b/src/utils/artifact.rs
@@ -34,7 +34,7 @@ pub fn resolve_artifact_path(pattern: &str) -> Result<PathBuf> {
 
     match newest {
         Some(path) => {
-            eprintln!("[deploy] Resolved '{}' -> '{}'", pattern, path.display());
+            log_status!("deploy", "Resolved '{}' -> '{}'", pattern, path.display());
             Ok(path)
         }
         None => Err(Error::other(format!("No files match pattern: {}", pattern))),


### PR DESCRIPTION
## Summary

Replaces 60 raw `eprintln!` calls with a `log_status!` macro and adds a `to_json_string()` serialization helper.

### log_status! macro
- Consistent `[prefix]` formatting across all commands
- Only prints when stderr is a terminal (no noise in piped/JSON mode)
- Standardized prefixes: `deploy`, `deploy:git`, `release`, `transfer`, `fleet`, `permissions`, `config`, `ssh`, `upgrade`, `update`, `version`, `files`

### to_json_string() helper
- `config::to_json_string<T: Serialize>(data) -> Result<String>` with proper `internal_json` error handling
- Replaces 6 manual `serde_json::to_string().map_err(|e| Error::internal_unexpected(...))` patterns

### What's left (7 intentional eprintln!)
- `tty.rs` internals (2) — the macro definition and status function
- `lib.rs` (1) — macro definition
- `main.rs` (1) — clap error augmentation
- `release.rs` (1) — empty line separator
- `transfer.rs` (2) — error messages that should always print

### Phase 2 (follow-up)
`--quiet` / `--verbose` global flags — the macro is already the single control point for this.

Closes #187