### PR TITLE
fix: resolve upgrade panic caused by stale /proc/self/exe after binary replacement

### DIFF
--- a/src/core/upgrade.rs
+++ b/src/core/upgrade.rs
@@ -372,12 +372,34 @@ fn execute_upgrade(method: InstallMethod) -> Result<(bool, Option<String>)> {
 pub fn restart_with_new_binary() -> ! {
     use std::os::unix::process::CommandExt;
 
-    let binary = std::env::current_exe().expect("Failed to get current executable path");
+    // After an upgrade, std::env::current_exe() reads /proc/self/exe which
+    // points to the *deleted* old binary inode. Resolve the fresh binary from
+    // $PATH instead so we exec into the newly-installed version.
+    let binary = resolve_binary_on_path()
+        .unwrap_or_else(|| std::env::current_exe().expect("Failed to get current executable path"));
 
     let err = Command::new(&binary).arg("--version").exec();
 
-    // exec() only returns on error
-    panic!("Failed to exec into new binary: {}", err);
+    // exec() only returns on error — fall back to a clean exit instead of panicking
+    eprintln!(
+        "Warning: could not restart automatically ({}). Please run `homeboy --version` to confirm the upgrade.",
+        err
+    );
+    std::process::exit(0);
+}
+
+/// Resolve the `homeboy` binary via $PATH, returning the first match that
+/// exists on disk. This avoids the stale `/proc/self/exe` problem on Linux
+/// where the old inode is deleted after the upgrade replaces the binary.
+fn resolve_binary_on_path() -> Option<std::path::PathBuf> {
+    let path_var = std::env::var("PATH").ok()?;
+    for dir in path_var.split(':') {
+        let candidate = std::path::PathBuf::from(dir).join("homeboy");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

- Fixes the `Failed to exec into new binary: No such file or directory` panic that occurs after every `homeboy upgrade` on Linux (#396)
- Resolves the new binary via `$PATH` lookup instead of `std::env::current_exe()` (which reads the deleted old inode via `/proc/self/exe`)
- Replaces the `panic!` with a graceful exit + warning message as a safety net

## Root Cause

On Linux, `std::env::current_exe()` reads `/proc/self/exe`, which is a symlink to the **running** binary's inode. When the upgrade script uses `install` to replace the binary at `/usr/local/bin/homeboy`, the old inode is unlinked. `/proc/self/exe` then points to a deleted path, so `exec()` fails with ENOENT.

## Fix

1. New `resolve_binary_on_path()` walks `$PATH` and returns the first existing `homeboy` binary — this always finds the freshly-installed one
2. Falls back to `current_exe()` only if PATH resolution fails (e.g. unusual environments)
3. If `exec()` still fails for any reason, prints a helpful warning and exits cleanly instead of panicking

Fixes #396