### PR TITLE
fix: repair stale doc reference fixer and eliminate example-path false positives

### DIFF
--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -643,6 +643,11 @@ fn detect_doc_drift(root: &Path, component_id: &str) -> Vec<Finding> {
         let claims = docs_audit::claims::extract_claims(&content, &finding_file, &ignore_patterns);
 
         for claim in claims {
+            // Skip example/placeholder paths — they're illustrative, not real references
+            if claim.confidence == ClaimConfidence::Example {
+                continue;
+            }
+
             let result = docs_audit::verify::verify_claim(&claim, root, &docs_path, None);
 
             match result {

--- a/src/core/refactor/plan/generate/doc_fixes.rs
+++ b/src/core/refactor/plan/generate/doc_fixes.rs
@@ -5,11 +5,19 @@ use std::path::Path;
 use super::insertion;
 
 pub(crate) fn extract_suggested_path(suggestion: &str) -> Option<String> {
-    let needle = "Replace with `";
-    let start = suggestion.find(needle)? + needle.len();
-    let rest = &suggestion[start..];
-    let end = rest.find('`')?;
-    Some(rest[..end].to_string())
+    // Support both suggestion formats:
+    //   "Replace with `new/path`"
+    //   "Did you mean `new/path`?"
+    let needles = ["Replace with `", "Did you mean `"];
+    for needle in needles {
+        if let Some(pos) = suggestion.find(needle) {
+            let start = pos + needle.len();
+            let rest = &suggestion[start..];
+            let end = rest.find('`')?;
+            return Some(rest[..end].to_string());
+        }
+    }
+    None
 }
 
 pub(crate) fn should_remove_broken_doc_line(line: &str, dead_path: &str) -> bool {
@@ -120,5 +128,74 @@ pub(super) fn apply_broken_doc_reference_fixes(
             )],
             applied: false,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_suggested_path_replace_with_format() {
+        let suggestion = "Replace with `src/core/engine/shell.rs`";
+        assert_eq!(
+            extract_suggested_path(suggestion),
+            Some("src/core/engine/shell.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_suggested_path_did_you_mean_format() {
+        let suggestion = "Did you mean `src/core/engine/shell.rs`? File 'src/utils/shell.rs' no longer exists at the documented path.";
+        assert_eq!(
+            extract_suggested_path(suggestion),
+            Some("src/core/engine/shell.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_suggested_path_did_you_mean_directory() {
+        let suggestion = "Did you mean `src/core/release/changelog/`? Directory 'src/core/changelog/' no longer exists at the documented path.";
+        assert_eq!(
+            extract_suggested_path(suggestion),
+            Some("src/core/release/changelog/".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_suggested_path_no_match() {
+        let suggestion = "File no longer exists. Update or remove this reference.";
+        assert_eq!(extract_suggested_path(suggestion), None);
+    }
+
+    #[test]
+    fn should_remove_broken_doc_line_bullet_with_path() {
+        assert!(should_remove_broken_doc_line(
+            "- **Location:** `src/core/ssh/`",
+            "src/core/ssh/"
+        ));
+    }
+
+    #[test]
+    fn should_remove_broken_doc_line_prose_not_bullet() {
+        assert!(!should_remove_broken_doc_line(
+            "For example, in a project containing `src/widget/widget.rs`",
+            "src/widget/widget.rs"
+        ));
+    }
+
+    #[test]
+    fn extract_stale_ref_path_from_description() {
+        let desc = "Stale file reference `src/utils/shell.rs` (line 87) — target has moved";
+        assert_eq!(
+            extract_stale_ref_path(desc),
+            Some("src/utils/shell.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_line_number_from_description() {
+        let desc = "Stale file reference `src/utils/shell.rs` (line 87) — target has moved";
+        assert_eq!(extract_line_number(desc), Some(87));
     }
 }


### PR DESCRIPTION
## Summary

- **Fix stale doc reference fixer** — `extract_suggested_path()` only matched `"Replace with"` but the audit outputs `"Did you mean"`, silently skipping all 8 stale doc reference fixes. Now supports both formats.
- **Eliminate false positives** — skip `Example`-confidence claims in `detect_doc_drift()` entirely. Paths like `src/widget/widget.rs` in documentation examples are illustrative, not real references. Removes 4 false positives (3 broken + 1 stale from `docs/commands/refactor.md`).
- **Add 8 tests** for `doc_fixes` helper functions covering both suggestion formats, broken doc line detection, path extraction, and line number parsing.

## Impact

- Audit findings: 825 → 821 (4 false positives removed)
- Stale doc reference fixer: 0 → 7 fixes now proposable (was silently broken)
- All 45 tests + 1 integration test passing