### PR TITLE
feat: add version undo command

### DIFF
--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -3,7 +3,9 @@ use serde::Serialize;
 
 use homeboy::component;
 use homeboy::release::{self, ReleasePlan, ReleaseRun};
-use homeboy::version::{read_component_version, read_version, VersionTargetInfo};
+use homeboy::version::{
+    read_component_version, read_version, undo_version_bump, UndoResult, VersionTargetInfo,
+};
 
 use super::release::BumpType;
 
@@ -15,6 +17,7 @@ use super::CmdResult;
 pub enum VersionOutput {
     Show(VersionShowOutput),
     Bump(VersionBumpOutput),
+    Undo(VersionUndoOutput),
 }
 
 #[derive(Args)]
@@ -67,6 +70,15 @@ enum VersionCommand {
         #[arg(long)]
         allow_underbump: bool,
     },
+    /// Undo the last version bump (reset or revert the release commit)
+    Undo {
+        /// Component ID
+        component_id: String,
+
+        /// Preview what will happen without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Serialize)]
@@ -89,6 +101,14 @@ pub struct VersionBumpOutput {
     plan: Option<ReleasePlan>,
     #[serde(skip_serializing_if = "Option::is_none")]
     run: Option<ReleaseRun>,
+}
+
+#[derive(Serialize)]
+pub struct VersionUndoOutput {
+    command: String,
+    component_id: String,
+    #[serde(flatten)]
+    result: UndoResult,
 }
 
 pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<VersionOutput> {
@@ -198,6 +218,20 @@ pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
                     exit_code,
                 ))
             }
+        }
+        VersionCommand::Undo {
+            component_id,
+            dry_run,
+        } => {
+            let result = undo_version_bump(&component_id, dry_run)?;
+            Ok((
+                VersionOutput::Undo(VersionUndoOutput {
+                    command: "version.undo".to_string(),
+                    component_id,
+                    result,
+                }),
+                0,
+            ))
         }
     }
 }

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -828,6 +828,84 @@ pub fn get_head_commit(path: &str) -> Result<String> {
     crate::utils::command::run_in(path, "git", &["rev-parse", "HEAD"], "get HEAD commit")
 }
 
