### PR TITLE
feat: test baseline ratchet — CI floor for pass/fail counts

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use homeboy::component::{self, Component};
 use homeboy::error::Error;
 use homeboy::extension::{self, ExtensionRunner};
+use homeboy::test_baseline::{self, TestBaselineComparison, TestCounts};
 use homeboy::utils::io;
 
 use super::CmdResult;
@@ -29,6 +30,18 @@ pub struct TestArgs {
     #[arg(long, value_name = "PERCENT")]
     coverage_min: Option<f64>,
 
+    /// Save current test results as baseline for future ratchet checks
+    #[arg(long)]
+    baseline: bool,
+
+    /// Skip baseline comparison even if a baseline exists
+    #[arg(long)]
+    ignore_baseline: bool,
+
+    /// Auto-update baseline when test results improve (ratchet forward)
+    #[arg(long)]
+    ratchet: bool,
+
     /// Override settings as key=value pairs
     #[arg(long, value_parser = super::parse_key_val)]
     setting: Vec<(String, String)>,
@@ -52,7 +65,11 @@ pub struct TestOutput {
     component: String,
     exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    test_counts: Option<TestCounts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     coverage: Option<CoverageOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_comparison: Option<TestBaselineComparison>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hints: Option<Vec<String>>,
 }
@@ -163,12 +180,17 @@ pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput>
         None
     };
 
+    // Create temp file for test results output
+    let results_file =
+        std::env::temp_dir().join(format!("homeboy-test-results-{}.json", std::process::id()));
+
     let mut runner = ExtensionRunner::new(&args.component, &script_path)
         .path_override(args.path.clone())
         .settings(&args.setting)
         .env_if(args.skip_lint, "HOMEBOY_SKIP_LINT", "1")
         .env_if(args.fix, "HOMEBOY_AUTO_FIX", "1")
-        .env_if(coverage_enabled, "HOMEBOY_COVERAGE", "1");
+        .env_if(coverage_enabled, "HOMEBOY_COVERAGE", "1")
+        .env("HOMEBOY_TEST_RESULTS_FILE", &results_file.to_string_lossy());
 
     if let Some(ref file) = coverage_file {
         runner = runner.env("HOMEBOY_COVERAGE_FILE", &file.to_string_lossy());
@@ -182,6 +204,12 @@ pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput>
 
     let status = if output.success { "passed" } else { "failed" };
 
+    // Read test results if available
+    let test_counts = parse_test_results_file(&results_file);
+
+    // Clean up test results temp file
+    let _ = std::fs::remove_file(&results_file);
+
     // Read coverage results if available
     let coverage = coverage_file
         .as_ref()
@@ -190,6 +218,73 @@ pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput>
     // Clean up coverage temp file
     if let Some(ref f) = coverage_file {
         let _ = std::fs::remove_file(f);
+    }
+
+    // Resolve source path for baseline storage
+    let source_path = if let Some(ref path) = args.path {
+        std::path::PathBuf::from(path)
+    } else {
+        let expanded = shellexpand::tilde(&component.local_path);
+        std::path::PathBuf::from(expanded.as_ref())
+    };
+
+    // --baseline: save current state
+    if args.baseline {
+        if let Some(ref counts) = test_counts {
+            let saved = test_baseline::save_baseline(&source_path, &args.component, counts)?;
+            eprintln!(
+                "[test] Baseline saved to {} ({} passed, {} failed, {} total)",
+                saved.display(),
+                counts.passed,
+                counts.failed,
+                counts.total,
+            );
+        } else {
+            eprintln!(
+                "[test] Cannot save baseline: no test results available. \
+                 Ensure the extension writes HOMEBOY_TEST_RESULTS_FILE."
+            );
+        }
+    }
+
+    // Baseline comparison
+    let mut baseline_comparison = None;
+    let mut baseline_exit_override = None;
+
+    if !args.baseline && !args.ignore_baseline {
+        if let Some(ref counts) = test_counts {
+            if let Some(existing_baseline) = test_baseline::load_baseline(&source_path) {
+                let comparison = test_baseline::compare(counts, &existing_baseline);
+
+                if comparison.regression {
+                    eprintln!(
+                        "[test] REGRESSION: {}",
+                        comparison.reasons.join("; ")
+                    );
+                    baseline_exit_override = Some(1);
+                } else {
+                    if comparison.passed_delta > 0 || comparison.failed_delta < 0 {
+                        eprintln!(
+                            "[test] Improvement: passed {} ({:+}), failed {} ({:+})",
+                            counts.passed, comparison.passed_delta,
+                            counts.failed, comparison.failed_delta,
+                        );
+
+                        // Auto-ratchet: update baseline when results improve
+                        if args.ratchet {
+                            let _ = test_baseline::save_baseline(
+                                &source_path,
+                                &args.component,
+                                counts,
+                            );
+                            eprintln!("[test] Baseline ratcheted forward");
+                        }
+                    }
+                }
+
+                baseline_comparison = Some(comparison);
+            }
+        }
     }
 
     let mut hints = Vec::new();
@@ -218,6 +313,22 @@ pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput>
         ));
     }
 
