### PR TITLE
feat: auto-fix for duplicated functions via audit --fix

### DIFF
--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -290,6 +290,7 @@ mod tests {
             conventions: vec![],
             directory_conventions: vec![],
             findings,
+            duplicate_groups: vec![],
         }
     }
 

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -3,6 +3,10 @@
 //! Uses method body hashes from fingerprinting to detect exact duplicates.
 //! Extension scripts normalize whitespace and hash function bodies during
 //! fingerprinting — this module groups by hash to find duplicates.
+//!
+//! Two outputs:
+//! - `detect_duplicates()` → flat `Vec<Finding>` for the audit report
+//! - `detect_duplicate_groups()` → structured `Vec<DuplicateGroup>` for the fixer
 
 use std::collections::HashMap;
 
@@ -13,24 +17,97 @@ use super::findings::{Finding, Severity};
 /// Minimum number of locations for a function to count as duplicated.
 const MIN_DUPLICATE_LOCATIONS: usize = 2;
 
+/// A group of files containing an identical function.
+///
+/// The fixer uses this to keep the canonical copy and remove the rest.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DuplicateGroup {
+    /// The duplicated function name.
+    pub function_name: String,
+    /// File chosen to keep the function (canonical location).
+    pub canonical_file: String,
+    /// Files where the duplicate should be removed and replaced with an import.
+    pub remove_from: Vec<String>,
+}
+
+/// Build grouped duplication data from fingerprints.
+///
+/// For each group of identical functions, picks a canonical file (shortest
+/// path, then alphabetical) and lists the rest as removal targets.
+fn build_groups(fingerprints: &[&FileFingerprint]) -> HashMap<(String, String), Vec<String>> {
+    let mut hash_groups: HashMap<(String, String), Vec<String>> = HashMap::new();
+
+    for fp in fingerprints {
+        for (method_name, body_hash) in &fp.method_hashes {
+            hash_groups
+                .entry((method_name.clone(), body_hash.clone()))
+                .or_default()
+                .push(fp.relative_path.clone());
+        }
+    }
+
+    hash_groups
+}
+
+/// Pick the canonical file from a list of locations.
+///
+/// Heuristics (in order):
+/// 1. Files in a `utils/` directory are preferred (already shared)
+/// 2. Shortest path (most general module)
+/// 3. Alphabetical (deterministic tiebreaker)
+fn pick_canonical(locations: &[String]) -> String {
+    let mut sorted = locations.to_vec();
+    sorted.sort_by(|a, b| {
+        let a_utils = a.contains("/utils/") || a.contains("/utils.");
+        let b_utils = b.contains("/utils/") || b.contains("/utils.");
+        // utils files first
+        b_utils
+            .cmp(&a_utils)
+            // then shortest path
+            .then_with(|| a.len().cmp(&b.len()))
+            // then alphabetical
+            .then_with(|| a.cmp(b))
+    });
+    sorted[0].clone()
+}
+
+/// Detect duplicate groups with canonical file selection.
+///
+/// Returns structured data the fixer uses to remove duplicates.
+pub fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<DuplicateGroup> {
+    let hash_groups = build_groups(fingerprints);
+    let mut groups = Vec::new();
+
+    for ((method_name, _hash), locations) in &hash_groups {
+        if locations.len() < MIN_DUPLICATE_LOCATIONS {
+            continue;
+        }
+
+        let canonical = pick_canonical(locations);
+        let remove_from: Vec<String> = locations
+            .iter()
+            .filter(|f| **f != canonical)
+            .cloned()
+            .collect();
+
+        groups.push(DuplicateGroup {
+            function_name: method_name.clone(),
+            canonical_file: canonical,
+            remove_from,
+        });
+    }
+
+    groups.sort_by(|a, b| a.function_name.cmp(&b.function_name));
+    groups
+}
+
 /// Detect duplicated functions across all fingerprinted files.
 ///
 /// Groups functions by their body hash. When two or more files contain a
 /// function with the same name and the same normalized body hash, a finding
 /// is emitted for each location.
 pub fn detect_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
-    // Group: (method_name, body_hash) → list of file paths
-    let mut hash_groups: HashMap<(&str, &str), Vec<&str>> = HashMap::new();
-
-    for fp in fingerprints {
-        for (method_name, body_hash) in &fp.method_hashes {
-            hash_groups
-                .entry((method_name.as_str(), body_hash.as_str()))
-                .or_default()
-                .push(&fp.relative_path);
-        }
-    }
-
+    let hash_groups = build_groups(fingerprints);
     let mut findings = Vec::new();
 
     for ((method_name, _hash), locations) in &hash_groups {
@@ -38,30 +115,26 @@ pub fn detect_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
             continue;
         }
 
