### PR TITLE
feat: test scaffold — generate test stubs from source file conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tempfile",
+ "toml",
  "uuid",
  "zip",
 ]
@@ -1880,6 +1881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2173,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.0.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -2692,6 +2741,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ semver = "1.0"
 
 # CLI dependencies
 clap = { version = "4.5", features = ["derive", "string"] }
+toml = "1.0.3"
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -7,6 +7,7 @@ use homeboy::extension::{self, ExtensionRunner};
 use homeboy::test_analyze::{self, TestAnalysis, TestAnalysisInput};
 use homeboy::test_baseline::{self, TestBaselineComparison, TestCounts};
 use homeboy::test_drift::{self, DriftOptions, DriftReport};
+use homeboy::test_scaffold::{self, ScaffoldConfig};
 use homeboy::utils::io;
 
 use super::CmdResult;
@@ -52,6 +53,18 @@ pub struct TestArgs {
     #[arg(long)]
     drift: bool,
 
+    /// Generate test stubs for untested source files
+    #[arg(long)]
+    scaffold: bool,
+
+    /// Scaffold a specific source file (relative to component root)
+    #[arg(long, value_name = "FILE")]
+    scaffold_file: Option<String>,
+
+    /// Write scaffold files to disk (default: dry-run)
+    #[arg(long)]
+    write: bool,
+
     /// Git ref to compare against for drift detection (tag, commit, branch)
     #[arg(long, value_name = "REF", default_value = "HEAD~10")]
     since: String,
@@ -90,6 +103,25 @@ pub struct TestOutput {
     hints: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     drift: Option<DriftReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scaffold: Option<ScaffoldOutput>,
+}
+
+#[derive(Serialize)]
+pub struct ScaffoldOutput {
+    results: Vec<ScaffoldFileOutput>,
+    total_stubs: usize,
+    total_written: usize,
+    total_skipped: usize,
+}
+
+#[derive(Serialize)]
+pub struct ScaffoldFileOutput {
+    source_file: String,
+    test_file: String,
+    stub_count: usize,
+    written: bool,
+    skipped: bool,
 }
 
 #[derive(Serialize)]
@@ -185,6 +217,16 @@ pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput>
     let mut component = component::load(&args.component)?;
     if let Some(ref path) = args.path {
         component.local_path = path.clone();
+    }
+
+    // Scaffold mode — generate test stubs without running tests
+    if args.scaffold || args.scaffold_file.is_some() {
+        return run_scaffold(
+            &args.component,
+            &component,
+            args.scaffold_file.as_deref(),
+            args.write,
+        );
     }
 
     // Drift detection mode — skip running tests, analyze git changes instead
@@ -434,6 +476,7 @@ pub fn run(args: TestArgs, _global: &super::GlobalArgs) -> CmdResult<TestOutput>
             analysis,
             hints,
             drift: None,
+            scaffold: None,
         },
         exit_code,
     ))
@@ -644,7 +687,190 @@ fn run_drift(component_id: &str, component: &Component, since: &str) -> CmdResul
             analysis: None,
             hints: None,
             drift: Some(report),
+            scaffold: None,
         },
         exit_code,
     ))
