### PR TITLE
feat(ci): enable autofix on all CI jobs + release autofix PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
@@ -23,6 +32,10 @@ jobs:
           extension: rust
           component: homeboy
           commands: lint
+          autofix: 'true'
+          autofix-mode: 'on-failure'
+          autofix-max-commits: '2'
+          app-token: ${{ steps.app-token.outputs.token || '' }}
 
   test:
     name: Test
@@ -30,7 +43,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
@@ -38,6 +60,10 @@ jobs:
           extension: rust
           component: homeboy
           commands: test
+          autofix: 'true'
+          autofix-mode: 'on-failure'
+          autofix-max-commits: '2'
+          app-token: ${{ steps.app-token.outputs.token || '' }}
 
   # ── Homeboy audit (dogfooding via homeboy-action) ──
   # Uses source build mode to compile from the PR branch, avoiding the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,14 @@ jobs:
       - name: cargo test
         run: cargo test
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
       - uses: Extra-Chill/homeboy-action@v1
         with:
           source: '.'
@@ -164,6 +172,12 @@ jobs:
           component: homeboy
           commands: audit
           auto-issue: 'true'
+          autofix: 'true'
+          autofix-mode: 'always'
+          autofix-open-pr: 'true'
+          autofix-commands: 'lint --fix,audit --fix --write'
+          autofix-max-commits: '3'
+          app-token: ${{ steps.app-token.outputs.token || '' }}
 
   # ── Step 3: Version bump + changelog + tag ──
   prepare:


### PR DESCRIPTION
## Summary
- **All 3 CI jobs now have autofix enabled** — lint (on-failure), test (on-failure), audit (always)
- **Release quality gate opens autofix PRs** — when the cron release finds fixable issues, it creates a PR with the fixes instead of just failing. The PR CI loop verifies and iterates. Next cron run releases cleanly.

## Changes

### ci.yml
- Lint and test jobs: added `ref: github.head_ref` checkout, GitHub App token, `autofix: 'true'` with `autofix-mode: 'on-failure'`
- All 3 jobs now use the same pattern: checkout PR head → app token → homeboy-action with autofix

### release.yml
- Quality gate: added GitHub App token + homeboy-action autofix with `autofix-open-pr: 'true'`
- Autofix commands: `lint --fix,audit --fix --write` (unscoped — full codebase, not just changed files)
- Max 3 commits per autofix PR to prevent runaway loops

## Flow
1. **PR CI**: scoped autofix → pushes fixup commits to PR branch → re-triggers CI
2. **Release cron**: full quality gate → fixable findings? → opens autofix PR → PR CI verifies → merge → next cron releases