### PR TITLE
feat: structural near-duplicate detection in audit (Phase 4d)

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -98,6 +98,8 @@ pub enum DeviationKind {
     HighItemCount,
     /// Function body is duplicated across files.
     DuplicateFunction,
+    /// Function has identical structure but different identifiers/literals.
+    NearDuplicate,
 }
 
 // ============================================================================
@@ -559,6 +561,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/webhook.php".to_string(),
@@ -575,6 +578,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/agent-ping.php".to_string(),
@@ -587,6 +591,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -618,6 +623,7 @@ mod tests {
             imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
         }];
 
         assert!(discover_conventions("Single", "*.php", &fingerprints).is_none());
@@ -646,6 +652,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/update.php".to_string(),
@@ -658,6 +665,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/helpers.php".to_string(),
@@ -670,6 +678,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -703,6 +712,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "b.php".to_string(),
@@ -715,6 +725,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "c.php".to_string(),
@@ -727,6 +738,7 @@ mod tests {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -1005,6 +1017,7 @@ class AgentPing {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/UpdateFlow.php".to_string(),
@@ -1017,6 +1030,7 @@ class AgentPing {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/DeleteFlow.php".to_string(),
@@ -1029,6 +1043,7 @@ class AgentPing {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -1058,6 +1073,7 @@ class AgentPing {
                 imports: vec!["DataMachine\\Core\\Base".to_string()],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/B.php".to_string(),
@@ -1070,6 +1086,7 @@ class AgentPing {
                 imports: vec!["DataMachine\\Core\\Base".to_string()],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "abilities/C.php".to_string(),
@@ -1083,6 +1100,7 @@ class AgentPing {
                 // File uses Base but doesn't import it
                 content: "class C extends Base {\n    public function execute() {}\n}".to_string(),
                 method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
         ];
 
@@ -1110,6 +1128,7 @@ class AgentPing {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/B.php".to_string(),
@@ -1122,6 +1141,7 @@ class AgentPing {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
             FileFingerprint {
                 relative_path: "steps/C.php".to_string(),
@@ -1134,6 +1154,7 @@ class AgentPing {
                 imports: vec![],
             content: String::new(),
             method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
             },
         ];
 

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -1,12 +1,15 @@
-//! Duplication detection — find identical functions across source files.
+//! Duplication detection — find identical and near-identical functions across
+//! source files.
 //!
-//! Uses method body hashes from fingerprinting to detect exact duplicates.
-//! Extension scripts normalize whitespace and hash function bodies during
-//! fingerprinting — this module groups by hash to find duplicates.
+//! Uses method body hashes from fingerprinting to detect exact duplicates,
+//! and structural hashes (identifiers/literals normalized to positional tokens)
+//! to detect near-duplicates — functions with identical control flow that differ
+//! only in variable names, constant references, or string values.
 //!
-//! Two outputs:
-//! - `detect_duplicates()` → flat `Vec<Finding>` for the audit report
+//! Three outputs:
+//! - `detect_duplicates()` → flat `Vec<Finding>` for exact duplicates
 //! - `detect_duplicate_groups()` → structured `Vec<DuplicateGroup>` for the fixer
+//! - `detect_near_duplicates()` → flat `Vec<Finding>` for structural near-duplicates
 
 use std::collections::HashMap;
 
@@ -151,6 +154,209 @@ pub fn detect_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
 }
 
 // ============================================================================
+// Near-Duplicate Detection (structural similarity)
+// ============================================================================
+
+/// Names that are too generic to flag as near-duplicates.
+/// These appear in many files with completely unrelated implementations.
+const GENERIC_NAMES: &[&str] = &[
+    "run", "new", "default", "build", "list", "show", "set", "get",
+    "delete", "remove", "clear", "create", "update", "status", "search",
+    "find", "read", "write", "rename", "init", "test", "fmt", "from",
+    "into", "clone", "drop", "display", "parse", "validate", "execute",
+    "handle", "process", "merge", "resolve", "pin", "plan",
+];
+
+/// Minimum body line count — skip trivial functions (1-2 line bodies).
+/// Functions like `fn default_true() -> bool { true }` are too small
+/// to meaningfully refactor into shared code with a parameter.
+const MIN_BODY_LINES: usize = 3;
+
+/// Build structural hash groups from fingerprints.
+///
+/// Groups functions by (name, structural_hash), returning only groups
+/// where the exact body hashes differ (otherwise they'd already be caught
+/// by the exact-duplicate detector).
+fn build_structural_groups(
+    fingerprints: &[&FileFingerprint],
+) -> HashMap<(String, String), Vec<(String, String)>> {
+    // Collect: (fn_name, structural_hash) → [(file, body_hash), ...]
+    let mut groups: HashMap<(String, String), Vec<(String, String)>> = HashMap::new();
+
+    for fp in fingerprints {
+        for (method_name, struct_hash) in &fp.structural_hashes {
+            groups
+                .entry((method_name.clone(), struct_hash.clone()))
+                .or_default()
+                .push((
+                    fp.relative_path.clone(),
+                    fp.method_hashes.get(method_name).cloned().unwrap_or_default(),
+                ));
+        }
+    }
+
+    groups
+}
+
+/// Check if a file path looks like a CLI command module.
+///
+/// Command modules (`src/commands/*.rs`) are expected to have identically-
+/// named functions (`run`, `list`, etc.) with completely different bodies.
+fn is_command_file(path: &str) -> bool {
+    path.contains("/commands/") || path.starts_with("commands/")
+}
+
+/// Count the body lines of a function in a file's structural hash data.
+///
+/// Uses heuristic: count lines in the content between `fn <name>` and the
+/// matching closing brace. Returns 0 if function not found or content empty.
+fn count_body_lines(fp: &FileFingerprint, method_name: &str) -> usize {
+    let pattern = format!("fn {}", method_name);
+    let lines: Vec<&str> = fp.content.lines().collect();
+    let mut start = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        if line.contains(&pattern) {
+            start = Some(i);
+            break;
+        }
+    }
+
+    let Some(start_idx) = start else { return 0 };
+
+    let mut brace_depth = 0i32;
+    let mut found_open = false;
+    for (offset, line) in lines[start_idx..].iter().enumerate() {
+        for ch in line.chars() {
+            if ch == '{' {
+                brace_depth += 1;
+                found_open = true;
+            } else if ch == '}' {
+                brace_depth -= 1;
+            }
+        }
+        if found_open && brace_depth == 0 {
+            return offset + 1;
+        }
+    }
+
+    0
+}
+
+/// Detect structural near-duplicates across all fingerprinted files.
+///
+/// Groups functions by (name, structural_hash). When two or more files
+/// contain a function with the same name and the same structural hash
+/// but *different* exact body hashes, it means the functions have
+/// identical control flow but differ in identifiers/constants.
+///
+/// Filters out:
+/// - Functions already caught by exact-duplicate detection
+/// - Generic names (`run`, `list`, `show`, etc.)
+/// - Command/core delegation pairs (command module ↔ core module)
+/// - Trivial functions (< 3 body lines)
+pub fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    let structural_groups = build_structural_groups(fingerprints);
+    let exact_groups = build_groups(fingerprints);
+
+    // Collect exact-duplicate (name, hash) pairs for exclusion
+    let exact_duplicate_names: std::collections::HashSet<String> = exact_groups
+        .iter()
+        .filter(|(_, locs)| locs.len() >= MIN_DUPLICATE_LOCATIONS)
+        .map(|((name, _), _)| name.clone())
+        .collect();
+
+    let mut findings = Vec::new();
+
+    for ((method_name, _struct_hash), file_hashes) in &structural_groups {
+        // Need at least 2 locations
+        if file_hashes.len() < MIN_DUPLICATE_LOCATIONS {
+            continue;
+        }
+
+        // Skip if already an exact duplicate
+        if exact_duplicate_names.contains(method_name) {
+            continue;
+        }
+
+        // Skip generic names
+        if GENERIC_NAMES.contains(&method_name.as_str()) {
+            continue;
+        }
+
+        // Check that exact hashes actually differ (otherwise exact detection covers it)
+        let unique_body_hashes: std::collections::HashSet<&str> = file_hashes
+            .iter()
+            .map(|(_, h)| h.as_str())
+            .collect();
+        if unique_body_hashes.len() < 2 {
+            continue;
+        }
+
+        let files: Vec<&str> = file_hashes.iter().map(|(f, _)| f.as_str()).collect();
+
+        // Filter: skip if all files are command modules (delegation pattern)
+        if files.iter().all(|f| is_command_file(f)) {
+            continue;
+        }
+
+        // Filter: skip command↔core pairs where one is in commands/ and another in core/
+        // These are the delegation pattern — the command calls the core function.
+        let has_command = files.iter().any(|f| is_command_file(f));
+        let has_non_command = files.iter().any(|f| !is_command_file(f));
+        if has_command && has_non_command && files.len() == 2 {
+            continue;
+        }
+
+        // Filter: skip trivial functions (< MIN_BODY_LINES)
+        let body_lines: Vec<usize> = files
+            .iter()
+            .filter_map(|file_path| {
+                fingerprints
+                    .iter()
+                    .find(|fp| fp.relative_path == *file_path)
+                    .map(|fp| count_body_lines(fp, method_name))
+            })
+            .collect();
+        if body_lines.iter().all(|&l| l < MIN_BODY_LINES) {
+            continue;
+        }
+
+        let suggestion = format!(
+            "Function `{}` has identical structure in {} files but different \
+             identifiers/constants. Consider extracting shared logic into a \
+             parameterized function.",
+            method_name,
+            files.len()
+        );
+
+        for (file, _body_hash) in file_hashes {
+            let also_in = file_hashes
+                .iter()
+                .filter(|(f, _)| f != file)
+                .map(|(f, _)| f.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            findings.push(Finding {
+                convention: "near-duplication".to_string(),
+                severity: Severity::Info,
+                file: file.clone(),
+                description: format!(
+                    "Near-duplicate `{}` — structurally identical to {}",
+                    method_name, also_in
+                ),
+                suggestion: suggestion.clone(),
+                kind: DeviationKind::NearDuplicate,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then_with(|| a.description.cmp(&b.description)));
+    findings
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -164,6 +370,15 @@ mod tests {
         methods: &[&str],
         hashes: &[(&str, &str)],
     ) -> FileFingerprint {
+        make_fingerprint_with_structural(path, methods, hashes, &[])
+    }
+
+    fn make_fingerprint_with_structural(
+        path: &str,
+        methods: &[&str],
+        hashes: &[(&str, &str)],
+        structural: &[(&str, &str)],
+    ) -> FileFingerprint {
         FileFingerprint {
             relative_path: path.to_string(),
             language: Language::Rust,
@@ -175,6 +390,10 @@ mod tests {
             imports: vec![],
             content: String::new(),
             method_hashes: hashes
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            structural_hashes: structural
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
@@ -322,5 +541,171 @@ mod tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].remove_from.len(), 2);
         assert!(!groups[0].remove_from.contains(&groups[0].canonical_file));
+    }
+
+    // ========================================================================
+    // Near-duplicate detection tests
+    // ========================================================================
+
+    /// Helper to build a fingerprint with content for body-line counting.
+    fn make_fp_with_content(
+        path: &str,
+        content: &str,
+        hashes: &[(&str, &str)],
+        structural: &[(&str, &str)],
+    ) -> FileFingerprint {
+        let mut fp = make_fingerprint_with_structural(path, &[], hashes, structural);
+        fp.content = content.to_string();
+        fp
+    }
+
+    #[test]
+    fn near_duplicate_detected_when_structural_match_but_exact_differs() {
+        // cache_path in two files: same structure, different constants
+        let content_a = "fn cache_path() -> Option<PathBuf> {\n    paths::homeboy().ok().map(|p| p.join(CACHE_A))\n}\n";
+        let content_b = "fn cache_path() -> Option<PathBuf> {\n    paths::homeboy().ok().map(|p| p.join(CACHE_B))\n}\n";
+
+        let fp1 = make_fp_with_content(
+            "src/core/update_check.rs",
+            content_a,
+            &[("cache_path", "hash_a")],
+            &[("cache_path", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/ext_update_check.rs",
+            content_b,
+            &[("cache_path", "hash_b")],
+            &[("cache_path", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+
+        assert_eq!(findings.len(), 2, "Should flag both locations");
+        assert!(findings.iter().all(|f| f.kind == DeviationKind::NearDuplicate));
+        assert!(findings[0].description.contains("cache_path"));
+        assert_eq!(findings[0].severity, Severity::Info);
+    }
+
+    #[test]
+    fn near_duplicate_skips_exact_duplicates() {
+        // If exact hashes match, exact-duplicate detector already handles it
+        let fp1 = make_fingerprint_with_structural(
+            "src/a.rs",
+            &["helper"],
+            &[("helper", "SAME")],
+            &[("helper", "SAME_STRUCT")],
+        );
+        let fp2 = make_fingerprint_with_structural(
+            "src/b.rs",
+            &["helper"],
+            &[("helper", "SAME")],
+            &[("helper", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "Exact duplicates should be excluded");
+    }
+
+    #[test]
+    fn near_duplicate_skips_generic_names() {
+        let content = "fn run() {\n    do_something();\n    do_more();\n}\n";
+        let fp1 = make_fp_with_content(
+            "src/core/a.rs",
+            content,
+            &[("run", "hash_a")],
+            &[("run", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/b.rs",
+            content,
+            &[("run", "hash_b")],
+            &[("run", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "'run' is a generic name — should be skipped");
+    }
+
+    #[test]
+    fn near_duplicate_skips_command_core_pairs() {
+        let content = "fn deploy_site() {\n    connect();\n    upload();\n    verify();\n}\n";
+        let fp1 = make_fp_with_content(
+            "src/commands/deploy.rs",
+            content,
+            &[("deploy_site", "hash_a")],
+            &[("deploy_site", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/deploy.rs",
+            content,
+            &[("deploy_site", "hash_b")],
+            &[("deploy_site", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "Command↔core pair should be skipped");
+    }
+
+    #[test]
+    fn near_duplicate_skips_trivial_functions() {
+        // default_true is only 1 line — too trivial to refactor
+        let content = "fn default_true() -> bool { true }\n";
+        let fp1 = make_fp_with_content(
+            "src/core/defaults.rs",
+            content,
+            &[("default_true", "hash_a")],
+            &[("default_true", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/project.rs",
+            content,
+            &[("default_true", "hash_b")],
+            &[("default_true", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "Trivial functions should be skipped");
+    }
+
+    #[test]
+    fn near_duplicate_not_skipped_for_multi_line_core_functions() {
+        // Non-trivial functions in core/ (not commands/) SHOULD be flagged
+        let content = "fn cache_path() -> Option<PathBuf> {\n    let base = paths::homeboy()?;\n    let file = base.join(FILENAME);\n    Some(file)\n}\n";
+        let fp1 = make_fp_with_content(
+            "src/core/update.rs",
+            content,
+            &[("cache_path", "hash_a")],
+            &[("cache_path", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/ext_update.rs",
+            content,
+            &[("cache_path", "hash_b")],
+            &[("cache_path", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert_eq!(findings.len(), 2, "Non-trivial core↔core near-duplicates should be flagged");
+    }
+
+    #[test]
+    fn near_duplicate_skips_all_command_files() {
+        // Multiple command files with same structural hash — normal pattern
+        let content = "fn components() {\n    let list = config::list();\n    for item in list {\n        output::print(item);\n    }\n}\n";
+        let fp1 = make_fp_with_content(
+            "src/commands/fleet.rs",
+            content,
+            &[("components", "hash_a")],
+            &[("components", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/commands/project.rs",
+            content,
+            &[("components", "hash_b")],
+            &[("components", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert!(findings.is_empty(), "All-commands group should be skipped");
     }
 }

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -30,6 +30,10 @@ pub struct FileFingerprint {
     /// Method name → normalized body hash for duplication detection.
     /// Populated by extension scripts that support it; empty otherwise.
     pub method_hashes: HashMap<String, String>,
+    /// Method name → structural hash for near-duplicate detection.
+    /// Identifiers/literals replaced with positional tokens before hashing.
+    /// Populated by extension scripts that support it; empty otherwise.
+    pub structural_hashes: HashMap<String, String>,
 }
 
 /// Extract a structural fingerprint from a source file.
@@ -63,5 +67,6 @@ pub fn fingerprint_file(path: &Path, root: &Path) -> Option<FileFingerprint> {
         imports: output.imports,
         content,
         method_hashes: output.method_hashes,
+        structural_hashes: output.structural_hashes,
     })
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -265,6 +265,17 @@ fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAudit
         all_findings.extend(duplication_findings);
     }
 
+    // Phase 4d: Near-duplicate detection (structural similarity)
+    let near_dup_findings = duplication::detect_near_duplicates(&all_fingerprints);
+    if !near_dup_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Near-duplicates: {} finding(s) (structural matches with different identifiers)",
+            near_dup_findings.len()
+        );
+        all_findings.extend(near_dup_findings);
+    }
+
     // Phase 5: Build report
     let total_outliers: usize = discovered_conventions.iter().map(|c| c.outliers.len()).sum();
     let total_conforming: usize = discovered_conventions.iter().map(|c| c.conforming.len()).sum();

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -175,6 +175,12 @@ pub struct FingerprintOutput {
     /// the function body. Optional — older scripts may not emit this.
     #[serde(default)]
     pub method_hashes: std::collections::HashMap<String, String>,
+    /// Method name → structural hash for near-duplicate detection.
+    /// Identifiers and literals are replaced with positional tokens before
+    /// hashing, so functions with identical control flow but different
+    /// variable names or constants produce the same hash.
+    #[serde(default)]
+    pub structural_hashes: std::collections::HashMap<String, String>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds Phase 4d to the audit pipeline: structural near-duplicate detection
- Functions with identical control flow but different identifiers/constants are flagged (e.g., forked modules that reference different constants)
- Extends `FingerprintOutput` and `FileFingerprint` with `structural_hashes` field (backward compatible via `#[serde(default)]`)
- Adds `NearDuplicate` variant to `DeviationKind`
- Filters out false positives: generic names (`run`, `list`, `show`...), command↔core delegation pairs, trivial functions, exact duplicates
- Severity is `Info` (not `Warning`) — requires human judgment about whether extraction is worthwhile
- 7 new tests, 461 total pass
- Dogfood: catches 6 real near-duplicates in homeboy, 0 false positives

## Dogfood results on homeboy

| Function | File A | File B |
|---|---|---|
| `cache_path` | update_check.rs | extension_update_check.rs |
| `now_unix` | update_check.rs | extension_update_check.rs |
| `is_disabled_by_config` | update_check.rs | extension_update_check.rs |
| `read_cache` | update_check.rs | extension_update_check.rs |
| `write_cache` | update_check.rs | extension_update_check.rs |
| `default_true` | defaults.rs | project.rs |

Companion: Extra-Chill/homeboy-extensions#52 (merged)

Closes #347