### PR TITLE
feat: auto-discover misplaced tests + FileMove autofix

### DIFF
--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -19,7 +19,9 @@ use regex::Regex;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use super::test_mapping::{partition_fingerprints, source_to_test_path, test_to_source_path};
+use super::test_mapping::{
+    build_source_name_index, partition_fingerprints, source_to_test_path, test_to_source_path,
+};
 use crate::extension::TestMappingConfig;
 
 /// Analyze test coverage gaps given source fingerprints and a test mapping config.
@@ -266,11 +268,20 @@ pub(crate) fn analyze_test_coverage(
         }
     }
 
-    // Check 3: Orphaned tests — test files with no corresponding source file
+    // Check 3: Orphaned tests — test files with no corresponding source file.
+    //
+    // Uses two-tier matching:
+    // - Tier 1: template-based path matching (existing behavior)
+    // - Tier 2: name-based auto-discovery (finds source files that moved)
+    //
+    // When a test file's source is found by name at a different path, the test
+    // is "misplaced" not "orphaned" — the suggestion is to move it.
     let source_paths: HashSet<&str> = source_fps
         .iter()
         .map(|fp| fp.relative_path.as_str())
         .collect();
+
+    let source_name_index = build_source_name_index(&source_fps);
 
     for test_fp in &test_fps {
         let expected_source_path = test_to_source_path(&test_fp.relative_path, config);
@@ -280,17 +291,48 @@ pub(crate) fn analyze_test_coverage(
                 source_paths.contains(source_path.as_str()) || root.join(source_path).exists();
 
             if !source_exists {
-                findings.push(Finding {
-                    convention: "test_coverage".to_string(),
-                    severity: Severity::Info,
-                    file: test_fp.relative_path.clone(),
-                    description: format!(
-                        "Test file has no corresponding source file (expected '{}')",
-                        source_path
-                    ),
-                    suggestion: "Remove the orphaned test or create the source file".to_string(),
-                    kind: AuditFinding::OrphanedTest,
-                });
+                // Tier 2: Try name-based discovery — maybe the source moved
+                let discovered = super::test_mapping::discover_source_file(
+                    &test_fp.relative_path,
+                    config,
+                    &source_name_index,
+                );
+
+                if let Some(actual_source_path) = discovered {
+                    // Source exists at a different path — this is a misplaced test, not orphaned.
+                    // Compute where the test SHOULD be based on the actual source location.
+                    let correct_test_path =
+                        source_to_test_path(actual_source_path, config).unwrap_or_default();
+
+                    findings.push(Finding {
+                        convention: "test_coverage".to_string(),
+                        severity: Severity::Info,
+                        file: test_fp.relative_path.clone(),
+                        description: format!(
+                            "Test file is misplaced — source moved to '{}' (expected test at '{}')",
+                            actual_source_path, correct_test_path
+                        ),
+                        suggestion: format!(
+                            "Move test file to '{}' to match source structure",
+                            correct_test_path
+                        ),
+                        kind: AuditFinding::OrphanedTest,
+                    });
+                } else {
+                    // Truly orphaned — no source found anywhere
+                    findings.push(Finding {
+                        convention: "test_coverage".to_string(),
+                        severity: Severity::Info,
+                        file: test_fp.relative_path.clone(),
+                        description: format!(
+                            "Test file has no corresponding source file (expected '{}')",
+                            source_path
+                        ),
+                        suggestion: "Remove the orphaned test or create the source file"
+                            .to_string(),
+                        kind: AuditFinding::OrphanedTest,
+                    });
+                }
             }
         }
     }

--- a/src/core/code_audit/test_mapping.rs
+++ b/src/core/code_audit/test_mapping.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use super::fingerprint::FileFingerprint;
@@ -20,6 +21,93 @@ pub fn partition_fingerprints<'a>(
     }
 
     (source, test)
