### PR TITLE
fix: defer artifact cleanup when --deploy follows release (#853)

### DIFF
--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -870,15 +870,20 @@ fn build_release_steps(
         }
 
         // 7. Cleanup step (runs after all publish steps)
-        steps.push(ReleasePlanStep {
-            id: "cleanup".to_string(),
-            step_type: "cleanup".to_string(),
-            label: Some("Clean up release artifacts".to_string()),
-            needs: publish_step_ids,
-            config: std::collections::HashMap::new(),
-            status: ReleasePlanStatus::Ready,
-            missing: vec![],
-        });
+        // Skip cleanup when --deploy is pending — the deploy step needs the
+        // build artifact (ZIP) that cleanup would delete. Cleanup runs after
+        // deployment completes instead.
+        if !options.deploy {
+            steps.push(ReleasePlanStep {
+                id: "cleanup".to_string(),
+                step_type: "cleanup".to_string(),
+                label: Some("Clean up release artifacts".to_string()),
+                needs: publish_step_ids,
+                config: std::collections::HashMap::new(),
+                status: ReleasePlanStatus::Ready,
+                missing: vec![],
+            });
+        }
     } else if options.skip_publish && !publish_targets.is_empty() {
         log_status!("release", "Skipping publish/package steps (--skip-publish)");
     }

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -153,6 +153,9 @@ pub struct ReleaseOptions {
     /// Use when CI handles publishing after the tag is pushed.
     #[serde(default)]
     pub skip_publish: bool,
+    /// Deploy after release — defers artifact cleanup until after deployment.
+    #[serde(default)]
+    pub deploy: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -88,6 +88,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         path_override: input.path_override,
         skip_checks: input.skip_checks,
         skip_publish: input.skip_publish,
+        deploy: input.deploy,
     };
 
     if options.dry_run {
@@ -124,7 +125,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         0
     };
     let (deployment, deploy_exit_code) = if input.deploy {
-        execute_deployment(&input.component_id)
+        execute_deployment(&input.component_id, &component.local_path)
     } else {
         (None, 0)
     };
@@ -251,7 +252,7 @@ fn plan_deployment(component_id: &str) -> ReleaseDeploymentResult {
     }
 }
 
-fn execute_deployment(component_id: &str) -> (Option<ReleaseDeploymentResult>, i32) {
+fn execute_deployment(component_id: &str, local_path: &str) -> (Option<ReleaseDeploymentResult>, i32) {
     let projects = component::projects_using(component_id).unwrap_or_default();
 
     if projects.is_empty() {
@@ -339,6 +340,18 @@ fn execute_deployment(component_id: &str) -> (Option<ReleaseDeploymentResult>, i
 
     let total = project_results.len() as u32;
     let exit_code = if failed > 0 { 1 } else { 0 };
+
+    // Clean up build artifacts now that deployment is complete.
+    // The release pipeline skipped cleanup when --deploy was set so the
+    // deploy step could find the ZIP artifact.
+    let distrib_path = format!("{}/target/distrib", local_path);
+    if std::path::Path::new(&distrib_path).exists() {
+        if let Err(e) = std::fs::remove_dir_all(&distrib_path) {
+            log_status!("release", "Warning: failed to clean up {}: {}", distrib_path, e);
+        } else {
+            log_status!("release", "Cleaned up {}", distrib_path);
+        }
+    }
 
     (
         Some(ReleaseDeploymentResult {


### PR DESCRIPTION
## Summary

- Fixes `release --deploy` failing to find the build artifact because the cleanup step deletes it first
- Closes #853

## Root Cause

The release pipeline runs steps in order:
```
package → publish → cleanup → (pipeline done) → deploy
```

The cleanup step deletes `target/distrib/` (the ZIP artifact). The deploy step runs *after* the pipeline completes and passes `skip_build: true`, expecting the artifact to still be there. It isn't.

## Fix

1. Added `deploy: bool` to `ReleaseOptions` (propagated from `ReleaseCommandInput`)
2. When `deploy` is true, the cleanup step is **skipped** in the release pipeline
3. After all project deployments complete, `execute_deployment()` cleans up `target/distrib/` itself

```
package → publish → (pipeline done) → deploy → cleanup
```

## Changes

- **`types.rs`**: Added `deploy: bool` field to `ReleaseOptions`
- **`workflow.rs`**: Pass `deploy` flag through, run cleanup after deployment
- **`pipeline.rs`**: Conditionally skip cleanup step when `options.deploy` is true

All 805 lib tests pass.