+    // Baseline hints
+    if test_counts.is_some() && !args.baseline && baseline_comparison.is_none() {
+        hints.push(format!(
+            "Save test baseline: homeboy test {} --baseline",
+            args.component
+        ));
+    }
+
+    // Ratchet hint when baseline exists but --ratchet not used
+    if baseline_comparison.is_some() && !args.ratchet {
+        hints.push(format!(
+            "Auto-update baseline on improvement: homeboy test {} --ratchet",
+            args.component
+        ));
+    }
+
     // Capability hint when not using passthrough args
     if args.args.is_empty() {
         hints.push("Pass args to test runner: homeboy test <component> -- [args]".to_string());
@@ -228,16 +339,34 @@ pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput>
 
     let hints = if hints.is_empty() { None } else { Some(hints) };
 
+    // Exit code: baseline regression overrides test exit code
+    let exit_code = baseline_exit_override.unwrap_or(output.exit_code);
+
     Ok((
         TestOutput {
             status: status.to_string(),
             component: args.component,
-            exit_code: output.exit_code,
+            exit_code,
+            test_counts,
             coverage,
+            baseline_comparison,
             hints,
         },
-        output.exit_code,
+        exit_code,
     ))
+}
+
+/// Parse the test results JSON file written by the extension test runner.
+fn parse_test_results_file(path: &std::path::Path) -> Option<TestCounts> {
+    let content = io::read_file(path, "read test results file").ok()?;
+    let data: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    let total = data.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
+    let passed = data.get("passed").and_then(|v| v.as_u64()).unwrap_or(0);
+    let failed = data.get("failed").and_then(|v| v.as_u64()).unwrap_or(0);
+    let skipped = data.get("skipped").and_then(|v| v.as_u64()).unwrap_or(0);
+
+    Some(TestCounts::new(total, passed, failed, skipped))
 }
 
 /// Parse the coverage JSON file written by the extension test runner.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -28,6 +28,7 @@ pub mod refactor;
 pub mod release;
 
 pub mod server;
+pub mod test_baseline;
 pub mod ssh;
 pub mod update_check;
 pub mod upgrade;

