### PR TITLE
fix: remove .homeboy/audit-rules.json dual path (#779)

### DIFF
--- a/src/core/code_audit/layer_ownership.rs
+++ b/src/core/code_audit/layer_ownership.rs
@@ -1,8 +1,6 @@
 //! Layer ownership rules for architecture-level audit constraints.
 //!
-//! Rules are optional and loaded from either:
-//! - `.homeboy/audit-rules.json`
-//! - `homeboy.json` under `audit_rules`
+//! Rules are optional and loaded from `homeboy.json` under `audit_rules`.
 
 use std::path::Path;
 
@@ -149,13 +147,6 @@ fn walk_candidate_files(root: &Path) -> std::io::Result<Vec<std::path::PathBuf>>
 }
 
 fn load_rules_config(root: &Path) -> Option<AuditRulesConfig> {
-    let rules_path = root.join(".homeboy").join("audit-rules.json");
-    if let Ok(content) = std::fs::read_to_string(&rules_path) {
-        if let Ok(cfg) = serde_json::from_str::<AuditRulesConfig>(&content) {
-            return Some(cfg);
-        }
-    }
-
     let homeboy_json = root.join("homeboy.json");
     let content = std::fs::read_to_string(homeboy_json).ok()?;
     let value: serde_json::Value = serde_json::from_str(&content).ok()?;
@@ -190,26 +181,26 @@ mod tests {
     }
 
     #[test]
-    fn test_detects_violation_from_audit_rules_file() {
+    fn test_detects_violation_from_homeboy_json() {
         let dir = tempfile::tempdir().unwrap();
-        let homeboy_dir = dir.path().join(".homeboy");
         let steps_dir = dir.path().join("inc/Core/Steps");
-        std::fs::create_dir_all(&homeboy_dir).unwrap();
         std::fs::create_dir_all(&steps_dir).unwrap();
 
         std::fs::write(
-            homeboy_dir.join("audit-rules.json"),
+            dir.path().join("homeboy.json"),
             r#"{
-              "layer_rules": [
-                {
-                  "name": "engine-owns-terminal-status",
-                  "forbid": {
-                    "glob": "inc/Core/Steps/**/*.php",
-                    "patterns": ["JobStatus::", "datamachine_fail_job"]
-                  },
-                  "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
-                }
-              ]
+              "audit_rules": {
+                "layer_rules": [
+                  {
+                    "name": "engine-owns-terminal-status",
+                    "forbid": {
+                      "glob": "inc/Core/Steps/**/*.php",
+                      "patterns": ["JobStatus::", "datamachine_fail_job"]
+                    },
+                    "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
+                  }
+                ]
+              }
             }"#,
         )
         .unwrap();

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -758,22 +758,23 @@ mod tests {
     #[test]
     fn test_analyze_layer_ownership() {
         let dir = std::env::temp_dir().join("homeboy_audit_layer_test");
-        let _ = fs::create_dir_all(dir.join(".homeboy"));
         let _ = fs::create_dir_all(dir.join("inc/Core/Steps"));
 
         fs::write(
-            dir.join(".homeboy/audit-rules.json"),
+            dir.join("homeboy.json"),
             r#"{
-              "layer_rules": [
-                {
-                  "name": "engine-owns-terminal-status",
-                  "forbid": {
-                    "glob": "inc/Core/Steps/**/*.php",
-                    "patterns": ["JobStatus::"]
-                  },
-                  "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
-                }
-              ]
+              "audit_rules": {
+                "layer_rules": [
+                  {
+                    "name": "engine-owns-terminal-status",
+                    "forbid": {
+                      "glob": "inc/Core/Steps/**/*.php",
+                      "patterns": ["JobStatus::"]
+                    },
+                    "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
+                  }
+                ]
+              }
             }"#,
         )
         .unwrap();


### PR DESCRIPTION
## Summary
Removes the `.homeboy/audit-rules.json` config path. `homeboy.json` under `audit_rules` is now the only source for layer ownership rules.

**Before:** Rules loaded from `.homeboy/audit-rules.json` first, falling back to `homeboy.json`. If both existed, `.homeboy/` silently won — creating config drift risk.

**After:** Only `homeboy.json` → `audit_rules`. No `.homeboy/` directory needed.

## Changes
- `layer_ownership.rs`: Remove `.homeboy/audit-rules.json` check from `load_rules_config()`
- 2 tests updated to use `homeboy.json` instead of `.homeboy/audit-rules.json`

Closes #779.