### PR TITLE
feat(test/docs): support path-first dogfood workflows

### DIFF
--- a/src/commands/args.rs
+++ b/src/commands/args.rs
@@ -10,6 +10,7 @@ use clap::Args;
 use std::path::PathBuf;
 
 use homeboy::component::{self, Component};
+use homeboy::error::ErrorCode;
 
 // ============================================================================
 // ComponentArgs: --component + --path + resolve()
@@ -95,11 +96,23 @@ pub struct PositionalComponentArgs {
 impl PositionalComponentArgs {
     /// Load the component, applying path override if provided.
     pub fn load(&self) -> homeboy::Result<Component> {
-        let mut comp = component::load(&self.component)?;
         if let Some(ref path) = self.path {
-            comp.local_path = path.clone();
+            match component::load(&self.component) {
+                Ok(mut comp) => {
+                    comp.local_path = path.clone();
+                    Ok(comp)
+                }
+                Err(err) if matches!(err.code, ErrorCode::ComponentNotFound) => Ok(Component::new(
+                    self.component.clone(),
+                    path.clone(),
+                    String::new(),
+                    None,
+                )),
+                Err(err) => Err(err),
+            }
+        } else {
+            component::load(&self.component)
         }
-        Ok(comp)
     }
 
     /// Get the component ID.
@@ -116,6 +129,27 @@ impl PositionalComponentArgs {
             let expanded = shellexpand::tilde(&comp.local_path);
             Ok(PathBuf::from(expanded.as_ref()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_uses_path_when_component_missing() {
+        let args = PositionalComponentArgs {
+            component: "missing-component".to_string(),
+            path: Some("/tmp/homeboy-missing-component".to_string()),
+        };
+
+        let loaded = args
+            .load()
+            .expect("path-based synthetic component should load");
+
+        assert_eq!(loaded.id, "missing-component");
+        assert_eq!(loaded.local_path, "/tmp/homeboy-missing-component");
+        assert_eq!(loaded.remote_path, "");
     }
 }
 

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -28,6 +28,10 @@ pub enum DocsCommand {
         /// Component ID or direct filesystem path to audit
         component_id: String,
 
+        /// Override component local_path for this audit run
+        #[arg(long)]
+        path: Option<String>,
+
         /// Docs directory relative to component/project root (overrides config, default: docs)
         #[arg(long)]
         docs_dir: Option<String>,
@@ -243,7 +247,21 @@ pub fn run_markdown(args: DocsArgs) -> CmdResult<String> {
 /// JSON output mode (audit, map, generate subcommands)
 pub fn run(args: DocsArgs, _global: &super::GlobalArgs) -> CmdResult<DocsOutput> {
     match args.command {
-        Some(DocsCommand::Audit { component_id, docs_dir, baseline, ignore_baseline, features }) => run_audit(&component_id, docs_dir.as_deref(), features, baseline, ignore_baseline),
+        Some(DocsCommand::Audit {
+            component_id,
+            path,
+            docs_dir,
+            baseline,
+            ignore_baseline,
+            features,
+        }) => run_audit(
+            &component_id,
+            path.as_deref(),
+            docs_dir.as_deref(),
+            features,
+            baseline,
+            ignore_baseline,
+        ),
         Some(DocsCommand::Map { component_id, source_dirs, include_private, write, output_dir }) => run_map(&component_id, source_dirs, include_private, write, &output_dir),
         Some(DocsCommand::Generate { spec, json, from_audit, dry_run }) => {
             if let Some(ref audit_source) = from_audit {
@@ -1211,26 +1229,37 @@ fn collect_fingerprints_recursive(
 
 fn run_audit(
     component_id: &str,
+    path_override: Option<&str>,
     docs_dir: Option<&str>,
     features: bool,
     baseline: bool,
     ignore_baseline: bool,
 ) -> CmdResult<DocsOutput> {
-    // If the argument looks like a filesystem path, audit it directly
-    // without requiring component registration
-    let result = if std::path::Path::new(component_id).is_dir() {
-        docs_audit::audit_path(component_id, docs_dir, features)?
-    } else {
-        docs_audit::audit_component(component_id, docs_dir, features)?
-    };
-
-    // Resolve source path for baseline storage
-    let source_path = if std::path::Path::new(component_id).is_dir() {
-        std::path::PathBuf::from(component_id)
+    // Resolve effective source path with --path parity to `homeboy audit`
+    let (resolved_id, source_path) = if std::path::Path::new(component_id).is_dir() {
+        let effective = path_override.unwrap_or(component_id);
+        let path = std::path::PathBuf::from(effective);
+        let label = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        (label, path)
+    } else if let Some(path) = path_override {
+        (component_id.to_string(), std::path::PathBuf::from(path))
     } else {
         let comp = homeboy::component::load(component_id)?;
-        std::path::PathBuf::from(&comp.local_path)
+        (
+            component_id.to_string(),
+            std::path::PathBuf::from(&comp.local_path),
+        )
     };
+
+    let source_path_str = source_path.to_string_lossy().to_string();
+
+    // Audit directly by path so --path semantics are consistent
+    let mut result = docs_audit::audit_path(&source_path_str, docs_dir, features)?;
+    result.component_id = resolved_id;
 
     // --baseline: save current state
     if baseline {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -155,6 +155,12 @@ fn auto_detect_extension(component: &Component) -> Option<String> {
         return Some("wordpress".to_string());
     }
 
+    // Check for Cargo.toml in local_path (indicates Rust component)
+    let cargo_path = std::path::Path::new(expanded.as_ref()).join("Cargo.toml");
+    if cargo_path.exists() {
+        return Some("rust".to_string());
+    }
+
     None
 }
 

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -273,6 +273,19 @@ pub fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
                 "-h",
             ],
         ),
+        (
+            "docs",
+            "audit",
+            &[
+                "--path",
+                "--docs-dir",
+                "--baseline",
+                "--ignore-baseline",
+                "--features",
+                "--help",
+                "-h",
+            ],
+        ),
     ];
 
     // Find matching command pattern
@@ -457,6 +470,20 @@ mod tests {
             "/tmp/workspace".into(),
             "--setting".into(),
             "key=value".into(),
+        ];
+        let result = normalize_trailing_flags(args.clone());
+        assert_eq!(result, args); // No separator inserted
+    }
+
+    #[test]
+    fn test_docs_audit_allows_path_flag() {
+        let args = vec![
+            "homeboy".into(),
+            "docs".into(),
+            "audit".into(),
+            "homeboy".into(),
+            "--path".into(),
+            "/tmp/workspace/homeboy".into(),
         ];
         let result = normalize_trailing_flags(args.clone());
         assert_eq!(result, args); // No separator inserted


### PR DESCRIPTION
## Summary
- make `homeboy test` support path-first runs when `--path` is provided, even if the component ID is not pre-registered
- add Rust auto-detection in `homeboy test` (`Cargo.toml` => `rust`) so path-only workflows resolve test scripts consistently
- add `--path` support to `homeboy docs audit` and normalize docs audit flags in CLI trailing-arg handling

## Why
Dogfood/CI/worktree runs often operate on local checkouts that are not preconfigured components. This unblocks path-based execution and keeps command behavior consistent with `homeboy audit`.

## Validation
- `cargo test`
- `cargo run -- docs audit homeboy --path /var/lib/datamachine/workspace/homeboy --ignore-baseline`
- `cargo run -- test fake-component --path /var/lib/datamachine/workspace/homeboy --changed-since HEAD~1 -- --filter=test_docs_audit_allows_path_flag`

## Closes
- #488
- #491
- #483