### PR TITLE
docs: add missing command docs and fix stale references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'

--- a/build.rs
+++ b/build.rs
@@ -64,9 +64,9 @@ fn generate_docs_rs(docs_root: &Path, doc_paths: &[PathBuf]) -> String {
 
         out.push_str("    (\"");
         out.push_str(&escape_rust_string(&key));
-        out.push_str("\", r#\"");
+        out.push_str("\", r###\"");
         out.push_str(&content);
-        out.push_str("\"#),\n");
+        out.push_str("\"###),\n");
     }
 
     out.push_str("];\n");

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -1,0 +1,180 @@
+# `homeboy audit`
+
+## Synopsis
+
+```sh
+homeboy audit <component-id|path> [options]
+```
+
+## Description
+
+Audit a component's codebase for convention drift, structural complexity, dead code, duplication, and test coverage gaps. The audit engine fingerprints source files, discovers conventions (patterns most files follow), detects outliers, and produces actionable findings.
+
+Works with registered components (by ID) or raw filesystem paths.
+
+## Arguments
+
+- `<component-id|path>`: Component ID to audit, or a direct filesystem path
+
+## Options
+
+- `--conventions`: Only show discovered conventions (skip findings)
+- `--fix`: Generate fix stubs for outlier files (dry run by default)
+- `--write`: Apply fixes to disk (requires `--fix`)
+- `--baseline`: Save current audit state as baseline for future comparisons
+- `--ignore-baseline`: Skip baseline comparison even if a baseline exists
+- `--path <PATH>`: Override `local_path` for this audit run (use a workspace clone or temp checkout)
+
+## Audit Pipeline
+
+The audit runs in 6 phases:
+
+1. **Discovery** — Auto-discover file groups by walking the source tree and fingerprinting files via installed extensions
+2. **Convention detection** — For each file group, discover conventions (patterns shared by a majority of files): expected methods, registrations, interfaces, namespaces, imports
+3. **Convention checking** — Check all files against discovered conventions, flagging outliers
+4. **Findings** — Build actionable findings from multiple analyses:
+   - **4a: Convention outliers** — Files missing expected methods/registrations
+   - **4b: Structural complexity** — God files, high item counts
+   - **4c: Exact duplication** — Identical function bodies across files
+   - **4d: Near-duplication** — Structurally similar files with different identifiers
+   - **4e: Dead code** — Unused params, unreferenced exports, orphaned internals
+   - **4f: Test coverage gaps** — Missing test files, uncovered methods, orphaned tests (requires extension `test_mapping` config)
+5. **Report** — Aggregate findings, compute alignment score
+6. **Cross-directory conventions** — Detect patterns shared by sibling subdirectories
+
+## Baseline Workflow
+
+Baselines enable drift detection — track whether code quality is improving or regressing:
+
+```sh
+# Save current state as baseline
+homeboy audit my-component --baseline
+
+# Future audits compare against baseline automatically
+homeboy audit my-component
+# Output includes: new findings, resolved findings, drift direction
+
+# Skip baseline comparison for a clean audit
+homeboy audit my-component --ignore-baseline
+```
+
+The baseline file is saved at `.homeboy/audit-baseline.json` inside the component's `local_path`.
+
+When a baseline exists, the audit exit code reflects drift:
+- `0`: No drift increase (same or improved)
+- `1`: Drift increased (new findings since baseline)
+
+## Fix Stubs
+
+The `--fix` flag generates mechanical fixes for convention outliers:
+
+```sh
+# Preview fixes (dry run)
+homeboy audit my-component --fix
+
+# Apply fixes to disk
+homeboy audit my-component --fix --write
+```
+
+Fix stubs insert missing method declarations, registration calls, and interface implementations that the convention expects.
+
+## Examples
+
+```sh
+# Audit a registered component
+homeboy audit data-machine
+
+# Audit a raw filesystem path
+homeboy audit /path/to/project
+
+# Show only conventions (no findings)
+homeboy audit homeboy --conventions
+
+# Save baseline after a cleanup sprint
+homeboy audit my-plugin --baseline
+
+# Audit a workspace clone instead of local_path
+homeboy audit my-plugin --path /var/lib/datamachine/workspace/my-plugin
+```
+
+## JSON Output
+
+```json
+{
+  "success": true,
+  "data": {
+    "command": "audit",
+    "component_id": "my-plugin",
+    "source_path": "/path/to/source",
+    "summary": {
+      "files_scanned": 45,
+      "conventions_detected": 3,
+      "outliers_found": 5,
+      "alignment_score": 0.89,
+      "files_skipped": 2,
+      "warnings": []
+    },
+    "conventions": [
+      {
+        "name": "Steps",
+        "glob": "inc/Steps/*.php",
+        "status": "partial",
+        "expected_methods": ["register", "validate", "execute"],
+        "conforming": ["step_a.php", "step_b.php"],
+        "outliers": [
+          {
+            "file": "step_c.php",
+            "deviations": [
+              { "kind": "missing_method", "detail": "validate" }
+            ]
+          }
+        ],
+        "total_files": 3,
+        "confidence": 0.85
+      }
+    ],
+    "findings": [
+      {
+        "file": "inc/Steps/step_c.php",
+        "severity": "warning",
+        "category": "convention_outlier",
+        "description": "Missing method 'validate' expected by Steps convention"
+      }
+    ],
+    "duplicate_groups": [],
+    "directory_conventions": []
+  }
+}
+```
+
+With `--baseline` comparison:
+
+```json
+{
+  "success": true,
+  "data": {
+    "command": "audit.compared",
+    "component_id": "my-plugin",
+    "summary": { "..." : "..." },
+    "baseline_comparison": {
+      "drift_increased": false,
+      "new_findings": [],
+      "resolved_findings": ["inc/Steps/step_c.php: missing validate"],
+      "baseline_findings_count": 6,
+      "current_findings_count": 5
+    }
+  }
+}
+```
+
+## Exit Code
+
+- `0`: No outliers found (or no drift increase when baseline exists)
+- `1`: Outliers found (or drift increased since baseline)
+
+## Related
+
+- [cleanup](cleanup.md) — config-level health checks (complementary to code audit)
+- [docs audit](docs.md) — documentation-level auditing (broken links, stale references)
+- [lint](lint.md) — extension-driven code style validation
+- [JSON output contract](../architecture/output-system.md)

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -1,0 +1,139 @@
+# `homeboy cleanup`
+
+## Synopsis
+
+```sh
+homeboy cleanup [component-id] [options]
+```
+
+## Description
+
+Identify config drift, stale state, and hygiene issues in component configurations. Checks for broken paths, dead version targets, unused extensions, and other config-level problems that accumulate as projects evolve.
+
+Without a component ID, checks all registered components.
+
+## Arguments
+
+- `[component-id]`: Component to check (optional — omit to check all components)
+
+## Options
+
+- `--severity <LEVEL>`: Show only issues of a specific severity: `error`, `warning`, `info`
+- `--category <CATEGORY>`: Show only issues in a specific category: `local_path`, `remote_path`, `version_targets`, `extensions`
+
+## Health Checks
+
+Cleanup runs four categories of config health checks:
+
+### `local_path`
+
+- **Error**: `local_path` is empty
+- **Error**: `local_path` is relative (must be absolute)
+- **Error**: `local_path` does not exist on disk
+
+### `remote_path`
+
+- **Info**: `remote_path` is empty (deploy will not work)
+
+### `version_targets`
+
+- **Error**: Version target file does not exist at the expected path
+- **Warning**: Version target file exists but the configured pattern doesn't match any version string
+- **Warning**: Version target has no pattern and no extension provides a default for the file type
+
+### `extensions`
+
+- **Error**: Linked extension could not be loaded (missing or malformed manifest)
+- **Info**: Linked extension has no build, lint, test, or CLI capabilities
+
+## Examples
+
+```sh
+# Check a single component
+homeboy cleanup my-plugin
+
+# Check all registered components
+homeboy cleanup
+
+# Show only errors (skip warnings and info)
+homeboy cleanup --severity error
+
+# Show only local_path issues
+homeboy cleanup --category local_path
+
+# Show only extension issues for a specific component
+homeboy cleanup my-plugin --category extensions
+```
+
+## JSON Output
+
+Single component:
+
+```json
+{
+  "success": true,
+  "data": {
+    "command": "cleanup",
+    "component_id": "my-plugin",
+    "total_issues": 2,
+    "result": {
+      "component_id": "my-plugin",
+      "summary": { "config_issues": 2 },
+      "config_issues": [
+        {
+          "severity": "error",
+          "category": "local_path",
+          "message": "local_path does not exist: /old/path/to/plugin",
+          "fix_hint": "homeboy component set my-plugin --local-path \"/correct/path\""
+        },
+        {
+          "severity": "info",
+          "category": "remote_path",
+          "message": "remote_path is empty. Deploy will not work.",
+          "fix_hint": "homeboy component set my-plugin --remote-path \"server:/path/to/deploy\""
+        }
+      ]
+    },
+    "hints": ["2 config issue(s) found. Review and fix with `homeboy component set`."]
+  }
+}
+```
+
+All components:
+
+```json
+{
+  "success": true,
+  "data": {
+    "command": "cleanup",
+    "total_issues": 5,
+    "results": [
+      {
+        "component_id": "plugin-a",
+        "summary": { "config_issues": 3 },
+        "config_issues": ["..."]
+      },
+      {
+        "component_id": "plugin-b",
+        "summary": { "config_issues": 2 },
+        "config_issues": ["..."]
+      }
+    ],
+    "hints": ["5 total issue(s) across 2 component(s)."]
+  }
+}
+```
+
+## Fix Hints
+
+Each issue includes a `fix_hint` field with the exact `homeboy component set` command to resolve it. Copy-paste the hint to fix the issue.
+
+## Exit Code
+
+- `0`: Always (cleanup is informational, does not fail on issues)
+
+## Related
+
+- [audit](audit.md) — code-level convention drift and structural analysis
+- [component](component.md) — manage component configurations
+- [JSON output contract](../architecture/output-system.md)

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -1,27 +1,33 @@
 # Commands index
 
