### PR TITLE
feat(extension): expose core runner helper

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -12,6 +12,7 @@ use super::exec_context;
 use super::load_extension;
 use super::manifest::{ActionConfig, ActionType, ExtensionManifest, HttpMethod, RuntimeConfig};
 use super::runner_contract::RunnerStepFilter;
+use super::runtime_helper;
 use super::scope::ExtensionScope;
 
 /// Result of executing a extension.
@@ -624,6 +625,13 @@ pub fn build_exec_env(
         env.push((exec_context::EXTENSION_PATH.to_string(), mp.to_string()));
     }
 
+    if let Ok(helper_path) = runtime_helper::ensure_runner_steps_helper() {
+        env.push((
+            runtime_helper::RUNNER_STEPS_ENV.to_string(),
+            helper_path.to_string_lossy().to_string(),
+        ));
+    }
+
     if let Some(pbp) = project_base_path {
         env.push((exec_context::PROJECT_PATH.to_string(), pbp.to_string()));
     }
@@ -818,5 +826,39 @@ fn interpolate_payload_value(
             Ok(serde_json::Value::Object(result))
         }
         _ => Ok(value.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_exec_env_includes_runtime_runner_helper_path() {
+        let env = build_exec_env("rust", None, None, "{}", Some("/tmp/ext"), None, None, None);
+
+        let helper = env
+            .iter()
+            .find(|(k, _)| k == runtime_helper::RUNNER_STEPS_ENV)
+            .map(|(_, v)| v.clone());
+
+        assert!(helper.is_some());
+        assert!(helper.unwrap().ends_with("runner-steps.sh"));
+    }
+
+    #[test]
+    fn build_exec_env_preserves_step_filter_contract() {
+        let filter = RunnerStepFilter {
+            step: Some("lint,test".to_string()),
+            skip: Some("lint".to_string()),
+        };
+
+        let mut env = build_exec_env("rust", None, None, "{}", Some("/tmp/ext"), None, None, None);
+        env.extend(filter.to_env_pairs());
+
+        assert!(env
+            .iter()
+            .any(|(k, v)| k == "HOMEBOY_STEP" && v == "lint,test"));
+        assert!(env.iter().any(|(k, v)| k == "HOMEBOY_SKIP" && v == "lint"));
     }
 }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -3,6 +3,7 @@ mod lifecycle;
 mod manifest;
 mod runner;
 mod runner_contract;
+mod runtime_helper;
 mod scope;
 pub mod version;
 
@@ -11,6 +12,7 @@ pub mod exec_context;
 // Re-export runner types
 pub use runner::{ExtensionRunner, RunnerOutput};
 pub use runner_contract::RunnerStepFilter;
+pub use runtime_helper::RUNNER_STEPS_ENV;
 
 // Re-export manifest types
 pub use manifest::{

--- a/src/core/extension/runtime/runner-steps.sh
+++ b/src/core/extension/runtime/runner-steps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Shared step filtering contract for extension runner scripts.
+#
+# Reads HOMEBOY_STEP / HOMEBOY_SKIP as comma-separated step names and exposes
+# should_run_step <name> with the same semantics as Homeboy core's
+# RunnerStepFilter:
+# - HOMEBOY_STEP present => only listed steps run
+# - HOMEBOY_SKIP present => listed steps are skipped
+# - empty step name => runs by default
+
+should_run_step() {
+    local step_name="${1:-}"
+    step_name="$(printf '%s' "$step_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+    if [ -z "$step_name" ]; then
+        return 0
+    fi
+
+    if [ -n "${HOMEBOY_STEP:-}" ]; then
+        case ",${HOMEBOY_STEP}," in
+            *",${step_name},"*) ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    if [ -n "${HOMEBOY_SKIP:-}" ]; then
+        case ",${HOMEBOY_SKIP}," in
+            *",${step_name},"*) return 1 ;;
+        esac
+    fi
+
+    return 0
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -1,0 +1,41 @@
+use crate::error::{Error, Result};
+use crate::paths;
+use crate::utils::io;
+use std::fs;
+use std::path::PathBuf;
+
+const RUNNER_STEPS_SH: &str = include_str!("runtime/runner-steps.sh");
+
+pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
+
+pub fn ensure_runner_steps_helper() -> Result<PathBuf> {
+    let runtime_dir = paths::homeboy()?.join("runtime");
+    fs::create_dir_all(&runtime_dir).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("create homeboy runtime directory".to_string()),
+        )
+    })?;
+
+    let helper_path = runtime_dir.join("runner-steps.sh");
+    let current = fs::read_to_string(&helper_path).ok();
+
+    if current.as_deref() != Some(RUNNER_STEPS_SH) {
+        io::write_file_atomic(&helper_path, RUNNER_STEPS_SH, "write runtime runner helper")?;
+    }
+
+    Ok(helper_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_runner_steps_helper_writes_expected_contents() {
+        let path = ensure_runner_steps_helper().expect("helper should be written");
+        let contents = std::fs::read_to_string(&path).expect("helper should be readable");
+        assert_eq!(contents, RUNNER_STEPS_SH);
+        assert!(path.ends_with("runner-steps.sh"));
+    }
+}


### PR DESCRIPTION
## Summary
- embed a generic runner step helper in Homeboy core and materialize it under the Homeboy config runtime directory
- expose the helper path to extensions through `HOMEBOY_RUNTIME_RUNNER_STEPS` in the canonical extension execution environment
- add focused tests covering runtime helper emission and preservation of the existing `HOMEBOY_STEP` / `HOMEBOY_SKIP` contract

## Testing
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test core::extension::runtime_helper::tests::ensure_runner_steps_helper_writes_expected_contents -- --exact
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test core::extension::execution::tests::build_exec_env_includes_runtime_runner_helper_path -- --exact
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test core::extension::execution::tests::build_exec_env_preserves_step_filter_contract -- --exact
- source \"$HOME/.cargo/env\" && export TMPDIR=/root/tmp && cargo test core::extension::runner_contract::tests::test_should_run -- --exact