### PR TITLE
chore: migrate CI and release workflows to homeboy-action v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: audit
-          autofix: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   # ── Stage 2: Lint ──
@@ -119,13 +116,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: lint
-          autofix: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   # ── Stage 3: Test ──
@@ -154,13 +148,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: test
-          autofix: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   # ── Stage 4: Auto-refactor ──
@@ -191,15 +182,12 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: 'refactor --from all'
           autofix: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
           autofix-mode: 'on-failure'
-          autofix-commands: 'refactor --from all --write'
           autofix-max-commits: '3'
           comment-section-title: 'Auto-refactor'
           app-token: ${{ steps.app-token.outputs.token || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,9 @@ jobs:
 
       - name: Dry-run release check
         id: release-check
-        uses: Extra-Chill/homeboy-action@v1
+        uses: Extra-Chill/homeboy-action@v2
         with:
           source: '.'
-          extension: rust
-          component: homeboy
           commands: release
           release-dry-run: 'true'
 
@@ -160,15 +158,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: audit
-          auto-issue: 'true'
-          autofix: 'true'
-          autofix-commands: 'audit --fix --write'
           autofix-open-pr: 'true'
           autofix-max-commits: '3'
           app-token: ${{ steps.app-token.outputs.token || '' }}
@@ -200,15 +193,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: lint
-          autofix: 'true'
-          autofix-commands: 'lint --fix'
-          autofix-open-pr: 'true'
           autofix-max-commits: '3'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
@@ -239,13 +227,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: test
-          autofix: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   gate-refactor:
@@ -276,15 +261,11 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
           binary-path: .homeboy-bin/homeboy
-          extension: rust
-          component: homeboy
           commands: 'refactor --from all'
-          autofix: 'true'
           autofix-mode: 'always'
-          autofix-open-pr: 'true'
           autofix-commands: 'refactor --from all --write'
           autofix-max-commits: '3'
           comment-section-title: 'Auto-refactor'
@@ -324,12 +305,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         id: release
         with:
           source: '.'
-          extension: rust
-          component: homeboy
           commands: release
           release-dry-run: ${{ inputs.dry-run || 'false' }}
           app-token: ${{ steps.app-token.outputs.token || '' }}


### PR DESCRIPTION
## Summary

Update all 10 homeboy-action invocations in `ci.yml` and `release.yml` from `@v1` to `@v2`. Removes 33 lines of deprecated inputs that v2 infers automatically.

## What was removed

v2 infers these from `homeboy.json` and event context:
- `extension: rust`
- `component: homeboy`
- `autofix: true` (auto-enabled when app-token present)
- `autofix-commands: 'audit --fix --write'` / `'lint --fix'` (defaults to `refactor --from all --write`)
- `autofix-open-pr: true` (auto-enabled on non-PR with app-token)
- `auto-issue: true` (auto-enabled on non-PR)

## What stays

The homeboy repo keeps its custom multi-job structure (build from source, shared binary artifact, parallel quality gates, cargo-dist). The consumer template doesn't apply here — but the action inputs are now v2-clean.