### PR TITLE
Standardize rename and delete_safe as universal entity primitives

### DIFF
--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -498,13 +498,13 @@ fn remove(project_id: Option<&str>, json: &str) -> homeboy::Result<(ProjectOutpu
 }
 
 fn rename(project_id: &str, new_id: &str) -> homeboy::Result<(ProjectOutput, i32)> {
-    let result = project::rename(project_id, new_id)?;
+    let project = project::rename(project_id, new_id)?;
 
     Ok((
         ProjectOutput {
             command: "project.rename".to_string(),
-            id: Some(result.new_id.clone()),
-            entity: Some(project::load(&result.new_id)?),
+            id: Some(project.id.clone()),
+            entity: Some(project),
             updated_fields: vec!["id".to_string()],
             ..Default::default()
         },

--- a/src/core/fleet.rs
+++ b/src/core/fleet.rs
@@ -89,13 +89,6 @@ pub fn remove_project(fleet_id: &str, project_id: &str) -> Result<Fleet> {
     Ok(fleet)
 }
 
-/// Rename a fleet
-pub fn rename(id: &str, new_id: &str) -> Result<Fleet> {
-    let new_id = new_id.to_lowercase();
-    config::rename::<Fleet>(id, &new_id)?;
-    load(&new_id)
-}
-
 /// Get all projects in a fleet with full project data
 pub fn get_projects(fleet_id: &str) -> Result<Vec<crate::project::Project>> {
     let fleet = load(fleet_id)?;


### PR DESCRIPTION
## Summary

- Moves `rename()` and `delete_safe()` from copy-pasted per-entity implementations into the `ConfigEntity` trait + `entity_crud!` macro as universal operations (like `load`, `save`, `delete`, `exists`, `create`)
- Adds two trait hooks: `dependents(id)` for safe-delete integrity checks, `on_rename(old, new)` for cascading reference updates
- Removes ~194 net lines of dead code from the post-merge audit

## What Changed

**config.rs** — trait gets `dependents()` + `on_rename()` hooks, new generic `delete_safe<T>()`, macro generates `rename` + `delete_safe` (9 universal wrappers, up from 7)

**component.rs** — implements both hooks (delegates to existing `projects_using` + `update_project_references`), removes standalone `rename()`, `delete_safe()`, dead `update()` + `UpdateResult` + `RenameResult`

**server.rs** — implements `dependents` (projects with matching server_id), removes standalone `delete_safe()`, dead `update()` + `UpdateResult` + `rename()`

**project.rs** — uses trait defaults, removes standalone `delete_safe()`, `rename()`, dead `update()` + `UpdateResult` + `RenameResult`, `NullableUpdate`, `clear_components()`

**fleet.rs** — uses trait defaults, removes standalone `rename()` (now macro-generated)

**commands/project.rs** — adapts to `rename()` returning `Project` instead of `RenameResult`

Closes #198, closes #200, closes #202