### PR TITLE
fix: pass path override to git commit and tag operations

### DIFF
--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -16,7 +16,10 @@ fn execute_git(path: &str, args: &[&str]) -> std::io::Result<std::process::Outpu
     Command::new("git").args(args).current_dir(path).output()
 }
 
-fn resolve_target(component_id: Option<&str>) -> crate::error::Result<(String, String)> {
+fn resolve_target(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+) -> crate::error::Result<(String, String)> {
     let id = component_id.ok_or_else(|| {
         Error::validation_invalid_argument(
             "componentId",
@@ -28,6 +31,11 @@ fn resolve_target(component_id: Option<&str>) -> crate::error::Result<(String, S
             ]),
         )
     })?;
-    let comp = crate::component::load(id)?;
-    Ok((id.to_string(), comp.local_path))
+    let path = if let Some(p) = path_override {
+        p.to_string()
+    } else {
+        let comp = crate::component::load(id)?;
+        comp.local_path
+    };
+    Ok((id.to_string(), path))
 }


### PR DESCRIPTION
## Summary

Fixes #225 — `version set --path` reports `success: true` but doesn't actually commit or tag.

## Root Cause

When `--path` is provided to `version set`, the version files are correctly modified in the override directory. But when `create_version_commit()` calls `commit()` and `tag()`, those functions call `resolve_target()` which reloads the component from config and uses its **stored** `local_path` — completely ignoring the `--path` override.

The git operations run in the wrong directory, find nothing to commit, and report success silently.

```
version set --path=/workspace/repo
  ├─ Modifies files in /workspace/repo          ✅
  └─ commit() / tag()
       └─ resolve_target() → component::load()
            └─ uses stored /original/path        ❌
```

## Fix

- Add `path_override: Option<&str>` parameter to `resolve_target()` that takes precedence over config lookup
- Add `commit_at()` and `tag_at()` public functions that accept the path override
- Original `commit()` and `tag()` delegate to `*_at()` with `None` — **fully backward compatible**
- `create_version_commit()` now passes `repo_root` through to `commit_at()` and `tag_at()`

## Files changed

- `src/core/git/mod.rs` — `resolve_target()` accepts `path_override`
- `src/core/git/operations.rs` — new `commit_at()`, `tag_at()`; existing callers pass `None`
- `src/commands/version.rs` — `create_version_commit()` uses `commit_at`/`tag_at` with `repo_root`

## Testing

- All 301 tests pass (286 unit + 14 command + 1 integration)
- Zero compilation warnings