### PR TITLE
fix(release): publish to crates.io again in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,15 +383,42 @@ jobs:
           done
           git push
 
+  publish-crates:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    if: ${{ (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) && secrets.CARGO_REGISTRY_TOKEN != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io
+        shell: bash
+        run: |
+          cargo publish --locked || {
+            if cargo search homeboy --limit 1 | grep -q '^homeboy = '; then
+              echo "Version already published on crates.io; skipping"
+              exit 0
+            fi
+            exit 1
+          }
+
   announce:
     needs:
       - plan
       - host
       - publish-homebrew-formula
+      - publish-crates
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-crates.result == 'skipped' || needs.publish-crates.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,7 +14,7 @@ formula = "homeboy"
 # A GitHub repo to push Homebrew formulas to
 tap = "Extra-Chill/homebrew-tap"
 # Publish jobs to run in CI
-publish-jobs = ["homebrew"]
+publish-jobs = ["homebrew", "cargo"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Allow manual CI edits

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -229,6 +229,9 @@ Publish steps are designed to be idempotent:
 - **GitHub releases**: If tag exists, assets are updated via `--clobber`
 - **crates.io**: If version already published, step skips gracefully
 
+GitHub release CI publishes to crates.io when the repository has a `CARGO_REGISTRY_TOKEN`
+secret configured.
+
 This allows safe retry after `partial_success` without manual cleanup.
 ```
 

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -370,8 +370,8 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
 #[cfg(test)]
 mod tests {
     use super::default_audit_exit_code;
-    use homeboy::code_audit::{AuditSummary, CodeAuditResult, Finding, Severity};
     use homeboy::code_audit::DeviationKind;
+    use homeboy::code_audit::{AuditSummary, CodeAuditResult, Finding, Severity};
 
     fn mk_result(outliers_found: usize, findings_len: usize) -> CodeAuditResult {
         CodeAuditResult {


### PR DESCRIPTION
## Summary
- restore crates.io publishing in release CI by adding a dedicated `publish-crates` job and wiring it into release completion gating
- update cargo-dist config so publish jobs include both `homebrew` and `cargo` instead of homebrew-only publishing
- document that release CI publishes to crates.io when `CARGO_REGISTRY_TOKEN` is configured and gracefully skips already-published versions

## Validation
- `cargo fmt --check`
- `cargo test -- --nocapture`
- `homeboy audit homeboy --changed-since origin/main`