+}
+
+/// Run scaffold mode — generate test stubs from source files.
+fn run_scaffold(
+    component_id: &str,
+    component: &Component,
+    scaffold_file: Option<&str>,
+    write: bool,
+) -> CmdResult<TestOutput> {
+    let source_path = {
+        let expanded = shellexpand::tilde(&component.local_path);
+        std::path::PathBuf::from(expanded.as_ref())
+    };
+
+    // Auto-detect language
+    let config = if source_path.join("Cargo.toml").exists() {
+        ScaffoldConfig::rust()
+    } else {
+        ScaffoldConfig::php()
+    };
+
+    let mode_label = if write { "write" } else { "dry-run" };
+
+    if let Some(file) = scaffold_file {
+        // Single file mode
+        let file_path = source_path.join(file);
+        homeboy::log_status!(
+            "scaffold",
+            "Scaffolding tests for {} ({})",
+            file,
+            mode_label
+        );
+
+        let result = test_scaffold::scaffold_file(&file_path, &source_path, &config, write)?;
+
+        if result.skipped {
+            homeboy::log_status!(
+                "scaffold",
+                "Skipped — test file already exists: {}",
+                result.test_file
+            );
+        } else if result.stub_count == 0 {
+            homeboy::log_status!("scaffold", "No public methods found in {}", file);
+        } else {
+            homeboy::log_status!(
+                "scaffold",
+                "Generated {} test stub{} → {}{}",
+                result.stub_count,
+                if result.stub_count == 1 { "" } else { "s" },
+                result.test_file,
+                if write { " (written)" } else { " (dry-run)" }
+            );
+
+            if !write {
+                // Show preview
+                eprintln!("---");
+                for line in result.content.lines().take(40) {
+                    eprintln!("{}", line);
+                }
+                if result.content.lines().count() > 40 {
+                    eprintln!("... ({} more lines)", result.content.lines().count() - 40);
+                }
+                eprintln!("---");
+            }
+        }
+
+        let scaffold_output = ScaffoldOutput {
+            results: vec![ScaffoldFileOutput {
+                source_file: result.source_file.clone(),
+                test_file: result.test_file.clone(),
+                stub_count: result.stub_count,
+                written: result.written,
+                skipped: result.skipped,
+            }],
+            total_stubs: result.stub_count,
+            total_written: if result.written { 1 } else { 0 },
+            total_skipped: if result.skipped { 1 } else { 0 },
+        };
+
+        Ok((
+            TestOutput {
+                status: "scaffold".to_string(),
+                component: component_id.to_string(),
+                exit_code: 0,
+                test_counts: None,
+                coverage: None,
+                baseline_comparison: None,
+                analysis: None,
+                hints: None,
+                drift: None,
+                scaffold: Some(scaffold_output),
+            },
+            0,
+        ))
+    } else {
+        // Batch mode — scaffold all untested files
+        homeboy::log_status!(
+            "scaffold",
+            "Scanning {} for untested {} files ({})",
+            component_id,
+            config.language,
+            mode_label
+        );
+
+        let batch = test_scaffold::scaffold_untested(&source_path, &config, write)?;
+
+        let files_needing_tests = batch
+            .results
+            .iter()
+            .filter(|r| !r.skipped && r.stub_count > 0)
+            .count();
+        let already_tested = batch.total_skipped;
+
+        homeboy::log_status!(
+            "scaffold",
+            "{} file{} need tests, {} already have tests",
+            files_needing_tests,
+            if files_needing_tests == 1 { "" } else { "s" },
+            already_tested
+        );
+
+        if write {
+            homeboy::log_status!(
+                "scaffold",
+                "Wrote {} test file{} with {} total stubs",
+                batch.total_written,
+                if batch.total_written == 1 { "" } else { "s" },
+                batch.total_stubs
+            );
+        } else if files_needing_tests > 0 {
+            // Show summary of what would be created
+            for result in &batch.results {
+                if !result.skipped && result.stub_count > 0 {
+                    homeboy::log_status!(
+                        "  new",
+                        "{} → {} ({} stubs)",
+                        result.source_file,
+                        result.test_file,
+                        result.stub_count
+                    );
+                }
+            }
+            homeboy::log_status!(
+                "hint",
+                "Run with --write to create test files: homeboy test {} --scaffold --write",
+                component_id
+            );
+        }
+
+        let scaffold_output = ScaffoldOutput {
+            results: batch
+                .results
+                .iter()
+                .map(|r| ScaffoldFileOutput {
+                    source_file: r.source_file.clone(),
+                    test_file: r.test_file.clone(),
+                    stub_count: r.stub_count,
+                    written: r.written,
+                    skipped: r.skipped,
+                })
+                .collect(),
+            total_stubs: batch.total_stubs,
+            total_written: batch.total_written,
+            total_skipped: batch.total_skipped,
+        };
+
+        Ok((
+            TestOutput {
+                status: "scaffold".to_string(),
+                component: component_id.to_string(),
+                exit_code: 0,
+                test_counts: None,
+                coverage: None,
+                baseline_comparison: None,
+                analysis: None,
+                hints: None,
+                drift: None,
+                scaffold: Some(scaffold_output),
+            },
+            0,
+        ))
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,6 +32,7 @@ pub mod ssh;
 pub mod test_analyze;
 pub mod test_baseline;
 pub mod test_drift;
+pub mod test_scaffold;
 pub mod update_check;
 pub mod upgrade;
 pub mod version;

--- a/src/core/test_scaffold.rs
+++ b/src/core/test_scaffold.rs
@@ -1,0 +1,1007 @@
+//! Test scaffold — generate test stubs from source file conventions.
+//!
+//! Reads a source file, extracts its public API (methods, functions),
+//! and generates a test file with one stub per public method. The output
+//! follows project conventions for test file naming, base classes, and
+//! assertion style.
+//!
+//! Phase 1: regex-based extraction, no extension scripts needed.
+
+use regex::Regex;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+use crate::utils::io;
+
+// ============================================================================
+// Models
+// ============================================================================
+
+/// A public method/function extracted from a source file.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractedMethod {
+    /// Method/function name.
+    pub name: String,
+    /// Visibility (public, protected, pub, pub(crate)).
+    pub visibility: String,
+    /// Whether it's static.
+    pub is_static: bool,
+    /// Line number in source file.
+    pub line: usize,
+    /// Parameters (raw string, not parsed).
+    pub params: String,
+}
+
+/// Extracted class/struct info from a source file.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractedClass {
+    /// Class/struct/trait name.
+    pub name: String,
+    /// Namespace (PHP) or module path (Rust).
+    pub namespace: String,
+    /// Kind: class, trait, interface, struct, enum.
+    pub kind: String,
+    /// Public methods.
+    pub methods: Vec<ExtractedMethod>,
+}
+
+/// Configuration for scaffold generation.
+#[derive(Debug, Clone)]
+pub struct ScaffoldConfig {
+    /// Base test class to extend (e.g., "WP_UnitTestCase", "TestCase").
+    pub base_class: String,
+    /// Base test class import.
+    pub base_class_import: String,
+    /// Test method prefix (e.g., "test_").
+    pub test_prefix: String,
+    /// Body for incomplete tests.
+    pub incomplete_body: String,
+    /// Language: "php" or "rust".
+    pub language: String,
+}
+
+impl ScaffoldConfig {
+    /// WordPress/PHPUnit defaults.
+    pub fn php() -> Self {
+        Self {
+            base_class: "WP_UnitTestCase".to_string(),
+            base_class_import: "WP_UnitTestCase".to_string(),
+            test_prefix: "test_".to_string(),
+            incomplete_body: "$this->markTestIncomplete('TODO: implement');".to_string(),
+            language: "php".to_string(),
+        }
+    }
+
+    /// Rust defaults.
+    pub fn rust() -> Self {
+        Self {
+            base_class: String::new(),
+            base_class_import: String::new(),
+            test_prefix: "test_".to_string(),
+            incomplete_body: "todo!(\"implement test\");".to_string(),
+            language: "rust".to_string(),
+        }
+    }
+}
+
+/// Result of scaffold generation.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScaffoldResult {
+    /// Source file analyzed.
+    pub source_file: String,
+    /// Generated test file path.
+    pub test_file: String,
+    /// Number of test stubs generated.
+    pub stub_count: usize,
+    /// The generated test file content.
+    pub content: String,
+    /// Whether the file was written to disk.
+    pub written: bool,
+    /// Whether a test file already existed (skipped).
+    pub skipped: bool,
+    /// Classes/structs found in source.
+    pub classes: Vec<ExtractedClass>,
+}
+
+/// Result of scaffolding multiple files.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScaffoldBatchResult {
+    /// Individual results per source file.
+    pub results: Vec<ScaffoldResult>,
+    /// Total test stubs generated.
+    pub total_stubs: usize,
+    /// Total files written.
+    pub total_written: usize,
+    /// Total files skipped (test already exists).
+    pub total_skipped: usize,
+}
+
+// ============================================================================
+// Source extraction
+// ============================================================================
+
+/// Extract classes and their public methods from a PHP source file.
+pub fn extract_php(content: &str) -> Vec<ExtractedClass> {
+    let mut classes = Vec::new();
+
+    // Match namespace
+    let ns_re = Regex::new(r"(?m)^namespace\s+([\w\\]+);").unwrap();
+    let namespace = ns_re
+        .captures(content)
+        .map(|c| c[1].to_string())
+        .unwrap_or_default();
+
+    // Match class/trait/interface declarations
+    let class_re =
+        Regex::new(r"(?m)^(?:abstract\s+)?(?:final\s+)?(class|trait|interface)\s+(\w+)").unwrap();
+
+    for cap in class_re.captures_iter(content) {
+        let kind = cap[1].to_string();
+        let name = cap[2].to_string();
+
+        // Extract methods for this class
+        let methods = extract_php_methods(content);
+
+        classes.push(ExtractedClass {
+            name,
+            namespace: namespace.clone(),
+            kind,
+            methods,
+        });
+    }
+
+    // If no class found but there are functions, treat as procedural
+    if classes.is_empty() {
+        let methods = extract_php_functions(content);
+        if !methods.is_empty() {
+            classes.push(ExtractedClass {
+                name: String::new(),
+                namespace: namespace.clone(),
+                kind: "procedural".to_string(),
+                methods,
+            });
+        }
+    }
+
+    classes
+}
+
+/// Extract public/protected methods from PHP content.
+fn extract_php_methods(content: &str) -> Vec<ExtractedMethod> {
+    let method_re = Regex::new(
+        r"(?m)^\s*((?:(?:public|protected|private|static|abstract|final)\s+)*)function\s+(\w+)\s*\(([^)]*)\)"
+    ).unwrap();
+
+    let mut methods = Vec::new();
+
+    for (i, line) in content.lines().enumerate() {
+        if let Some(cap) = method_re.captures(line) {
+            let modifiers = cap[1].to_string();
+            let name = cap[2].to_string();
+            let params = cap[3].trim().to_string();
+
+            // Skip magic methods except __construct
+            if name.starts_with("__") && name != "__construct" {
+                continue;
+            }
+
+            let visibility = if modifiers.contains("private") {
+                "private"
+            } else if modifiers.contains("protected") {
+                "protected"
+            } else {
+                "public"
+            };
+
+            // Only scaffold public and protected methods
+            if visibility == "private" {
+                continue;
+            }
+
+            let is_static = modifiers.contains("static");
+
+            methods.push(ExtractedMethod {
+                name,
+                visibility: visibility.to_string(),
+                is_static,
+                line: i + 1,
+                params,
+            });
+        }
+    }
+
+    methods
+}
+
+/// Extract top-level functions from PHP content (procedural files).
+fn extract_php_functions(content: &str) -> Vec<ExtractedMethod> {
+    let fn_re = Regex::new(r"(?m)^function\s+(\w+)\s*\(([^)]*)\)").unwrap();
+    let mut methods = Vec::new();
+
+    for (i, line) in content.lines().enumerate() {
+        if let Some(cap) = fn_re.captures(line) {
+            methods.push(ExtractedMethod {
+                name: cap[1].to_string(),
+                visibility: "public".to_string(),
+                is_static: false,
+                line: i + 1,
+                params: cap[2].trim().to_string(),
+            });
+        }
+    }
+
+    methods
+}
+
+/// Extract public functions/methods from a Rust source file.
+pub fn extract_rust(content: &str) -> Vec<ExtractedClass> {
+    let mut classes = Vec::new();
+
+    // Match struct/enum/trait with impl blocks
+    let struct_re =
+        Regex::new(r"(?m)^(?:pub(?:\(crate\))?\s+)?(?:struct|enum|trait)\s+(\w+)").unwrap();
+
+    for cap in struct_re.captures_iter(content) {
+        let name = cap[1].to_string();
+        let methods = extract_rust_impl_methods(content, &name);
+
+        if !methods.is_empty() {
+            classes.push(ExtractedClass {
+                name,
+                namespace: String::new(),
+                kind: "struct".to_string(),
+                methods,
+            });
+        }
+    }
+
+    // Also get free functions
+    let free_fns = extract_rust_free_functions(content);
+    if !free_fns.is_empty() {
+        classes.push(ExtractedClass {
+            name: String::new(),
+            namespace: String::new(),
+            kind: "module".to_string(),
+            methods: free_fns,
+        });
+    }
+
+    classes
+}
+
+/// Extract pub methods from an impl block for a specific type.
+fn extract_rust_impl_methods(content: &str, type_name: &str) -> Vec<ExtractedMethod> {
+    let impl_re = Regex::new(&format!(
+        r"impl(?:<[^>]*>)?\s+{}\b",
+        regex::escape(type_name)
+    ))
+    .unwrap();
+    let fn_re = Regex::new(r"(?m)^\s*(pub(?:\(crate\))?\s+)?(?:async\s+)?fn\s+(\w+)\s*\(([^)]*)\)")
+        .unwrap();
+
+    let mut methods = Vec::new();
+    let mut in_impl = false;
+    let mut brace_depth: i32 = 0;
+
+    for (i, line) in content.lines().enumerate() {
+        if !in_impl {
+            if impl_re.is_match(line) {
+                in_impl = true;
+                brace_depth = 0;
+            }
+            if !in_impl {
+                continue;
+            }
+        }
+
+        // Track brace depth
+        for ch in line.chars() {
+            if ch == '{' {
+                brace_depth += 1;
+            } else if ch == '}' {
+                brace_depth -= 1;
+                if brace_depth <= 0 {
+                    in_impl = false;
+                }
+            }
+        }
+
+        // Match function declarations inside the impl block
+        if let Some(cap) = fn_re.captures(line) {
+            let vis = cap.get(1).map_or("", |m| m.as_str().trim());
+            let name = cap[2].to_string();
+            let params = cap[3].trim().to_string();
+
+            // Only pub functions
+            if !vis.starts_with("pub") {
+                continue;
+            }
+
+            // Skip test functions
+            if name.starts_with("test_") {
+                continue;
+            }
+
+            methods.push(ExtractedMethod {
+                name,
+                visibility: vis.to_string(),
+                is_static: !params.contains("self"),
+                line: i + 1,
+                params,
+            });
+        }
+    }
+
+    methods
+}
+
+/// Extract top-level pub functions (not in impl blocks).
+fn extract_rust_free_functions(content: &str) -> Vec<ExtractedMethod> {
+    let fn_re =
+        Regex::new(r"(?m)^(pub(?:\(crate\))?\s+)(?:async\s+)?fn\s+(\w+)\s*\(([^)]*)\)").unwrap();
+
+    let mut methods = Vec::new();
+
+    // Simple heuristic: only match functions at zero indentation
+    for (i, line) in content.lines().enumerate() {
+        if !line.starts_with("pub") {
+            continue;
+        }
+
+        if let Some(cap) = fn_re.captures(line) {
+            let name = cap[2].to_string();
+            let params = cap[3].trim().to_string();
+
+            // Skip test functions and main
+            if name.starts_with("test_") || name == "main" {
+                continue;
+            }
+
+            methods.push(ExtractedMethod {
+                name,
+                visibility: "pub".to_string(),
+                is_static: true,
+                line: i + 1,
+                params,
+            });
+        }
+    }
+
+    methods
+}
+
+// ============================================================================
+// Test file generation
+// ============================================================================
+
+/// Determine the test file path for a given source file.
+pub fn test_file_path(source_path: &Path, root: &Path) -> PathBuf {
+    let relative = source_path.strip_prefix(root).unwrap_or(source_path);
+    let rel_str = relative.to_string_lossy();
+
+    // PHP: src/Abilities/Foo.php → tests/Unit/Abilities/FooTest.php
+    // PHP: inc/Abilities/Foo.php → tests/Unit/Abilities/FooTest.php
+    if rel_str.ends_with(".php") {
+        let stripped = rel_str
+            .strip_prefix("src/")
+            .or_else(|| rel_str.strip_prefix("inc/"))
+            .or_else(|| rel_str.strip_prefix("lib/"))
+            .unwrap_or(&rel_str);
+
+        let without_ext = stripped.strip_suffix(".php").unwrap_or(stripped);
+        return root.join(format!("tests/Unit/{}Test.php", without_ext));
+    }
+
+    // Rust: src/core/foo.rs → tests/core/foo_test.rs
+    if rel_str.ends_with(".rs") {
+        let stripped = rel_str.strip_prefix("src/").unwrap_or(&rel_str);
+        let without_ext = stripped.strip_suffix(".rs").unwrap_or(stripped);
+        return root.join(format!("tests/{}_test.rs", without_ext));
+    }
+
+    // Fallback
+    root.join("tests").join(relative)
+}
+
+/// Generate PHP test file content.
+pub fn generate_php_test(classes: &[ExtractedClass], config: &ScaffoldConfig) -> String {
+    let mut out = String::new();
+    out.push_str("<?php\n");
+
+    for class in classes {
+        if class.kind == "procedural" {
+            // Procedural test file
+            if !class.namespace.is_empty() {
+                out.push_str(&format!("namespace {}\\Tests;\n\n", class.namespace));
+            }
+            out.push_str(&format!("use {};\n\n", config.base_class_import));
+
+            out.push_str(&format!(
+                "class FunctionsTest extends {} {{\n\n",
+                config.base_class
+            ));
+
+            for method in &class.methods {
+                let test_name = to_snake_case(&method.name);
+                out.push_str(&format!(
+                    "    public function {}{}() {{\n        {}\n    }}\n\n",
+                    config.test_prefix, test_name, config.incomplete_body
+                ));
+            }
+
+            out.push_str("}\n");
+            continue;
+        }
+
+        // Class-based test file
+        let test_namespace = if !class.namespace.is_empty() {
+            format!("{}\\Tests\\Unit", namespace_root(&class.namespace))
+        } else {
+            String::new()
+        };
+
+        if !test_namespace.is_empty() {
+            out.push_str(&format!("namespace {};\n\n", test_namespace));
+        }
+
+        // Imports
+        out.push_str(&format!("use {};\n", config.base_class_import));
+        if !class.namespace.is_empty() {
+            out.push_str(&format!("use {}\\{};\n", class.namespace, class.name));
+        }
+        out.push('\n');
+
+        // Class doc
+        if !class.namespace.is_empty() {
+            out.push_str(&format!(
+                "/**\n * @covers \\{}\\{}\n */\n",
+                class.namespace, class.name
+            ));
+        }
+
+        // Class declaration
+        out.push_str(&format!(
+            "class {}Test extends {} {{\n\n",
+            class.name, config.base_class
+        ));
+
+        // Test methods
+        for method in &class.methods {
+            // Skip constructor — tested implicitly
+            if method.name == "__construct" {
+                continue;
+            }
+
+            let test_name = to_snake_case(&method.name);
+            out.push_str(&format!(
+                "    public function {}{}() {{\n        {}\n    }}\n\n",
+                config.test_prefix, test_name, config.incomplete_body
+            ));
+        }
+
+        out.push_str("}\n");
+    }
+
+    out
+}
+
+/// Generate Rust test file content.
+pub fn generate_rust_test(classes: &[ExtractedClass], _config: &ScaffoldConfig) -> String {
+    let mut out = String::new();
+
+    // Module-level test block
+    out.push_str("#[cfg(test)]\nmod tests {\n    use super::*;\n\n");
+
+    for class in classes {
+        if !class.name.is_empty() {
+            out.push_str(&format!("    // Tests for {}\n\n", class.name));
+        }
+
+        for method in &class.methods {
+            let test_name = if class.name.is_empty() {
+                format!("test_{}", to_snake_case(&method.name))
+            } else {
+                format!(
+                    "test_{}_{}",
+                    to_snake_case(&class.name),
+                    to_snake_case(&method.name)
+                )
+            };
+
+            out.push_str(&format!(
+                "    #[test]\n    fn {}() {{\n        todo!(\"implement test\");\n    }}\n\n",
+                test_name
+            ));
+        }
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+/// Scaffold tests for a single source file.
+pub fn scaffold_file(
+    source_path: &Path,
+    root: &Path,
+    config: &ScaffoldConfig,
+    write: bool,
+) -> Result<ScaffoldResult> {
+    let relative = source_path
+        .strip_prefix(root)
+        .unwrap_or(source_path)
+        .to_string_lossy()
+        .to_string();
+
+    let content = io::read_file(source_path, "read source file")?;
+
+    let classes = if config.language == "rust" {
+        extract_rust(&content)
+    } else {
+        extract_php(&content)
+    };
+
+    let test_path = test_file_path(source_path, root);
+    let test_relative = test_path
+        .strip_prefix(root)
+        .unwrap_or(&test_path)
+        .to_string_lossy()
+        .to_string();
+
+    // Check if test file already exists
+    if test_path.exists() {
+        return Ok(ScaffoldResult {
+            source_file: relative,
+            test_file: test_relative,
+            stub_count: 0,
+            content: String::new(),
+            written: false,
+            skipped: true,
+            classes,
+        });
+    }
+
+    let stub_count: usize = classes
+        .iter()
+        .map(|c| c.methods.iter().filter(|m| m.name != "__construct").count())
+        .sum();
+
+    let generated = if config.language == "rust" {
+        generate_rust_test(&classes, config)
+    } else {
+        generate_php_test(&classes, config)
+    };
+
+    if write && !generated.is_empty() {
+        // Create directory if needed
+        if let Some(parent) = test_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                Error::internal_io(
+                    format!("Failed to create test directory: {}", e),
+                    Some("scaffold.write".to_string()),
+                )
+            })?;
+        }
+        io::write_file(&test_path, &generated, "write test scaffold")?;
+    }
+
+    Ok(ScaffoldResult {
+        source_file: relative,
+        test_file: test_relative,
+        stub_count,
+        content: generated,
+        written: write,
+        skipped: false,
+        classes,
+    })
+}
+
+/// Scaffold tests for all untested files under a root directory.
+pub fn scaffold_untested(
+    root: &Path,
+    config: &ScaffoldConfig,
+    write: bool,
+) -> Result<ScaffoldBatchResult> {
+    let source_dirs = if config.language == "rust" {
+        vec!["src"]
+    } else {
+        vec!["src", "inc", "lib"]
+    };
+
+    let ext = if config.language == "rust" {
+        "rs"
+    } else {
+        "php"
+    };
+
+    let mut source_files = Vec::new();
+    for dir in &source_dirs {
+        let dir_path = root.join(dir);
+        if dir_path.exists() {
+            collect_source_files(&dir_path, ext, &mut source_files);
+        }
+    }
+
+    let mut results = Vec::new();
+    let mut total_stubs = 0;
+    let mut total_written = 0;
+    let mut total_skipped = 0;
+
+    for source_file in &source_files {
+        let result = scaffold_file(source_file, root, config, write)?;
+        if result.skipped {
+            total_skipped += 1;
+        } else {
+            total_stubs += result.stub_count;
+            if result.written {
+                total_written += 1;
+            }
+        }
+        results.push(result);
+    }
+
+    Ok(ScaffoldBatchResult {
+        results,
+        total_stubs,
+        total_written,
+        total_skipped,
+    })
+}
+
+fn collect_source_files(dir: &Path, ext: &str, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path.file_name().unwrap_or_default().to_string_lossy();
+            if name == ".git" || name == "vendor" || name == "node_modules" || name == "target" {
+                continue;
+            }
+            collect_source_files(&path, ext, files);
+        } else if path.extension().and_then(|e| e.to_str()) == Some(ext) {
+            files.push(path);
+        }
+    }
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+/// Convert CamelCase or camelCase to snake_case.
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            // Don't insert underscore between consecutive capitals
+            let prev = s.chars().nth(i - 1).unwrap_or('_');
+            if prev.is_lowercase() || prev.is_ascii_digit() {
+                result.push('_');
+            }
+        }
+        result.push(ch.to_lowercase().next().unwrap_or(ch));
+    }
+    result
+}
+
+/// Get the root namespace (first segment) from a PHP namespace.
+fn namespace_root(ns: &str) -> &str {
+    ns.split('\\').next().unwrap_or(ns)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn extract_php_class_methods() {
+        let content = r#"<?php
+namespace DataMachine\Abilities;
+
+class PipelineAbilities {
+    public function register() {}
+    public function executeCreate($config) {}
+    protected function validate($input) {}
+    private function internal() {}
+    public static function getInstance() {}
+}
+"#;
+        let classes = extract_php(content);
+        assert_eq!(classes.len(), 1);
+        assert_eq!(classes[0].name, "PipelineAbilities");
+        assert_eq!(classes[0].namespace, "DataMachine\\Abilities");
+
+        let names: Vec<&str> = classes[0].methods.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"register"));
+        assert!(names.contains(&"executeCreate"));
+        assert!(names.contains(&"validate")); // protected included
+        assert!(!names.contains(&"internal")); // private excluded
+        assert!(names.contains(&"getInstance"));
+    }
+
+    #[test]
+    fn extract_php_magic_methods_skipped() {
+        let content = r#"<?php
+class Foo {
+    public function __construct() {}
+    public function __toString() {}
+    public function __get($name) {}
+    public function realMethod() {}
+}
+"#;
+        let classes = extract_php(content);
+        let names: Vec<&str> = classes[0].methods.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"__construct")); // constructor kept
+        assert!(!names.contains(&"__toString")); // magic skipped
+        assert!(!names.contains(&"__get")); // magic skipped
+        assert!(names.contains(&"realMethod"));
+    }
+
+    #[test]
+    fn extract_php_procedural() {
+        let content = r#"<?php
+function datamachine_init() {}
+function datamachine_activate() {}
+"#;
+        let classes = extract_php(content);
+        assert_eq!(classes.len(), 1);
+        assert_eq!(classes[0].kind, "procedural");
+        assert_eq!(classes[0].methods.len(), 2);
+    }
+
+    #[test]
+    fn extract_rust_struct_methods() {
+        let content = r#"
+pub struct Config {
+    data: HashMap<String, String>,
+}
+
+impl Config {
+    pub fn new() -> Self { Self { data: HashMap::new() } }
+    pub fn get(&self, key: &str) -> Option<&str> { None }
+    fn private_method(&self) {}
+    pub async fn load(path: &Path) -> Result<Self> { todo!() }
+}
+"#;
+        let classes = extract_rust(content);
+        let config = classes.iter().find(|c| c.name == "Config").unwrap();
+        let names: Vec<&str> = config.methods.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"new"));
+        assert!(names.contains(&"get"));
+        assert!(names.contains(&"load"));
+        assert!(!names.contains(&"private_method"));
+    }
+
+    #[test]
+    fn extract_rust_free_functions() {
+        let content = r#"
+pub fn parse_config(path: &Path) -> Config { todo!() }
+pub fn validate(config: &Config) -> bool { true }
+fn internal_helper() {}
+"#;
+        let classes = extract_rust(content);
+        let module = classes.iter().find(|c| c.kind == "module").unwrap();
+        let names: Vec<&str> = module.methods.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"parse_config"));
+        assert!(names.contains(&"validate"));
+        assert!(!names.contains(&"internal_helper"));
+    }
+
+    #[test]
+    fn test_file_path_php() {
+        let root = Path::new("/project");
+        assert_eq!(
+            test_file_path(Path::new("/project/src/Abilities/Foo.php"), root),
+            PathBuf::from("/project/tests/Unit/Abilities/FooTest.php")
+        );
+        assert_eq!(
+            test_file_path(Path::new("/project/inc/Core/Bar.php"), root),
+            PathBuf::from("/project/tests/Unit/Core/BarTest.php")
+        );
+    }
+
+    #[test]
+    fn test_file_path_rust() {
+        let root = Path::new("/project");
+        assert_eq!(
+            test_file_path(Path::new("/project/src/core/config.rs"), root),
+            PathBuf::from("/project/tests/core/config_test.rs")
+        );
+    }
+
+    #[test]
+    fn generate_php_test_output() {
+        let classes = vec![ExtractedClass {
+            name: "FooAbilities".to_string(),
+            namespace: "DataMachine\\Abilities".to_string(),
+            kind: "class".to_string(),
+            methods: vec![
+                ExtractedMethod {
+                    name: "register".to_string(),
+                    visibility: "public".to_string(),
+                    is_static: false,
+                    line: 5,
+                    params: String::new(),
+                },
+                ExtractedMethod {
+                    name: "executeCreate".to_string(),
+                    visibility: "public".to_string(),
+                    is_static: false,
+                    line: 10,
+                    params: "$config".to_string(),
+                },
+            ],
+        }];
+
+        let config = ScaffoldConfig::php();
+        let output = generate_php_test(&classes, &config);
+
+        assert!(output.contains("class FooAbilitiesTest extends WP_UnitTestCase"));
+        assert!(output.contains("@covers \\DataMachine\\Abilities\\FooAbilities"));
+        assert!(output.contains("function test_register()"));
+        assert!(output.contains("function test_execute_create()"));
+        assert!(output.contains("markTestIncomplete"));
+        assert!(output.contains("use DataMachine\\Abilities\\FooAbilities;"));
+    }
+
+    #[test]
+    fn generate_rust_test_output() {
+        let classes = vec![ExtractedClass {
+            name: "Config".to_string(),
+            namespace: String::new(),
+            kind: "struct".to_string(),
+            methods: vec![
+                ExtractedMethod {
+                    name: "new".to_string(),
+                    visibility: "pub".to_string(),
+                    is_static: true,
+                    line: 5,
+                    params: String::new(),
+                },
+                ExtractedMethod {
+                    name: "load".to_string(),
+                    visibility: "pub".to_string(),
+                    is_static: true,
+                    line: 10,
+                    params: "path: &Path".to_string(),
+                },
+            ],
+        }];
+
+        let config = ScaffoldConfig::rust();
+        let output = generate_rust_test(&classes, &config);
+
+        assert!(output.contains("#[cfg(test)]"));
+        assert!(output.contains("mod tests"));
+        assert!(output.contains("fn test_config_new()"));
+        assert!(output.contains("fn test_config_load()"));
+        assert!(output.contains("todo!(\"implement test\")"));
+    }
+
+    #[test]
+    fn to_snake_case_works() {
+        assert_eq!(to_snake_case("executeCreate"), "execute_create");
+        assert_eq!(to_snake_case("getInstance"), "get_instance");
+        assert_eq!(to_snake_case("register"), "register");
+        assert_eq!(to_snake_case("HTMLParser"), "htmlparser"); // consecutive caps
+        assert_eq!(to_snake_case("loadConfig"), "load_config");
+    }
+
+    #[test]
+    fn scaffold_file_creates_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let src_dir = root.join("src/Abilities");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::write(
+            src_dir.join("FooAbilities.php"),
+            r#"<?php
+namespace App\Abilities;
+
+class FooAbilities {
+    public function register() {}
+    public function execute($id) {}
+}
+"#,
+        )
+        .unwrap();
+
+        let config = ScaffoldConfig::php();
+        let result =
+            scaffold_file(&src_dir.join("FooAbilities.php"), root, &config, false).unwrap();
+
+        assert!(!result.skipped);
+        assert_eq!(result.stub_count, 2);
+        assert!(result.content.contains("class FooAbilitiesTest"));
+        assert!(result.content.contains("test_register"));
+        assert!(result.content.contains("test_execute"));
+        assert!(!result.written);
+    }
+
+    #[test]
+    fn scaffold_file_skips_existing_test() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let src_dir = root.join("src");
+        let test_dir = root.join("tests/Unit");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::create_dir_all(&test_dir).unwrap();
+
+        fs::write(
+            src_dir.join("Foo.php"),
+            "<?php\nclass Foo {\n    public function bar() {}\n}\n",
+        )
+        .unwrap();
+        // Pre-existing test file
+        fs::write(test_dir.join("FooTest.php"), "<?php // existing").unwrap();
+
+        let config = ScaffoldConfig::php();
+        let result = scaffold_file(&src_dir.join("Foo.php"), root, &config, false).unwrap();
+        assert!(result.skipped);
+        assert_eq!(result.stub_count, 0);
+    }
+
+    #[test]
+    fn scaffold_file_write_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let src_dir = root.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::write(
+            src_dir.join("Bar.php"),
+            "<?php\nclass Bar {\n    public function doThing() {}\n}\n",
+        )
+        .unwrap();
+
+        let config = ScaffoldConfig::php();
+        let result = scaffold_file(&src_dir.join("Bar.php"), root, &config, true).unwrap();
+
+        assert!(result.written);
+        assert!(root.join("tests/Unit/BarTest.php").exists());
+
+        let written_content = fs::read_to_string(root.join("tests/Unit/BarTest.php")).unwrap();
+        assert!(written_content.contains("class BarTest"));
+    }
+
+    #[test]
+    fn scaffold_untested_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let src_dir = root.join("src");
+        let test_dir = root.join("tests/Unit");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::create_dir_all(&test_dir).unwrap();
+
+        // One file with tests, one without
+        fs::write(
+            src_dir.join("HasTests.php"),
+            "<?php\nclass HasTests {\n    public function foo() {}\n}\n",
+        )
+        .unwrap();
+        fs::write(test_dir.join("HasTestsTest.php"), "<?php // existing").unwrap();
+
+        fs::write(
+            src_dir.join("NoTests.php"),
+            "<?php\nclass NoTests {\n    public function bar() {}\n    public function baz() {}\n}\n",
+        )
+        .unwrap();
+
+        let config = ScaffoldConfig::php();
+        let result = scaffold_untested(root, &config, false).unwrap();
+
+        assert_eq!(result.total_skipped, 1); // HasTests already has test
+        assert_eq!(result.total_stubs, 2); // bar + baz from NoTests
+    }
+}

