### PR TITLE
fix: remove accidentally committed binary and gitignore .homeboy-bin/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 /target/
 dist-manifest.json
+.homeboy-bin/
 
 # Dependencies
 /node_modules/

--- a/homeboy.json
+++ b/homeboy.json
@@ -3,7 +3,7 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-03-08T16:12:27Z",
+      "created_at": "2026-03-08T16:44:44Z",
       "item_count": 929,
       "known_fingerprints": [
         "Commands::src/commands/docs.rs::NamespaceMismatch",


### PR DESCRIPTION
## Summary

- Removes the 19MB homeboy binary that was accidentally committed to the repo
- Adds `.homeboy-bin/` to `.gitignore`

## What happened

The build-once CI pattern downloads the homeboy binary artifact to `.homeboy-bin/`. The audit autofix step runs `git add -A` which picked up the binary and committed it. 

The `.gitignore` didn't have an entry for this directory since it only exists in CI.