### PR TITLE
refactor(code-factory): move test helper parsing into plan

### DIFF
--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -14,7 +14,6 @@ use regex::Regex;
 
 use super::conventions::{AuditFinding, Language};
 use super::naming::{detect_naming_suffix, suffix_matches};
-use super::test_mapping::source_to_test_path;
 use super::CodeAuditResult;
 use crate::core::refactor::decompose;
 
@@ -366,59 +365,6 @@ pub(crate) fn first_failed_detail(report: &PreflightReport) -> Option<String> {
         .iter()
         .find(|check| !check.passed)
         .map(|check| format!("Blocked by preflight {}: {}", check.name, check.detail))
-}
-
-fn extract_source_file_from_comment(content: &str) -> Option<String> {
-    content.lines().find_map(|line| {
-        line.trim()
-            .strip_prefix("// Source: ")
-            .or_else(|| line.trim().strip_prefix("* Source: "))
-            .or_else(|| line.trim().strip_prefix("// Source: "))
-            .map(|value| value.trim().to_string())
-    })
-}
-
-pub(crate) fn mapping_from_source_comment(content: &str) -> Option<(String, String)> {
-    let source_file = extract_source_file_from_comment(content)?;
-    let expected_test_path = derive_expected_test_file_path(Path::new("."), &source_file)
-        .or_else(|| fallback_expected_test_path(&source_file))?;
-
-    Some((source_file, expected_test_path))
-}
-
-fn fallback_expected_test_path(source_file: &str) -> Option<String> {
-    let source_path = Path::new(source_file);
-    let ext = source_path.extension()?.to_str()?;
-    let name = source_path.file_stem()?.to_str()?;
-    let dir = source_path
-        .parent()
-        .and_then(|parent| parent.strip_prefix("src").ok())
-        .map(|parent| parent.to_string_lossy().trim_start_matches('/').to_string())
-        .unwrap_or_default();
-
-    Some(if dir.is_empty() {
-        format!("tests/{}_test.{}", name, ext)
-    } else {
-        format!("tests/{}/{}_test.{}", dir, name, ext)
-    })
-}
-
-pub(crate) fn extract_source_file_from_test_stub(description: &str) -> Option<String> {
-    let marker = " for '";
-    let start = description.find(marker)? + marker.len();
-    let rest = &description[start..];
-    let end = rest.find("::")?;
-    Some(rest[..end].to_string())
-}
-
-pub(crate) fn extract_expected_test_method_from_fix_description(
-    description: &str,
-) -> Option<String> {
-    let marker = "Scaffold missing test method '";
-    let start = description.find(marker)? + marker.len();
-    let rest = &description[start..];
-    let end = rest.find('"').or_else(|| rest.find('\''))?;
-    Some(rest[..end].to_string())
 }
 
 // ============================================================================
@@ -997,7 +943,7 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
             crate::core::refactor::plan::generate::extract_test_file_from_missing_test_method(
                 &finding.description,
             )
-            .or_else(|| derive_expected_test_file_path(root, &finding.file));
+            .or_else(|| crate::core::refactor::plan::generate::derive_expected_test_file_path(root, &finding.file));
 
         // For inline-test languages (Rust), when no separate test file is derived,
         // insert the test method directly into the source file's #[cfg(test)] module.
@@ -1062,7 +1008,12 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
             .map(Language::from_extension)
             .unwrap_or(Language::Unknown);
 
-        if test_method_exists_in_file(root, &test_file, &expected_test_method, &new_files) {
+        if crate::core::refactor::plan::generate::test_method_exists_in_file(
+            root,
+            &test_file,
+            &expected_test_method,
+            &new_files,
+        ) {
             continue;
         }
 
@@ -1272,44 +1223,6 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
         total_insertions,
         files_modified,
     }
