### PR TITLE
fix: build homeboy from source in CI audit (closes #416)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,52 @@ jobs:
         run: cargo test
 
   # ── Homeboy audit (dogfooding) ──
-  # Compares audit findings against the committed baseline. Only fails
-  # if a PR introduces NEW drift (new findings not in the baseline).
-  # Resolving existing findings is always allowed (ratchet down).
+  # Build from source instead of downloading a release binary.
+  # This avoids the chicken-and-egg problem: homeboy-action downloads from
+  # the latest GitHub release, but that binary doesn't include the PR's code.
+  # For the homeboy repo itself, we compile the PR branch and audit with that.
+  # See: https://github.com/Extra-Chill/homeboy/issues/416
   audit:
     name: Homeboy Audit
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Extra-Chill/homeboy-action@v1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
         with:
-          extension: rust
-          commands: audit
-          component: homeboy
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build homeboy
+        run: cargo build
+
+      - name: Install extension and register component
+        run: |
+          BINARY=$(find target/debug -maxdepth 1 -name "homeboy" -type f | head -1)
+          if [ -z "$BINARY" ]; then
+            echo "::error::Could not find homeboy binary in target/debug"
+            exit 1
+          fi
+          chmod +x "$BINARY"
+
+          echo "Using $($BINARY --version)"
+
+          # Install the rust extension for audit rules
+          "$BINARY" extension install https://github.com/Extra-Chill/homeboy-extensions --id rust
+
+          # Register the component so audit can find it
+          "$BINARY" component create --local-path "$(pwd)" --extension rust
+
+      - name: Run audit
+        run: |
+          BINARY=$(find target/debug -maxdepth 1 -name "homeboy" -type f | head -1)
+          "$BINARY" audit homeboy


### PR DESCRIPTION
## Summary

- **Replaces `homeboy-action@v1`** in the CI audit job with a build-from-source approach
- Compiles the PR branch with `cargo build` and runs `homeboy audit` with that binary
- Audit job now `needs: [build]` so the cargo cache is warm

## Root Cause

The `homeboy-action@v1` resolves `version: latest` → downloads the binary from the latest GitHub release. This 404s because releases v0.54.1+ have no binary artifacts (the release pipeline's pre-release gate had the same chicken-and-egg bug — already fixed on main in `release.yml`).

Even with working releases, this was always wrong for the homeboy repo: CI was auditing with old released code, not the PR's changes.

## What Changed

**`.github/workflows/ci.yml`** — the `audit` job now:
1. Depends on `build` (cargo cache is primed)
2. Installs Rust toolchain + restores cargo cache
3. Runs `cargo build` to compile the PR branch
4. Installs the `rust` extension from homeboy-extensions
5. Registers the component and runs `homeboy audit`

## Follow-up

After merging, a new release should be tagged to restore binary artifacts in GitHub releases. The `release.yml` on main already has the equivalent fix (uses `target/debug/homeboy` instead of homeboy-action), so the next release should produce full binaries and unblock homeboy-action for other repos (data-machine, etc.).

Closes #416