### PR TITLE
feat: structural complexity findings in audit (#334)

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -114,6 +114,10 @@ pub enum DeviationKind {
     SignatureMismatch,
     NamespaceMismatch,
     MissingImport,
+    /// File exceeds line count threshold.
+    GodFile,
+    /// File has too many top-level items.
+    HighItemCount,
 }
 
 // ============================================================================

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -1,19 +1,22 @@
-//! Code audit system for convention detection and drift analysis.
+//! Code audit system for convention detection, drift analysis, and structural complexity.
 //!
 //! Scans source code to discover structural conventions, detect outliers,
-//! and report architectural drift. Works by:
+//! report architectural drift, and flag structural issues (god files, high item counts).
+//! Works by:
 //!
 //! 1. Fingerprinting source files (extract methods, registrations, types)
 //! 2. Grouping files by directory and language
 //! 3. Discovering conventions (patterns most files follow)
 //! 4. Checking all files against discovered conventions
 //! 5. Producing actionable findings for outliers
+//! 6. Analyzing structural complexity (god files, high item counts)
 
 pub mod baseline;
 mod checks;
 mod conventions;
 mod findings;
 pub mod fixer;
+mod structural;
 
 use std::path::Path;
 
@@ -217,7 +220,18 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
     let check_results = checks::check_conventions(&discovered_conventions);
 
     // Phase 4: Build findings
-    let all_findings = findings::build_findings(&check_results);
+    let mut all_findings = findings::build_findings(&check_results);
+
+    // Phase 4b: Structural complexity analysis (god files, high item counts)
+    let structural_findings = structural::analyze_structure(root);
+    if !structural_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Structural: {} finding(s) (god files, high item counts)",
+            structural_findings.len()
+        );
+        all_findings.extend(structural_findings);
+    }
 
     // Phase 5: Build report
     let total_outliers: usize = discovered_conventions.iter().map(|c| c.outliers.len()).sum();

