### PR TITLE
refactor(architecture): use project attachments in build

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -86,12 +86,8 @@ pub fn run(
             ));
         }
 
-        let json_spec = serde_json::json!({
-            "componentIds": proj.component_ids
-        })
-        .to_string();
-
-        return build::run(&json_spec);
+        let components = project::resolve_project_components(&proj)?;
+        return build::run_components(&components);
     }
 
     // Multiple positional args: use shared resolver
@@ -126,12 +122,12 @@ pub fn run(
             ));
         }
 
-        let json_spec = serde_json::json!({
-            "componentIds": component_ids
-        })
-        .to_string();
+        let components: Result<Vec<_>, _> = component_ids
+            .iter()
+            .map(|id| project::resolve_project_component(&proj, id))
+            .collect();
 
-        return build::run(&json_spec);
+        return build::run_components(&components?);
     }
 
     // Single target_id: treat as component ID

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -541,10 +541,11 @@ fn status(id: &str, cached: bool, health_only: bool) -> CmdResult<FleetOutput> {
 
                     let mut component_statuses = Vec::new();
                     for component_id in &proj.component_ids {
-                        let comp_version = match project::resolve_project_component(&proj, component_id) {
-                            Ok(comp) => version::get_component_version(&comp),
-                            Err(_) => None,
-                        };
+                        let comp_version =
+                            match project::resolve_project_component(&proj, component_id) {
+                                Ok(comp) => version::get_component_version(&comp),
+                                Err(_) => None,
+                            };
 
                         component_statuses.push(FleetComponentStatus {
                             component_id: component_id.clone(),

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -1072,7 +1072,10 @@ mod tests {
         assert_eq!(comp.id, "homeboy-test-discover");
         assert_eq!(comp.local_path, dir.to_string_lossy());
         assert_eq!(comp.changelog_target.as_deref(), Some("docs/CHANGELOG.md"));
-        assert!(comp.extensions.as_ref().is_some_and(|m| m.contains_key("rust")));
+        assert!(comp
+            .extensions
+            .as_ref()
+            .is_some_and(|m| m.contains_key("rust")));
         assert!(comp.version_targets.is_some());
         assert!(comp.remote_path.is_empty()); // default
 

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -345,6 +345,53 @@ pub fn run_component(component: &Component) -> Result<(BuildResult, i32)> {
     Ok((BuildResult::Single(output), exit_code))
 }
 
+/// Build multiple pre-resolved components.
+pub fn run_components(components: &[Component]) -> Result<(BuildResult, i32)> {
+    let mut results = Vec::with_capacity(components.len());
+    let mut succeeded = 0usize;
+    let mut failed = 0usize;
+
+    for component in components {
+        match execute_build_component(component) {
+            Ok((output, _)) => {
+                if output.success {
+                    succeeded += 1;
+                } else {
+                    failed += 1;
+                }
+                results.push(ItemOutcome {
+                    id: component.id.clone(),
+                    result: Some(output),
+                    error: None,
+                });
+            }
+            Err(error) => {
+                failed += 1;
+                results.push(ItemOutcome {
+                    id: component.id.clone(),
+                    result: None,
+                    error: Some(error.to_string()),
+                });
+            }
+        }
+    }
+
+    let exit_code = if failed > 0 { 1 } else { 0 };
+
+    Ok((
+        BuildResult::Bulk(BulkResult {
+            action: "build".to_string(),
+            results,
+            summary: BulkSummary {
+                total: succeeded + failed,
+                succeeded,
+                failed,
+            },
+        }),
+        exit_code,
+    ))
+}
+
 fn execute_build(component_id: &str, path_override: Option<&str>) -> Result<(BuildOutput, i32)> {
     let mut comp = component::load(component_id)?;
     if let Some(path) = path_override {

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -454,7 +454,9 @@ pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result
     project
         .component_ids
         .retain(|id| !component_ids.contains(id));
-    project.components.retain(|component| !component_ids.contains(&component.id));
+    project
+        .components
+        .retain(|component| !component_ids.contains(&component.id));
     save(&project)?;
     Ok(project.component_ids)
 }
@@ -512,20 +514,29 @@ pub fn apply_component_overrides(
     merged
 }
 
-pub fn resolve_project_component(project: &Project, component_id: &str) -> Result<crate::component::Component> {
-    let component = if let Some(attachment) = project.components.iter().find(|component| component.id == component_id) {
+pub fn resolve_project_component(
+    project: &Project,
+    component_id: &str,
+) -> Result<crate::component::Component> {
+    let component = if let Some(attachment) = project
+        .components
+        .iter()
+        .find(|component| component.id == component_id)
+    {
         if let Some(local_path) = &attachment.local_path {
-            crate::component::discover_from_portable(std::path::Path::new(local_path)).ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "components.local_path",
-                    format!(
-                        "Project component '{}' points to '{}' but no homeboy.json was found",
-                        component_id, local_path
-                    ),
-                    Some(project.id.clone()),
-                    None,
-                )
-            })?
+            crate::component::discover_from_portable(std::path::Path::new(local_path)).ok_or_else(
+                || {
+                    Error::validation_invalid_argument(
+                        "components.local_path",
+                        format!(
+                            "Project component '{}' points to '{}' but no homeboy.json was found",
+                            component_id, local_path
+                        ),
+                        Some(project.id.clone()),
+                        None,
+                    )
+                },
+            )?
         } else {
             crate::component::load(component_id)?
         }


### PR DESCRIPTION
## Summary
- route project-scoped build flows through project-owned effective component resolution instead of bulk component IDs that fall back to global component config
- add `build::run_components()` so bulk project builds can operate on pre-resolved components, including repo-backed attachments discovered from `homeboy.json`
- keep single-component and generic bulk-ID behavior intact while moving project-context build behavior onto the newer attachment model

## Why
- `#707` introduced project-owned repo-backed component attachments and started adopting them in deploy/fleet/git/project flows
- build was still dropping back to raw component IDs, which reintroduced the old global component-config assumption in project context
- this continues the runtime adoption phase without adding any new schema or conceptual complexity

## Testing
- `source \"$HOME/.cargo/env\" && cargo check`