### PR TITLE
Remove dead utility functions (~182 LOC)

### DIFF
--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -81,17 +81,6 @@ pub fn error_text(output: &Output) -> String {
     }
 }
 
-/// Check if a command succeeds without capturing output.
-///
-/// Returns true if the command exits with status 0.
-pub fn succeeded(program: &str, args: &[&str]) -> bool {
-    Command::new(program)
-        .args(args)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
 /// Check if a command succeeds in a directory without capturing output.
 pub fn succeeded_in(dir: &str, program: &str, args: &[&str]) -> bool {
     Command::new(program)
@@ -151,16 +140,6 @@ mod tests {
     fn run_fails_with_invalid_command() {
         let result = run("nonexistent_command_xyz", &[], "test");
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn succeeded_returns_true_for_valid_command() {
-        assert!(succeeded("true", &[]));
-    }
-
-    #[test]
-    fn succeeded_returns_false_for_failing_command() {
-        assert!(!succeeded("false", &[]));
     }
 
     #[test]

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -98,41 +98,9 @@ where
     Ok(values[0].clone())
 }
 
-/// Extract all matches and validate they are identical.
-/// Combines extract_all + require_identical for the common pattern.
-pub fn extract_unique(content: &str, pattern: &str, context: &str) -> Result<String> {
-    let values = extract_all(content, pattern).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "pattern",
-            format!("Invalid regex pattern: {}", pattern),
-            None,
-            None,
-        )
-    })?;
-
-    if values.is_empty() {
-        return Err(Error::internal_unexpected(format!(
-            "No matches found in {} using pattern: {}",
-            context, pattern
-        )));
-    }
-
-    require_identical(&values, context)
-}
-
 /// Parse output into non-empty lines.
 pub fn lines(output: &str) -> impl Iterator<Item = &str> {
     output.lines().filter(|line| !line.is_empty())
-}
-
-/// Convert content into a Vec of owned line strings.
-///
-/// Replaces the common pattern:
-/// ```ignore
-/// content.lines().map(|s| s.to_string()).collect()
-/// ```
-pub fn lines_to_vec(content: &str) -> Vec<String> {
-    content.lines().map(|s| s.to_string()).collect()
 }
 
 /// Parse output into lines with custom filter.
@@ -302,20 +270,6 @@ mod tests {
         let items = vec!["a", "b", "a", "c", "b"];
         let result = dedupe(items);
         assert_eq!(result, vec!["a", "b", "c"]);
-    }
-
-    #[test]
-    fn lines_to_vec_splits_correctly() {
-        let content = "line1\nline2\nline3";
-        let result = lines_to_vec(content);
-        assert_eq!(result, vec!["line1", "line2", "line3"]);
-    }
-
-    #[test]
-    fn lines_to_vec_preserves_empty_lines() {
-        let content = "line1\n\nline3";
-        let result = lines_to_vec(content);
-        assert_eq!(result, vec!["line1", "", "line3"]);
     }
 
     #[test]

--- a/src/utils/shell.rs
+++ b/src/utils/shell.rs
@@ -2,7 +2,7 @@
 
 /// Escape a value for use inside single quotes.
 /// Replaces `'` with `'\''` (end quote, escaped quote, start quote).
