### PR TITLE
fix: format sandbox between refactor stages so lint sees clean code

### DIFF
--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -254,6 +254,13 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
             _ => unreachable!("sources are normalized before planning"),
         };
 
+        // Format generated/modified files in the sandbox so subsequent stages
+        // (especially lint) see properly formatted code. Without this, auto-generated
+        // test files cause `cargo fmt --check` to fail during the lint stage.
+        if stage.summary.files_modified > 0 {
+            format_sandbox(working_root.path(), &stage.summary.changed_files, &mut warnings);
+        }
+
         accumulator.extend(stage.fix_results.clone());
         planned_stages.push(stage);
     }
@@ -438,6 +445,53 @@ pub fn normalize_sources(sources: &[String]) -> crate::Result<Vec<String>> {
     }
 
     Ok(ordered)
+}
+
+/// Format modified files inside the sandbox between refactor stages.
+///
+/// This ensures generated code (test files, refactored sources) is properly
+/// formatted before subsequent stages run. Without this, the lint stage's
+/// `cargo fmt --check` fails on unformatted auto-generated code — blocking
+/// the pipeline on problems it didn't create.
+///
+/// Uses the same `format_after_write` as the post-write step. Non-fatal:
+/// if formatting fails, it logs a warning and continues.
+fn format_sandbox(sandbox_root: &Path, changed_files: &[String], warnings: &mut Vec<String>) {
+    if changed_files.is_empty() {
+        return;
+    }
+
+    let abs_changed: Vec<PathBuf> = changed_files
+        .iter()
+        .map(|f| sandbox_root.join(f))
+        .collect();
+
+    match crate::engine::format_write::format_after_write(sandbox_root, &abs_changed) {
+        Ok(fmt) => {
+            if let Some(cmd) = &fmt.command {
+                if fmt.success {
+                    crate::log_status!(
+                        "format",
+                        "Formatted {} sandbox file(s) via {}",
+                        abs_changed.len(),
+                        cmd
+                    );
+                } else {
+                    warnings.push(format!(
+                        "Sandbox formatter ({}) exited non-zero (continuing)",
+                        cmd
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            crate::log_status!(
+                "format",
+                "Warning: sandbox format failed (continuing): {}",
+                e
+            );
+        }
+    }
 }
 
 fn collect_fix_proposals(stages: &[PlannedStage]) -> Vec<FixProposal> {


### PR DESCRIPTION
## Summary

Fixes the recurring issue where auto-generated test files block the refactor pipeline because `cargo fmt --check` fails on unformatted code.

### The problem

```
homeboy refactor homeboy --from audit --only missing_test_file
```

1. **Audit stage** generates test files in the sandbox ✅
2. **Lint stage** runs `cargo fmt --check` on the sandbox ❌ — fails because generated code isn't formatted
3. Pipeline is blocked by formatting issues it didn't create

### The fix

After each stage that modifies files in the sandbox, run the project's formatter before the next stage:

```
Audit stage → generates test files
     ↓
format_sandbox() → runs cargo fmt on sandbox  ← NEW
     ↓
Lint stage → cargo fmt --check passes ✅
```

### Implementation

One new function `format_sandbox()` (44 lines) in `planner.rs`. Reuses `format_after_write()` which already resolves the formatter from the extension manifest (`scripts.format`). Non-fatal — if formatting fails, it logs a warning and continues.

No new dependencies, no extension changes needed. The Rust extension already has `scripts/format.sh` registered. WordPress has it too.

### 826 tests pass, 0 failures.