### PR TITLE
Surface post-release hook failures to stderr with non-zero exit code

### DIFF
--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -231,6 +231,14 @@ pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
             } else {
                 let run_result = release::run(&component_id, &options)?;
                 super::release::display_release_summary(&run_result);
+
+                // Exit code 3 when post-release hooks failed (matches `release` command behavior)
+                let exit_code = if super::release::has_post_release_warnings(&run_result) {
+                    3
+                } else {
+                    0
+                };
+
                 Ok((
                     VersionOutput::Bump(VersionBumpOutput {
                         command: "version.bump".to_string(),
@@ -240,7 +248,7 @@ pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
                         plan: None,
                         run: Some(run_result),
                     }),
-                    0,
+                    exit_code,
                 ))
             }
         }


### PR DESCRIPTION
## Summary

- `display_release_summary()` now prints step-level warnings and hints to stderr via `log_status!` — post-release hook failures (e.g. `cargo publish`) are no longer buried in JSON
- Exit code **3** when release succeeded but post-release hooks failed (distinct from 1 = release failure)
- Applied to both `homeboy release` and `homeboy version bump`
- JSON output unchanged — warnings/hints were already in step data, they just weren't surfaced to stderr

Closes #255