### PR TITLE
fix: deploy from latest tag by default, fleet status checks live versions

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -63,6 +63,9 @@ pub struct DeployArgs {
     /// Skip auto-pulling latest changes before deploy
     #[arg(long)]
     pub no_pull: bool,
+    /// Deploy from current branch HEAD instead of the latest tag
+    #[arg(long)]
+    pub head: bool,
 }
 
 #[derive(Serialize)]
@@ -265,6 +268,7 @@ pub fn run(
         keep_deps: args.keep_deps,
         expected_version: args.version.clone(),
         no_pull: args.no_pull,
+        head: args.head,
     };
 
     let result = deploy::run(&project_id, &config).map_err(|e| {
@@ -409,6 +413,7 @@ fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<Dep
             keep_deps: args.keep_deps,
             expected_version: args.version.clone(),
             no_pull: args.no_pull || !first_project, // Only pull on first project
+            head: args.head,
         };
 
         match deploy::run(project_id, &config) {

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -78,10 +78,14 @@ enum FleetCommand {
         /// Fleet ID
         id: String,
     },
-    /// Show component versions across a fleet (local only)
+    /// Show live component versions across a fleet (via SSH)
     Status {
         /// Fleet ID
         id: String,
+
+        /// Use locally cached versions instead of live SSH check
+        #[arg(long)]
+        cached: bool,
     },
     /// Check component drift across a fleet (compares local vs remote)
     Check {
@@ -220,6 +224,9 @@ pub struct FleetComponentStatus {
     pub component_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Where the version was resolved from: "live" (SSH) or "cached" (local file)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_source: Option<String>,
 }
 
 pub fn run(args: FleetArgs, _global: &super::GlobalArgs) -> CmdResult<FleetOutput> {
@@ -237,7 +244,7 @@ pub fn run(args: FleetArgs, _global: &super::GlobalArgs) -> CmdResult<FleetOutpu
         FleetCommand::Remove { id, project } => remove(&id, &project),
         FleetCommand::Projects { id } => projects(&id),
         FleetCommand::Components { id } => components(&id),
-        FleetCommand::Status { id } => status(&id),
+        FleetCommand::Status { id, cached } => status(&id, cached),
         FleetCommand::Check { id, outdated } => check(&id, outdated),
         FleetCommand::Exec {
             id,
@@ -423,34 +430,111 @@ fn components(id: &str) -> CmdResult<FleetOutput> {
     ))
 }
 
-fn status(id: &str) -> CmdResult<FleetOutput> {
+fn status(id: &str, cached: bool) -> CmdResult<FleetOutput> {
     let fl = fleet::load(id)?;
     let mut project_statuses = Vec::new();
 
-    for project_id in &fl.project_ids {
-        let proj = match project::load(project_id) {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        let mut component_statuses = Vec::new();
-        for component_id in &proj.component_ids {
-            let comp_version = match component::load(component_id) {
-                Ok(comp) => version::get_component_version(&comp),
-                Err(_) => None,
+    if cached {
+        // Cached mode: read versions from local files (old behavior)
+        for project_id in &fl.project_ids {
+            let proj = match project::load(project_id) {
+                Ok(p) => p,
+                Err(_) => continue,
             };
 
-            component_statuses.push(FleetComponentStatus {
-                component_id: component_id.clone(),
-                version: comp_version,
+            let mut component_statuses = Vec::new();
+            for component_id in &proj.component_ids {
+                let comp_version = match component::load(component_id) {
+                    Ok(comp) => version::get_component_version(&comp),
+                    Err(_) => None,
+                };
+
+                component_statuses.push(FleetComponentStatus {
+                    component_id: component_id.clone(),
+                    version: comp_version,
+                    version_source: Some("cached".to_string()),
+                });
+            }
+
+            project_statuses.push(FleetProjectStatus {
+                project_id: project_id.clone(),
+                server_id: proj.server_id.clone(),
+                components: component_statuses,
             });
         }
+    } else {
+        // Live mode (default): SSH into each server to get actual deployed versions
+        for project_id in &fl.project_ids {
+            let proj = match project::load(project_id) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
 
-        project_statuses.push(FleetProjectStatus {
-            project_id: project_id.clone(),
-            server_id: proj.server_id.clone(),
-            components: component_statuses,
-        });
+            log_status!("fleet", "Checking versions on '{}'...", project_id);
+
+            // Use the deploy check infrastructure to get remote versions via SSH
+            let config = DeployConfig {
+                component_ids: vec![],
+                all: true,
+                outdated: false,
+                dry_run: false,
+                check: true,
+                force: false,
+                skip_build: true,
+                keep_deps: false,
+                expected_version: None,
+                no_pull: true,
+                head: true,
+            };
+
+            match deploy::run(project_id, &config) {
+                Ok(result) => {
+                    let mut component_statuses = Vec::new();
+                    for comp_result in &result.results {
+                        component_statuses.push(FleetComponentStatus {
+                            component_id: comp_result.id.clone(),
+                            version: comp_result.remote_version.clone(),
+                            version_source: Some("live".to_string()),
+                        });
+                    }
+
+                    project_statuses.push(FleetProjectStatus {
+                        project_id: project_id.clone(),
+                        server_id: proj.server_id.clone(),
+                        components: component_statuses,
+                    });
+                }
+                Err(e) => {
+                    // SSH failed — fall back to cached versions with indicator
+                    log_status!(
+                        "fleet",
+                        "Warning: could not reach '{}' — falling back to cached versions: {}",
+                        project_id,
+                        e
+                    );
+
+                    let mut component_statuses = Vec::new();
+                    for component_id in &proj.component_ids {
+                        let comp_version = match component::load(component_id) {
+                            Ok(comp) => version::get_component_version(&comp),
+                            Err(_) => None,
+                        };
+
+                        component_statuses.push(FleetComponentStatus {
+                            component_id: component_id.clone(),
+                            version: comp_version,
+                            version_source: Some("cached".to_string()),
+                        });
+                    }
+
+                    project_statuses.push(FleetProjectStatus {
+                        project_id: project_id.clone(),
+                        server_id: proj.server_id.clone(),
+                        components: component_statuses,
+                    });
+                }
+            }
+        }
     }
 
     Ok((
@@ -490,6 +574,7 @@ fn check(id: &str, only_outdated: bool) -> CmdResult<FleetOutput> {
             keep_deps: false,
             expected_version: None,
             no_pull: true, // Fleet checks are read-only
+            head: true,    // Fleet checks don't build — skip tag checkout
         };
 
         match deploy::run(project_id, &config) {

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -293,6 +293,7 @@ fn execute_deployment(component_id: &str) -> (Option<DeploymentResult>, i32) {
             keep_deps: false,
             expected_version: None, // Release already validated version
             no_pull: true,          // Release already pushed, no need to pull
+            head: true,             // Release just tagged — deploy from current state
         };
 
         match deploy::run(project_id, &config) {

--- a/src/core/deploy/orchestration.inc
+++ b/src/core/deploy/orchestration.inc
@@ -130,6 +130,14 @@ fn deploy_components(
         check_uncommitted_changes(&components)?;
     }
 
+    // Checkout latest tag for each component (unless --head)
+    // This ensures only released, tagged code reaches production.
+    let tag_checkouts = if !config.head && !config.skip_build {
+        checkout_latest_tags(&components)?
+    } else {
+        Vec::new()
+    };
+
     // Verify expected version if --version was specified
     if let Some(ref expected) = config.expected_version {
         verify_expected_version(&components, expected)?;
@@ -143,7 +151,7 @@ fn deploy_components(
     for component in &components {
         // Apply per-project overrides (e.g. different extract_command or remote_owner)
         let component = apply_component_overrides(component, project);
-        let result = execute_component_deploy(
+        let mut result = execute_component_deploy(
             &component,
             config,
             ctx,
@@ -152,12 +160,32 @@ fn deploy_components(
             local_versions.get(&component.id).cloned(),
             remote_versions.get(&component.id).cloned(),
         );
+
+        // Record which git ref was deployed
+        if let Some(checkout) = tag_checkouts.iter().find(|c| c.component_id == component.id) {
+            result = result.with_deployed_ref(checkout.tag.clone());
+        } else if config.head {
+            // Deploying from HEAD — record the current branch
+            if let Some(branch) = crate::utils::command::run_in_optional(
+                &component.local_path,
+                "git",
+                &["rev-parse", "--abbrev-ref", "HEAD"],
+            ) {
+                result = result.with_deployed_ref(format!("{} (HEAD)", branch));
+            }
+        }
+
         if result.status == "deployed" {
             succeeded += 1;
         } else {
             failed += 1;
         }
         results.push(result);
+    }
+
+    // Restore original branches after deployment
+    if !tag_checkouts.is_empty() {
+        restore_branches(&tag_checkouts);
     }
 
     Ok(DeployOrchestrationResult {
@@ -315,6 +343,133 @@ fn sync_components(components: &[Component]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Record of a tag checkout for later branch restoration.
+struct TagCheckout {
+    component_id: String,
+    tag: String,
+    original_ref: String,
+    local_path: String,
+}
+
+/// Checkout the latest version tag for each component before building.
+///
+/// For each component, finds the latest semver tag, saves the current
+/// branch/ref, and checks out the tag. Returns a list of checkouts
+/// so branches can be restored after deployment.
+///
+/// Components without tags are skipped with a warning — they deploy
+/// from HEAD as before (the pre-tag-checkout behavior).
+fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
+    let mut checkouts = Vec::new();
+
+    for component in components {
+        let path = &component.local_path;
+
+        // Get the latest tag
+        let tag = match git::get_latest_tag(path) {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                log_status!(
+                    "deploy",
+                    "Warning: '{}' has no version tags — deploying from HEAD (use --head to suppress this warning)",
+                    component.id
+                );
+                continue;
+            }
+            Err(_) => {
+                log_status!(
+                    "deploy",
+                    "Warning: could not read tags for '{}' — deploying from HEAD",
+                    component.id
+                );
+                continue;
+            }
+        };
+
+        // Save the current ref (branch name or commit hash for detached HEAD)
+        let original_ref = crate::utils::command::run_in_optional(
+            path,
+            "git",
+            &["rev-parse", "--abbrev-ref", "HEAD"],
+        )
+        .unwrap_or_else(|| "main".to_string());
+
+        // If already on this tag's commit, skip checkout
+        let tag_commit = crate::utils::command::run_in_optional(path, "git", &["rev-parse", &tag]);
+        let head_commit = crate::utils::command::run_in_optional(path, "git", &["rev-parse", "HEAD"]);
+        if tag_commit.is_some() && tag_commit == head_commit {
+            log_status!("deploy", "'{}' is already at tag {} — no checkout needed", component.id, tag);
+            checkouts.push(TagCheckout {
+                component_id: component.id.clone(),
+                tag: tag.clone(),
+                original_ref,
+                local_path: path.clone(),
+            });
+            continue;
+        }
+
+        // Checkout the tag
+        log_status!("deploy", "'{}' checking out tag {} for deploy...", component.id, tag);
+        match crate::utils::command::run_in(path, "git", &["checkout", &tag], "git checkout tag") {
+            Ok(_) => {
+                checkouts.push(TagCheckout {
+                    component_id: component.id.clone(),
+                    tag: tag.clone(),
+                    original_ref,
+                    local_path: path.clone(),
+                });
+            }
+            Err(e) => {
+                return Err(Error::git_command_failed(format!(
+                    "Failed to checkout tag {} for '{}': {}",
+                    tag, component.id, e
+                )));
+            }
+        }
+    }
+
+    Ok(checkouts)
+}
+
+/// Restore original branches after deployment.
+///
+/// Best-effort: logs warnings on failure but does not abort.
+/// The deployment already completed — failing to restore a branch
+/// is inconvenient but not destructive.
+fn restore_branches(checkouts: &[TagCheckout]) {
+    for checkout in checkouts {
+        // Don't restore if original was detached HEAD (already on a tag/commit)
+        if checkout.original_ref == "HEAD" {
+            continue;
+        }
+        let restore = crate::utils::command::run_in(
+            &checkout.local_path,
+            "git",
+            &["checkout", &checkout.original_ref],
+            "git checkout restore",
+        );
+        match restore {
+            Ok(_) => {
+                log_status!(
+                    "deploy",
+                    "'{}' restored to {}",
+                    checkout.component_id,
+                    checkout.original_ref
+                );
+            }
+            Err(e) => {
+                log_status!(
+                    "deploy",
+                    "Warning: could not restore '{}' to {}: {}",
+                    checkout.component_id,
+                    checkout.original_ref,
+                    e
+                );
+            }
+        }
+    }
 }
 
 /// Verify that component versions match the expected version.

--- a/src/core/deploy/types.inc
+++ b/src/core/deploy/types.inc
@@ -44,6 +44,8 @@ pub struct DeployConfig {
     pub expected_version: Option<String>,
     /// Skip auto-pulling latest changes before deploy
     pub no_pull: bool,
+    /// Deploy from current branch HEAD instead of latest tag
+    pub head: bool,
 }
 
 /// Reason why a component was selected for deployment.
@@ -115,6 +117,9 @@ pub struct ComponentDeployResult {
     pub deploy_exit_code: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release_state: Option<ReleaseState>,
+    /// The git ref (tag or branch) that was built and deployed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployed_ref: Option<String>,
 }
 
 impl ComponentDeployResult {
@@ -133,6 +138,7 @@ impl ComponentDeployResult {
             build_exit_code: None,
             deploy_exit_code: None,
             release_state: None,
+            deployed_ref: None,
         }
     }
 
@@ -188,6 +194,11 @@ impl ComponentDeployResult {
 
     fn with_release_state(mut self, state: ReleaseState) -> Self {
         self.release_state = Some(state);
+        self
+    }
+
+    fn with_deployed_ref(mut self, git_ref: String) -> Self {
+        self.deployed_ref = Some(git_ref);
         self
     }
 }


### PR DESCRIPTION
## Summary

Fixes two bugs that undermine deploy safety and fleet visibility:

- **#556**: `homeboy deploy` now checks out the latest version tag before building, ensuring only released/tagged code reaches production. This prevents the outage scenario where unreleased commits on `main` silently ship to production.
- **#557**: `fleet status` now SSHes into each server to report live deployed versions instead of reading stale local files. Falls back gracefully to cached versions (with `(cached)` indicator) if SSH fails.

## Changes

### Deploy from latest tag (#556)
- New `checkout_latest_tags()` function finds the latest semver tag for each component and checks it out before building
- New `restore_branches()` restores original branches after deployment completes
- New `--head` flag opts into deploying from current branch HEAD (the old behavior)
- `deployed_ref` field added to `ComponentDeployResult` — logs exactly which git ref was built
- Components without tags get a warning and deploy from HEAD (safe degradation)
- `release --deploy` and `fleet check` automatically use `--head` mode (they already handle their own git state)

### Live fleet status (#557)
- `fleet status` now uses the deploy check infrastructure to SSH into each project's server and read actual deployed versions
- New `--cached` flag for the old local-only behavior (fast, but potentially stale)
- `version_source` field added to `FleetComponentStatus` — reports `"live"` or `"cached"`
- Graceful SSH fallback: if a server is unreachable, falls back to cached version with clear indicator

## Testing
- All 60 tests pass
- `cargo fmt --check` clean
- `cargo clippy` clean
- Release build succeeds

Closes #556, closes #557