### PR TITLE
feat: baseline/ratchet integration for docs audit and cleanup

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::cleanup::{self, CleanupResult};
+use homeboy::cleanup::{self, baseline as cleanup_baseline, CleanupResult};
 
 use super::CmdResult;
 
@@ -17,6 +17,18 @@ pub struct CleanupArgs {
     /// Show only issues in a specific category: local_path, remote_path, version_targets, extensions
     #[arg(long)]
     pub category: Option<String>,
+
+    /// Save current cleanup state as baseline for future comparisons
+    #[arg(long)]
+    pub baseline: bool,
+
+    /// Skip baseline comparison even if a baseline exists
+    #[arg(long)]
+    pub ignore_baseline: bool,
+
+    /// Override local_path for this cleanup run
+    #[arg(long)]
+    pub path: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -31,6 +43,8 @@ pub struct CleanupOutput {
     pub results: Vec<CleanupResult>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub hints: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<cleanup_baseline::BaselineComparison>,
 }
 
 pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<CleanupOutput> {
@@ -46,6 +60,67 @@ pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<CleanupO
 
         let total_issues = result.summary.config_issues;
 
+        // Resolve source path for baseline storage
+        let source_path = if let Some(ref path) = args.path {
+            std::path::PathBuf::from(path)
+        } else {
+            let comp = homeboy::component::load(component_id)?;
+            std::path::PathBuf::from(&comp.local_path)
+        };
+
+        // --baseline: save current state
+        if args.baseline {
+            let saved = cleanup_baseline::save_baseline(&source_path, &result)?;
+            eprintln!(
+                "[cleanup] Baseline saved to {} ({} issue(s))",
+                saved.display(),
+                total_issues,
+            );
+
+            return Ok((
+                CleanupOutput {
+                    command: "cleanup.baseline",
+                    component_id: Some(component_id.clone()),
+                    total_issues,
+                    result: Some(result),
+                    results: Vec::new(),
+                    hints: vec!["Full docs: homeboy docs commands/cleanup".to_string()],
+                    baseline_comparison: None,
+                },
+                0,
+            ));
+        }
+
+        // Compare against baseline if one exists
+        let baseline_comparison = if !args.ignore_baseline {
+            if let Some(existing_baseline) = cleanup_baseline::load_baseline(&source_path) {
+                let comparison = cleanup_baseline::compare(&result, &existing_baseline);
+
+                if comparison.drift_increased {
+                    eprintln!(
+                        "[cleanup] DRIFT INCREASED: {} new issue(s) since baseline",
+                        comparison.new_items.len()
+                    );
+                } else if !comparison.resolved_fingerprints.is_empty() {
+                    eprintln!(
+                        "[cleanup] Drift reduced: {} issue(s) resolved since baseline",
+                        comparison.resolved_fingerprints.len()
+                    );
+                }
+
+                Some(comparison)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let exit_code = baseline_comparison
+            .as_ref()
+            .map(|c| if c.drift_increased { 1 } else { 0 })
+            .unwrap_or(0);
+
         Ok((
             CleanupOutput {
                 command: "cleanup",
@@ -54,8 +129,9 @@ pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<CleanupO
                 result: Some(result),
                 results: Vec::new(),
                 hints: vec!["Full docs: homeboy docs commands/cleanup".to_string()],
+                baseline_comparison,
             },
-            0,
+            exit_code,
         ))
     } else {
         // All components mode
@@ -91,6 +167,7 @@ pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<CleanupO
                 result: None,
                 results,
                 hints,
+                baseline_comparison: None,
             },
             0,
         ))

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -32,6 +32,14 @@ pub enum DocsCommand {
         #[arg(long)]
         docs_dir: Option<String>,
 
+        /// Save current audit state as baseline for future comparisons
+        #[arg(long)]
+        baseline: bool,
+
+        /// Skip baseline comparison even if a baseline exists
+        #[arg(long)]
+        ignore_baseline: bool,
+
         /// Include full list of all detected features in output
         #[arg(long)]
         features: bool,
@@ -159,6 +167,21 @@ pub enum DocsOutput {
     #[serde(rename = "docs.audit")]
     Audit(AuditResult),
 
+    #[serde(rename = "docs.audit.baseline")]
+    AuditBaselineSaved {
+        component_id: String,
+        path: String,
+        broken_references: usize,
+        docs_scanned: usize,
+    },
+
+    #[serde(rename = "docs.audit.compared")]
+    AuditCompared {
+        #[serde(flatten)]
+        result: AuditResult,
+        baseline_comparison: homeboy::docs_audit::baseline::BaselineComparison,
+    },
+
     #[serde(rename = "docs.map")]
     Map(CodebaseMap),
 
@@ -220,7 +243,7 @@ pub fn run_markdown(args: DocsArgs) -> CmdResult<String> {
 /// JSON output mode (audit, map, generate subcommands)
 pub fn run(args: DocsArgs, _global: &super::GlobalArgs) -> CmdResult<DocsOutput> {
     match args.command {
-        Some(DocsCommand::Audit { component_id, docs_dir, features }) => run_audit(&component_id, docs_dir.as_deref(), features),
+        Some(DocsCommand::Audit { component_id, docs_dir, baseline, ignore_baseline, features }) => run_audit(&component_id, docs_dir.as_deref(), features, baseline, ignore_baseline),
         Some(DocsCommand::Map { component_id, source_dirs, include_private, write, output_dir }) => run_map(&component_id, source_dirs, include_private, write, &output_dir),
         Some(DocsCommand::Generate { spec, json, from_audit, dry_run }) => {
             if let Some(ref audit_source) = from_audit {
@@ -1186,7 +1209,13 @@ fn collect_fingerprints_recursive(
 // Audit (Claim-Based Documentation Verification)
 // ============================================================================
 
-fn run_audit(component_id: &str, docs_dir: Option<&str>, features: bool) -> CmdResult<DocsOutput> {
+fn run_audit(
+    component_id: &str,
+    docs_dir: Option<&str>,
+    features: bool,
+    baseline: bool,
+    ignore_baseline: bool,
+) -> CmdResult<DocsOutput> {
     // If the argument looks like a filesystem path, audit it directly
     // without requiring component registration
     let result = if std::path::Path::new(component_id).is_dir() {
@@ -1194,6 +1223,68 @@ fn run_audit(component_id: &str, docs_dir: Option<&str>, features: bool) -> CmdR
     } else {
         docs_audit::audit_component(component_id, docs_dir, features)?
     };
+
+    // Resolve source path for baseline storage
+    let source_path = if std::path::Path::new(component_id).is_dir() {
+        std::path::PathBuf::from(component_id)
+    } else {
+        let comp = homeboy::component::load(component_id)?;
+        std::path::PathBuf::from(&comp.local_path)
+    };
+
+    // --baseline: save current state
+    if baseline {
+        let saved = docs_audit::baseline::save_baseline(&source_path, &result)?;
+
+        eprintln!(
+            "[docs audit] Baseline saved to {} ({} broken reference(s), {} docs scanned)",
+            saved.display(),
+            result.summary.broken_references,
+            result.summary.docs_scanned,
+        );
+
+        return Ok((
+            DocsOutput::AuditBaselineSaved {
+                component_id: result.component_id,
+                path: saved.to_string_lossy().to_string(),
+                broken_references: result.summary.broken_references,
+                docs_scanned: result.summary.docs_scanned,
+            },
+            0,
+        ));
+    }
+
+    // Default: compare against baseline if one exists
+    if !ignore_baseline {
+        if let Some(existing_baseline) = docs_audit::baseline::load_baseline(&source_path) {
+            let comparison = docs_audit::baseline::compare(&result, &existing_baseline);
+
+            let exit_code = if comparison.drift_increased { 1 } else { 0 };
+
+            if comparison.drift_increased {
+                eprintln!(
+                    "[docs audit] DRIFT INCREASED: {} new broken reference(s) since baseline",
+                    comparison.new_items.len()
+                );
+            } else if !comparison.resolved_fingerprints.is_empty() {
+                eprintln!(
+                    "[docs audit] Drift reduced: {} broken reference(s) resolved since baseline",
+                    comparison.resolved_fingerprints.len()
+                );
+            } else {
+                eprintln!("[docs audit] No change from baseline");
+            }
+
+            return Ok((
+                DocsOutput::AuditCompared {
+                    result,
+                    baseline_comparison: comparison,
+                },
+                exit_code,
+            ));
+        }
+    }
+
     Ok((DocsOutput::Audit(result), 0))
 }
 

--- a/src/core/cleanup/baseline.rs
+++ b/src/core/cleanup/baseline.rs
@@ -1,0 +1,161 @@
+//! Cleanup baseline — delegates to the generic `utils::baseline` primitive.
+//!
+//! Baselines config health issues so CI only fails on NEW issues.
+
+use std::path::Path;
+
+use crate::baseline::{self as generic, BaselineConfig, Fingerprintable};
+
+use super::config::ConfigIssue;
+use super::CleanupResult;
+
+// ============================================================================
+// Baseline key
+// ============================================================================
+
+/// Key used in `homeboy.json` → `baselines.cleanup`.
+const BASELINE_KEY: &str = "cleanup";
+
+// ============================================================================
+// Fingerprintable implementation for config issues
+// ============================================================================
+
+/// Wrapper that implements [`Fingerprintable`] for config issues.
+///
+/// Uses `category::message` as the identity. The message contains enough
+/// context (file paths, extension names) to be stable across runs.
+struct CleanupFinding<'a>(&'a ConfigIssue);
+
+impl Fingerprintable for CleanupFinding<'_> {
+    fn fingerprint(&self) -> String {
+        format!("{}::{}", self.0.category, self.0.message)
+    }
+
+    fn description(&self) -> String {
+        self.0.message.clone()
+    }
+
+    fn context_label(&self) -> String {
+        self.0.category.clone()
+    }
+}
+
+// ============================================================================
+// Public types (re-exports from generic)
+// ============================================================================
+
+/// A saved cleanup baseline snapshot.
+pub type CleanupBaseline = generic::Baseline<()>;
+
+/// Result of comparing cleanup against a baseline.
+pub type BaselineComparison = generic::Comparison;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Save the current cleanup result as a baseline.
+pub fn save_baseline(
+    source_path: &Path,
+    result: &CleanupResult,
+) -> crate::error::Result<std::path::PathBuf> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+
+    let items: Vec<CleanupFinding> = result.config_issues.iter().map(CleanupFinding).collect();
+
+    generic::save(&config, &result.component_id, &items, ())
+}
+
+/// Load a cleanup baseline if one exists.
+pub fn load_baseline(source_path: &Path) -> Option<CleanupBaseline> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    generic::load::<()>(&config).ok().flatten()
+}
+
+/// Compare cleanup result against a saved baseline.
+pub fn compare(result: &CleanupResult, baseline: &CleanupBaseline) -> BaselineComparison {
+    let items: Vec<CleanupFinding> = result.config_issues.iter().map(CleanupFinding).collect();
+    generic::compare(&items, baseline)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cleanup::config::IssueSeverity;
+    use crate::cleanup::CleanupSummary;
+
+    fn make_issue(category: &str, message: &str) -> ConfigIssue {
+        ConfigIssue {
+            severity: IssueSeverity::Warning,
+            category: category.to_string(),
+            message: message.to_string(),
+            fix_hint: None,
+        }
+    }
+
+    fn make_result(issues: Vec<ConfigIssue>) -> CleanupResult {
+        CleanupResult {
+            component_id: "test".to_string(),
+            summary: CleanupSummary {
+                config_issues: issues.len(),
+            },
+            config_issues: issues,
+            hints: vec![],
+        }
+    }
+
+    #[test]
+    fn save_and_load_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = make_result(vec![
+            make_issue("local_path", "local_path does not exist: /old/path"),
+            make_issue("extensions", "Extension 'old-ext' could not be loaded"),
+        ]);
+
+        save_baseline(dir.path(), &result).unwrap();
+        let loaded = load_baseline(dir.path()).unwrap();
+
+        assert_eq!(loaded.context_id, "test");
+        assert_eq!(loaded.item_count, 2);
+    }
+
+    #[test]
+    fn compare_detects_new_issue() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = make_result(vec![make_issue("local_path", "local_path does not exist")]);
+
+        save_baseline(dir.path(), &original).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = make_result(vec![
+            make_issue("local_path", "local_path does not exist"),
+            make_issue("extensions", "Extension 'bad' could not be loaded"),
+        ]);
+
+        let comparison = compare(&current, &baseline);
+        assert!(comparison.drift_increased);
+        assert_eq!(comparison.new_items.len(), 1);
+    }
+
+    #[test]
+    fn compare_detects_resolved_issue() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = make_result(vec![
+            make_issue("local_path", "local_path does not exist"),
+            make_issue("extensions", "Extension 'old' could not be loaded"),
+        ]);
+
+        save_baseline(dir.path(), &original).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = make_result(vec![make_issue("local_path", "local_path does not exist")]);
+
+        let comparison = compare(&current, &baseline);
+        assert!(!comparison.drift_increased);
+        assert_eq!(comparison.resolved_fingerprints.len(), 1);
+    }
+}

--- a/src/core/cleanup/mod.rs
+++ b/src/core/cleanup/mod.rs
@@ -4,6 +4,7 @@
 //! 1. Config health - broken paths, dead version targets, unused extensions
 //! 2. Future: git staleness, orphan detection, unused registrations
 
+pub mod baseline;
 pub mod config;
 
 use serde::Serialize;

--- a/src/core/docs_audit/baseline.rs
+++ b/src/core/docs_audit/baseline.rs
@@ -1,0 +1,216 @@
+//! Docs audit baseline — delegates to the generic `utils::baseline` primitive.
+//!
+//! Baselines broken references so CI only fails on NEW broken refs.
+
+use std::path::Path;
+
+use crate::baseline::{self as generic, BaselineConfig, Fingerprintable};
+
+use super::{AuditResult, BrokenReference};
+
+// ============================================================================
+// Baseline key
+// ============================================================================
+
+/// Key used in `homeboy.json` → `baselines.docs`.
+const BASELINE_KEY: &str = "docs";
+
+// ============================================================================
+// Docs-specific metadata
+// ============================================================================
+
+/// Domain-specific metadata stored alongside the generic baseline.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DocsBaselineMetadata {
+    /// Total docs scanned at baseline time.
+    pub docs_scanned: usize,
+    /// Total undocumented features at baseline time.
+    pub undocumented_features: usize,
+}
+
+// ============================================================================
+// Fingerprintable implementation for broken references
+// ============================================================================
+
+/// Wrapper that implements [`Fingerprintable`] for broken references.
+///
+/// Uses `doc::claim` as the identity. Line numbers are excluded because
+/// editing a doc file shifts line numbers without changing the reference.
+struct DocsFinding<'a>(&'a BrokenReference);
+
+impl Fingerprintable for DocsFinding<'_> {
+    fn fingerprint(&self) -> String {
+        format!("{}::{}", self.0.doc, self.0.claim)
+    }
+
+    fn description(&self) -> String {
+        self.0.action.clone()
+    }
+
+    fn context_label(&self) -> String {
+        self.0.doc.clone()
+    }
+}
+
+// ============================================================================
+// Public types (re-exports from generic)
+// ============================================================================
+
+/// A saved docs baseline snapshot.
+pub type DocsBaseline = generic::Baseline<DocsBaselineMetadata>;
+
+/// Result of comparing docs audit against a baseline.
+pub type BaselineComparison = generic::Comparison;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Save the current docs audit result as a baseline.
+pub fn save_baseline(
+    source_path: &Path,
+    result: &AuditResult,
+) -> crate::error::Result<std::path::PathBuf> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+
+    let metadata = DocsBaselineMetadata {
+        docs_scanned: result.summary.docs_scanned,
+        undocumented_features: result.summary.undocumented_features,
+    };
+
+    let items: Vec<DocsFinding> = result.broken_references.iter().map(DocsFinding).collect();
+
+    generic::save(&config, &result.component_id, &items, metadata)
+}
+
+/// Load a docs baseline if one exists.
+pub fn load_baseline(source_path: &Path) -> Option<DocsBaseline> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    generic::load::<DocsBaselineMetadata>(&config)
+        .ok()
+        .flatten()
+}
+
+/// Compare docs audit result against a saved baseline.
+pub fn compare(result: &AuditResult, baseline: &DocsBaseline) -> BaselineComparison {
+    let items: Vec<DocsFinding> = result.broken_references.iter().map(DocsFinding).collect();
+    generic::compare(&items, baseline)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::docs_audit::{AlignmentSummary, ClaimConfidence};
+
+    fn make_broken_ref(doc: &str, claim: &str) -> BrokenReference {
+        BrokenReference {
+            doc: doc.to_string(),
+            line: 10,
+            claim: claim.to_string(),
+            confidence: ClaimConfidence::Real,
+            doc_context: None,
+            action: "Stale reference".to_string(),
+        }
+    }
+
+    fn make_result(broken: Vec<BrokenReference>) -> AuditResult {
+        AuditResult {
+            component_id: "test".to_string(),
+            baseline_ref: None,
+            summary: AlignmentSummary {
+                docs_scanned: 5,
+                priority_docs: 0,
+                broken_references: broken.len(),
+                unchanged_docs: 5,
+                total_features: 0,
+                documented_features: 0,
+                undocumented_features: 0,
+            },
+            changed_files: vec![],
+            priority_docs: vec![],
+            broken_references: broken,
+            undocumented_features: vec![],
+            detected_features: vec![],
+        }
+    }
+
+    #[test]
+    fn save_and_load_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = make_result(vec![
+            make_broken_ref("api.md", "file path `src/old.rs`"),
+            make_broken_ref("guide.md", "class `OldClass`"),
+        ]);
+
+        save_baseline(dir.path(), &result).unwrap();
+        let loaded = load_baseline(dir.path()).unwrap();
+
+        assert_eq!(loaded.context_id, "test");
+        assert_eq!(loaded.item_count, 2);
+        assert_eq!(loaded.metadata.docs_scanned, 5);
+    }
+
+    #[test]
+    fn compare_detects_new_broken_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = make_result(vec![make_broken_ref("api.md", "file path `src/old.rs`")]);
+
+        save_baseline(dir.path(), &original).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = make_result(vec![
+            make_broken_ref("api.md", "file path `src/old.rs`"),
+            make_broken_ref("guide.md", "file path `src/removed.rs`"),
+        ]);
+
+        let comparison = compare(&current, &baseline);
+        assert!(comparison.drift_increased);
+        assert_eq!(comparison.new_items.len(), 1);
+    }
+
+    #[test]
+    fn compare_detects_resolved_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = make_result(vec![
+            make_broken_ref("api.md", "file path `src/old.rs`"),
+            make_broken_ref("guide.md", "class `OldClass`"),
+        ]);
+
+        save_baseline(dir.path(), &original).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = make_result(vec![make_broken_ref("api.md", "file path `src/old.rs`")]);
+
+        let comparison = compare(&current, &baseline);
+        assert!(!comparison.drift_increased);
+        assert_eq!(comparison.resolved_fingerprints.len(), 1);
+    }
+
+    #[test]
+    fn fingerprint_ignores_line_number() {
+        let ref1 = BrokenReference {
+            doc: "api.md".to_string(),
+            line: 10,
+            claim: "file path `src/old.rs`".to_string(),
+            confidence: ClaimConfidence::Real,
+            doc_context: None,
+            action: "Stale".to_string(),
+        };
+        let ref2 = BrokenReference {
+            doc: "api.md".to_string(),
+            line: 42, // different line
+            claim: "file path `src/old.rs`".to_string(),
+            confidence: ClaimConfidence::Real,
+            doc_context: None,
+            action: "Stale".to_string(),
+        };
+        assert_eq!(
+            DocsFinding(&ref1).fingerprint(),
+            DocsFinding(&ref2).fingerprint()
+        );
+    }
+}

