### PR TITLE
feat: extension versioning, version constraints, and auto-update checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.49.1"
+version = "0.50.1"
 dependencies = [
  "arboard",
  "base64",

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -55,6 +55,9 @@ pub struct Component {
     pub remote_path: String,
     pub build_artifact: Option<String>,
     pub modules: Option<HashMap<String, ScopedModuleConfig>>,
+    /// Extension version requirements: module_id -> version constraint string.
+    /// Example: `{"wordpress": ">=2.0.0", "php": "^1.0"}`
+    pub extensions: Option<HashMap<String, String>>,
     pub version_targets: Option<Vec<VersionTarget>>,
     pub changelog_target: Option<String>,
     pub changelog_next_section_label: Option<String>,
@@ -92,6 +95,8 @@ struct RawComponent {
     build_artifact: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     modules: Option<HashMap<String, ScopedModuleConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extensions: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     version_targets: Option<Vec<VersionTarget>>,
     #[serde(skip_serializing_if = "Option::is_none", alias = "changelog_targets")]
@@ -156,6 +161,7 @@ impl From<RawComponent> for Component {
             remote_path: raw.remote_path,
             build_artifact: raw.build_artifact,
             modules: raw.modules,
+            extensions: raw.extensions,
             version_targets: raw.version_targets,
             changelog_target: raw.changelog_target,
             changelog_next_section_label: raw.changelog_next_section_label,
@@ -182,6 +188,7 @@ impl From<Component> for RawComponent {
             remote_path: c.remote_path,
             build_artifact: c.build_artifact,
             modules: c.modules,
+            extensions: c.extensions,
             version_targets: c.version_targets,
             changelog_target: c.changelog_target,
             changelog_next_section_label: c.changelog_next_section_label,
@@ -251,6 +258,7 @@ impl Component {
             remote_path,
             build_artifact,
             modules: None,
+            extensions: None,
             version_targets: None,
             changelog_target: None,
             changelog_next_section_label: None,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -21,6 +21,7 @@ pub mod git;
 pub mod hooks;
 pub mod logs;
 pub mod module;
+pub mod module_update_check;
 pub mod output;
 pub mod project;
 pub mod release;

--- a/src/core/module/version.rs
+++ b/src/core/module/version.rs
@@ -1,0 +1,422 @@
+//! Version constraint parsing and matching for module/extension versioning.
+//!
+//! Supports semver version constraints used in component configs to declare
+//! required extension versions:
+//!
+//! - Exact: `1.2.3` — must match exactly
+//! - Caret: `^1.2.3` — compatible updates (>=1.2.3, <2.0.0)
+//! - Tilde: `~1.2.3` — patch-level updates (>=1.2.3, <1.3.0)
+//! - Greater/equal: `>=1.2.3`
+//! - Greater: `>1.2.3`
+//! - Less/equal: `<=1.2.3`
+//! - Less: `<1.2.3`
+//! - Wildcard: `*` — any version
+
+use crate::error::{Error, Result};
+use semver::Version;
+
+/// A parsed version constraint that can check whether a given version satisfies it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionConstraint {
+    /// Any version matches.
+    Any,
+    /// Must match exactly.
+    Exact(Version),
+    /// `^major.minor.patch` — compatible updates.
+    /// ^1.2.3 means >=1.2.3, <2.0.0
+    /// ^0.2.3 means >=0.2.3, <0.3.0
+    /// ^0.0.3 means >=0.0.3, <0.0.4
+    Caret(Version),
+    /// `~major.minor.patch` — patch-level updates.
+    /// ~1.2.3 means >=1.2.3, <1.3.0
+    Tilde(Version),
+    /// `>=version`
+    GreaterEqual(Version),
+    /// `>version`
+    Greater(Version),
+    /// `<=version`
+    LessEqual(Version),
+    /// `<version`
+    Less(Version),
+}
+
+impl VersionConstraint {
+    /// Parse a version constraint string.
+    ///
+    /// Examples: `">=1.0.0"`, `"^2.0"`, `"~1.5"`, `"1.2.3"`, `"*"`
+    pub fn parse(input: &str) -> Result<Self> {
+        let input = input.trim();
+
+        if input == "*" {
+            return Ok(VersionConstraint::Any);
+        }
+
+        if let Some(rest) = input.strip_prefix(">=") {
+            let v = parse_version(rest.trim(), input)?;
+            return Ok(VersionConstraint::GreaterEqual(v));
+        }
+
+        if let Some(rest) = input.strip_prefix('>') {
+            let v = parse_version(rest.trim(), input)?;
+            return Ok(VersionConstraint::Greater(v));
+        }
+
+        if let Some(rest) = input.strip_prefix("<=") {
+            let v = parse_version(rest.trim(), input)?;
+            return Ok(VersionConstraint::LessEqual(v));
+        }
+
+        if let Some(rest) = input.strip_prefix('<') {
+            let v = parse_version(rest.trim(), input)?;
+            return Ok(VersionConstraint::Less(v));
+        }
+
+        if let Some(rest) = input.strip_prefix('^') {
+            let v = parse_version(rest.trim(), input)?;
+            return Ok(VersionConstraint::Caret(v));
+        }
+
+        if let Some(rest) = input.strip_prefix('~') {
+            let v = parse_version(rest.trim(), input)?;
+            return Ok(VersionConstraint::Tilde(v));
+        }
+
+        // No prefix — exact match
+        let v = parse_version(input, input)?;
+        Ok(VersionConstraint::Exact(v))
+    }
+
+    /// Check if a version satisfies this constraint.
+    pub fn matches(&self, version: &Version) -> bool {
+        match self {
+            VersionConstraint::Any => true,
+            VersionConstraint::Exact(v) => version == v,
+            VersionConstraint::GreaterEqual(v) => version >= v,
+            VersionConstraint::Greater(v) => version > v,
+            VersionConstraint::LessEqual(v) => version <= v,
+            VersionConstraint::Less(v) => version < v,
+            VersionConstraint::Caret(v) => caret_matches(v, version),
+            VersionConstraint::Tilde(v) => tilde_matches(v, version),
+        }
+    }
+}
+
+impl std::fmt::Display for VersionConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VersionConstraint::Any => write!(f, "*"),
+            VersionConstraint::Exact(v) => write!(f, "{}", v),
+            VersionConstraint::GreaterEqual(v) => write!(f, ">={}", v),
+            VersionConstraint::Greater(v) => write!(f, ">{}", v),
+            VersionConstraint::LessEqual(v) => write!(f, "<={}", v),
+            VersionConstraint::Less(v) => write!(f, "<{}", v),
+            VersionConstraint::Caret(v) => write!(f, "^{}", v),
+            VersionConstraint::Tilde(v) => write!(f, "~{}", v),
+        }
+    }
+}
+
+/// Parse a potentially partial version string (e.g. "1", "1.2", "1.2.3").
+fn parse_version(s: &str, original_input: &str) -> Result<Version> {
+    let s = s.trim();
+
+    // Try parsing as-is first
+    if let Ok(v) = Version::parse(s) {
+        return Ok(v);
+    }
+
+    // Try padding partial versions: "1" -> "1.0.0", "1.2" -> "1.2.0"
+    let parts: Vec<&str> = s.split('.').collect();
+    let padded = match parts.len() {
+        1 => format!("{}.0.0", s),
+        2 => format!("{}.0", s),
+        _ => s.to_string(),
+    };
+
+    Version::parse(&padded).map_err(|e| {
+        Error::validation_invalid_argument(
+            "version_constraint",
+            format!("Invalid version in constraint '{}': {}", original_input, e),
+            Some(original_input.to_string()),
+            None,
+        )
+    })
+}
+
+/// Caret matching: ^X.Y.Z
+/// - ^1.2.3 := >=1.2.3, <2.0.0
+/// - ^0.2.3 := >=0.2.3, <0.3.0
+/// - ^0.0.3 := >=0.0.3, <0.0.4
+fn caret_matches(constraint: &Version, version: &Version) -> bool {
+    if version < constraint {
+        return false;
+    }
+
+    if constraint.major != 0 {
+        // ^1.2.3: same major, anything else goes
+        version.major == constraint.major
+    } else if constraint.minor != 0 {
+        // ^0.2.3: same major + minor
+        version.major == constraint.major && version.minor == constraint.minor
+    } else {
+        // ^0.0.3: exact match on all three
+        version.major == constraint.major
+            && version.minor == constraint.minor
+            && version.patch == constraint.patch
+    }
+}
+
+/// Tilde matching: ~X.Y.Z
+/// - ~1.2.3 := >=1.2.3, <1.3.0
+fn tilde_matches(constraint: &Version, version: &Version) -> bool {
+    if version < constraint {
+        return false;
+    }
+    version.major == constraint.major && version.minor == constraint.minor
+}
+
+/// Parse a module's version string, returning a useful error if invalid.
+pub fn parse_module_version(version_str: &str, module_id: &str) -> Result<Version> {
+    Version::parse(version_str).map_err(|e| {
+        Error::validation_invalid_argument(
+            "version",
+            format!(
+                "Module '{}' has invalid semver version '{}': {}",
+                module_id, version_str, e
+            ),
+            Some(version_str.to_string()),
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    // ========================================================================
+    // Parsing
+    // ========================================================================
+
+    #[test]
+    fn parse_exact() {
+        let c = VersionConstraint::parse("1.2.3").unwrap();
+        assert_eq!(c, VersionConstraint::Exact(v("1.2.3")));
+    }
+
+    #[test]
+    fn parse_wildcard() {
+        let c = VersionConstraint::parse("*").unwrap();
+        assert_eq!(c, VersionConstraint::Any);
+    }
+
+    #[test]
+    fn parse_caret() {
+        let c = VersionConstraint::parse("^1.2.3").unwrap();
+        assert_eq!(c, VersionConstraint::Caret(v("1.2.3")));
+    }
+
+    #[test]
+    fn parse_caret_partial() {
+        let c = VersionConstraint::parse("^2.0").unwrap();
+        assert_eq!(c, VersionConstraint::Caret(v("2.0.0")));
+    }
+
+    #[test]
+    fn parse_tilde() {
+        let c = VersionConstraint::parse("~1.5").unwrap();
+        assert_eq!(c, VersionConstraint::Tilde(v("1.5.0")));
+    }
+
+    #[test]
+    fn parse_gte() {
+        let c = VersionConstraint::parse(">=1.0.0").unwrap();
+        assert_eq!(c, VersionConstraint::GreaterEqual(v("1.0.0")));
+    }
+
+    #[test]
+    fn parse_gt() {
+        let c = VersionConstraint::parse(">2.0.0").unwrap();
+        assert_eq!(c, VersionConstraint::Greater(v("2.0.0")));
+    }
+
+    #[test]
+    fn parse_lte() {
+        let c = VersionConstraint::parse("<=3.0.0").unwrap();
+        assert_eq!(c, VersionConstraint::LessEqual(v("3.0.0")));
+    }
+
+    #[test]
+    fn parse_lt() {
+        let c = VersionConstraint::parse("<1.0.0").unwrap();
+        assert_eq!(c, VersionConstraint::Less(v("1.0.0")));
+    }
+
+    #[test]
+    fn parse_with_spaces() {
+        let c = VersionConstraint::parse(">= 1.0.0 ").unwrap();
+        assert_eq!(c, VersionConstraint::GreaterEqual(v("1.0.0")));
+    }
+
+    #[test]
+    fn parse_single_number() {
+        let c = VersionConstraint::parse("^2").unwrap();
+        assert_eq!(c, VersionConstraint::Caret(v("2.0.0")));
+    }
+
+    #[test]
+    fn parse_invalid_version() {
+        assert!(VersionConstraint::parse(">=abc").is_err());
+    }
+
+    // ========================================================================
+    // Matching — Exact
+    // ========================================================================
+
+    #[test]
+    fn exact_matches_same() {
+        let c = VersionConstraint::Exact(v("1.2.3"));
+        assert!(c.matches(&v("1.2.3")));
+    }
+
+    #[test]
+    fn exact_rejects_different() {
+        let c = VersionConstraint::Exact(v("1.2.3"));
+        assert!(!c.matches(&v("1.2.4")));
+        assert!(!c.matches(&v("1.3.0")));
+        assert!(!c.matches(&v("2.0.0")));
+    }
+
+    // ========================================================================
+    // Matching — Wildcard
+    // ========================================================================
+
+    #[test]
+    fn any_matches_everything() {
+        let c = VersionConstraint::Any;
+        assert!(c.matches(&v("0.0.0")));
+        assert!(c.matches(&v("999.999.999")));
+    }
+
+    // ========================================================================
+    // Matching — Caret
+    // ========================================================================
+
+    #[test]
+    fn caret_major_nonzero() {
+        let c = VersionConstraint::Caret(v("1.2.3"));
+        assert!(c.matches(&v("1.2.3")));
+        assert!(c.matches(&v("1.2.4")));
+        assert!(c.matches(&v("1.3.0")));
+        assert!(c.matches(&v("1.99.99")));
+        assert!(!c.matches(&v("2.0.0")));
+        assert!(!c.matches(&v("1.2.2")));
+        assert!(!c.matches(&v("0.9.0")));
+    }
+
+    #[test]
+    fn caret_minor_nonzero() {
+        let c = VersionConstraint::Caret(v("0.2.3"));
+        assert!(c.matches(&v("0.2.3")));
+        assert!(c.matches(&v("0.2.4")));
+        assert!(c.matches(&v("0.2.99")));
+        assert!(!c.matches(&v("0.3.0")));
+        assert!(!c.matches(&v("0.2.2")));
+        assert!(!c.matches(&v("1.0.0")));
+    }
+
+    #[test]
+    fn caret_all_zero() {
+        let c = VersionConstraint::Caret(v("0.0.3"));
+        assert!(c.matches(&v("0.0.3")));
+        assert!(!c.matches(&v("0.0.4")));
+        assert!(!c.matches(&v("0.0.2")));
+        assert!(!c.matches(&v("0.1.0")));
+    }
+
+    // ========================================================================
+    // Matching — Tilde
+    // ========================================================================
+
+    #[test]
+    fn tilde_allows_patch() {
+        let c = VersionConstraint::Tilde(v("1.2.3"));
+        assert!(c.matches(&v("1.2.3")));
+        assert!(c.matches(&v("1.2.4")));
+        assert!(c.matches(&v("1.2.99")));
+        assert!(!c.matches(&v("1.3.0")));
+        assert!(!c.matches(&v("1.2.2")));
+        assert!(!c.matches(&v("2.0.0")));
+    }
+
+    // ========================================================================
+    // Matching — Comparison operators
+    // ========================================================================
+
+    #[test]
+    fn gte_matches() {
+        let c = VersionConstraint::GreaterEqual(v("1.0.0"));
+        assert!(c.matches(&v("1.0.0")));
+        assert!(c.matches(&v("1.0.1")));
+        assert!(c.matches(&v("2.0.0")));
+        assert!(!c.matches(&v("0.9.9")));
+    }
+
+    #[test]
+    fn gt_matches() {
+        let c = VersionConstraint::Greater(v("1.0.0"));
+        assert!(!c.matches(&v("1.0.0")));
+        assert!(c.matches(&v("1.0.1")));
+    }
+
+    #[test]
+    fn lte_matches() {
+        let c = VersionConstraint::LessEqual(v("1.0.0"));
+        assert!(c.matches(&v("1.0.0")));
+        assert!(c.matches(&v("0.9.9")));
+        assert!(!c.matches(&v("1.0.1")));
+    }
+
+    #[test]
+    fn lt_matches() {
+        let c = VersionConstraint::Less(v("1.0.0"));
+        assert!(!c.matches(&v("1.0.0")));
+        assert!(c.matches(&v("0.9.9")));
+    }
+
+    // ========================================================================
+    // Display
+    // ========================================================================
+
+    #[test]
+    fn display_roundtrip() {
+        let cases = vec!["*", "1.2.3", ">=1.0.0", ">1.0.0", "<=1.0.0", "<1.0.0", "^1.2.3", "~1.2.3"];
+        for case in cases {
+            let c = VersionConstraint::parse(case).unwrap();
+            let displayed = c.to_string();
+            let reparsed = VersionConstraint::parse(&displayed).unwrap();
+            assert_eq!(c, reparsed, "roundtrip failed for '{}'", case);
+        }
+    }
+
+    // ========================================================================
+    // Module version parsing
+    // ========================================================================
+
+    #[test]
+    fn parse_module_version_valid() {
+        let v = parse_module_version("1.2.3", "test-module").unwrap();
+        assert_eq!(v, Version::new(1, 2, 3));
+    }
+
+    #[test]
+    fn parse_module_version_invalid() {
+        let err = parse_module_version("not-a-version", "test-module").unwrap_err();
+        assert!(err.message.contains("test-module"));
+        assert!(err.message.contains("not-a-version"));
+    }
+}

--- a/src/core/module_update_check.rs
+++ b/src/core/module_update_check.rs
@@ -1,0 +1,180 @@
+//! Startup module update check — warns users when installed modules have updates available.
+//!
+//! Same pattern as the CLI update check (`update_check.rs`):
+//! - Check on first run of the day (24h cache)
+//! - Print notice to stderr if any module has updates
+//! - `homeboy module update <name>` to apply
+//!
+//! Shares the disable mechanisms with CLI update check:
+//! - `HOMEBOY_NO_UPDATE_CHECK=1`
+//! - `homeboy config set /update_check false`
+
+use crate::module;
+use crate::paths;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CACHE_FILENAME: &str = "module_update_check.json";
+const CHECK_INTERVAL_SECS: u64 = 86400; // 24 hours
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleUpdateCache {
+    /// Module ID -> number of commits behind
+    pub modules_behind: HashMap<String, usize>,
+    pub checked_at: u64,
+}
+
+fn cache_path() -> Option<std::path::PathBuf> {
+    paths::homeboy().ok().map(|p| p.join(CACHE_FILENAME))
+}
+
+fn read_cache() -> Option<ModuleUpdateCache> {
+    let path = cache_path()?;
+    let content = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn write_cache(cache: &ModuleUpdateCache) {
+    let Some(path) = cache_path() else { return };
+    let Ok(content) = serde_json::to_string_pretty(cache) else {
+        return;
+    };
+    let _ = std::fs::write(&path, content);
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn is_cache_fresh(cache: &ModuleUpdateCache) -> bool {
+    let elapsed = now_unix().saturating_sub(cache.checked_at);
+    elapsed < CHECK_INTERVAL_SECS
+}
+
+fn is_disabled_by_env() -> bool {
+    std::env::var("HOMEBOY_NO_UPDATE_CHECK")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn is_disabled_by_config() -> bool {
+    !crate::defaults::load_config().update_check
+}
+
+fn print_module_hints(modules_behind: &HashMap<String, usize>) {
+    if modules_behind.is_empty() {
+        return;
+    }
+
+    if modules_behind.len() == 1 {
+        let (id, count) = modules_behind.iter().next().unwrap();
+        log_status!(
+            "update",
+            "Module '{}' has {} new commit{}. Run `homeboy module update {}` to update.",
+            id,
+            count,
+            if *count == 1 { "" } else { "s" },
+            id
+        );
+    } else {
+        let names: Vec<&String> = modules_behind.keys().collect();
+        log_status!(
+            "update",
+            "{} modules have updates: {}. Run `homeboy module update <name>` to update.",
+            modules_behind.len(),
+            names
+                .iter()
+                .map(|n| n.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+}
+
+/// Run the startup module update check. Prints hints to stderr if updates are available.
+///
+/// Silently returns on any error. Call from main.rs alongside the CLI update check.
+pub fn run_startup_check() {
+    if is_disabled_by_env() || is_disabled_by_config() {
+        return;
+    }
+
+    let mut already_printed = false;
+
+    // Read cache — if it has updates, print hint immediately
+    let cached = read_cache();
+
+    if let Some(ref cache) = cached {
+        if !cache.modules_behind.is_empty() {
+            print_module_hints(&cache.modules_behind);
+            already_printed = true;
+        }
+
+        if is_cache_fresh(cache) {
+            return;
+        }
+    }
+
+    // Cache stale or missing — check all modules
+    let module_ids = module::available_module_ids();
+    let mut modules_behind: HashMap<String, usize> = HashMap::new();
+
+    for id in &module_ids {
+        if let Some(update) = module::check_update_available(id) {
+            modules_behind.insert(update.module_id, update.behind_count);
+        }
+    }
+
+    // Write refreshed cache
+    write_cache(&ModuleUpdateCache {
+        modules_behind: modules_behind.clone(),
+        checked_at: now_unix(),
+    });
+
+    // Print hint if updates found and we haven't already
+    if !already_printed && !modules_behind.is_empty() {
+        print_module_hints(&modules_behind);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_freshness_within_24h() {
+        let cache = ModuleUpdateCache {
+            modules_behind: HashMap::new(),
+            checked_at: now_unix() - 100,
+        };
+        assert!(is_cache_fresh(&cache));
+    }
+
+    #[test]
+    fn cache_stale_after_24h() {
+        let cache = ModuleUpdateCache {
+            modules_behind: HashMap::new(),
+            checked_at: now_unix() - CHECK_INTERVAL_SECS - 1,
+        };
+        assert!(!is_cache_fresh(&cache));
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let mut behind = HashMap::new();
+        behind.insert("wordpress".to_string(), 3);
+        let cache = ModuleUpdateCache {
+            modules_behind: behind,
+            checked_at: 1700000000,
+        };
+        let json = serde_json::to_string(&cache).unwrap();
+        let parsed: ModuleUpdateCache = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.modules_behind.len(), 1);
+        assert_eq!(parsed.modules_behind["wordpress"], 3);
+        assert_eq!(parsed.checked_at, 1700000000);
+    }
+}

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -9,7 +9,6 @@ use crate::utils::{io, parser, validation};
 use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,9 +271,10 @@ fn main() -> std::process::ExitCode {
         Err(e) => e.exit(),
     };
 
-    // Startup update check — skip for upgrade/update commands (they handle this themselves)
+    // Startup update checks — skip for upgrade/update commands (they handle this themselves)
     if !matches!(&cli.command, Commands::Upgrade(_) | Commands::Update(_)) {
         homeboy::update_check::run_startup_check();
+        homeboy::module_update_check::run_startup_check();
     }
 
     let mode = response_mode(&cli.command);


### PR DESCRIPTION
## Summary

Implements #285 — extension versioning and auto-update infrastructure.

- **Version constraint parsing** (`src/core/module/version.rs`) — supports `>=1.0.0`, `^2.0`, `~1.5`, exact, `>`, `<`, `<=`, and `*` with full semver via the `semver` crate. 26 tests covering parsing, matching, display roundtrip.
- **`provides` field on module manifests** — declares `file_extensions` and `capabilities` a module handles (foundation for #286 language extractors)
- **`extensions` field on component config** — version-constrained dependency declarations like `{"wordpress": ">=2.0.0", "php": "^1.0"}`
- **`validate_extension_requirements()`** — runtime enforcement that refuses to proceed when requirements aren't met, with actionable error messages and install/update hints
- **Module auto-update check** (`src/core/module_update_check.rs`) — runs at startup alongside CLI update check, 24h cache, prints stderr notice when modules have updates available
- **`homeboy module update --all`** — update every installed module at once, with `--force` flag and version change reporting (`old_version` → `new_version`)
- **Cleanup** — removed unused `HashSet` import from `version.rs` (zero warnings)

## Testing

430 tests pass, 0 failures, 0 warnings.

Closes #285