-}
-
-pub(crate) fn test_method_exists_in_file(
-    root: &Path,
-    test_file: &str,
-    test_method: &str,
-    pending_new_files: &[NewFile],
-) -> bool {
-    if let Some(nf) = pending_new_files.iter().find(|nf| nf.file == test_file) {
-        return nf.content.contains(test_method);
-    }
-
-    let path = root.join(test_file);
-    if !path.exists() {
-        return false;
-    }
-
-    std::fs::read_to_string(path)
-        .map(|content| content.contains(test_method))
-        .unwrap_or(false)
-}
-
-pub(crate) fn derive_expected_test_file_path(root: &Path, source_file: &str) -> Option<String> {
-    let ext = Path::new(source_file).extension()?.to_str()?;
-    let manifest = crate::extension::find_extension_for_file_ext(ext, "audit")?;
-    let mapping = manifest.test_mapping()?;
-
-    let mut path = source_to_test_path(source_file, mapping)?;
-    if path.starts_with('/') {
-        path = path.trim_start_matches('/').to_string();
-    }
-
-    let abs = root.join(&path);
-    if abs.components().count() == 0 {
-        return None;
-    }
-
-    Some(path)
 }
 
 fn generate_fallback_signature(method_name: &str, language: &Language) -> MethodSignature {
@@ -3756,7 +3669,10 @@ class FlowAbilities {
             files_modified: 0,
         };
 
-        let (_, expected_path) = mapping_from_source_comment(&result.new_files[0].content).unwrap();
+        let (_, expected_path) = crate::core::refactor::plan::generate::mapping_from_source_comment(
+            &result.new_files[0].content,
+        )
+        .unwrap();
         assert_eq!(expected_path, "tests/utils/token_test.rs");
 
         let summary = apply_fix_policy(

--- a/src/core/refactor/auto/preflight.rs
+++ b/src/core/refactor/auto/preflight.rs
@@ -1,10 +1,11 @@
 use crate::code_audit::conventions::{AuditFinding, Language};
 use crate::code_audit::fixer::{
-    apply_insertions_to_content, derive_expected_test_file_path, detect_language,
-    extract_expected_test_method_from_fix_description, extract_source_file_from_test_stub,
-    first_failed_detail, mapping_from_source_comment, test_method_exists_in_file, Fix,
-    FixSafetyTier, Insertion, NewFile, PreflightCheck, PreflightContext, PreflightReport,
-    PreflightStatus,
+    apply_insertions_to_content, detect_language, first_failed_detail, Fix, FixSafetyTier,
+    Insertion, NewFile, PreflightCheck, PreflightContext, PreflightReport, PreflightStatus,
+};
+use crate::core::refactor::plan::generate::{
+    derive_expected_test_file_path, extract_expected_test_method_from_fix_description,
+    extract_source_file_from_test_stub, mapping_from_source_comment, test_method_exists_in_file,
 };
 
 pub fn run_insertion_preflight(

--- a/src/core/refactor/plan/generate.rs
+++ b/src/core/refactor/plan/generate.rs
@@ -218,6 +218,94 @@ pub(crate) fn generate_test_file_candidate(
     })
 }
 
+fn extract_source_file_from_comment(content: &str) -> Option<String> {
+    content.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix("// Source: ")
+            .or_else(|| line.trim().strip_prefix("* Source: "))
+            .or_else(|| line.trim().strip_prefix("// Source: "))
+            .map(|value| value.trim().to_string())
+    })
+}
+
+pub(crate) fn mapping_from_source_comment(content: &str) -> Option<(String, String)> {
+    let source_file = extract_source_file_from_comment(content)?;
+    let expected_test_path = derive_expected_test_file_path(Path::new("."), &source_file)
+        .or_else(|| fallback_expected_test_path(&source_file))?;
+
+    Some((source_file, expected_test_path))
+}
+
+fn fallback_expected_test_path(source_file: &str) -> Option<String> {
+    let source_path = Path::new(source_file);
+    let ext = source_path.extension()?.to_str()?;
+    let name = source_path.file_stem()?.to_str()?;
+    let dir = source_path
+        .parent()
+        .and_then(|parent| parent.strip_prefix("src").ok())
+        .map(|parent| parent.to_string_lossy().trim_start_matches('/').to_string())
+        .unwrap_or_default();
+
+    Some(if dir.is_empty() {
+        format!("tests/{}_test.{}", name, ext)
+    } else {
+        format!("tests/{}/{}_test.{}", dir, name, ext)
+    })
+}
+
+pub(crate) fn extract_source_file_from_test_stub(description: &str) -> Option<String> {
+    let marker = " for '";
+    let start = description.find(marker)? + marker.len();
+    let rest = &description[start..];
+    let end = rest.find("::")?;
+    Some(rest[..end].to_string())
+}
+
+pub(crate) fn extract_expected_test_method_from_fix_description(
+    description: &str,
+) -> Option<String> {
+    let marker = "Scaffold missing test method '";
+    let start = description.find(marker)? + marker.len();
+    let rest = &description[start..];
+    let end = rest.find('"').or_else(|| rest.find('\''))?;
+    Some(rest[..end].to_string())
+}
+
+pub(crate) fn test_method_exists_in_file(
+    root: &Path,
+    test_file: &str,
+    expected_test_method: &str,
+    new_files: &[fixer::NewFile],
+) -> bool {
+    if let Some(new_file) = new_files.iter().find(|new_file| new_file.file == test_file) {
+        return new_file.content.contains(&expected_test_method);
+    }
+
+    let abs_path = root.join(test_file);
+    match std::fs::read_to_string(&abs_path) {
+        Ok(content) => content.contains(expected_test_method),
+        Err(_) => false,
+    }
+}
+
+pub(crate) fn derive_expected_test_file_path(root: &Path, source_file: &str) -> Option<String> {
+    let ext = Path::new(source_file).extension()?.to_str()?;
+    let manifest = crate::extension::find_extension_for_file_ext(ext, "audit")?;
+    let mapping = manifest.test_mapping()?;
+
+    let mut path = crate::code_audit::test_mapping::source_to_test_path(source_file, mapping)?;
+    if path.starts_with('/') {
+        path = path.trim_start_matches('/').to_string();
+    }
+
+    let abs = root.join(&path);
+    if abs.components().count() == 0 {
+        return None;
+    }
+
+    Some(path)
+}
+
 fn generate_test_file_from_scaffold(
     root: &Path,
     test_file: &str,


### PR DESCRIPTION
## Summary
- move test-mapping, description-parsing, and expected test target helpers out of `code_audit/fixer.rs` into `src/core/refactor/plan/generate.rs`
- update `refactor/auto/preflight.rs` and remaining fixer call sites to use the plan-owned helper cluster
- keep reducing `fixer.rs` toward compatibility and fix-data ownership instead of helper/source-of-truth ownership

## Validation
- cargo check
- cargo test missing_test_file_preflight_uses_source_mapping --lib
- cargo test build_refactor_plan_audit_write_uses_audit_refactor_engine --lib *(fails on this VPS due to disk full in temp-dir-writing test, not due to compile/logic regression)*