### PR TITLE
feat: batch version bump for multiple components

### DIFF
--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -1,15 +1,32 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::release::{self, ReleaseCommandInput, ReleaseCommandResult};
+use homeboy::component;
+use homeboy::deploy::{self, ReleaseStateStatus};
+use homeboy::project;
+use homeboy::release::{
+    self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult,
+};
 
-use super::utils::args::{DryRunArgs, HiddenJsonArgs, PositionalComponentArgs};
+use super::utils::args::{DryRunArgs, HiddenJsonArgs};
 use super::CmdResult;
 
 #[derive(Args)]
 pub struct ReleaseArgs {
-    #[command(flatten)]
-    comp: PositionalComponentArgs,
+    /// Component ID(s) to release
+    pub components: Vec<String>,
+
+    /// Release all components in a project that need a version bump
+    #[arg(long, short = 'p')]
+    pub project: Option<String>,
+
+    /// Only release components with unreleased code commits (use with --project)
+    #[arg(long)]
+    pub outdated: bool,
+
+    /// Override local_path for version file lookup (single component only)
+    #[arg(long)]
+    pub path: Option<String>,
 
     #[command(flatten)]
     dry_run_args: DryRunArgs,
@@ -46,17 +63,200 @@ pub struct ReleaseOutput {
     pub result: ReleaseCommandResult,
 }
 
-pub fn run(args: ReleaseArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<ReleaseOutput> {
-    let (result, exit_code) = release::run_command(ReleaseCommandInput {
-        component_id: args.comp.id().to_string(),
-        path_override: args.comp.path.clone(),
+#[derive(Serialize)]
+#[serde(tag = "command", rename = "release.batch")]
+pub struct BatchReleaseOutput {
+    pub result: BatchReleaseResult,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum ReleaseCommandOutput {
+    Single(ReleaseOutput),
+    Batch(BatchReleaseOutput),
+}
+
+impl ReleaseArgs {
+    /// Construct ReleaseArgs programmatically (used by `version bump` delegation).
+    pub fn from_parts(
+        components: Vec<String>,
+        project: Option<String>,
+        outdated: bool,
+        path: Option<String>,
+        dry_run: bool,
+        deploy: bool,
+        recover: bool,
+        skip_checks: bool,
+        major: bool,
+        skip_publish: bool,
+    ) -> Self {
+        Self {
+            components,
+            project,
+            outdated,
+            path,
+            dry_run_args: DryRunArgs { dry_run },
+            _json: HiddenJsonArgs::default(),
+            deploy,
+            recover,
+            skip_checks,
+            major,
+            skip_publish,
+        }
+    }
+}
+
+pub fn run(
+    args: ReleaseArgs,
+    _global: &crate::commands::GlobalArgs,
+) -> CmdResult<ReleaseCommandOutput> {
+    let component_ids = resolve_component_ids(&args)?;
+
+    // Single component: use the original single-release flow
+    if component_ids.len() == 1 {
+        let component_id = &component_ids[0];
+        let (result, exit_code) = release::run_command(ReleaseCommandInput {
+            component_id: component_id.clone(),
+            path_override: args.path.clone(),
+            dry_run: args.dry_run_args.dry_run,
+            deploy: args.deploy,
+            recover: args.recover,
+            skip_checks: args.skip_checks,
+            major: args.major,
+            skip_publish: args.skip_publish,
+        })?;
+
+        return Ok((
+            ReleaseCommandOutput::Single(ReleaseOutput { result }),
+            exit_code,
+        ));
+    }
+
+    // Multiple components: batch release
+    if args.path.is_some() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "path",
+            "--path is not supported for batch releases (multiple components)",
+            None,
+            None,
+        ));
+    }
+    if args.recover {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "recover",
+            "--recover is not supported for batch releases — run recovery per-component",
+            None,
+            None,
+        ));
+    }
+
+    let input_template = ReleaseCommandInput {
+        component_id: String::new(), // overridden per component
+        path_override: None,
         dry_run: args.dry_run_args.dry_run,
         deploy: args.deploy,
-        recover: args.recover,
+        recover: false,
         skip_checks: args.skip_checks,
         major: args.major,
         skip_publish: args.skip_publish,
-    })?;
+    };
 
