### PR TITLE
feat: project-scoped status dashboard with version drift view

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -217,10 +217,7 @@ pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusRes
 ///
 /// Combines local version, remote (deployed) version, release state, and
 /// unreleased commit count into a single view per component.
-fn run_project_dashboard(
-    project_id: &str,
-    args: &StatusArgs,
-) -> CmdResult<StatusResult> {
+fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<StatusResult> {
     let proj = project::load(project_id)?;
     let components = project::resolve_project_components(&proj)?;
 
@@ -345,9 +342,7 @@ fn run_project_dashboard(
 ///
 /// Uses deploy check mode internally, which handles SSH resolution.
 /// Returns empty map on failure (e.g., no server configured, SSH unavailable).
-fn fetch_project_remote_versions(
-    project_id: &str,
-) -> std::collections::HashMap<String, String> {
+fn fetch_project_remote_versions(project_id: &str) -> std::collections::HashMap<String, String> {
     let config = DeployConfig {
         component_ids: vec![],
         all: true,
@@ -407,12 +402,11 @@ fn log_dashboard_table(rows: &[ProjectStatusRow]) {
 
     // Header
     eprintln!(
-        "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:>10}  {}",
+        "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:>10}  Status",
         "Component",
         "Local",
         "Remote",
         "Unreleased",
-        "Status",
         id_w = id_width,
         local_w = local_width,
         remote_w = remote_width,

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,13 +1,18 @@
 use clap::Args;
 use homeboy::component;
 use homeboy::context;
-use homeboy::deploy::{self, ReleaseStateStatus};
+use homeboy::deploy::{self, DeployConfig, ReleaseStateStatus};
+use homeboy::project;
+use homeboy::version;
 use serde::Serialize;
 
 use super::CmdResult;
 
 #[derive(Args)]
 pub struct StatusArgs {
+    /// Project ID — show version dashboard for a project's components
+    pub project: Option<String>,
+
     /// Show the full workspace/context report (the old init behavior)
     #[arg(long)]
     pub full: bool,
@@ -31,6 +36,10 @@ pub struct StatusArgs {
     /// Show all components regardless of current directory context
     #[arg(long, short = 'a')]
     pub all: bool,
+
+    /// Show only outdated components (local != remote)
+    #[arg(long)]
+    pub outdated: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -48,9 +57,59 @@ pub struct StatusOutput {
     pub clean: usize,
 }
 
+/// A single row in the project status dashboard.
+#[derive(Debug, Serialize)]
+pub struct ProjectStatusRow {
+    pub component_id: String,
+    pub local_version: Option<String>,
+    pub remote_version: Option<String>,
+    pub unreleased_commits: u32,
+    pub status: ProjectComponentDashboardStatus,
+}
+
+/// Status indicator for the project dashboard.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectComponentDashboardStatus {
+    /// Local and remote versions match, no unreleased commits
+    Current,
+    /// Local version differs from remote (needs deploy)
+    Outdated,
+    /// Unreleased commits since last tag (needs version bump)
+    NeedsBump,
+    /// Only docs changes since last tag
+    DocsOnly,
+    /// Uncommitted changes in working directory
+    Uncommitted,
+    /// Cannot determine status
+    Unknown,
+}
+
+/// Output for the project status dashboard.
+#[derive(Debug, Serialize)]
+pub struct ProjectDashboardOutput {
+    pub command: &'static str,
+    pub project_id: String,
+    pub total: usize,
+    pub components: Vec<ProjectStatusRow>,
+    pub summary: ProjectDashboardSummary,
+}
+
+/// Summary counts for the project dashboard.
+#[derive(Debug, Serialize)]
+pub struct ProjectDashboardSummary {
+    pub current: usize,
+    pub outdated: usize,
+    pub needs_bump: usize,
+    pub docs_only: usize,
+    pub uncommitted: usize,
+    pub unknown: usize,
+}
+
 pub enum StatusResult {
     Summary(StatusOutput),
     Full(homeboy::context::report::ContextReport),
+    Dashboard(ProjectDashboardOutput),
 }
 
 impl serde::Serialize for StatusResult {
@@ -61,11 +120,17 @@ impl serde::Serialize for StatusResult {
         match self {
             StatusResult::Summary(output) => output.serialize(serializer),
             StatusResult::Full(output) => output.serialize(serializer),
+            StatusResult::Dashboard(output) => output.serialize(serializer),
         }
     }
 }
 
 pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusResult> {
+    // Project dashboard mode: `homeboy status <project-id>`
+    if let Some(ref project_id) = args.project {
+        return run_project_dashboard(project_id, &args);
+    }
+
     if args.full {
         let mut report = context::build_report(args.all, "status")?;
         report.command = "status".to_string();
@@ -146,4 +211,246 @@ pub fn run(args: StatusArgs, _global: &super::GlobalArgs) -> CmdResult<StatusRes
         }),
         0,
     ))
+}
+
+/// Project dashboard: show version drift across all components in a project.
+///
+/// Combines local version, remote (deployed) version, release state, and
+/// unreleased commit count into a single view per component.
+fn run_project_dashboard(
+    project_id: &str,
+    args: &StatusArgs,
+) -> CmdResult<StatusResult> {
+    let proj = project::load(project_id)?;
+    let components = project::resolve_project_components(&proj)?;
+
+    if components.is_empty() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "project",
+            format!("Project '{}' has no components attached", project_id),
+            Some(project_id.to_string()),
+            Some(vec![
+                "Attach components with: homeboy project set <project> --json '{\"components\":[{\"id\":\"...\",\"local_path\":\"...\"}]}'".to_string(),
+            ]),
+        ));
+    }
+
+    // Gather local versions
+    let local_versions: std::collections::HashMap<String, String> = components
+        .iter()
+        .filter_map(|c| version::get_component_version(c).map(|v| (c.id.clone(), v)))
+        .collect();
+
+    // Gather remote versions via deploy check mode (handles SSH internally)
+    let remote_versions = fetch_project_remote_versions(project_id);
+
+    // Build per-component rows
+    let mut rows: Vec<ProjectStatusRow> = Vec::new();
+    let mut summary = ProjectDashboardSummary {
+        current: 0,
+        outdated: 0,
+        needs_bump: 0,
+        docs_only: 0,
+        uncommitted: 0,
+        unknown: 0,
+    };
+
+    for comp in &components {
+        let local_ver = local_versions.get(&comp.id).cloned();
+        let remote_ver = remote_versions.get(&comp.id).cloned();
+
+        let release_state = deploy::calculate_release_state(comp);
+        let release_status = release_state
+            .as_ref()
+            .map(|s| s.status())
+            .unwrap_or(ReleaseStateStatus::Unknown);
+
+        let unreleased_commits = release_state
+            .as_ref()
+            .map(|s| s.commits_since_version)
+            .unwrap_or(0);
+
+        // Determine dashboard status.
+        // Priority: uncommitted > needs_bump > docs_only > outdated > current > unknown
+        let dashboard_status = match release_status {
+            ReleaseStateStatus::Uncommitted => ProjectComponentDashboardStatus::Uncommitted,
+            ReleaseStateStatus::NeedsBump => ProjectComponentDashboardStatus::NeedsBump,
+            ReleaseStateStatus::DocsOnly => ProjectComponentDashboardStatus::DocsOnly,
+            ReleaseStateStatus::Clean => {
+                // Clean release state — check if deployed version matches local
+                match (&local_ver, &remote_ver) {
+                    (Some(local), Some(remote)) if local != remote => {
+                        ProjectComponentDashboardStatus::Outdated
+                    }
+                    (Some(_), None) => ProjectComponentDashboardStatus::Outdated,
+                    _ => ProjectComponentDashboardStatus::Current,
+                }
+            }
+            ReleaseStateStatus::Unknown => ProjectComponentDashboardStatus::Unknown,
+        };
+
+        match &dashboard_status {
+            ProjectComponentDashboardStatus::Current => summary.current += 1,
+            ProjectComponentDashboardStatus::Outdated => summary.outdated += 1,
+            ProjectComponentDashboardStatus::NeedsBump => summary.needs_bump += 1,
+            ProjectComponentDashboardStatus::DocsOnly => summary.docs_only += 1,
+            ProjectComponentDashboardStatus::Uncommitted => summary.uncommitted += 1,
+            ProjectComponentDashboardStatus::Unknown => summary.unknown += 1,
+        }
+
+        rows.push(ProjectStatusRow {
+            component_id: comp.id.clone(),
+            local_version: local_ver,
+            remote_version: remote_ver,
+            unreleased_commits,
+            status: dashboard_status,
+        });
+    }
+
+    // Apply filters
+    if args.outdated {
+        rows.retain(|r| matches!(r.status, ProjectComponentDashboardStatus::Outdated));
+    }
+    if args.needs_bump {
+        rows.retain(|r| matches!(r.status, ProjectComponentDashboardStatus::NeedsBump));
+    }
+    if args.uncommitted {
+        rows.retain(|r| matches!(r.status, ProjectComponentDashboardStatus::Uncommitted));
+    }
+    if args.docs_only {
+        rows.retain(|r| matches!(r.status, ProjectComponentDashboardStatus::DocsOnly));
+    }
+    if args.ready {
+        rows.retain(|r| matches!(r.status, ProjectComponentDashboardStatus::Current));
+    }
+
+    // Log the table to stderr for human-readable output
+    log_dashboard_table(&rows);
+
+    let total = rows.len();
+
+    Ok((
+        StatusResult::Dashboard(ProjectDashboardOutput {
+            command: "status",
+            project_id: project_id.to_string(),
+            total,
+            components: rows,
+            summary,
+        }),
+        0,
+    ))
+}
+
+/// Fetch remote (deployed) versions for all components in a project.
+///
+/// Uses deploy check mode internally, which handles SSH resolution.
+/// Returns empty map on failure (e.g., no server configured, SSH unavailable).
+fn fetch_project_remote_versions(
+    project_id: &str,
+) -> std::collections::HashMap<String, String> {
+    let config = DeployConfig {
+        component_ids: vec![],
+        all: true,
+        outdated: false,
+        dry_run: false,
+        check: true,
+        force: false,
+        skip_build: true,
+        keep_deps: false,
+        expected_version: None,
+        no_pull: true,
+        head: true,
+    };
+
+    match deploy::run(project_id, &config) {
+        Ok(result) => result
+            .results
+            .into_iter()
+            .filter_map(|r| r.remote_version.map(|v| (r.id, v)))
+            .collect(),
+        Err(_) => {
+            homeboy::log_status!(
+                "status",
+                "Warning: could not fetch remote versions for project '{}' — showing local data only",
+                project_id
+            );
+            std::collections::HashMap::new()
+        }
+    }
+}
+
+/// Log a human-readable table to stderr.
+fn log_dashboard_table(rows: &[ProjectStatusRow]) {
+    if rows.is_empty() || !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return;
+    }
+
+    // Calculate column widths
+    let id_width = rows
+        .iter()
+        .map(|r| r.component_id.len())
+        .max()
+        .unwrap_or(9)
+        .max(9);
+    let local_width = rows
+        .iter()
+        .map(|r| r.local_version.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let remote_width = rows
+        .iter()
+        .map(|r| r.remote_version.as_deref().unwrap_or("-").len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+
+    // Header
+    eprintln!(
+        "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:>10}  {}",
+        "Component",
+        "Local",
+        "Remote",
+        "Unreleased",
+        "Status",
+        id_w = id_width,
+        local_w = local_width,
+        remote_w = remote_width,
+    );
+    eprintln!(
+        "{:-<id_w$}  {:-<local_w$}  {:-<remote_w$}  {:->10}  {:-<10}",
+        "",
+        "",
+        "",
+        "",
+        "",
+        id_w = id_width,
+        local_w = local_width,
+        remote_w = remote_width,
+    );
+
+    for row in rows {
+        let local = row.local_version.as_deref().unwrap_or("-");
+        let remote = row.remote_version.as_deref().unwrap_or("-");
+        let status_icon = match &row.status {
+            ProjectComponentDashboardStatus::Current => "✅ current",
+            ProjectComponentDashboardStatus::Outdated => "⚠️  outdated",
+            ProjectComponentDashboardStatus::NeedsBump => "🔶 needs bump",
+            ProjectComponentDashboardStatus::DocsOnly => "📝 docs only",
+            ProjectComponentDashboardStatus::Uncommitted => "🔴 uncommitted",
+            ProjectComponentDashboardStatus::Unknown => "❓ unknown",
+        };
+
+        eprintln!(
+            "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:>10}  {}",
+            row.component_id,
+            local,
+            remote,
+            row.unreleased_commits,
+            status_icon,
+            id_w = id_width,
+            local_w = local_width,
+            remote_w = remote_width,
+        );
+    }
 }

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -15,6 +15,7 @@ pub use types::{
     DeployOrchestrationResult, DeployReason, DeploySummary, MultiDeployResult, MultiDeploySummary,
     ProjectDeployResult, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
 };
+pub use version_overrides::fetch_remote_versions;
 
 use crate::component;
 use crate::context::resolve_project_ssh_with_base_path;

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -433,3 +433,304 @@ pub(super) fn run_post_deploy_hooks(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_artifact_is_fresh_some_p_p() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_none_return_false() {
+        let component = Default::default();
+        let result = artifact_is_fresh(&component);
+        assert!(!result, "expected false when: None => return false,");
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_ok_p_p() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_err_return_false_artifact_doesn_t_exist_yet() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_ok_t_t() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_err_return_false() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_some_ts() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_ok_s_s() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_err_return_false() {
+        let component = Default::default();
+        let _result = artifact_is_fresh(&component);
+    }
+
+    #[test]
+    fn test_artifact_is_fresh_none_return_false() {
+        let component = Default::default();
+        let result = artifact_is_fresh(&component);
+        assert!(!result, "expected false when: None => return false,");
+    }
+
+    #[test]
+    fn test_is_self_deploy_some_p_p() {
+        let component = Default::default();
+        let _result = is_self_deploy(&component);
+    }
+
+    #[test]
+    fn test_is_self_deploy_none_return_false() {
+        let component = Default::default();
+        let result = is_self_deploy(&component);
+        assert!(!result, "expected false when: None => return false,");
+    }
+
+    #[test]
+    fn test_is_self_deploy_match_exe_name() {
+        let component = Default::default();
+        let _result = is_self_deploy(&component);
+    }
+
+    #[test]
+    fn test_prefer_installed_binary_default_path() {
+        let build_artifact = Path::new("");
+        let _result = prefer_installed_binary(&build_artifact);
+    }
+
+    #[test]
+    fn test_prefer_installed_binary_exe_path_build_artifact() {
+        let build_artifact = Path::new("");
+        let result = prefer_installed_binary(&build_artifact);
+        assert!(
+            result.is_none(),
+            "expected None for: exe_path == build_artifact"
+        );
+    }
+
+    #[test]
+    fn test_prefer_installed_binary_exe_path_build_artifact() {
+        let build_artifact = Path::new("");
+        let _result = prefer_installed_binary(&build_artifact);
+    }
+
+    #[test]
+    fn test_prefer_installed_binary_exe_path_build_artifact() {
+        let build_artifact = Path::new("");
+        let _result = prefer_installed_binary(&build_artifact);
+    }
+
+    #[test]
+    fn test_prefer_installed_binary_some_exe_path() {
+        let build_artifact = Path::new("");
+        let result = prefer_installed_binary(&build_artifact);
+        let inner = result.expect("expected Some for: Some(exe_path)");
+        // Branch returns Some(exe_path)
+        let _ = inner; // TODO: assert value matches "exe_path"
+    }
+
+    #[test]
+    fn test_prefer_installed_binary_else() {
+        let build_artifact = Path::new("");
+        let result = prefer_installed_binary(&build_artifact);
+        assert!(result.is_none(), "expected None for: else");
+    }
+
+    #[test]
+    fn test_prefer_installed_binary_has_expected_effects() {
+        // Expected effects: logging
+        let build_artifact = Path::new("");
+        let _ = prefer_installed_binary(&build_artifact);
+    }
+
+    #[test]
+    fn test_fetch_remote_versions_if_let_some_ver_fetch_version_from_file_component_base_path_() {
+        let result = fetch_remote_versions();
+        assert!(result.is_ok(), "expected Ok for: if let Some(ver) = fetch_version_from_file(component, base_path, client) {");
+    }
+
+    #[test]
+    fn test_fetch_remote_versions_if_let_some_ver_fetch_version_from_binary_component_client() {
+        let result = fetch_remote_versions();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: if let Some(ver) = fetch_version_from_binary(component, client) {"
+        );
+    }
+
+    #[test]
+    fn test_fetch_remote_versions_has_expected_effects() {
+        // Expected effects: mutation
+
+        let _ = fetch_remote_versions();
+    }
+
+    #[test]
+    fn test_find_deploy_verification_target_path_contains_verification_path_pattern() {
+        let target_path = "";
+        let result = find_deploy_verification(&target_path);
+        let inner =
+            result.expect("expected Some for: target_path.contains(&verification.path_pattern)");
+        // Branch returns Some(verification.clone()
+        assert_eq!(inner.path_pattern, String::new());
+        assert_eq!(inner.verify_command, None);
+        assert_eq!(inner.verify_error_message, None);
+    }
+
+    #[test]
+    fn test_find_deploy_verification_target_path_contains_verification_path_pattern() {
+        let target_path = "";
+        let result = find_deploy_verification(&target_path);
+        assert!(
+            result.is_none(),
+            "expected None for: target_path.contains(&verification.path_pattern)"
+        );
+    }
+
+    #[test]
+    fn test_find_deploy_override_target_path_contains_override_config_path_pattern() {
+        let result = find_deploy_override();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: target_path.contains(&override_config.path_pattern)"
+        );
+    }
+
+    #[test]
+    fn test_find_deploy_override_target_path_contains_override_config_path_pattern() {
+        let result = find_deploy_override();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: target_path.contains(&override_config.path_pattern)"
+        );
+    }
+
+    #[test]
+    fn test_deploy_with_override_some_local_path_display_to_string() {
+        let result = deploy_with_override();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: Some(local_path.display().to_string()),"
+        );
+    }
+
+    #[test]
+    fn test_deploy_with_override_default_path() {
+        let result = deploy_with_override();
+        assert!(result.is_ok(), "expected Ok for: default path");
+    }
+
+    #[test]
+    fn test_deploy_with_override_default_path() {
+        let result = deploy_with_override();
+        assert!(result.is_ok(), "expected Ok for: default path");
+    }
+
+    #[test]
+    fn test_deploy_with_override_upload_result_success() {
+        let result = deploy_with_override();
+        assert!(result.is_ok(), "expected Ok for: !upload_result.success");
+    }
+
+    #[test]
+    fn test_deploy_with_override_if_let_some_cleanup_cmd_template_override_config_cleanup_com() {
+        let result = deploy_with_override();
+        assert!(result.is_ok(), "expected Ok for: if let Some(cleanup_cmd_template) = &override_config.cleanup_command {");
+    }
+
+    #[test]
+    fn test_deploy_with_override_override_config_skip_permissions_fix() {
+        let result = deploy_with_override();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: !override_config.skip_permissions_fix"
+        );
+    }
+
+    #[test]
+    fn test_deploy_with_override_if_let_some_v_verification() {
+        let result = deploy_with_override();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: if let Some(v) = verification {"
+        );
+    }
+
+    #[test]
+    fn test_deploy_with_override_let_some_v_verification() {
+        let result = deploy_with_override();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: let Some(v) = verification"
+        );
+    }
+
+    #[test]
+    fn test_deploy_with_override_default_path() {
+        let result = deploy_with_override();
+        assert!(result.is_ok(), "expected Ok for: default path");
+    }
+
+    #[test]
+    fn test_deploy_with_override_ok_deployresult_success_0() {
+        let result = deploy_with_override();
+        assert!(
+            result.is_ok(),
+            "expected Ok for: Ok(DeployResult::success(0))"
+        );
+    }
+
+    #[test]
+    fn test_deploy_with_override_has_expected_effects() {
+        // Expected effects: logging, mutation
+
+        let _ = deploy_with_override();
+    }
+
+    #[test]
+    fn test_run_post_deploy_hooks_ok_result() {
+        let result = run_post_deploy_hooks();
+        assert!(result.is_ok(), "expected Ok for: Ok(result) => {");
+    }
+
+    #[test]
+    fn test_run_post_deploy_hooks_err_e() {
+        let result = run_post_deploy_hooks();
+        assert!(result.is_ok(), "expected Ok for: Err(e) => {");
+    }
+
+    #[test]
+    fn test_run_post_deploy_hooks_has_expected_effects() {
+        // Expected effects: logging, mutation
+
+        let _ = run_post_deploy_hooks();
+    }
+}

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -112,7 +112,7 @@ pub(super) fn prefer_installed_binary(build_artifact: &Path) -> Option<std::path
 }
 
 /// Fetch versions from remote server for components.
