### PR TITLE
feat: generic baseline/ratchet primitive in utils

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -145,18 +145,18 @@ pub fn run(args: AuditArgs, _global: &super::GlobalArgs) -> CmdResult<AuditOutpu
                 homeboy::Error::internal_unexpected("Failed to read back saved baseline")
             })?;
 
-        if let Some(score) = baseline_data.alignment_score {
+        if let Some(score) = baseline_data.metadata.alignment_score {
             eprintln!(
                 "[audit] Baseline saved to {} ({} findings, {:.0}% alignment)",
                 saved.display(),
-                baseline_data.findings_count,
+                baseline_data.item_count,
                 score * 100.0
             );
         } else {
             eprintln!(
                 "[audit] Baseline saved to {} ({} findings, alignment: N/A)",
                 saved.display(),
-                baseline_data.findings_count,
+                baseline_data.item_count,
             );
         }
 
@@ -164,9 +164,9 @@ pub fn run(args: AuditArgs, _global: &super::GlobalArgs) -> CmdResult<AuditOutpu
             AuditOutput::BaselineSaved {
                 component_id: result.component_id,
                 path: saved.to_string_lossy().to_string(),
-                findings_count: baseline_data.findings_count,
-                outliers_count: baseline_data.outliers_count,
-                alignment_score: baseline_data.alignment_score,
+                findings_count: baseline_data.item_count,
+                outliers_count: baseline_data.metadata.outliers_count,
+                alignment_score: baseline_data.metadata.alignment_score,
             },
             0,
         ));
@@ -182,12 +182,12 @@ pub fn run(args: AuditArgs, _global: &super::GlobalArgs) -> CmdResult<AuditOutpu
             if comparison.drift_increased {
                 eprintln!(
                     "[audit] DRIFT INCREASED: {} new finding(s) since baseline",
-                    comparison.new_findings.len()
+                    comparison.new_items.len()
                 );
-            } else if !comparison.resolved_findings.is_empty() {
+            } else if !comparison.resolved_fingerprints.is_empty() {
                 eprintln!(
                     "[audit] Drift reduced: {} finding(s) resolved since baseline",
-                    comparison.resolved_findings.len()
+                    comparison.resolved_fingerprints.len()
                 );
             } else {
                 eprintln!("[audit] No change from baseline");

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -1,81 +1,96 @@
-//! Baseline management for CI-friendly audit drift detection.
+//! Audit-specific baseline — delegates to the generic `utils::baseline` primitive.
 //!
-//! Saves a snapshot of audit state and compares future runs against it.
-//! Only NEW drift (findings not in the baseline) triggers a failure.
+//! Provides the audit domain's [`Fingerprintable`] implementation for findings,
+//! plus backward-compatible wrappers (`save_baseline`, `load_baseline`, `compare`)
+//! that the audit command uses directly.
 
-use std::collections::HashSet;
 use std::path::Path;
 
+use crate::baseline::{self as generic, BaselineConfig, Fingerprintable};
+
+use super::findings::Finding;
 use super::CodeAuditResult;
 
-/// A saved baseline snapshot.
+// ============================================================================
+// Baseline key
+// ============================================================================
+
+/// Key used in `homeboy.json` → `baselines.audit`.
+const BASELINE_KEY: &str = "audit";
+
+// ============================================================================
+// Audit-specific metadata
+// ============================================================================
+
+/// Domain-specific metadata stored alongside the generic baseline.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct AuditBaseline {
-    /// ISO 8601 timestamp when the baseline was created.
-    pub created_at: String,
-    /// Component that was audited.
-    pub component_id: String,
-    /// Total findings at baseline time.
-    pub findings_count: usize,
+pub struct AuditBaselineMetadata {
     /// Total outlier files at baseline time.
     pub outliers_count: usize,
     /// Alignment score at baseline time.
     pub alignment_score: Option<f32>,
     /// Set of known outlier file paths (accepted drift).
     pub known_outliers: Vec<String>,
-    /// Fingerprint of each known finding: "convention::file::kind::description"
-    pub known_findings: Vec<String>,
 }
+
+// ============================================================================
+// Fingerprintable implementation for audit findings
+// ============================================================================
+
+/// Wrapper that implements [`Fingerprintable`] for audit findings.
+///
+/// Uses `convention::file::kind` as the core identity. The description is
+/// excluded because structural findings embed volatile values (e.g. exact
+/// line counts) that change when a file grows by even one line. Including
+/// them would cause the same finding to appear as "resolved + new" on every
+/// minor change, defeating the baseline ratchet.
+struct AuditFinding<'a>(&'a Finding);
+
+impl Fingerprintable for AuditFinding<'_> {
+    fn fingerprint(&self) -> String {
+        format!("{}::{}::{:?}", self.0.convention, self.0.file, self.0.kind)
+    }
+
+    fn description(&self) -> String {
+        self.0.description.clone()
+    }
+
+    fn context_label(&self) -> String {
+        self.0.convention.clone()
+    }
+}
+
+// ============================================================================
+// Backward-compatible public types
+// ============================================================================
+
+/// A saved baseline snapshot (backward-compatible alias).
+///
+/// This is the generic baseline parameterized with audit metadata.
+pub type AuditBaseline = generic::Baseline<AuditBaselineMetadata>;
 
 /// Result of comparing an audit against a baseline.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct BaselineComparison {
-    /// Findings that are new since the baseline.
-    pub new_findings: Vec<NewFinding>,
-    /// Findings that were in the baseline but are now resolved.
-    pub resolved_findings: Vec<String>,
-    /// Net change in findings count.
-    pub delta: i64,
-    /// Whether drift increased (true = fail in CI).
-    pub drift_increased: bool,
-}
+pub type BaselineComparison = generic::Comparison;
 
 /// A finding that wasn't in the baseline.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct NewFinding {
-    /// The finding fingerprint.
-    pub fingerprint: String,
-    /// Human-readable description.
-    pub description: String,
-    /// The file involved.
-    pub file: String,
-    /// The convention involved.
-    pub convention: String,
-}
+pub type NewFinding = generic::NewItem;
 
 // ============================================================================
-// Baseline file path
+// Backward-compatible public API
 // ============================================================================
-
-const BASELINE_DIR: &str = ".homeboy";
-const BASELINE_FILE: &str = "audit-baseline.json";
 
 /// Get the baseline file path for a source directory.
