### PR TITLE
refactor(code-factory): route apply mutations through refactor auto

### DIFF
--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -832,7 +832,12 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
             for conformance in &missing_interfaces {
                 let Some(type_name) = content
                     .lines()
-                    .find_map(|line| primary_type_name_from_declaration(line, &language))
+                    .find_map(|line| {
+                        crate::core::refactor::auto::apply::primary_type_name_from_declaration(
+                            line,
+                            &language,
+                        )
+                    })
                     .or_else(|| {
                         abs_path
                             .file_stem()
@@ -1556,7 +1561,11 @@ class MyClass {
 }
 "#;
         let stub = "\n    public function newMethod() {\n        // stub\n    }\n";
-        let result = insert_before_closing_brace(content, stub, &Language::Php);
+        let result = crate::core::refactor::auto::apply::insert_before_closing_brace(
+            content,
+            stub,
+            &Language::Php,
+        );
 
         assert!(result.contains("newMethod"));
         assert!(result.contains("existing"));
@@ -1571,7 +1580,11 @@ class MyClass {
         let content = "<?php\nclass FlowAbility extends BaseAbility {\n}\n";
         let declaration = "AbilityInterface".to_string();
 
-        let result = insert_type_conformance(content, &[&declaration], &Language::Php);
+        let result = crate::core::refactor::auto::apply::insert_type_conformance(
+            content,
+            &[&declaration],
+            &Language::Php,
+        );
 
         assert!(
             result.contains("class FlowAbility extends BaseAbility implements AbilityInterface {")
@@ -1584,7 +1597,11 @@ class MyClass {
         let declaration =
             generate_type_conformance_declaration("FlowAbility", "Runnable", &Language::Rust);
 
-        let result = insert_type_conformance(content, &[&declaration], &Language::Rust);
+        let result = crate::core::refactor::auto::apply::insert_type_conformance(
+            content,
+            &[&declaration],
+            &Language::Rust,
+        );
 
         assert!(result.contains("impl Runnable for FlowAbility"));
     }
@@ -1671,7 +1688,11 @@ class MyAbility {
 "#;
         let reg = "        add_action('wp_abilities_api_init', [$this, 'abilities_api_init']);"
             .to_string();
-        let result = insert_into_constructor(content, &[&reg], &Language::Php);
+        let result = crate::core::refactor::auto::apply::insert_into_constructor(
+            content,
+            &[&reg],
+            &Language::Php,
+        );
 
         assert!(result.contains("add_action('wp_abilities_api_init'"));
         // Registration should be inside __construct
@@ -1683,7 +1704,11 @@ class MyAbility {
     #[test]
     fn insert_namespace_declaration_replaces_existing_php_namespace() {
         let content = "<?php\nnamespace Old\\Space;\n\nclass FlowAbility {}\n";
-        let result = insert_namespace_declaration(content, "namespace New\\Space;", &Language::Php);
+        let result = crate::core::refactor::auto::apply::insert_namespace_declaration(
+            content,
+            "namespace New\\Space;",
+            &Language::Php,
+        );
 
         assert!(result.contains("namespace New\\Space;"));
         assert!(!result.contains("namespace Old\\Space;"));
@@ -1692,7 +1717,7 @@ class MyAbility {
     #[test]
     fn insert_namespace_declaration_adds_missing_php_namespace() {
         let content = "<?php\n\nclass FlowAbility {}\n";
-        let result = insert_namespace_declaration(
+        let result = crate::core::refactor::auto::apply::insert_namespace_declaration(
             content,
             "namespace DataMachine\\Abilities;",
             &Language::Php,
@@ -2312,7 +2337,11 @@ pub struct MyOutput {}
 
 pub fn run() {}
 "#;
-        let result = insert_import(content, "use super::CmdResult;", &Language::Rust);
+        let result = crate::core::refactor::auto::apply::insert_import(
+            content,
+            "use super::CmdResult;",
+            &Language::Rust,
+        );
         assert!(result.contains("use super::CmdResult;"));
         // Should be after the last existing use line
         let cmd_pos = result.find("use super::CmdResult;").unwrap();
@@ -2331,7 +2360,11 @@ pub fn run() {}
 
 pub struct Output {}
 "#;
-        let result = insert_import(content, "use super::CmdResult;", &Language::Rust);
+        let result = crate::core::refactor::auto::apply::insert_import(
+            content,
+            "use super::CmdResult;",
+            &Language::Rust,
+        );
         assert!(result.contains("use super::CmdResult;"));
         assert!(result.contains("pub struct Output"));
     }
@@ -2353,7 +2386,7 @@ mod tests {
     fn test_something() {}
 }
 "#;
-        let result = insert_import(
+        let result = crate::core::refactor::auto::apply::insert_import(
             content,
             "use crate::core::something::new_dep;",
             &Language::Rust,

--- a/src/core/refactor/auto/apply.rs
+++ b/src/core/refactor/auto/apply.rs
@@ -200,6 +200,11 @@ fn insert_imports(content: &str, imports: &[&String], language: &Language) -> St
     result
 }
 
+pub(crate) fn insert_import(content: &str, import_line: &str, language: &Language) -> String {
+    let import = import_line.to_string();
+    insert_imports(content, &[&import], language)
+}
+
 fn insert_namespace_declarations(
     content: &str,
     declarations: &[&String],
@@ -210,7 +215,7 @@ fn insert_namespace_declarations(
     })
 }
 
-fn insert_namespace_declaration(content: &str, declaration: &str, language: &Language) -> String {
+pub(crate) fn insert_namespace_declaration(content: &str, declaration: &str, language: &Language) -> String {
     match language {
         Language::Php => {
             let namespace_re = Regex::new(r"(?m)^\s*namespace\s+[^;]+;").unwrap();
@@ -242,7 +247,7 @@ fn insert_type_conformances(
     insert_type_conformance(content, declarations, language)
 }
 
-fn insert_type_conformance(content: &str, declarations: &[&String], language: &Language) -> String {
+pub(crate) fn insert_type_conformance(content: &str, declarations: &[&String], language: &Language) -> String {
     let Some(declaration) = declarations.first() else {
         return content.to_string();
     };
@@ -307,7 +312,7 @@ fn insert_inline_type_conformance(content: &str, declaration: &str, language: &L
     result
 }
 
-fn primary_type_name_from_declaration(line: &str, language: &Language) -> Option<String> {
+pub(crate) fn primary_type_name_from_declaration(line: &str, language: &Language) -> Option<String> {
     let trimmed = line.trim();
     match language {
         Language::Php | Language::TypeScript => Regex::new(r"\b(?:class|interface|trait)\s+(\w+)")
@@ -340,7 +345,7 @@ fn insert_method_stubs(content: &str, stubs: &[&String], language: &Language) ->
     insert_before_closing_brace(content, &combined, language)
 }
 
-fn insert_into_constructor(content: &str, stubs: &[&String], language: &Language) -> String {
+pub(crate) fn insert_into_constructor(content: &str, stubs: &[&String], language: &Language) -> String {
     let constructor_pattern = match language {
         Language::Php => r"function\s+__construct\s*\([^)]*\)\s*\{",
         Language::Rust => r"fn\s+new\s*\([^)]*\)\s*(?:->[^{]*)?\{",
@@ -367,7 +372,7 @@ fn insert_into_constructor(content: &str, stubs: &[&String], language: &Language
     }
 }
 
-fn insert_trait_uses(content: &str, stubs: &[&String], language: &Language) -> String {
+pub(crate) fn insert_trait_uses(content: &str, stubs: &[&String], language: &Language) -> String {
     match language {
         Language::Php => {
             let class_re = Regex::new(r"(?:class|trait|interface)\s+\w+[^\{]*\{").unwrap();
@@ -393,7 +398,7 @@ fn insert_trait_uses(content: &str, stubs: &[&String], language: &Language) -> S
     }
 }
 
-fn insert_before_closing_brace(content: &str, code: &str, _language: &Language) -> String {
+pub(crate) fn insert_before_closing_brace(content: &str, code: &str, _language: &Language) -> String {
     if let Some(last_brace) = content.rfind('}') {
         let mut result = String::with_capacity(content.len() + code.len());
         result.push_str(&content[..last_brace]);


### PR DESCRIPTION
## Summary
- move `apply_insertions_to_content` and the content-mutation helper cluster into `src/core/refactor/auto/apply.rs`
- keep `code_audit/fixer` as a compatibility router for apply behavior instead of the source of truth
- update existing fixer tests to call the refactor-owned apply helpers where needed

## Validation
- cargo check
- cargo test apply_multiple_removals_same_file --lib
- cargo test insert_type_conformance_updates_php_class_declaration --lib
- cargo test insert_namespace_declaration_replaces_existing_php_namespace --lib
- cargo test insert_import_after_existing_rust_imports --lib
- cargo test build_refactor_plan_audit_write_uses_audit_refactor_engine --lib