### PR TITLE
fix: extract duplicate test helpers to shared module (#535)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,8 +3,8 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-03-18T16:01:08Z",
-      "item_count": 673,
+      "created_at": "2026-03-18T16:09:58Z",
+      "item_count": 669,
       "known_fingerprints": [
         "Commands (Tests)::tests/commands/deploy_test.rs::MissingMethod",
         "Commands (Tests)::tests/commands/deploy_test.rs::MissingMethod",
@@ -56,10 +56,6 @@
         "dead_code::src/core/refactor/plan/planner.rs::UnreferencedExport",
         "dead_code::src/core/refactor/plan/planner.rs::UnreferencedExport",
         "dead_code::src/core/release/utils.rs::UnreferencedExport",
-        "duplication::tests/core/code_audit/report_test.rs::DuplicateFunction",
-        "duplication::tests/core/code_audit/report_test.rs::DuplicateFunction",
-        "duplication::tests/core/code_audit/run_test.rs::DuplicateFunction",
-        "duplication::tests/core/code_audit/run_test.rs::DuplicateFunction",
         "intra-method-duplication::src/commands/component.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/commands/config.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/commands/refactor.rs::IntraMethodDuplicate",

--- a/src/core/code_audit/test_helpers.rs
+++ b/src/core/code_audit/test_helpers.rs
@@ -4,7 +4,7 @@
 //! reducing boilerplate across test modules.
 
 use super::checks::CheckStatus;
-use super::ConventionReport;
+use super::{AuditFinding, AuditSummary, CodeAuditResult, ConventionReport, Finding, Severity};
 
 /// Build a `ConventionReport` with sensible defaults for testing.
 ///
@@ -29,5 +29,37 @@ pub fn make_convention(
         outliers: vec![],
         total_files: 3,
         confidence: 1.0,
+    }
+}
+
+/// Build an empty `CodeAuditResult` for testing.
+pub fn empty_result() -> CodeAuditResult {
+    CodeAuditResult {
+        component_id: "test-component".to_string(),
+        source_path: "/tmp/test".to_string(),
+        summary: AuditSummary {
+            files_scanned: 0,
+            conventions_detected: 0,
+            outliers_found: 0,
+            alignment_score: None,
+            files_skipped: 0,
+            warnings: vec![],
+        },
+        conventions: vec![],
+        directory_conventions: vec![],
+        findings: vec![],
+        duplicate_groups: vec![],
+    }
+}
+
+/// Build a `Finding` with the given severity for testing.
+pub fn make_finding(severity: Severity) -> Finding {
+    Finding {
+        convention: "TestConvention".to_string(),
+        severity,
+        file: "src/example.rs".to_string(),
+        description: "Test finding".to_string(),
+        suggestion: "Fix it".to_string(),
+        kind: AuditFinding::MissingMethod,
     }
 }

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -1,38 +1,9 @@
 use crate::code_audit::report::{
     build_audit_summary, build_fix_hints, build_fix_policy_summary, compute_fixability,
 };
-use crate::code_audit::{AuditSummary, CodeAuditResult, Finding, Severity};
+use crate::code_audit::test_helpers::{empty_result, make_finding};
+use crate::code_audit::Severity;
 use crate::refactor::auto::PolicySummary;
-
-fn empty_result() -> CodeAuditResult {
-    CodeAuditResult {
-        component_id: "test-component".to_string(),
-        source_path: "/tmp/test".to_string(),
-        summary: AuditSummary {
-            files_scanned: 0,
-            conventions_detected: 0,
-            outliers_found: 0,
-            alignment_score: None,
-            files_skipped: 0,
-            warnings: vec![],
-        },
-        conventions: vec![],
-        directory_conventions: vec![],
-        findings: vec![],
-        duplicate_groups: vec![],
-    }
-}
-
-fn make_finding(severity: Severity) -> Finding {
-    Finding {
-        convention: "TestConvention".to_string(),
-        severity,
-        file: "src/example.rs".to_string(),
-        description: "Test finding".to_string(),
-        suggestion: "Fix it".to_string(),
-        kind: crate::code_audit::AuditFinding::MissingMethod,
-    }
-}
 
 #[test]
 fn test_build_audit_summary_empty_result() {

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -1,32 +1,3 @@
 use crate::code_audit::run::default_audit_exit_code;
-use crate::code_audit::{AuditSummary, CodeAuditResult, Finding, Severity};
-
-fn empty_result() -> CodeAuditResult {
-    CodeAuditResult {
-        component_id: "test-component".to_string(),
-        source_path: "/tmp/test".to_string(),
-        summary: AuditSummary {
-            files_scanned: 0,
-            conventions_detected: 0,
-            outliers_found: 0,
-            alignment_score: None,
-            files_skipped: 0,
-            warnings: vec![],
-        },
-        conventions: vec![],
-        directory_conventions: vec![],
-        findings: vec![],
-        duplicate_groups: vec![],
-    }
-}
-
-fn make_finding(severity: Severity) -> Finding {
-    Finding {
-        convention: "TestConvention".to_string(),
-        severity,
-        file: "src/example.rs".to_string(),
-        description: "Test finding".to_string(),
-        suggestion: "Fix it".to_string(),
-        kind: crate::code_audit::AuditFinding::MissingMethod,
-    }
-}
+use crate::code_audit::test_helpers::{empty_result, make_finding};
+use crate::code_audit::Severity;


### PR DESCRIPTION
## Summary

- Extracts `empty_result()` and `make_finding()` from `report_test.rs` and `run_test.rs` into the existing `test_helpers.rs` shared module
- Closes #535 (duplicate function findings)
- Audit baseline: 673 → 669 findings (−4)

## Changes

`empty_result()` and `make_finding()` had identical implementations in both test files. Moved them to `src/core/code_audit/test_helpers.rs` (which already existed as the canonical shared test helper module) and updated both test files to import from there.

807/807 tests pass.