+}
+
+/// Build a class/stem name → test file path index from test fingerprints.
+///
+/// This enables auto-discovery: when a template-based match fails, we can
+/// find the test file by class name regardless of directory structure.
+pub fn build_test_name_index<'a>(test_fps: &[&'a FileFingerprint]) -> HashMap<String, &'a str> {
+    let mut index = HashMap::new();
+    for fp in test_fps {
+        if let Some(stem) = extract_test_stem(&fp.relative_path) {
+            index.insert(stem.to_lowercase(), fp.relative_path.as_str());
+        }
+    }
+    index
+}
+
+/// Build a class/stem name → source file path index from source fingerprints.
+pub fn build_source_name_index<'a>(source_fps: &[&'a FileFingerprint]) -> HashMap<String, &'a str> {
+    let mut index = HashMap::new();
+    for fp in source_fps {
+        if let Some(stem) = extract_file_stem(&fp.relative_path) {
+            index.insert(stem.to_lowercase(), fp.relative_path.as_str());
+        }
+    }
+    index
+}
+
+/// Discover a test file for a source file by class name, falling back from template matching.
+///
+/// Tries template first (fast, exact). On failure, falls back to name-based auto-discovery
+/// by searching the test name index for a matching class name.
+pub fn discover_test_file<'a>(
+    source_path: &str,
+    config: &TestMappingConfig,
+    test_file_map: &HashMap<&str, &'a FileFingerprint>,
+    test_name_index: &HashMap<String, &'a str>,
+) -> Option<&'a str> {
+    // Tier 1: Template match (existing behavior)
+    if let Some(template_path) = source_to_test_path(source_path, config) {
+        if test_file_map.contains_key(template_path.as_str()) {
+            return Some(test_file_map[template_path.as_str()].relative_path.as_str());
+        }
+    }
+
+    // Tier 2: Name-based auto-discovery
+    let stem = extract_file_stem(source_path)?;
+    let test_key = format!("{}test", stem.to_lowercase());
+    test_name_index.get(&test_key).copied()
+}
+
+/// Discover a source file for a test file by class name, falling back from template matching.
+pub fn discover_source_file<'a>(
+    test_path: &str,
+    config: &TestMappingConfig,
+    source_name_index: &HashMap<String, &'a str>,
+) -> Option<&'a str> {
+    // Tier 1: Template match (existing behavior)
+    if let Some(template_path) = test_to_source_path(test_path, config) {
+        if let Some(&source_path) =
+            source_name_index.get(&extract_file_stem(&template_path)?.to_lowercase())
+        {
+            if source_path == template_path {
+                return Some(source_path);
+            }
+        }
+    }
+
+    // Tier 2: Name-based auto-discovery
+    let test_stem = extract_test_stem(test_path)?;
+    source_name_index.get(&test_stem.to_lowercase()).copied()
+}
+
+/// Extract the file stem (class name) from a path, e.g., "inc/Foo/Bar.php" → "Bar"
+fn extract_file_stem(path: &str) -> Option<&str> {
+    Path::new(path).file_stem()?.to_str()
+}
+
+/// Extract the source class name from a test file path.
+/// "tests/Unit/Foo/BarTest.php" → "bar" (lowercased, "Test" suffix stripped)
+fn extract_test_stem(path: &str) -> Option<String> {
+    let stem = Path::new(path).file_stem()?.to_str()?;
+    // Strip common test suffixes
+    let base = stem
+        .strip_suffix("Test")
+        .or_else(|| stem.strip_suffix("_test"))
+        .unwrap_or(stem);
+    Some(base.to_string())
 }
 
 /// Check if a file path is within one of the configured source directories.

--- a/src/core/refactor/auto/apply.rs
+++ b/src/core/refactor/auto/apply.rs
@@ -63,6 +63,9 @@ pub(crate) fn apply_insertions_to_content(
                 old_text,
                 new_text,
             } => line_replacements.push((*line, old_text.as_str(), new_text.as_str())),
+            InsertionKind::FileMove { .. } => {
+                // File moves are handled by apply_file_moves(), not content transformation.
+            }
         }
     }
 
@@ -985,4 +988,98 @@ mod tests {
         remove_from_pub_use_block(&mut lines, "baz");
         assert_eq!(lines[0], "pub use other::{foo, bar};");
     }
