### PR TITLE
refactor: remove docs scaffold subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Topics cover commands, schemas, architecture, and developer guides — all embed
 | `server` | CRUD for server configs. SSH key generation and management. |
 | `extension` | Install, list, update, and manage extensions. |
 | `config` | View and modify global Homeboy settings. |
-| `docs` | Read embedded documentation. `scaffold` to analyze doc gaps. `audit` to verify docs match code. `generate` for bulk doc creation from JSON spec. |
+| `docs` | Read embedded documentation. `audit` to verify docs match code. `map` for machine-optimized codebase maps. `generate` for bulk doc creation from JSON spec. |
 | `init` | Read-only environment discovery. Returns actionable status: what's ready to deploy, what needs a version bump, config gaps. |
 | `upgrade` | Upgrade Homeboy to the latest version. |
 

--- a/docs/commands/docs.md
+++ b/docs/commands/docs.md
@@ -5,8 +5,8 @@
 ```sh
 homeboy docs [TOPIC]
 homeboy docs list
-homeboy docs scaffold <component-id> [--docs-dir <dir>]
 homeboy docs audit <component-id>
+homeboy docs map <component-id>
 homeboy docs generate --json '<spec>'
 homeboy docs generate @spec.json
 homeboy docs generate -
@@ -20,51 +20,13 @@ This command renders documentation topics and provides tooling for documentation
 1. Embedded core docs in the CLI binary
 2. Installed extension docs under `<config dir>/homeboy/extensions/<extension_id>/docs/`
 
-**Scaffold** analyzes a component's codebase and reports documentation status (read-only).
+**Audit** validates documentation links, detects stale references, and identifies undocumented features.
 
-**Audit** validates documentation links and detects stale references.
+**Map** generates machine-optimized codebase maps for AI documentation.
 
 **Generate** creates documentation files in bulk from a JSON spec.
 
 ## Subcommands
-
-### `scaffold`
-
-Analyzes a component's codebase and reports:
-- Source directories found
-- Existing documentation files
-- Potentially undocumented areas
-
-This is read-only - no files are created. Use the analysis to inform documentation planning.
-
-```sh
-homeboy docs scaffold homeboy
-homeboy docs scaffold extrachill-api --docs-dir documentation
-```
-
-**Arguments:**
-- `<component-id>`: Component to analyze (required)
-
-**Options:**
-- `--docs-dir <dir>`: Documentation directory to scan (default: `docs`)
-
-**Output:**
-```json
-{
-  "success": true,
-  "data": {
-    "command": "docs.scaffold",
-    "analysis": {
-      "component_id": "homeboy",
-      "source_directories": ["src", "src/api", "src/models"],
-      "existing_docs": ["overview.md", "core-system/engine.md"],
-      "undocumented": ["src/api", "src/models"]
-    },
-    "instructions": "Run `homeboy docs documentation/generation` for writing guidelines",
-    "hints": ["Found 3 source directories", "2 docs already exist"]
-  }
-}
-```
 
 ### `audit`
 
@@ -206,18 +168,17 @@ Homeboy includes embedded documentation for AI agents:
 
 Typical documentation workflow using these commands:
 
-1. **Analyze**: `homeboy docs scaffold <component>` - understand current state
+1. **Audit**: `homeboy docs audit <component>` - understand current state, find broken refs and gaps
 2. **Learn**: `homeboy docs documentation/generation` - read guidelines
-3. **Plan**: AI determines structure based on analysis + guidelines
+3. **Map**: `homeboy docs map <component>` - generate codebase map for AI context
 4. **Generate**: `homeboy docs generate --json '<spec>'` - bulk create files
-5. **Validate**: `homeboy docs audit <component>` - check for broken links and stale docs
-6. **Maintain**: `homeboy docs documentation/alignment` - keep docs current
+5. **Maintain**: `homeboy docs documentation/alignment` - keep docs current
 
 ## Errors
 
 If a topic does not exist, the command fails with an error indicating the topic was not found.
 
-If a component does not exist (for scaffold/audit), the command fails with a component not found error.
+If a component does not exist (for audit/map), the command fails with a component not found error.
 
 ## Related
 

--- a/docs/documentation/generation.md
+++ b/docs/documentation/generation.md
@@ -41,7 +41,7 @@ Find actual usage workflows in existing code, tests, and examples. Document real
 Create subdirectories in `/docs` that directly correspond to actual code extensions and components.
 
 ### 6. Create Documentation Files
-Use `homeboy docs scaffold <component>` to analyze the component and create the file structure with H1 titles, or create files manually following the structure standards in `homeboy docs documentation/structure`.
+Use `homeboy docs audit <component>` to identify gaps, then create files manually following the structure standards in `homeboy docs documentation/structure`. Use `homeboy docs map <component>` to generate a codebase map for AI-assisted documentation.
 
 ### 7. Write Content
 For each file:

--- a/docs/documentation/structure.md
+++ b/docs/documentation/structure.md
@@ -123,12 +123,6 @@ These belong elsewhere, not in `/docs`:
 - CHANGELOG.md (project root)
 - Build documentation (in code comments or separate dev docs)
 
-## Scaffold Command
+## Documentation Commands
 
-Use `homeboy docs scaffold <component>` to analyze a component's codebase. The command:
-1. Scans source directories
-2. Lists existing documentation files
-3. Identifies potentially undocumented areas
-4. Returns instructions for next steps
-
-This is read-only analysis. Use `homeboy docs generate` to create files.
+Use `homeboy docs audit <component>` to validate existing docs and find gaps. Use `homeboy docs map <component>` to generate a machine-optimized codebase map. Use `homeboy docs generate` to create files in bulk from a JSON spec.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,8 +48,8 @@ Guides for contributing to Homeboy:
 
 Homeboy provides tooling for AI-assisted documentation generation and maintenance:
 
-- `homeboy docs scaffold <component>` - Analyze codebase and report documentation status
-- `homeboy docs audit <component>` - Validate documentation links and detect stale references
+- `homeboy docs audit <component>` - Validate documentation links, detect stale references and gaps
+- `homeboy docs map <component>` - Generate machine-optimized codebase map for AI context
 - `homeboy docs generate --json` - Bulk create documentation files from JSON spec
 - `homeboy docs documentation/index` - Documentation philosophy and principles
 - `homeboy docs documentation/alignment` - Instructions for maintaining existing docs

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -23,28 +23,6 @@ pub struct DocsArgs {
 
 #[derive(Subcommand)]
 pub enum DocsCommand {
-    /// Analyze codebase and report documentation status (read-only)
-    Scaffold {
-        /// Component to analyze
-        component_id: String,
-
-        /// Docs directory to check for existing documentation (default: docs)
-        #[arg(long, default_value = "docs")]
-        docs_dir: String,
-
-        /// Source directories to analyze (comma-separated, or repeat flag). Overrides auto-detection.
-        #[arg(long, value_delimiter = ',')]
-        source_dirs: Option<Vec<String>>,
-
-        /// File extensions to detect as source code (default: php,rs,js,ts,py,go,java,rb,swift,kt)
-        #[arg(long, value_delimiter = ',')]
-        source_extensions: Option<Vec<String>>,
-
-        /// Include all directories containing source files (extension-based detection)
-        #[arg(long)]
-        detect_by_extension: bool,
-    },
-
     /// Audit documentation for broken links and stale references
     Audit {
         /// Component ID or direct filesystem path to audit
@@ -103,14 +81,6 @@ pub enum DocsCommand {
 // ============================================================================
 // Output Types
 // ============================================================================
-
-#[derive(Serialize)]
-pub struct ScaffoldAnalysis {
-    pub component_id: String,
-    pub source_directories: Vec<String>,
-    pub existing_docs: Vec<String>,
-    pub undocumented: Vec<String>,
-}
 
 /// A module in the codebase map — a group of related files.
 #[derive(Serialize)]
@@ -186,13 +156,6 @@ pub struct CodebaseMap {
 #[derive(Serialize)]
 #[serde(tag = "command")]
 pub enum DocsOutput {
-    #[serde(rename = "docs.scaffold")]
-    Scaffold {
-        analysis: ScaffoldAnalysis,
-        instructions: String,
-        hints: Vec<String>,
-    },
-
     #[serde(rename = "docs.audit")]
     Audit(AuditResult),
 
@@ -230,12 +193,11 @@ pub struct GenerateFileSpec {
 // Public API
 // ============================================================================
 
-/// Check if this invocation should return JSON (scaffold, audit, map, or generate subcommand)
+/// Check if this invocation should return JSON (audit, map, or generate subcommand)
 pub fn is_json_mode(args: &DocsArgs) -> bool {
     matches!(
         args.command,
-        Some(DocsCommand::Scaffold { .. })
-            | Some(DocsCommand::Audit { .. })
+        Some(DocsCommand::Audit { .. })
             | Some(DocsCommand::Map { .. })
             | Some(DocsCommand::Generate { .. })
     )
@@ -255,22 +217,9 @@ pub fn run_markdown(args: DocsArgs) -> CmdResult<String> {
     Ok((resolved.content, 0))
 }
 
-/// JSON output mode (scaffold, audit, generate subcommands)
+/// JSON output mode (audit, map, generate subcommands)
 pub fn run(args: DocsArgs, _global: &super::GlobalArgs) -> CmdResult<DocsOutput> {
     match args.command {
-        Some(DocsCommand::Scaffold {
-            component_id,
-            docs_dir,
-            source_dirs,
-            source_extensions,
-            detect_by_extension,
-        }) => run_scaffold(
-            &component_id,
-            &docs_dir,
-            source_dirs,
-            source_extensions,
-            detect_by_extension,
-        ),
         Some(DocsCommand::Audit { component_id, docs_dir, features }) => run_audit(&component_id, docs_dir.as_deref(), features),
         Some(DocsCommand::Map { component_id, source_dirs, include_private, write, output_dir }) => run_map(&component_id, source_dirs, include_private, write, &output_dir),
         Some(DocsCommand::Generate { spec, json, from_audit, dry_run }) => {
@@ -283,95 +232,17 @@ pub fn run(args: DocsArgs, _global: &super::GlobalArgs) -> CmdResult<DocsOutput>
         }
         None => Err(homeboy::Error::validation_invalid_argument(
             "command",
-            "JSON output requires scaffold, audit, map, or generate subcommand. Use `homeboy docs <topic>` for topic display.",
+            "JSON output requires audit, map, or generate subcommand. Use `homeboy docs <topic>` for topic display.",
             None,
             Some(vec![
-                "homeboy docs scaffold <component-id>".to_string(),
                 "homeboy docs audit <component-id>".to_string(),
+                "homeboy docs map <component-id>".to_string(),
                 "homeboy docs generate --json '<spec>'".to_string(),
                 "homeboy docs generate --from-audit @audit.json".to_string(),
                 "homeboy docs commands/deploy".to_string(),
             ]),
         )),
     }
-}
-
-// ============================================================================
-// Scaffold (Analysis Only)
-// ============================================================================
-
-fn run_scaffold(
-    component_id: &str,
-    docs_dir: &str,
-    explicit_source_dirs: Option<Vec<String>>,
-    source_extensions: Option<Vec<String>>,
-    detect_by_extension: bool,
-) -> CmdResult<DocsOutput> {
-    let comp = component::load(component_id)?;
-    let source_path = Path::new(&comp.local_path);
-    let docs_path = source_path.join(docs_dir);
-
-    // Analyze source structure
-    let source_directories = if let Some(dirs) = explicit_source_dirs {
-        // User provided explicit directories
-        dirs
-    } else if detect_by_extension {
-        // Extension-based detection
-        let extensions = source_extensions
-            .clone()
-            .unwrap_or_else(default_source_extensions);
-        find_source_directories_by_extension(source_path, &extensions)
-    } else if let Some(extensions) = source_extensions {
-        // Custom extensions provided - use extension-based detection automatically
-        find_source_directories_by_extension(source_path, &extensions)
-    } else {
-        // Try conventional directories first
-        let conventional = find_source_directories(source_path);
-        if conventional.is_empty() {
-            // Fallback to extension-based detection with defaults
-            let extensions = default_source_extensions();
-            find_source_directories_by_extension(source_path, &extensions)
-        } else {
-            conventional
-        }
-    };
-
-    // Find existing documentation
-    let existing_docs = find_existing_docs(&docs_path);
-
-    // Identify undocumented areas (source dirs without corresponding docs)
-    let undocumented = identify_undocumented(&source_directories, &existing_docs, &docs_path);
-
-    // Generate hints
-    let mut hints = Vec::new();
-    hints.push(format!(
-        "Found {} source directories",
-        source_directories.len()
-    ));
-    if !existing_docs.is_empty() {
-        hints.push(format!("{} docs already exist", existing_docs.len()));
-    }
-    if !undocumented.is_empty() {
-        hints.push(format!(
-            "{} directories may need documentation",
-            undocumented.len()
-        ));
-    }
-
-    Ok((
-        DocsOutput::Scaffold {
-            analysis: ScaffoldAnalysis {
-                component_id: component_id.to_string(),
-                source_directories,
-                existing_docs,
-                undocumented,
-            },
-            instructions: "Run `homeboy docs documentation/generation` for writing guidelines"
-                .to_string(),
-            hints,
-        },
-        0,
-    ))
 }
 
 // ============================================================================
@@ -1327,7 +1198,7 @@ fn run_audit(component_id: &str, docs_dir: Option<&str>, features: bool) -> CmdR
 }
 
 // ============================================================================
-// Scaffold Helper Functions
+// Source Directory Detection Helpers (shared by map)
 // ============================================================================
 
 fn default_source_extensions() -> Vec<String> {
@@ -1454,93 +1325,6 @@ fn directory_contains_source_files(dir: &Path, extensions: &[String]) -> bool {
         }
     }
     false
-}
-
-fn find_existing_docs(docs_path: &Path) -> Vec<String> {
-    let mut docs = Vec::new();
-
-    if !docs_path.exists() {
-        return docs;
-    }
-
-    fn scan_docs(dir: &Path, prefix: &str, docs: &mut Vec<String>) {
-        if let Ok(entries) = fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let name = entry.file_name().to_string_lossy().to_string();
-
-                if name.starts_with('.') {
-                    continue;
-                }
-
-                if path.is_file() && name.ends_with(".md") {
-                    let relative = if prefix.is_empty() {
-                        name
-                    } else {
-                        format!("{}/{}", prefix, name)
-                    };
-                    docs.push(relative);
-                } else if path.is_dir() {
-                    let new_prefix = if prefix.is_empty() {
-                        name.clone()
-                    } else {
-                        format!("{}/{}", prefix, name)
-                    };
-                    scan_docs(&path, &new_prefix, docs);
-                }
-            }
-        }
-    }
-
-    scan_docs(docs_path, "", &mut docs);
-    docs.sort();
-    docs
-}
-
-fn identify_undocumented(
-    source_dirs: &[String],
-    existing_docs: &[String],
-    docs_path: &Path,
-) -> Vec<String> {
-    // Build a set of doc content references by scanning doc files for source dir mentions
-    let mut referenced_dirs: std::collections::HashSet<String> = std::collections::HashSet::new();
-
-    for doc_file in existing_docs {
-        let doc_full_path = docs_path.join(doc_file);
-        if let Ok(content) = fs::read_to_string(&doc_full_path) {
-            for src_dir in source_dirs {
-                // Check if the doc references this source directory by path or name
-                let dir_name = src_dir.split('/').next_back().unwrap_or(src_dir);
-                if content.contains(src_dir)
-                    || content.contains(&format!("`{}`", src_dir))
-                    || content.contains(&format!("`{}/", src_dir))
-                    || content.contains(&format!("{}/", src_dir))
-                {
-                    referenced_dirs.insert(src_dir.clone());
-                }
-                // Also check if the dir name appears meaningfully (as path segment)
-                if content.contains(&format!("{}/", dir_name))
-                    || content.contains(&format!("`{}`", dir_name))
-                {
-                    referenced_dirs.insert(src_dir.clone());
-                }
-            }
-        }
-    }
-
-    source_dirs
-        .iter()
-        .filter(|src_dir| {
-            // Check both: doc filename matching AND content references
-            let dir_name = src_dir.split('/').next_back().unwrap_or(src_dir);
-            let has_matching_doc = existing_docs
-                .iter()
-                .any(|doc| doc.contains(dir_name) || doc.replace(".md", "").contains(dir_name));
-            let is_referenced = referenced_dirs.contains(*src_dir);
-            !has_matching_doc && !is_referenced
-        })
-        .cloned()
-        .collect()
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Removes `homeboy docs scaffold` — it has been superseded by `docs audit` (precise gap analysis) and `docs map` (codebase maps from fingerprints).

Closes #357

### What was removed

- `DocsCommand::Scaffold` CLI variant and args
- `ScaffoldAnalysis` struct + `DocsOutput::Scaffold` enum variant
- `run_scaffold()` function
- `find_existing_docs()` — duplicated by audit's `find_doc_files()`
- `identify_undocumented()` — superseded by audit's feature detection

### What was kept

Shared helpers still used by `docs map`:
- `find_source_directories()`
- `find_source_directories_by_extension()`
- `default_source_extensions()`
- `directory_contains_source_files()`

### Docs updated

- README.md — command table
- docs/commands/docs.md — synopsis, subcommands, workflow, errors
- docs/index.md — docs bullet list
- docs/documentation/generation.md — step 6 reference
- docs/documentation/structure.md — replaced scaffold section

### Net change

**-280 lines, +19 lines** across 6 files. All 531 tests pass. Audit baseline unchanged (69.7% alignment).

### Mental model after this change

```
docs audit    → verify existing docs, find gaps
docs map      → generate codebase map for AI
docs generate → bulk create files from spec
```