--- a/src/core/code_audit/structural.rs
+++ b/src/core/code_audit/structural.rs
@@ -1,0 +1,464 @@
+//! Structural complexity analysis — detect god files, high item counts,
+//! and other structural issues that convention-based analysis can't catch.
+//!
+//! Plugs into the audit pipeline as an additional findings source.
+
+use std::path::Path;
+
+use super::conventions::DeviationKind;
+use super::findings::{Finding, Severity};
+
+/// Thresholds for structural findings.
+const GOD_FILE_LINE_THRESHOLD: usize = 500;
+const HIGH_ITEM_COUNT_THRESHOLD: usize = 15;
+
+/// Known source file extensions for structural analysis.
+/// Matches the walker's known extensions so we analyze the same files.
+const SOURCE_EXTENSIONS: &[&str] = &[
+    "rs", "php", "js", "ts", "jsx", "tsx", "mjs", "py", "go", "java", "rb",
+    "swift", "kt", "c", "cpp", "h",
+];
+
+/// Directories to skip during structural analysis.
+const SKIP_DIRS: &[&str] = &[
+    "node_modules", "vendor", ".git", "build", "dist", "target",
+    ".svn", ".hg", "cache", "tmp",
+];
+
+/// Run structural analysis on all source files under a root directory.
+///
+/// Returns findings for files that exceed structural thresholds.
+pub fn analyze_structure(root: &Path) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            if path.is_dir() {
+                let name = path.file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("");
+                if !SKIP_DIRS.contains(&name) {
+                    stack.push(path);
+                }
+                continue;
+            }
+
+            let ext = path.extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if !SOURCE_EXTENSIONS.contains(&ext) {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            let relative = path.strip_prefix(root)
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| path.to_string_lossy().to_string());
+
+            // Check line count
+            let line_count = content.lines().count();
+            if line_count > GOD_FILE_LINE_THRESHOLD {
+                let suggestion = format!(
+                    "Consider decomposing into focused modules. \
+                     Use `homeboy refactor move` to extract related groups of items."
+                );
+                findings.push(Finding {
+                    convention: "structural".to_string(),
+                    severity: Severity::Warning,
+                    file: relative.clone(),
+                    description: format!(
+                        "File has {} lines (threshold: {})",
+                        line_count, GOD_FILE_LINE_THRESHOLD
+                    ),
+                    suggestion,
+                    kind: DeviationKind::GodFile,
+                });
+            }
+
+            // Count top-level items (functions, structs, enums, consts, etc.)
+            let item_count = count_top_level_items(&content, ext);
+            if item_count > HIGH_ITEM_COUNT_THRESHOLD {
+                findings.push(Finding {
+                    convention: "structural".to_string(),
+                    severity: Severity::Info,
+                    file: relative,
+                    description: format!(
+                        "File has {} top-level items (threshold: {})",
+                        item_count, HIGH_ITEM_COUNT_THRESHOLD
+                    ),
+                    suggestion: "Group related items and extract into focused modules".to_string(),
+                    kind: DeviationKind::HighItemCount,
+                });
+            }
+        }
+    }
+
+    // Sort by file path for deterministic output
+    findings.sort_by(|a, b| a.file.cmp(&b.file));
+    findings
+}
+
+/// Count top-level items in a source file.
+///
+/// Uses lightweight pattern matching rather than full parsing — we just need
+/// approximate counts for threshold detection, not exact ASTs.
+fn count_top_level_items(content: &str, ext: &str) -> usize {
+    match ext {
+        "rs" => count_rust_items(content),
+        "php" => count_php_items(content),
+        "js" | "jsx" | "mjs" | "ts" | "tsx" => count_js_items(content),
+        _ => 0, // Unknown languages get no item count findings
+    }
+}
+
+/// Count top-level items in Rust source.
+///
+/// Matches: fn, struct, enum, const, static, type, trait, impl at zero indentation.
+fn count_rust_items(content: &str) -> usize {
+    let mut count = 0;
+    let mut in_test_module = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Skip items inside test modules (everything after #[cfg(test)])
+        if trimmed == "#[cfg(test)]" {
+            in_test_module = true;
+            continue;
+        }
+        if in_test_module {
+            continue;
+        }
+
+        // Only count items at top level (zero indentation)
+        let indent = line.len() - line.trim_start().len();
+        if indent > 0 {
+            continue;
+        }
+
+        if is_rust_item_declaration(trimmed) {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+/// Check if a trimmed line starts a Rust item declaration.
+fn is_rust_item_declaration(trimmed: &str) -> bool {
+    // Strip visibility prefix
+    let rest = if let Some(r) = trimmed.strip_prefix("pub(crate) ") {
+        r
+    } else if let Some(r) = trimmed.strip_prefix("pub(super) ") {
+        r
+    } else if let Some(r) = trimmed.strip_prefix("pub ") {
+        r
+    } else {
+        trimmed
+    };
+
+    // Strip async/unsafe/const modifiers for functions
+    let rest = if let Some(r) = rest.strip_prefix("async ") { r } else { rest };
+    let rest = if let Some(r) = rest.strip_prefix("unsafe ") { r } else { rest };
+
+    rest.starts_with("fn ")
+        || rest.starts_with("struct ")
+        || rest.starts_with("enum ")
+        || rest.starts_with("const ")
+        || rest.starts_with("static ")
+        || rest.starts_with("type ")
+        || rest.starts_with("trait ")
+        || rest.starts_with("impl ")
+        || rest.starts_with("impl<")
+}
+
+/// Count top-level items in PHP source.
+///
+/// Matches: function, class, interface, trait, const at zero indentation.
+fn count_php_items(content: &str) -> usize {
+    let mut count = 0;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let indent = line.len() - line.trim_start().len();
+        if indent > 0 {
+            continue;
+        }
+
+        // Strip visibility
+        let rest = trimmed
+            .strip_prefix("public ")
+            .or_else(|| trimmed.strip_prefix("protected "))
+            .or_else(|| trimmed.strip_prefix("private "))
+            .unwrap_or(trimmed);
+        let rest = rest
+            .strip_prefix("static ")
+            .or_else(|| rest.strip_prefix("abstract "))
+            .or_else(|| rest.strip_prefix("final "))
+            .unwrap_or(rest);
+
+        if rest.starts_with("function ")
+            || rest.starts_with("class ")
+            || rest.starts_with("interface ")
+            || rest.starts_with("trait ")
+            || rest.starts_with("const ")
+        {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+/// Count top-level items in JavaScript/TypeScript source.
+///
+/// Matches: function, class, const, let, var, export at zero indentation.
+fn count_js_items(content: &str) -> usize {
+    let mut count = 0;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let indent = line.len() - line.trim_start().len();
+        if indent > 0 {
+            continue;
+        }
+
+        let rest = trimmed
+            .strip_prefix("export default ")
+            .or_else(|| trimmed.strip_prefix("export "))
+            .unwrap_or(trimmed);
+
+        if rest.starts_with("function ")
+            || rest.starts_with("class ")
+            || rest.starts_with("const ")
+            || rest.starts_with("let ")
+            || rest.starts_with("var ")
+            || rest.starts_with("interface ")
+            || rest.starts_with("type ")
+            || rest.starts_with("enum ")
+        {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_rust_items_basic() {
+        let content = r#"
+use std::path::Path;
+
+pub struct Foo {
+    name: String,
+}
+
+fn helper() -> bool {
+    true
+}
+
+pub fn main_logic() {
+    // ...
+}
+
+impl Foo {
+    pub fn new() -> Self {
+        Self { name: String::new() }
+    }
+}
+
+const MAX: usize = 100;
+
+#[cfg(test)]
+mod tests {
+    fn test_something() {}
+    fn test_another() {}
+}
+"#;
+        // Should count: struct Foo, fn helper, pub fn main_logic, impl Foo, const MAX = 5
+        // Should NOT count: use, items inside #[cfg(test)]
+        let count = count_rust_items(content);
+        assert_eq!(count, 5, "Expected 5 top-level items");
+    }
+
+    #[test]
+    fn count_rust_items_with_visibility() {
+        let content = r#"
+pub(crate) fn internal() {}
+pub struct Public {}
+pub(super) const X: i32 = 1;
+pub async fn async_handler() {}
+"#;
+        assert_eq!(count_rust_items(content), 4);
+    }
+
+    #[test]
+    fn count_php_items_basic() {
+        let content = r#"<?php
+namespace App\Models;
+
+class User {
+    public function getName() {}
+    public function getEmail() {}
+}
+
+function helper() {}
+
+interface Cacheable {
+    public function cache();
+}
+"#;
+        // class User, function helper, interface Cacheable = 3
+        // Methods inside class are indented, so not counted
+        assert_eq!(count_php_items(content), 3);
+    }
+
+    #[test]
+    fn count_js_items_basic() {
+        let content = r#"
+import { foo } from './bar';
+
+export function processData() {}
+
+export class DataProcessor {
+    transform() {}
+}
+
+const CONFIG = {};
+
+export default function main() {}
+"#;
+        // export function, export class, const CONFIG, export default function = 4
+        assert_eq!(count_js_items(content), 4);
+    }
+
+    #[test]
+    fn god_file_detected() {
+        let dir = std::env::temp_dir().join("homeboy_structural_god_test");
+        let _ = std::fs::create_dir_all(&dir);
+
+        // Create a file with 600 lines
+        let mut content = String::new();
+        for i in 0..600 {
+            content.push_str(&format!("fn func_{}() {{}}\n", i));
+        }
+        std::fs::write(dir.join("big.rs"), &content).unwrap();
+
+        // Create a small file (under threshold)
+        std::fs::write(dir.join("small.rs"), "fn tiny() {}\n").unwrap();
+
+        let findings = analyze_structure(&dir);
+        let god_findings: Vec<&Finding> = findings.iter()
+            .filter(|f| f.kind == DeviationKind::GodFile)
+            .collect();
+
+        assert_eq!(god_findings.len(), 1, "Should flag big.rs as god file");
+        assert_eq!(god_findings[0].file, "big.rs");
+        assert!(god_findings[0].description.contains("600 lines"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn high_item_count_detected() {
+        let dir = std::env::temp_dir().join("homeboy_structural_items_test");
+        let _ = std::fs::create_dir_all(&dir);
+
+        // Create a file with 20 top-level functions (over threshold of 15)
+        let mut content = String::new();
+        for i in 0..20 {
+            content.push_str(&format!("fn func_{}() {{}}\n", i));
+        }
+        std::fs::write(dir.join("many.rs"), &content).unwrap();
+
+        let findings = analyze_structure(&dir);
+        let item_findings: Vec<&Finding> = findings.iter()
+            .filter(|f| f.kind == DeviationKind::HighItemCount)
+            .collect();
+
+        assert_eq!(item_findings.len(), 1, "Should flag many.rs for high item count");
+        assert!(item_findings[0].description.contains("20 top-level items"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn skips_non_source_files() {
+        let dir = std::env::temp_dir().join("homeboy_structural_skip_test");
+        let _ = std::fs::create_dir_all(&dir);
+
+        // A big non-source file should not be flagged
+        let mut content = String::new();
+        for _ in 0..1000 {
+            content.push_str("some data line\n");
+        }
+        std::fs::write(dir.join("data.csv"), &content).unwrap();
+        std::fs::write(dir.join("readme.md"), &content).unwrap();
+
+        let findings = analyze_structure(&dir);
+        assert!(findings.is_empty(), "Non-source files should not produce findings");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn skips_vendor_directories() {
+        let dir = std::env::temp_dir().join("homeboy_structural_vendor_test");
+        let vendor = dir.join("vendor");
+        let _ = std::fs::create_dir_all(&vendor);
+
+        let mut content = String::new();
+        for i in 0..600 {
+            content.push_str(&format!("fn func_{}() {{}}\n", i));
+        }
+        std::fs::write(vendor.join("big.rs"), &content).unwrap();
+
+        let findings = analyze_structure(&dir);
+        assert!(findings.is_empty(), "Files in vendor/ should be skipped");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn under_threshold_no_findings() {
+        let dir = std::env::temp_dir().join("homeboy_structural_clean_test");
+        let _ = std::fs::create_dir_all(&dir);
+
+        // A reasonable 100-line file with 5 items
+        let mut content = String::new();
+        for i in 0..5 {
+            content.push_str(&format!("/// Doc for func_{}\n", i));
+            content.push_str(&format!("pub fn func_{}() {{\n", i));
+            for j in 0..15 {
+                content.push_str(&format!("    let x{} = {};\n", j, j));
+            }
+            content.push_str("}\n\n");
+        }
+        std::fs::write(dir.join("clean.rs"), &content).unwrap();
+
+        let findings = analyze_structure(&dir);
+        assert!(findings.is_empty(), "Clean files should produce no findings");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **god file detection** and **high item count warnings** to `homeboy audit`
- New Phase 4b in the audit pipeline: structural complexity analysis runs after convention-based findings
- New `DeviationKind` variants: `GodFile`, `HighItemCount`
- Language-aware item counting for Rust, PHP, and JS/TS
- Plugs into existing `Finding` / `Severity` system — shows alongside convention drift findings

## Self-audit results on homeboy

```
Structural: 59 finding(s)
  27 god file warnings  (>500 lines)
  32 high item count    (>15 top-level items)
```

Top offenders:
| File | Lines | Items |
|---|---|---|
| `conventions.rs` | 1,966 | 27 |
| `deploy.rs` | 1,809 | 44 |
| `docs_audit/mod.rs` | 1,611 | 27 |
| `fixer.rs` | 1,579 | 29 |
| `config.rs` | 1,529 | 53 |
| `version.rs` | 1,145 | 30 |
| `git/operations.rs` | 1,131 | 46 |

## The audit → refactor pipeline

This completes the detection side. The tools to act on findings are already merged:

```
audit (detect)  →  refactor add   (fix imports)
                →  refactor move  (decompose god files)
                →  refactor rename (rename across codebase)
```

## Testing

- All 466 tests pass (9 new tests for structural analysis)
- Tests cover: Rust/PHP/JS item counting, god file threshold, high item count threshold, skipping non-source files, skipping vendor directories, clean files producing no findings

Closes #334