### PR TITLE
feat: include fixability metadata in full audit output

### DIFF
--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -51,7 +51,12 @@ pub struct AuditSummaryFinding {
 #[serde(tag = "command")]
 pub enum AuditCommandOutput {
     #[serde(rename = "audit")]
-    Full(CodeAuditResult),
+    Full {
+        #[serde(flatten)]
+        result: CodeAuditResult,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        fixability: Option<AuditFixability>,
+    },
 
     #[serde(rename = "audit.conventions")]
     Conventions {

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -54,22 +54,25 @@ pub fn run_main_audit_workflow(
         Some(r) => r,
         None => {
             return Ok(AuditRunWorkflowResult {
-                output: AuditCommandOutput::Full(CodeAuditResult {
-                    component_id: args.component_id,
-                    source_path: args.source_path,
-                    summary: code_audit::AuditSummary {
-                        files_scanned: 0,
-                        conventions_detected: 0,
-                        outliers_found: 0,
-                        alignment_score: None,
-                        files_skipped: 0,
-                        warnings: vec![],
+                output: AuditCommandOutput::Full {
+                    result: CodeAuditResult {
+                        component_id: args.component_id,
+                        source_path: args.source_path,
+                        summary: code_audit::AuditSummary {
+                            files_scanned: 0,
+                            conventions_detected: 0,
+                            outliers_found: 0,
+                            alignment_score: None,
+                            files_skipped: 0,
+                            warnings: vec![],
+                        },
+                        conventions: vec![],
+                        directory_conventions: vec![],
+                        findings: vec![],
+                        duplicate_groups: vec![],
                     },
-                    conventions: vec![],
-                    directory_conventions: vec![],
-                    findings: vec![],
-                    duplicate_groups: vec![],
-                }),
+                    fixability: None,
+                },
                 exit_code: 0,
             });
         }
@@ -390,8 +393,12 @@ fn run_comparison_workflow(
             exit_code,
         })
     } else {
+        let fixability = report::compute_fixability(&result);
         Ok(AuditRunWorkflowResult {
-            output: AuditCommandOutput::Full(result),
+            output: AuditCommandOutput::Full {
+                result,
+                fixability,
+            },
             exit_code,
         })
     }


### PR DESCRIPTION
## Summary

- Adds `fixability: Option<AuditFixability>` to `AuditCommandOutput::Full`, matching what `Compared` and `Summary` already provide
- Computes per-kind fixability in the no-baseline audit path so CI consumers get the data without a separate `--fix` dry-run
- No JSON shape change — result fields stay at top level via `#[serde(flatten)]`, fixability appears alongside them

Closes #861 (homeboy side — paired with Extra-Chill/homeboy-action PR for the rendering side)