### PR TITLE
fix(deploy): improve 'no components configured' error with actionable details

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -248,7 +248,9 @@ pub fn run(
     };
 
     let result = deploy::run(&project_id, &config).map_err(|e| {
-        if e.message.contains("No components configured for project") {
+        if e.message.contains("No components configured for project")
+            || e.message.contains("No deployable components found")
+        {
             e.with_hint(format!(
                 "Run 'homeboy project components add {} <component-id>' to add components",
                 project_id

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -431,6 +431,23 @@ fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
             "No components linked - add with: homeboy project components add {} <component-id>",
             project.id
         ));
+    } else {
+        // Check if at least one component is actually deployable (has artifact or git strategy)
+        let has_deployable = project.component_ids.iter().any(|id| {
+            if let Ok(comp) = component::load(id) {
+                let is_git = comp.deploy_strategy.as_deref() == Some("git");
+                let has_artifact = component::resolve_artifact(&comp).is_some();
+                is_git || has_artifact
+            } else {
+                false
+            }
+        });
+        if !has_deployable {
+            blockers.push(format!(
+                "No deployable components - {} component(s) exist but none have a build artifact or deploy strategy configured",
+                project.component_ids.len()
+            ));
+        }
     }
 
     let deploy_ready = blockers.is_empty();

--- a/src/core/deploy.rs
+++ b/src/core/deploy.rs
@@ -757,17 +757,29 @@ fn deploy_components(
     ctx: &RemoteProjectContext,
     base_path: &str,
 ) -> Result<DeployOrchestrationResult> {
-    let all_components = load_project_components(&project.component_ids)?;
-    if all_components.is_empty() {
+    let loaded = load_project_components(&project.component_ids)?;
+    if loaded.deployable.is_empty() {
+        let message = if loaded.skipped.is_empty() {
+            "No components configured for project".to_string()
+        } else {
+            format!(
+                "No deployable components found — {} component(s) skipped (no build artifact or deploy strategy): {}",
+                loaded.skipped.len(),
+                loaded.skipped.join(", ")
+            )
+        };
         return Err(Error::validation_invalid_argument(
             "componentIds",
-            "No components configured for project",
+            message,
             None,
-            None,
+            Some(vec![
+                "Ensure components have a buildArtifact, an extension with artifact_pattern, or deploy_strategy: \"git\"".to_string(),
+                format!("Check with: homeboy component show <id>"),
+            ]),
         ));
     }
 
-    let components = plan_components(config, &all_components, base_path, &ctx.client)?;
+    let components = plan_components(config, &loaded.deployable, base_path, &ctx.client)?;
 
     if components.is_empty() {
         return Ok(DeployOrchestrationResult {
@@ -1408,13 +1420,23 @@ fn calculate_release_state(component: &Component) -> Option<ReleaseState> {
     })
 }
 
+/// Result of loading project components, including skipped (non-deployable) component IDs.
+struct LoadedComponents {
+    deployable: Vec<Component>,
+    skipped: Vec<String>,
+}
+
 /// Load components by ID, resolve artifact paths via extension patterns, and filter non-deployable.
 ///
 /// Validates that any extensions declared in the component's `extensions` field are installed.
 /// Returns an actionable error with install instructions when extensions are missing,
 /// rather than silently skipping the component.
-fn load_project_components(component_ids: &[String]) -> Result<Vec<Component>> {
-    let mut components = Vec::new();
+///
+/// Returns both the deployable components and the IDs of skipped (non-deployable) ones,
+/// so callers can produce accurate error messages.
+fn load_project_components(component_ids: &[String]) -> Result<LoadedComponents> {
+    let mut deployable = Vec::new();
+    let mut skipped = Vec::new();
 
     for id in component_ids {
         let mut loaded = component::load(id)?;
@@ -1434,11 +1456,11 @@ fn load_project_components(component_ids: &[String]) -> Result<Vec<Component>> {
             Some(artifact) if !is_git_deploy => {
                 let resolved_artifact = parser::resolve_path_string(&loaded.local_path, &artifact);
                 loaded.build_artifact = Some(resolved_artifact);
-                components.push(loaded);
+                deployable.push(loaded);
             }
             _ if is_git_deploy => {
                 // Git-deploy components are deployable without an artifact
-                components.push(loaded);
+                deployable.push(loaded);
             }
             Some(_) | None => {
                 // Skip - component is intentionally non-deployable
@@ -1447,12 +1469,13 @@ fn load_project_components(component_ids: &[String]) -> Result<Vec<Component>> {
                     "Skipping '{}': no artifact configured (non-deployable component)",
                     loaded.id
                 );
+                skipped.push(loaded.id.clone());
                 continue;
             }
         }
     }
 
-    Ok(components)
+    Ok(LoadedComponents { deployable, skipped })
 }
 
 /// Check if a component's build artifact is newer than its latest source commit.


### PR DESCRIPTION
## Summary

Fixes #329 — `homeboy deploy` showed "No components configured for project" even when components existed but were non-deployable.

- **`load_project_components`** now returns both deployable components and skipped component IDs via a `LoadedComponents` struct
- **Error message** now says "No deployable components found" and lists which components were skipped and why, with actionable hints
- **`deploy_ready` in `project show`** now checks whether at least one component is actually deployable (has artifact or git strategy), so `deploy_ready: true` is accurate
- **Hint matching** in the commands layer updated to catch both old and new error messages

## Before/After

**Before:**
```json
{"error": {"message": "No components configured for project"}}
```

**After:**
```json
{"error": {"message": "No deployable components found — 3 component(s) skipped (no build artifact or deploy strategy): comp-a, comp-b, comp-c", "hints": ["Ensure components have a buildArtifact...", "Check with: homeboy component show <id>"]}}
```

## Testing

All 464 existing tests pass. No new tests needed — this is an error message improvement.