+- [api](api.md)
+- [audit](audit.md) — code convention drift and structural analysis
+- [auth](auth.md)
 - [build](build.md)
 - [changelog](changelog.md)
-- [component](component.md)
 - [changes](changes.md)
+- [cleanup](cleanup.md) — config health checks and hygiene
+- [component](component.md)
 - [config](config.md)
 - [db](db.md)
 - [deploy](deploy.md)
-- [docs](docs.md)
+- [docs](docs.md) — topic display, audit, map, generate
+- [extension](extension.md)
 - [file](file.md)
 - [fleet](fleet.md)
 - [git](git.md)
-- [init](init.md) (alias: `status`)
-- [api](api.md)
-- [auth](auth.md)
+- [init](init.md) — repo context (read-only)
+- [lint](lint.md)
 - [list](list.md)
 - [logs](logs.md)
-- [extension](extension.md)
 - [project](project.md)
 - [refactor](refactor.md)
-- [release](release.md) (local release pipeline)
+- [release](release.md) — local release pipeline
 - [server](server.md)
 - [ssh](ssh.md)
+- status — actionable component overview (`--uncommitted`, `--needs-bump`, `--ready`, `--docs-only`, `--all`)
+- [test](test.md)
+- transfer — transfer files between servers (`<source> <destination>`, supports `-r`, `-c`, `--dry-run`, `--exclude`)
 - [upgrade](upgrade.md)
 - [version](version.md)
 

