### PR TITLE
fix: Dogfood pipeline fixes and cleanup (#320, #321, #323, #318)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,249 @@
+# Config Structures
+
+## Configuration
+
+### `ScopedExtensionConfig`
+
+- `version` — Version constraint string (e.g., ">=2.0.0", "^1.0").
+- `settings` — Settings passed to the extension at runtime.
+
+### `GitDeployConfig`
+
+- `remote`
+- `branch`
+- `post_pull` — Commands to run after git pull (e.g., "composer install", "npm run build")
+- `tag_pattern` — Pull a specific tag instead of branch HEAD (e.g., "v{{version}}")
+
+### `TestConfig`
+
+- `name`
+- `description`
+- `tags`
+- `extensions`
+
+### `HomeboyConfig`
+
+- `defaults`
+- `update_check` — Enable automatic update check on startup (default: true). Disable with `homeboy config set /update_check false` or set HOMEBOY_NO_UPDATE_CHECK=1.
+
+### `InstallMethodsConfig`
+
+- `homebrew`
+- `cargo`
+- `source`
+- `binary`
+
+### `InstallMethodConfig`
+
+- `path_patterns`
+- `upgrade_command`
+- `list_command`
+
+### `VersionCandidateConfig`
+
+- `file`
+- `pattern`
+
+### `DeployConfig`
+
+- `scp_flags`
+- `artifact_prefix`
+- `default_ssh_port`
+
+### `PermissionsConfig`
+
+- `local`
+- `remote`
+
+### `ProvidesConfig`
+
+- `file_extensions` — File extensions this extension can process (e.g., ["php", "inc"]).
+- `capabilities` — Capabilities this extension supports (e.g., ["fingerprint", "refactor"]).
+
+### `ScriptsConfig`
+
+- `fingerprint` — Script that extracts structural fingerprints from source files. Receives file content on stdin, outputs FileFingerprint JSON on stdout.
+- `refactor` — Script that applies refactoring edits to source files. Receives edit instructions on stdin, outputs transformed content on stdout.
+
+### `RequirementsConfig`
+
+- `extensions`
+- `components`
+
+### `DatabaseConfig`
+
+- `cli`
+
+### `DatabaseCliConfig`
+
+- `tables_command`
+- `describe_command`
+- `query_command`
+
+### `CliHelpConfig`
+
+- `project_id_help`
+- `args_help`
+- `examples`
+
+### `CliConfig`
+
+- `tool`
+- `display_name`
+- `command_template`
+- `default_cli_path`
+- `working_dir_template`
+- `settings_flags`
+- `help`
+
+### `DiscoveryConfig`
+
+- `find_command`
+- `base_path_transform`
+- `display_name_command`
+
+### `VersionPatternConfig`
+
+- `extension`
+- `pattern`
+
+### `SinceTagConfig`
+
+- `extensions` — File extensions to scan (e.g., [".php"]).
+- `placeholder_pattern` — Regex pattern matching placeholder versions in `@since` tags. Default: `0\.0\.0|NEXT|TBD|TODO|UNRELEASED|x\.x\.x`
+
+### `BuildConfig`
+
+- `artifact_extensions`
+- `script_names`
+- `command_template`
+- `extension_script`
+- `pre_build_script`
+- `artifact_pattern` — Default artifact path pattern with template support. Supports: {component_id}, {local_path}
+- `cleanup_paths` — Paths to clean up after successful deploy (e.g., node_modules, vendor, target)
+
+### `LintConfig`
+
+- `extension_script`
+
+### `RuntimeConfig`
+
+- `runtime_type` — Desktop app runtime type (python/shell/cli). CLI ignores this field.
+- `run_command` — Shell command to execute when running the extension. Template variables: {{entrypoint}}, {{args}}, {{extensionPath}}, plus project context vars.
+- `setup_command` — Shell command to set up the extension (e.g., create venv, install deps).
+- `ready_check` — Shell command to check if extension is ready. Exit 0 = ready.
+- `env` — Environment variables to set when running the extension.
+- `entrypoint` — Entry point file (used in template substitution).
+- `args` — Default args template (used in template substitution).
+- `default_site` — Default site for this extension (used by some CLI extensions).
+- `dependencies` — Desktop app: Python dependencies to install.
+- `playwright_browsers` — Desktop app: Playwright browsers to install.
+
+### `InputConfig`
+
+- `id`
+- `input_type`
+- `label`
+- `placeholder`
+- `default`
+- `min`
+- `max`
+- `options`
+- `arg`
+
+### `OutputConfig`
+
+- `schema`
+- `display`
+- `selectable`
+
+### `ActionConfig`
+
+- `id`
+- `label`
+- `action_type`
+- `endpoint`
+- `method`
+- `requires_auth`
+- `payload`
+- `command`
+- `builtin` — Builtin action type (Desktop app only). CLI parses but does not execute.
+- `column` — Column identifier for copy-column builtin action.
+
+### `SettingConfig`
+
+- `id`
+- `setting_type`
+- `label`
+- `placeholder`
+- `default`
+
+### `RemoteFileConfig`
+
+- `pinned_files`
+
+### `RemoteLogConfig`
+
+- `pinned_logs`
+
+### `ApiConfig`
+
+- `enabled`
+- `base_url`
+- `auth`
+
+### `AuthConfig`
+
+- `header`
+- `variables`
+- `login`
+- `refresh`
+
+### `AuthFlowConfig`
+
+- `endpoint`
+- `method`
+- `body`
+- `store`
+
+### `ToolsConfig`
+
+- `bandcamp_scraper`
+- `newsletter`
+
+### `BandcampScraperConfig`
+
+- `default_tag`
+
+### `NewsletterConfig`
+
+- `sendy_list_id`
+
+## Manifests
+
+### `ExtensionManifest`
+
+- `id`
+- `name`
+- `version`
+- `provides`
+- `scripts`
+- `icon`
+- `description`
+- `author`
+- `homepage`
+- `source_url`
+- `deploy`
+- `audit`
+- `executable`
+- `platform`
+- `cli`
+- `build`
+- `lint`
+- `test`
+- `actions`
+- `hooks`
+- `settings`
+- `requires`
+- `extra`
+- `extension_path`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,660 @@
+# CLI Commands
+
+## Commands
+
+- `homeboy` — 
+
+## Command Arguments
+
+### `ApiArgs`
+
+- `project_id` — Project ID
+- `command`
+
+### `AuditArgs`
+
+- `component_id` — Component ID or direct filesystem path to audit
+- `conventions` — Only show discovered conventions (skip findings)
+- `fix` — Generate fix stubs for outlier files (dry run by default)
+- `write` — Apply fixes to disk (requires --fix)
+- `baseline` — Save current audit state as baseline for future comparisons
+- `ignore_baseline` — Skip baseline comparison even if a baseline exists
+
+### `AuthArgs`
+
+- `command`
+
+### `BuildArgs`
+
+- `json` — JSON input spec for bulk operations: {"componentIds": ["id1", "id2"]}
+- `target_id` — Target ID: component ID or project ID (when using --all)
+- `component_ids` — Additional component IDs (enables project/component order detection)
+- `all` — Build all components in the project
+- `path` — Override local_path for this build (use a workspace clone or temp checkout)
+
+### `ChangelogArgs`
+
+- `show_self` — Show Homeboy's own changelog (release notes)
+- `command`
+
+### `ChangesArgs`
+
+- `target_id` — Target ID: component ID (single mode) or project ID (if followed by component IDs)
+- `component_ids` — Component IDs to filter (when target_id is a project)
+- `project` — Show changes for all components in a project (alternative to positional project mode)
+- `json` — JSON input spec for bulk operations: {"componentIds": ["id1", "id2"]}
+- `since` — Compare against specific tag instead of latest
+- `git_diffs` — Include commit range diff in output (uncommitted diff is always included)
+
+### `CleanupArgs`
+
+- `component_id` — Component to check (omit for all components)
+- `severity` — Show only issues of a specific severity: error, warning, info
+- `category` — Show only issues in a specific category: local_path, remote_path, version_targets, extensions
+
+### `CliArgs`
+
+- `tool`
+- `identifier`
+- `args`
+
+### `ComponentArgs`
+
+- `command`
+
+### `ConfigArgs`
+
+- `command`
+
+### `DbArgs`
+
+- `command`
+
+### `DeployArgs`
+
+- `target_id` — Target ID: project ID or component ID (order is auto-detected)
+- `component_ids` — Additional component IDs (enables project/component order detection)
+- `project` — Explicit project ID (takes precedence over positional detection)
+- `component` — Explicit component IDs (takes precedence over positional)
+- `json` — JSON input spec for bulk operations
+- `all` — Deploy all configured components
+- `outdated` — Deploy only outdated components
+- `dry_run` — Preview what would be deployed without executing
+- `check` — Check component status without building or deploying
+- `force` — Deploy even with uncommitted changes
+- `projects` — Deploy to multiple projects (comma-separated or repeated)
+- `fleet` — Deploy to all projects in a fleet
+- `shared` — Deploy to all projects using the specified component(s)
+- `keep_deps` — Keep build dependencies (skip post-deploy cleanup)
+
+### `DocsArgs`
+
+- `command`
+- `topic` — Topic path (e.g., 'commands/deploy') or 'list' to show available topics
+
+### `ExtensionArgs`
+
+- `command`
+
+### `FileArgs`
+
+- `command`
+
+### `FleetArgs`
+
+- `command`
+
+### `GitArgs`
+
+- `command`
+
+### `InitArgs`
+
+- `all` — Show all components, extensions, projects, and servers
+- `json` — Accept --json for compatibility (output is JSON by default)
+
+### `LintArgs`
+
+- `component` — Component name to lint
+- `fix` — Auto-fix formatting issues before validating
+- `summary` — Show compact summary instead of full output
+- `file` — Lint only a single file (path relative to component root)
+- `glob` — Lint only files matching glob pattern (e.g., "inc/**/*.php")
+- `changed_only` — Lint only files modified in the working tree (staged, unstaged, untracked)
+- `errors_only` — Show only errors, suppress warnings
+- `sniffs` — Only check specific sniffs (comma-separated codes)
+- `exclude_sniffs` — Exclude sniffs from checking (comma-separated codes)
+- `category` — Filter by category: security, i18n, yoda, whitespace
+- `setting` — Override settings as key=value pairs
+- `path` — Override local_path for this lint run (use a workspace clone or temp checkout)
+- `json` — Accept --json for compatibility (output is JSON by default)
+
+### `LogsArgs`
+
+- `command`
+
+### `DynamicSetArgs`
+
+- `id` — Entity ID (optional if provided in JSON body)
+- `spec` — JSON spec (positional, supports @file and - for stdin)
+- `json` — Explicit JSON spec (takes precedence over positional)
+- `base64` — Base64-encoded JSON spec (bypasses shell escaping issues)
+- `replace` — Replace these fields instead of merging arrays
+- `extra` — Dynamic key=value flags (e.g., --remote_path /var/www). When combined with --json, add '--' separator first: `homeboy component set ID --json '{}' -- --key value`
+
+### `ProjectArgs`
+
+- `command`
+
+### `RefactorArgs`
+
+- `command`
+
+### `ReleaseArgs`
+
+- `component_id` — Component ID
+- `bump_type`
+- `dry_run` — Preview what will happen without making changes
+- `json` — Accept --json for compatibility (output is JSON by default)
+- `deploy` — Deploy to all projects using this component after release
+- `recover` — Recover from an interrupted release (tag + push current version)
+
+### `ServerArgs`
+
+- `command`
+
+### `KeyArgs`
+
+- `command`
+
+### `SshArgs`
+
+- `target` — Target ID (project or server; project wins when ambiguous)
+- `command` — Command to execute (omit for interactive shell).  Examples: homeboy ssh my-project -- ls -la homeboy ssh my-project -- wp plugin list  If you need shell operators (&&, |, redirects), pass a single quoted string: homeboy ssh my-project "cd /var/www && ls | head"
+- `as_server` — Force interpretation as server ID
+- `subcommand`
+
+### `StatusArgs`
+
+- `uncommitted` — Show only components with uncommitted changes
+- `needs_bump` — Show only components that need a version bump
+- `ready` — Show only components ready to deploy
+- `docs_only` — Show only components with docs-only changes
+- `all` — Show all components regardless of current directory context
+
+### `TestArgs`
+
+- `component` — Component name to test
+- `skip_lint` — Skip linting before running tests
+- `fix` — Auto-fix linting issues before running tests
+- `setting` — Override settings as key=value pairs
+- `path` — Override local_path for this test run (use a workspace clone or temp checkout)
+- `args` — Additional arguments to pass to the test runner (after --)
+- `json` — Accept --json for compatibility (output is JSON by default)
+
+### `TransferArgs`
+
+- `source` — Source: local path or server_id:/path
+- `destination` — Destination: local path or server_id:/path
+- `recursive` — Transfer directories recursively
+- `compress` — Compress data during transfer
+- `dry_run` — Show what would be transferred without doing it
+- `exclude` — Exclude patterns (can be specified multiple times)
+
+### `UpgradeArgs`
+
+- `check` — Check for updates without installing
+- `force` — Force upgrade even if already at latest version
+- `no_restart` — Skip automatic restart after upgrade
+- `method` — Override install method detection (homebrew|cargo|source|binary)
+- `json` — Accept --json for compatibility (output is JSON by default)
+
+### `VersionArgs`
+
+- `command`
+
+### `SshResolveArgs`
+
+- `id` — Bare ID (tries project first, then server)
+- `project` — Force project resolution
+- `server` — Force server resolution
+
+## Subcommands
+
+### `ApiCommand`
+
+- `Get` — Make a GET request
+- `endpoint` — API endpoint (e.g., /wp/v2/posts)
+- `Post` — Make a POST request
+- `endpoint` — API endpoint
+- `body` — JSON body
+- `Put` — Make a PUT request
+- `endpoint` — API endpoint
+- `body` — JSON body
+- `Patch` — Make a PATCH request
+- `endpoint` — API endpoint
+- `body` — JSON body
+- `Delete` — Make a DELETE request
+- `endpoint` — API endpoint
+
+### `AuthCommand`
+
+- `Login` — Authenticate with a project's API
+- `project` — Project ID
+- `identifier` — Username or email
+- `password` — Password (or read from stdin)
+- `Logout` — Clear stored authentication for a project
+- `project` — Project ID
+- `Status` — Show authentication status for a project
+- `project` — Project ID
+
+### `ChangelogCommand`
+
+- `Show` — Show a changelog (Homeboy's own if no component specified)
+- `component_id` — Component ID to show changelog for
+- `EXAMPLES` — Add changelog items to the configured "next" section  Examples: homeboy changelog add my-plugin "Fixed login bug" homeboy changelog add my-plugin "Removed legacy API" --type Removed homeboy changelog add my-plugin -m "Added search" -m "Added filters"
+- `Add`
+- `json` — JSON input spec for batch operations.  Use "-" to read from stdin, "@file.json" to read from a file, or an inline JSON string.
+- `component_id` — Component ID (non-JSON mode)
+- `positional_message` — Changelog item content (positional, for backward compatibility)
+- `messages` — Changelog message (repeatable: -m "first" -m "second")
+- `entry_type` — Changelog subsection type (Added, Changed, Deprecated, Removed, Fixed, Security, Refactored)
+- `Init` — Initialize a new changelog file
+- `path` — Path for the changelog file (relative to component)
+- `configure` — Also update component config to add changelogTargets
+- `component_id` — Component ID
+
+### `ComponentCommand`
+
+- `Create` — Create a new component configuration
+- `json` — JSON input spec for create/update (supports single or bulk)
+- `skip_existing` — Skip items that already exist (JSON mode only)
+- `local_path` — Absolute path to local source directory (ID derived from directory name)
+- `remote_path` — Remote path relative to project basePath
+- `build_artifact` — Build artifact path relative to localPath
+- `version_targets` — Version targets in the form "file" or "file::pattern" (repeatable). For complex patterns, use --version-targets @file.json to avoid shell escaping
+- `version_targets_json`
+- `build_command` — Build command to run in localPath
+- `extract_command` — Extract command to run after upload (e.g., "unzip -o {artifact} && rm {artifact}")
+- `changelog_target` — Path to changelog file relative to localPath
+- `extensions` — Extension(s) this component uses (e.g., "wordpress"). Repeatable.
+- `Show` — Display component configuration
+- `id` — Component ID
+- `Set` — Update component configuration fields  Supports dedicated flags for common fields (e.g., --local-path, --build-command) as well as --json for arbitrary updates. When combining --json with dynamic trailing flags, use '--' separator.
+- `args`
+- `local_path` — Absolute path to local source directory
+- `remote_path` — Remote path relative to project basePath
+- `build_artifact` — Build artifact path relative to localPath
+- `build_command` — Build command to run in localPath
+- `extract_command` — Extract command to run after upload (e.g., "unzip -o {artifact} && rm {artifact}")
+- `changelog_target` — Path to changelog file relative to localPath
+- `version_targets` — Version targets in the form "file" or "file::pattern" (repeatable). Same format as `component create --version-target`.
+- `extensions` — Extension(s) this component uses (e.g., "wordpress"). Repeatable.
+- `Delete` — Delete a component configuration
+- `id` — Component ID
+- `Rename` — Rename a component (changes ID directly)
+- `id` — Current component ID
+- `new_id` — New component ID (should match repository directory name)
+- `List` — List all available components
+- `Projects` — List projects using this component
+- `id` — Component ID
+- `Shared` — Show which components are shared across projects
+- `id` — Specific component ID to check (optional, shows all if omitted)
+- `AddVersionTarget` — Add a version target to a component
+- `id` — Component ID
+- `file` — Target file path relative to component root
+- `pattern` — Regex pattern with capture group for version
+
+### `ConfigCommand`
+
+- `Show` — Display configuration (merged defaults + file)
+- `builtin` — Show only built-in defaults (ignore homeboy.json)
+- `Set` — Set a configuration value at a JSON pointer path
+- `pointer` — JSON pointer path (e.g., /defaults/deploy/scp_flags)
+- `value` — Value to set (JSON)
+- `Remove` — Remove a configuration value at a JSON pointer path
+- `pointer` — JSON pointer path (e.g., /defaults/deploy/scp_flags)
+- `Reset` — Reset configuration to built-in defaults (deletes homeboy.json)
+- `Path` — Show the path to homeboy.json
+
+### `DbCommand`
+
+- `Tables` — List database tables
+- `project_id` — Project ID
+- `args` — Optional subtarget
+- `Describe` — Show table structure
+- `project_id` — Project ID
+- `args` — Optional subtarget and table name
+- `Query` — Execute SELECT query
+- `project_id` — Project ID
+- `args` — Optional subtarget and SQL query
+- `Search` — Search table by column value
+- `project_id` — Project ID
+- `table` — Table name
+- `column` — Column to search
+- `pattern` — Search pattern
+- `exact` — Use exact match instead of LIKE
+- `limit` — Maximum rows to return
+- `subtarget` — Optional subtarget
+- `DeleteRow` — Delete a row from a table
+- `project_id` — Project ID
+- `args` — Table name and row ID
+- `DropTable` — Drop a database table
+- `project_id` — Project ID
+- `args` — Table name
+- `Tunnel` — Open SSH tunnel to database
+- `project_id` — Project ID
+- `local_port` — Local port to bind
+
+### `DocsCommand`
+
+- `Scaffold` — Analyze codebase and report documentation status (read-only)
+- `component_id` — Component to analyze
+- `docs_dir` — Docs directory to check for existing documentation (default: docs)
+- `source_dirs` — Source directories to analyze (comma-separated, or repeat flag). Overrides auto-detection.
+- `source_extensions` — File extensions to detect as source code (default: php,rs,js,ts,py,go,java,rb,swift,kt)
+- `detect_by_extension` — Include all directories containing source files (extension-based detection)
+- `Audit` — Audit documentation for broken links and stale references
+- `component_id` — Component ID or direct filesystem path to audit
+- `docs_dir` — Docs directory relative to component/project root (overrides config, default: docs)
+- `features` — Include full list of all detected features in output
+- `Generate` — Generate documentation files from JSON spec
+- `spec` — JSON spec (positional, supports @file and - for stdin)
+- `json` — Explicit JSON spec (takes precedence over positional)
+- `from_audit` — Generate docs from audit output (pipe from `docs audit --features` or use @file)
+- `dry_run` — Show what would be generated without writing files
+
+### `ExtensionCommand`
+
+- `List` — Show available extensions with compatibility status
+- `project` — Project ID to filter compatible extensions
+- `Show` — Show detailed information about a extension
+- `extension_id` — Extension ID
+- `Run` — Execute a extension
+- `extension_id` — Extension ID
+- `project` — Project ID (defaults to active project)
+- `component` — Component ID (required when ambiguous)
+- `input` — Input values as key=value pairs
+- `step` — Run only specific steps (comma-separated, e.g. --step phpunit,phpcs)
+- `skip` — Skip specific steps (comma-separated, e.g. --skip phpstan,lint)
+- `args` — Arguments to pass to the extension (for CLI extensions)
+- `stream` — Stream output directly to terminal (default: auto-detect based on TTY)
+- `no_stream` — Disable streaming and capture output (default: auto-detect based on TTY)
+- `Setup` — Run the extension's setup command (if defined)
+- `extension_id` — Extension ID
+- `Install` — Install a extension from a git URL or local path
+- `source` — Git URL or local path to extension directory
+- `id` — Override extension id
+- `Update` — Update an installed extension (git pull)
+- `extension_id` — Extension ID (omit with --all to update everything)
+- `all` — Update all installed extensions
+- `force` — Force update even with uncommitted changes
+- `Uninstall` — Uninstall a extension
+- `extension_id` — Extension ID
+- `Action` — Execute a extension action (API call or builtin)
+- `extension_id` — Extension ID
+- `action_id` — Action ID
+- `project` — Project ID (required for API actions)
+- `data` — JSON array of selected data rows
+- `Exec` — Run a tool from a extension's vendor directory
+- `extension_id` — Extension ID
+- `component` — Component ID (sets working directory to component path)
+- `args` — Command and arguments to run
+- `Set` — Update extension manifest fields
+- `extension_id` — Extension ID (optional if provided in JSON body)
+- `json` — JSON object to merge into manifest (supports @file and - for stdin)
+- `replace` — Replace these fields instead of merging arrays
+
+### `FileCommand`
+
+- `List` — List directory contents
+- `project_id` — Project ID
+- `path` — Remote directory path
+- `Read` — Read file content
+- `project_id` — Project ID
+- `path` — Remote file path
+- `raw` — Output raw content only (no JSON wrapper)
+- `Write` — Write content to file (from stdin)
+- `project_id` — Project ID
+- `path` — Remote file path
+- `Delete` — Delete a file or directory
+- `project_id` — Project ID
+- `path` — Remote path to delete
+- `recursive` — Delete directories recursively
+- `Rename` — Rename or move a file
+- `project_id` — Project ID
+- `old_path` — Current path
+- `new_path` — New path
+- `Find` — Find files by name pattern
+- `project_id` — Project ID
+- `path` — Directory path to search
+- `name` — Filename pattern (glob, e.g., "*.php")
+- `file_type` — File type: f (file), d (directory), l (symlink)
+- `max_depth` — Maximum directory depth
+- `Grep` — Search file contents
+- `project_id` — Project ID
+- `path` — Directory path to search
+- `pattern` — Search pattern
+- `name` — Filter files by name pattern (e.g., "*.php")
+- `max_depth` — Maximum directory depth
+- `ignore_case` — Case insensitive search
+- `Download` — Download a file or directory from remote server
+- `project_id` — Project ID
+- `path` — Remote file path
+- `local_path` — Local destination path (defaults to current directory)
+- `recursive` — Download directories recursively
+- `Edit` — Edit file with line-based or pattern-based operations
+
+### `FleetCommand`
+
+- `Create` — Create a new fleet
+- `id` — Fleet ID
+- `projects` — Project IDs to include (comma-separated or repeated)
+- `description` — Description of the fleet
+- `Show` — Display fleet configuration
+- `id` — Fleet ID
+- `Set` — Update fleet configuration
+- `args`
+- `Delete` — Delete a fleet
+- `id` — Fleet ID
+- `List` — List all fleets
+- `Add` — Add a project to a fleet
+- `id` — Fleet ID
+- `project` — Project ID to add
+- `Remove` — Remove a project from a fleet
+- `id` — Fleet ID
+- `project` — Project ID to remove
+- `Projects` — Show projects in a fleet
+- `id` — Fleet ID
+- `Components` — Show component usage across a fleet
+- `id` — Fleet ID
+- `Status` — Show component versions across a fleet (local only)
+- `id` — Fleet ID
+- `Check` — Check component drift across a fleet (compares local vs remote)
+- `id` — Fleet ID
+- `outdated` — Only show components that need updates
+- `Sync` — [DEPRECATED] Use 'homeboy deploy' instead. See issue #101.
+- `id` — Fleet ID
+- `category` — Sync only specific categories (repeatable)
+- `dry_run` — Show what would be synced without doing it
+- `leader` — Override leader server (defaults to fleet-sync.json config)
+
+### `GitCommand`
+
+### `LogsCommand`
+
+- `List` — List pinned log files
+- `project_id` — Project ID
+- `Show` — Show log file content (shows all pinned logs if path omitted)
+- `project_id` — Project ID
+- `path` — Log file path (optional - shows all pinned logs if omitted)
+- `lines` — Number of lines to show
+- `follow` — Follow log output (like tail -f)
+- `local` — Execute locally instead of via SSH (for when running on the target server)
+- `Clear` — Clear log file contents
+- `project_id` — Project ID
+- `path` — Log file path
+- `local` — Execute locally instead of via SSH
+- `Search` — Search log file for pattern
+- `project_id` — Project ID
+- `path` — Log file path
+- `pattern` — Search pattern
+- `ignore_case` — Case insensitive search
+- `lines` — Limit to last N lines before searching
+- `context` — Lines of context around matches
+- `local` — Execute locally instead of via SSH
+
+### `ProjectCommand`
+
+- `List` — List all configured projects
+- `Show` — Show project configuration
+- `project_id` — Project ID
+- `Create` — Create a new project
+- `json` — JSON input spec for create/update (supports single or bulk)
+- `skip_existing` — Skip items that already exist (JSON mode only)
+- `id` — Project ID (CLI mode)
+- `domain` — Public site domain (CLI mode)
+- `server_id` — Optional server ID
+- `base_path` — Optional remote base path
+- `table_prefix` — Optional table prefix
+- `Set` — Update project configuration fields
+- `args`
+- `Remove` — Remove items from project configuration arrays
+- `project_id` — Project ID (optional if provided in JSON body)
+- `spec` — JSON spec (positional, supports @file and - for stdin)
+- `json` — Explicit JSON spec (takes precedence over positional)
+- `Rename` — Rename a project (changes ID)
+- `project_id` — Current project ID
+- `new_id` — New project ID
+- `Components` — Manage project components
+- `command`
+- `Pin` — Manage pinned files and logs
+- `command`
+- `Delete` — Delete a project configuration
+- `project_id` — Project ID
+
+### `ProjectComponentsCommand`
+
+- `List` — List associated components
+- `project_id` — Project ID
+- `Set` — Replace project components with the provided list
+- `project_id` — Project ID
+- `component_ids` — Component IDs
+- `Add` — Add one or more components
+- `project_id` — Project ID
+- `component_ids` — Component IDs
+- `Remove` — Remove one or more components
+- `project_id` — Project ID
+- `component_ids` — Component IDs
+- `Clear` — Remove all components
+- `project_id` — Project ID
+
+### `ProjectPinCommand`
+
+- `List` — List pinned items
+- `project_id` — Project ID
+- `Add` — Pin a file or log
+- `project_id` — Project ID
+- `path` — Path to pin (relative to basePath or absolute)
+- `label` — Optional display label
+- `tail` — Number of lines to tail (logs only)
+- `Remove` — Unpin a file or log
+- `project_id` — Project ID
+- `path` — Path to unpin
+
+### `RefactorCommand`
+
+- `Rename` — Rename a term across the codebase with case-variant awareness
+- `from` — Term to rename from
+- `to` — Term to rename to
+- `component` — Component ID (uses its local_path as the root)
+- `path` — Directory path to refactor (alternative to --component)
+- `scope` — Scope: code, config, all (default: all)
+- `literal` — Exact string matching (no boundary detection, no case variants)
+- `write` — Apply changes to disk (default is dry-run)
+
+### `ServerCommand`
+
+- `Create` — Register a new SSH server
+- `json` — JSON input spec for create/update (supports single or bulk)
+- `skip_existing` — Skip items that already exist (JSON mode only)
+- `id` — Server ID (CLI mode)
+- `host` — SSH host
+- `user` — SSH username
+- `port` — SSH port (default: 22)
+- `Show` — Display server configuration
+- `server_id` — Server ID
+- `Set` — Modify server settings
+- `args`
+- `Delete` — Remove a server configuration
+- `server_id` — Server ID
+- `List` — List all configured servers
+- `Key` — Manage SSH keys
+
+### `KeyCommand`
+
+- `Generate` — Generate a new SSH key pair and set it for this server
+- `server_id` — Server ID
+- `Show` — Display the public SSH key
+- `server_id` — Server ID
+- `Import` — Import an existing SSH private key and set it for this server
+- `server_id` — Server ID
+- `private_key_path` — Path to private key file
+- `Use` — Use an existing SSH private key file path for this server
+- `server_id` — Server ID
+- `private_key_path` — Path to private key file
+- `Unset` — Unset the server SSH identity file (use normal SSH resolution)
+- `server_id` — Server ID
+
+### `SshSubcommand`
+
+- `List` — List configured SSH server targets
+
+### `VersionCommand`
+
+- `Show` — Show current version (default: homeboy binary)
+- `component_id` — Component ID (optional - shows homeboy binary version when omitted)
+- `path` — Override local_path for version file lookup
+- `Set` — [DEPRECATED] Use 'homeboy version bump' or 'homeboy release' instead. See issue #259.
+- `component_id` — Component ID
+- `new_version` — New version (e.g., 1.2.3)
+- `path` — Override local_path for version file lookup
+- `Bump` — Bump version with semantic versioning (alias for `release`)
+- `component_id` — Component ID
+- `bump_type` — Version bump type (patch, minor, major)
+- `dry_run` — Preview what will happen without making changes
+- `path` — Override local_path for version operations
+
+### `Commands`
+
+- `Project` — Manage project configuration
+- `Ssh` — SSH into a project server or configured server
+- `Server` — Manage SSH server configurations
+- `Test` — Run tests for a component
+- `Lint` — Lint a component
+- `Cleanup` — Identify config drift, stale state, and hygiene issues
+- `Db` — Database operations
+- `File` — Remote file operations
+- `Fleet` — Manage fleets (groups of projects)
+- `Logs` — Remote log viewing
+- `Transfer` — Transfer files between servers
+- `Deploy` — Deploy components to remote server
+- `Component` — Manage standalone component configurations
+- `Config` — Manage global Homeboy configuration
+- `Extension` — Execute CLI-compatible extensions
+- `Init` — Get repo context (read-only, creates no state)
+- `Status` — Actionable component status overview
+- `Docs` — Display CLI documentation
+- `Changelog` — Changelog operations
+- `Git` — Git operations for components
+- `Version` — Version management for components
+- `Build` — Build a component
+- `Changes` — Show changes since last version tag
+- `Release` — Plan release workflows
+- `Audit` — Audit code conventions and detect architectural drift
+- `Refactor` — Structural refactoring (rename terms across codebase)
+- `Auth` — Authenticate with a project's API
+- `Api` — Make API requests to a project
+- `Upgrade` — Upgrade Homeboy to the latest version
+- `Update` — Alias for upgrade
+- `List` — List available commands (alias for --help)

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -61,7 +61,8 @@ pub enum AuditOutput {
         path: String,
         findings_count: usize,
         outliers_count: usize,
-        alignment_score: f32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        alignment_score: Option<f32>,
     },
 
     #[serde(rename = "audit.compared")]
@@ -125,12 +126,20 @@ pub fn run(args: AuditArgs, _global: &super::GlobalArgs) -> CmdResult<AuditOutpu
                 "Failed to read back saved baseline",
             ))?;
 
