### PR TITLE
feat: auto-ratchet baseline after audit fix resolves findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
   # chicken-and-egg problem of needing a released binary to audit itself.
   # Falls back to latest release binary if source build fails.
   # Runs independently of build job so PR comments are always posted.
-  # Autofix enabled: on audit failure, applies safe fixes and commits back to the PR.
+  # Autofix mode "always": runs autofix on every PR (not just failures),
+  # so the baseline auto-ratchets as the factory eliminates fixable findings.
   # App token: autofix pushes use the GitHub App token so CI re-triggers on the new commit.
   audit:
     name: Homeboy Audit
@@ -70,6 +71,7 @@ jobs:
           component: homeboy
           commands: audit
           autofix: 'true'
+          autofix-mode: 'always'
           autofix-commands: 'audit --fix --write'
           autofix-max-commits: '2'
           app-token: ${{ steps.app-token.outputs.token || '' }}

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -125,6 +125,8 @@ pub enum AuditOutput {
         written: bool,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         hints: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        ratchet_summary: Option<AutoRatchetSummary>,
     },
 
     #[serde(rename = "audit.baseline")]
@@ -148,6 +150,18 @@ pub enum AuditOutput {
 
     #[serde(rename = "audit.summary")]
     Summary(AuditSummaryOutput),
+}
+
+#[derive(Debug, Serialize)]
+pub struct AutoRatchetSummary {
+    /// Number of findings resolved by autofix.
+    pub resolved_count: usize,
+    /// Baseline finding count before auto-ratchet.
+    pub previous_count: usize,
+    /// Current finding count after auto-ratchet.
+    pub current_count: usize,
+    /// Whether the baseline file was successfully updated.
+    pub baseline_updated: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -483,6 +497,52 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
             final_fix_result = fix_result;
         }
 
+        // Auto-ratchet: if --fix --write applied changes and a baseline exists,
+        // automatically update the baseline to remove resolved findings.
+        // This makes the baseline self-dissolving — it shrinks on every CI run
+        // as autofix eliminates fixable findings.
+        let mut ratchet_summary = None;
+        if written && !args.baseline_args.ignore_baseline {
+            if let Some(existing_baseline) =
+                baseline::load_baseline(Path::new(&current_result.source_path))
+            {
+                let comparison = baseline::compare(&current_result, &existing_baseline);
+                if !comparison.resolved_fingerprints.is_empty() {
+                    // Findings were eliminated — save updated baseline
+                    match baseline::save_baseline(&current_result) {
+                        Ok(_path) => {
+                            homeboy::log_status!(
+                                "ratchet",
+                                "Auto-updated baseline: {} finding(s) resolved ({} → {})",
+                                comparison.resolved_fingerprints.len(),
+                                existing_baseline.item_count,
+                                current_result.findings.len()
+                            );
+                            ratchet_summary = Some(AutoRatchetSummary {
+                                resolved_count: comparison.resolved_fingerprints.len(),
+                                previous_count: existing_baseline.item_count,
+                                current_count: current_result.findings.len(),
+                                baseline_updated: true,
+                            });
+                        }
+                        Err(e) => {
+                            homeboy::log_status!(
+                                "ratchet",
+                                "Warning: failed to auto-update baseline: {}",
+                                e
+                            );
+                        }
+                    }
+                } else if comparison.new_items.is_empty() {
+                    homeboy::log_status!(
+                        "ratchet",
+                        "No findings resolved — baseline unchanged ({} findings)",
+                        existing_baseline.item_count
+                    );
+                }
+            }
+        }
+
         let outcome = autofix::standard_outcome(
             if written {
                 AutofixMode::Write
@@ -528,6 +588,7 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
                 iterations,
                 written,
                 hints: outcome.hints,
+                ratchet_summary,
             },
             exit_code,
         ));

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -307,6 +307,78 @@ mod tests {
     }
 
     #[test]
