### PR TITLE
feat(audit): add --path flag for CI-friendly path override

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -30,6 +30,10 @@ pub struct AuditArgs {
     /// Skip baseline comparison even if a baseline exists
     #[arg(long)]
     pub ignore_baseline: bool,
+
+    /// Override local_path for this audit run (use a workspace clone or temp checkout)
+    #[arg(long)]
+    pub path: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -75,7 +79,12 @@ pub enum AuditOutput {
 
 pub fn run(args: AuditArgs, _global: &super::GlobalArgs) -> CmdResult<AuditOutput> {
     let result = if Path::new(&args.component_id).is_dir() {
-        code_audit::audit_path(&args.component_id)?
+        // Raw path mode — use --path override if provided, otherwise use the positional arg
+        let effective_path = args.path.as_deref().unwrap_or(&args.component_id);
+        code_audit::audit_path(effective_path)?
+    } else if let Some(ref path) = args.path {
+        // Component mode with --path override — use component ID but audit at the given path
+        code_audit::audit_path_with_id(&args.component_id, path)?
     } else {
         code_audit::audit_component(&args.component_id)?
     };

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -158,7 +158,8 @@ pub fn audit_path(path: &str) -> Result<CodeAuditResult> {
 }
 
 /// Core audit logic shared by both entry points.
-fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAuditResult> {
+/// Also available for callers that have a component ID and an overridden path.
+pub fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAuditResult> {
     let root = Path::new(source_path);
 
     log_status!("audit", "Scanning {} for conventions...", source_path);


### PR DESCRIPTION
## Summary

- Adds `--path` flag to `homeboy audit`, matching the pattern already used by `lint` and `test`
- Makes `audit_path_with_id` public so the command layer can use it when both a component ID and path override are needed
- Enables audit in CI checkouts where the code is at a temp path, not the configured `local_path`

## Usage

```bash
# CI: audit component at checkout path
homeboy audit my-plugin --path /tmp/ci-checkout

# Same as before — raw path mode still works
homeboy audit /path/to/project

# Component mode without override — unchanged
homeboy audit my-plugin
```

## Changes

- `src/commands/audit.rs` — new `--path` field on `AuditArgs`, three-way path resolution in `run()`
- `src/core/code_audit/mod.rs` — `audit_path_with_id` changed from `fn` to `pub fn`

This was the last blocker preventing the `homeboy-action` from running audit in CI. The action's workaround comment (`// See: https://github.com/Extra-Chill/homeboy/issues/374`) can now be simplified.

Fixes #374