### PR TITLE
fix(refactor): add include/exclude targeting to rename command

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use homeboy::code_audit::{fixer, CodeAuditResult};
 use homeboy::component;
 use homeboy::extension;
-use homeboy::refactor::{self, AddResult, MoveResult, RenameScope, RenameSpec};
+use homeboy::refactor::{self, AddResult, MoveResult, RenameScope, RenameSpec, RenameTargeting};
 
 use super::args::{ComponentArgs, WriteModeArgs};
 use crate::commands::CmdResult;
@@ -34,6 +34,15 @@ enum RefactorCommand {
         /// Exact string matching (no boundary detection, no case variants)
         #[arg(long)]
         literal: bool,
+        /// Include only files matching this glob (repeatable)
+        #[arg(long = "files", value_name = "GLOB")]
+        files: Vec<String>,
+        /// Exclude files matching this glob (repeatable)
+        #[arg(long, value_name = "GLOB")]
+        exclude: Vec<String>,
+        /// Disable file/directory path renames (content edits only)
+        #[arg(long)]
+        no_file_renames: bool,
         #[command(flatten)]
         write_mode: WriteModeArgs,
     },
@@ -169,6 +178,9 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             component,
             scope,
             literal,
+            files,
+            exclude,
+            no_file_renames,
             write_mode,
         } => run_rename(
             &from,
@@ -177,6 +189,9 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             component.path.as_deref(),
             &scope,
             literal,
+            &files,
+            &exclude,
+            no_file_renames,
             write_mode.write,
         ),
 
