### PR TITLE
feat(audit): make baseline ratchet opt-in via --ratchet flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@
 # A single build job compiles homeboy from source and shares the binary
 # via artifact. Each stage downloads it instead of rebuilding.
 # If fixes are committed, the App token push triggers a full re-run.
-# Scoped to changed files only (--changed-since / lint-changed-only).
+# Scoped to changed files only (--changed-since via scope module).
+#
+# Fork PRs: CI runs read-only checks (no autofix, no baseline writes).
+# The checkout uses the PR head SHA which works for both same-repo and fork PRs.
+# Secrets (App token) are unavailable for forks — continue-on-error handles this.
 
 name: CI
 
@@ -26,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -52,9 +56,10 @@ jobs:
           retention-days: 1
 
   # ── Stage 1: Audit + Fix ──
-  # Runs first — most likely to induce changes. Autofix mode "always"
-  # grinds down the baseline on every PR, not just failures.
-  # If fixes are committed, App token push triggers re-run of all stages.
+  # Runs first — most likely to induce changes. Autofix applies code fixes
+  # via --fix --write but does NOT ratchet the baseline (no --ratchet).
+  # Baseline ratchet only happens on main to avoid homeboy.json conflicts.
+  # Fork PRs: autofix skipped (action detects fork via SCOPE_IS_FORK).
   audit:
     name: Audit
     needs: [build]
@@ -62,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Download homeboy binary
@@ -85,8 +90,8 @@ jobs:
           extension: rust
           component: homeboy
           commands: audit
-          autofix: 'true'
-          autofix-mode: 'always'
+          autofix: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
+          autofix-mode: 'on-failure'
           autofix-commands: 'audit --fix --write'
           autofix-max-commits: '3'
           app-token: ${{ steps.app-token.outputs.token || '' }}
@@ -95,6 +100,7 @@ jobs:
   # Runs after audit passes. Cargo fmt and clippy. Autofixes formatting
   # and clippy warnings. If fixes are committed, App token push triggers
   # re-run of all stages.
+  # Fork PRs: autofix skipped.
   lint:
     name: Lint
     needs: [build, audit]
@@ -102,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Download homeboy binary
@@ -125,7 +131,7 @@ jobs:
           extension: rust
           component: homeboy
           commands: lint
-          autofix: 'true'
+          autofix: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
           autofix-mode: 'on-failure'
           autofix-max-commits: '3'
           app-token: ${{ steps.app-token.outputs.token || '' }}
@@ -133,6 +139,7 @@ jobs:
   # ── Stage 3: Test + Fix ──
   # Runs after lint passes. If tests fail and fixes are available,
   # commits and triggers re-run.
+  # Fork PRs: autofix skipped.
   test:
     name: Test
     needs: [build, lint]
@@ -140,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Download homeboy binary
@@ -163,7 +170,7 @@ jobs:
           extension: rust
           component: homeboy
           commands: test
