### PR TITLE
refactor: move ssh module into server/

### DIFF
--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, Result};
-use crate::server::Server;
 use crate::engine::shell;
+
+use super::Server;
 use std::process::{Command, Stdio};
 
 pub struct SshClient {

--- a/src/core/server/connection.rs
+++ b/src/core/server/connection.rs
@@ -1,10 +1,7 @@
-mod client;
-
-pub use client::*;
-
 use crate::error::{Error, Result};
 use crate::project::{self, Project};
-use crate::server::{self, Server};
+
+use super::Server;
 
 /// Arguments for SSH context resolution
 #[derive(Default)]
@@ -88,7 +85,7 @@ fn resolve_internal(
 
     // --server flag: force server resolution
     if let Some(server_id) = &args.server {
-        let server = server::load(server_id)?;
+        let server = super::load(server_id)?;
         return Ok(("server".to_string(), None, server_id.clone(), server, None));
     }
 
@@ -107,7 +104,7 @@ fn resolve_internal(
         ));
     }
 
-    if let Ok(server) = server::load(id) {
+    if let Ok(server) = super::load(id) {
         return Ok(("server".to_string(), None, id.clone(), server, None));
     }
 
@@ -128,6 +125,6 @@ fn resolve_from_project(project: &Project) -> Result<(String, Server)> {
             None,
         )
     })?;
-    let server = server::load(&server_id)?;
+    let server = super::load(&server_id)?;
     Ok((server_id, server))
 }

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -1,6 +1,10 @@
 mod keys;
+mod client;
+mod connection;
 
 pub use keys::*;
+pub use client::*;
+pub use connection::*;
 
 use crate::config::{self, ConfigEntity};
 use crate::error::{Error, Result};

--- a/src/core/ssh.rs
+++ b/src/core/ssh.rs
@@ -1,0 +1,7 @@
+//! Re-exports from server module for backward compatibility.
+//!
+//! SSH client, connection resolution, and local command execution
+//! now live in `core::server`. This module re-exports them so existing
+//! `use crate::ssh::*` imports continue to work.
+
+pub use crate::server::*;


### PR DESCRIPTION
## Summary
- Moves `ssh/client.rs` → `server/client.rs` (SSH client, local command execution)
- Moves `ssh/mod.rs` → `server/connection.rs` (SSH context resolution)
- `server/mod.rs` re-exports everything via `pub use client::*` and `pub use connection::*`
- Thin `ssh.rs` stub re-exports from `server` for backward compat — all existing `use crate::ssh::*` imports unchanged
- Compiles clean, 725 tests pass (same 4 pre-existing failures)