### PR TITLE
fix: validate_write on all refactor write paths

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -578,7 +578,28 @@ fn run_rename(
             &affected_files,
         );
 
+        let abs_changed: Vec<std::path::PathBuf> =
+            affected_files.iter().map(|f| root.join(f)).collect();
+        let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
+        for file in &abs_changed {
+            validation_rollback.capture(file);
+        }
+
         refactor::apply_renames(&mut result, &root)?;
+
+        // Validate that renamed code compiles
+        let validation = homeboy::engine::validate_write::validate_write(
+            &root,
+            &abs_changed,
+            &validation_rollback,
+        )?;
+        if !validation.success {
+            homeboy::log_status!(
+                "validate",
+                "Post-write validation failed — changes rolled back"
+            );
+            result.applied = false;
+        }
     }
 
     let scope_str = match scope {
@@ -972,6 +993,15 @@ fn run_propagate(
         );
     }
 
+    // Capture pre-write state for validation rollback
+    let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
+    if write {
+        let preview = refactor::propagate(&config)?;
+        for edit in &preview.edits {
+            validation_rollback.capture(&root.join(&edit.file));
+        }
+    }
+
     // Run the actual propagation (with write mode as requested)
     let write_config = refactor::PropagateConfig {
         struct_name,
@@ -979,7 +1009,25 @@ fn run_propagate(
         root: &root,
         write,
     };
-    let result = refactor::propagate(&write_config)?;
+    let mut result = refactor::propagate(&write_config)?;
+
+    // Validate written code compiles
+    if write && result.applied {
+        let abs_changed: Vec<std::path::PathBuf> =
+            result.edits.iter().map(|e| root.join(&e.file)).collect();
+        let validation = homeboy::engine::validate_write::validate_write(
+            &root,
+            &abs_changed,
+            &validation_rollback,
+        )?;
+        if !validation.success {
+            homeboy::log_status!(
+                "validate",
+                "Post-write validation failed — changes rolled back"
+            );
+            result.applied = false;
+        }
+    }
 
     // Log results to stderr
     homeboy::log_status!(

--- a/src/core/refactor/add.rs
+++ b/src/core/refactor/add.rs
@@ -51,8 +51,35 @@ pub fn fixes_from_audit(audit: &CodeAuditResult, write: bool) -> Result<FixResul
     let mut fix_result = plan::generate_audit_fixes(audit, root);
 
     if write && !fix_result.fixes.is_empty() {
+        // Capture pre-write state for rollback on validation failure
+        let affected_files: Vec<PathBuf> = fix_result
+            .fixes
+            .iter()
+            .map(|f| root.join(&f.file))
+            .collect();
+        let mut rollback = crate::engine::undo::InMemoryRollback::new();
+        for file in &affected_files {
+            rollback.capture(file);
+        }
+
         let applied = auto::apply_fixes(&mut fix_result.fixes, root);
         fix_result.files_modified = applied;
+
+        // Validate written code compiles
+        if applied > 0 {
+            let validation = crate::engine::validate_write::validate_write(
+                root,
+                &affected_files,
+                &rollback,
+            )?;
+            if !validation.success {
+                crate::log_status!(
+                    "validate",
+                    "Post-write validation failed — changes rolled back"
+                );
+                fix_result.files_modified = 0;
+            }
+        }
     }
 
     Ok(fix_result)
@@ -123,7 +150,30 @@ pub fn add_import(
     let mut files_modified = 0;
 
     if write && !fixes.is_empty() {
+        // Capture pre-write state for rollback on validation failure
+        let affected_files: Vec<PathBuf> = fixes.iter().map(|f| root.join(&f.file)).collect();
+        let mut rollback = crate::engine::undo::InMemoryRollback::new();
+        for file in &affected_files {
+            rollback.capture(file);
+        }
+
         files_modified = auto::apply_fixes(&mut fixes, &root);
+
+        // Validate written code compiles
+        if files_modified > 0 {
+            let validation = crate::engine::validate_write::validate_write(
+                &root,
+                &affected_files,
+                &rollback,
+            )?;
+            if !validation.success {
+                crate::log_status!(
+                    "validate",
+                    "Post-write validation failed — changes rolled back"
+                );
+                files_modified = 0;
+            }
+        }
     }
 
     Ok(AddResult {

--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -1,6 +1,7 @@
 use crate::component::Component;
 use crate::engine::temp;
-use crate::engine::undo::UndoSnapshot;
+use crate::engine::undo::{InMemoryRollback, UndoSnapshot};
+use crate::engine::validate_write;
 use crate::extension;
 use crate::extension::test::compute_changed_test_files;
 use crate::git;
@@ -294,12 +295,18 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
             }
         }
 
+        // Capture pre-write state for rollback if validation fails
+        let abs_changed: Vec<PathBuf> =
+            changed_files.iter().map(|f| request.root.join(f)).collect();
+        let mut validation_rollback = InMemoryRollback::new();
+        for file in &abs_changed {
+            validation_rollback.capture(file);
+        }
+
         copy_changed_files(working_root.path(), &request.root, &changed_files)?;
 
         // Run the project's formatter on written files so generated code matches style.
         // Non-fatal: formatting failure logs a warning but doesn't block the refactor.
-        let abs_changed: Vec<std::path::PathBuf> =
-            changed_files.iter().map(|f| request.root.join(f)).collect();
         match crate::engine::format_write::format_after_write(&request.root, &abs_changed) {
             Ok(fmt) => {
                 if let Some(cmd) = &fmt.command {
@@ -311,6 +318,46 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
             Err(e) => {
                 crate::log_status!("format", "Warning: post-write format failed: {}", e);
             }
+        }
+
+        // Validate that written code compiles. If validation fails, roll back
+        // all changes and report as dry-run (no files modified).
+        let validation = validate_write::validate_write(
+            &request.root,
+            &abs_changed,
+            &validation_rollback,
+        )?;
+        if !validation.success {
+            crate::log_status!(
+                "validate",
+                "Post-write validation failed — all changes rolled back"
+            );
+            if let Some(output) = &validation.output {
+                warnings.push(format!("Validation failed: {}", output));
+            }
+            // Reset: no files were modified (rolled back by validate_write)
+            for stage in &mut stage_summaries {
+                stage.applied = false;
+            }
+            return Ok(RefactorPlan {
+                component_id: request.component.id.clone(),
+                source_path: request.root.to_string_lossy().to_string(),
+                sources: sources.clone(),
+                dry_run: false,
+                applied: false,
+                merge_strategy: merge_order.clone(),
+                proposals,
+                stages: stage_summaries,
+                plan_totals,
+                overlaps,
+                files_modified: 0,
+                changed_files: vec![],
+                fix_summary: None,
+                warnings,
+                hints: vec![
+                    "Validation failed — changes were rolled back. Fix compilation errors and retry.".to_string(),
+                ],
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the validate_write gap that caused #832. Every refactor subcommand that writes files now validates compilation and rolls back on failure.

## Before

| Subcommand | validate_write? |
|---|---|
| refactor move (items) | ✅ |
| refactor move (file) | ✅ |
| refactor transform | ✅ |
| refactor decompose | ✅ |
| **refactor --from audit/lint/test** | **❌ — the CI autofix path** |
| **refactor rename** | **❌** |
| **refactor add --from-audit** | **❌** |
| **refactor add --import** | **❌** |
| **refactor propagate** | **❌** |

## After

All 9 subcommands validate. 5 gaps closed.

## How it works

Each gap follows the same pattern:
1. Capture pre-write state via `InMemoryRollback`
2. Apply writes (fixes, renames, propagation)
3. Call `validate_write()` with the changed files
4. If validation fails → `validate_write` rolls back automatically, function reports 0 files modified

## Why this matters

`homeboy refactor --from audit --write` is what CI calls. Without validation, broken decompositions (like #832's `mod` declarations without target files) get committed and pushed. With this fix, homeboy itself guarantees it never leaves broken code in the working tree. The CI action doesn't need to implement any validation logic — it just calls homeboy and trusts the exit code.