### PR TITLE
fix(release): require changelog commit coverage

### DIFF
--- a/src/core/changelog/sections.rs
+++ b/src/core/changelog/sections.rs
@@ -233,6 +233,32 @@ pub fn count_unreleased_entries(content: &str, aliases: &[String]) -> usize {
         .count()
 }
 
+/// Extract bullet item text from the unreleased section.
+/// Returns normalized bullet content without the leading marker.
+pub fn get_unreleased_entries(content: &str, aliases: &[String]) -> Vec<String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let start = match find_next_section_start(&lines, aliases) {
+        Some(idx) => idx,
+        None => return vec![],
+    };
+
+    let end = find_section_end(&lines, start);
+
+    lines[start + 1..end]
+        .iter()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("- ") {
+                Some(rest.trim().to_string())
+            } else {
+                trimmed
+                    .strip_prefix("* ")
+                    .map(|rest| rest.trim().to_string())
+            }
+        })
+        .collect()
+}
+
 pub(super) fn ensure_next_section(content: &str, aliases: &[String]) -> Result<(String, bool)> {
     let lines: Vec<&str> = content.lines().collect();
     if find_next_section_start(&lines, aliases).is_some() {
@@ -974,5 +1000,15 @@ mod tests {
         let content = "# Changelog\n\n## Unreleased\n\n- Dash item\n* Asterisk item\n\n## 0.1.0\n";
         let aliases = vec!["Unreleased".to_string()];
         assert_eq!(count_unreleased_entries(content, &aliases), 2);
+    }
+
+    #[test]
+    fn get_unreleased_entries_extracts_bullet_text() {
+        let content = "# Changelog\n\n## Unreleased\n\n### Fixed\n\n- Dash item\n* Asterisk item\n\n## 0.1.0\n";
+        let aliases = vec!["Unreleased".to_string()];
+        assert_eq!(
+            get_unreleased_entries(content, &aliases),
+            vec!["Dash item".to_string(), "Asterisk item".to_string()]
+        );
     }
 }

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -519,15 +519,17 @@ fn validate_commits_vs_changelog(component: &Component) -> Result<()> {
         return Ok(());
     }
 
-    // Count unreleased changelog entries
+    // Read unreleased changelog entries
     let changelog_path = changelog::resolve_changelog_path(component)?;
     let changelog_content = crate::core::local_files::local().read(&changelog_path)?;
     let settings = changelog::resolve_effective_settings(Some(component));
-    let entry_count =
-        changelog::count_unreleased_entries(&changelog_content, &settings.next_section_aliases);
+    let unreleased_entries =
+        changelog::get_unreleased_entries(&changelog_content, &settings.next_section_aliases);
 
-    // If entries exist, validation passes
-    if entry_count > 0 {
+    let missing_commits = find_uncovered_commits(&commits, &unreleased_entries);
+
+    // If all relevant commits are represented, validation passes.
+    if missing_commits.is_empty() {
         return Ok(());
     }
 
@@ -547,9 +549,44 @@ fn validate_commits_vs_changelog(component: &Component) -> Result<()> {
         }
     }
 
-    // Auto-generate changelog entries from conventional commits
-    auto_generate_changelog_entries(component, &commits)?;
+    // Auto-generate changelog entries only for uncovered commits.
+    auto_generate_changelog_entries(component, &missing_commits)?;
     Ok(())
+}
+
+fn normalize_changelog_text(value: &str) -> String {
+    value
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn find_uncovered_commits<'a>(
+    commits: &'a [git::CommitInfo],
+    unreleased_entries: &[String],
+) -> Vec<git::CommitInfo> {
+    let normalized_entries: Vec<String> = unreleased_entries
+        .iter()
+        .map(|entry| normalize_changelog_text(entry))
+        .collect();
+
+    commits
+        .iter()
+        .filter(|commit| commit.category.to_changelog_entry_type().is_some())
+        .filter(|commit| {
+            let normalized_subject =
+                normalize_changelog_text(git::strip_conventional_prefix(&commit.subject));
+
+            !normalized_entries
+                .iter()
+                .any(|entry| !entry.is_empty() && entry.contains(&normalized_subject))
+        })
+        .cloned()
+        .collect()
 }
 
 /// Generate changelog entries from conventional commit messages.
@@ -605,6 +642,82 @@ fn auto_generate_changelog_entries(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_uncovered_commits, normalize_changelog_text};
+    use crate::git::{CommitCategory, CommitInfo};
+
+    fn commit(subject: &str, category: CommitCategory) -> CommitInfo {
+        CommitInfo {
+            hash: "abc1234".to_string(),
+            subject: subject.to_string(),
+            category,
+        }
+    }
+
+    #[test]
+    fn test_normalize_changelog_text() {
+        assert_eq!(
+            normalize_changelog_text(
+                "Fixed scoped audit exit codes to ignore unchanged legacy outliers"
+            ),
+            "fixed scoped audit exit codes to ignore unchanged legacy outliers"
+        );
+        assert_eq!(
+            normalize_changelog_text("fix(audit): use scoped findings for changed-since exit"),
+            "fix audit use scoped findings for changed since exit"
+        );
+    }
+
+    #[test]
+    fn test_find_uncovered_commits_ignores_covered_fix_commit() {
+        let commits = vec![commit(
+            "fix(audit): use scoped findings for changed-since exit",
+            CommitCategory::Fix,
+        )];
+        let unreleased = vec![
+            "use scoped findings for changed-since exit".to_string(),
+            "another manual note".to_string(),
+        ];
+
+        let uncovered = find_uncovered_commits(&commits, &unreleased);
+        assert!(uncovered.is_empty());
+    }
+
+    #[test]
+    fn test_find_uncovered_commits_requires_feature_coverage() {
+        let commits = vec![
+            commit(
+                "fix(audit): use scoped findings for changed-since exit",
+                CommitCategory::Fix,
+            ),
+            commit(
+                "feat(refactor): apply decompose plans with audit impact projection",
+                CommitCategory::Feature,
+            ),
+        ];
+        let unreleased = vec!["use scoped findings for changed-since exit".to_string()];
+
+        let uncovered = find_uncovered_commits(&commits, &unreleased);
+        assert_eq!(uncovered.len(), 1);
+        assert_eq!(
+            uncovered[0].subject,
+            "feat(refactor): apply decompose plans with audit impact projection"
+        );
+    }
+
+    #[test]
+    fn test_find_uncovered_commits_skips_docs_and_merge() {
+        let commits = vec![
+            commit("docs: update release notes", CommitCategory::Docs),
+            commit("Merge pull request #1 from branch", CommitCategory::Merge),
+        ];
+
+        let uncovered = find_uncovered_commits(&commits, &[]);
+        assert!(uncovered.is_empty());
+    }
 }
 
 /// Derive publish targets from extensions that have `release.publish` action.


### PR DESCRIPTION
## Summary
- replace the current \"any unreleased entry means good enough\" release check with commit-coverage validation against changelog bullets
- auto-generate changelog items only for uncovered changelog-relevant commits so manual entries and generated entries stay aligned
- add targeted tests for unreleased entry extraction and partial manual coverage cases

## Validation
- `cargo test find_uncovered_commits`
- `cargo test get_unreleased_entries_extracts_bullet_text`