### PR TITLE
refactor: extract deploy orchestration to core

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,11 +1,13 @@
 use clap::Args;
-use homeboy::log_status;
 use serde::Serialize;
 
-use homeboy::deploy::{self, ComponentDeployResult, DeployConfig, DeploySummary};
+use homeboy::deploy::{
+    self, ComponentDeployResult, DeployConfig, DeploySummary, MultiDeploySummary,
+    ProjectDeployResult,
+};
 
 use super::utils::resolve::{infer_project_for_components, resolve_project_components};
-use super::{CmdResult, ProjectsSummary};
+use super::CmdResult;
 
 const DEPLOY_RECIPES: &[&str] = &[
     "Deploy single component: homeboy deploy <component-id>",
@@ -86,20 +88,10 @@ pub struct MultiProjectDeployOutput {
     pub command: String,
     pub component_ids: Vec<String>,
     pub projects: Vec<ProjectDeployResult>,
-    pub summary: ProjectsSummary,
+    pub summary: MultiDeploySummary,
     pub dry_run: bool,
     pub check: bool,
     pub force: bool,
-}
-
-#[derive(Serialize)]
-pub struct ProjectDeployResult {
-    pub project_id: String,
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-    pub results: Vec<ComponentDeployResult>,
-    pub summary: DeploySummary,
 }
 
 #[derive(Serialize)]
@@ -113,141 +105,31 @@ pub fn run(
     mut args: DeployArgs,
     _global: &crate::commands::GlobalArgs,
 ) -> CmdResult<DeployCommandOutput> {
+    // Fleet deploy
     if let Some(ref fleet_id) = args.fleet {
         let fl = homeboy::fleet::load(fleet_id)?;
-        return run_multi_project(&args, &fl.project_ids);
+        let (component_ids, config) = resolve_multi_args(&args)?;
+        return run_multi_output(&fl.project_ids, &component_ids, &config, &args);
     }
 
-    // Resolve --shared: find all projects using the specified component(s)
+    // Shared component deploy (find all projects using the component)
     if args.shared {
-        let component_ids: Vec<String> = if let Some(ref comps) = args.component {
-            comps.clone()
-        } else if let Some(ref target) = args.target_id {
-            vec![target.clone()]
-        } else {
-            return Err(homeboy::Error::validation_invalid_argument(
-                "component",
-                "At least one component ID is required when using --shared",
-                None,
-                None,
-            ));
-        };
-
-        if component_ids.is_empty() {
-            return Err(homeboy::Error::validation_invalid_argument(
-                "component",
-                "At least one component ID is required when using --shared",
-                None,
-                None,
-            ));
-        }
-
-        let mut project_ids: Vec<String> = Vec::new();
-        for component_id in &component_ids {
-            let using = homeboy::component::projects_using(component_id).unwrap_or_default();
-            for pid in using {
-                if !project_ids.contains(&pid) {
-                    project_ids.push(pid);
-                }
-            }
-        }
-
-        if project_ids.is_empty() {
-            return Err(homeboy::Error::validation_invalid_argument(
-                "component",
-                format!("No projects found using component(s): {:?}", component_ids),
-                None,
-                Some(vec![
-                    "Run 'homeboy component shared' to see component usage".to_string(),
-                ]),
-            ));
-        }
-
+        let component_ids = resolve_shared_component_ids(&args)?;
+        let project_ids = deploy::resolve_shared_targets(&component_ids)?;
         args.component_ids = component_ids;
         args.target_id = None;
-
-        return run_multi_project(&args, &project_ids);
+        let (component_ids, config) = resolve_multi_args(&args)?;
+        return run_multi_output(&project_ids, &component_ids, &config, &args);
     }
 
-    // Handle multi-project case first
+    // Multi-project deploy
     if let Some(ref project_ids) = args.projects {
-        return run_multi_project(&args, project_ids);
+        let (component_ids, config) = resolve_multi_args(&args)?;
+        return run_multi_output(project_ids, &component_ids, &config, &args);
     }
 
-    // Resolve project and component IDs based on flag/positional combinations
-    let (project_id, component_ids) = match (&args.project, &args.component, &args.target_id) {
-        // Both flags provided - use them directly (no positional required)
-        (Some(proj), Some(comps), _) => (proj.clone(), comps.clone()),
-
-        // Only --project flag - optional positional components
-        (Some(proj), None, target) => {
-            let mut comps = Vec::new();
-            if let Some(first) = target {
-                comps.push(first.clone());
-            }
-            comps.extend(args.component_ids.clone());
-
-            let has_selector_flag = args.all || args.outdated || args.check || args.json.is_some();
-            if comps.is_empty() && !has_selector_flag {
-                return Err(homeboy::Error::validation_invalid_argument(
-                    "input",
-                    "Provide component IDs with --project, or add --all/--outdated/--check",
-                    None,
-                    Some(DEPLOY_RECIPES.iter().map(|r| (*r).to_string()).collect()),
-                ));
-            }
-
-            (proj.clone(), comps)
-        }
-
-        // Only --component flag - optional positional project, else infer
-        (None, Some(comps), target) => {
-            let projects = homeboy::project::list_ids().unwrap_or_default();
-
-            if let Some(first) = target {
-                if projects.contains(first) {
-                    (first.clone(), comps.clone())
-                } else {
-                    match infer_project_for_components(comps) {
-                        Some(proj) => (proj, comps.clone()),
-                        None => {
-                            return Err(homeboy::Error::validation_invalid_argument(
-                                "project_id",
-                                "Could not infer project. Use --project flag or provide project as first argument.",
-                                None,
-                                None,
-                            ));
-                        }
-                    }
-                }
-            } else {
-                match infer_project_for_components(comps) {
-                    Some(proj) => (proj, comps.clone()),
-                    None => {
-                        return Err(homeboy::Error::validation_invalid_argument(
-                            "project_id",
-                            "Could not infer project. Use --project flag or provide project as first argument.",
-                            None,
-                            None,
-                        ));
-                    }
-                }
-            }
-        }
-
-        // No flags - positional args required
-        (None, None, Some(target)) => resolve_project_components(target, &args.component_ids)?,
-        (None, None, None) => {
-            return Err(homeboy::Error::validation_invalid_argument(
-                "input",
-                "Provide component ID, project ID with --all, or use flags",
-                None,
-                Some(DEPLOY_RECIPES.iter().map(|r| (*r).to_string()).collect()),
-            ));
-        }
-    };
-
-    // Update args with resolved values
+    // Single-project deploy: resolve project and component IDs
+    let (project_id, component_ids) = resolve_single_deploy_target(&args)?;
     args.target_id = Some(project_id.clone());
     args.component_ids = component_ids;
 
@@ -256,20 +138,7 @@ pub fn run(
         args.component_ids = deploy::parse_bulk_component_ids(spec)?;
     }
 
-    // Build config and call core orchestration
-    let config = DeployConfig {
-        component_ids: args.component_ids.clone(),
-        all: args.all,
-        outdated: args.outdated,
-        dry_run: args.dry_run,
-        check: args.check,
-        force: args.force,
-        skip_build: false,
-        keep_deps: args.keep_deps,
-        expected_version: args.version.clone(),
-        no_pull: args.no_pull,
-        head: args.head,
-    };
+    let config = build_config(&args, false);
 
     let result = deploy::run(&project_id, &config).map_err(|e| {
         if e.message.contains("No components configured for project")
@@ -292,7 +161,7 @@ pub fn run(
     Ok((
         DeployCommandOutput::Single(DeployOutput {
             command: "deploy.run".to_string(),
-            project_id: project_id.clone(),
+            project_id,
             all: args.all,
             outdated: args.outdated,
             dry_run: args.dry_run,
@@ -305,198 +174,122 @@ pub fn run(
     ))
 }
 
-fn run_multi_project(args: &DeployArgs, project_ids: &[String]) -> CmdResult<DeployCommandOutput> {
-    // Collect component IDs from positional arguments
+// === Argument resolution helpers ===
+
+fn resolve_shared_component_ids(args: &DeployArgs) -> homeboy::Result<Vec<String>> {
+    if let Some(ref comps) = args.component {
+        Ok(comps.clone())
+    } else if let Some(ref target) = args.target_id {
+        Ok(vec![target.clone()])
+    } else {
+        Err(homeboy::Error::validation_invalid_argument(
+            "component",
+            "At least one component ID is required when using --shared",
+            None,
+            None,
+        ))
+    }
+}
+
+fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, Vec<String>)> {
+    match (&args.project, &args.component, &args.target_id) {
+        (Some(proj), Some(comps), _) => Ok((proj.clone(), comps.clone())),
+
+        (Some(proj), None, target) => {
+            let mut comps = Vec::new();
+            if let Some(first) = target {
+                comps.push(first.clone());
+            }
+            comps.extend(args.component_ids.clone());
+
+            let has_selector_flag = args.all || args.outdated || args.check || args.json.is_some();
+            if comps.is_empty() && !has_selector_flag {
+                return Err(homeboy::Error::validation_invalid_argument(
+                    "input",
+                    "Provide component IDs with --project, or add --all/--outdated/--check",
+                    None,
+                    Some(DEPLOY_RECIPES.iter().map(|r| (*r).to_string()).collect()),
+                ));
+            }
+
+            Ok((proj.clone(), comps))
+        }
+
+        (None, Some(comps), target) => {
+            let projects = homeboy::project::list_ids().unwrap_or_default();
+
+            if let Some(first) = target {
+                if projects.contains(first) {
+                    return Ok((first.clone(), comps.clone()));
+                }
+            }
+
+            match infer_project_for_components(comps) {
+                Some(proj) => Ok((proj, comps.clone())),
+                None => Err(homeboy::Error::validation_invalid_argument(
+                    "project_id",
+                    "Could not infer project. Use --project flag or provide project as first argument.",
+                    None,
+                    None,
+                )),
+            }
+        }
+
+        (None, None, Some(target)) => resolve_project_components(target, &args.component_ids),
+        (None, None, None) => Err(homeboy::Error::validation_invalid_argument(
+            "input",
+            "Provide component ID, project ID with --all, or use flags",
+            None,
+            Some(DEPLOY_RECIPES.iter().map(|r| (*r).to_string()).collect()),
+        )),
+    }
+}
+
+fn resolve_multi_args(args: &DeployArgs) -> homeboy::Result<(Vec<String>, DeployConfig)> {
     let mut component_ids: Vec<String> = Vec::new();
     if let Some(ref target) = args.target_id {
         component_ids.push(target.clone());
     }
     component_ids.extend(args.component_ids.clone());
-
-    // Filter out empty strings
     let component_ids: Vec<String> = component_ids
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect();
 
-    if component_ids.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
-            "component_ids",
-            "At least one component ID is required for multi-project deployment",
-            None,
-            None,
-        ));
+    Ok((component_ids, build_config(args, false)))
+}
+
+fn build_config(args: &DeployArgs, skip_build: bool) -> DeployConfig {
+    DeployConfig {
+        component_ids: args.component_ids.clone(),
+        all: args.all,
+        outdated: args.outdated,
+        dry_run: args.dry_run,
+        check: args.check,
+        force: args.force,
+        skip_build,
+        keep_deps: args.keep_deps,
+        expected_version: args.version.clone(),
+        no_pull: args.no_pull,
+        head: args.head,
     }
+}
 
-    // Validate specified projects exist, skip unknown ones instead of aborting.
-    // Fleet configs can accumulate stale project references — one missing project
-    // should not block deploying to the rest.
-    let known_projects = homeboy::project::list_ids().unwrap_or_default();
-    let mut unknown_projects = Vec::new();
-    let valid_project_ids: Vec<&String> = project_ids
-        .iter()
-        .filter(|pid| {
-            if known_projects.contains(pid) {
-                true
-            } else {
-                unknown_projects.push(pid.to_string());
-                false
-            }
-        })
-        .collect();
-
-    for pid in &unknown_projects {
-        log_status!(
-            "deploy",
-            "Skipping unknown project '{}' — remove from fleet with: homeboy fleet remove-project <fleet> {}",
-            pid,
-            pid
-        );
-    }
-
-    if valid_project_ids.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
-            "projects",
-            format!(
-                "No valid projects found — all specified projects are unknown: {}",
-                unknown_projects.join(", ")
-            ),
-            None,
-            None,
-        ));
-    }
-
-    log_status!(
-        "deploy",
-        "Deploying {:?} to {} project(s){}...",
-        component_ids,
-        valid_project_ids.len(),
-        if unknown_projects.is_empty() {
-            String::new()
-        } else {
-            format!(" ({} skipped)", unknown_projects.len())
-        }
-    );
-
-    let mut project_results = Vec::new();
-    let mut succeeded: u32 = 0;
-    let mut failed: u32 = 0;
-    let skipped: u32 = unknown_projects.len() as u32;
-    let mut planned: u32 = 0;
-    let mut first_project = true;
-
-    // Add skipped results for unknown projects
-    for pid in &unknown_projects {
-        project_results.push(ProjectDeployResult {
-            project_id: pid.clone(),
-            status: "skipped".to_string(),
-            error: Some(format!("Project '{}' not found — skipped", pid)),
-            results: vec![],
-            summary: DeploySummary {
-                total: 0,
-                succeeded: 0,
-                skipped: 0,
-                failed: 0,
-            },
-        });
-    }
-
-    for project_id in &valid_project_ids {
-        log_status!("deploy", "Deploying to project '{}'...", project_id);
-
-        let config = DeployConfig {
-            component_ids: component_ids.clone(),
-            all: args.all,
-            outdated: args.outdated,
-            dry_run: args.dry_run,
-            check: args.check,
-            force: args.force,
-            skip_build: !first_project, // Build only on first project
-            keep_deps: args.keep_deps,
-            expected_version: args.version.clone(),
-            no_pull: args.no_pull || !first_project, // Only pull on first project
-            head: args.head,
-        };
-
-        match deploy::run(project_id, &config) {
-            Ok(result) => {
-                let deploy_failed = result.summary.failed > 0;
-
-                // Determine the correct project-level status:
-                // - dry-run/check modes never actually deploy, so report "planned"
-                // - real deploys report "deployed" or "failed" based on results
-                let is_planned = args.dry_run || args.check;
-
-                if deploy_failed {
-                    let error_msg = result
-                        .results
-                        .iter()
-                        .find_map(|r| r.error.clone())
-                        .unwrap_or_else(|| "Deployment failed".to_string());
-
-                    project_results.push(ProjectDeployResult {
-                        project_id: project_id.to_string(),
-                        status: "failed".to_string(),
-                        error: Some(error_msg),
-                        results: result.results,
-                        summary: result.summary,
-                    });
-                    failed += 1;
-                } else if is_planned {
-                    project_results.push(ProjectDeployResult {
-                        project_id: project_id.to_string(),
-                        status: "planned".to_string(),
-                        error: None,
-                        results: result.results,
-                        summary: result.summary,
-                    });
-                    planned += 1;
-                } else {
-                    project_results.push(ProjectDeployResult {
-                        project_id: project_id.to_string(),
-                        status: "deployed".to_string(),
-                        error: None,
-                        results: result.results,
-                        summary: result.summary,
-                    });
-                    succeeded += 1;
-                }
-            }
-            Err(e) => {
-                project_results.push(ProjectDeployResult {
-                    project_id: project_id.to_string(),
-                    status: "failed".to_string(),
-                    error: Some(e.to_string()),
-                    results: vec![],
-                    summary: DeploySummary {
-                        total: 0,
-                        succeeded: 0,
-                        skipped: 0,
-                        failed: 1,
-                    },
-                });
-                failed += 1;
-            }
-        }
-
-        first_project = false;
-    }
-
-    let total = project_results.len() as u32;
-    let exit_code = if failed > 0 { 1 } else { 0 };
+fn run_multi_output(
+    project_ids: &[String],
+    component_ids: &[String],
+    config: &DeployConfig,
+    args: &DeployArgs,
+) -> CmdResult<DeployCommandOutput> {
+    let result = deploy::run_multi(project_ids, component_ids, config)?;
+    let exit_code = if result.summary.failed > 0 { 1 } else { 0 };
 
     Ok((
         DeployCommandOutput::Multi(MultiProjectDeployOutput {
             command: "deploy.run_multi".to_string(),
-            component_ids,
-            projects: project_results,
-            summary: ProjectsSummary {
-                total_projects: total,
-                succeeded,
-                failed,
-                skipped,
-                planned,
-            },
+            component_ids: result.component_ids,
+            projects: result.projects,
+            summary: result.summary,
             dry_run: args.dry_run,
             check: args.check,
             force: args.force,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,25 +1,8 @@
 use base64::Engine;
 use clap::Args;
-use serde::Serialize;
 use serde_json::{json, Map, Value};
 
 pub type CmdResult<T> = homeboy::Result<(T, i32)>;
-
-/// Summary of a multi-project operation (deploy, release deploy, etc.).
-#[derive(Serialize)]
-pub struct ProjectsSummary {
-    pub total_projects: u32,
-    pub succeeded: u32,
-    pub failed: u32,
-    #[serde(skip_serializing_if = "is_zero")]
-    pub skipped: u32,
-    #[serde(skip_serializing_if = "is_zero")]
-    pub planned: u32,
-}
-
-fn is_zero(v: &u32) -> bool {
-    *v == 0
-}
 
 /// Parse a `KEY=value` string into a (key, value) tuple.
 /// Used by clap `value_parser` attributes on `--setting` and `--input` flags.

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -11,12 +11,13 @@ mod version_overrides;
 pub use planning::{bucket_release_states, calculate_release_state, classify_release_state};
 pub use types::{
     parse_bulk_component_ids, ComponentDeployResult, ComponentStatus, DeployConfig,
-    DeployOrchestrationResult, DeployReason, DeploySummary, ReleaseState, ReleaseStateBuckets,
-    ReleaseStateStatus,
+    DeployOrchestrationResult, DeployReason, DeploySummary, MultiDeployResult, MultiDeploySummary,
+    ProjectDeployResult, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
 };
 
+use crate::component;
 use crate::context::resolve_project_ssh_with_base_path;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::project;
 
 /// High-level deploy entry point. Resolves SSH context internally.
@@ -27,4 +28,228 @@ pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestratio
     let project = project::load(project_id)?;
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)?;
     orchestration::deploy_components(config, &project, &ctx, &base_path)
+}
+
+/// Deploy components across multiple projects.
+///
+/// Handles the build-skip optimization: only the first project builds
+/// from source; subsequent projects reuse the already-built artifact.
+/// Similarly, only the first project pulls latest changes.
+///
+/// Unknown project IDs are skipped (not fatal) — fleet configs can
+/// accumulate stale references that shouldn't block the rest.
+pub fn run_multi(
+    project_ids: &[String],
+    component_ids: &[String],
+    config: &DeployConfig,
+) -> Result<MultiDeployResult> {
+    if component_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "component_ids",
+            "At least one component ID is required for multi-project deployment",
+            None,
+            None,
+        ));
+    }
+
+    // Validate project IDs, skip unknown ones
+    let known_projects = project::list_ids().unwrap_or_default();
+    let mut unknown_projects = Vec::new();
+    let valid_project_ids: Vec<&String> = project_ids
+        .iter()
+        .filter(|pid| {
+            if known_projects.contains(pid) {
+                true
+            } else {
+                unknown_projects.push(pid.to_string());
+                false
+            }
+        })
+        .collect();
+
+    for pid in &unknown_projects {
+        log_status!(
+            "deploy",
+            "Skipping unknown project '{}' — remove from fleet with: homeboy fleet remove-project <fleet> {}",
+            pid,
+            pid
+        );
+    }
+
+    if valid_project_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "projects",
+            format!(
+                "No valid projects found — all specified projects are unknown: {}",
+                unknown_projects.join(", ")
+            ),
+            None,
+            None,
+        ));
+    }
+
+    log_status!(
+        "deploy",
+        "Deploying {:?} to {} project(s){}...",
+        component_ids,
+        valid_project_ids.len(),
+        if unknown_projects.is_empty() {
+            String::new()
+        } else {
+            format!(" ({} skipped)", unknown_projects.len())
+        }
+    );
+
+    let mut project_results = Vec::new();
+    let mut succeeded: u32 = 0;
+    let mut failed: u32 = 0;
+    let skipped: u32 = unknown_projects.len() as u32;
+    let mut planned: u32 = 0;
+    let mut first_project = true;
+
+    // Record skipped results for unknown projects
+    for pid in &unknown_projects {
+        project_results.push(ProjectDeployResult {
+            project_id: pid.clone(),
+            status: "skipped".to_string(),
+            error: Some(format!("Project '{}' not found — skipped", pid)),
+            results: vec![],
+            summary: DeploySummary {
+                total: 0,
+                succeeded: 0,
+                skipped: 0,
+                failed: 0,
+            },
+        });
+    }
+
+    for project_id in &valid_project_ids {
+        log_status!("deploy", "Deploying to project '{}'...", project_id);
+
+        let project_config = DeployConfig {
+            component_ids: component_ids.to_vec(),
+            all: config.all,
+            outdated: config.outdated,
+            dry_run: config.dry_run,
+            check: config.check,
+            force: config.force,
+            // Build-skip optimization: only build on first project
+            skip_build: config.skip_build || !first_project,
+            keep_deps: config.keep_deps,
+            expected_version: config.expected_version.clone(),
+            // Only pull on first project
+            no_pull: config.no_pull || !first_project,
+            head: config.head,
+        };
+
+        match run(project_id, &project_config) {
+            Ok(result) => {
+                let deploy_failed = result.summary.failed > 0;
+                let is_planned = config.dry_run || config.check;
+
+                if deploy_failed {
+                    let error_msg = result
+                        .results
+                        .iter()
+                        .find_map(|r| r.error.clone())
+                        .unwrap_or_else(|| "Deployment failed".to_string());
+
+                    project_results.push(ProjectDeployResult {
+                        project_id: project_id.to_string(),
+                        status: "failed".to_string(),
+                        error: Some(error_msg),
+                        results: result.results,
+                        summary: result.summary,
+                    });
+                    failed += 1;
+                } else if is_planned {
+                    project_results.push(ProjectDeployResult {
+                        project_id: project_id.to_string(),
+                        status: "planned".to_string(),
+                        error: None,
+                        results: result.results,
+                        summary: result.summary,
+                    });
+                    planned += 1;
+                } else {
+                    project_results.push(ProjectDeployResult {
+                        project_id: project_id.to_string(),
+                        status: "deployed".to_string(),
+                        error: None,
+                        results: result.results,
+                        summary: result.summary,
+                    });
+                    succeeded += 1;
+                }
+            }
+            Err(e) => {
+                project_results.push(ProjectDeployResult {
+                    project_id: project_id.to_string(),
+                    status: "failed".to_string(),
+                    error: Some(e.to_string()),
+                    results: vec![],
+                    summary: DeploySummary {
+                        total: 0,
+                        succeeded: 0,
+                        skipped: 0,
+                        failed: 1,
+                    },
+                });
+                failed += 1;
+            }
+        }
+
+        first_project = false;
+    }
+
+    let total_projects = project_results.len() as u32;
+
+    Ok(MultiDeployResult {
+        component_ids: component_ids.to_vec(),
+        projects: project_results,
+        summary: MultiDeploySummary {
+            total_projects,
+            succeeded,
+            failed,
+            skipped,
+            planned,
+        },
+    })
+}
+
+/// Find all projects that use any of the specified components.
+///
+/// Used by `--shared` flag to deploy a component to every project that has it.
+pub fn resolve_shared_targets(component_ids: &[String]) -> Result<Vec<String>> {
+    if component_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "component",
+            "At least one component ID is required when using --shared",
+            None,
+            None,
+        ));
+    }
+
+    let mut project_ids: Vec<String> = Vec::new();
+    for component_id in component_ids {
+        let using = component::projects_using(component_id).unwrap_or_default();
+        for pid in using {
+            if !project_ids.contains(&pid) {
+                project_ids.push(pid);
+            }
+        }
+    }
+
+    if project_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "component",
+            format!("No projects found using component(s): {:?}", component_ids),
+            None,
+            Some(vec![
+                "Run 'homeboy component shared' to see component usage".to_string(),
+            ]),
+        ));
+    }
+
+    Ok(project_ids)
 }

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -257,6 +257,35 @@ impl ComponentDeployResult {
     }
 }
 