-pub fn escape_single_quote_content(value: &str) -> String {
+fn escape_single_quote_content(value: &str) -> String {
     value.replace('\'', "'\\''")
 }
 
@@ -99,33 +99,9 @@ fn split_respecting_quotes(input: &str) -> Vec<String> {
     result
 }
 
-/// Escape an entire command string for sh -c execution.
-/// Use this when passing a complete command (with operators) to sh -c.
-/// Wraps entire command in single quotes and escapes embedded quotes.
-pub fn escape_command_for_shell(command: &str) -> String {
-    format!("'{}'", escape_single_quote_content(command))
-}
-
 /// Quote a path for shell execution (always quotes).
 pub fn quote_path(path: &str) -> String {
     format!("'{}'", escape_single_quote_content(path))
-}
-
-/// Escape special characters for perl regex patterns.
-/// Characters: \ ^ $ . | ? * + ( ) [ ] { } and the delimiter /
-pub fn escape_perl_regex(pattern: &str) -> String {
-    let mut escaped = String::new();
-    for c in pattern.chars() {
-        match c {
-            '\\' | '^' | '$' | '.' | '|' | '?' | '*' | '+' | '(' | ')' | '[' | ']' | '{' | '}'
-            | '/' => {
-                escaped.push('\\');
-                escaped.push(c);
-            }
-            _ => escaped.push(c),
-        }
-    }
-    escaped
 }
 
 #[cfg(test)]
@@ -175,33 +151,6 @@ mod tests {
     #[test]
     fn quote_path_with_quote() {
         assert_eq!(quote_path("/var/www/it's"), "'/var/www/it'\\''s'");
-    }
-
-    #[test]
-    fn escape_perl_regex_simple() {
-        assert_eq!(escape_perl_regex("hello"), "hello");
-        assert_eq!(escape_perl_regex("test123"), "test123");
-    }
-
-    #[test]
-    fn escape_perl_regex_special_chars() {
-        assert_eq!(escape_perl_regex("hello.world"), "hello\\.world");
-        assert_eq!(escape_perl_regex("price$100"), "price\\$100");
-        assert_eq!(escape_perl_regex("a|b|c"), "a\\|b\\|c");
-        assert_eq!(escape_perl_regex("foo+"), "foo\\+");
-        assert_eq!(escape_perl_regex("test*"), "test\\*");
-    }
-
-    #[test]
-    fn escape_perl_regex_brackets() {
-        assert_eq!(escape_perl_regex("[test]"), "\\[test\\]");
-        assert_eq!(escape_perl_regex("func()"), "func\\(\\)");
-    }
-
-    #[test]
-    fn escape_perl_regex_slash() {
-        assert_eq!(escape_perl_regex("path/to/file"), "path\\/to\\/file");
-        assert_eq!(escape_perl_regex("/var/www"), "\\/var\\/www");
     }
 
     #[test]

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -33,31 +33,6 @@ pub fn require_with_hints<T>(
     opt.ok_or_else(|| Error::validation_invalid_argument(field, message, None, Some(hints)))
 }
 
-/// Require a string to be non-empty after trimming.
-///
-/// Returns a reference to the trimmed string on success.
-pub fn require_non_empty<'a>(value: &'a str, field: &str, message: &str) -> Result<&'a str> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        Err(Error::validation_invalid_argument(
-            field, message, None, None,
-        ))
-    } else {
-        Ok(trimmed)
-    }
-}
-
-/// Require a collection to be non-empty.
-pub fn require_non_empty_vec<'a, T>(vec: &'a [T], field: &str, message: &str) -> Result<&'a [T]> {
-    if vec.is_empty() {
-        Err(Error::validation_invalid_argument(
-            field, message, None, None,
-        ))
-    } else {
-        Ok(vec)
-    }
-}
-
 /// Collects validation errors for aggregated reporting.
 ///
 /// Use when a command has multiple independent validations that should
@@ -169,44 +144,6 @@ mod tests {
     #[test]
     fn require_returns_error_when_none() {
         let result: Result<&str> = require(None, "field", "Missing field");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn require_non_empty_passes_for_non_empty() {
-        let result = require_non_empty("hello", "field", "msg");
-        assert_eq!(result.unwrap(), "hello");
-    }
-
-    #[test]
-    fn require_non_empty_trims_whitespace() {
-        let result = require_non_empty("  hello  ", "field", "msg");
-        assert_eq!(result.unwrap(), "hello");
-    }
-
-    #[test]
-    fn require_non_empty_fails_for_empty() {
-        let result = require_non_empty("", "field", "Cannot be empty");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn require_non_empty_fails_for_whitespace_only() {
-        let result = require_non_empty("   ", "field", "Cannot be empty");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn require_non_empty_vec_passes_for_non_empty() {
-        let vec = vec![1, 2, 3];
-        let result = require_non_empty_vec(&vec, "field", "msg");
-        assert_eq!(result.unwrap(), &[1, 2, 3]);
-    }
-
-    #[test]
-    fn require_non_empty_vec_fails_for_empty() {
-        let vec: Vec<i32> = vec![];
-        let result = require_non_empty_vec(&vec, "field", "Cannot be empty");
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
## Summary

- Removes 7 utility functions with zero callers outside their own tests
- Makes `escape_single_quote_content` private (still used internally by `quote_arg`/`quote_path`)
- **-181 net lines**

## Removed

| Function | File | LOC (incl tests) |
|----------|------|-------------------|
| `escape_command_for_shell()` | utils/shell.rs | 3 |
| `escape_perl_regex()` + 4 tests | utils/shell.rs | 37 |
| `extract_unique()` | utils/parser.rs | 19 |
| `lines_to_vec()` + 2 tests | utils/parser.rs | 15 |
| `require_non_empty()` + 4 tests | utils/validation.rs | 32 |
| `require_non_empty_vec()` + 2 tests | utils/validation.rs | 22 |
| `succeeded()` + 2 tests | utils/command.rs | 17 |

Closes #201