### PR TITLE
fix(audit): resolve naming mismatch false positives via type_names

### DIFF
--- a/src/core/code_audit/comment_hygiene.rs
+++ b/src/core/code_audit/comment_hygiene.rs
@@ -146,23 +146,8 @@ mod tests {
         FileFingerprint {
             relative_path: path.to_string(),
             language: lang,
-            methods: vec![],
-            registrations: vec![],
-            type_name: None,
-            extends: None,
-            implements: vec![],
-            namespace: None,
-            imports: vec![],
             content: content.to_string(),
-            method_hashes: HashMap::new(),
-            structural_hashes: HashMap::new(),
-            visibility: HashMap::new(),
-            properties: vec![],
-            hooks: vec![],
-            unused_parameters: vec![],
-            dead_code_markers: vec![],
-            internal_calls: vec![],
-            public_api: vec![],
+            ..Default::default()
         }
     }
 

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -12,13 +12,14 @@ use super::import_matching::has_import;
 use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     Php,
     Rust,
     JavaScript,
     TypeScript,
+    #[default]
     Unknown,
 }
 
@@ -240,22 +241,32 @@ pub fn discover_conventions(
         .map(|(name, _)| name.clone())
         .collect();
 
-    let naming_suffix = detect_naming_suffix(
-        &fingerprints
-            .iter()
-            .filter_map(|fp| fp.type_name.clone())
-            .collect::<Vec<_>>(),
-    );
+    // Use primary type_name (one per file) for suffix detection so multi-type
+    // files don't dilute the convention signal. The full type_names list is only
+    // used below for the per-file conformance check.
+    let primary_type_names: Vec<String> = fingerprints
+        .iter()
+        .filter_map(|fp| fp.type_name.clone())
+        .collect();
+
+    let naming_suffix = detect_naming_suffix(&primary_type_names);
 
     // Classify files
     let mut conforming = Vec::new();
     let mut outliers = Vec::new();
 
     for fp in fingerprints {
+        // A file is "helper-like" only if NONE of its types match the convention suffix.
+        // This prevents false positives where the primary type_name doesn't match but
+        // the file contains another type that does (e.g., VersionOutput + VersionArgs).
         let helper_like = naming_suffix.as_ref().is_some_and(|suffix| {
-            fp.type_name
-                .as_deref()
-                .is_some_and(|name| !suffix_matches(name, suffix))
+            let names_to_check: Vec<&str> = if !fp.type_names.is_empty() {
+                fp.type_names.iter().map(|s| s.as_str()).collect()
+            } else {
+                fp.type_name.as_deref().into_iter().collect()
+            };
+            !names_to_check.is_empty()
+                && names_to_check.iter().all(|name| !suffix_matches(name, suffix))
         });
 
         let mut deviations = Vec::new();
@@ -624,22 +635,8 @@ mod tests {
                     "validate".to_string(),
                     "execute".to_string(),
                 ],
-                registrations: vec![],
                 type_name: Some("AiChat".to_string()),
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "steps/webhook.php".to_string(),
@@ -649,43 +646,15 @@ mod tests {
                     "validate".to_string(),
                     "execute".to_string(),
                 ],
-                registrations: vec![],
                 type_name: Some("Webhook".to_string()),
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "steps/agent-ping.php".to_string(),
                 language: Language::Php,
                 methods: vec!["register".to_string(), "execute".to_string()],
-                registrations: vec![],
                 type_name: Some("AgentPing".to_string()),
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
         ];
 
@@ -711,22 +680,7 @@ mod tests {
             relative_path: "single.php".to_string(),
             language: Language::Php,
             methods: vec!["run".to_string()],
-            registrations: vec![],
-            type_name: None,
-            implements: vec![],
-            namespace: None,
-            imports: vec![],
-            content: String::new(),
-            method_hashes: std::collections::HashMap::new(),
-            structural_hashes: std::collections::HashMap::new(),
-            extends: None,
-            visibility: std::collections::HashMap::new(),
-            properties: vec![],
-            hooks: vec![],
-            unused_parameters: vec![],
-            dead_code_markers: vec![],
-            internal_calls: vec![],
-            public_api: vec![],
+            ..Default::default()
         }];
 
         assert!(discover_conventions("Single", "*.php", &fingerprints).is_none());
@@ -748,64 +702,24 @@ mod tests {
                 relative_path: "abilities/create.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string(), "register".to_string()],
-                registrations: vec![],
                 type_name: Some("CreateAbility".to_string()),
                 implements: vec!["AbilityInterface".to_string()],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/update.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string(), "register".to_string()],
-                registrations: vec![],
                 type_name: Some("UpdateAbility".to_string()),
                 implements: vec!["AbilityInterface".to_string()],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/helpers.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string(), "register".to_string()],
-                registrations: vec![],
                 type_name: Some("Helpers".to_string()),
