### PR TITLE
chore: sync v0.72.0 release commit to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.71.1"
+version = "0.72.0"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homeboy"
-version = "0.71.1"
+version = "0.72.0"
 edition = "2021"
 license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,16 @@ All notable changes to Homeboy CLI are documented in this file.
 
 (This file is embedded into the CLI binary and is also viewable via `homeboy changelog`.)
 
+## [0.72.0] - 2026-03-08
+### Added
+- enable autofix on all CI jobs + release autofix PRs
+- auto-detect bump type from conventional commits
+- auto-ratchet baseline after audit --fix --write resolves findings
+### Fixed
+- decompose rollback now covers caller files, unify snapshot systems
+- repair broken imports from squash merge of feat/auto-release
+- separate test files from convention groups and normalize signatures
+
 ## [0.71.1] - 2026-03-07
 ### Fixed
 - improve test coverage precision with visibility filtering and skip patterns (#577) (audit)


### PR DESCRIPTION
## Summary

Cherry-picks the v0.72.0 release commit (`9673882`) to main.

## What happened

The release pipeline checked out main before PRs #601 and #605 merged. By the time the Prepare Release step ran, main had diverged. The pipeline created the release commit + tag on the old checkout, pushed the tag, but the release commit (changelog + version bump) never landed on main.

Result: `v0.72.0` tag exists with correct changelog, but main still shows `version = "0.71.1"` and missing changelog entry.

## Prevention

The `git pull --ff-only` fix in homeboy-action PR #66 prevents this for future releases — the prepare step syncs with remote before running the release command.