+///
+/// Now points to `homeboy.json` instead of `.homeboy/audit-baseline.json`.
 pub fn baseline_path(source_path: &Path) -> std::path::PathBuf {
-    source_path.join(BASELINE_DIR).join(BASELINE_FILE)
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    config.json_path()
 }
-
-// ============================================================================
-// Save baseline
-// ============================================================================
 
 /// Save the current audit result as a baseline.
 pub fn save_baseline(result: &CodeAuditResult) -> Result<std::path::PathBuf, String> {
     let source = Path::new(&result.source_path);
-    let dir = source.join(BASELINE_DIR);
-
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| format!("Failed to create {}: {}", dir.display(), e))?;
+    let config = BaselineConfig::new(source, BASELINE_KEY);
 
     let known_outliers: Vec<String> = result
         .conventions
@@ -83,206 +98,28 @@ pub fn save_baseline(result: &CodeAuditResult) -> Result<std::path::PathBuf, Str
         .flat_map(|c| c.outliers.iter().map(|o| o.file.clone()))
         .collect();
 
-    let known_findings: Vec<String> = result
-        .findings
-        .iter()
-        .map(|f| {
-            finding_fingerprint(
-                &f.convention,
-                &f.file,
-                &format!("{:?}", f.kind),
-                &f.description,
-            )
-        })
-        .collect();
-
-    let baseline = AuditBaseline {
-        created_at: chrono_now(),
-        component_id: result.component_id.clone(),
-        findings_count: result.findings.len(),
+    let metadata = AuditBaselineMetadata {
         outliers_count: known_outliers.len(),
         alignment_score: result.summary.alignment_score,
         known_outliers,
-        known_findings,
     };
 
-    let path = baseline_path(source);
-    let json = serde_json::to_string_pretty(&baseline)
-        .map_err(|e| format!("Failed to serialize baseline: {}", e))?;
+    let items: Vec<AuditFinding> = result.findings.iter().map(AuditFinding).collect();
 
-    std::fs::write(&path, json)
-        .map_err(|e| format!("Failed to write {}: {}", path.display(), e))?;
-
-    Ok(path)
+    generic::save(&config, &result.component_id, &items, metadata)
+        .map_err(|e| e.message)
 }
-
-// ============================================================================
-// Load baseline
-// ============================================================================
 
 /// Load a baseline if one exists for the given source path.
 pub fn load_baseline(source_path: &Path) -> Option<AuditBaseline> {
-    let path = baseline_path(source_path);
-    if !path.exists() {
-        return None;
-    }
-
-    let content = std::fs::read_to_string(&path).ok()?;
-    serde_json::from_str(&content).ok()
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    generic::load::<AuditBaselineMetadata>(&config).ok().flatten()
 }
-
-// ============================================================================
-// Compare against baseline
-// ============================================================================
 
 /// Compare an audit result against a saved baseline.
 pub fn compare(result: &CodeAuditResult, baseline: &AuditBaseline) -> BaselineComparison {
-    let current_fingerprints: HashSet<String> = result
-        .findings
-        .iter()
-        .map(|f| {
-            finding_fingerprint(
-                &f.convention,
-                &f.file,
-                &format!("{:?}", f.kind),
-                &f.description,
-            )
-        })
-        .collect();
-
-    let baseline_fingerprints: HashSet<String> = baseline.known_findings.iter().cloned().collect();
-
-    // New = in current but not in baseline
-    let new_findings: Vec<NewFinding> = result
-        .findings
-        .iter()
-        .filter(|f| {
-            let fp = finding_fingerprint(
-                &f.convention,
-                &f.file,
-                &format!("{:?}", f.kind),
-                &f.description,
-            );
-            !baseline_fingerprints.contains(&fp)
-        })
-        .map(|f| NewFinding {
-            fingerprint: finding_fingerprint(
-                &f.convention,
-                &f.file,
-                &format!("{:?}", f.kind),
-                &f.description,
-            ),
-            description: f.description.clone(),
-            file: f.file.clone(),
-            convention: f.convention.clone(),
-        })
-        .collect();
-
-    // Resolved = in baseline but not in current
-    let resolved_findings: Vec<String> = baseline_fingerprints
-        .difference(&current_fingerprints)
-        .cloned()
-        .collect();
-
-    let delta = result.findings.len() as i64 - baseline.findings_count as i64;
-    let drift_increased = !new_findings.is_empty();
-
-    BaselineComparison {
-        new_findings,
-        resolved_findings,
-        delta,
-        drift_increased,
-    }
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/// Create a stable fingerprint for a finding.
-///
-/// Uses `convention::file::kind` as the core identity. The description is
-/// excluded because structural findings embed volatile values (e.g. exact
-/// line counts) that change when a file grows by even one line. Including
-/// them would cause the same finding to appear as "resolved + new" on every
-/// minor change, defeating the baseline ratchet.
-fn finding_fingerprint(convention: &str, file: &str, kind: &str, _description: &str) -> String {
-    format!("{}::{}::{}", convention, file, kind)
-}
-
-/// Get current UTC timestamp as ISO 8601.
-fn chrono_now() -> String {
-    // Use std::time since we don't want a chrono dependency
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    // Simple ISO 8601 from unix timestamp
-    // 2026-02-27T21:00:00Z format
-    let secs_per_day = 86400u64;
-    let secs_per_hour = 3600u64;
-    let secs_per_min = 60u64;
-
-    let days = now / secs_per_day;
-    let remaining = now % secs_per_day;
-    let hours = remaining / secs_per_hour;
-    let remaining = remaining % secs_per_hour;
-    let minutes = remaining / secs_per_min;
-    let seconds = remaining % secs_per_min;
-
-    // Calculate date from days since epoch (1970-01-01)
-    let (year, month, day) = days_to_date(days);
-
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-        year, month, day, hours, minutes, seconds
-    )
-}
-
-/// Convert days since Unix epoch to (year, month, day).
-fn days_to_date(mut days: u64) -> (u64, u64, u64) {
-    let mut year = 1970u64;
-
-    loop {
-        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
-        if days < days_in_year {
-            break;
-        }
-        days -= days_in_year;
-        year += 1;
-    }
-
-    let leap = is_leap_year(year);
-    let month_days = [
-        31,
-        if leap { 29 } else { 28 },
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ];
-
-    let mut month = 1u64;
-    for &md in &month_days {
-        if days < md {
-            break;
-        }
-        days -= md;
-        month += 1;
-    }
-
-    (year, month, days + 1)
-}
-
-fn is_leap_year(year: u64) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+    let items: Vec<AuditFinding> = result.findings.iter().map(AuditFinding).collect();
+    generic::compare(&items, baseline)
 }
 
 // ============================================================================
