### PR TITLE
feat(ci): enable audit autofix on PRs and release pre-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -46,11 +46,15 @@ jobs:
   # chicken-and-egg problem of needing a released binary to audit itself.
   # Falls back to latest release binary if source build fails.
   # Runs independently of build job so PR comments are always posted.
+  # Autofix enabled: on audit failure, applies safe fixes and commits back to the PR.
   audit:
     name: Homeboy Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
@@ -58,3 +62,6 @@ jobs:
           extension: rust
           component: homeboy
           commands: audit
+          autofix: 'true'
+          autofix-commands: 'audit --fix --write'
+          autofix-max-commits: '2'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       - name: cargo test
         run: cargo test
 
-      # Audit via homeboy-action (source build, auto-file issue on failure)
+      # Audit via homeboy-action (source build, auto-file issue on failure, auto-fix PR on failure)
       - uses: Extra-Chill/homeboy-action@v1
         with:
           source: '.'
@@ -132,6 +132,9 @@ jobs:
           component: homeboy
           commands: audit
           auto-issue: 'true'
+          autofix: 'true'
+          autofix-open-pr: 'true'
+          autofix-commands: 'audit --fix --write'
 
   # Build and packages all the platform-specific things
   build-local-artifacts:


### PR DESCRIPTION
## Summary

Enables homeboy-action's autofix system on both CI pipelines. This is the first step toward the code factory loop where CI self-heals audit findings.

## PR workflow (`ci.yml`)
- `autofix: 'true'` — on audit failure, runs `audit --fix --write`, commits fixes back to the PR branch
- Max 2 autofix commits per branch (loop safety guard)
- Checks out PR head ref with full history for accurate baseline comparison
- Permissions upgraded to `contents: write` for push-back

## Release workflow (`release.yml`)
- `autofix-open-pr: 'true'` — on release audit failure, creates a `ci/autofix/*` branch with fixes and opens a PR
- Complements existing `auto-issue: 'true'` for non-fixable failures

## Safety guards (built into homeboy-action)
- Max commit count prevents infinite loops
- Bot actor detection prevents self-triggering
- Branch name guard prevents re-autofix on autofix branches
- Fork detection prevents push to upstream

## What this PR itself will test
This PR only changes workflow YAML files. The audit job will run but there's nothing to autofix (baseline is clean). The real test comes when the next PR introduces audit drift — the autofix system will attempt to resolve it automatically.