--- a/src/core/test_scaffold.rs
+++ b/src/core/test_scaffold.rs
@@ -5,14 +5,16 @@
 //! follows project conventions for test file naming, base classes, and
 //! assertion style.
 //!
-//! Phase 1: regex-based extraction, no extension scripts needed.
+//! Supports two extraction modes:
+//! - Grammar-based: uses extension-provided grammar.toml (preferred)
+//! - Legacy regex: hardcoded patterns as fallback
 
 use regex::Regex;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
-use crate::utils::io;
+use crate::utils::{grammar, io};
 
 // ============================================================================
 // Models
@@ -693,6 +695,161 @@ fn namespace_root(ns: &str) -> &str {
 }
 
 // ============================================================================
+// Grammar-based extraction (preferred path)
+// ============================================================================
+
+/// Extract classes and methods using a grammar file.
+///
+/// This is the preferred extraction path. It delegates to `utils/grammar.rs`
+/// which applies the extension-provided grammar patterns with structural
+/// awareness (brace depth, comment/string skipping).
+pub fn extract_with_grammar(content: &str, grammar_def: &grammar::Grammar) -> Vec<ExtractedClass> {
+    let symbols = grammar::extract(content, grammar_def);
+
+    // Get namespace
+    let ns = grammar::namespace(&symbols).unwrap_or_default();
+
+    // Get classes/structs/traits
+    let type_symbols: Vec<_> = symbols
+        .iter()
+        .filter(|s| {
+            s.concept == "class"
+                || s.concept == "struct"
+                || s.concept == "trait"
+                || s.concept == "interface"
+                || s.concept == "type"
+        })
+        .collect();
+
+    // Get methods/functions
+    let method_symbols: Vec<_> = symbols
+        .iter()
+        .filter(|s| {
+            s.concept == "method" || s.concept == "function" || s.concept == "free_function"
+        })
+        .collect();
+
+    let mut classes = Vec::new();
+
+    if !type_symbols.is_empty() {
+        for ts in &type_symbols {
+            let name = ts.name().unwrap_or("").to_string();
+            let kind = ts.get("kind").unwrap_or(ts.concept.as_str()).to_string();
+
+            // Collect methods that belong to this type (inside its block)
+            // For now, associate all methods with each class (same as legacy behavior)
+            let methods: Vec<ExtractedMethod> = method_symbols
+                .iter()
+                .filter(|m| {
+                    let mname = m.name().unwrap_or("");
+                    // Skip magic methods except __construct
+                    if mname.starts_with("__") && mname != "__construct" {
+                        return false;
+                    }
+                    // Skip private methods for PHP
+                    if let Some(mods) = m.get("modifiers") {
+                        if mods.contains("private") {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .map(|m| {
+                    let mname = m.name().unwrap_or("").to_string();
+                    let vis = if let Some(mods) = m.get("modifiers") {
+                        if mods.contains("private") {
+                            "private"
+                        } else if mods.contains("protected") {
+                            "protected"
+                        } else {
+                            "public"
+                        }
+                    } else if let Some(v) = m.visibility() {
+                        if v.contains("pub") {
+                            "pub"
+                        } else {
+                            "private"
+                        }
+                    } else {
+                        "public"
+                    };
+
+                    ExtractedMethod {
+                        name: mname,
+                        visibility: vis.to_string(),
+                        is_static: m
+                            .get("modifiers")
+                            .map_or(false, |mods| mods.contains("static"))
+                            || m.get("params").map_or(false, |p| !p.contains("self")),
+                        line: m.line,
+                        params: m.get("params").unwrap_or("").to_string(),
+                    }
+                })
+                .collect();
+
+            classes.push(ExtractedClass {
+                name,
+                namespace: ns.clone(),
+                kind,
+                methods,
+            });
+        }
+    } else if !method_symbols.is_empty() {
+        // No classes — procedural/module level
+        let kind = if grammar_def.language.id == "rust" {
+            "module"
+        } else {
+            "procedural"
+        };
+        let methods: Vec<ExtractedMethod> = method_symbols
+            .iter()
+            .map(|m| {
+                let mname = m.name().unwrap_or("").to_string();
+                ExtractedMethod {
+                    name: mname,
+                    visibility: m.visibility().unwrap_or("public").to_string(),
+                    is_static: true,
+                    line: m.line,
+                    params: m.get("params").unwrap_or("").to_string(),
+                }
+            })
+            .collect();
+
+        classes.push(ExtractedClass {
+            name: String::new(),
+            namespace: ns,
+            kind: kind.to_string(),
+            methods,
+        });
+    }
+
+    classes
+}
+
+/// Try to load a grammar from the extension path.
+/// Returns None if the grammar file doesn't exist.
+pub fn load_extension_grammar(extension_path: &Path, language: &str) -> Option<grammar::Grammar> {
+    // Try TOML first, then JSON
+    let toml_path = extension_path.join("grammar.toml");
+    if toml_path.exists() {
+        return grammar::load_grammar(&toml_path).ok();
+    }
+
+    let json_path = extension_path.join("grammar.json");
+    if json_path.exists() {
+        return grammar::load_grammar_json(&json_path).ok();
+    }
+
+    // Try language-specific subdirectory
+    let lang_toml = extension_path.join(language).join("grammar.toml");
+    if lang_toml.exists() {
+        return grammar::load_grammar(&lang_toml).ok();
+    }
+
+    None
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -893,6 +1050,79 @@ fn internal_helper() {}
         assert_eq!(to_snake_case("register"), "register");
         assert_eq!(to_snake_case("HTMLParser"), "htmlparser"); // consecutive caps
         assert_eq!(to_snake_case("loadConfig"), "load_config");
+    }
+
+    #[test]
+    fn extract_with_grammar_php() {
+        let grammar_path = std::path::Path::new(
+            "/var/lib/datamachine/workspace/homeboy-modules/wordpress/grammar.toml",
+        );
+        if !grammar_path.exists() {
+            return; // Skip if not in dev environment
+        }
+        let grammar_def = grammar::load_grammar(grammar_path).unwrap();
+
+        let content = r#"<?php
+namespace App\Abilities;
+
+class FooAbilities {
+    public function register() {}
+    public function executeCreate($config) {}
+    protected function validate($input) {}
+    private function internal() {}
+}
+"#;
+
+        let classes = extract_with_grammar(content, &grammar_def);
+        assert!(!classes.is_empty(), "Should extract at least one class");
+
+        let foo = &classes[0];
+        assert_eq!(foo.name, "FooAbilities");
+        assert_eq!(foo.namespace, "App\\Abilities");
+
+        // Private methods should be filtered
+        let names: Vec<&str> = foo.methods.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"register"));
+        assert!(names.contains(&"executeCreate"));
+        assert!(names.contains(&"validate"));
+        assert!(!names.contains(&"internal"));
+    }
+
+    #[test]
+    fn extract_with_grammar_rust() {
+        let grammar_path = std::path::Path::new(
+            "/var/lib/datamachine/workspace/homeboy-modules/rust/grammar.toml",
+        );
+        if !grammar_path.exists() {
+            return;
+        }
+        let grammar_def = grammar::load_grammar(grammar_path).unwrap();
+
+        let content = r#"
+pub struct Config {
+    data: String,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self { data: String::new() }
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        todo!()
+    }
+
+    fn private_method(&self) {}
+}
+"#;
+
+        let classes = extract_with_grammar(content, &grammar_def);
+        assert!(!classes.is_empty());
+
+        let config = classes.iter().find(|c| c.name == "Config").unwrap();
+        let names: Vec<&str> = config.methods.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"new"));
+        assert!(names.contains(&"load"));
     }
 
     #[test]

