### PR TITLE
fix: rename HOMEBOY_MODULE env vars to HOMEBOY_EXTENSION

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -722,8 +722,8 @@ fn exec_extension_tool(
 
     let env = vec![
         ("PATH", enriched_path.as_str()),
-        ("HOMEBOY_MODULE_PATH", extension_path),
-        ("HOMEBOY_MODULE_ID", extension_id),
+        (homeboy::extension::exec_context::EXTENSION_PATH, extension_path),
+        (homeboy::extension::exec_context::EXTENSION_ID, extension_id),
     ];
 
     let command = args.join(" ");

--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -444,7 +444,7 @@ fn run_pre_build_scripts(comp: &Component) -> Result<Option<(i32, String)>> {
         }
 
         let env: [(&str, &str); 4] = [
-            ("HOMEBOY_MODULE_PATH", &extension_path.to_string_lossy()),
+            (exec_context::EXTENSION_PATH, &extension_path.to_string_lossy()),
             (exec_context::COMPONENT_ID, &comp.id),
             (exec_context::COMPONENT_PATH, &comp.local_path),
             ("HOMEBOY_PLUGIN_PATH", &comp.local_path),
@@ -482,7 +482,7 @@ fn get_build_env_vars(comp: &Component) -> Vec<(String, String)> {
                 if extension.build.is_some() {
                     if let Ok(extension_path) = paths::extension(extension_id) {
                         let extension_path_str = extension_path.to_string_lossy().to_string();
-                        env.push(("HOMEBOY_MODULE_PATH".to_string(), extension_path_str));
+                        env.push((exec_context::EXTENSION_PATH.to_string(), extension_path_str));
                         env.push((
                             exec_context::COMPONENT_PATH.to_string(),
                             comp.local_path.clone(),

--- a/src/core/extension/exec_context.rs
+++ b/src/core/extension/exec_context.rs
@@ -3,7 +3,7 @@
 /// Version of the exec context protocol. Extensions can check this for compatibility.
 pub const VERSION: &str = "HOMEBOY_EXEC_CONTEXT_VERSION";
 /// ID of the extension being executed.
-pub const EXTENSION_ID: &str = "HOMEBOY_MODULE_ID";
+pub const EXTENSION_ID: &str = "HOMEBOY_EXTENSION_ID";
 /// JSON-serialized settings (merged from app, project, and component levels).
 pub const SETTINGS_JSON: &str = "HOMEBOY_SETTINGS_JSON";
 /// Project ID (only set when extension requires project context).
@@ -11,7 +11,7 @@ pub const PROJECT_ID: &str = "HOMEBOY_PROJECT_ID";
 /// Component ID (only set when extension requires component context).
 pub const COMPONENT_ID: &str = "HOMEBOY_COMPONENT_ID";
 /// Filesystem path to the extension directory.
-pub const EXTENSION_PATH: &str = "HOMEBOY_MODULE_PATH";
+pub const EXTENSION_PATH: &str = "HOMEBOY_EXTENSION_PATH";
 /// Filesystem path to the project directory (base_path).
 pub const PROJECT_PATH: &str = "HOMEBOY_PROJECT_PATH";
 /// Filesystem path to the component directory.


### PR DESCRIPTION
## Summary

Renames the environment variable contract from `HOMEBOY_MODULE_PATH` / `HOMEBOY_MODULE_ID` to `HOMEBOY_EXTENSION_PATH` / `HOMEBOY_EXTENSION_ID`.

These survived the #284 rename because they were hardcoded strings rather than derived from the module/extension concept, and the exec_context constants used the old names.

## Changes

- `src/core/extension/exec_context.rs` — constants updated
- `src/core/build.rs` — replaced hardcoded strings with constants
- `src/commands/extension.rs` — replaced hardcoded strings with constants

Companion commit in homeboy-extensions repo updates the build scripts.

## Tests

430 pass, 0 failures, 0 warnings.