### PR TITLE
refactor: consolidate walk_source_files into codebase_scan::walk_files

### DIFF
--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use crate::extension::{self, ExtensionManifest};
+use crate::utils::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 #[derive(Debug, Clone, serde::Deserialize, Default)]
 pub struct AuditRulesConfig {
@@ -81,7 +82,22 @@ fn analyze_test_topology(root: &Path) -> Vec<Finding> {
             continue;
         };
 
-        let files = walk_files(root);
+        let files = codebase_scan::walk_files(
+            root,
+            &ScanConfig {
+                // Use extra_skip_dirs so build dirs are skipped at all depths
+                // (matching prior flat skip-list behavior)
+                extra_skip_dirs: vec![
+                    "build".into(),
+                    "dist".into(),
+                    "target".into(),
+                    "cache".into(),
+                    "tmp".into(),
+                ],
+                extensions: ExtensionFilter::All,
+                ..Default::default()
+            },
+        );
         for file in files {
             let rel = match file.strip_prefix(root) {
                 Ok(p) => p.to_string_lossy().replace('\\', "/"),
@@ -204,54 +220,6 @@ fn matches_any(path: &str, globs: &[String]) -> bool {
     globs.iter().any(|g| glob_match::glob_match(g, path))
 }
 
-fn walk_files(root: &Path) -> Vec<std::path::PathBuf> {
-    const SKIP_DIRS: &[&str] = &[
-        "node_modules",
-        "vendor",
-        ".git",
-        "build",
-        "dist",
-        "target",
-        ".svn",
-        ".hg",
-        "cache",
-        "tmp",
-    ];
-
-    fn recurse(
-        dir: &Path,
-        skip_dirs: &[&str],
-        files: &mut Vec<std::path::PathBuf>,
-    ) -> std::io::Result<()> {
-        if !dir.is_dir() {
-            return Ok(());
-        }
-
-        for entry in std::fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if path.is_dir() {
-                let name = path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or_default();
-                if !skip_dirs.contains(&name) {
-                    recurse(&path, skip_dirs, files)?;
-                }
-            } else {
-                files.push(path);
-            }
-        }
-
-        Ok(())
-    }
-
-    let mut files = Vec::new();
-    let _ = recurse(root, SKIP_DIRS, &mut files);
-    files
-}
-
 fn load_rules(root: &Path) -> Option<TestTopologyRules> {
     let homeboy_json = root.join("homeboy.json");
     let content = std::fs::read_to_string(homeboy_json).ok()?;
@@ -359,7 +327,13 @@ mod tests {
         std::fs::create_dir_all(&src_dir).expect("src dir should be created");
         std::fs::write(src_dir.join("lib.rs"), "pub fn x(){}\n").expect("file should be written");
 
-        let files = walk_files(dir.path());
+        let files = codebase_scan::walk_files(
+            dir.path(),
+            &ScanConfig {
+                extensions: ExtensionFilter::All,
+                ..Default::default()
+            },
+        );
         assert!(
             files
                 .iter()

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -17,6 +17,7 @@ use crate::core::test_scaffold::load_extension_grammar;
 use crate::extension::{
     self, AdjustedItem, ExtensionManifest, ParsedItem, RelatedTests, ResolvedImports,
 };
+use crate::utils::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use crate::utils::grammar_items;
 use crate::{component, Result};
 
@@ -548,7 +549,13 @@ pub fn move_items_with_options(
         let dest_module = module_path_from_file(to);
 
         if source_module != dest_module {
-            let all_files = walk_source_files(root);
+            let all_files = codebase_scan::walk_files(
+                root,
+                &ScanConfig {
+                    extensions: ExtensionFilter::All,
+                    ..Default::default()
+                },
+            );
             for file_path in &all_files {
                 let rel_path = file_path
                     .strip_prefix(root)
@@ -734,46 +741,6 @@ fn module_path_from_file(file_path: &str) -> String {
     let p = p.strip_suffix(".rs").unwrap_or(p);
     let p = p.strip_suffix("/mod").unwrap_or(p);
     p.replace('/', "::")
-}
-
-/// Walk source files recursively, skipping common non-source directories.
-fn walk_source_files(root: &Path) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    walk_recursive(root, root, &mut files);
-    files
-}
-
-/// Directories to always skip at any depth.
-const ALWAYS_SKIP_DIRS: &[&str] = &["node_modules", "vendor", ".git", ".svn", ".hg"];
-
-/// Directories to skip only at root level.
-const ROOT_ONLY_SKIP_DIRS: &[&str] = &["build", "dist", "target", "cache", "tmp"];
-
-fn walk_recursive(dir: &Path, root: &Path, files: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-
-    let is_root = dir == root;
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            let name = path
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default();
-            if ALWAYS_SKIP_DIRS.contains(&name.as_str()) {
-                continue;
-            }
-            if is_root && ROOT_ONLY_SKIP_DIRS.contains(&name.as_str()) {
-                continue;
-            }
-            walk_recursive(&path, root, files);
-        } else if path.is_file() {
-            files.push(path);
-        }
-    }
 }
 
 // ============================================================================

--- a/src/core/refactor/transform.rs
+++ b/src/core/refactor/transform.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
+use crate::utils::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use crate::utils::io;
 
 // ============================================================================
@@ -217,7 +218,13 @@ pub fn apply_transforms(
     }
 
     // Walk all files once
-    let files = walk_source_files(root);
+    let files = codebase_scan::walk_files(
+        root,
+        &ScanConfig {
+            extensions: ExtensionFilter::All,
+            ..Default::default()
+        },
+    );
 
     // Apply each rule
     let mut rule_results = Vec::new();
@@ -364,48 +371,6 @@ fn apply_file_context(
 
     let new_content = regex.replace_all(content, replace).to_string();
     (new_content, matches)
-}
-
-// ============================================================================
-// File walking
-// ============================================================================
-
-const ALWAYS_SKIP_DIRS: &[&str] = &["node_modules", "vendor", ".git", ".svn", ".hg"];
-const ROOT_ONLY_SKIP_DIRS: &[&str] = &["build", "dist", "target", "cache", "tmp"];
-
-/// Walk all files in a directory tree (excluding VCS/dependency dirs).
-fn walk_source_files(root: &Path) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    walk_recursive(root, root, &mut files);
-    files
-}
-
-fn walk_recursive(dir: &Path, root: &Path, files: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-
-    let is_root = dir == root;
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            let name = path
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default();
-            if ALWAYS_SKIP_DIRS.contains(&name.as_str()) {
-                continue;
-            }
-            if is_root && ROOT_ONLY_SKIP_DIRS.contains(&name.as_str()) {
-                continue;
-            }
-            walk_recursive(&path, root, files);
-        } else if path.is_file() {
-            // No extension filter — glob pattern handles file selection
-            files.push(path);
-        }
-    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Replace 3 independent `walk_source_files` implementations with the shared `codebase_scan::walk_files` utility
- **move_items.rs**: removed private `walk_source_files` + `walk_recursive` + 2 constants (direct replacement, same two-tier skip behavior)
- **transform.rs**: same — removed identical copy of the same walker
- **test_topology.rs**: uses `extra_skip_dirs` to preserve flat skip-list behavior (build dirs skipped at all depths)

## Impact

- Net **-94 lines** of duplicated code
- All 3 callers gain `__pycache__` skipping for free from the shared implementation
- No behavioral changes for `move_items` or `transform` callers
- `test_topology` gains `__pycache__` skip (harmless improvement)

## Not included

- `walker.rs` — has domain-specific behavior (dynamic extension detection from plugins, index file post-filtering). Needs separate treatment.
- `version.rs` — callback-based API, unique `tests` skip dir, most divergent. Needs separate treatment.

## Testing

- 893 lib tests pass, 58/59 binary tests pass (1 pre-existing failure on main: `test_chunk_verifier_rejects_new_findings_in_changed_files`)
- Clean release build, no warnings