### PR TITLE
fix: auto-resolve remote_path at component resolution time

### DIFF
--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -300,6 +300,57 @@ impl Component {
             scopes: None,
         }
     }
+
+    /// Auto-resolve `remote_path` for WordPress components when not explicitly set.
+    ///
+    /// If the component has the `wordpress` extension and `remote_path` is empty,
+    /// detect whether it's a plugin or theme from source files and return the
+    /// canonical WordPress path (`wp-content/plugins/{id}` or `wp-content/themes/{id}`).
+    ///
+    /// Returns `Some(path)` if auto-resolved, `None` if not applicable or not detectable.
+    pub fn auto_resolve_remote_path(&self) -> Option<String> {
+        // Only applies to components with the wordpress extension.
+        let extensions = self.extensions.as_ref()?;
+        if !extensions.contains_key("wordpress") {
+            return None;
+        }
+
+        let local = std::path::Path::new(&self.local_path);
+
+        // Check for plugin: {id}.php with "Plugin Name:" header
+        let plugin_file = local.join(format!("{}.php", self.id));
+        if plugin_file.exists() {
+            if let Ok(content) = std::fs::read_to_string(&plugin_file) {
+                if content.contains("Plugin Name:") {
+                    return Some(format!("wp-content/plugins/{}", self.id));
+                }
+            }
+        }
+
+        // Check for theme: style.css with "Theme Name:" header
+        let style_file = local.join("style.css");
+        if style_file.exists() {
+            if let Ok(content) = std::fs::read_to_string(&style_file) {
+                if content.contains("Theme Name:") {
+                    return Some(format!("wp-content/themes/{}", self.id));
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Ensure `remote_path` is populated. If empty, attempt auto-resolution.
+    ///
+    /// This should be called after all config layers (repo portable, project overrides)
+    /// have been applied. It fills in `remote_path` only if still empty.
+    pub fn resolve_remote_path(&mut self) {
+        if self.remote_path.trim().is_empty() {
+            if let Some(resolved) = self.auto_resolve_remote_path() {
+                self.remote_path = resolved;
+            }
+        }
+    }
 }
 
 /// Normalize empty strings to None. Treats "", null, and field omission identically for consistent validation.
@@ -439,6 +490,109 @@ mod tests {
             result[0].pattern.as_ref().unwrap(),
             r"Version:\s*(\d+\.\d+\.\d+)"
         );
+    }
+
+    // ========================================================================
+    // Auto-resolve remote_path tests
+    // ========================================================================
+
+    #[test]
+    fn auto_resolve_remote_path_detects_wordpress_plugin() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Create a WordPress plugin file
+        std::fs::write(
+            dir.join("my-plugin.php"),
+            "<?php\n/**\n * Plugin Name: My Plugin\n */\n",
+        )
+        .unwrap();
+
+        let component = Component {
+            id: "my-plugin".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            ..Component::default()
+        };
+
+        assert_eq!(
+            component.auto_resolve_remote_path(),
+            Some("wp-content/plugins/my-plugin".to_string()),
+        );
+    }
+
+    #[test]
+    fn auto_resolve_remote_path_detects_wordpress_theme() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Create a WordPress theme style.css
+        std::fs::write(
+            dir.join("style.css"),
+            "/*\nTheme Name: My Theme\n*/\n",
+        )
+        .unwrap();
+
+        let component = Component {
+            id: "my-theme".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            ..Component::default()
+        };
+
+        assert_eq!(
+            component.auto_resolve_remote_path(),
+            Some("wp-content/themes/my-theme".to_string()),
+        );
+    }
+
+    #[test]
+    fn auto_resolve_remote_path_returns_none_without_wordpress_extension() {
+        let component = Component {
+            id: "my-crate".to_string(),
+            local_path: "/tmp".to_string(),
+            extensions: Some(HashMap::from([("rust".to_string(), ScopedExtensionConfig::default())])),
+            ..Component::default()
+        };
+
+        assert_eq!(component.auto_resolve_remote_path(), None);
+    }
+
+    #[test]
+    fn resolve_remote_path_fills_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        std::fs::write(
+            dir.join("my-plugin.php"),
+            "<?php\n/**\n * Plugin Name: My Plugin\n */\n",
+        )
+        .unwrap();
+
+        let mut component = Component {
+            id: "my-plugin".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            remote_path: String::new(),
+            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            ..Component::default()
+        };
+
+        component.resolve_remote_path();
+        assert_eq!(component.remote_path, "wp-content/plugins/my-plugin");
+    }
+
+    #[test]
+    fn resolve_remote_path_preserves_explicit_value() {
+        let mut component = Component {
+            id: "my-plugin".to_string(),
+            local_path: "/tmp".to_string(),
+            remote_path: "custom/deploy/path".to_string(),
+            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            ..Component::default()
+        };
+
+        component.resolve_remote_path();
+        assert_eq!(component.remote_path, "custom/deploy/path");
     }
 
     // ========================================================================

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -511,7 +511,10 @@ mod tests {
         let component = Component {
             id: "my-plugin".to_string(),
             local_path: dir.to_string_lossy().to_string(),
-            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            extensions: Some(HashMap::from([(
+                "wordpress".to_string(),
+                ScopedExtensionConfig::default(),
+            )])),
             ..Component::default()
         };
 
@@ -527,16 +530,15 @@ mod tests {
         let dir = tmp.path();
 
         // Create a WordPress theme style.css
-        std::fs::write(
-            dir.join("style.css"),
-            "/*\nTheme Name: My Theme\n*/\n",
-        )
-        .unwrap();
+        std::fs::write(dir.join("style.css"), "/*\nTheme Name: My Theme\n*/\n").unwrap();
 
         let component = Component {
             id: "my-theme".to_string(),
             local_path: dir.to_string_lossy().to_string(),
-            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            extensions: Some(HashMap::from([(
+                "wordpress".to_string(),
+                ScopedExtensionConfig::default(),
+            )])),
             ..Component::default()
         };
 
@@ -551,7 +553,10 @@ mod tests {
         let component = Component {
             id: "my-crate".to_string(),
             local_path: "/tmp".to_string(),
-            extensions: Some(HashMap::from([("rust".to_string(), ScopedExtensionConfig::default())])),
+            extensions: Some(HashMap::from([(
+                "rust".to_string(),
+                ScopedExtensionConfig::default(),
+            )])),
             ..Component::default()
         };
 
@@ -573,7 +578,10 @@ mod tests {
             id: "my-plugin".to_string(),
             local_path: dir.to_string_lossy().to_string(),
             remote_path: String::new(),
-            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            extensions: Some(HashMap::from([(
+                "wordpress".to_string(),
+                ScopedExtensionConfig::default(),
+            )])),
             ..Component::default()
         };
 
@@ -587,7 +595,10 @@ mod tests {
             id: "my-plugin".to_string(),
             local_path: "/tmp".to_string(),
             remote_path: "custom/deploy/path".to_string(),
-            extensions: Some(HashMap::from([("wordpress".to_string(), ScopedExtensionConfig::default())])),
+            extensions: Some(HashMap::from([(
+                "wordpress".to_string(),
+                ScopedExtensionConfig::default(),
+            )])),
             ..Component::default()
         };
 

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -194,6 +194,7 @@ pub fn resolve_effective(
             if let Some(mut discovered) = discover_from_portable(Path::new(path)) {
                 discovered.id = id.to_string();
                 discovered.local_path = path.to_string();
+                discovered.resolve_remote_path();
                 Ok(discovered)
             } else {
                 // Fallback: create a synthetic component when --path is

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -67,9 +67,11 @@ pub(super) fn execute_component_deploy(
     }
 
     // Auto-resolve remote_path for WordPress components when not explicitly set.
-    // Plugins deploy to wp-content/plugins/{id}, themes to wp-content/themes/{id}.
+    // This is a deploy-time safety net; the primary resolution happens in
+    // resolve_project_component (#812). Plugins deploy to wp-content/plugins/{id},
+    // themes to wp-content/themes/{id}.
     let effective_remote_path = if component.remote_path.trim().is_empty() {
-        if let Some(resolved) = auto_resolve_wordpress_remote_path(component) {
+        if let Some(resolved) = component.auto_resolve_remote_path() {
             log_status!("deploy", "Auto-resolved remote path: {}", resolved);
             resolved
         } else {
@@ -481,39 +483,4 @@ fn cleanup_build_dependencies(
     }
 }
 
-/// Auto-resolve `remote_path` for WordPress components based on project type.
-///
-/// If a component has the `wordpress` extension and no explicit `remote_path`,
-/// detect whether it's a plugin or theme from the source files and return the
-/// canonical WordPress path (`wp-content/plugins/{id}` or `wp-content/themes/{id}`).
-fn auto_resolve_wordpress_remote_path(component: &Component) -> Option<String> {
-    // Only applies to components with the wordpress extension.
-    let extensions = component.extensions.as_ref()?;
-    if !extensions.contains_key("wordpress") {
-        return None;
-    }
 
-    let local = Path::new(&component.local_path);
-
-    // Check for plugin: {id}.php with "Plugin Name:" header
-    let plugin_file = local.join(format!("{}.php", component.id));
-    if plugin_file.exists() {
-        if let Ok(content) = std::fs::read_to_string(&plugin_file) {
-            if content.contains("Plugin Name:") {
-                return Some(format!("wp-content/plugins/{}", component.id));
-            }
-        }
-    }
-
-    // Check for theme: style.css with "Theme Name:" header
-    let style_file = local.join("style.css");
-    if style_file.exists() {
-        if let Ok(content) = std::fs::read_to_string(&style_file) {
-            if content.contains("Theme Name:") {
-                return Some(format!("wp-content/themes/{}", component.id));
-            }
-        }
-    }
-
-    None
-}

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -482,5 +482,3 @@ fn cleanup_build_dependencies(
         Ok(Some(summary))
     }
 }
-
-

--- a/src/core/engine/contract_extract.rs
+++ b/src/core/engine/contract_extract.rs
@@ -7,9 +7,6 @@
 //! This is the primary extraction path. The `scripts/contract.sh` extension
 //! hook exists as a fallback for languages that need full AST parsing.
 
-use std::collections::HashMap;
-use std::path::Path;
-
 use regex::Regex;
 
 use super::contract::*;
@@ -55,7 +52,7 @@ pub fn extract_contracts_from_grammar(
         // Extract signature info
         let params_str = sym.get("params").unwrap_or("");
         let visibility = sym.get("visibility").map(|v| v.trim());
-        let is_public = visibility.map_or(false, |v| v.starts_with("pub"));
+        let is_public = visibility.is_some_and(|v| v.starts_with("pub"));
 
         // Detect return type from the declaration line(s)
         let decl_text = raw_lines

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -38,7 +38,14 @@ pub fn resolve_project_component(
         ));
     };
 
-    Ok(apply_component_overrides(&component, project))
+    let mut resolved = apply_component_overrides(&component, project);
+
+    // Auto-resolve remote_path if still empty after all config layers.
+    // Repo homeboy.json intentionally omits remote_path (it's deploy config),
+    // so auto-detect it from source files when possible (#812).
+    resolved.resolve_remote_path();
+
+    Ok(resolved)
 }
 
 pub fn resolve_project_components(project: &Project) -> Result<Vec<crate::component::Component>> {


### PR DESCRIPTION
## Summary

Fixes #812 — `attach-path` and `set` produced components with blank `remote_path` because repo `homeboy.json` intentionally omits it (it's deploy config, not repo config).

## Changes

- **Moved** `auto_resolve_wordpress_remote_path` from `deploy/execution.rs` to `Component::auto_resolve_remote_path()` — shared method on the Component struct
- **Added** `Component::resolve_remote_path()` — fills in `remote_path` if empty after all config layers
- **Called** `resolve_remote_path()` in `resolve_project_component` after applying project overrides
- **Called** `resolve_remote_path()` in `resolve_effective` for path-override discovery
- **Kept** deploy-time auto-resolve as a safety net, now calling the shared method
- **Added** 5 unit tests for auto-resolution (plugin detection, theme detection, non-WP skip, empty fill, explicit preserve)

## How it works

Resolution now layers: repo portable config → project overrides → **auto-resolve** (new step). For WordPress components, if `remote_path` is still empty, it detects `wp-content/plugins/{id}` or `wp-content/themes/{id}` from source files.