### PR TITLE
refactor: remove all language-specific code from core test generation

### DIFF
--- a/src/core/engine/contract.rs
+++ b/src/core/engine/contract.rs
@@ -280,17 +280,19 @@ pub struct FieldDef {
 
 /// Parse field definitions from a struct/class source body using a regex pattern.
 ///
-/// The `field_pattern` is a regex with two capture groups:
-///   - Group 1: field name
-///   - Group 2: field type
+/// The `field_pattern` is a regex with capture groups for field name and type.
+/// `name_group` and `type_group` specify which capture groups to use (1-indexed).
 ///
 /// `visibility_pattern` optionally matches a visibility prefix (e.g., `pub`).
 ///
-/// This is language-agnostic: the grammar provides the regex patterns.
+/// This is language-agnostic: the grammar provides the regex patterns and
+/// capture group assignments.
 pub fn parse_fields_from_source(
     source: &str,
     field_pattern: &str,
     visibility_pattern: Option<&str>,
+    name_group: usize,
+    type_group: usize,
 ) -> Vec<FieldDef> {
     let field_re = match regex::Regex::new(field_pattern) {
         Ok(re) => re,
@@ -324,11 +326,11 @@ pub fn parse_fields_from_source(
 
         if let Some(caps) = field_re.captures(trimmed) {
             let name = caps
-                .get(1)
+                .get(name_group)
                 .map(|m| m.as_str().to_string())
                 .unwrap_or_default();
             let field_type = caps
-                .get(2)
+                .get(type_group)
                 .map(|m| m.as_str().trim_end_matches(',').trim().to_string())
                 .unwrap_or_default();
 

--- a/src/core/engine/contract_testgen.rs
+++ b/src/core/engine/contract_testgen.rs
@@ -194,6 +194,7 @@ pub(crate) fn generate_test_plan_with_types(
                 type_registry,
                 type_defaults,
                 &contract_grammar.fallback_default,
+                contract_grammar.field_assertion_template.as_deref(),
             );
             vars.insert("assertion_code".to_string(), assertion);
 
@@ -908,6 +909,7 @@ fn enrich_assertion_with_fields(
     type_registry: &HashMap<String, TypeDefinition>,
     type_defaults: &[TypeDefault],
     fallback_default: &str,
+    field_assertion_template: Option<&str>,
 ) -> String {
     // Only enrich if the assertion has a TODO placeholder
     if !assertion.contains("TODO:") {
@@ -954,6 +956,12 @@ fn enrich_assertion_with_fields(
         return assertion.to_string();
     }
 
+    // Must have a field assertion template from the grammar to generate assertions
+    let template = match field_assertion_template {
+        Some(t) => t,
+        None => return assertion.to_string(),
+    };
+
     let indent = "        ";
 
     // Find the TODO line and everything after it (including the `let _ = inner;` line before it)
@@ -979,14 +987,15 @@ fn enrich_assertion_with_fields(
         .map(|p| todo_pos + p + 1)
         .unwrap_or(assertion.len());
 
-    // Build real field assertions
+    // Build real field assertions using the grammar's field_assertion_template
     let mut field_assertions = Vec::new();
     for field in &public_fields {
         let expected = default_for_field_type(&field.field_type, type_defaults, fallback_default);
-        field_assertions.push(format!(
-            "{indent}assert_eq!(inner.{}, {});",
-            field.name, expected
-        ));
+        let rendered = template
+            .replace("{indent}", indent)
+            .replace("{field_name}", &field.name)
+            .replace("{expected_value}", &expected);
+        field_assertions.push(rendered);
     }
 
     format!(
@@ -999,7 +1008,8 @@ fn enrich_assertion_with_fields(
 
 /// Resolve a default/zero value for a field type to use as expected assertion value.
 ///
-/// Uses the grammar's type_defaults first, then falls back to common patterns.
+/// Uses the grammar's `type_defaults` exclusively — no language-specific fallbacks
+/// in core. If no `type_default` matches, uses `fallback_default` from the grammar.
 fn default_for_field_type(
     field_type: &str,
     type_defaults: &[TypeDefault],
@@ -1007,33 +1017,12 @@ fn default_for_field_type(
 ) -> String {
     let trimmed = field_type.trim();
 
-    // Try grammar type_defaults first
     for td in type_defaults {
         if let Ok(re) = Regex::new(&td.pattern) {
             if re.is_match(trimmed) {
                 return td.value.clone();
             }
         }
-    }
-
-    // Common fallbacks for types that might not be in type_defaults
-    if trimmed == "bool" {
-        return "false".to_string();
-    }
-    if trimmed == "usize" || trimmed == "u32" || trimmed == "u64" || trimmed == "i32" || trimmed == "i64" {
-        return "0".to_string();
-    }
-    if trimmed.starts_with("Option<") || trimmed.starts_with("Option ") {
-        return "None".to_string();
-    }
-    if trimmed.starts_with("Vec<") {
-        return "vec![]".to_string();
-    }
-    if trimmed == "String" {
-        return "String::new()".to_string();
-    }
-    if trimmed == "&str" {
-        return r#""""#.to_string();
     }
 
     fallback_default.to_string()
@@ -1545,6 +1534,26 @@ mod tests {
                 value: "Vec::new()".to_string(),
                 imports: vec![],
             },
+            TypeDefault {
+                pattern: r"^bool$".to_string(),
+                value: "false".to_string(),
+                imports: vec![],
+            },
+            TypeDefault {
+                pattern: r"^Option<.*>$".to_string(),
+                value: "None".to_string(),
+                imports: vec![],
+            },
+            TypeDefault {
+                pattern: r"^usize$|^u\d+$|^i\d+$".to_string(),
+                value: "0".to_string(),
+                imports: vec![],
+            },
+            TypeDefault {
+                pattern: r"^String$".to_string(),
+                value: "String::new()".to_string(),
+                imports: vec![],
+            },
         ]
     }
 
@@ -1568,6 +1577,9 @@ mod tests {
             type_constructors: sample_type_constructors(),
             assertion_templates: sample_assertion_templates(),
             test_templates: sample_test_templates(),
+            field_assertion_template: Some(
+                "{indent}assert_eq!(inner.{field_name}, {expected_value});".to_string(),
+            ),
             ..Default::default()
         }
     }
@@ -2518,6 +2530,7 @@ class AbilityResult {
             &type_registry,
             &type_defaults,
             "Default::default()",
+            Some("{indent}assert_eq!(inner.{field_name}, {expected_value});"),
         );
 
         // Should generate real assert_eq! statements, not comments
@@ -2569,6 +2582,7 @@ class AbilityResult {
             &type_registry,
             &[],
             "Default::default()",
+            Some("{indent}assert_eq!(inner.{field_name}, {expected_value});"),
         );
 
         assert_eq!(

--- a/src/core/engine/contract_testgen.rs
+++ b/src/core/engine/contract_testgen.rs
@@ -1232,6 +1232,8 @@ fn build_type_registry(
             source,
             field_pattern,
             contract_grammar.field_visibility_pattern.as_deref(),
+            contract_grammar.field_name_group,
+            contract_grammar.field_type_group,
         );
 
         let is_public = sym
@@ -2420,6 +2422,8 @@ pub struct ValidationResult {
             source,
             r"^\s*(?:pub\s+)?(\w+)\s*:\s*(.+?),?\s*$",
             Some(r"^\s*pub\b"),
+            1, // name_group
+            2, // type_group
         );
 
         assert_eq!(fields.len(), 5, "should find 5 fields");
@@ -2430,6 +2434,39 @@ pub struct ValidationResult {
         assert_eq!(fields[1].field_type, "Option<String>");
         assert_eq!(fields[4].name, "files_checked");
         assert!(!fields[4].is_public, "files_checked should be private");
+    }
+
+    #[test]
+    fn test_parse_fields_from_php_class_source() {
+        let source = r#"
+class AbilityResult {
+    public string $status;
+    public ?array $data;
+    protected int $code;
+    private string $internal_key;
+    public bool $success;
+}
+"#;
+        // PHP: type is group 1, name is group 2
+        let fields = parse_fields_from_source(
+            source,
+            r"^\s*(?:public|protected|private)\s+(?:readonly\s+)?(\??\w+)\s+\$(\w+)",
+            Some(r"^\s*public\b"),
+            2, // name_group (PHP has name in group 2)
+            1, // type_group (PHP has type in group 1)
+        );
+
+        assert_eq!(fields.len(), 5, "should find 5 PHP properties, got {:?}", fields);
+        assert_eq!(fields[0].name, "status");
+        assert_eq!(fields[0].field_type, "string");
+        assert!(fields[0].is_public, "status should be public");
+        assert_eq!(fields[1].name, "data");
+        assert_eq!(fields[1].field_type, "?array");
+        assert_eq!(fields[2].name, "code");
+        assert_eq!(fields[2].field_type, "int");
+        assert!(!fields[2].is_public, "code should not be public (protected)");
+        assert_eq!(fields[4].name, "success");
+        assert!(fields[4].is_public, "success should be public");
     }
 
     #[test]

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -189,6 +189,16 @@ pub struct ContractGrammar {
     /// Rust: `"^\s*pub\b"`, PHP: `"^\s*public\b"`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field_visibility_pattern: Option<String>,
+
+    /// Template for asserting a single struct field in a generated test.
+    /// Variables: `{field_name}`, `{expected_value}`, `{indent}`.
+    ///
+    /// Rust:  `"{indent}assert_eq!(inner.{field_name}, {expected_value});"`
+    /// PHP:   `"{indent}$this->assertSame( {expected_value}, $result->{field_name} );"`
+    ///
+    /// If not set, field-level assertions are not generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field_assertion_template: Option<String>,
 }
 
 fn default_fallback_default() -> String {

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -164,13 +164,24 @@ pub struct ContractGrammar {
     pub fallback_default: String,
 
     /// Regex pattern for extracting struct/class field declarations.
-    /// Must have two capture groups: (1) field name, (2) field type.
+    /// Must have two capture groups for field name and field type.
     /// Applied to each line inside a struct/class body.
     ///
-    /// Rust example: `"^\s*(?:pub\s+)?(\w+)\s*:\s*(.+?),?\s*$"`
-    /// PHP example: `"(?:public|protected|private)\s+(?:\?\w+\s+)?(\$\w+)\s*;"`
+    /// Which capture group is name vs type is controlled by `field_name_group`
+    /// and `field_type_group` (default: group 1 = name, group 2 = type).
+    ///
+    /// Rust: `"^\s*(?:pub\s+)?(\w+)\s*:\s*(.+?),?\s*$"` — name:1, type:2
+    /// PHP:  `"^\s*(?:public|protected|private)\s+(?:readonly\s+)?(\??\w+)\s+\$(\w+)"` — type:1, name:2
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field_pattern: Option<String>,
+
+    /// Which capture group in `field_pattern` contains the field name. Default: 1.
+    #[serde(default = "default_group_1")]
+    pub field_name_group: usize,
+
+    /// Which capture group in `field_pattern` contains the field type. Default: 2.
+    #[serde(default = "default_group_2")]
+    pub field_type_group: usize,
 
     /// Regex pattern that identifies public visibility on a field line.
     /// Used to set `FieldDef.is_public`.
@@ -182,6 +193,14 @@ pub struct ContractGrammar {
 
 fn default_fallback_default() -> String {
     "Default::default()".to_string()
+}
+
+fn default_group_1() -> usize {
+    1
+}
+
+fn default_group_2() -> usize {
+    2
 }
 
 fn default_return_type_separator() -> String {


### PR DESCRIPTION
Core had hardcoded Rust type names (bool, Vec, Option) and assertion syntax (assert_eq!) in production code. Moved everything to grammar: type_defaults for expected values, field_assertion_template for assertion syntax. Core is now 100% language-agnostic.