--- a/src/utils/grammar.rs
+++ b/src/utils/grammar.rs
@@ -1,0 +1,1169 @@
+//! Language grammar primitive — structure-aware regex matching.
+//!
+//! A generic engine for extracting structural information from source files.
+//! The engine itself has zero language knowledge. Languages are defined by
+//! grammar files shipped in extensions.
+//!
+//! # Architecture
+//!
+//! ```text
+//! utils/grammar.rs   (this file)
+//!   ├── Grammar       — loaded from extension TOML, defines patterns for a language
+//!   ├── StructuralParser — brace-depth, string/comment-aware iteration
+//!   └── Extractor     — applies Grammar patterns via StructuralParser
+//!
+//! Extension grammar.toml → Grammar → Extractor → Vec<Symbol>
+//! ```
+//!
+//! # Design Principles
+//!
+//! - **Zero built-in language knowledge** — all patterns come from grammars
+//! - **Structure-aware** — tracks brace depth, skips strings and comments
+//! - **Composable** — features query for concepts ("give me methods") not languages
+//! - **Same model as `utils/baseline.rs`** — dumb primitive, smart consumers
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::error::{Error, Result};
+use crate::utils::io;
+
+// ============================================================================
+// Grammar definition (loaded from extension TOML/JSON)
+// ============================================================================
+
+/// A language grammar defining patterns for structural concepts.
+///
+/// Grammars are loaded from extension files (e.g., `grammar.toml`).
+/// Each grammar defines how to recognize methods, classes, imports, etc.
+/// in a specific language.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Grammar {
+    /// Language metadata.
+    pub language: LanguageMeta,
+
+    /// Comment syntax for this language.
+    pub comments: CommentSyntax,
+
+    /// String literal syntax for this language.
+    pub strings: StringSyntax,
+
+    /// Block delimiter (usually braces, but could be indentation).
+    #[serde(default)]
+    pub blocks: BlockSyntax,
+
+    /// Named patterns for structural concepts.
+    pub patterns: HashMap<String, ConceptPattern>,
+}
+
+/// Language identification metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LanguageMeta {
+    /// Language identifier (e.g., "php", "rust", "javascript").
+    pub id: String,
+
+    /// File extensions this grammar applies to.
+    pub extensions: Vec<String>,
+}
+
+/// How comments work in this language.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommentSyntax {
+    /// Single-line comment prefixes (e.g., ["//", "#"]).
+    #[serde(default)]
+    pub line: Vec<String>,
+
+    /// Multi-line comment delimiters (e.g., [["/*", "*/"]]).
+    #[serde(default)]
+    pub block: Vec<(String, String)>,
+
+    /// Doc comment prefixes (e.g., ["///", "//!"]).
+    #[serde(default)]
+    pub doc: Vec<String>,
+}
+
+/// How string literals work in this language.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StringSyntax {
+    /// Quote characters (e.g., ["\"", "'", "`"]).
+    #[serde(default = "default_quotes")]
+    pub quotes: Vec<String>,
+
+    /// Escape character (usually backslash).
+    #[serde(default = "default_escape_string")]
+    pub escape: String,
+
+    /// Multi-line string delimiters (e.g., Python's triple-quote).
+    #[serde(default)]
+    pub multiline: Vec<(String, String)>,
+}
+
+fn default_quotes() -> Vec<String> {
+    vec!["\"".to_string(), "'".to_string()]
+}
+
+fn default_escape_string() -> String {
+    "\\".to_string()
+}
+
+/// Block (scope) delimiters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockSyntax {
+    /// Opening delimiter (default: "{").
+    #[serde(default = "default_open")]
+    pub open: String,
+
+    /// Closing delimiter (default: "}").
+    #[serde(default = "default_close")]
+    pub close: String,
+}
+
+impl Default for BlockSyntax {
+    fn default() -> Self {
+        Self {
+            open: "{".to_string(),
+            close: "}".to_string(),
+        }
+    }
+}
+
+fn default_open() -> String {
+    "{".to_string()
+}
+
+fn default_close() -> String {
+    "}".to_string()
+}
+
+/// A pattern for a structural concept (method, class, import, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptPattern {
+    /// Regex pattern to match this concept.
+    pub regex: String,
+
+    /// Named capture group mapping.
+    /// Maps semantic names to capture group indices.
+    /// e.g., {"name": 1, "visibility": 2, "params": 3}
+    #[serde(default)]
+    pub captures: HashMap<String, usize>,
+
+    /// Context constraint: where this pattern is valid.
+    /// - "any" (default) — match anywhere
+    /// - "top_level" — only at brace depth 0
+    /// - "in_block" — only inside a block (depth > 0)
+    /// - "line" — match per-line (default for most patterns)
+    #[serde(default = "default_context")]
+    pub context: String,
+
+    /// Whether to skip matches inside comments.
+    #[serde(default = "default_true")]
+    pub skip_comments: bool,
+
+    /// Whether to skip matches inside string literals.
+    #[serde(default = "default_true")]
+    pub skip_strings: bool,
+
+    /// Filter: only include matches where this capture group is non-empty.
+    #[serde(default)]
+    pub require_capture: Option<String>,
+}
+
+fn default_context() -> String {
+    "any".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+// ============================================================================
+// Structural parser — context-aware iteration over source text
+// ============================================================================
+
+/// Region classification for a line or span of text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Region {
+    /// Normal code.
+    Code,
+    /// Inside a single-line comment.
+    LineComment,
+    /// Inside a block comment.
+    BlockComment,
+    /// Inside a string literal.
+    StringLiteral,
+}
+
+/// Tracks structural context while parsing source text.
+#[derive(Debug, Clone)]
+pub struct StructuralContext {
+    /// Current brace nesting depth.
+    pub depth: i32,
+
+    /// Current region (code, comment, string).
+    pub region: Region,
+
+    /// Stack of block contexts: (kind_label, depth_when_entered).
+    /// Features can push/pop to track impl blocks, test modules, etc.
+    pub block_stack: Vec<(String, i32)>,
+}
+
+impl StructuralContext {
+    pub fn new() -> Self {
+        Self {
+            depth: 0,
+            region: Region::Code,
+            block_stack: Vec::new(),
+        }
+    }
+
+    /// Whether we're inside a block with the given label.
+    pub fn is_inside(&self, label: &str) -> bool {
+        self.block_stack.iter().any(|(l, _)| l == label)
+    }
+
+    /// The label of the innermost block, if any.
+    pub fn current_block_label(&self) -> Option<&str> {
+        self.block_stack.last().map(|(l, _)| l.as_str())
+    }
+
+    /// Push a labeled block at the current depth.
+    pub fn push_block(&mut self, label: String) {
+        self.block_stack.push((label, self.depth));
+    }
+
+    /// Pop blocks that have been exited (depth dropped below entry depth).
+    pub fn pop_exited_blocks(&mut self) {
+        while let Some((_, entry_depth)) = self.block_stack.last() {
+            if self.depth <= *entry_depth {
+                self.block_stack.pop();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl Default for StructuralContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A line of source with its structural context.
+#[derive(Debug, Clone)]
+pub struct ContextualLine<'a> {
+    /// The line content.
+    pub text: &'a str,
+
+    /// 1-indexed line number.
+    pub line_num: usize,
+
+    /// Brace depth at the start of this line.
+    pub depth: i32,
+
+    /// What region this line is in.
+    pub region: Region,
+}
+
+/// Iterate lines with structural context, tracking brace depth and regions.
+///
+/// This is the core primitive — it walks the file line-by-line, tracking
+/// brace depth and whether we're inside comments or strings. Consumers
+/// can then filter lines by depth, region, etc.
+pub fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<ContextualLine<'a>> {
+    let mut ctx = StructuralContext::new();
+    let mut result = Vec::new();
+    let mut in_block_comment = false;
+    let mut block_comment_end = String::new();
+
+    for (i, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        let depth_at_start = ctx.depth;
+
+        // Determine region for this line
+        let region = if in_block_comment {
+            // Check if block comment ends on this line
+            if let Some(pos) = trimmed.find(block_comment_end.as_str()) {
+                // Comment ends partway through this line
+                in_block_comment = false;
+                let after = &trimmed[pos + block_comment_end.len()..].trim();
+                if after.is_empty() {
+                    Region::BlockComment
+                } else {
+                    // Mixed line — treat as code (conservative)
+                    Region::Code
+                }
+            } else {
+                Region::BlockComment
+            }
+        } else if is_line_comment(trimmed, &grammar.comments) {
+            Region::LineComment
+        } else {
+            // Check for block comment start
+            for (open, close) in &grammar.comments.block {
+                if trimmed.starts_with(open.as_str()) {
+                    if !trimmed.contains(close.as_str()) || trimmed.ends_with(open.as_str()) {
+                        in_block_comment = true;
+                        block_comment_end = close.clone();
+                    }
+                }
+            }
+            if in_block_comment {
+                Region::BlockComment
+            } else {
+                Region::Code
+            }
+        };
+
+        // Track brace depth for code lines
+        if region == Region::Code {
+            update_depth(line, &grammar.blocks, &grammar.strings, &mut ctx);
+        }
+
+        result.push(ContextualLine {
+            text: line,
+            line_num: i + 1,
+            depth: depth_at_start,
+            region,
+        });
+
+        // Pop exited blocks
+        ctx.pop_exited_blocks();
+    }
+
+    result
+}
+
+/// Check if a trimmed line is a single-line comment.
+fn is_line_comment(trimmed: &str, comments: &CommentSyntax) -> bool {
+    for prefix in &comments.line {
+        if trimmed.starts_with(prefix.as_str()) {
+            return true;
+        }
+    }
+    for prefix in &comments.doc {
+        if trimmed.starts_with(prefix.as_str()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Update brace depth for a line, skipping strings.
+fn update_depth(
+    line: &str,
+    blocks: &BlockSyntax,
+    strings: &StringSyntax,
+    ctx: &mut StructuralContext,
+) {
+    let mut in_string: Option<char> = None;
+    let mut prev_char = '\0';
+
+    for ch in line.chars() {
+        if let Some(quote) = in_string {
+            if ch == quote && prev_char != strings.escape.chars().next().unwrap_or('\\') {
+                in_string = None;
+            }
+        } else if strings.quotes.iter().any(|q| q.starts_with(ch)) {
+            in_string = Some(ch);
+        } else if blocks.open.starts_with(ch) {
+            ctx.depth += 1;
+        } else if blocks.close.starts_with(ch) {
+            ctx.depth -= 1;
+        }
+        prev_char = ch;
+    }
+}
+
+// ============================================================================
+// Extraction — apply grammar patterns to get symbols
+// ============================================================================
+
+/// A symbol extracted from source code.
+#[derive(Debug, Clone, Serialize)]
+pub struct Symbol {
+    /// What kind of concept this is (matches the pattern key in the grammar).
+    /// e.g., "method", "class", "import", "namespace"
+    pub concept: String,
+
+    /// Named captures from the pattern match.
+    /// e.g., {"name": "foo", "visibility": "pub", "params": "&self, key: &str"}
+    pub captures: HashMap<String, String>,
+
+    /// 1-indexed line number where the symbol was found.
+    pub line: usize,
+
+    /// Brace depth at the match location.
+    pub depth: i32,
+
+    /// The full matched text.
+    pub matched_text: String,
+}
+
+impl Symbol {
+    /// Get a named capture value.
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.captures.get(key).map(|s| s.as_str())
+    }
+
+    /// Get the "name" capture (most symbols have one).
+    pub fn name(&self) -> Option<&str> {
+        self.get("name")
+    }
+
+    /// Get the "visibility" capture.
+    pub fn visibility(&self) -> Option<&str> {
+        self.get("visibility")
+    }
+}
+
+/// Extract all symbols from source content using a grammar.
+pub fn extract(content: &str, grammar: &Grammar) -> Vec<Symbol> {
+    let lines = walk_lines(content, grammar);
+    let mut symbols = Vec::new();
+
+    for (concept_name, pattern) in &grammar.patterns {
+        let re = match Regex::new(&pattern.regex) {
+            Ok(r) => r,
+            Err(_) => continue, // Skip invalid patterns
+        };
+
+        for ctx_line in &lines {
+            // Skip based on region
+            if pattern.skip_comments
+                && (ctx_line.region == Region::LineComment
+                    || ctx_line.region == Region::BlockComment)
+            {
+                continue;
+            }
+
+            // Skip based on context constraint
+            match pattern.context.as_str() {
+                "top_level" => {
+                    if ctx_line.depth != 0 {
+                        continue;
+                    }
+                }
+                "in_block" => {
+                    if ctx_line.depth == 0 {
+                        continue;
+                    }
+                }
+                _ => {} // "any" or "line" — no constraint
+            }
+
+            // Try to match
+            if let Some(caps) = re.captures(ctx_line.text) {
+                let mut capture_map = HashMap::new();
+
+                for (name, &index) in &pattern.captures {
+                    if let Some(m) = caps.get(index) {
+                        capture_map.insert(name.clone(), m.as_str().to_string());
+                    }
+                }
+
+                // Check require_capture filter
+                if let Some(ref required) = pattern.require_capture {
+                    if capture_map.get(required).map_or(true, |v| v.is_empty()) {
+                        continue;
+                    }
+                }
+
+                symbols.push(Symbol {
+                    concept: concept_name.clone(),
+                    captures: capture_map,
+                    line: ctx_line.line_num,
+                    depth: ctx_line.depth,
+                    matched_text: caps[0].to_string(),
+                });
+            }
+        }
+    }
+
+    // Sort by line number for stable output
+    symbols.sort_by_key(|s| s.line);
+    symbols
+}
+
+/// Extract symbols of a specific concept only.
+pub fn extract_concept(content: &str, grammar: &Grammar, concept: &str) -> Vec<Symbol> {
+    extract(content, grammar)
+        .into_iter()
+        .filter(|s| s.concept == concept)
+        .collect()
+}
+
+// ============================================================================
+// Grammar loading
+// ============================================================================
+
+/// Load a grammar from a TOML file.
+pub fn load_grammar(path: &Path) -> Result<Grammar> {
+    let content = io::read_file(path, "read grammar file")?;
+    toml::from_str(&content).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to parse grammar {}: {}", path.display(), e),
+            Some("grammar.load".to_string()),
+        )
+    })
+}
+
+/// Load a grammar from a JSON file.
+pub fn load_grammar_json(path: &Path) -> Result<Grammar> {
+    let content = io::read_file(path, "read grammar file")?;
+    serde_json::from_str(&content).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to parse grammar {}: {}", path.display(), e),
+            Some("grammar.load".to_string()),
+        )
+    })
+}
+
+// ============================================================================
+// Convenience helpers for feature consumers
+// ============================================================================
+
+/// Get all method/function names from extracted symbols.
+pub fn method_names(symbols: &[Symbol]) -> Vec<String> {
+    symbols
+        .iter()
+        .filter(|s| {
+            s.concept == "method" || s.concept == "function" || s.concept == "free_function"
+        })
+        .filter_map(|s| s.name().map(|n| n.to_string()))
+        .collect()
+}
+
+/// Get all class/struct/trait names from extracted symbols.
+pub fn type_names(symbols: &[Symbol]) -> Vec<String> {
+    symbols
+        .iter()
+        .filter(|s| {
+            s.concept == "class"
+                || s.concept == "struct"
+                || s.concept == "trait"
+                || s.concept == "enum"
+                || s.concept == "interface"
+                || s.concept == "type"
+        })
+        .filter_map(|s| s.name().map(|n| n.to_string()))
+        .collect()
+}
+
+/// Get all import paths from extracted symbols.
+pub fn import_paths(symbols: &[Symbol]) -> Vec<String> {
+    symbols
+        .iter()
+        .filter(|s| s.concept == "import" || s.concept == "use")
+        .filter_map(|s| s.get("path").map(|p| p.to_string()))
+        .collect()
+}
+
+/// Get the namespace from extracted symbols.
+pub fn namespace(symbols: &[Symbol]) -> Option<String> {
+    symbols
+        .iter()
+        .find(|s| s.concept == "namespace" || s.concept == "module")
+        .and_then(|s| s.name().map(|n| n.to_string()))
+}
+
+/// Filter symbols to only public API (visibility contains "pub" or "public").
+pub fn public_symbols(symbols: &[Symbol]) -> Vec<&Symbol> {
+    symbols
+        .iter()
+        .filter(|s| {
+            s.visibility()
+                .map_or(true, |v| v.contains("pub") || v == "public")
+        })
+        .collect()
+}
+
+// ============================================================================
+// Block body extraction
+// ============================================================================
+
+/// Extract the body of a block starting from a given line.
+///
+/// Finds the opening brace on or after `start_line` (0-indexed into lines),
+/// then returns all lines until the matching closing brace.
+pub fn extract_block_body<'a>(
+    lines: &[ContextualLine<'a>],
+    start_line_idx: usize,
+    grammar: &Grammar,
+) -> Option<Vec<&'a str>> {
+    let open = grammar.blocks.open.chars().next().unwrap_or('{');
+    let close = grammar.blocks.close.chars().next().unwrap_or('}');
+
+    // Find the opening brace
+    let mut idx = start_line_idx;
+    let mut found_open = false;
+    let mut depth: i32 = 0;
+    let mut body_lines = Vec::new();
+
+    while idx < lines.len() {
+        let line = lines[idx].text;
+        for ch in line.chars() {
+            if ch == open {
+                depth += 1;
+                found_open = true;
+            } else if ch == close {
+                depth -= 1;
+                if found_open && depth == 0 {
+                    body_lines.push(line);
+                    return Some(body_lines);
+                }
+            }
+        }
+        if found_open {
+            body_lines.push(line);
+        }
+        idx += 1;
+    }
+
+    None
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rust_grammar() -> Grammar {
+        Grammar {
+            language: LanguageMeta {
+                id: "rust".to_string(),
+                extensions: vec!["rs".to_string()],
+            },
+            comments: CommentSyntax {
+                line: vec!["//".to_string()],
+                block: vec![("/*".to_string(), "*/".to_string())],
+                doc: vec!["///".to_string(), "//!".to_string()],
+            },
+            strings: StringSyntax {
+                quotes: vec!["\"".to_string()],
+                escape: "\\".to_string(),
+                multiline: vec![],
+            },
+            blocks: BlockSyntax::default(),
+            patterns: {
+                let mut p = HashMap::new();
+                p.insert(
+                    "function".to_string(),
+                    ConceptPattern {
+                        regex: r"(?:pub(?:\(crate\))?\s+)?(?:async\s+)?fn\s+(\w+)\s*\(([^)]*)\)"
+                            .to_string(),
+                        captures: {
+                            let mut c = HashMap::new();
+                            c.insert("name".to_string(), 1);
+                            c.insert("params".to_string(), 2);
+                            c
+                        },
+                        context: "any".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p.insert(
+                    "struct".to_string(),
+                    ConceptPattern {
+                        regex: r"(?:pub(?:\(crate\))?\s+)?(?:struct|enum|trait)\s+(\w+)"
+                            .to_string(),
+                        captures: {
+                            let mut c = HashMap::new();
+                            c.insert("name".to_string(), 1);
+                            c
+                        },
+                        context: "top_level".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p.insert(
+                    "import".to_string(),
+                    ConceptPattern {
+                        regex: r"use\s+([\w:]+(?:::\{[^}]+\})?);".to_string(),
+                        captures: {
+                            let mut c = HashMap::new();
+                            c.insert("path".to_string(), 1);
+                            c
+                        },
+                        context: "top_level".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p
+            },
+        }
+    }
+
+    fn php_grammar() -> Grammar {
+        Grammar {
+            language: LanguageMeta {
+                id: "php".to_string(),
+                extensions: vec!["php".to_string()],
+            },
+            comments: CommentSyntax {
+                line: vec!["//".to_string(), "#".to_string()],
+                block: vec![("/*".to_string(), "*/".to_string())],
+                doc: vec![],
+            },
+            strings: StringSyntax {
+                quotes: vec!["\"".to_string(), "'".to_string()],
+                escape: "\\".to_string(),
+                multiline: vec![],
+            },
+            blocks: BlockSyntax::default(),
+            patterns: {
+                let mut p = HashMap::new();
+                p.insert(
+                    "method".to_string(),
+                    ConceptPattern {
+                        regex: r"(?:(?:public|protected|private|static|abstract|final)\s+)*function\s+(\w+)\s*\(([^)]*)\)".to_string(),
+                        captures: {
+                            let mut c = HashMap::new();
+                            c.insert("name".to_string(), 1);
+                            c.insert("params".to_string(), 2);
+                            c
+                        },
+                        context: "any".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p.insert(
+                    "class".to_string(),
+                    ConceptPattern {
+                        regex: r"(?:abstract\s+)?(?:final\s+)?(class|trait|interface)\s+(\w+)"
+                            .to_string(),
+                        captures: {
+                            let mut c = HashMap::new();
+                            c.insert("kind".to_string(), 1);
+                            c.insert("name".to_string(), 2);
+                            c
+                        },
+                        context: "top_level".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p.insert(
+                    "namespace".to_string(),
+                    ConceptPattern {
+                        regex: r"namespace\s+([\w\\]+);".to_string(),
+                        captures: {
+                            let mut c = HashMap::new();
+                            c.insert("name".to_string(), 1);
+                            c
+                        },
+                        context: "top_level".to_string(),
+                        skip_comments: true,
+                        skip_strings: true,
+                        require_capture: None,
+                    },
+                );
+                p
+            },
+        }
+    }
+
+    // ---- Structural parser tests ----
+
+    #[test]
+    fn walk_lines_tracks_depth() {
+        let content = "fn main() {\n    let x = 1;\n    if true {\n        foo();\n    }\n}\n";
+        let grammar = rust_grammar();
+        let lines = walk_lines(content, &grammar);
+
+        assert_eq!(lines[0].depth, 0); // fn main() {
+        assert_eq!(lines[1].depth, 1); // let x = 1;
+        assert_eq!(lines[2].depth, 1); // if true {
+        assert_eq!(lines[3].depth, 2); // foo();
+        assert_eq!(lines[4].depth, 2); // }
+        assert_eq!(lines[5].depth, 1); // }
+    }
+
+    #[test]
+    fn walk_lines_detects_line_comments() {
+        let content = "let x = 1;\n// this is a comment\nlet y = 2;\n";
+        let grammar = rust_grammar();
+        let lines = walk_lines(content, &grammar);
+
+        assert_eq!(lines[0].region, Region::Code);
+        assert_eq!(lines[1].region, Region::LineComment);
+        assert_eq!(lines[2].region, Region::Code);
+    }
+
+    #[test]
+    fn walk_lines_detects_block_comments() {
+        let content = "let x = 1;\n/* multi\nline\ncomment */\nlet y = 2;\n";
+        let grammar = rust_grammar();
+        let lines = walk_lines(content, &grammar);
+
+        assert_eq!(lines[0].region, Region::Code);
+        assert_eq!(lines[1].region, Region::BlockComment);
+        assert_eq!(lines[2].region, Region::BlockComment);
+        assert_eq!(lines[3].region, Region::BlockComment);
+        assert_eq!(lines[4].region, Region::Code);
+    }
+
+    #[test]
+    fn depth_skips_braces_in_strings() {
+        let content = "let x = \"{ not a block }\";\nlet y = 1;\n";
+        let grammar = rust_grammar();
+        let lines = walk_lines(content, &grammar);
+
+        // Braces inside string should NOT change depth
+        assert_eq!(lines[0].depth, 0);
+        assert_eq!(lines[1].depth, 0);
+    }
+
+    #[test]
+    fn php_hash_comments() {
+        let content = "<?php\n# this is a comment\n$x = 1;\n";
+        let grammar = php_grammar();
+        let lines = walk_lines(content, &grammar);
+
+        assert_eq!(lines[1].region, Region::LineComment);
+        assert_eq!(lines[2].region, Region::Code);
+    }
+
+    // ---- Extraction tests ----
+
+    #[test]
+    fn extract_rust_functions() {
+        let content = "pub fn parse_config(path: &Path) -> Config {\n    todo!()\n}\n\nfn internal() {}\n\npub(crate) fn helper() {}\n";
+        let grammar = rust_grammar();
+        let symbols = extract(content, &grammar);
+
+        let fns: Vec<_> = symbols.iter().filter(|s| s.concept == "function").collect();
+        assert_eq!(fns.len(), 3);
+        assert_eq!(fns[0].name(), Some("parse_config"));
+        assert_eq!(fns[1].name(), Some("internal"));
+        assert_eq!(fns[2].name(), Some("helper"));
+    }
+
+    #[test]
+    fn extract_rust_structs() {
+        let content = "pub struct Config {\n    data: String,\n}\n\nenum State {\n    Running,\n    Stopped,\n}\n";
+        let grammar = rust_grammar();
+        let symbols = extract_concept(content, &grammar, "struct");
+
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name(), Some("Config"));
+        assert_eq!(symbols[1].name(), Some("State"));
+    }
+
+    #[test]
+    fn extract_rust_imports() {
+        let content = "use std::path::Path;\nuse crate::error::Result;\n\nfn foo() {}\n";
+        let grammar = rust_grammar();
+        let paths = import_paths(&extract(content, &grammar));
+
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], "std::path::Path");
+        assert_eq!(paths[1], "crate::error::Result");
+    }
+
+    #[test]
+    fn extract_php_methods() {
+        let content = "<?php\nclass Foo {\n    public function bar() {}\n    protected function baz($x) {}\n    private function internal() {}\n}\n";
+        let grammar = php_grammar();
+        let methods = extract_concept(content, &grammar, "method");
+
+        assert_eq!(methods.len(), 3);
+        assert_eq!(methods[0].name(), Some("bar"));
+        assert_eq!(methods[1].name(), Some("baz"));
+        assert_eq!(methods[2].name(), Some("internal"));
+    }
+
+    #[test]
+    fn extract_php_class() {
+        let content =
+            "<?php\nnamespace App\\Models;\n\nclass User {\n    public function save() {}\n}\n";
+        let grammar = php_grammar();
+        let symbols = extract(content, &grammar);
+
+        let ns = namespace(&symbols);
+        assert_eq!(ns, Some("App\\Models".to_string()));
+
+        let types = type_names(&symbols);
+        assert_eq!(types, vec!["User"]);
+    }
+
+    #[test]
+    fn skip_comments_in_extraction() {
+        let content = "// pub fn commented_out() {}\npub fn real_fn() {}\n";
+        let grammar = rust_grammar();
+        let symbols = extract_concept(content, &grammar, "function");
+
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name(), Some("real_fn"));
+    }
+
+    #[test]
+    fn top_level_context_filter() {
+        let content = "pub struct Outer {\n    inner: Inner,\n}\n\nimpl Outer {\n    pub struct NotTopLevel {}\n}\n";
+        let grammar = rust_grammar();
+        // struct pattern has context: "top_level"
+        let symbols = extract_concept(content, &grammar, "struct");
+
+        // Should only find Outer (depth 0), not NotTopLevel (depth > 0)
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name(), Some("Outer"));
+    }
+
+    #[test]
+    fn method_names_helper() {
+        let content = "pub fn alpha() {}\nfn beta() {}\n";
+        let grammar = rust_grammar();
+        let symbols = extract(content, &grammar);
+        let names = method_names(&symbols);
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn extract_block_body_basic() {
+        let content = "fn foo() {\n    let x = 1;\n    let y = 2;\n}\n";
+        let grammar = rust_grammar();
+        let lines = walk_lines(content, &grammar);
+        let body = extract_block_body(&lines, 0, &grammar);
+        assert!(body.is_some());
+        let body = body.unwrap();
+        assert_eq!(body.len(), 4); // All 4 lines (fn { ... })
+    }
+
+    #[test]
+    fn grammar_roundtrip_toml() {
+        let grammar = rust_grammar();
+        let toml_str = toml::to_string_pretty(&grammar).unwrap();
+        let parsed: Grammar = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.language.id, "rust");
+        assert_eq!(parsed.patterns.len(), 3);
+    }
+
+    #[test]
+    fn grammar_roundtrip_json() {
+        let grammar = rust_grammar();
+        let json_str = serde_json::to_string_pretty(&grammar).unwrap();
+        let parsed: Grammar = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed.language.id, "rust");
+        assert_eq!(parsed.patterns.len(), 3);
+    }
+
+    #[test]
+    fn structural_context_block_tracking() {
+        let mut ctx = StructuralContext::new();
+        ctx.depth = 1;
+        ctx.push_block("impl".to_string());
+        assert!(ctx.is_inside("impl"));
+        assert_eq!(ctx.current_block_label(), Some("impl"));
+
+        ctx.depth = 0;
+        ctx.pop_exited_blocks();
+        assert!(!ctx.is_inside("impl"));
+        assert_eq!(ctx.current_block_label(), None);
+    }
+
+    #[test]
+    fn public_symbols_filter() {
+        let content = "pub fn visible() {}\nfn hidden() {}\npub(crate) fn semi() {}\n";
+        let grammar = rust_grammar();
+        let symbols = extract(content, &grammar);
+
+        // All three are extracted, but public_symbols includes those without
+        // visibility info (no visibility capture group → defaults to included)
+        // since our simple grammar doesn't capture visibility
+        let pub_syms = public_symbols(&symbols);
+        assert_eq!(pub_syms.len(), 3); // All pass because no "visibility" capture
+    }
+}
+
+// ============================================================================
+// Integration tests — load real grammar files from extensions
+// ============================================================================
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+
+    /// Load the Rust grammar from the extensions workspace and validate it
+    /// against real Rust source code (this file!).
+    #[test]
+    fn load_and_use_rust_grammar() {
+        // Try to find the Rust grammar in the extensions workspace
+        let grammar_path = std::path::Path::new(
+            "/var/lib/datamachine/workspace/homeboy-modules/rust/grammar.toml",
+        );
+        if !grammar_path.exists() {
+            // Skip if not in development environment
+            eprintln!("Skipping: Rust grammar not found at {:?}", grammar_path);
+            return;
+        }
+
+        let grammar = load_grammar(grammar_path).expect("Failed to load Rust grammar");
+        assert_eq!(grammar.language.id, "rust");
+        assert!(grammar.patterns.contains_key("function"));
+        assert!(grammar.patterns.contains_key("struct"));
+        assert!(grammar.patterns.contains_key("import"));
+
+        // Test against a sample of Rust code
+        let sample = r#"
+use std::path::Path;
+use crate::error::Result;
+
+pub struct Config {
+    data: String,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self { data: String::new() }
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        todo!()
+    }
+
+    fn private_helper(&self) {}
+}
+
+pub fn standalone(x: i32) -> bool {
+    x > 0
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert!(true);
+    }
+}
+"#;
+
+        let symbols = extract(sample, &grammar);
+
+        // Should find functions
+        let fns: Vec<_> = symbols.iter().filter(|s| s.concept == "function").collect();
+        assert!(
+            fns.len() >= 3,
+            "Expected at least 3 functions, got {}: {:?}",
+            fns.len(),
+            fns.iter().map(|f| f.name()).collect::<Vec<_>>()
+        );
+
+        // Should find struct
+        let structs: Vec<_> = symbols.iter().filter(|s| s.concept == "struct").collect();
+        assert_eq!(structs.len(), 1);
+        assert_eq!(structs[0].name(), Some("Config"));
+
+        // Should find imports
+        let imports: Vec<_> = symbols.iter().filter(|s| s.concept == "import").collect();
+        assert_eq!(imports.len(), 2);
+
+        // Should find impl block
+        let impls: Vec<_> = symbols
+            .iter()
+            .filter(|s| s.concept == "impl_block")
+            .collect();
+        assert_eq!(impls.len(), 1);
+
+        // Should find cfg(test)
+        let cfg_tests: Vec<_> = symbols.iter().filter(|s| s.concept == "cfg_test").collect();
+        assert_eq!(cfg_tests.len(), 1);
+
+        // Should find test attribute
+        let test_attrs: Vec<_> = symbols
+            .iter()
+            .filter(|s| s.concept == "test_attribute")
+            .collect();
+        assert_eq!(test_attrs.len(), 1);
+    }
+
+    /// Load the PHP grammar and validate it against sample PHP code.
+    #[test]
+    fn load_and_use_php_grammar() {
+        let grammar_path = std::path::Path::new(
+            "/var/lib/datamachine/workspace/homeboy-modules/wordpress/grammar.toml",
+        );
+        if !grammar_path.exists() {
+            eprintln!("Skipping: PHP grammar not found at {:?}", grammar_path);
+            return;
+        }
+
+        let grammar = load_grammar(grammar_path).expect("Failed to load PHP grammar");
+        assert_eq!(grammar.language.id, "php");
+        assert!(grammar.patterns.contains_key("method"));
+        assert!(grammar.patterns.contains_key("class"));
+        assert!(grammar.patterns.contains_key("namespace"));
+
+        let sample = r#"<?php
+namespace DataMachine\Abilities;
+
+use WP_UnitTestCase;
+use DataMachine\Core\Pipeline;
+
+class PipelineAbilities extends BaseAbilities {
+    public function register() {
+        add_action('init', [$this, 'setup']);
+    }
+
+    public function executeCreate($config) {
+        return new Pipeline($config);
+    }
+
+    protected function validate($input) {
+        return true;
+    }
+
+    private function internal() {}
+
+    public static function getInstance() {
+        return new static();
+    }
+}
+"#;
+
+        let symbols = extract(sample, &grammar);
+
+        // Should find namespace
+        let ns = namespace(&symbols);
+        assert_eq!(ns, Some("DataMachine\\Abilities".to_string()));
+
+        // Should find class
+        let classes: Vec<_> = symbols.iter().filter(|s| s.concept == "class").collect();
+        assert_eq!(classes.len(), 1);
+        assert_eq!(classes[0].name(), Some("PipelineAbilities"));
+        assert_eq!(classes[0].get("extends"), Some("BaseAbilities"));
+
+        // Should find methods
+        let methods: Vec<_> = symbols.iter().filter(|s| s.concept == "method").collect();
+        assert!(
+            methods.len() >= 4,
+            "Expected at least 4 methods, got {}",
+            methods.len()
+        );
+
+        // Should find imports
+        let imports: Vec<_> = symbols.iter().filter(|s| s.concept == "import").collect();
+        assert_eq!(imports.len(), 2);
+
+        // Should find add_action
+        let actions: Vec<_> = symbols
+            .iter()
+            .filter(|s| s.concept == "add_action")
+            .collect();
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].name(), Some("init"));
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,6 +20,7 @@ pub mod base_path;
 pub mod baseline;
 pub mod command;
 pub mod entity_suggest;
