### PR TITLE
feat: audit reference dependencies — include framework source in cross-reference analysis

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -93,6 +93,11 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
     let only_kinds = parse_finding_kinds(&args.only, "only")?;
     let exclude_kinds = parse_finding_kinds(&args.exclude, "exclude")?;
 
+    // Run extension audit reference setup if configured.
+    // This resolves framework dependencies (e.g. WordPress core) so their
+    // fingerprints are included in cross-reference analysis (dead code detection).
+    run_audit_reference_setup(&args.comp.component);
+
     // Resolve component ID and source path
     let (resolved_id, resolved_path) = if Path::new(&args.comp.component).is_dir() {
         // Bare directory path — no registered component
@@ -147,6 +152,91 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
     })?;
 
     Ok(report::from_main_workflow(workflow))
+}
+
+/// Run the extension's audit reference setup script if configured.
+///
+/// Looks up the component's extension, checks for `audit.setup_references`, and runs it.
+/// The script exports `HOMEBOY_AUDIT_REFERENCE_PATHS` which the audit core reads
+/// to include framework dependencies in cross-reference analysis.
+fn run_audit_reference_setup(component_id_or_path: &str) {
+    // Skip for bare directory paths — no extension to look up
+    if Path::new(component_id_or_path).is_dir() {
+        return;
+    }
+
+    // Load component to find its extensions
+    let comp = match homeboy::component::load(component_id_or_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let extensions = match &comp.extensions {
+        Some(ext) => ext,
+        None => return,
+    };
+
+    for ext_id in extensions.keys() {
+        let ext_manifest = match homeboy::extension::load_extension(ext_id) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        let setup_script = match ext_manifest.audit_setup_references() {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Resolve script path relative to extension directory
+        let ext_path = homeboy::extension::extension_path(ext_id);
+        if !ext_path.is_dir() {
+            continue;
+        }
+        let script_path = ext_path.join(setup_script);
+        if !script_path.is_file() {
+            continue;
+        }
+
+        homeboy::log_status!(
+            "audit",
+            "Running reference setup: {}",
+            script_path.display()
+        );
+
+        // Run the script with --export flag and capture stdout
+        let output = std::process::Command::new("bash")
+            .arg(script_path.to_str().unwrap_or(""))
+            .arg("--export")
+            .env("HOMEBOY_COMPONENT_PATH", &comp.local_path)
+            .current_dir(&comp.local_path)
+            .output();
+
+        if let Ok(output) = output {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // Parse the export line: export HOMEBOY_AUDIT_REFERENCE_PATHS='...'
+            for line in stdout.lines() {
+                if let Some(value) = line
+                    .strip_prefix("export HOMEBOY_AUDIT_REFERENCE_PATHS=")
+                {
+                    // Remove shell quoting (the value may be $'...' or '...' quoted)
+                    let clean = value
+                        .trim_start_matches("$'")
+                        .trim_start_matches('\'')
+                        .trim_end_matches('\'');
+                    std::env::set_var("HOMEBOY_AUDIT_REFERENCE_PATHS", clean);
+                    break;
+                }
+            }
+
+            // Log stderr (the script's informational output)
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            for line in stderr.lines() {
+                if !line.is_empty() {
+                    homeboy::log_status!("audit", "{}", line);
+                }
+            }
+        }
+    }
 }
 
 // Core function tests (finding_fingerprint, score_delta, weighted_finding_score_with,

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -160,6 +160,22 @@ pub fn audit_component(component_id: &str) -> Result<CodeAuditResult> {
     audit_path_with_id(component_id, &comp.local_path)
 }
 
+/// Read reference dependency paths from HOMEBOY_AUDIT_REFERENCE_PATHS env var.
+///
+/// Reference dependencies are external codebases (e.g. WordPress core, plugin
+/// dependencies) whose fingerprints are included in cross-reference analysis
+/// (dead code detection) but excluded from convention discovery and duplication
+/// detection. This eliminates false positives for functions called via framework
+/// hooks, callbacks, or inherited methods.
+fn read_reference_paths_from_env() -> Vec<String> {
+    std::env::var("HOMEBOY_AUDIT_REFERENCE_PATHS")
+        .unwrap_or_default()
+        .lines()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && Path::new(s).is_dir())
+        .collect()
+}
+
 /// Audit a filesystem path directly (no registered component needed).
 pub fn audit_path(path: &str) -> Result<CodeAuditResult> {
     let p = Path::new(path);
@@ -184,7 +200,8 @@ pub fn audit_path(path: &str) -> Result<CodeAuditResult> {
 /// Core audit logic shared by both entry points.
 /// Also available for callers that have a component ID and an overridden path.
 pub fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAuditResult> {
-    audit_internal(component_id, source_path, None, None)
+    let ref_paths = read_reference_paths_from_env();
+    audit_internal(component_id, source_path, None, None, &ref_paths)
 }
 
 /// Audit only specific files within a component path.
@@ -203,15 +220,21 @@ pub fn audit_path_scoped(
     file_filter: &[String],
     git_ref: Option<&str>,
 ) -> Result<CodeAuditResult> {
-    audit_internal(component_id, source_path, Some(file_filter), git_ref)
+    let ref_paths = read_reference_paths_from_env();
+    audit_internal(component_id, source_path, Some(file_filter), git_ref, &ref_paths)
 }
 
 /// Internal audit implementation supporting optional file scoping and impact tracing.
+///
+/// `reference_paths` are external codebases whose fingerprints are included in
+/// cross-reference analysis (dead code) but excluded from convention discovery,
+/// duplication detection, and structural analysis.
 fn audit_internal(
     component_id: &str,
     source_path: &str,
     file_filter: Option<&[String]>,
     git_ref: Option<&str>,
+    reference_paths: &[String],
 ) -> Result<CodeAuditResult> {
     let root = Path::new(source_path);
 
@@ -362,7 +385,17 @@ fn audit_internal(
     }
 
     // Phase 4e: Dead code detection (unused params, unreferenced exports, orphaned internals)
-    let dead_code_findings = dead_code::analyze_dead_code(&all_fingerprints);
+    //
+    // Reference dependencies (e.g. WordPress core, plugin dependencies) are fingerprinted
+    // and included in the cross-reference set so that functions called via framework hooks,
+    // callbacks, or inherited methods are recognized as referenced.
+    let ref_fingerprints = fingerprint_reference_paths(reference_paths);
+    let all_with_refs: Vec<&fingerprint::FileFingerprint> = all_fingerprints
+        .iter()
+        .copied()
+        .chain(ref_fingerprints.iter())
+        .collect();
+    let dead_code_findings = dead_code::analyze_dead_code(&all_with_refs);
     if !dead_code_findings.is_empty() {
         log_status!(
             "audit",
@@ -738,6 +771,55 @@ fn classify_broken_doc_ref(
             ),
         )
     }
+}
+
+// ============================================================================
+// Reference dependency fingerprinting
+// ============================================================================
+
+/// Fingerprint external reference paths for cross-reference analysis.
+///
+/// Walks each reference path and fingerprints all source files found.
+/// These fingerprints provide the call/import data that dead code detection
+/// uses to determine whether a function is referenced externally (e.g. by
+/// WordPress core calling a hook callback, or a parent plugin importing a class).
+///
+/// Reference fingerprints are NOT used for convention discovery, duplication
+/// detection, or structural analysis — they only enrich the cross-reference set.
+fn fingerprint_reference_paths(reference_paths: &[String]) -> Vec<fingerprint::FileFingerprint> {
+    if reference_paths.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ref_fps = Vec::new();
+    let mut total_files = 0;
+
+    for ref_path in reference_paths {
+        let root = Path::new(ref_path);
+        if !root.is_dir() {
+            continue;
+        }
+
+        if let Ok(walker_iter) = walker::walk_source_files(root) {
+            for path in walker_iter {
+                if let Some(fp) = fingerprint::fingerprint_file(&path, root) {
+                    ref_fps.push(fp);
+                    total_files += 1;
+                }
+            }
+        }
+    }
+
+    if total_files > 0 {
+        log_status!(
+            "audit",
+            "Reference dependencies: {} file(s) fingerprinted from {} path(s)",
+            total_files,
+            reference_paths.len()
+        );
+    }
+
+    ref_fps
 }
 
 // ============================================================================

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -93,6 +93,13 @@ fn default_test_prefix() -> String {
 /// Docs audit: ignore patterns and feature detection patterns.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditCapability {
+    /// Shell script that resolves reference dependencies and exports
+    /// `HOMEBOY_AUDIT_REFERENCE_PATHS` (newline-separated directory paths).
+    /// Reference dependencies are fingerprinted for cross-reference analysis
+    /// (dead code detection) but excluded from convention and duplication detection.
+    /// Example: WordPress core + plugin dependencies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setup_references: Option<String>,
     /// Glob patterns for paths to ignore during docs audit.
     /// Uses `*` for single segment and `**` for multiple segments (e.g., `/wp-json/**`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -373,6 +380,13 @@ impl ExtensionManifest {
             .as_ref()
             .map(|e| e.inputs.as_slice())
             .unwrap_or(&[])
+    }
+
+    /// Convenience: get audit reference setup script path (relative to extension dir).
+    pub fn audit_setup_references(&self) -> Option<&str> {
+        self.audit
+            .as_ref()
+            .and_then(|a| a.setup_references.as_deref())
     }
 
     /// Convenience: get audit ignore claim patterns (empty if no audit capability).


### PR DESCRIPTION
## Summary

- **Add reference dependency support to the audit** — extensions can declare external codebases whose fingerprints are included in cross-reference analysis (dead code detection) but excluded from convention discovery and duplication detection.
- **Eliminates false positives** for functions called via framework hooks, callbacks, or inherited base class methods (e.g. WordPress `add_action` callbacks, REST permission callbacks, `WP_UnitTestCase` methods).

## How it works

```
┌───────────────────────────────────────────────────┐
│  Extension manifest (e.g. wordpress.json)         │
│  "audit": {                                       │
│    "setup_references": "scripts/audit/setup.sh"   │
│  }                                                │
└───────────────┬───────────────────────────────────┘
                │ runs before audit
                ▼
┌───────────────────────────────────────────────────┐
│  Setup script exports:                            │
│  HOMEBOY_AUDIT_REFERENCE_PATHS="/path/to/wp-core  │
│  /path/to/dependency-plugin"                      │
└───────────────┬───────────────────────────────────┘
                │
                ▼
┌───────────────────────────────────────────────────┐
│  audit_internal()                                 │
│  1. Fingerprint component files → conventions,    │
│     duplication, structural analysis              │
│  2. Fingerprint reference paths → cross-ref only  │
│  3. dead_code::analyze_dead_code() sees both      │
│     sets → fewer false positives                  │
└───────────────────────────────────────────────────┘
```

## Changes (3 files)

| File | Change |
|------|--------|
| `src/core/code_audit/mod.rs` | `audit_internal` accepts `reference_paths`, `fingerprint_reference_paths()` walks external dirs, `read_reference_paths_from_env()` reads the env var |
| `src/core/extension/manifest.rs` | `AuditCapability.setup_references` field, `audit_setup_references()` accessor |
| `src/commands/audit.rs` | `run_audit_reference_setup()` runs extension script and sets env var before audit |

## Tests

281 audit tests pass. No regressions.

## Companion PR

WordPress extension: Extra-Chill/homeboy-extensions (branch `feat/audit-reference-dependencies`) — provides the `setup-references.sh` script that downloads WordPress core and resolves plugin dependencies.