### PR TITLE
fix: strip conventional prefixes and PR refs from auto-generated changelog entries

### DIFF
--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -381,7 +381,7 @@ pub fn strip_conventional_prefix(subject: &str) -> &str {
         // Check if it looks like a conventional commit prefix
         if prefix
             .chars()
-            .all(|c| c.is_alphanumeric() || c == '(' || c == ')' || c == '!')
+            .all(|c| c.is_alphanumeric() || c == '(' || c == ')' || c == '!' || c == '#')
         {
             return &subject[pos + 2..];
         }
@@ -446,6 +446,22 @@ mod tests {
         assert_eq!(
             strip_conventional_prefix("Regular commit"),
             "Regular commit"
+        );
+    }
+
+    #[test]
+    fn strip_conventional_prefix_handles_issue_number_scope() {
+        assert_eq!(
+            strip_conventional_prefix("feat(#741): delete AgentType class"),
+            "delete AgentType class"
+        );
+        assert_eq!(
+            strip_conventional_prefix("fix(#730): queue-add uses unified check-duplicate"),
+            "queue-add uses unified check-duplicate"
+        );
+        assert_eq!(
+            strip_conventional_prefix("feat(#123): add new feature"),
+            "add new feature"
         );
     }
 

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -709,11 +709,11 @@ fn group_commits_for_changelog(
 
     for commit in commits {
         if let Some(entry_type) = commit.category.to_changelog_entry_type() {
-            let message = git::strip_conventional_prefix(&commit.subject);
+            let message = strip_pr_reference(git::strip_conventional_prefix(&commit.subject));
             entries_by_type
                 .entry(entry_type.to_string())
                 .or_default()
-                .push(message.to_string());
+                .push(message);
         }
     }
 
@@ -729,7 +729,7 @@ fn group_commits_for_changelog(
                         | git::CommitCategory::Merge
                 )
             })
-            .map(|c| git::strip_conventional_prefix(&c.subject).to_string())
+            .map(|c| strip_pr_reference(git::strip_conventional_prefix(&c.subject)))
             .unwrap_or_else(|| "Internal improvements".to_string());
 
         entries_by_type.insert("changed".to_string(), vec![fallback]);
@@ -1123,6 +1123,58 @@ mod tests {
         assert!(
             uncovered.is_empty(),
             "Should match when commit subject is contained in the entry"
+        );
+    }
+
+    #[test]
+    fn test_group_commits_strips_conventional_prefix_with_issue_scope() {
+        use super::group_commits_for_changelog;
+
+        let commits = vec![
+            commit(
+                "feat(#741): delete AgentType class — replace with string literals",
+                CommitCategory::Feature,
+            ),
+            commit(
+                "fix(#730): queue-add uses unified check-duplicate",
+                CommitCategory::Fix,
+            ),
+        ];
+
+        let entries = group_commits_for_changelog(&commits);
+        let added = &entries["added"];
+        let fixed = &entries["fixed"];
+
+        assert_eq!(
+            added[0],
+            "delete AgentType class — replace with string literals"
+        );
+        assert_eq!(fixed[0], "queue-add uses unified check-duplicate");
+    }
+
+    #[test]
+    fn test_group_commits_strips_pr_references() {
+        use super::group_commits_for_changelog;
+
+        let commits = vec![
+            commit(
+                "feat: agent-first scoping — Phase 1 schema (#738)",
+                CommitCategory::Feature,
+            ),
+            commit(
+                "fix: rename $class param — fixes bootstrap crash (#711)",
+                CommitCategory::Fix,
+            ),
+        ];
+
+        let entries = group_commits_for_changelog(&commits);
+        let added = &entries["added"];
+        let fixed = &entries["fixed"];
+
+        assert_eq!(added[0], "agent-first scoping — Phase 1 schema");
+        assert_eq!(
+            fixed[0],
+            "rename $class param — fixes bootstrap crash"
         );
     }
 }

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -1172,9 +1172,6 @@ mod tests {
         let fixed = &entries["fixed"];
 
         assert_eq!(added[0], "agent-first scoping — Phase 1 schema");
-        assert_eq!(
-            fixed[0],
-            "rename $class param — fixes bootstrap crash"
-        );
+        assert_eq!(fixed[0], "rename $class param — fixes bootstrap crash");
     }
 }


### PR DESCRIPTION
## Summary
- `strip_conventional_prefix()` now handles `#` in scope (e.g. `feat(#741):`) — previously the `#` char wasn't in the allowed set, so the entire prefix leaked into changelog entries
- `strip_pr_reference()` is now applied to actual changelog entry text in `group_commits_for_changelog()`, not just the fuzzy-matching path — trailing `(#123)` refs were appearing in the changelog

Fixes the v0.39.0 data-machine changelog regression where entries like `feat(#741): delete AgentType class` appeared instead of just `delete AgentType class`.