### PR TITLE
feat(upgrade): auto-update extensions after homeboy upgrade

### DIFF
--- a/src/core/upgrade/helpers.inc
+++ b/src/core/upgrade/helpers.inc
@@ -163,12 +163,23 @@ pub fn run_upgrade_with_method(
                 upgraded: false,
                 message: "Already at latest version".to_string(),
                 restart_required: false,
+                extensions_updated: vec![],
+                extensions_skipped: vec![],
             });
         }
     }
 
     // Execute the upgrade
     let (success, new_version) = execute_upgrade(install_method)?;
+
+    // Auto-update all installed extensions after a successful upgrade.
+    // This prevents CI/local extension version drift that causes baseline
+    // mismatches and inconsistent audit findings.
+    let (extensions_updated, extensions_skipped) = if success {
+        update_all_extensions()
+    } else {
+        (vec![], vec![])
+    };
 
     Ok(UpgradeResult {
         command: "upgrade".to_string(),
@@ -182,7 +193,69 @@ pub fn run_upgrade_with_method(
             "Upgrade command completed but version unchanged".to_string()
         },
         restart_required: success,
+        extensions_updated,
+        extensions_skipped,
     })
+}
+
+/// Update all installed extensions. Best-effort — failures are logged and
+/// the extension is added to the skipped list.
+fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
+    use crate::extension;
+
+    let extension_ids = extension::available_extension_ids();
+    if extension_ids.is_empty() {
+        return (vec![], vec![]);
+    }
+
+    log_status!("upgrade", "Updating {} installed extension(s)...", extension_ids.len());
+
+    let mut updated = Vec::new();
+    let mut skipped = Vec::new();
+
+    for id in &extension_ids {
+        // Skip linked extensions (they're managed externally)
+        if extension::is_extension_linked(id) {
+            skipped.push(id.clone());
+            continue;
+        }
+
+        let old_version = extension::load_extension(id)
+            .ok()
+            .map(|m| m.version.clone())
+            .unwrap_or_default();
+
+        match extension::update(id, false) {
+            Ok(_) => {
+                let new_version = extension::load_extension(id)
+                    .ok()
+                    .map(|m| m.version.clone())
+                    .unwrap_or_default();
+
+                if old_version != new_version {
+                    log_status!(
+                        "upgrade",
+                        "  {} {} → {}",
+                        id, old_version, new_version
+                    );
+                } else {
+                    log_status!("upgrade", "  {} {} (up to date)", id, new_version);
+                }
+
+                updated.push(ExtensionUpgradeEntry {
+                    extension_id: id.clone(),
+                    old_version,
+                    new_version,
+                });
+            }
+            Err(e) => {
+                log_status!("upgrade", "  {} skipped: {}", id, e.message);
+                skipped.push(id.clone());
+            }
+        }
+    }
+
+    (updated, skipped)
 }
 
 #[cfg(unix)]

--- a/src/core/upgrade/types.inc
+++ b/src/core/upgrade/types.inc
@@ -29,6 +29,17 @@ pub struct UpgradeResult {
     pub upgraded: bool,
     pub message: String,
     pub restart_required: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub extensions_updated: Vec<ExtensionUpgradeEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub extensions_skipped: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtensionUpgradeEntry {
+    pub extension_id: String,
+    pub old_version: String,
+    pub new_version: String,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

After a successful `homeboy upgrade`, automatically update all installed extensions. This prevents the recurring CI/local extension version drift that causes different audit findings, baseline mismatches, and merge conflicts.

## The Problem

Every environment (CI, local dev, VPS) installs extensions independently. When the extension repo gets updated:
- CI rebuilds from source and gets the latest
- Local/VPS stays on the old version until someone manually runs `homeboy extension update`
- Different extension versions produce different findings (e.g., 254 vs 578 audit items)
- Baselines diverge, autofix commits produce massive diffs, merge conflicts everywhere

## The Fix

`homeboy upgrade` now calls `extension update` on all installed extensions automatically:

```
$ homeboy upgrade
[upgrade] Upgraded to 0.72.0
[upgrade] Updating 4 installed extension(s)...
[upgrade]   rust 1.7.0 → 1.8.0
[upgrade]   wordpress 2.7.0 (up to date)
[upgrade]   nodejs 2.0.0 (up to date)
[upgrade]   openclaw 1.0.0 (up to date)
```

- Best-effort: extension update failures are logged and skipped, upgrade still succeeds
- Linked extensions are skipped (managed externally)
- Results included in JSON output (`extensions_updated`, `extensions_skipped`)
- Happens before restart so the new binary + new extensions are in sync