### PR TITLE
refactor establish core project modules

### DIFF
--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -3,12 +3,9 @@ use homeboy::log_status;
 use serde::Serialize;
 use std::path::Path;
 
-use homeboy::component::{self, Component};
-use homeboy::deploy::{self, DeployConfig};
-use homeboy::health::{self, ServerHealth};
+use homeboy::component::Component;
+use homeboy::health::ServerHealth;
 use homeboy::project::{self, Project};
-use homeboy::server;
-use homeboy::version;
 use homeboy::EntityCrudOutput;
 
 use super::CmdResult;
@@ -256,7 +253,7 @@ pub struct ProjectComponentVersion {
     pub component_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
-    /// Where the version was resolved from: "live" (SSH) or "cached" (local file)
+    /// Where the version was resolved from.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version_source: Option<String>,
 }
@@ -400,7 +397,7 @@ fn show(project_id: &str) -> CmdResult<ProjectOutput> {
     };
 
     // Calculate deploy readiness
-    let (deploy_ready, deploy_blockers) = calculate_deploy_readiness(&project);
+    let (deploy_ready, deploy_blockers) = project::calculate_deploy_readiness(&project);
 
     Ok((
         ProjectOutput {
@@ -421,69 +418,6 @@ fn show(project_id: &str) -> CmdResult<ProjectOutput> {
         },
         0,
     ))
-}
-
-fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
-    let mut blockers = Vec::new();
-
-    // Check server_id
-    match &project.server_id {
-        None => {
-            blockers.push(format!(
-                "Missing server_id - set with: homeboy project set {} '{{\"server_id\": \"<server-id>\"}}'",
-                project.id
-            ));
-        }
-        Some(sid) if !server::exists(sid) => {
-            blockers.push(format!(
-                "Server '{}' not found - create with: homeboy server set {} '{{\"host\": \"...\", \"user\": \"...\"}}'",
-                sid, sid
-            ));
-        }
-        _ => {}
-    }
-
-    // Check base_path
-    if project
-        .base_path
-        .as_ref()
-        .map(|p| p.is_empty())
-        .unwrap_or(true)
-    {
-        blockers.push(format!(
-            "Missing base_path - set with: homeboy project set {} '{{\"base_path\": \"/path/to/webroot\"}}'",
-            project.id
-        ));
-    }
-
-    // Check components
-    if project.components.is_empty() {
-        blockers.push(format!(
-            "No components linked - add with: homeboy project components add {} <component-id> or attach a repo: homeboy project components attach-path {} <component-id> <path>",
-            project.id,
-            project.id
-        ));
-    } else {
-        // Check if at least one component is actually deployable (has artifact or git strategy)
-        let has_deployable = project.components.iter().any(|attachment| {
-            if let Ok(comp) = project::resolve_project_component(project, &attachment.id) {
-                let is_git = comp.deploy_strategy.as_deref() == Some("git");
-                let has_artifact = component::resolve_artifact(&comp).is_some();
-                is_git || has_artifact
-            } else {
-                false
-            }
-        });
-        if !has_deployable {
-            blockers.push(format!(
-                "No deployable components - {} component(s) exist but none have a build artifact or deploy strategy configured",
-                project.components.len()
-            ));
-        }
-    }
-
-    let deploy_ready = blockers.is_empty();
-    (deploy_ready, blockers)
 }
 
 fn set(args: super::DynamicSetArgs) -> CmdResult<ProjectOutput> {
@@ -623,8 +557,7 @@ fn components_set(project_id: &str, json: &str) -> CmdResult<ProjectOutput> {
 }
 
 fn components_attach_path(project_id: &str, local_path: &str) -> CmdResult<ProjectOutput> {
-    let component_id = component::infer_portable_component_id(Path::new(local_path))?;
-    project::attach_component_path(project_id, &component_id, local_path)?;
+    project::attach_discovered_component_path(project_id, Path::new(local_path))?;
     let project = project::load(project_id)?;
     write_project_components(project_id, "attach_path", &project)
 }
@@ -636,9 +569,8 @@ fn components_remove(project_id: &str, component_ids: Vec<String>) -> CmdResult<
 }
 
 fn components_clear(project_id: &str) -> CmdResult<ProjectOutput> {
-    let mut project = project::load(project_id)?;
-    project.components.clear();
-
+    project::clear_component_attachments(project_id)?;
+    let project = project::load(project_id)?;
     write_project_components(project_id, "clear", &project)
 }
 
