### PR TITLE
fix(baseline): skip write when fingerprints are unchanged

### DIFF
--- a/src/utils/baseline.rs
+++ b/src/utils/baseline.rs
@@ -173,13 +173,29 @@ pub struct NewItem {
 ///
 /// Reads the existing `homeboy.json` (or creates one), sets
 /// `baselines.<key>` to the new baseline, and writes it back.
-pub fn save<M: Serialize>(
+/// Skips the write if the fingerprints haven't changed (avoids
+/// timestamp-only diffs that create noise in CI autofix).
+pub fn save<M: Serialize + for<'de> Deserialize<'de>>(
     config: &BaselineConfig,
     context_id: &str,
     items: &[impl Fingerprintable],
     metadata: M,
 ) -> Result<PathBuf> {
-    let known_fingerprints: Vec<String> = items.iter().map(|i| i.fingerprint()).collect();
+    let mut known_fingerprints: Vec<String> = items.iter().map(|i| i.fingerprint()).collect();
+    known_fingerprints.sort();
+
+    // Skip write if fingerprints are unchanged — avoids timestamp-only diffs.
+    // Only check when there are actual fingerprints (test baselines use empty
+    // fingerprints with metadata-only counts, so they always need to write).
+    if !known_fingerprints.is_empty() {
+        if let Ok(Some(existing)) = load::<M>(config) {
+            let mut existing_sorted = existing.known_fingerprints.clone();
+            existing_sorted.sort();
+            if existing_sorted == known_fingerprints {
+                return Ok(config.json_path());
+            }
+        }
+    }
 
     let baseline = Baseline {
         created_at: utc_now_iso8601(),
@@ -264,6 +280,9 @@ pub fn save_scoped<M: Serialize + for<'de> Deserialize<'de> + Clone>(
     // Build a set of scoped file paths for fast lookup
     let scope_set: HashSet<&str> = scope.iter().map(|s| s.as_str()).collect();
 
+    // Snapshot existing fingerprints before consuming them
+    let existing_fingerprints_snapshot = existing.known_fingerprints.clone();
+
     // Keep fingerprints that are outside the scope
     let mut merged_fingerprints: Vec<String> = existing
         .known_fingerprints
@@ -283,6 +302,13 @@ pub fn save_scoped<M: Serialize + for<'de> Deserialize<'de> + Clone>(
     // Sort for deterministic output
     merged_fingerprints.sort();
     merged_fingerprints.dedup();
+
+    // Skip write if fingerprints are unchanged — avoids timestamp-only diffs
+    let mut existing_sorted = existing_fingerprints_snapshot.clone();
+    existing_sorted.sort();
+    if existing_sorted == merged_fingerprints {
+        return Ok(json_path);
+    }
 
     let baseline = Baseline {
         created_at: utc_now_iso8601(),


### PR DESCRIPTION
## Summary

`save()` and `save_scoped()` now compare fingerprints against the existing baseline before writing. If identical, they return early without touching `created_at`.

## Problem

`homeboy audit --write` always rewrites `homeboy.json` even when nothing changed — only the `created_at` timestamp gets a new value. In CI, the audit autofix (mode: always) sees a dirty working tree, commits the timestamp-only diff, and opens a PR with no meaningful changes.

Example noise PR:
```diff
-      "created_at": "2026-03-08T16:12:27Z",
+      "created_at": "2026-03-08T16:32:59Z",
```
Same `item_count` (929), same fingerprints. Just a timestamp.

## Fix

- `save()`: loads existing baseline, compares sorted fingerprints, skips write if identical
- `save_scoped()`: same check after merging scoped fingerprints with existing
- Test baselines (empty fingerprints, metadata-only counts) always write — they don't use fingerprints for meaningful state

All 68 baseline tests pass.