### PR TITLE
fix(audit): tighten visibility for 51 unreferenced exports

### DIFF
--- a/src/commands/args.rs
+++ b/src/commands/args.rs
@@ -233,7 +233,7 @@ pub struct WriteModeArgs {
 #[allow(dead_code)]
 impl WriteModeArgs {
     /// Whether this is a dry run (write was NOT specified).
-    pub fn is_dry_run(&self) -> bool {
+    pub(crate) fn is_dry_run(&self) -> bool {
         !self.write
     }
 }

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -130,7 +130,7 @@ pub fn run_markdown(args: ChangelogArgs) -> CmdResult<String> {
     }
 }
 
-pub fn is_show_markdown(args: &ChangelogArgs) -> bool {
+pub(crate) fn is_show_markdown(args: &ChangelogArgs) -> bool {
     matches!(args.command, Some(ChangelogCommand::Show { .. }))
         || (args.command.is_none() && args.show_self)
 }

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -221,7 +221,7 @@ pub struct GenerateFileSpec {
 // ============================================================================
 
 /// Check if this invocation should return JSON (audit, map, or generate subcommand)
-pub fn is_json_mode(args: &DocsArgs) -> bool {
+pub(crate) fn is_json_mode(args: &DocsArgs) -> bool {
     matches!(
         args.command,
         Some(DocsCommand::Audit { .. })

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -249,7 +249,7 @@ pub enum FileCommandOutput {
     Raw(String),
 }
 
-pub fn is_raw_read(args: &FileArgs) -> bool {
+pub(crate) fn is_raw_read(args: &FileArgs) -> bool {
     matches!(&args.command, FileCommand::Read { raw: true, .. })
 }
 

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -67,7 +67,7 @@ pub enum LogsCommand {
     },
 }
 
-pub fn is_interactive(args: &LogsArgs) -> bool {
+pub(crate) fn is_interactive(args: &LogsArgs) -> bool {
     matches!(&args.command, LogsCommand::Show { follow: true, .. })
 }
 

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -82,7 +82,7 @@ pub type NewFinding = generic::NewItem;
 /// Get the baseline file path for a source directory.
 ///
 /// Now points to `homeboy.json` instead of `.homeboy/audit-baseline.json`.
-pub fn baseline_path(source_path: &Path) -> std::path::PathBuf {
+pub(crate) fn baseline_path(source_path: &Path) -> std::path::PathBuf {
     let config = BaselineConfig::new(source_path, BASELINE_KEY);
     config.json_path()
 }

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -18,7 +18,7 @@ use super::fingerprint::FileFingerprint;
 /// 2. Dead code markers (from extension fingerprint data)
 /// 3. Unreferenced exports (cross-file: public API never imported/called)
 /// 4. Orphaned internals (single-file: private function never called internally)
-pub fn analyze_dead_code(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+pub(crate) fn analyze_dead_code(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let mut findings = Vec::new();
 
     // Build a global set of all internal calls and imports across all files

--- a/src/core/code_audit/discovery.rs
+++ b/src/core/code_audit/discovery.rs
@@ -21,7 +21,7 @@ pub struct DiscoveryResult {
 ///
 /// Returns groups of (group_name, glob_pattern, files) for directories that
 /// contain 2+ files of the same language, plus counts of walked vs fingerprinted files.
-pub fn auto_discover_groups(root: &Path) -> DiscoveryResult {
+pub(crate) fn auto_discover_groups(root: &Path) -> DiscoveryResult {
     let mut groups: Vec<(String, String, Vec<FileFingerprint>)> = Vec::new();
 
     // Walk directories, group files by parent dir + language
@@ -96,7 +96,7 @@ pub fn auto_discover_groups(root: &Path) -> DiscoveryResult {
 /// Example: if `inc/Abilities/Flow/` and `inc/Abilities/Job/` both expect
 /// `execute`, `registerAbility`, `__construct` — that's a cross-directory
 /// convention for `inc/Abilities/`.
-pub fn discover_cross_directory(
+pub(crate) fn discover_cross_directory(
     conventions: &[super::ConventionReport],
 ) -> Vec<super::DirectoryConvention> {
     // Group conventions by their parent directory (one level up from glob)

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -78,7 +78,7 @@ fn pick_canonical(locations: &[String]) -> String {
 /// Detect duplicate groups with canonical file selection.
 ///
 /// Returns structured data the fixer uses to remove duplicates.
-pub fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<DuplicateGroup> {
+pub(crate) fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<DuplicateGroup> {
     let hash_groups = build_groups(fingerprints);
     let mut groups = Vec::new();
 
@@ -111,7 +111,7 @@ pub fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<Duplica
 /// Groups functions by their body hash. When two or more files contain a
 /// function with the same name and the same normalized body hash, a finding
 /// is emitted for each location.
-pub fn detect_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+pub(crate) fn detect_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let hash_groups = build_groups(fingerprints);
     let mut findings = Vec::new();
 
@@ -258,7 +258,7 @@ fn count_body_lines(fp: &FileFingerprint, method_name: &str) -> usize {
 /// - Generic names (`run`, `list`, `show`, etc.)
 /// - Command/core delegation pairs (command module ↔ core module)
 /// - Trivial functions (< 3 body lines)
-pub fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let structural_groups = build_structural_groups(fingerprints);
     let exact_groups = build_groups(fingerprints);
 
@@ -377,7 +377,7 @@ const MIN_INTRA_BLOCK_LINES: usize = 5;
 /// lines. When the same window hash appears at two non-overlapping positions
 /// within one method, it means a block of code was copy-pasted (merge
 /// artifacts, copy-paste errors, etc.).
-pub fn detect_intra_method_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+pub(crate) fn detect_intra_method_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let mut findings = Vec::new();
 
     for fp in fingerprints {

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -26,7 +26,7 @@ use crate::extension::TestMappingConfig;
 /// `root` is the component root directory (for resolving test file existence).
 /// `fingerprints` are all fingerprinted source files from the audit pipeline.
 /// `config` is the extension-provided test mapping convention.
-pub fn analyze_test_coverage(
+pub(crate) fn analyze_test_coverage(
     root: &Path,
     fingerprints: &[&FileFingerprint],
     config: &TestMappingConfig,

--- a/src/core/code_audit/walker.rs
+++ b/src/core/code_audit/walker.rs
@@ -68,7 +68,7 @@ const COMMON_SOURCE_EXTENSIONS: &[&str] = &[
 
 /// Count source files that exist in the tree but aren't claimed by any extension.
 /// Used to warn when no extension provides fingerprinting for the dominant language.
-pub fn count_unclaimed_source_files(root: &Path) -> usize {
+pub(crate) fn count_unclaimed_source_files(root: &Path) -> usize {
     let skip_dirs = [
         "node_modules",
         "vendor",

--- a/src/core/docs_audit/tasks.rs
+++ b/src/core/docs_audit/tasks.rs
@@ -42,7 +42,7 @@ pub struct AuditTask {
 }
 
 /// Build an actionable task from a claim and its verification result.
-pub fn build_task(claim: Claim, result: VerifyResult) -> AuditTask {
+pub(crate) fn build_task(claim: Claim, result: VerifyResult) -> AuditTask {
     let (status, action) = match result {
         VerifyResult::Verified => (AuditTaskStatus::Verified, None),
         VerifyResult::Broken { suggestion } => (AuditTaskStatus::Broken, suggestion),

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -116,7 +116,7 @@ pub struct BaselineInfo {
 
 /// Detect baseline for a path (public wrapper).
 /// For version-aware baseline detection, use detect_baseline_with_version().
-pub fn detect_baseline_for_path(path: &str) -> Result<BaselineInfo> {
+pub(crate) fn detect_baseline_for_path(path: &str) -> Result<BaselineInfo> {
     detect_baseline_with_version(path, None)
 }
 
@@ -487,7 +487,7 @@ pub fn commit(
 }
 
 /// Like [`commit`] but with an explicit path override for git operations.
-pub fn commit_at(
+pub(crate) fn commit_at(
     component_id: Option<&str>,
     message: Option<&str>,
     options: CommitOptions,
@@ -770,7 +770,7 @@ pub fn tag(
 }
 
 /// Like [`tag`] but with an explicit path override for git operations.
-pub fn tag_at(
+pub(crate) fn tag_at(
     component_id: Option<&str>,
     tag_name: Option<&str>,
     message: Option<&str>,

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -41,7 +41,7 @@ pub fn is_workdir_clean(path: &Path) -> bool {
 
 /// Get the root directory of a git repository containing the given path.
 /// Returns None if the path is not within a git repository.
-pub fn get_git_root(path: &str) -> Option<String> {
+pub(crate) fn get_git_root(path: &str) -> Option<String> {
     command::run_in_optional(path, "git", &["rev-parse", "--show-toplevel"])
 }
 

--- a/src/core/hooks.rs
+++ b/src/core/hooks.rs
@@ -146,7 +146,7 @@ pub fn run_commands(
 /// (using `{{key}}` syntax), then executes each command on the remote server.
 /// Uses the same resolution order as `run_hooks` (extension hooks first, then
 /// component hooks).
-pub fn run_hooks_remote(
+pub(crate) fn run_hooks_remote(
     ssh_client: &SshClient,
     component: &Component,
     event: &str,
@@ -165,7 +165,7 @@ pub fn run_hooks_remote(
 ///
 /// This is the low-level remote executor. Use `run_hooks_remote` for the full
 /// resolve+expand+execute flow.
-pub fn run_commands_remote(
+pub(crate) fn run_commands_remote(
     ssh_client: &SshClient,
     commands: &[String],
     event: &str,

--- a/src/core/test_scaffold.rs
+++ b/src/core/test_scaffold.rs
@@ -188,7 +188,7 @@ fn passes_scaffold_quality_gate(test_names: &[String]) -> bool {
 // ============================================================================
 
 /// Extract classes and their public methods from a PHP source file.
-pub fn extract_php(content: &str) -> Vec<ExtractedClass> {
+pub(crate) fn extract_php(content: &str) -> Vec<ExtractedClass> {
     let mut classes = Vec::new();
 
     // Match namespace
@@ -301,7 +301,7 @@ fn extract_php_functions(content: &str) -> Vec<ExtractedMethod> {
 }
 
 /// Extract public functions/methods from a Rust source file.
-pub fn extract_rust(content: &str) -> Vec<ExtractedClass> {
+pub(crate) fn extract_rust(content: &str) -> Vec<ExtractedClass> {
     let mut classes = Vec::new();
 
     // Match struct/enum/trait with impl blocks
@@ -497,7 +497,7 @@ pub fn test_file_path(source_path: &Path, root: &Path) -> PathBuf {
 }
 
 /// Generate PHP test file content.
-pub fn generate_php_test(classes: &[ExtractedClass], config: &ScaffoldConfig) -> String {
+pub(crate) fn generate_php_test(classes: &[ExtractedClass], config: &ScaffoldConfig) -> String {
     let mut out = String::new();
     let mut emitted = HashSet::new();
     out.push_str("<?php\n");

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -21,11 +21,11 @@ pub fn parse_version(content: &str, pattern: &str) -> Option<String> {
 
 /// Parse all versions from content using regex pattern.
 /// Content is trimmed to handle trailing newlines in VERSION files.
-pub fn parse_versions(content: &str, pattern: &str) -> Option<Vec<String>> {
+pub(crate) fn parse_versions(content: &str, pattern: &str) -> Option<Vec<String>> {
     parser::extract_all(content, pattern)
 }
 
-pub fn replace_versions(
+pub(crate) fn replace_versions(
     content: &str,
     pattern: &str,
     new_version: &str,
@@ -80,7 +80,7 @@ pub fn increment_version(version: &str, bump_type: &str) -> Option<String> {
 
 /// Update version in a file, handling both JSON and text-based version files.
 /// Returns the number of replacements made.
-pub fn update_version_in_file(
+pub(crate) fn update_version_in_file(
     path: &str,
     pattern: &str,
     old_version: &str,
@@ -167,7 +167,10 @@ pub fn get_component_version(component: &Component) -> Option<String> {
 
 /// Read version from a local file for a component's version target.
 /// Returns None if file doesn't exist or version can't be parsed.
-pub fn read_local_version(local_path: &str, version_target: &VersionTarget) -> Option<String> {
+pub(crate) fn read_local_version(
+    local_path: &str,
+    version_target: &VersionTarget,
+) -> Option<String> {
     let path = resolve_version_file_path(local_path, &version_target.file);
     let content = local_files::local().read(Path::new(&path)).ok()?;
 
@@ -370,7 +373,7 @@ pub fn validate_changelog_for_bump(
 /// Validate and finalize changelog for a version operation.
 /// Ensures changelog is in sync with current version and has valid unreleased content.
 /// Finalizes the next section to the new version.
-pub fn validate_and_finalize_changelog(
+pub(crate) fn validate_and_finalize_changelog(
     component: &Component,
     current_version: &str,
     new_version: &str,
@@ -621,7 +624,7 @@ pub struct SetResult {
 }
 
 /// Set a component's version directly (without incrementing).
-pub fn set_component_version(component: &Component, new_version: &str) -> Result<SetResult> {
+pub(crate) fn set_component_version(component: &Component, new_version: &str) -> Result<SetResult> {
     // Validate local_path is absolute and exists before any file operations
     component::validate_local_path(component)?;
 
@@ -760,7 +763,7 @@ pub fn set_component_version(component: &Component, new_version: &str) -> Result
 
 /// Bump a component's version and finalize changelog.
 /// bump_type: "patch", "minor", or "major"
-pub fn bump_component_version(component: &Component, bump_type: &str) -> Result<BumpResult> {
+pub(crate) fn bump_component_version(component: &Component, bump_type: &str) -> Result<BumpResult> {
     // Validate local_path is absolute and exists before any file operations
     component::validate_local_path(component)?;
 

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -6,7 +6,7 @@
 /// Normalize version bump arguments to support --patch/--minor/--major syntax.
 /// Converts `version bump <component> --patch` to `version bump <component> -- patch`.
 /// The bump type must appear last (after `--`) so other flags like `--dry-run` are parsed correctly.
-pub fn normalize_version_bump(args: Vec<String>) -> Vec<String> {
+pub(crate) fn normalize_version_bump(args: Vec<String>) -> Vec<String> {
     let is_version_bump = args.len() >= 3
         && args.get(1).map(|s| s == "version").unwrap_or(false)
         && args.get(2).map(|s| s == "bump").unwrap_or(false);
@@ -38,7 +38,7 @@ pub fn normalize_version_bump(args: Vec<String>) -> Vec<String> {
 /// Normalize version command arguments.
 /// Converts `homeboy version <component_id>` to `homeboy version show <component_id>`
 /// when the argument is not a recognized subcommand (show, set, bump, edit, merge).
-pub fn normalize_version_show(args: Vec<String>) -> Vec<String> {
+pub(crate) fn normalize_version_show(args: Vec<String>) -> Vec<String> {
     if args.len() < 3 {
         return args;
     }
@@ -70,7 +70,7 @@ pub fn normalize_version_show(args: Vec<String>) -> Vec<String> {
 
 /// Normalize version --bump flag to subcommand form.
 /// Converts `version <component> --bump <type>` to `version bump <component> <type>`.
-pub fn normalize_version_bump_flag(args: Vec<String>) -> Vec<String> {
+pub(crate) fn normalize_version_bump_flag(args: Vec<String>) -> Vec<String> {
     // Must have: homeboy version <something> --bump <type>
     if args.len() < 5 {
         return args;
@@ -127,7 +127,7 @@ pub fn normalize_version_bump_flag(args: Vec<String>) -> Vec<String> {
 
 /// Normalize changelog add --component flag to positional form.
 /// Converts `changelog add --component <value>` to `changelog add <value>`.
-pub fn normalize_changelog_component(args: Vec<String>) -> Vec<String> {
+pub(crate) fn normalize_changelog_component(args: Vec<String>) -> Vec<String> {
     let is_changelog_add = args.len() >= 4
         && args.get(1).map(|s| s == "changelog").unwrap_or(false)
         && args.get(2).map(|s| s == "add").unwrap_or(false);
@@ -175,7 +175,7 @@ pub fn normalize_changelog_component(args: Vec<String>) -> Vec<String> {
 /// Both styles work identically:
 ///   homeboy component set my-plugin --field value
 ///   homeboy component set my-plugin -- --field value
-pub fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
+pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
     // Define commands and their known flags
     let commands: &[(&str, &str, &[&str])] = &[
         // (command, subcommand, known_flags)

--- a/src/utils/base_path.rs
+++ b/src/utils/base_path.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{Error, Result};
 
-pub fn resolve_optional_base_path(base_path: Option<&str>) -> Option<&str> {
+pub(crate) fn resolve_optional_base_path(base_path: Option<&str>) -> Option<&str> {
     base_path.and_then(|value| (!value.trim().is_empty()).then_some(value.trim()))
 }
 
@@ -33,7 +33,7 @@ pub fn join_remote_path(base_path: Option<&str>, path: &str) -> Result<String> {
     }
 }
 
-pub fn join_remote_child(base_path: Option<&str>, dir: &str, child: &str) -> Result<String> {
+pub(crate) fn join_remote_child(base_path: Option<&str>, dir: &str, child: &str) -> Result<String> {
     let dir_path = join_remote_path(base_path, dir)?;
     let child = child.trim();
 

--- a/src/utils/grammar.rs
+++ b/src/utils/grammar.rs
@@ -219,22 +219,22 @@ impl StructuralContext {
     }
 
     /// Whether we're inside a block with the given label.
-    pub fn is_inside(&self, label: &str) -> bool {
+    pub(crate) fn is_inside(&self, label: &str) -> bool {
         self.block_stack.iter().any(|(l, _)| l == label)
     }
 
     /// The label of the innermost block, if any.
-    pub fn current_block_label(&self) -> Option<&str> {
+    pub(crate) fn current_block_label(&self) -> Option<&str> {
         self.block_stack.last().map(|(l, _)| l.as_str())
     }
 
     /// Push a labeled block at the current depth.
-    pub fn push_block(&mut self, label: String) {
+    pub(crate) fn push_block(&mut self, label: String) {
         self.block_stack.push((label, self.depth));
     }
 
     /// Pop blocks that have been exited (depth dropped below entry depth).
-    pub fn pop_exited_blocks(&mut self) {
+    pub(crate) fn pop_exited_blocks(&mut self) {
         while let Some((_, entry_depth)) = self.block_stack.last() {
             if self.depth <= *entry_depth {
                 self.block_stack.pop();
@@ -272,7 +272,7 @@ pub struct ContextualLine<'a> {
 /// This is the core primitive — it walks the file line-by-line, tracking
 /// brace depth and whether we're inside comments or strings. Consumers
 /// can then filter lines by depth, region, etc.
-pub fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<ContextualLine<'a>> {
+pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<ContextualLine<'a>> {
     let mut ctx = StructuralContext::new();
     let mut result = Vec::new();
     let mut in_block_comment = false;
@@ -488,7 +488,7 @@ pub fn extract(content: &str, grammar: &Grammar) -> Vec<Symbol> {
 }
 
 /// Extract symbols of a specific concept only.
-pub fn extract_concept(content: &str, grammar: &Grammar, concept: &str) -> Vec<Symbol> {
+pub(crate) fn extract_concept(content: &str, grammar: &Grammar, concept: &str) -> Vec<Symbol> {
     extract(content, grammar)
         .into_iter()
         .filter(|s| s.concept == concept)
@@ -526,7 +526,7 @@ pub fn load_grammar_json(path: &Path) -> Result<Grammar> {
 // ============================================================================
 
 /// Get all method/function names from extracted symbols.
-pub fn method_names(symbols: &[Symbol]) -> Vec<String> {
+pub(crate) fn method_names(symbols: &[Symbol]) -> Vec<String> {
     symbols
         .iter()
         .filter(|s| {
@@ -537,7 +537,7 @@ pub fn method_names(symbols: &[Symbol]) -> Vec<String> {
 }
 
 /// Get all class/struct/trait names from extracted symbols.
-pub fn type_names(symbols: &[Symbol]) -> Vec<String> {
+pub(crate) fn type_names(symbols: &[Symbol]) -> Vec<String> {
     symbols
         .iter()
         .filter(|s| {
@@ -553,7 +553,7 @@ pub fn type_names(symbols: &[Symbol]) -> Vec<String> {
 }
 
 /// Get all import paths from extracted symbols.
-pub fn import_paths(symbols: &[Symbol]) -> Vec<String> {
+pub(crate) fn import_paths(symbols: &[Symbol]) -> Vec<String> {
     symbols
         .iter()
         .filter(|s| s.concept == "import" || s.concept == "use")
@@ -570,7 +570,7 @@ pub fn namespace(symbols: &[Symbol]) -> Option<String> {
 }
 
 /// Filter symbols to only public API (visibility contains "pub" or "public").
-pub fn public_symbols(symbols: &[Symbol]) -> Vec<&Symbol> {
+pub(crate) fn public_symbols(symbols: &[Symbol]) -> Vec<&Symbol> {
     symbols
         .iter()
         .filter(|s| {
@@ -588,7 +588,7 @@ pub fn public_symbols(symbols: &[Symbol]) -> Vec<&Symbol> {
 ///
 /// Finds the opening brace on or after `start_line` (0-indexed into lines),
 /// then returns all lines until the matching closing brace.
-pub fn extract_block_body<'a>(
+pub(crate) fn extract_block_body<'a>(
     lines: &[ContextualLine<'a>],
     start_line_idx: usize,
     grammar: &Grammar,

--- a/src/utils/token.rs
+++ b/src/utils/token.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering;
 
-pub fn normalize_identifier(input: &str) -> String {
+pub(crate) fn normalize_identifier(input: &str) -> String {
     input.trim().to_lowercase()
 }
 


### PR DESCRIPTION
## Summary

- Changes 51 `pub fn` declarations to `pub(crate) fn` across 21 files where functions are only used within the library crate
- These were flagged as `unreferenced_export` findings by `homeboy audit`
- 11 functions were kept `pub` because they are re-exported via `pub use` in parent `mod.rs` files (6) or consumed by the binary crate's `main.rs`/command files (5)

## Why not all 62?

The audit's `unreferenced_export` finding correctly flags functions not referenced elsewhere in the codebase. However, some are:
1. **Re-exported** — `pub use` in `mod.rs` makes them part of the module's public API (`parse_release_artifacts`, `derive_id_from_url`, `is_git_url`, `find_references`, `find_references_with_targeting`, `generate_renames`)
2. **Used by the binary crate** — `main.rs` imports from the library, which is a separate crate boundary (`find_entity_match`, `generate_entity_hints`, `files::write`, `normalize_doc_segment`, `args::normalize`)

## Side effect: dead code surfaced

Changing to `pub(crate)` lets the compiler warn about genuinely unused functions. 3 functions appear to be dead code (`baseline_path`, `get_git_root`, `set_component_version`). These are pre-existing and can be addressed separately.

Several other warnings are false positives — functions used only in `#[cfg(test)]` blocks within the same file (grammar helpers, etc.).

## Verification

- `cargo build --release` ✅
- `cargo test` ✅ (60 tests pass)
- `cargo fmt --check` ✅