@@ -822,75 +754,28 @@ fn pin_remove(project_id: &str, path: &str, pin_type: ProjectPinType) -> CmdResu
 }
 
 fn status(project_id: &str, health_only: bool) -> CmdResult<ProjectOutput> {
-    let proj = project::load(project_id)?;
+    project::load(project_id)?;
 
     log_status!("project", "Checking '{}'...", project_id);
 
-    // Collect health metrics via the shared core primitive
-    let project_health = health::collect_project_health(&proj);
-
-    let component_versions = if health_only {
-        None
-    } else {
-        // Collect live component versions via deploy check infrastructure
-        let config = DeployConfig {
-            component_ids: vec![],
-            all: true,
-            outdated: false,
-            dry_run: false,
-            check: true,
-            force: false,
-            skip_build: true,
-            keep_deps: false,
-            expected_version: None,
-            no_pull: true,
-            head: true,
-        };
-
-        match deploy::run(project_id, &config) {
-            Ok(result) => Some(
-                result
-                    .results
-                    .iter()
-                    .map(|r| ProjectComponentVersion {
-                        component_id: r.id.clone(),
-                        version: r.remote_version.clone(),
-                        version_source: Some("live".to_string()),
-                    })
-                    .collect(),
-            ),
-            Err(e) => {
-                // SSH failed for versions — fall back to cached
-                log_status!(
-                    "project",
-                    "Warning: could not reach server — falling back to cached versions: {}",
-                    e
-                );
-                Some(
-                    proj.components
-                        .iter()
-                        .map(|cid| {
-                            let comp_version = component::load(&cid.id)
-                                .ok()
-                                .and_then(|comp| version::get_component_version(&comp));
-                            ProjectComponentVersion {
-                                component_id: cid.id.clone(),
-                                version: comp_version,
-                                version_source: Some("cached".to_string()),
-                            }
-                        })
-                        .collect(),
-                )
-            }
-        }
-    };
+    let snapshot = project::collect_status(project_id, health_only);
+    let component_versions = snapshot.component_versions.map(|versions| {
+        versions
+            .into_iter()
+            .map(|version| ProjectComponentVersion {
+                component_id: version.component_id,
+                version: version.version,
+                version_source: version.version_source,
+            })
+            .collect()
+    });
 
     Ok((
         ProjectOutput {
             command: "project.status".to_string(),
             id: Some(project_id.to_string()),
             extra: ProjectExtra {
-                health: project_health,
+                health: snapshot.health,
                 component_versions,
                 ..Default::default()
             },

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -6,6 +6,19 @@ use crate::server;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub mod component;
+mod readiness;
+mod status;
+
+pub use component::{
+    apply_component_overrides, attach_component_path, attach_discovered_component_path,
+    clear_component_attachments, has_component, project_component_ids, remove_components,
+    resolve_project_component, resolve_project_components,
+    set_component_attachments,
+};
+pub use readiness::calculate_deploy_readiness;
+pub use status::{collect_status, ProjectComponentStatus, ProjectStatusSnapshot};
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProjectComponentAttachment {
     pub id: String,
@@ -323,191 +336,6 @@ pub struct NewsletterConfig {
 // ============================================================================
 
 entity_crud!(Project; list_ids, merge, slugify_id);
-
-// ============================================================================
-// Operations
-// ============================================================================
-
-fn component_ids_from_attachments(components: &[ProjectComponentAttachment]) -> Vec<String> {
-    components
-        .iter()
-        .map(|component| component.id.clone())
-        .collect()
-}
-
-pub fn project_component_ids(project: &Project) -> Vec<String> {
-    component_ids_from_attachments(&project.components)
-}
-
-pub fn has_component(project: &Project, component_id: &str) -> bool {
-    project
-        .components
-        .iter()
-        .any(|component| component.id == component_id)
-}
-
-pub fn set_component_attachments(
-    project_id: &str,
-    components: Vec<ProjectComponentAttachment>,
-) -> Result<Vec<String>> {
-    if components.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "components",
-            "At least one component attachment is required",
-            Some(project_id.to_string()),
-            None,
-        ));
-    }
-
-    let mut deduped = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for component in components {
-        if component.local_path.trim().is_empty() {
-            return Err(Error::validation_invalid_argument(
-                "components.local_path",
-                "Project component attachments require a non-empty local_path",
-                Some(project_id.to_string()),
-                None,
-            ));
-        }
-        if seen.insert(component.id.clone()) {
-            deduped.push(component);
-        }
-    }
-
-    let mut project = load(project_id)?;
-    project.components = deduped;
-    save(&project)?;
-    Ok(project_component_ids(&project))
-}
-
-pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result<Vec<String>> {
-    if component_ids.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "componentIds",
-            "At least one component ID is required",
-            Some(project_id.to_string()),
-            None,
-        ));
-    }
-
-    let mut project = load(project_id)?;
-
-    let mut missing = Vec::new();
-    for id in &component_ids {
-        if !has_component(&project, id) {
-            missing.push(id.clone());
-        }
-    }
-
-    if !missing.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "componentIds",
-            "Component IDs not attached to project",
-            Some(project_id.to_string()),
-            Some(missing),
-        ));
-    }
-
-    project
-        .components
-        .retain(|component| !component_ids.contains(&component.id));
-    save(&project)?;
-    Ok(project_component_ids(&project))
-}
-
-pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &str) -> Result<()> {
-    let mut project = load(project_id)?;
-
-    if let Some(component) = project.components.iter_mut().find(|c| c.id == component_id) {
-        component.local_path = local_path.to_string();
-    } else {
-        project.components.push(ProjectComponentAttachment {
-            id: component_id.to_string(),
-            local_path: local_path.to_string(),
-        });
-    }
-
-    save(&project)
-}
-
-pub fn apply_component_overrides(
-    component: &crate::component::Component,
-    project: &Project,
-) -> crate::component::Component {
-    let Some(overrides) = project.component_overrides.get(&component.id) else {
-        return component.clone();
-    };
-
-    let mut merged = component.clone();
-
-    if let Some(build_artifact) = &overrides.build_artifact {
-        merged.build_artifact = Some(build_artifact.clone());
-    }
-    if let Some(extract_command) = &overrides.extract_command {
-        merged.extract_command = Some(extract_command.clone());
-    }
-    if let Some(remote_owner) = &overrides.remote_owner {
-        merged.remote_owner = Some(remote_owner.clone());
-    }
-    if let Some(deploy_strategy) = &overrides.deploy_strategy {
-        merged.deploy_strategy = Some(deploy_strategy.clone());
-    }
-    if let Some(git_deploy) = &overrides.git_deploy {
-        merged.git_deploy = Some(git_deploy.clone());
-    }
-    if !overrides.hooks.is_empty() {
-        merged.hooks = overrides.hooks.clone();
-    }
-    if let Some(scopes) = &overrides.scopes {
-        merged.scopes = Some(scopes.clone());
-    }
-
-    merged
-}
-
-pub fn resolve_project_component(
-    project: &Project,
-    component_id: &str,
-) -> Result<crate::component::Component> {
-    let component = if let Some(attachment) = project
-        .components
-        .iter()
-        .find(|component| component.id == component_id)
-    {
-        crate::component::discover_from_portable(std::path::Path::new(&attachment.local_path))
-            .ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "components.local_path",
-                    format!(
-                        "Project component '{}' points to '{}' but no homeboy.json was found",
-                        component_id, attachment.local_path
-                    ),
-                    Some(project.id.clone()),
-                    None,
-                )
-            })?
-    } else {
-        return Err(Error::validation_invalid_argument(
-            "components",
-            format!(
-                "Project '{}' has no attached component '{}'",
-                project.id, component_id
-            ),
-            Some(project.id.clone()),
-            None,
-        ));
-    };
-    Ok(apply_component_overrides(&component, project))
-}
-
-pub fn resolve_project_components(project: &Project) -> Result<Vec<crate::component::Component>> {
-    project
-        .components
-        .iter()
-        .map(|component| resolve_project_component(project, &component.id))
-        .collect()
-}
 
 pub fn pin(project_id: &str, pin_type: PinType, path: &str, options: PinOptions) -> Result<()> {
     let mut project = load(project_id)?;

--- a/src/core/project/component/attachments.rs
+++ b/src/core/project/component/attachments.rs
@@ -1,0 +1,122 @@
+use std::path::Path;
+
+use crate::error::{Error, Result};
+
+use super::discovery::infer_attached_component_id;
+use crate::project::{load, save, Project, ProjectComponentAttachment};
+
+fn component_ids_from_attachments(components: &[ProjectComponentAttachment]) -> Vec<String> {
+    components
+        .iter()
+        .map(|component| component.id.clone())
+        .collect()
+}
+
+pub fn project_component_ids(project: &Project) -> Vec<String> {
+    component_ids_from_attachments(&project.components)
+}
+
+pub fn has_component(project: &Project, component_id: &str) -> bool {
+    project
+        .components
+        .iter()
+        .any(|component| component.id == component_id)
+}
+
+pub fn set_component_attachments(
+    project_id: &str,
+    components: Vec<ProjectComponentAttachment>,
+) -> Result<Vec<String>> {
+    if components.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "components",
+            "At least one component attachment is required",
+            Some(project_id.to_string()),
+            None,
+        ));
+    }
+
+    let mut deduped = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for component in components {
+        if component.local_path.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "components.local_path",
+                "Project component attachments require a non-empty local_path",
+                Some(project_id.to_string()),
+                None,
+            ));
+        }
+        if seen.insert(component.id.clone()) {
+            deduped.push(component);
+        }
+    }
+
+    let mut project = load(project_id)?;
+    project.components = deduped;
+    save(&project)?;
+    Ok(project_component_ids(&project))
+}
+
+pub fn remove_components(project_id: &str, component_ids: Vec<String>) -> Result<Vec<String>> {
+    if component_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "componentIds",
+            "At least one component ID is required",
+            Some(project_id.to_string()),
+            None,
+        ));
+    }
+
+    let mut project = load(project_id)?;
+
+    let mut missing = Vec::new();
+    for id in &component_ids {
+        if !has_component(&project, id) {
+            missing.push(id.clone());
+        }
+    }
+
+    if !missing.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "componentIds",
+            "Component IDs not attached to project",
+            Some(project_id.to_string()),
+            Some(missing),
+        ));
+    }
+
+    project
+        .components
+        .retain(|component| !component_ids.contains(&component.id));
+    save(&project)?;
+    Ok(project_component_ids(&project))
+}
+
+pub fn clear_component_attachments(project_id: &str) -> Result<Vec<String>> {
+    let mut project = load(project_id)?;
+    project.components.clear();
+    save(&project)?;
+    Ok(project_component_ids(&project))
+}
+
+pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &str) -> Result<()> {
+    let mut project = load(project_id)?;
+
+    if let Some(component) = project.components.iter_mut().find(|c| c.id == component_id) {
+        component.local_path = local_path.to_string();
+    } else {
+        project.components.push(ProjectComponentAttachment {
+            id: component_id.to_string(),
+            local_path: local_path.to_string(),
+        });
+    }
+
+    save(&project)
+}
+
+pub fn attach_discovered_component_path(project_id: &str, local_path: &Path) -> Result<String> {
+    let component_id = infer_attached_component_id(local_path)?;
+    attach_component_path(project_id, &component_id, &local_path.to_string_lossy())?;
+    Ok(component_id)
+}

