### PR TITLE
refactor(architecture): use effective components in command flows

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -60,7 +60,7 @@ pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<CleanupO
         let source_path = if let Some(ref path) = args.path {
             std::path::PathBuf::from(path)
         } else {
-            let comp = homeboy::component::load(component_id)?;
+            let comp = homeboy::component::resolve_effective(Some(component_id), None, None)?;
             std::path::PathBuf::from(&comp.local_path)
         };
 

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -278,7 +278,8 @@ pub fn run(
 }
 
 fn show(id: &str) -> CmdResult<ComponentOutput> {
-    let component = component::load(id).map_err(|e| e.with_contextual_hint())?;
+    let component = component::resolve_effective(Some(id), None, None)
+        .map_err(|e| e.with_contextual_hint())?;
 
     Ok((
         ComponentOutput {
@@ -400,7 +401,7 @@ fn set(
 
     match component::merge(args.id.as_deref(), &json_string, &replace_fields)? {
         homeboy::MergeOutput::Single(result) => {
-            let comp = component::load(&result.id)?;
+            let comp = component::resolve_effective(Some(&result.id), None, None)?;
             Ok((
                 ComponentOutput {
                     command: "component.set".to_string(),
@@ -444,7 +445,8 @@ fn add_version_target(id: &str, file: &str, pattern: &str) -> CmdResult<Componen
     component::validate_version_pattern(pattern)?;
 
     // Load component to check existing targets
-    let comp = component::load(id).map_err(|e| e.with_contextual_hint())?;
+    let comp = component::resolve_effective(Some(id), None, None)
+        .map_err(|e| e.with_contextual_hint())?;
 
     // Validate no conflicting target exists
     if let Some(ref existing) = comp.version_targets {
@@ -462,7 +464,7 @@ fn add_version_target(id: &str, file: &str, pattern: &str) -> CmdResult<Componen
 
     match component::merge(Some(id), &json_string, &[])? {
         homeboy::MergeOutput::Single(result) => {
-            let comp = component::load(&result.id)?;
+            let comp = component::resolve_effective(Some(&result.id), None, None)?;
             Ok((
                 ComponentOutput {
                     command: "component.add-version-target".to_string(),

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -739,7 +739,7 @@ fn exec_extension_tool(
 
     // Resolve working directory: component path if given, otherwise current dir
     let working_dir = if let Some(ref cid) = component {
-        let comp = homeboy::component::load(cid)?;
+        let comp = homeboy::component::resolve_effective(Some(cid), None, None)?;
         comp.local_path.clone()
     } else {
         std::env::current_dir()

--- a/src/core/code_audit/docs_audit/mod.rs
+++ b/src/core/code_audit/docs_audit/mod.rs
@@ -221,7 +221,7 @@ pub fn audit_component(
     docs_dir_override: Option<&str>,
     include_features: bool,
 ) -> Result<AuditResult> {
-    let comp = component::load(component_id)?;
+    let comp = component::resolve_effective(Some(component_id), None, None)?;
     let source_path = Path::new(&comp.local_path);
 
     // Resolve docs directories: CLI override > docs_dirs > docs_dir > default "docs"

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -628,7 +628,7 @@ pub fn read_version(component_id: Option<&str>) -> Result<ComponentVersionInfo> 
         Some(id) => id,
     };
 
-    let component = component::load(id)?;
+    let component = component::resolve_effective(Some(id), None, None)?;
     read_component_version(&component)
 }
 


### PR DESCRIPTION
## Summary
- switch more component-centric command/runtime flows from direct stored-component loads to `component::resolve_effective(...)`
- apply that to component show/update responses, cleanup baseline path resolution, extension command working-directory resolution, docs audit component loading, and release version loading
- continue shrinking the assumption that a stored local component blob is the primary object shown to users or used by runtime paths

## Why
- `#714` established the shared effective component resolver
- `#715` and `#716` started replacing storage-backed inventory and association authority
- this follow-up keeps the same direction by making more command-facing flows show and use the effective derived component view instead of reaching straight for local component config

## Testing
- `source \"$HOME/.cargo/env\" && cargo check`