### PR TITLE
fix: pre-1.0 semver — breaking changes bump minor, not major

### DIFF
--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -22,7 +22,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
     )?;
 
-    let (bump_type, releasable_count) = match resolve_bump(&component.local_path)? {
+    let (mut bump_type, releasable_count) = match resolve_bump(&component.local_path)? {
         Some(result) => result,
         None => {
             log_status!(
@@ -46,6 +46,25 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             ));
         }
     };
+
+    // Pre-1.0 semver: breaking changes bump minor, not major.
+    // In semver, 0.x.y signals "initial development" where the public API is
+    // not stable. Breaking changes are expected and land as minor bumps.
+    // A major bump to 1.0.0 should only happen when the author explicitly
+    // decides the API is stable (via --major).
+    if bump_type == "major" {
+        let current_version = super::version::read_version(Some(&input.component_id))
+            .ok()
+            .and_then(|v| v.version.split('.').next().map(String::from))
+            .unwrap_or_default();
+        if current_version == "0" {
+            log_status!(
+                "release",
+                "Pre-1.0: downgrading major → minor (breaking changes are minor bumps in 0.x)"
+            );
+            bump_type = "minor".to_string();
+        }
+    }
 
     if bump_type == "major" && !input.major {
         log_status!(


### PR DESCRIPTION
## Problem

The release pipeline has been blocked since the two `feat!:` PRs merged (#865, #866). The `!` suffix signals a breaking change, which homeboy correctly computed as a **major** bump. But the safety guard (`major-requires-flag`) blocked it — correctly refusing to auto-release v1.0.0 from a cron job.

The real issue: for a pre-1.0 project (v0.82.0), breaking changes should bump **minor** (→ 0.83.0), not **major** (→ 1.0.0). Per semver spec, 0.x.y means "initial development — anything may change at any time."

## Fix

After `resolve_bump()` returns `major`, check if the current version is `0.x`. If so, downgrade to `minor` with a log message. The `--major` flag still works for the eventual deliberate 1.0.0 release.

## Where it lives

`src/core/release/workflow.rs` — the policy decision lives at the workflow level, not in the commit parser. `recommended_bump_from_commits()` stays pure (it reports what the commits say), and the workflow applies the pre-1.0 semver convention.

## Once merged

The next cron run (every 15 min) will detect `fix:` + `feat!:` commits, compute minor bump (0.83.0), and release automatically.