-    Ok((ReleaseOutput { result }, exit_code))
+    let batch_result = release::run_batch(&component_ids, &input_template);
+    let exit_code = if batch_result.summary.failed > 0 { 1 } else { 0 };
+
+    Ok((
+        ReleaseCommandOutput::Batch(BatchReleaseOutput {
+            result: batch_result,
+        }),
+        exit_code,
+    ))
+}
+
+/// Resolve which components to release from CLI arguments.
+///
+/// Priority:
+/// 1. `--project <id>` + `--outdated` — components with unreleased code commits
+/// 2. `--project <id>` — all components in the project that need a bump
+/// 3. Positional component IDs
+fn resolve_component_ids(args: &ReleaseArgs) -> homeboy::Result<Vec<String>> {
+    if let Some(ref project_id) = args.project {
+        let proj = project::load(project_id)?;
+        let components = project::resolve_project_components(&proj)?;
+
+        if components.is_empty() {
+            return Err(homeboy::Error::validation_invalid_argument(
+                "project",
+                format!("Project '{}' has no components attached", project_id),
+                Some(project_id.to_string()),
+                None,
+            ));
+        }
+
+        // Filter to components that need releasing
+        let releasable: Vec<String> = components
+            .iter()
+            .filter(|c| {
+                let state = deploy::calculate_release_state(c);
+                let status = state
+                    .as_ref()
+                    .map(|s| s.status())
+                    .unwrap_or(ReleaseStateStatus::Unknown);
+
+                if args.outdated {
+                    // --outdated: only components with unreleased code commits
+                    matches!(status, ReleaseStateStatus::NeedsBump)
+                } else {
+                    // Without --outdated: anything that's not clean
+                    matches!(
+                        status,
+                        ReleaseStateStatus::NeedsBump | ReleaseStateStatus::DocsOnly
+                    )
+                }
+            })
+            .map(|c| c.id.clone())
+            .collect();
+
+        if releasable.is_empty() {
+            let filter_desc = if args.outdated {
+                "with unreleased code commits"
+            } else {
+                "that need a version bump"
+            };
+            return Err(homeboy::Error::validation_invalid_argument(
+                "project",
+                format!(
+                    "No components {} in project '{}'",
+                    filter_desc, project_id
+                ),
+                Some(project_id.to_string()),
+                Some(vec![format!(
+                    "Check with: homeboy status {}",
+                    project_id
+                )]),
+            ));
+        }
+
+        homeboy::log_status!(
+            "release",
+            "Resolved {} component(s) from project '{}': {}",
+            releasable.len(),
+            project_id,
+            releasable.join(", ")
+        );
+
+        return Ok(releasable);
+    }
+
+    // Positional component IDs
+    if args.components.is_empty() {
+        // Try CWD-based component detection
+        match component::resolve_effective(None, None, None) {
+            Ok(comp) => Ok(vec![comp.id]),
+            Err(_) => Err(homeboy::Error::validation_missing_argument(vec![
+                "component ID(s), or --project <project-id>".to_string(),
+            ])),
+        }
+    } else {
+        Ok(args.components.clone())
+    }
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -2,10 +2,10 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::component;
-use homeboy::release::{self, ReleaseCommandInput, ReleaseCommandResult};
+use homeboy::release::{BatchReleaseResult, ReleaseCommandResult};
 use homeboy::version::{read_component_version, read_version, VersionTargetInfo};
 
-use super::utils::args::{DryRunArgs, HiddenJsonArgs, PositionalComponentArgs};
+use super::utils::args::{DryRunArgs, HiddenJsonArgs};
 use super::CmdResult;
 
 #[derive(Serialize)]
@@ -13,6 +13,7 @@ use super::CmdResult;
 pub enum VersionOutput {
     Show(VersionShowOutput),
     Bump(VersionBumpOutput),
+    BatchBump(VersionBatchBumpOutput),
 }
 
 #[derive(Args)]
@@ -35,8 +36,20 @@ enum VersionCommand {
 
     /// Bump version and release (alias for `homeboy release`)
     Bump {
-        #[command(flatten)]
-        comp: PositionalComponentArgs,
+        /// Component ID(s) to release
+        components: Vec<String>,
+
+        /// Release all components in a project that need a version bump
+        #[arg(long, short = 'p')]
+        project: Option<String>,
+
+        /// Only release components with unreleased code commits (use with --project)
+        #[arg(long)]
+        outdated: bool,
+
+        /// Override local_path for version file lookup (single component only)
+        #[arg(long)]
+        path: Option<String>,
 
         #[command(flatten)]
         dry_run_args: DryRunArgs,
@@ -83,6 +96,12 @@ pub struct VersionBumpOutput {
     pub result: ReleaseCommandResult,
 }
 
+#[derive(Serialize)]
+#[serde(tag = "command", rename = "release.batch")]
+pub struct VersionBatchBumpOutput {
+    pub result: BatchReleaseResult,
+}
+
 pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<VersionOutput> {
     match args.command {
         VersionCommand::Show { component_id, path } => {
@@ -124,7 +143,10 @@ pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
             ))
         }
         VersionCommand::Bump {
-            comp,
+            components,
+            project,
+            outdated,
+            path,
             dry_run_args,
             _json: _,
             deploy,
@@ -133,18 +155,28 @@ pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
             major,
             skip_publish,
         } => {
-            let (result, exit_code) = release::run_command(ReleaseCommandInput {
-                component_id: comp.id().to_string(),
-                path_override: comp.path.clone(),
-                dry_run: dry_run_args.dry_run,
+            // Delegate to the release command's batch infrastructure
+            let release_args = super::release::ReleaseArgs::from_parts(
+                components,
+                project,
+                outdated,
+                path,
+                dry_run_args.dry_run,
                 deploy,
                 recover,
                 skip_checks,
                 major,
                 skip_publish,
-            })?;
+            );
 
-            Ok((VersionOutput::Bump(VersionBumpOutput { result }), exit_code))
+            match super::release::run(release_args, _global)? {
+                (super::release::ReleaseCommandOutput::Single(output), exit_code) => {
+                    Ok((VersionOutput::Bump(VersionBumpOutput { result: output.result }), exit_code))
+                }
+                (super::release::ReleaseCommandOutput::Batch(output), exit_code) => {
+                    Ok((VersionOutput::BatchBump(VersionBatchBumpOutput { result: output.result }), exit_code))
+                }
+            }
         }
     }
 }

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -9,9 +9,10 @@ mod workflow;
 
 pub use pipeline::{plan, run};
 pub use types::{
-    ReleaseArtifact, ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult,
-    ReleaseDeploymentSummary, ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep,
-    ReleaseProjectDeployResult, ReleaseRun,
+    BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
+    ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
+    ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep, ReleaseProjectDeployResult,
+    ReleaseRun,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
-pub use workflow::run_command;
+pub use workflow::{run_batch, run_command};

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -223,3 +223,30 @@ pub struct ReleaseCommandResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployment: Option<ReleaseDeploymentResult>,
 }
+
+/// Result of a batch release across multiple components.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchReleaseResult {
+    pub results: Vec<BatchReleaseComponentResult>,
+    pub summary: BatchReleaseSummary,
+}
+
+/// Per-component result within a batch release.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchReleaseComponentResult {
+    pub component_id: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<ReleaseCommandResult>,
+}
+
+/// Summary counts for a batch release.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchReleaseSummary {
+    pub total: u32,
+    pub released: u32,
+    pub skipped: u32,
+    pub failed: u32,
+}

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -5,8 +5,9 @@ use crate::git;
 
 use super::pipeline::load_component;
 use super::types::{
-    ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
-    ReleaseOptions, ReleasePlan, ReleaseProjectDeployResult, ReleaseRun,
+    BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseCommandInput,
+    ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary, ReleaseOptions,
+    ReleasePlan, ReleaseProjectDeployResult, ReleaseRun,
 };
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
@@ -530,6 +531,98 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
         },
         0,
     ))
