### PR TITLE
feat: audit interface/trait compliance detection

### DIFF
--- a/src/core/code_audit/checks.rs
+++ b/src/core/code_audit/checks.rs
@@ -71,6 +71,7 @@ mod tests {
             glob: "*.rs".to_string(),
             expected_methods: vec!["run".to_string()],
             expected_registrations: vec![],
+            expected_interfaces: vec![],
             conforming: vec!["a.rs".to_string(), "b.rs".to_string()],
             outliers: vec![],
             total_files: 2,
@@ -88,6 +89,7 @@ mod tests {
             glob: "*.rs".to_string(),
             expected_methods: vec!["run".to_string()],
             expected_registrations: vec![],
+            expected_interfaces: vec![],
             conforming: vec!["a.rs".to_string(), "b.rs".to_string()],
             outliers: vec![Outlier {
                 file: "c.rs".to_string(),
@@ -113,6 +115,7 @@ mod tests {
             glob: "*.rs".to_string(),
             expected_methods: vec!["run".to_string()],
             expected_registrations: vec![],
+            expected_interfaces: vec![],
             conforming: vec!["a.rs".to_string()],
             outliers: vec![
                 Outlier {

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -947,6 +947,7 @@ class BadAbility {
                     "registerAbility".to_string(),
                 ],
                 expected_registrations: vec!["wp_abilities_api_init".to_string()],
+                expected_interfaces: vec![],
                 conforming: vec!["abilities/GoodAbility.php".to_string()],
                 outliers: vec![Outlier {
                     file: "abilities/BadAbility.php".to_string(),
@@ -1180,6 +1181,7 @@ class {} {{
                     "registerAbility".to_string(),
                 ],
                 expected_registrations: vec!["wp_abilities_api_init".to_string()],
+                expected_interfaces: vec![],
                 conforming: vec![
                     "abilities/CreateFlowAbility.php".to_string(),
                     "abilities/UpdateFlowAbility.php".to_string(),
@@ -1246,6 +1248,7 @@ class {} {{
                 status: CheckStatus::Fragmented,
                 expected_methods: vec!["get_job".to_string()],
                 expected_registrations: vec![],
+                expected_interfaces: vec![],
                 conforming: vec!["jobs/Jobs.php".to_string()],
                 outliers: vec![
                     Outlier {

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -57,6 +57,8 @@ pub struct ConventionReport {
     pub expected_methods: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub expected_registrations: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub expected_interfaces: Vec<String>,
     pub conforming: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub outliers: Vec<Outlier>,
@@ -159,6 +161,7 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
             status: check.status.clone(),
             expected_methods: conv.expected_methods.clone(),
             expected_registrations: conv.expected_registrations.clone(),
+            expected_interfaces: conv.expected_interfaces.clone(),
             conforming: conv.conforming.clone(),
             outliers: conv.outliers.clone(),
             total_files: conv.total_files,


### PR DESCRIPTION
## Summary

Adds interface/trait compliance checking to `homeboy audit`. If an interface appears in ≥60% of files in a directory, it becomes an expected convention. Files missing it get flagged.

- New `expected_interfaces` field on conventions
- New `MissingInterface` deviation kind
- Wires existing `FileFingerprint.implements` data into convention discovery

## Impact

Low-effort change — the fingerprinting already extracted `implements` data but never used it. This adds ~30 lines to convention discovery and the rest is plumbing + tests.

## Tests

329 total pass, 0 failures, 0 warnings. 2 new tests:
- `discover_interface_convention` — verifies detection and outlier flagging
- `no_interface_convention_when_none_shared` — verifies no false positives

Closes #242