### PR TITLE
feat(audit fix): scaffold missing test files from coverage findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "arboard",
  "base64",

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -2230,8 +2230,7 @@ pub struct TestOutput {}
 
     #[test]
     fn extract_expected_test_path_parses_description() {
-        let desc =
-            "No test file found (expected 'tests/utils/token_test.rs') and no inline tests";
+        let desc = "No test file found (expected 'tests/utils/token_test.rs') and no inline tests";
         let parsed = extract_expected_test_path(desc);
         assert_eq!(parsed, Some("tests/utils/token_test.rs".to_string()));
     }


### PR DESCRIPTION
## Summary
- extend homeboy audit --fix to auto-generate missing test files from test_coverage findings (missing_test_file)
- add deterministic parsing for expected test file paths from finding descriptions and generate minimal compile-safe placeholders
- add tests for path extraction, missing-test scaffold creation, dedupe behavior, and file write application

## Validation
- cargo test code_audit::fixer -- --nocapture
- cargo test -- --nocapture