### PR TITLE
feat: cross-directory convention detection (#243)

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -42,6 +42,8 @@ pub enum AuditOutput {
     Conventions {
         component_id: String,
         conventions: Vec<homeboy::code_audit::ConventionReport>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        directory_conventions: Vec<homeboy::code_audit::DirectoryConvention>,
     },
 
     #[serde(rename = "audit.fix")]
@@ -83,6 +85,7 @@ pub fn run(args: AuditArgs, _global: &super::GlobalArgs) -> CmdResult<AuditOutpu
             AuditOutput::Conventions {
                 component_id: result.component_id,
                 conventions: result.conventions,
+                directory_conventions: result.directory_conventions,
             },
             0,
         ));

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -286,6 +286,7 @@ mod tests {
                 alignment_score: 0.8,
             },
             conventions: vec![],
+            directory_conventions: vec![],
             findings,
         }
     }

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -498,6 +498,122 @@ pub fn auto_discover_groups(root: &Path) -> Vec<(String, String, Vec<FileFingerp
     groups
 }
 
+// ============================================================================
+// Cross-Directory Discovery
+// ============================================================================
+
+/// Discover cross-directory conventions by analyzing sibling subdirectories.
+///
+/// Groups discovered conventions by their grandparent directory, then checks
+/// if sibling subdirectories share the same expected methods/registrations.
+///
+/// Example: if `inc/Abilities/Flow/` and `inc/Abilities/Job/` both expect
+/// `execute`, `registerAbility`, `__construct` — that's a cross-directory
+/// convention for `inc/Abilities/`.
+pub fn discover_cross_directory(
+    conventions: &[super::ConventionReport],
+) -> Vec<super::DirectoryConvention> {
+    // Group conventions by their parent directory (one level up from glob)
+    let mut parent_groups: HashMap<String, Vec<&super::ConventionReport>> = HashMap::new();
+
+    for conv in conventions {
+        // Extract parent from glob: "inc/Abilities/Flow/*" → "inc/Abilities"
+        let parts: Vec<&str> = conv.glob.trim_end_matches("/*").rsplitn(2, '/').collect();
+        if parts.len() == 2 {
+            let parent = parts[1].to_string();
+            parent_groups.entry(parent).or_default().push(conv);
+        }
+    }
+
+    let mut results = Vec::new();
+
+    for (parent, child_convs) in &parent_groups {
+        if child_convs.len() < 2 {
+            continue; // Need at least 2 sibling dirs to detect a pattern
+        }
+
+        let total = child_convs.len();
+        let threshold = (total as f32 * 0.6).ceil() as usize;
+
+        // Count method frequency across sibling conventions
+        let mut method_counts: HashMap<&str, usize> = HashMap::new();
+        for conv in child_convs {
+            for method in &conv.expected_methods {
+                *method_counts.entry(method.as_str()).or_insert(0) += 1;
+            }
+        }
+
+        let expected_methods: Vec<String> = method_counts
+            .iter()
+            .filter(|(_, count)| **count >= threshold)
+            .map(|(name, _)| name.to_string())
+            .collect();
+
+        // Count registration frequency across sibling conventions
+        let mut reg_counts: HashMap<&str, usize> = HashMap::new();
+        for conv in child_convs {
+            for reg in &conv.expected_registrations {
+                *reg_counts.entry(reg.as_str()).or_insert(0) += 1;
+            }
+        }
+
+        let expected_registrations: Vec<String> = reg_counts
+            .iter()
+            .filter(|(_, count)| **count >= threshold)
+            .map(|(name, _)| name.to_string())
+            .collect();
+
+        if expected_methods.is_empty() && expected_registrations.is_empty() {
+            continue; // No shared pattern across siblings
+        }
+
+        // Classify sibling directories
+        let mut conforming_dirs = Vec::new();
+        let mut outlier_dirs = Vec::new();
+
+        for conv in child_convs {
+            let dir_name = conv.glob.trim_end_matches("/*").to_string();
+
+            let missing_methods: Vec<String> = expected_methods
+                .iter()
+                .filter(|m| !conv.expected_methods.contains(m))
+                .cloned()
+                .collect();
+
+            let missing_registrations: Vec<String> = expected_registrations
+                .iter()
+                .filter(|r| !conv.expected_registrations.contains(r))
+                .cloned()
+                .collect();
+
+            if missing_methods.is_empty() && missing_registrations.is_empty() {
+                conforming_dirs.push(dir_name);
+            } else {
+                outlier_dirs.push(super::DirectoryOutlier {
+                    dir: dir_name,
+                    missing_methods,
+                    missing_registrations,
+                });
+            }
+        }
+
+        let confidence = conforming_dirs.len() as f32 / total as f32;
+
+        results.push(super::DirectoryConvention {
+            parent: parent.clone(),
+            expected_methods,
+            expected_registrations,
+            conforming_dirs,
+            outlier_dirs,
+            total_dirs: total,
+            confidence,
+        });
+    }
+
+    results.sort_by(|a, b| a.parent.cmp(&b.parent));
+    results
+}
+
 /// Walk source files under a root, skipping common non-source directories.
 fn walk_source_files(root: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
     let skip_dirs = [
@@ -773,5 +889,159 @@ register_rest_route('api/v1', '/data', []);
 
         // No interface appears in ≥60% of files
         assert!(convention.expected_interfaces.is_empty());
+    }
+
+    // ========================================================================
+    // Cross-directory convention tests
+    // ========================================================================
+
+    use super::super::checks::CheckStatus;
+    use super::super::ConventionReport;
+
+    fn make_convention(
+        name: &str,
+        glob: &str,
+        methods: &[&str],
+        registrations: &[&str],
+    ) -> ConventionReport {
+        ConventionReport {
+            name: name.to_string(),
+            glob: glob.to_string(),
+            status: CheckStatus::Clean,
+            expected_methods: methods.iter().map(|s| s.to_string()).collect(),
+            expected_registrations: registrations.iter().map(|s| s.to_string()).collect(),
+            expected_interfaces: vec![],
+            conforming: vec![],
+            outliers: vec![],
+            total_files: 3,
+            confidence: 1.0,
+        }
+    }
+
+    #[test]
+    fn cross_directory_detects_shared_methods() {
+        let conventions = vec![
+            make_convention("Flow", "inc/Abilities/Flow/*", &["execute", "__construct", "registerAbility"], &[]),
+            make_convention("Job", "inc/Abilities/Job/*", &["execute", "__construct", "registerAbility"], &[]),
+            make_convention("Data", "inc/Abilities/Data/*", &["execute", "__construct", "registerAbility"], &[]),
+        ];
+
+        let results = discover_cross_directory(&conventions);
+
+        assert_eq!(results.len(), 1);
+        let result = &results[0];
+        assert_eq!(result.parent, "inc/Abilities");
+        assert!(result.expected_methods.contains(&"execute".to_string()));
+        assert!(result.expected_methods.contains(&"__construct".to_string()));
+        assert!(result.expected_methods.contains(&"registerAbility".to_string()));
+        assert_eq!(result.conforming_dirs.len(), 3);
+        assert!(result.outlier_dirs.is_empty());
+        assert_eq!(result.total_dirs, 3);
+        assert!((result.confidence - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cross_directory_detects_outlier_missing_method() {
+        let conventions = vec![
+            make_convention("Flow", "inc/Abilities/Flow/*", &["execute", "__construct", "registerAbility"], &[]),
+            make_convention("Job", "inc/Abilities/Job/*", &["execute", "__construct", "registerAbility"], &[]),
+            make_convention("Data", "inc/Abilities/Data/*", &["execute", "__construct"], &[]), // missing registerAbility
+        ];
+
+        let results = discover_cross_directory(&conventions);
+
+        assert_eq!(results.len(), 1);
+        let result = &results[0];
+        assert_eq!(result.conforming_dirs.len(), 2);
+        assert_eq!(result.outlier_dirs.len(), 1);
+        assert_eq!(result.outlier_dirs[0].dir, "inc/Abilities/Data");
+        assert!(result.outlier_dirs[0].missing_methods.contains(&"registerAbility".to_string()));
+    }
+
+    #[test]
+    fn cross_directory_needs_at_least_two_siblings() {
+        // Only one subdirectory — no cross-directory convention possible
+        let conventions = vec![
+            make_convention("Flow", "inc/Abilities/Flow/*", &["execute", "__construct"], &[]),
+        ];
+
+        let results = discover_cross_directory(&conventions);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn cross_directory_skips_when_no_shared_methods() {
+        // Sibling directories have completely different method sets
+        let conventions = vec![
+            make_convention("Flow", "inc/Modules/Flow/*", &["run_flow", "validate_flow"], &[]),
+            make_convention("Job", "inc/Modules/Job/*", &["dispatch_job", "cancel_job"], &[]),
+        ];
+
+        let results = discover_cross_directory(&conventions);
+        // No method appears in ≥60% of siblings (each appears in 1 of 2 = 50%)
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn cross_directory_threshold_allows_partial_overlap() {
+        // 3 of 4 siblings share "execute" (75% > 60% threshold) — should detect
+        let conventions = vec![
+            make_convention("A", "app/Services/A/*", &["execute", "validate"], &[]),
+            make_convention("B", "app/Services/B/*", &["execute", "validate"], &[]),
+            make_convention("C", "app/Services/C/*", &["execute", "validate"], &[]),
+            make_convention("D", "app/Services/D/*", &["process"], &[]), // outlier
+        ];
+
+        let results = discover_cross_directory(&conventions);
+
+        assert_eq!(results.len(), 1);
+        let result = &results[0];
+        assert!(result.expected_methods.contains(&"execute".to_string()));
+        assert!(result.expected_methods.contains(&"validate".to_string()));
+        assert_eq!(result.conforming_dirs.len(), 3);
+        assert_eq!(result.outlier_dirs.len(), 1);
+        assert_eq!(result.outlier_dirs[0].dir, "app/Services/D");
+    }
+
+    #[test]
+    fn cross_directory_includes_shared_registrations() {
+        let conventions = vec![
+            make_convention("Flow", "inc/Abilities/Flow/*", &["execute"], &["wp_abilities_api_init"]),
+            make_convention("Job", "inc/Abilities/Job/*", &["execute"], &["wp_abilities_api_init"]),
+        ];
+
+        let results = discover_cross_directory(&conventions);
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].expected_registrations.contains(&"wp_abilities_api_init".to_string()));
+    }
+
+    #[test]
+    fn cross_directory_separate_parents_produce_separate_conventions() {
+        let conventions = vec![
+            make_convention("Flow", "inc/Abilities/Flow/*", &["execute", "register"], &[]),
+            make_convention("Job", "inc/Abilities/Job/*", &["execute", "register"], &[]),
+            make_convention("Auth", "inc/Middleware/Auth/*", &["handle", "boot"], &[]),
+            make_convention("Cache", "inc/Middleware/Cache/*", &["handle", "boot"], &[]),
+        ];
+
+        let results = discover_cross_directory(&conventions);
+
+        assert_eq!(results.len(), 2);
+        let parents: Vec<&str> = results.iter().map(|r| r.parent.as_str()).collect();
+        assert!(parents.contains(&"inc/Abilities"));
+        assert!(parents.contains(&"inc/Middleware"));
+    }
+
+    #[test]
+    fn cross_directory_ignores_top_level_globs() {
+        // Glob "steps/*" has no parent directory — rsplitn won't find 2 parts
+        let conventions = vec![
+            make_convention("Steps", "steps/*", &["execute"], &[]),
+            make_convention("Jobs", "jobs/*", &["execute"], &[]),
+        ];
+
+        let results = discover_cross_directory(&conventions);
+        assert!(results.is_empty()); // These aren't siblings under a common parent
     }
 }

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -973,6 +973,7 @@ class BadAbility {
                 confidence: 0.5,
             }],
             findings: vec![],
+            directory_conventions: vec![],
         };
 
         let fix_result = generate_fixes(&audit_result, &dir);
@@ -1211,6 +1212,7 @@ class {} {{
                 confidence: 0.75,
             }],
             findings: vec![],
+            directory_conventions: vec![],
         };
 
         let fix_result = generate_fixes(&audit_result, &dir);
