### PR TITLE
fix: post-release hooks run even with --skip-publish

### DIFF
--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -883,11 +883,14 @@ fn build_release_steps(
         log_status!("release", "Skipping publish/package steps (--skip-publish)");
     }
 
-    // === POST-RELEASE STEP (optional, runs after everything else, skipped with --skip-publish) ===
+    // === POST-RELEASE STEP (optional, runs after everything else) ===
+    // Always runs when hooks are configured — NOT gated on --skip-publish.
+    // Post-release hooks (e.g., moving floating tags) are distinct from publish
+    // targets (crates.io, npm, etc.). --skip-publish only skips publish/package steps.
     let post_release_hooks =
         crate::engine::hooks::resolve_hooks(component, crate::engine::hooks::events::POST_RELEASE);
-    if !post_release_hooks.is_empty() && !options.skip_publish {
-        let post_release_needs = if !publish_targets.is_empty() {
+    if !post_release_hooks.is_empty() {
+        let post_release_needs = if !options.skip_publish && !publish_targets.is_empty() {
             vec!["cleanup".to_string()]
         } else {
             vec!["git.push".to_string()]


### PR DESCRIPTION
## Summary

One-line fix: `post:release` hooks no longer gated on `--skip-publish`.

## Problem

`--skip-publish` was suppressing ALL post-release hooks, not just publish targets. This caused homeboy-action's `v1` floating tag to never update in CI because the release script always passes `--skip-publish` (CI doesn't publish to crates.io — a separate workflow handles that).

The `v1` tag on homeboy-action was stuck at v1.5.3 for a week despite v1.6.0, v1.6.1, and v1.7.0 all releasing successfully. Every consumer using `@v1` was running stale code.

## Fix

```rust
// Before: post-release hooks skipped when --skip-publish
if !post_release_hooks.is_empty() && !options.skip_publish {

// After: post-release hooks always run when configured
if !post_release_hooks.is_empty() {
```

The dependency chain adjusts: depends on `cleanup` when publish ran, or `git.push` when publish was skipped.

## Impact

- homeboy-action: `v1` floating tag will now auto-update on every release
- Any component with `post:release` hooks in homeboy.json will now execute them in CI
- No change for components without hooks

## Closes

- #815 (root cause identified and fixed)