### PR TITLE
Fix: eliminate orphaned_internal false positives

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,8 +3,8 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-03-14T20:31:39Z",
-      "item_count": 864,
+      "created_at": "2026-03-14T21:13:18Z",
+      "item_count": 861,
       "known_fingerprints": [
         "Commands::src/commands/auth.rs::NamespaceMismatch",
         "Commands::src/commands/build.rs::MissingMethod",
@@ -14,16 +14,14 @@
         "Commands::src/commands/deploy.rs::MissingMethod",
         "Commands::src/commands/docs.rs::NamespaceMismatch",
         "Commands::src/commands/extension.rs::MissingMethod",
-        "Undo::src/core/undo/snapshot.rs::SignatureMismatch",
+        "Undo::src/core/undo/rollback.rs::SignatureMismatch",
         "dead_code::src/commands/changelog.rs::UnreferencedExport",
         "dead_code::src/commands/docs.rs::UnreferencedExport",
-        "dead_code::src/commands/file.rs::OrphanedInternal",
         "dead_code::src/commands/file.rs::UnreferencedExport",
         "dead_code::src/commands/logs.rs::UnreferencedExport",
         "dead_code::src/commands/test_scope.rs::DeadCodeMarker",
         "dead_code::src/commands/test_scope.rs::DeadCodeMarker",
         "dead_code::src/commands/utils/entity_suggest.rs::UnreferencedExport",
-        "dead_code::src/core/code_audit/core_fingerprint.rs::OrphanedInternal",
         "dead_code::src/core/code_audit/core_fingerprint.rs::UnreferencedExport",
         "dead_code::src/core/code_audit/core_fingerprint.rs::UnreferencedExport",
         "dead_code::src/core/code_audit/core_fingerprint.rs::UnusedParameter",
@@ -64,7 +62,6 @@
         "dead_code::src/core/git/commits.rs::UnreferencedExport",
         "dead_code::src/core/git/commits.rs::UnreferencedExport",
         "dead_code::src/core/git/primitives.rs::UnreferencedExport",
-        "dead_code::src/core/local_files.rs::OrphanedInternal",
         "dead_code::src/core/paths.rs::UnreferencedExport",
         "dead_code::src/core/permissions.rs::UnreferencedExport",
         "dead_code::src/core/project/component/attachments.rs::UnreferencedExport",
@@ -882,7 +879,7 @@
           "src/commands/changelog.rs",
           "src/commands/deploy.rs",
           "src/commands/component.rs",
-          "src/core/undo/snapshot.rs"
+          "src/core/undo/rollback.rs"
         ],
         "outliers_count": 9
       }