--- a/src/core/project/component/discovery.rs
+++ b/src/core/project/component/discovery.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use crate::component;
+use crate::error::Result;
+
+pub fn infer_attached_component_id(local_path: &Path) -> Result<String> {
+    component::infer_portable_component_id(local_path)
+}
+
+pub fn discover_attached_component(local_path: &Path) -> Option<component::Component> {
+    component::discover_from_portable(local_path)
+}

--- a/src/core/project/component/mod.rs
+++ b/src/core/project/component/mod.rs
@@ -1,0 +1,11 @@
+pub mod attachments;
+pub mod discovery;
+pub mod overrides;
+pub mod resolution;
+
+pub use attachments::{
+    attach_component_path, attach_discovered_component_path, clear_component_attachments,
+    has_component, project_component_ids, remove_components, set_component_attachments,
+};
+pub use overrides::apply_component_overrides;
+pub use resolution::{resolve_project_component, resolve_project_components};

--- a/src/core/project/component/overrides.rs
+++ b/src/core/project/component/overrides.rs
@@ -1,0 +1,36 @@
+use crate::project::Project;
+
+pub fn apply_component_overrides(
+    component: &crate::component::Component,
+    project: &Project,
+) -> crate::component::Component {
+    let Some(overrides) = project.component_overrides.get(&component.id) else {
+        return component.clone();
+    };
+
+    let mut merged = component.clone();
+
+    if let Some(build_artifact) = &overrides.build_artifact {
+        merged.build_artifact = Some(build_artifact.clone());
+    }
+    if let Some(extract_command) = &overrides.extract_command {
+        merged.extract_command = Some(extract_command.clone());
+    }
+    if let Some(remote_owner) = &overrides.remote_owner {
+        merged.remote_owner = Some(remote_owner.clone());
+    }
+    if let Some(deploy_strategy) = &overrides.deploy_strategy {
+        merged.deploy_strategy = Some(deploy_strategy.clone());
+    }
+    if let Some(git_deploy) = &overrides.git_deploy {
+        merged.git_deploy = Some(git_deploy.clone());
+    }
+    if !overrides.hooks.is_empty() {
+        merged.hooks = overrides.hooks.clone();
+    }
+    if let Some(scopes) = &overrides.scopes {
+        merged.scopes = Some(scopes.clone());
+    }
+
+    merged
+}

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -1,0 +1,48 @@
+use crate::error::{Error, Result};
+use crate::project::Project;
+
+use super::discovery::discover_attached_component;
+use super::overrides::apply_component_overrides;
+
+pub fn resolve_project_component(
+    project: &Project,
+    component_id: &str,
+) -> Result<crate::component::Component> {
+    let component = if let Some(attachment) = project
+        .components
+        .iter()
+        .find(|component| component.id == component_id)
+    {
+        discover_attached_component(std::path::Path::new(&attachment.local_path)).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "components.local_path",
+                format!(
+                    "Project component '{}' points to '{}' but no homeboy.json was found",
+                    component_id, attachment.local_path
+                ),
+                Some(project.id.clone()),
+                None,
+            )
+        })?
+    } else {
+        return Err(Error::validation_invalid_argument(
+            "components",
+            format!(
+                "Project '{}' has no attached component '{}'",
+                project.id, component_id
+            ),
+            Some(project.id.clone()),
+            None,
+        ));
+    };
+
+    Ok(apply_component_overrides(&component, project))
+}
+
+pub fn resolve_project_components(project: &Project) -> Result<Vec<crate::component::Component>> {
+    project
+        .components
+        .iter()
+        .map(|component| resolve_project_component(project, &component.id))
+        .collect()
+}

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -1,0 +1,62 @@
+use crate::component;
+
+use super::Project;
+
+pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
+    let mut blockers = Vec::new();
+
+    match &project.server_id {
+        None => {
+            blockers.push(format!(
+                "Missing server_id - set with: homeboy project set {} '{{\"server_id\": \"<server-id>\"}}'",
+                project.id
+            ));
+        }
+        Some(sid) if !crate::server::exists(sid) => {
+            blockers.push(format!(
+                "Server '{}' not found - create with: homeboy server set {} '{{\"host\": \"...\", \"user\": \"...\"}}'",
+                sid, sid
+            ));
+        }
+        _ => {}
+    }
+
+    if project
+        .base_path
+        .as_ref()
+        .map(|p| p.is_empty())
+        .unwrap_or(true)
+    {
+        blockers.push(format!(
+            "Missing base_path - set with: homeboy project set {} '{{\"base_path\": \"/path/to/webroot\"}}'",
+            project.id
+        ));
+    }
+
+    if project.components.is_empty() {
+        blockers.push(format!(
+            "No components linked - add with: homeboy project components add {} <component-id> or attach a repo: homeboy project components attach-path {} <component-id> <path>",
+            project.id,
+            project.id
+        ));
+    } else {
+        let has_deployable = project.components.iter().any(|attachment| {
+            if let Ok(comp) = super::resolve_project_component(project, &attachment.id) {
+                let is_git = comp.deploy_strategy.as_deref() == Some("git");
+                let has_artifact = component::resolve_artifact(&comp).is_some();
+                is_git || has_artifact
+            } else {
+                false
+            }
+        });
+
+        if !has_deployable {
+            blockers.push(format!(
+                "No deployable components - {} component(s) exist but none have a build artifact or deploy strategy configured",
+                project.components.len()
+            ));
+        }
+    }
+
+    (blockers.is_empty(), blockers)
+}