-          autofix: 'true'
+          autofix: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
           autofix-mode: 'on-failure'
           autofix-max-commits: '3'
           app-token: ${{ steps.app-token.outputs.token || '' }}

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -58,6 +58,12 @@ pub struct AuditArgs {
     #[arg(long = "exclude", value_name = "kind")]
     pub exclude: Vec<String>,
 
+    /// Update baseline when findings are resolved (ratchet forward).
+    /// Without this flag, --fix --write applies code fixes but does not
+    /// touch the baseline in homeboy.json.
+    #[arg(long)]
+    pub ratchet: bool,
+
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
 
@@ -499,15 +505,17 @@ fn run_inner(args: AuditArgs) -> CmdResult<AuditOutput> {
             final_fix_result = fix_result;
         }
 
-        // Auto-ratchet: if --fix --write applied changes and a baseline exists,
-        // automatically update the baseline to remove resolved findings.
-        // This makes the baseline self-dissolving — it shrinks on every CI run
-        // as autofix eliminates fixable findings.
+        // Ratchet: if --ratchet is set and --fix --write applied changes,
+        // update the baseline to remove resolved findings.
+        // This makes the baseline shrink as autofix eliminates fixable findings.
+        //
+        // Ratchet is opt-in to avoid homeboy.json merge conflicts in CI:
+        // only main/release workflows should pass --ratchet, never PR branches.
         //
         // When --changed-since is active, use scoped baseline update to avoid
         // touching fingerprints for files outside the change set.
         let mut ratchet_summary = None;
-        if written && !args.baseline_args.ignore_baseline {
+        if args.ratchet && written && !args.baseline_args.ignore_baseline {
             if let Some(existing_baseline) =
                 baseline::load_baseline(Path::new(&current_result.source_path))
             {
@@ -1753,6 +1761,7 @@ mod tests {
             conventions: false,
             fix: true,
             write: true,
+            ratchet: false,
             max_iterations: 3,
             warning_weight: 3,
             info_weight: 1,

--- a/src/commands/supports.rs
+++ b/src/commands/supports.rs
@@ -56,6 +56,7 @@ const SUPPORT_MATRIX: &[(&str, &[&str])] = &[
             "--conventions",
             "--fix",
             "--write",
+            "--ratchet",
             "--baseline",
             "--ignore-baseline",
             "--path",

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -12,7 +12,7 @@ use homeboy::test_scaffold::{self, ScaffoldConfig};
 use homeboy::utils::autofix::{self, AutofixMode, FixResultsSummary};
 
 use super::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
-use super::test_scope::{build_phpunit_filter_regex, compute_changed_test_scope, TestScopeOutput};
+use super::test_scope::{compute_changed_test_scope, TestScopeOutput};
 use super::{CmdResult, GlobalArgs};
 
 mod parsing;
@@ -396,7 +396,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestOutput> {
         runner = runner.env("HOMEBOY_COVERAGE_MIN", &format!("{}", min));
     }
 
-    let mut passthrough_args = filter_homeboy_flags(&args.args);
+    let passthrough_args = filter_homeboy_flags(&args.args);
 
     if let Some(ref scope) = changed_scope {
         if scope.selected_files.is_empty() {
@@ -439,8 +439,14 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestOutput> {
             ));
         }
 
-        let filter_regex = build_phpunit_filter_regex(&scope.selected_files);
-        passthrough_args.push(format!("--filter={}", filter_regex));
+        // Pass changed test files to the extension via env var.
+        // The extension's test runner decides how to scope (e.g., PHPUnit
+        // uses --filter, Cargo uses positional test names, Jest uses
+        // --testPathPattern). Core does not generate runner-specific args.
+        runner = runner.env(
+            "HOMEBOY_CHANGED_TEST_FILES",
+            &scope.selected_files.join("\n"),
+        );
 
         homeboy::log_status!(
             "test",


### PR DESCRIPTION
## Summary

- Makes audit baseline ratchet **opt-in** via `--ratchet` flag, fixing the `homeboy.json` merge conflict storm on concurrent PRs
- Moves language-specific test scoping to extensions (passes `HOMEBOY_CHANGED_TEST_FILES` env var instead of generating `--filter=`)
- Makes CI workflow **fork-safe** with SHA-based checkout and conditional autofix

## Problem

1. Every PR that triggered audit autofix wrote a different baseline to `homeboy.json`. Merging one PR invalidated every other PR's `homeboy.json`.
2. `test.rs` generated PHPUnit-specific `--filter=` args, which broke Rust (`cargo test` doesn't understand `--filter`). Language-specific code doesn't belong in core.

## Solution

### Ratchet

`--write` no longer auto-ratchets the baseline. To update the baseline, pass `--ratchet` explicitly:

```bash
# Apply code fixes only (safe for PRs)
homeboy audit myproject --fix --write

# Apply code fixes AND ratchet baseline (for main/release only)
homeboy audit myproject --fix --write --ratchet
```

### Test scoping

Core passes `HOMEBOY_CHANGED_TEST_FILES` (newline-separated paths) to the extension's test runner. Each extension converts to its native scoping:

- **WordPress**: `--filter (BarBazTest|FooTest)` for PHPUnit
- **Rust**: positional module path filter for `cargo test`

Companion PR: Extra-Chill/homeboy-extensions#131

## CI changes

- Checkout uses `github.event.pull_request.head.sha` (fork-safe)
- Autofix disabled for fork PRs
- Audit autofix uses `--fix --write` (no `--ratchet`)
- Audit mode changed to `on-failure`

## Files changed

| File | Change |
|---|---|
| `src/commands/audit.rs` | Add `--ratchet` flag, gate ratchet block on it |
| `src/commands/test.rs` | Replace `--filter=` generation with `HOMEBOY_CHANGED_TEST_FILES` env var |
| `src/commands/supports.rs` | Add `--ratchet` to audit support matrix |
| `.github/workflows/ci.yml` | SHA checkout, fork-safe autofix, remove ratchet from PR autofix |

Refs #653