### PR TITLE
Normalize command module conventions (CmdResult, run signature, CliArgs)

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -33,7 +33,7 @@ pub struct CleanupOutput {
     pub hints: Vec<String>,
 }
 
-pub fn run_json(args: CleanupArgs) -> CmdResult<CleanupOutput> {
+pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<CleanupOutput> {
     let severity_filter = args.severity.as_deref();
     let category_filter = args.category.as_deref();
 

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -3,21 +3,21 @@ use serde::Serialize;
 
 use super::CmdResult;
 
-#[derive(Serialize)]
+pub struct CliArgs {
+    pub tool: String,
+    pub identifier: String,
+    pub args: Vec<String>,
+}
 
+#[derive(Serialize)]
 pub struct CliOutput {
     pub command: String,
     #[serde(flatten)]
     pub result: CliToolResult,
 }
 
-pub fn run(
-    tool: &str,
-    identifier: &str,
-    args: Vec<String>,
-    _global: &crate::commands::GlobalArgs,
-) -> CmdResult<CliOutput> {
-    let result = cli_tool::run(tool, identifier, &args)?;
+pub fn run(args: CliArgs, _global: &super::GlobalArgs) -> CmdResult<CliOutput> {
+    let result = cli_tool::run(&args.tool, &args.identifier, &args.args)?;
     let exit_code = result.exit_code;
 
     Ok((

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -5,6 +5,8 @@ use homeboy::db::{self, DbResult, DbTunnelResult};
 use homeboy::project;
 use homeboy::token;
 
+use super::CmdResult;
+
 #[derive(Args)]
 pub struct DbArgs {
     #[command(subcommand)]
@@ -103,7 +105,7 @@ pub enum DbResultVariant {
 pub fn run(
     args: DbArgs,
     _global: &crate::commands::GlobalArgs,
-) -> homeboy::Result<(DbOutput, i32)> {
+) -> CmdResult<DbOutput> {
     match args.command {
         DbCommand::Tables { project_id, args } => tables(&project_id, &args),
         DbCommand::Describe { project_id, args } => describe(&project_id, &args),
@@ -156,7 +158,7 @@ fn parse_subtarget(
     Ok((None, args.to_vec()))
 }
 
-fn tables(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i32)> {
+fn tables(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     let (subtarget, _) = parse_subtarget(project_id, args)?;
     let result = db::list_tables(project_id, subtarget.as_deref())?;
     let exit_code = result.exit_code;
@@ -170,7 +172,7 @@ fn tables(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i32)>
     ))
 }
 
-fn describe(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i32)> {
+fn describe(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     let (subtarget, remaining) = parse_subtarget(project_id, args)?;
 
     // Core validates table_name
@@ -187,7 +189,7 @@ fn describe(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i32
     ))
 }
 
-fn query(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i32)> {
+fn query(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     let (subtarget, remaining) = parse_subtarget(project_id, args)?;
     let sql = remaining.join(" ");
 
@@ -211,7 +213,7 @@ fn search(
     exact: bool,
     limit: Option<u32>,
     subtarget: Option<&str>,
-) -> homeboy::Result<(DbOutput, i32)> {
+) -> CmdResult<DbOutput> {
     let result = db::search(project_id, table, column, pattern, exact, limit, subtarget)?;
     let exit_code = result.exit_code;
 
@@ -224,7 +226,7 @@ fn search(
     ))
 }
 
-fn delete_row(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i32)> {
+fn delete_row(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     let (subtarget, remaining) = parse_subtarget(project_id, args)?;
 
     // Core validates table_name and row_id
@@ -242,7 +244,7 @@ fn delete_row(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i
     ))
 }
 
-fn drop_table(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i32)> {
+fn drop_table(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     let (subtarget, remaining) = parse_subtarget(project_id, args)?;
 
     // Core validates table_name
@@ -259,7 +261,7 @@ fn drop_table(project_id: &str, args: &[String]) -> homeboy::Result<(DbOutput, i
     ))
 }
 
-fn tunnel(project_id: &str, local_port: Option<u16>) -> homeboy::Result<(DbOutput, i32)> {
+fn tunnel(project_id: &str, local_port: Option<u16>) -> CmdResult<DbOutput> {
     let result = db::create_tunnel(project_id, local_port)?;
     let exit_code = result.exit_code;
 

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -3,6 +3,8 @@ use serde::Serialize;
 
 use homeboy::files::{self, FileEntry, GrepMatch, LineChange};
 
+use super::CmdResult;
+
 #[derive(Args)]
 pub struct FileArgs {
     #[command(subcommand)]
@@ -253,7 +255,7 @@ pub fn is_raw_read(args: &FileArgs) -> bool {
 pub fn run(
     args: FileArgs,
     _global: &crate::commands::GlobalArgs,
-) -> homeboy::Result<(FileCommandOutput, i32)> {
+) -> CmdResult<FileCommandOutput> {
     match args.command {
         FileCommand::List { project_id, path } => {
             let (out, code) = list(&project_id, &path)?;
@@ -353,7 +355,7 @@ pub fn run(
     }
 }
 
-fn list(project_id: &str, path: &str) -> homeboy::Result<(FileOutput, i32)> {
+fn list(project_id: &str, path: &str) -> CmdResult<FileOutput> {
     let result = files::list(project_id, path)?;
 
     Ok((
@@ -377,7 +379,7 @@ fn list(project_id: &str, path: &str) -> homeboy::Result<(FileOutput, i32)> {
     ))
 }
 
-fn read(project_id: &str, path: &str) -> homeboy::Result<(FileOutput, i32)> {
+fn read(project_id: &str, path: &str) -> CmdResult<FileOutput> {
     let result = files::read(project_id, path)?;
 
     Ok((
@@ -401,7 +403,7 @@ fn read(project_id: &str, path: &str) -> homeboy::Result<(FileOutput, i32)> {
     ))
 }
 
-fn write(project_id: &str, path: &str) -> homeboy::Result<(FileOutput, i32)> {
+fn write(project_id: &str, path: &str) -> CmdResult<FileOutput> {
     let content = files::read_stdin()?;
     let result = files::write(project_id, path, &content)?;
 
@@ -426,7 +428,7 @@ fn write(project_id: &str, path: &str) -> homeboy::Result<(FileOutput, i32)> {
     ))
 }
 
-fn delete(project_id: &str, path: &str, recursive: bool) -> homeboy::Result<(FileOutput, i32)> {
+fn delete(project_id: &str, path: &str, recursive: bool) -> CmdResult<FileOutput> {
     let result = files::delete(project_id, path, recursive)?;
 
     Ok((
@@ -450,7 +452,7 @@ fn delete(project_id: &str, path: &str, recursive: bool) -> homeboy::Result<(Fil
     ))
 }
 
-fn rename(project_id: &str, old_path: &str, new_path: &str) -> homeboy::Result<(FileOutput, i32)> {
+fn rename(project_id: &str, old_path: &str, new_path: &str) -> CmdResult<FileOutput> {
     let result = files::rename(project_id, old_path, new_path)?;
 
     Ok((
@@ -480,7 +482,7 @@ fn find(
     name_pattern: Option<&str>,
     file_type: Option<&str>,
     max_depth: Option<u32>,
-) -> homeboy::Result<(FileFindOutput, i32)> {
+) -> CmdResult<FileFindOutput> {
     let result = files::find(project_id, path, name_pattern, file_type, max_depth)?;
     let match_count = result.matches.len();
 
@@ -505,7 +507,7 @@ fn grep(
     name_filter: Option<&str>,
     max_depth: Option<u32>,
     case_insensitive: bool,
-) -> homeboy::Result<(FileGrepOutput, i32)> {
+) -> CmdResult<FileGrepOutput> {
     let result = files::grep(
         project_id,
         path,
@@ -530,7 +532,7 @@ fn grep(
     ))
 }
 
-fn edit(args: EditArgs) -> homeboy::Result<(FileEditOutput, i32)> {
+fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
     let EditArgs {
         project_id,
         file_path,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -215,7 +215,7 @@ pub struct ComponentWithState {
     pub gaps: Vec<ComponentGap>,
 }
 
-pub fn run_json(args: InitArgs) -> CmdResult<InitOutput> {
+pub fn run(args: InitArgs, _global: &super::GlobalArgs) -> CmdResult<InitOutput> {
     // Get context for current directory
     let (context_output, _) = context::run(None)?;
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -120,7 +120,7 @@ fn resolve_lint_script(component: &Component) -> homeboy::error::Result<String> 
         })
 }
 
-pub fn run_json(args: LintArgs) -> CmdResult<LintOutput> {
+pub fn run(args: LintArgs, _global: &super::GlobalArgs) -> CmdResult<LintOutput> {
     let mut component = component::load(&args.component)?;
     if let Some(ref path) = args.path {
         component.local_path = path.clone();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -302,9 +302,6 @@ pub(crate) fn run_markdown(
 
 /// Dispatch a command to its handler and map result to JSON.
 macro_rules! dispatch {
-    ($args:expr, $module:ident) => {
-        crate::output::map_cmd_result_to_json($module::run_json($args))
-    };
     ($args:expr, $global:expr, $module:ident) => {
         crate::output::map_cmd_result_to_json($module::run($args, $global))
     };
@@ -317,14 +314,12 @@ pub(crate) fn run_json(
     crate::tty::status("homeboy is working...");
 
     match command {
-        // Commands without global context
-        crate::Commands::Init(args) => dispatch!(args, init),
-        crate::Commands::Status(args) => dispatch!(args, status),
-        crate::Commands::Test(args) => dispatch!(args, test),
-        crate::Commands::Lint(args) => dispatch!(args, lint),
-        crate::Commands::Cleanup(args) => dispatch!(args, cleanup),
-
-        // Commands with global context
+        // All commands use global context
+        crate::Commands::Init(args) => dispatch!(args, global, init),
+        crate::Commands::Status(args) => dispatch!(args, global, status),
+        crate::Commands::Test(args) => dispatch!(args, global, test),
+        crate::Commands::Lint(args) => dispatch!(args, global, lint),
+        crate::Commands::Cleanup(args) => dispatch!(args, global, cleanup),
         crate::Commands::Project(args) => dispatch!(args, global, project),
         crate::Commands::Ssh(args) => dispatch!(args, global, ssh),
         crate::Commands::Server(args) => dispatch!(args, global, server),

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use homeboy::server::{self, Server};
 use homeboy::{EntityCrudOutput, MergeOutput};
 
-use super::DynamicSetArgs;
+use super::{CmdResult, DynamicSetArgs};
 
 /// Entity-specific fields for server commands.
 #[derive(Debug, Default, Serialize)]
@@ -119,7 +119,7 @@ enum KeyCommand {
 pub fn run(
     args: ServerArgs,
     _global: &crate::commands::GlobalArgs,
-) -> homeboy::Result<(ServerOutput, i32)> {
+) -> CmdResult<ServerOutput> {
     match args.command {
         ServerCommand::Create {
             json,
@@ -203,7 +203,7 @@ pub fn run(
     }
 }
 
-fn run_key(args: KeyArgs) -> homeboy::Result<(ServerOutput, i32)> {
+fn run_key(args: KeyArgs) -> CmdResult<ServerOutput> {
     match args.command {
         KeyCommand::Generate { server_id } => key_generate(&server_id),
         KeyCommand::Show { server_id } => key_show(&server_id),
@@ -219,7 +219,7 @@ fn run_key(args: KeyArgs) -> homeboy::Result<(ServerOutput, i32)> {
     }
 }
 
-fn show(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
+fn show(server_id: &str) -> CmdResult<ServerOutput> {
     let svr = server::load(server_id)
         .or_else(|original_error| server::find_by_host(server_id).ok_or(original_error))?;
 
@@ -234,7 +234,7 @@ fn show(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
     ))
 }
 
-fn set(args: DynamicSetArgs) -> homeboy::Result<(ServerOutput, i32)> {
+fn set(args: DynamicSetArgs) -> CmdResult<ServerOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
         homeboy::Error::validation_invalid_argument(
             "spec",
@@ -273,7 +273,7 @@ fn set(args: DynamicSetArgs) -> homeboy::Result<(ServerOutput, i32)> {
     }
 }
 
-fn delete(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
+fn delete(server_id: &str) -> CmdResult<ServerOutput> {
     server::delete_safe(server_id)?;
 
     Ok((
@@ -287,7 +287,7 @@ fn delete(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
     ))
 }
 
-fn list() -> homeboy::Result<(ServerOutput, i32)> {
+fn list() -> CmdResult<ServerOutput> {
     let servers = server::list()?;
 
     Ok((
@@ -300,7 +300,7 @@ fn list() -> homeboy::Result<(ServerOutput, i32)> {
     ))
 }
 
-fn key_generate(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
+fn key_generate(server_id: &str) -> CmdResult<ServerOutput> {
     let result = server::generate_key(server_id)?;
 
     Ok((
@@ -324,7 +324,7 @@ fn key_generate(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
     ))
 }
 
-fn key_show(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
+fn key_show(server_id: &str) -> CmdResult<ServerOutput> {
     let public_key = server::get_public_key(server_id)?;
 
     Ok((
@@ -346,7 +346,7 @@ fn key_show(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
     ))
 }
 
-fn key_use(server_id: &str, private_key_path: &str) -> homeboy::Result<(ServerOutput, i32)> {
+fn key_use(server_id: &str, private_key_path: &str) -> CmdResult<ServerOutput> {
     let server = server::use_key(server_id, private_key_path)?;
     let identity_file = server.identity_file.clone();
 
@@ -371,7 +371,7 @@ fn key_use(server_id: &str, private_key_path: &str) -> homeboy::Result<(ServerOu
     ))
 }
 
-fn key_unset(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
+fn key_unset(server_id: &str) -> CmdResult<ServerOutput> {
     let server = server::unset_key(server_id)?;
 
     Ok((
@@ -395,7 +395,7 @@ fn key_unset(server_id: &str) -> homeboy::Result<(ServerOutput, i32)> {
     ))
 }
 
-fn key_import(server_id: &str, private_key_path: &str) -> homeboy::Result<(ServerOutput, i32)> {
+fn key_import(server_id: &str, private_key_path: &str) -> CmdResult<ServerOutput> {
     let result = server::import_key(server_id, private_key_path)?;
 
     Ok((

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -46,7 +46,7 @@ pub struct StatusOutput {
     pub clean: usize,
 }
 
-pub fn run_json(args: StatusArgs) -> CmdResult<StatusOutput> {
+pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusOutput> {
     let (context_output, _) = context::run(None)?;
 
     let relevant_ids: std::collections::HashSet<String> = context_output

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -119,7 +119,7 @@ fn resolve_test_script(component: &Component) -> homeboy::error::Result<String> 
         })
 }
 
-pub fn run_json(args: TestArgs) -> CmdResult<TestOutput> {
+pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput> {
     let mut component = component::load(&args.component)?;
     if let Some(ref path) = args.path {
         component.local_path = path.clone();

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -195,7 +195,7 @@ pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
 
 
 
-pub fn show_version_output(component_id: &str) -> homeboy::Result<(VersionShowOutput, i32)> {
+pub fn show_version_output(component_id: &str) -> CmdResult<VersionShowOutput> {
     let info = read_version(Some(component_id))?;
 
     Ok((

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,12 +254,12 @@ fn main() -> std::process::ExitCode {
     let global = GlobalArgs {};
 
     if let Some(module_cmd) = try_parse_module_cli_command(&matches, &module_info) {
-        let result = cli::run(
-            &module_cmd.tool,
-            &module_cmd.project_id,
-            module_cmd.args,
-            &global,
-        );
+        let cli_args = cli::CliArgs {
+            tool: module_cmd.tool,
+            identifier: module_cmd.project_id,
+            args: module_cmd.args,
+        };
+        let result = cli::run(cli_args, &global);
 
         let (json_result, exit_code) = output::map_cmd_result_to_json(result);
         output::print_json_result(json_result).ok();


### PR DESCRIPTION
## Summary

- **CmdResult<T>** type alias used consistently across all command modules (was raw `homeboy::Result<(T, i32)>` in db, file, server, project, version) — closes #279
- **run_json → run** unified dispatch pattern — all 5 modules (init, status, test, lint, cleanup) now use `run(args, _global)` like every other command, 2-arg dispatch macro removed — closes #278
- **cli.rs normalized** — wraps raw params in `CliArgs` struct so `cli::run()` matches the standard signature convention — closes #280

All changes are mechanical normalization caught by `homeboy audit homeboy` dogfooding (round 3). Tests pass, compilation clean.