### PR TITLE
fix: scoped baseline updates to prevent merge conflicts

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -501,6 +501,9 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
         // automatically update the baseline to remove resolved findings.
         // This makes the baseline self-dissolving — it shrinks on every CI run
         // as autofix eliminates fixable findings.
+        //
+        // When --changed-since is active, use scoped baseline update to avoid
+        // touching fingerprints for files outside the change set.
         let mut ratchet_summary = None;
         if written && !args.baseline_args.ignore_baseline {
             if let Some(existing_baseline) =
@@ -509,7 +512,17 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
                 let comparison = baseline::compare(&current_result, &existing_baseline);
                 if !comparison.resolved_fingerprints.is_empty() {
                     // Findings were eliminated — save updated baseline
-                    match baseline::save_baseline(&current_result) {
+                    let save_result = if let Some(ref git_ref) = args.changed_since {
+                        let changed = git::get_files_changed_since(
+                            &current_result.source_path,
+                            git_ref,
+                        )
+                        .unwrap_or_default();
+                        baseline::save_baseline_scoped(&current_result, &changed)
+                    } else {
+                        baseline::save_baseline(&current_result)
+                    };
+                    match save_result {
                         Ok(_path) => {
                             homeboy::log_status!(
                                 "ratchet",
@@ -596,8 +609,25 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
 
     // --baseline: save current state
     if args.baseline_args.baseline {
-        let saved =
-            baseline::save_baseline(&result).map_err(homeboy::Error::internal_unexpected)?;
+        let saved = if let Some(ref git_ref) = args.changed_since {
+            // Scoped baseline: only update fingerprints for changed files
+            let changed = git::get_files_changed_since(&resolved_path, git_ref)?;
+            if changed.is_empty() {
+                homeboy::log_status!("baseline", "No files changed since {} — baseline unchanged", git_ref);
+            } else {
+                homeboy::log_status!(
+                    "baseline",
+                    "Scoped baseline update: {} file(s) in scope",
+                    changed.len()
+                );
+            }
+            baseline::save_baseline_scoped(&result, &changed)
+                .map_err(homeboy::Error::internal_unexpected)?
+        } else {
+            // Full baseline: replace everything
+            baseline::save_baseline(&result)
+                .map_err(homeboy::Error::internal_unexpected)?
+        };
 
         let baseline_data =
             baseline::load_baseline(Path::new(&result.source_path)).ok_or_else(|| {

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -109,6 +109,58 @@ pub fn save_baseline(result: &CodeAuditResult) -> Result<std::path::PathBuf, Str
     generic::save(&config, &result.component_id, &items, metadata).map_err(|e| e.message)
 }
 
+/// Save a scoped baseline update — merges with existing baseline instead of replacing.
+///
+/// Only fingerprints for files in `changed_files` are updated:
+/// - Removes old fingerprints for files in scope
+/// - Adds current fingerprints from the scoped audit result
+/// - Preserves all fingerprints outside the scope untouched
+///
+/// This prevents CI/local environment parity from causing baseline churn
+/// on files that weren't part of the current change set.
+pub fn save_baseline_scoped(
+    result: &CodeAuditResult,
+    changed_files: &[String],
+) -> Result<std::path::PathBuf, String> {
+    let source = Path::new(&result.source_path);
+    let config = BaselineConfig::new(source, BASELINE_KEY);
+
+    let known_outliers: Vec<String> = result
+        .conventions
+        .iter()
+        .flat_map(|c| c.outliers.iter().map(|o| o.file.clone()))
+        .collect();
+
+    let metadata = AuditBaselineMetadata {
+        outliers_count: known_outliers.len(),
+        alignment_score: result.summary.alignment_score,
+        known_outliers,
+    };
+
+    let items: Vec<AuditFinding> = result.findings.iter().map(AuditFinding).collect();
+
+    generic::save_scoped(
+        &config,
+        &result.component_id,
+        &items,
+        metadata,
+        changed_files,
+        file_from_audit_fingerprint,
+    )
+    .map_err(|e| e.message)
+}
+
+/// Extract the file path from an audit fingerprint.
+///
+/// Audit fingerprints have the format `convention::file::kind`.
+/// The file path is the middle segment between the first `::` and the last `::`.
+fn file_from_audit_fingerprint(fingerprint: &str) -> Option<String> {
+    let first = fingerprint.find("::")?;
+    let rest = &fingerprint[first + 2..];
+    let last = rest.rfind("::")?;
+    Some(rest[..last].to_string())
+}
+
 /// Load a baseline if one exists for the given source path.
 pub fn load_baseline(source_path: &Path) -> Option<AuditBaseline> {
     let config = BaselineConfig::new(source_path, BASELINE_KEY);
@@ -439,5 +491,102 @@ mod tests {
             AuditFinding(&f2).fingerprint(),
             "fingerprint should not change when line count changes"
         );
+    }
+
+    #[test]
+    fn file_from_audit_fingerprint_extracts_file_path() {
+        assert_eq!(
+            file_from_audit_fingerprint("Commands::src/commands/version.rs::NamingMismatch"),
+            Some("src/commands/version.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn file_from_audit_fingerprint_handles_nested_paths() {
+        assert_eq!(
+            file_from_audit_fingerprint(
+                "test_coverage::src/core/code_audit/baseline.rs::MissingTestMethod"
+            ),
+            Some("src/core/code_audit/baseline.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn file_from_audit_fingerprint_returns_none_for_invalid() {
+        assert_eq!(file_from_audit_fingerprint("no_separators"), None);
+        assert_eq!(file_from_audit_fingerprint("only::one"), None);
+    }
+
+    #[test]
+    fn save_baseline_scoped_preserves_out_of_scope() {
+        let result_initial = make_result(
+            vec![
+                make_finding("Flow", "a.php", "Missing method: execute"),
+                make_finding("Flow", "b.php", "Missing method: validate"),
+                make_finding("Flow", "c.php", "Missing method: register"),
+            ],
+            "scoped_preserve",
+        );
+        let _ = save_baseline(&result_initial).unwrap();
+        let baseline_before = load_baseline(Path::new(&result_initial.source_path)).unwrap();
+        assert_eq!(baseline_before.item_count, 3);
+
+        // Scoped update: only a.php changed, finding resolved
+        let mut result_scoped = make_result(vec![], "scoped_preserve_update");
+        result_scoped.source_path = result_initial.source_path.clone();
+
+        let changed = vec!["a.php".to_string()];
+        let _ = save_baseline_scoped(&result_scoped, &changed).unwrap();
+
+        let baseline_after = load_baseline(Path::new(&result_initial.source_path)).unwrap();
+        // a.php removed (was in scope, no new findings), b.php + c.php preserved
+        assert_eq!(baseline_after.item_count, 2);
+        assert!(!baseline_after
+            .known_fingerprints
+            .iter()
+            .any(|fp| fp.contains("a.php")));
+        assert!(baseline_after
+            .known_fingerprints
+            .iter()
+            .any(|fp| fp.contains("b.php")));
+        assert!(baseline_after
+            .known_fingerprints
+            .iter()
+            .any(|fp| fp.contains("c.php")));
+
+        let _ = std::fs::remove_dir_all(Path::new(&result_initial.source_path));
+    }
+
+    #[test]
+    fn save_baseline_scoped_adds_new_in_scope() {
+        let result_initial = make_result(
+            vec![make_finding("Flow", "a.php", "Missing method: execute")],
+            "scoped_add",
+        );
+        let _ = save_baseline(&result_initial).unwrap();
+
+        // Scoped update: b.php is in scope with a new finding
+        let mut result_scoped = make_result(
+            vec![make_finding("Flow", "b.php", "Missing method: validate")],
+            "scoped_add_update",
+        );
+        result_scoped.source_path = result_initial.source_path.clone();
+
+        let changed = vec!["b.php".to_string()];
+        let _ = save_baseline_scoped(&result_scoped, &changed).unwrap();
+
+        let baseline_after = load_baseline(Path::new(&result_initial.source_path)).unwrap();
+        // a.php preserved, b.php added
+        assert_eq!(baseline_after.item_count, 2);
+        assert!(baseline_after
+            .known_fingerprints
+            .iter()
+            .any(|fp| fp.contains("a.php")));
+        assert!(baseline_after
+            .known_fingerprints
+            .iter()
+            .any(|fp| fp.contains("b.php")));
+
+        let _ = std::fs::remove_dir_all(Path::new(&result_initial.source_path));
     }
 }

--- a/src/utils/baseline.rs
+++ b/src/utils/baseline.rs
@@ -229,6 +229,108 @@ pub fn save<M: Serialize>(
     Ok(json_path)
 }
 
+/// Save a scoped baseline update into `homeboy.json`.
+///
+/// Unlike [`save`], this merges with the existing baseline instead of
+/// replacing it. Only fingerprints for files in `scope` are updated:
+///
+/// 1. Load the existing baseline (if any)
+/// 2. Remove all fingerprints whose file path matches any file in `scope`
+/// 3. Add fingerprints from `current_items` (which should be scoped findings)
+/// 4. Preserve all fingerprints outside the scope untouched
+///
+/// This prevents CI/local environment parity issues from causing baseline
+/// churn on files that weren't part of the current change set.
+///
+/// `file_from_fingerprint` extracts the file path from a fingerprint string.
+/// This is domain-specific — the caller knows how their fingerprints are
+/// structured (e.g., `convention::file::kind` for audit).
+pub fn save_scoped<M: Serialize + for<'de> Deserialize<'de> + Clone>(
+    config: &BaselineConfig,
+    context_id: &str,
+    current_items: &[impl Fingerprintable],
+    metadata: M,
+    scope: &[String],
+    file_from_fingerprint: impl Fn(&str) -> Option<String>,
+) -> Result<PathBuf> {
+    let json_path = config.json_path();
+
+    // If no existing baseline, fall back to full save
+    let existing: Option<Baseline<M>> = load(config)?;
+    let Some(existing) = existing else {
+        return save(config, context_id, current_items, metadata);
+    };
+
+    // Build a set of scoped file paths for fast lookup
+    let scope_set: HashSet<&str> = scope.iter().map(|s| s.as_str()).collect();
+
+    // Keep fingerprints that are outside the scope
+    let mut merged_fingerprints: Vec<String> = existing
+        .known_fingerprints
+        .into_iter()
+        .filter(|fp| {
+            file_from_fingerprint(fp)
+                .as_deref()
+                .is_none_or(|file| !scope_set.contains(file))
+        })
+        .collect();
+
+    // Add fingerprints from the current scoped items
+    for item in current_items {
+        merged_fingerprints.push(item.fingerprint());
+    }
+
+    // Sort for deterministic output
+    merged_fingerprints.sort();
+    merged_fingerprints.dedup();
+
+    let baseline = Baseline {
+        created_at: utc_now_iso8601(),
+        context_id: context_id.to_string(),
+        item_count: merged_fingerprints.len(),
+        known_fingerprints: merged_fingerprints,
+        metadata,
+    };
+
+    let baseline_value = serde_json::to_value(&baseline).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to serialize baseline: {}", e),
+            Some("baseline.save_scoped".to_string()),
+        )
+    })?;
+
+    // Read existing homeboy.json or start fresh
+    let mut root = read_json_or_empty(&json_path)?;
+
+    // Ensure baselines object exists
+    let baselines = root
+        .as_object_mut()
+        .ok_or_else(|| {
+            Error::internal_io(
+                "homeboy.json root is not an object".to_string(),
+                Some("baseline.save_scoped".to_string()),
+            )
+        })?
+        .entry(BASELINES_KEY)
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+
+    // Set the specific baseline key
+    baselines
+        .as_object_mut()
+        .ok_or_else(|| {
+            Error::internal_io(
+                "baselines key is not an object".to_string(),
+                Some("baseline.save_scoped".to_string()),
+            )
+        })?
+        .insert(config.key.clone(), baseline_value);
+
+    // Write back
+    write_json(&json_path, &root)?;
+
+    Ok(json_path)
+}
+
 /// Load a baseline if one exists in `homeboy.json`.
 ///
 /// Returns `Ok(None)` if:
@@ -897,5 +999,192 @@ mod tests {
 
         let result = load_from_git_ref::<()>(path, "HEAD", "audit");
         assert!(result.is_none());
+    }
+
+    // -- Scoped save ----------------------------------------------------------
+
+    /// Helper to extract file from fingerprints of format `category::file`.
+    fn test_file_from_fingerprint(fp: &str) -> Option<String> {
+        let first = fp.find("::")?;
+        Some(fp[first + 2..].to_string())
+    }
+
+    #[test]
+    fn save_scoped_preserves_out_of_scope_fingerprints() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+
+        // Initial full baseline: findings in a.rs, b.rs, c.rs
+        let original = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "b.rs", "dead code"),
+            item("lint", "c.rs", "missing docs"),
+        ];
+        save(&config, "test", &original, ()).unwrap();
+
+        // Scoped update: only a.rs is in scope, with a new finding
+        let scoped_items = vec![item("lint", "a.rs", "new finding in a")];
+        let scope = vec!["a.rs".to_string()];
+        save_scoped(
+            &config,
+            "test",
+            &scoped_items,
+            (),
+            &scope,
+            test_file_from_fingerprint,
+        )
+        .unwrap();
+
+        let loaded = load::<()>(&config).unwrap().unwrap();
+        // a.rs replaced (1 finding), b.rs + c.rs preserved (2 findings) = 3 total
+        assert_eq!(loaded.item_count, 3);
+        assert!(loaded.known_fingerprints.contains(&"lint::a.rs".to_string()));
+        assert!(loaded.known_fingerprints.contains(&"lint::b.rs".to_string()));
+        assert!(loaded.known_fingerprints.contains(&"lint::c.rs".to_string()));
+    }
+
+    #[test]
+    fn save_scoped_removes_resolved_findings_in_scope() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+
+        // Initial: findings in a.rs and b.rs
+        let original = vec![
+            item("lint", "a.rs", "unused import"),
+            item("lint", "b.rs", "dead code"),
+        ];
+        save(&config, "test", &original, ()).unwrap();
+
+        // Scoped update: a.rs is in scope but has no findings (resolved)
+        let scoped_items: Vec<TestItem> = vec![];
+        let scope = vec!["a.rs".to_string()];
+        save_scoped(
+            &config,
+            "test",
+            &scoped_items,
+            (),
+            &scope,
+            test_file_from_fingerprint,
+        )
+        .unwrap();
+
+        let loaded = load::<()>(&config).unwrap().unwrap();
+        // a.rs findings removed, b.rs preserved
+        assert_eq!(loaded.item_count, 1);
+        assert!(!loaded.known_fingerprints.contains(&"lint::a.rs".to_string()));
+        assert!(loaded.known_fingerprints.contains(&"lint::b.rs".to_string()));
+    }
+
+    #[test]
+    fn save_scoped_adds_new_findings_in_scope() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+
+        // Initial: only a.rs
+        let original = vec![item("lint", "a.rs", "unused import")];
+        save(&config, "test", &original, ()).unwrap();
+
+        // Scoped update: b.rs is in scope with a new finding
+        let scoped_items = vec![item("lint", "b.rs", "new finding")];
+        let scope = vec!["b.rs".to_string()];
+        save_scoped(
+            &config,
+            "test",
+            &scoped_items,
+            (),
+            &scope,
+            test_file_from_fingerprint,
+        )
+        .unwrap();
+
+        let loaded = load::<()>(&config).unwrap().unwrap();
+        assert_eq!(loaded.item_count, 2);
+        assert!(loaded.known_fingerprints.contains(&"lint::a.rs".to_string()));
+        assert!(loaded.known_fingerprints.contains(&"lint::b.rs".to_string()));
+    }
+
+    #[test]
+    fn save_scoped_falls_back_to_full_save_when_no_baseline_exists() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+
+        // No existing baseline — should create one from scratch
+        let scoped_items = vec![
+            item("lint", "a.rs", "finding"),
+            item("lint", "b.rs", "finding"),
+        ];
+        let scope = vec!["a.rs".to_string()];
+        save_scoped(
+            &config,
+            "test",
+            &scoped_items,
+            (),
+            &scope,
+            test_file_from_fingerprint,
+        )
+        .unwrap();
+
+        let loaded = load::<()>(&config).unwrap().unwrap();
+        assert_eq!(loaded.item_count, 2);
+    }
+
+    #[test]
+    fn save_scoped_deduplicates_fingerprints() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+
+        // Initial: a.rs finding
+        let original = vec![item("lint", "a.rs", "unused import")];
+        save(&config, "test", &original, ()).unwrap();
+
+        // Scoped update with b.rs in scope but also including a.rs item
+        // (shouldn't create duplicates)
+        let scoped_items = vec![
+            item("lint", "b.rs", "new finding"),
+        ];
+        let scope = vec!["b.rs".to_string()];
+        save_scoped(
+            &config,
+            "test",
+            &scoped_items,
+            (),
+            &scope,
+            test_file_from_fingerprint,
+        )
+        .unwrap();
+
+        let loaded = load::<()>(&config).unwrap().unwrap();
+        assert_eq!(loaded.item_count, 2);
+        // Verify no duplicates
+        let unique: HashSet<&String> = loaded.known_fingerprints.iter().collect();
+        assert_eq!(unique.len(), loaded.known_fingerprints.len());
+    }
+
+    #[test]
+    fn save_scoped_produces_sorted_output() {
+        let dir = TempDir::new().unwrap();
+        let config = BaselineConfig::new(dir.path(), "audit");
+
+        // Initial: z.rs finding
+        let original = vec![item("lint", "z.rs", "finding")];
+        save(&config, "test", &original, ()).unwrap();
+
+        // Scoped: add a.rs finding
+        let scoped_items = vec![item("lint", "a.rs", "finding")];
+        let scope = vec!["a.rs".to_string()];
+        save_scoped(
+            &config,
+            "test",
+            &scoped_items,
+            (),
+            &scope,
+            test_file_from_fingerprint,
+        )
+        .unwrap();
+
+        let loaded = load::<()>(&config).unwrap().unwrap();
+        let fps = &loaded.known_fingerprints;
+        assert_eq!(fps[0], "lint::a.rs");
+        assert_eq!(fps[1], "lint::z.rs");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the recurring problem where CI autofix commits produce massive `homeboy.json` diffs (300+ lines) that conflict with main on every PR merge. Root cause: the autofix script runs a full unscoped `homeboy audit --baseline` which regenerates all fingerprints, but CI's extension environment produces different findings than local (256 vs 578 items).

## Changes

- **Generic layer** (`utils/baseline.rs`): New `save_scoped()` function that merges with existing baseline — removes fingerprints for files in scope, adds current ones, preserves everything outside scope untouched
- **Audit layer** (`code_audit/baseline.rs`): New `save_baseline_scoped()` wrapper + `file_from_audit_fingerprint()` to extract file paths from `convention::file::kind` fingerprint format
- **Command layer** (`commands/audit.rs`): When `--changed-since` is active, both `--baseline` and auto-ratchet paths now use scoped save instead of full overwrite
- **12 new tests** covering scope isolation, deduplication, sorting, fallback to full save, and audit-specific fingerprint parsing

## How it works

Before: `homeboy audit homeboy --baseline` → full replace of all fingerprints → 578→256 item swing → merge conflict

After: `homeboy audit homeboy --baseline --changed-since origin/main` → only update fingerprints for PR-changed files → surgical 5-10 line diff → no conflict

Companion PR: Extra-Chill/homeboy-action (passes `--changed-since` to baseline command in autofix script)