### PR TITLE
Consolidate duplicate HOMEBOY_COMPONENT_PATH env builders

### DIFF
--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::component::{self, Component};
 use crate::config::{is_json_input, parse_bulk_ids};
 use crate::error::{Error, Result};
-use crate::module;
+use crate::module::{self, exec_context};
 use crate::output::{BulkResult, BulkSummary, ItemOutcome};
 use crate::paths;
 use crate::permissions;
@@ -445,7 +445,7 @@ fn run_pre_build_scripts(comp: &Component) -> Result<Option<(i32, String)>> {
 
         let env: [(&str, &str); 3] = [
             ("HOMEBOY_MODULE_PATH", &module_path.to_string_lossy()),
-            ("HOMEBOY_COMPONENT_PATH", &comp.local_path),
+            (exec_context::COMPONENT_PATH, &comp.local_path),
             ("HOMEBOY_PLUGIN_PATH", &comp.local_path),
         ];
 
@@ -477,7 +477,7 @@ fn get_build_env_vars(comp: &Component) -> Vec<(String, String)> {
                         let module_path_str = module_path.to_string_lossy().to_string();
                         env.push(("HOMEBOY_MODULE_PATH".to_string(), module_path_str));
                         env.push((
-                            "HOMEBOY_COMPONENT_PATH".to_string(),
+                            exec_context::COMPONENT_PATH.to_string(),
                             comp.local_path.clone(),
                         ));
                         env.push(("HOMEBOY_PLUGIN_PATH".to_string(), comp.local_path.clone()));

--- a/src/core/module/exec_context.rs
+++ b/src/core/module/exec_context.rs
@@ -14,6 +14,8 @@ pub const COMPONENT_ID: &str = "HOMEBOY_COMPONENT_ID";
 pub const MODULE_PATH: &str = "HOMEBOY_MODULE_PATH";
 /// Filesystem path to the project directory (base_path).
 pub const PROJECT_PATH: &str = "HOMEBOY_PROJECT_PATH";
+/// Filesystem path to the component directory.
+pub const COMPONENT_PATH: &str = "HOMEBOY_COMPONENT_PATH";
 
 /// Run only specific steps (comma-separated). Scripts should skip steps not in this list.
 pub const STEP: &str = "HOMEBOY_STEP";


### PR DESCRIPTION
## Summary

Fixes #216 — consolidates two duplicate env builder functions into one canonical path.

## Problem

Two separate code paths built the `HOMEBOY_COMPONENT_PATH` env var:

| Builder | File | Used by | path_override? |
|---------|------|---------|----------------|
| `prepare_env_vars()` | runner.rs | test, lint | Yes (implicit) |
| `build_exec_env()` | execution.rs | module run, deploy hooks, actions | No |

They also had semantic bugs:
- `prepare_env_vars()` set `HOMEBOY_PROJECT_PATH` to the **component** path (wrong — should be project base_path)
- `build_exec_env()` re-loaded the component from storage, ignoring any `--path` override
- `HOMEBOY_COMPONENT_PATH` was a raw string literal in 5 places with no constant

## Changes

**`exec_context.rs`** — Added `COMPONENT_PATH` constant

**`execution.rs`** — Added `component_path_override: Option<&str>` parameter to `build_exec_env()`. When provided, uses it instead of re-loading from storage. Uses `exec_context::COMPONENT_PATH` constant.

**`runner.rs`** — `prepare_env_vars()` now delegates to `build_exec_env()` with the component path as `component_path_override`. No longer sets `PROJECT_PATH` to the component path (fixes the semantic bug). Removed unused `exec_context` import.

**`build.rs`** — Uses `exec_context::COMPONENT_PATH` constant instead of raw string.

## What this fixes

- Single source of truth for module env vars
- `--path` override now works correctly everywhere
- `PROJECT_PATH` no longer misused as component path in test/lint context
- All `HOMEBOY_COMPONENT_PATH` usages go through the constant

## Testing

All 301 existing tests pass. Net -4 lines of code.