### PR TITLE
feat(audit): detect parallel implementations across files

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -132,6 +132,10 @@ pub enum DeviationKind {
     ScatteredTestFile,
     /// Duplicated code block found within the same method/function body.
     IntraMethodDuplicate,
+    /// Two functions in different files follow the same call pattern —
+    /// they invoke a parallel sequence of helpers, suggesting the shared
+    /// workflow should be abstracted into a single parameterized function.
+    ParallelImplementation,
 }
 
 // ============================================================================

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -592,6 +592,346 @@ fn normalize_line(line: &str) -> String {
 }
 
 // ============================================================================
+// Parallel Implementation Detection (call-sequence similarity)
+// ============================================================================
+
+/// Minimum number of function calls in a method body to consider it for
+/// parallel implementation detection. Trivial methods (< 4 calls) are
+/// too simple to meaningfully abstract.
+const MIN_CALL_COUNT: usize = 4;
+
+/// Minimum Jaccard similarity (|intersection| / |union|) between two
+/// call sets to flag as a parallel implementation.
+const MIN_JACCARD_SIMILARITY: f64 = 0.5;
+
+/// Minimum longest-common-subsequence ratio to flag as parallel.
+/// This captures sequential ordering — two methods that call helpers
+/// in the same order score higher than ones that share calls but in
+/// a different order.
+const MIN_LCS_RATIO: f64 = 0.5;
+
+/// Per-method call sequence extracted from file content.
+#[derive(Debug)]
+struct MethodCallSequence {
+    file: String,
+    method: String,
+    /// Ordered list of function/method calls made in the body.
+    calls: Vec<String>,
+}
+
+/// Extract function call names from a code block.
+///
+/// Matches patterns like `function_name(`, `self.method(`, `Type::method(`.
+/// Returns the called name (without receiver/namespace prefix).
+fn extract_calls_from_body(body: &str) -> Vec<String> {
+    let mut calls = Vec::new();
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+        // Skip comments
+        if trimmed.starts_with("//") || trimmed.starts_with("/*") || trimmed.starts_with('*') {
+            continue;
+        }
+
+        // Find all `identifier(` patterns
+        let chars: Vec<char> = trimmed.chars().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            // Look for `(`
+            if chars[i] == '(' && i > 0 {
+                // Walk backwards to find the identifier
+                let end = i;
+                let mut start = i;
+                while start > 0 && (chars[start - 1].is_alphanumeric() || chars[start - 1] == '_') {
+                    start -= 1;
+                }
+                if start < end {
+                    let name: String = chars[start..end].iter().collect();
+                    // Skip language keywords and control flow
+                    if !is_keyword(&name) && !name.is_empty() {
+                        calls.push(name);
+                    }
+                }
+            }
+            i += 1;
+        }
+    }
+
+    calls
+}
+
+/// Check if a name is a language keyword (not a function call).
+fn is_keyword(name: &str) -> bool {
+    matches!(
+        name,
+        "if" | "else"
+            | "for"
+            | "while"
+            | "loop"
+            | "match"
+            | "return"
+            | "let"
+            | "mut"
+            | "const"
+            | "fn"
+            | "pub"
+            | "use"
+            | "mod"
+            | "struct"
+            | "enum"
+            | "impl"
+            | "trait"
+            | "type"
+            | "where"
+            | "self"
+            | "Self"
+            | "super"
+            | "crate"
+            | "as"
+            | "in"
+            | "ref"
+            | "Some"
+            | "None"
+            | "Ok"
+            | "Err"
+            | "true"
+            | "false"
+            | "assert"
+            | "assert_eq"
+            | "assert_ne"
+            | "println"
+            | "eprintln"
+            | "format"
+            | "vec"
+            | "todo"
+            | "unimplemented"
+            | "unreachable"
+            | "panic"
+            | "dbg"
+    )
+}
+
+/// Extract per-method call sequences from all fingerprints.
+fn extract_call_sequences(fingerprints: &[&FileFingerprint]) -> Vec<MethodCallSequence> {
+    let mut sequences = Vec::new();
+
+    for fp in fingerprints {
+        if fp.content.is_empty() {
+            continue;
+        }
+
+        let lines: Vec<&str> = fp.content.lines().collect();
+
+        for method_name in &fp.methods {
+            // Skip generic names — they're expected to have similar call patterns
+            if GENERIC_NAMES.contains(&method_name.as_str()) {
+                continue;
+            }
+
+            let Some((body_start, body_end)) = find_method_body(&lines, method_name) else {
+                continue;
+            };
+
+            if body_start + 1 >= body_end {
+                continue;
+            }
+
+            let body: String = lines[body_start + 1..body_end].join("\n");
+            let calls = extract_calls_from_body(&body);
+
+            if calls.len() >= MIN_CALL_COUNT {
+                sequences.push(MethodCallSequence {
+                    file: fp.relative_path.clone(),
+                    method: method_name.clone(),
+                    calls,
+                });
+            }
+        }
+    }
+
+    sequences
+}
+
+/// Compute Jaccard similarity between two sets.
+fn jaccard_similarity(a: &[String], b: &[String]) -> f64 {
+    let set_a: std::collections::HashSet<&str> = a.iter().map(|s| s.as_str()).collect();
+    let set_b: std::collections::HashSet<&str> = b.iter().map(|s| s.as_str()).collect();
+
+    let intersection = set_a.intersection(&set_b).count();
+    let union = set_a.union(&set_b).count();
+
+    if union == 0 {
+        0.0
+    } else {
+        intersection as f64 / union as f64
+    }
+}
+
+/// Compute longest common subsequence length between two sequences.
+fn lcs_length(a: &[String], b: &[String]) -> usize {
+    let m = a.len();
+    let n = b.len();
+    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+
+    for i in 1..=m {
+        for j in 1..=n {
+            if a[i - 1] == b[j - 1] {
+                dp[i][j] = dp[i - 1][j - 1] + 1;
+            } else {
+                dp[i][j] = dp[i - 1][j].max(dp[i][j - 1]);
+            }
+        }
+    }
+
+    dp[m][n]
+}
+
+/// Compute LCS ratio: 2 * LCS / (len(a) + len(b)).
+fn lcs_ratio(a: &[String], b: &[String]) -> f64 {
+    let total = a.len() + b.len();
+    if total == 0 {
+        return 0.0;
+    }
+    2.0 * lcs_length(a, b) as f64 / total as f64
+}
+
+/// Detect parallel implementations across files.
+///
+/// Compares all method pairs (in different files) by their call sequences.
+/// When two methods make a similar set of calls in a similar order — but
+/// have different names and different exact implementations — they're
+/// likely parallel implementations of the same workflow that should be
+/// abstracted into a shared parameterized function.
+///
+/// Filters out:
+/// - Methods in the same file
+/// - Generic names (run, new, build, etc.)
+/// - Methods with fewer than MIN_CALL_COUNT calls
+/// - Pairs already caught by exact or near-duplicate detection
+/// - Pairs below both similarity thresholds
+pub(crate) fn detect_parallel_implementations(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    let sequences = extract_call_sequences(fingerprints);
+
+    // Build sets of already-flagged pairs (exact + near duplicates) to avoid double-flagging
+    let exact_groups = build_groups(fingerprints);
+    let exact_dup_fns: std::collections::HashSet<String> = exact_groups
+        .iter()
+        .filter(|(_, locs)| locs.len() >= MIN_DUPLICATE_LOCATIONS)
+        .map(|((name, _), _)| name.clone())
+        .collect();
+
+    let mut findings = Vec::new();
+    let mut reported_pairs: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::new();
+
+    for i in 0..sequences.len() {
+        for j in (i + 1)..sequences.len() {
+            let a = &sequences[i];
+            let b = &sequences[j];
+
+            // Skip same file
+            if a.file == b.file {
+                continue;
+            }
+
+            // Skip if same function name (already caught by other detectors)
+            if a.method == b.method {
+                continue;
+            }
+
+            // Skip if either function is an exact duplicate
+            if exact_dup_fns.contains(&a.method) || exact_dup_fns.contains(&b.method) {
+                continue;
+            }
+
+            // Skip already-reported pairs (both directions)
+            let pair_key = if a.file < b.file || (a.file == b.file && a.method < b.method) {
+                (
+                    format!("{}::{}", a.file, a.method),
+                    format!("{}::{}", b.file, b.method),
+                )
+            } else {
+                (
+                    format!("{}::{}", b.file, b.method),
+                    format!("{}::{}", a.file, a.method),
+                )
+            };
+            if reported_pairs.contains(&pair_key) {
+                continue;
+            }
+
+            let jaccard = jaccard_similarity(&a.calls, &b.calls);
+            let lcs = lcs_ratio(&a.calls, &b.calls);
+
+            if jaccard >= MIN_JACCARD_SIMILARITY && lcs >= MIN_LCS_RATIO {
+                reported_pairs.insert(pair_key);
+
+                // Find the shared calls for the description
+                let set_a: std::collections::HashSet<&str> =
+                    a.calls.iter().map(|s| s.as_str()).collect();
+                let set_b: std::collections::HashSet<&str> =
+                    b.calls.iter().map(|s| s.as_str()).collect();
+                let mut shared: Vec<&&str> = set_a.intersection(&set_b).collect();
+                shared.sort();
+                let shared_preview: String = shared
+                    .iter()
+                    .take(5)
+                    .map(|s| format!("`{}`", s))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let extra = if shared.len() > 5 {
+                    format!(" (+{} more)", shared.len() - 5)
+                } else {
+                    String::new()
+                };
+
+                let suggestion = format!(
+                    "`{}` and `{}` follow the same call pattern (Jaccard: {:.0}%, sequence: {:.0}%). \
+                     Consider extracting the shared workflow into a parameterized function.",
+                    a.method,
+                    b.method,
+                    jaccard * 100.0,
+                    lcs * 100.0
+                );
+
+                // Emit finding for file A
+                findings.push(Finding {
+                    convention: "parallel-implementation".to_string(),
+                    severity: Severity::Info,
+                    file: a.file.clone(),
+                    description: format!(
+                        "Parallel implementation: `{}` has similar call pattern to `{}` in {} — shared calls: {}{}",
+                        a.method, b.method, b.file, shared_preview, extra
+                    ),
+                    suggestion: suggestion.clone(),
+                    kind: DeviationKind::ParallelImplementation,
+                });
+
+                // Emit finding for file B
+                findings.push(Finding {
+                    convention: "parallel-implementation".to_string(),
+                    severity: Severity::Info,
+                    file: b.file.clone(),
+                    description: format!(
+                        "Parallel implementation: `{}` has similar call pattern to `{}` in {} — shared calls: {}{}",
+                        b.method, a.method, a.file, shared_preview, extra
+                    ),
+                    suggestion: suggestion,
+                    kind: DeviationKind::ParallelImplementation,
+                });
+            }
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.description.cmp(&b.description))
+    });
+    findings
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -1043,5 +1383,176 @@ mod tests {
         let lines: Vec<&str> = content.lines().collect();
         let result = find_method_body(&lines, "nonexistent");
         assert!(result.is_none());
+    }
+
+    // ========================================================================
+    // Parallel Implementation Detection tests
+    // ========================================================================
+
+    fn make_fingerprint_with_content(
+        path: &str,
+        methods: &[&str],
+        content: &str,
+    ) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Rust,
+            methods: methods.iter().map(|s| s.to_string()).collect(),
+            registrations: vec![],
+            type_name: None,
+            extends: None,
+            implements: vec![],
+            namespace: None,
+            imports: vec![],
+            content: content.to_string(),
+            method_hashes: std::collections::HashMap::new(),
+            structural_hashes: std::collections::HashMap::new(),
+            visibility: std::collections::HashMap::new(),
+            properties: vec![],
+            hooks: vec![],
+            unused_parameters: vec![],
+            dead_code_markers: vec![],
+            internal_calls: vec![],
+            public_api: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_parallel_implementation() {
+        let fp1 = make_fingerprint_with_content(
+            "src/deploy.rs",
+            &["deploy_to_server"],
+            "fn deploy_to_server() {\n    validate_component();\n    build_artifact();\n    upload_to_host();\n    run_post_hooks();\n    notify_complete();\n}",
+        );
+        let fp2 = make_fingerprint_with_content(
+            "src/upgrade.rs",
+            &["upgrade_on_server"],
+            "fn upgrade_on_server() {\n    validate_component();\n    build_artifact();\n    upload_to_host();\n    run_post_hooks();\n    send_notification();\n}",
+        );
+
+        let findings = detect_parallel_implementations(&[&fp1, &fp2]);
+
+        assert_eq!(findings.len(), 2, "Should emit one finding per file");
+        assert!(findings
+            .iter()
+            .all(|f| f.kind == DeviationKind::ParallelImplementation));
+        assert!(findings.iter().any(|f| f.file == "src/deploy.rs"));
+        assert!(findings.iter().any(|f| f.file == "src/upgrade.rs"));
+    }
+
+    #[test]
+    fn no_parallel_for_unrelated_functions() {
+        let fp1 = make_fingerprint_with_content(
+            "src/deploy.rs",
+            &["deploy_to_server"],
+            "fn deploy_to_server() {\n    validate();\n    build();\n    upload();\n    notify();\n}",
+        );
+        let fp2 = make_fingerprint_with_content(
+            "src/parser.rs",
+            &["parse_config"],
+            "fn parse_config() {\n    read_file();\n    tokenize();\n    parse_ast();\n    validate_schema();\n}",
+        );
+
+        let findings = detect_parallel_implementations(&[&fp1, &fp2]);
+        assert!(
+            findings.is_empty(),
+            "Completely different call sets should not flag"
+        );
+    }
+
+    #[test]
+    fn no_parallel_for_same_file() {
+        let fp = make_fingerprint_with_content(
+            "src/ops.rs",
+            &["deploy_op", "upgrade_op"],
+            "fn deploy_op() {\n    validate();\n    build();\n    upload();\n    notify();\n}\nfn upgrade_op() {\n    validate();\n    build();\n    upload();\n    notify();\n}",
+        );
+
+        let findings = detect_parallel_implementations(&[&fp]);
+        assert!(
+            findings.is_empty(),
+            "Same-file methods should not be flagged as parallel"
+        );
+    }
+
+    #[test]
+    fn no_parallel_for_trivial_methods() {
+        let fp1 = make_fingerprint_with_content(
+            "src/a.rs",
+            &["small_a"],
+            "fn small_a() {\n    foo();\n    bar();\n}",
+        );
+        let fp2 = make_fingerprint_with_content(
+            "src/b.rs",
+            &["small_b"],
+            "fn small_b() {\n    foo();\n    bar();\n}",
+        );
+
+        let findings = detect_parallel_implementations(&[&fp1, &fp2]);
+        assert!(
+            findings.is_empty(),
+            "Methods with < MIN_CALL_COUNT calls should be skipped"
+        );
+    }
+
+    #[test]
+    fn no_parallel_for_generic_names() {
+        // "run" is in GENERIC_NAMES
+        let fp1 = make_fingerprint_with_content(
+            "src/a.rs",
+            &["run"],
+            "fn run() {\n    validate();\n    build();\n    upload();\n    notify();\n}",
+        );
+        let fp2 = make_fingerprint_with_content(
+            "src/b.rs",
+            &["execute"],
+            "fn execute() {\n    validate();\n    build();\n    upload();\n    notify();\n}",
+        );
+
+        // "run" is skipped, so only one method in the pool — no pair to compare
+        let findings = detect_parallel_implementations(&[&fp1, &fp2]);
+        // Only fp2's "execute" has a valid call sequence; fp1's "run" is filtered
+        // So there's only 1 candidate, no pair → no findings
+        assert!(findings.is_empty(), "Generic names should be filtered out");
+    }
+
+    #[test]
+    fn extract_calls_skips_keywords() {
+        let body = "if something() {\n    let x = process();\n    for item in list() {\n        handle(item);\n    }\n}";
+        let calls = extract_calls_from_body(body);
+        assert!(calls.contains(&"something".to_string()));
+        assert!(calls.contains(&"process".to_string()));
+        assert!(calls.contains(&"list".to_string()));
+        assert!(calls.contains(&"handle".to_string()));
+        assert!(!calls.contains(&"if".to_string()));
+        assert!(!calls.contains(&"for".to_string()));
+        assert!(!calls.contains(&"let".to_string()));
+    }
+
+    #[test]
+    fn jaccard_identical_sets() {
+        let a = vec!["foo".to_string(), "bar".to_string()];
+        assert!((jaccard_similarity(&a, &a) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn jaccard_disjoint_sets() {
+        let a = vec!["foo".to_string()];
+        let b = vec!["bar".to_string()];
+        assert!((jaccard_similarity(&a, &b)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lcs_identical_sequences() {
+        let a = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(lcs_length(&a, &a), 3);
+        assert!((lcs_ratio(&a, &a) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lcs_partial_overlap() {
+        let a = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let b = vec!["a".to_string(), "x".to_string(), "c".to_string()];
+        assert_eq!(lcs_length(&a, &b), 2); // a, c
     }
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -337,6 +337,17 @@ fn audit_internal(
         all_findings.extend(near_dup_findings);
     }
 
+    // Phase 4d2: Parallel implementation detection (similar call patterns across files)
+    let parallel_findings = duplication::detect_parallel_implementations(&all_fingerprints);
+    if !parallel_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Parallel implementations: {} finding(s) (similar call patterns in different functions)",
+            parallel_findings.len()
+        );
+        all_findings.extend(parallel_findings);
+    }
+
     // Phase 4e: Dead code detection (unused params, unreferenced exports, orphaned internals)
     let dead_code_findings = dead_code::analyze_dead_code(&all_fingerprints);
     if !dead_code_findings.is_empty() {


### PR DESCRIPTION
## Summary

- Adds `ParallelImplementation` deviation kind to the audit system that detects when two functions in different files follow the same call pattern (invoking parallel sequences of helpers), suggesting shared workflows that should be abstracted
- Algorithm compares cross-file method pairs using Jaccard set similarity + longest common subsequence ratio on extracted call sequences
- Filters out same-file pairs, generic method names (run, new, build, etc.), and trivial methods with fewer than 4 calls
- Wired into audit pipeline as Phase 4d2 (after near-duplicate detection)
- Includes 5 new tests covering detection, filtering, and edge cases (34 total duplication tests pass)

## Thresholds

| Constant | Value | Purpose |
|---|---|---|
| `MIN_CALL_COUNT` | 4 | Minimum calls in a method to be considered |
| `MIN_JACCARD_SIMILARITY` | 0.5 | Minimum set overlap between call sets |
| `MIN_LCS_RATIO` | 0.5 | Minimum sequence ordering similarity |

## Files Changed

- `src/core/code_audit/conventions.rs` — Added `ParallelImplementation` to `DeviationKind` enum
- `src/core/code_audit/duplication.rs` — Detection algorithm + helper functions + tests (~515 lines)
- `src/core/code_audit/mod.rs` — Wired into audit pipeline (Phase 4d2)