### PR TITLE
Batch 1 quick wins: dead code, helpers, visibility

### DIFF
--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -215,8 +215,7 @@ fn create(
     let mut new_fleet = Fleet::new(id.to_string(), project_ids);
     new_fleet.description = description;
 
-    let json_spec = serde_json::to_string(&new_fleet)
-        .map_err(|e| homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e)))?;
+    let json_spec = homeboy::config::to_json_string(&new_fleet)?;
 
     match fleet::create(&json_spec, false)? {
         homeboy::CreateOutput::Single(result) => Ok((

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -269,16 +269,7 @@ pub fn run(
                     ..Default::default()
                 };
 
-                // Serialize to Value first so we can inject the id field.
-                // Project's serde(skip) on id means to_string() drops it,
-                // but create_single_from_json() needs id in the JSON.
-                let mut value = serde_json::to_value(&new_project).map_err(|e| {
-                    homeboy::Error::internal_unexpected(format!("Failed to serialize: {}", e))
-                })?;
-                if let serde_json::Value::Object(ref mut map) = value {
-                    map.insert("id".to_string(), serde_json::json!(id));
-                }
-                homeboy::config::to_json_string(&value)?
+                homeboy::config::serialize_with_id(&new_project, &id)?
             };
 
             match project::create(&json_spec, skip_existing)? {

--- a/src/core/fleet.rs
+++ b/src/core/fleet.rs
@@ -25,14 +25,6 @@ impl Fleet {
         }
     }
 
-    /// Returns project IDs that actually exist
-    pub fn valid_project_ids(&self) -> Vec<String> {
-        self.project_ids
-            .iter()
-            .filter(|id| project::exists(id))
-            .cloned()
-            .collect()
-    }
 }
 
 impl ConfigEntity for Fleet {

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -54,25 +54,6 @@ pub struct Project {
     pub component_ids: Vec<String>,
 }
 
-impl Project {
-    pub fn has_sub_targets(&self) -> bool {
-        !self.sub_targets.is_empty()
-    }
-
-    pub fn default_sub_target(&self) -> Option<&SubTarget> {
-        self.sub_targets
-            .iter()
-            .find(|t| t.is_default)
-            .or_else(|| self.sub_targets.first())
-    }
-
-    pub fn find_sub_target(&self, target_id: &str) -> Option<&SubTarget> {
-        self.sub_targets
-            .iter()
-            .find(|t| slugify_id(&t.name).ok().as_deref() == Some(target_id))
-    }
-}
-
 impl ConfigEntity for Project {
     const ENTITY_TYPE: &'static str = "project";
     const DIR_NAME: &'static str = "projects";

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -28,16 +28,8 @@ fn default_port() -> u16 {
 }
 
 impl Server {
-    pub fn keychain_service_name(&self, prefix: &str) -> String {
-        format!("{}.{}", prefix, self.id)
-    }
-
     pub fn is_valid(&self) -> bool {
         !self.host.is_empty() && !self.user.is_empty()
-    }
-
-    pub fn generate_id(host: &str) -> String {
-        format!("server-{}", host.replace('.', "-"))
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove 6 dead public functions across server, project, and fleet modules
- Add `to_details()` helper in error module — eliminates 13 `serde_json::to_value(...).unwrap_or_else(...)` boilerplate patterns
- Add `config::serialize_with_id()` — replaces duplicate id-injection pattern in component and project create commands
- Add `ComponentDeployResult::failed()` constructor — simplifies 8 repetitive failure chains in deploy.rs
- Narrow `deploy_via_git`, `deploy_artifact`, `deploy_components` from `pub fn` to `fn` (module-private, not used externally)
- Replace 2 manual `serde_json::to_string().map_err(...)` calls with `to_json_string()`

**Net: -60 LOC across 9 files. All 301 tests pass.**