### PR TITLE
ci: use homeboy-action v1 floating tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Extra-Chill/homeboy-action@v1.1.1
+      - uses: Extra-Chill/homeboy-action@v1
         with:
           source: '.'
           extension: rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         run: cargo test
 
       # Audit via homeboy-action (source build, auto-file issue on failure)
-      - uses: Extra-Chill/homeboy-action@v1.1.1
+      - uses: Extra-Chill/homeboy-action@v1
         with:
           source: '.'
           extension: rust


### PR DESCRIPTION
## Summary
- switch Homeboy CI workflow from Extra-Chill/homeboy-action@v1.1.1 to Extra-Chill/homeboy-action@v1
- switch Homeboy release pre-gate workflow from Extra-Chill/homeboy-action@v1.1.1 to Extra-Chill/homeboy-action@v1
- enables fleet-wide automatic pickup of future Homeboy Action updates without workflow edits

## Why
Extra-Chill/homeboy-action@v1 is force-updated to stable latest behavior for the major line, so pinning to patch tags blocks fleet rollout speed.