### PR TITLE
feat!: remove changelog add — release owns all changelog entries

### DIFF
--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use super::CmdResult;
-use homeboy::changelog::{self, AddItemsOutput, InitOutput, ShowOutput};
+use homeboy::changelog::{self, InitOutput, ShowOutput};
 
 #[derive(Args)]
 pub struct ChangelogArgs {
@@ -20,50 +20,6 @@ pub enum ChangelogCommand {
     Show {
         /// Component ID to show changelog for
         component_id: Option<String>,
-    },
-
-    /// Add changelog items to the configured "next" section
-    ///
-    /// Examples:
-    ///   homeboy changelog add my-plugin "Fixed login bug"
-    ///   homeboy changelog add my-plugin "Removed legacy API" --type Removed
-    ///   homeboy changelog add my-plugin -m "Added search" -m "Added filters"
-    #[command(after_long_help = "\
-EXAMPLES:
-  Add a simple entry:
-    homeboy changelog add my-plugin \"Fixed login bug\"
-
-  Add with a type (Added, Changed, Removed, Fixed, etc.):
-    homeboy changelog add my-plugin \"Removed legacy API\" --type Removed
-
-  Add multiple entries at once:
-    homeboy changelog add my-plugin -m \"Added search\" -m \"Added filters\"
-
-  Add with type and multiple messages:
-    homeboy changelog add my-plugin -m \"New auth flow\" -m \"New API keys\" --type Added
-")]
-    Add {
-        /// JSON input spec for batch operations.
-        ///
-        /// Use "-" to read from stdin, "@file.json" to read from a file, or an inline JSON string.
-        #[arg(long)]
-        json: Option<String>,
-
-        /// Component ID (non-JSON mode)
-        #[arg(index = 1)]
-        component_id: Option<String>,
-
-        /// Changelog item content (positional, for backward compatibility)
-        #[arg(index = 2)]
-        positional_message: Option<String>,
-
-        /// Changelog message (repeatable: -m "first" -m "second")
-        #[arg(short = 'm', long = "message", action = clap::ArgAction::Append)]
-        messages: Vec<String>,
-
-        /// Changelog subsection type (Added, Changed, Deprecated, Removed, Fixed, Security, Refactored)
-        #[arg(short = 't', long = "type")]
-        entry_type: Option<String>,
     },
 
     /// Initialize a new changelog file
@@ -95,8 +51,6 @@ pub enum ChangelogOutput {
 
     ShowComponent(ShowOutput),
 
-    Add(AddItemsOutput),
-
     Init(InitOutput),
 }
 
@@ -110,16 +64,15 @@ pub fn run_markdown(args: ChangelogArgs) -> CmdResult<String> {
         }
         (None, false) => Err(homeboy::Error::validation_invalid_argument(
             "command",
-            "No subcommand provided. Use a subcommand (add, init, show) or --self to view Homeboy's changelog",
+            "No subcommand provided. Use a subcommand (init, show) or --self to view Homeboy's changelog",
             None,
             Some(vec![
-                "homeboy changelog add <component_id> <message>".to_string(),
                 "homeboy changelog init <component_id>".to_string(),
                 "homeboy changelog show".to_string(),
                 "homeboy changelog show <component_id>".to_string(),
             ]),
         )),
-        (Some(ChangelogCommand::Add { .. }) | Some(ChangelogCommand::Init { .. }), _) => {
+        (Some(ChangelogCommand::Init { .. }), _) => {
             Err(homeboy::Error::validation_invalid_argument(
                 "command",
                 "Markdown output is only supported for 'changelog show'",
@@ -154,40 +107,14 @@ pub fn run(
         }
         (None, false) => Err(homeboy::Error::validation_invalid_argument(
             "command",
-            "No subcommand provided. Use a subcommand (add, init, show) or --self to view Homeboy's changelog",
+            "No subcommand provided. Use a subcommand (init, show) or --self to view Homeboy's changelog",
             None,
             Some(vec![
-                "homeboy changelog add <component_id> <message>".to_string(),
                 "homeboy changelog init <component_id>".to_string(),
                 "homeboy changelog show".to_string(),
                 "homeboy changelog show <component_id>".to_string(),
             ]),
         )),
-        (Some(ChangelogCommand::Add {
-            json,
-            component_id,
-            positional_message,
-            messages,
-            entry_type,
-        }), _) => {
-            // Priority: --json > component_id (auto-detects JSON)
-            // Merge positional message with -m flags (positional goes first)
-            let mut all_messages: Vec<String> = Vec::new();
-            if let Some(msg) = positional_message {
-                all_messages.push(msg.clone());
-            }
-            all_messages.extend(messages.iter().cloned());
-
-            // Explicit --json takes precedence
-            if let Some(spec) = json.as_deref() {
-                let output = changelog::add_items_bulk(spec)?;
-                return Ok((ChangelogOutput::Add(output), 0));
-            }
-
-            // Core handles auto-detection of JSON in component_id
-            let output = changelog::add_items(component_id.as_deref(), &all_messages, entry_type.as_deref())?;
-            Ok((ChangelogOutput::Add(output), 0))
-        }
         (Some(ChangelogCommand::Init {
             path,
             configure,

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -38,42 +38,6 @@ pub(crate) fn normalize_version_show(args: Vec<String>) -> Vec<String> {
     result
 }
 
-/// Normalize changelog add --component flag to positional form.
-pub(crate) fn normalize_changelog_component(args: Vec<String>) -> Vec<String> {
-    let is_changelog_add = args.len() >= 4
-        && args.get(1).map(|s| s == "changelog").unwrap_or(false)
-        && args.get(2).map(|s| s == "add").unwrap_or(false);
-
-    if !is_changelog_add {
-        return args;
-    }
-
-    let component_pos = args.iter().position(|s| s == "--component");
-    let Some(component_pos) = component_pos else {
-        return args;
-    };
-
-    let Some(component_value) = args.get(component_pos + 1) else {
-        return args;
-    };
-
-    let mut result = vec![
-        args[0].clone(),
-        args[1].clone(),
-        args[2].clone(),
-        component_value.clone(),
-    ];
-
-    for (i, arg) in args.iter().enumerate().skip(3) {
-        if i == component_pos || i == component_pos + 1 {
-            continue;
-        }
-        result.push(arg.clone());
-    }
-
-    result
-}
-
 /// Auto-insert '--' separator before unknown flags for trailing_var_arg commands.
 pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
     let commands: &[(&str, &str, &[&str])] = &[
@@ -257,7 +221,6 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
 /// Apply all argument normalizations in sequence.
 pub fn normalize(args: Vec<String>) -> Vec<String> {
     let args = normalize_version_show(args);
-    let args = normalize_changelog_component(args);
     normalize_trailing_flags(args)
 }
 

--- a/src/core/release/changelog/bulk.rs
+++ b/src/core/release/changelog/bulk.rs
@@ -1,137 +1,16 @@
 use chrono::Local;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::path::Path;
 
 use crate::component;
-use crate::config::read_json_spec_to_string;
 use crate::core::release::version;
 use crate::engine::local_files::{self, FileSystem};
-use crate::engine::validation;
 use crate::error::{Error, Result};
 use crate::paths::resolve_path;
 
 use super::io::*;
 use super::sections::*;
 use super::settings::*;
-
-// === Bulk Operations with JSON Spec ===
-
-#[derive(Debug, Clone, Serialize)]
-
-pub struct AddItemsOutput {
-    pub component_id: String,
-    pub changelog_path: String,
-    pub next_section_label: String,
-    pub messages: Vec<String>,
-    pub items_added: usize,
-    pub changed: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subsection_type: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(into = "NormalizedAddItemsInput")]
-struct AddItemsInput {
-    component_id: String,
-    #[serde(default)]
-    messages: Vec<String>,
-    #[serde(default, alias = "message")]
-    message: Option<String>,
-}
-
-#[derive(Debug)]
-struct NormalizedAddItemsInput {
-    component_id: String,
-    messages: Vec<String>,
-}
-
-impl From<AddItemsInput> for NormalizedAddItemsInput {
-    fn from(input: AddItemsInput) -> Self {
-        let messages = if input.message.is_some() {
-            input.message.into_iter().collect()
-        } else {
-            input.messages
-        };
-        Self {
-            component_id: input.component_id,
-            messages,
-        }
-    }
-}
-
-/// Add changelog items from a JSON spec.
-pub fn add_items_bulk(json_spec: &str) -> Result<AddItemsOutput> {
-    let raw = read_json_spec_to_string(json_spec)?;
-
-    let input: AddItemsInput = serde_json::from_str(&raw).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some("parse changelog add input".to_string()),
-            Some(raw.chars().take(200).collect::<String>()),
-        )
-        .with_hint(r#"Example: {"component_id": "my-component", "messages": ["Fixed: bug"]}"#)
-    })?;
-
-    let normalized: NormalizedAddItemsInput = input.into();
-    add_items(Some(&normalized.component_id), &normalized.messages, None)
-}
-
-/// Add changelog items to a component. Auto-detects JSON in component_id.
-/// If entry_type is provided, items are placed under the corresponding Keep a Changelog subsection.
-pub fn add_items(
-    component_id: Option<&str>,
-    messages: &[String],
-    entry_type: Option<&str>,
-) -> Result<AddItemsOutput> {
-    // Auto-detect JSON in component_id
-    if let Some(input) = component_id {
-        if crate::config::is_json_input(input) {
-            return add_items_bulk(input);
-        }
-    }
-
-    let id = validation::require_with_hints(
-        component_id,
-        "componentId",
-        "Missing componentId",
-        vec![
-            "Provide a component ID: homeboy changelog add <component-id> -m \"message\""
-                .to_string(),
-            "List available components: homeboy component list".to_string(),
-        ],
-    )?;
-
-    if messages.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "message",
-            "Missing message",
-            None,
-            None,
-        ));
-    }
-
-    // Validate entry type if provided
-    let validated_type = entry_type.map(validate_entry_type).transpose()?;
-
-    let component = component::resolve_effective(Some(id), None, None)?;
-    let settings = resolve_effective_settings(Some(&component));
-
-    let (path, changed, items_added) = if let Some(ref entry_type_val) = validated_type {
-        read_and_add_next_section_items_typed(&component, &settings, messages, entry_type_val)?
-    } else {
-        read_and_add_next_section_items(&component, &settings, messages)?
-    };
-
-    Ok(AddItemsOutput {
-        component_id: id.to_string(),
-        changelog_path: path.to_string_lossy().to_string(),
-        next_section_label: settings.next_section_label,
-        messages: messages.to_vec(),
-        items_added,
-        changed,
-        subsection_type: validated_type,
-    })
-}
 
 // === Changelog Show Operations ===
 

--- a/src/core/release/changelog/io.rs
+++ b/src/core/release/changelog/io.rs
@@ -37,69 +37,6 @@ fn resolve_target_path(local_path: &str, file: &str) -> Result<PathBuf> {
     Ok(resolve_path(local_path, file))
 }
 
-pub fn read_and_add_next_section_items(
-    component: &Component,
-    settings: &EffectiveChangelogSettings,
-    messages: &[String],
-) -> Result<(PathBuf, bool, usize)> {
-    let path = resolve_changelog_path(component)?;
-    let content = local_files::read_file(&path, "read changelog")?;
-
-    let (new_content, changed, items_added) =
-        add_next_section_items(&content, &settings.next_section_aliases, messages)?;
-
-    if changed {
-        local_files::write_file(&path, &new_content, "write changelog")?;
-    }
-
-    Ok((path, changed, items_added))
-}
-
-pub fn read_and_add_next_section_items_typed(
-    component: &Component,
-    settings: &EffectiveChangelogSettings,
-    messages: &[String],
-    entry_type: &str,
-) -> Result<(PathBuf, bool, usize)> {
-    let path = resolve_changelog_path(component)?;
-    let content = local_files::read_file(&path, "read changelog")?;
-
-    let (with_section, _) = ensure_next_section(&content, &settings.next_section_aliases)?;
-    let mut current_content = with_section;
-    let mut items_added = 0;
-    let mut changed = false;
-
-    for message in messages {
-        let trimmed_message = message.trim();
-        if trimmed_message.is_empty() {
-            return Err(crate::error::Error::validation_invalid_argument(
-                "messages",
-                "Changelog messages cannot include empty values",
-                None,
-                None,
-            ));
-        }
-
-        let (new_content, item_changed) = append_item_to_subsection(
-            &current_content,
-            &settings.next_section_aliases,
-            trimmed_message,
-            entry_type,
-        )?;
-        if item_changed {
-            items_added += 1;
-            changed = true;
-        }
-        current_content = new_content;
-    }
-
-    if changed {
-        local_files::write_file(&path, &current_content, "write changelog")?;
-    }
-
-    Ok((path, changed, items_added))
-}
-
 #[derive(Debug, Clone)]
 pub struct ChangelogSnapshotData {
     pub path: String,

--- a/src/core/release/changelog/settings.rs
+++ b/src/core/release/changelog/settings.rs
@@ -13,16 +13,6 @@ pub(super) const KEEP_A_CHANGELOG_SUBSECTIONS: &[&str] = &[
     "### Security",
 ];
 
-pub(super) const VALID_ENTRY_TYPES: &[&str] = &[
-    "added",
-    "changed",
-    "deprecated",
-    "removed",
-    "fixed",
-    "security",
-    "refactored",
-];
-
 #[derive(Debug, Clone)]
 pub struct EffectiveChangelogSettings {
     pub next_section_label: String,
@@ -80,35 +70,6 @@ pub fn resolve_effective_settings(component: Option<&Component>) -> EffectiveCha
     EffectiveChangelogSettings {
         next_section_label,
         next_section_aliases,
-    }
-}
-
-pub(super) fn validate_entry_type(entry_type: &str) -> crate::error::Result<String> {
-    use crate::error::Error;
-    let normalized = entry_type.to_lowercase();
-    // Accept "refactor" as alias for "refactored"
-    let normalized = if normalized == "refactor" {
-        "refactored".to_string()
-    } else {
-        normalized
-    };
-    if VALID_ENTRY_TYPES.contains(&normalized.as_str()) {
-        Ok(normalized)
-    } else {
-        Err(Error::validation_invalid_argument(
-            "type",
-            format!(
-                "Invalid changelog entry type '{}'. Valid types: Added, Changed, Deprecated, Removed, Fixed, Security, Refactored",
-                entry_type
-            ),
-            None,
-            Some(vec![
-                "Use --type added for new features".to_string(),
-                "Use --type fixed for bug fixes".to_string(),
-                "Use --type changed for modifications".to_string(),
-                "Use --type refactored for code restructuring".to_string(),
-            ]),
-        ))
     }
 }
 


### PR DESCRIPTION
## Summary

Resolves #860. Remove `homeboy changelog add` — changelog entries are now generated exclusively by the release workflow from conventional commit messages.

## The problem

`changelog add` and `release` both create changelog entries. When both are used, entries are duplicated (happened with data-machine v0.47.0). Same dual-path problem we just fixed with `--fix` → `refactor`.

## The fix

One path: **commit messages become the changelog.** The release workflow already handles categorization from conventional commit prefixes (`feat:` → Added, `fix:` → Fixed, `refactor:` → Changed). Manual `changelog add` is removed.

## What was removed (-338 lines)

- `ChangelogCommand::Add` variant and all its CLI args (json, component_id, messages, entry_type)
- `add_items()`, `add_items_bulk()`, `AddItemsOutput` from core
- `read_and_add_next_section_items()`, `read_and_add_next_section_items_typed()` from io.rs
- `validate_entry_type()`, `VALID_ENTRY_TYPES` from settings.rs
- `normalize_changelog_component()` arg normalizer from args.rs

## What stays

- `changelog show` — view changelogs
- `changelog init` — initialize a changelog file
- The release workflow's auto-generated changelog entries

## Verification

- `cargo check` — clean compile, zero warnings
- `cargo test` — all 831 tests pass