### PR TITLE
fix(decompose): preserve impl blocks in type buckets

### DIFF
--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -765,8 +765,13 @@ fn group_items(file: &str, items: &[ParsedItem], content: &str) -> Vec<Decompose
         buckets.entry(key).or_default().extend(names);
     }
 
-    // Deduplicate within buckets
-    for names in buckets.values_mut() {
+    // Deduplicate within buckets — but skip type buckets because impl names
+    // match their target struct/enum names (e.g., struct Foo + impl Foo both
+    // have name "Foo" and should both be kept)
+    for (bucket_key, names) in buckets.iter_mut() {
+        if type_bucket_keys.contains(bucket_key) {
+            continue; // Type buckets may have struct name == impl name, keep both
+        }
         let mut seen = HashSet::new();
         names.retain(|name| seen.insert(name.clone()));
     }


### PR DESCRIPTION
## Summary

When `colocate_types` groups a type with its impl (e.g., `struct Foo` + `impl Foo`), both items have the same name. The deduplication logic was incorrectly treating them as duplicates and dropping the impl.

This fix skips deduplication for type buckets entirely, since `colocate_types` already handles the grouping correctly.

## Testing

- All 18 decompose tests pass
- Verified that impl blocks now appear in the plan alongside their types:
  - `fix_result`: FixResult (struct) + FixResult (impl)
  - `insertion_kind`: InsertionKind (enum) + InsertionKind (impl)
  - `policy_summary`: PolicySummary (struct) + PolicySummary (impl)

## Related

- Part of #656 (mod.rs generation is still needed for full decompose support)