### PR TITLE
fix: fixability key mismatch + PHP import generation in duplicate fixer

### DIFF
--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -151,6 +151,19 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
     }
 }
 
+/// Serialize an [`AuditFinding`] variant to its serde snake_case key.
+///
+/// This must match the `#[serde(rename_all = "snake_case")]` on the enum so that
+/// `fixability.by_kind` keys align with the finding group keys in JSON output.
+/// Using `format!("{:?}", ...)` would produce Debug PascalCase (e.g. `compilerwarning`)
+/// which doesn't match the serde output (`compiler_warning`).
+pub(crate) fn finding_kind_key(finding: &AuditFinding) -> String {
+    serde_json::to_value(finding)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_else(|| format!("{:?}", finding).to_lowercase())
+}
+
 /// Compute fixability metadata from an audit result without applying fixes.
 ///
 /// Runs the fix generator in dry-run mode and counts how many findings
@@ -184,7 +197,7 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
 
     for fix in &fix_result.fixes {
         for insertion in &fix.insertions {
-            let kind_key = format!("{:?}", insertion.finding).to_lowercase();
+            let kind_key = finding_kind_key(&insertion.finding);
             let entry = by_kind.entry(kind_key).or_insert(FixabilityKindBreakdown {
                 total: 0,
                 safe: 0,
@@ -206,7 +219,7 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
     }
 
     for new_file in &fix_result.new_files {
-        let kind_key = format!("{:?}", new_file.finding).to_lowercase();
+        let kind_key = finding_kind_key(&new_file.finding);
         let entry = by_kind.entry(kind_key).or_insert(FixabilityKindBreakdown {
             total: 0,
             safe: 0,

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -119,15 +119,45 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
 fn test_finding_kind_key_produces_snake_case() {
     // finding_kind_key must produce serde-compatible snake_case keys
     // so that fixability.by_kind matches the JSON finding group keys.
-    assert_eq!(finding_kind_key(&AuditFinding::CompilerWarning), "compiler_warning");
-    assert_eq!(finding_kind_key(&AuditFinding::UnusedParameter), "unused_parameter");
-    assert_eq!(finding_kind_key(&AuditFinding::UnreferencedExport), "unreferenced_export");
-    assert_eq!(finding_kind_key(&AuditFinding::IntraMethodDuplicate), "intra_method_duplicate");
-    assert_eq!(finding_kind_key(&AuditFinding::OrphanedTest), "orphaned_test");
-    assert_eq!(finding_kind_key(&AuditFinding::MissingTestFile), "missing_test_file");
-    assert_eq!(finding_kind_key(&AuditFinding::MissingTestMethod), "missing_test_method");
-    assert_eq!(finding_kind_key(&AuditFinding::MissingMethod), "missing_method");
+    assert_eq!(
+        finding_kind_key(&AuditFinding::CompilerWarning),
+        "compiler_warning"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::UnusedParameter),
+        "unused_parameter"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::UnreferencedExport),
+        "unreferenced_export"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::IntraMethodDuplicate),
+        "intra_method_duplicate"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::OrphanedTest),
+        "orphaned_test"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::MissingTestFile),
+        "missing_test_file"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::MissingTestMethod),
+        "missing_test_method"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::MissingMethod),
+        "missing_method"
+    );
     assert_eq!(finding_kind_key(&AuditFinding::GodFile), "god_file");
-    assert_eq!(finding_kind_key(&AuditFinding::DuplicateFunction), "duplicate_function");
-    assert_eq!(finding_kind_key(&AuditFinding::NearDuplicate), "near_duplicate");
+    assert_eq!(
+        finding_kind_key(&AuditFinding::DuplicateFunction),
+        "duplicate_function"
+    );
+    assert_eq!(
+        finding_kind_key(&AuditFinding::NearDuplicate),
+        "near_duplicate"
+    );
 }

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -1,6 +1,6 @@
-use crate::code_audit::report::{build_audit_summary, compute_fixability};
+use crate::code_audit::report::{build_audit_summary, compute_fixability, finding_kind_key};
 use crate::code_audit::test_helpers::{empty_result, make_finding};