@@ -343,9 +180,9 @@ mod tests {
         assert!(path.exists());
 
         let loaded = load_baseline(Path::new(&result.source_path)).unwrap();
-        assert_eq!(loaded.component_id, "test");
-        assert_eq!(loaded.findings_count, 2);
-        assert_eq!(loaded.known_findings.len(), 2);
+        assert_eq!(loaded.context_id, "test");
+        assert_eq!(loaded.item_count, 2);
+        assert_eq!(loaded.known_fingerprints.len(), 2);
 
         let _ = std::fs::remove_dir_all(Path::new(&result.source_path));
     }
@@ -364,8 +201,8 @@ mod tests {
 
         let comparison = compare(&result, &baseline);
         assert!(!comparison.drift_increased);
-        assert!(comparison.new_findings.is_empty());
-        assert!(comparison.resolved_findings.is_empty());
+        assert!(comparison.new_items.is_empty());
+        assert!(comparison.resolved_fingerprints.is_empty());
         assert_eq!(comparison.delta, 0);
 
         let _ = std::fs::remove_dir_all(Path::new(&result.source_path));
@@ -392,8 +229,8 @@ mod tests {
 
         let comparison = compare(&current, &baseline);
         assert!(comparison.drift_increased);
-        assert_eq!(comparison.new_findings.len(), 1);
-        assert_eq!(comparison.new_findings[0].file, "c.php");
+        assert_eq!(comparison.new_items.len(), 1);
+        assert_eq!(comparison.new_items[0].fingerprint, "Flow::c.php::MissingMethod");
         assert_eq!(comparison.delta, 1);
 
         let _ = std::fs::remove_dir_all(Path::new(&result_original.source_path));
@@ -419,8 +256,8 @@ mod tests {
 
         let comparison = compare(&current, &baseline);
         assert!(!comparison.drift_increased);
-        assert!(comparison.new_findings.is_empty());
-        assert_eq!(comparison.resolved_findings.len(), 1);
+        assert!(comparison.new_items.is_empty());
+        assert_eq!(comparison.resolved_fingerprints.len(), 1);
         assert_eq!(comparison.delta, -1);
 
         let _ = std::fs::remove_dir_all(Path::new(&result_original.source_path));
@@ -450,8 +287,8 @@ mod tests {
 
         let comparison = compare(&current, &baseline);
         assert!(comparison.drift_increased);
-        assert_eq!(comparison.new_findings.len(), 1);
-        assert_eq!(comparison.resolved_findings.len(), 1);
+        assert_eq!(comparison.new_items.len(), 1);
+        assert_eq!(comparison.resolved_fingerprints.len(), 1);
         assert_eq!(comparison.delta, 0);
 
         let _ = std::fs::remove_dir_all(Path::new(&result_original.source_path));
@@ -464,49 +301,59 @@ mod tests {
     }
 
     #[test]
-    fn finding_fingerprint_is_stable() {
-        let fp1 = finding_fingerprint("Flow", "a.php", "MissingMethod", "Missing method: execute");
-        let fp2 = finding_fingerprint("Flow", "a.php", "MissingMethod", "Missing method: execute");
-        assert_eq!(fp1, fp2);
+    fn audit_metadata_roundtrips() {
+        let result = make_result(
+            vec![make_finding("Flow", "a.php", "Missing method")],
+            "metadata_roundtrip",
+        );
+
+        let _ = save_baseline(&result).unwrap();
+        let loaded = load_baseline(Path::new(&result.source_path)).unwrap();
+
+        assert_eq!(loaded.metadata.alignment_score, Some(0.8));
+
+        let _ = std::fs::remove_dir_all(Path::new(&result.source_path));
+    }
+
+    #[test]
+    fn fingerprint_is_stable() {
+        let f1 = make_finding("Flow", "a.php", "Missing method: execute");
+        let f2 = make_finding("Flow", "a.php", "Missing method: execute");
+        assert_eq!(
+            AuditFinding(&f1).fingerprint(),
+            AuditFinding(&f2).fingerprint()
+        );
 
         // Different file = different fingerprint
-        let fp3 = finding_fingerprint("Flow", "b.php", "MissingMethod", "Missing method: execute");
-        assert_ne!(fp1, fp3);
+        let f3 = make_finding("Flow", "b.php", "Missing method: execute");
+        assert_ne!(
+            AuditFinding(&f1).fingerprint(),
+            AuditFinding(&f3).fingerprint()
+        );
     }
 
     #[test]
-    fn finding_fingerprint_ignores_description() {
-        // Structural findings embed volatile values (line counts, item counts)
-        // in the description. The fingerprint must be stable across these changes.
-        let fp1 = finding_fingerprint(
-            "structural",
-            "deploy.rs",
-            "GodFile",
-            "File has 2484 lines (threshold: 500)",
-        );
-        let fp2 = finding_fingerprint(
-            "structural",
-            "deploy.rs",
-            "GodFile",
-            "File has 2645 lines (threshold: 500)",
-        );
+    fn fingerprint_ignores_description() {
+        let f1 = Finding {
+            convention: "structural".to_string(),
+            severity: Severity::Warning,
+            file: "deploy.rs".to_string(),
+            description: "File has 2484 lines (threshold: 500)".to_string(),
+            suggestion: String::new(),
+            kind: DeviationKind::GodFile,
+        };
+        let f2 = Finding {
+            convention: "structural".to_string(),
+            severity: Severity::Warning,
+            file: "deploy.rs".to_string(),
+            description: "File has 2645 lines (threshold: 500)".to_string(),
+            suggestion: String::new(),
+            kind: DeviationKind::GodFile,
+        };
         assert_eq!(
-            fp1, fp2,
+            AuditFinding(&f1).fingerprint(),
+            AuditFinding(&f2).fingerprint(),
             "fingerprint should not change when line count changes"
         );
-    }
-
-    #[test]
-    fn chrono_now_produces_valid_iso8601() {
-        let now = chrono_now();
-        // Should match YYYY-MM-DDTHH:MM:SSZ
-        assert!(
-            now.len() == 20,
-            "Expected 20 chars, got {}: {}",
-            now.len(),
-            now
-        );
-        assert!(now.ends_with('Z'));
-        assert!(now.contains('T'));
     }
 }

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -106,14 +106,15 @@ pub fn save_baseline(result: &CodeAuditResult) -> Result<std::path::PathBuf, Str
 
     let items: Vec<AuditFinding> = result.findings.iter().map(AuditFinding).collect();
 
-    generic::save(&config, &result.component_id, &items, metadata)
-        .map_err(|e| e.message)
+    generic::save(&config, &result.component_id, &items, metadata).map_err(|e| e.message)
 }
 
 /// Load a baseline if one exists for the given source path.
 pub fn load_baseline(source_path: &Path) -> Option<AuditBaseline> {
     let config = BaselineConfig::new(source_path, BASELINE_KEY);
-    generic::load::<AuditBaselineMetadata>(&config).ok().flatten()
+    generic::load::<AuditBaselineMetadata>(&config)
+        .ok()
+        .flatten()
 }
 
 /// Compare an audit result against a saved baseline.
@@ -230,7 +231,10 @@ mod tests {
         let comparison = compare(&current, &baseline);
         assert!(comparison.drift_increased);
         assert_eq!(comparison.new_items.len(), 1);
-        assert_eq!(comparison.new_items[0].fingerprint, "Flow::c.php::MissingMethod");
+        assert_eq!(
+            comparison.new_items[0].fingerprint,
+            "Flow::c.php::MissingMethod"
+        );
         assert_eq!(comparison.delta, 1);
 
         let _ = std::fs::remove_dir_all(Path::new(&result_original.source_path));

--- a/src/utils/baseline.rs
+++ b/src/utils/baseline.rs
@@ -247,9 +247,7 @@ pub fn load<M: for<'de> Deserialize<'de> + Serialize>(
 
     let root = read_json_or_empty(&json_path)?;
 
-    let baseline_value = root
-        .get(BASELINES_KEY)
-        .and_then(|b| b.get(&config.key));
+    let baseline_value = root.get(BASELINES_KEY).and_then(|b| b.get(&config.key));
 
     let Some(value) = baseline_value else {
         return Ok(None);
@@ -546,8 +544,12 @@ mod tests {
         assert_eq!(loaded.context_id, "my-component");
         assert_eq!(loaded.item_count, 2);
         assert_eq!(loaded.known_fingerprints.len(), 2);
-        assert!(loaded.known_fingerprints.contains(&"lint::a.rs".to_string()));
-        assert!(loaded.known_fingerprints.contains(&"lint::b.rs".to_string()));
+        assert!(loaded
+            .known_fingerprints
+            .contains(&"lint::a.rs".to_string()));
+        assert!(loaded
+            .known_fingerprints
+            .contains(&"lint::b.rs".to_string()));
     }
 
     #[test]
@@ -578,11 +580,7 @@ mod tests {
         );
         assert!(root.get("extensions").is_some());
         assert!(root.get("baselines").is_some());
-        assert!(root
-            .get("baselines")
-            .unwrap()
-            .get("audit")
-            .is_some());
+        assert!(root.get("baselines").unwrap().get("audit").is_some());
     }
 
     #[test]
@@ -605,8 +603,12 @@ mod tests {
 
         assert_eq!(audit.item_count, 1);
         assert_eq!(lint.item_count, 1);
-        assert!(audit.known_fingerprints.contains(&"conv::a.php".to_string()));
-        assert!(lint.known_fingerprints.contains(&"psr12::b.php".to_string()));
+        assert!(audit
+            .known_fingerprints
+            .contains(&"conv::a.php".to_string()));
+        assert!(lint
+            .known_fingerprints
+            .contains(&"psr12::b.php".to_string()));
     }
 
     #[test]
@@ -739,7 +741,13 @@ mod tests {
     #[test]
     fn utc_now_produces_valid_iso8601() {
         let now = utc_now_iso8601();
-        assert_eq!(now.len(), 20, "Expected 20 chars, got {}: {}", now.len(), now);
+        assert_eq!(
+            now.len(),
+            20,
+            "Expected 20 chars, got {}: {}",
+            now.len(),
+            now
+        );
         assert!(now.ends_with('Z'));
         assert!(now.contains('T'));
     }
@@ -765,10 +773,7 @@ mod tests {
         let items_v1 = vec![item("lint", "a.rs", "v1")];
         save(&config, "test", &items_v1, ()).unwrap();
 
-        let items_v2 = vec![
-            item("lint", "a.rs", "v2"),
-            item("lint", "b.rs", "new"),
-        ];
+        let items_v2 = vec![item("lint", "a.rs", "v2"), item("lint", "b.rs", "new")];
         save(&config, "test", &items_v2, ()).unwrap();
 
         let loaded = load::<()>(&config).unwrap().unwrap();
@@ -777,10 +782,7 @@ mod tests {
 
     #[test]
     fn compare_empty_current_against_populated_baseline() {
-        let original = vec![
-            item("lint", "a.rs", "unused"),
-            item("lint", "b.rs", "dead"),
-        ];
+        let original = vec![item("lint", "a.rs", "unused"), item("lint", "b.rs", "dead")];
 
         let dir = TempDir::new().unwrap();
         let config = BaselineConfig::new(dir.path(), "test");
@@ -827,11 +829,7 @@ mod tests {
     #[test]
     fn load_returns_error_for_malformed_json() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(
-            dir.path().join("homeboy.json"),
-            "not valid json {{{",
-        )
-        .unwrap();
+        std::fs::write(dir.path().join("homeboy.json"), "not valid json {{{").unwrap();
 
         let config = BaselineConfig::new(dir.path(), "audit");
         let result = load::<()>(&config);

--- a/src/utils/baseline.rs
+++ b/src/utils/baseline.rs
@@ -1,0 +1,840 @@
+//! Generic baseline & ratchet primitive for drift detection.
+//!
+//! Captures a snapshot of "current state" (any set of fingerprintable items)
+//! and compares future runs against it. Only NEW items (not in the baseline)
+//! trigger a failure — resolved items are celebrated, same-state passes.
+//!
+//! Zero domain knowledge. The caller decides:
+//! - What gets fingerprinted (via [`Fingerprintable`])
+//! - What metadata to store (via the `M` type parameter)
+//! - What key to use in `homeboy.json` (via [`BaselineConfig`])
+//!
+//! Baselines are stored in the project's `homeboy.json` under a `baselines`
+//! key, keeping all component configuration in a single portable file.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use homeboy::utils::baseline::{self, Fingerprintable, BaselineConfig};
+//!
+//! impl Fingerprintable for MyFinding {
+//!     fn fingerprint(&self) -> String {
+//!         format!("{}::{}", self.category, self.file)
+//!     }
+//!     fn description(&self) -> String {
+//!         self.message.clone()
+//!     }
+//!     fn context_label(&self) -> String {
+//!         self.category.clone()
+//!     }
+//! }
+//!
+//! let config = BaselineConfig::new(source_path, "audit");
+//!
+//! // First run: save baseline
+//! baseline::save(&config, "my-component", &items, my_metadata)?;
+//!
+//! // Subsequent runs: compare
+//! if let Some(saved) = baseline::load::<MyMeta>(&config)? {
+//!     let comparison = baseline::compare(&items, &saved);
+//!     if comparison.drift_increased {
+//!         // CI fails — new findings introduced
+//!     }
+//! }
+//! ```
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+
+// ============================================================================
+// Trait: Fingerprintable
+// ============================================================================
+
+/// Any item that can produce a stable identity for baseline comparison.
+///
+/// The fingerprint must be stable across runs for the same logical item.
+/// Volatile values (line counts, timestamps) should be excluded.
+pub trait Fingerprintable {
+    /// Stable identity string for this item.
+    ///
+    /// Two items with the same fingerprint are considered "the same finding."
+    /// Exclude volatile values — if line counts change but the finding is
+    /// conceptually the same, the fingerprint must not change.
+    fn fingerprint(&self) -> String;
+
+    /// Human-readable description for reporting.
+    fn description(&self) -> String;
+
+    /// Context label (e.g., convention name, lint rule, category).
+    /// Used in [`NewItem`] for human-readable reports.
+    fn context_label(&self) -> String;
+}
+
+// ============================================================================
+// Config
+// ============================================================================
+
+/// Configuration for a baseline: where to store it and under what key.
+///
+/// Baselines are stored in `homeboy.json` under `baselines.<key>`.
+pub struct BaselineConfig {
+    /// Root directory containing `homeboy.json`.
+    root: PathBuf,
+    /// Key within the `baselines` object (e.g., "audit", "lint", "test").
+    key: String,
+}
+
+const HOMEBOY_JSON: &str = "homeboy.json";
+const BASELINES_KEY: &str = "baselines";
+
+impl BaselineConfig {
+    /// Create a baseline config.
+    ///
+    /// - `root`: directory containing `homeboy.json` (component source path)
+    /// - `key`: baseline key within `baselines` object (e.g., "audit", "lint")
+    pub fn new(root: impl Into<PathBuf>, key: impl Into<String>) -> Self {
+        Self {
+            root: root.into(),
+            key: key.into(),
+        }
+    }
+
+    /// Path to the `homeboy.json` file.
+    pub fn json_path(&self) -> PathBuf {
+        self.root.join(HOMEBOY_JSON)
+    }
+
+    /// The baseline key.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+// ============================================================================
+// Stored baseline
+// ============================================================================
+
+/// A saved baseline snapshot.
+///
+/// `M` is caller-defined metadata (e.g., alignment score, coverage percentage).
+/// Use `()` if no metadata is needed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Baseline<M: Serialize> {
+    /// ISO 8601 timestamp when the baseline was created.
+    pub created_at: String,
+    /// Identifier for what was baselined (component ID, lint target, etc.).
+    pub context_id: String,
+    /// Total item count at baseline time.
+    pub item_count: usize,
+    /// Fingerprints of all known items (the snapshot).
+    pub known_fingerprints: Vec<String>,
+    /// Domain-specific metadata (alignment score, coverage %, etc.).
+    pub metadata: M,
+}
+
+// ============================================================================
+// Comparison result
+// ============================================================================
+
+/// Result of comparing current items against a saved baseline.
+#[derive(Debug, Clone, Serialize)]
+pub struct Comparison {
+    /// Items that are new since the baseline.
+    pub new_items: Vec<NewItem>,
+    /// Fingerprints that were in the baseline but are now gone (resolved).
+    pub resolved_fingerprints: Vec<String>,
+    /// Net change in item count (positive = more items, negative = fewer).
+    pub delta: i64,
+    /// Whether drift increased (true = new items appeared = ratchet failure).
+    pub drift_increased: bool,
+}
+
+/// An item that wasn't in the baseline.
+#[derive(Debug, Clone, Serialize)]
+pub struct NewItem {
+    /// The item's fingerprint.
+    pub fingerprint: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Context label (convention, rule, category).
+    pub context_label: String,
+}
+
+// ============================================================================
+// Core operations
+// ============================================================================
+
+/// Save a baseline snapshot into `homeboy.json`.
+///
+/// Reads the existing `homeboy.json` (or creates one), sets
+/// `baselines.<key>` to the new baseline, and writes it back.
+pub fn save<M: Serialize>(
+    config: &BaselineConfig,
+    context_id: &str,
+    items: &[impl Fingerprintable],
+    metadata: M,
+) -> Result<PathBuf> {
+    let known_fingerprints: Vec<String> = items.iter().map(|i| i.fingerprint()).collect();
+
+    let baseline = Baseline {
+        created_at: utc_now_iso8601(),
+        context_id: context_id.to_string(),
+        item_count: items.len(),
+        known_fingerprints,
+        metadata,
+    };
+
+    let baseline_value = serde_json::to_value(&baseline).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to serialize baseline: {}", e),
+            Some("baseline.save".to_string()),
+        )
+    })?;
+
+    // Read existing homeboy.json or start fresh
+    let json_path = config.json_path();
+    let mut root = read_json_or_empty(&json_path)?;
+
+    // Ensure baselines object exists
+    let baselines = root
+        .as_object_mut()
+        .ok_or_else(|| {
+            Error::internal_io(
+                "homeboy.json root is not an object".to_string(),
+                Some("baseline.save".to_string()),
+            )
+        })?
+        .entry(BASELINES_KEY)
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+
+    // Set the specific baseline key
+    baselines
+        .as_object_mut()
+        .ok_or_else(|| {
+            Error::internal_io(
+                "baselines key is not an object".to_string(),
+                Some("baseline.save".to_string()),
+            )
+        })?
+        .insert(config.key.clone(), baseline_value);
+
+    // Write back
+    write_json(&json_path, &root)?;
+
+    Ok(json_path)
+}
+
+/// Load a baseline if one exists in `homeboy.json`.
+///
+/// Returns `Ok(None)` if:
+/// - No `homeboy.json` exists
+/// - No `baselines` key exists
+/// - No baseline for the configured key exists
+///
+/// Returns `Err` if the file exists but the baseline data is malformed.
+pub fn load<M: for<'de> Deserialize<'de> + Serialize>(
+    config: &BaselineConfig,
+) -> Result<Option<Baseline<M>>> {
+    let json_path = config.json_path();
+    if !json_path.exists() {
+        return Ok(None);
+    }
+
+    let root = read_json_or_empty(&json_path)?;
+
+    let baseline_value = root
+        .get(BASELINES_KEY)
+        .and_then(|b| b.get(&config.key));
+
+    let Some(value) = baseline_value else {
+        return Ok(None);
+    };
+
+    let baseline: Baseline<M> = serde_json::from_value(value.clone()).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Malformed baseline '{}' in {}: {}",
+                config.key,
+                json_path.display(),
+                e
+            ),
+            Some("baseline.load".to_string()),
+        )
+    })?;
+
+    Ok(Some(baseline))
+}
+
+/// Compare current items against a saved baseline.
+///
+/// This is the ratchet check:
+/// - `drift_increased = true` if ANY new items appeared (not in baseline)
+/// - Resolved items (in baseline but not in current) are tracked but don't fail
+/// - `delta` is the net change in item count
+pub fn compare<M: Serialize>(
+    current_items: &[impl Fingerprintable],
+    baseline: &Baseline<M>,
+) -> Comparison {
+    let current_fingerprints: HashSet<String> =
+        current_items.iter().map(|i| i.fingerprint()).collect();
+    let baseline_fingerprints: HashSet<String> =
+        baseline.known_fingerprints.iter().cloned().collect();
+
+    // New = in current but not in baseline
+    let new_items: Vec<NewItem> = current_items
+        .iter()
+        .filter(|item| !baseline_fingerprints.contains(&item.fingerprint()))
+        .map(|item| NewItem {
+            fingerprint: item.fingerprint(),
+            description: item.description(),
+            context_label: item.context_label(),
+        })
+        .collect();
+
+    // Resolved = in baseline but not in current
+    let resolved_fingerprints: Vec<String> = baseline_fingerprints
+        .difference(&current_fingerprints)
+        .cloned()
+        .collect();
+
+    let delta = current_items.len() as i64 - baseline.item_count as i64;
+    let drift_increased = !new_items.is_empty();
+
+    Comparison {
+        new_items,
+        resolved_fingerprints,
+        delta,
+        drift_increased,
+    }
+}
+
+// ============================================================================
+// JSON helpers
+// ============================================================================
+
+/// Read homeboy.json as a serde_json::Value, or return an empty object.
+fn read_json_or_empty(path: &Path) -> Result<Value> {
+    if !path.exists() {
+        return Ok(Value::Object(serde_json::Map::new()));
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read {}: {}", path.display(), e),
+            Some("baseline.read_json".to_string()),
+        )
+    })?;
+
+    serde_json::from_str(&content).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to parse {}: {}", path.display(), e),
+            Some("baseline.read_json".to_string()),
+        )
+    })
+}
+
+/// Write a serde_json::Value to homeboy.json with pretty formatting.
+fn write_json(path: &Path, value: &Value) -> Result<()> {
+    let json = serde_json::to_string_pretty(value).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to serialize JSON: {}", e),
+            Some("baseline.write_json".to_string()),
+        )
+    })?;
+
+    // Ensure trailing newline (git-friendly)
+    let content = if json.ends_with('\n') {
+        json
+    } else {
+        format!("{}\n", json)
+    };
+
+    std::fs::write(path, content).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to write {}: {}", path.display(), e),
+            Some("baseline.write_json".to_string()),
+        )
+    })?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Timestamp helpers
+// ============================================================================
+
+/// Get current UTC timestamp as ISO 8601 (no external dependencies).
+pub fn utc_now_iso8601() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let secs_per_day = 86400u64;
+    let secs_per_hour = 3600u64;
+    let secs_per_min = 60u64;
+
+    let days = now / secs_per_day;
+    let remaining = now % secs_per_day;
+    let hours = remaining / secs_per_hour;
+    let remaining = remaining % secs_per_hour;
+    let minutes = remaining / secs_per_min;
+    let seconds = remaining % secs_per_min;
+
+    let (year, month, day) = days_to_date(days);
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hours, minutes, seconds
+    )
+}
+
+/// Convert days since Unix epoch to (year, month, day).
+fn days_to_date(mut days: u64) -> (u64, u64, u64) {
+    let mut year = 1970u64;
+
+    loop {
+        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    let leap = is_leap_year(year);
+    let month_days = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+
+    let mut month = 1u64;
+    for &md in &month_days {
+        if days < md {
+            break;
+        }
+        days -= md;
+        month += 1;
+    }
+
+    (year, month, days + 1)
+}
+
+fn is_leap_year(year: u64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // -- Test implementation of Fingerprintable -------------------------------
+
+    #[derive(Clone)]
+    struct TestItem {
+        category: String,
+        file: String,
+        message: String,
+    }
+
+    impl Fingerprintable for TestItem {
+        fn fingerprint(&self) -> String {
+            format!("{}::{}", self.category, self.file)
+        }
+        fn description(&self) -> String {
+            self.message.clone()
+        }
+        fn context_label(&self) -> String {
+            self.category.clone()
+        }
+    }
+
+    fn item(category: &str, file: &str, message: &str) -> TestItem {
+        TestItem {
+            category: category.to_string(),
+            file: file.to_string(),
+            message: message.to_string(),
+        }
+    }
+
+    // -- Save & Load ----------------------------------------------------------
+
+    #[test]
+    fn save_creates_homeboy_json() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let items = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "b.rs", "dead code"),
+        ];
+
+        let path = save(&config, "test-component", &items, ()).unwrap();
+        assert!(path.exists());
+        assert!(path.to_string_lossy().ends_with("homeboy.json"));
+    }
+
+    #[test]
+    fn load_returns_none_when_no_file() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let result = load::<()>(&config).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_no_baselines_key() {
+        let dir = TempDir::new().unwrap();
+        // Write a homeboy.json without baselines
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{"remote_path": "wp-content/plugins/test"}"#,
+        )
+        .unwrap();
+
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let result = load::<()>(&config).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_key_missing() {
+        let dir = TempDir::new().unwrap();
+        // Write homeboy.json with baselines but different key
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{"baselines": {"lint": {"created_at": "x", "context_id": "y", "item_count": 0, "known_fingerprints": [], "metadata": null}}}"#,
+        )
+        .unwrap();
+
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let result = load::<()>(&config).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let items = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "b.rs", "dead code"),
+        ];
+
+        save(&config, "my-component", &items, ()).unwrap();
+        let loaded = load::<()>(&config).unwrap().unwrap();
+
+        assert_eq!(loaded.context_id, "my-component");
+        assert_eq!(loaded.item_count, 2);
+        assert_eq!(loaded.known_fingerprints.len(), 2);
+        assert!(loaded.known_fingerprints.contains(&"lint::a.rs".to_string()));
+        assert!(loaded.known_fingerprints.contains(&"lint::b.rs".to_string()));
+    }
+
+    #[test]
+    fn save_preserves_existing_config() {
+        let dir = TempDir::new().unwrap();
+
+        // Pre-existing homeboy.json with component config
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+  "remote_path": "wp-content/plugins/data-machine",
+  "extensions": { "wordpress": {} }
+}"#,
+        )
+        .unwrap();
+
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let items = vec![item("conv", "a.php", "missing method")];
+        save(&config, "data-machine", &items, ()).unwrap();
+
+        // Re-read the full file and verify existing keys are preserved
+        let content = std::fs::read_to_string(dir.path().join("homeboy.json")).unwrap();
+        let root: Value = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(
+            root.get("remote_path").and_then(|v| v.as_str()),
+            Some("wp-content/plugins/data-machine")
+        );
+        assert!(root.get("extensions").is_some());
+        assert!(root.get("baselines").is_some());
+        assert!(root
+            .get("baselines")
+            .unwrap()
+            .get("audit")
+            .is_some());
+    }
+
+    #[test]
+    fn save_preserves_other_baselines() {
+        let dir = TempDir::new().unwrap();
+        let audit_config = BaselineConfig::new(dir.path(), "audit");
+        let lint_config = BaselineConfig::new(dir.path(), "lint");
+
+        // Save audit baseline
+        let audit_items = vec![item("conv", "a.php", "missing method")];
+        save(&audit_config, "test", &audit_items, ()).unwrap();
+
+        // Save lint baseline
+        let lint_items = vec![item("psr12", "b.php", "wrong indent")];
+        save(&lint_config, "test", &lint_items, ()).unwrap();
+
+        // Both should exist
+        let audit = load::<()>(&audit_config).unwrap().unwrap();
+        let lint = load::<()>(&lint_config).unwrap().unwrap();
+
+        assert_eq!(audit.item_count, 1);
+        assert_eq!(lint.item_count, 1);
+        assert!(audit.known_fingerprints.contains(&"conv::a.php".to_string()));
+        assert!(lint.known_fingerprints.contains(&"psr12::b.php".to_string()));
+    }
+
+    #[test]
+    fn save_with_typed_metadata_roundtrips() {
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        struct AuditMeta {
+            alignment_score: f32,
+            outlier_count: usize,
+        }
+
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let items = vec![item("conv", "a.php", "missing method")];
+        let meta = AuditMeta {
+            alignment_score: 0.85,
+            outlier_count: 3,
+        };
+
+        save(&config, "data-machine", &items, meta.clone()).unwrap();
+        let loaded = load::<AuditMeta>(&config).unwrap().unwrap();
+
+        assert_eq!(loaded.metadata, meta);
+    }
+
+    // -- Compare: no drift ----------------------------------------------------
+
+    #[test]
+    fn compare_identical_items_shows_no_drift() {
+        let items = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "b.rs", "dead code"),
+        ];
+
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "test");
+        save(&config, "test", &items, ()).unwrap();
+        let baseline = load::<()>(&config).unwrap().unwrap();
+
+        let comparison = compare(&items, &baseline);
+        assert!(!comparison.drift_increased);
+        assert!(comparison.new_items.is_empty());
+        assert!(comparison.resolved_fingerprints.is_empty());
+        assert_eq!(comparison.delta, 0);
+    }
+
+    // -- Compare: new drift ---------------------------------------------------
+
+    #[test]
+    fn compare_detects_new_items() {
+        let original = vec![item("lint", "a.rs", "unused import")];
+
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "test");
+        save(&config, "test", &original, ()).unwrap();
+        let baseline = load::<()>(&config).unwrap().unwrap();
+
+        let current = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "c.rs", "missing docs"),
+        ];
+
+        let comparison = compare(&current, &baseline);
+        assert!(comparison.drift_increased);
+        assert_eq!(comparison.new_items.len(), 1);
+        assert_eq!(comparison.new_items[0].fingerprint, "lint::c.rs");
+        assert_eq!(comparison.delta, 1);
+    }
+
+    // -- Compare: resolved items ----------------------------------------------
+
+    #[test]
+    fn compare_detects_resolved_items() {
+        let original = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "b.rs", "dead code"),
+        ];
+
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "test");
+        save(&config, "test", &original, ()).unwrap();
+        let baseline = load::<()>(&config).unwrap().unwrap();
+
+        let current = vec![item("lint", "a.rs", "unused import")];
+
+        let comparison = compare(&current, &baseline);
+        assert!(!comparison.drift_increased);
+        assert!(comparison.new_items.is_empty());
+        assert_eq!(comparison.resolved_fingerprints.len(), 1);
+        assert_eq!(comparison.delta, -1);
+    }
+
+    // -- Compare: new AND resolved simultaneously -----------------------------
+
+    #[test]
+    fn compare_new_and_resolved_simultaneously() {
+        let original = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "b.rs", "dead code"),
+        ];
+
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "test");
+        save(&config, "test", &original, ()).unwrap();
+        let baseline = load::<()>(&config).unwrap().unwrap();
+
+        // b.rs resolved, c.rs introduced
+        let current = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "c.rs", "missing docs"),
+        ];
+
+        let comparison = compare(&current, &baseline);
+        assert!(comparison.drift_increased); // new item = fail
+        assert_eq!(comparison.new_items.len(), 1);
+        assert_eq!(comparison.resolved_fingerprints.len(), 1);
+        assert_eq!(comparison.delta, 0); // net zero, but still fails
+    }
+
+    // -- Fingerprint stability ------------------------------------------------
+
+    #[test]
+    fn fingerprint_ignores_description_changes() {
+        let item1 = item("structural", "deploy.rs", "File has 2484 lines");
+        let item2 = item("structural", "deploy.rs", "File has 2645 lines");
+        assert_eq!(item1.fingerprint(), item2.fingerprint());
+    }
+
+    // -- Timestamp ------------------------------------------------------------
+
+    #[test]
+    fn utc_now_produces_valid_iso8601() {
+        let now = utc_now_iso8601();
+        assert_eq!(now.len(), 20, "Expected 20 chars, got {}: {}", now.len(), now);
+        assert!(now.ends_with('Z'));
+        assert!(now.contains('T'));
+    }
+
+    // -- BaselineConfig -------------------------------------------------------
+
+    #[test]
+    fn config_json_path() {
+        let config = BaselineConfig::new("/project/root", "audit");
+        assert_eq!(
+            config.json_path(),
+            PathBuf::from("/project/root/homeboy.json")
+        );
+    }
+
+    // -- Edge cases -----------------------------------------------------------
+
+    #[test]
+    fn save_overwrites_same_key() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+
+        let items_v1 = vec![item("lint", "a.rs", "v1")];
+        save(&config, "test", &items_v1, ()).unwrap();
+
+        let items_v2 = vec![
+            item("lint", "a.rs", "v2"),
+            item("lint", "b.rs", "new"),
+        ];
+        save(&config, "test", &items_v2, ()).unwrap();
+
+        let loaded = load::<()>(&config).unwrap().unwrap();
+        assert_eq!(loaded.item_count, 2);
+    }
+
+    #[test]
+    fn compare_empty_current_against_populated_baseline() {
+        let original = vec![
+            item("lint", "a.rs", "unused"),
+            item("lint", "b.rs", "dead"),
+        ];
+
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "test");
+        save(&config, "test", &original, ()).unwrap();
+        let baseline = load::<()>(&config).unwrap().unwrap();
+
+        let current: Vec<TestItem> = vec![];
+        let comparison = compare(&current, &baseline);
+        assert!(!comparison.drift_increased);
+        assert_eq!(comparison.resolved_fingerprints.len(), 2);
+        assert_eq!(comparison.delta, -2);
+    }
+
+    #[test]
+    fn compare_populated_current_against_empty_baseline() {
+        let original: Vec<TestItem> = vec![];
+
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "test");
+        save(&config, "test", &original, ()).unwrap();
+        let baseline = load::<()>(&config).unwrap().unwrap();
+
+        let current = vec![item("lint", "a.rs", "new finding")];
+        let comparison = compare(&current, &baseline);
+        assert!(comparison.drift_increased);
+        assert_eq!(comparison.new_items.len(), 1);
+        assert_eq!(comparison.delta, 1);
+    }
+
+    #[test]
+    fn load_returns_error_for_malformed_baseline() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{"baselines": {"audit": "not a valid baseline object"}}"#,
+        )
+        .unwrap();
+
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let result = load::<()>(&config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_returns_error_for_malformed_json() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            "not valid json {{{",
+        )
+        .unwrap();
+
+        let config = BaselineConfig::new(dir.path(), "audit");
+        let result = load::<()>(&config);
+        assert!(result.is_err());
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! - `args` - CLI argument normalization
 //! - `base_path` - Remote path joining utilities
