### PR TITLE
Warn about unconfigured version targets during version set

### DIFF
--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -108,6 +108,8 @@ pub struct VersionSetOutput {
     changelog_changed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     git_commit: Option<GitCommitInfo>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -196,6 +198,7 @@ pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
                     changelog_finalized: result.changelog_finalized,
                     changelog_changed: result.changelog_changed,
                     git_commit,
+                    warnings: result.warnings,
                 }),
                 0,
             ))


### PR DESCRIPTION
## Summary

Closes #222.

When running `homeboy version set`, this now warns about version-defining patterns found in source files that aren't configured as version targets. These patterns will silently drift out of sync on future version changes if not tracked.

## Changes

- **`src/core/version.rs`**: After updating configured targets, calls the existing `detect_unconfigured_patterns()` to scan for untracked patterns. Emits a warning for each one with a ready-to-run `homeboy component add-version-target` command. Adds `warnings: Vec<String>` to `SetResult`.
- **`src/commands/version.rs`**: Surfaces `warnings` in `VersionSetOutput` (JSON output, skipped when empty).

## How it works

`detect_unconfigured_patterns()` already existed (used by `homeboy init`) — it scans PHP files for `define('..._VERSION', ...)` patterns not present in the component's `version_targets`. This PR reuses that function at the end of `set_component_version()` so users get actionable warnings at the moment it matters most.

## Testing

- `cargo test` — all 301 tests pass
- No new tests needed (reuses existing detection logic; output is informational warnings)