-                implements: vec![], // Missing interface
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
         ];
 
@@ -837,64 +751,22 @@ mod tests {
                 relative_path: "abilities/CreateAbility.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string(), "register".to_string()],
-                registrations: vec![],
                 type_name: Some("CreateAbility".to_string()),
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/UpdateAbility.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string(), "register".to_string()],
-                registrations: vec![],
                 type_name: Some("UpdateAbility".to_string()),
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/FlowHelpers.php".to_string(),
                 language: Language::Php,
                 methods: vec!["formatFlow".to_string()],
-                registrations: vec![],
                 type_name: Some("FlowHelpers".to_string()),
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
         ];
 
@@ -917,64 +789,21 @@ mod tests {
                 relative_path: "a.php".to_string(),
                 language: Language::Php,
                 methods: vec!["run".to_string()],
-                registrations: vec![],
-                type_name: None,
                 implements: vec!["FooInterface".to_string()],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "b.php".to_string(),
                 language: Language::Php,
                 methods: vec!["run".to_string()],
-                registrations: vec![],
-                type_name: None,
                 implements: vec!["BarInterface".to_string()],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "c.php".to_string(),
                 language: Language::Php,
                 methods: vec!["run".to_string()],
-                registrations: vec![],
-                type_name: None,
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
         ];
 
@@ -1307,64 +1136,25 @@ class AgentPing {
                 relative_path: "abilities/CreateFlow.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                registrations: vec![],
                 type_name: Some("CreateFlow".to_string()),
-                implements: vec![],
                 namespace: Some("DataMachine\\Abilities\\Flow".to_string()),
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/UpdateFlow.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                registrations: vec![],
                 type_name: Some("UpdateFlow".to_string()),
-                implements: vec![],
                 namespace: Some("DataMachine\\Abilities\\Flow".to_string()),
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/DeleteFlow.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                registrations: vec![],
                 type_name: Some("DeleteFlow".to_string()),
-                implements: vec![],
                 namespace: Some("DataMachine\\Flow".to_string()), // WRONG namespace
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
         ];
 
@@ -1390,65 +1180,23 @@ class AgentPing {
                 relative_path: "abilities/A.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                registrations: vec![],
-                type_name: None,
-                implements: vec![],
-                namespace: None,
                 imports: vec!["DataMachine\\Core\\Base".to_string()],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/B.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                registrations: vec![],
-                type_name: None,
-                implements: vec![],
-                namespace: None,
                 imports: vec!["DataMachine\\Core\\Base".to_string()],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/C.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                registrations: vec![],
-                type_name: None,
-                implements: vec![],
-                namespace: None,
-                imports: vec![],
                 // File uses Base but doesn't import it
                 content: "class C extends Base {\n    public function execute() {}\n}".to_string(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
         ];
 
@@ -1471,64 +1219,22 @@ class AgentPing {
                 relative_path: "steps/A.php".to_string(),
                 language: Language::Php,
                 methods: vec!["run".to_string()],
-                registrations: vec![],
-                type_name: None,
-                implements: vec![],
                 namespace: Some("App\\Steps".to_string()),
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "steps/B.php".to_string(),
                 language: Language::Php,
                 methods: vec!["run".to_string()],
-                registrations: vec![],
-                type_name: None,
-                implements: vec![],
                 namespace: Some("App\\Steps".to_string()),
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                ..Default::default()
             },
             FileFingerprint {
                 relative_path: "steps/C.php".to_string(),
                 language: Language::Php,
                 methods: vec!["run".to_string()],
-                registrations: vec![],
-                type_name: None,
-                implements: vec![],
-                namespace: None, // Missing namespace entirely
-                imports: vec![],
-                content: String::new(),
-                method_hashes: std::collections::HashMap::new(),
-                structural_hashes: std::collections::HashMap::new(),
-                extends: None,
-                visibility: std::collections::HashMap::new(),
-                properties: vec![],
-                hooks: vec![],
-                unused_parameters: vec![],
-                dead_code_markers: vec![],
-                internal_calls: vec![],
-                public_api: vec![],
+                // Missing namespace entirely
+                ..Default::default()
             },
         ];
 
