### PR TITLE
refactor: unify Build execution with ExtensionRunner contract

### DIFF
--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -161,78 +161,29 @@ pub fn run(input: &str) -> Result<(BuildResult, i32)> {
 /// Build a component for deploy context.
 /// Returns (exit_code, error_message) - None error means success.
 ///
-/// Shell execution is required for build commands by design:
-/// - Build commands execute shell scripts (bash, sh, npm, composer, etc.)
-/// - Scripts use shell features (pipes, redirects, environment variables)
-/// - Examples: "bash {{script}}", "sh build.sh", "npm run build"
-/// - Build processes often require chaining with &&, ||, ;
-/// - Direct execution cannot handle shell scripts or shell features
-///
-/// See executor.rs for detailed execution strategy decision tree
+/// Thin wrapper around `execute_build_component` that adapts the return type
+/// for the deploy pipeline's error handling convention.
 pub(crate) fn build_component(component: &component::Component) -> (Option<i32>, Option<String>) {
-    // Validate local_path before attempting build
-    let validated_path = match component::validate_local_path(component) {
-        Ok(p) => p,
-        Err(e) => return (Some(1), Some(format_path_validation_error(component, &e))),
-    };
-
-    let resolved = match resolve_build_command(component) {
-        Ok(r) => r,
-        Err(e) => return (Some(1), Some(e.to_string())),
-    };
-
-    let build_cmd = resolved.command().to_string();
-    let build_context = match &resolved {
-        ResolvedBuildCommand::ExtensionProvided { context, .. } => Some(context),
-        _ => None,
-    };
-
-    // Fix local permissions before build to ensure zip has correct permissions
-    let local_path_str = validated_path.to_string_lossy().to_string();
-    permissions::fix_local_permissions(&local_path_str);
-
-    // Get extension path env vars for build command (matches pre-build script behavior)
-    let env_vars = get_build_env_vars(component, build_context);
-    let env_refs: Vec<(&str, &str)> = env_vars
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-
-    let output = execute_local_command_in_dir(
-        &build_cmd,
-        Some(&local_path_str),
-        if env_refs.is_empty() {
-            None
-        } else {
-            Some(&env_refs)
-        },
-    );
-
-    if output.success {
-        (Some(output.exit_code), None)
-    } else {
-        (
-            Some(output.exit_code),
-            Some(format_build_error(
-                &component.id,
-                &build_cmd,
-                &local_path_str,
-                output.exit_code,
-                &output.stderr,
-                &output.stdout,
-            )),
-        )
+    match execute_build_component(component) {
+        Ok((output, exit_code)) => {
+            if output.success {
+                (Some(exit_code), None)
+            } else {
+                (
+                    Some(exit_code),
+                    Some(format_build_error(
+                        &component.id,
+                        &output.build_command,
+                        &component.local_path,
+                        exit_code,
+                        &output.output.stderr,
+                        &output.output.stdout,
+                    )),
+                )
+            }
+        }
+        Err(e) => (Some(1), Some(e.to_string())),
     }
-}
-
-/// Format a path validation error with build context.
-fn format_path_validation_error(component: &component::Component, error: &Error) -> String {
-    format!(
-        "Build failed for component '{}':\n  {}\n\nHint: Update local_path with:\n  homeboy component set {} --local-path \"/path/to/component\"",
-        component.id,
-        error.message,
-        component.id
-    )
 }
 
 /// Format a build error message with context from stderr/stdout.
@@ -438,32 +389,37 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
     // Fix local permissions before build to ensure zip has correct permissions
     permissions::fix_local_permissions(&local_path_str);
 
-    // Get extension path env vars for build command (matches pre-build script behavior)
-    let env_vars = get_build_env_vars(comp, build_context);
-    let env_refs: Vec<(&str, &str)> = env_vars
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-
-    let cmd_output = execute_local_command_in_dir(
-        &build_cmd,
-        Some(&local_path_str),
-        if env_refs.is_empty() {
-            None
-        } else {
-            Some(&env_refs)
-        },
-    );
+    // Execute via ExtensionRunner — uses the full exec context protocol (settings,
+    // project info, context version) instead of the minimal env var set.
+    let runner_output = if let Some(context) = build_context {
+        extension::ExtensionRunner::for_context(context.clone())
+            .component(comp.clone())
+            .working_dir(&local_path_str)
+            .command_override(build_cmd.clone())
+            // Legacy env var for backward compat with existing build scripts
+            .env("HOMEBOY_PLUGIN_PATH", &comp.local_path)
+            .run()?
+    } else {
+        // LocalScript variant — no extension context, run command directly
+        let context =
+            extension::resolve_execution_context(comp, extension::ExtensionCapability::Build)?;
+        extension::ExtensionRunner::for_context(context)
+            .component(comp.clone())
+            .working_dir(&local_path_str)
+            .command_override(build_cmd.clone())
+            .env("HOMEBOY_PLUGIN_PATH", &comp.local_path)
+            .run()?
+    };
 
     Ok((
         BuildOutput {
             command: "build.run".to_string(),
             component_id: comp.id.clone(),
             build_command: build_cmd,
-            output: CapturedOutput::new(cmd_output.stdout, cmd_output.stderr),
-            success: cmd_output.success,
+            output: CapturedOutput::new(runner_output.stdout, runner_output.stderr),
+            success: runner_output.success,
         },
-        cmd_output.exit_code,
+        runner_output.exit_code,
     ))
 }
 
@@ -515,33 +471,6 @@ fn run_pre_build_scripts(
     }
 
     Ok(None)
-}
-
-/// Get environment variables for build commands (extension path, component path).
-/// Matches the env vars passed to pre-build scripts for consistency.
-fn get_build_env_vars(
-    comp: &Component,
-    build_context: Option<&ExtensionExecutionContext>,
-) -> Vec<(String, String)> {
-    let mut env = Vec::new();
-
-    // Always pass the component ID so build scripts can name artifacts consistently
-    env.push((exec_context::COMPONENT_ID.to_string(), comp.id.clone()));
-
-    if let Some(build_context) = build_context {
-        let extension_path_str = build_context.extension_path.to_string_lossy().to_string();
-        env.push((exec_context::EXTENSION_PATH.to_string(), extension_path_str));
-        env.push((
-            exec_context::COMPONENT_PATH.to_string(),
-            build_context.component.local_path.clone(),
-        ));
-        env.push((
-            "HOMEBOY_PLUGIN_PATH".to_string(),
-            build_context.component.local_path.clone(),
-        ));
-    }
-
-    env
 }
 
 #[cfg(test)]

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -52,6 +52,7 @@ pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBui
         let extension_id = context.extension_id.clone();
         let extension = extension::load_extension(&extension_id)?;
         if let Some(build) = &extension.build {
+            // Priority 1: Extension's bundled build script
             let bundled = build
                 .extension_script
                 .as_ref()
@@ -79,6 +80,7 @@ pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBui
                 return Ok(result);
             }
 
