### PR TITLE
fix: enable lint autofix in release pipeline + cargo fmt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,9 @@ jobs:
           component: homeboy
           commands: lint
           autofix: 'true'
+          autofix-commands: 'lint --fix'
+          autofix-open-pr: 'true'
+          autofix-max-commits: '3'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   gate-test:

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -843,12 +843,20 @@ fn run_move_file(
     let root = refactor::move_items::resolve_root(component_id, path)?;
 
     if write {
-        homeboy::engine::undo::UndoSnapshot::capture_and_save(&root, "refactor move --file", [file, to]);
+        homeboy::engine::undo::UndoSnapshot::capture_and_save(
+            &root,
+            "refactor move --file",
+            [file, to],
+        );
     }
 
     let result = refactor::move_items::move_file(file, to, &root, write)?;
 
-    let exit_code = if result.imports_updated > 0 || result.mod_declarations_updated { 0 } else { 1 };
+    let exit_code = if result.imports_updated > 0 || result.mod_declarations_updated {
+        0
+    } else {
+        1
+    };
 
     homeboy::log_status!(
         "refactor",

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -833,10 +833,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
             // For a whole-module move, we need to find all files that import
             // anything from the source module. We use the module name as the
             // search term — any file that mentions it might have imports to update.
-            let source_module_leaf = source_module
-                .rsplit("::")
-                .next()
-                .unwrap_or(&source_module);
+            let source_module_leaf = source_module.rsplit("::").next().unwrap_or(&source_module);
 
             let all_files = codebase_scan::walk_files(
                 root,
@@ -879,8 +876,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
                     continue;
                 }
 
-                let file_ext_str =
-                    file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                let file_ext_str = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
                 if !ext.handles_file_extension(file_ext_str) {
                     continue;
                 }
@@ -891,8 +887,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
                 };
 
                 // Quick check: does this file mention the source module?
-                let mentions_source =
-                    search_refs.iter().any(|term| file_content.contains(term));
+                let mentions_source = search_refs.iter().any(|term| file_content.contains(term));
                 if !mentions_source {
                     continue;
                 }
@@ -935,10 +930,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
 
         // Move the file
         std::fs::rename(&source_abs, &dest_abs).map_err(|e| {
-            crate::Error::internal_io(
-                e.to_string(),
-                Some(format!("move {} → {}", from, to)),
-            )
+            crate::Error::internal_io(e.to_string(), Some(format!("move {} → {}", from, to)))
         })?;
 
         // Update old parent mod.rs — remove mod declaration
@@ -1076,7 +1068,8 @@ fn add_mod_declaration(content: &str, module_name: &str) -> String {
     let mut insert_after = None;
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
-        if trimmed.starts_with("mod ") || trimmed.starts_with("pub mod ")
+        if trimmed.starts_with("mod ")
+            || trimmed.starts_with("pub mod ")
             || trimmed.starts_with("pub(crate) mod ")
         {
             insert_after = Some(i);


### PR DESCRIPTION
## Summary
Two fixes:

### 1. Enable lint autofix in release pipeline
The lint step had `autofix: true` but no `autofix-commands` or `autofix-open-pr`. Formatting issues detected by `cargo fmt --check` couldn't self-heal — the pipeline just failed.

Now the lint step has `autofix-commands: lint --fix` which runs `cargo fmt` in fix mode (the Rust extension already supports `HOMEBOY_AUTO_FIX=1`). When formatting issues are found, the pipeline auto-commits the fix.

### 2. Format today's code
`move_items.rs` and `commands/refactor.rs` from PR #789 (move --file) had formatting that `cargo fmt --check` caught. This is what caused the lint failure in the latest release run.

Going forward, if this happens again, the lint autofix will catch it automatically.