+}
+
+/// Apply file move operations from fixes.
+///
+/// Extracts all `InsertionKind::FileMove` from fixes, executes them via
+/// `refactor move --file`, and returns the number of files moved.
+///
+/// Runs after content fixes so moved files contain their updated content.
+pub fn apply_file_moves(fixes: &[Fix], root: &Path) -> Vec<ApplyChunkResult> {
+    let mut results = Vec::new();
+
+    for fix in fixes {
+        for insertion in &fix.insertions {
+            if let InsertionKind::FileMove { from, to } = &insertion.kind {
+                let from_abs = root.join(from);
+                let to_abs = root.join(to);
+
+                // Validate source exists
+                if !from_abs.exists() {
+                    results.push(ApplyChunkResult {
+                        chunk_id: format!("file_move:{}", from),
+                        files: vec![from.clone(), to.clone()],
+                        status: ChunkStatus::Reverted,
+                        applied_files: 0,
+                        reverted_files: 0,
+                        verification: None,
+                        error: Some(format!("Source file does not exist: {}", from)),
+                    });
+                    continue;
+                }
+
+                // Skip if destination already exists
+                if to_abs.exists() {
+                    results.push(ApplyChunkResult {
+                        chunk_id: format!("file_move:{}", from),
+                        files: vec![from.clone(), to.clone()],
+                        status: ChunkStatus::Reverted,
+                        applied_files: 0,
+                        reverted_files: 0,
+                        verification: None,
+                        error: Some(format!("Destination already exists: {}", to)),
+                    });
+                    continue;
+                }
+
+                // Create parent directories
+                if let Some(parent) = to_abs.parent() {
+                    if !parent.exists() {
+                        if let Err(e) = std::fs::create_dir_all(parent) {
+                            results.push(ApplyChunkResult {
+                                chunk_id: format!("file_move:{}", from),
+                                files: vec![from.clone(), to.clone()],
+                                status: ChunkStatus::Reverted,
+                                applied_files: 0,
+                                reverted_files: 0,
+                                verification: None,
+                                error: Some(format!("Failed to create directory: {}", e)),
+                            });
+                            continue;
+                        }
+                    }
+                }
+
+                // Execute the move
+                match std::fs::rename(&from_abs, &to_abs) {
+                    Ok(_) => {
+                        crate::log_status!("move", "Moved {} → {}", from, to);
+                        results.push(ApplyChunkResult {
+                            chunk_id: format!("file_move:{}", from),
+                            files: vec![from.clone(), to.clone()],
+                            status: ChunkStatus::Applied,
+                            applied_files: 1,
+                            reverted_files: 0,
+                            verification: None,
+                            error: None,
+                        });
+                    }
+                    Err(e) => {
+                        results.push(ApplyChunkResult {
+                            chunk_id: format!("file_move:{}", from),
+                            files: vec![from.clone(), to.clone()],
+                            status: ChunkStatus::Reverted,
+                            applied_files: 0,
+                            reverted_files: 0,
+                            verification: None,
+                            error: Some(format!("Move failed: {}", e)),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    results
 }

--- a/src/core/refactor/auto/contracts.rs
+++ b/src/core/refactor/auto/contracts.rs
@@ -156,6 +156,14 @@ pub enum InsertionKind {
         /// Replacement text.
         new_text: String,
     },
+    /// Move a file to a new path. Creates parent directories as needed.
+    /// Used for relocating misplaced test files to match source structure.
+    FileMove {
+        /// Current file path (relative to root).
+        from: String,
+        /// Target file path (relative to root).
+        to: String,
+    },
 }
 
 impl InsertionKind {
@@ -173,7 +181,8 @@ impl InsertionKind {
             | Self::NamespaceDeclaration
             | Self::VisibilityChange { .. }
             | Self::ReexportRemoval { .. }
-            | Self::LineReplacement { .. } => FixSafetyTier::Safe,
+            | Self::LineReplacement { .. }
+            | Self::FileMove { .. } => FixSafetyTier::Safe,
 
             // Plan-only: requires human review.
             Self::MethodStub | Self::FunctionRemoval { .. } | Self::TraitUse => {

--- a/src/core/refactor/auto/mod.rs
+++ b/src/core/refactor/auto/mod.rs
@@ -8,7 +8,7 @@ pub mod summary;
 pub mod tracking;
 
 pub use apply::{
-    apply_decompose_plans, apply_fixes, apply_fixes_chunked, apply_new_files,
+    apply_decompose_plans, apply_file_moves, apply_fixes, apply_fixes_chunked, apply_new_files,
     apply_new_files_chunked, auto_apply_subset,
 };
 pub use contracts::{

--- a/src/core/refactor/plan/generate/orphaned_test_fixes.rs
+++ b/src/core/refactor/plan/generate/orphaned_test_fixes.rs
@@ -6,6 +6,17 @@ use std::path::Path;
 
 use super::insertion;
 
+/// Extract the correct test path from a misplaced test finding description.
+///
+/// Expected format: "Test file is misplaced — source moved to '...' (expected test at 'correct/path')"
+fn extract_correct_test_path(description: &str) -> Option<String> {
+    let needle = "expected test at '";
+    let start = description.find(needle)? + needle.len();
+    let rest = &description[start..];
+    let end = rest.find('\'')?;
+    Some(rest[..end].to_string())
+}
+
 /// Extract the test method name from an orphaned-test finding description.
 ///
 /// Expected format: "Test method 'test_foo' references 'foo' which no longer exists in the source"
@@ -200,6 +211,35 @@ pub(crate) fn generate_orphaned_test_fixes(
 ) {
     for finding in &result.findings {
         if finding.kind != AuditFinding::OrphanedTest {
+            continue;
+        }
+
+        // Handle file-level misplaced tests — generate FileMove fixes.
+        // Description format: "Test file is misplaced — source moved to '...' (expected test at '...')"
+        if finding.description.contains("is misplaced") {
+            if let Some(correct_path) = extract_correct_test_path(&finding.description) {
+                let mut ins = insertion(
+                    InsertionKind::FileMove {
+                        from: finding.file.clone(),
+                        to: correct_path.clone(),
+                    },
+                    AuditFinding::OrphanedTest,
+                    String::new(),
+                    format!(
+                        "Move misplaced test '{}' → '{}'",
+                        finding.file, correct_path
+                    ),
+                );
+                ins.safety_tier = FixSafetyTier::Safe;
+
+                fixes.push(Fix {
+                    file: finding.file.clone(),
+                    required_methods: vec![],
+                    required_registrations: vec![],
+                    insertions: vec![ins],
+                    applied: false,
+                });
+            }
             continue;
         }
 

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -472,6 +472,25 @@ fn run_fix_iteration(
         fix_result.chunk_results.extend(decompose_chunk_results);
     }
 
+    // Apply file moves (e.g., misplaced test files → correct paths).
+    // Runs after content fixes so moved files contain updated content.
+    {
+        let move_results = fixer::apply_file_moves(&auto_apply_result.fixes, root);
+        let move_count: usize = move_results
+            .iter()
+            .filter(|c| matches!(c.status, fixer::ChunkStatus::Applied))
+            .map(|c| c.applied_files)
+            .sum();
+        if move_count > 0 {
+            total_modified += move_count;
+            applied_chunks += move_results
+                .iter()
+                .filter(|c| matches!(c.status, fixer::ChunkStatus::Applied))
+                .count();
+        }
+        fix_result.chunk_results.extend(move_results);
+    }
+
     for applied_fix in auto_apply_result.fixes {
         if let Some(original) = fix_result
             .fixes


### PR DESCRIPTION
## Summary

- **Test auto-discovery**: when template-based path matching fails, falls back to name-based discovery (search by ClassName)
- **Misplaced test detection**: reports tests at wrong paths as "misplaced" with correct destination, not "orphaned"
- **FileMove autofix**: new `InsertionKind::FileMove` relocates test files to match source structure
- Wired into the full autofix pipeline via `apply_file_moves()`

## Problem

24 orphaned test findings in data-machine were false positives. Source files moved to `inc/Engine/AI/...` but test files stayed at `tests/Unit/AI/...`. The template-based mapping correctly computed the expected test path but couldn't find the existing test at its old location.

## How it works

```
1. Template match: inc/Engine/AI/Tools/BingWebmaster.php
                   → tests/Unit/Engine/AI/Tools/BingWebmasterTest.php
                   → NOT FOUND

2. Name discovery: search test dirs for "BingWebmasterTest.php"
                   → FOUND at tests/Unit/AI/Tools/BingWebmasterTest.php

3. Finding: "Test file is misplaced — move to tests/Unit/Engine/AI/Tools/BingWebmasterTest.php"

4. Autofix: FileMove { from: old_path, to: correct_path }
```

## Files changed

| File | Change |
|---|---|
| `test_mapping.rs` | Name index builders, `discover_test_file`, `discover_source_file` |
| `test_coverage.rs` | Two-tier matching in Check 3 (orphaned tests) |
| `contracts.rs` | `InsertionKind::FileMove` variant |
| `apply.rs` | `apply_file_moves()` execution function |
| `mod.rs` | Export `apply_file_moves` |
| `orphaned_test_fixes.rs` | Generate FileMove for misplaced tests |
| `verify.rs` | Wire `apply_file_moves` into fix pipeline |