### PR TITLE
refactor move logs under project

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -11,10 +11,10 @@ use homeboy::deploy;
 use homeboy::extension::{
     extension_ready_status, is_extension_compatible, is_extension_linked, load_all_extensions,
 };
-use homeboy::{is_zero, is_zero_u32};
 use homeboy::project::{self, Project};
 use homeboy::server::{self, Server};
 use homeboy::{changelog, git, version};
+use homeboy::{is_zero, is_zero_u32};
 use std::path::{Path, PathBuf};
 
 fn collect_focused_components(
@@ -434,7 +434,6 @@ fn compute_status(
                 command: gap.command.clone(),
             });
         }
-
     }
 
     InitStatus {
@@ -769,14 +768,17 @@ fn validate_version_baseline_alignment(
     version: &Option<VersionSnapshot>,
     git: &Option<GitSnapshot>,
 ) -> Option<String> {
-    let version_snapshot = version.as_ref().map(|snapshot| version::ComponentVersionSnapshot {
-        component_id: snapshot.component_id.clone(),
-        version: snapshot.version.clone(),
-        targets: snapshot.targets.clone(),
-    });
+    let version_snapshot = version
+        .as_ref()
+        .map(|snapshot| version::ComponentVersionSnapshot {
+            component_id: snapshot.component_id.clone(),
+            version: snapshot.version.clone(),
+            targets: snapshot.targets.clone(),
+        });
 
     version::validate_baseline_alignment(
         version_snapshot.as_ref(),
-        git.as_ref().and_then(|snapshot| snapshot.baseline_ref.as_deref()),
+        git.as_ref()
+            .and_then(|snapshot| snapshot.baseline_ref.as_deref()),
     )
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::logs::{self, LogContent, LogEntry, LogSearchResult, PinnedLogsContent};
+use homeboy::project::logs::{self, LogContent, LogEntry, LogSearchResult, PinnedLogsContent};
 
 use crate::commands::CmdResult;
 

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -77,18 +77,137 @@ pub(crate) fn normalize_changelog_component(args: Vec<String>) -> Vec<String> {
 /// Auto-insert '--' separator before unknown flags for trailing_var_arg commands.
 pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
     let commands: &[(&str, &str, &[&str])] = &[
-        ("component", "set", &["--json", "--base64", "--replace", "--version-target", "--extension", "--help", "-h"]),
-        ("component", "edit", &["--json", "--base64", "--replace", "--version-target", "--extension", "--help", "-h"]),
-        ("component", "merge", &["--json", "--base64", "--replace", "--version-target", "--extension", "--help", "-h"]),
-        ("server", "set", &["--json", "--base64", "--replace", "--help", "-h"]),
-        ("server", "edit", &["--json", "--base64", "--replace", "--help", "-h"]),
-        ("server", "merge", &["--json", "--base64", "--replace", "--help", "-h"]),
-        ("fleet", "set", &["--json", "--base64", "--replace", "--help", "-h"]),
-        ("fleet", "edit", &["--json", "--base64", "--replace", "--help", "-h"]),
-        ("fleet", "merge", &["--json", "--base64", "--replace", "--help", "-h"]),
-        ("test", "", &["--skip-lint", "--fix", "--coverage", "--coverage-min", "--baseline", "--ignore-baseline", "--ratchet", "--analyze", "--drift", "--scaffold", "--scaffold-file", "--write", "--since", "--changed-since", "--setting", "--path", "--json-summary", "--json", "--help", "-h"]),
-        ("docs", "audit", &["--path", "--docs-dir", "--baseline", "--ignore-baseline", "--features", "--help", "-h"]),
-        ("lint", "", &["--fix", "--baseline", "--ignore-baseline", "--summary", "--file", "--glob", "--changed-only", "--changed-since", "--errors-only", "--sniffs", "--exclude-sniffs", "--category", "--setting", "--path", "--json", "--help", "-h"]),
+        (
+            "component",
+            "set",
+            &[
+                "--json",
+                "--base64",
+                "--replace",
+                "--version-target",
+                "--extension",
+                "--help",
+                "-h",
+            ],
+        ),
+        (
+            "component",
+            "edit",
+            &[
+                "--json",
+                "--base64",
+                "--replace",
+                "--version-target",
+                "--extension",
+                "--help",
+                "-h",
+            ],
+        ),
+        (
+            "component",
+            "merge",
+            &[
+                "--json",
+                "--base64",
+                "--replace",
+                "--version-target",
+                "--extension",
+                "--help",
+                "-h",
+            ],
+        ),
+        (
+            "server",
+            "set",
+            &["--json", "--base64", "--replace", "--help", "-h"],
+        ),
+        (
+            "server",
+            "edit",
+            &["--json", "--base64", "--replace", "--help", "-h"],
+        ),
+        (
+            "server",
+            "merge",
+            &["--json", "--base64", "--replace", "--help", "-h"],
+        ),
+        (
+            "fleet",
+            "set",
+            &["--json", "--base64", "--replace", "--help", "-h"],
+        ),
+        (
+            "fleet",
+            "edit",
+            &["--json", "--base64", "--replace", "--help", "-h"],
+        ),
+        (
+            "fleet",
+            "merge",
+            &["--json", "--base64", "--replace", "--help", "-h"],
+        ),
+        (
+            "test",
+            "",
+            &[
+                "--skip-lint",
+                "--fix",
+                "--coverage",
+                "--coverage-min",
+                "--baseline",
+                "--ignore-baseline",
+                "--ratchet",
+                "--analyze",
+                "--drift",
+                "--scaffold",
+                "--scaffold-file",
+                "--write",
+                "--since",
+                "--changed-since",
+                "--setting",
+                "--path",
+                "--json-summary",
+                "--json",
+                "--help",
+                "-h",
+            ],
+        ),
+        (
+            "docs",
+            "audit",
+            &[
+                "--path",
+                "--docs-dir",
+                "--baseline",
+                "--ignore-baseline",
+                "--features",
+                "--help",
+                "-h",
+            ],
+        ),
+        (
+            "lint",
+            "",
+            &[
+                "--fix",
+                "--baseline",
+                "--ignore-baseline",
+                "--summary",
+                "--file",
+                "--glob",
+                "--changed-only",
+                "--changed-since",
+                "--errors-only",
+                "--sniffs",
+                "--exclude-sniffs",
+                "--category",
+                "--setting",
+                "--path",
+                "--json",
+                "--help",
+                "-h",
+            ],
+        ),
     ];
 
     let known_flags = commands.iter().find_map(|(cmd, subcmd, flags)| {
@@ -98,7 +217,11 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
             args.get(1).map(|s| s == *cmd).unwrap_or(false)
                 && args.get(2).map(|s| s == *subcmd).unwrap_or(false)
         };
-        if matches { Some(*flags) } else { None }
+        if matches {
+            Some(*flags)
+        } else {
+            None
+        }
     });
 
     let Some(known_flags) = known_flags else {
@@ -116,7 +239,9 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
         if !found_separator
             && arg.starts_with("--")
             && !known_flags.contains(&arg.as_str())
-            && !known_flags.iter().any(|f| arg.starts_with(&format!("{}=", f)))
+            && !known_flags
+                .iter()
+                .any(|f| arg.starts_with(&format!("{}=", f)))
             && insert_position.is_none()
         {
             insert_position = Some(i);

--- a/src/commands/utils/entity_suggest.rs
+++ b/src/commands/utils/entity_suggest.rs
@@ -34,23 +34,39 @@ pub fn find_entity_match(input: &str) -> Option<EntityMatch> {
 
     if let Ok(ids) = component::list_ids() {
         if let Some(m) = find_match_in_list(&input_lower, &ids) {
-            return Some(EntityMatch { entity_type: EntityType::Component, entity_id: m.0, exact: m.1 });
+            return Some(EntityMatch {
+                entity_type: EntityType::Component,
+                entity_id: m.0,
+                exact: m.1,
+            });
         }
     }
     if let Ok(ids) = project::list_ids() {
         if let Some(m) = find_match_in_list(&input_lower, &ids) {
-            return Some(EntityMatch { entity_type: EntityType::Project, entity_id: m.0, exact: m.1 });
+            return Some(EntityMatch {
+                entity_type: EntityType::Project,
+                entity_id: m.0,
+                exact: m.1,
+            });
         }
     }
     if let Ok(servers) = server::list() {
         let ids: Vec<String> = servers.into_iter().map(|s| s.id).collect();
         if let Some(m) = find_match_in_list(&input_lower, &ids) {
-            return Some(EntityMatch { entity_type: EntityType::Server, entity_id: m.0, exact: m.1 });
+            return Some(EntityMatch {
+                entity_type: EntityType::Server,
+                entity_id: m.0,
+                exact: m.1,
+            });
         }
     }
     let extension_ids = extension::available_extension_ids();
     if let Some(m) = find_match_in_list(&input_lower, &extension_ids) {
-        return Some(EntityMatch { entity_type: EntityType::Extension, entity_id: m.0, exact: m.1 });
+        return Some(EntityMatch {
+            entity_type: EntityType::Extension,
+            entity_id: m.0,
+            exact: m.1,
+        });
     }
     None
 }
@@ -80,7 +96,11 @@ fn find_match_in_list(input_lower: &str, ids: &[String]) -> Option<(String, bool
     None
 }
 
-pub fn generate_entity_hints(entity_match: &EntityMatch, parent_command: &str, unrecognized: &str) -> Vec<String> {
+pub fn generate_entity_hints(
+    entity_match: &EntityMatch,
+    parent_command: &str,
+    unrecognized: &str,
+) -> Vec<String> {
     let id = &entity_match.entity_id;
     let entity_label = entity_match.entity_type.label();
     let mut hints = Vec::new();
@@ -90,14 +110,38 @@ pub fn generate_entity_hints(entity_match: &EntityMatch, parent_command: &str, u
     }
 
     match parent_command {
-        "changelog" => hints.push(format!("'{}' matches {} '{}'. Try: homeboy changelog show {}", unrecognized, entity_label, id, id)),
-        "version" => hints.push(format!("'{}' matches {} '{}'. Try: homeboy version show {}", unrecognized, entity_label, id, id)),
-        "build" => hints.push(format!("'{}' matches {} '{}'. Run: homeboy build {}", unrecognized, entity_label, id, id)),
-        "deploy" => hints.push(format!("'{}' matches {} '{}'. Try: homeboy deploy --component {}", unrecognized, entity_label, id, id)),
-        "changes" => hints.push(format!("'{}' matches {} '{}'. Try: homeboy changes show {}", unrecognized, entity_label, id, id)),
-        "git" => hints.push(format!("'{}' matches {} '{}'. Try: homeboy git {} status", unrecognized, entity_label, id, id)),
-        "release" => hints.push(format!("'{}' matches {} '{}'. Try: homeboy release {}", unrecognized, entity_label, id, id)),
-        _ => hints.push(format!("'{}' matches {} '{}'. Try: homeboy {} {}", unrecognized, entity_label, id, entity_label, id)),
+        "changelog" => hints.push(format!(
+            "'{}' matches {} '{}'. Try: homeboy changelog show {}",
+            unrecognized, entity_label, id, id
+        )),
+        "version" => hints.push(format!(
+            "'{}' matches {} '{}'. Try: homeboy version show {}",
+            unrecognized, entity_label, id, id
+        )),
+        "build" => hints.push(format!(
+            "'{}' matches {} '{}'. Run: homeboy build {}",
+            unrecognized, entity_label, id, id
+        )),
+        "deploy" => hints.push(format!(
+            "'{}' matches {} '{}'. Try: homeboy deploy --component {}",
+            unrecognized, entity_label, id, id
+        )),
+        "changes" => hints.push(format!(
+            "'{}' matches {} '{}'. Try: homeboy changes show {}",
+            unrecognized, entity_label, id, id
+        )),
+        "git" => hints.push(format!(
+            "'{}' matches {} '{}'. Try: homeboy git {} status",
+            unrecognized, entity_label, id, id
+        )),
+        "release" => hints.push(format!(
+            "'{}' matches {} '{}'. Try: homeboy release {}",
+            unrecognized, entity_label, id, id
+        )),
+        _ => hints.push(format!(
+            "'{}' matches {} '{}'. Try: homeboy {} {}",
+            unrecognized, entity_label, id, entity_label, id
+        )),
     }
 
     hints

--- a/src/core/engine/text.rs
+++ b/src/core/engine/text.rs
@@ -264,7 +264,10 @@ mod tests {
     #[test]
     fn require_identical_passes_duplicates() {
         let values = vec!["1.0.0".to_string(), "1.0.0".to_string()];
-        assert_eq!(require_identical(&values, "test").unwrap(), "1.0.0".to_string());
+        assert_eq!(
+            require_identical(&values, "test").unwrap(),
+            "1.0.0".to_string()
+        );
     }
 
     #[test]
@@ -284,11 +287,17 @@ mod tests {
     #[test]
     fn json_path_str_extracts_nested_value() {
         let json = serde_json::json!({"release": {"local_path": "/path/to/file"}});
-        assert_eq!(json_path_str(&json, &["release", "local_path"]), Some("/path/to/file"));
+        assert_eq!(
+            json_path_str(&json, &["release", "local_path"]),
+            Some("/path/to/file")
+        );
     }
 
     #[test]
     fn split_identifier_preserves_subtarget_colons() {
-        assert_eq!(split_identifier("project:sub:target"), ("project", Some("sub:target")));
+        assert_eq!(
+            split_identifier("project:sub:target"),
+            ("project", Some("sub:target"))
+        );
     }
 }

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use crate::component::{self, Component};
 use crate::engine::shell;
 use crate::error::{Error, Result};
-use crate::ssh::{execute_local_command_passthrough, CommandOutput};
 use crate::local_files;
+use crate::ssh::{execute_local_command_passthrough, CommandOutput};
 
 /// Output from a extension runner script execution.
 pub struct RunnerOutput {
@@ -202,7 +202,8 @@ impl ExtensionRunner {
             ));
         }
 
-        let content = local_files::read_file(&manifest_path, &format!("read {}", manifest_path.display()))?;
+        let content =
+            local_files::read_file(&manifest_path, &format!("read {}", manifest_path.display()))?;
 
         serde_json::from_str(&content).map_err(|e| {
             Error::validation_invalid_json(e, Some("parse manifest".to_string()), None)

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
-use crate::paths;
 use crate::local_files;
+use crate::paths;
 use std::fs;
 use std::path::PathBuf;
 
@@ -21,7 +21,11 @@ pub fn ensure_runner_steps_helper() -> Result<PathBuf> {
     let current = fs::read_to_string(&helper_path).ok();
 
     if current.as_deref() != Some(RUNNER_STEPS_SH) {
-        local_files::write_file_atomic(&helper_path, RUNNER_STEPS_SH, "write runtime runner helper")?;
+        local_files::write_file_atomic(
+            &helper_path,
+            RUNNER_STEPS_SH,
+            "write runtime runner helper",
+        )?;
     }
 
     Ok(helper_path)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -18,7 +18,6 @@ pub mod fleet;
 pub mod git;
 pub mod health;
 pub mod hooks;
-pub mod logs;
 pub mod output;
 pub mod project;
 pub mod refactor;

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -14,8 +14,7 @@ mod status;
 pub use component::{
     apply_component_overrides, attach_component_path, attach_discovered_component_path,
     clear_component_attachments, has_component, project_component_ids, remove_components,
-    resolve_project_component, resolve_project_components,
-    set_component_attachments,
+    resolve_project_component, resolve_project_components, set_component_attachments,
 };
 pub use logs::{LogContent, LogEntry, LogSearchResult, PinnedLogsContent};
 pub use readiness::calculate_deploy_readiness;

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub mod component;
+pub mod logs;
 mod readiness;
 mod status;
 
@@ -16,6 +17,7 @@ pub use component::{
     resolve_project_component, resolve_project_components,
     set_component_attachments,
 };
+pub use logs::{LogContent, LogEntry, LogSearchResult, PinnedLogsContent};
 pub use readiness::calculate_deploy_readiness;
 pub use status::{collect_status, ProjectComponentStatus, ProjectStatusSnapshot};
 

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -13,17 +13,19 @@ pub fn resolve_project_component(
         .iter()
         .find(|component| component.id == component_id)
     {
-        discover_attached_component(std::path::Path::new(&attachment.local_path)).ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "components.local_path",
-                format!(
-                    "Project component '{}' points to '{}' but no homeboy.json was found",
-                    component_id, attachment.local_path
-                ),
-                Some(project.id.clone()),
-                None,
-            )
-        })?
+        discover_attached_component(std::path::Path::new(&attachment.local_path)).ok_or_else(
+            || {
+                Error::validation_invalid_argument(
+                    "components.local_path",
+                    format!(
+                        "Project component '{}' points to '{}' but no homeboy.json was found",
+                        component_id, attachment.local_path
+                    ),
+                    Some(project.id.clone()),
+                    None,
+                )
+            },
+        )?
     } else {
         return Err(Error::validation_invalid_argument(
             "components",

--- a/src/core/project/logs.rs
+++ b/src/core/project/logs.rs
@@ -1,20 +1,19 @@
-//! Log file operations.
+//! Project log file operations.
 //!
-//! Provides viewing, following, and clearing of log files.
+//! Provides viewing, following, and clearing of project log files.
 //! Routes to local or SSH execution based on project configuration.
 //! Pass `local: true` to bypass SSH and execute commands directly on the
 //! current machine (useful when homeboy runs on the target server itself).
 
 use crate::context::require_project_base_path;
 use crate::engine::executor::{execute_for_project, execute_for_project_interactive};
+use crate::engine::shell;
 use crate::error::{Error, Result};
 use crate::paths as base_path;
 use crate::project::{self, Project};
-use crate::engine::shell;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
-
 pub struct LogEntry {
     pub path: String,
     pub label: Option<String>,
@@ -22,7 +21,6 @@ pub struct LogEntry {
 }
 
 #[derive(Debug, Serialize)]
-
 pub struct LogContent {
     pub path: String,
     pub lines: u32,
@@ -30,14 +28,12 @@ pub struct LogContent {
 }
 
 #[derive(Debug, Clone, Serialize)]
-
 pub struct LogSearchMatch {
     pub line_number: u32,
     pub content: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
-
 pub struct LogSearchResult {
     pub path: String,
     pub pattern: String,
@@ -59,7 +55,6 @@ pub struct PinnedLogsContent {
     pub total_logs: usize,
 }
 
-/// Load a project, optionally forcing local execution by clearing server_id.
 fn load_project(project_id: &str, local: bool) -> Result<Project> {
     let mut project = project::load(project_id)?;
     if local {
@@ -68,7 +63,6 @@ fn load_project(project_id: &str, local: bool) -> Result<Project> {
     Ok(project)
 }
 
-/// Lists pinned log files for a project.
 pub fn list(project_id: &str) -> Result<Vec<LogEntry>> {
     let project = project::load(project_id)?;
 
@@ -84,7 +78,6 @@ pub fn list(project_id: &str) -> Result<Vec<LogEntry>> {
         .collect())
 }
 
-/// Shows all pinned logs for a project.
 pub fn show_pinned(project_id: &str, lines: u32, local: bool) -> Result<PinnedLogsContent> {
     let project = load_project(project_id, local)?;
 
@@ -129,7 +122,6 @@ pub fn show_pinned(project_id: &str, lines: u32, local: bool) -> Result<PinnedLo
     Ok(PinnedLogsContent { logs, total_logs })
 }
 
-/// Shows the last N lines of a log file.
 pub fn show(project_id: &str, path: &str, lines: u32, local: bool) -> Result<LogContent> {
     let project = load_project(project_id, local)?;
     let base_path = require_project_base_path(project_id, &project)?;
@@ -145,10 +137,6 @@ pub fn show(project_id: &str, path: &str, lines: u32, local: bool) -> Result<Log
     })
 }
 
-/// Follows a log file (tail -f). Returns exit code from interactive session.
-///
-/// Note: This requires an interactive terminal. The caller is responsible
-/// for ensuring terminal availability before calling.
 pub fn follow(project_id: &str, path: &str, local: bool) -> Result<i32> {
     let project = load_project(project_id, local)?;
     let base_path = require_project_base_path(project_id, &project)?;
@@ -158,7 +146,6 @@ pub fn follow(project_id: &str, path: &str, local: bool) -> Result<i32> {
     execute_for_project_interactive(&project, &tail_cmd)
 }
 
-/// Clears the contents of a log file. Returns the full path that was cleared.
 pub fn clear(project_id: &str, path: &str, local: bool) -> Result<String> {
     let project = load_project(project_id, local)?;
     let base_path = require_project_base_path(project_id, &project)?;
@@ -170,7 +157,6 @@ pub fn clear(project_id: &str, path: &str, local: bool) -> Result<String> {
     Ok(full_path)
 }
 
-/// Searches a log file for a pattern.
 pub fn search(
     project_id: &str,
     path: &str,
@@ -210,8 +196,6 @@ pub fn search(
     };
 
     let output = execute_for_project(&project, &command)?;
-
-    // grep returns exit code 1 when no matches found, which is not an error
     let matches = parse_grep_output(&output.stdout);
     let match_count = matches.len();
 
@@ -223,7 +207,6 @@ pub fn search(
     })
 }
 
-/// Parse grep -n output into structured matches.
 fn parse_grep_output(output: &str) -> Vec<LogSearchMatch> {
     let mut matches = Vec::new();
 
@@ -232,7 +215,6 @@ fn parse_grep_output(output: &str) -> Vec<LogSearchMatch> {
             continue;
         }
 
-        // grep -n format: "line_number:content" or "line_number-content" (for context lines)
         if let Some(colon_pos) = line.find(':') {
             if let Ok(line_num) = line[..colon_pos].parse::<u32>() {
                 matches.push(LogSearchMatch {
@@ -241,7 +223,6 @@ fn parse_grep_output(output: &str) -> Vec<LogSearchMatch> {
                 });
             }
         } else if let Some(dash_pos) = line.find('-') {
-            // Context lines use dash separator
             if let Ok(line_num) = line[..dash_pos].parse::<u32>() {
                 matches.push(LogSearchMatch {
                     line_number: line_num,

--- a/src/core/release/changelog/bulk.rs
+++ b/src/core/release/changelog/bulk.rs
@@ -146,7 +146,7 @@ pub fn show(component_id: &str) -> Result<ShowOutput> {
     let component = component::resolve_effective(Some(component_id), None, None)?;
     let changelog_path = resolve_changelog_path(&component)?;
 
-        let content = local_files::read_file(
+    let content = local_files::read_file(
         &changelog_path,
         &format!("read changelog at {}", changelog_path.display()),
     )?;
@@ -192,13 +192,11 @@ pub fn init(component_id: &str, path: Option<&str>, configure: bool) -> Result<I
 
     // Determine changelog path (relative to component)
     let mut relative_path = path.unwrap_or("CHANGELOG.md").to_string();
-    let mut changelog_path =
-        resolve_path(&component.local_path, &relative_path);
+    let mut changelog_path = resolve_path(&component.local_path, &relative_path);
 
     // Check for existing changelog_target configuration
     if let Some(ref configured_target) = component.changelog_target {
-        let configured_path =
-            resolve_path(&component.local_path, configured_target);
+        let configured_path = resolve_path(&component.local_path, configured_target);
 
         // If user didn't specify a custom path, or specified the same path, check for existing changelog
         if (path.is_none() || path == Some(configured_target)) && configured_path.exists() {

--- a/src/core/release/changelog/io.rs
+++ b/src/core/release/changelog/io.rs
@@ -116,7 +116,10 @@ pub struct FinalizedReleaseSnapshot {
 
 pub fn read_component_snapshots(
     component: &Component,
-) -> Result<(Option<FinalizedReleaseSnapshot>, Option<ChangelogSnapshotData>)> {
+) -> Result<(
+    Option<FinalizedReleaseSnapshot>,
+    Option<ChangelogSnapshotData>,
+)> {
     let changelog_path = resolve_changelog_path(component)?;
     let content = local_files::read_file(&changelog_path, "read changelog")?;
     let settings = resolve_effective_settings(Some(component));

--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -408,7 +408,8 @@ pub fn extract_last_release_snapshot(content: &str) -> Option<FinalizedReleaseSn
 
         let label = trimmed.trim_start_matches("## ").trim();
         let normalized = normalize_heading_label(label);
-        if normalized.eq_ignore_ascii_case("unreleased") || normalized.eq_ignore_ascii_case("next") {
+        if normalized.eq_ignore_ascii_case("unreleased") || normalized.eq_ignore_ascii_case("next")
+        {
             continue;
         }
 

--- a/src/core/server.rs
+++ b/src/core/server.rs
@@ -176,7 +176,8 @@ pub fn import_key(server_id: &str, source_path: &str) -> Result<KeyImportResult>
 
     let expanded_path = shellexpand::tilde(source_path).to_string();
 
-    let private_key = local_files::read_file(std::path::Path::new(&expanded_path), "read ssh private key")?;
+    let private_key =
+        local_files::read_file(std::path::Path::new(&expanded_path), "read ssh private key")?;
 
     if !private_key.contains("-----BEGIN") || !private_key.contains("PRIVATE KEY-----") {
         return Err(Error::validation_invalid_argument(

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,12 @@ mod docs;
 mod output;
 mod tty;
 
+use commands::utils::{args, entity_suggest};
 use commands::{
     api, audit, auth, build, changelog, changes, cleanup, cli, component, config, db, deploy,
     extension, file, fleet, git, init, lint, logs, project, refactor, release, server, ssh, status,
     test, transfer, undo, upgrade, version,
 };
-use commands::utils::{args, entity_suggest};
 use homeboy::extension::load_all_extensions;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -420,7 +420,8 @@ fn try_augment_clap_error(e: &clap::Error) -> Option<String> {
     let entity_match = entity_suggest::find_entity_match(&unrecognized)?;
 
     // Generate hints
-    let hints = entity_suggest::generate_entity_hints(&entity_match, &parent_command, &unrecognized);
+    let hints =
+        entity_suggest::generate_entity_hints(&entity_match, &parent_command, &unrecognized);
 
     // Build augmented output
     let mut output = format!("error: unrecognized subcommand '{}'\n\n", unrecognized);


### PR DESCRIPTION
## Summary
- move the core logs implementation from `core/logs.rs` to `core/project/logs.rs`
- re-export project log types from the project domain and update the logs command to use the project-owned path
- remove the old top-level `core::logs` module so project-scoped log behavior lives with the rest of the project domain

## Why
- logs are already project-scoped in practice: they depend on project log pins, project base path, and project execution context
- server remains a reusable infrastructure target shared by projects, but log ownership belongs to the project domain
- this continues the project-domain cleanup after PR #721 by moving another clearly project-owned concern under `core/project/`

## Validation
- `source \"$HOME/.cargo/env\" && cargo check --quiet`