### PR TITLE
feat: add refactor add command (#308)

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -1,8 +1,9 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
+use homeboy::code_audit::{fixer, CodeAuditResult};
 use homeboy::component;
-use homeboy::refactor::{self, RenameScope, RenameSpec};
+use homeboy::refactor::{self, AddResult, RenameScope, RenameSpec};
 
 use crate::commands::CmdResult;
 
@@ -38,6 +39,37 @@ enum RefactorCommand {
         #[arg(long)]
         write: bool,
     },
+
+    /// Add imports, stubs, or fixes to source files
+    ///
+    /// Two modes:
+    ///   From audit: `refactor add --from-audit @audit.json [--write]`
+    ///   Explicit:   `refactor add --import "use serde::Serialize;" --to "src/**/*.rs" [--write]`
+    Add {
+        /// Apply fixes from saved audit JSON (supports @file, -, or inline JSON)
+        #[arg(long, value_name = "AUDIT_JSON")]
+        from_audit: Option<String>,
+
+        /// Import/use statement to add (explicit mode)
+        #[arg(long, value_name = "IMPORT")]
+        import: Option<String>,
+
+        /// Target file or glob pattern for explicit additions
+        #[arg(long, value_name = "PATTERN")]
+        to: Option<String>,
+
+        /// Component ID (uses its local_path as the root)
+        #[arg(short, long)]
+        component: Option<String>,
+
+        /// Directory path (alternative to --component)
+        #[arg(long)]
+        path: Option<String>,
+
+        /// Apply changes to disk (default is dry-run)
+        #[arg(long)]
+        write: bool,
+    },
 }
 
 pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<RefactorOutput> {
@@ -51,6 +83,15 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             literal,
             write,
         } => run_rename(&from, &to, component_id.as_deref(), path.as_deref(), &scope, literal, write),
+
+        RefactorCommand::Add {
+            from_audit,
+            import,
+            to,
+            component: component_id,
+            path,
+            write,
+        } => run_add(from_audit.as_deref(), import.as_deref(), to.as_deref(), component_id.as_deref(), path.as_deref(), write),
     }
 }
 
@@ -70,6 +111,23 @@ pub enum RefactorOutput {
         file_renames: Vec<RenameSummary>,
         warnings: Vec<WarningSummary>,
         applied: bool,
+    },
+
+    #[serde(rename = "refactor.add.from_audit")]
+    AddFromAudit {
+        source_path: String,
+        #[serde(flatten)]
+        fix_result: fixer::FixResult,
+        dry_run: bool,
+    },
+
+    #[serde(rename = "refactor.add.import")]
+    AddImport {
+        import: String,
+        target: String,
+        #[serde(flatten)]
+        result: AddResult,
+        dry_run: bool,
     },
 }
 
@@ -200,6 +258,142 @@ fn run_rename(
                 })
                 .collect(),
             applied: result.applied,
