### PR TITLE
refactor(architecture): type project component overrides

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -1,46 +1,3 @@
-/// Apply per-project component overrides to a cloned component.
-///
-/// If the project has `component_overrides` entries for this component,
-/// merge them onto a clone. Only deploy-relevant fields are applied:
-/// `extract_command`, `remote_owner`, `build_command`, `build_artifact`,
-/// `deploy_strategy`, and `hooks`.
-fn apply_component_overrides(component: &Component, project: &Project) -> Component {
-    let overrides = match project.component_overrides.get(&component.id) {
-        Some(v) if v.is_object() => v,
-        _ => return component.clone(),
-    };
-
-    // Serialize the component to JSON, merge overrides, deserialize back.
-    // This reuses serde for all field types without manual field-by-field code.
-    let mut base = match serde_json::to_value(component) {
-        Ok(v) => v,
-        Err(_) => return component.clone(),
-    };
-
-    if let (Some(base_obj), Some(override_obj)) = (base.as_object_mut(), overrides.as_object()) {
-        for (key, value) in override_obj {
-            // Skip identity fields — overriding id/local_path/remote_path per-project
-            // would break deploy targeting. Use project base_path for path changes.
-            if matches!(
-                key.as_str(),
-                "id" | "local_path" | "remote_path" | "aliases"
-            ) {
-                continue;
-            }
-            base_obj.insert(key.clone(), value.clone());
-        }
-    }
-
-    match serde_json::from_value::<Component>(base) {
-        Ok(mut merged) => {
-            // Preserve identity fields from original
-            merged.id = component.id.clone();
-            merged
-        }
-        Err(_) => component.clone(),
-    }
-}
-
 /// Main deploy orchestration entry point.
 /// Handles component selection, building, and deployment.
 fn deploy_components(
@@ -150,7 +107,7 @@ fn deploy_components(
 
     for component in &components {
         // Apply per-project overrides (e.g. different extract_command or remote_owner)
-        let component = apply_component_overrides(component, project);
+        let component = crate::project::apply_component_overrides(component, project);
         let mut result = execute_component_deploy(
             &component,
             config,

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -8,6 +8,24 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ProjectComponentOverrides {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_artifact: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extract_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_strategy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_deploy: Option<crate::component::GitDeployConfig>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub hooks: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<crate::component::ScopeConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 
 pub struct Project {
     #[serde(skip)]
@@ -52,13 +70,11 @@ pub struct Project {
     pub shared_tables: Vec<String>,
     #[serde(default)]
     pub component_ids: Vec<String>,
-    /// Per-component field overrides. Keys are component IDs, values are
-    /// partial JSON objects whose fields override the component's defaults
-    /// when deploying through this project.
+    /// Per-component field overrides applied when a component runs in this project.
     ///
     /// Example: `{"data-machine": {"extract_command": "...", "remote_owner": "opencode:opencode"}}`
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub component_overrides: HashMap<String, serde_json::Value>,
+    pub component_overrides: HashMap<String, ProjectComponentOverrides>,
 
     /// Service names to check in fleet health status (e.g. ["kimaki", "php8.4-fpm", "nginx"]).
     /// These are checked via `systemctl is-active <name>` on the remote server.
@@ -416,6 +432,54 @@ pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result
         .retain(|id| !component_ids.contains(id));
     save(&project)?;
     Ok(project.component_ids)
+}
+
+pub fn apply_component_overrides(
+    component: &crate::component::Component,
+    project: &Project,
+) -> crate::component::Component {
+    let Some(overrides) = project.component_overrides.get(&component.id) else {
+        return component.clone();
+    };
+
+    let mut merged = component.clone();
+
+    if let Some(build_artifact) = &overrides.build_artifact {
+        merged.build_artifact = Some(build_artifact.clone());
+    }
+    if let Some(extract_command) = &overrides.extract_command {
+        merged.extract_command = Some(extract_command.clone());
+    }
+    if let Some(remote_owner) = &overrides.remote_owner {
+        merged.remote_owner = Some(remote_owner.clone());
+    }
+    if let Some(deploy_strategy) = &overrides.deploy_strategy {
+        merged.deploy_strategy = Some(deploy_strategy.clone());
+    }
+    if let Some(git_deploy) = &overrides.git_deploy {
+        merged.git_deploy = Some(git_deploy.clone());
+    }
+    if !overrides.hooks.is_empty() {
+        merged.hooks = overrides.hooks.clone();
+    }
+    if let Some(scopes) = &overrides.scopes {
+        merged.scopes = Some(scopes.clone());
+    }
+
+    merged
+}
+
+pub fn resolve_project_component(project: &Project, component_id: &str) -> Result<crate::component::Component> {
+    let component = crate::component::load(component_id)?;
+    Ok(apply_component_overrides(&component, project))
+}
+
+pub fn resolve_project_components(project: &Project) -> Result<Vec<crate::component::Component>> {
+    project
+        .component_ids
+        .iter()
+        .map(|component_id| resolve_project_component(project, component_id))
+        .collect()
 }
 
 pub fn pin(project_id: &str, pin_type: PinType, path: &str, options: PinOptions) -> Result<()> {


### PR DESCRIPTION
## Summary
- replace raw JSON project `component_overrides` values with a typed `ProjectComponentOverrides` model
- move per-project effective-component resolution into `core/project.rs` so deploy stops owning a private JSON merge hack
- formalize the architecture seam between portable component truth and project-specific behavior without removing any existing functionality

## Why
- `homeboy.json` is increasingly the portable source of truth for component/repo behavior
- project-specific behavior should mature into explicit project-owned overrides instead of leaking through ad hoc component mutation
- this creates the stable seam needed for future migrations from component config into project-level behavior without breaking current workflows

## Testing
- `source \"$HOME/.cargo/env\" && cargo check`