### PR TITLE
fix(deploy): improve fleet/multi-project error handling and resilience

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -294,38 +294,85 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
     if component_ids.is_empty() {
         return Err(homeboy::Error::validation_invalid_argument(
             "component_ids",
-            "At least one component ID is required when using --projects",
+            "At least one component ID is required for multi-project deployment",
             None,
             None,
         ));
     }
 
-    // Validate all specified projects exist
+    // Validate specified projects exist, skip unknown ones instead of aborting.
+    // Fleet configs can accumulate stale project references — one missing project
+    // should not block deploying to the rest.
     let known_projects = homeboy::project::list_ids().unwrap_or_default();
-    for project_id in project_ids {
-        if !known_projects.contains(project_id) {
-            return Err(homeboy::Error::validation_invalid_argument(
-                "projects",
-                &format!("Unknown project: '{}'", project_id),
-                None,
-                None,
-            ));
-        }
+    let mut unknown_projects = Vec::new();
+    let valid_project_ids: Vec<&String> = project_ids
+        .iter()
+        .filter(|pid| {
+            if known_projects.contains(pid) {
+                true
+            } else {
+                unknown_projects.push(pid.to_string());
+                false
+            }
+        })
+        .collect();
+
+    for pid in &unknown_projects {
+        log_status!(
+            "deploy",
+            "Skipping unknown project '{}' — remove from fleet with: homeboy fleet remove-project <fleet> {}",
+            pid,
+            pid
+        );
+    }
+
+    if valid_project_ids.is_empty() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "projects",
+            format!(
+                "No valid projects found — all specified projects are unknown: {}",
+                unknown_projects.join(", ")
+            ),
+            None,
+            None,
+        ));
     }
 
     log_status!(
         "deploy",
-        "Deploying {:?} to {} project(s)...",
+        "Deploying {:?} to {} project(s){}...",
         component_ids,
-        project_ids.len()
+        valid_project_ids.len(),
+        if unknown_projects.is_empty() {
+            String::new()
+        } else {
+            format!(" ({} skipped)", unknown_projects.len())
+        }
     );
 
     let mut project_results = Vec::new();
     let mut succeeded: u32 = 0;
     let mut failed: u32 = 0;
+    let skipped: u32 = unknown_projects.len() as u32;
     let mut first_project = true;
 
-    for project_id in project_ids {
+    // Add skipped results for unknown projects
+    for pid in &unknown_projects {
+        project_results.push(ProjectDeployResult {
+            project_id: pid.clone(),
+            status: "skipped".to_string(),
+            error: Some(format!("Project '{}' not found — skipped", pid)),
+            results: vec![],
+            summary: DeploySummary {
+                total: 0,
+                succeeded: 0,
+                skipped: 0,
+                failed: 0,
+            },
+        });
+    }
+
+    for project_id in &valid_project_ids {
         log_status!("deploy", "Deploying to project '{}'...", project_id);
 
         let config = DeployConfig {
@@ -351,7 +398,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
                         .unwrap_or_else(|| "Deployment failed".to_string());
 
                     project_results.push(ProjectDeployResult {
-                        project_id: project_id.clone(),
+                        project_id: project_id.to_string(),
                         status: "failed".to_string(),
                         error: Some(error_msg),
                         results: result.results,
@@ -360,7 +407,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
                     failed += 1;
                 } else {
                     project_results.push(ProjectDeployResult {
-                        project_id: project_id.clone(),
+                        project_id: project_id.to_string(),
                         status: "deployed".to_string(),
                         error: None,
                         results: result.results,
@@ -371,7 +418,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
             }
             Err(e) => {
                 project_results.push(ProjectDeployResult {
-                    project_id: project_id.clone(),
+                    project_id: project_id.to_string(),
                     status: "failed".to_string(),
                     error: Some(e.to_string()),
                     results: vec![],
@@ -401,6 +448,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
                 total_projects: total,
                 succeeded,
                 failed,
+                skipped,
             },
             dry_run: args.dry_run,
             check: args.check,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,12 @@ pub struct ProjectsSummary {
     pub total_projects: u32,
     pub succeeded: u32,
     pub failed: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub skipped: u32,
+}
+
+fn is_zero(v: &u32) -> bool {
+    *v == 0
 }
 
 /// Parse a `KEY=value` string into a (key, value) tuple.

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -222,6 +222,7 @@ fn plan_deployment(component_id: &str) -> DeploymentResult {
             total_projects: total,
             succeeded: 0,
             failed: 0,
+            skipped: 0,
         },
     }
 }
@@ -242,6 +243,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
                     total_projects: 0,
                     succeeded: 0,
                     failed: 0,
+                    skipped: 0,
                 },
             }),
             0,
@@ -323,6 +325,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
                 total_projects: total,
                 succeeded,
                 failed,
+                skipped: 0,
             },
         }),
         exit_code,


### PR DESCRIPTION
## Summary

Three fixes for fleet and multi-project deployment error handling:

1. **Context-aware error message** — when no component IDs are provided, the error now says "multi-project deployment" instead of `--projects`, which was misleading when triggered from `--fleet` or `--shared` flags

2. **Graceful handling of stale project references** — unknown projects in fleet configs are now skipped with a warning instead of aborting the entire deploy. One deleted project no longer blocks deploying to all other fleet members. Skipped projects appear in the JSON output with `"status": "skipped"`

3. **`ProjectsSummary` now includes `skipped` count** — shown in JSON output when > 0 (backward-compatible via `skip_serializing_if`). Updated in both deploy.rs and release.rs

## Before/After

**Before:** Fleet deploy with one stale project reference → entire fleet deploy fails
```
homeboy deploy my-plugin --fleet production
→ Error: "Unknown project: 'deleted-project'"  (all projects blocked)
```

**After:** Stale projects skipped, valid projects deployed
```
homeboy deploy my-plugin --fleet production
→ Skipping unknown project 'deleted-project'
→ Deploying to 'site-a'... deployed
→ Deploying to 'site-b'... deployed
→ summary: { succeeded: 2, skipped: 1 }
```

## Testing

All 464 existing tests pass. No warnings.