### PR TITLE
refactor(architecture): make project attachments canonical

### DIFF
--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -609,7 +609,7 @@ fn components_list(project_id: &str) -> CmdResult<ProjectOutput> {
                 components: Some(ProjectComponentsOutput {
                     action: "list".to_string(),
                     project_id: project_id.to_string(),
-                    component_ids: project.component_ids.clone(),
+                    component_ids: project::project_component_ids(&project),
                     components,
                 }),
                 ..Default::default()
@@ -650,7 +650,7 @@ fn components_remove(project_id: &str, component_ids: Vec<String>) -> CmdResult<
 
 fn components_clear(project_id: &str) -> CmdResult<ProjectOutput> {
     let mut project = project::load(project_id)?;
-    project.component_ids.clear();
+    project.components.clear();
 
     write_project_components(project_id, "clear", &project)
 }
@@ -672,7 +672,7 @@ fn write_project_components(
                 components: Some(ProjectComponentsOutput {
                     action: action.to_string(),
                     project_id: project_id.to_string(),
-                    component_ids: project.component_ids.clone(),
+                    component_ids: project::project_component_ids(project),
                     components,
                 }),
                 ..Default::default()

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -582,17 +582,10 @@ pub fn set_changelog_target(component_id: &str, file_path: &str) -> Result<()> {
 fn update_project_references(old_id: &str, new_id: &str) -> Result<()> {
     let projects = project::list().unwrap_or_default();
     for proj in projects {
-        if proj.component_ids.contains(&old_id.to_string()) {
-            let updated_ids: Vec<String> = proj
-                .component_ids
-                .iter()
-                .map(|comp_id: &String| {
-                    if comp_id == old_id {
-                        new_id.to_string()
-                    } else {
-                        comp_id.clone()
-                    }
-                })
+        if project::has_component(&proj, old_id) {
+            let updated_ids: Vec<String> = project::project_component_ids(&proj)
+                .into_iter()
+                .map(|comp_id| if comp_id == old_id { new_id.to_string() } else { comp_id })
                 .collect();
             project::set_components(&proj.id, updated_ids)?;
         }
@@ -604,7 +597,7 @@ pub fn projects_using(component_id: &str) -> Result<Vec<String>> {
     let projects = project::list().unwrap_or_default();
     Ok(projects
         .iter()
-        .filter(|p| p.component_ids.contains(&component_id.to_string()))
+        .filter(|p| project::has_component(p, component_id))
         .map(|p| p.id.clone())
         .collect())
 }
@@ -617,9 +610,9 @@ pub fn shared_components() -> Result<std::collections::HashMap<String, Vec<Strin
         std::collections::HashMap::new();
 
     for project in projects {
-        for component_id in &project.component_ids {
+        for component_id in project::project_component_ids(&project) {
             sharing
-                .entry(component_id.clone())
+                .entry(component_id)
                 .or_default()
                 .push(project.id.clone());
         }

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -1076,7 +1076,7 @@ pub fn changes_project_filtered(
     // Filter to only components that are in the project
     let filtered: Vec<String> = component_ids
         .iter()
-        .filter(|id| proj.component_ids.contains(id))
+        .filter(|id| project::has_component(&proj, id))
         .cloned()
         .collect();
 
@@ -1086,7 +1086,7 @@ pub fn changes_project_filtered(
             format!(
                 "None of the specified components are in project '{}'. Available: {}",
                 project_id,
-                proj.component_ids.join(", ")
+                project::project_component_ids(&proj).join(", ")
             ),
             None,
             None,

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -332,6 +332,33 @@ entity_crud!(Project; list_ids, merge, slugify_id);
 // Operations
 // ============================================================================
 
+fn component_ids_from_attachments(components: &[ProjectComponentAttachment]) -> Vec<String> {
+    components.iter().map(|component| component.id.clone()).collect()
+}
+
+fn sync_components_and_ids(project: &mut Project) {
+    if project.components.is_empty() && !project.component_ids.is_empty() {
+        project.components = project
+            .component_ids
+            .iter()
+            .map(|id| ProjectComponentAttachment {
+                id: id.clone(),
+                local_path: None,
+            })
+            .collect();
+    }
+
+    project.component_ids = component_ids_from_attachments(&project.components);
+}
+
+pub fn project_component_ids(project: &Project) -> Vec<String> {
+    component_ids_from_attachments(&project.components)
+}
+
+pub fn has_component(project: &Project, component_id: &str) -> bool {
+    project.components.iter().any(|component| component.id == component_id)
+}
+
 pub fn set_components(project_id: &str, component_ids: Vec<String>) -> Result<Vec<String>> {
     use crate::component;
 
@@ -363,6 +390,7 @@ pub fn set_components(project_id: &str, component_ids: Vec<String>) -> Result<Ve
     let deduped = parser::dedupe(component_ids);
 
     let mut project = load(project_id)?;
+    sync_components_and_ids(&mut project);
     project.components = deduped
         .iter()
         .map(|id| ProjectComponentAttachment {
@@ -374,9 +402,9 @@ pub fn set_components(project_id: &str, component_ids: Vec<String>) -> Result<Ve
                 .and_then(|component| component.local_path.clone()),
         })
         .collect();
-    project.component_ids = deduped.clone();
+    sync_components_and_ids(&mut project);
     save(&project)?;
-    Ok(deduped)
+    Ok(project_component_ids(&project))
 }
 
 pub fn add_components(project_id: &str, component_ids: Vec<String>) -> Result<Vec<String>> {
@@ -410,17 +438,18 @@ pub fn add_components(project_id: &str, component_ids: Vec<String>) -> Result<Ve
     let deduped = parser::dedupe(component_ids);
 
     let mut project = load(project_id)?;
+    sync_components_and_ids(&mut project);
     for id in deduped {
-        if !project.component_ids.contains(&id) {
-            project.component_ids.push(id.clone());
+        if !has_component(&project, &id) {
             project.components.push(ProjectComponentAttachment {
                 id,
                 local_path: None,
             });
         }
     }
+    sync_components_and_ids(&mut project);
     save(&project)?;
-    Ok(project.component_ids)
+    Ok(project_component_ids(&project))
 }
 
 pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result<Vec<String>> {
@@ -434,10 +463,11 @@ pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result
     }
 
     let mut project = load(project_id)?;
+    sync_components_and_ids(&mut project);
 
     let mut missing = Vec::new();
     for id in &component_ids {
-        if !project.component_ids.contains(id) {
+        if !has_component(&project, id) {
             missing.push(id.clone());
         }
     }
@@ -452,17 +482,16 @@ pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result
     }
 
     project
-        .component_ids
-        .retain(|id| !component_ids.contains(id));
-    project
         .components
         .retain(|component| !component_ids.contains(&component.id));
+    sync_components_and_ids(&mut project);
     save(&project)?;
-    Ok(project.component_ids)
+    Ok(project_component_ids(&project))
 }
 
 pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &str) -> Result<()> {
     let mut project = load(project_id)?;
+    sync_components_and_ids(&mut project);
 
     if let Some(component) = project.components.iter_mut().find(|c| c.id == component_id) {
         component.local_path = Some(local_path.to_string());
@@ -471,11 +500,9 @@ pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &
             id: component_id.to_string(),
             local_path: Some(local_path.to_string()),
         });
-        if !project.component_ids.contains(&component_id.to_string()) {
-            project.component_ids.push(component_id.to_string());
-        }
     }
 
+    sync_components_and_ids(&mut project);
     save(&project)
 }
 
@@ -518,6 +545,9 @@ pub fn resolve_project_component(
     project: &Project,
     component_id: &str,
 ) -> Result<crate::component::Component> {
+    let mut project = project.clone();
+    sync_components_and_ids(&mut project);
+
     let component = if let Some(attachment) = project
         .components
         .iter()
@@ -543,14 +573,17 @@ pub fn resolve_project_component(
     } else {
         crate::component::load(component_id)?
     };
-    Ok(apply_component_overrides(&component, project))
+    Ok(apply_component_overrides(&component, &project))
 }
 
 pub fn resolve_project_components(project: &Project) -> Result<Vec<crate::component::Component>> {
+    let mut project = project.clone();
+    sync_components_and_ids(&mut project);
+
     project
-        .component_ids
+        .components
         .iter()
-        .map(|component_id| resolve_project_component(project, component_id))
+        .map(|component| resolve_project_component(&project, &component.id))
         .collect()
 }
 


### PR DESCRIPTION
## Summary
- make `Project.components` the source of truth inside project logic and treat `component_ids` as compatibility/derived state
- centralize attachment/id synchronization in `core/project.rs` so project operations normalize around attachments first
- replace more lingering project-scoped legacy assumptions with canonical project attachment helpers across project UX, build, fleet runtime, git filtering, context lookup, and extension compatibility/execution paths

## Why
- after `#707`, `#708`, and `#709`, the system can already resolve repo-backed attached components in real runtime paths
- the next structural step is to stop centering the old `component_ids` and global component-config worldview and make project attachments the actual owner
- this PR continues that shift by deleting more project-context assumptions that still reached for raw membership checks or direct global component loads

## Included in this PR
- `Project.components` is treated as canonical inside `core/project.rs`
- `component_ids` is synchronized as compatibility/derived state
- project/component/git call sites use attachment helpers
- project UX, build validation, fleet cached paths, context project matching, and extension compatibility/execution all lean more heavily on canonical project attachment resolution

## Testing
- `source \"$HOME/.cargo/env\" && cargo check`