### PR TITLE
fix: preserve array/object values in extension settings JSON (#844)

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -79,7 +79,19 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             component_label: args.comp.component.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
-            settings: ctx.settings.clone(),
+            settings: ctx
+                .settings
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        match v {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        },
+                    )
+                })
+                .collect(),
             summary: args.summary,
             file: args.file.clone(),
             glob: args.glob.clone(),

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -202,7 +202,19 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             component_label: args.comp.component.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
-            settings: ctx.settings.clone(),
+            settings: ctx
+                .settings
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        match v {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        },
+                    )
+                })
+                .collect(),
             skip_lint: args.skip_lint,
             fix: args.fix,
             coverage: args.coverage,

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -47,7 +47,7 @@ pub struct ExecutionContext {
     pub extension_path: Option<PathBuf>,
 
     /// Merged settings (manifest defaults → component → overrides).
-    pub settings: Vec<(String, String)>,
+    pub settings: Vec<(String, serde_json::Value)>,
 }
 
 /// What to resolve when building an execution context.
@@ -132,11 +132,11 @@ pub fn resolve(options: &ResolveOptions) -> Result<ExecutionContext> {
     let (extension_id, extension_path, settings) = if let Some(capability) = options.capability {
         let ext_context = extension::resolve_execution_context(&component, capability)?;
         let mut settings = ext_context.settings.clone();
-        // Merge CLI overrides on top
+        // Merge CLI overrides on top (CLI values are always strings)
         for (key, value) in &options.settings_overrides {
             // Remove existing key if present (override semantics)
             settings.retain(|(k, _)| k != key);
-            settings.push((key.clone(), value.clone()));
+            settings.push((key.clone(), serde_json::Value::String(value.clone())));
         }
         (
             Some(ext_context.extension_id.clone()),
@@ -144,7 +144,13 @@ pub fn resolve(options: &ResolveOptions) -> Result<ExecutionContext> {
             settings,
         )
     } else {
-        (None, None, options.settings_overrides.clone())
+        // No extension context — only CLI overrides, wrapped as JSON strings.
+        let settings = options
+            .settings_overrides
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect();
+        (None, None, settings)
     };
 
     Ok(ExecutionContext {

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -409,34 +409,33 @@ pub(crate) fn load_extension_manifest_from_dir(extension_path: &Path) -> Result<
 
 pub(crate) fn build_settings_json_from_manifest(
     manifest: &serde_json::Value,
-    extension_settings: &[(String, String)],
+    extension_settings: &[(String, serde_json::Value)],
     settings_overrides: &[(String, String)],
 ) -> Result<String> {
     let mut settings = serde_json::json!({});
 
+    // Load defaults from manifest — preserve original JSON types.
     if let Some(manifest_settings) = manifest.get("settings") {
         if let Some(settings_array) = manifest_settings.as_array() {
             if let serde_json::Value::Object(ref mut obj) = settings {
                 for setting in settings_array {
-                    if let (Some(id), Some(default)) = (
-                        setting.get("id").and_then(|v| v.as_str()),
-                        setting.get("default").and_then(|v| v.as_str()),
-                    ) {
-                        obj.insert(
-                            id.to_string(),
-                            serde_json::Value::String(default.to_string()),
-                        );
+                    if let Some(id) = setting.get("id").and_then(|v| v.as_str()) {
+                        if let Some(default) = setting.get("default") {
+                            obj.insert(id.to_string(), default.clone());
+                        }
                     }
                 }
             }
         }
     }
 
+    // Apply component/project extension settings — preserves arrays, objects, etc.
     if let serde_json::Value::Object(ref mut obj) = settings {
         for (key, value) in extension_settings {
-            obj.insert(key.clone(), serde_json::Value::String(value.clone()));
+            obj.insert(key.clone(), value.clone());
         }
 
+        // CLI overrides are always strings (from --setting key=value).
         for (key, value) in settings_overrides {
             obj.insert(key.clone(), serde_json::Value::String(value.clone()));
         }
@@ -1071,6 +1070,68 @@ mod tests {
 
         assert!(helper.is_some());
         assert!(helper.unwrap().ends_with("runner-steps.sh"));
+    }
+
+    #[test]
+    fn build_settings_json_preserves_array_values() {
+        // Regression test for #844: array values in extension settings
+        // were serialized as empty strings.
+        let manifest = serde_json::json!({
+            "settings": [
+                { "id": "string_setting", "default": "hello" },
+                { "id": "array_default", "default": ["a", "b"] }
+            ]
+        });
+
+        let extension_settings: Vec<(String, serde_json::Value)> = vec![
+            (
+                "validation_dependencies".to_string(),
+                serde_json::json!(["data-machine"]),
+            ),
+            (
+                "plain_string".to_string(),
+                serde_json::Value::String("value".to_string()),
+            ),
+        ];
+
+        let overrides: Vec<(String, String)> = vec![];
+
+        let json = build_settings_json_from_manifest(&manifest, &extension_settings, &overrides)
+            .expect("should serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
+
+        // Array from extension settings is preserved
+        assert_eq!(
+            parsed["validation_dependencies"],
+            serde_json::json!(["data-machine"]),
+            "Array setting should be preserved, not flattened to empty string"
+        );
+
+        // String from extension settings is preserved
+        assert_eq!(parsed["plain_string"], serde_json::json!("value"));
+
+        // String default from manifest is preserved
+        assert_eq!(parsed["string_setting"], serde_json::json!("hello"));
+
+        // Array default from manifest is preserved
+        assert_eq!(parsed["array_default"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn build_settings_json_cli_overrides_replace_values() {
+        let manifest = serde_json::json!({});
+        let extension_settings: Vec<(String, serde_json::Value)> = vec![(
+            "key".to_string(),
+            serde_json::json!(["original"]),
+        )];
+        let overrides = vec![("key".to_string(), "override_value".to_string())];
+
+        let json = build_settings_json_from_manifest(&manifest, &extension_settings, &overrides)
+            .expect("should serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
+
+        // CLI override replaces the array value with a string
+        assert_eq!(parsed["key"], serde_json::json!("override_value"));
     }
 
     #[test]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -126,7 +126,7 @@ pub struct ExtensionExecutionContext {
     pub extension_id: String,
     pub extension_path: PathBuf,
     pub script_path: String,
-    pub settings: Vec<(String, String)>,
+    pub settings: Vec<(String, serde_json::Value)>,
 }
 
 fn no_extensions_error(component: &Component) -> Error {
@@ -210,7 +210,7 @@ fn linked_extensions(
 pub fn extract_component_extension_settings(
     component: &Component,
     extension_id: &str,
-) -> Vec<(String, String)> {
+) -> Vec<(String, serde_json::Value)> {
     component
         .extensions
         .as_ref()
@@ -219,7 +219,7 @@ pub fn extract_component_extension_settings(
             extension_config
                 .settings
                 .iter()
-                .filter_map(|(key, value)| value.as_str().map(|v| (key.clone(), v.to_string())))
+                .map(|(key, value)| (key.clone(), value.clone()))
                 .collect()
         })
         .unwrap_or_default()


### PR DESCRIPTION
## Summary

- Fixes extension settings with array values (like `"validation_dependencies": ["data-machine"]`) being serialized as empty strings in `HOMEBOY_SETTINGS_JSON`
- Closes #844

## Root Cause

Three points in the settings pipeline forced `String` types, silently dropping arrays/objects:

```
homeboy.json                    ExtensionExecutionContext        HOMEBOY_SETTINGS_JSON
{"deps": ["data-machine"]}  →  Vec<(String, String)>         →  {"deps": ""}
                                ↑ .as_str() returns None
                                  for arrays → filter_map
                                  drops the entry entirely
```

## Fix

Changed the core settings type from `(String, String)` to `(String, serde_json::Value)` so the original JSON structure is preserved:

```
homeboy.json                    ExtensionExecutionContext        HOMEBOY_SETTINGS_JSON
{"deps": ["data-machine"]}  →  Vec<(String, Value)>          →  {"deps": ["data-machine"]}
```

**Files changed:**
- **`extension/mod.rs`** — `extract_component_extension_settings()` now preserves all JSON value types
- **`extension/execution.rs`** — `build_settings_json_from_manifest()` accepts `Value` for extension settings; manifest defaults also preserve original types
- **`engine/execution_context.rs`** — `ExecutionContext.settings` changed to `Vec<(String, serde_json::Value)>`
- **`commands/lint.rs` + `commands/test.rs`** — Convert `Value` to `String` at the CLI boundary (workflow args still use strings for override semantics)

CLI overrides (`--setting key=value`) remain strings since they're text input.

## Tests

Added 2 new tests:
- `build_settings_json_preserves_array_values` — arrays, strings, and manifest defaults all round-trip correctly
- `build_settings_json_cli_overrides_replace_values` — CLI string overrides correctly replace array values

All 807 lib tests pass.