### PR TITLE
fix: ExtensionRunner falls back to portable config when component not registered

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use homeboy::code_audit::{self, baseline, fixer, CodeAuditResult};
-use homeboy::component;
+use homeboy::component::{self, Component};
 use homeboy::extension::ExtensionRunner;
 use homeboy::git;
 use homeboy::utils::autofix::{self, AutofixMode};
@@ -651,12 +651,22 @@ fn findings_fingerprint(result: &CodeAuditResult) -> Vec<String> {
     fingerprints
 }
 
+/// Load a component by ID, falling back to portable config discovery.
+fn load_or_discover(component_id: &str, source_path: &str) -> Option<Component> {
+    component::load(component_id).ok().or_else(|| {
+        let mut comp = component::discover_from_portable(Path::new(source_path))?;
+        comp.id = component_id.to_string();
+        comp.local_path = source_path.to_string();
+        Some(comp)
+    })
+}
+
 fn build_smoke_verifier<'a>(
     component_id: &'a str,
     source_path: &'a str,
     changed_files: &'a [String],
 ) -> Option<impl Fn(&fixer::ApplyChunkResult) -> Result<String, String> + 'a> {
-    let component = component::load(component_id).ok()?;
+    let component = load_or_discover(component_id, source_path)?;
     let script_path = super::lint::resolve_lint_script(&component).ok()?;
     let root = PathBuf::from(source_path);
     Some(move |chunk: &fixer::ApplyChunkResult| {
@@ -708,7 +718,7 @@ fn build_test_smoke_verifier<'a>(
     source_path: &'a str,
     changed_files: &'a [String],
 ) -> Option<impl Fn(&fixer::ApplyChunkResult) -> Result<String, String> + 'a> {
-    let component = component::load(component_id).ok()?;
+    let component = load_or_discover(component_id, source_path)?;
     let script_path = super::test::resolve_test_script(&component).ok()?;
     let changed_scope = compute_changed_test_scope(&component, "HEAD~1").ok();
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -230,6 +230,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintOutput> {
     };
 
     let output = ExtensionRunner::new(args.comp.id(), &script_path)
+        .component(component.clone())
         .path_override(args.comp.path.clone())
         .settings(&args.setting_args.setting)
         .env_if(args.fix, "HOMEBOY_AUTO_FIX", "1")

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -352,6 +352,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestOutput> {
     };
 
     let mut runner = ExtensionRunner::new(args.comp.id(), &script_path)
+        .component(component.clone())
         .path_override(args.comp.path.clone())
         .settings(&args.setting_args.setting)
         .env_if(args.skip_lint, "HOMEBOY_SKIP_LINT", "1")

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::component::{self, Component, ScopedExtensionConfig};
-use crate::error::{Error, Result};
+use crate::error::{Error, ErrorCode, Result};
 use crate::ssh::{execute_local_command_passthrough, CommandOutput};
 use crate::utils::{io, shell};
 
@@ -24,6 +24,7 @@ pub struct ExtensionRunner {
     env_vars: Vec<(String, String)>,
     script_args: Vec<String>,
     path_override: Option<String>,
+    pre_loaded_component: Option<Component>,
 }
 
 impl ExtensionRunner {
@@ -39,7 +40,17 @@ impl ExtensionRunner {
             env_vars: Vec::new(),
             script_args: Vec::new(),
             path_override: None,
+            pre_loaded_component: None,
         }
+    }
+
+    /// Use a pre-loaded component instead of loading by ID.
+    ///
+    /// This avoids re-loading from config when the caller already has a
+    /// resolved component (e.g., from portable config discovery in CI).
+    pub fn component(mut self, comp: Component) -> Self {
+        self.pre_loaded_component = Some(comp);
+        self
     }
 
     /// Override the component's `local_path` for this execution.
@@ -119,7 +130,35 @@ impl ExtensionRunner {
     }
 
     fn find_component(&self) -> Result<Component> {
-        let mut comp = component::load(&self.component_id)?;
+        let mut comp = if let Some(ref pre_loaded) = self.pre_loaded_component {
+            pre_loaded.clone()
+        } else {
+            match component::load(&self.component_id) {
+                Ok(c) => c,
+                Err(err) if matches!(err.code, ErrorCode::ComponentNotFound) => {
+                    // Fall back to portable config discovery when --path is provided
+                    if let Some(ref path) = self.path_override {
+                        if let Some(mut discovered) =
+                            component::discover_from_portable(Path::new(path))
+                        {
+                            discovered.id = self.component_id.clone();
+                            discovered.local_path = path.clone();
+                            discovered
+                        } else {
+                            Component::new(
+                                self.component_id.clone(),
+                                path.clone(),
+                                String::new(),
+                                None,
+                            )
+                        }
+                    } else {
+                        return Err(err);
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        };
         if let Some(ref path) = self.path_override {
             comp.local_path = path.clone();
         }

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -492,6 +492,7 @@ fn validate_code_quality(component: &Component) -> Result<()> {
         ));
 
         match ExtensionRunner::new(&component.id, lint_script)
+            .component(component.clone())
             .env(
                 "HOMEBOY_LINT_FINDINGS_FILE",
                 &lint_findings_file.to_string_lossy(),
@@ -552,7 +553,10 @@ fn validate_code_quality(component: &Component) -> Result<()> {
     // Run tests if extension provides them
     if let Some(test_script) = manifest.test_script() {
         log_status!("release", "Running tests ({})...", extension_id);
-        match ExtensionRunner::new(&component.id, test_script).run() {
+        match ExtensionRunner::new(&component.id, test_script)
+            .component(component.clone())
+            .run()
+        {
             Ok(output) if output.success => {
                 log_status!("release", "Tests passed");
                 checks_run += 1;


### PR DESCRIPTION
## Summary

- **Root cause**: `ExtensionRunner::find_component()` called `component::load()` directly, which fails with `component.not_found` in CI where the component isn't registered in `~/.config/homeboy/components/`
- **Why it was hidden**: `PositionalComponentArgs::load()` correctly falls back to `discover_from_portable()`, but the runner re-loaded the component by ID internally, discarding the discovered component
- **Fix**: `find_component()` now falls back to `discover_from_portable()` when `ComponentNotFound` + `path_override` is available. Callers with pre-loaded components can also use `.component(comp)` to skip re-loading entirely.

## Impact

Unblocks **all 4 data-machine PRs** (#656, #659, #666, #669) whose CI jobs fail with exit code 4 (`component.not_found`). The homeboy-action passes `homeboy lint data-machine --path <workspace> --changed-since <sha>` which triggers this code path.

## Files Changed

- `src/core/extension/runner.rs` — add `pre_loaded_component` field, `.component()` builder, portable fallback in `find_component()`
- `src/commands/lint.rs` — pass pre-loaded component to ExtensionRunner
- `src/commands/test.rs` — pass pre-loaded component to ExtensionRunner
- `src/commands/audit.rs` — add `load_or_discover()` helper for smoke verifiers
- `src/core/release/pipeline.rs` — pass pre-loaded component to ExtensionRunner

## Testing

- Reproduced locally by removing `data-machine.json` from components dir
- Before fix: `component.not_found` exit 4
- After fix: lint passes with portable config discovery, baseline comparison works
- 814 tests pass, 0 failures