--- a/docs/commands/docs.md
+++ b/docs/commands/docs.md
@@ -5,11 +5,10 @@
 ```sh
 homeboy docs [TOPIC]
 homeboy docs list
-homeboy docs audit <component-id>
-homeboy docs map <component-id>
+homeboy docs audit <component-id> [--features] [--docs-dir <DIR>]
+homeboy docs map <component-id> [--write] [--include-private]
 homeboy docs generate --json '<spec>'
-homeboy docs generate @spec.json
-homeboy docs generate -
+homeboy docs generate --from-audit @audit.json
 ```
 
 ## Description
@@ -20,35 +19,40 @@ This command renders documentation topics and provides tooling for documentation
 1. Embedded core docs in the CLI binary
 2. Installed extension docs under `<config dir>/homeboy/extensions/<extension_id>/docs/`
 
-**Audit** validates documentation links, detects stale references, and identifies undocumented features.
+**Audit** validates documentation links, detects stale references, identifies undocumented features, and flags priority docs that need review.
 
 **Map** generates machine-optimized codebase maps for AI documentation.
 
-**Generate** creates documentation files in bulk from a JSON spec.
+**Generate** creates documentation files in bulk from a JSON spec or from audit output.
 
 ## Subcommands
 
 ### `audit`
 
-Extracts claims from documentation and verifies them against the codebase. Outputs a structured task list that agents can execute step-by-step.
-
-**Claim types extracted:**
-- **File paths**: Backtick paths like `src/core/mod.rs` - verified against filesystem
-- **Directory paths**: Paths ending with `/` like `src/core/` - verified against filesystem
-- **Code examples**: Fenced code blocks - flagged for manual verification
-
-**Task statuses:**
-- `verified`: Claim confirmed true, no action needed
-- `broken`: Claim confirmed false, action required
-- `needs_verification`: Cannot verify mechanically, agent must check
+Validates documentation against the codebase. Extracts claims (file paths, directory paths) from docs and verifies them against the filesystem. Also detects features in source code and checks whether they're documented.
 
 ```sh
 homeboy docs audit homeboy
-homeboy docs audit data-machine
+homeboy docs audit data-machine --features
+homeboy docs audit /path/to/project --docs-dir documentation
 ```
 
 **Arguments:**