-use crate::code_audit::Severity;
+use crate::code_audit::{AuditFinding, Severity};
 
 #[test]
 fn test_build_audit_summary_empty_result() {
@@ -113,4 +113,21 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
     }
     // Note: fixability may also be None if the minimal codebase doesn't trigger
     // enough conventions — that's acceptable for this test.
+}
+
+#[test]
+fn test_finding_kind_key_produces_snake_case() {
+    // finding_kind_key must produce serde-compatible snake_case keys
+    // so that fixability.by_kind matches the JSON finding group keys.
+    assert_eq!(finding_kind_key(&AuditFinding::CompilerWarning), "compiler_warning");
+    assert_eq!(finding_kind_key(&AuditFinding::UnusedParameter), "unused_parameter");
+    assert_eq!(finding_kind_key(&AuditFinding::UnreferencedExport), "unreferenced_export");
+    assert_eq!(finding_kind_key(&AuditFinding::IntraMethodDuplicate), "intra_method_duplicate");
+    assert_eq!(finding_kind_key(&AuditFinding::OrphanedTest), "orphaned_test");
+    assert_eq!(finding_kind_key(&AuditFinding::MissingTestFile), "missing_test_file");
+    assert_eq!(finding_kind_key(&AuditFinding::MissingTestMethod), "missing_test_method");
+    assert_eq!(finding_kind_key(&AuditFinding::MissingMethod), "missing_method");
+    assert_eq!(finding_kind_key(&AuditFinding::GodFile), "god_file");
+    assert_eq!(finding_kind_key(&AuditFinding::DuplicateFunction), "duplicate_function");
+    assert_eq!(finding_kind_key(&AuditFinding::NearDuplicate), "near_duplicate");
 }


### PR DESCRIPTION
## Summary

Two bugs that compound to break the entire audit → autofix → issue lifecycle:

1. **Fixability key mismatch** — `compute_fixability()` produced wrong `by_kind` map keys, making all fixers invisible to issue reporting
2. **JS-style imports in PHP files** — `DuplicateFunction` fixer generated `import { fn } from 'path'` instead of `use Namespace\Class;` for PHP, introducing syntax errors that blocked autofix PRs

## Bug 1: Fixability Key Format Mismatch

`compute_fixability()` used `format!("{:?}", finding).to_lowercase()` for `by_kind` map keys, producing `"compilerwarning"` instead of `"compiler_warning"`. Since `AuditFinding` uses `#[serde(rename_all = "snake_case")]`, the JSON finding groups use snake_case keys. The homeboy-action issue filing script looked up `.fixability["compiler_warning"]` but the map had `"compilerwarning"` — so every audit issue showed "❌ No fixer available" even though fixers exist.

**Fix:** Use `serde_json::to_value()` serialization via new `finding_kind_key()` helper.

## Bug 2: JavaScript Imports in PHP Files

`generate_simple_duplicate_fixes()` in `duplicate_fixes.rs` had:
```rust
match ext {
    "rs" => format!("use crate::{}::{};", ...),
    _ => format!("import {{ {} }} from '{}';", ...),  // ← JS syntax for everything else
};
```

For PHP files, this produced:
```
import { httpGet } from 'inc::Abilities::Fetch::FetchRssAbility.php';
```

Which caused PHP syntax errors (`unexpected identifier "from"`) across ~14 files in data-machine. Since lint fails after autofix, the autofix PR gate (`!contains(results, '"fail"')`) prevents PR creation — so the 119 files of audit+test fixes never reach main.

**Fix:** New `generate_duplicate_import()` function that dispatches on `Language` enum. For PHP, reads the canonical file to extract `namespace` + `class` declarations and generates proper `use DataMachine\Namespace\ClassName;` statements.

## Expected Outcome

After merge + release:
1. Audit issues show accurate fixability status (✅/❌ with counts)
2. Data-machine autofix stops introducing PHP syntax errors
3. Autofix PRs can actually be created (lint passes after autofix)
4. The code factory pipeline burns down fixable findings automatically

## Tests

- `test_finding_kind_key_produces_snake_case` — 11 AuditFinding variants
- `test_extract_php_fqcn_*` — 4 tests for PHP namespace+class extraction
- `test_generate_duplicate_import_*` — 3 tests for Rust/PHP/JS import generation