### PR TITLE
feat: add failure-trap and write-test-results runtime helpers

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -851,11 +851,8 @@ pub fn build_exec_env(
         env.push((exec_context::EXTENSION_PATH.to_string(), mp.to_string()));
     }
 
-    if let Ok(helper_path) = runtime_helper::ensure_runner_steps_helper() {
-        env.push((
-            runtime_helper::RUNNER_STEPS_ENV.to_string(),
-            helper_path.to_string_lossy().to_string(),
-        ));
+    if let Ok(helper_pairs) = runtime_helper::ensure_all_helpers() {
+        env.extend(helper_pairs);
     }
 
     if let Some(pbp) = project_base_path {

--- a/src/core/extension/runtime/failure-trap.sh
+++ b/src/core/extension/runtime/failure-trap.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Shared failure summary trap for extension runner scripts.
+#
+# Provides a structured error banner on script exit when a step fails.
+# Extensions set FAILED_STEP to the name of the failing step, and optionally
+# FAILURE_OUTPUT to captured error output and FAILURE_REPLAY_MODE to control
+# whether captured output is replayed.
+#
+# Usage:
+#   source "${HOMEBOY_RUNTIME_FAILURE_TRAP:-/path/to/fallback}"
+#   homeboy_init_failure_trap
+#
+# Then in your script:
+#   FAILED_STEP="phpunit"
+#   FAILURE_OUTPUT="$captured_stderr"
+#   FAILURE_REPLAY_MODE="full"  # or "none" to skip replay
+
+FAILED_STEP=""
+FAILURE_OUTPUT=""
+FAILURE_REPLAY_MODE="full"
+
+homeboy_print_failure_summary() {
+    if [ -n "$FAILED_STEP" ]; then
+        echo ""
+        echo "============================================"
+        echo "BUILD FAILED: $FAILED_STEP"
+        echo "============================================"
+        if [ "$FAILURE_REPLAY_MODE" = "none" ]; then
+            echo ""
+            echo "See output above (not replayed)."
+        elif [ -n "$FAILURE_OUTPUT" ]; then
+            echo ""
+            echo "Error details:"
+            echo "$FAILURE_OUTPUT"
+        fi
+    fi
+}
+
+homeboy_init_failure_trap() {
+    trap homeboy_print_failure_summary EXIT
+}

--- a/src/core/extension/runtime/write-test-results.sh
+++ b/src/core/extension/runtime/write-test-results.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Shared test results writer for extension runner scripts.
+#
+# Writes the standard test results JSON sidecar and prints a summary to stderr.
+# Extensions parse their tool-specific output to extract counts, then call
+# this function to write the results in the canonical format.
+#
+# Usage:
+#   source "${HOMEBOY_RUNTIME_WRITE_TEST_RESULTS:-/path/to/fallback}"
+#   homeboy_write_test_results <total> <passed> <failed> <skipped> [partial_label]
+#
+# Arguments:
+#   total    — total number of tests
+#   passed   — number of passing tests
+#   failed   — number of failing tests
+#   skipped  — number of skipped/ignored tests
+#   partial  — optional label indicating incomplete results (e.g. "testdox-fallback")
+#
+# Writes to HOMEBOY_TEST_RESULTS_FILE if set. Always prints summary to stderr.
+
+homeboy_write_test_results() {
+    local total="${1:-0}"
+    local passed="${2:-0}"
+    local failed="${3:-0}"
+    local skipped="${4:-0}"
+    local partial="${5:-}"
+
+    # Write JSON to file if requested
+    if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+        if [ -n "${partial}" ]; then
+            cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
+{
+  "total": ${total},
+  "passed": ${passed},
+  "failed": ${failed},
+  "skipped": ${skipped},
+  "partial": "${partial}"
+}
+JSONEOF
+        else
+            cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
+{
+  "total": ${total},
+  "passed": ${passed},
+  "failed": ${failed},
+  "skipped": ${skipped}
+}
+JSONEOF
+        fi
+    fi
+
+    # Print summary to stderr for visibility
+    if [ -n "${partial}" ]; then
+        echo "[test-results] Total: ${total}, Passed: ${passed}, Failed: ${failed}, Skipped: ${skipped} (${partial})" >&2
+    else
+        echo "[test-results] Total: ${total}, Passed: ${passed}, Failed: ${failed}, Skipped: ${skipped}" >&2
+    fi
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -5,10 +5,55 @@ use std::fs;
 use std::path::PathBuf;
 
 const RUNNER_STEPS_SH: &str = include_str!("runtime/runner-steps.sh");
+const FAILURE_TRAP_SH: &str = include_str!("runtime/failure-trap.sh");
+const WRITE_TEST_RESULTS_SH: &str = include_str!("runtime/write-test-results.sh");
 
 pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
+pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
+pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
 
-pub fn ensure_runner_steps_helper() -> Result<PathBuf> {
+struct RuntimeHelper {
+    filename: &'static str,
+    content: &'static str,
+    env_var: &'static str,
+}
+
+const HELPERS: &[RuntimeHelper] = &[
+    RuntimeHelper {
+        filename: "runner-steps.sh",
+        content: RUNNER_STEPS_SH,
+        env_var: RUNNER_STEPS_ENV,
+    },
+    RuntimeHelper {
+        filename: "failure-trap.sh",
+        content: FAILURE_TRAP_SH,
+        env_var: FAILURE_TRAP_ENV,
+    },
+    RuntimeHelper {
+        filename: "write-test-results.sh",
+        content: WRITE_TEST_RESULTS_SH,
+        env_var: WRITE_TEST_RESULTS_ENV,
+    },
+];
+
+/// Write a single runtime helper to disk if it's missing or stale.
+fn ensure_helper(runtime_dir: &std::path::Path, helper: &RuntimeHelper) -> Result<PathBuf> {
+    let helper_path = runtime_dir.join(helper.filename);
+    let current = fs::read_to_string(&helper_path).ok();
+
+    if current.as_deref() != Some(helper.content) {
+        local_files::write_file_atomic(
+            &helper_path,
+            helper.content,
+            &format!("write runtime {} helper", helper.filename),
+        )?;
+    }
+
+    Ok(helper_path)
+}
+
+/// Ensure all runtime helpers are written and return (env_var, path) pairs.
+pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
     let runtime_dir = paths::homeboy()?.join("runtime");
     fs::create_dir_all(&runtime_dir).map_err(|e| {
         Error::internal_io(
@@ -17,18 +62,16 @@ pub fn ensure_runner_steps_helper() -> Result<PathBuf> {
         )
     })?;
 
-    let helper_path = runtime_dir.join("runner-steps.sh");
-    let current = fs::read_to_string(&helper_path).ok();
-
-    if current.as_deref() != Some(RUNNER_STEPS_SH) {
-        local_files::write_file_atomic(
-            &helper_path,
-            RUNNER_STEPS_SH,
-            "write runtime runner helper",
-        )?;
+    let mut env_pairs = Vec::with_capacity(HELPERS.len());
+    for helper in HELPERS {
+        let path = ensure_helper(&runtime_dir, helper)?;
+        env_pairs.push((
+            helper.env_var.to_string(),
+            path.to_string_lossy().to_string(),
+        ));
     }
 
-    Ok(helper_path)
+    Ok(env_pairs)
 }
 
 #[cfg(test)]
@@ -36,10 +79,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ensure_runner_steps_helper_writes_expected_contents() {
-        let path = ensure_runner_steps_helper().expect("helper should be written");
-        let contents = std::fs::read_to_string(&path).expect("helper should be readable");
-        assert_eq!(contents, RUNNER_STEPS_SH);
-        assert!(path.ends_with("runner-steps.sh"));
+    fn ensure_all_helpers_writes_all_files() {
+        let pairs = ensure_all_helpers().expect("all helpers should be written");
+        assert_eq!(pairs.len(), HELPERS.len());
+
+        for (i, (env_var, path)) in pairs.iter().enumerate() {
+            assert_eq!(env_var, HELPERS[i].env_var);
+            let contents = std::fs::read_to_string(path).expect("helper should be readable");
+            assert_eq!(contents, HELPERS[i].content);
+        }
+
+        // Verify specific helpers are present
+        assert!(
+            pairs.iter().any(|(k, _)| k == FAILURE_TRAP_ENV),
+            "failure trap helper should be in pairs"
+        );
+        assert!(
+            pairs.iter().any(|(k, _)| k == WRITE_TEST_RESULTS_ENV),
+            "write test results helper should be in pairs"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Extends the runtime helper system with two new shared scripts that eliminate duplicated boilerplate in extensions.

- **`failure-trap.sh`** — structured error banner on script exit via EXIT trap
- **`write-test-results.sh`** — canonical test results JSON writer

## Architecture

```
homeboy binary (Rust)
  │
  │  include_str!("runtime/runner-steps.sh")      ← existing
  │  include_str!("runtime/failure-trap.sh")       ← new
  │  include_str!("runtime/write-test-results.sh") ← new
  │
  ▼
~/.config/homeboy/runtime/
  ├── runner-steps.sh
  ├── failure-trap.sh           ← new
  └── write-test-results.sh     ← new
  │
  ▼ injected as env vars
HOMEBOY_RUNTIME_RUNNER_STEPS         ← existing
HOMEBOY_RUNTIME_FAILURE_TRAP         ← new
HOMEBOY_RUNTIME_WRITE_TEST_RESULTS   ← new
```

Extensions source these via the env var with a local fallback:
```bash
source "${HOMEBOY_RUNTIME_FAILURE_TRAP:-${SCRIPT_DIR}/lib/failure-trap.sh}"
homeboy_init_failure_trap
```

## What changed

| File | Change |
|---|---|
| `runtime/failure-trap.sh` | New: `homeboy_init_failure_trap()` + `homeboy_print_failure_summary()` |
| `runtime/write-test-results.sh` | New: `homeboy_write_test_results total passed failed skipped [partial]` |
| `runtime_helper.rs` | Refactored from single-helper to table-driven `HELPERS` array with `ensure_all_helpers()` |
| `execution.rs` | Now calls `ensure_all_helpers()` instead of single `ensure_runner_steps_helper()` |

## Duplication eliminated

| Pattern | Before (per extension) | After |
|---|---|---|
| Failure summary trap | ~15 lines inline in each runner | `source` + `homeboy_init_failure_trap` |
| Test results JSON write | ~25 lines per parse script | `homeboy_write_test_results $total $passed $failed $skipped` |

Adoption PR in homeboy-extensions will follow.