### PR TITLE
refactor(code-factory): derive signatures from grammar symbols

### DIFF
--- a/src/core/code_audit/fixer.rs
+++ b/src/core/code_audit/fixer.rs
@@ -385,73 +385,7 @@ pub(crate) struct MethodSignature {
 
 /// Extract full method signatures from a source file.
 pub(crate) fn extract_signatures(content: &str, language: &Language) -> Vec<MethodSignature> {
-    match language {
-        Language::Php => extract_php_signatures(content),
-        Language::Rust => extract_rust_signatures(content),
-        Language::JavaScript | Language::TypeScript => extract_js_signatures(content),
-        Language::Unknown => vec![],
-    }
-}
-
-pub(crate) fn extract_php_signatures(content: &str) -> Vec<MethodSignature> {
-    let re = Regex::new(
-        r"(?m)^\s*((?:public|protected|private)\s+(?:static\s+)?function\s+(\w+)\s*\([^)]*\)(?:\s*:\s*[\w\\|?]+)?)",
-    )
-    .unwrap();
-
-    re.captures_iter(content)
-        .map(|cap| MethodSignature {
-            name: cap[2].to_string(),
-            signature: cap[1].trim().to_string(),
-            language: Language::Php,
-        })
-        .collect()
-}
-
-pub(crate) fn extract_rust_signatures(content: &str) -> Vec<MethodSignature> {
-    let re = Regex::new(
-        r"(?m)^\s*(pub(?:\(crate\))?\s+(?:async\s+)?fn\s+(\w+)\s*\([^)]*\)(?:\s*->\s*[^\{]+)?)",
-    )
-    .unwrap();
-
-    re.captures_iter(content)
-        .map(|cap| MethodSignature {
-            name: cap[2].to_string(),
-            signature: cap[1].trim().to_string(),
-            language: Language::Rust,
-        })
-        .collect()
-}
-
-pub(crate) fn extract_js_signatures(content: &str) -> Vec<MethodSignature> {
-    // Named function declarations
-    let fn_re =
-        Regex::new(r"(?m)^\s*((?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\([^)]*\))").unwrap();
-    // Class methods
-    let method_re = Regex::new(r"(?m)^\s+((?:async\s+)?(\w+)\s*\([^)]*\))\s*\{").unwrap();
-
-    let mut sigs: Vec<MethodSignature> = fn_re
-        .captures_iter(content)
-        .map(|cap| MethodSignature {
-            name: cap[2].to_string(),
-            signature: cap[1].trim().to_string(),
-            language: Language::JavaScript,
-        })
-        .collect();
-
-    let skip = ["if", "for", "while", "switch", "catch", "return"];
-    for cap in method_re.captures_iter(content) {
-        let name = cap[2].to_string();
-        if !skip.contains(&name.as_str()) && !sigs.iter().any(|s| s.name == name) {
-            sigs.push(MethodSignature {
-                name,
-                signature: cap[1].trim().to_string(),
-                language: Language::JavaScript,
-            });
-        }
-    }
-
-    sigs
+    crate::core::refactor::plan::generate::extract_signatures_from_items(content, language)
 }
 
 // ============================================================================
@@ -1309,7 +1243,7 @@ class MyAbility {
     }
 }
 "#;
-        let sigs = extract_php_signatures(content);
+        let sigs = extract_signatures(content, &Language::Php);
         assert_eq!(sigs.len(), 4);
 
         let execute = sigs.iter().find(|s| s.name == "execute").unwrap();
@@ -1337,7 +1271,7 @@ impl Handler {
     }
 }
 "#;
-        let sigs = extract_rust_signatures(content);
+        let sigs = extract_signatures(content, &Language::Rust);
         assert!(sigs.len() >= 2);
 
         let run = sigs.iter().find(|s| s.name == "run").unwrap();

--- a/src/core/refactor/auto/preflight.rs
+++ b/src/core/refactor/auto/preflight.rs
@@ -374,16 +374,12 @@ fn syntax_shape_check(content: &str, insertion: &Insertion, language: &Language)
     };
 
     let parsed_ok = match language {
-        Language::Php => {
-            !crate::code_audit::fixer::extract_php_signatures(content).is_empty()
-                || content.contains("class ")
-        }
-        Language::Rust => {
-            !crate::code_audit::fixer::extract_rust_signatures(content).is_empty()
-                || content.contains("fn ")
-        }
+        Language::Php => !crate::code_audit::fixer::extract_signatures(content, language).is_empty()
+            || content.contains("class "),
+        Language::Rust => !crate::code_audit::fixer::extract_signatures(content, language).is_empty()
+            || content.contains("fn "),
         Language::JavaScript | Language::TypeScript => {
-            !crate::code_audit::fixer::extract_js_signatures(content).is_empty()
+            !crate::code_audit::fixer::extract_signatures(content, language).is_empty()
                 || content.contains("function ")
         }
         Language::Unknown => true,

--- a/src/core/refactor/plan/generate.rs
+++ b/src/core/refactor/plan/generate.rs
@@ -427,6 +427,46 @@ pub(crate) fn parse_items_for_dedup(
         .and_then(|v| serde_json::from_value(v).ok())
 }
 
+pub(crate) fn extract_signatures_from_items(
+    content: &str,
+    language: &Language,
+) -> Vec<fixer::MethodSignature> {
+    let file_ext = match language {
+        Language::Php => "php",
+        Language::Rust => "rs",
+        Language::JavaScript => "js",
+        Language::TypeScript => "ts",
+        Language::Unknown => return Vec::new(),
+    };
+
+    let Some(grammar) = crate::code_audit::core_fingerprint::load_grammar_for_ext(file_ext) else {
+        return Vec::new();
+    };
+
+    let symbols = crate::utils::grammar::extract(content, &grammar);
+    let lines: Vec<&str> = content.lines().collect();
+
+    symbols
+        .into_iter()
+        .filter(|symbol| matches!(symbol.concept.as_str(), "function" | "free_function" | "method"))
+        .filter_map(|symbol| {
+            let name = symbol.name()?.to_string();
+            let line_idx = symbol.line.checked_sub(1)?;
+            let signature = lines
+                .get(line_idx)
+                .map(|line| line.trim().to_string())
+                .filter(|line| !line.is_empty())
+                .unwrap_or_else(|| name.clone());
+
+            Some(fixer::MethodSignature {
+                name,
+                signature,
+                language: language.clone(),
+            })
+        })
+        .collect()
+}
+
 fn insertion(
     kind: fixer::InsertionKind,
     finding: AuditFinding,


### PR DESCRIPTION
## Summary
- replace the remaining signature extraction path with the existing grammar/symbol primitive instead of language-specific regex helpers in core
- derive method signatures from grammar symbols in `src/core/refactor/plan/generate.rs`, respecting generic concept names like `function`, `free_function`, and `method`
- keep `code_audit/fixer` and preflight callers on the generic signature adapter instead of bypassing Homeboy's parsing primitive

## Validation
- cargo check
- cargo test extract_php_signature_with_types --lib
- cargo test extract_rust_signature_with_return_type --lib