--- a/src/core/docs_audit/mod.rs
+++ b/src/core/docs_audit/mod.rs
@@ -6,6 +6,7 @@
 //! 3. Correlate docs with git changes to identify priority docs needing review
 //! 4. Build an alignment report focused on actionable items
 
+pub mod baseline;
 mod claims;
 mod tasks;
 mod verify;


### PR DESCRIPTION
## Summary

Wires the generic baseline primitive (#413) into two more consumers: **docs audit** and **cleanup**. Both follow the same pattern established by code_audit — implement `Fingerprintable` for the domain's finding type, delegate persistence and comparison to `utils::baseline`.

Addresses #415 (lint and test baselines tracked separately in #411).

## What changed

### Docs audit (`homeboy docs audit`)
- **New: `docs_audit/baseline.rs`** — `Fingerprintable` impl for `BrokenReference` using `doc::claim` as fingerprint (excludes line numbers since they shift on edits). Stores as `baselines.docs` in `homeboy.json`.
- **New flags**: `--baseline` (save) and `--ignore-baseline` (skip comparison)
- **New output variants**: `docs.audit.baseline` and `docs.audit.compared`

```bash
homeboy docs audit data-machine --baseline        # save current broken refs as baseline
homeboy docs audit data-machine                   # compare against baseline, fail on new refs
homeboy docs audit data-machine --ignore-baseline # skip comparison
```

### Cleanup (`homeboy cleanup`)
- **New: `cleanup/baseline.rs`** — `Fingerprintable` impl for `ConfigIssue` using `category::message` as fingerprint. Stores as `baselines.cleanup` in `homeboy.json`.
- **New flags**: `--baseline`, `--ignore-baseline`, `--path`
- Baseline comparison included in JSON output when available

```bash
homeboy cleanup data-machine --baseline        # save current config issues as baseline
homeboy cleanup data-machine                   # compare against baseline, fail on new issues
homeboy cleanup data-machine --ignore-baseline # skip comparison
```

### Storage

All baselines in the same `homeboy.json`:

```json
{
  "remote_path": "wp-content/plugins/data-machine",
  "baselines": {
    "audit": { ... },
    "docs": { ... },
    "cleanup": { ... }
  }
}
```

## Tests

- 4 new tests for docs audit baseline (roundtrip, new drift, resolved drift, fingerprint stability)
- 3 new tests for cleanup baseline (roundtrip, new drift, resolved drift)
- Full suite: **551 passed, 0 failed** (up from 544)