+/// Get the commit message for HEAD.
+pub fn get_head_message(path: &str) -> Result<String> {
+    crate::utils::command::run_in(
+        path,
+        "git",
+        &["log", "-1", "--format=%s"],
+        "get HEAD commit message",
+    )
+}
+
+/// Check if HEAD has been pushed to the remote tracking branch.
+/// Returns true if HEAD is contained in the remote branch, false if ahead.
+pub fn is_head_pushed(path: &str) -> Result<bool> {
+    // Check if upstream exists
+    let upstream = crate::utils::command::run_in_optional(
+        path,
+        "git",
+        &["rev-parse", "--abbrev-ref", "@{upstream}"],
+    );
+    if upstream.is_none() {
+        return Ok(false); // No upstream = not pushed
+    }
+
+    // Get ahead count
+    let counts = crate::utils::command::run_in_optional(
+        path,
+        "git",
+        &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
+    );
+
+    match counts {
+        Some(output) => {
+            let (ahead, _) = parse_ahead_behind(&output);
+            Ok(ahead.unwrap_or(0) == 0)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Delete a local tag.
+pub fn delete_local_tag(path: &str, tag_name: &str) -> Result<()> {
+    crate::utils::command::run_in(
+        path,
+        "git",
+        &["tag", "-d", tag_name],
+        &format!("delete local tag '{}'", tag_name),
+    )?;
+    Ok(())
+}
+
+/// Delete a remote tag.
+pub fn delete_remote_tag(path: &str, tag_name: &str) -> Result<()> {
+    crate::utils::command::run_in(
+        path,
+        "git",
+        &["push", "origin", &format!(":refs/tags/{}", tag_name)],
+        &format!("delete remote tag '{}'", tag_name),
+    )?;
+    Ok(())
+}
+
+/// Soft reset HEAD by n commits (keeps changes staged).
+pub fn reset_soft(path: &str, count: usize) -> Result<()> {
+    crate::utils::command::run_in(
+        path,
+        "git",
+        &["reset", "--soft", &format!("HEAD~{}", count)],
+        &format!("soft reset {} commit(s)", count),
+    )?;
+    Ok(())
+}
+
+/// Reset staging area (unstage all files).
+pub fn reset_staging(path: &str) -> Result<()> {
+    crate::utils::command::run_in(path, "git", &["reset", "HEAD"], "unstage all files")?;
+    Ok(())
+}
+
 /// Fetch from remote and return count of commits behind upstream.
 /// Returns Ok(Some(n)) if behind by n commits, Ok(None) if not behind or no upstream.
 pub fn fetch_and_get_behind_count(path: &str) -> Result<Option<u32>> {

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -1113,9 +1113,166 @@ fn walk_source_files(dir: &Path, extensions: &[String], callback: &mut impl FnMu
     }
 }
 
+// ── Version Undo ──
+
+/// Result of undoing a version bump.
+#[derive(Debug, Clone, Serialize)]
+pub struct UndoResult {
+    /// The version that was undone (e.g., "0.66.0").
+    pub version: String,
+    /// Tag name that was removed (e.g., "v0.66.0").
+    pub tag_name: String,
+    /// Whether the release commit had been pushed to remote.
+    pub was_pushed: bool,
+    /// Whether the local tag was deleted.
+    pub tag_deleted_local: bool,
+    /// Whether the remote tag was deleted.
+    pub tag_deleted_remote: bool,
+    /// How the commit was undone: "reset" (unpushed) or "revert" (pushed).
+    pub undo_method: String,
+    /// Whether this was a dry run.
+    pub dry_run: bool,
+}
+
+/// Release commit prefix used by the release pipeline.
+const RELEASE_COMMIT_PREFIX: &str = "release: v";
+
+/// Parse a version from a release commit message.
+/// Returns `Some("X.Y.Z")` for messages like "release: vX.Y.Z".
+fn parse_release_version(message: &str) -> Option<String> {
+    message
+        .strip_prefix(RELEASE_COMMIT_PREFIX)
+        .map(|v| v.trim().to_string())
+}
+
+/// Undo a version bump.
+///
+/// Checks that HEAD is a release commit, then:
+/// - If not pushed: `git reset --soft HEAD~1` + unstage + delete local tag
+/// - If pushed: `git revert HEAD` + delete local/remote tag
+pub fn undo_version_bump(component_id: &str, dry_run: bool) -> Result<UndoResult> {
+    use crate::git;
+
+    let component = component::load(component_id)?;
+    component::validate_local_path(&component)?;
+    let path = &component.local_path;
+
+    // 1. Verify HEAD is a release commit
+    let head_message = git::get_head_message(path)?;
+    let version = parse_release_version(&head_message).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "version.undo",
+            &format!(
+                "HEAD commit is not a release commit.\n  \
+                 Expected: \"{RELEASE_COMMIT_PREFIX}X.Y.Z\"\n  \
+                 Found:    \"{}\"",
+                head_message
+            ),
+            None,
+            None,
+        )
+    })?;
+
+    let tag_name = format!("v{}", version);
+
+    // 2. Check push status (fetch first to get accurate state)
+    let _ = git::fetch_and_get_behind_count(path);
+    let was_pushed = git::is_head_pushed(path)?;
+
+    // 3. Check tag existence
+    let tag_local = git::tag_exists_locally(path, &tag_name)?;
+    let tag_remote = git::tag_exists_on_remote(path, &tag_name)?;
+
+    if dry_run {
+        let method = if was_pushed { "revert" } else { "reset" };
+        log_status!("version", "Would undo release v{}", version);
+        log_status!("version", "  Commit pushed: {}", was_pushed);
+        log_status!("version", "  Undo method: {}", method);
+        if tag_local {
+            log_status!("version", "  Would delete local tag: {}", tag_name);
+        }
+        if tag_remote {
+            log_status!("version", "  Would delete remote tag: {}", tag_name);
+        }
+
+        return Ok(UndoResult {
+            version,
+            tag_name,
+            was_pushed,
+            tag_deleted_local: tag_local,
+            tag_deleted_remote: tag_remote,
+            undo_method: method.to_string(),
+            dry_run: true,
+        });
+    }
+
+    // 4. Delete tags
+    if tag_local {
+        git::delete_local_tag(path, &tag_name)?;
+        log_status!("version", "Deleted local tag: {}", tag_name);
+    }
+    if tag_remote {
+        git::delete_remote_tag(path, &tag_name)?;
+        log_status!("version", "Deleted remote tag: {}", tag_name);
+    }
+
+    // 5. Undo the commit
+    let undo_method = if was_pushed {
+        // Already pushed — create a revert commit
+        crate::utils::command::run_in(
+            path,
+            "git",
+            &["revert", "--no-edit", "HEAD"],
+            "revert release commit",
+        )?;
+        log_status!("version", "Created revert commit for release v{}", version);
+        "revert"
+    } else {
+        // Not pushed — soft reset and unstage
+        git::reset_soft(path, 1)?;
+        git::reset_staging(path)?;
+        log_status!(
+            "version",
+            "Reset release commit (changes left in working tree)"
+        );
+        "reset"
+    };
+
+    log_status!("version", "Undone release v{}", version);
+
+    Ok(UndoResult {
+        version,
+        tag_name,
+        was_pushed,
+        tag_deleted_local: tag_local,
+        tag_deleted_remote: tag_remote,
+        undo_method: undo_method.to_string(),
+        dry_run: false,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_release_version_valid() {
+        assert_eq!(
+            parse_release_version("release: v0.66.0"),
+            Some("0.66.0".to_string())
+        );
+        assert_eq!(
+            parse_release_version("release: v1.0.0"),
+            Some("1.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_release_version_invalid() {
+        assert_eq!(parse_release_version("feat: add something"), None);
+        assert_eq!(parse_release_version("Release: v1.0.0"), None); // wrong case
+        assert_eq!(parse_release_version("chore: bump version"), None);
+    }
 
     #[test]
     fn since_tag_regex_matches_placeholders() {


### PR DESCRIPTION
## Summary

- Adds `homeboy version undo <component>` to reverse a version bump
- Smart handling: soft reset if unpushed, revert commit if already pushed
- Cleans up local and remote tags automatically
- `--dry-run` support to preview actions

## Behavior

| Scenario | Action |
|----------|--------|
| HEAD is not a release commit | Error with explanation |
| Not pushed to remote | `git reset --soft HEAD~1` + unstage → changes in working tree |
| Already pushed | `git revert --no-edit HEAD` → clean revert commit |
| Tag exists locally | Deletes it |
| Tag exists on remote | Deletes it |

## New git primitives

`get_head_message`, `is_head_pushed`, `delete_local_tag`, `delete_remote_tag`, `reset_soft`, `reset_staging`

## Testing

838 tests passing (778 lib + 59 bin + 1 integration), including 2 new unit tests for release commit parsing.

## Closes #406