--- a/src/core/project/status.rs
+++ b/src/core/project/status.rs
@@ -1,0 +1,67 @@
+use crate::deploy::{self, DeployConfig};
+use crate::health::{self, ServerHealth};
+
+#[derive(Debug, Clone)]
+pub struct ProjectComponentStatus {
+    pub component_id: String,
+    pub version: Option<String>,
+    pub version_source: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectStatusSnapshot {
+    pub health: Option<ServerHealth>,
+    pub component_versions: Option<Vec<ProjectComponentStatus>>,
+}
+
+pub fn collect_status(project_id: &str, health_only: bool) -> ProjectStatusSnapshot {
+    let proj = match super::load(project_id) {
+        Ok(project) => project,
+        Err(_) => {
+            return ProjectStatusSnapshot {
+                health: None,
+                component_versions: None,
+            };
+        }
+    };
+
+    let health = health::collect_project_health(&proj);
+    let component_versions = if health_only {
+        None
+    } else {
+        collect_component_versions(project_id)
+    };
+
+    ProjectStatusSnapshot {
+        health,
+        component_versions,
+    }
+}
+
+fn collect_component_versions(project_id: &str) -> Option<Vec<ProjectComponentStatus>> {
+    let config = DeployConfig {
+        component_ids: vec![],
+        all: true,
+        outdated: false,
+        dry_run: false,
+        check: true,
+        force: false,
+        skip_build: true,
+        keep_deps: false,
+        expected_version: None,
+        no_pull: true,
+        head: true,
+    };
+
+    deploy::run(project_id, &config).ok().map(|result| {
+        result
+            .results
+            .iter()
+            .map(|r| ProjectComponentStatus {
+                component_id: r.id.clone(),
+                version: r.remote_version.clone(),
+                version_source: Some("live".to_string()),
+            })
+            .collect()
+    })
+}


### PR DESCRIPTION
## Summary
- establish `core/project/` as a real domain seam with submodules for readiness, status, and project-attached component behavior
- move project-attached portable component logic behind `core/project/component/` so attachment, discovery, resolution, and overrides are owned together
- remove project status command-layer business logic and drop the cached version fallback so project status only reports live component versions when available

## Why
- project is now the configuration layer, but its logic was still split between a flat core file and a heavy command layer
- portable `homeboy.json` components are associated through projects, so that bridge should be owned by `project/component`, not by command code reaching into generic component APIs
- the cached project-status fallback added complexity without enough benefit

## Validation
- `source \"$HOME/.cargo/env\" && cargo check --quiet`