### PR TITLE
feat: detect naming collisions in refactor rename (#292)

### DIFF
--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -7,5 +7,5 @@ mod rename;
 
 pub use rename::{
     find_references, generate_renames, apply_renames, CaseVariant,
-    FileEdit, FileRename, Reference, RenameResult, RenameScope, RenameSpec,
+    FileEdit, FileRename, Reference, RenameResult, RenameScope, RenameSpec, RenameWarning,
 };


### PR DESCRIPTION
## Summary

Adds collision detection to `homeboy refactor rename` that warns when a rename would create duplicate identifiers or overwrite existing files.

Closes #292

## What it detects

### 1. File rename collisions
When a rename target already exists on disk:
```json
{"kind": "file_collision", "file": "new.rs", "message": "Rename target 'new.rs' already exists on disk (from 'old.rs')"}
```

### 2. Duplicate identifiers in struct/block scope
When a rename creates two fields with the same name at the same indentation level:
```json
{"kind": "duplicate_identifier", "file": "component.rs", "line": 60, "message": "Duplicate identifier 'extensions' at line 60 (first at line 57)"}
```

This catches the exact bug from #284 where `modules` → `extensions` collided with an existing `extensions` field.

## How it works

- `detect_collisions()` runs at the end of `generate_renames()`, before returning results
- `detect_duplicate_identifiers()` scans edited content by indentation blocks, parsing struct field declarations
- `extract_field_identifier()` handles `pub`/`pub(crate)`/`let`/`fn`/`const` patterns
- Warnings appear in JSON output (`warnings` array) and are printed to stderr
- Non-blocking: `--write` still applies changes, but logs warnings first

## Tests

5 new tests covering:
- `extract_field_identifier_works` — identifier parsing from various declaration styles
- `detect_duplicate_identifiers_catches_collision` — duplicate fields detected
- `detect_duplicate_identifiers_no_false_positive` — distinct fields pass clean
- `collision_detection_file_rename_target_exists` — file target exists on disk
- `collision_detection_in_generate_renames` — full integration test simulating the #284 bug

430 tests total, 0 failures, 0 warnings.