### PR TITLE
fix: decompose rollback covers caller files + unify snapshot systems

### DIFF
--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -305,11 +305,7 @@ pub struct ApplyOptions<'a> {
     pub verifier: Option<&'a dyn Fn(&ApplyChunkResult) -> Result<String, String>>,
 }
 
-#[derive(Debug, Clone)]
-struct FileSnapshot {
-    path: std::path::PathBuf,
-    original: Option<String>,
-}
+use crate::core::undo::InMemoryRollback;
 
 #[derive(Debug, Clone, Default)]
 pub struct FixPolicy {
@@ -2442,10 +2438,6 @@ pub fn apply_fixes_chunked(
 
         let language = detect_language(&abs_path);
         let modified = apply_insertions_to_content(&content, &fix.insertions, &language);
-        let snapshot = FileSnapshot {
-            path: abs_path.clone(),
-            original: Some(content.clone()),
-        };
 
         if modified == content {
             results.push(ApplyChunkResult {
@@ -2459,6 +2451,9 @@ pub fn apply_fixes_chunked(
             });
             continue;
         }
+
+        let mut rollback = InMemoryRollback::new();
+        rollback.capture(&abs_path);
 
         match std::fs::write(&abs_path, &modified) {
             Ok(_) => {
@@ -2478,7 +2473,7 @@ pub fn apply_fixes_chunked(
                             chunk.verification = Some(verification);
                         }
                         Err(error) => {
-                            rollback_snapshot(&snapshot);
+                            rollback.restore_all();
                             chunk.status = ChunkStatus::Reverted;
                             chunk.reverted_files = 1;
                             chunk.error = Some(error);
@@ -2555,10 +2550,8 @@ pub fn apply_new_files_chunked(
             continue;
         }
 
-        let snapshot = FileSnapshot {
-            path: abs_path.clone(),
-            original: None,
-        };
+        let mut rollback = InMemoryRollback::new();
+        rollback.capture(&abs_path);
 
         match std::fs::write(&abs_path, &nf.content) {
             Ok(_) => {
@@ -2578,7 +2571,7 @@ pub fn apply_new_files_chunked(
                             chunk.verification = Some(verification);
                         }
                         Err(error) => {
-                            rollback_snapshot(&snapshot);
+                            rollback.restore_all();
                             chunk.status = ChunkStatus::Reverted;
                             chunk.reverted_files = 1;
                             chunk.error = Some(error);
@@ -2633,23 +2626,33 @@ pub fn apply_decompose_plans(
                 continue;
             }
         };
-        let mut snapshots = vec![FileSnapshot {
-            path: source_abs,
-            original: Some(source_content),
-        }];
+        let mut rollback = InMemoryRollback::new();
+        rollback.capture(&source_abs);
         let mut all_files = vec![dfp.file.clone()];
         for group in &dfp.plan.groups {
             let target_abs = root.join(&group.suggested_target);
             all_files.push(group.suggested_target.clone());
-            snapshots.push(FileSnapshot {
-                path: target_abs.clone(),
-                original: if target_abs.exists() {
-                    std::fs::read_to_string(&target_abs).ok()
-                } else {
-                    None
-                },
-            });
+            rollback.capture(&target_abs);
         }
+
+        // Dry-run first to discover caller files that rewrite_caller_imports
+        // will modify. We must snapshot these BEFORE the real write so rollback
+        // restores them too. Without this, a reverted decompose leaks broken
+        // import rewrites into caller files across the codebase.
+        if let Ok(dry_run_results) = decompose::apply_plan(&dfp.plan, root, false) {
+            for mr in &dry_run_results {
+                for caller_path in &mr.caller_files_modified {
+                    let rel = caller_path
+                        .strip_prefix(root)
+                        .unwrap_or(caller_path)
+                        .to_string_lossy()
+                        .to_string();
+                    all_files.push(rel);
+                    rollback.capture(caller_path);
+                }
+            }
+        }
+
         match decompose::apply_plan(&dfp.plan, root, true) {
             Ok(move_results) => {
                 let files_modified = move_results.iter().filter(|r| r.applied).count();
@@ -2668,9 +2671,7 @@ pub fn apply_decompose_plans(
                             chunk.verification = Some(verification);
                         }
                         Err(error) => {
-                            for snapshot in &snapshots {
-                                rollback_snapshot(snapshot);
-                            }
+                            rollback.restore_all();
                             chunk.status = ChunkStatus::Reverted;
                             chunk.reverted_files = files_modified;
                             chunk.error = Some(error);
@@ -2690,9 +2691,7 @@ pub fn apply_decompose_plans(
                 results.push(chunk);
             }
             Err(e) => {
-                for snapshot in &snapshots {
-                    rollback_snapshot(snapshot);
-                }
+                rollback.restore_all();
                 results.push(ApplyChunkResult {
                     chunk_id: format!("decompose:{}", index + 1),
                     files: vec![dfp.file.clone()],
@@ -2706,17 +2705,6 @@ pub fn apply_decompose_plans(
         }
     }
     results
-}
-
-fn rollback_snapshot(snapshot: &FileSnapshot) {
-    match &snapshot.original {
-        Some(original) => {
-            let _ = std::fs::write(&snapshot.path, original);
-        }
-        None => {
-            let _ = std::fs::remove_file(&snapshot.path);
-        }
-    }
 }
 
 /// Apply insertions to file content, returning the modified content.

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -33,6 +33,10 @@ pub struct MoveResult {
     pub file_created: bool,
     /// Number of import references updated across the codebase.
     pub imports_updated: usize,
+    /// Absolute paths of caller files whose imports were rewritten.
+    /// Used by decompose rollback to restore these files if the move is reverted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub caller_files_modified: Vec<PathBuf>,
     /// Related tests that were moved alongside items.
     pub tests_moved: Vec<MovedItem>,
     /// Whether changes were written to disk.
@@ -690,6 +694,10 @@ pub fn move_items_with_options(
         to_file: to.to_string(),
         file_created,
         imports_updated,
+        caller_files_modified: caller_rewrites
+            .iter()
+            .map(|(path, _)| path.clone())
+            .collect(),
         tests_moved,
         applied: write,
         warnings,

--- a/src/core/undo.rs
+++ b/src/core/undo.rs
@@ -63,6 +63,84 @@ pub struct SnapshotSummary {
     pub age: String,
 }
 
+/// In-memory file rollback for per-chunk undo within a single operation.
+///
+/// Unlike `UndoSnapshot` (which persists to disk for `homeboy undo`), this is
+/// ephemeral — used by the fixer's chunk verifier to rollback individual chunks
+/// that fail verification without affecting the persistent undo stack.
+///
+/// Usage:
+/// ```ignore
+/// let mut rollback = InMemoryRollback::new();
+/// rollback.capture(&abs_path);           // existing file — saves content
+/// rollback.capture(&new_file_path);      // doesn't exist yet — recorded as created
+/// // ... do the write ...
+/// if verification_failed {
+///     rollback.restore_all();            // restores originals, removes created files
+/// }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryRollback {
+    entries: Vec<RollbackEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct RollbackEntry {
+    path: PathBuf,
+    /// Original content if the file existed, None if it was newly created.
+    original: Option<Vec<u8>>,
+}
+
+impl InMemoryRollback {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Capture a file's current state before modification.
+    /// Deduplicates — capturing the same path twice is a no-op.
+    pub fn capture(&mut self, path: &Path) {
+        if self.entries.iter().any(|e| e.path == path) {
+            return;
+        }
+        let original = if path.is_file() {
+            std::fs::read(path).ok()
+        } else {
+            None
+        };
+        self.entries.push(RollbackEntry {
+            path: path.to_path_buf(),
+            original,
+        });
+    }
+
+    /// Restore all captured files to their original state.
+    /// Files that existed are restored. Files that were created are removed.
+    pub fn restore_all(&self) {
+        for entry in &self.entries {
+            match &entry.original {
+                Some(content) => {
+                    let _ = std::fs::write(&entry.path, content);
+                }
+                None => {
+                    let _ = std::fs::remove_file(&entry.path);
+                }
+            }
+        }
+    }
+
+    /// Number of files captured.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether any files have been captured.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 /// A builder for creating snapshots before write operations.
 ///
 /// Usage:
@@ -706,5 +784,89 @@ mod tests {
         assert_eq!(format_age(90), "1m ago");
         assert_eq!(format_age(7200), "2h ago");
         assert_eq!(format_age(172800), "2d ago");
+    }
+
+    // InMemoryRollback tests
+
+    #[test]
+    fn in_memory_rollback_restores_modified_file() {
+        let root = test_root("imr-restore");
+        fs::create_dir_all(&root).unwrap();
+        let file = root.join("a.rs");
+        fs::write(&file, "original\n").unwrap();
+
+        let mut rollback = InMemoryRollback::new();
+        rollback.capture(&file);
+        assert_eq!(rollback.len(), 1);
+
+        // Simulate a write
+        fs::write(&file, "modified\n").unwrap();
+        assert!(fs::read_to_string(&file).unwrap().contains("modified"));
+
+        // Rollback
+        rollback.restore_all();
+        assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn in_memory_rollback_removes_created_file() {
+        let root = test_root("imr-remove");
+        fs::create_dir_all(&root).unwrap();
+        let file = root.join("new.rs");
+
+        let mut rollback = InMemoryRollback::new();
+        rollback.capture(&file); // doesn't exist yet
+
+        // Simulate a write
+        fs::write(&file, "created\n").unwrap();
+        assert!(file.exists());
+
+        // Rollback
+        rollback.restore_all();
+        assert!(!file.exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn in_memory_rollback_deduplicates() {
+        let root = test_root("imr-dedup");
+        fs::create_dir_all(&root).unwrap();
+        let file = root.join("dup.rs");
+        fs::write(&file, "content\n").unwrap();
+
+        let mut rollback = InMemoryRollback::new();
+        rollback.capture(&file);
+        rollback.capture(&file); // duplicate — should be ignored
+        assert_eq!(rollback.len(), 1);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn in_memory_rollback_handles_mixed_files() {
+        let root = test_root("imr-mixed");
+        fs::create_dir_all(&root).unwrap();
+        let existing = root.join("existing.rs");
+        let new_file = root.join("new.rs");
+        fs::write(&existing, "before\n").unwrap();
+
+        let mut rollback = InMemoryRollback::new();
+        rollback.capture(&existing);
+        rollback.capture(&new_file);
+        assert_eq!(rollback.len(), 2);
+
+        // Simulate writes
+        fs::write(&existing, "after\n").unwrap();
+        fs::write(&new_file, "created\n").unwrap();
+
+        // Rollback
+        rollback.restore_all();
+        assert_eq!(fs::read_to_string(&existing).unwrap(), "before\n");
+        assert!(!new_file.exists());
+
+        let _ = fs::remove_dir_all(root);
     }
 }


### PR DESCRIPTION
## Summary
- **Fixes decompose snapshot leak**: when `rewrite_caller_imports` modifies caller files during decompose, those files are now included in the rollback snapshot. Previously, a reverted decompose left broken import rewrites in caller files across the codebase (root cause of broken autofix commits in CI).
- **Unifies two duplicate rollback systems**: replaced fixer.rs `FileSnapshot` struct + `rollback_snapshot()` with new `InMemoryRollback` from `undo.rs`. All three apply functions (fixes, new_files, decompose) now use the same primitive.
- **Adds `caller_files_modified` to `MoveResult`**: surfaces which files were modified by import rewrites so callers (like decompose) can snapshot them.

## Changes
- `src/core/undo.rs` — added `InMemoryRollback` (ephemeral per-chunk rollback, no persistence) + 4 tests
- `src/core/code_audit/fixer.rs` — removed `FileSnapshot`/`rollback_snapshot`, replaced with `InMemoryRollback`. Decompose now dry-runs first to discover caller files, snapshots them before the real write.
- `src/core/refactor/move_items.rs` — added `caller_files_modified: Vec<PathBuf>` to `MoveResult`, populated from `caller_rewrites`

## Testing
927 tests pass (867 lib + 59 integration + 1 output), 0 failures. Clippy clean (pre-existing warnings only).