### PR TITLE
refactor: remove PHPUnit-specific code and unify is_test_path (#653)

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use super::args::{BaselineArgs, PositionalComponentArgs};
-use super::test_scope::{build_phpunit_filter_regex, compute_changed_test_scope};
+use super::test_scope::compute_changed_test_scope;
 use super::{CmdResult, GlobalArgs};
 
 #[derive(Args)]
@@ -938,7 +938,20 @@ fn build_test_smoke_verifier<'a>(
 ) -> Option<impl Fn(&fixer::ApplyChunkResult) -> Result<String, String> + 'a> {
     let component = load_or_discover(component_id, source_path)?;
     let script_path = super::test::resolve_test_script(&component).ok()?;
-    let changed_scope = compute_changed_test_scope(&component, "HEAD~1").ok();
+    // Pre-compute the changed test files string so the closure can use it.
+    // The extension's test runner decides how to scope (e.g., PHPUnit uses
+    // --filter, Cargo uses positional test names). Core does not generate
+    // runner-specific args — it passes HOMEBOY_CHANGED_TEST_FILES and lets
+    // the extension handle conversion.
+    let changed_test_files: Option<String> = compute_changed_test_scope(&component, "HEAD~1")
+        .ok()
+        .and_then(|scope| {
+            if scope.selected_files.is_empty() {
+                None
+            } else {
+                Some(scope.selected_files.join("\n"))
+            }
+        });
 
     Some(move |chunk: &fixer::ApplyChunkResult| {
         if chunk.files.is_empty() || changed_files.is_empty() {
@@ -961,23 +974,16 @@ fn build_test_smoke_verifier<'a>(
             chunk.chunk_id.replace(':', "-")
         ));
 
-        let runner = ExtensionRunner::new(component_id, &script_path)
+        let mut runner = ExtensionRunner::new(component_id, &script_path)
             .path_override(Some(source_path.to_string()))
             .env("HOMEBOY_SKIP_LINT", "1")
             .env("HOMEBOY_TEST_RESULTS_FILE", &results_file.to_string_lossy());
 
-        let mut args = Vec::new();
-        if let Some(scope) = &changed_scope {
-            if !scope.selected_files.is_empty() {
-                args.push(format!(
-                    "--filter={}",
-                    build_phpunit_filter_regex(&scope.selected_files)
-                ));
-            }
+        if let Some(ref files) = changed_test_files {
+            runner = runner.env("HOMEBOY_CHANGED_TEST_FILES", files);
         }
 
         let output = runner
-            .script_args(&args)
             .run()
             .map_err(|error| format!("test smoke run failed: {}", error))?;
 

--- a/src/commands/test_scope.rs
+++ b/src/commands/test_scope.rs
@@ -1,9 +1,10 @@
 use clap::Args;
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde::Serialize;
 
+use homeboy::code_audit::is_test_path;
 use homeboy::component::Component;
 use homeboy::git;
 use homeboy::test_drift::{self, DriftOptions};
@@ -88,39 +89,6 @@ pub fn compute_changed_test_scope(
     })
 }
 
