### PR TITLE
fix: include field and problem in validation error messages (#258)

### DIFF
--- a/src/core/engine/pipeline.rs
+++ b/src/core/engine/pipeline.rs
@@ -616,7 +616,7 @@ fn execute_single_step(
             missing: Vec::new(),
             warnings: Vec::new(),
             hints: err.hints.clone(),
-            data: None,
+            data: Some(serde_json::json!({ "error_details": err.details })),
             error: Some(err.message.clone()),
         }),
     }

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -272,16 +272,19 @@ impl Error {
         id: Option<String>,
         tried: Option<Vec<String>>,
     ) -> Self {
+        let field_str = field.into();
+        let problem_str = problem.into();
+        let message = format!("Invalid argument '{}': {}", field_str, problem_str);
         let details = to_details(InvalidArgumentDetails {
-            field: field.into(),
-            problem: problem.into(),
+            field: field_str,
+            problem: problem_str,
             id,
             tried,
         });
 
         Self::new(
             ErrorCode::ValidationInvalidArgument,
-            "Invalid argument",
+            message,
             details,
         )
     }


### PR DESCRIPTION
## Summary

- **`validation_invalid_argument` errors now include the field name and problem in the message** instead of just "Invalid argument". Before: `"error": "Invalid argument"`. After: `"error": "Invalid argument 'version': Invalid version format: 0.12.8"`.
- **Pipeline step failures now preserve error details** in the step `data` field, so the full error context (field, problem, tried values) is visible in release/bump output.

## Problem

`version bump` was failing with just `"error": "Invalid argument"` — no indication of which argument or what was wrong. The actual problem details were in a `details` JSON object that the pipeline executor dropped when converting errors to step results.

Closes #258