### PR TITLE
ci: pin homeboy-action to v1.1.1 across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v1.1.1
         with:
           source: '.'
           extension: rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         run: cargo test
 
       # Audit via homeboy-action (source build, auto-file issue on failure)
-      - uses: Extra-Chill/homeboy-action@feat/source-build
+      - uses: Extra-Chill/homeboy-action@v1.1.1
         with:
           source: '.'
           extension: rust


### PR DESCRIPTION
Updates all homeboy-action uses to v1.1.1 (includes fork-safe best-effort PR comment/review publishing).