-- `<component-id>`: Component to audit (required)
+- `<component-id>`: Component ID or filesystem path to audit (required)
+
+**Options:**
+- `--features`: Include full list of all detected features in output (needed for `generate --from-audit`)
+- `--docs-dir <DIR>`: Docs directory relative to component root (overrides config, default: `docs`)
+
+**Output fields:**
+
+| Field | Description |
+|-------|-------------|
+| `broken_references` | File/directory paths in docs that don't exist on disk |
+| `undocumented_features` | Source features (structs, enums) with no documentation reference |
+| `priority_docs` | Docs whose referenced source files changed since the baseline tag |
+| `detected_features` | All features found in source (only with `--features`) |
+| `summary` | Counts: `docs_scanned`, `broken_references`, `priority_docs`, `documented_features`, `total_features` |
 
 **Output:**
 ```json
@@ -57,52 +61,88 @@ homeboy docs audit data-machine
   "data": {
     "command": "docs.audit",
     "component_id": "homeboy",
+    "baseline_ref": "v0.52.1",
     "summary": {
-      "docs_scanned": 48,
-      "claims_extracted": 81,
-      "verified": 37,
-      "broken": 44,
-      "needs_verification": 0
+      "docs_scanned": 53,
+      "broken_references": 3,
+      "priority_docs": 8,
+      "documented_features": 90,
+      "total_features": 91,
+      "unchanged_docs": 45,
+      "undocumented_features": 1
     },
-    "tasks": [
+    "broken_references": [
       {
-        "doc": "architecture/output-system.md",
-        "line": 12,
-        "claim": "directory path `src/core/`",
-        "type": "directory_path",
-        "claim_value": "src/core/",
-        "status": "verified"
-      },
-      {
-        "doc": "developer-guide/architecture-overview.md",
-        "line": 62,
-        "claim": "file path `src/core/template.rs`",
-        "type": "file_path",
-        "claim_value": "src/core/template.rs",
-        "status": "broken",
-        "action": "File 'src/core/template.rs' not found. Search codebase for actual location or remove if deleted."
+        "doc": "commands/refactor.md",
+        "line": 95,
+        "claim": "directory path `scripts/build/`",
+        "confidence": "unclear",
+        "action": "Directory 'scripts/build/' no longer exists. Update or remove this reference."
       }
     ],
-    "changes_context": {
-      "commits_since_tag": 5,
-      "changed_files": ["src/core/mod.rs", "src/commands/docs.rs"],
-      "priority_docs": ["architecture/output-system.md"]
-    }
+    "priority_docs": [
+      {
+        "doc": "commands/docs.md",
+        "reason": "6 referenced source file(s) changed since baseline",
+        "changed_files_referenced": ["src/commands/docs.rs", "..."],
+        "code_examples": 0,
+        "action": "Review documentation for accuracy against current implementation."
+      }
+    ],
+    "undocumented_features": [
+      {
+        "name": "TestMappingConfig",
+        "source_file": "src/core/extension/manifest.rs",
+        "line": 59
+      }
+    ]
   }
 }
 ```
 
 **Agent workflow:**
 1. Run `homeboy docs audit <component>`