--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -382,6 +382,13 @@ pub fn fingerprint_from_grammar(
         .into_iter()
         .collect();
 
+    // --- Trait impl methods ---
+    let trait_impl_methods: Vec<String> = functions
+        .iter()
+        .filter(|f| f.is_trait_impl && !f.is_test)
+        .map(|f| f.name.clone())
+        .collect();
+
     // --- Unused parameters ---
     let unused_parameters = detect_unused_params(&functions, lang_id);
 
@@ -415,6 +422,7 @@ pub fn fingerprint_from_grammar(
         dead_code_markers,
         internal_calls,
         public_api,
+        trait_impl_methods,
     })
 }
 

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -131,7 +131,23 @@ pub(crate) fn analyze_dead_code(fingerprints: &[&FileFingerprint]) -> Vec<Findin
             .collect();
 
         for method in private_methods {
+            // Skip trait impl methods — they're called via trait dispatch,
+            // not direct function calls, so internal_calls won't contain them.
+            if fp.trait_impl_methods.contains(method) {
+                continue;
+            }
+
             if !fp.internal_calls.contains(method) {
+                // Fallback: check if the method name appears as a call in the
+                // file content. internal_calls may miss names in the skip list
+                // (e.g., "write" is skipped to avoid matching the write! macro,
+                // but it could also be a real function name in this file).
+                let call_pattern = format!("{}(", method);
+                let method_pattern = format!(".{}(", method);
+                if fp.content.contains(&call_pattern) || fp.content.contains(&method_pattern) {
+                    continue;
+                }
+
                 findings.push(Finding {
                     convention: "dead_code".to_string(),
                     severity: Severity::Warning,
@@ -402,6 +418,61 @@ mod tests {
         assert!(
             unreferenced.is_empty(),
             "Framework entry points should not be flagged"
+        );
+    }
+
+    #[test]
+    fn trait_impl_methods_not_flagged_as_orphaned() {
+        let mut fp = make_fingerprint(
+            "src/local_files.rs",
+            vec!["read", "write", "delete"],
+            vec![],
+            vec!["read", "delete"], // write not in internal_calls (skip list)
+            vec![
+                ("read", "private"),
+                ("write", "private"),
+                ("delete", "private"),
+            ],
+        );
+        fp.trait_impl_methods = vec![
+            "read".to_string(),
+            "write".to_string(),
+            "delete".to_string(),
+        ];
+
+        let findings = analyze_dead_code(&[&fp]);
+        let orphaned: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::OrphanedInternal)
+            .collect();
+        assert!(
+            orphaned.is_empty(),
+            "Trait impl methods should not be flagged as orphaned, got: {:?}",
+            orphaned.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn skipped_call_name_found_in_content_not_flagged() {
+        let mut fp = make_fingerprint(
+            "src/file.rs",
+            vec!["run", "write"],
+            vec!["run"],
+            vec!["run"], // write not in internal_calls (it's in skip list)
+            vec![("write", "private")],
+        );
+        // The file content contains a direct call to write()
+        fp.content = "fn run() { let result = write(&id, &path); }".to_string();
+
+        let findings = analyze_dead_code(&[&fp]);
+        let orphaned: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::OrphanedInternal)
+            .collect();
+        assert!(
+            orphaned.is_empty(),
+            "Function called in content should not be flagged, got: {:?}",
+            orphaned.iter().map(|f| &f.description).collect::<Vec<_>>()
         );
     }
 }

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -51,6 +51,8 @@ pub struct FileFingerprint {
     pub internal_calls: Vec<String>,
     /// Public functions/methods exported from this file.
     pub public_api: Vec<String>,
+    /// Method names that are trait implementations (called via trait dispatch).
+    pub trait_impl_methods: Vec<String>,
 }
 
 /// Extract a structural fingerprint from a source file.
@@ -114,5 +116,6 @@ fn fingerprint_via_extension(
         dead_code_markers: output.dead_code_markers,
         internal_calls: output.internal_calls,
         public_api: output.public_api,
+        trait_impl_methods: Vec::new(), // Extension scripts don't track this
     })
 }

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -159,6 +159,7 @@ pub fn fingerprint_from_git_ref(
         dead_code_markers: output.dead_code_markers,
         internal_calls: output.internal_calls,
         public_api: output.public_api,
+        trait_impl_methods: Vec::new(),
     })
 }
 


### PR DESCRIPTION
## Summary

- Eliminates all **3** `orphaned_internal` false positives — all were trait impl methods or functions with names in the skip list
- Adds `trait_impl_methods` field to `FileFingerprint` for trait dispatch awareness
- Total findings: **864 → 861** (-3)

## Root Causes

### 1. Trait impl methods flagged as orphaned
Methods like `write()` in `impl FileSystem for LocalFs` are called via trait dispatch (`fs.write(...)` from other files), not direct function calls. The `internal_calls` list doesn't capture trait dispatch, so the detector incorrectly flagged them.

**Fix**: Track `trait_impl_methods` in the fingerprint and skip them in the orphaned check.

### 2. Skipped call names create blind spots
`write` is in `SKIP_CALLS_RUST` (to avoid matching the `write!` macro). But when `write` is also a real function name in the file, it gets excluded from `internal_calls`, making the detector think it's never called.

**Fix**: When `internal_calls` doesn't contain the method, do a raw content search for `method(` or `.method(` as a fallback before flagging.

## Tests

- `trait_impl_methods_not_flagged_as_orphaned` — verifies trait impl methods are skipped
- `skipped_call_name_found_in_content_not_flagged` — verifies content fallback works for skip-listed names