### PR TITLE
perf: batch verification for audit --fix --write

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -66,8 +66,25 @@ pub(super) fn execute_component_deploy(
         .with_build_exit_code(build_exit_code);
     }
 
+    // Auto-resolve remote_path for WordPress components when not explicitly set.
+    // Plugins deploy to wp-content/plugins/{id}, themes to wp-content/themes/{id}.
+    let effective_remote_path = if component.remote_path.trim().is_empty() {
+        if let Some(resolved) = auto_resolve_wordpress_remote_path(component) {
+            log_status!(
+                "deploy",
+                "Auto-resolved remote path: {}",
+                resolved
+            );
+            resolved
+        } else {
+            component.remote_path.clone()
+        }
+    } else {
+        component.remote_path.clone()
+    };
+
     // Resolve install directory
-    let install_dir = match base_path::join_remote_path(Some(base_path), &component.remote_path) {
+    let install_dir = match base_path::join_remote_path(Some(base_path), &effective_remote_path) {
         Ok(v) => v,
         Err(err) => {
             return ComponentDeployResult::failed(
@@ -466,4 +483,41 @@ fn cleanup_build_dependencies(
         );
         Ok(Some(summary))
     }
+}
+
+/// Auto-resolve `remote_path` for WordPress components based on project type.
+///
+/// If a component has the `wordpress` extension and no explicit `remote_path`,
+/// detect whether it's a plugin or theme from the source files and return the
+/// canonical WordPress path (`wp-content/plugins/{id}` or `wp-content/themes/{id}`).
+fn auto_resolve_wordpress_remote_path(component: &Component) -> Option<String> {
+    // Only applies to components with the wordpress extension.
+    let extensions = component.extensions.as_ref()?;
+    if !extensions.contains_key("wordpress") {
+        return None;
+    }
+
+    let local = Path::new(&component.local_path);
+
+    // Check for plugin: {id}.php with "Plugin Name:" header
+    let plugin_file = local.join(format!("{}.php", component.id));
+    if plugin_file.exists() {
+        if let Ok(content) = std::fs::read_to_string(&plugin_file) {
+            if content.contains("Plugin Name:") {
+                return Some(format!("wp-content/plugins/{}", component.id));
+            }
+        }
+    }
+
+    // Check for theme: style.css with "Theme Name:" header
+    let style_file = local.join("style.css");
+    if style_file.exists() {
+        if let Ok(content) = std::fs::read_to_string(&style_file) {
+            if content.contains("Theme Name:") {
+                return Some(format!("wp-content/themes/{}", component.id));
+            }
+        }
+    }
+
+    None
 }

--- a/src/core/project/component/overrides.rs
+++ b/src/core/project/component/overrides.rs
@@ -10,6 +10,9 @@ pub fn apply_component_overrides(
 
     let mut merged = component.clone();
 
+    if let Some(remote_path) = &overrides.remote_path {
+        merged.remote_path = remote_path.clone();
+    }
     if let Some(build_artifact) = &overrides.build_artifact {
         merged.build_artifact = Some(build_artifact.clone());
     }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -45,6 +45,8 @@ pub struct ProjectComponentAttachment {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProjectComponentOverrides {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub build_artifact: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extract_command: Option<String>,


### PR DESCRIPTION
## Summary

- Replace per-chunk verification with batch apply + batch verify for convention fixes
- **Before:** O(n × scoped_audit + n × lint_smoke) per iteration — 98 files = 98 audit invocations + 98 lint runs
- **After:** O(1 × scoped_audit) per iteration — 1 batch audit of all changed files
- Decompose plans (structural file splits) still use per-chunk verification since they're higher-risk

Fixes #813

## What changed

`run_fix_iteration` in `verify.rs` now:
1. Applies all convention fixes without per-chunk verification (just file writes)
2. Applies all new files without per-chunk verification
3. Runs ONE scoped re-audit of all applied files as a batch sanity check
4. Logs new hard findings for manual review instead of rolling back per-chunk
5. Decompose plans retain per-chunk verification with lint/test smoke

Also includes uncommitted changes from main: deploy execution remote path support and component overrides.