### PR TITLE
feat: auto-fix HighItemCount findings via decompose pipeline

### DIFF
--- a/src/core/refactor/auto/contracts.rs
+++ b/src/core/refactor/auto/contracts.rs
@@ -244,11 +244,12 @@ pub struct FixResult {
     pub files_modified: usize,
 }
 
-/// A decompose operation generated from a GodFile finding.
+/// A decompose operation generated from a GodFile or HighItemCount finding.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DecomposeFixPlan {
     pub file: String,
     pub plan: decompose::DecomposePlan,
+    pub source_finding: AuditFinding,
     #[serde(default)]
     pub applied: bool,
 }
@@ -279,8 +280,8 @@ impl FixResult {
         for new_file in &self.new_files {
             *counts.entry(new_file.finding.clone()).or_insert(0) += 1;
         }
-        if !self.decompose_plans.is_empty() {
-            *counts.entry(AuditFinding::GodFile).or_insert(0) += self.decompose_plans.len();
+        for plan in &self.decompose_plans {
+            *counts.entry(plan.source_finding.clone()).or_insert(0) += 1;
         }
         counts
     }

--- a/src/core/refactor/auto/policy.rs
+++ b/src/core/refactor/auto/policy.rs
@@ -191,14 +191,16 @@ pub fn apply_fix_policy(
         })
         .collect();
 
+    // Filter decompose plans by policy — retain plans whose source finding
+    // matches the --only filter, or isn't in the --exclude list.
     if let Some(ref only) = policy.only {
-        if !only.contains(&AuditFinding::GodFile) {
-            result.decompose_plans.clear();
-        }
+        result
+            .decompose_plans
+            .retain(|p| only.contains(&p.source_finding));
     }
-    if policy.exclude.contains(&AuditFinding::GodFile) {
-        result.decompose_plans.clear();
-    }
+    result
+        .decompose_plans
+        .retain(|p| !policy.exclude.contains(&p.source_finding));
 
     result.total_insertions = summary.visible_insertions + summary.visible_new_files;
     summary

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -70,8 +70,16 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
     orphaned_test_fixes::generate_orphaned_test_fixes(result, root, &mut fixes, &mut skipped);
 
     let mut decompose_plans = Vec::new();
+    let mut decompose_seen = std::collections::HashSet::new();
     for finding in &result.findings {
-        if finding.kind != AuditFinding::GodFile {
+        if !matches!(
+            finding.kind,
+            AuditFinding::GodFile | AuditFinding::HighItemCount
+        ) {
+            continue;
+        }
+        // A file can trigger both GodFile and HighItemCount — only plan once.
+        if decompose_seen.contains(&finding.file) {
             continue;
         }
         let is_test = crate::code_audit::walker::is_test_path(&finding.file);
@@ -81,14 +89,17 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
         match decompose::build_plan(&finding.file, root, "grouped") {
             Ok(plan) => {
                 if plan.groups.len() > 1 {
+                    decompose_seen.insert(finding.file.clone());
                     decompose_plans.push(DecomposeFixPlan {
                         file: finding.file.clone(),
                         plan,
+                        source_finding: finding.kind.clone(),
                         applied: false,
                     });
                 }
             }
             Err(error) => {
+                decompose_seen.insert(finding.file.clone());
                 skipped.push(SkippedFile {
                     file: finding.file.clone(),
                     reason: format!("Decompose plan failed: {}", error),


### PR DESCRIPTION
## Summary

HighItemCount findings (files with >15 top-level items) now enter the same decompose pipeline as GodFile findings. This adds **46 new fixable findings** to the autofix pipeline (issue #537).

## How it works

The decompose engine is finding-type agnostic — it takes a file, parses items, groups them by section headers / call graph / name clustering, and splits the file into focused modules. It was already doing this for GodFile findings. Now HighItemCount findings trigger it too.

## Changes (3 files, +24 / -10 lines)

**`generate/mod.rs`** — widen the decompose gate:
- Accept `GodFile | HighItemCount` instead of just `GodFile`
- Add dedup: files triggering both findings only plan once

**`contracts.rs`** — track source finding:
- New `source_finding: AuditFinding` field on `DecomposeFixPlan`
- `finding_counts()` reports decompose fixes under correct finding type

**`policy.rs`** — per-type policy filtering:
- `--only` and `--exclude` now filter decompose plans individually by source finding type

## What's unchanged

- The decompose engine (`decompose.rs`) — unchanged
- The apply logic (`apply.rs`) — unchanged  
- Detection (`structural.rs`) — HighItemCount already detected correctly
- Verification (`verify.rs`) — HighItemCount already in cascading findings list

## Verification

- `cargo check` — clean compile, zero warnings
- `cargo test` — all 831 tests pass