### PR TITLE
fix: exclude build artifacts from refactor sandbox

### DIFF
--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -14,7 +14,8 @@ use std::path::{Path, PathBuf};
 
 use super::verify::{AuditConvergenceScoring, AuditVerificationToggles};
 use crate::refactor::sandbox::{
-    clone_tree, copy_changed_files, diff_tree_snapshots, snapshot_tree, SandboxDir,
+    clone_tree, copy_changed_files, diff_tree_snapshots, resolve_build_exclusions, snapshot_tree,
+    SandboxDir,
 };
 
 pub const KNOWN_PLAN_SOURCES: &[&str] = &["audit", "lint", "test"];
@@ -223,7 +224,8 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
     let mut warnings = vec![format!("Deterministic merge order: {}", merge_order)];
     let mut accumulator = FixAccumulator::default();
 
-    let working_root = clone_tree(&request.root)?;
+    let build_exclusions = resolve_build_exclusions(&request.component);
+    let working_root = clone_tree(&request.root, &build_exclusions)?;
 
     for source in &sources {
         let stage = match source.as_str() {
@@ -242,6 +244,7 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
                 &request.lint,
                 scoped_changed_files.as_deref(),
                 true,
+                &build_exclusions,
             )?,
             "test" => run_test_stage(
                 &request.component,
@@ -250,6 +253,7 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
                 &request.test,
                 scoped_test_files.as_deref(),
                 true,
+                &build_exclusions,
             )?,
             _ => unreachable!("sources are normalized before planning"),
         };
