### PR TITLE
feat: duplication detection in audit — find identical functions across files

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -96,6 +96,8 @@ pub enum DeviationKind {
     GodFile,
     /// File has too many top-level items.
     HighItemCount,
+    /// Function body is duplicated across files.
+    DuplicateFunction,
 }
 
 // ============================================================================
@@ -556,6 +558,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/webhook.php".to_string(),
@@ -571,6 +574,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/agent-ping.php".to_string(),
@@ -582,6 +586,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -611,7 +616,8 @@ mod tests {
             implements: vec![],
             namespace: None,
             imports: vec![],
-        content: String::new(),
+            content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
         }];
 
         assert!(discover_conventions("Single", "*.php", &fingerprints).is_none());
@@ -639,6 +645,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/update.php".to_string(),
@@ -650,6 +657,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/helpers.php".to_string(),
@@ -661,6 +669,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -693,6 +702,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "b.php".to_string(),
@@ -704,6 +714,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "c.php".to_string(),
@@ -715,6 +726,7 @@ mod tests {
                 namespace: None,
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -992,6 +1004,7 @@ class AgentPing {
                 namespace: Some("DataMachine\\Abilities\\Flow".to_string()),
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/UpdateFlow.php".to_string(),
@@ -1003,6 +1016,7 @@ class AgentPing {
                 namespace: Some("DataMachine\\Abilities\\Flow".to_string()),
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/DeleteFlow.php".to_string(),
@@ -1014,6 +1028,7 @@ class AgentPing {
                 namespace: Some("DataMachine\\Flow".to_string()), // WRONG namespace
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -1042,6 +1057,7 @@ class AgentPing {
                 namespace: None,
                 imports: vec!["DataMachine\\Core\\Base".to_string()],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/B.php".to_string(),
@@ -1053,6 +1069,7 @@ class AgentPing {
                 namespace: None,
                 imports: vec!["DataMachine\\Core\\Base".to_string()],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/C.php".to_string(),
@@ -1065,6 +1082,7 @@ class AgentPing {
                 imports: vec![],
                 // File uses Base but doesn't import it
                 content: "class C extends Base {\n    public function execute() {}\n}".to_string(),
+                method_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -1091,6 +1109,7 @@ class AgentPing {
                 namespace: Some("App\\Steps".to_string()),
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/B.php".to_string(),
@@ -1102,6 +1121,7 @@ class AgentPing {
                 namespace: Some("App\\Steps".to_string()),
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/C.php".to_string(),
@@ -1113,6 +1133,7 @@ class AgentPing {
                 namespace: None, // Missing namespace entirely
                 imports: vec![],
             content: String::new(),
+            method_hashes: std::collections::HashMap::new(),
             },
         ];
 

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -1,0 +1,201 @@
+//! Duplication detection — find identical functions across source files.
+//!
+//! Uses method body hashes from fingerprinting to detect exact duplicates.
+//! Extension scripts normalize whitespace and hash function bodies during
+//! fingerprinting — this module groups by hash to find duplicates.
+
+use std::collections::HashMap;
+
+use super::conventions::DeviationKind;
+use super::fingerprint::FileFingerprint;
+use super::findings::{Finding, Severity};
+
+/// Minimum number of locations for a function to count as duplicated.
+const MIN_DUPLICATE_LOCATIONS: usize = 2;
+
+/// Detect duplicated functions across all fingerprinted files.
+///
+/// Groups functions by their body hash. When two or more files contain a
+/// function with the same name and the same normalized body hash, a finding
+/// is emitted for each location.
+pub fn detect_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    // Group: (method_name, body_hash) → list of file paths
+    let mut hash_groups: HashMap<(&str, &str), Vec<&str>> = HashMap::new();
+
+    for fp in fingerprints {
+        for (method_name, body_hash) in &fp.method_hashes {
+            hash_groups
+                .entry((method_name.as_str(), body_hash.as_str()))
+                .or_default()
+                .push(&fp.relative_path);
+        }
+    }
+
+    let mut findings = Vec::new();
+
+    for ((method_name, _hash), locations) in &hash_groups {
+        if locations.len() < MIN_DUPLICATE_LOCATIONS {
+            continue;
+        }
+
+        let other_files: Vec<&str> = locations.to_vec();
+        let suggestion = format!(
+            "Function `{}` has identical body in {} files. \
+             Extract to a shared module and import it.",
+            method_name,
+            other_files.len()
+        );
+
+        // Emit one finding per file that has the duplicate
+        for file in &other_files {
+            let other_locations: Vec<&&str> = other_files
+                .iter()
+                .filter(|f| *f != file)
+                .collect();
+            let also_in = other_locations
+                .iter()
+                .map(|f| f.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            findings.push(Finding {
+                convention: "duplication".to_string(),
+                severity: Severity::Warning,
+                file: file.to_string(),
+                description: format!(
+                    "Duplicate function `{}` — also in {}",
+                    method_name, also_in
+                ),
+                suggestion: suggestion.clone(),
+                kind: DeviationKind::DuplicateFunction,
+            });
+        }
+    }
+
+    // Sort by file path then description for deterministic output
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then_with(|| a.description.cmp(&b.description)));
+    findings
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code_audit::conventions::Language;
+
+    fn make_fingerprint(
+        path: &str,
+        methods: &[&str],
+        hashes: &[(&str, &str)],
+    ) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Rust,
+            methods: methods.iter().map(|s| s.to_string()).collect(),
+            registrations: vec![],
+            type_name: None,
+            implements: vec![],
+            namespace: None,
+            imports: vec![],
+            content: String::new(),
+            method_hashes: hashes
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn detects_exact_duplicate() {
+        let fp1 = make_fingerprint(
+            "src/utils/io.rs",
+            &["is_zero"],
+            &[("is_zero", "abc123")],
+        );
+        let fp2 = make_fingerprint(
+            "src/utils/validation.rs",
+            &["is_zero"],
+            &[("is_zero", "abc123")],
+        );
+
+        let findings = detect_duplicates(&[&fp1, &fp2]);
+
+        assert_eq!(findings.len(), 2, "Should emit one finding per location");
+        assert!(findings.iter().all(|f| f.kind == DeviationKind::DuplicateFunction));
+        assert!(findings.iter().any(|f| f.file == "src/utils/io.rs"));
+        assert!(findings.iter().any(|f| f.file == "src/utils/validation.rs"));
+        assert!(findings[0].description.contains("is_zero"));
+    }
+
+    #[test]
+    fn no_duplicates_different_hashes() {
+        let fp1 = make_fingerprint(
+            "src/a.rs",
+            &["process"],
+            &[("process", "hash_a")],
+        );
+        let fp2 = make_fingerprint(
+            "src/b.rs",
+            &["process"],
+            &[("process", "hash_b")],
+        );
+
+        let findings = detect_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "Different hashes should not flag duplicates");
+    }
+
+    #[test]
+    fn no_duplicates_single_location() {
+        let fp = make_fingerprint(
+            "src/only.rs",
+            &["unique_fn"],
+            &[("unique_fn", "abc123")],
+        );
+
+        let findings = detect_duplicates(&[&fp]);
+        assert!(findings.is_empty(), "Single location is not a duplicate");
+    }
+
+    #[test]
+    fn three_way_duplicate() {
+        let fp1 = make_fingerprint("src/a.rs", &["helper"], &[("helper", "same_hash")]);
+        let fp2 = make_fingerprint("src/b.rs", &["helper"], &[("helper", "same_hash")]);
+        let fp3 = make_fingerprint("src/c.rs", &["helper"], &[("helper", "same_hash")]);
+
+        let findings = detect_duplicates(&[&fp1, &fp2, &fp3]);
+
+        assert_eq!(findings.len(), 3, "Should flag all 3 locations");
+        assert!(findings[0].suggestion.contains("3 files"));
+    }
+
+    #[test]
+    fn empty_method_hashes_no_findings() {
+        let fp1 = make_fingerprint("src/a.rs", &["foo", "bar"], &[]);
+        let fp2 = make_fingerprint("src/b.rs", &["foo", "bar"], &[]);
+
+        let findings = detect_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "No hashes means no duplication findings");
+    }
+
+    #[test]
+    fn mixed_duplicates_and_unique() {
+        let fp1 = make_fingerprint(
+            "src/a.rs",
+            &["shared", "unique_a"],
+            &[("shared", "same"), ("unique_a", "hash_a")],
+        );
+        let fp2 = make_fingerprint(
+            "src/b.rs",
+            &["shared", "unique_b"],
+            &[("shared", "same"), ("unique_b", "hash_b")],
+        );
+
+        let findings = detect_duplicates(&[&fp1, &fp2]);
+
+        assert_eq!(findings.len(), 2, "Only 'shared' should be flagged");
+        assert!(findings.iter().all(|f| f.description.contains("shared")));
+    }
+}

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -1,5 +1,6 @@
 //! fingerprint — extracted from conventions.rs.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use super::conventions::Language;
@@ -26,6 +27,9 @@ pub struct FileFingerprint {
     pub imports: Vec<String>,
     /// Raw file content (for import usage analysis).
     pub content: String,
+    /// Method name → normalized body hash for duplication detection.
+    /// Populated by extension scripts that support it; empty otherwise.
+    pub method_hashes: HashMap<String, String>,
 }
 
 /// Extract a structural fingerprint from a source file.
@@ -58,5 +62,6 @@ pub fn fingerprint_file(path: &Path, root: &Path) -> Option<FileFingerprint> {
         namespace: output.namespace,
         imports: output.imports,
         content,
+        method_hashes: output.method_hashes,
     })
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -15,6 +15,7 @@ pub mod baseline;
 mod checks;
 pub(crate) mod conventions;
 mod discovery;
+mod duplication;
 mod findings;
 mod fingerprint;
 pub mod fixer;
@@ -240,6 +241,22 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
             structural_findings.len()
         );
         all_findings.extend(structural_findings);
+    }
+
+    // Phase 4c: Duplication detection (identical function bodies across files)
+    let all_fingerprints: Vec<&fingerprint::FileFingerprint> = discovery
+        .groups
+        .iter()
+        .flat_map(|(_, _, fps)| fps.iter())
+        .collect();
+    let duplication_findings = duplication::detect_duplicates(&all_fingerprints);
+    if !duplication_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Duplication: {} finding(s) (identical functions across files)",
+            duplication_findings.len()
+        );
+        all_findings.extend(duplication_findings);
     }
 
     // Phase 5: Build report

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -170,6 +170,11 @@ pub struct FingerprintOutput {
     pub namespace: Option<String>,
     #[serde(default)]
     pub imports: Vec<String>,
+    /// Method name → normalized body hash for duplication detection.
+    /// Extension scripts compute this by normalizing whitespace and hashing
+    /// the function body. Optional — older scripts may not emit this.
+    #[serde(default)]
+    pub method_hashes: std::collections::HashMap<String, String>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add Phase 4c to the audit pipeline: detect functions with identical normalized body hashes across source files
- New `duplication.rs` module with `detect_duplicates()` + 6 tests
- Add `method_hashes` field to `FingerprintOutput` and `FileFingerprint` (backward compatible — `#[serde(default)]`)
- Add `DuplicateFunction` variant to `DeviationKind`
- All 448 tests pass

## How it works

```
Extension script                    Homeboy core
─────────────────                   ────────────
fingerprint.sh                      fingerprint.rs
  extract fn bodies    ───JSON───>    FileFingerprint.method_hashes
  normalize whitespace                    │
  SHA-256 hash (16 chars)                 ▼
                                    duplication.rs
                                      group by (name, hash)
                                      flag if 2+ locations
                                          │
                                          ▼
                                    Finding { kind: DuplicateFunction }
```

## Live test on homeboy

Found 4 real duplicates:

| Function | Files |
|----------|-------|
| `default_true` | `defaults.rs` ↔ `project.rs` |
| `cache_path` | `extension_update_check.rs` ↔ `update_check.rs` |
| `is_disabled_by_config` | `extension_update_check.rs` ↔ `update_check.rs` |
| `now_unix` | `extension_update_check.rs` ↔ `update_check.rs` |

Companion PR: Extra-Chill/homeboy-extensions#51 (merged)

Closes #315