### PR TITLE
feat: test templates + end-to-end generate_tests_for_file

### DIFF
--- a/src/core/engine/contract_extract.rs
+++ b/src/core/engine/contract_extract.rs
@@ -624,6 +624,7 @@ mod tests {
                 r"unreachable!\s*\(".to_string(),
                 r"\.unwrap\(\)".to_string(),
             ],
+            test_templates: HashMap::new(),
         }
     }
 

--- a/src/core/engine/contract_testgen.rs
+++ b/src/core/engine/contract_testgen.rs
@@ -280,6 +280,62 @@ fn slugify(s: &str) -> String {
         .collect()
 }
 
+// ── End-to-end API ──
+
+/// Generate test source code for all functions in a source file.
+///
+/// This is the full pipeline: grammar → contracts → test plans → rendered source.
+/// Returns `None` if the grammar has no contract or test_templates section.
+pub fn generate_tests_for_file(
+    content: &str,
+    file_path: &str,
+    grammar: &crate::extension::grammar::Grammar,
+) -> Option<String> {
+    let contract_grammar = grammar.contract.as_ref()?;
+
+    // Must have test templates to render
+    if contract_grammar.test_templates.is_empty() {
+        return None;
+    }
+
+    // Extract contracts
+    let contracts =
+        super::contract_extract::extract_contracts_from_grammar(content, file_path, grammar)?;
+
+    if contracts.is_empty() {
+        return None;
+    }
+
+    // Generate and render test plans
+    let mut output = String::new();
+
+    for contract in &contracts {
+        // Skip test functions, private functions, and trivial functions
+        if contract.name.starts_with("test_") {
+            continue;
+        }
+        if !contract.signature.is_public {
+            continue;
+        }
+
+        let plan = generate_test_plan(contract);
+        if plan.cases.is_empty() {
+            continue;
+        }
+
+        let rendered = render_test_plan(&plan, &contract_grammar.test_templates);
+        if !rendered.trim().is_empty() {
+            output.push_str(&rendered);
+        }
+    }
+
+    if output.trim().is_empty() {
+        None
+    } else {
+        Some(output)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -100,6 +100,14 @@ pub struct ContractGrammar {
     /// Patterns for detecting panic/abort/unreachable paths.
     #[serde(default)]
     pub panic_patterns: Vec<String>,
+
+    /// Test code templates keyed by template name (e.g., "result_ok", "option_none").
+    /// Templates contain variables like `{fn_name}`, `{param_names}`, `{test_name}`,
+    /// `{condition}`, etc. that are replaced by the test plan renderer.
+    ///
+    /// This is what makes test output language-specific without any language code in core.
+    #[serde(default)]
+    pub test_templates: HashMap<String, String>,
 }
 
 /// Language identification metadata.


### PR DESCRIPTION
## Summary

- Adds `test_templates: HashMap<String, String>` to `ContractGrammar`
- Adds `generate_tests_for_file()` — full pipeline in one call: grammar → contracts → test plans → rendered source
- Filters out test functions, private functions, trivial code

## How it closes the loop

```
grammar.toml                     homeboy core
┌──────────────────┐             ┌────────────────────────────────┐
│ [contract]       │             │                                │
│  effects.*       │──extract──>│ FunctionContract               │
│  return_patterns │             │       │                        │
│  guard_patterns  │             │       ▼                        │
│                  │             │ TestPlan (one case per branch) │
│ [contract.       │             │       │                        │
│  test_templates] │──render───>│       ▼                        │
│  result_ok = "…" │             │ Compilable test source code    │
│  option_none="…" │             │                                │
└──────────────────┘             └────────────────────────────────┘
```

Extensions provide BOTH the analysis patterns AND the output templates. Core is language-agnostic.

## Related

- #818 — Algorithmic test generation
- #820 — FunctionContract architecture