### PR TITLE
fix: lint envelope trust + component path resolution (#696, #694)

### DIFF
--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -84,6 +84,36 @@ pub fn detect_from_cwd() -> Option<String> {
     None
 }
 
+/// Check if the CWD (or its git root) is a checkout of the given component.
+///
+/// Returns the CWD-discovered component when the portable `homeboy.json` in the
+/// current directory (or git root) has a matching `id`. This means the user is
+/// standing inside a clone of this component and intends to operate on it,
+/// even if the registered `local_path` points elsewhere (#694).
+fn prefer_cwd_for_component(component_id: &str) -> Option<Component> {
+    let cwd = std::env::current_dir().ok()?;
+
+    // Check CWD directly
+    if let Some(discovered) = discover_from_portable(&cwd) {
+        if discovered.id == component_id {
+            return Some(discovered);
+        }
+    }
+
+    // Check git root if different from CWD
+    if let Some(git_root) = detect_git_root(&cwd) {
+        if git_root != cwd {
+            if let Some(discovered) = discover_from_portable(&git_root) {
+                if discovered.id == component_id {
+                    return Some(discovered);
+                }
+            }
+        }
+    }
+
+    None
+}
+
 /// Find the git root directory for a given path.
 pub(crate) fn detect_git_root(dir: &Path) -> Option<PathBuf> {
     let output = std::process::Command::new("git")
@@ -176,6 +206,13 @@ pub fn resolve_effective(
                 })
             }
         } else {
+            // No --path provided. Before falling back to the registry, check
+            // if the CWD (or its git root) is a checkout of this component.
+            // This ensures `homeboy test foo` from a different clone of `foo`
+            // operates on the current checkout, not the registered local_path (#694).
+            if let Some(cwd_component) = prefer_cwd_for_component(id) {
+                return Ok(cwd_component);
+            }
             load(id)
         }
     } else {

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -30,12 +30,19 @@ pub struct LintCommandOutput {
 
 /// Build output from a main lint workflow result.
 pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, i32) {
-    let exit_code = result.exit_code;
+    // Exit code should reflect the computed status, not just the extension's
+    // shell exit code. When findings exist but the extension exited 0, the
+    // process must still exit non-zero so CI treats it as a failure (#696).
+    let exit_code = if result.status == "failed" && result.exit_code == 0 {
+        1
+    } else {
+        result.exit_code
+    };
     (
         LintCommandOutput {
             status: result.status,
             component: result.component,
-            exit_code: result.exit_code,
+            exit_code,
             autofix: result.autofix,
             hints: result.hints,
             baseline_comparison: result.baseline_comparison,

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -110,20 +110,33 @@ pub fn run_main_lint_workflow(
     let lint_findings = lint_baseline::parse_findings_file(&lint_findings_file)?;
     let _ = std::fs::remove_file(&lint_findings_file);
 
-    // Status computation
-    let mut status = if output.success { "passed" } else { "failed" }.to_string();
+    // Status computation — check findings first, exit code as fallback.
+    // The extension runner uses passthrough mode (stdout goes to terminal),
+    // so `output.success` only reflects the shell exit code. PHPCS/PHPStan
+    // wrappers may exit 0 even when findings exist, so the sidecar findings
+    // file is the canonical source of truth (mirrors test command pattern).
+    let mut status = if !lint_findings.is_empty() {
+        "failed"
+    } else if output.success {
+        "passed"
+    } else {
+        "failed"
+    }
+    .to_string();
     let autofix = planned_autofix
         .as_ref()
         .map(|(plan, outcome)| AppliedRefactor::from_plan(plan, outcome.rerun_recommended));
 
     let mut hints = Vec::new();
 
+    let lint_clean = lint_findings.is_empty() && output.success;
+
     if let Some((plan, outcome)) = &planned_autofix {
-        if output.success && outcome.status == "auto_fixed" {
+        if lint_clean && outcome.status == "auto_fixed" {
             status = outcome.status.clone();
         }
         hints.extend(outcome.hints.clone());
-        if plan.files_modified == 0 && output.success {
+        if plan.files_modified == 0 && lint_clean {
             status = "passed".to_string();
         }
     }
@@ -133,7 +146,7 @@ pub fn run_main_lint_workflow(
         process_baseline(source_path, &args, &lint_findings)?;
 
     // Hint assembly
-    if !output.success && !args.fix {
+    if !lint_clean && !args.fix {
         hints.push(format!(
             "Run 'homeboy lint {} --fix' to auto-fix formatting issues",
             args.component_label


### PR DESCRIPTION
## Summary
Two CI-trust bugs that block the autonomous code factory pipeline.

### Fix 1: Lint JSON envelope lies about pass/fail (#696)

**Before:** `homeboy lint` reported `status: "passed"` and `exit_code: 0` even when PHPCS/PHPStan found failures. The status was determined solely by the extension script's shell exit code, but PHPCS wrappers may exit 0 while writing findings to the sidecar JSON file.

**After:** Status is determined by checking the lint findings file first (canonical source of truth). If findings exist → `status: "failed"`, `exit_code: 1`. Mirrors the test command's pattern (`test_counts.failed == 0`).

**Files:** `src/core/extension/lint/run.rs`, `src/core/extension/lint/report.rs`

### Fix 2: test/lint/build resolves wrong checkout path (#694)

**Before:** `homeboy test data-machine` from `/tmp/repos/data-machine/` operated on the registered `local_path` (e.g., `/home/chubes/repos/data-machine`) instead of the current directory.

**After:** Before falling back to the registry, `resolve_effective()` checks if the CWD (or its git root) has a `homeboy.json` with a matching component ID. If so, it uses the CWD.

**Resolution order:** `--path` > CWD match > registry `local_path`

**Files:** `src/core/component/resolution.rs`

## Why these matter for the code factory

- #696: CI can't trust the JSON envelope → autofix pipeline can't distinguish pass from fail → agents make wrong decisions
- #694: When homeboy-action checks out a fresh clone in CI and runs `homeboy audit homeboy`, it should operate on that checkout, not a stale registered path

Closes #696. Closes #694.