### PR TITLE
Fix: prune stale refactor sandbox directories on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +756,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "filetime",
  "glob",
  "glob-match",
  "heck",
@@ -1113,7 +1125,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1377,7 +1392,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1428,6 +1443,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -1613,6 +1634,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ toml = "1.0.3"
 sha2 = "0.10.9"
 
 [dev-dependencies]
+filetime = "0.2"
 tempfile = "3.14"
 
 [profile.dist]

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -2,9 +2,16 @@ use crate::error::{Error, Result};
 use crate::paths;
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 const HOMEBOY_RUNTIME_TMPDIR_ENV: &str = "HOMEBOY_RUNTIME_TMPDIR";
+
+/// Maximum age for sandbox directories before they are pruned (1 hour).
+const STALE_SANDBOX_MAX_AGE: Duration = Duration::from_secs(3600);
+
+/// Prefix used by refactor sandbox directories.
+const SANDBOX_PREFIX: &str = "homeboy-refactor-ci-";
 
 fn runtime_root() -> Result<PathBuf> {
     if let Ok(override_dir) = env::var(HOMEBOY_RUNTIME_TMPDIR_ENV) {
@@ -25,7 +32,51 @@ pub fn ensure_runtime_tmp_dir() -> Result<PathBuf> {
             Some("create homeboy runtime tmp directory".to_string()),
         )
     })?;
+
+    // Prune stale sandbox directories left behind by killed processes.
+    prune_stale_sandboxes(&runtime_dir);
+
     Ok(runtime_dir)
+}
+
+/// Remove sandbox directories older than `STALE_SANDBOX_MAX_AGE`.
+///
+/// Sandboxes are created by `SandboxDir` (refactor pipeline) and normally
+/// cleaned up by its `Drop` impl. When the process is killed by a signal
+/// (SIGKILL, SIGTERM, Ctrl+C), `Drop` never fires and directories accumulate.
+/// This sweeper runs on the next `ensure_runtime_tmp_dir()` call and prunes
+/// any orphans.
+fn prune_stale_sandboxes(runtime_dir: &Path) {
+    let now = SystemTime::now();
+
+    let entries = match fs::read_dir(runtime_dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if !name_str.starts_with(SANDBOX_PREFIX) {
+            continue;
+        }
+
+        if !entry.path().is_dir() {
+            continue;
+        }
+
+        let is_stale = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|age| age > STALE_SANDBOX_MAX_AGE);
+
+        if is_stale {
+            let _ = fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 pub fn runtime_temp_file(prefix: &str, suffix: &str) -> Result<PathBuf> {
@@ -95,5 +146,53 @@ mod tests {
         unsafe {
             env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
         }
+    }
+
+    #[test]
+    fn prune_removes_stale_sandbox_dirs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        // Create a "stale" sandbox directory and backdate its mtime.
+        let stale = tmp.path().join("homeboy-refactor-ci-aaaa-1111");
+        fs::create_dir(&stale).expect("create stale dir");
+        let two_hours_ago = SystemTime::now() - Duration::from_secs(7200);
+        filetime::set_file_mtime(&stale, filetime::FileTime::from_system_time(two_hours_ago))
+            .expect("set mtime");
+
+        // Create a "fresh" sandbox directory (just created, mtime = now).
+        let fresh = tmp.path().join("homeboy-refactor-ci-bbbb-2222");
+        fs::create_dir(&fresh).expect("create fresh dir");
+
+        // Create a non-sandbox directory that should be left alone.
+        let other = tmp.path().join("some-other-dir");
+        fs::create_dir(&other).expect("create other dir");
+
+        prune_stale_sandboxes(tmp.path());
+
+        assert!(!stale.exists(), "stale sandbox should be removed");
+        assert!(fresh.exists(), "fresh sandbox should be kept");
+        assert!(other.exists(), "non-sandbox dir should be untouched");
+    }
+
+    #[test]
+    fn prune_ignores_non_directory_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        // Create a file (not a directory) with the sandbox prefix.
+        let file_path = tmp.path().join("homeboy-refactor-ci-file-3333");
+        fs::write(&file_path, "not a dir").expect("write file");
+        let two_hours_ago = SystemTime::now() - Duration::from_secs(7200);
+        filetime::set_file_mtime(
+            &file_path,
+            filetime::FileTime::from_system_time(two_hours_ago),
+        )
+        .expect("set mtime");
+
+        prune_stale_sandboxes(tmp.path());
+
+        assert!(
+            file_path.exists(),
+            "non-directory file should not be removed"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds a startup sweeper that removes orphaned `homeboy-refactor-ci-*` sandbox directories older than 1 hour
- Sandboxes have a `Drop` guard, but it doesn't fire on SIGKILL/SIGTERM/Ctrl+C — causing directories to accumulate indefinitely
- Found **47G of stale sandboxes** filling a 75G disk to 100% on the VPS

## Changes

| File | Change |
|------|--------|
| `src/core/engine/temp.rs` | Added `prune_stale_sandboxes()` called from `ensure_runtime_tmp_dir()` |
| `Cargo.toml` | Added `filetime` dev-dependency for mtime manipulation in tests |

## How it works

```
ensure_runtime_tmp_dir()
  ├── create dir if needed
  └── prune_stale_sandboxes()
       ├── scan for homeboy-refactor-ci-* directories
       ├── check mtime > 1 hour
       └── remove_dir_all() on stale ones
```

The sweeper runs every time a new sandbox is about to be created. It silently ignores errors (best-effort cleanup).

## Tests

- `prune_removes_stale_sandbox_dirs` — verifies stale dirs are removed, fresh dirs kept, non-sandbox dirs untouched
- `prune_ignores_non_directory_files` — verifies files with the sandbox prefix are not removed

Closes #755