-        let other_files: Vec<&str> = locations.to_vec();
         let suggestion = format!(
             "Function `{}` has identical body in {} files. \
              Extract to a shared module and import it.",
             method_name,
-            other_files.len()
+            locations.len()
         );
 
         // Emit one finding per file that has the duplicate
-        for file in &other_files {
-            let other_locations: Vec<&&str> = other_files
+        for file in locations {
+            let also_in = locations
                 .iter()
                 .filter(|f| *f != file)
-                .collect();
-            let also_in = other_locations
-                .iter()
-                .map(|f| f.to_string())
+                .cloned()
                 .collect::<Vec<_>>()
                 .join(", ");
 
             findings.push(Finding {
                 convention: "duplication".to_string(),
                 severity: Severity::Warning,
-                file: file.to_string(),
+                file: file.clone(),
                 description: format!(
                     "Duplicate function `{}` — also in {}",
                     method_name, also_in
@@ -197,5 +270,57 @@ mod tests {
 
         assert_eq!(findings.len(), 2, "Only 'shared' should be flagged");
         assert!(findings.iter().all(|f| f.description.contains("shared")));
+    }
+
+    // ========================================================================
+    // DuplicateGroup / canonical selection tests
+    // ========================================================================
+
+    #[test]
+    fn group_picks_canonical_by_shortest_path() {
+        let fp1 = make_fingerprint("src/core/deep/nested/helper.rs", &["foo"], &[("foo", "h1")]);
+        let fp2 = make_fingerprint("src/utils.rs", &["foo"], &[("foo", "h1")]);
+
+        let groups = detect_duplicate_groups(&[&fp1, &fp2]);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].canonical_file, "src/utils.rs");
+        assert_eq!(groups[0].remove_from, vec!["src/core/deep/nested/helper.rs"]);
+    }
+
+    #[test]
+    fn group_prefers_utils_directory() {
+        let fp1 = make_fingerprint("src/core/a.rs", &["shared"], &[("shared", "h1")]);
+        let fp2 = make_fingerprint("src/utils/helpers.rs", &["shared"], &[("shared", "h1")]);
+
+        let groups = detect_duplicate_groups(&[&fp1, &fp2]);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].canonical_file, "src/utils/helpers.rs");
+        assert_eq!(groups[0].remove_from, vec!["src/core/a.rs"]);
+    }
+
+    #[test]
+    fn group_alphabetical_tiebreaker() {
+        let fp1 = make_fingerprint("src/b.rs", &["dup"], &[("dup", "h1")]);
+        let fp2 = make_fingerprint("src/a.rs", &["dup"], &[("dup", "h1")]);
+
+        let groups = detect_duplicate_groups(&[&fp1, &fp2]);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].canonical_file, "src/a.rs");
+    }
+
+    #[test]
+    fn group_three_way_has_two_removals() {
+        let fp1 = make_fingerprint("src/a.rs", &["f"], &[("f", "h")]);
+        let fp2 = make_fingerprint("src/b.rs", &["f"], &[("f", "h")]);
+        let fp3 = make_fingerprint("src/c.rs", &["f"], &[("f", "h")]);
+
+        let groups = detect_duplicate_groups(&[&fp1, &fp2, &fp3]);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].remove_from.len(), 2);
+        assert!(!groups[0].remove_from.contains(&groups[0].canonical_file));
     }
 }

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -46,6 +46,13 @@ pub enum InsertionKind {
     ConstructorWithRegistration,
     /// Add a missing import/use statement at the top of the file.
     ImportAdd,
+    /// Remove a function definition (lines start_line..=end_line) and replace with an import.
+    FunctionRemoval {
+        /// 1-indexed start line (includes doc comments and attributes).
+        start_line: usize,
+        /// 1-indexed end line (inclusive).
+        end_line: usize,
+    },
 }
 
 /// A file that was skipped by the fixer with a reason.
@@ -572,6 +579,116 @@ pub fn generate_fixes(result: &CodeAuditResult, root: &Path) -> FixResult {
         }
     }
 
