### PR TITLE
Batch 3: broad sweep — 11 dead functions, visibility narrowing

### DIFF
--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -41,7 +41,7 @@ impl ResolvedBuildCommand {
 /// 1. Explicit component.build_command (always wins)
 /// 2. Module's bundled script (module.build.module_script)
 /// 3. Local script matching module's script_names pattern
-pub fn resolve_build_command(component: &Component) -> Result<ResolvedBuildCommand> {
+pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBuildCommand> {
     // 1. Explicit component override takes precedence
     if let Some(cmd) = &component.build_command {
         return Ok(ResolvedBuildCommand::ComponentDefined(cmd.clone()));
@@ -166,7 +166,7 @@ pub fn run(input: &str) -> Result<(BuildResult, i32)> {
 /// - Direct execution cannot handle shell scripts or shell features
 ///
 /// See executor.rs for detailed execution strategy decision tree
-pub fn build_component(component: &component::Component) -> (Option<i32>, Option<String>) {
+pub(crate) fn build_component(component: &component::Component) -> (Option<i32>, Option<String>) {
     // Validate local_path before attempting build
     let validated_path = match component::validate_local_path(component) {
         Ok(p) => p,

--- a/src/core/changelog/io.rs
+++ b/src/core/changelog/io.rs
@@ -35,24 +35,6 @@ fn resolve_target_path(local_path: &str, file: &str) -> Result<PathBuf> {
     Ok(parser::resolve_path(local_path, file))
 }
 
-pub fn read_and_add_next_section_item(
-    component: &Component,
-    settings: &EffectiveChangelogSettings,
-    message: &str,
-) -> Result<(PathBuf, bool)> {
-    let path = resolve_changelog_path(component)?;
-    let content = io::read_file(&path, "read changelog")?;
-
-    let (new_content, changed) =
-        add_next_section_item(&content, &settings.next_section_aliases, message)?;
-
-    if changed {
-        io::write_file(&path, &new_content, "write changelog")?;
-    }
-
-    Ok((path, changed))
-}
-
 pub fn read_and_add_next_section_items(
     component: &Component,
     settings: &EffectiveChangelogSettings,

--- a/src/core/changelog/sections.rs
+++ b/src/core/changelog/sections.rs
@@ -315,29 +315,6 @@ pub fn get_latest_finalized_version(content: &str) -> Option<String> {
     None
 }
 
-pub fn add_next_section_item(
-    changelog_content: &str,
-    next_section_aliases: &[String],
-    message: &str,
-) -> Result<(String, bool)> {
-    let trimmed_message = message.trim();
-    if trimmed_message.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "message",
-            "Changelog message cannot be empty",
-            None,
-            None,
-        ));
-    }
-
-    let (with_section, section_changed) =
-        ensure_next_section(changelog_content, next_section_aliases)?;
-    let (with_item, item_changed) =
-        append_item_to_next_section(&with_section, next_section_aliases, trimmed_message)?;
-
-    Ok((with_item, section_changed || item_changed))
-}
-
 pub fn add_next_section_items(
     changelog_content: &str,
     next_section_aliases: &[String],

--- a/src/core/files.rs
+++ b/src/core/files.rs
@@ -68,7 +68,7 @@ pub struct RenameResult {
 }
 
 /// Parse `ls -la` output into structured file entries.
-pub fn parse_ls_output(output: &str, base_path: &str) -> Vec<FileEntry> {
+fn parse_ls_output(output: &str, base_path: &str) -> Vec<FileEntry> {
     let mut entries: Vec<FileEntry> =
         parser::lines_filtered(output, |line| !line.starts_with("total "))
             .filter_map(|line| parse_ls_line(line, base_path))

--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -308,19 +308,6 @@ pub fn categorize_commits(path: &str, commits: &[CommitInfo]) -> CommitCounts {
     counts
 }
 
-/// Convert commits to changelog entries.
-/// Strips conventional commit prefixes for cleaner changelog.
-pub fn commits_to_changelog_entries(commits: &[CommitInfo]) -> Vec<String> {
-    commits
-        .iter()
-        .map(|c| {
-            // Strip conventional commit prefix if present
-            let subject = strip_conventional_prefix(&c.subject);
-            subject.to_string()
-        })
-        .collect()
-}
-
 /// Strip conventional commit prefix from a subject line.
 /// "feat: Add new feature" -> "Add new feature"
 /// "fix(scope): Fix bug" -> "Fix bug"

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -804,14 +804,6 @@ pub fn get_head_commit(path: &str) -> Result<String> {
     crate::utils::command::run_in(path, "git", &["rev-parse", "HEAD"], "get HEAD commit")
 }
 
-/// Stage specific files in a git repository.
-pub fn stage_files(path: &str, files: &[&str]) -> Result<()> {
-    let mut args = vec!["add", "--"];
-    args.extend(files);
-    crate::utils::command::run_in(path, "git", &args, "stage files")?;
-    Ok(())
-}
-
 /// Fetch from remote and return count of commits behind upstream.
 /// Returns Ok(Some(n)) if behind by n commits, Ok(None) if not behind or no upstream.
 pub fn fetch_and_get_behind_count(path: &str) -> Result<Option<u32>> {

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -70,28 +70,6 @@ pub fn list_tracked_markdown_files(path: &Path) -> Result<Vec<String>> {
         .collect())
 }
 
-/// Pull with fast-forward only, inheriting stdio for interactive output.
-pub fn pull_ff_only_interactive(path: &Path) -> Result<()> {
-    use std::process::Stdio;
-
-    let status = Command::new("git")
-        .args(["pull", "--ff-only"])
-        .current_dir(path)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .map_err(|e| Error::git_command_failed(format!("Failed to run git pull: {}", e)))?;
-
-    if !status.success() {
-        return Err(Error::git_command_failed(
-            "git pull --ff-only failed".to_string(),
-        ));
-    }
-
-    Ok(())
-}
-
 pub(crate) fn is_git_repo(path: &str) -> bool {
     command::succeeded_in(path, "git", &["rev-parse", "--git-dir"])
 }

--- a/src/core/module/execution.rs
+++ b/src/core/module/execution.rs
@@ -694,11 +694,6 @@ pub fn module_ready_status(module: &ModuleManifest) -> ModuleReadyStatus {
     }
 }
 
-/// Check if a module is ready (setup complete).
-pub fn is_module_ready(module: &ModuleManifest) -> bool {
-    module_ready_status(module).ready
-}
-
 /// Check if a module is compatible with a project.
 pub fn is_module_compatible(module: &ModuleManifest, project: Option<&Project>) -> bool {
     let Some(ref requires) = module.requires else {

--- a/src/core/module/manifest.rs
+++ b/src/core/module/manifest.rs
@@ -171,10 +171,6 @@ impl ModuleManifest {
         self.cli.is_some()
     }
 
-    pub fn has_runtime(&self) -> bool {
-        self.executable.is_some()
-    }
-
     pub fn has_build(&self) -> bool {
         self.build.is_some()
     }
@@ -343,18 +339,6 @@ pub struct DiscoveryConfig {
     pub base_path_transform: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name_command: Option<String>,
-}
-
-impl DiscoveryConfig {
-    pub fn transform_to_base_path(&self, path: &str) -> String {
-        match self.base_path_transform.as_str() {
-            "dirname" => std::path::Path::new(path)
-                .parent()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|| path.to_string()),
-            _ => path.to_string(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/module/mod.rs
+++ b/src/core/module/mod.rs
@@ -21,9 +21,8 @@ pub use manifest::{
 // Re-export execution types and functions
 pub(crate) use execution::execute_action;
 pub use execution::{
-    build_exec_env, is_module_compatible, is_module_ready, module_ready_status, run_action,
-    run_module, run_setup, ModuleExecutionMode, ModuleReadyStatus, ModuleRunResult,
-    ModuleSetupResult, ModuleStepFilter,
+    is_module_compatible, module_ready_status, run_action, run_module, run_setup,
+    ModuleExecutionMode, ModuleReadyStatus, ModuleRunResult, ModuleSetupResult, ModuleStepFilter,
 };
 
 // Re-export scope types

--- a/src/core/ssh/client.rs
+++ b/src/core/ssh/client.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
+use crate::error::{Error, Result};
 use crate::server::Server;
 use crate::utils::shell;
 use std::process::{Command, Stdio};
@@ -15,22 +15,6 @@ pub struct CommandOutput {
     pub stderr: String,
     pub success: bool,
     pub exit_code: i32,
-}
-
-impl CommandOutput {
-    pub fn into_remote_result(self, command: &str, target: TargetDetails) -> Result<Self> {
-        if self.success {
-            return Ok(self);
-        }
-
-        Err(Error::remote_command_failed(RemoteCommandFailedDetails {
-            command: command.to_string(),
-            exit_code: self.exit_code,
-            stdout: self.stdout,
-            stderr: self.stderr,
-            target,
-        }))
-    }
 }
 
 impl SshClient {

--- a/src/core/upgrade.rs
+++ b/src/core/upgrade.rs
@@ -30,18 +30,6 @@ impl InstallMethod {
         }
     }
 
-    pub fn upgrade_instructions(&self) -> String {
-        let defaults = defaults::load_defaults();
-        match self {
-            InstallMethod::Homebrew => defaults.install_methods.homebrew.upgrade_command.clone(),
-            InstallMethod::Cargo => defaults.install_methods.cargo.upgrade_command.clone(),
-            InstallMethod::Source => defaults.install_methods.source.upgrade_command.clone(),
-            InstallMethod::Binary => defaults.install_methods.binary.upgrade_command.clone(),
-            InstallMethod::Unknown => {
-                "Please reinstall using Homebrew, Cargo, or a release binary".to_string()
-            }
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -226,10 +214,6 @@ fn version_is_newer(latest: &str, current: &str) -> bool {
         (Some(l), Some(c)) => l > c,
         _ => latest != current,
     }
-}
-
-pub fn run_upgrade(force: bool) -> Result<UpgradeResult> {
-    run_upgrade_with_method(force, None)
 }
 
 pub fn run_upgrade_with_method(

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -678,13 +678,6 @@ pub fn set_component_version(component: &Component, new_version: &str) -> Result
     })
 }
 
-/// Set version by component ID.
-pub fn set_version(component_id: Option<&str>, new_version: &str) -> Result<SetResult> {
-    let id = validation::require(component_id, "componentId", "Missing componentId")?;
-    let component = component::load(id)?;
-    set_component_version(&component, new_version)
-}
-
 /// Bump a component's version and finalize changelog.
 /// bump_type: "patch", "minor", or "major"
 pub fn bump_component_version(component: &Component, bump_type: &str) -> Result<BumpResult> {


### PR DESCRIPTION
## Summary
Systematic scan of all `pub fn` in `core/` against `commands/` usage. Found and removed 11 completely dead functions across 10 files, plus visibility narrowing.

### Dead code removed
| Function | File | LOC |
|----------|------|-----|
| `commits_to_changelog_entries` | git/commits.rs | 10 |
| `has_runtime` | module/manifest.rs | 3 |
| `into_remote_result` | ssh/client.rs | 14 |
| `pull_ff_only_interactive` | git/primitives.rs | 20 |
| `read_and_add_next_section_item` | changelog/io.rs | 17 |
| `add_next_section_item` | changelog/sections.rs | 22 |
| `run_upgrade` | upgrade.rs | 3 |
| `upgrade_instructions` | upgrade.rs | 12 |
| `set_version` | version.rs | 5 |
| `stage_files` | git/operations.rs | 6 |
| `transform_to_base_path` | module/manifest.rs | 10 |
| `is_module_ready` | module/execution.rs | 3 |

### Visibility narrowed
- `resolve_build_command`, `build_component` → `pub(crate)` (internal to core/)
- `parse_ls_output` → `fn` (private to files.rs)
- `build_exec_env`, `is_module_ready` removed from `pub` re-exports in module/mod.rs

**Net: -145 LOC across 13 files. All 301 tests pass.**