### PR TITLE
docs: fix embedded docs references and stale paths

### DIFF
--- a/docs/architecture/embedded-docs-topic-resolution.md
+++ b/docs/architecture/embedded-docs-topic-resolution.md
@@ -1,6 +1,6 @@
 # Embedded docs: topic resolution and keys
 
-Homeboy embeds markdown files from `homeboy/docs/` into the CLI binary at build time.
+Homeboy embeds markdown files from `docs/` into the CLI binary at build time.
 
 In addition, `homeboy docs` reads documentation provided by installed extensions. For each installed extension, it looks under:
 
@@ -18,9 +18,9 @@ Embedded documentation keys are derived from markdown file paths:
 
 Examples:
 
-- `homeboy/docs/index.md` → key `index`
-- `homeboy/docs/changelog.md` → key `changelog`
-- `homeboy/docs/commands/docs.md` → key `commands/docs`
+- `docs/index.md` → key `index`
+- `docs/changelog.md` → key `changelog`
+- `docs/commands/docs.md` → key `commands/docs`
 
 ## `homeboy docs <topic...>` normalization
 

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -39,7 +39,7 @@ Related:
 
 - [Root command](../cli/homeboy-root-command.md)
 - [JSON output contract](../architecture/output-system.md) (global output envelope)
-- [Embedded docs](../architecture/embedded-docs/embedded-docs-topic-resolution.md)
+- [Embedded docs](../architecture/embedded-docs-topic-resolution.md)
 - [Schema Reference](../schemas/) - JSON configuration schemas (component, project, server, extension)
 - [Architecture](../architecture/) - System internals (API client, keychain, SSH, release pipeline, execution context)
 - [Developer Guide](../developer-guide/) - Contributing guides (architecture overview, config directory, error handling)

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -18,7 +18,7 @@ By default, after a successful upgrade, Homeboy restarts itself to use the new v
 - `--check`: Check for updates without installing. Returns version information without making changes.
 - `--force`: Force upgrade even if already at the latest version.
 - `--no-restart`: Skip automatic restart after upgrade. Useful for scripted environments.
-- `--method`: Override install method detection (homebrew|cargo|source|binary).
+- `--method`: Override install method detection (`homebrew|cargo|source|binary`).
 
 ## Installation Method Detection
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Homeboy is a config-driven automation engine for development and deployment auto
 - Config health checks: [cleanup](commands/cleanup.md)
 - Changes summary: [changes](commands/changes.md)
 - JSON output envelope: [JSON output contract](architecture/output-system.md)
-- Embedded docs behavior: [Embedded docs topic resolution](architecture/embedded-docs/embedded-docs-topic-resolution.md)
+- Embedded docs behavior: [Embedded docs topic resolution](architecture/embedded-docs-topic-resolution.md)
 - Changelog content: [Changelog](changelog.md)
 - Template variables: [Template variables reference](templates.md)
 
@@ -36,7 +36,7 @@ Internal system architecture and internals:
 - [SSH key management](architecture/ssh-key-management.md) - SSH key handling
 - [Release pipeline system](architecture/release-pipeline.md) - Local release orchestration
 - [Execution context](architecture/execution-context.md) - Runtime context for extensions
-- [Embedded docs](architecture/embedded-docs/embedded-docs-topic-resolution.md) - Documentation system internals
+- [Embedded docs](architecture/embedded-docs-topic-resolution.md) - Documentation system internals
 
 ## Developer Guide
 
@@ -78,7 +78,7 @@ Common paths:
 
 Notes:
 
-- Embedded CLI docs ship inside the binary (see [Embedded docs topic resolution](architecture/embedded-docs/embedded-docs-topic-resolution.md)).
+- Embedded CLI docs ship inside the binary (see [Embedded docs topic resolution](architecture/embedded-docs-topic-resolution.md)).
 - Extension docs load from each installed extension's `docs/` folder under the Homeboy config root: `~/.config/homeboy/extensions/<extension_id>/docs/` (same topic-key rules as core docs).
 - The CLI does not write documentation into `~/.config/homeboy/docs/`.
 


### PR DESCRIPTION
## Summary
- fix stale embedded-docs links in docs index and commands index
- update embedded docs architecture examples from `homeboy/docs/...` to current `docs/...` layout
- clarify `upgrade --method` option with code formatting for valid values

## Dogfooding
- ran `homeboy docs audit /root/.kimaki/projects/homeboy` before and after edits
- reduced broken references from 13 to 9 (remaining items are primarily changelog historical/example references)

## Why
Issue #433 flagged docs drift since the v0.55.0 baseline. This PR addresses immediate low-risk stale references and path updates that map directly to current repository layout.

Closes #433