-        eprintln!(
-            "[audit] Baseline saved to {} ({} findings, {:.0}% alignment)",
-            saved.display(),
-            baseline_data.findings_count,
-            baseline_data.alignment_score * 100.0
-        );
+        if let Some(score) = baseline_data.alignment_score {
+            eprintln!(
+                "[audit] Baseline saved to {} ({} findings, {:.0}% alignment)",
+                saved.display(),
+                baseline_data.findings_count,
+                score * 100.0
+            );
+        } else {
+            eprintln!(
+                "[audit] Baseline saved to {} ({} findings, alignment: N/A)",
+                saved.display(),
+                baseline_data.findings_count,
+            );
+        }
 
         return Ok((
             AuditOutput::BaselineSaved {

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -822,6 +822,14 @@ fn run_generate_from_audit(source: &str, dry_run: bool) -> CmdResult<DocsOutput>
         hints.insert(0, "Dry run — no files written".to_string());
     }
 
+    // Deduplicate file lists (a file may be appended to multiple times)
+    let mut seen = std::collections::HashSet::new();
+    files_created.retain(|f| seen.insert(f.clone()));
+    seen.clear();
+    files_updated.retain(|f| seen.insert(f.clone()));
+    // A file that was created shouldn't also appear in updated
+    files_updated.retain(|f| !files_created.contains(f));
+
     Ok((
         DocsOutput::Generate {
             files_created,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -12,7 +12,7 @@ use homeboy::extension::{
 };
 use homeboy::project::{self, Project};
 use homeboy::server::{self, Server};
-use homeboy::utils::parser;
+use homeboy::utils::{self, parser};
 use homeboy::{changelog, git, version};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -48,14 +48,10 @@ pub struct InitStatus {
     pub docs_only: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub has_uncommitted: Vec<String>,
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(skip_serializing_if = "utils::is_zero")]
     pub config_gaps: usize,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub gap_details: Vec<GapSummary>,
-}
-
-fn is_zero(n: &usize) -> bool {
-    *n == 0
 }
 
 #[derive(Debug, Serialize)]
@@ -72,16 +68,12 @@ pub struct ComponentSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension: Option<String>,
     pub status: String,
-    #[serde(skip_serializing_if = "is_zero_u32")]
+    #[serde(skip_serializing_if = "utils::is_zero_u32")]
     pub commits_since_version: u32,
-    #[serde(skip_serializing_if = "is_zero_u32")]
+    #[serde(skip_serializing_if = "utils::is_zero_u32")]
     pub code_commits: u32,
-    #[serde(skip_serializing_if = "is_zero_u32")]
+    #[serde(skip_serializing_if = "utils::is_zero_u32")]
     pub docs_only_commits: u32,
-}
-
-fn is_zero_u32(n: &u32) -> bool {
-    *n == 0
 }
 
 #[derive(Debug, Serialize)]
@@ -194,9 +186,9 @@ pub struct ChangelogSnapshot {
 #[derive(Debug, Clone, Serialize)]
 pub struct ComponentReleaseState {
     pub commits_since_version: u32,
-    #[serde(skip_serializing_if = "is_zero_u32")]
+    #[serde(skip_serializing_if = "utils::is_zero_u32")]
     pub code_commits: u32,
-    #[serde(skip_serializing_if = "is_zero_u32")]
+    #[serde(skip_serializing_if = "utils::is_zero_u32")]
     pub docs_only_commits: u32,
     pub has_uncommitted_changes: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -20,7 +20,7 @@ pub struct AuditBaseline {
     /// Total outlier files at baseline time.
     pub outliers_count: usize,
     /// Alignment score at baseline time.
-    pub alignment_score: f32,
+    pub alignment_score: Option<f32>,
     /// Set of known outlier file paths (accepted drift).
     pub known_outliers: Vec<String>,
     /// Fingerprint of each known finding: "convention::file::kind::description"
@@ -283,7 +283,9 @@ mod tests {
                 files_scanned: 10,
                 conventions_detected: 1,
                 outliers_found: findings.len(),
-                alignment_score: 0.8,
+                alignment_score: Some(0.8),
+                files_skipped: 0,
+                warnings: vec![],
             },
             conventions: vec![],
             directory_conventions: vec![],

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -814,19 +814,33 @@ pub fn check_signature_consistency(conventions: &mut [Convention], root: &Path) 
 // Auto-Discovery
 // ============================================================================
 
+/// Result of auto-discovering file groups.
+pub struct DiscoveryResult {
+    /// Grouped files with conventions.
+    pub groups: Vec<(String, String, Vec<FileFingerprint>)>,
+    /// Total source files found by the walker.
+    pub files_walked: usize,
+    /// Files that were successfully fingerprinted by an extension.
+    pub files_fingerprinted: usize,
+}
+
 /// Auto-discover file groups by scanning directories for clusters of similar files.
 ///
-/// Returns (group_name, glob_pattern, files) tuples for directories that
-/// contain 2+ files of the same language.
-pub fn auto_discover_groups(root: &Path) -> Vec<(String, String, Vec<FileFingerprint>)> {
+/// Returns groups of (group_name, glob_pattern, files) for directories that
+/// contain 2+ files of the same language, plus counts of walked vs fingerprinted files.
+pub fn auto_discover_groups(root: &Path) -> DiscoveryResult {
     let mut groups: Vec<(String, String, Vec<FileFingerprint>)> = Vec::new();
 
     // Walk directories, group files by parent dir + language
     let mut dir_files: HashMap<(String, Language), Vec<FileFingerprint>> = HashMap::new();
+    let mut files_walked: usize = 0;
+    let mut files_fingerprinted: usize = 0;
 
     if let Ok(walker) = walk_source_files(root) {
         for path in walker {
+            files_walked += 1;
             if let Some(fp) = fingerprint_file(&path, root) {
+                files_fingerprinted += 1;
                 let parent = path
                     .parent()
                     .and_then(|p| p.strip_prefix(root).ok())
@@ -875,7 +889,11 @@ pub fn auto_discover_groups(root: &Path) -> Vec<(String, String, Vec<FileFingerp
 
     // Sort by group name for deterministic output
     groups.sort_by(|a, b| a.0.cmp(&b.0));
-    groups
+    DiscoveryResult {
+        groups,
+        files_walked,
+        files_fingerprinted,
+    }
 }
 
 // ============================================================================
@@ -1028,6 +1046,11 @@ fn extension_provided_file_extensions() -> Vec<String> {
         .collect()
 }
 
+/// Known source file extensions that may be present even if no extension claims them.
+const COMMON_SOURCE_EXTENSIONS: &[&str] = &[
+    "rs", "php", "js", "ts", "py", "go", "java", "rb", "swift", "kt", "c", "cpp", "h",
+];
+
 fn walk_source_files(root: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
     let skip_dirs = [
         "node_modules",
@@ -1051,6 +1074,36 @@ fn walk_source_files(root: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
     files.retain(|f| !is_index_file(f));
 
     Ok(files)
+}
+
+/// Count source files that exist in the tree but aren't claimed by any extension.
+/// Used to warn when no extension provides fingerprinting for the dominant language.
+pub fn count_unclaimed_source_files(root: &Path) -> usize {
+    let skip_dirs = [
+        "node_modules", "vendor", ".git", "build", "dist", "target", ".svn", ".hg", "cache", "tmp",
+    ];
+    let claimed = extension_provided_file_extensions();
+
+    let mut count = 0;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let name = path.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();
+                    if !skip_dirs.contains(&name.as_str()) {
+                        stack.push(path);
+                    }
+                } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                    if COMMON_SOURCE_EXTENSIONS.contains(&ext) && !claimed.iter().any(|c| c == ext) {
+                        count += 1;
+                    }
+                }
+            }
+        }
+    }
+    count
 }
 
 fn walk_recursive(

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -1052,7 +1052,9 @@ class BadAbility {
                 files_scanned: 2,
                 conventions_detected: 1,
                 outliers_found: 1,
-                alignment_score: 0.5,
+                alignment_score: Some(0.5),
+                files_skipped: 0,
+                warnings: vec![],
             },
             conventions: vec![ConventionReport {
                 name: "Abilities".to_string(),
@@ -1289,7 +1291,9 @@ class {} {{
                 files_scanned: 4,
                 conventions_detected: 1,
                 outliers_found: 1,
-                alignment_score: 0.75,
+                alignment_score: Some(0.75),
+                files_skipped: 0,
+                warnings: vec![],
             },
             conventions: vec![ConventionReport {
                 name: "Flow".to_string(),
@@ -1363,7 +1367,9 @@ class {} {{
                 files_scanned: 3,
                 conventions_detected: 1,
                 outliers_found: 2,
-                alignment_score: 0.33,
+                alignment_score: Some(0.33),
+                files_skipped: 0,
+                warnings: vec![],
             },
             conventions: vec![ConventionReport {
                 name: "Jobs".to_string(),
@@ -1499,7 +1505,9 @@ pub struct TestOutput {}
                 files_scanned: 2,
                 conventions_detected: 1,
                 outliers_found: 1,
-                alignment_score: 0.5,
+                alignment_score: Some(0.5),
+                files_skipped: 0,
+                warnings: vec![],
             },
             conventions: vec![ConventionReport {
                 name: "Commands".to_string(),

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -21,12 +21,7 @@ pub use checks::{CheckResult, CheckStatus};
 pub use conventions::{Convention, Deviation, DeviationKind, Language, Outlier};
 pub use findings::{Finding, Severity};
 
-use crate::{component, Result};
-
-/// Helper for `skip_serializing_if` on zero-value usize fields.
-fn is_zero(v: &usize) -> bool {
-    *v == 0
-}
+use crate::{component, utils::is_zero, Result};
 
 /// Summary counts for the audit report.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -36,7 +31,15 @@ pub struct AuditSummary {
     #[serde(skip_serializing_if = "is_zero")]
     pub outliers_found: usize,
     /// Overall alignment score (0.0 = total chaos, 1.0 = perfect consistency).
-    pub alignment_score: f32,
+    /// Null when no files could be fingerprinted (score would be meaningless).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alignment_score: Option<f32>,
+    /// Source files found but not fingerprinted (no extension provides fingerprinting).
+    #[serde(skip_serializing_if = "is_zero")]
+    pub files_skipped: usize,
+    /// Warnings about the audit (e.g., unsupported file types).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 /// Complete result of auditing a component's code conventions.
@@ -145,10 +148,38 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
     log_status!("audit", "Scanning {} for conventions...", source_path);
 
     // Phase 1: Auto-discover file groups
-    let groups = conventions::auto_discover_groups(root);
+    let discovery = conventions::auto_discover_groups(root);
+    let files_skipped = discovery.files_walked.saturating_sub(discovery.files_fingerprinted);
 
-    if groups.is_empty() {
-        log_status!("audit", "No source files found");
+    if discovery.groups.is_empty() {
+        let mut warnings = Vec::new();
+        let unclaimed = conventions::count_unclaimed_source_files(root);
+        let total_skipped = files_skipped + unclaimed;
+
+        if unclaimed > 0 {
+            warnings.push(format!(
+                "Found {} source file(s) but no installed extension provides fingerprinting for these file types. \
+                 Install or update an extension with a `provides.file_extensions` and `scripts.fingerprint` config.",
+                unclaimed
+            ));
+            log_status!(
+                "audit",
+                "WARNING: {} source files found but none could be fingerprinted (no extension claims these file types)",
+                unclaimed
+            );
+        } else if discovery.files_walked > 0 && discovery.files_fingerprinted == 0 {
+            warnings.push(format!(
+                "Found {} source file(s) but no extension could fingerprint them.",
+                discovery.files_walked
+            ));
+            log_status!(
+                "audit",
+                "WARNING: {} source files found but none could be fingerprinted",
+                discovery.files_walked
+            );
+        } else {
+            log_status!("audit", "No source files found");
+        }
         return Ok(CodeAuditResult {
             component_id: component_id.to_string(),
             source_path: source_path.to_string(),
@@ -156,7 +187,9 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
                 files_scanned: 0,
                 conventions_detected: 0,
                 outliers_found: 0,
-                alignment_score: 1.0,
+                alignment_score: None,
+                files_skipped: total_skipped,
+                warnings,
             },
             conventions: vec![],
             directory_conventions: vec![],
@@ -168,7 +201,7 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
     let mut discovered_conventions = Vec::new();
     let mut total_files = 0;
 
-    for (name, glob, fingerprints) in &groups {
+    for (name, glob, fingerprints) in &discovery.groups {
         total_files += fingerprints.len();
         if let Some(convention) =
             conventions::discover_conventions(name, glob, fingerprints)
@@ -191,10 +224,18 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
     let total_conforming: usize = discovered_conventions.iter().map(|c| c.conforming.len()).sum();
     let total_in_conventions = total_conforming + total_outliers;
     let alignment_score = if total_in_conventions > 0 {
-        total_conforming as f32 / total_in_conventions as f32
+        Some(total_conforming as f32 / total_in_conventions as f32)
     } else {
-        1.0
+        None
     };
+
+    let mut warnings = Vec::new();
+    if files_skipped > 0 {
+        warnings.push(format!(
+            "{} source file(s) found but could not be fingerprinted (no extension provides fingerprinting for these file types)",
+            files_skipped
+        ));
+    }
 
     let convention_reports: Vec<ConventionReport> = discovered_conventions
         .iter()
@@ -221,7 +262,7 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
         total_files,
         convention_reports.len(),
         total_outliers,
-        alignment_score * 100.0
+        alignment_score.unwrap_or(0.0) * 100.0
     );
 
     // Phase 6: Cross-directory convention discovery
@@ -245,6 +286,8 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
             conventions_detected: convention_reports.len(),
             outliers_found: total_outliers,
             alignment_score,
+            files_skipped,
+            warnings,
         },
         conventions: convention_reports,
         directory_conventions,
@@ -274,7 +317,7 @@ mod tests {
 
         let result = audit_path(dir.to_str().unwrap()).unwrap();
         assert_eq!(result.summary.files_scanned, 0);
-        assert_eq!(result.summary.alignment_score, 1.0);
+        assert!(result.summary.alignment_score.is_none());
         assert!(result.conventions.is_empty());
 
         let _ = fs::remove_dir_all(&dir);
@@ -328,7 +371,7 @@ class StepC {
         assert_eq!(result.summary.files_scanned, 3);
         assert!(result.summary.conventions_detected >= 1);
         assert!(result.summary.outliers_found >= 1);
-        assert!(result.summary.alignment_score < 1.0);
+        assert!(result.summary.alignment_score.unwrap() < 1.0);
 
         // Find the steps convention
         let steps_conv = result

--- a/src/core/deploy.rs
+++ b/src/core/deploy.rs
@@ -18,7 +18,7 @@ use crate::extension::{
 use crate::permissions;
 use crate::project::{self, Project};
 use crate::ssh::SshClient;
-use crate::utils::artifact;
+use crate::utils::{self, artifact};
 use crate::utils::base_path;
 use crate::utils::parser;
 use crate::utils::shell;
@@ -612,20 +612,16 @@ pub struct ReleaseState {
     /// Number of commits since the last version tag
     pub commits_since_version: u32,
     /// Number of code commits (non-docs)
-    #[serde(skip_serializing_if = "is_zero_u32")]
+    #[serde(skip_serializing_if = "utils::is_zero_u32")]
     pub code_commits: u32,
     /// Number of docs-only commits
-    #[serde(skip_serializing_if = "is_zero_u32")]
+    #[serde(skip_serializing_if = "utils::is_zero_u32")]
     pub docs_only_commits: u32,
     /// Whether there are uncommitted changes in the working directory
     pub has_uncommitted_changes: bool,
     /// The baseline reference (tag or commit hash) used for comparison
     #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline_ref: Option<String>,
-}
-
-fn is_zero_u32(n: &u32) -> bool {
-    *n == 0
 }
 
 /// Result for a single component deployment.

--- a/src/core/docs_audit/mod.rs
+++ b/src/core/docs_audit/mod.rs
@@ -20,12 +20,7 @@ pub use verify::VerifyResult;
 
 use regex::Regex;
 
-use crate::{component, git, extension, Result};
-
-/// Helper for `skip_serializing_if` on zero-value usize fields.
-fn is_zero(v: &usize) -> bool {
-    *v == 0
-}
+use crate::{component, git, extension, utils::is_zero, Result};
 
 /// A doc that needs content review due to referenced files changing.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -91,12 +86,12 @@ pub struct AlignmentSummary {
     pub broken_references: usize,
     pub unchanged_docs: usize,
     /// Total features detected by extension-defined patterns (omitted when 0).
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub total_features: usize,
     /// Features with at least one mention in documentation (omitted when 0).
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub documented_features: usize,
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub undocumented_features: usize,
 }
 

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -5,7 +5,7 @@ use crate::error::{Error, Result};
 use crate::hooks::{self, HookFailureMode};
 use crate::local_files::{self, FileSystem};
 use crate::extension::{load_all_extensions, ExtensionManifest};
-use crate::utils::{io, parser, validation};
+use crate::utils::{self, io, parser, validation};
 use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
@@ -210,12 +210,8 @@ pub struct BumpResult {
     pub changelog_finalized: bool,
     pub changelog_changed: bool,
     /// Number of `@since` placeholder tags replaced with the new version.
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(skip_serializing_if = "utils::is_zero")]
     pub since_tags_replaced: usize,
-}
-
-fn is_zero(v: &usize) -> bool {
-    *v == 0
 }
 
 /// Resolve pattern for a version target, using explicit pattern or extension default.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,3 +26,17 @@ pub mod slugify;
 pub(crate) mod template;
 pub mod token;
 pub mod validation;
+
+// ============================================================================
+// Serde helpers
+// ============================================================================
+
+/// Helper for `#[serde(skip_serializing_if = "is_zero")]` on `usize` fields.
+pub fn is_zero(v: &usize) -> bool {
+    *v == 0
+}
+
+/// Helper for `#[serde(skip_serializing_if = "is_zero_u32")]` on `u32` fields.
+pub fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}


### PR DESCRIPTION
## Summary

Fixes discovered by running Homeboy's own tools against itself:

- **#320 (P1):** `docs generate --from-audit` now successfully parses output from `docs audit --features` — `AlignmentSummary` was missing `#[serde(default)]` on fields with `skip_serializing_if`, causing round-trip deserialization failure
- **#321 (P2):** `homeboy audit` now warns when it finds source files no extension can fingerprint — was silently reporting "1.0 alignment" with 0 files scanned. Now reports `files_skipped: 124` and an actionable warning. `alignment_score` is `Option<f32>` (null when meaningless)
- **#323:** `docs generate` output deduplicates file lists — was showing `cli-reference.md` 3 times
- **#318:** `is_zero()`/`is_zero_u32()` moved to `utils/` — was copy-pasted across 5 files

Also generates `docs/cli-reference.md` and `docs/architecture.md` via the fixed pipeline (90/90 features documented).

## Testing

`cargo test` — 424 passed, 0 failed.

Pipeline verification:
```bash
homeboy docs audit homeboy --features > audit.json
homeboy docs generate --from-audit @audit.json  # ✓ works now
homeboy audit homeboy  # ✓ warns about 124 unfingerprintable .rs files
```

## Related issues

- Closes #320
- Closes #321
- Closes #323
- Closes #318
- Partially addresses #317 (88→0 undocumented features via generated docs)
- Opened #326 for mechanical struct refactoring commands (the manual work this PR required)