-2. For each task where `status != "verified"`:
-   - If `broken`: Execute the action (fix or remove reference)
-   - If `needs_verification`: Read the referenced file, verify claim, update if wrong
-3. Re-run audit to confirm all tasks resolved
+2. Fix `broken_references` — update or remove stale paths
+3. Review `priority_docs` — source changed, verify doc accuracy
+4. Document `undocumented_features` if they're part of the public API
+5. Re-run audit to confirm findings resolved
+
+### `map`
+
+Generates a machine-optimized codebase map by fingerprinting source files and extracting classes, methods, properties, hooks, and inheritance hierarchies.
+
+```sh
+# JSON output to stdout
+homeboy docs map my-plugin
+
+# Write markdown files to docs directory
+homeboy docs map my-plugin --write
+
+# Include protected methods
+homeboy docs map my-plugin --include-private
+
+# Custom source directories
+homeboy docs map my-plugin --source-dirs src,lib
+```
+
+**Arguments:**
+- `<component-id>`: Component to analyze (required)
+
+**Options:**
+- `--source-dirs <DIRS>`: Source directories to analyze (comma-separated, overrides auto-detection)
+- `--include-private`: Include protected methods and internals (default: public API surface only)
+- `--write`: Write markdown files to disk instead of JSON to stdout
+- `--output-dir <DIR>`: Output directory for markdown files (default: `docs`)
+
+**Auto-detection:** Without `--source-dirs`, the map command looks for conventional directories (`src`, `lib`, `inc`, `app`, `components`, `extensions`, `crates`). Falls back to extension-based file detection if none found.
+
+**Markdown output (--write):** Generates module pages, class hierarchy, hooks summary. Large modules (>30 classes) are split into sub-pages by class name prefix.
 
 ### `generate`
 
-Creates or updates documentation files from a JSON spec. Supports bulk creation with optional content.
+Creates or updates documentation files from a JSON spec or from audit output.
 
+**From JSON spec:**
 ```sh
 homeboy docs generate --json '<spec>'
 homeboy docs generate @spec.json
@@ -125,20 +165,19 @@ homeboy docs generate -  # read from stdin
 - `path` (required): Relative path within output_dir
 - `content`: Full markdown content to write
 - `title`: Creates file with `# {title}\n` (used if no content)
-- Neither: Uses filename converted to title case
+- Neither: Uses filename converted to title case; infers section headings from sibling docs
 
