### PR TITLE
fix: enable audit baseline ratchet in CI — stop blocking PRs on pre-existing debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
         run: cargo test
 
   # ── Homeboy audit (dogfooding) ──
-  # Informational only on PRs — reports findings but doesn't fail on
-  # baseline drift. The release workflow's pre-release gate enforces
-  # the strict baseline ratchet before binaries ship.
+  # Compares audit findings against the committed baseline. Only fails
+  # if a PR introduces NEW drift (new findings not in the baseline).
+  # Resolving existing findings is always allowed (ratchet down).
   audit:
     name: Homeboy Audit
     runs-on: ubuntu-latest
@@ -56,4 +56,3 @@ jobs:
           extension: rust
           commands: audit
           component: homeboy
-          args: '--ignore-baseline'

--- a/.homeboy/audit-baseline.json
+++ b/.homeboy/audit-baseline.json
@@ -1,5 +1,5 @@
 {
-  "created_at": "2026-03-03T23:07:03Z",
+  "created_at": "2026-03-03T23:14:59Z",
   "component_id": "homeboy",
   "findings_count": 461,
   "outliers_count": 10,


### PR DESCRIPTION
## Summary

- Removes `--ignore-baseline` from the CI audit step
- Audit now compares against the committed baseline — only fails on **new** drift
- Refreshes baseline to capture current state (461 findings, 70% alignment)

## Problem

Every PR was failing the Homeboy Audit CI check because it ran with `--ignore-baseline`, which exits 1 if **any** findings exist anywhere in the codebase. The baseline comparison system was already built and working — it just wasn't being used in CI.

## Fix

One line change in `ci.yml`: remove `args: '--ignore-baseline'`

The audit now uses the committed `.homeboy/audit-baseline.json` to compare:
- **New findings** (not in baseline) → CI fails
- **Same or fewer findings** → CI passes
- **Resolved findings** → ratchets down automatically

This is the exact behavior described in #403 Option B (baseline + regression detection).

## Verification

```
$ homeboy audit /path/to/homeboy
[audit] No change from baseline
exit code: 0
```

Fixes #403