### PR TITLE
feat(lint): add --changed-since <ref> for CI-friendly changed-file linting

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -30,8 +30,12 @@ pub struct LintArgs {
     glob: Option<String>,
 
     /// Lint only files modified in the working tree (staged, unstaged, untracked)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "changed_since")]
     changed_only: bool,
+
+    /// Lint only files changed since a git ref (branch, tag, or SHA) — CI-friendly
+    #[arg(long, conflicts_with = "changed_only")]
+    changed_since: Option<String>,
 
     /// Show only errors, suppress warnings
     #[arg(long)]
@@ -127,7 +131,7 @@ pub fn run(args: LintArgs, _global: &super::GlobalArgs) -> CmdResult<LintOutput>
     }
     let script_path = resolve_lint_script(&component)?;
 
-    // Resolve glob from --changed-only flag
+    // Resolve glob from --changed-only or --changed-since flags
     let effective_glob = if args.changed_only {
         let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
 
@@ -158,6 +162,33 @@ pub fn run(args: LintArgs, _global: &super::GlobalArgs) -> CmdResult<LintOutput>
             .collect();
 
         // Pass ALL files to extension - let lint runner filter to relevant types
+        if abs_files.len() == 1 {
+            Some(abs_files[0].clone())
+        } else {
+            Some(format!("{{{}}}", abs_files.join(",")))
+        }
+    } else if let Some(ref git_ref) = args.changed_since {
+        let changed_files = git::get_files_changed_since(&component.local_path, git_ref)?;
+
+        if changed_files.is_empty() {
+            println!("No files changed since {}", git_ref);
+            return Ok((
+                LintOutput {
+                    status: "passed".to_string(),
+                    component: args.component,
+                    exit_code: 0,
+                    hints: None,
+                },
+                0,
+            ));
+        }
+
+        // Make paths absolute (git diff returns repo-relative paths)
+        let abs_files: Vec<String> = changed_files
+            .iter()
+            .map(|f| format!("{}/{}", component.local_path, f))
+            .collect();
+
         if abs_files.len() == 1 {
             Some(abs_files[0].clone())
         } else {
@@ -194,9 +225,13 @@ pub fn run(args: LintArgs, _global: &super::GlobalArgs) -> CmdResult<LintOutput>
     }
 
     // Capability hints when running component-wide lint (no targeting options used)
-    if args.file.is_none() && args.glob.is_none() && !args.changed_only {
+    if args.file.is_none()
+        && args.glob.is_none()
+        && !args.changed_only
+        && args.changed_since.is_none()
+    {
         hints.push(
-            "For targeted linting: --file <path>, --glob <pattern>, or --changed-only".to_string(),
+            "For targeted linting: --file <path>, --glob <pattern>, --changed-only, or --changed-since <ref>".to_string(),
         );
     }
 

--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -66,6 +66,42 @@ pub fn get_uncommitted_changes(path: &str) -> Result<UncommittedChanges> {
     })
 }
 
+/// Get file paths changed between a ref and HEAD.
+/// Uses `--diff-filter=ACMR` to include only Added, Copied, Modified, Renamed files
+/// (excludes Deleted files since there's nothing to lint).
+/// Returns repo-relative paths.
+pub fn get_files_changed_since(path: &str, git_ref: &str) -> Result<Vec<String>> {
+    // Use triple-dot (merge-base) so we get only the changes on the current
+    // branch relative to the ref, not changes on the ref's branch.
+    let output = execute_git(
+        path,
+        &[
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            &format!("{}...HEAD", git_ref),
+        ],
+    )
+    .map_err(|e| Error::git_command_failed(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "git diff --name-only {}...HEAD failed: {}",
+            git_ref, stderr
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let files: Vec<String> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+
+    Ok(files)
+}
+
 /// Get diff of uncommitted changes.
 pub fn get_diff(path: &str) -> Result<String> {
     // Get both staged and unstaged diff


### PR DESCRIPTION
## Summary

- Adds `--changed-since <ref>` flag to `homeboy lint` that finds files changed since a git ref (branch, tag, or SHA) using `git diff --name-only --diff-filter=ACMR <ref>...HEAD`
- This is the CI equivalent of `--changed-only` — in CI checkouts the working tree is clean, so `--changed-only` finds nothing. `--changed-since` compares committed changes against a baseline ref instead.
- The two flags are mutually exclusive (clap `conflicts_with`)
- Both resolve into the same `effective_glob` / `HOMEBOY_LINT_GLOB` mechanism — no extension runner changes needed

## Usage

```bash
# In CI (GitHub Actions):
homeboy lint my-plugin --changed-since ${{ github.event.pull_request.base.sha }}

# Locally — what broke since last release?
homeboy lint my-plugin --changed-since v0.52.0

# What needs linting on this branch?
homeboy lint my-plugin --changed-since main
```

## Changes

- `src/core/git/changes.rs` — new `get_files_changed_since()` function
- `src/commands/lint.rs` — new `--changed-since` arg, wired into `effective_glob` resolution

Fixes #376