+    // Phase 2: Duplication fixes — remove duplicate functions and add imports
+    for group in &result.duplicate_groups {
+        for remove_file in &group.remove_from {
+            let abs_path = root.join(remove_file);
+            let ext = abs_path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+
+            // Use the refactor extension to find function boundaries
+            let ext_manifest = crate::extension::find_extension_for_file_ext(ext, "refactor");
+            let content = match std::fs::read_to_string(&abs_path) {
+                Ok(c) => c,
+                Err(_) => {
+                    skipped.push(SkippedFile {
+                        file: remove_file.clone(),
+                        reason: format!("Cannot read file to remove duplicate `{}`", group.function_name),
+                    });
+                    continue;
+                }
+            };
+
+            let Some(manifest) = ext_manifest else {
+                skipped.push(SkippedFile {
+                    file: remove_file.clone(),
+                    reason: format!(
+                        "No refactor extension for .{} files — cannot locate `{}` boundaries",
+                        ext, group.function_name
+                    ),
+                });
+                continue;
+            };
+
+            // Call parse_items to find the function boundaries
+            let parse_cmd = serde_json::json!({
+                "command": "parse_items",
+                "file_path": remove_file,
+                "content": content,
+                "items": [group.function_name],
+            });
+
+            let parsed: Option<Vec<crate::extension::ParsedItem>> =
+                crate::extension::run_refactor_script(&manifest, &parse_cmd)
+                    .and_then(|v| v.get("items").cloned())
+                    .and_then(|v| serde_json::from_value(v).ok());
+
+            let Some(items) = parsed else {
+                skipped.push(SkippedFile {
+                    file: remove_file.clone(),
+                    reason: format!(
+                        "Extension could not parse `{}` boundaries in {}",
+                        group.function_name, remove_file
+                    ),
+                });
+                continue;
+            };
+
+            let Some(item) = items.iter().find(|i| i.name == group.function_name) else {
+                skipped.push(SkippedFile {
+                    file: remove_file.clone(),
+                    reason: format!(
+                        "Function `{}` not found by parser in {}",
+                        group.function_name, remove_file
+                    ),
+                });
+                continue;
+            };
+
+            // Build the import path from the canonical file
+            let import_path = module_path_from_file(&group.canonical_file);
+            let import_stmt = match ext {
+                "rs" => format!("use crate::{}::{};", import_path, group.function_name),
+                "php" => format!("use {};", group.function_name), // simplified
+                _ => format!("import {{ {} }} from '{}';", group.function_name, import_path),
+            };
+
+            let mut insertions = vec![
+                Insertion {
+                    kind: InsertionKind::FunctionRemoval {
+                        start_line: item.start_line,
+                        end_line: item.end_line,
+                    },
+                    code: String::new(),
+                    description: format!(
+                        "Remove duplicate `{}` (canonical copy in {})",
+                        group.function_name, group.canonical_file
+                    ),
+                },
+            ];
+
+            // Only add the import if the file doesn't already have it
+            if !content.contains(&import_stmt) {
+                insertions.push(Insertion {
+                    kind: InsertionKind::ImportAdd,
+                    code: import_stmt,
+                    description: format!(
+                        "Import `{}` from canonical location",
+                        group.function_name
+                    ),
+                });
+            }
+
+            fixes.push(Fix {
+                file: remove_file.clone(),
+                insertions,
+                applied: false,
+            });
+        }
+    }
+
     let total_insertions: usize = fixes.iter().map(|f| f.insertions.len()).sum();
     let files_modified = fixes.len();
 
@@ -581,6 +698,17 @@ pub fn generate_fixes(result: &CodeAuditResult, root: &Path) -> FixResult {
         total_insertions,
         files_modified,
     }
+}
+
+/// Convert a relative file path to a Rust module path.
+///
+/// `src/core/update_check.rs` → `core::update_check`
+/// `src/utils/mod.rs` → `utils`
+fn module_path_from_file(file_path: &str) -> String {
+    let p = file_path.strip_prefix("src/").unwrap_or(file_path);
+    let p = p.strip_suffix(".rs").unwrap_or(p);
+    let p = p.strip_suffix("/mod").unwrap_or(p);
+    p.replace('/', "::")
 }
 
 /// Detect the common naming suffix among conforming files.
@@ -766,17 +894,46 @@ fn apply_insertions_to_content(
     let mut registration_stubs = Vec::new();
     let mut constructor_stubs = Vec::new();
     let mut import_adds = Vec::new();
+    let mut removals: Vec<(usize, usize)> = Vec::new();
 
     for insertion in insertions {
-        match insertion.kind {
+        match &insertion.kind {
             InsertionKind::MethodStub => method_stubs.push(&insertion.code),
             InsertionKind::RegistrationStub => registration_stubs.push(&insertion.code),
             InsertionKind::ConstructorWithRegistration => constructor_stubs.push(&insertion.code),
             InsertionKind::ImportAdd => import_adds.push(&insertion.code),
+            InsertionKind::FunctionRemoval { start_line, end_line } => {
+                removals.push((*start_line, *end_line));
+            }
         }
     }
 
-    // Apply import additions first (they go at the top)
+    // Apply function removals first (before adding imports, to avoid line shifts)
+    // Process in reverse order so earlier removals don't invalidate later line numbers
+    if !removals.is_empty() {
+        removals.sort_by(|a, b| b.0.cmp(&a.0)); // reverse by start_line
+        let mut lines: Vec<&str> = result.lines().collect();
+        for (start, end) in &removals {
+            let start_idx = start.saturating_sub(1); // 1-indexed → 0-indexed
+            let end_idx = (*end).min(lines.len());
+            if start_idx < lines.len() {
+                // Also remove trailing blank line if present
+                let remove_end = if end_idx < lines.len() && lines[end_idx].trim().is_empty() {
+                    end_idx + 1
+                } else {
+                    end_idx
+                };
+                lines.drain(start_idx..remove_end);
+            }
+        }
+        result = lines.join("\n");
+        // Preserve trailing newline if original had one
+        if content.ends_with('\n') && !result.ends_with('\n') {
+            result.push('\n');
+        }
+    }
+
+    // Apply import additions (they go at the top)
     for import_line in &import_adds {
         result = insert_import(&result, import_line, language);
     }
@@ -1095,6 +1252,7 @@ class BadAbility {
             }],
             findings: vec![],
             directory_conventions: vec![],
+            duplicate_groups: vec![],
         };
 
         let fix_result = generate_fixes(&audit_result, &dir);