-**Output:**
-```json
-{
-  "success": true,
-  "data": {
-    "command": "docs.generate",
-    "files_created": ["docs/core-system/engine.md", "docs/core-system/handlers.md"],
-    "files_updated": [],
-    "hints": ["Created 2 files"]
-  }
-}
+**From audit output:**
+```sh
+homeboy docs audit my-plugin --features > audit.json
+homeboy docs generate --from-audit @audit.json
+homeboy docs generate --from-audit @audit.json --dry-run
 ```
+
+Generates reference documentation from detected features, grouped by extension-configured labels and written to configured doc targets.
+
+**Options:**
+- `--dry-run`: Show what would be generated without writing files
 
 ## Topic Display
 
@@ -168,11 +207,11 @@ Homeboy includes embedded documentation for AI agents:
 
 Typical documentation workflow using these commands:
 
-1. **Audit**: `homeboy docs audit <component>` - understand current state, find broken refs and gaps
-2. **Learn**: `homeboy docs documentation/generation` - read guidelines
-3. **Map**: `homeboy docs map <component>` - generate codebase map for AI context
-4. **Generate**: `homeboy docs generate --json '<spec>'` - bulk create files
-5. **Maintain**: `homeboy docs documentation/alignment` - keep docs current
+1. **Audit**: `homeboy docs audit <component>` — find broken refs, stale docs, undocumented features
+2. **Learn**: `homeboy docs documentation/generation` — read guidelines
+3. **Map**: `homeboy docs map <component>` — generate codebase map for AI context
+4. **Generate**: `homeboy docs generate --from-audit @audit.json` — bulk create from audit data
+5. **Maintain**: `homeboy docs documentation/alignment` — keep docs current
 
 ## Errors
 
@@ -182,5 +221,6 @@ If a component does not exist (for audit/map), the command fails with a componen
 
 ## Related
 
-- [Changelog command](changelog.md)
+- [audit](audit.md) — code-level convention auditing (different from docs audit)
+- [changelog](changelog.md)
 - [JSON output contract](../architecture/output-system.md)

--- a/docs/commands/refactor.md
+++ b/docs/commands/refactor.md
@@ -92,7 +92,7 @@ The engine walks the target directory recursively, scanning files with these ext
 
 **Always skipped** (any depth): `node_modules`, `vendor`, `.git`, `.svn`, `.hg`
 
-**Skipped at root only**: `build`, `dist`, `target`, `cache`, `tmp` — these are safe to skip at root (build artifacts), but scanned at deeper levels (e.g. `scripts/build/` may contain source files).
+**Skipped at root only**: `build`, `dist`, `target`, `cache`, `tmp` — these are safe to skip at root (build artifacts), but scanned at deeper levels (e.g. a `scripts/build/` directory inside your project may contain source files).
 
 ## Collision Detection
 
@@ -105,7 +105,7 @@ Warnings are informational — `--write` applies changes even when warnings exis
 
 ## File Renames
 
-In addition to content edits, the engine detects files and directories whose names contain the rename term and generates path renames. For example, renaming `widget` → `gadget` would rename `widget/widget.rs` → `gadget/gadget.rs`.
+In addition to content edits, the engine detects files and directories whose names contain the rename term and generates path renames. For example, in a project containing `src/widget/widget.rs`, renaming `widget` → `gadget` would generate the path rename `src/widget/widget.rs` → `src/gadget/gadget.rs`.
 
 ## JSON Output
 

--- a/docs/developer-guide/architecture-overview.md
+++ b/docs/developer-guide/architecture-overview.md
@@ -170,6 +170,47 @@ Step types:
 - Built-in: build, version_bump, git_commit, git_tag, git_push
 - Extension: extension_run, extension_action
 
+### Code Audit
+
+**Location:** `src/core/code_audit/`
+
+Convention detection and drift analysis:
+- Fingerprints source files (methods, registrations, types) via extensions
+- Groups files by directory and language
+- Discovers conventions (patterns most files follow)
+- Detects outliers, structural complexity, duplication, dead code, test coverage gaps
+- Baseline comparison for drift tracking
+- Fix stub generation for outlier files
+
+Audit pipeline phases:
+1. Discovery (auto-discover file groups)
+2. Convention detection
+3. Convention checking
+4. Findings (outliers, structural, duplication, dead code, test coverage)
+5. Report (alignment score)
+6. Cross-directory convention discovery
+
+### Docs Audit
+
+**Location:** `src/core/docs_audit/`
+
+Documentation verification:
+- Extracts claims (file paths, directory paths) from markdown docs
+- Verifies claims against the filesystem
+- Detects features in source code and checks documentation coverage
+- Identifies priority docs (source files changed since baseline tag)
+- Supports `--features` for machine-readable feature inventory
+
+### Cleanup
+
+**Location:** `src/core/cleanup/`
+
+Config health checking:
+- Validates component configs (local_path, remote_path, version_targets, extensions)
+- Detects broken paths, dead version targets, unused extension links
+- Provides actionable fix hints (`homeboy component set` commands)
+- Single component or all-components mode
+
 ### Fleet Management
 
 **Location:** `src/core/fleet.rs`

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,9 @@ Homeboy is a config-driven automation engine for development and deployment auto
 
 - Root command + global flags: [Root command](cli/homeboy-root-command.md)
 - Full built-in command list: [Commands index](commands/commands-index.md)
-- Changes summary command: [changes](commands/changes.md)
+- Code audit (convention drift, structural analysis): [audit](commands/audit.md)
+- Config health checks: [cleanup](commands/cleanup.md)
+- Changes summary: [changes](commands/changes.md)
 - JSON output envelope: [JSON output contract](architecture/output-system.md)
 - Embedded docs behavior: [Embedded docs topic resolution](architecture/embedded-docs/embedded-docs-topic-resolution.md)
 - Changelog content: [Changelog](changelog.md)

--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -10,11 +10,16 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
   "id": "string",
   "version": "string",
   "description": "string",
-  "runtime": {},
+  "provides": {},
+  "scripts": {},
+  "audit": {},
+  "deploy": {},
+  "executable": {},
   "platform": {},
   "commands": {},
   "actions": {},
   "release_actions": {},
+  "hooks": {},
   "docs": [],
   "capabilities": [],
   "storage_backend": "string"
@@ -32,14 +37,110 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
 ### Optional Fields
 
 - **`description`** (string): Extension description
-- **`runtime`** (object): Executable extension runtime configuration
-- **`platform`** (object): Platform behavior definitions
+- **`provides`** (object): File extensions and capabilities this extension handles
+- **`scripts`** (object): Scripts that implement extension capabilities (fingerprint, refactor)
+- **`audit`** (object): Docs audit config — ignore patterns, feature detection, test mapping
+- **`deploy`** (object): Deploy lifecycle — verifications, overrides, version patterns
+- **`executable`** (object): Standalone tool runtime, inputs, output schema
+- **`platform`** (object): Platform behavior definitions (database, deployment, version patterns)
 - **`commands`** (object): Additional CLI commands provided by extension
 - **`actions`** (object): Action definitions for `homeboy extension action`
 - **`release_actions`** (object): Release pipeline step definitions
+- **`hooks`** (object): Lifecycle hooks (pre/post version bump, deploy, release)
 - **`docs`** (array): Documentation topic paths
 - **`capabilities`** (array): Capabilities provided by extension (e.g., `["storage"]`)
 - **`storage_backend`** (string): Storage backend identifier for storage capability
+
+## Provides Configuration
+
+Declares what file types and capabilities this extension handles. Used by the audit system to route files to the correct extension for fingerprinting.
+
+```json
+{
+  "provides": {
+    "file_extensions": ["php", "inc"],
+    "capabilities": ["fingerprint", "refactor"]
+  }
+}
+```
+
+### Provides Fields
+
+- **`file_extensions`** (array): File extensions this extension can process (e.g., `["php", "inc"]`, `["rs"]`)
+- **`capabilities`** (array): Capabilities this extension supports (e.g., `["fingerprint", "refactor"]`)
+
+## Scripts Configuration
+
+Scripts that implement extension capabilities. Each script path is relative to the extension directory.
+
+```json
+{
+  "scripts": {
+    "fingerprint": "scripts/fingerprint.sh",
+    "refactor": "scripts/refactor.sh"
+  }
+}
+```
+
+### Scripts Fields
+
+- **`fingerprint`** (string): Script that extracts structural fingerprints from source files. Receives file content on stdin, outputs `FileFingerprint` JSON on stdout.
+- **`refactor`** (string): Script that applies refactoring edits to source files. Receives edit instructions on stdin, outputs transformed content on stdout.
+
+## Audit Configuration
+
+Configuration for docs audit, feature detection, and test coverage analysis.
+
+```json
+{
+  "audit": {
+    "ignore_claim_patterns": ["/wp-json/**", "*.min.js"],
+    "feature_patterns": ["register_post_type\\(\\s*['\"]([^'\"]+)['\"]"],
+    "feature_labels": {
+      "register_post_type": "Post Types",
+      "register_rest_route": "REST API Routes"
+    },
+    "doc_targets": {
+      "Post Types": {
+        "file": "api-reference.md",
+        "heading": "## Post Types"
+      }
+    },
+    "feature_context": {
+      "register_post_type": {
+        "doc_comment": true,
+        "block_fields": true
+      }
+    },
+    "test_mapping": {
+      "source_dirs": ["src"],
+      "test_dirs": ["tests"],
+      "test_file_pattern": "tests/{dir}/{name}_test.{ext}",
+      "method_prefix": "test_",
+      "inline_tests": true,
+      "critical_patterns": ["src/core/"]
+    }
+  }
+}
+```
+
+### Audit Fields
+
+- **`ignore_claim_patterns`** (array): Glob patterns for paths to ignore during docs audit
+- **`feature_patterns`** (array): Regex patterns to detect features in source code (must have a capture group for the feature name)
+- **`feature_labels`** (object): Maps pattern substrings to human-readable labels for grouping
+- **`doc_targets`** (object): Maps feature labels to documentation file paths and headings
+- **`feature_context`** (object): Context extraction rules per feature pattern (doc comments, block fields)
+- **`test_mapping`** (object): Test coverage mapping convention
+
+### Test Mapping Fields
+
+- **`source_dirs`** (array): Source directories to scan (e.g., `["src"]`, `["inc"]`)
+- **`test_dirs`** (array): Test directories to scan (e.g., `["tests"]`)
+- **`test_file_pattern`** (string): How source paths map to test paths. Variables: `{dir}`, `{name}`, `{ext}`
+- **`method_prefix`** (string): Prefix for test method names (default: `"test_"`)
+- **`inline_tests`** (boolean): Whether the language uses inline tests (e.g., Rust `#[cfg(test)]`)
+- **`critical_patterns`** (array): Directory patterns that indicate high-priority test coverage (get `Warning` severity instead of `Info`)
 
 ## Runtime Configuration
 