+//! - `baseline` - Baseline & ratchet drift detection
 //! - `command` - Command execution with error handling
 //! - `entity_suggest` - Entity suggestion for unrecognized CLI subcommands
 //! - `io` - File I/O with consistent error handling
@@ -16,6 +17,7 @@
 pub mod args;
 pub mod artifact;
 pub mod base_path;
+pub mod baseline;
 pub mod command;
 pub mod entity_suggest;
 pub mod io;


### PR DESCRIPTION
## Summary

Extracts the baseline + ratchet pattern from `code_audit` into a reusable `utils/baseline.rs` primitive. Any system that produces findings can now baseline and ratchet — audit, lint, test, docs, cleanup, fleet drift — without reinventing save/load/compare/fingerprint mechanics.

## What changed

- **New: `utils/baseline.rs`** — generic primitive with `Fingerprintable` trait, `Baseline<M>` (typed metadata), `Comparison`, `save()`/`load()`/`compare()`, timestamp helpers
- **Refactored: `code_audit/baseline.rs`** — now delegates to the generic primitive via an `AuditFinding` wrapper that implements `Fingerprintable`. Same public API, audit command unchanged
- **Updated: `commands/audit.rs`** — field names adjusted for the generic types (`item_count` vs `findings_count`, `metadata.alignment_score` vs `alignment_score`)

## Storage

Baselines stored in `homeboy.json` under a `baselines.<key>` structure. Each domain picks its own key:

```json
{
  "remote_path": "wp-content/plugins/data-machine",
  "baselines": {
    "audit": { "created_at": "...", "item_count": 12, "known_fingerprints": [...], "metadata": {...} },
    "lint": { "created_at": "...", ... }
  }
}
```

Existing component config is preserved — `save()` reads the existing `homeboy.json`, sets only `baselines.<key>`, writes back.

## The ratchet rule

- `drift_increased = true` if ANY new items appeared (not in baseline) → CI fails
- Resolved items tracked but don't fail → progress celebrated
- Same state → pass

## Tests

- 20 new tests for the generic primitive
- 9 refactored tests for the audit consumer  
- Full suite: **544 passed, 0 failed**