### PR TITLE
fix: pub use removal comma bug + cascading findings from decompose

### DIFF
--- a/src/core/refactor/auto/apply.rs
+++ b/src/core/refactor/auto/apply.rs
@@ -229,30 +229,36 @@ fn remove_from_pub_use_block(lines: &mut Vec<String>, fn_name: &str) {
             while i < lines.len() {
                 let inner = lines[i].trim().to_string();
                 if word_re.is_match(&inner) {
-                    // Remove this line entirely if it's just the name
+                    // Remove the matched name (and surrounding comma/whitespace)
                     let cleaned = word_re
                         .replace(&inner, "")
                         .to_string()
                         .replace(", ,", ",")
                         .trim()
                         .to_string();
-                    if cleaned.is_empty() || cleaned == "," {
-                        lines.remove(i);
-                        continue;
-                    }
-                    // Remove trailing comma if it's the last item before }
-                    let cleaned = cleaned.trim_end_matches(',').trim().to_string();
+                    // Strip leading/trailing commas to normalize
+                    let cleaned = cleaned
+                        .trim_start_matches(',')
+                        .trim_end_matches(',')
+                        .trim()
+                        .to_string();
                     if cleaned.is_empty() {
                         lines.remove(i);
                         continue;
                     }
-                    lines[i] = format!(
-                        "{}{}",
-                        " ".repeat(lines[i].len() - lines[i].trim_start().len()),
+                    // Restore trailing comma for non-closing lines in a multi-line block.
+                    // Without this, removing an item from the end of a line leaves the
+                    // previous items without a trailing comma, breaking the next line.
+                    let needs_trailing_comma = !cleaned.contains('}');
+                    let final_cleaned = if needs_trailing_comma && !cleaned.ends_with(',') {
+                        format!("{},", cleaned)
+                    } else {
                         cleaned
-                    );
+                    };
+                    let indent = " ".repeat(lines[i].len() - lines[i].trim_start().len());
+                    lines[i] = format!("{}{}", indent, final_cleaned);
                 }
-                if inner.contains('}') {
+                if lines[i].trim().contains('}') {
                     break;
                 }
                 i += 1;

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -529,6 +529,12 @@ fn run_fix_iteration(
     ))
 }
 
+/// Findings that are expected side effects of structural refactoring.
+///
+/// When decompose splits a god file into submodules, the new smaller files
+/// may trigger findings that weren't visible before (e.g., duplication
+/// patterns become detectable at the file level, or new files lack tests).
+/// These are the next step to fix, not a reason to rollback the refactor.
 fn is_cascading_finding_kind(kind: &crate::code_audit::AuditFinding) -> bool {
     use crate::code_audit::AuditFinding;
 
@@ -539,6 +545,10 @@ fn is_cascading_finding_kind(kind: &crate::code_audit::AuditFinding) -> bool {
             | AuditFinding::DirectorySprawl
             | AuditFinding::MissingTestFile
             | AuditFinding::MissingTestMethod
+            | AuditFinding::IntraMethodDuplicate
+            | AuditFinding::NearDuplicate
+            | AuditFinding::ParallelImplementation
+            | AuditFinding::UnreferencedExport
     )
 }
 


### PR DESCRIPTION
## Summary
Two fixes for the autofix convergence problem that caused 48/66 fix chunks to be reverted in CI.

### 1. Trailing comma bug in pub use removal
When `remove_from_pub_use_block` removed an item from the end of a line in a multi-line `pub use` block, it unconditionally stripped the trailing comma. This left the remaining items without a separator:

```rust
// Before fix removal:
    apply_decompose_plans, apply_fix_policy, apply_fixes, apply_fixes_chunked, apply_new_files,
    apply_new_files_chunked, ...

// After removing apply_new_files (BROKEN — missing comma):
    apply_decompose_plans, apply_fixes, apply_fixes_chunked
    apply_new_files_chunked, ...

// After this fix (CORRECT):
    apply_decompose_plans, apply_fixes, apply_fixes_chunked,
    apply_new_files_chunked, ...
```

### 2. Cascading findings treated as expected
When decompose splits a god file into submodules, the new smaller files trigger `IntraMethodDuplicate`, `NearDuplicate`, `ParallelImplementation`, and `UnreferencedExport` findings that weren't visible in the larger file. The verifier was treating these as regressions and rolling back the decompose.

Now these finding kinds are recognized as cascading — expected side-effects of structural refactoring that should be fixed in the next iteration, not used to reject the current fix.

## Impact
In the latest CI run, iteration 1 applied 18 chunks but reverted 48. Both bugs contributed to the reverts. With these fixes, decompose splits should survive verification and the regular fix chunks should produce valid code.