### PR TITLE
fix: scoped audit exits 0 when no baseline exists anywhere

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -650,8 +650,23 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
         }
     }
 
-    // No baseline at all — standard output
-    let exit_code = default_audit_exit_code(&result, args.changed_since.is_some());
+    // No baseline at all
+    //
+    // When --changed-since is active but no baseline exists anywhere (neither
+    // explicit file nor at the base ref), we cannot determine which findings
+    // are new vs pre-existing. In this case, pass — the correct fix is to
+    // add a baseline, not to fail PRs on unattributable debt.
+    let exit_code = if args.changed_since.is_some() {
+        if !result.findings.is_empty() {
+            eprintln!(
+                "[audit] {} finding(s) in changed files — no baseline to compare against, treating as pre-existing",
+                result.findings.len()
+            );
+        }
+        0
+    } else {
+        default_audit_exit_code(&result, false)
+    };
     if args.json_summary {
         Ok((
             AuditOutput::Summary(build_audit_summary(&result, exit_code)),


### PR DESCRIPTION
## Summary
- When `--changed-since` is active but no baseline exists (neither explicit file nor at the base ref), audit now exits 0 instead of failing on unattributable legacy debt
- Prints informational message: `N finding(s) in changed files — no baseline to compare against, treating as pre-existing`
- The correct fix for the project is to add a baseline, not to block PRs on unknown debt

## Context
This completes the differential CI story started in #562. That PR added baseline comparison against the base ref, but the fallback when NO baseline exists anywhere still used the strict exit code path — failing data-machine PRs on 70+ pre-existing outliers.

Closes #559 (remaining edge case)