### PR TITLE
fix: reject build_command when extension provides build lifecycle

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -435,6 +435,47 @@ fn set(
         }
     }
 
+    // Validate: reject build_command when component has an extension.
+    // Extensions own the build lifecycle; a component-level build_command
+    // creates ambiguity about which build path runs.
+    if let Some(id) = args.id.as_deref() {
+        let has_build_command = merged
+            .get("build_command")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty());
+
+        if has_build_command {
+            // Check if the component already has extensions
+            let existing_has_extension = component::load(id)
+                .ok()
+                .and_then(|c| c.extensions)
+                .is_some_and(|ext| !ext.is_empty());
+
+            // Also check if extensions are being set in this same command
+            let setting_extension = merged
+                .get("extensions")
+                .and_then(|v| v.as_object())
+                .is_some_and(|ext| !ext.is_empty());
+
+            if existing_has_extension || setting_extension {
+                return Err(homeboy::Error::validation_invalid_argument(
+                    "build_command",
+                    format!(
+                        "Component '{}' uses an extension which owns the build lifecycle. \
+                         Setting build_command creates ambiguous build paths.",
+                        id
+                    ),
+                    None,
+                    None,
+                )
+                .with_hint(format!(
+                    "Remove the extension first: homeboy component set {} --replace extensions",
+                    id
+                )));
+            }
+        }
+    }
+
     let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;
 
     match component::merge(args.id.as_deref(), &json_string, &replace_fields)? {

--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -38,16 +38,15 @@ impl ResolvedBuildCommand {
 }
 
 /// Resolve build command for a component using the following priority:
-/// 1. Explicit component.build_command (always wins)
-/// 2. Extension's bundled script (extension.build.extension_script)
-/// 3. Local script matching extension's script_names pattern
+/// 1. Extension's bundled script (extension.build.extension_script)
+/// 2. Local script matching extension's script_names pattern
+/// 3. Explicit component.build_command (fallback when no extension provides build)
+///
+/// Extensions own the build lifecycle for their component type.
+/// If a component has both an extension with build support AND a build_command,
+/// the extension wins and a warning is emitted.
 pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBuildCommand> {
-    // 1. Explicit component override takes precedence
-    if let Some(cmd) = &component.build_command {
-        return Ok(ResolvedBuildCommand::ComponentDefined(cmd.clone()));
-    }
-
-    // 2. Check extension for bundled script or local script patterns
+    // 1. Check extension for bundled script or local script patterns (takes priority)
     if let Some(extensions) = &component.extensions {
         for extension_id in extensions.keys() {
             if let Ok(extension) = extension::load_extension(extension_id) {
@@ -102,6 +101,25 @@ pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBui
                 }
             }
         }
+    }
+
+    // 2. Fallback: explicit component.build_command (only when no extension provides build)
+    if let Some(cmd) = &component.build_command {
+        if extension::extension_provides_build(component) {
+            // Extension provides build but no scripts found — warn about build_command being ignored
+            log_status!(
+                "build",
+                "Warning: component '{}' has both an extension with build support AND a build_command. \
+                 The extension owns the build lifecycle; build_command is ignored.",
+                component.id
+            );
+            log_status!(
+                "hint",
+                "Remove build_command: homeboy component set {} --replace build_command",
+                component.id
+            );
+        }
+        return Ok(ResolvedBuildCommand::ComponentDefined(cmd.clone()));
     }
 
     // Check if any extension provides build (makes build_command optional)


### PR DESCRIPTION
## Summary

- **Set time**: `homeboy component set <id> --build-command "..."` now errors if the component has an extension configured
- **Build time**: Extension build scripts take priority over `build_command`. If both exist and extension scripts aren't found, `build_command` is used as fallback with a warning
- Reordered `resolve_build_command()` priority: extension → build_command (was: build_command → extension)

## Problem

A component could have both `extensions.wordpress` AND a `build_command`, creating two build paths with no clear precedence. Extensions own the build lifecycle for their component type — having a component-level `build_command` bypasses the extension's build pipeline silently.

Fixes #521