@@ -1338,6 +1496,7 @@ class {} {{
             }],
             findings: vec![],
             directory_conventions: vec![],
+            duplicate_groups: vec![],
         };
 
         let fix_result = generate_fixes(&audit_result, &dir);
@@ -1404,6 +1563,7 @@ class {} {{
             }],
             findings: vec![],
             directory_conventions: vec![],
+            duplicate_groups: vec![],
         };
 
         let fix_result = generate_fixes(&audit_result, &dir);
@@ -1532,6 +1692,7 @@ pub struct TestOutput {}
             }],
             findings: vec![],
             directory_conventions: vec![],
+            duplicate_groups: vec![],
         };
 
         let fix_result = generate_fixes(&audit_result, &dir);

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -65,6 +65,9 @@ pub struct CodeAuditResult {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub directory_conventions: Vec<DirectoryConvention>,
     pub findings: Vec<Finding>,
+    /// Grouped duplications for the fixer — each group has a canonical file and removal targets.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub duplicate_groups: Vec<duplication::DuplicateGroup>,
 }
 
 /// A cross-directory convention: a pattern that sibling subdirectories share.
@@ -207,6 +210,7 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
             conventions: vec![],
             directory_conventions: vec![],
             findings: vec![],
+            duplicate_groups: vec![],
         });
     }
 
@@ -250,11 +254,13 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
         .flat_map(|(_, _, fps)| fps.iter())
         .collect();
     let duplication_findings = duplication::detect_duplicates(&all_fingerprints);
+    let duplicate_groups = duplication::detect_duplicate_groups(&all_fingerprints);
     if !duplication_findings.is_empty() {
         log_status!(
             "audit",
-            "Duplication: {} finding(s) (identical functions across files)",
-            duplication_findings.len()
+            "Duplication: {} finding(s) across {} group(s)",
+            duplication_findings.len(),
+            duplicate_groups.len()
         );
         all_findings.extend(duplication_findings);
     }
@@ -332,6 +338,7 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
         conventions: convention_reports,
         directory_conventions,
         findings: all_findings,
+        duplicate_groups,
     })
 }
 

--- a/src/core/refactor/add.rs
+++ b/src/core/refactor/add.rs
@@ -334,6 +334,7 @@ mod tests {
             conventions: vec![],
             directory_conventions: vec![],
             findings: vec![],
+            duplicate_groups: vec![],
         };
 
         let result = fixes_from_audit(&audit, false);


### PR DESCRIPTION
## Summary

- `homeboy audit --fix` now generates removal + import fixes for duplicated functions
- New `DuplicateGroup` struct with canonical file selection (prefers `utils/`, then shortest path, then alphabetical)
- New `FunctionRemoval` insertion kind that removes lines by range
- Calls `parse_items` via refactor extension to locate function boundaries
- 452 tests pass

## How it works

```
audit detects duplicate          fixer generates fix
────────────────────             ──────────────────
DuplicateGroup {                 Fix {
  function: "cache_path"           file: "extension_update_check.rs"
  canonical: "update_check.rs"     insertions: [
  remove_from: [                     FunctionRemoval { lines 28-30 },
    "extension_update_check.rs"      ImportAdd("use crate::...::cache_path;")
  ]                                ]
}                                }
```

## Live test on homeboy

```
src/core/extension_update_check.rs:
  REMOVE lines 28-30: duplicate cache_path (canonical in update_check.rs)
  ADD IMPORT: use crate::core::update_check::cache_path;
  REMOVE lines 64-66: duplicate is_disabled_by_config
  ADD IMPORT: use crate::core::update_check::is_disabled_by_config;
  REMOVE lines 46-51: duplicate now_unix
  ADD IMPORT: use crate::core::update_check::now_unix;

src/core/defaults.rs:
  REMOVE lines 29-31: duplicate default_true (canonical in project.rs)
  ADD IMPORT: use crate::core::project::default_true;
```

Follow-up to #344 (duplication detection). Builds on extensions PR #51 (method body hashes).