+        },
+        exit_code,
+    ))
+}
+
+fn run_add(
+    from_audit: Option<&str>,
+    import: Option<&str>,
+    to: Option<&str>,
+    component_id: Option<&str>,
+    path: Option<&str>,
+    write: bool,
+) -> CmdResult<RefactorOutput> {
+    // Mode 1: From audit JSON
+    if let Some(audit_source) = from_audit {
+        return run_add_from_audit(audit_source, write);
+    }
+
+    // Mode 2: Explicit import addition
+    if let Some(import_line) = import {
+        let target = to.ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "to",
+                "--to is required when using --import",
+                None,
+                Some(vec![
+                    "homeboy refactor add --import \"use serde::Serialize;\" --to \"src/**/*.rs\"".to_string(),
+                ]),
+            )
+        })?;
+
+        return run_add_import(import_line, target, component_id, path, write);
+    }
+
+    // Neither mode specified
+    Err(homeboy::Error::validation_invalid_argument(
+        "add",
+        "Specify either --from-audit or --import with --to",
+        None,
+        Some(vec![
+            "homeboy refactor add --from-audit @audit.json".to_string(),
+            "homeboy refactor add --import \"use serde::Serialize;\" --to \"src/**/*.rs\"".to_string(),
+        ]),
+    ))
+}
+
+fn run_add_from_audit(source: &str, write: bool) -> CmdResult<RefactorOutput> {
+    // Parse audit JSON from @file, stdin (-), file path, or inline string.
+    // Auto-detect bare file paths (same pattern as docs generate --from-audit).
+    let effective_source = if !source.starts_with('{')
+        && !source.starts_with('[')
+        && source != "-"
+        && !source.starts_with('@')
+        && std::path::Path::new(source).exists()
+    {
+        format!("@{}", source)
+    } else {
+        source.to_string()
+    };
+
+    let json_content = crate::commands::merge_json_sources(Some(&effective_source), &[])?;
+
+    // Parse audit result — handle both envelope and raw formats.
+    // The envelope format wraps the audit in a "data" field (from `homeboy --format json audit`).
+    let audit: CodeAuditResult = if let Some(data) = json_content.get("data") {
+        serde_json::from_value(data.clone())
+    } else {
+        serde_json::from_value(json_content)
+    }
+    .map_err(|e| {
+        homeboy::Error::validation_invalid_json(
+            e,
+            Some("parse audit result for refactor add".to_string()),
+            Some(
+                "Input must be output from `homeboy audit <component>`. \
+                 Save it with: homeboy --format json audit <component> > audit.json"
+                    .to_string(),
+            ),
+        )
+    })?;
+
+    let fix_result = refactor::fixes_from_audit(&audit, write)?;
+
+    let exit_code = if fix_result.total_insertions > 0 { 1 } else { 0 };
+
+    homeboy::log_status!(
+        "refactor",
+        "{} fix(es) across {} file(s){}",
+        fix_result.total_insertions,
+        fix_result.fixes.len(),
+        if write {
+            format!(" — {} written", fix_result.files_modified)
+        } else {
+            " (dry run)".to_string()
+        }
+    );
+
+    Ok((
+        RefactorOutput::AddFromAudit {
+            source_path: audit.source_path,
+            fix_result,
+            dry_run: !write,
+        },
+        exit_code,
+    ))
+}
+
+fn run_add_import(
+    import_line: &str,
+    target: &str,
+    component_id: Option<&str>,
+    path: Option<&str>,
+    write: bool,
+) -> CmdResult<RefactorOutput> {
+    let result = refactor::add_import(import_line, target, component_id, path, write)?;
+
+    let exit_code = if result.total_insertions > 0 { 1 } else { 0 };
+
+    homeboy::log_status!(
+        "refactor",
+        "{} file(s) to update with '{}'{}",
+        result.total_insertions,
+        import_line,
+        if write {
+            format!(" — {} written", result.files_modified)
+        } else {
+            " (dry run)".to_string()
+        }
+    );
+
+    Ok((
+        RefactorOutput::AddImport {
+            import: import_line.to_string(),
+            target: target.to_string(),
+            result,
+            dry_run: !write,
         },
         exit_code,
     ))

--- a/src/core/code_audit/checks.rs
+++ b/src/core/code_audit/checks.rs
@@ -20,7 +20,7 @@ pub struct CheckResult {
     pub outliers: Vec<Outlier>,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckStatus {
     /// All files conform.

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -33,7 +33,7 @@ pub struct FileFingerprint {
     pub content: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     Php,
@@ -83,7 +83,7 @@ pub struct Convention {
 }
 
 /// A file that deviates from a convention.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Outlier {
     /// Relative file path.
     pub file: String,
@@ -92,7 +92,7 @@ pub struct Outlier {
 }
 
 /// A specific deviation from the convention.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Deviation {
     /// What kind of deviation.
     pub kind: DeviationKind,
@@ -102,7 +102,7 @@ pub struct Deviation {
     pub suggestion: String,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeviationKind {
     MissingMethod,

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -4,7 +4,7 @@ use super::checks::{CheckResult, CheckStatus};
 use super::conventions::DeviationKind;
 
 /// An actionable finding from the code audit.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Finding {
     /// The convention this finding relates to.
     pub convention: String,
@@ -20,7 +20,7 @@ pub struct Finding {
     pub kind: DeviationKind,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     /// Convention violation — should be fixed.

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -16,19 +16,19 @@ use super::conventions::{DeviationKind, Language};
 use super::CodeAuditResult;
 
 /// A planned fix for a single file.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Fix {
     /// Relative path to the file being fixed.
     pub file: String,
     /// What will be inserted.
     pub insertions: Vec<Insertion>,
     /// Whether the fix was applied to disk.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub applied: bool,
 }
 
 /// A single insertion into a file.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Insertion {
     /// What kind of fix.
     pub kind: InsertionKind,
@@ -38,7 +38,7 @@ pub struct Insertion {
     pub description: String,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InsertionKind {
     MethodStub,
@@ -49,7 +49,7 @@ pub enum InsertionKind {
 }
 
 /// A file that was skipped by the fixer with a reason.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SkippedFile {
     /// Relative file path.
     pub file: String,
@@ -58,10 +58,10 @@ pub struct SkippedFile {
 }
 
 /// Result of running the fixer.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FixResult {
     pub fixes: Vec<Fix>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub skipped: Vec<SkippedFile>,
     pub total_insertions: usize,
     pub files_modified: usize,

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -24,50 +24,50 @@ pub use findings::{Finding, Severity};
 use crate::{component, utils::is_zero, Result};
 
 /// Summary counts for the audit report.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AuditSummary {
     pub files_scanned: usize,
     pub conventions_detected: usize,
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(skip_serializing_if = "is_zero", default)]
     pub outliers_found: usize,
     /// Overall alignment score (0.0 = total chaos, 1.0 = perfect consistency).
     /// Null when no files could be fingerprinted (score would be meaningless).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub alignment_score: Option<f32>,
     /// Source files found but not fingerprinted (no extension provides fingerprinting).
-    #[serde(skip_serializing_if = "is_zero")]
+    #[serde(skip_serializing_if = "is_zero", default)]
     pub files_skipped: usize,
     /// Warnings about the audit (e.g., unsupported file types).
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub warnings: Vec<String>,
 }
 
 /// Complete result of auditing a component's code conventions.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CodeAuditResult {
     pub component_id: String,
     pub source_path: String,
     pub summary: AuditSummary,
     pub conventions: Vec<ConventionReport>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub directory_conventions: Vec<DirectoryConvention>,
     pub findings: Vec<Finding>,
 }
 
 /// A cross-directory convention: a pattern that sibling subdirectories share.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DirectoryConvention {
     /// Parent directory path (e.g., "inc/Abilities").
     pub parent: String,
     /// Expected methods that most subdirectories' conventions share.
     pub expected_methods: Vec<String>,
     /// Expected registrations that most subdirectories share.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub expected_registrations: Vec<String>,
     /// Subdirectories that conform.
     pub conforming_dirs: Vec<String>,
     /// Subdirectories that deviate.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub outlier_dirs: Vec<DirectoryOutlier>,
     /// How many subdirectories were analyzed.
     pub total_dirs: usize,
@@ -76,34 +76,34 @@ pub struct DirectoryConvention {
 }
 
 /// A subdirectory that deviates from the cross-directory convention.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DirectoryOutlier {
     /// Subdirectory name.
     pub dir: String,
     /// What's missing compared to sibling conventions.
     pub missing_methods: Vec<String>,
     /// Missing registrations.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub missing_registrations: Vec<String>,
 }
 
 /// A convention as reported to the user (includes check status).
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ConventionReport {
     pub name: String,
     pub glob: String,
     pub status: CheckStatus,
     pub expected_methods: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub expected_registrations: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub expected_interfaces: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expected_namespace: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub expected_imports: Vec<String>,
     pub conforming: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub outliers: Vec<Outlier>,
     pub total_files: usize,
     pub confidence: f32,

--- a/src/core/refactor/add.rs
+++ b/src/core/refactor/add.rs
@@ -1,0 +1,344 @@
+//! Refactor add — apply fixes from audit results or explicit additions.
+//!
+//! Two modes:
+//! - **From audit**: Parse saved audit JSON, generate fixes via `fixer::generate_fixes()`,
+//!   optionally apply. Composable pipeline step: `audit > audit.json && refactor add --from-audit @audit.json`
+//! - **Explicit**: Add imports/stubs to files matching a glob pattern.
+//!   Example: `refactor add --import "use serde::Serialize" --to "src/commands/*.rs"`
+
+use std::path::{Path, PathBuf};
+
+use crate::code_audit::fixer::{self, Fix, FixResult, Insertion, InsertionKind};
+use crate::code_audit::CodeAuditResult;
+use crate::{component, Result};
+
+/// Result of an explicit import addition (not from audit).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AddResult {
+    /// Files that were modified (or would be in dry-run).
+    pub fixes: Vec<Fix>,
+    /// Total number of insertions planned.
+    pub total_insertions: usize,
+    /// Number of files actually written (0 in dry-run).
+    pub files_modified: usize,
+}
+
+// ============================================================================
+// From Audit Mode
+// ============================================================================
+
+/// Generate fixes from a deserialized audit result.
+///
+/// This is the composable version of `audit --fix`: parse saved audit JSON
+/// and generate the same fixes that `audit --fix` would produce.
+pub fn fixes_from_audit(audit: &CodeAuditResult, write: bool) -> Result<FixResult> {
+    let root = Path::new(&audit.source_path);
+
+    if !root.is_dir() {
+        return Err(crate::Error::validation_invalid_argument(
+            "from-audit",
+            format!(
+                "Audit source_path '{}' is not a directory on this machine. \
+                 Run from the same machine where the audit was performed.",
+                audit.source_path
+            ),
+            None,
+            None,
+        ));
+    }
+
+    let mut fix_result = fixer::generate_fixes(audit, root);
+
+    if write && !fix_result.fixes.is_empty() {
+        let applied = fixer::apply_fixes(&mut fix_result.fixes, root);
+        fix_result.files_modified = applied;
+    }
+
+    Ok(fix_result)
+}
+
+// ============================================================================
+// Explicit Add Mode
+// ============================================================================
+
+/// Add an import statement to files matching a glob or path pattern.
+///
+/// The `import_line` is the exact code to add (e.g., `use serde::Serialize;`).
+/// The `target` is a glob pattern or directory path resolved against the root.
+pub fn add_import(
+    import_line: &str,
+    target: &str,
+    component_id: Option<&str>,
+    path: Option<&str>,
+    write: bool,
+) -> Result<AddResult> {
+    let root = resolve_root(component_id, path)?;
+    let matched_files = resolve_target_files(&root, target)?;
+
+    if matched_files.is_empty() {
+        return Err(crate::Error::validation_invalid_argument(
+            "to",
+            format!("No files matched pattern '{}'", target),
+            None,
+            Some(vec![
+                "Use a glob pattern: --to \"src/**/*.rs\"".to_string(),
+                "Use a relative path: --to src/commands/refactor.rs".to_string(),
+            ]),
+        ));
+    }
+
+    let mut fixes: Vec<Fix> = Vec::new();
+
+    for file_path in &matched_files {
+        let abs_path = root.join(file_path);
+        let content = std::fs::read_to_string(&abs_path).map_err(|e| {
+            crate::Error::internal_io(e.to_string(), Some(format!("read {}", file_path)))
+        })?;
+
+        // Skip if the import already exists in the file
+        if content.contains(import_line.trim()) {
+            continue;
+        }
+
+        fixes.push(Fix {
+            file: file_path.clone(),
+            insertions: vec![Insertion {
+                kind: InsertionKind::ImportAdd,
+                code: import_line.trim().to_string(),
+                description: format!("Add import: {}", import_line.trim()),
+            }],
+            applied: false,
+        });
+    }
+
+    let total_insertions = fixes.len();
+    let mut files_modified = 0;
+
+    if write && !fixes.is_empty() {
+        files_modified = fixer::apply_fixes(&mut fixes, &root);
+    }
+
+    Ok(AddResult {
+        fixes,
+        total_insertions,
+        files_modified,
+    })
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Resolve the root directory from component ID or explicit path.
+fn resolve_root(component_id: Option<&str>, path: Option<&str>) -> Result<PathBuf> {
+    if let Some(p) = path {
+        let pb = PathBuf::from(p);
+        if !pb.is_dir() {
+            return Err(crate::Error::validation_invalid_argument(
+                "path",
+                format!("Not a directory: {}", p),
+                None,
+                None,
+            ));
+        }
+        Ok(pb)
+    } else {
+        let comp = component::resolve(component_id)?;
+        let validated = component::validate_local_path(&comp)?;
+        Ok(validated)
+    }
+}
+
+/// Resolve target files from a glob pattern or direct file path.
+///
+/// Returns relative paths from root.
+fn resolve_target_files(root: &Path, target: &str) -> Result<Vec<String>> {
+    let abs_target = root.join(target);
+
+    // If it's a direct file path, return it
+    if abs_target.is_file() {
+        let rel = abs_target
+            .strip_prefix(root)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| target.to_string());
+        return Ok(vec![rel]);
+    }
+
+    // Try as a glob pattern
+    let glob_pattern = root.join(target).to_string_lossy().to_string();
+    let entries: Vec<String> = glob::glob(&glob_pattern)
+        .map_err(|e| {
+            crate::Error::validation_invalid_argument(
+                "to",
+                format!("Invalid glob pattern '{}': {}", target, e),
+                None,
+                None,
+            )
+        })?
+        .filter_map(|entry| entry.ok())
+        .filter(|p| p.is_file())
+        .filter_map(|p| {
+            p.strip_prefix(root)
+                .ok()
+                .map(|rel| rel.to_string_lossy().to_string())
+        })
+        .collect();
+
+    Ok(entries)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_import_to_matching_files() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_add_test");
+        let src = dir.join("src");
+        let _ = std::fs::create_dir_all(&src);
+
+        std::fs::write(
+            src.join("one.rs"),
+            "use std::path::Path;\n\nfn main() {}\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            src.join("two.rs"),
+            "use std::io;\n\nfn helper() {}\n",
+        )
+        .unwrap();
+
+        // File that already has the import
+        std::fs::write(
+            src.join("three.rs"),
+            "use serde::Serialize;\n\nfn other() {}\n",
+        )
+        .unwrap();
+
+        let result = add_import(
+            "use serde::Serialize;",
+            "src/*.rs",
+            None,
+            Some(dir.to_str().unwrap()),
+            false,
+        )
+        .unwrap();
+
+        // Should generate fixes for one.rs and two.rs, but skip three.rs
+        assert_eq!(result.total_insertions, 2);
+        assert_eq!(result.files_modified, 0); // dry run
+
+        let fixed_files: Vec<&str> = result.fixes.iter().map(|f| f.file.as_str()).collect();
+        assert!(fixed_files.contains(&"src/one.rs"));
+        assert!(fixed_files.contains(&"src/two.rs"));
+        assert!(!fixed_files.contains(&"src/three.rs"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_import_with_write() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_add_write_test");
+        let src = dir.join("src");
+        let _ = std::fs::create_dir_all(&src);
+
+        std::fs::write(
+            src.join("target.rs"),
+            "use std::path::Path;\n\nfn main() {}\n",
+        )
+        .unwrap();
+
+        let result = add_import(
+            "use serde::Serialize;",
+            "src/target.rs",
+            None,
+            Some(dir.to_str().unwrap()),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result.total_insertions, 1);
+        assert_eq!(result.files_modified, 1);
+
+        let content = std::fs::read_to_string(src.join("target.rs")).unwrap();
+        assert!(content.contains("use serde::Serialize;"));
+        assert!(content.contains("use std::path::Path;")); // preserved
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_import_skips_existing() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_add_skip_test");
+        let _ = std::fs::create_dir_all(&dir);
+
+        std::fs::write(
+            dir.join("existing.rs"),
+            "use serde::Serialize;\n\nfn main() {}\n",
+        )
+        .unwrap();
+
+        let result = add_import(
+            "use serde::Serialize;",
+            "existing.rs",
+            None,
+            Some(dir.to_str().unwrap()),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.total_insertions, 0);
+        assert!(result.fixes.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_import_no_match_returns_error() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_add_nomatch_test");
+        let _ = std::fs::create_dir_all(&dir);
+
+        let result = add_import(
+            "use serde::Serialize;",
+            "nonexistent/*.rs",
+            None,
+            Some(dir.to_str().unwrap()),
+            false,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("No files matched"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fixes_from_audit_validates_source_path() {
+        let audit = CodeAuditResult {
+            component_id: "test".to_string(),
+            source_path: "/nonexistent/path/that/should/not/exist".to_string(),
+            summary: crate::code_audit::AuditSummary {
+                files_scanned: 0,
+                conventions_detected: 0,
+                outliers_found: 0,
+                alignment_score: Some(1.0),
+                files_skipped: 0,
+                warnings: vec![],
+            },
+            conventions: vec![],
+            directory_conventions: vec![],
+            findings: vec![],
+        };
+
+        let result = fixes_from_audit(&audit, false);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("not a directory"));
+    }
+}

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -1,10 +1,12 @@
-//! Structural refactoring — rename concepts across a codebase.
+//! Structural refactoring — rename, add, and transform code across a codebase.
 //!
 //! Walks source files, finds all references to a term (with word-boundary matching
 //! and case-variant awareness), generates edits, and optionally applies them.
 
+pub mod add;
 mod rename;
 
+pub use add::{add_import, fixes_from_audit, AddResult};
 pub use rename::{
     find_references, generate_renames, apply_renames, CaseVariant,
     FileEdit, FileRename, Reference, RenameResult, RenameScope, RenameSpec, RenameWarning,


### PR DESCRIPTION
## Summary

- Adds `homeboy refactor add` command with two modes:
  - **From audit**: `refactor add --from-audit @audit.json [--write]` — parses saved audit JSON, generates fixes via `fixer::generate_fixes()`, optionally applies. This is the composable pipeline version of `audit --fix`.
  - **Explicit**: `refactor add --import "use serde::Serialize;" --to "src/**/*.rs" [--write]` — adds imports to files matching a glob, skipping files that already have the import.
- Adds `Deserialize` to all code audit types (`CodeAuditResult`, `AuditSummary`, `ConventionReport`, `Outlier`, `Deviation`, `DeviationKind`, `CheckStatus`, `Finding`, `Severity`, `Fix`, `Insertion`, `InsertionKind`, `FixResult`, etc.) so audit JSON can be round-tripped through save/load.
- Adds `#[serde(default)]` alongside `skip_serializing_if` to prevent deserialization failures on omitted fields (same pattern fixed in PR #327 for `AlignmentSummary`).

## Testing

- All 444 existing tests pass
- 5 new unit tests for `refactor::add` (import matching, write mode, skip existing, no-match error, source path validation)
- End-to-end tested: `homeboy audit homeboy > audit.json && homeboy refactor add --from-audit @audit.json` — correctly finds 7 missing imports across 7 command files

## Design

The command follows existing patterns:
- Dry-run by default, `--write` to apply (same as `refactor rename`)
- `@file` / `-` stdin / bare path auto-detection (same as `docs generate --from-audit`)
- Envelope-aware JSON parsing (handles both `{data: {...}}` and raw formats)
- Exit code 1 when fixes are found (same as `audit`)

Closes #308