### PR TITLE
refactor(architecture): derive component inventory

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -536,7 +536,7 @@ fn rename(id: &str, new_id: &str) -> CmdResult<ComponentOutput> {
 }
 
 fn list() -> CmdResult<ComponentOutput> {
-    let components: Vec<Value> = component::list()?
+    let components: Vec<Value> = component::inventory()?
         .into_iter()
         .map(|component| {
             let mut value = serde_json::to_value(&component).map_err(|error| {
@@ -565,7 +565,7 @@ fn list() -> CmdResult<ComponentOutput> {
 }
 
 fn projects(id: &str) -> CmdResult<ComponentOutput> {
-    let project_ids = component::projects_using(id)?;
+    let project_ids = component::associated_projects(id)?;
 
     let mut projects_list = Vec::new();
     for pid in &project_ids {
@@ -592,7 +592,7 @@ fn projects(id: &str) -> CmdResult<ComponentOutput> {
 fn shared(id: Option<&str>) -> CmdResult<ComponentOutput> {
     if let Some(component_id) = id {
         // Show projects for a specific component
-        let project_ids = component::projects_using(component_id)?;
+        let project_ids = component::associated_projects(component_id)?;
         let mut shared_map = std::collections::HashMap::new();
         shared_map.insert(component_id.to_string(), project_ids);
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -256,7 +256,7 @@ pub fn run(args: InitArgs, _global: &super::GlobalArgs) -> CmdResult<InitOutput>
         .collect();
 
     // Load all data sources
-    let all_components = component::list().unwrap_or_default();
+    let all_components = component::inventory().unwrap_or_default();
     let all_projects = project::list().unwrap_or_default();
     let all_servers = server::list().unwrap_or_default();
     let all_extensions = load_all_extensions().unwrap_or_default();

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -56,7 +56,7 @@ pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusOut
         .cloned()
         .collect();
 
-    let all_components = component::list().unwrap_or_default();
+    let all_components = component::inventory().unwrap_or_default();
 
     let show_all = args.all || relevant_ids.is_empty();
 

--- a/src/core/cleanup/mod.rs
+++ b/src/core/cleanup/mod.rs
@@ -55,7 +55,7 @@ pub fn cleanup_component(component_id: &str) -> Result<CleanupResult> {
 
 /// Run cleanup checks across ALL registered components.
 pub fn cleanup_all() -> Result<Vec<CleanupResult>> {
-    let components: Vec<Component> = crate::component::list().unwrap_or_default();
+    let components: Vec<Component> = crate::component::inventory().unwrap_or_default();
     let mut results = Vec::new();
 
     for comp in &components {

--- a/src/core/component.rs
+++ b/src/core/component.rs
@@ -6,7 +6,7 @@ use crate::project;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -690,6 +690,45 @@ pub fn shared_components() -> Result<std::collections::HashMap<String, Vec<Strin
     }
 
     Ok(sharing)
+}
+
+/// Derive a runtime component inventory from project attachments plus legacy stored components.
+///
+/// Project-attached repo-backed components win over stored config because they reflect
+/// the newer canonical model. Stored config remains as a compatibility fallback.
+pub fn inventory() -> Result<Vec<Component>> {
+    let projects = project::list().unwrap_or_default();
+    let mut components = Vec::new();
+    let mut seen = HashSet::new();
+
+    for project in &projects {
+        for attachment in &project.components {
+            if let Ok(component) = project::resolve_project_component(project, &attachment.id) {
+                if seen.insert(component.id.clone()) {
+                    components.push(component);
+                }
+            }
+        }
+    }
+
+    for component in list().unwrap_or_default() {
+        if seen.insert(component.id.clone()) {
+            components.push(component);
+        }
+    }
+
+    components.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(components)
+}
+
+/// Find project associations using the canonical project attachment model.
+pub fn associated_projects(component_id: &str) -> Result<Vec<String>> {
+    let projects = project::list().unwrap_or_default();
+    Ok(projects
+        .into_iter()
+        .filter(|project| project::has_component(project, component_id))
+        .map(|project| project.id)
+        .collect())
 }
 
 /// Resolve effective artifact path for a component.

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -65,25 +65,15 @@ pub fn run(path: Option<&str>) -> Result<(ContextOutput, i32)> {
     let cwd_str = cwd.to_string_lossy().to_string();
     let git_root = detect_git_root(&cwd);
 
-    let components = component::list().unwrap_or_default();
-    let projects = project::list().unwrap_or_default();
-    let attached_components = collect_attached_components(&projects);
-
-    let matched_registered: Vec<String> = components
+    let components = component::inventory().unwrap_or_default();
+    let matched_components: Vec<String> = components
         .iter()
         .filter(|c| path_matches(&cwd, &c.local_path))
         .map(|c| c.id.clone())
         .collect();
 
-    let matched_attached: Vec<String> = attached_components
-        .iter()
-        .filter(|c| path_matches(&cwd, &c.local_path))
-        .map(|c| c.id.clone())
-        .collect();
-
-    let matched: Vec<String> = matched_registered
+    let matched: Vec<String> = matched_components
         .into_iter()
-        .chain(matched_attached)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
@@ -91,8 +81,7 @@ pub fn run(path: Option<&str>) -> Result<(ContextOutput, i32)> {
     let managed = !matched.is_empty();
 
     // Check for contained components (monorepo pattern)
-    let all_local_components: Vec<component::Component> =
-        components.into_iter().chain(attached_components).collect();
+    let all_local_components: Vec<component::Component> = components;
 
     let contained: Vec<&component::Component> = all_local_components
         .iter()
@@ -203,30 +192,6 @@ pub fn run(path: Option<&str>) -> Result<(ContextOutput, i32)> {
         },
         0,
     ))
-}
-
-fn collect_attached_components(projects: &[project::Project]) -> Vec<component::Component> {
-    let mut components = Vec::new();
-    let mut seen = HashSet::new();
-
-    for project in projects {
-        for attachment in &project.components {
-            let Some(local_path) = attachment.local_path.as_deref() else {
-                continue;
-            };
-
-            if !seen.insert((attachment.id.clone(), local_path.to_string())) {
-                continue;
-            }
-
-            if let Some(mut component) = component::discover_from_portable(Path::new(local_path)) {
-                component.id = attachment.id.clone();
-                components.push(component);
-            }
-        }
-    }
-
-    components
 }
 
 fn detect_git_root(cwd: &PathBuf) -> Option<String> {


### PR DESCRIPTION
## Summary
- add a derived runtime component inventory built from project attachments first, with legacy stored component config as fallback
- add canonical project-association lookup via `component::associated_projects(...)`
- migrate high-value listing/index consumers (`context`, `init`, `status`, `cleanup_all`, `component list`, and component project/shared views) off direct storage-backed component indexing assumptions

## Why
- after centralizing effective component resolution, the next remaining unique responsibility of local component config was acting like the canonical component index
- the target model is repo `homeboy.json` + project attachment/overrides, so the inventory of components should be derived from that runtime truth rather than primarily from stored component blobs
- this keeps compatibility fallback in place while shrinking another major reason local component config still exists

## Testing
- `source \"$HOME/.cargo/env\" && cargo check`