-pub(super) fn fetch_remote_versions(
+pub fn fetch_remote_versions(
     components: &[Component],
     base_path: &str,
     client: &SshClient,


### PR DESCRIPTION
## Summary

Closes #919

Adds `homeboy status <project-id>` — a single command to see version drift across all components in a project.

## What it does

```bash
homeboy status chubes-site
```

Shows per-component:
- **Local version** — from version targets (Cargo.toml, plugin.php, etc.)
- **Remote version** — fetched via SSH from deployed server
- **Unreleased commits** — commits since last version tag
- **Status** — current, outdated, needs_bump, docs_only, uncommitted, unknown

### Example JSON output
```json
{
  "command": "status",
  "project_id": "chubes-site",
  "components": [
    {
      "component_id": "data-machine",
      "local_version": "0.55.2",
      "remote_version": "0.54.0",
      "unreleased_commits": 0,
      "status": "outdated"
    }
  ],
  "summary": { "current": 0, "outdated": 1, "needs_bump": 0, ... }
}
```

### Filters
- `--outdated` — only components where local != remote
- `--needs-bump` — only components with unreleased code commits
- `--uncommitted` — only components with dirty working trees
- `--docs-only` — only components with docs-only changes
- `--ready` — only current/clean components

### Human-readable table (stderr)
When running in a terminal, a formatted table is printed to stderr alongside the JSON.

## Implementation

- Reuses `deploy::run()` in check mode for remote version fetching — keeps SSH plumbing encapsulated
- Exposes `fetch_remote_versions` as public API from deploy module
- Gracefully degrades when SSH is unavailable (shows local data only)
- Existing `homeboy status` behavior (component bucketing) is preserved when no project is specified

## Changes
- `src/commands/status.rs` — new `project` positional arg, `ProjectDashboardOutput` types, dashboard logic, table renderer
- `src/core/deploy/mod.rs` — re-export `fetch_remote_versions`
- `src/core/deploy/version_overrides.rs` — promote `fetch_remote_versions` to `pub`