### PR TITLE
refactor: convert upgrade from include!() fragments to proper modules

### DIFF
--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -1,3 +1,10 @@
+use crate::defaults;
+use crate::error::{Error, Result};
+use std::process::Command;
+
+use super::helpers::fetch_latest_version;
+use super::types::InstallMethod;
+
 pub(crate) fn execute_upgrade(method: InstallMethod) -> Result<(bool, Option<String>)> {
     let defaults = defaults::load_defaults();
 

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -1,3 +1,13 @@
+use crate::defaults;
+use crate::error::{Error, Result};
+use std::process::Command;
+
+use super::constants::{CRATES_IO_API, GITHUB_RELEASES_API, VERSION};
+use super::execution::execute_upgrade;
+use super::planning::resolve_binary_on_path;
+use super::types::*;
+use super::validation::check_for_updates;
+
 pub fn current_version() -> &'static str {
     VERSION
 }
@@ -256,6 +266,11 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
     }
 
     (updated, skipped)
+}
+
+#[cfg(not(unix))]
+pub fn restart_with_new_binary() {
+    log_status!("upgrade", "Please restart homeboy to use the new version.");
 }
 
 #[cfg(unix)]

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -1,16 +1,18 @@
-use crate::defaults;
-use crate::error::{Error, Result};
-use serde::{Deserialize, Serialize};
-use std::process::Command;
-
-include!("upgrade/types.rs");
-include!("upgrade/constants.rs");
-include!("upgrade/helpers.rs");
-include!("upgrade/planning.rs");
-include!("upgrade/execution.rs");
-include!("upgrade/validation.rs");
-
+mod types;
+mod constants;
+mod helpers;
+mod planning;
+mod execution;
+mod validation;
 pub mod update_check;
+
+pub use types::*;
+pub use helpers::{
+    current_version, detect_install_method, fetch_latest_version,
+    restart_with_new_binary, run_upgrade_with_method,
+};
+pub use planning::resolve_binary_on_path;
+pub use validation::check_for_updates;
 
 impl InstallMethod {
     pub fn as_str(&self) -> &'static str {
@@ -24,12 +26,6 @@ impl InstallMethod {
     }
 }
 
-#[cfg(not(unix))]
-pub fn restart_with_new_binary() {
-    // On Windows, just print a message
-    log_status!("upgrade", "Please restart homeboy to use the new version.");
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -38,11 +34,11 @@ mod tests {
 
     #[test]
     fn test_version_comparison() {
-        assert!(version_is_newer("0.12.0", "0.11.0"));
-        assert!(version_is_newer("1.0.0", "0.99.99"));
-        assert!(version_is_newer("0.11.1", "0.11.0"));
-        assert!(!version_is_newer("0.11.0", "0.11.0"));
-        assert!(!version_is_newer("0.10.0", "0.11.0"));
+        assert!(helpers::version_is_newer("0.12.0", "0.11.0"));
+        assert!(helpers::version_is_newer("1.0.0", "0.99.99"));
+        assert!(helpers::version_is_newer("0.11.1", "0.11.0"));
+        assert!(!helpers::version_is_newer("0.11.0", "0.11.0"));
+        assert!(!helpers::version_is_newer("0.10.0", "0.11.0"));
     }
 
     #[test]
@@ -71,7 +67,7 @@ mod tests {
         fs::write(second.join("homeboy"), "#!/bin/sh\n").unwrap();
 
         let path_var = format!("{}:{}", first.display(), second.display());
-        let found = resolve_binary_on_path_var(&path_var).unwrap();
+        let found = planning::resolve_binary_on_path_var(&path_var).unwrap();
         assert_eq!(found, second.join("homeboy"));
     }
 
@@ -84,7 +80,7 @@ mod tests {
         fs::create_dir_all(&second).unwrap();
 
         let path_var = format!("{}:{}", first.display(), second.display());
-        let found = resolve_binary_on_path_var(&path_var);
+        let found = planning::resolve_binary_on_path_var(&path_var);
         assert!(found.is_none());
     }
 }

--- a/src/core/upgrade/planning.rs
+++ b/src/core/upgrade/planning.rs
@@ -1,12 +1,12 @@
 /// Resolve the `homeboy` binary via $PATH, returning the first match that
 /// exists on disk. This avoids the stale `/proc/self/exe` problem on Linux
 /// where the old inode is deleted after the upgrade replaces the binary.
-pub(crate) fn resolve_binary_on_path() -> Option<std::path::PathBuf> {
+pub fn resolve_binary_on_path() -> Option<std::path::PathBuf> {
     let path_var = std::env::var("PATH").ok()?;
     resolve_binary_on_path_var(&path_var)
 }
 
-pub(crate) fn resolve_binary_on_path_var(path_var: &str) -> Option<std::path::PathBuf> {
+pub fn resolve_binary_on_path_var(path_var: &str) -> Option<std::path::PathBuf> {
     for dir in path_var.split(':') {
         let candidate = std::path::PathBuf::from(dir).join("homeboy");
         if candidate.exists() {

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InstallMethod {
@@ -43,17 +45,17 @@ pub struct ExtensionUpgradeEntry {
 }
 
 #[derive(Deserialize)]
-pub(crate) struct CratesIoResponse {
+pub(super) struct CratesIoResponse {
     #[serde(rename = "crate")]
-    crate_info: CrateInfo,
+    pub(super) crate_info: CrateInfo,
 }
 
 #[derive(Deserialize)]
-pub(crate) struct CrateInfo {
-    newest_version: String,
+pub(super) struct CrateInfo {
+    pub(super) newest_version: String,
 }
 
 #[derive(Deserialize)]
-pub(crate) struct GitHubRelease {
-    tag_name: String,
+pub(super) struct GitHubRelease {
+    pub(super) tag_name: String,
 }

--- a/src/core/upgrade/validation.rs
+++ b/src/core/upgrade/validation.rs
@@ -1,3 +1,8 @@
+use crate::error::Result;
+
+use super::helpers::{current_version, detect_install_method, fetch_latest_version, version_is_newer};
+use super::types::VersionCheck;
+
 pub fn check_for_updates() -> Result<VersionCheck> {
     let install_method = detect_install_method();
     let current = current_version().to_string();


### PR DESCRIPTION
## Summary
- Replaces `upgrade.rs` with `upgrade/mod.rs` using real `mod` declarations instead of `include!()` hack
- Each fragment file now has its own imports and compiles independently
- Public API unchanged — all exports preserved
- 725 tests pass (same 4 pre-existing failures)