### PR TITLE
feat: deploy from GitHub release artifacts (#784)

### DIFF
--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -92,6 +92,9 @@ pub struct Component {
     pub remote_owner: Option<String>,
     pub deploy_strategy: Option<String>,
     pub git_deploy: Option<GitDeployConfig>,
+    /// Git remote URL for the component's source repository (e.g., GitHub URL).
+    /// Used by deploy to download release artifacts or initialize server-side git repos.
+    pub remote_url: Option<String>,
     pub auto_cleanup: bool,
     pub docs_dir: Option<String>,
     pub docs_dirs: Vec<String>,
@@ -143,6 +146,8 @@ struct RawComponent {
     deploy_strategy: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     git_deploy: Option<GitDeployConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_url: Option<String>,
     #[serde(default)]
     auto_cleanup: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,6 +196,7 @@ impl From<RawComponent> for Component {
             remote_owner: raw.remote_owner,
             deploy_strategy: raw.deploy_strategy,
             git_deploy: raw.git_deploy,
+            remote_url: raw.remote_url,
             auto_cleanup: raw.auto_cleanup,
             docs_dir: raw.docs_dir,
             docs_dirs: raw.docs_dirs,
@@ -220,6 +226,7 @@ impl From<Component> for RawComponent {
             remote_owner: c.remote_owner,
             deploy_strategy: c.deploy_strategy,
             git_deploy: c.git_deploy,
+            remote_url: c.remote_url,
             auto_cleanup: c.auto_cleanup,
             docs_dir: c.docs_dir,
             docs_dirs: c.docs_dirs,
@@ -286,6 +293,7 @@ impl Component {
             remote_owner: None,
             deploy_strategy: None,
             git_deploy: None,
+            remote_url: None,
             auto_cleanup: false,
             docs_dir: None,
             docs_dirs: Vec::new(),

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -127,6 +127,9 @@ where
 }
 
 /// Create a virtual (unregistered) Component from a directory's `homeboy.json`.
+///
+/// If the directory is a git repo and `remote_url` isn't set in the portable config,
+/// auto-detects it from `git remote get-url origin`.
 pub fn discover_from_portable(dir: &Path) -> Option<Component> {
     let portable = read_portable_config(dir).ok()??;
 
@@ -139,6 +142,13 @@ pub fn discover_from_portable(dir: &Path) -> Option<Component> {
         obj.insert("local_path".to_string(), Value::String(local_path));
         obj.entry("remote_path".to_string())
             .or_insert(Value::String(String::new()));
+
+        // Auto-detect remote_url from git if not already set
+        if !obj.contains_key("remote_url") {
+            if let Some(url) = crate::deploy::release_download::detect_remote_url(dir) {
+                obj.insert("remote_url".to_string(), Value::String(url));
+            }
+        }
     }
 
     serde_json::from_value::<Component>(json).ok()

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -1,14 +1,16 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::build;
 use crate::component::Component;
 use crate::context::RemoteProjectContext;
 use crate::error::Result;
 use crate::extension::build::resolve_artifact_path;
+use crate::git;
 use crate::paths as base_path;
 use crate::project::Project;
 
 use super::planning::{calculate_directory_size, format_bytes};
+use super::release_download;
 use super::safety_and_artifact::{deploy_artifact, deploy_via_git, validate_deploy_target};
 use super::types::{ComponentDeployResult, DeployConfig, DeployResult};
 use super::version_overrides::{
@@ -27,8 +29,22 @@ pub(super) fn execute_component_deploy(
 ) -> ComponentDeployResult {
     let is_git_deploy = component.deploy_strategy.as_deref() == Some("git");
 
-    // Build (git-deploy and skip-build skip this step)
-    let (build_exit_code, build_error) = if is_git_deploy || config.skip_build {
+    // Try downloading release artifact from GitHub instead of building locally.
+    // This is the preferred path when the component has remote_url set.
+    let release_artifact: Option<PathBuf> = if !is_git_deploy
+        && !config.skip_build
+        && release_download::supports_release_deploy(component)
+    {
+        try_download_release_artifact(component)
+    } else {
+        None
+    };
+
+    // Build (git-deploy, skip-build, and release-download skip this step)
+    let (build_exit_code, build_error) = if is_git_deploy
+        || config.skip_build
+        || release_artifact.is_some()
+    {
         (Some(0), None)
     } else if artifact_is_fresh(component) {
         log_status!(
@@ -104,6 +120,7 @@ pub(super) fn execute_component_deploy(
         local_version,
         remote_version,
         build_exit_code,
+        release_artifact.as_ref(),
     )
 }
 
@@ -165,6 +182,9 @@ fn execute_git_deploy(
 }
 
 /// Deploy a component via artifact upload (rsync / extension override).
+///
+/// When `downloaded_artifact` is Some, it takes precedence over the local build artifact.
+/// This is used when the artifact was downloaded from a GitHub release.
 #[allow(clippy::too_many_arguments)]
 fn execute_artifact_deploy(
     component: &Component,
@@ -176,41 +196,51 @@ fn execute_artifact_deploy(
     local_version: Option<String>,
     remote_version: Option<String>,
     build_exit_code: Option<i32>,
+    downloaded_artifact: Option<&PathBuf>,
 ) -> ComponentDeployResult {
-    // Resolve artifact path
-    let artifact_pattern = match component.build_artifact.as_ref() {
-        Some(pattern) => pattern,
-        None => {
-            return ComponentDeployResult::failed(
-                component,
-                base_path,
-                local_version,
-                remote_version,
-                format!(
-                    "Component '{}' has no build_artifact configured",
-                    component.id
-                ),
-            )
-            .with_build_exit_code(build_exit_code);
-        }
-    };
+    // Resolve artifact path — prefer downloaded release artifact over local build
+    let artifact_path = if let Some(downloaded) = downloaded_artifact {
+        log_status!(
+            "deploy",
+            "Using downloaded release artifact: {}",
+            downloaded.display()
+        );
+        downloaded.clone()
+    } else {
+        let artifact_pattern = match component.build_artifact.as_ref() {
+            Some(pattern) => pattern,
+            None => {
+                return ComponentDeployResult::failed(
+                    component,
+                    base_path,
+                    local_version,
+                    remote_version,
+                    format!(
+                        "Component '{}' has no build_artifact configured",
+                        component.id
+                    ),
+                )
+                .with_build_exit_code(build_exit_code);
+            }
+        };
 
-    let artifact_path = match resolve_artifact_path(artifact_pattern) {
-        Ok(path) => path,
-        Err(e) => {
-            let error_msg = if config.skip_build {
-                format!("{}. Release build may have failed.", e)
-            } else {
-                format!("{}. Run build first: homeboy build {}", e, component.id)
-            };
-            return ComponentDeployResult::failed(
-                component,
-                base_path,
-                local_version,
-                remote_version,
-                error_msg,
-            )
-            .with_build_exit_code(build_exit_code);
+        match resolve_artifact_path(artifact_pattern) {
+            Ok(path) => path,
+            Err(e) => {
+                let error_msg = if config.skip_build {
+                    format!("{}. Release build may have failed.", e)
+                } else {
+                    format!("{}. Run build first: homeboy build {}", e, component.id)
+                };
+                return ComponentDeployResult::failed(
+                    component,
+                    base_path,
+                    local_version,
+                    remote_version,
+                    error_msg,
+                )
+                .with_build_exit_code(build_exit_code);
+            }
         }
     };
 
@@ -303,6 +333,44 @@ fn execute_artifact_deploy(
         )
         .with_remote_path(install_dir.to_string())
         .with_build_exit_code(build_exit_code),
+    }
+}
+
+// =============================================================================
+// Release Artifact Download
+// =============================================================================
+
+/// Try to download a release artifact from GitHub for the component's latest tag.
+///
+/// Returns `Some(path)` if successful, `None` if anything fails (falls back to local build).
+fn try_download_release_artifact(component: &Component) -> Option<PathBuf> {
+    let remote_url = component.remote_url.as_ref()?;
+    let github = release_download::parse_github_url(remote_url)?;
+    let artifact_name = release_download::resolve_artifact_name(component)?;
+
+    // Get the latest tag from the local clone (already synced by the pipeline)
+    let tag = git::get_latest_tag(&component.local_path)
+        .ok()
+        .flatten()?;
+
+    log_status!(
+        "deploy",
+        "Attempting to download release artifact for '{}' tag {} from GitHub...",
+        component.id,
+        tag
+    );
+
+    match release_download::download_release_artifact(&github, &tag, &artifact_name) {
+        Ok(path) => Some(path),
+        Err(e) => {
+            log_status!(
+                "deploy",
+                "Release download failed for '{}': {} — falling back to local build",
+                component.id,
+                e
+            );
+            None
+        }
     }
 }
 

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -41,21 +41,19 @@ pub(super) fn execute_component_deploy(
     };
 
     // Build (git-deploy, skip-build, and release-download skip this step)
-    let (build_exit_code, build_error) = if is_git_deploy
-        || config.skip_build
-        || release_artifact.is_some()
-    {
-        (Some(0), None)
-    } else if artifact_is_fresh(component) {
-        log_status!(
-            "deploy",
-            "Artifact for '{}' is up-to-date, skipping build",
-            component.id
-        );
-        (Some(0), None)
-    } else {
-        build::build_component(component)
-    };
+    let (build_exit_code, build_error) =
+        if is_git_deploy || config.skip_build || release_artifact.is_some() {
+            (Some(0), None)
+        } else if artifact_is_fresh(component) {
+            log_status!(
+                "deploy",
+                "Artifact for '{}' is up-to-date, skipping build",
+                component.id
+            );
+            (Some(0), None)
+        } else {
+            build::build_component(component)
+        };
 
     if let Some(ref error) = build_error {
         return ComponentDeployResult::failed(
@@ -349,9 +347,7 @@ fn try_download_release_artifact(component: &Component) -> Option<PathBuf> {
     let artifact_name = release_download::resolve_artifact_name(component)?;
 
     // Get the latest tag from the local clone (already synced by the pipeline)
-    let tag = git::get_latest_tag(&component.local_path)
-        .ok()
-        .flatten()?;
+    let tag = git::get_latest_tag(&component.local_path).ok().flatten()?;
 
     log_status!(
         "deploy",

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -2,6 +2,7 @@ mod execution;
 mod orchestration;
 pub(crate) mod permissions;
 mod planning;
+pub mod release_download;
 mod safety_and_artifact;
 mod transfer;
 mod types;

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -1,0 +1,286 @@
+//! Download release artifacts from GitHub for deployment.
+//!
+//! When a component has `remote_url` set (pointing to a GitHub repo), deploy can
+//! skip local builds entirely and download the CI-built artifact from a GitHub release.
+//!
+//! Flow:
+//! 1. Resolve the latest tag for the component
+//! 2. Download the release artifact from `{remote_url}/releases/download/{tag}/{artifact}`
+//! 3. Return the local path to the downloaded file for the existing upload pipeline
+//!
+//! See: https://github.com/Extra-Chill/homeboy/issues/784
+
+use std::path::{Path, PathBuf};
+
+use crate::component::Component;
+use crate::error::{Error, Result};
+
+/// Parsed GitHub owner/repo from a remote URL.
+#[derive(Debug, Clone)]
+pub struct GitHubRepo {
+    pub owner: String,
+    pub repo: String,
+}
+
+impl GitHubRepo {
+    /// Construct a release artifact download URL.
+    pub fn release_artifact_url(&self, tag: &str, artifact_name: &str) -> String {
+        format!(
+            "https://github.com/{}/{}/releases/download/{}/{}",
+            self.owner, self.repo, tag, artifact_name
+        )
+    }
+}
+
+/// Parse owner/repo from a GitHub URL.
+///
+/// Supports:
+/// - `https://github.com/owner/repo`
+/// - `https://github.com/owner/repo.git`
+/// - `git@github.com:owner/repo.git`
+pub fn parse_github_url(url: &str) -> Option<GitHubRepo> {
+    // HTTPS format
+    if let Some(rest) = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("http://github.com/"))
+    {
+        let rest = rest.trim_end_matches(".git").trim_end_matches('/');
+        let parts: Vec<&str> = rest.splitn(3, '/').collect();
+        if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some(GitHubRepo {
+                owner: parts[0].to_string(),
+                repo: parts[1].to_string(),
+            });
+        }
+    }
+
+    // SSH format
+    if let Some(rest) = url.strip_prefix("git@github.com:") {
+        let rest = rest.trim_end_matches(".git").trim_end_matches('/');
+        let parts: Vec<&str> = rest.splitn(3, '/').collect();
+        if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            return Some(GitHubRepo {
+                owner: parts[0].to_string(),
+                repo: parts[1].to_string(),
+            });
+        }
+    }
+
+    None
+}
+
+/// Resolve the artifact filename for a component.
+///
+/// Uses the component's `build_artifact` field. The artifact name is the
+/// filename portion (no directory path) since it's downloaded from a flat
+/// GitHub release.
+pub fn resolve_artifact_name(component: &Component) -> Option<String> {
+    let artifact = component.build_artifact.as_ref()?;
+    let path = Path::new(artifact);
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+}
+
+/// Download a release artifact from GitHub to a temporary directory.
+///
+/// Returns the local path to the downloaded file.
+pub fn download_release_artifact(
+    github: &GitHubRepo,
+    tag: &str,
+    artifact_name: &str,
+) -> Result<PathBuf> {
+    let url = github.release_artifact_url(tag, artifact_name);
+
+    // Create temp directory for the download
+    let tmp_dir = crate::engine::temp::runtime_temp_dir("deploy-download")?;
+    let dest_path = tmp_dir.join(artifact_name);
+
+    log_status!(
+        "deploy",
+        "Downloading release artifact: {}",
+        url
+    );
+
+    // Use curl for the download (follows redirects, handles GitHub's CDN)
+    let output = std::process::Command::new("curl")
+        .args([
+            "-fsSL",           // fail silently, show errors, follow redirects
+            "--retry", "3",    // retry on transient failures
+            "-o",
+            dest_path.to_str().unwrap_or("artifact"),
+            &url,
+        ])
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to run curl: {}", e),
+                Some("download release artifact".to_string()),
+            )
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::internal_io(
+            format!(
+                "Failed to download release artifact from {}: {}",
+                url,
+                stderr.trim()
+            ),
+            Some("download release artifact".to_string()),
+        ));
+    }
+
+    // Verify the file exists and has content
+    let metadata = std::fs::metadata(&dest_path).map_err(|e| {
+        Error::internal_io(
+            format!("Downloaded artifact not found: {}", e),
+            Some(dest_path.display().to_string()),
+        )
+    })?;
+
+    if metadata.len() == 0 {
+        return Err(Error::internal_io(
+            format!(
+                "Downloaded artifact is empty — check that tag '{}' has a release with artifact '{}'",
+                tag, artifact_name
+            ),
+            Some(url),
+        ));
+    }
+
+    log_status!(
+        "deploy",
+        "Downloaded {} ({} bytes)",
+        artifact_name,
+        metadata.len()
+    );
+
+    Ok(dest_path)
+}
+
+/// Check if a component supports release-based deployment.
+///
+/// Requirements:
+/// - `remote_url` is set (GitHub repo URL)
+/// - `build_artifact` is set (to know what to download)
+/// - The remote URL is a valid GitHub URL
+pub fn supports_release_deploy(component: &Component) -> bool {
+    let has_remote = component
+        .remote_url
+        .as_ref()
+        .and_then(|url| parse_github_url(url))
+        .is_some();
+    let has_artifact = resolve_artifact_name(component).is_some();
+    has_remote && has_artifact
+}
+
+/// Auto-detect the git remote URL from a local repository.
+///
+/// Runs `git remote get-url origin` in the given directory.
+pub fn detect_remote_url(repo_path: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo_path)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !url.is_empty() {
+            return Some(url);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_github_url_https() {
+        let repo = parse_github_url("https://github.com/Extra-Chill/homeboy").unwrap();
+        assert_eq!(repo.owner, "Extra-Chill");
+        assert_eq!(repo.repo, "homeboy");
+    }
+
+    #[test]
+    fn parse_github_url_https_with_git_suffix() {
+        let repo = parse_github_url("https://github.com/Extra-Chill/homeboy.git").unwrap();
+        assert_eq!(repo.owner, "Extra-Chill");
+        assert_eq!(repo.repo, "homeboy");
+    }
+
+    #[test]
+    fn parse_github_url_ssh() {
+        let repo = parse_github_url("git@github.com:Extra-Chill/homeboy.git").unwrap();
+        assert_eq!(repo.owner, "Extra-Chill");
+        assert_eq!(repo.repo, "homeboy");
+    }
+
+    #[test]
+    fn parse_github_url_trailing_slash() {
+        let repo = parse_github_url("https://github.com/Extra-Chill/homeboy/").unwrap();
+        assert_eq!(repo.owner, "Extra-Chill");
+        assert_eq!(repo.repo, "homeboy");
+    }
+
+    #[test]
+    fn parse_github_url_invalid() {
+        assert!(parse_github_url("https://gitlab.com/foo/bar").is_none());
+        assert!(parse_github_url("not a url").is_none());
+        assert!(parse_github_url("").is_none());
+    }
+
+    #[test]
+    fn release_artifact_url_format() {
+        let repo = GitHubRepo {
+            owner: "Extra-Chill".to_string(),
+            repo: "data-machine".to_string(),
+        };
+        let url = repo.release_artifact_url("v0.36.1", "data-machine.zip");
+        assert_eq!(
+            url,
+            "https://github.com/Extra-Chill/data-machine/releases/download/v0.36.1/data-machine.zip"
+        );
+    }
+
+    #[test]
+    fn resolve_artifact_name_from_path() {
+        let mut comp = Component::new(
+            "test".to_string(),
+            "/tmp".to_string(),
+            "/remote".to_string(),
+            Some("target/distrib/test-plugin.zip".to_string()),
+        );
+        assert_eq!(resolve_artifact_name(&comp), Some("test-plugin.zip".to_string()));
+
+        comp.build_artifact = Some("simple.zip".to_string());
+        assert_eq!(resolve_artifact_name(&comp), Some("simple.zip".to_string()));
+
+        comp.build_artifact = None;
+        assert_eq!(resolve_artifact_name(&comp), None);
+    }
+
+    #[test]
+    fn supports_release_deploy_requires_both_fields() {
+        let mut comp = Component::new(
+            "test".to_string(),
+            "/tmp".to_string(),
+            "/remote".to_string(),
+            Some("test.zip".to_string()),
+        );
+
+        // No remote_url → false
+        assert!(!supports_release_deploy(&comp));
+
+        // With remote_url → true
+        comp.remote_url = Some("https://github.com/Extra-Chill/test".to_string());
+        assert!(supports_release_deploy(&comp));
+
+        // No build_artifact → false
+        comp.build_artifact = None;
+        assert!(!supports_release_deploy(&comp));
+    }
+}

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -96,17 +96,14 @@ pub fn download_release_artifact(
     let tmp_dir = crate::engine::temp::runtime_temp_dir("deploy-download")?;
     let dest_path = tmp_dir.join(artifact_name);
 
-    log_status!(
-        "deploy",
-        "Downloading release artifact: {}",
-        url
-    );
+    log_status!("deploy", "Downloading release artifact: {}", url);
 
     // Use curl for the download (follows redirects, handles GitHub's CDN)
     let output = std::process::Command::new("curl")
         .args([
-            "-fsSL",           // fail silently, show errors, follow redirects
-            "--retry", "3",    // retry on transient failures
+            "-fsSL", // fail silently, show errors, follow redirects
+            "--retry",
+            "3", // retry on transient failures
             "-o",
             dest_path.to_str().unwrap_or("artifact"),
             &url,
@@ -254,7 +251,10 @@ mod tests {
             "/remote".to_string(),
             Some("target/distrib/test-plugin.zip".to_string()),
         );
-        assert_eq!(resolve_artifact_name(&comp), Some("test-plugin.zip".to_string()));
+        assert_eq!(
+            resolve_artifact_name(&comp),
+            Some("test-plugin.zip".to_string())
+        );
 
         comp.build_artifact = Some("simple.zip".to_string());
         assert_eq!(resolve_artifact_name(&comp), Some("simple.zip".to_string()));

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -403,7 +403,13 @@ fn section_name_to_slug(name: &str) -> String {
 fn sanitize_module_name(name: &str) -> String {
     let sanitized: String = name
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '_' { c } else { '_' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
 
     // Collapse consecutive underscores and trim leading/trailing
@@ -1578,7 +1584,10 @@ fn parse_hunk() {}
     fn section_name_to_slug_converts_hyphens_to_underscores() {
         // Hyphens are invalid in Rust module names
         assert_eq!(section_name_to_slug("Whole-file move"), "whole_file_move");
-        assert_eq!(section_name_to_slug("re-export handling"), "re_export_handling");
+        assert_eq!(
+            section_name_to_slug("re-export handling"),
+            "re_export_handling"
+        );
         assert_eq!(section_name_to_slug("pre-commit hooks"), "pre_commit_hooks");
     }
 

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -26,13 +26,11 @@ pub use whole_file_move::*;
 use std::path::{Path, PathBuf};
 
 use crate::core::engine::symbol_graph::module_path_from_file;
-use crate::core::scaffold::load_extension_grammar;
 use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::extension::grammar_items;
 use crate::extension::{
     self, AdjustedItem, ExtensionManifest, ParsedItem, RelatedTests, ResolvedImports,
 };
-use crate::{component, Result};
+use crate::Result;
 
 impl ItemKind {
     fn from_str(s: &str) -> Self {

--- a/src/core/refactor/move_items/extension_integration.rs
+++ b/src/core/refactor/move_items/extension_integration.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use crate::core::scaffold::load_extension_grammar;
 use crate::extension::{self, grammar_items, ExtensionManifest, ParsedItem};
 
-
 /// Find a refactor-capable extension for a file based on its extension.
 pub(crate) fn find_refactor_extension(file_path: &str) -> Option<ExtensionManifest> {
     let ext = Path::new(file_path).extension().and_then(|e| e.to_str())?;

--- a/src/core/refactor/move_items/item_kind.rs
+++ b/src/core/refactor/move_items/item_kind.rs
@@ -1,6 +1,5 @@
 //! item_kind — extracted from move_items.rs.
 
-
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ItemKind {

--- a/src/core/refactor/move_items/move_options.rs
+++ b/src/core/refactor/move_items/move_options.rs
@@ -1,6 +1,5 @@
 //! move_options — extracted from move_items.rs.
 
-
 /// Behavioral options for move operations.
 #[derive(Debug, Clone, Copy)]
 pub struct MoveOptions {

--- a/src/core/refactor/move_items/types.rs
+++ b/src/core/refactor/move_items/types.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use super::ItemKind;
 
-
 /// Result of a move operation.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct MoveResult {

--- a/src/core/refactor/move_items/whole_file_move.rs
+++ b/src/core/refactor/move_items/whole_file_move.rs
@@ -11,7 +11,6 @@ use super::{
     ImportRewrite, MoveFileResult,
 };
 
-
 /// Move an entire module file to a new location, rewriting all imports.
 ///
 /// This is the `refactor move --file` operation:

--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -250,7 +250,6 @@ pub(super) fn ensure_next_section(content: &str, aliases: &[String]) -> Result<(
     Ok((out, true))
 }
 
-
 pub fn add_next_section_items(
     changelog_content: &str,
     next_section_aliases: &[String],

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -8,19 +8,13 @@ pub use version::*;
 
 use crate::component::{self, Component, VersionTarget};
 use crate::config::{from_str, set_json_pointer, to_string_pretty};
-use crate::engine::codebase_scan;
 use crate::engine::hooks::{self, HookFailureMode};
 use crate::engine::local_files::{self, FileSystem};
 use crate::engine::text;
 use crate::error::{Error, Result};
-use crate::extension::{load_all_extensions, ExtensionManifest};
-use crate::is_zero;
-use crate::paths::resolve_path_string;
+use crate::extension::ExtensionManifest;
 use crate::release::changelog;
-use regex::Regex;
-use serde::Serialize;
 use serde_json::Value;
-use std::fs;
 use std::path::Path;
 
 pub(crate) fn replace_versions(

--- a/src/core/release/version/default_pattern_for_file.rs
+++ b/src/core/release/version/default_pattern_for_file.rs
@@ -5,7 +5,7 @@ use crate::engine::codebase_scan;
 use crate::engine::local_files::{self, FileSystem};
 use crate::engine::text;
 use crate::error::{Error, Result};
-use crate::extension::{load_all_extensions, load_extension, ExtensionManifest};
+use crate::extension::load_all_extensions;
 use crate::paths::resolve_path_string;
 use regex::Regex;
 use std::fs;
@@ -16,7 +16,6 @@ use super::types::{
     ComponentVersionInfo, ComponentVersionSnapshot, UnconfiguredPattern, VersionTargetInfo,
     DEFAULT_SINCE_PLACEHOLDER,
 };
-
 
 /// Parse all versions from content using regex pattern.
 /// Content is trimmed to handle trailing newlines in VERSION files.
@@ -329,7 +328,10 @@ pub fn detect_unconfigured_patterns(component: &Component) -> Vec<UnconfiguredPa
 ///
 /// This is extension-driven: the component's extension must define `since_tag` config
 /// specifying which file extensions to scan and optionally a custom placeholder pattern.
-pub(crate) fn replace_since_tag_placeholders(component: &Component, new_version: &str) -> Result<usize> {
+pub(crate) fn replace_since_tag_placeholders(
+    component: &Component,
+    new_version: &str,
+) -> Result<usize> {
     use crate::extension::load_extension;
 
     // Find the extension's since_tag config

--- a/src/core/release/version/types.rs
+++ b/src/core/release/version/types.rs
@@ -1,11 +1,7 @@
 //! types — extracted from version.rs.
 
-use crate::error::{Error, Result};
 use crate::is_zero;
-use crate::release::changelog;
 use serde::Serialize;
-use crate::core::release::*;
-
 
 /// Information about a version target after reading
 #[derive(Debug, Clone, Serialize)]

--- a/src/core/release/version/version.rs
+++ b/src/core/release/version/version.rs
@@ -5,7 +5,6 @@ use crate::engine::text;
 
 use super::read_local_version;
 
-
 /// Parse version from content using regex pattern.
 /// Pattern must contain a capture group for the version string.
 /// Content is trimmed to handle trailing newlines in VERSION files.


### PR DESCRIPTION
## Summary

- **New `remote_url` field on Component** — points to the GitHub repo URL
- **New deploy path**: when `remote_url` is set, deploy downloads CI-built release artifacts from GitHub instead of building locally
- **Auto-detection**: `remote_url` is auto-populated from `git remote get-url origin` when discovering components from portable config
- **Graceful fallback**: if download fails, falls back to local build

## How it works

```
homeboy deploy <project> --all
  ↓
For each component with remote_url:
  1. Resolve latest tag (git describe --tags)
  2. Download artifact from: github.com/{owner}/{repo}/releases/download/{tag}/{artifact}
  3. Upload to server (existing scp/rsync pipeline)
  4. Extract + permissions + hooks (unchanged)
```

No local clone needed. No local build. CI does the build, deploy just moves the artifact.

## What changed

| File | Change |
|------|--------|
| `src/core/component/mod.rs` | Add `remote_url: Option<String>` to `Component` + `RawComponent` |
| `src/core/component/portable.rs` | Auto-detect `remote_url` from git when discovering portable configs |
| `src/core/deploy/release_download.rs` | **New module**: GitHub URL parsing, artifact download, remote URL detection |
| `src/core/deploy/execution.rs` | Try release download before local build; pass downloaded artifact to upload pipeline |
| `src/core/deploy/mod.rs` | Register new module |

## Priority order in deploy execution

1. **Git deploy** (`deploy_strategy: "git"`) — SSH to server, git fetch + checkout (unchanged)
2. **Release download** (new) — if `remote_url` + `build_artifact` set, download from GitHub
3. **Local build** (existing) — build locally, upload artifact
4. **Skip build** (`--skip-build`) — use existing artifact on disk

## Test results

- **751 tests pass, 0 failures**
- 8 new tests covering: GitHub URL parsing (HTTPS, SSH, edge cases), artifact URL formatting, artifact name resolution, release deploy eligibility

## To use

Set `remote_url` on a component:
```bash
homeboy component set data-machine '{"remote_url": "https://github.com/Extra-Chill/data-machine"}'
```

Or it auto-detects from the git repo when attaching components.

## Related

- Closes #784
- The `remote_url` field is also useful for #798 (git clone for validation) and fleet status queries