### PR TITLE
feat: configurable field capture groups for PHP class property parsing (#818)

### DIFF
--- a/src/core/engine/contract.rs
+++ b/src/core/engine/contract.rs
@@ -280,17 +280,19 @@ pub struct FieldDef {
 
 /// Parse field definitions from a struct/class source body using a regex pattern.
 ///
-/// The `field_pattern` is a regex with two capture groups:
-///   - Group 1: field name
-///   - Group 2: field type
+/// The `field_pattern` is a regex with capture groups for field name and type.
+/// `name_group` and `type_group` specify which capture groups to use (1-indexed).
 ///
 /// `visibility_pattern` optionally matches a visibility prefix (e.g., `pub`).
 ///
-/// This is language-agnostic: the grammar provides the regex patterns.
+/// This is language-agnostic: the grammar provides the regex patterns and
+/// capture group assignments.
 pub fn parse_fields_from_source(
     source: &str,
     field_pattern: &str,
     visibility_pattern: Option<&str>,
+    name_group: usize,
+    type_group: usize,
 ) -> Vec<FieldDef> {
     let field_re = match regex::Regex::new(field_pattern) {
         Ok(re) => re,
@@ -324,11 +326,11 @@ pub fn parse_fields_from_source(
 
         if let Some(caps) = field_re.captures(trimmed) {
             let name = caps
-                .get(1)
+                .get(name_group)
                 .map(|m| m.as_str().to_string())
                 .unwrap_or_default();
             let field_type = caps
-                .get(2)
+                .get(type_group)
                 .map(|m| m.as_str().trim_end_matches(',').trim().to_string())
                 .unwrap_or_default();
 

--- a/src/core/engine/contract_testgen.rs
+++ b/src/core/engine/contract_testgen.rs
@@ -1232,6 +1232,8 @@ fn build_type_registry(
             source,
             field_pattern,
             contract_grammar.field_visibility_pattern.as_deref(),
+            contract_grammar.field_name_group,
+            contract_grammar.field_type_group,
         );
 
         let is_public = sym
@@ -2420,6 +2422,8 @@ pub struct ValidationResult {
             source,
             r"^\s*(?:pub\s+)?(\w+)\s*:\s*(.+?),?\s*$",
             Some(r"^\s*pub\b"),
+            1, // name_group
+            2, // type_group
         );
 
         assert_eq!(fields.len(), 5, "should find 5 fields");
@@ -2430,6 +2434,39 @@ pub struct ValidationResult {
         assert_eq!(fields[1].field_type, "Option<String>");
         assert_eq!(fields[4].name, "files_checked");
         assert!(!fields[4].is_public, "files_checked should be private");
+    }
+
+    #[test]
+    fn test_parse_fields_from_php_class_source() {
+        let source = r#"
+class AbilityResult {
+    public string $status;
+    public ?array $data;
+    protected int $code;
+    private string $internal_key;
+    public bool $success;
+}
+"#;
+        // PHP: type is group 1, name is group 2
+        let fields = parse_fields_from_source(
+            source,
+            r"^\s*(?:public|protected|private)\s+(?:readonly\s+)?(\??\w+)\s+\$(\w+)",
+            Some(r"^\s*public\b"),
+            2, // name_group (PHP has name in group 2)
+            1, // type_group (PHP has type in group 1)
+        );
+
+        assert_eq!(fields.len(), 5, "should find 5 PHP properties, got {:?}", fields);
+        assert_eq!(fields[0].name, "status");
+        assert_eq!(fields[0].field_type, "string");
+        assert!(fields[0].is_public, "status should be public");
+        assert_eq!(fields[1].name, "data");
+        assert_eq!(fields[1].field_type, "?array");
+        assert_eq!(fields[2].name, "code");
+        assert_eq!(fields[2].field_type, "int");
+        assert!(!fields[2].is_public, "code should not be public (protected)");
+        assert_eq!(fields[4].name, "success");
+        assert!(fields[4].is_public, "success should be public");
     }
 
     #[test]

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -164,13 +164,24 @@ pub struct ContractGrammar {
     pub fallback_default: String,
 
     /// Regex pattern for extracting struct/class field declarations.
-    /// Must have two capture groups: (1) field name, (2) field type.
+    /// Must have two capture groups for field name and field type.
     /// Applied to each line inside a struct/class body.
     ///
-    /// Rust example: `"^\s*(?:pub\s+)?(\w+)\s*:\s*(.+?),?\s*$"`
-    /// PHP example: `"(?:public|protected|private)\s+(?:\?\w+\s+)?(\$\w+)\s*;"`
+    /// Which capture group is name vs type is controlled by `field_name_group`
+    /// and `field_type_group` (default: group 1 = name, group 2 = type).
+    ///
+    /// Rust: `"^\s*(?:pub\s+)?(\w+)\s*:\s*(.+?),?\s*$"` — name:1, type:2
+    /// PHP:  `"^\s*(?:public|protected|private)\s+(?:readonly\s+)?(\??\w+)\s+\$(\w+)"` — type:1, name:2
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field_pattern: Option<String>,
+
+    /// Which capture group in `field_pattern` contains the field name. Default: 1.
+    #[serde(default = "default_group_1")]
+    pub field_name_group: usize,
+
+    /// Which capture group in `field_pattern` contains the field type. Default: 2.
+    #[serde(default = "default_group_2")]
+    pub field_type_group: usize,
 
     /// Regex pattern that identifies public visibility on a field line.
     /// Used to set `FieldDef.is_public`.
@@ -182,6 +193,14 @@ pub struct ContractGrammar {
 
 fn default_fallback_default() -> String {
     "Default::default()".to_string()
+}
+
+fn default_group_1() -> usize {
+    1
+}
+
+fn default_group_2() -> usize {
+    2
 }
 
 fn default_return_type_separator() -> String {


### PR DESCRIPTION
Adds field_name_group / field_type_group to ContractGrammar so PHP can use type-before-name order. Includes PHP property parsing test.