### PR TITLE
refactor: merge SafeAuto + SafeWithChecks into single Safe tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ Runs the project's test suite. Supports test drift detection — when source sym
 
 Structural improvements with safety tiers:
 
-- **SafeAuto** — import additions, doc reference updates (always auto-applied)
-- **SafeWithChecks** — registration stubs, namespace fixes (auto-applied after preflight validation)
+- **Safe** — deterministic fixes auto-applied with preflight validation (imports, registrations, namespace fixes, visibility changes, doc updates)
 - **PlanOnly** — method stubs, function removals (human review required)
 
 ## The Autofix Loop

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -138,10 +138,8 @@ pub struct AuditFixPolicySummary {
 pub struct AuditFixability {
     /// Total findings that have any kind of automated fix.
     pub fixable_count: usize,
-    /// Findings with `SafeAuto` tier — can be applied without checks.
-    pub auto_fixable_count: usize,
-    /// Findings with `SafeWithChecks` tier — require preflight validation.
-    pub guarded_fixable_count: usize,
+    /// Findings with `Safe` tier — can be auto-applied (preflight runs when applicable).
+    pub safe_count: usize,
     /// Findings with `PlanOnly` tier — preview only, needs manual review.
     pub plan_only_count: usize,
     /// Breakdown by finding kind.
@@ -153,8 +151,7 @@ pub struct AuditFixability {
 #[derive(Debug, Serialize)]
 pub struct FixabilityKindBreakdown {
     pub total: usize,
-    pub auto: usize,
-    pub guarded: usize,
+    pub safe: usize,
     pub plan_only: usize,
 }
 
@@ -224,21 +221,21 @@ pub fn build_fix_hints(written: bool, summary: &PolicySummary) -> Vec<String> {
 
     if !written && summary.has_blocked_items() {
         hints.push(format!(
-            "{} fix(es) are visible but would be blocked on --write because they are safe_with_checks or plan_only.",
+            "{} fix(es) are visible but would be blocked on --write (preflight failed or plan-only).",
             summary.blocked_insertions + summary.blocked_new_files
         ));
     }
 
     if summary.preflight_failures > 0 {
         hints.push(format!(
-            "{} fix(es) failed deterministic preflight checks and will stay preview-only until their validator passes.",
+            "{} fix(es) failed preflight checks and will stay preview-only until their validator passes.",
             summary.preflight_failures
         ));
     }
 
     if written && summary.has_blocked_items() {
         hints.push(format!(
-            "Applied only safe_auto fixes. {} fix(es) were left as preview because they need checks or manual review.",
+            "Applied safe fixes. {} fix(es) were left as preview (preflight failed or plan-only).",
             summary.blocked_insertions + summary.blocked_new_files
         ));
     }
@@ -274,8 +271,7 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
     crate::refactor::auto::apply_fix_policy(&mut fix_result, false, &policy, &context);
 
     // Count by safety tier
-    let mut auto_fixable = 0usize;
-    let mut guarded = 0usize;
+    let mut safe_count = 0usize;
     let mut plan_only = 0usize;
     let mut by_kind: BTreeMap<String, FixabilityKindBreakdown> = BTreeMap::new();
 
@@ -284,20 +280,15 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
             let kind_key = format!("{:?}", insertion.finding).to_lowercase();
             let entry = by_kind.entry(kind_key).or_insert(FixabilityKindBreakdown {
                 total: 0,
-                auto: 0,
-                guarded: 0,
+                safe: 0,
                 plan_only: 0,
             });
             entry.total += 1;
 
             match insertion.safety_tier {
-                FixSafetyTier::SafeAuto => {
-                    auto_fixable += 1;
-                    entry.auto += 1;
-                }
-                FixSafetyTier::SafeWithChecks => {
-                    guarded += 1;
-                    entry.guarded += 1;
+                FixSafetyTier::Safe => {
+                    safe_count += 1;
+                    entry.safe += 1;
                 }
                 FixSafetyTier::PlanOnly => {
                     plan_only += 1;
@@ -311,20 +302,15 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
         let kind_key = format!("{:?}", new_file.finding).to_lowercase();
         let entry = by_kind.entry(kind_key).or_insert(FixabilityKindBreakdown {
             total: 0,
-            auto: 0,
-            guarded: 0,
+            safe: 0,
             plan_only: 0,
         });
         entry.total += 1;
 
         match new_file.safety_tier {
-            FixSafetyTier::SafeAuto => {
-                auto_fixable += 1;
-                entry.auto += 1;
-            }
-            FixSafetyTier::SafeWithChecks => {
-                guarded += 1;
-                entry.guarded += 1;
+            FixSafetyTier::Safe => {
+                safe_count += 1;
+                entry.safe += 1;
             }
             FixSafetyTier::PlanOnly => {
                 plan_only += 1;
@@ -333,12 +319,11 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
         }
     }
 
-    let fixable_count = auto_fixable + guarded + plan_only;
+    let fixable_count = safe_count + plan_only;
 
     Some(AuditFixability {
         fixable_count,
-        auto_fixable_count: auto_fixable,
-        guarded_fixable_count: guarded,
+        safe_count,
         plan_only_count: plan_only,
         by_kind,
     })

--- a/src/core/refactor/auto/contracts.rs
+++ b/src/core/refactor/auto/contracts.rs
@@ -47,11 +47,24 @@ pub struct Insertion {
     pub description: String,
 }
 
+/// Safety classification for automated code fixes.
+///
+/// Two tiers: `Safe` fixes are auto-applied (with preflight validation when applicable).
+/// `PlanOnly` fixes are preview-only and require human review.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 pub enum FixSafetyTier {
-    SafeAuto,
-    SafeWithChecks,
+    /// Fix can be auto-applied. Preflight validation runs when applicable.
+    #[serde(
+        rename = "safe",
+        alias = "safe_auto",
+        alias = "safe_with_checks",
+        alias = "Safe",
+        alias = "SafeAuto",
+        alias = "SafeWithChecks"
+    )]
+    Safe,
+    /// Fix requires human review — never auto-applied.
+    #[serde(rename = "plan_only", alias = "PlanOnly")]
     PlanOnly,
 }
 
@@ -137,17 +150,23 @@ pub enum InsertionKind {
 impl InsertionKind {
     pub fn safety_tier(&self) -> FixSafetyTier {
         match self {
-            Self::ImportAdd | Self::DocReferenceUpdate { .. } | Self::DocLineRemoval { .. } => {
-                FixSafetyTier::SafeAuto
-            }
-            Self::RegistrationStub
+            // Safe: all deterministic, mechanical fixes that can be auto-applied.
+            // Preflight validation runs when applicable (registration stubs get
+            // collision checks, visibility changes get simulation checks, etc).
+            Self::ImportAdd
+            | Self::DocReferenceUpdate { .. }
+            | Self::DocLineRemoval { .. }
+            | Self::RegistrationStub
             | Self::ConstructorWithRegistration
             | Self::TypeConformance
             | Self::NamespaceDeclaration
             | Self::VisibilityChange { .. }
-            | Self::ReexportRemoval { .. } => FixSafetyTier::SafeWithChecks,
-            Self::MethodStub => FixSafetyTier::PlanOnly,
-            Self::FunctionRemoval { .. } | Self::TraitUse => FixSafetyTier::PlanOnly,
+            | Self::ReexportRemoval { .. } => FixSafetyTier::Safe,
+
+            // Plan-only: requires human review.
+            Self::MethodStub | Self::FunctionRemoval { .. } | Self::TraitUse => {
+                FixSafetyTier::PlanOnly
+            }
         }
     }
 }

--- a/src/core/refactor/auto/policy.rs
+++ b/src/core/refactor/auto/policy.rs
@@ -22,6 +22,44 @@ fn finding_allowed(finding: &AuditFinding, policy: &FixPolicy) -> bool {
     included && !policy.exclude.contains(finding)
 }
 
+/// Determine if an insertion should be auto-applied.
+///
+/// Safe tier: auto-apply if preflight passes (or no preflight applicable).
+/// PlanOnly: never auto-apply.
+/// In dry-run mode (write=false): everything is "auto-apply" for preview purposes.
+fn should_auto_apply(
+    tier: FixSafetyTier,
+    preflight: Option<&PreflightReport>,
+    write: bool,
+) -> bool {
+    if !write {
+        return true;
+    }
+    match tier {
+        FixSafetyTier::Safe => preflight
+            .map(|report| {
+                matches!(
+                    report.status,
+                    PreflightStatus::Passed | PreflightStatus::NotApplicable
+                )
+            })
+            .unwrap_or(true), // No preflight report → auto-apply (simple fix)
+        FixSafetyTier::PlanOnly => false,
+    }
+}
+
+/// Determine the blocked reason for a non-auto-applied fix.
+fn blocked_reason(tier: FixSafetyTier, preflight: Option<&PreflightReport>) -> String {
+    match tier {
+        FixSafetyTier::Safe => preflight
+            .and_then(blocked_reason_from_preflight)
+            .unwrap_or_else(|| "Blocked by preflight validation".to_string()),
+        FixSafetyTier::PlanOnly => {
+            "Blocked: plan-only fix, not eligible for auto-write".to_string()
+        }
+    }
+}
+
 fn annotate_insertion_for_policy(
     file: &str,
     insertion: &mut Insertion,
@@ -34,38 +72,18 @@ fn annotate_insertion_for_policy(
     }
 
     insertion.preflight = preflight::run_insertion_preflight(file, insertion, context);
-
-    insertion.auto_apply = if !write {
-        true
-    } else {
-        match insertion.safety_tier {
-            FixSafetyTier::SafeAuto => true,
-            FixSafetyTier::SafeWithChecks => insertion.preflight.as_ref().is_some_and(|report| {
-                matches!(
-                    report.status,
-                    PreflightStatus::Passed | PreflightStatus::NotApplicable
-                )
-            }),
-            FixSafetyTier::PlanOnly => false,
-        }
-    };
-
+    insertion.auto_apply = should_auto_apply(
+        insertion.safety_tier,
+        insertion.preflight.as_ref(),
+        write,
+    );
     insertion.blocked_reason = if insertion.auto_apply {
         None
     } else {
-        Some(match insertion.safety_tier {
-            FixSafetyTier::SafeAuto => "Blocked by current write policy".to_string(),
-            FixSafetyTier::SafeWithChecks => insertion
-                .preflight
-                .as_ref()
-                .and_then(blocked_reason_from_preflight)
-                .unwrap_or_else(|| {
-                    "Blocked: requires preflight validation before auto-write".to_string()
-                }),
-            FixSafetyTier::PlanOnly => {
-                "Blocked: plan-only fix, not eligible for auto-write".to_string()
-            }
-        })
+        Some(blocked_reason(
+            insertion.safety_tier,
+            insertion.preflight.as_ref(),
+        ))
     };
 
     true
@@ -82,38 +100,18 @@ fn annotate_new_file_for_policy(
     }
 
     new_file.preflight = preflight::run_new_file_preflight(new_file, context);
-
-    new_file.auto_apply = if !write {
-        true
-    } else {
-        match new_file.safety_tier {
-            FixSafetyTier::SafeAuto => true,
-            FixSafetyTier::SafeWithChecks => new_file.preflight.as_ref().is_some_and(|report| {
-                matches!(
-                    report.status,
-                    PreflightStatus::Passed | PreflightStatus::NotApplicable
-                )
-            }),
-            FixSafetyTier::PlanOnly => false,
-        }
-    };
-
+    new_file.auto_apply = should_auto_apply(
+        new_file.safety_tier,
+        new_file.preflight.as_ref(),
+        write,
+    );
     new_file.blocked_reason = if new_file.auto_apply {
         None
     } else {
-        Some(match new_file.safety_tier {
-            FixSafetyTier::SafeAuto => "Blocked by current write policy".to_string(),
-            FixSafetyTier::SafeWithChecks => new_file
-                .preflight
-                .as_ref()
-                .and_then(blocked_reason_from_preflight)
-                .unwrap_or_else(|| {
-                    "Blocked: requires preflight validation before auto-write".to_string()
-                }),
-            FixSafetyTier::PlanOnly => {
-                "Blocked: plan-only fix, not eligible for auto-write".to_string()
-            }
-        })
+        Some(blocked_reason(
+            new_file.safety_tier,
+            new_file.preflight.as_ref(),
+        ))
     };
 
     true
@@ -137,41 +135,20 @@ pub fn apply_fix_policy(
 
             preflight::run_fix_preflight(&mut fix, context, write);
 
+            // Re-evaluate auto_apply after fix-level preflight
             for insertion in &mut fix.insertions {
-                insertion.auto_apply = if !write {
-                    true
-                } else {
-                    match insertion.safety_tier {
-                        FixSafetyTier::SafeAuto => true,
-                        FixSafetyTier::SafeWithChecks => {
-                            insertion.preflight.as_ref().is_some_and(|report| {
-                                matches!(
-                                    report.status,
-                                    PreflightStatus::Passed | PreflightStatus::NotApplicable
-                                )
-                            })
-                        }
-                        FixSafetyTier::PlanOnly => false,
-                    }
-                };
-
+                insertion.auto_apply = should_auto_apply(
+                    insertion.safety_tier,
+                    insertion.preflight.as_ref(),
+                    write,
+                );
                 insertion.blocked_reason = if insertion.auto_apply {
                     None
                 } else {
-                    Some(match insertion.safety_tier {
-                        FixSafetyTier::SafeAuto => "Blocked by current write policy".to_string(),
-                        FixSafetyTier::SafeWithChecks => insertion
-                            .preflight
-                            .as_ref()
-                            .and_then(blocked_reason_from_preflight)
-                            .unwrap_or_else(|| {
-                                "Blocked: requires preflight validation before auto-write"
-                                    .to_string()
-                            }),
-                        FixSafetyTier::PlanOnly => {
-                            "Blocked: plan-only fix, not eligible for auto-write".to_string()
-                        }
-                    })
+                    Some(blocked_reason(
+                        insertion.safety_tier,
+                        insertion.preflight.as_ref(),
+                    ))
                 };
 
                 summary.visible_insertions += 1;

--- a/src/core/refactor/auto/preflight.rs
+++ b/src/core/refactor/auto/preflight.rs
@@ -222,41 +222,22 @@ pub fn run_fix_preflight(fix: &mut Fix, context: &PreflightContext<'_>, write: b
         ));
     }
 
+    // Append fix-level checks (required_methods, required_registrations) to all
+    // Safe-tier insertions that have preflight reports.
     for insertion in &mut fix.insertions {
-        if insertion.safety_tier != FixSafetyTier::SafeWithChecks {
+        if insertion.safety_tier == FixSafetyTier::PlanOnly {
             continue;
         }
 
         if let Some(report) = &mut insertion.preflight {
-            report.checks.extend(extra_checks.clone());
-            *report = finalize_report(report.checks.clone());
+            if !extra_checks.is_empty() {
+                report.checks.extend(extra_checks.clone());
+                *report = finalize_report(report.checks.clone());
+            }
         }
-
-        insertion.auto_apply = if !write {
-            true
-        } else {
-            insertion.preflight.as_ref().is_some_and(|report| {
-                matches!(
-                    report.status,
-                    PreflightStatus::Passed | PreflightStatus::NotApplicable
-                )
-            })
-        };
-
-        insertion.blocked_reason = if insertion.auto_apply {
-            None
-        } else {
-            Some(
-                insertion
-                    .preflight
-                    .as_ref()
-                    .and_then(blocked_reason_from_preflight)
-                    .unwrap_or_else(|| {
-                        "Blocked: requires preflight validation before auto-write".to_string()
-                    }),
-            )
-        };
     }
+    // Note: auto_apply is re-evaluated by the caller (apply_fix_policy)
+    // after this function returns — we only mutate preflight reports here.
 }
 
 pub fn run_new_file_preflight(

--- a/src/core/refactor/plan/generate/orphaned_test_fixes.rs
+++ b/src/core/refactor/plan/generate/orphaned_test_fixes.rs
@@ -177,7 +177,7 @@ pub(crate) fn generate_orphaned_test_fixes(
                 test_method
             ),
         );
-        ins.safety_tier = FixSafetyTier::SafeWithChecks;
+        ins.safety_tier = FixSafetyTier::Safe;
 
         fixes.push(Fix {
             file: finding.file.clone(),

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -531,6 +531,7 @@ pub(crate) fn bump_component_version(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use regex::Regex;
 
     #[test]
     fn since_tag_regex_matches_placeholders() {

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -114,7 +114,7 @@ fn test_build_fix_hints_written_with_blocked() {
     };
     let hints = build_fix_hints(true, &policy);
     assert_eq!(hints.len(), 1);
-    assert!(hints[0].contains("Applied only safe_auto"));
+    assert!(hints[0].contains("Applied safe fixes"));
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn test_build_fix_hints_preflight_failures() {
     };
     let hints = build_fix_hints(false, &policy);
     assert_eq!(hints.len(), 1);
-    assert!(hints[0].contains("3 fix(es) failed deterministic preflight"));
+    assert!(hints[0].contains("3 fix(es) failed preflight"));
 }
 
 #[test]
@@ -219,10 +219,10 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
     // Should have at least some fixable findings (the missing method outlier)
     if let Some(fix) = fixability {
         assert!(fix.fixable_count > 0, "expected at least one fixable finding");
-        // auto_fixable + guarded + plan_only should equal fixable_count
+        // safe + plan_only should equal fixable_count
         assert_eq!(
             fix.fixable_count,
-            fix.auto_fixable_count + fix.guarded_fixable_count + fix.plan_only_count
+            fix.safe_count + fix.plan_only_count
         );
         // by_kind should not be empty
         assert!(!fix.by_kind.is_empty(), "expected per-kind breakdown");


### PR DESCRIPTION
## Summary

Eliminate the artificial three-tier safety system. **If preflight passes, it's safe.**

Before: `SafeAuto` | `SafeWithChecks` | `PlanOnly`
After: `Safe` | `PlanOnly`

## Why

Two flavors of "safe" was overengineered complexity. Every `SafeWithChecks` kind already has working preflight validators. If the validator says it's good, just apply it. No need for a separate tier.

## What changed

| File | Change |
|------|--------|
| `contracts.rs` | `FixSafetyTier` → 2 variants: `Safe`, `PlanOnly`. Serde aliases for backward compat. |
| `contracts.rs` | `InsertionKind::safety_tier()` → all mechanical fixes return `Safe` |
| `policy.rs` | Rewritten with `should_auto_apply()` and `blocked_reason()` helpers. -38 lines net. |
| `preflight.rs` | Removed `SafeWithChecks`-only guard. Fix-level preflight applies to all Safe insertions. |
| `report.rs` | `AuditFixability` uses `safe_count` instead of `auto_fixable_count` + `guarded_fixable_count` |
| `orphaned_test_fixes.rs` | Override uses `Safe` instead of `SafeWithChecks` |
| `README.md` | Updated safety tier documentation |

## Behavioral change

Insertions that were `SafeWithChecks` now behave the same as what was `SafeAuto` — preflight runs, and if it passes, the fix is auto-applied. Since all SafeWithChecks kinds already had working validators, this is a **no-op in practice** — the same fixes get applied.

## Tests

**759 tests pass, 0 failures**

Toward closing #505