+    fn auto_ratchet_saves_updated_baseline_after_resolving_findings() {
+        // Simulates the auto-ratchet flow:
+        // 1. Save baseline with 3 findings
+        // 2. "Fix" resolves 1 finding (current has 2)
+        // 3. Re-save baseline from current state
+        // 4. Verify baseline now has 2 findings
+        let result_original = make_result(
+            vec![
+                make_finding("Flow", "a.php", "Missing method: execute"),
+                make_finding("Flow", "b.php", "Missing method: validate"),
+                make_finding("Flow", "c.php", "Missing method: register"),
+            ],
+            "auto_ratchet",
+        );
+        let _ = save_baseline(&result_original).unwrap();
+        let baseline_before = load_baseline(Path::new(&result_original.source_path)).unwrap();
+        assert_eq!(baseline_before.item_count, 3);
+
+        // After autofix: c.php finding was resolved
+        let mut current = make_result(
+            vec![
+                make_finding("Flow", "a.php", "Missing method: execute"),
+                make_finding("Flow", "b.php", "Missing method: validate"),
+            ],
+            "auto_ratchet_current",
+        );
+        current.source_path = result_original.source_path.clone();
+
+        // Compare detects resolved findings
+        let comparison = compare(&current, &baseline_before);
+        assert!(!comparison.drift_increased);
+        assert_eq!(comparison.resolved_fingerprints.len(), 1);
+
+        // Auto-ratchet: save updated baseline
+        let _ = save_baseline(&current).unwrap();
+        let baseline_after = load_baseline(Path::new(&current.source_path)).unwrap();
+        assert_eq!(baseline_after.item_count, 2);
+
+        // Verify the resolved finding is gone from the new baseline
+        let recheck = compare(&current, &baseline_after);
+        assert!(!recheck.drift_increased);
+        assert!(recheck.resolved_fingerprints.is_empty());
+        assert_eq!(recheck.delta, 0);
+
+        let _ = std::fs::remove_dir_all(Path::new(&result_original.source_path));
+    }
+
+    #[test]
+    fn auto_ratchet_preserves_baseline_when_no_findings_resolved() {
+        let result = make_result(
+            vec![
+                make_finding("Flow", "a.php", "Missing method: execute"),
+                make_finding("Flow", "b.php", "Missing method: validate"),
+            ],
+            "auto_ratchet_no_change",
+        );
+        let _ = save_baseline(&result).unwrap();
+        let baseline_before = load_baseline(Path::new(&result.source_path)).unwrap();
+
+        // Same findings — nothing resolved
+        let comparison = compare(&result, &baseline_before);
+        assert!(comparison.resolved_fingerprints.is_empty());
+        assert!(!comparison.drift_increased);
+
+        // Baseline should NOT be re-saved (unchanged)
+        // The auto-ratchet code checks resolved_fingerprints.is_empty()
+        // and skips the save in that case
+
+        let _ = std::fs::remove_dir_all(Path::new(&result.source_path));
+    }
+
+    #[test]
     fn no_baseline_returns_none() {
         let result = load_baseline(Path::new("/nonexistent/path"));
         assert!(result.is_none());


### PR DESCRIPTION
## Summary

- After `--fix --write` resolves findings, auto-updates the baseline to remove them
- CI config uses `autofix-mode: always` so autofix runs every PR (requires [homeboy-action#54](https://github.com/Extra-Chill/homeboy-action/pull/54))
- Two new tests for the auto-ratchet save/compare cycle

## How it works

The baseline exists as a temporary scaffold. This PR makes it self-dissolving:

1. `audit --fix --write` runs the convergent fix loop (already existed)
2. **NEW**: After fixes complete, check if a baseline exists
3. **NEW**: Compare post-fix findings against baseline — if any were resolved, auto-save updated baseline
4. **NEW**: `AutoRatchetSummary` in JSON output reports what was resolved

The CI workflow sets `autofix-mode: always` so autofix runs on every PR, not just on failure. Combined with the core auto-ratchet, the baseline shrinks on every CI run until it reaches zero.

## Dependency

Requires homeboy-action [#54](https://github.com/Extra-Chill/homeboy-action/pull/54) for the `autofix-mode: always` input. The homeboy-action PR should be merged first and v1 tag updated before this PR's CI can fully exercise the new flow.

## Testing

- 867 tests pass (including 2 new auto-ratchet tests)
- `cargo fmt --check` clean