+            // Priority 2: Local script matching the extension's script_names pattern
             let local_path = PathBuf::from(&component.local_path);
             for script_name in &build.script_names {
                 let local_script = local_path.join(script_name);

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -501,25 +501,37 @@ pub(crate) fn execute_capability_script(
     script_path: &str,
     script_args: &[String],
     env_vars: &[(String, String)],
+    working_dir: Option<&str>,
+    command_override: Option<&str>,
 ) -> Result<CommandOutput> {
-    let script_path = extension_path.join(script_path);
-    let mut command = shell::quote_path(&script_path.to_string_lossy());
-
-    if !script_args.is_empty() {
-        command.push(' ');
-        command.push_str(&shell::quote_args(script_args));
-    }
+    let command = if let Some(cmd) = command_override {
+        cmd.to_string()
+    } else {
+        let resolved = extension_path.join(script_path);
+        let mut cmd = shell::quote_path(&resolved.to_string_lossy());
+        if !script_args.is_empty() {
+            cmd.push(' ');
+            cmd.push_str(&shell::quote_args(script_args));
+        }
+        cmd
+    };
 
     let env_refs: Vec<(&str, &str)> = env_vars
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
 
-    Ok(execute_local_command_passthrough(
-        &command,
-        None,
-        Some(&env_refs),
-    ))
+    let env_opt = if env_refs.is_empty() {
+        None
+    } else {
+        Some(env_refs.as_slice())
+    };
+
+    if let Some(dir) = working_dir {
+        Ok(execute_local_command_in_dir(&command, Some(dir), env_opt))
+    } else {
+        Ok(execute_local_command_passthrough(&command, None, env_opt))
+    }
 }
 
 pub(crate) struct PreparedCapabilityRun {
@@ -565,16 +577,21 @@ pub(crate) fn prepare_capability_run(
     pre_loaded_component: Option<&Component>,
     path_override: Option<&str>,
     settings_overrides: &[(String, String)],
+    skip_script_validation: bool,
 ) -> Result<PreparedCapabilityRun> {
     let component =
         resolve_capability_component(execution_context, pre_loaded_component, path_override)?;
     let execution = build_capability_execution_context(execution_context, component, path_override);
 
-    validate_capability_script_exists(
-        &execution.extension_path,
-        &execution.script_path,
-        execution.capability,
-    )?;
+    // Skip validation when a command_override is provided (e.g., Build with command_template)
+    // since the script_path may be empty or not point to an actual file.
+    if !skip_script_validation && !execution.script_path.is_empty() {
+        validate_capability_script_exists(
+            &execution.extension_path,
+            &execution.script_path,
+            execution.capability,
+        )?;
+    }
 
     let manifest = load_extension_manifest_from_dir(&execution.extension_path)?;
     let settings_json =

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -317,6 +317,12 @@ impl ExtensionManifest {
             .and_then(|c| c.extension_script.as_deref())
     }
 
+    pub fn build_script(&self) -> Option<&str> {
+        self.build
+            .as_ref()
+            .and_then(|c| c.extension_script.as_deref())
+    }
+
     /// Convenience: get deploy verifications (empty if no deploy capability).
     pub fn deploy_verifications(&self) -> &[DeployVerification] {
         self.deploy

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -256,9 +256,18 @@ pub fn resolve_execution_context(
     let script_path = match capability {
         ExtensionCapability::Lint => manifest.lint_script(),
         ExtensionCapability::Test => manifest.test_script(),
-        ExtensionCapability::Build => None,
+        ExtensionCapability::Build => manifest.build_script(),
     }
     .map(|s| s.to_string())
+    // Build's extension_script is optional (builds can use local scripts or command templates),
+    // so we allow an empty script_path for Build. Lint/Test require it.
+    .or_else(|| {
+        if capability == ExtensionCapability::Build {
+            Some(String::new())
+        } else {
+            None
+        }
+    })
     .ok_or_else(|| {
         Error::validation_invalid_argument(
             "extension",

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -14,7 +14,7 @@ pub struct RunnerOutput {
 
 use super::ExtensionExecutionContext;
 
-/// Orchestrates extension script execution for test/lint runners.
+/// Orchestrates extension script execution for lint/test/build runners.
 ///
 /// Encapsulates the shared logic for finding components, resolving extensions,
 /// loading manifests, merging settings, and executing runner scripts.
@@ -25,6 +25,13 @@ pub struct ExtensionRunner {
     script_args: Vec<String>,
     path_override: Option<String>,
     pre_loaded_component: Option<Component>,
+    /// Override the working directory for script execution.
+    /// When set, the script runs in this directory instead of deriving it from the extension path.
+    /// Used by Build to run in the component's `local_path`.
+    working_dir: Option<String>,
+    /// Override the command string instead of constructing from extension_path + script_path.
+    /// Used by Build when `command_template` produces a pre-resolved command.
+    command_override: Option<String>,
 }
 
 impl ExtensionRunner {
@@ -46,6 +53,8 @@ impl ExtensionRunner {
             script_args: Vec::new(),
             path_override: None,
             pre_loaded_component: None,
+            working_dir: None,
+            command_override: None,
         }
     }
 
@@ -92,13 +101,31 @@ impl ExtensionRunner {
         self
     }
 
+    /// Set the working directory for script execution.
+    ///
+    /// By default, scripts run relative to the extension path. Use this to
+    /// run in a different directory (e.g., the component's `local_path` for builds).
+    pub fn working_dir(mut self, dir: &str) -> Self {
+        self.working_dir = Some(dir.to_string());
+        self
+    }
+
+    /// Override the command string instead of constructing from extension_path + script_path.
+    ///
+    /// Use this when the command is pre-resolved (e.g., Build's `command_template`
+    /// has already been interpolated with the script path).
+    pub fn command_override(mut self, command: String) -> Self {
+        self.command_override = Some(command);
+        self
+    }
+
     /// Execute the extension runner script.
     ///
     /// Performs the full orchestration:
     /// 1. Load component configuration
     /// 2. Determine extension from component config
     /// 3. Find extension path
-    /// 4. Validate script exists
+    /// 4. Validate script exists (unless command_override is set)
     /// 5. Load manifest
     /// 6. Merge settings (manifest defaults → component → overrides)
     /// 7. Prepare environment variables
@@ -109,6 +136,7 @@ impl ExtensionRunner {
             self.pre_loaded_component.as_ref(),
             self.path_override.as_deref(),
             &self.settings_overrides,
+            self.command_override.is_some(),
         )?;
 
         let project_path = PathBuf::from(&prepared.execution.component.local_path);
@@ -156,6 +184,8 @@ impl ExtensionRunner {
             &self.execution_context.script_path,
             &self.script_args,
             env_vars,
+            self.working_dir.as_deref(),
+            self.command_override.as_deref(),
         )
     }
 }

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -114,7 +114,7 @@ impl ExtensionRunner {
     ///
     /// Use this when the command is pre-resolved (e.g., Build's `command_template`
     /// has already been interpolated with the script path).
-    pub fn command_override(mut self, command: String) -> Self {
+    pub(crate) fn command_override(mut self, command: String) -> Self {
         self.command_override = Some(command);
         self
     }


### PR DESCRIPTION
## Summary

- Build now uses `ExtensionRunner` for script execution instead of reimplementing env vars and shell execution independently
- Extends `ExtensionRunner` with `.working_dir()` and `.command_override()` for Build's unique needs
- Build scripts now receive the **full exec context** (settings, project info, context version) — previously they only got 4 env vars

**Depends on #768** (cherry-picked)

## What Changed

### ExtensionRunner (runner.rs)
- New `.working_dir(path)` — run in a specific directory instead of the extension dir
- New `.command_override(cmd)` — use a pre-resolved command string instead of extension_path/script_path

### Build (build/mod.rs): 575 → 487 lines (-88)
- `execute_build_component()` now creates an `ExtensionRunner` with working_dir + command_override
- `build_component()` is now a thin wrapper (was a near-duplicate before)
- **Removed** `get_build_env_vars()` — Runner handles it
- **Removed** `format_path_validation_error()` — dead code
- Kept `HOMEBOY_PLUGIN_PATH` via `.env()` for backward compat

### execution.rs
- `execute_capability_script()` accepts optional `working_dir` and `command_override`
- `prepare_capability_run()` accepts `skip_script_validation` for command_override paths

## Before vs After: Build Script Env Vars

| Env Var | Before | After |
|---|---|---|
| `HOMEBOY_COMPONENT_ID` | ✅ | ✅ |
| `HOMEBOY_EXTENSION_PATH` | ✅ | ✅ |
| `HOMEBOY_COMPONENT_PATH` | ✅ | ✅ |
| `HOMEBOY_PLUGIN_PATH` | ✅ | ✅ |
| `HOMEBOY_SETTINGS_JSON` | ❌ | ✅ |
| `HOMEBOY_PROJECT_ID` | ❌ | ✅ |
| `HOMEBOY_PROJECT_PATH` | ❌ | ✅ |
| `HOMEBOY_EXEC_CONTEXT_VERSION` | ❌ | ✅ |
| `HOMEBOY_EXTENSION_ID` | ❌ | ✅ |
| `HOMEBOY_RUNNER_STEPS_HELPER` | ❌ | ✅ |

## Verification

- 776 tests pass, 0 failures
- `cargo fmt` clean
- Zero new warnings

Refs #667