### PR DESCRIPTION
## Summary

Addresses 5 open documentation issues in one batch:

- **#312** — New `docs/commands/audit.md` — full audit command documentation covering all 6 pipeline phases, baseline workflow, fix stubs, JSON output examples
- **#313** — New `docs/commands/cleanup.md` — cleanup command documentation covering all 4 health check categories, severity/category filters, fix hints
- **#314** — Updated `commands-index.md` — added audit, cleanup, lint, test, transfer, status; alphabetized the full list
- **#316** — Fixed 3 broken doc references in `refactor.md` — clarified example paths so docs audit no longer flags them
- **#319** — Updated 5 stale docs flagged by `homeboy docs audit`:
  - `commands/docs.md` — rewrote audit output format (broken_references, priority_docs, undocumented_features), added `--features`, `--docs-dir`, `--from-audit` options
  - `developer-guide/architecture-overview.md` — added Code Audit, Docs Audit, Cleanup system sections
  - `index.md` — added audit and cleanup to CLI section
  - `schemas/extension-manifest-schema.md` — added `provides`, `scripts`, `audit` (with `test_mapping`, `feature_patterns`, `feature_labels`, `doc_targets`, `feature_context`) to manifest schema

**8 files changed, +589 -80 lines**

Closes #312, closes #313, closes #314, closes #316, closes #319