### PR TITLE
refactor(architecture): move runtime temp paths into engine

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -1,11 +1,12 @@
 use clap::Args;
 use serde::Serialize;
 
+use homeboy::engine::temp;
 use homeboy::extension::lint as extension_lint;
-use homeboy::git;
 use homeboy::extension::lint::baseline::{
     self as lint_baseline, BaselineComparison as LintBaselineComparison, LintFinding,
 };
+use homeboy::git;
 use homeboy::refactor::{
     auto::{self, AutofixMode},
     run_lint_refactor, AppliedRefactor, LintSourceOptions,
@@ -87,14 +88,7 @@ pub struct LintOutput {
 pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintOutput> {
     let component = args.comp.load()?;
     let source_path = args.comp.source_path()?;
-    let lint_findings_file = std::env::temp_dir().join(format!(
-        "homeboy-lint-findings-{}-{}.json",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
+    let lint_findings_file = temp::runtime_temp_file("homeboy-lint-findings", ".json")?;
     // Resolve glob from --changed-only or --changed-since flags
     let effective_glob = if args.changed_only {
         let uncommitted = git::get_uncommitted_changes(&component.local_path)?;

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -11,3 +11,4 @@ pub mod baseline;
 pub mod executor;
 pub mod pipeline;
 pub mod symbol_graph;
+pub mod temp;

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -1,0 +1,95 @@
+use crate::error::{Error, Result};
+use crate::paths;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+const HOMEBOY_RUNTIME_TMPDIR_ENV: &str = "HOMEBOY_RUNTIME_TMPDIR";
+
+fn runtime_root() -> Result<PathBuf> {
+    if let Ok(override_dir) = env::var(HOMEBOY_RUNTIME_TMPDIR_ENV) {
+        let trimmed = override_dir.trim();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed));
+        }
+    }
+
+    Ok(paths::homeboy()?.join("runtime").join("tmp"))
+}
+
+pub fn ensure_runtime_tmp_dir() -> Result<PathBuf> {
+    let runtime_dir = runtime_root()?;
+    fs::create_dir_all(&runtime_dir).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("create homeboy runtime tmp directory".to_string()),
+        )
+    })?;
+    Ok(runtime_dir)
+}
+
+pub fn runtime_temp_file(prefix: &str, suffix: &str) -> Result<PathBuf> {
+    Ok(ensure_runtime_tmp_dir()?.join(unique_name(prefix, suffix)))
+}
+
+pub fn runtime_temp_dir(prefix: &str) -> Result<PathBuf> {
+    let path = ensure_runtime_tmp_dir()?.join(unique_name(prefix, ""));
+    fs::create_dir_all(&path).map_err(|e| {
+        Error::internal_io(e.to_string(), Some(format!("create temp dir {prefix}")))
+    })?;
+    Ok(path)
+}
+
+fn unique_name(prefix: &str, suffix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+
+    format!("{prefix}-{}-{nanos}{suffix}", uuid::Uuid::new_v4())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn runtime_temp_file_honors_override() {
+        let _guard = env_lock().lock().expect("env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        unsafe {
+            env::set_var(HOMEBOY_RUNTIME_TMPDIR_ENV, dir.path());
+        }
+
+        let path = runtime_temp_file("homeboy-test", ".json").expect("temp file path");
+        assert!(path.starts_with(dir.path()));
+        assert!(path.file_name().unwrap().to_string_lossy().ends_with(".json"));
+
+        unsafe {
+            env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
+        }
+    }
+
+    #[test]
+    fn runtime_temp_dir_honors_override() {
+        let _guard = env_lock().lock().expect("env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        unsafe {
+            env::set_var(HOMEBOY_RUNTIME_TMPDIR_ENV, dir.path());
+        }
+
+        let path = runtime_temp_dir("homeboy-test-dir").expect("temp dir path");
+        assert!(path.starts_with(dir.path()));
+        assert!(path.is_dir());
+
+        unsafe {
+            env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
+        }
+    }
+}

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -69,7 +69,11 @@ mod tests {
 
         let path = runtime_temp_file("homeboy-test", ".json").expect("temp file path");
         assert!(path.starts_with(dir.path()));
-        assert!(path.file_name().unwrap().to_string_lossy().ends_with(".json"));
+        assert!(path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .ends_with(".json"));
 
         unsafe {
             env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -1,4 +1,7 @@
 use crate::component::Component;
+use crate::engine::temp;
+use crate::extension::test::analyze::{analyze, TestAnalysis, TestAnalysisInput};
+use crate::extension::test::baseline::{self, TestBaselineComparison, TestCounts};
 use crate::extension::test::{
     build_test_runner, build_test_summary, compute_changed_test_scope, parse_coverage_file,
     parse_failures_file, parse_test_results_file, parse_test_results_text, CoverageOutput,
@@ -8,8 +11,6 @@ use crate::refactor::{
     auto::{self, AutofixMode},
     run_test_refactor, AppliedRefactor, TestSourceOptions,
 };
-use crate::extension::test::analyze::{analyze, TestAnalysis, TestAnalysisInput};
-use crate::extension::test::baseline::{self, TestBaselineComparison, TestCounts};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -60,16 +61,13 @@ pub fn run_main_test_workflow(
 
     let coverage_enabled = args.coverage || args.coverage_min.is_some();
     let coverage_file = if coverage_enabled {
-        Some(std::env::temp_dir().join(format!("homeboy-coverage-{}.json", std::process::id())))
+        Some(temp::runtime_temp_file("homeboy-coverage", ".json")?)
     } else {
         None
     };
-    let results_file =
-        std::env::temp_dir().join(format!("homeboy-test-results-{}.json", std::process::id()));
+    let results_file = temp::runtime_temp_file("homeboy-test-results", ".json")?;
     let failures_file = if args.analyze {
-        Some(
-            std::env::temp_dir().join(format!("homeboy-test-failures-{}.json", std::process::id())),
-        )
+        Some(temp::runtime_temp_file("homeboy-test-failures", ".json")?)
     } else {
         None
     };

--- a/src/core/refactor/auto/sidecar.rs
+++ b/src/core/refactor/auto/sidecar.rs
@@ -1,4 +1,5 @@
 use super::outcome::{AutofixSidecarFiles, FixApplied};
+use crate::engine::temp;
 use std::path::Path;
 
 impl AutofixSidecarFiles {
@@ -63,23 +64,11 @@ pub fn read_fix_results(results_file: &Path, plan_file: Option<&Path>) -> Vec<Fi
 }
 
 pub fn fix_results_temp_path() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "homeboy-fix-results-{}-{}.json",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ))
+    temp::runtime_temp_file("homeboy-fix-results", ".json")
+        .expect("runtime temp path should be creatable for fix results")
 }
 
 pub fn fix_plan_temp_path() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "homeboy-fix-plan-{}-{}.json",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ))