--- a/src/core/test_baseline.rs
+++ b/src/core/test_baseline.rs
@@ -1,0 +1,312 @@
+//! Test baseline — ratchet for test pass/fail counts.
+//!
+//! Unlike other baselines that track individual findings (Fingerprintable items),
+//! the test baseline tracks aggregate pass/fail/skip counts. The ratchet check is:
+//! - `passed >= baseline.passed` (can't lose passing tests)
+//! - `failed <= baseline.failed` (can't introduce new failures)
+//!
+//! This lets CI go green with the current test state as a floor, while preventing
+//! regressions. Every PR that fixes tests ratchets the baseline forward.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::baseline::{self as generic, BaselineConfig};
+use crate::error::Result;
+
+// ============================================================================
+// Baseline key
+// ============================================================================
+
+/// Key used in `homeboy.json` → `baselines.test`.
+const BASELINE_KEY: &str = "test";
+
+// ============================================================================
+// Test counts
+// ============================================================================
+
+/// Aggregate test results — the data that gets baselined.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TestCounts {
+    /// Total test count.
+    pub total: u64,
+    /// Passing tests.
+    pub passed: u64,
+    /// Failing tests.
+    pub failed: u64,
+    /// Skipped/incomplete tests.
+    pub skipped: u64,
+}
+
+impl TestCounts {
+    pub fn new(total: u64, passed: u64, failed: u64, skipped: u64) -> Self {
+        Self {
+            total,
+            passed,
+            failed,
+            skipped,
+        }
+    }
+}
+
+// ============================================================================
+// Baseline comparison
+// ============================================================================
+
+/// Result of comparing current test counts against a saved baseline.
+#[derive(Debug, Clone, Serialize)]
+pub struct TestBaselineComparison {
+    /// The baseline counts (what we're comparing against).
+    pub baseline: TestCounts,
+    /// The current counts.
+    pub current: TestCounts,
+    /// Change in passing tests (positive = more passing).
+    pub passed_delta: i64,
+    /// Change in failing tests (positive = more failing).
+    pub failed_delta: i64,
+    /// Whether the ratchet check failed (regression detected).
+    pub regression: bool,
+    /// Human-readable reasons for regression.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}
+
+// ============================================================================
+// Stored baseline type
+// ============================================================================
+
+/// A saved test baseline snapshot.
+pub type TestBaseline = generic::Baseline<TestCounts>;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Save the current test counts as a baseline.
+pub fn save_baseline(
+    source_path: &Path,
+    component_id: &str,
+    counts: &TestCounts,
+) -> Result<std::path::PathBuf> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+
+    // We store the counts as metadata. The generic baseline expects Fingerprintable
+    // items, but for test counts we don't have individual items — just aggregates.
+    // We pass an empty item list and rely solely on the metadata for comparison.
+    let empty: Vec<EmptyItem> = Vec::new();
+    generic::save(&config, component_id, &empty, counts.clone())
+}
+
+/// Load a test baseline if one exists.
+pub fn load_baseline(source_path: &Path) -> Option<TestBaseline> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    generic::load::<TestCounts>(&config).ok().flatten()
+}
+
+/// Compare current test counts against a saved baseline.
+///
+/// The ratchet rule:
+/// - `regression = true` if passed < baseline.passed OR failed > baseline.failed
+/// - Improvements (more passes or fewer failures) are tracked but don't fail
+pub fn compare(current: &TestCounts, baseline: &TestBaseline) -> TestBaselineComparison {
+    let baseline_counts = &baseline.metadata;
+
+    let passed_delta = current.passed as i64 - baseline_counts.passed as i64;
+    let failed_delta = current.failed as i64 - baseline_counts.failed as i64;
+
+    let mut reasons = Vec::new();
+
+    if current.passed < baseline_counts.passed {
+        reasons.push(format!(
+            "Passing tests decreased: {} \u{2192} {} ({})",
+            baseline_counts.passed, current.passed, passed_delta
+        ));
+    }
+
+    if current.failed > baseline_counts.failed {
+        reasons.push(format!(
+            "Failing tests increased: {} \u{2192} {} (+{})",
+            baseline_counts.failed, current.failed, failed_delta
+        ));
+    }
+
+    let regression = !reasons.is_empty();
+
+    TestBaselineComparison {
+        baseline: baseline_counts.clone(),
+        current: current.clone(),
+        passed_delta,
+        failed_delta,
+        regression,
+        reasons,
+    }
+}
+
+// ============================================================================
+// Internal: empty Fingerprintable for generic save()
+// ============================================================================
+
+/// Placeholder for the generic baseline save — test baselines don't use
+/// individual items, only aggregate counts in metadata.
+struct EmptyItem;
+
+impl generic::Fingerprintable for EmptyItem {
+    fn fingerprint(&self) -> String {
+        String::new()
+    }
+    fn description(&self) -> String {
+        String::new()
+    }
+    fn context_label(&self) -> String {
+        String::new()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn counts(total: u64, passed: u64, failed: u64, skipped: u64) -> TestCounts {
+        TestCounts::new(total, passed, failed, skipped)
+    }
+
+    #[test]
+    fn save_and_load_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = counts(100, 80, 15, 5);
+
+        save_baseline(dir.path(), "data-machine", &c).unwrap();
+        let loaded = load_baseline(dir.path()).unwrap();
+
+        assert_eq!(loaded.context_id, "data-machine");
+        assert_eq!(loaded.metadata, c);
+    }
+
+    #[test]
+    fn load_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_baseline(dir.path()).is_none());
+    }
+
+    #[test]
+    fn compare_no_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_counts = counts(100, 80, 15, 5);
+        save_baseline(dir.path(), "test", &baseline_counts).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = counts(100, 80, 15, 5);
+        let result = compare(&current, &baseline);
+        assert!(!result.regression);
+        assert_eq!(result.passed_delta, 0);
+        assert_eq!(result.failed_delta, 0);
+        assert!(result.reasons.is_empty());
+    }
+
+    #[test]
+    fn compare_improvement_is_not_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_counts = counts(100, 80, 15, 5);
+        save_baseline(dir.path(), "test", &baseline_counts).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = counts(100, 90, 5, 5);
+        let result = compare(&current, &baseline);
+        assert!(!result.regression);
+        assert_eq!(result.passed_delta, 10);
+        assert_eq!(result.failed_delta, -10);
+    }
+
+    #[test]
+    fn compare_fewer_passing_is_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_counts = counts(100, 80, 15, 5);
+        save_baseline(dir.path(), "test", &baseline_counts).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = counts(100, 75, 20, 5);
+        let result = compare(&current, &baseline);
+        assert!(result.regression);
+        assert_eq!(result.passed_delta, -5);
+        assert_eq!(result.reasons.len(), 2);
+    }
+
+    #[test]
+    fn compare_more_failing_is_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_counts = counts(100, 80, 15, 5);
+        save_baseline(dir.path(), "test", &baseline_counts).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = counts(105, 80, 20, 5);
+        let result = compare(&current, &baseline);
+        assert!(result.regression);
+        assert_eq!(result.failed_delta, 5);
+        assert_eq!(result.reasons.len(), 1);
+        assert!(result.reasons[0].contains("Failing tests increased"));
+    }
+
+    #[test]
+    fn compare_new_tests_all_passing_is_not_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_counts = counts(100, 80, 15, 5);
+        save_baseline(dir.path(), "test", &baseline_counts).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = counts(120, 100, 15, 5);
+        let result = compare(&current, &baseline);
+        assert!(!result.regression);
+        assert_eq!(result.passed_delta, 20);
+        assert_eq!(result.failed_delta, 0);
+    }
+
+    #[test]
+    fn save_preserves_other_baselines() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let audit_config = generic::BaselineConfig::new(dir.path(), "audit");
+        let empty: Vec<EmptyItem> = Vec::new();
+        generic::save(&audit_config, "test", &empty, ()).unwrap();
+
+        let c = counts(100, 80, 15, 5);
+        save_baseline(dir.path(), "test", &c).unwrap();
+
+        let test_baseline = load_baseline(dir.path());
+        assert!(test_baseline.is_some());
+
+        let audit_baseline = generic::load::<()>(&audit_config).unwrap();
+        assert!(audit_baseline.is_some());
+    }
+
+    #[test]
+    fn save_overwrites_previous_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let c1 = counts(100, 80, 15, 5);
+        save_baseline(dir.path(), "test", &c1).unwrap();
+
+        let c2 = counts(120, 100, 15, 5);
+        save_baseline(dir.path(), "test", &c2).unwrap();
+
+        let loaded = load_baseline(dir.path()).unwrap();
+        assert_eq!(loaded.metadata, c2);
+    }
+
+    #[test]
+    fn compare_zero_baseline_any_failure_is_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_counts = counts(50, 50, 0, 0);
+        save_baseline(dir.path(), "test", &baseline_counts).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = counts(50, 49, 1, 0);
+        let result = compare(&current, &baseline);
+        assert!(result.regression);
+        assert_eq!(result.reasons.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the generic baseline primitive (#413) into `homeboy test` as a **pass/fail ratchet**. CI can go green immediately with the current test state as a floor — every PR that regresses tests fails, every PR that fixes tests ratchets the baseline forward.

Closes #411.

## What changed

### New module: `src/core/test_baseline.rs`

Unlike other baselines (audit, docs, cleanup) that track individual `Fingerprintable` items, the test baseline tracks **aggregate counts**:

```json
{
  "total": 533,
  "passed": 481,
  "failed": 49,
  "skipped": 3
}
```

The ratchet rule:
- **FAIL** if `passed < baseline.passed` (lost passing tests)
- **FAIL** if `failed > baseline.failed` (introduced new failures)
- **PASS** otherwise — improvements are celebrated, same-state passes

### Updated: `src/commands/test.rs`

Three new flags:

| Flag | Effect |
|---|---|
| `--baseline` | Save current test results as baseline |
| `--ignore-baseline` | Skip baseline comparison for this run |
| `--ratchet` | Auto-update baseline when results improve |

Extension integration via `HOMEBOY_TEST_RESULTS_FILE` env var — the extension test runner writes `{total, passed, failed, skipped}` JSON to a temp file, homeboy core reads it back (same pattern as `HOMEBOY_COVERAGE_FILE`).

### Usage

```bash
# Save current state as baseline
homeboy test data-machine --baseline

# Normal CI run — fails only if regression
homeboy test data-machine

# CI with auto-ratchet — baseline moves forward on improvement
homeboy test data-machine --ratchet
```

### Output (JSON)

```json
{
  "status": "passed",
  "component": "data-machine",
  "exit_code": 0,
  "test_counts": {
    "total": 533,
    "passed": 481,
    "failed": 49,
    "skipped": 3
  },
  "baseline_comparison": {
    "baseline": { "total": 530, "passed": 460, "failed": 70, "skipped": 0 },
    "current": { "total": 533, "passed": 481, "failed": 49, "skipped": 3 },
    "passed_delta": 21,
    "failed_delta": -21,
    "regression": false,
    "reasons": []
  }
}
```

### Extension support needed

Requires corresponding extension changes to parse test output and write `HOMEBOY_TEST_RESULTS_FILE`:
- **WordPress**: Parse PHPUnit summary line (`Tests: X, Assertions: Y, Failures: Z`)
- **Rust**: Parse `test result: ok. X passed; Y failed;` from cargo output

These are follow-up PRs to homeboy-extensions.

## Tests

10 new unit tests for `test_baseline` module:
- save/load roundtrip
- load returns None when missing
- no regression (same counts)
- improvement is not regression
- fewer passing is regression
- more failing is regression
- new tests all passing is not regression
- preserves other baselines
- overwrites previous baseline
- zero-baseline any failure is regression

**Full suite: 576 passed, 0 failed** (up from 551)