### PR TITLE
perf(ci): build homeboy once, share binary across quality gate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 # PR quality pipeline.
 #
-# Strict serial pipeline: lint+fix → test+fix → audit+fix
-# Each stage fixes what it can and commits back. If anything was fixed,
-# the App token push triggers a full re-run to verify the fixes.
+# Build once, then strict serial pipeline: lint+fix → test+fix → audit+fix
+# A single build job compiles homeboy from source and shares the binary
+# via artifact. Each stage downloads it instead of rebuilding.
+# If fixes are committed, the App token push triggers a full re-run.
 # Scoped to changed files only (--changed-since / lint-changed-only).
 
 name: CI
@@ -16,17 +17,58 @@ permissions:
   pull-requests: write
 
 jobs:
+  # ── Stage 0: Build once ──
+  # Compile homeboy from source once and share the binary with all
+  # subsequent stages. Eliminates 3× redundant cargo builds.
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-ci-
+
+      - name: Build homeboy
+        run: cargo build --release
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: homeboy-binary
+          path: target/release/homeboy
+          retention-days: 1
+
   # ── Stage 1: Lint + Fix ──
   # Runs cargo fmt and clippy. Autofixes formatting and clippy warnings.
   # If fixes are committed, App token push triggers re-run of all stages.
   lint:
     name: Lint
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
 
       - name: Generate GitHub App token
         id: app-token
@@ -38,7 +80,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
-          source: '.'
+          binary-path: .homeboy-bin/homeboy
           extension: rust
           component: homeboy
           commands: lint
@@ -52,13 +94,19 @@ jobs:
   # commits and triggers re-run.
   test:
     name: Test
-    needs: [lint]
+    needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
 
       - name: Generate GitHub App token
         id: app-token
@@ -70,7 +118,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
-          source: '.'
+          binary-path: .homeboy-bin/homeboy
           extension: rust
           component: homeboy
           commands: test
@@ -82,16 +130,21 @@ jobs:
   # ── Stage 3: Audit + Fix ──
   # Runs after test passes. Autofix mode "always" — grinds down the
   # baseline on every PR, not just failures.
-  # Uses source build so the audit binary matches the PR code.
   audit:
     name: Audit
-    needs: [test]
+    needs: [build, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
 
       - name: Generate GitHub App token
         id: app-token
@@ -103,7 +156,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
-          source: '.'
+          binary-path: .homeboy-bin/homeboy
           extension: rust
           component: homeboy
           commands: audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ on:
         type: boolean
         default: false
 
-# Only one release at a time. Newer run cancels older pending run,
-# picking up all accumulated commits since last tag.
-concurrency:
-  group: release
-  cancel-in-progress: true
+# No concurrency group — let overlapping runs race. The check job exits
+# in seconds when there are no releasable commits (the common case when
+# an in-flight release already tagged HEAD). The failure cache prevents
+# retrying the same broken SHA. This avoids both canceling in-flight
+# releases (wastes work) and queuing idle runners (wastes capacity).
 
 jobs:
   # ── Step 1: Check for releasable commits ──

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,19 +122,61 @@ jobs:
             echo "::notice::${COUNT} releasable commits → ${BUMP} bump"
           fi
 
-  # ── Step 2: Quality gate (lint + fix whole codebase) ──
+  # ── Step 2: Build once ──
+  # Compile homeboy from source once and share the binary with all
+  # quality gate jobs. Eliminates 3× redundant cargo builds.
+  gate-build:
+    name: Build
+    needs: check
+    if: needs.check.outputs.should-release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-gate-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-gate-
+
+      - name: Build homeboy
+        run: cargo build --release
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: homeboy-binary
+          path: target/release/homeboy
+          retention-days: 1
+
+  # ── Step 3: Quality gate (lint + fix whole codebase) ──
   # Unlike PR CI (scoped to changed files), release quality gate runs
   # unscoped — fixes the entire codebase before releasing.
   # Serial pipeline: lint+fix → test+fix → audit+fix → release.
   gate-lint:
     name: Lint + Fix
-    needs: check
+    needs:
+      - check
+      - gate-build
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
 
       - name: Generate GitHub App token
         id: app-token
@@ -146,7 +188,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
-          source: '.'
+          binary-path: .homeboy-bin/homeboy
           extension: rust
           component: homeboy
           commands: lint
@@ -160,6 +202,7 @@ jobs:
     name: Test + Fix
     needs:
       - check
+      - gate-build
       - gate-lint
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
@@ -167,6 +210,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
 
       - name: Generate GitHub App token
         id: app-token
@@ -178,7 +227,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
-          source: '.'
+          binary-path: .homeboy-bin/homeboy
           extension: rust
           component: homeboy
           commands: test
@@ -192,6 +241,7 @@ jobs:
     name: Audit + Fix
     needs:
       - check
+      - gate-build
       - gate-test
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
@@ -199,6 +249,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Download homeboy binary
+        uses: actions/download-artifact@v4
+        with:
+          name: homeboy-binary
+          path: .homeboy-bin
 
       - name: Generate GitHub App token
         id: app-token
@@ -210,7 +266,7 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v1
         with:
-          source: '.'
+          binary-path: .homeboy-bin/homeboy
           extension: rust
           component: homeboy
           commands: audit
@@ -227,6 +283,7 @@ jobs:
     name: Prepare Release
     needs:
       - check
+      - gate-build
       - gate-lint
       - gate-test
       - gate-audit
@@ -593,11 +650,12 @@ jobs:
     name: Record failure
     needs:
       - check
+      - gate-build
       - gate-lint
       - gate-test
       - gate-audit
       - prepare
-    if: ${{ always() && needs.check.outputs.should-release == 'true' && (needs.gate-lint.result == 'failure' || needs.gate-test.result == 'failure' || needs.gate-audit.result == 'failure' || needs.prepare.result == 'failure') }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && (needs.gate-build.result == 'failure' || needs.gate-lint.result == 'failure' || needs.gate-test.result == 'failure' || needs.gate-audit.result == 'failure' || needs.prepare.result == 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/homeboy.json
+++ b/homeboy.json
@@ -3,7 +3,7 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-03-08T15:22:55Z",
+      "created_at": "2026-03-08T16:12:27Z",
       "item_count": 929,
       "known_fingerprints": [
         "Commands::src/commands/docs.rs::NamespaceMismatch",


### PR DESCRIPTION
## Summary

- Adds a **Build** job to both `ci.yml` and `release.yml` that compiles homeboy once from source
- Uploads the binary as a GitHub Actions artifact
- All downstream quality gate jobs (Lint, Test, Audit) download and use the pre-built binary via `binary-path`

## Before

```
lint:  checkout → rust toolchain → cargo build (~2m) → run lint
test:  checkout → rust toolchain → cargo build (~2m) → run test
audit: checkout → rust toolchain → cargo build (~2m) → run audit
```

**Total: ~6-9 min of cargo builds** (serial, so all 3 happen sequentially)

## After

```
build: checkout → rust toolchain → cargo build (~2m) → upload artifact
lint:  checkout → download artifact (3s) → run lint
test:  checkout → download artifact (3s) → run test
audit: checkout → download artifact (3s) → run audit
```

**Total: ~2 min of cargo build** (once) + seconds for artifact download

## Depends On

- homeboy-action PR #64 (merged) — adds `binary-path` input
- `v1` tag updated to include the new input