### PR TITLE
Batch 2: unify summary struct, dead code removal, visibility narrowing

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use homeboy::deploy::{self, ComponentDeployResult, DeployConfig, DeploySummary};
 use homeboy::resolve::{infer_project_for_components, resolve_project_components};
 
-use super::CmdResult;
+use super::{CmdResult, ProjectsSummary};
 
 #[derive(Args)]
 pub struct DeployArgs {
@@ -83,7 +83,7 @@ pub struct MultiProjectDeployOutput {
     pub command: String,
     pub component_ids: Vec<String>,
     pub projects: Vec<ProjectDeployResult>,
-    pub summary: MultiProjectDeploySummary,
+    pub summary: ProjectsSummary,
     pub dry_run: bool,
     pub check: bool,
     pub force: bool,
@@ -97,13 +97,6 @@ pub struct ProjectDeployResult {
     pub error: Option<String>,
     pub results: Vec<ComponentDeployResult>,
     pub summary: DeploySummary,
-}
-
-#[derive(Serialize)]
-pub struct MultiProjectDeploySummary {
-    pub total_projects: u32,
-    pub succeeded: u32,
-    pub failed: u32,
 }
 
 #[derive(Serialize)]
@@ -404,7 +397,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
             command: "deploy.run_multi".to_string(),
             component_ids,
             projects: project_results,
-            summary: MultiProjectDeploySummary {
+            summary: ProjectsSummary {
                 total_projects: total,
                 succeeded,
                 failed,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,17 @@
 use base64::Engine;
 use clap::Args;
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 
 pub type CmdResult<T> = homeboy::Result<(T, i32)>;
+
+/// Summary of a multi-project operation (deploy, release deploy, etc.).
+#[derive(Serialize)]
+pub struct ProjectsSummary {
+    pub total_projects: u32,
+    pub succeeded: u32,
+    pub failed: u32,
+}
 
 /// Parse a `KEY=value` string into a (key, value) tuple.
 /// Used by clap `value_parser` attributes on `--setting` and `--input` flags.

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -6,7 +6,7 @@ use homeboy::component;
 use homeboy::deploy::{self, DeployConfig};
 use homeboy::release::{self, ReleasePlan, ReleaseRun};
 
-use super::CmdResult;
+use super::{CmdResult, ProjectsSummary};
 
 #[derive(Clone, ValueEnum)]
 pub enum BumpType {
@@ -59,7 +59,7 @@ pub struct ReleaseArgs {
 #[derive(Serialize)]
 pub struct DeploymentResult {
     pub projects: Vec<ProjectDeployResult>,
-    pub summary: DeploymentSummary,
+    pub summary: ProjectsSummary,
 }
 
 #[derive(Serialize)]
@@ -70,13 +70,6 @@ pub struct ProjectDeployResult {
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_result: Option<homeboy::deploy::ComponentDeployResult>,
-}
-
-#[derive(Serialize)]
-pub struct DeploymentSummary {
-    pub total_projects: u32,
-    pub succeeded: u32,
-    pub failed: u32,
 }
 
 #[derive(Serialize)]
@@ -196,7 +189,7 @@ fn plan_deployment(component_id: &str) -> DeploymentResult {
     let total = project_results.len() as u32;
     DeploymentResult {
         projects: project_results,
-        summary: DeploymentSummary {
+        summary: ProjectsSummary {
             total_projects: total,
             succeeded: 0,
             failed: 0,
@@ -216,7 +209,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
         return (
             Some(DeploymentResult {
                 projects: vec![],
-                summary: DeploymentSummary {
+                summary: ProjectsSummary {
                     total_projects: 0,
                     succeeded: 0,
                     failed: 0,
@@ -297,7 +290,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
     (
         Some(DeploymentResult {
             projects: project_results,
-            summary: DeploymentSummary {
+            summary: ProjectsSummary {
                 total_projects: total,
                 succeeded,
                 failed,

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -360,18 +360,13 @@ pub fn build_component_info(component: &component::Component) -> ContainedCompon
 
 // === Project/Server Context Resolution ===
 
-pub struct ProjectServerContext {
+pub(crate) struct ProjectServerContext {
     pub project: Project,
     pub server_id: String,
     pub server: Server,
 }
 
-pub enum ResolvedTarget {
-    Project(Box<ProjectServerContext>),
-    Server { server_id: String, server: Server },
-}
-
-pub fn resolve_project_server(project_id: &str) -> Result<ProjectServerContext> {
+pub(crate) fn resolve_project_server(project_id: &str) -> Result<ProjectServerContext> {
     let project = project::load(project_id)?;
 
     let server_id = project.server_id.clone().ok_or_else(|| {
@@ -394,27 +389,6 @@ pub fn require_project_base_path(project_id: &str, project: &Project) -> Result<
         .clone()
         .filter(|p| !p.is_empty())
         .ok_or_else(|| Error::config_missing_key("project.base_path", Some(project_id.to_string())))
-}
-
-pub fn resolve_project_server_with_base_path(
-    project_id: &str,
-) -> Result<(ProjectServerContext, String)> {
-    let ctx = resolve_project_server(project_id)?;
-    let base_path = require_project_base_path(project_id, &ctx.project)?;
-    Ok((ctx, base_path))
-}
-
-pub fn resolve_project_or_server_id(id: &str) -> Result<ResolvedTarget> {
-    if let Ok(ctx) = resolve_project_server(id) {
-        return Ok(ResolvedTarget::Project(Box::new(ctx)));
-    }
-
-    let server = server::load(id).map_err(|_| Error::server_not_found(id.to_string(), vec![]))?;
-
-    Ok(ResolvedTarget::Server {
-        server_id: id.to_string(),
-        server,
-    })
 }
 
 pub struct RemoteProjectContext {


### PR DESCRIPTION
## Summary
- Unify identical `MultiProjectDeploySummary` (deploy.rs) and `DeploymentSummary` (release.rs) into shared `ProjectsSummary` in `commands/mod.rs`
- Remove dead `detect_version_targets()` — 47 LOC, zero callers
- Remove dead `resolve_project_server_with_base_path()` and `resolve_project_or_server_id()` + `ResolvedTarget` enum from context.rs
- Narrow `resolve_project_server` and `ProjectServerContext` from `pub` to `pub(crate)` — only used within core/
- Remove stale `use crate::defaults` import from version.rs

**Net: -80 LOC across 5 files. All 301 tests pass.**