### PR TITLE
feat: namespace and import convention detection (#245)

### DIFF
--- a/src/core/code_audit/checks.rs
+++ b/src/core/code_audit/checks.rs
@@ -72,6 +72,8 @@ mod tests {
             expected_methods: vec!["run".to_string()],
             expected_registrations: vec![],
             expected_interfaces: vec![],
+            expected_namespace: None,
+            expected_imports: vec![],
             conforming: vec!["a.rs".to_string(), "b.rs".to_string()],
             outliers: vec![],
             total_files: 2,
@@ -90,6 +92,8 @@ mod tests {
             expected_methods: vec!["run".to_string()],
             expected_registrations: vec![],
             expected_interfaces: vec![],
+            expected_namespace: None,
+            expected_imports: vec![],
             conforming: vec!["a.rs".to_string(), "b.rs".to_string()],
             outliers: vec![Outlier {
                 file: "c.rs".to_string(),
@@ -116,6 +120,8 @@ mod tests {
             expected_methods: vec!["run".to_string()],
             expected_registrations: vec![],
             expected_interfaces: vec![],
+            expected_namespace: None,
+            expected_imports: vec![],
             conforming: vec!["a.rs".to_string()],
             outliers: vec![
                 Outlier {

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -949,6 +949,8 @@ class BadAbility {
                 ],
                 expected_registrations: vec!["wp_abilities_api_init".to_string()],
                 expected_interfaces: vec![],
+                expected_namespace: None,
+                expected_imports: vec![],
                 conforming: vec!["abilities/GoodAbility.php".to_string()],
                 outliers: vec![Outlier {
                     file: "abilities/BadAbility.php".to_string(),
@@ -1184,6 +1186,8 @@ class {} {{
                 ],
                 expected_registrations: vec!["wp_abilities_api_init".to_string()],
                 expected_interfaces: vec![],
+                expected_namespace: None,
+                expected_imports: vec![],
                 conforming: vec![
                     "abilities/CreateFlowAbility.php".to_string(),
                     "abilities/UpdateFlowAbility.php".to_string(),
@@ -1252,6 +1256,8 @@ class {} {{
                 expected_methods: vec!["get_job".to_string()],
                 expected_registrations: vec![],
                 expected_interfaces: vec![],
+                expected_namespace: None,
+                expected_imports: vec![],
                 conforming: vec!["jobs/Jobs.php".to_string()],
                 outliers: vec![
                     Outlier {

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -95,6 +95,10 @@ pub struct ConventionReport {
     pub expected_registrations: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub expected_interfaces: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_namespace: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub expected_imports: Vec<String>,
     pub conforming: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub outliers: Vec<Outlier>,
@@ -202,6 +206,8 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
             expected_methods: conv.expected_methods.clone(),
             expected_registrations: conv.expected_registrations.clone(),
             expected_interfaces: conv.expected_interfaces.clone(),
+            expected_namespace: conv.expected_namespace.clone(),
+            expected_imports: conv.expected_imports.clone(),
             conforming: conv.conforming.clone(),
             outliers: conv.outliers.clone(),
             total_files: conv.total_files,


### PR DESCRIPTION
## Summary

- Adds namespace declaration and import/use statement extraction to the code audit fingerprinting system (PHP, Rust, JS/TS)
- Convention discovery now detects expected namespaces (majority wins) and expected imports (frequency threshold ≥60%), flagging mismatches and missing imports as deviations
- New `DeviationKind` variants: `NamespaceMismatch`, `MissingImport`; new `Convention` fields: `expected_namespace`, `expected_imports`

## Details

This is the 5th and final audit enhancement (#245), completing the batch (#241–#245). Replaces #250 which had stacking issues from pre-squash-merge commits.

**What it detects:**
- PHP files in the same directory with different `namespace` declarations
- PHP files missing a namespace when siblings all have one
- Missing `use` statements that most sibling files share
- JS/TS files missing common `import` statements
- Rust files missing common `use` declarations

**Tests:** 6 new tests covering PHP namespace extraction, JS import extraction, namespace mismatch detection, missing import detection, and missing namespace detection. All 356 tests pass.

Closes #245