### PR TITLE
fix: use autofix: false instead of autofix-mode: disabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,9 +130,8 @@ jobs:
    # Unlike PR CI (scoped to changed files), release quality gate runs
   # unscoped against the entire codebase.
   # Serial pipeline: audit → lint → test → release.
-  # All quality gates are read-only. The dedicated auto-refactor job at
-  # the end owns all code changes (refactor --from all --write).
-   # audit/lint/test are read-only here; the dedicated auto-refactor job owns all writes.
+   # All quality gates are read-only (autofix: false). The dedicated
+  # auto-refactor job at the end owns all code changes.
   gate-audit:
     name: Audit
     needs:
@@ -163,7 +162,7 @@ jobs:
         with:
           binary-path: .homeboy-bin/homeboy
           commands: audit
-          autofix-mode: 'disabled'
+          autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   gate-lint:
@@ -197,7 +196,7 @@ jobs:
         with:
           binary-path: .homeboy-bin/homeboy
           commands: lint
-          autofix-mode: 'disabled'
+          autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   gate-test:
@@ -231,6 +230,7 @@ jobs:
         with:
           binary-path: .homeboy-bin/homeboy
           commands: test
+          autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   gate-refactor:


### PR DESCRIPTION
## Summary

`autofix-mode: 'disabled'` doesn't actually disable autofix. The action's step-level `if` condition only checks the `autofix` input:

```yaml
# Action's if guard (simplified):
if: inputs.autofix == 'true' || (inputs.autofix == '' && inputs.app-token != '')
```

Since `autofix` defaults to `''` and `app-token` is set, the autofix step runs regardless of `autofix-mode`. The mode is only checked inside the script after the step has already started running `refactor --from all --write`.

**Before:** Audit/lint/test gates spent 30+ minutes each running refactor, only to have it fail or produce unwanted changes.

**After:** `autofix: 'false'` is checked in the `if` guard — the autofix steps don't run at all.

Also a bug to file on homeboy-action: `autofix-mode: 'disabled'` should be respected in the step `if` condition.