### PR TITLE
fix: pass HOMEBOY_COMPONENT_ID to build scripts

### DIFF
--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -443,8 +443,9 @@ fn run_pre_build_scripts(comp: &Component) -> Result<Option<(i32, String)>> {
             continue;
         }
 
-        let env: [(&str, &str); 3] = [
+        let env: [(&str, &str); 4] = [
             ("HOMEBOY_MODULE_PATH", &module_path.to_string_lossy()),
+            (exec_context::COMPONENT_ID, &comp.id),
             (exec_context::COMPONENT_PATH, &comp.local_path),
             ("HOMEBOY_PLUGIN_PATH", &comp.local_path),
         ];
@@ -468,6 +469,12 @@ fn run_pre_build_scripts(comp: &Component) -> Result<Option<(i32, String)>> {
 /// Matches the env vars passed to pre-build scripts for consistency.
 fn get_build_env_vars(comp: &Component) -> Vec<(String, String)> {
     let mut env = Vec::new();
+
+    // Always pass the component ID so build scripts can name artifacts consistently
+    env.push((
+        exec_context::COMPONENT_ID.to_string(),
+        comp.id.clone(),
+    ));
 
     if let Some(modules) = &comp.modules {
         for module_id in modules.keys() {


### PR DESCRIPTION
## Summary

Fixes #227 — deploy fails with artifact name mismatch when component ID differs from directory name.

## Problem

`homeboy build extrachill-theme` produces `build/extrachill.zip` (named after directory), but `homeboy deploy extrachill-theme` looks for `build/extrachill-theme.zip` (named after component ID via `artifact_pattern: "build/{component_id}.zip"`).

## Root Cause

The build system passes `HOMEBOY_COMPONENT_PATH` and `HOMEBOY_MODULE_PATH` to build scripts but **not** `HOMEBOY_COMPONENT_ID`. The WordPress build script falls back to `basename $PWD` for themes, which uses the directory name instead of the component ID.

## Fix

Pass `HOMEBOY_COMPONENT_ID` (already defined as a constant in `exec_context`) to both:
- `get_build_env_vars()` — main build execution
- Pre-build script env vars

The companion PR in homeboy-modules updates the WordPress build script to use `HOMEBOY_COMPONENT_ID` when available: Extra-Chill/homeboy-modules#41

## Files changed

- `src/core/build.rs` — add `HOMEBOY_COMPONENT_ID` to build env vars

## Testing

All 301 tests pass.