@@ -1272,6 +1274,7 @@ class {} {{
                 confidence: 0.33,
             }],
             findings: vec![],
+            directory_conventions: vec![],
         };
 
         let fix_result = generate_fixes(&audit_result, &dir);


### PR DESCRIPTION
## Summary

Closes #243

Adds Phase 6 to the audit pipeline: cross-directory convention detection. Analyzes sibling subdirectories under shared parent directories to discover higher-level architectural patterns that span multiple subdirectories.

## How it works

- Groups existing per-directory conventions by their parent directory (e.g., `inc/Abilities/Chat/*`, `inc/Abilities/Flow/*` → parent `inc/Abilities`)
- Applies a 60% frequency threshold to identify methods/registrations shared across siblings
- Classifies each subdirectory as conforming or outlier based on the cross-directory convention
- Outliers include details about which methods/registrations they're missing

## Testing against Data Machine

Found 5 cross-directory patterns:

| Parent | Siblings | Shared Pattern | Outliers | Confidence |
|--------|----------|---------------|----------|------------|
| `inc/Abilities` | 10 | `execute`, `registerAbility`, `__construct`, `wp_abilities_api_init` | 3 (Analytics, Content, Fetch) | 70% |
| `inc/Core` | 2 | `__construct` | 0 | 100% |
| `tests/Unit` | 2 | `set_up` | 0 | 100% |
| `tests/Unit/AI` | 2 | `set_up` | 0 | 100% |
| React modals | 2 | `export default` | 0 | 100% |

## Changes

- **`mod.rs`**: Add `DirectoryConvention`, `DirectoryOutlier` structs; `directory_conventions` field on `CodeAuditResult`; Phase 6 in pipeline
- **`conventions.rs`**: Add `discover_cross_directory()` function + 8 unit tests
- **`fixer.rs`**: Add `directory_conventions: vec![]` to 3 test constructors
- **`audit.rs` (CLI)**: Include `directory_conventions` in `--conventions` output

335 tests pass, release build zero warnings.