### PR TITLE
feat: add `homeboy validate` CLI command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -249,6 +249,7 @@ pub mod api;
 pub mod audit;
 pub mod auth;
 pub mod build;
+pub mod validate;
 pub mod changelog;
 pub mod changes;
 pub mod cli;
@@ -329,6 +330,7 @@ pub(crate) fn run_json(
         crate::Commands::Git(args) => dispatch!(args, global, git),
         crate::Commands::Version(args) => dispatch!(args, global, version),
         crate::Commands::Build(args) => dispatch!(args, global, build),
+        crate::Commands::Validate(args) => dispatch!(args, global, validate),
         crate::Commands::Changes(args) => dispatch!(args, global, changes),
         crate::Commands::Release(args) => dispatch!(args, global, release),
         crate::Commands::Audit(args) => dispatch!(args, global, audit),

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -1,0 +1,56 @@
+use clap::Args;
+use serde::Serialize;
+use std::path::PathBuf;
+
+use homeboy::component;
+use homeboy::engine::codebase_scan::{self, ScanConfig};
+use homeboy::engine::validate_write::{self, ValidationResult};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct ValidateArgs {
+    /// Component ID (optional — auto-discovers from CWD if omitted)
+    pub component_id: Option<String>,
+
+    /// Override source path for validation
+    #[arg(long)]
+    pub path: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ValidateOutput {
+    command: String,
+    #[serde(flatten)]
+    result: ValidationResult,
+}
+
+pub fn run(
+    args: ValidateArgs,
+    _global: &crate::commands::GlobalArgs,
+) -> CmdResult<ValidateOutput> {
+    let comp =
+        component::resolve_effective(args.component_id.as_deref(), args.path.as_deref(), None)?;
+
+    let root = PathBuf::from(&comp.local_path);
+
+    // Collect one source file so the validator can resolve the correct extension.
+    // For project-level validators (cargo check, tsc), the file list doesn't
+    // matter — they check the whole project. We just need one to detect the language.
+    let changed_files: Vec<PathBuf> = codebase_scan::walk_files(&root, &ScanConfig::default())
+        .into_iter()
+        .take(1)
+        .collect();
+
+    let result = validate_write::validate_only(&root, &changed_files)?;
+
+    let exit_code = if result.success { 0 } else { 1 };
+
+    Ok((
+        ValidateOutput {
+            command: "validate".to_string(),
+            result,
+        },
+        exit_code,
+    ))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use commands::utils::{args, entity_suggest, response as output, tty};
 use commands::{
     api, audit, auth, build, changelog, changes, cli, component, config, db, deploy, extension,
     file, fleet, git, init, lint, logs, project, refactor, release, server, ssh, status, test,
-    transfer, undo, upgrade, version,
+    transfer, undo, upgrade, validate, version,
 };
 use homeboy::extension::load_all_extensions;
 
@@ -92,6 +92,8 @@ enum Commands {
     Version(version::VersionArgs),
     /// Build a component
     Build(build::BuildArgs),
+    /// Validate that code compiles/parses (runs extension scripts.validate)
+    Validate(validate::ValidateArgs),
     /// Show changes since last version tag
     Changes(changes::ChangesArgs),
     /// Plan release workflows


### PR DESCRIPTION
## Summary

New CLI command that runs extension-provided validation (scripts.validate) on a component.

```bash
homeboy validate homeboy          # → cargo check (via rust extension)
homeboy validate data-machine     # → php -l (via wordpress extension)
homeboy validate --path /tmp/foo  # → auto-detect from path
```

## Why

CI autofix needs to validate changes compile before committing. The previous approach hardcoded language detection heuristics (`if Cargo.toml exists → cargo check`). This command uses the extension system — the same `validate_write` infrastructure that local `--write` commands use.

## How it works

1. Resolves the component (by ID, `--path`, or CWD auto-discovery)
2. Finds one source file to detect the language extension
3. Calls `validate_write::validate_only()` which resolves `scripts.validate` from the extension
4. Returns exit 0 on pass, exit 1 on fail, with JSON output

## Usage in CI

```bash
# In homeboy-action's autofix scripts:
homeboy validate "${COMP_ID}" --path "${WORKSPACE}"
```

Replaces the hardcoded language detection in `validate_autofix_compilation()`.