### PR TITLE
refactor(architecture): extract lint workflow and report into core

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -1,7 +1,9 @@
 use clap::Args;
 use std::path::PathBuf;
 
-use homeboy::extension::lint::{report, run_main_lint_workflow, LintCommandOutput, LintRunWorkflowArgs};
+use homeboy::extension::lint::{
+    report, run_main_lint_workflow, LintCommandOutput, LintRunWorkflowArgs,
+};
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -1,16 +1,7 @@
 use clap::Args;
-use serde::Serialize;
+use std::path::PathBuf;
 
-use homeboy::engine::temp;
-use homeboy::extension::lint as extension_lint;
-use homeboy::extension::lint::baseline::{
-    self as lint_baseline, BaselineComparison as LintBaselineComparison, LintFinding,
-};
-use homeboy::git;
-use homeboy::refactor::{
-    auto::{self, AutofixMode},
-    run_lint_refactor, AppliedRefactor, LintSourceOptions,
-};
+use homeboy::extension::lint::{report, run_main_lint_workflow, LintCommandOutput, LintRunWorkflowArgs};
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
@@ -70,273 +61,43 @@ pub struct LintArgs {
     _json: HiddenJsonArgs,
 }
 
-#[derive(Serialize)]
-pub struct LintOutput {
-    status: String,
-    component: String,
-    exit_code: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    autofix: Option<AppliedRefactor>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    hints: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    baseline_comparison: Option<LintBaselineComparison>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    lint_findings: Option<Vec<LintFinding>>,
-}
-
-pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintOutput> {
+pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput> {
     let component = args.comp.load()?;
     let source_path = args.comp.source_path()?;
-    let lint_findings_file = temp::runtime_temp_file("homeboy-lint-findings", ".json")?;
-    // Resolve glob from --changed-only or --changed-since flags
-    let effective_glob = if args.changed_only {
-        let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
 
-        // Collect all changed files
-        let mut changed_files: Vec<String> = Vec::new();
-        changed_files.extend(uncommitted.staged);
-        changed_files.extend(uncommitted.unstaged);
-        changed_files.extend(uncommitted.untracked);
-
-        if changed_files.is_empty() {
-            println!("No files in working tree changes");
-            return Ok((
-                LintOutput {
-                    status: "passed".to_string(),
-                    component: args.comp.component,
-                    exit_code: 0,
-                    autofix: None,
-                    hints: None,
-                    baseline_comparison: None,
-                    lint_findings: None,
-                },
-                0,
-            ));
-        }
-
-        // Make paths absolute so lint runners can find files regardless of
-        // the shell's working directory (git status returns repo-relative paths)
-        let abs_files: Vec<String> = changed_files
-            .iter()
-            .map(|f| format!("{}/{}", component.local_path, f))
-            .collect();
-
-        // Pass ALL files to extension - let lint runner filter to relevant types
-        if abs_files.len() == 1 {
-            Some(abs_files[0].clone())
-        } else {
-            Some(format!("{{{}}}", abs_files.join(",")))
-        }
-    } else if let Some(ref git_ref) = args.changed_since {
-        let changed_files = git::get_files_changed_since(&component.local_path, git_ref)?;
-
-        if changed_files.is_empty() {
-            println!("No files changed since {}", git_ref);
-            return Ok((
-                LintOutput {
-                    status: "passed".to_string(),
-                    component: args.comp.component,
-                    exit_code: 0,
-                    autofix: None,
-                    hints: None,
-                    baseline_comparison: None,
-                    lint_findings: None,
-                },
-                0,
-            ));
-        }
-
-        // Make paths absolute (git diff returns repo-relative paths)
-        let abs_files: Vec<String> = changed_files
-            .iter()
-            .map(|f| format!("{}/{}", component.local_path, f))
-            .collect();
-
-        if abs_files.len() == 1 {
-            Some(abs_files[0].clone())
-        } else {
-            Some(format!("{{{}}}", abs_files.join(",")))
-        }
-    } else {
-        args.glob.clone()
-    };
-
-    let planned_autofix = if args.fix {
-        let changed_files = if args.changed_only {
-            let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
-            let mut changed_files: Vec<String> = Vec::new();
-            changed_files.extend(uncommitted.staged);
-            changed_files.extend(uncommitted.unstaged);
-            changed_files.extend(uncommitted.untracked);
-            Some(changed_files)
-        } else if let Some(ref git_ref) = args.changed_since {
-            Some(git::get_files_changed_since(
-                &component.local_path,
-                git_ref,
-            )?)
-        } else {
-            None
-        };
-
-        let plan = run_lint_refactor(
-            component.clone(),
-            source_path.clone(),
-            args.setting_args.setting.clone(),
-            LintSourceOptions {
-                selected_files: changed_files,
-                file: args.file.clone(),
-                glob: effective_glob.clone(),
-                errors_only: args.errors_only,
-                sniffs: args.sniffs.clone(),
-                exclude_sniffs: args.exclude_sniffs.clone(),
-                category: args.category.clone(),
-            },
-            true,
-        )?;
-
-        let outcome = auto::standard_outcome(
-            AutofixMode::Write,
-            plan.files_modified,
-            Some(format!("homeboy test {} --analyze", args.comp.component)),
-            plan.hints.clone(),
-        );
-
-        Some((plan, outcome))
-    } else {
-        None
-    };
-
-    let findings_file_str = lint_findings_file.to_string_lossy().to_string();
-    let output = extension_lint::build_lint_runner(
+    let workflow = run_main_lint_workflow(
         &component,
-        args.comp.path.clone(),
-        &args.setting_args.setting,
-        args.summary,
-        args.file.as_deref(),
-        effective_glob.as_deref(),
-        args.errors_only,
-        args.sniffs.as_deref(),
-        args.exclude_sniffs.as_deref(),
-        args.category.as_deref(),
-        &findings_file_str,
-    )?
-    .run()?;
-
-    let lint_findings = lint_baseline::parse_findings_file(&lint_findings_file)?;
-    let _ = std::fs::remove_file(&lint_findings_file);
-
-    let mut status = if output.success { "passed" } else { "failed" }.to_string();
-    let autofix = planned_autofix
-        .as_ref()
-        .map(|(plan, outcome)| AppliedRefactor::from_plan(plan, outcome.rerun_recommended));
-
-    let mut hints = Vec::new();
-
-    if let Some((plan, outcome)) = &planned_autofix {
-        if output.success && outcome.status == "auto_fixed" {
-            status = outcome.status.clone();
-        }
-
-        hints.extend(outcome.hints.clone());
-
-        if plan.files_modified == 0 && output.success {
-            status = "passed".to_string();
-        }
-    }
-
-    // Baseline lifecycle
-    let mut baseline_comparison = None;
-    let mut baseline_exit_override = None;
-
-    if args.baseline_args.baseline {
-        let saved = lint_baseline::save_baseline(&source_path, args.comp.id(), &lint_findings)?;
-        eprintln!(
-            "[lint] Baseline saved to {} ({} findings)",
-            saved.display(),
-            lint_findings.len()
-        );
-    }
-
-    if !args.baseline_args.baseline && !args.baseline_args.ignore_baseline {
-        if let Some(existing) = lint_baseline::load_baseline(&source_path) {
-            let comparison = lint_baseline::compare(&lint_findings, &existing);
-
-            if comparison.drift_increased {
-                eprintln!(
-                    "[lint] DRIFT INCREASED: {} new finding(s) since baseline",
-                    comparison.new_items.len()
-                );
-                baseline_exit_override = Some(1);
-            } else if !comparison.resolved_fingerprints.is_empty() {
-                eprintln!(
-                    "[lint] Drift reduced: {} finding(s) resolved since baseline",
-                    comparison.resolved_fingerprints.len()
-                );
-            } else {
-                eprintln!("[lint] No change from baseline");
-            }
-
-            baseline_comparison = Some(comparison);
-        }
-    }
-
-    // Fix hint when linting fails
-    if !output.success && !args.fix {
-        hints.push(format!(
-            "Run 'homeboy lint {} --fix' to auto-fix formatting issues",
-            args.comp.component
-        ));
-        hints.push("Some issues may require manual fixes".to_string());
-    }
-
-    // Capability hints when running component-wide lint (no targeting options used)
-    if args.file.is_none()
-        && args.glob.is_none()
-        && !args.changed_only
-        && args.changed_since.is_none()
-    {
-        hints.push(
-            "For targeted linting: --file <path>, --glob <pattern>, --changed-only, or --changed-since <ref>".to_string(),
-        );
-    }
-
-    // Always include docs reference
-    hints.push("Full options: homeboy docs commands/lint".to_string());
-
-    if !args.baseline_args.baseline && baseline_comparison.is_none() {
-        hints.push(format!(
-            "Save lint baseline: homeboy lint {} --baseline",
-            args.comp.component
-        ));
-    }
-
-    let hints = if hints.is_empty() { None } else { Some(hints) };
-    let exit_code = baseline_exit_override.unwrap_or(output.exit_code);
-    if exit_code != output.exit_code {
-        status = "failed".to_string();
-    }
-
-    Ok((
-        LintOutput {
-            status,
-            component: args.comp.component,
-            exit_code,
-            autofix,
-            hints,
-            baseline_comparison,
-            lint_findings: Some(lint_findings),
+        &PathBuf::from(&source_path),
+        LintRunWorkflowArgs {
+            component_label: args.comp.component.clone(),
+            component_id: args.comp.id().to_string(),
+            path_override: args.comp.path.clone(),
+            settings: args.setting_args.setting.clone(),
+            summary: args.summary,
+            file: args.file.clone(),
+            glob: args.glob.clone(),
+            changed_only: args.changed_only,
+            changed_since: args.changed_since.clone(),
+            errors_only: args.errors_only,
+            sniffs: args.sniffs.clone(),
+            exclude_sniffs: args.exclude_sniffs.clone(),
+            category: args.category.clone(),
+            fix: args.fix,
+            baseline: args.baseline_args.baseline,
+            ignore_baseline: args.baseline_args.ignore_baseline,
         },
-        exit_code,
-    ))
+    )?;
+
+    Ok(report::from_main_workflow(workflow))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use homeboy::component::Component;
+    use homeboy::extension::lint as extension_lint;
     use homeboy::extension::lint::baseline::{self as lint_baseline, LintFinding};
     use homeboy::refactor::lint_refactor_request;
+    use homeboy::refactor::LintSourceOptions;
     use std::path::Path;
 
     #[test]

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -166,7 +166,10 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             args.scaffold_file.as_deref(),
             args.write,
         )?;
-        return Ok(report::from_scaffold_workflow(result.component, result.output));
+        return Ok(report::from_scaffold_workflow(
+            result.component,
+            result.output,
+        ));
     }
 
     // Drift detection mode — delegate to core drift workflows

--- a/src/core/extension/lint/mod.rs
+++ b/src/core/extension/lint/mod.rs
@@ -1,9 +1,13 @@
 pub mod baseline;
+pub mod report;
+pub mod run;
 
 use crate::component::Component;
 use crate::extension::{ExtensionCapability, ExtensionExecutionContext, ExtensionRunner};
 
 pub use baseline::{BaselineComparison, LintBaseline, LintBaselineMetadata, LintFinding};
+pub use report::LintCommandOutput;
+pub use run::{run_main_lint_workflow, LintRunWorkflowArgs, LintRunWorkflowResult};
 
 pub fn resolve_lint_command(
     component: &Component,

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -1,0 +1,46 @@
+//! Lint command output builders — owns the unified lint output envelope.
+//!
+//! Mirrors `core/extension/test/report.rs` — the command layer calls a single
+//! builder function to convert a workflow result into the command output tuple.
+
+use crate::extension::lint::baseline::{BaselineComparison, LintFinding};
+use crate::refactor::AppliedRefactor;
+use serde::Serialize;
+
+use super::run::LintRunWorkflowResult;
+
+/// Unified output envelope for the lint command.
+///
+/// This is the single serialization target. The workflow populates relevant
+/// fields; unused fields are `None` and skipped in serialization.
+#[derive(Serialize)]
+pub struct LintCommandOutput {
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autofix: Option<AppliedRefactor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<BaselineComparison>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lint_findings: Option<Vec<LintFinding>>,
+}
+
+/// Build output from a main lint workflow result.
+pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, i32) {
+    let exit_code = result.exit_code;
+    (
+        LintCommandOutput {
+            status: result.status,
+            component: result.component,
+            exit_code: result.exit_code,
+            autofix: result.autofix,
+            hints: result.hints,
+            baseline_comparison: result.baseline_comparison,
+            lint_findings: result.lint_findings,
+        },
+        exit_code,
+    )
+}

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -78,7 +78,12 @@ pub fn run_main_lint_workflow(
 
     // Autofix planning (--fix)
     let planned_autofix = if args.fix {
-        Some(plan_autofix(component, source_path, &args, effective_glob.as_deref())?)
+        Some(plan_autofix(
+            component,
+            source_path,
+            &args,
+            effective_glob.as_deref(),
+        )?)
     } else {
         None
     };
@@ -285,8 +290,7 @@ fn process_baseline(
     let mut baseline_exit_override = None;
 
     if args.baseline {
-        let saved =
-            lint_baseline::save_baseline(source_path, &args.component_id, lint_findings)?;
+        let saved = lint_baseline::save_baseline(source_path, &args.component_id, lint_findings)?;
         eprintln!(
             "[lint] Baseline saved to {} ({} findings)",
             saved.display(),

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -1,0 +1,321 @@
+//! Lint workflow orchestration — runs lint, resolves changed-file scoping,
+//! drives autofix, processes baseline lifecycle, and assembles results.
+//!
+//! Mirrors `core/extension/test/run.rs` — the command layer provides CLI args,
+//! this module owns all business logic and returns a structured result.
+
+use crate::component::Component;
+use crate::engine::temp;
+use crate::extension::lint::baseline::{self as lint_baseline, LintFinding};
+use crate::extension::lint::build_lint_runner;
+use crate::git;
+use crate::refactor::{
+    auto::{self, AutofixMode},
+    run_lint_refactor, AppliedRefactor, LintSourceOptions,
+};
+use serde::Serialize;
+use std::path::PathBuf;
+
+/// Arguments for the main lint workflow — populated by the command layer from CLI flags.
+#[derive(Debug, Clone)]
+pub struct LintRunWorkflowArgs {
+    pub component_label: String,
+    pub component_id: String,
+    pub path_override: Option<String>,
+    pub settings: Vec<(String, String)>,
+    pub summary: bool,
+    pub file: Option<String>,
+    pub glob: Option<String>,
+    pub changed_only: bool,
+    pub changed_since: Option<String>,
+    pub errors_only: bool,
+    pub sniffs: Option<String>,
+    pub exclude_sniffs: Option<String>,
+    pub category: Option<String>,
+    pub fix: bool,
+    pub baseline: bool,
+    pub ignore_baseline: bool,
+}
+
+/// Result of the main lint workflow — ready for report assembly.
+#[derive(Debug, Clone, Serialize)]
+pub struct LintRunWorkflowResult {
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    pub autofix: Option<AppliedRefactor>,
+    pub hints: Option<Vec<String>>,
+    pub baseline_comparison: Option<lint_baseline::BaselineComparison>,
+    pub lint_findings: Option<Vec<LintFinding>>,
+}
+
+/// Run the main lint workflow.
+///
+/// Handles changed-file scoping, autofix planning, lint runner execution,
+/// baseline lifecycle, hint assembly, and result construction.
+pub fn run_main_lint_workflow(
+    component: &Component,
+    source_path: &PathBuf,
+    args: LintRunWorkflowArgs,
+) -> crate::Result<LintRunWorkflowResult> {
+    // Resolve effective glob from --changed-only or --changed-since flags
+    let effective_glob = resolve_effective_glob(component, &args)?;
+
+    // Early exit if changed-file mode produced no files
+    if let Some(ref glob_val) = effective_glob {
+        if glob_val.is_empty() {
+            return Ok(LintRunWorkflowResult {
+                status: "passed".to_string(),
+                component: args.component_label,
+                exit_code: 0,
+                autofix: None,
+                hints: None,
+                baseline_comparison: None,
+                lint_findings: None,
+            });
+        }
+    }
+
+    // Autofix planning (--fix)
+    let planned_autofix = if args.fix {
+        Some(plan_autofix(component, source_path, &args, effective_glob.as_deref())?)
+    } else {
+        None
+    };
+
+    // Run lint
+    let lint_findings_file = temp::runtime_temp_file("homeboy-lint-findings", ".json")?;
+    let findings_file_str = lint_findings_file.to_string_lossy().to_string();
+
+    let output = build_lint_runner(
+        component,
+        args.path_override.clone(),
+        &args.settings,
+        args.summary,
+        args.file.as_deref(),
+        effective_glob.as_deref(),
+        args.errors_only,
+        args.sniffs.as_deref(),
+        args.exclude_sniffs.as_deref(),
+        args.category.as_deref(),
+        &findings_file_str,
+    )?
+    .run()?;
+
+    let lint_findings = lint_baseline::parse_findings_file(&lint_findings_file)?;
+    let _ = std::fs::remove_file(&lint_findings_file);
+
+    // Status computation
+    let mut status = if output.success { "passed" } else { "failed" }.to_string();
+    let autofix = planned_autofix
+        .as_ref()
+        .map(|(plan, outcome)| AppliedRefactor::from_plan(plan, outcome.rerun_recommended));
+
+    let mut hints = Vec::new();
+
+    if let Some((plan, outcome)) = &planned_autofix {
+        if output.success && outcome.status == "auto_fixed" {
+            status = outcome.status.clone();
+        }
+        hints.extend(outcome.hints.clone());
+        if plan.files_modified == 0 && output.success {
+            status = "passed".to_string();
+        }
+    }
+
+    // Baseline lifecycle
+    let (baseline_comparison, baseline_exit_override) =
+        process_baseline(source_path, &args, &lint_findings)?;
+
+    // Hint assembly
+    if !output.success && !args.fix {
+        hints.push(format!(
+            "Run 'homeboy lint {} --fix' to auto-fix formatting issues",
+            args.component_label
+        ));
+        hints.push("Some issues may require manual fixes".to_string());
+    }
+
+    if args.file.is_none()
+        && args.glob.is_none()
+        && !args.changed_only
+        && args.changed_since.is_none()
+    {
+        hints.push(
+            "For targeted linting: --file <path>, --glob <pattern>, --changed-only, or --changed-since <ref>".to_string(),
+        );
+    }
+
+    hints.push("Full options: homeboy docs commands/lint".to_string());
+
+    if !args.baseline && baseline_comparison.is_none() {
+        hints.push(format!(
+            "Save lint baseline: homeboy lint {} --baseline",
+            args.component_label
+        ));
+    }
+
+    let hints = if hints.is_empty() { None } else { Some(hints) };
+    let exit_code = baseline_exit_override.unwrap_or(output.exit_code);
+    if exit_code != output.exit_code {
+        status = "failed".to_string();
+    }
+
+    Ok(LintRunWorkflowResult {
+        status,
+        component: args.component_label,
+        exit_code,
+        autofix,
+        hints,
+        baseline_comparison,
+        lint_findings: Some(lint_findings),
+    })
+}
+
+/// Resolve effective glob from --changed-only or --changed-since flags.
+///
+/// Returns `Some("")` (empty string) when changed-file mode is active but no files
+/// were found — the caller should treat this as an early "passed" exit.
+/// Returns `None` when no changed-file scoping is active (use args.glob directly).
+fn resolve_effective_glob(
+    component: &Component,
+    args: &LintRunWorkflowArgs,
+) -> crate::Result<Option<String>> {
+    if args.changed_only {
+        let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
+        let mut changed_files: Vec<String> = Vec::new();
+        changed_files.extend(uncommitted.staged);
+        changed_files.extend(uncommitted.unstaged);
+        changed_files.extend(uncommitted.untracked);
+
+        if changed_files.is_empty() {
+            println!("No files in working tree changes");
+            return Ok(Some(String::new()));
+        }
+
+        let abs_files: Vec<String> = changed_files
+            .iter()
+            .map(|f| format!("{}/{}", component.local_path, f))
+            .collect();
+
+        if abs_files.len() == 1 {
+            Ok(Some(abs_files[0].clone()))
+        } else {
+            Ok(Some(format!("{{{}}}", abs_files.join(","))))
+        }
+    } else if let Some(ref git_ref) = args.changed_since {
+        let changed_files = git::get_files_changed_since(&component.local_path, git_ref)?;
+
+        if changed_files.is_empty() {
+            println!("No files changed since {}", git_ref);
+            return Ok(Some(String::new()));
+        }
+
+        let abs_files: Vec<String> = changed_files
+            .iter()
+            .map(|f| format!("{}/{}", component.local_path, f))
+            .collect();
+
+        if abs_files.len() == 1 {
+            Ok(Some(abs_files[0].clone()))
+        } else {
+            Ok(Some(format!("{{{}}}", abs_files.join(","))))
+        }
+    } else {
+        Ok(args.glob.clone())
+    }
+}
+
+/// Plan autofix — run lint refactor in write mode, produce outcome.
+fn plan_autofix(
+    component: &Component,
+    source_path: &PathBuf,
+    args: &LintRunWorkflowArgs,
+    effective_glob: Option<&str>,
+) -> crate::Result<(crate::refactor::RefactorPlan, auto::AutofixOutcome)> {
+    let changed_files = if args.changed_only {
+        let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
+        let mut changed_files: Vec<String> = Vec::new();
+        changed_files.extend(uncommitted.staged);
+        changed_files.extend(uncommitted.unstaged);
+        changed_files.extend(uncommitted.untracked);
+        Some(changed_files)
+    } else if let Some(ref git_ref) = args.changed_since {
+        Some(git::get_files_changed_since(
+            &component.local_path,
+            git_ref,
+        )?)
+    } else {
+        None
+    };
+
+    let plan = run_lint_refactor(
+        component.clone(),
+        source_path.clone(),
+        args.settings.clone(),
+        LintSourceOptions {
+            selected_files: changed_files,
+            file: args.file.clone(),
+            glob: effective_glob.map(String::from),
+            errors_only: args.errors_only,
+            sniffs: args.sniffs.clone(),
+            exclude_sniffs: args.exclude_sniffs.clone(),
+            category: args.category.clone(),
+        },
+        true,
+    )?;
+
+    let outcome = auto::standard_outcome(
+        AutofixMode::Write,
+        plan.files_modified,
+        Some(format!("homeboy test {} --analyze", args.component_label)),
+        plan.hints.clone(),
+    );
+
+    Ok((plan, outcome))
+}
+
+/// Process baseline lifecycle — save, load, compare.
+fn process_baseline(
+    source_path: &PathBuf,
+    args: &LintRunWorkflowArgs,
+    lint_findings: &[LintFinding],
+) -> crate::Result<(Option<lint_baseline::BaselineComparison>, Option<i32>)> {
+    let mut baseline_comparison = None;
+    let mut baseline_exit_override = None;
+
+    if args.baseline {
+        let saved =
+            lint_baseline::save_baseline(source_path, &args.component_id, lint_findings)?;
+        eprintln!(
+            "[lint] Baseline saved to {} ({} findings)",
+            saved.display(),
+            lint_findings.len()
+        );
+    }
+
+    if !args.baseline && !args.ignore_baseline {
+        if let Some(existing) = lint_baseline::load_baseline(source_path) {
+            let comparison = lint_baseline::compare(lint_findings, &existing);
+
+            if comparison.drift_increased {
+                eprintln!(
+                    "[lint] DRIFT INCREASED: {} new finding(s) since baseline",
+                    comparison.new_items.len()
+                );
+                baseline_exit_override = Some(1);
+            } else if !comparison.resolved_fingerprints.is_empty() {
+                eprintln!(
+                    "[lint] Drift reduced: {} finding(s) resolved since baseline",
+                    comparison.resolved_fingerprints.len()
+                );
+            } else {
+                eprintln!("[lint] No change from baseline");
+            }
+
+            baseline_comparison = Some(comparison);
+        }
+    }
+
+    Ok((baseline_comparison, baseline_exit_override))
+}

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -93,10 +93,16 @@ pub fn build_test_runner(
     Ok(runner)
 }
 
-pub fn compute_changed_test_scope(
+/// Compute which test files are impacted by changes since a git ref.
+///
+/// Combines two sources: (1) changed files that are test paths, and
+/// (2) test files flagged by drift detection as needing re-runs.
+/// This is the single source of truth — used by test scope, refactor
+/// planning, and verification smoke tests.
+pub fn compute_changed_test_files(
     component: &Component,
     git_ref: &str,
-) -> crate::error::Result<TestScopeOutput> {
+) -> crate::error::Result<Vec<String>> {
     let source_path = {
         let expanded = shellexpand::tilde(&component.local_path);
         PathBuf::from(expanded.as_ref())
@@ -123,7 +129,18 @@ pub fn compute_changed_test_scope(
         selected.insert(drifted.test_file.clone());
     }
 
-    let selected_files: Vec<String> = selected.into_iter().collect();
+    Ok(selected.into_iter().collect())
+}
+
+/// Compute changed test scope with metadata for command-layer output.
+///
+/// Wraps [`compute_changed_test_files`] with the `TestScopeOutput` envelope
+/// that the test command uses for JSON output.
+pub fn compute_changed_test_scope(
+    component: &Component,
+    git_ref: &str,
+) -> crate::error::Result<TestScopeOutput> {
+    let selected_files = compute_changed_test_files(component, git_ref)?;
 
     Ok(TestScopeOutput {
         mode: "changed".to_string(),

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -5,15 +5,15 @@
 //! envelope and builder functions that assemble results into command-ready output.
 
 use crate::extension::test::{
-    CoverageOutput, DriftReport, TestAnalysis, TestBaselineComparison, TestCounts,
-    TestScopeOutput, TestSummaryOutput,
+    CoverageOutput, DriftReport, TestAnalysis, TestBaselineComparison, TestCounts, TestScopeOutput,
+    TestSummaryOutput,
 };
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
 
+use super::run::TestRunWorkflowResult;
 use super::scaffold::ScaffoldOutput;
 use super::workflow::{AutoFixDriftOutput, AutoFixDriftWorkflowResult, DriftWorkflowResult};
-use super::run::TestRunWorkflowResult;
 
 /// Unified output envelope for all test command modes.
 ///
@@ -97,9 +97,16 @@ pub fn from_drift_workflow(result: DriftWorkflowResult) -> (TestCommandOutput, i
 }
 
 /// Build output from an auto-fix drift workflow result.
-pub fn from_auto_fix_drift_workflow(result: AutoFixDriftWorkflowResult) -> (TestCommandOutput, i32) {
+pub fn from_auto_fix_drift_workflow(
+    result: AutoFixDriftWorkflowResult,
+) -> (TestCommandOutput, i32) {
     let status = if result.output.replacements > 0 || !result.hints.is_empty() {
-        if result.output.written { "fixed" } else { "planned" }.to_string()
+        if result.output.written {
+            "fixed"
+        } else {
+            "planned"
+        }
+        .to_string()
     } else {
         "passed".to_string()
     };

--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -1,8 +1,7 @@
-use crate::code_audit::is_test_path;
 use crate::component::Component;
 use crate::engine::temp;
 use crate::extension;
-use crate::extension::test::drift::{detect_drift, DriftOptions};
+use crate::extension::test::compute_changed_test_files;
 use crate::git;
 use crate::refactor::auto as fixer;
 use crate::refactor::auto::{self, FixApplied, FixResultsSummary};
@@ -402,32 +401,6 @@ fn collect_fix_proposals(stages: &[PlannedStage]) -> Vec<FixProposal> {
     });
 
     proposals
-}
-
-fn compute_changed_test_files(component: &Component, git_ref: &str) -> crate::Result<Vec<String>> {
-    let source_path = std::path::PathBuf::from(shellexpand::tilde(&component.local_path).as_ref());
-    let changed_files = git::get_files_changed_since(&source_path.to_string_lossy(), git_ref)?;
-
-    let opts = if source_path.join("Cargo.toml").exists() {
-        DriftOptions::rust(&source_path, git_ref)
-    } else {
-        DriftOptions::php(&source_path, git_ref)
-    };
-
-    let report = detect_drift(&component.id, &opts)?;
-    let mut selected: BTreeSet<String> = BTreeSet::new();
-
-    for file in &changed_files {
-        if is_test_path(file) {
-            selected.insert(file.clone());
-        }
-    }
-
-    for drifted in &report.drifted_tests {
-        selected.insert(drifted.test_file.clone());
-    }
-
-    Ok(selected.into_iter().collect())
 }
 
 fn collect_stage_changed_files(stages: &[PlanStageSummary]) -> Vec<String> {

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -1,12 +1,12 @@
-use crate::code_audit::{self, is_test_path, CodeAuditResult};
+use crate::code_audit::{self, CodeAuditResult};
 use crate::component::{self, Component};
 use crate::engine::temp;
-use crate::extension::test::drift::{detect_drift, DriftOptions};
+use crate::extension::test::compute_changed_test_files;
 use crate::extension::{lint as extension_lint, test as extension_test};
 use crate::refactor::auto as fixer;
 use crate::undo::UndoSnapshot;
 use serde::Serialize;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 pub use crate::code_audit::{
@@ -343,33 +343,6 @@ fn build_test_smoke_verifier<'a>(
             Err("test smoke failed".to_string())
         }
     })
-}
-
-fn compute_changed_test_files(component: &Component, git_ref: &str) -> crate::Result<Vec<String>> {
-    let source_path = PathBuf::from(shellexpand::tilde(&component.local_path).as_ref());
-    let changed_files =
-        crate::git::get_files_changed_since(&source_path.to_string_lossy(), git_ref)?;
-
-    let opts = if source_path.join("Cargo.toml").exists() {
-        DriftOptions::rust(&source_path, git_ref)
-    } else {
-        DriftOptions::php(&source_path, git_ref)
-    };
-
-    let report = detect_drift(&component.id, &opts)?;
-    let mut selected: BTreeSet<String> = BTreeSet::new();
-
-    for file in &changed_files {
-        if is_test_path(file) {
-            selected.insert(file.clone());
-        }
-    }
-
-    for drifted in &report.drifted_tests {
-        selected.insert(drifted.test_file.clone());
-    }
-
-    Ok(selected.into_iter().collect())
 }
 
 fn run_fix_iteration(


### PR DESCRIPTION
## Summary

Continues the architecture refactor (following PR #727) — thins `commands/lint.rs` by extracting all orchestration logic into `core/extension/lint/`.

- **`core/extension/lint/run.rs`** — owns the main lint workflow: changed-file scoping (`--changed-only`, `--changed-since`), autofix planning (`--fix`), lint runner execution, baseline lifecycle (save/load/compare), hint assembly, and result construction
- **`core/extension/lint/report.rs`** — unified output envelope (`LintCommandOutput`) with `from_main_workflow()` builder, matching the test command pattern
- **`commands/lint.rs`** — now pure CLI glue: clap args + thin `run()` that delegates to `run_main_lint_workflow()` + report builder

### Line counts

| File | Before | After |
|------|--------|-------|
| `commands/lint.rs` | 431 | 191 |
| `core/extension/lint/run.rs` | — | 321 |
| `core/extension/lint/report.rs` | — | 46 |
| `core/extension/lint/mod.rs` | 46 | 49 |

**56% reduction** in the command layer. All 6 lint tests pass. `cargo check` clean.

### Pattern

Follows the same extraction pattern as the test command thinning in PR #727:
- `LintRunWorkflowArgs` struct for all workflow inputs (populated by command layer from clap)
- `LintRunWorkflowResult` struct for all workflow outputs (consumed by report builder)
- `from_main_workflow()` builder converts result → `(LintCommandOutput, i32)` tuple for dispatch