### PR TITLE
fix: load portable extensions for path-based commands

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,6 +1,9 @@
 {
   "auto_cleanup": false,
   "id": "homeboy",
+  "extensions": {
+    "rust": {}
+  },
   "baselines": {
     "audit": {
       "context_id": "homeboy",

--- a/src/commands/args.rs
+++ b/src/commands/args.rs
@@ -7,6 +7,7 @@
 //! See: https://github.com/Extra-Chill/homeboy/issues/436
 
 use clap::Args;
+use std::path::Path;
 use std::path::PathBuf;
 
 use homeboy::component::{self, Component};
@@ -102,12 +103,21 @@ impl PositionalComponentArgs {
                     comp.local_path = path.clone();
                     Ok(comp)
                 }
-                Err(err) if matches!(err.code, ErrorCode::ComponentNotFound) => Ok(Component::new(
-                    self.component.clone(),
-                    path.clone(),
-                    String::new(),
-                    None,
-                )),
+                Err(err) if matches!(err.code, ErrorCode::ComponentNotFound) => {
+                    if let Some(mut discovered) = component::discover_from_portable(Path::new(path))
+                    {
+                        discovered.id = self.component.clone();
+                        discovered.local_path = path.clone();
+                        Ok(discovered)
+                    } else {
+                        Ok(Component::new(
+                            self.component.clone(),
+                            path.clone(),
+                            String::new(),
+                            None,
+                        ))
+                    }
+                }
                 Err(err) => Err(err),
             }
         } else {
@@ -150,6 +160,43 @@ mod tests {
         assert_eq!(loaded.id, "missing-component");
         assert_eq!(loaded.local_path, "/tmp/homeboy-missing-component");
         assert_eq!(loaded.remote_path, "");
+    }
+
+    #[test]
+    fn load_prefers_portable_config_when_path_contains_homeboy_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+  "extensions": {
+    "wordpress": {}
+  },
+  "changelog_target": "docs/CHANGELOG.md"
+}"#,
+        )
+        .unwrap();
+
+        let args = PositionalComponentArgs {
+            component: "data-machine".to_string(),
+            path: Some(dir.path().to_string_lossy().to_string()),
+        };
+
+        let loaded = args
+            .load()
+            .expect("portable config should seed synthetic component");
+
+        assert_eq!(loaded.id, "data-machine");
+        assert_eq!(loaded.local_path, dir.path().to_string_lossy());
+        assert!(loaded.extensions.is_some());
+        assert!(loaded
+            .extensions
+            .as_ref()
+            .unwrap()
+            .contains_key("wordpress"));
+        assert_eq!(
+            loaded.changelog_target.as_deref(),
+            Some("docs/CHANGELOG.md")
+        );
     }
 }
 

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -1092,4 +1092,60 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[test]
+    fn discover_from_portable_with_baselines_and_extensions() {
+        // Mirrors data-machine's real homeboy.json — includes baselines (unknown field)
+        // and extensions (known field). This must not silently fail.
+        let dir = std::env::temp_dir().join("homeboy_test_baselines");
+        let _ = std::fs::create_dir_all(&dir);
+
+        let config = serde_json::json!({
+            "auto_cleanup": false,
+            "baselines": {
+                "lint": {
+                    "context_id": "data-machine",
+                    "created_at": "2026-03-06T04:47:29Z",
+                    "item_count": 0,
+                    "known_fingerprints": [],
+                    "metadata": {
+                        "findings_count": 0
+                    }
+                }
+            },
+            "changelog_target": "docs/CHANGELOG.md",
+            "extensions": {
+                "wordpress": {}
+            },
+            "id": "data-machine",
+            "version_targets": [
+                {"file": "data-machine.php", "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"}
+            ]
+        });
+        std::fs::write(dir.join("homeboy.json"), config.to_string()).unwrap();
+
+        let result = discover_from_portable(&dir);
+        assert!(
+            result.is_some(),
+            "Should discover component even with baselines field in homeboy.json"
+        );
+
+        let comp = result.unwrap();
+        // id derived from dir name, not portable
+        assert_eq!(comp.id, "homeboy-test-baselines");
+        assert_eq!(comp.local_path, dir.to_string_lossy());
+        // extensions must be present
+        assert!(
+            comp.extensions.is_some(),
+            "extensions should be set from portable config"
+        );
+        assert!(
+            comp.extensions.as_ref().unwrap().contains_key("wordpress"),
+            "wordpress extension should be present"
+        );
+        assert_eq!(comp.changelog_target.as_deref(), Some("docs/CHANGELOG.md"));
+        assert!(comp.version_targets.is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary

- `PositionalComponentArgs::load()` now calls `discover_from_portable()` as a fallback when the component is not registered, before falling back to a bare `Component::new()`
- Adds test coverage for `discover_from_portable` with `baselines` and `extensions` fields (mirrors data-machine's real `homeboy.json`)

Closes #518

## Context

In CI environments (homeboy-action), components are not registered in `~/.config/homeboy/components/`. The `--path` flag is meant to point at the repo checkout which contains `homeboy.json` (portable config). Before this fix, lint and test ignored the portable config and created bare components with `extensions: None`, causing immediate failure.

Audit was unaffected because it uses its own component resolution that doesn't go through `PositionalComponentArgs::load()`.