-pub fn build_phpunit_filter_regex(selected_files: &[String]) -> String {
-    // Build a regex that matches test class names derived from selected file basenames.
-    // Example: tests/Unit/Foo/BarBazTest.php -> BarBazTest
-    let mut classes: Vec<String> = selected_files
-        .iter()
-        .filter_map(|f| {
-            if !f.ends_with(".php") {
-                return None;
-            }
-            Path::new(f)
-                .file_stem()
-                .map(|s| s.to_string_lossy().to_string())
-        })
-        .filter(|stem| !stem.is_empty())
-        .map(|stem| regex::escape(&stem))
-        .collect();
-
-    classes.sort();
-    classes.dedup();
-
-    if classes.is_empty() {
-        // No PHP class-based test files selected. Use a non-matching regex
-        // to avoid accidentally running the full suite.
-        return "^$".to_string();
-    }
-
-    format!("({})", classes.join("|"))
-}
-
-fn is_test_path(path: &str) -> bool {
-    path.contains("/tests/") || path.ends_with("Test.php") || path.ends_with("_test.rs")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,21 +113,11 @@ mod tests {
     }
 
     #[test]
-    fn test_build_phpunit_filter_regex() {
-        let selected = vec![
-            "tests/Unit/Foo/BarBazTest.php".to_string(),
-            "tests/Unit/Foo/BatTest.php".to_string(),
-            "tests/core/thing_test.rs".to_string(),
-        ];
-
-        let regex = build_phpunit_filter_regex(&selected);
-        assert_eq!(regex, "(BarBazTest|BatTest)");
-    }
-
-    #[test]
-    fn test_is_test_path() {
+    fn test_is_test_path_uses_canonical() {
+        // Verify canonical is_test_path (from code_audit::walker) is used
         assert!(is_test_path("tests/unit/foo_test.rs"));
         assert!(is_test_path("plugin/tests/FooTest.php"));
+        assert!(is_test_path("src/components/Button.test.tsx"));
         assert!(!is_test_path("src/core/component.rs"));
     }
 

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -46,6 +46,7 @@ pub use checks::{CheckResult, CheckStatus};
 pub use conventions::{AuditFinding, Convention, Deviation, Language, Outlier};
 pub use findings::{Finding, Severity};
 pub use fingerprint::FileFingerprint;
+pub use walker::is_test_path;
 
 use crate::{component, utils::is_zero, Result};
 

--- a/src/core/code_audit/walker.rs
+++ b/src/core/code_audit/walker.rs
@@ -71,7 +71,7 @@ pub(crate) fn walk_source_files(root: &Path) -> std::io::Result<Vec<std::path::P
 /// Matches common test file patterns across languages:
 /// - Paths under `tests/`, `Tests/`, `test/`, `__tests__/` directories
 /// - Files named `*_test.rs`, `*Test.php`, `*.test.js`, `*.spec.ts`, etc.
-pub(crate) fn is_test_path(relative_path: &str) -> bool {
+pub fn is_test_path(relative_path: &str) -> bool {
     // Directory-based detection
     let path_lower = relative_path.to_lowercase();
     if path_lower.starts_with("tests/")

--- a/src/core/test_drift.rs
+++ b/src/core/test_drift.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::code_audit::walker::is_test_path;
 use crate::error::{Error, Result};
 use crate::git;
 
@@ -142,7 +143,7 @@ pub fn detect_drift(component: &str, opts: &DriftOptions) -> Result<DriftReport>
     // Filter to production files only (exclude tests)
     let prod_files: Vec<&str> = changed_files
         .iter()
-        .filter(|f| !is_test_file(f))
+        .filter(|f| !is_test_path(f))
         .map(|s| s.as_str())
         .collect();
 
@@ -169,7 +170,7 @@ pub fn detect_drift(component: &str, opts: &DriftOptions) -> Result<DriftReport>
     // Also detect file renames
     let renames = get_renamed_files(opts.root, opts.since)?;
     for (old, new) in &renames {
-        if !is_test_file(old) {
+        if !is_test_path(old) {
             changes.push(ProductionChange {
                 change_type: ChangeType::FileMove,
                 file: new.clone(),
@@ -450,11 +451,6 @@ fn extract_changes_from_diff(file: &str, diff: &str) -> Vec<ProductionChange> {
 // ============================================================================
 // Test file scanning
 // ============================================================================
-
-/// Check if a file path looks like a test file.
-fn is_test_file(path: &str) -> bool {
-    path.contains("/tests/") || path.contains("Test.php") || path.contains("_test.rs")
-}
 
 /// Collect all test files in the repo.
 fn collect_test_files(root: &Path) -> Vec<PathBuf> {
@@ -776,11 +772,11 @@ mod tests {
     }
 
     #[test]
-    fn is_test_file_detection() {
-        assert!(is_test_file("tests/Unit/FooTest.php"));
-        assert!(is_test_file("tests/integration/bar_test.rs"));
-        assert!(!is_test_file("src/Foo.php"));
-        assert!(!is_test_file("src/config.rs"));
+    fn is_test_path_detection() {
+        assert!(is_test_path("tests/Unit/FooTest.php"));
+        assert!(is_test_path("tests/integration/bar_test.rs"));
+        assert!(!is_test_path("src/Foo.php"));
+        assert!(!is_test_path("src/config.rs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 1 of #653 — removing language-specific code from homeboy core.

- **Remove `build_phpunit_filter_regex`** — audit's test-smoke verifier now passes `HOMEBOY_CHANGED_TEST_FILES` env var (same pattern `test.rs` already uses), letting each extension's test runner convert to its native filter format
- **Unify `is_test_path`** — consolidated 3 separate copies (test_scope.rs, test_drift.rs, walker.rs) into the single canonical `walker::is_test_path` which handles Rust, PHP, JS/TS, and Python patterns. The removed copies only checked PHP and Rust.
- **Re-export** `is_test_path` from `code_audit` public API so the binary crate can use it

Net: -39 lines, 0 new language-specific code.

## What stays

- `test_mapping::is_test_file()` — this uses extension-provided config (`test_dirs`), which is the correct generic pattern. Different function, different purpose.
- `DriftOptions::php()`/`::rust()` and `compute_changed_test_scope` Cargo.toml sniffing — Phase 2 will make these generic via extension manifest.

## Testing

`cargo test` — all 934 tests pass, 0 failures.