### PR TITLE
feat(audit): add configurable layer ownership rules

### DIFF
--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -1,0 +1,38 @@
+# Audit Layer Ownership Rules
+
+Homeboy audit supports optional architecture/layer ownership rules to catch design-level drift that
+passes lint/static checks.
+
+## Rule file locations
+
+Use one of:
+
+- `.homeboy/audit-rules.json`
+- `homeboy.json` under `audit_rules`
+
+## Example
+
+```json
+{
+  "layer_rules": [
+    {
+      "name": "engine-owns-terminal-status",
+      "forbid": {
+        "glob": "inc/Core/Steps/**/*.php",
+        "patterns": ["JobStatus::", "datamachine_fail_job"]
+      },
+      "allow": {
+        "glob": "inc/Abilities/Engine/**/*.php"
+      }
+    }
+  ]
+}
+```
+
+## Finding output
+
+- `convention`: `layer_ownership`
+- `kind`: `layer_ownership_violation`
+- severity: warning
+
+These findings participate in baseline comparisons like any other audit finding.

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -41,6 +41,7 @@ The audit runs in 6 phases:
    - **4d: Near-duplication** — Structurally similar files with different identifiers
    - **4e: Dead code** — Unused params, unreferenced exports, orphaned internals
    - **4f: Test coverage gaps** — Missing test files, uncovered methods, orphaned tests (requires extension `test_mapping` config)
+   - **4h: Layer ownership** — Optional architecture/layer ownership rule violations (`layer_ownership_violation`)
 5. **Report** — Aggregate findings, compute alignment score
 6. **Cross-directory conventions** — Detect patterns shared by sibling subdirectories
 