@@ -379,6 +394,9 @@ fn run_rename(
     path: Option<&str>,
     scope: &str,
     literal: bool,
+    include_globs: &[String],
+    exclude_globs: &[String],
+    no_file_renames: bool,
     write: bool,
 ) -> CmdResult<RefactorOutput> {
     let scope = RenameScope::from_str(scope)?;
@@ -396,7 +414,12 @@ fn run_rename(
     } else {
         RenameSpec::new(from, to, scope.clone())
     };
-    let mut result = refactor::generate_renames(&spec, &root);
+    let targeting = RenameTargeting {
+        include_globs: include_globs.to_vec(),
+        exclude_globs: exclude_globs.to_vec(),
+        rename_files: !no_file_renames,
+    };
+    let mut result = refactor::generate_renames_with_targeting(&spec, &root, &targeting);
 
     // Print warnings to stderr before applying
     for warning in &result.warnings {

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -13,8 +13,9 @@ pub use add::{add_import, fixes_from_audit, AddResult};
 pub use decompose::{apply_plan_skeletons, build_plan, DecomposeGroup, DecomposePlan};
 pub use move_items::{move_items, ImportRewrite, ItemKind, MoveResult, MovedItem};
 pub use rename::{
-    apply_renames, find_references, generate_renames, CaseVariant, FileEdit, FileRename, Reference,
-    RenameResult, RenameScope, RenameSpec, RenameWarning,
+    apply_renames, find_references, find_references_with_targeting, generate_renames,
+    generate_renames_with_targeting, CaseVariant, FileEdit, FileRename, Reference, RenameResult,
+    RenameScope, RenameSpec, RenameTargeting, RenameWarning,
 };
 pub use transform::{
     ad_hoc_transform, apply_transforms, load_transform_set, TransformResult, TransformRule,

--- a/src/core/refactor/rename.rs
+++ b/src/core/refactor/rename.rs
@@ -8,11 +8,12 @@
 
 use crate::error::{Error, Result};
 use crate::utils::codebase_scan::{
-    self, discover_casing, find_boundary_matches, find_literal_matches, ExtensionFilter, ScanConfig,
+    self, find_boundary_matches, find_case_insensitive_matches, find_literal_matches,
+    ExtensionFilter, ScanConfig,
 };
 use serde::Serialize;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // ============================================================================
 // Types
@@ -63,6 +64,27 @@ pub struct RenameSpec {
     pub variants: Vec<CaseVariant>,
     /// When true, use exact string matching (no boundary detection).
     pub literal: bool,
+}
+
+/// Optional file-targeting controls for rename operations.
+#[derive(Debug, Clone)]
+pub struct RenameTargeting {
+    /// Include only files matching at least one glob. Empty = include all.
+    pub include_globs: Vec<String>,
+    /// Exclude files matching any glob.
+    pub exclude_globs: Vec<String>,
+    /// Whether file/directory renames should be generated/applied.
+    pub rename_files: bool,
+}
+
+impl Default for RenameTargeting {
+    fn default() -> Self {
+        Self {
+            include_globs: Vec::new(),
+            exclude_globs: Vec::new(),
+            rename_files: true,
+        }
+    }
 }
 
 impl RenameSpec {
@@ -429,8 +451,17 @@ fn scan_config_for_scope(scope: &RenameScope) -> ScanConfig {
 /// After the initial pass, discovers additional case variants that exist in the
 /// codebase but weren't generated (e.g., `WPAgent` when `WpAgent` was generated).
 pub fn find_references(spec: &RenameSpec, root: &Path) -> Vec<Reference> {
+    find_references_with_targeting(spec, root, &RenameTargeting::default())
+}
+
+/// Find references using optional include/exclude targeting controls.
+pub fn find_references_with_targeting(
+    spec: &RenameSpec,
+    root: &Path,
+    targeting: &RenameTargeting,
+) -> Vec<Reference> {
     let config = scan_config_for_scope(&spec.scope);
-    let files = codebase_scan::walk_files(root, &config);
+    let files = target_files(codebase_scan::walk_files(root, &config), root, targeting);
 
     // Build the working variant list — may be extended by discovery
     let mut all_variants = spec.variants.clone();
@@ -455,7 +486,7 @@ pub fn find_references(spec: &RenameSpec, root: &Path) -> Vec<Reference> {
 
             if !has_matches {
                 // No matches — discover what casing actually exists
-                let casings = discover_casing(root, &variant.from, &config);
+                let casings = discover_casing_in_files(&files, &variant.from, spec.literal);
                 for (actual_casing, _count) in &casings {
                     // Skip if it's the same as what we already have
                     if actual_casing == &variant.from {
@@ -530,15 +561,56 @@ pub fn find_references(spec: &RenameSpec, root: &Path) -> Vec<Reference> {
     references
 }
 
+fn discover_casing_in_files(
+    files: &[PathBuf],
+    pattern: &str,
+    literal: bool,
+) -> Vec<(String, usize)> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+
+    for file in files {
+        let Ok(content) = std::fs::read_to_string(file) else {
+            continue;
+        };
+
+        for line in content.lines() {
+            if literal {
+                for pos in find_literal_matches(line, pattern) {
+                    let matched = &line[pos..pos + pattern.len()];
+                    *counts.entry(matched.to_string()).or_insert(0) += 1;
+                }
+                continue;
+            }
+
+            for (_start, matched) in find_case_insensitive_matches(line, pattern) {
+                *counts.entry(matched).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let mut out: Vec<(String, usize)> = counts.into_iter().collect();
+    out.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    out
+}
+
 // ============================================================================
 // Rename generation
 // ============================================================================
 
 /// Generate file edits and file renames from found references.
 pub fn generate_renames(spec: &RenameSpec, root: &Path) -> RenameResult {
-    let references = find_references(spec, root);
+    generate_renames_with_targeting(spec, root, &RenameTargeting::default())
+}
+
+/// Generate renames using optional include/exclude targeting controls.
+pub fn generate_renames_with_targeting(
+    spec: &RenameSpec,
+    root: &Path,
+    targeting: &RenameTargeting,
+) -> RenameResult {
+    let references = find_references_with_targeting(spec, root, targeting);
     let config = scan_config_for_scope(&spec.scope);
-    let files = codebase_scan::walk_files(root, &config);
+    let files = target_files(codebase_scan::walk_files(root, &config), root, targeting);
 
     // Sort variants longest-first to prevent partial matches
     let mut sorted_variants = spec.variants.clone();
@@ -602,24 +674,26 @@ pub fn generate_renames(spec: &RenameSpec, root: &Path) -> RenameResult {
 
     // Generate file/directory renames
     let mut file_renames = Vec::new();
-    for file_path in &files {
-        let relative = file_path
-            .strip_prefix(root)
-            .unwrap_or(file_path)
-            .to_string_lossy()
-            .to_string();
+    if targeting.rename_files {
+        for file_path in &files {
+            let relative = file_path
+                .strip_prefix(root)
+                .unwrap_or(file_path)
+                .to_string_lossy()
+                .to_string();
 
-        let mut new_relative = relative.clone();
-        for variant in &sorted_variants {
-            // Replace in path segments (word-boundary aware in file names)
-            new_relative = new_relative.replace(&variant.from, &variant.to);
-        }
+            let mut new_relative = relative.clone();
+            for variant in &sorted_variants {
+                // Replace in path segments (word-boundary aware in file names)
+                new_relative = new_relative.replace(&variant.from, &variant.to);
+            }
 
-        if new_relative != relative {
-            file_renames.push(FileRename {
-                from: relative,
-                to: new_relative,
-            });
+            if new_relative != relative {
+                file_renames.push(FileRename {
+                    from: relative,
+                    to: new_relative,
+                });
+            }
         }
     }
 
@@ -642,6 +716,38 @@ pub fn generate_renames(spec: &RenameSpec, root: &Path) -> RenameResult {
         total_files,
         applied: false,
     }
+}
+
+fn target_files(files: Vec<PathBuf>, root: &Path, targeting: &RenameTargeting) -> Vec<PathBuf> {
+    files
+        .into_iter()
+        .filter(|file| {
+            let relative = file
+                .strip_prefix(root)
+                .unwrap_or(file)
+                .to_string_lossy()
+                .replace('\\', "/");
+
+            if !targeting.include_globs.is_empty()
+                && !targeting
+                    .include_globs
+                    .iter()
+                    .any(|glob| glob_match::glob_match(glob, &relative))
+            {
+                return false;
+            }
+
+            if targeting
+                .exclude_globs
+                .iter()
+                .any(|glob| glob_match::glob_match(glob, &relative))
+            {
+                return false;
+            }
+
+            true
+        })
+        .collect()
 }
 
 // ============================================================================
@@ -1710,6 +1816,95 @@ mod tests {
             content.contains("data-machine-agents"),
             "Should rename plural kebab: {}",
             content
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn include_glob_limits_edits_to_targeted_files() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_target_include_test");
+        let _ = std::fs::create_dir_all(dir.join("src"));
+        let _ = std::fs::create_dir_all(dir.join("tests"));
+
+        std::fs::write(dir.join("src/lib.rs"), "fn mark_item_processed() {}\n").unwrap();
+        std::fs::write(
+            dir.join("tests/lib_test.rs"),
+            "fn test_mark_item_processed() {}\n",
+        )
+        .unwrap();
+
+        let spec = RenameSpec::new(
+            "mark_item_processed",
+            "add_processed_item",
+            RenameScope::All,
+        );
+        let targeting = RenameTargeting {
+            include_globs: vec!["tests/**/*.rs".to_string()],
+            ..RenameTargeting::default()
+        };
+
+        let result = generate_renames_with_targeting(&spec, &dir, &targeting);
+
+        assert_eq!(result.edits.len(), 1, "Should only edit tests files");
+        assert_eq!(result.edits[0].file, "tests/lib_test.rs");
+        assert!(result.edits[0].new_content.contains("add_processed_item"));
+        assert!(!result.edits[0].new_content.contains("mark_item_processed"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn exclude_glob_omits_matching_files() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_target_exclude_test");
+        let _ = std::fs::create_dir_all(dir.join("src"));
+        let _ = std::fs::create_dir_all(dir.join("tests"));
+
+        std::fs::write(dir.join("src/lib.rs"), "fn mark_item_processed() {}\n").unwrap();
+        std::fs::write(
+            dir.join("tests/lib_test.rs"),
+            "fn test_mark_item_processed() {}\n",
+        )
+        .unwrap();
+
+        let spec = RenameSpec::new(
+            "mark_item_processed",
+            "add_processed_item",
+            RenameScope::All,
+        );
+        let targeting = RenameTargeting {
+            exclude_globs: vec!["src/**/*.rs".to_string()],
+            ..RenameTargeting::default()
+        };
+
+        let result = generate_renames_with_targeting(&spec, &dir, &targeting);
+
+        assert_eq!(result.edits.len(), 1, "Should skip excluded src files");
+        assert_eq!(result.edits[0].file, "tests/lib_test.rs");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn no_file_renames_suppresses_path_renames() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_no_file_rename_test");
+        let _ = std::fs::create_dir_all(&dir);
+        std::fs::write(dir.join("mark_item_processed_test.rs"), "fn ok() {}\n").unwrap();
+
+        let spec = RenameSpec::new(
+            "mark_item_processed",
+            "add_processed_item",
+            RenameScope::All,
+        );
+        let targeting = RenameTargeting {
+            rename_files: false,
+            ..RenameTargeting::default()
+        };
+
+        let result = generate_renames_with_targeting(&spec, &dir, &targeting);
+        assert!(
+            result.file_renames.is_empty(),
+            "File renames should be disabled when rename_files=false"
         );
 
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary
- add safe targeting controls to `homeboy refactor rename`: repeatable `--files` include globs, repeatable `--exclude` globs, and `--no-file-renames`
- route CLI rename execution through a new `RenameTargeting` model so scoped renames affect only selected files and can skip path renames entirely
- add focused tests for include filtering, exclude filtering, and no-file-rename mode to prevent broad unintended rewrites during automated test migrations

Closes #470.