### PR TITLE
feat: differential CI — only fail on findings introduced by the PR

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -611,7 +611,46 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
         }
     }
 
-    // No baseline — standard output
+    // No explicit baseline — try differential comparison from git ref
+    if let Some(ref git_ref) = args.changed_since {
+        if let Some(ref_baseline) = baseline::load_baseline_from_ref(&result.source_path, git_ref) {
+            let comparison = baseline::compare(&result, &ref_baseline);
+            let exit_code = if comparison.drift_increased { 1 } else { 0 };
+
+            if comparison.drift_increased {
+                eprintln!(
+                    "[audit] {} new finding(s) introduced by this change",
+                    comparison.new_items.len()
+                );
+            } else if !result.findings.is_empty() {
+                eprintln!(
+                    "[audit] {} finding(s) in changed files — all pre-existing (0 introduced)",
+                    result.findings.len()
+                );
+            }
+
+            let summary = if args.json_summary {
+                Some(build_audit_summary(&result, exit_code))
+            } else {
+                None
+            };
+
+            return Ok((
+                if args.json_summary {
+                    AuditOutput::Summary(build_audit_summary(&result, exit_code))
+                } else {
+                    AuditOutput::Compared {
+                        result,
+                        baseline_comparison: comparison,
+                        summary,
+                    }
+                },
+                exit_code,
+            ));
+        }
+    }
+
+    // No baseline at all — standard output
     let exit_code = default_audit_exit_code(&result, args.changed_since.is_some());
     if args.json_summary {
         Ok((

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -515,7 +515,24 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestOutput> {
 
     if !args.baseline_args.baseline && !args.baseline_args.ignore_baseline {
         if let Some(ref counts) = test_counts {
-            if let Some(existing_baseline) = test_baseline::load_baseline(&source_path) {
+            // Try explicit baseline first, then differential from git ref
+            let resolved_baseline = test_baseline::load_baseline(&source_path).or_else(|| {
+                args.changed_since.as_ref().and_then(|git_ref| {
+                    let bl = test_baseline::load_baseline_from_ref(
+                        &source_path.to_string_lossy(),
+                        git_ref,
+                    );
+                    if bl.is_some() {
+                        eprintln!(
+                            "[test] Using baseline from {} for differential comparison",
+                            git_ref
+                        );
+                    }
+                    bl
+                })
+            });
+
+            if let Some(existing_baseline) = resolved_baseline {
                 let comparison = test_baseline::compare(counts, &existing_baseline);
 
                 if comparison.regression {
@@ -535,6 +552,11 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestOutput> {
                         let _ = test_baseline::save_baseline(&source_path, args.comp.id(), counts);
                         eprintln!("[test] Baseline ratcheted forward");
                     }
+                } else {
+                    eprintln!(
+                        "[test] No regression: passed {} (same), failed {} (same)",
+                        counts.passed, counts.failed,
+                    );
                 }
 
                 baseline_comparison = Some(comparison);

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -123,6 +123,14 @@ pub fn compare(result: &CodeAuditResult, baseline: &AuditBaseline) -> BaselineCo
     generic::compare(&items, baseline)
 }
 
+/// Load an audit baseline from a git ref (e.g., `origin/main`).
+///
+/// Uses `git show <ref>:homeboy.json` to read the baseline without checkout.
+/// Returns `None` if the ref doesn't have a baseline.
+pub fn load_baseline_from_ref(source_path: &str, git_ref: &str) -> Option<AuditBaseline> {
+    generic::load_from_git_ref::<AuditBaselineMetadata>(source_path, git_ref, BASELINE_KEY)
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/src/core/test_baseline.rs
+++ b/src/core/test_baseline.rs
@@ -104,6 +104,14 @@ pub fn load_baseline(source_path: &Path) -> Option<TestBaseline> {
     generic::load::<TestCounts>(&config).ok().flatten()
 }
 
+/// Load a test baseline from a git ref (e.g., `origin/main`).
+///
+/// Uses `git show <ref>:homeboy.json` to read the baseline without checkout.
+/// Returns `None` if the ref doesn't have a test baseline.
+pub fn load_baseline_from_ref(source_path: &str, git_ref: &str) -> Option<TestBaseline> {
+    generic::load_from_git_ref::<TestCounts>(source_path, git_ref, BASELINE_KEY)
+}
+
 /// Compare current test counts against a saved baseline.
 ///
 /// The ratchet rule:

--- a/src/utils/baseline.rs
+++ b/src/utils/baseline.rs
@@ -311,6 +311,33 @@ pub fn compare<M: Serialize>(
     }
 }
 
+/// Load a baseline from a git ref's `homeboy.json` (e.g., `origin/main`).
+///
+/// Uses `git show <ref>:homeboy.json` to read the baseline as it existed
+/// at a specific commit without checking out that ref. Returns `None` if:
+/// - `homeboy.json` doesn't exist at that ref
+/// - No `baselines.<key>` entry exists
+/// - The ref or file is invalid
+///
+/// This is the core primitive for differential CI: compare current findings
+/// against the base ref's state to detect only newly introduced issues.
+pub fn load_from_git_ref<M: for<'de> Deserialize<'de> + Serialize>(
+    source_path: &str,
+    git_ref: &str,
+    key: &str,
+) -> Option<Baseline<M>> {
+    // Read homeboy.json from the git ref
+    let git_spec = format!("{}:{}", git_ref, HOMEBOY_JSON);
+    let content = crate::utils::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
+
+    // Parse JSON
+    let root: Value = serde_json::from_str(&content).ok()?;
+
+    // Extract baseline
+    let value = root.get(BASELINES_KEY)?.get(key)?;
+    serde_json::from_value::<Baseline<M>>(value.clone()).ok()
+}
+
 // ============================================================================
 // JSON helpers
 // ============================================================================
@@ -834,5 +861,41 @@ mod tests {
         let config = BaselineConfig::new(dir.path(), "audit");
         let result = load::<()>(&config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_from_git_ref_returns_none_for_nonexistent_ref() {
+        // Non-git directory should return None (not panic)
+        let dir = TempDir::new().unwrap();
+        let result = load_from_git_ref::<()>(dir.path().to_str().unwrap(), "origin/main", "audit");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_from_git_ref_returns_none_for_missing_baseline_key() {
+        // Git repo with homeboy.json but no baselines key should return None
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+
+        // Create a git repo with a homeboy.json that has no baselines
+        let _ = crate::utils::command::run_in(path, "git", &["init"], "git init");
+        let _ = crate::utils::command::run_in(
+            path,
+            "git",
+            &["config", "user.email", "test@test.com"],
+            "git config email",
+        );
+        let _ = crate::utils::command::run_in(
+            path,
+            "git",
+            &["config", "user.name", "Test"],
+            "git config name",
+        );
+        std::fs::write(dir.path().join("homeboy.json"), r#"{"id": "test"}"#).unwrap();
+        let _ = crate::utils::command::run_in(path, "git", &["add", "."], "git add");
+        let _ = crate::utils::command::run_in(path, "git", &["commit", "-m", "init"], "git commit");
+
+        let result = load_from_git_ref::<()>(path, "HEAD", "audit");
+        assert!(result.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Makes homeboy CI usable for projects with pre-existing debt by comparing audit findings and test counts against the **base ref's state**, not against zero.

- **#559**: Scoped audit (`--changed-since`) now auto-compares against the base ref's audit baseline via `git show <ref>:homeboy.json`. Pre-existing findings in changed files no longer fail the PR — only **newly introduced** findings do.
- **#560**: Test ratchet now falls back to the base ref's test baseline when no explicit baseline exists. PRs only fail if they **introduce new test failures** relative to main.

## Architecture

### New core primitive: `baseline::load_from_git_ref()`

```rust
pub fn load_from_git_ref<M>(source_path: &str, git_ref: &str, key: &str) -> Option<Baseline<M>>
```

Reads `homeboy.json` from a git ref via `git show <ref>:homeboy.json` without checkout. Both audit and test baseline modules expose this through domain-specific wrappers.

### Audit differential flow

```
1. Run scoped audit (conventions from full codebase, findings filtered to changed files)
2. Check for explicit baseline → use it (existing behavior)
3. No explicit baseline? Load baseline from --changed-since ref
4. Compare: only findings NOT in base ref's baseline are "introduced"
5. Exit 1 only if introduced findings > 0
```

### Test differential flow

```
1. Run tests with --changed-since scope
2. Check for explicit test baseline → use it (existing behavior)
3. No explicit baseline? Load test counts from --changed-since ref
4. Ratchet: passed >= base.passed AND failed <= base.failed
5. Exit 1 only on regression vs base ref's counts
```

### Backward compatibility

- Projects WITH explicit baselines: no behavior change (explicit baseline takes priority)
- Projects WITHOUT baselines and WITHOUT `--changed-since`: no behavior change
- Projects WITHOUT baselines WITH `--changed-since`: **NEW** — auto-compares against base ref
- If base ref has no `homeboy.json` or no baseline key: falls back to current behavior

## Testing

- 851 tests pass (791 lib + 59 bin + 1 integration), including 2 new unit tests
- `cargo fmt --check` clean
- `cargo clippy` clean (only pre-existing warnings)
- Release build succeeds

Closes #559, closes #560