@@ -61,6 +62,13 @@ homeboy audit my-component --ignore-baseline
 ```
 
 The baseline is saved in `homeboy.json` under `baselines.audit` inside the component's `local_path`.
+
+Layer ownership rule config is optional and read from either:
+
+- `.homeboy/audit-rules.json`
+- `homeboy.json` key: `audit_rules`
+
+See: `docs/commands/audit-rules.md`
 
 When a baseline exists, the audit exit code reflects drift:
 - `0`: No drift increase (same or improved)

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -116,6 +116,8 @@ pub enum DeviationKind {
     MissingTestMethod,
     /// Test file or test method has no corresponding source file/method.
     OrphanedTest,
+    /// File violates a configured architecture/layer ownership rule.
+    LayerOwnershipViolation,
 }
 
 // ============================================================================

--- a/src/core/code_audit/layer_ownership.rs
+++ b/src/core/code_audit/layer_ownership.rs
@@ -42,7 +42,7 @@ pub fn analyze_layer_ownership(root: &Path) -> Vec<Finding> {
         return Vec::new();
     };
 
-    let files = match super::walker::walk_source_files(root) {
+    let files = match walk_candidate_files(root) {
         Ok(v) => v,
         Err(_) => return Vec::new(),
     };
@@ -96,6 +96,54 @@ pub fn analyze_layer_ownership(root: &Path) -> Vec<Finding> {
     findings
 }
 
+fn walk_candidate_files(root: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
+    const SKIP_DIRS: &[&str] = &[
+        "node_modules",
+        "vendor",
+        ".git",
+        "build",
+        "dist",
+        "target",
+        ".svn",
+        ".hg",
+        "cache",
+        "tmp",
+    ];
+
+    fn recurse(
+        dir: &Path,
+        skip_dirs: &[&str],
+        files: &mut Vec<std::path::PathBuf>,
+    ) -> std::io::Result<()> {
+        if !dir.is_dir() {
+            return Ok(());
+        }
+
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_dir() {
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+                if !skip_dirs.contains(&name) {
+                    recurse(&path, skip_dirs, files)?;
+                }
+            } else {
+                files.push(path);
+            }
+        }
+
+        Ok(())
+    }
+
+    let mut files = Vec::new();
+    recurse(root, SKIP_DIRS, &mut files)?;
+    Ok(files)
+}
+
 fn load_rules_config(root: &Path) -> Option<AuditRulesConfig> {
     let rules_path = root.join(".homeboy").join("audit-rules.json");
     if let Ok(content) = std::fs::read_to_string(&rules_path) {
@@ -114,6 +162,28 @@ fn load_rules_config(root: &Path) -> Option<AuditRulesConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn walk_candidate_files_finds_non_extension_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let steps_dir = dir.path().join("inc/Core/Steps");
+        std::fs::create_dir_all(&steps_dir).unwrap();
+        std::fs::write(steps_dir.join("agent_ping.php"), "<?php\n").unwrap();
+        std::fs::write(steps_dir.join("README.txt"), "notes\n").unwrap();
+
+        let files = walk_candidate_files(dir.path()).unwrap();
+        let names: Vec<String> = files
+            .iter()
+            .filter_map(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(ToString::to_string)
+            })
+            .collect();
+
+        assert!(names.contains(&"agent_ping.php".to_string()));
+        assert!(names.contains(&"README.txt".to_string()));
+    }
 
     #[test]
     fn detects_violation_from_audit_rules_file() {

--- a/src/core/code_audit/layer_ownership.rs
+++ b/src/core/code_audit/layer_ownership.rs
@@ -37,7 +37,11 @@ pub struct LayerAllow {
     pub glob: String,
 }
 
-pub fn analyze_layer_ownership(root: &Path) -> Vec<Finding> {
+pub(super) fn run(root: &Path) -> Vec<Finding> {
+    analyze_layer_ownership(root)
+}
+
+fn analyze_layer_ownership(root: &Path) -> Vec<Finding> {
     let Some(config) = load_rules_config(root) else {
         return Vec::new();
     };
@@ -164,7 +168,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn walk_candidate_files_finds_non_extension_files() {
+    fn test_walk_candidate_files_finds_non_extension_files() {
         let dir = tempfile::tempdir().unwrap();
         let steps_dir = dir.path().join("inc/Core/Steps");
         std::fs::create_dir_all(&steps_dir).unwrap();
@@ -186,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn detects_violation_from_audit_rules_file() {
+    fn test_detects_violation_from_audit_rules_file() {
         let dir = tempfile::tempdir().unwrap();
         let homeboy_dir = dir.path().join(".homeboy");
         let steps_dir = dir.path().join("inc/Core/Steps");
@@ -223,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn supports_homeboy_json_audit_rules() {
+    fn test_supports_homeboy_json_audit_rules() {
         let dir = tempfile::tempdir().unwrap();
         let steps_dir = dir.path().join("inc/Core/Steps");
         std::fs::create_dir_all(&steps_dir).unwrap();
@@ -257,9 +261,52 @@ mod tests {
     }
 
     #[test]
-    fn no_config_means_no_findings() {
+    fn test_no_config_means_no_findings() {
         let dir = tempfile::tempdir().unwrap();
         let findings = analyze_layer_ownership(dir.path());
         assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = run(dir.path());
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_load_rules_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+              "audit_rules": {
+                "layer_rules": [
+                  {
+                    "name": "example-rule",
+                    "forbid": {
+                      "glob": "src/**/*.rs",
+                      "patterns": ["println!"]
+                    }
+                  }
+                ]
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let config = load_rules_config(dir.path()).expect("config should load");
+        assert_eq!(config.layer_rules.len(), 1);
+        assert_eq!(config.layer_rules[0].name, "example-rule");
+    }
+
+    #[test]
+    fn test_walk_candidate_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), "pub fn x() {}\n").unwrap();
+
+        let files = walk_candidate_files(dir.path()).expect("walk should succeed");
+        assert!(files.iter().any(|p| p.ends_with("src/lib.rs")));
     }
 }

--- a/src/core/code_audit/layer_ownership.rs
+++ b/src/core/code_audit/layer_ownership.rs
@@ -1,0 +1,195 @@
+//! Layer ownership rules for architecture-level audit constraints.
+//!
+//! Rules are optional and loaded from either:
+//! - `.homeboy/audit-rules.json`
+//! - `homeboy.json` under `audit_rules`
+
+use std::path::Path;
+
+use glob_match::glob_match;
+
+use super::conventions::DeviationKind;
+use super::findings::{Finding, Severity};
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct AuditRulesConfig {
+    #[serde(default)]
+    pub layer_rules: Vec<LayerRule>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct LayerRule {
+    pub name: String,
+    pub forbid: LayerForbid,
+    #[serde(default)]
+    pub allow: Option<LayerAllow>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct LayerForbid {
+    pub glob: String,
+    #[serde(default)]
+    pub patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct LayerAllow {
+    pub glob: String,
+}
+
+pub fn analyze_layer_ownership(root: &Path) -> Vec<Finding> {
+    let Some(config) = load_rules_config(root) else {
+        return Vec::new();
+    };
+
+    let files = match super::walker::walk_source_files(root) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut findings = Vec::new();
+
+    for file in files {
+        let relative = match file.strip_prefix(root) {
+            Ok(p) => p.to_string_lossy().to_string(),
+            Err(_) => continue,
+        };
+        let normalized = relative.replace('\\', "/");
+
+        for rule in &config.layer_rules {
+            if !glob_match(&rule.forbid.glob, &normalized) {
+                continue;
+            }
+
+            if let Some(allow) = &rule.allow {
+                if glob_match(&allow.glob, &normalized) {
+                    continue;
+                }
+            }
+
+            let Ok(content) = std::fs::read_to_string(&file) else {
+                continue;
+            };
+
+            for pattern in &rule.forbid.patterns {
+                if content.contains(pattern) {
+                    findings.push(Finding {
+                        convention: "layer_ownership".to_string(),
+                        severity: Severity::Warning,
+                        file: normalized.clone(),
+                        description: format!(
+                            "Rule '{}' violated: forbidden pattern '{}' matched",
+                            rule.name, pattern
+                        ),
+                        suggestion: format!(
+                            "Move this responsibility to the owning layer for rule '{}'",
+                            rule.name
+                        ),
+                        kind: DeviationKind::LayerOwnershipViolation,
+                    });
+                }
+            }
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn load_rules_config(root: &Path) -> Option<AuditRulesConfig> {
+    let rules_path = root.join(".homeboy").join("audit-rules.json");
+    if let Ok(content) = std::fs::read_to_string(&rules_path) {
+        if let Ok(cfg) = serde_json::from_str::<AuditRulesConfig>(&content) {
+            return Some(cfg);
+        }
+    }
+
+    let homeboy_json = root.join("homeboy.json");
+    let content = std::fs::read_to_string(homeboy_json).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let audit_rules = value.get("audit_rules")?.clone();
+    serde_json::from_value::<AuditRulesConfig>(audit_rules).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_violation_from_audit_rules_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let homeboy_dir = dir.path().join(".homeboy");
+        let steps_dir = dir.path().join("inc/Core/Steps");
+        std::fs::create_dir_all(&homeboy_dir).unwrap();
+        std::fs::create_dir_all(&steps_dir).unwrap();
+
+        std::fs::write(
+            homeboy_dir.join("audit-rules.json"),
+            r#"{
+              "layer_rules": [
+                {
+                  "name": "engine-owns-terminal-status",
+                  "forbid": {
+                    "glob": "inc/Core/Steps/**/*.php",
+                    "patterns": ["JobStatus::", "datamachine_fail_job"]
+                  },
+                  "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        std::fs::write(
+            steps_dir.join("agent_ping.php"),
+            "<?php\n$status = JobStatus::FAILED;\n",
+        )
+        .unwrap();
+
+        let findings = analyze_layer_ownership(dir.path());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].convention, "layer_ownership");
+        assert_eq!(findings[0].kind, DeviationKind::LayerOwnershipViolation);
+    }
+
+    #[test]
+    fn supports_homeboy_json_audit_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let steps_dir = dir.path().join("inc/Core/Steps");
+        std::fs::create_dir_all(&steps_dir).unwrap();
+
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+              "audit_rules": {
+                "layer_rules": [
+                  {
+                    "name": "engine-owns-terminal-status",
+                    "forbid": {
+                      "glob": "inc/Core/Steps/**/*.php",
+                      "patterns": ["datamachine_fail_job"]
+                    }
+                  }
+                ]
+              }
+            }"#,
+        )
+        .unwrap();
+
+        std::fs::write(
+            steps_dir.join("agent_ping.php"),
+            "<?php\ndatamachine_fail_job($job_id);\n",
+        )
+        .unwrap();
+
+        let findings = analyze_layer_ownership(dir.path());
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn no_config_means_no_findings() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = analyze_layer_ownership(dir.path());
+        assert!(findings.is_empty());
+    }
+}

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -32,6 +32,8 @@ pub(crate) mod test_helpers;
 
 use std::path::Path;
 
+use self::layer_ownership::run as run_layer_ownership;
+
 pub use checks::{CheckResult, CheckStatus};
 pub use conventions::{Convention, Deviation, DeviationKind, Language, Outlier};
 pub use findings::{Finding, Severity};
@@ -350,7 +352,7 @@ fn audit_internal(
     }
 
     // Phase 4h: Architecture/layer ownership rule checks (optional config)
-    let layer_findings = layer_ownership::analyze_layer_ownership(root);
+    let layer_findings = run_layer_ownership(root);
     if !layer_findings.is_empty() {
         log_status!(
             "audit",
@@ -520,7 +522,7 @@ mod tests {
         )
         .unwrap();
 
-        let findings = layer_ownership::analyze_layer_ownership(&dir);
+        let findings = layer_ownership::run(&dir);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].convention, "layer_ownership");
 

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -21,6 +21,7 @@ mod findings;
 pub mod fingerprint;
 pub mod fixer;
 pub(crate) mod import_matching;
+mod layer_ownership;
 mod signatures;
 mod structural;
 mod test_coverage;
@@ -348,6 +349,17 @@ fn audit_internal(
         }
     }
 
+    // Phase 4h: Architecture/layer ownership rule checks (optional config)
+    let layer_findings = layer_ownership::analyze_layer_ownership(root);
+    if !layer_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Layer ownership: {} finding(s) (architecture ownership violations)",
+            layer_findings.len()
+        );
+        all_findings.extend(layer_findings);
+    }
+
     // Phase 4g: Scope filtering — when auditing changed files only, remove
     // findings for files that weren't changed. Conventions are still discovered
     // from the full codebase so drift detection is accurate.
@@ -475,6 +487,42 @@ mod tests {
         assert_eq!(result.summary.files_scanned, 0);
         assert!(result.summary.alignment_score.is_none());
         assert!(result.conventions.is_empty());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_analyze_layer_ownership() {
+        let dir = std::env::temp_dir().join("homeboy_audit_layer_test");
+        let _ = fs::create_dir_all(dir.join(".homeboy"));
+        let _ = fs::create_dir_all(dir.join("inc/Core/Steps"));
+
+        fs::write(
+            dir.join(".homeboy/audit-rules.json"),
+            r#"{
+              "layer_rules": [
+                {
+                  "name": "engine-owns-terminal-status",
+                  "forbid": {
+                    "glob": "inc/Core/Steps/**/*.php",
+                    "patterns": ["JobStatus::"]
+                  },
+                  "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        fs::write(
+            dir.join("inc/Core/Steps/agent_ping.php"),
+            "<?php\n$status = JobStatus::FAILED;\n",
+        )
+        .unwrap();
+
+        let findings = layer_ownership::analyze_layer_ownership(&dir);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].convention, "layer_ownership");
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/tests/core/code_audit/layer_ownership_test.rs
+++ b/tests/core/code_audit/layer_ownership_test.rs
@@ -1,4 +1,13 @@
 use homeboy::code_audit::audit_path;
+use std::path::PathBuf;
+
+fn tmp_dir(name: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("homeboy-layer-ownership-{name}-{nanos}"))
+}
 
 #[test]
 fn test_analyze_layer_ownership() {
@@ -38,4 +47,11 @@ fn test_analyze_layer_ownership() {
                 .contains("engine-owns-terminal-status")
             && f.description.contains("JobStatus::")
     }));
+}
+
+#[test]
+fn test_tmp_dir() {
+    let one = tmp_dir("a");
+    let two = tmp_dir("b");
+    assert_ne!(one, two);
 }

--- a/tests/core/code_audit/layer_ownership_test.rs
+++ b/tests/core/code_audit/layer_ownership_test.rs
@@ -1,0 +1,41 @@
+use homeboy::code_audit::audit_path;
+
+#[test]
+fn test_analyze_layer_ownership() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join(".homeboy")).unwrap();
+    std::fs::create_dir_all(root.join("inc/Core/Steps")).unwrap();
+
+    std::fs::write(
+        root.join(".homeboy/audit-rules.json"),
+        r#"{
+          "layer_rules": [
+            {
+              "name": "engine-owns-terminal-status",
+              "forbid": {
+                "glob": "inc/Core/Steps/**/*.php",
+                "patterns": ["JobStatus::"]
+              },
+              "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
+            }
+          ]
+        }"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        root.join("inc/Core/Steps/agent_ping.php"),
+        "<?php\n$status = JobStatus::FAILED;\n",
+    )
+    .unwrap();
+
+    let result = audit_path(root.to_str().unwrap()).unwrap();
+    assert!(result.findings.iter().any(|f| {
+        f.convention == "layer_ownership"
+            && f.description
+                .contains("engine-owns-terminal-status")
+            && f.description.contains("JobStatus::")
+    }));
+}


### PR DESCRIPTION
## Summary
- add optional architecture/layer ownership checks to code audit via new `src/core/code_audit/layer_ownership.rs`
- support rule config from `.homeboy/audit-rules.json` or `homeboy.json` under `audit_rules`
- emit `layer_ownership` findings with kind `layer_ownership_violation` and include them in normal baseline/ratchet flows

## Why
Issue #482 asks audit to catch architecture regressions that pass static checks but violate ownership boundaries (for example, step-layer files owning engine-level status mapping logic).

## Rule shape
```json
{
  "layer_rules": [
    {
      "name": "engine-owns-terminal-status",
      "forbid": {
        "glob": "inc/Core/Steps/**/*.php",
        "patterns": ["JobStatus::", "datamachine_fail_job"]
      },
      "allow": {
        "glob": "inc/Abilities/Engine/**/*.php"
      }
    }
  ]
}
```

## Validation
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- targeted tests:
  - `detects_violation_from_audit_rules_file`
  - `supports_homeboy_json_audit_rules`
  - `no_config_means_no_findings`
  - `test_analyze_layer_ownership`

## Closes
- #482