### PR TITLE
fix: scope monorepo releases to component subdirectories

### DIFF
--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -188,7 +188,13 @@ pub fn get_latest_tag_with_prefix(path: &str, tag_prefix: Option<&str>) -> Resul
             Ok(command::run_in_optional(
                 path,
                 "git",
-                &["describe", "--tags", "--abbrev=0", "--match", &match_pattern],
+                &[
+                    "describe",
+                    "--tags",
+                    "--abbrev=0",
+                    "--match",
+                    &match_pattern,
+                ],
             ))
         }
         None => Ok(command::run_in_optional(

--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -8,6 +8,45 @@ use crate::error::Result;
 const DOCS_FILE_EXTENSIONS: [&str; 1] = [".md"];
 const DOCS_DIRECTORIES: [&str; 1] = ["docs/"];
 
+/// Context for a component that lives inside a monorepo.
+///
+/// When a component's `local_path` is a subdirectory of the git root,
+/// release operations need to scope commits and tags to that subdirectory.
+#[derive(Debug, Clone)]
+pub struct MonorepoContext {
+    /// The git repository root path.
+    pub git_root: String,
+    /// Relative path from git root to the component (e.g. "wordpress").
+    pub path_prefix: String,
+    /// Tag prefix for this component (e.g. "wordpress"), used to create
+    /// tags like `wordpress-v1.0.0`.
+    pub tag_prefix: String,
+}
+
+impl MonorepoContext {
+    /// Detect whether a component lives in a monorepo.
+    ///
+    /// Returns Some(context) if the component's path is a subdirectory of
+    /// the git root, None if it IS the root (single-repo component).
+    pub fn detect(local_path: &str, component_id: &str) -> Option<Self> {
+        let path_prefix = super::get_component_path_prefix(local_path)?;
+        let git_root = super::get_git_root(local_path).ok()?;
+
+        Some(MonorepoContext {
+            git_root,
+            path_prefix: path_prefix.clone(),
+            // Use component_id for tag prefix — it's the canonical name
+            tag_prefix: component_id.to_string(),
+        })
+    }
+
+    /// Format a version as a component-scoped tag name.
+    /// e.g. "1.2.3" -> "wordpress-v1.2.3"
+    pub fn format_tag(&self, version: &str) -> String {
+        format!("{}-v{}", self.tag_prefix, version)
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 
 pub struct CommitInfo {
@@ -130,12 +169,34 @@ pub(crate) fn extract_version_from_tag(tag: &str) -> Option<String> {
 
 /// Get the latest git tag in the repository.
 /// Returns None if no tags exist.
+///
+/// When `tag_prefix` is provided (e.g. "wordpress"), only matches tags starting
+/// with that prefix (e.g. `wordpress-v*`). This enables independent component
+/// versioning in monorepos where each component has its own tag namespace.
 pub fn get_latest_tag(path: &str) -> Result<Option<String>> {
-    Ok(command::run_in_optional(
-        path,
-        "git",
-        &["describe", "--tags", "--abbrev=0"],
-    ))
+    get_latest_tag_with_prefix(path, None)
+}
+
+/// Get the latest git tag, optionally filtered by a component prefix.
+///
+/// With prefix "wordpress", matches tags like `wordpress-v1.0.0`.
+/// Without prefix, matches any tag (backward compatible).
+pub fn get_latest_tag_with_prefix(path: &str, tag_prefix: Option<&str>) -> Result<Option<String>> {
+    match tag_prefix {
+        Some(prefix) => {
+            let match_pattern = format!("{}-v*", prefix);
+            Ok(command::run_in_optional(
+                path,
+                "git",
+                &["describe", "--tags", "--abbrev=0", "--match", &match_pattern],
+            ))
+        }
+        None => Ok(command::run_in_optional(
+            path,
+            "git",
+            &["describe", "--tags", "--abbrev=0"],
+        )),
+    }
 }
 
 /// Find the most recent commit containing a version number in its message.
@@ -229,10 +290,34 @@ pub fn get_last_n_commits(path: &str, n: usize) -> Result<Vec<CommitInfo>> {
 /// Get commits since a given tag (or all commits if tag is None).
 /// Returns commits in reverse chronological order (newest first).
 pub fn get_commits_since_tag(path: &str, tag: Option<&str>) -> Result<Vec<CommitInfo>> {
+    get_commits_since_tag_for_path(path, tag, None)
+}
+
+/// Get commits since a given tag, optionally filtered to only those touching files
+/// under `path_prefix` (relative to the git root).
+///
+/// In a monorepo, `path_prefix` scopes commit collection to a specific component
+/// directory (e.g. "wordpress/") so that only commits touching that component's
+/// files are included.
+pub fn get_commits_since_tag_for_path(
+    path: &str,
+    tag: Option<&str>,
+    path_prefix: Option<&str>,
+) -> Result<Vec<CommitInfo>> {
     let range = tag
         .map(|t| format!("{}..HEAD", t))
         .unwrap_or_else(|| "HEAD".to_string());
-    let stdout = command::run_in(path, "git", &["log", &range, "--format=%h|%s"], "git log")?;
+
+    let mut args = vec!["log".to_string(), range, "--format=%h|%s".to_string()];
+
+    // Add path filter for monorepo scoping: `git log <range> -- <path_prefix>`
+    if let Some(prefix) = path_prefix {
+        args.push("--".to_string());
+        args.push(prefix.to_string());
+    }
+
+    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let stdout = command::run_in(path, "git", &args_refs, "git log")?;
 
     let commits = stdout
         .lines()
@@ -589,6 +674,34 @@ mod tests {
         assert_eq!(
             recommended_bump_from_commits(&commits),
             Some(SemverBump::Patch)
+        );
+    }
+
+    #[test]
+    fn monorepo_context_format_tag() {
+        let ctx = MonorepoContext {
+            git_root: "/repo".to_string(),
+            path_prefix: "wordpress".to_string(),
+            tag_prefix: "wordpress".to_string(),
+        };
+        assert_eq!(ctx.format_tag("1.2.3"), "wordpress-v1.2.3");
+        assert_eq!(ctx.format_tag("0.1.0"), "wordpress-v0.1.0");
+    }
+
+    #[test]
+    fn extract_version_from_component_prefixed_tag() {
+        assert_eq!(
+            extract_version_from_tag("wordpress-v1.2.3"),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(
+            extract_version_from_tag("github-v0.5.0"),
+            Some("0.5.0".to_string())
+        );
+        // Standard tags still work
+        assert_eq!(
+            extract_version_from_tag("v1.0.0"),
+            Some("1.0.0".to_string())
         );
     }
 }

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -67,3 +67,30 @@ pub(crate) fn list_tracked_markdown_files(path: &Path) -> Result<Vec<String>> {
 pub(crate) fn is_git_repo(path: &str) -> bool {
     command::succeeded_in(path, "git", &["rev-parse", "--git-dir"])
 }
+
+/// Get the git repository root directory from any path within the repo.
+pub fn get_git_root(path: &str) -> Result<String> {
+    command::run_in(path, "git", &["rev-parse", "--show-toplevel"], "git root")
+        .map(|s| s.trim().to_string())
+        .map_err(|e| Error::git_command_failed(e.to_string()))
+}
+
+/// Compute the relative path prefix of a component within a monorepo.
+///
+/// If `local_path` is a subdirectory of the git root, returns the relative path
+/// (e.g. "wordpress" for `/repo/wordpress`). Returns None if local_path IS the
+/// git root (not a monorepo component).
+pub fn get_component_path_prefix(local_path: &str) -> Option<String> {
+    let git_root = get_git_root(local_path).ok()?;
+    let root = std::path::Path::new(&git_root).canonicalize().ok()?;
+    let component = std::path::Path::new(local_path).canonicalize().ok()?;
+
+    if root == component {
+        return None; // Not a monorepo — component IS the repo root
+    }
+
+    component
+        .strip_prefix(&root)
+        .ok()
+        .map(|p| p.to_string_lossy().to_string())
+}

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -93,7 +93,8 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
 
     // Build semver recommendation from commits early so both JSON output and
     // validation paths share a single source of truth.
-    let semver_recommendation = build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?;
+    let semver_recommendation =
+        build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?;
 
     // === Stage 1: Determine changelog entries from conventional commits ===
     // Returns Some(entries) when commits need changelog entries generated.
@@ -335,8 +336,7 @@ pub(super) fn resolve_tag_and_commits(
 ) -> Result<(Option<String>, Vec<git::CommitInfo>)> {
     match monorepo {
         Some(ctx) => {
-            let latest_tag =
-                git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix))?;
+            let latest_tag = git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix))?;
             let commits = git::get_commits_since_tag_for_path(
                 &ctx.git_root,
                 latest_tag.as_deref(),
@@ -872,10 +872,7 @@ fn build_release_steps(
         needs: tag_needs,
         config: {
             let mut config = std::collections::HashMap::new();
-            config.insert(
-                "name".to_string(),
-                serde_json::Value::String(tag_name),
-            );
+            config.insert("name".to_string(), serde_json::Value::String(tag_name));
             config
         },
         status: ReleasePlanStatus::Ready,

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -88,9 +88,12 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         v.capture(validate_code_quality(&component), "code_quality");
     }
 
+    // Detect monorepo context for path-scoped commits and component-prefixed tags.
+    let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
+
     // Build semver recommendation from commits early so both JSON output and
     // validation paths share a single source of truth.
-    let semver_recommendation = build_semver_recommendation(&component, &options.bump_type)?;
+    let semver_recommendation = build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?;
 
     // === Stage 1: Determine changelog entries from conventional commits ===
     // Returns Some(entries) when commits need changelog entries generated.
@@ -99,7 +102,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     // validations (they would false-fail since entries don't exist on disk yet).
     let pending_entries = v
         .capture(
-            validate_commits_vs_changelog(&component, options.dry_run),
+            validate_commits_vs_changelog(&component, options.dry_run, monorepo.as_ref()),
             "commits",
         )
         .flatten();
@@ -204,6 +207,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         &version_info.version,
         &new_version,
         options,
+        monorepo.as_ref(),
         &mut warnings,
         &mut hints,
     )?;
@@ -236,6 +240,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
 fn build_semver_recommendation(
     component: &Component,
     requested_bump: &str,
+    monorepo: Option<&git::MonorepoContext>,
 ) -> Result<Option<ReleaseSemverRecommendation>> {
     let requested = git::SemverBump::parse(requested_bump).ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -246,8 +251,7 @@ fn build_semver_recommendation(
         )
     })?;
 
-    let latest_tag = git::get_latest_tag(&component.local_path)?;
-    let commits = git::get_commits_since_tag(&component.local_path, latest_tag.as_deref())?;
+    let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, monorepo)?;
 
     if commits.is_empty() {
         return Ok(None);
@@ -319,6 +323,33 @@ fn build_semver_recommendation(
         is_underbump,
         reasons,
     }))
+}
+
+/// Resolve the latest tag and commits since that tag for a component.
+///
+/// In a monorepo, uses component-prefixed tags and path-scoped commits.
+/// In a single-repo, uses standard global tags and all commits.
+pub(super) fn resolve_tag_and_commits(
+    local_path: &str,
+    monorepo: Option<&git::MonorepoContext>,
+) -> Result<(Option<String>, Vec<git::CommitInfo>)> {
+    match monorepo {
+        Some(ctx) => {
+            let latest_tag =
+                git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix))?;
+            let commits = git::get_commits_since_tag_for_path(
+                &ctx.git_root,
+                latest_tag.as_deref(),
+                Some(&ctx.path_prefix),
+            )?;
+            Ok((latest_tag, commits))
+        }
+        None => {
+            let latest_tag = git::get_latest_tag(local_path)?;
+            let commits = git::get_commits_since_tag(local_path, latest_tag.as_deref())?;
+            Ok((latest_tag, commits))
+        }
+    }
 }
 
 fn validate_changelog(component: &Component) -> Result<()> {
@@ -535,12 +566,10 @@ fn validate_code_quality(component: &Component) -> Result<()> {
 fn validate_commits_vs_changelog(
     component: &Component,
     dry_run: bool,
+    monorepo: Option<&git::MonorepoContext>,
 ) -> Result<Option<std::collections::HashMap<String, Vec<String>>>> {
-    // Get latest tag
-    let latest_tag = git::get_latest_tag(&component.local_path)?;
-
-    // Get commits since tag
-    let commits = git::get_commits_since_tag(&component.local_path, latest_tag.as_deref())?;
+    // Get latest tag and commits (scoped to component in monorepo)
+    let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, monorepo)?;
 
     // If no commits, nothing to validate
     if commits.is_empty() {
@@ -747,6 +776,7 @@ fn build_release_steps(
     current_version: &str,
     new_version: &str,
     options: &ReleaseOptions,
+    monorepo: Option<&git::MonorepoContext>,
     warnings: &mut Vec<String>,
     _hints: &mut Vec<String>,
 ) -> Result<Vec<ReleasePlanStep>> {
@@ -831,16 +861,20 @@ fn build_release_steps(
     };
 
     // 4. Git tag (after package succeeds, or after commit if no package)
+    let tag_name = match monorepo {
+        Some(ctx) => ctx.format_tag(new_version),
+        None => format!("v{}", new_version),
+    };
     steps.push(ReleasePlanStep {
         id: "git.tag".to_string(),
         step_type: "git.tag".to_string(),
-        label: Some(format!("Tag v{}", new_version)),
+        label: Some(format!("Tag {}", tag_name)),
         needs: tag_needs,
         config: {
             let mut config = std::collections::HashMap::new();
             config.insert(
                 "name".to_string(),
-                serde_json::Value::String(format!("v{}", new_version)),
+                serde_json::Value::String(tag_name),
             );
             config
         },

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -23,7 +23,8 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     )?;
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
-    let (mut bump_type, releasable_count) = match resolve_bump(&component.local_path, monorepo.as_ref())? {
+    let (mut bump_type, releasable_count) =
+        match resolve_bump(&component.local_path, monorepo.as_ref())? {
         Some(result) => result,
         None => {
             log_status!(
@@ -114,7 +115,9 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     if options.dry_run {
         let plan = super::plan(&input.component_id, &options)?;
         let new_version = extract_new_version_from_plan(&plan);
-        let tag = new_version.as_ref().map(|v| format_tag(v, monorepo.as_ref()));
+        let tag = new_version
+            .as_ref()
+            .map(|v| format_tag(v, monorepo.as_ref()));
         let deployment = input.deploy.then(|| plan_deployment(&input.component_id));
 
         return Ok((
@@ -138,7 +141,9 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     display_release_summary(&run_result);
 
     let new_version = extract_new_version_from_run(&run_result);
-    let tag = new_version.as_ref().map(|v| format_tag(v, monorepo.as_ref()));
+    let tag = new_version
+        .as_ref()
+        .map(|v| format_tag(v, monorepo.as_ref()));
     let post_release_exit = if has_post_release_warnings(&run_result) {
         3
     } else {
@@ -172,7 +177,10 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     ))
 }
 
-fn resolve_bump(local_path: &str, monorepo: Option<&git::MonorepoContext>) -> Result<Option<(String, usize)>> {
+fn resolve_bump(
+    local_path: &str,
+    monorepo: Option<&git::MonorepoContext>,
+) -> Result<Option<(String, usize)>> {
     let (_latest_tag, commits) = super::pipeline::resolve_tag_and_commits(local_path, monorepo)?;
 
     if commits.is_empty() {

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -22,7 +22,8 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
     )?;
 
-    let (mut bump_type, releasable_count) = match resolve_bump(&component.local_path)? {
+    let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
+    let (mut bump_type, releasable_count) = match resolve_bump(&component.local_path, monorepo.as_ref())? {
         Some(result) => result,
         None => {
             log_status!(
@@ -113,7 +114,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     if options.dry_run {
         let plan = super::plan(&input.component_id, &options)?;
         let new_version = extract_new_version_from_plan(&plan);
-        let tag = new_version.as_ref().map(|v| format!("v{}", v));
+        let tag = new_version.as_ref().map(|v| format_tag(v, monorepo.as_ref()));
         let deployment = input.deploy.then(|| plan_deployment(&input.component_id));
 
         return Ok((
@@ -137,7 +138,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     display_release_summary(&run_result);
 
     let new_version = extract_new_version_from_run(&run_result);
-    let tag = new_version.as_ref().map(|v| format!("v{}", v));
+    let tag = new_version.as_ref().map(|v| format_tag(v, monorepo.as_ref()));
     let post_release_exit = if has_post_release_warnings(&run_result) {
         3
     } else {
@@ -171,9 +172,8 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     ))
 }
 
-fn resolve_bump(local_path: &str) -> Result<Option<(String, usize)>> {
-    let latest_tag = git::get_latest_tag(local_path)?;
-    let commits = git::get_commits_since_tag(local_path, latest_tag.as_deref())?;
+fn resolve_bump(local_path: &str, monorepo: Option<&git::MonorepoContext>) -> Result<Option<(String, usize)>> {
+    let (_latest_tag, commits) = super::pipeline::resolve_tag_and_commits(local_path, monorepo)?;
 
     if commits.is_empty() {
         return Ok(None);
@@ -188,6 +188,14 @@ fn resolve_bump(local_path: &str) -> Result<Option<(String, usize)>> {
             Ok(Some((bump.as_str().to_string(), releasable)))
         }
         None => Ok(None),
+    }
+}
+
+/// Format a version string as a tag name, using component prefix in monorepos.
+fn format_tag(version: &str, monorepo: Option<&git::MonorepoContext>) -> String {
+    match monorepo {
+        Some(ctx) => ctx.format_tag(version),
+        None => format!("v{}", version),
     }
 }
 
@@ -403,9 +411,10 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             ..Default::default()
         },
     )?;
+    let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
     let version_info = crate::version::read_component_version(&component)?;
     let current_version = &version_info.version;
-    let tag_name = format!("v{}", current_version);
+    let tag_name = format_tag(current_version, monorepo.as_ref());
 
     let tag_exists_local =
         git::tag_exists_locally(&component.local_path, &tag_name).unwrap_or(false);

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -25,29 +25,29 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
     let (mut bump_type, releasable_count) =
         match resolve_bump(&component.local_path, monorepo.as_ref())? {
-        Some(result) => result,
-        None => {
-            log_status!(
-                "release",
-                "No releasable commits since last tag — nothing to release"
-            );
-            return Ok((
-                ReleaseCommandResult {
-                    component_id: input.component_id,
-                    bump_type: "none".to_string(),
-                    dry_run: input.dry_run,
-                    releasable_commits: 0,
-                    new_version: None,
-                    tag: None,
-                    skipped_reason: Some("no-releasable-commits".to_string()),
-                    plan: None,
-                    run: None,
-                    deployment: None,
-                },
-                0,
-            ));
-        }
-    };
+            Some(result) => result,
+            None => {
+                log_status!(
+                    "release",
+                    "No releasable commits since last tag — nothing to release"
+                );
+                return Ok((
+                    ReleaseCommandResult {
+                        component_id: input.component_id,
+                        bump_type: "none".to_string(),
+                        dry_run: input.dry_run,
+                        releasable_commits: 0,
+                        new_version: None,
+                        tag: None,
+                        skipped_reason: Some("no-releasable-commits".to_string()),
+                        plan: None,
+                        run: None,
+                        deployment: None,
+                    },
+                    0,
+                ));
+            }
+        };
 
     // Pre-1.0 semver: breaking changes bump minor, not major.
     // In semver, 0.x.y signals "initial development" where the public API is


### PR DESCRIPTION
## Summary

Fixes release scoping for monorepos like `homeboy-extensions` where each subdirectory is an independent component with its own version.

**The bug:** `homeboy release github` would collect ALL commits since the last global tag and dump them into the github changelog — including wordpress-only and rust-only changes. Tags like `v1.1.0` (github) and `v1.0.1` (openclaw) collided in the same global namespace.

**The fix:**
- **Path-scoped commits:** `get_commits_since_tag_for_path()` adds `-- <path>` to `git log` so only commits touching the component's files are included
- **Component-prefixed tags:** `get_latest_tag_with_prefix()` uses `--match <component>-v*` so each component resolves its own tag history
- **`MonorepoContext`:** Auto-detects when `local_path` is a subdirectory of the git root and carries `path_prefix` + `tag_prefix` through the release pipeline
- **Tag format:** Monorepo components create tags like `wordpress-v2.10.0` instead of `v2.10.0`

## Before/After (homeboy-extensions)

| Component | Before | After |
|-----------|--------|-------|
| github | `v1.1.0` — changelog has 30+ entries from wordpress/rust | `github-v1.2.0` — only commits touching `github/` |
| openclaw | `v1.0.1` — "make frontend build non-fatal" (wordpress fix!) | `openclaw-v1.1.0` — only commits touching `openclaw/` |
| wordpress | Failed (no unreleased entries) | `wordpress-v2.10.0` — only wordpress commits |

## Backward Compatibility

- Single-repo components (not in a monorepo) are completely unaffected — `MonorepoContext::detect()` returns `None` and all existing behavior is preserved
- Existing global tags are not deleted; the first release with this fix will create new component-prefixed tags
- `extract_version_from_tag()` already handles `component-v1.0.0` format

## Tests

- 832 lib tests pass (0 failed, 1 pre-existing ignored)
- Added tests for `MonorepoContext::format_tag()` and `extract_version_from_tag()` with component prefixes
- Verified dry-run against homeboy-extensions for wordpress, openclaw, github, and swift components