### PR TITLE
fix: deploy robustness — skip unrelated components, force after bump, warn on failure

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -25,7 +25,7 @@ pub(super) fn deploy_components(
     ctx: &RemoteProjectContext,
     base_path: &str,
 ) -> Result<DeployOrchestrationResult> {
-    let loaded = load_project_components(project)?;
+    let loaded = load_project_components(project, &config.component_ids)?;
     if loaded.deployable.is_empty() {
         let message = if loaded.skipped.is_empty() {
             "No components configured for project".to_string()

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -264,17 +264,36 @@ pub(super) struct LoadedComponents {
 ///
 /// Returns both the deployable components and the IDs of skipped (non-deployable) ones,
 /// so callers can produce accurate error messages.
-pub(super) fn load_project_components(project: &Project) -> Result<LoadedComponents> {
+pub(super) fn load_project_components(
+    project: &Project,
+    requested_ids: &[String],
+) -> Result<LoadedComponents> {
     let mut deployable = Vec::new();
     let mut skipped = Vec::new();
 
     for attachment in &project.components {
+        // When specific components are requested, skip extension validation for
+        // unrelated components — a missing extension on an unrequested component
+        // should not block deploying the ones you asked for.
+        let is_requested =
+            requested_ids.is_empty() || requested_ids.contains(&attachment.id);
+
         let mut loaded = project::resolve_project_component(project, &attachment.id)?;
 
         // Validate required extensions are installed before attempting artifact resolution.
         // Without this check, missing extensions cause resolve_artifact() to silently
         // return None, and the component gets skipped with a vague "no artifact" message.
-        extension::validate_required_extensions(&loaded)?;
+        if is_requested {
+            extension::validate_required_extensions(&loaded)?;
+        } else if extension::validate_required_extensions(&loaded).is_err() {
+            log_status!(
+                "deploy",
+                "Skipping '{}': missing required extension (not requested for deploy)",
+                loaded.id
+            );
+            skipped.push(loaded.id.clone());
+            continue;
+        }
 
         // Resolve effective artifact (component value OR extension pattern)
         let effective_artifact = component::resolve_artifact(&loaded);

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -155,6 +155,21 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         (None, 0)
     };
     let exit_code = if deploy_exit_code != 0 {
+        // Deploy failed after the release was already tagged and pushed.
+        // The tag cannot be rolled back safely, so warn the user to retry.
+        if let Some(ref t) = tag {
+            eprintln!();
+            log_status!(
+                "release",
+                "⚠️  Release {} was tagged and pushed, but deploy FAILED.",
+                t
+            );
+            log_status!(
+                "release",
+                "Run `homeboy deploy {}` to finish deploying.",
+                input.component_id
+            );
+        }
         deploy_exit_code
     } else {
         post_release_exit
@@ -328,7 +343,10 @@ fn execute_deployment(
             outdated: false,
             dry_run: false,
             check: false,
-            force: false,
+            // Force: the release pipeline just committed and tagged, so the
+            // workspace is clean by definition. Skipping the uncommitted changes
+            // check avoids false positives that silently block deployment.
+            force: true,
             skip_build: true,
             keep_deps: false,
             expected_version: None,


### PR DESCRIPTION
## Summary

Three deploy bugs that compound to make `version bump --deploy` unreliable:

- **#916** — Deploy fails when unrelated component has missing build extension
- **#918** — Version bump --deploy tags+pushes before deploy, no recovery guidance on failure
- **#921** — Version bump --deploy reports success but doesn't actually update files on disk

## Changes

### #916: Skip unrelated components during deploy

`load_project_components()` validated extensions for ALL project components even when specific ones were requested. An unrelated component (`extrachill-tokens`) with a missing `npm` extension blocked deploying `data-machine`.

**Fix:** `load_project_components()` now accepts `requested_ids`. Only requested components get hard validation errors. Unrequested components with missing extensions are gracefully skipped with a log message.

### #921: Force deploy after version bump

`execute_deployment()` used `force: false` in the deploy config, which runs an uncommitted changes check. After the release pipeline just committed and tagged, the workspace is clean by definition — but edge cases could false-positive.

**Fix:** Set `force: true` in the deploy-after-bump config. The release pipeline guarantees a clean workspace.

### #918: Clear warning when deploy fails after tagging

When deploy fails after the release is already tagged and pushed, the tag can't be safely rolled back. Previously the command returned a non-zero exit code but gave no guidance.

**Fix:** Emit a clear warning with the tagged version and a recovery command:
```
⚠️  Release v0.54.1 was tagged and pushed, but deploy FAILED.
Run `homeboy deploy data-machine` to finish deploying.
```

## Testing

All existing tests pass. These are deploy/release pipeline changes that are inherently integration-level — the fixes are targeted and low-risk.

Closes #916, closes #918, closes #921