@@ -1548,4 +1254,135 @@ class AgentPing {
     // ========================================================================
     // has_import tests
     // ========================================================================
+
+    // ========================================================================
+    // type_names tests (issue #554)
+    // ========================================================================
+
+    #[test]
+    fn no_naming_mismatch_when_type_names_includes_matching_type() {
+        // Reproduces issue #554: version.rs has type_name=VersionOutput (first pub type)
+        // but also has VersionArgs which matches the convention. Should NOT flag.
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "commands/deploy.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("DeployArgs".to_string()),
+                type_names: vec!["DeployArgs".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "commands/lint.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("LintArgs".to_string()),
+                type_names: vec!["LintArgs".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "commands/version.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                // Primary type is VersionOutput (first pub type in file)
+                type_name: Some("VersionOutput".to_string()),
+                // But file also contains VersionArgs
+                type_names: vec![
+                    "VersionOutput".to_string(),
+                    "VersionArgs".to_string(),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let convention =
+            discover_conventions("Commands", "commands/*.rs", &fingerprints).unwrap();
+
+        // version.rs should NOT be an outlier because it has VersionArgs in type_names
+        assert_eq!(
+            convention.outliers.len(),
+            0,
+            "File with matching type in type_names should not be flagged"
+        );
+        assert_eq!(convention.conforming.len(), 3);
+    }
+
+    #[test]
+    fn naming_mismatch_when_no_type_names_match() {
+        // When type_names is populated but none match the convention, still flag it
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "commands/deploy.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("DeployArgs".to_string()),
+                type_names: vec!["DeployArgs".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "commands/lint.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("LintArgs".to_string()),
+                type_names: vec!["LintArgs".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "commands/utils.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("HelperUtils".to_string()),
+                // No type matches Args convention
+                type_names: vec!["HelperUtils".to_string(), "FormatConfig".to_string()],
+                ..Default::default()
+            },
+        ];
+
+        let convention =
+            discover_conventions("Commands", "commands/*.rs", &fingerprints).unwrap();
+
+        // utils.rs should be an outlier — no type in type_names matches the Args convention
+        assert_eq!(convention.outliers.len(), 1);
+        assert_eq!(convention.outliers[0].file, "commands/utils.rs");
+        assert!(convention.outliers[0]
+            .deviations
+            .iter()
+            .any(|d| matches!(d.kind, DeviationKind::NamingMismatch)));
+    }
+
+    #[test]
+    fn type_names_fallback_to_type_name_when_empty() {
+        // When type_names is not populated (legacy extensions), fall back to type_name
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "commands/deploy.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("DeployArgs".to_string()),
+                // type_names empty — simulates old extension
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "commands/lint.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("LintArgs".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "commands/utils.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["run".to_string()],
+                type_name: Some("HelperUtils".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let convention =
+            discover_conventions("Commands", "commands/*.rs", &fingerprints).unwrap();
+
+        // utils.rs should be flagged via fallback to type_name
+        assert_eq!(convention.outliers.len(), 1);
+        assert_eq!(convention.outliers[0].file, "commands/utils.rs");
+    }
 }

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -257,22 +257,10 @@ mod tests {
             relative_path: path.to_string(),
             language: Language::Rust,
             methods: methods.into_iter().map(String::from).collect(),
-            registrations: vec![],
-            type_name: None,
-            extends: None,
-            implements: vec![],
-            namespace: None,
-            imports: vec![],
-            content: String::new(),
-            method_hashes: HashMap::new(),
-            structural_hashes: HashMap::new(),
             visibility: vis_map,
-            properties: vec![],
-            hooks: vec![],
-            unused_parameters: vec![],
-            dead_code_markers: vec![],
             internal_calls: internal_calls.into_iter().map(String::from).collect(),
             public_api: public_api.into_iter().map(String::from).collect(),
+            ..Default::default()
         }
     }
 

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -954,13 +954,6 @@ mod tests {
             relative_path: path.to_string(),
             language: Language::Rust,
             methods: methods.iter().map(|s| s.to_string()).collect(),
-            registrations: vec![],
-            type_name: None,
-            extends: None,
-            implements: vec![],
-            namespace: None,
-            imports: vec![],
-            content: String::new(),
             method_hashes: hashes
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -969,13 +962,7 @@ mod tests {
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
-            visibility: std::collections::HashMap::new(),
-            properties: vec![],
-            hooks: vec![],
-            unused_parameters: vec![],
-            dead_code_markers: vec![],
-            internal_calls: vec![],
-            public_api: vec![],
+            ..Default::default()
         }
     }
 
@@ -1398,22 +1385,8 @@ mod tests {
             relative_path: path.to_string(),
             language: Language::Rust,
             methods: methods.iter().map(|s| s.to_string()).collect(),
-            registrations: vec![],
-            type_name: None,
-            extends: None,
-            implements: vec![],
-            namespace: None,
-            imports: vec![],
             content: content.to_string(),
-            method_hashes: std::collections::HashMap::new(),
-            structural_hashes: std::collections::HashMap::new(),
-            visibility: std::collections::HashMap::new(),
-            properties: vec![],
-            hooks: vec![],
-            unused_parameters: vec![],
-            dead_code_markers: vec![],
-            internal_calls: vec![],
-            public_api: vec![],
+            ..Default::default()
         }
     }
 

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use super::conventions::Language;
 
 /// A structural fingerprint extracted from a single source file.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FileFingerprint {
     /// Path relative to component root.
     pub relative_path: String,
@@ -18,6 +18,8 @@ pub struct FileFingerprint {
     pub registrations: Vec<String>,
     /// Class or struct name if found.
     pub type_name: Option<String>,
+    /// All public type names found in the file.
+    pub type_names: Vec<String>,
     /// Parent class name (e.g., "WC_Abstract_Order").
     pub extends: Option<String>,
     /// Interfaces or traits implemented.
@@ -77,6 +79,7 @@ pub fn fingerprint_file(path: &Path, root: &Path) -> Option<FileFingerprint> {
         methods: output.methods,
         registrations: output.registrations,
         type_name: output.type_name,
+        type_names: output.type_names,
         extends: output.extends,
         implements: output.implements,
         namespace: output.namespace,

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -141,6 +141,7 @@ pub fn fingerprint_from_git_ref(
         methods: output.methods,
         registrations: output.registrations,
         type_name: output.type_name,
+        type_names: output.type_names,
         extends: output.extends,
         implements: output.implements,
         namespace: output.namespace,
@@ -515,17 +516,9 @@ mod tests {
             relative_path: path.to_string(),
             language: Language::Php,
             methods: public_api.iter().map(|s| s.to_string()).collect(),
-            registrations: vec![],
             type_name: type_name.map(|s| s.to_string()),
             extends: extends.map(|s| s.to_string()),
-            implements: vec![],
-            namespace: None,
             imports: imports.iter().map(|s| s.to_string()).collect(),
-            content: String::new(),
-            method_hashes: HashMap::new(),
-            structural_hashes: HashMap::new(),
-            visibility: HashMap::new(),
-            properties: vec![],
             hooks: hooks
                 .iter()
                 .map(|(t, n)| crate::extension::HookRef {
@@ -533,10 +526,9 @@ mod tests {
                     name: n.to_string(),
                 })
                 .collect(),
-            unused_parameters: vec![],
-            dead_code_markers: vec![],
             internal_calls: internal_calls.iter().map(|s| s.to_string()).collect(),
             public_api: public_api.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
         }
     }
 

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -428,22 +428,7 @@ mod tests {
             relative_path: path.to_string(),
             language: Language::Rust,
             methods: methods.into_iter().map(String::from).collect(),
-            registrations: vec![],
-            type_name: None,
-            extends: None,
-            implements: vec![],
-            namespace: None,
-            imports: vec![],
-            content: String::new(),
-            method_hashes: HashMap::new(),
-            structural_hashes: HashMap::new(),
-            visibility: HashMap::new(),
-            properties: vec![],
-            hooks: vec![],
-            unused_parameters: vec![],
-            dead_code_markers: vec![],
-            internal_calls: vec![],
-            public_api: vec![],
+            ..Default::default()
         }
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -199,6 +199,12 @@ pub struct FingerprintOutput {
     pub methods: Vec<String>,
     #[serde(default)]
     pub type_name: Option<String>,
+    /// All public type names found in the file (struct/class/enum names).
+    /// Used for convention checks where the primary `type_name` may not
+    /// be the convention-conforming type (e.g., a file with both
+    /// `VersionOutput` and `VersionArgs` should not flag as a mismatch).
+    #[serde(default)]
+    pub type_names: Vec<String>,
     /// Parent class name (e.g., "WC_Abstract_Order").
     /// Separated from `implements` for clear hierarchy tracking.
     #[serde(default)]


### PR DESCRIPTION
## Summary

Closes #554

Files with multiple public types (e.g., `VersionOutput` + `VersionArgs` in `version.rs`) were flagged as naming mismatches because the convention checker only looked at `type_name` (the first public type in the file). Now it considers **all** public types via the new `type_names` field.

## How it works

```
Convention suffix detected: "Args" (from primary type_name, one per file)
                                    ↓
Per-file check:  Does ANY type in type_names match "Args"?
                                    ↓
version.rs:  type_names = ["VersionOutput", "VersionArgs"]
             → "VersionArgs" matches → ✅ conforming (was ❌ outlier)
```

## Changes

**Core data model:**
- `FingerprintOutput` + `FileFingerprint`: added `type_names: Vec<String>`
- `Language` enum: added `Default` derive (`Unknown` variant)
- `FileFingerprint`: added `Default` derive (reduces test boilerplate — net **-231 lines**)

**Convention checker** (`conventions.rs`):
- Suffix detection uses primary `type_name` (one per file) — avoids diluting the signal
- Per-file conformance check uses `type_names` if populated, falls back to `type_name`

**Impact analysis** (`impact.rs`): wires `type_names` through to fingerprints

## Tests

- 3 new tests: matching type_names, non-matching type_names, fallback to type_name
- All 953 tests pass

## Companion PR

Extension scripts need to emit `type_names` — see Extra-Chill/homeboy-extensions#TBD