### PR TITLE
refactor(architecture): derive component associations

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -144,7 +144,7 @@ pub fn run(
 
         let mut project_ids: Vec<String> = Vec::new();
         for component_id in &component_ids {
-            let using = homeboy::component::projects_using(component_id).unwrap_or_default();
+            let using = homeboy::component::associated_projects(component_id).unwrap_or_default();
             for pid in using {
                 if !project_ids.contains(&pid) {
                     project_ids.push(pid);

--- a/src/core/release/changelog/settings.rs
+++ b/src/core/release/changelog/settings.rs
@@ -31,7 +31,7 @@ pub struct EffectiveChangelogSettings {
 
 pub fn resolve_effective_settings(component: Option<&Component>) -> EffectiveChangelogSettings {
     let project_settings = component
-        .and_then(|c| component::projects_using(&c.id).ok())
+        .and_then(|c| component::associated_projects(&c.id).ok())
         .and_then(|projects| {
             if projects.len() == 1 {
                 project::load(&projects[0]).ok()

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -225,7 +225,7 @@ fn empty_deployment_summary(total_projects: u32) -> ReleaseDeploymentSummary {
 }
 
 fn plan_deployment(component_id: &str) -> ReleaseDeploymentResult {
-    let projects = component::projects_using(component_id).unwrap_or_default();
+    let projects = component::associated_projects(component_id).unwrap_or_default();
 
     if projects.is_empty() {
         log_status!(
@@ -252,7 +252,7 @@ fn plan_deployment(component_id: &str) -> ReleaseDeploymentResult {
 }
 
 fn execute_deployment(component_id: &str) -> (Option<ReleaseDeploymentResult>, i32) {
-    let projects = component::projects_using(component_id).unwrap_or_default();
+    let projects = component::associated_projects(component_id).unwrap_or_default();
 
     if projects.is_empty() {
         log_status!(

--- a/src/utils/resolve.rs
+++ b/src/utils/resolve.rs
@@ -45,7 +45,7 @@ pub fn resolve_project_components(first: &str, rest: &[String]) -> Result<(Strin
                 Ok((project_id, all_component_ids))
             } else {
                 // Build helpful error message
-                let associated_projects = component::projects_using(first).unwrap_or_default();
+                let associated_projects = component::associated_projects(first).unwrap_or_default();
 
                 let hint = if associated_projects.is_empty() {
                     format!(
@@ -111,7 +111,7 @@ pub fn infer_project_for_components(component_ids: &[String]) -> Option<String> 
     let mut common_projects: Option<Vec<String>> = None;
 
     for comp_id in component_ids {
-        let projects = component::projects_using(comp_id).unwrap_or_default();
+        let projects = component::associated_projects(comp_id).unwrap_or_default();
         if projects.is_empty() {
             return None; // Component has no project
         }


### PR DESCRIPTION
## Summary
- switch more project-association lookups from legacy storage-backed `component::projects_using(...)` toward canonical project-attachment-driven `component::associated_projects(...)`
- migrate project inference, deploy shared-target lookup, release deployment planning, and changelog project-setting resolution to the new association helper
- continue shrinking local component config's role as the authority for cross-project relationships

## Why
- `#715` starts deriving the component inventory from project attachments plus portable repo truth
- the next closely related dependency is cross-project association lookup, which still had a few paths reaching through old component-storage semantics
- stacking this after `#715` keeps the inventory/association cleanup coherent instead of splitting one model change across unrelated PRs

## Testing
- `source \"$HOME/.cargo/env\" && cargo check`