### PR TITLE
fix(deploy): dry-run and check modes report 'planned' instead of 'deployed'

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -356,6 +356,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
     let mut succeeded: u32 = 0;
     let mut failed: u32 = 0;
     let skipped: u32 = unknown_projects.len() as u32;
+    let mut planned: u32 = 0;
     let mut first_project = true;
 
     // Add skipped results for unknown projects
@@ -392,6 +393,11 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
             Ok(result) => {
                 let deploy_failed = result.summary.failed > 0;
 
+                // Determine the correct project-level status:
+                // - dry-run/check modes never actually deploy, so report "planned"
+                // - real deploys report "deployed" or "failed" based on results
+                let is_planned = args.dry_run || args.check;
+
                 if deploy_failed {
                     let error_msg = result
                         .results
@@ -407,6 +413,15 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
                         summary: result.summary,
                     });
                     failed += 1;
+                } else if is_planned {
+                    project_results.push(ProjectDeployResult {
+                        project_id: project_id.to_string(),
+                        status: "planned".to_string(),
+                        error: None,
+                        results: result.results,
+                        summary: result.summary,
+                    });
+                    planned += 1;
                 } else {
                     project_results.push(ProjectDeployResult {
                         project_id: project_id.to_string(),
@@ -451,6 +466,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
                 succeeded,
                 failed,
                 skipped,
+                planned,
             },
             dry_run: args.dry_run,
             check: args.check,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,8 @@ pub struct ProjectsSummary {
     pub failed: u32,
     #[serde(skip_serializing_if = "is_zero")]
     pub skipped: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub planned: u32,
 }
 
 fn is_zero(v: &u32) -> bool {

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -223,6 +223,7 @@ fn plan_deployment(component_id: &str) -> DeploymentResult {
             succeeded: 0,
             failed: 0,
             skipped: 0,
+            planned: 0,
         },
     }
 }
@@ -244,6 +245,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
                     succeeded: 0,
                     failed: 0,
                     skipped: 0,
+                    planned: 0,
                 },
             }),
             0,
@@ -326,6 +328,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
                 succeeded,
                 failed,
                 skipped: 0,
+                planned: 0,
             },
         }),
         exit_code,


### PR DESCRIPTION
## Summary

Fixes #359 — `homeboy deploy --dry-run --fleet` reported all projects as `"status": "deployed"` and `"succeeded": 3` when nothing actually ran.

**Root cause:** `run_multi_project` determined project status solely by checking `result.summary.failed > 0`. Dry-run results have `failed: 0` (correct — nothing failed because nothing ran), so they fell into the success branch and got stamped as `"deployed"`.

## Changes

- **Project status** now reports `"planned"` for dry-run and check modes, `"deployed"` only for real deploys
- **Summary** tracks `planned` count separately — no longer inflates `succeeded`
- **`ProjectsSummary`** gains a `planned` field (omitted from JSON when 0, backward-compatible)

## Before/After

**Before:**
```json
{"summary": {"succeeded": 3, "failed": 1}}
// projects[0].status: "deployed" (but nothing deployed!)
```

**After:**
```json
{"summary": {"succeeded": 0, "failed": 1, "planned": 3}}
// projects[0].status: "planned"
```

## Testing

All 508 tests pass.