+/// Result of deploying to a single project within a multi-project run.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectDeployResult {
+    pub project_id: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub results: Vec<ComponentDeployResult>,
+    pub summary: DeploySummary,
+}
+
+/// Result of a multi-project deployment.
+#[derive(Debug, Clone, Serialize)]
+pub struct MultiDeployResult {
+    pub component_ids: Vec<String>,
+    pub projects: Vec<ProjectDeployResult>,
+    pub summary: MultiDeploySummary,
+}
+
+/// Summary of multi-project deployment.
+#[derive(Debug, Clone, Serialize)]
+pub struct MultiDeploySummary {
+    pub total_projects: u32,
+    pub succeeded: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub planned: u32,
+}
+
 /// Summary of deploy orchestration.
 #[derive(Debug, Clone, Serialize)]
 


### PR DESCRIPTION
## Summary

Move multi-project deployment orchestration from commands/deploy.rs to core/deploy/. The command file was 68% business logic — build-skip optimization, project validation, status classification — all critical business rules that must be accessible to CI, fleet automation, and future integrations.

## New Core APIs

```rust
// Deploy to multiple projects with build-skip optimization
deploy::run_multi(project_ids, component_ids, config) -> Result<MultiDeployResult>

// Find all projects using specified components (--shared flag)
deploy::resolve_shared_targets(component_ids) -> Result<Vec<String>>
```

## Before vs After

| | Before | After |
|---|---|---|
| `commands/deploy.rs` | 507 lines (68% business logic) | 299 lines (thin wrapper) |
| `core/deploy/mod.rs` | 31 lines | 222 lines (full orchestration) |
| Build-skip optimization | CLI-only | Accessible to any consumer |
| Multi-deploy orchestration | CLI-only | Core API |

## What This Unlocks

- CI calling `deploy::run_multi()` directly for fleet-wide auto-deploy after release
- Release pipeline deploying without going through CLI
- Future WordPress/Data Machine integration for deploy orchestration
- Any Rust consumer gets the full orchestration including build-skip optimization

## Verification

- 771 tests pass, 0 failures
- `cargo fmt` clean
- Zero new warnings