+pub mod grammar;
 pub mod io;
 pub mod parser;
 pub mod resolve;


### PR DESCRIPTION
## Summary

Two features in one PR:

### 1. Test scaffold (`homeboy test --scaffold`)

Adds `homeboy test <component> --scaffold` to scan source files and generate test stubs for any untested public API. Closes #422.

- **PHP extraction**: classes, traits, interfaces — public/protected methods
- **Rust extraction**: structs/enums with impl blocks, pub methods, free functions
- **Convention-based path mapping**: `src/Abilities/Foo.php` → `tests/Unit/Abilities/FooTest.php`
- **Auto-detect language** from project structure
- **Single file**: `--scaffold-file <path>` with content preview
- **Batch mode**: `--scaffold` scans all source dirs
- **Dry-run by default**, `--write` to create files
- 14 unit tests

### 2. Grammar-driven structural regex engine (`utils/grammar.rs`)

Adds a language-agnostic structural regex engine as a core primitive. Part of #432.

- **Zero built-in language knowledge** — all patterns come from extension grammar files
- **Structure-aware** — tracks brace depth, skips strings and comments
- **Grammar loading** from TOML/JSON (extension-provided files)
- **Pattern extraction** with named captures and context constraints (top_level, in_block, any)
- **Convenience helpers**: `method_names()`, `type_names()`, `import_paths()`, `namespace()`, `public_symbols()`
- **Integration tests** validate against real Rust + PHP grammar files from homeboy-extensions
- 20 unit + integration tests
- Adds `toml` crate dependency

Companion PR: Extra-Chill/homeboy-extensions#86 (grammar TOML files)

## CLI

```bash
# Scaffold all untested files (dry-run)
homeboy test data-machine --scaffold

# Scaffold + write
homeboy test data-machine --scaffold --write

# Scaffold a specific file
homeboy test data-machine --scaffold-file src/Abilities/FooAbilities.php
```

## Tests

34 new tests (14 scaffold + 20 grammar). Full suite: 652 passing.

## Also includes

`cargo fmt` fixes for files from prior PRs (#424, #429, #430).