+    temp::runtime_temp_file("homeboy-fix-plan", ".json")
+        .expect("runtime temp path should be creatable for fix plan")
 }

--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -1,10 +1,11 @@
 use crate::code_audit::is_test_path;
 use crate::component::Component;
+use crate::engine::temp;
 use crate::extension;
+use crate::extension::test::drift::{detect_drift, DriftOptions};
 use crate::git;
 use crate::refactor::auto as fixer;
 use crate::refactor::auto::{self, FixApplied, FixResultsSummary};
-use crate::extension::test::drift::{detect_drift, DriftOptions};
 use crate::undo::UndoSnapshot;
 use crate::Error;
 use serde::Serialize;
@@ -577,15 +578,7 @@ fn run_lint_stage(
 ) -> crate::Result<PlannedStage> {
     let mut sandbox_component = component.clone();
     sandbox_component.local_path = sandbox.path().to_string_lossy().to_string();
-    let findings_file = std::env::temp_dir().join(format!(
-        "homeboy-lint-findings-{}-{}-{}.json",
-        std::process::id(),
-        uuid::Uuid::new_v4(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
+    let findings_file = temp::runtime_temp_file("homeboy-lint-findings", ".json")?;
     let fix_sidecars = auto::AutofixSidecarFiles::for_plan();
     let before_fix = if plan_mode {
         Some(snapshot_tree(&sandbox_component.local_path)?)
@@ -656,8 +649,8 @@ fn run_lint_stage(
 
     let fix_results = fix_sidecars.consume_fix_results();
     let fixes_proposed = fix_results.len();
-    let lint_findings = crate::extension::lint::baseline::parse_findings_file(&findings_file)
-        .unwrap_or_default();
+    let lint_findings =
+        crate::extension::lint::baseline::parse_findings_file(&findings_file).unwrap_or_default();
     let _ = std::fs::remove_file(&findings_file);
 
     Ok(PlannedStage {
@@ -687,11 +680,7 @@ fn run_test_stage(
 ) -> crate::Result<PlannedStage> {
     let mut sandbox_component = component.clone();
     sandbox_component.local_path = sandbox.path().to_string_lossy().to_string();
-    let results_file = std::env::temp_dir().join(format!(
-        "homeboy-test-results-{}-{}.json",
-        std::process::id(),
-        uuid::Uuid::new_v4()
-    ));
+    let results_file = temp::runtime_temp_file("homeboy-test-results", ".json")?;
     let fix_sidecars = auto::AutofixSidecarFiles::for_plan();
     let before_fix = if plan_mode {
         Some(snapshot_tree(&sandbox_component.local_path)?)

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -1,8 +1,9 @@
 use crate::code_audit::{self, is_test_path, CodeAuditResult};
 use crate::component::{self, Component};
+use crate::engine::temp;
+use crate::extension::test::drift::{detect_drift, DriftOptions};
 use crate::extension::{lint as extension_lint, test as extension_test};
 use crate::refactor::auto as fixer;
-use crate::extension::test::drift::{detect_drift, DriftOptions};
 use crate::undo::UndoSnapshot;
 use serde::Serialize;
 use std::collections::{BTreeSet, HashSet};
@@ -308,11 +309,8 @@ fn build_test_smoke_verifier<'a>(
             return Ok("test_smoke_skipped_no_overlap".to_string());
         }
 
-        let results_file = std::env::temp_dir().join(format!(
-            "homeboy-audit-test-smoke-{}-{}",
-            std::process::id(),
-            chunk.chunk_id.replace(':', "-")
-        ));
+        let results_file = temp::runtime_temp_file("homeboy-audit-test-smoke", ".json")
+            .map_err(|error| format!("create test smoke temp file failed: {}", error))?;
         let results_file_str = results_file.to_string_lossy().to_string();
         let selected_test_files = changed_test_files.as_ref().map(|files| {
             files

--- a/src/core/refactor/sandbox.rs
+++ b/src/core/refactor/sandbox.rs
@@ -1,3 +1,4 @@
+use crate::engine::temp;
 use crate::Error;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -19,13 +20,7 @@ impl Drop for SandboxDir {
 }
 
 pub fn clone_tree(src: &Path) -> crate::Result<SandboxDir> {
-    let temp = std::env::temp_dir().join(format!("homeboy-refactor-ci-{}", uuid::Uuid::new_v4()));
-    std::fs::create_dir_all(&temp).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("create temp refactor sandbox".to_string()),
-        )
-    })?;
+    let temp = temp::runtime_temp_dir("homeboy-refactor-ci")?;
     copy_dir_recursive(src, &temp)?;
     Ok(SandboxDir { path: temp })
 }

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 
-use crate::release::changelog;
 use crate::component::{self, Component};
 use crate::core::local_files::FileSystem;
 use crate::engine::pipeline::{self, PipelineStep};
+use crate::engine::temp;
 use crate::error::{Error, ErrorCode, Result};
 use crate::extension::{self, ExtensionManifest};
 use crate::git::{self, UncommittedChanges};
+use crate::release::changelog;
 use crate::utils::validation::ValidationCollector;
 use crate::version;
 
@@ -423,13 +424,7 @@ fn validate_code_quality(component: &Component) -> Result<()> {
         log_status!("release", "Running lint ({})...", lint_context.extension_id);
 
         // Create a temporary findings file so we can compare against baseline
-        let lint_findings_file = std::env::temp_dir().join(format!(
-            "homeboy-release-lint-{}.json",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        ));
+        let lint_findings_file = temp::runtime_temp_file("homeboy-release-lint", ".json")?;
 
         let lint_findings_file_str = lint_findings_file.to_string_lossy().to_string();
         match extension::lint::build_lint_runner(
@@ -461,8 +456,11 @@ fn validate_code_quality(component: &Component) -> Result<()> {
                             .unwrap_or_default();
                     let _ = std::fs::remove_file(&lint_findings_file);
 
-                    if let Some(baseline) = crate::extension::lint::baseline::load_baseline(source_path) {
-                        let comparison = crate::extension::lint::baseline::compare(&findings, &baseline);
+                    if let Some(baseline) =
+                        crate::extension::lint::baseline::load_baseline(source_path)
+                    {
+                        let comparison =
+                            crate::extension::lint::baseline::compare(&findings, &baseline);
                         if comparison.drift_increased {
                             log_status!(
                                 "release",
@@ -505,13 +503,7 @@ fn validate_code_quality(component: &Component) -> Result<()> {
             "Running tests ({})...",
             test_context.extension_id
         );
-        let results_file = std::env::temp_dir().join(format!(
-            "homeboy-release-test-{}.json",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        ));
+        let results_file = temp::runtime_temp_file("homeboy-release-test", ".json")?;
         let results_file_str = results_file.to_string_lossy().to_string();
         match extension::test::build_test_runner(
             component,


### PR DESCRIPTION
## Summary
- add an engine-owned runtime temp primitive under `core/engine/temp` so runtime scratch files stop depending on raw `/tmp`
- migrate the main runtime call sites (`lint`, test workflow, release quality checks, refactor planning/verification, sidecars, sandbox clones) to use the shared engine path
- make the `/tmp` failure root cause explicit: temp writes should go through a workspace/config-aware runtime layer instead of scattered `std::env::temp_dir()` calls

## Testing
- `source \"$HOME/.cargo/env\" && cargo check`
- `source \"$HOME/.cargo/env\" && cargo test --lib runtime_temp_`