### PR TITLE
fix(audit): reduce helper-file precision noise

### DIFF
--- a/src/core/code_audit/checks.rs
+++ b/src/core/code_audit/checks.rs
@@ -97,6 +97,7 @@ mod tests {
             conforming: vec!["a.rs".to_string(), "b.rs".to_string()],
             outliers: vec![Outlier {
                 file: "c.rs".to_string(),
+                noisy: false,
                 deviations: vec![Deviation {
                     kind: DeviationKind::MissingMethod,
                     description: "Missing method: run".to_string(),
@@ -126,6 +127,7 @@ mod tests {
             outliers: vec![
                 Outlier {
                     file: "b.rs".to_string(),
+                    noisy: false,
                     deviations: vec![Deviation {
                         kind: DeviationKind::MissingMethod,
                         description: "Missing".to_string(),
@@ -134,6 +136,7 @@ mod tests {
                 },
                 Outlier {
                     file: "c.rs".to_string(),
+                    noisy: false,
                     deviations: vec![Deviation {
                         kind: DeviationKind::MissingMethod,
                         description: "Missing".to_string(),

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use super::fingerprint::FileFingerprint;
 use super::import_matching::has_import;
+use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -65,6 +66,9 @@ pub struct Convention {
 pub struct Outlier {
     /// Relative file path.
     pub file: String,
+    /// Whether this outlier appears to be helper/utility drift rather than a real member.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub noisy: bool,
     /// What's missing or different.
     pub deviations: Vec<Deviation>,
 }
@@ -232,15 +236,49 @@ pub fn discover_conventions(
         .map(|(name, _)| name.clone())
         .collect();
 
+    let naming_suffix = detect_naming_suffix(
+        &fingerprints
+            .iter()
+            .filter_map(|fp| fp.type_name.clone())
+            .collect::<Vec<_>>(),
+    );
+
     // Classify files
     let mut conforming = Vec::new();
     let mut outliers = Vec::new();
 
     for fp in fingerprints {
+        let helper_like = naming_suffix.as_ref().is_some_and(|suffix| {
+            fp.type_name
+                .as_deref()
+                .is_some_and(|name| !suffix_matches(name, suffix))
+        });
+
         let mut deviations = Vec::new();
+
+        if helper_like {
+            let suffix = naming_suffix.as_deref().unwrap_or("member");
+            deviations.push(Deviation {
+                kind: DeviationKind::NamingMismatch,
+                description: format!(
+                    "Helper-like name does not match convention suffix '{}': {}",
+                    suffix,
+                    fp.type_name
+                        .clone()
+                        .unwrap_or_else(|| fp.relative_path.clone())
+                ),
+                suggestion: format!(
+                    "Treat this as a utility/helper or rename it to match the '{}' convention",
+                    suffix
+                ),
+            });
+        }
 
         // Check missing methods
         for expected in &expected_methods {
+            if helper_like {
+                continue;
+            }
             if !fp.methods.contains(expected) {
                 deviations.push(Deviation {
                     kind: DeviationKind::MissingMethod,
@@ -255,6 +293,9 @@ pub fn discover_conventions(
 
         // Check missing registrations
         for expected in &expected_registrations {
+            if helper_like {
+                continue;
+            }
             if !fp.registrations.contains(expected) {
                 deviations.push(Deviation {
                     kind: DeviationKind::MissingRegistration,
@@ -269,6 +310,9 @@ pub fn discover_conventions(
 
         // Check missing interfaces/traits
         for expected in &expected_interfaces {
+            if helper_like {
+                continue;
+            }
             if !fp.implements.contains(expected) {
                 deviations.push(Deviation {
                     kind: DeviationKind::MissingInterface,
@@ -327,6 +371,7 @@ pub fn discover_conventions(
         } else {
             outliers.push(Outlier {
                 file: fp.relative_path.clone(),
+                noisy: helper_like,
                 deviations,
             });
         }
@@ -529,6 +574,7 @@ pub fn check_signature_consistency(conventions: &mut [Convention], root: &Path) 
                 moved_files.push(file.clone());
                 conv.outliers.push(Outlier {
                     file: file.clone(),
+                    noisy: false,
                     deviations: devs,
                 });
             }
@@ -767,15 +813,97 @@ mod tests {
             .expected_interfaces
             .contains(&"AbilityInterface".to_string()));
 
-        // helpers.php should be an outlier due to missing interface
+        // helpers.php should be a noisy outlier due to naming mismatch
         assert_eq!(convention.outliers.len(), 1);
         assert_eq!(convention.outliers[0].file, "abilities/helpers.php");
-        assert!(convention.outliers[0].deviations.iter().any(|d| matches!(
-            d.kind,
-            DeviationKind::MissingInterface
-        ) && d
-            .description
-            .contains("AbilityInterface")));
+        assert!(
+            convention.outliers[0].noisy,
+            "Helper-like file should be marked noisy"
+        );
+        assert!(convention.outliers[0]
+            .deviations
+            .iter()
+            .any(|d| matches!(d.kind, DeviationKind::NamingMismatch)));
+    }
+
+    #[test]
+    fn helper_like_outlier_collapses_to_naming_mismatch() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "abilities/CreateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                registrations: vec![],
+                type_name: Some("CreateAbility".to_string()),
+                implements: vec![],
+                namespace: None,
+                imports: vec![],
+                content: String::new(),
+                method_hashes: std::collections::HashMap::new(),
+                structural_hashes: std::collections::HashMap::new(),
+                extends: None,
+                visibility: std::collections::HashMap::new(),
+                properties: vec![],
+                hooks: vec![],
+                unused_parameters: vec![],
+                dead_code_markers: vec![],
+                internal_calls: vec![],
+                public_api: vec![],
+            },
+            FileFingerprint {
+                relative_path: "abilities/UpdateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                registrations: vec![],
+                type_name: Some("UpdateAbility".to_string()),
+                implements: vec![],
+                namespace: None,
+                imports: vec![],
+                content: String::new(),
+                method_hashes: std::collections::HashMap::new(),
+                structural_hashes: std::collections::HashMap::new(),
+                extends: None,
+                visibility: std::collections::HashMap::new(),
+                properties: vec![],
+                hooks: vec![],
+                unused_parameters: vec![],
+                dead_code_markers: vec![],
+                internal_calls: vec![],
+                public_api: vec![],
+            },
+            FileFingerprint {
+                relative_path: "abilities/FlowHelpers.php".to_string(),
+                language: Language::Php,
+                methods: vec!["formatFlow".to_string()],
+                registrations: vec![],
+                type_name: Some("FlowHelpers".to_string()),
+                implements: vec![],
+                namespace: None,
+                imports: vec![],
+                content: String::new(),
+                method_hashes: std::collections::HashMap::new(),
+                structural_hashes: std::collections::HashMap::new(),
+                extends: None,
+                visibility: std::collections::HashMap::new(),
+                properties: vec![],
+                hooks: vec![],
+                unused_parameters: vec![],
+                dead_code_markers: vec![],
+                internal_calls: vec![],
+                public_api: vec![],
+            },
+        ];
+
+        let convention =
+            discover_conventions("Abilities", "abilities/*.php", &fingerprints).unwrap();
+
+        assert_eq!(convention.outliers.len(), 1);
+        assert!(convention.outliers[0].noisy);
+        assert_eq!(convention.outliers[0].deviations.len(), 1);
+        assert!(matches!(
+            convention.outliers[0].deviations[0].kind,
+            DeviationKind::NamingMismatch
+        ));
     }
 
     #[test]
@@ -966,6 +1094,7 @@ class AgentPing {
             ],
             outliers: vec![Outlier {
                 file: "steps/Bad.php".to_string(),
+                noisy: false,
                 deviations: vec![Deviation {
                     kind: DeviationKind::MissingMethod,
                     description: "Missing method: register".to_string(),

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -48,9 +48,16 @@ pub fn build_findings(results: &[CheckResult]) -> Vec<Finding> {
 
         for outlier in &result.outliers {
             for deviation in &outlier.deviations {
+                let severity =
+                    if outlier.noisy || matches!(deviation.kind, DeviationKind::NamingMismatch) {
+                        Severity::Info
+                    } else {
+                        severity.clone()
+                    };
+
                 findings.push(Finding {
                     convention: result.convention_name.clone(),
-                    severity: severity.clone(),
+                    severity,
                     file: outlier.file.clone(),
                     description: deviation.description.clone(),
                     suggestion: deviation.suggestion.clone(),
@@ -96,6 +103,7 @@ mod tests {
             total_count: 3,
             outliers: vec![Outlier {
                 file: "agent-ping.php".to_string(),
+                noisy: false,
                 deviations: vec![Deviation {
                     kind: DeviationKind::MissingMethod,
                     description: "Missing method: validate".to_string(),
@@ -124,6 +132,7 @@ mod tests {
             outliers: vec![
                 Outlier {
                     file: "a.php".to_string(),
+                    noisy: false,
                     deviations: vec![Deviation {
                         kind: DeviationKind::MissingMethod,
                         description: "Missing".to_string(),
@@ -132,6 +141,7 @@ mod tests {
                 },
                 Outlier {
                     file: "b.php".to_string(),
+                    noisy: false,
                     deviations: vec![Deviation {
                         kind: DeviationKind::MissingMethod,
                         description: "Missing".to_string(),
@@ -146,5 +156,31 @@ mod tests {
             findings.is_empty(),
             "Fragmented conventions should not produce findings"
         );
+    }
+
+    #[test]
+    fn naming_mismatch_is_downgraded_to_info() {
+        let results = vec![CheckResult {
+            convention_name: "Abilities".to_string(),
+            status: CheckStatus::Drift,
+            conforming_count: 2,
+            total_count: 3,
+            outliers: vec![Outlier {
+                file: "abilities/helpers.php".to_string(),
+                noisy: true,
+                deviations: vec![Deviation {
+                    kind: DeviationKind::NamingMismatch,
+                    description:
+                        "Helper-like name does not match convention suffix 'Ability': Helpers"
+                            .to_string(),
+                    suggestion: "Treat this as a utility/helper or rename it".to_string(),
+                }],
+            }],
+        }];
+
+        let findings = build_findings(&results);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Info);
+        assert_eq!(findings[0].kind, DeviationKind::NamingMismatch);
     }
 }

--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -14,6 +14,7 @@ use std::str::FromStr;
 use regex::Regex;
 
 use super::conventions::{DeviationKind, Language};
+use super::naming::{detect_naming_suffix, suffix_matches};
 use super::preflight;
 use super::test_mapping::source_to_test_path;
 use super::{duplication, CodeAuditResult};
@@ -1004,7 +1005,16 @@ pub fn generate_fixes(result: &CodeAuditResult, root: &Path) -> FixResult {
         }
 
         // Filter 2: Detect naming pattern from conforming files
-        let naming_suffix = detect_naming_suffix(&conv_report.conforming);
+        let conforming_names: Vec<String> = conv_report
+            .conforming
+            .iter()
+            .filter_map(|f| {
+                Path::new(f)
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().to_string())
+            })
+            .collect();
+        let naming_suffix = detect_naming_suffix(&conforming_names);
 
         // Build signature map from conforming files
         let sig_map = build_signature_map(&conv_report.conforming, root);
@@ -2123,134 +2133,6 @@ fn find_parsed_item_by_name<'a>(
     Some(first)
 }
 
-/// Detect the common naming suffix among conforming files.
-///
-/// If 4 out of 5 conforming files end in "Ability.php", returns Some("Ability").
-/// If no clear pattern, returns None.
-fn detect_naming_suffix(conforming: &[String]) -> Option<String> {
-    if conforming.len() < 2 {
-        return None;
-    }
-
-    // Extract file stems (without extension)
-    let stems: Vec<String> = conforming
-        .iter()
-        .filter_map(|f| {
-            Path::new(f)
-                .file_stem()
-                .map(|s| s.to_string_lossy().to_string())
-        })
-        .collect();
-
-    if stems.len() < 2 {
-        return None;
-    }
-
-    // Try common suffixes by checking the longest common suffix among all stems
-    // Start from the end of each stem and find the shared suffix
-    let mut suffix_counts: HashMap<String, usize> = HashMap::new();
-
-    for stem in &stems {
-        // Extract suffix: last uppercase-start word (e.g., "Ability" from "FlowAbility")
-        if let Some(suffix) = extract_class_suffix(stem) {
-            *suffix_counts.entry(suffix).or_insert(0) += 1;
-        }
-    }
-
-    // Find suffix that appears in ≥ 60% of conforming files
-    let threshold = (stems.len() as f32 * 0.6).ceil() as usize;
-    suffix_counts
-        .into_iter()
-        .filter(|(_, count)| *count >= threshold)
-        .max_by_key(|(_, count)| *count)
-        .map(|(suffix, _)| suffix)
-}
-
-/// Extract the class-style suffix from a PascalCase name.
-///
-/// "FlowAbility" → "Ability"
-/// "CreateFlowAbility" → "Ability"
-/// "FlowHelpers" → "Helpers"
-/// "step_a" → None (not PascalCase)
-fn extract_class_suffix(name: &str) -> Option<String> {
-    // Find the last uppercase letter that starts a "word"
-    let chars: Vec<char> = name.chars().collect();
-    let mut last_upper_start = None;
-
-    for (i, ch) in chars.iter().enumerate() {
-        if ch.is_uppercase() && i > 0 {
-            last_upper_start = Some(i);
-        }
-    }
-
-    last_upper_start.map(|i| chars[i..].iter().collect())
-}
-
-/// Check if a file stem matches a naming suffix, with plural tolerance.
-///
-/// "GitHubAbilities" matches suffix "Ability" (plural of Ability = Abilities)
-/// "CreateFlowAbility" matches suffix "Ability" (exact)
-/// "FlowHelpers" does NOT match suffix "Ability"
-fn suffix_matches(file_stem: &str, suffix: &str) -> bool {
-    if file_stem.ends_with(suffix) {
-        return true;
-    }
-
-    // Try plural forms: Ability/Abilities, Test/Tests, Provider/Providers
-    let plural_suffix = pluralize(suffix);
-    if file_stem.ends_with(&plural_suffix) {
-        return true;
-    }
-
-    // Try singular: if suffix is already plural, check if file matches singular
-    if let Some(singular) = singularize(suffix) {
-        if file_stem.ends_with(&singular) {
-            return true;
-        }
-    }
-
-    false
-}
-
-/// Simple English pluralization for class suffixes.
-fn pluralize(word: &str) -> String {
-    if word.ends_with('y')
-        && !word.ends_with("ey")
-        && !word.ends_with("ay")
-        && !word.ends_with("oy")
-    {
-        // Ability → Abilities, Entity → Entities
-        format!("{}ies", &word[..word.len() - 1])
-    } else if word.ends_with('s')
-        || word.ends_with('x')
-        || word.ends_with("ch")
-        || word.ends_with("sh")
-    {
-        format!("{}es", word)
-    } else {
-        format!("{}s", word)
-    }
-}
-
-/// Simple English singularization for class suffixes.
-fn singularize(word: &str) -> Option<String> {
-    if word.ends_with("ies") && word.len() > 3 {
-        // Abilities → Ability
-        Some(format!("{}y", &word[..word.len() - 3]))
-    } else if word.ends_with("ses")
-        || word.ends_with("xes")
-        || word.ends_with("ches")
-        || word.ends_with("shes")
-    {
-        Some(word[..word.len() - 2].to_string())
-    } else if word.ends_with('s') && !word.ends_with("ss") && word.len() > 1 {
-        // Tests → Test, Providers → Provider
-        Some(word[..word.len() - 1].to_string())
-    } else {
-        None
-    }
-}
-
 /// Generate a fallback signature when no conforming file has the method.
 fn generate_fallback_signature(method_name: &str, language: &Language) -> MethodSignature {
     let signature = match language {
@@ -2878,6 +2760,7 @@ fn insert_before_closing_brace(content: &str, code: &str, _language: &Language) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::code_audit::naming::{extract_class_suffix, pluralize, singularize};
 
     #[test]
     fn extract_php_signature_with_types() {
@@ -3107,6 +2990,7 @@ class BadAbility {
                 conforming: vec!["abilities/GoodAbility.php".to_string()],
                 outliers: vec![Outlier {
                     file: "abilities/BadAbility.php".to_string(),
+                    noisy: false,
                     deviations: vec![
                         Deviation {
                             kind: DeviationKind::MissingMethod,
@@ -3223,23 +3107,38 @@ class TestClass {
 
     #[test]
     fn detect_naming_suffix_from_ability_files() {
-        let conforming = vec![
-            "inc/Abilities/Flow/CreateFlowAbility.php".to_string(),
-            "inc/Abilities/Flow/UpdateFlowAbility.php".to_string(),
-            "inc/Abilities/Flow/DeleteFlowAbility.php".to_string(),
-            "inc/Abilities/Flow/GetFlowsAbility.php".to_string(),
-        ];
+        // Production code extracts file_stem() before calling detect_naming_suffix
+        let conforming: Vec<String> = vec![
+            "inc/Abilities/Flow/CreateFlowAbility.php",
+            "inc/Abilities/Flow/UpdateFlowAbility.php",
+            "inc/Abilities/Flow/DeleteFlowAbility.php",
+            "inc/Abilities/Flow/GetFlowsAbility.php",
+        ]
+        .into_iter()
+        .filter_map(|f| {
+            std::path::Path::new(f)
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+        })
+        .collect();
         let suffix = detect_naming_suffix(&conforming);
         assert_eq!(suffix, Some("Ability".to_string()));
     }
 
     #[test]
     fn detect_naming_suffix_returns_none_for_diverse_names() {
-        let conforming = vec![
-            "inc/Core/FileStorage.php".to_string(),
-            "inc/Core/AgentMemory.php".to_string(),
-            "inc/Core/Workspace.php".to_string(),
-        ];
+        let conforming: Vec<String> = vec![
+            "inc/Core/FileStorage.php",
+            "inc/Core/AgentMemory.php",
+            "inc/Core/Workspace.php",
+        ]
+        .into_iter()
+        .filter_map(|f| {
+            std::path::Path::new(f)
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+        })
+        .collect();
         let suffix = detect_naming_suffix(&conforming);
         // No common suffix — each has different ending
         assert!(suffix.is_none() || suffix == Some("Memory".to_string()).or(None));
@@ -3389,6 +3288,7 @@ class {} {{
                 ],
                 outliers: vec![Outlier {
                     file: "abilities/FlowHelpers.php".to_string(),
+                    noisy: true,
                     deviations: vec![
                         Deviation {
                             kind: DeviationKind::MissingMethod,
@@ -3462,6 +3362,7 @@ class {} {{
                 outliers: vec![
                     Outlier {
                         file: "jobs/JobsStatus.php".to_string(),
+                        noisy: false,
                         deviations: vec![Deviation {
                             kind: DeviationKind::MissingMethod,
                             description: "Missing method: get_job".to_string(),
@@ -3470,6 +3371,7 @@ class {} {{
                     },
                     Outlier {
                         file: "jobs/JobsOps.php".to_string(),
+                        noisy: false,
                         deviations: vec![Deviation {
                             kind: DeviationKind::MissingMethod,
                             description: "Missing method: get_job".to_string(),
@@ -3606,6 +3508,7 @@ pub struct TestOutput {}
                 conforming: vec!["commands/good.rs".to_string()],
                 outliers: vec![Outlier {
                     file: "commands/bad.rs".to_string(),
+                    noisy: false,
                     deviations: vec![Deviation {
                         kind: DeviationKind::MissingImport,
                         description: "Missing import: super::CmdResult".to_string(),

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -23,6 +23,7 @@ pub mod fingerprint;
 pub mod fixer;
 pub(crate) mod import_matching;
 mod layer_ownership;
+mod naming;
 pub(crate) mod preflight;
 mod signatures;
 mod structural;

--- a/src/core/code_audit/naming.rs
+++ b/src/core/code_audit/naming.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+
+/// Detect the common naming suffix among a set of class/type names.
+///
+/// If most names end in `Ability`, returns `Some("Ability")`.
+pub(crate) fn detect_naming_suffix(names: &[String]) -> Option<String> {
+    if names.len() < 2 {
+        return None;
+    }
+
+    let mut suffix_counts: HashMap<String, usize> = HashMap::new();
+
+    for name in names {
+        if let Some(suffix) = extract_class_suffix(name) {
+            *suffix_counts.entry(suffix).or_insert(0) += 1;
+        }
+    }
+
+    let threshold = (names.len() as f32 * 0.6).ceil() as usize;
+    suffix_counts
+        .into_iter()
+        .filter(|(_, count)| *count >= threshold)
+        .max_by_key(|(_, count)| *count)
+        .map(|(suffix, _)| suffix)
+}
+
+/// Extract the class-style suffix from a PascalCase name.
+///
+/// `FlowAbility` → `Ability`
+/// `FlowHelpers` → `Helpers`
+pub(crate) fn extract_class_suffix(name: &str) -> Option<String> {
+    let chars: Vec<char> = name.chars().collect();
+    let mut last_upper_start = None;
+
+    for (i, ch) in chars.iter().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            last_upper_start = Some(i);
+        }
+    }
+
+    last_upper_start.map(|i| chars[i..].iter().collect())
+}
+
+/// Check if a candidate name matches a detected suffix, with plural tolerance.
+pub(crate) fn suffix_matches(candidate: &str, suffix: &str) -> bool {
+    if candidate.ends_with(suffix) {
+        return true;
+    }
+
+    let plural_suffix = pluralize(suffix);
+    if candidate.ends_with(&plural_suffix) {
+        return true;
+    }
+
+    if let Some(singular) = singularize(suffix) {
+        if candidate.ends_with(&singular) {
+            return true;
+        }
+    }
+
+    false
+}
+
+pub(crate) fn pluralize(word: &str) -> String {
+    if word.ends_with('y')
+        && !word.ends_with("ey")
+        && !word.ends_with("ay")
+        && !word.ends_with("oy")
+    {
+        format!("{}ies", &word[..word.len() - 1])
+    } else if word.ends_with('s')
+        || word.ends_with('x')
+        || word.ends_with("ch")
+        || word.ends_with("sh")
+    {
+        format!("{}es", word)
+    } else {
+        format!("{}s", word)
+    }
+}
+
+pub(crate) fn singularize(word: &str) -> Option<String> {
+    if word.ends_with("ies") && word.len() > 3 {
+        Some(format!("{}y", &word[..word.len() - 3]))
+    } else if word.ends_with("ses")
+        || word.ends_with("xes")
+        || word.ends_with("ches")
+        || word.ends_with("shes")
+    {
+        Some(word[..word.len() - 2].to_string())
+    } else if word.ends_with('s') && !word.ends_with("ss") && word.len() > 1 {
+        Some(word[..word.len() - 1].to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_naming_suffix_majority() {
+        let names = vec![
+            "CreateFlowAbility".to_string(),
+            "UpdateFlowAbility".to_string(),
+            "DeleteFlowAbility".to_string(),
+            "FlowHelpers".to_string(),
+        ];
+
+        assert_eq!(detect_naming_suffix(&names), Some("Ability".to_string()));
+    }
+
+    #[test]
+    fn extract_class_suffix_pascal_case() {
+        assert_eq!(
+            extract_class_suffix("CreateFlowAbility"),
+            Some("Ability".to_string())
+        );
+        assert_eq!(
+            extract_class_suffix("FlowHelpers"),
+            Some("Helpers".to_string())
+        );
+        assert_eq!(
+            extract_class_suffix("BlockSanitizer"),
+            Some("Sanitizer".to_string())
+        );
+    }
+
+    #[test]
+    fn suffix_matches_exact() {
+        assert!(suffix_matches("CreateFlowAbility", "Ability"));
+        assert!(suffix_matches("WebhookTriggerAbility", "Ability"));
+        assert!(!suffix_matches("FlowHelpers", "Ability"));
+    }
+
+    #[test]
+    fn suffix_matches_plural_tolerance() {
+        assert!(suffix_matches("GitHubAbilities", "Ability"));
+        assert!(suffix_matches("FetchAbilities", "Ability"));
+        assert!(suffix_matches("CreateFlowAbility", "Abilities"));
+    }
+
+    #[test]
+    fn suffix_matches_simple_plural() {
+        assert!(suffix_matches("AllTests", "Test"));
+        assert!(suffix_matches("SingleTest", "Tests"));
+        assert!(suffix_matches("AuthProviders", "Provider"));
+    }
+
+    #[test]
+    fn suffix_matches_rejects_unrelated() {
+        assert!(!suffix_matches("FlowHelpers", "Ability"));
+        assert!(!suffix_matches("BlockSanitizer", "Ability"));
+        assert!(!suffix_matches("EngineHelpers", "Tool"));
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared code-audit naming helpers so convention discovery and autofix use the same suffix heuristics
- collapse helper-like convention outliers into a single `NamingMismatch` diagnostic instead of noisy missing-method/interface spam
- downgrade noisy helper-like naming mismatches to info while preserving existing helper-file autofix skips

## Testing
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test naming_mismatch_is_downgraded_to_info
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test helper_like_outlier_collapses_to_naming_mismatch
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test skip_helper_files_in_ability_directory
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test signature_check_detects_mismatch