+}
+
+/// Run releases for multiple components sequentially.
+///
+/// Continue-on-error: if one component fails, the rest still run.
+/// Each component releases independently (own tag, own push).
+pub fn run_batch(component_ids: &[String], input_template: &ReleaseCommandInput) -> BatchReleaseResult {
+    let mut results = Vec::new();
+    let mut released: u32 = 0;
+    let mut skipped: u32 = 0;
+    let mut failed: u32 = 0;
+
+    for component_id in component_ids {
+        log_status!(
+            "release",
+            "--- Releasing '{}' ({}/{}) ---",
+            component_id,
+            results.len() + 1,
+            component_ids.len()
+        );
+
+        let input = ReleaseCommandInput {
+            component_id: component_id.clone(),
+            path_override: None,
+            dry_run: input_template.dry_run,
+            deploy: input_template.deploy,
+            recover: input_template.recover,
+            skip_checks: input_template.skip_checks,
+            major: input_template.major,
+            skip_publish: input_template.skip_publish,
+        };
+
+        match run_command(input) {
+            Ok((result, _exit_code)) => {
+                let was_skipped = result.skipped_reason.is_some();
+                let status = if was_skipped {
+                    skipped += 1;
+                    "skipped"
+                } else {
+                    released += 1;
+                    "released"
+                };
+
+                results.push(BatchReleaseComponentResult {
+                    component_id: component_id.clone(),
+                    status: status.to_string(),
+                    error: None,
+                    result: Some(result),
+                });
+            }
+            Err(e) => {
+                log_status!(
+                    "release",
+                    "Failed to release '{}': {}",
+                    component_id,
+                    e
+                );
+                failed += 1;
+                results.push(BatchReleaseComponentResult {
+                    component_id: component_id.clone(),
+                    status: "failed".to_string(),
+                    error: Some(e.to_string()),
+                    result: None,
+                });
+            }
+        }
+    }
+
+    let total = results.len() as u32;
+
+    // Log summary
+    if total > 1 {
+        log_status!("release", "--- Batch summary ---");
+        log_status!(
+            "release",
+            "{} component(s): {} released, {} skipped, {} failed",
+            total,
+            released,
+            skipped,
+            failed
+        );
+    }
+
+    BatchReleaseResult {
+        results,
+        summary: BatchReleaseSummary {
+            total,
+            released,
+            skipped,
+            failed,
+        },
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes #917

Support releasing multiple components in one command instead of N separate invocations.

## Usage

### Multiple positional component IDs
```bash
homeboy release data-machine data-machine-events extrachill-events --skip-checks --deploy
homeboy version bump dm dm-events --skip-checks --deploy
```

### Project-scoped batch
```bash
# Release all components in a project that need a version bump
homeboy release --project extrachill-site --skip-checks --deploy

# Only release components with unreleased code commits
homeboy release --project extrachill-site --outdated --skip-checks --deploy
```

### Single component (unchanged behavior)
```bash
homeboy release data-machine --skip-checks --deploy
homeboy version bump data-machine --skip-checks
```

## How it works

- **Continue-on-error**: if component A fails, B and C still run (like deploy multi)
- **Each component releases independently**: own bump analysis, own tag, own push
- **`--project <id>`** resolves components from the project that have `needs_bump` or `docs_only` release state
- **`--project <id> --outdated`** filters to only components with unreleased code commits (`needs_bump`)
- **`--path` and `--recover`** are blocked for batch mode (single-component only)
- **CWD-based component detection** preserved for zero-arg usage
- **`version bump`** delegates to the release command's batch infrastructure (no duplication)

## Example output (batch)
```json
{
  "command": "release.batch",
  "result": {
    "results": [
      { "component_id": "data-machine", "status": "skipped", "result": { ... } },
      { "component_id": "homeboy", "status": "failed", "error": "..." }
    ],
    "summary": { "total": 2, "released": 0, "skipped": 1, "failed": 1 }
  }
}
```

## Changes
- `src/commands/release.rs` — multiple positional args, `--project`/`--outdated` flags, batch orchestration
- `src/commands/version.rs` — `version bump` delegates to release for batch support
- `src/core/release/workflow.rs` — `run_batch()` iterates components with continue-on-error
- `src/core/release/types.rs` — `BatchReleaseResult`, `BatchReleaseComponentResult`, `BatchReleaseSummary`
- `src/core/release/mod.rs` — export new types and `run_batch`

## Testing
- Build: ✅ clean (only pre-existing warnings)
- Binary tests: ✅ 25/25 pass
- Lib tests: ❌ pre-existing failures in `version_overrides.rs` (auto-generated tests with duplicate names — present on main before this PR)
- Smoke tested: single component, multi-component positional, `--project`, `--project --outdated`, `--path` with batch (correctly rejected), CWD detection