### PR TITLE
fix(test): --path and --fix flags not parsed by test command

### DIFF
--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -251,7 +251,15 @@ pub fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
         (
             "test",
             "",
-            &["--skip-lint", "--setting", "--json", "--help", "-h"],
+            &[
+                "--skip-lint",
+                "--fix",
+                "--setting",
+                "--path",
+                "--json",
+                "--help",
+                "-h",
+            ],
         ),
     ];
 
@@ -383,6 +391,60 @@ mod tests {
             "test".into(),
             "my-component".into(),
             "--skip-lint".into(),
+        ];
+        let result = normalize_trailing_flags(args.clone());
+        assert_eq!(result, args); // No separator inserted
+    }
+
+    #[test]
+    fn test_test_command_allows_path_flag() {
+        let args = vec![
+            "homeboy".into(),
+            "test".into(),
+            "my-component".into(),
+            "--path".into(),
+            "/tmp/workspace/my-component".into(),
+        ];
+        let result = normalize_trailing_flags(args.clone());
+        assert_eq!(result, args); // No separator inserted
+    }
+
+    #[test]
+    fn test_test_command_allows_path_flag_equals_syntax() {
+        let args = vec![
+            "homeboy".into(),
+            "test".into(),
+            "my-component".into(),
+            "--path=/tmp/workspace/my-component".into(),
+        ];
+        let result = normalize_trailing_flags(args.clone());
+        assert_eq!(result, args); // No separator inserted
+    }
+
+    #[test]
+    fn test_test_command_allows_fix_flag() {
+        let args = vec![
+            "homeboy".into(),
+            "test".into(),
+            "my-component".into(),
+            "--fix".into(),
+        ];
+        let result = normalize_trailing_flags(args.clone());
+        assert_eq!(result, args); // No separator inserted
+    }
+
+    #[test]
+    fn test_test_command_allows_all_known_flags_combined() {
+        let args = vec![
+            "homeboy".into(),
+            "test".into(),
+            "my-component".into(),
+            "--skip-lint".into(),
+            "--fix".into(),
+            "--path".into(),
+            "/tmp/workspace".into(),
+            "--setting".into(),
+            "key=value".into(),
         ];
         let result = normalize_trailing_flags(args.clone());
         assert_eq!(result, args); // No separator inserted


### PR DESCRIPTION
## Summary

- **Root cause**: `normalize_trailing_flags()` in `src/utils/args.rs` maintains a whitelist of known flags per command. For the `test` command, `--path` and `--fix` were missing from this whitelist. Any flag not in the list triggers automatic `--` insertion before it, causing Clap's `trailing_var_arg` to consume it as a passthrough arg instead of parsing it as a named flag.
- **Fix**: Added `--path` and `--fix` to the test command's known flags list.
- **Tests**: Added 4 new test cases covering `--path` (space-separated), `--path=` (equals syntax), `--fix`, and all flags combined.

## Reproduction

```bash
HOMEBOY_DEBUG=1 homeboy test data-machine --path=/var/lib/datamachine/workspace/data-machine
# Before: HOMEBOY_COMPONENT_PATH=/var/www/extrachill.com/wp-content/plugins/data-machine
# After:  HOMEBOY_COMPONENT_PATH=/var/lib/datamachine/workspace/data-machine
```

## How the bug worked

1. User runs `homeboy test my-component --path=/some/dir`
2. `normalize_trailing_flags()` scans args and finds `--path` is not in the known flags list
3. It inserts `--` before `--path`, turning the args into: `homeboy test my-component -- --path=/some/dir`
4. Clap sees `--path=/some/dir` after `--` and puts it in the `args` Vec (passthrough args)
5. `TestArgs.path` remains `None` → `HOMEBOY_COMPONENT_PATH` uses the configured `local_path`

Fixes #366