### PR TITLE
ci: use GitHub App token for autofix pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
   # Falls back to latest release binary if source build fails.
   # Runs independently of build job so PR comments are always posted.
   # Autofix enabled: on audit failure, applies safe fixes and commits back to the PR.
+  # App token: autofix pushes use the GitHub App token so CI re-triggers on the new commit.
   audit:
     name: Homeboy Audit
     runs-on: ubuntu-latest
@@ -53,6 +54,14 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
@@ -63,3 +72,4 @@ jobs:
           autofix: 'true'
           autofix-commands: 'audit --fix --write'
           autofix-max-commits: '2'
+          app-token: ${{ steps.app-token.outputs.token || '' }}


### PR DESCRIPTION
## Summary

Pushes from `GITHUB_TOKEN` never trigger workflow re-runs — this is a hardcoded GitHub anti-loop rule. Autofix commits currently don't get CI'd, which means the autofix feedback loop is broken.

**Fix**: Generate a short-lived token from the `homeboy-ci-bot` GitHub App (App ID: 3034937) using `actions/create-github-app-token@v1`. Pass it to homeboy-action via the new `app-token` input (see Extra-Chill/homeboy-action#50).

## Changes

- **`.github/workflows/ci.yml`**: Added "Generate GitHub App token" step before homeboy-action in the audit job. Token is passed via `app-token` input. Degrades gracefully when secrets aren't set.

## Dependencies

- **homeboy-action#50** must be merged and v1 tag updated first (adds `app-token` input)
- **Org secrets set**: `HOMEBOY_APP_ID` = 3034937, `HOMEBOY_APP_PRIVATE_KEY` = PEM contents ✅
- **App installed** on Extra-Chill org ✅

## Flow after merge

```
PR push → CI runs → audit fails → autofix runs →
app token push → CI re-triggers (new!) → passes → done
```