### PR TITLE
fix: fall back to rustfmt when cargo fmt fails in sandbox

### DIFF
--- a/src/core/engine/format_write.rs
+++ b/src/core/engine/format_write.rs
@@ -99,6 +99,47 @@ pub fn format_after_write(root: &Path, changed_files: &[PathBuf]) -> Result<Form
         return Ok(FormatResult::passed(format_command, changed_files.len()));
     }
 
+    // cargo fmt failed — try rustfmt directly on individual files.
+    // This handles sandbox/clean-clone environments where cargo fmt needs
+    // target/ for module resolution but it's excluded from the sandbox.
+    if format_command.starts_with("cargo fmt") {
+        let rust_files: Vec<&PathBuf> = changed_files
+            .iter()
+            .filter(|f| f.extension().and_then(|e| e.to_str()) == Some("rs"))
+            .collect();
+
+        if !rust_files.is_empty() {
+            crate::log_status!(
+                "format",
+                "cargo fmt failed, falling back to rustfmt on {} file(s)",
+                rust_files.len()
+            );
+
+            let mut all_succeeded = true;
+            for file in &rust_files {
+                let rustfmt_output = std::process::Command::new("rustfmt")
+                    .arg(file)
+                    .current_dir(root)
+                    .output();
+
+                match rustfmt_output {
+                    Ok(o) if o.status.success() => {}
+                    _ => {
+                        all_succeeded = false;
+                    }
+                }
+            }
+
+            if all_succeeded {
+                crate::log_status!("format", "rustfmt fallback complete");
+                return Ok(FormatResult::passed(
+                    "rustfmt (fallback)".to_string(),
+                    changed_files.len(),
+                ));
+            }
+        }
+    }
+
     // Formatting failed — log warning but do NOT rollback
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary

Unblocks the **unreferenced export fixer** — 39 findings in homeboy, 54 in data-machine-socials.

**The problem:** The refactor sandbox excludes `target/` (build artifacts). `cargo fmt` needs `target/` for module resolution. When the unreferenced export fixer applies `pub` → `pub(crate)` changes in the sandbox, `format_after_write()` runs `cargo fmt` which fails silently (`let _ =`). The files remain unformatted. The lint validation stage then runs `cargo fmt --check`, sees the extra `(crate)` characters pushed lines over the column limit, and fails. All changes get rolled back. No PR.

**The fix:** When `cargo fmt` fails, fall back to running `rustfmt` directly on each changed `.rs` file. `rustfmt` formats individual files without needing the cargo project context, so it works in sandboxes.

```
Before:  cargo fmt fails silently → unformatted → cargo fmt --check fails → rollback
After:   cargo fmt fails → rustfmt on each file → formatted → validation passes → PR created
```

This is the last blocker for the unreferenced export autofix. The fixer itself has been working correctly since it was built — it's been generating correct `pub(crate)` insertions but the sandbox formatter failure prevented them from ever landing.