@@ -664,13 +668,14 @@ fn run_lint_stage(
     options: &LintSourceOptions,
     changed_files: Option<&[String]>,
     plan_mode: bool,
+    build_exclusions: &[String],
 ) -> crate::Result<PlannedStage> {
     let mut sandbox_component = component.clone();
     sandbox_component.local_path = sandbox.path().to_string_lossy().to_string();
     let findings_file = temp::runtime_temp_file("homeboy-lint-findings", ".json")?;
     let fix_sidecars = auto::AutofixSidecarFiles::for_plan();
     let before_fix = if plan_mode {
-        Some(snapshot_tree(&sandbox_component.local_path)?)
+        Some(snapshot_tree(&sandbox_component.local_path, build_exclusions)?)
     } else {
         None
     };
@@ -727,7 +732,7 @@ fn run_lint_stage(
     runner.run()?;
 
     let changed_files = if plan_mode {
-        let after_fix = snapshot_tree(&sandbox_component.local_path)?;
+        let after_fix = snapshot_tree(&sandbox_component.local_path, build_exclusions)?;
         before_fix
             .as_ref()
             .map(|before| diff_tree_snapshots(before, &after_fix))
@@ -766,13 +771,14 @@ fn run_test_stage(
     options: &TestSourceOptions,
     changed_test_files: Option<&[String]>,
     plan_mode: bool,
+    build_exclusions: &[String],
 ) -> crate::Result<PlannedStage> {
     let mut sandbox_component = component.clone();
     sandbox_component.local_path = sandbox.path().to_string_lossy().to_string();
     let results_file = temp::runtime_temp_file("homeboy-test-results", ".json")?;
     let fix_sidecars = auto::AutofixSidecarFiles::for_plan();
     let before_fix = if plan_mode {
-        Some(snapshot_tree(&sandbox_component.local_path)?)
+        Some(snapshot_tree(&sandbox_component.local_path, build_exclusions)?)
     } else {
         None
     };
@@ -815,7 +821,7 @@ fn run_test_stage(
     runner.run()?;
 
     let changed_files = if plan_mode {
-        let after_fix = snapshot_tree(&sandbox_component.local_path)?;
+        let after_fix = snapshot_tree(&sandbox_component.local_path, build_exclusions)?;
         before_fix
             .as_ref()
             .map(|before| diff_tree_snapshots(before, &after_fix))

--- a/src/core/refactor/sandbox.rs
+++ b/src/core/refactor/sandbox.rs
@@ -1,6 +1,6 @@
 use crate::engine::temp;
 use crate::Error;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 pub struct SandboxDir {
@@ -19,9 +19,36 @@ impl Drop for SandboxDir {
     }
 }
 
-pub fn clone_tree(src: &Path) -> crate::Result<SandboxDir> {
+/// Resolve build artifact exclusion paths from a component's linked extensions.
+///
+/// Reads `build.cleanup_paths` from each extension manifest (e.g., `["target"]`
+/// for Rust, `["vendor", "node_modules"]` for PHP). These paths are relative
+/// directory names that should be excluded from sandbox operations.
+pub fn resolve_build_exclusions(component: &crate::component::Component) -> Vec<String> {
+    // Always exclude .git
+    let mut exclusions = vec![".git".to_string()];
+
+    if let Some(ref extensions) = component.extensions {
+        for extension_id in extensions.keys() {
+            if let Ok(manifest) = crate::extension::load_extension(extension_id) {
+                if let Some(ref build) = manifest.build {
+                    for path in &build.cleanup_paths {
+                        if !exclusions.contains(path) {
+                            exclusions.push(path.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    exclusions
+}
+
+pub fn clone_tree(src: &Path, exclusions: &[String]) -> crate::Result<SandboxDir> {
     let temp = temp::runtime_temp_dir("homeboy-refactor-ci")?;
-    copy_dir_recursive(src, &temp)?;
+    let exclude_set: HashSet<&str> = exclusions.iter().map(|s| s.as_str()).collect();
+    copy_dir_recursive(src, &temp, &exclude_set)?;
     Ok(SandboxDir { path: temp })
 }
 
@@ -48,10 +75,14 @@ pub fn copy_changed_files(
     Ok(())
 }
 
-pub fn snapshot_tree(root: &str) -> crate::Result<BTreeMap<String, u64>> {
+pub fn snapshot_tree(
+    root: &str,
+    exclusions: &[String],
+) -> crate::Result<BTreeMap<String, u64>> {
     let root_path = Path::new(root);
+    let exclude_set: HashSet<&str> = exclusions.iter().map(|s| s.as_str()).collect();
     let mut files = BTreeMap::new();
-    snapshot_tree_recursive(root_path, root_path, &mut files)?;
+    snapshot_tree_recursive(root_path, root_path, &exclude_set, &mut files)?;
     Ok(files)
 }
 
@@ -79,6 +110,7 @@ pub fn diff_tree_snapshots(
 fn snapshot_tree_recursive(
     root: &Path,
     dir: &Path,
+    exclusions: &HashSet<&str>,
     files: &mut BTreeMap<String, u64>,
 ) -> crate::Result<()> {
     for entry in std::fs::read_dir(dir)
@@ -90,7 +122,10 @@ fn snapshot_tree_recursive(
         let path = entry.path();
 
         if path.is_dir() {
-            snapshot_tree_recursive(root, &path, files)?;
+            if exclusions.contains(entry.file_name().to_string_lossy().as_ref()) {
+                continue;
+            }
+            snapshot_tree_recursive(root, &path, exclusions, files)?;
             continue;
         }
 
@@ -110,7 +145,7 @@ fn snapshot_tree_recursive(
     Ok(())
 }
 
-fn copy_dir_recursive(src: &Path, dst: &Path) -> crate::Result<()> {
+fn copy_dir_recursive(src: &Path, dst: &Path, exclusions: &HashSet<&str>) -> crate::Result<()> {
     std::fs::create_dir_all(dst)
         .map_err(|e| Error::internal_io(e.to_string(), Some("create sandbox dir".to_string())))?;
 
@@ -123,10 +158,10 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> crate::Result<()> {
         let dst_path = dst.join(entry.file_name());
 
         if src_path.is_dir() {
-            if entry.file_name() == ".git" {
+            if exclusions.contains(entry.file_name().to_string_lossy().as_ref()) {
                 continue;
             }
-            copy_dir_recursive(&src_path, &dst_path)?;
+            copy_dir_recursive(&src_path, &dst_path, exclusions)?;
         } else {
             std::fs::copy(&src_path, &dst_path).map_err(|e| {
                 Error::internal_io(e.to_string(), Some("copy sandbox file".to_string()))


### PR DESCRIPTION
## Summary
- Exclude `build.cleanup_paths` (e.g., `target/` for Rust) from sandbox clone, snapshot, and writeback
- Eliminates ~5,000 `target/debug/` noise entries from `changed_files` JSON output (was 73% of output)
- Reduces sandbox disk footprint from gigabytes to source-only
- Reads exclusions from extension manifests — same pattern deploy cleanup already uses

## Changes
- **`sandbox.rs`** — `clone_tree()`, `snapshot_tree()`, and `copy_dir_recursive()` now accept exclusion lists; `.git` always excluded; `resolve_build_exclusions()` reads `build.cleanup_paths` from linked extensions
- **`planner.rs`** — resolves build exclusions once at plan start, passes through to lint/test stages

## Impact
- Sandbox clone is faster (skips copying compiled artifacts)
- Sandbox JSON output is clean (only source changes)
- `--write` mode no longer copies build artifacts back to the real tree
- Cold compilation in sandbox adds ~15-20s on CI but is correct behavior