### PR TITLE
feat: method signature consistency checking (#244)

### DIFF
--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -71,17 +71,18 @@ pub struct FixResult {
 
 /// Full method signature extracted from a conforming file.
 #[derive(Debug, Clone)]
-struct MethodSignature {
+pub(super) struct MethodSignature {
     /// Method name.
-    name: String,
+    pub(super) name: String,
     /// Full signature line (e.g., "public function execute(array $config): array").
-    signature: String,
+    pub(super) signature: String,
     /// The language this was extracted from.
-    language: Language,
+    #[allow(dead_code)]
+    pub(super) language: Language,
 }
 
 /// Extract full method signatures from a source file.
-fn extract_signatures(content: &str, language: &Language) -> Vec<MethodSignature> {
+pub(super) fn extract_signatures(content: &str, language: &Language) -> Vec<MethodSignature> {
     match language {
         Language::Php => extract_php_signatures(content),
         Language::Rust => extract_rust_signatures(content),

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -173,6 +173,9 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
         }
     }
 
+    // Phase 2b: Check signature consistency within conventions
+    conventions::check_signature_consistency(&mut discovered_conventions, root);
+
     // Phase 3: Check all conventions
     let check_results = checks::check_conventions(&discovered_conventions);
 


### PR DESCRIPTION
## Summary

Closes #244

Adds method signature consistency checking to the audit pipeline. Currently the audit detects method **presence** but not method **shape**. This adds detection for files that have the expected methods but with different signatures (missing type hints, wrong visibility, different parameters).

## How it works

- For each convention, reads all conforming files and extracts full method signatures using the existing `extract_signatures()` from fixer.rs (now `pub(super)`)
- Builds canonical signatures by majority vote (most common signature wins)
- Compares all files (conforming + outliers) against the canonical signatures
- Files with mismatches get a `SignatureMismatch` deviation and are moved from conforming to outlier
- Existing outliers with signature mismatches get the deviation appended

## Testing against Data Machine

Found 3 real signature mismatches:

| Convention | File | Issue |
|-----------|------|-------|
| FilesRepository | `WorkspaceReader.php` | Constructor takes `Workspace $workspace` param vs parameterless |
| FilesRepository | `WorkspaceWriter.php` | Same — dependency-injected while others aren't |
| System | `SystemAgent.php` | `private function __construct()` vs `public function __construct()` (singleton pattern) |

## Changes

- **`conventions.rs`**: Add `SignatureMismatch` to `DeviationKind`, add `PartialEq` derive, add `check_signature_consistency()` function + 5 tests
- **`fixer.rs`**: Make `MethodSignature` and `extract_signatures` `pub(super)` for reuse
- **`mod.rs`**: Wire as Phase 2b in pipeline

**Note**: Stacked on #243 (cross-directory). 340 tests pass, release build zero warnings.