### PR TITLE
feat: enhance fleet status with observability dashboard

### DIFF
--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -1,9 +1,8 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::fleet::{self, Fleet};
+use homeboy::fleet::{self, Fleet, FleetComponentDrift, FleetStatusResult};
 use homeboy::project::Project;
-use homeboy::server::health::ServerHealth;
 use homeboy::EntityCrudOutput;
 
 use super::{CmdResult, DynamicSetArgs};
@@ -124,7 +123,7 @@ pub struct FleetExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub components: Option<std::collections::HashMap<String, Vec<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<Vec<FleetProjectStatus>>,
+    pub status: Option<FleetStatusResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub check: Option<Vec<homeboy::fleet::FleetProjectCheck>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -136,26 +135,6 @@ pub struct FleetExtra {
 }
 
 pub type FleetOutput = EntityCrudOutput<Fleet, FleetExtra>;
-
-#[derive(Debug, Default, Serialize)]
-pub struct FleetProjectStatus {
-    pub project_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub server_id: Option<String>,
-    pub components: Vec<FleetComponentStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub health: Option<ServerHealth>,
-}
-
-#[derive(Debug, Default, Serialize)]
-pub struct FleetComponentStatus {
-    pub component_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    /// Where the version was resolved from: "live" (SSH) or "cached" (local file)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version_source: Option<String>,
-}
 
 pub fn run(args: FleetArgs, _global: &super::GlobalArgs) -> CmdResult<FleetOutput> {
     match args.command {
@@ -357,36 +336,128 @@ fn components(id: &str) -> CmdResult<FleetOutput> {
 }
 
 fn status(id: &str, cached: bool, health_only: bool) -> CmdResult<FleetOutput> {
-    let project_statuses = fleet::collect_status(id, cached, health_only)?
-        .into_iter()
-        .map(|status| FleetProjectStatus {
-            project_id: status.project_id,
-            server_id: status.server_id,
-            components: status
-                .components
-                .into_iter()
-                .map(|component| FleetComponentStatus {
-                    component_id: component.component_id,
-                    version: component.version,
-                    version_source: component.version_source,
-                })
-                .collect(),
-            health: status.health,
-        })
-        .collect();
+    let result = fleet::collect_status(id, cached, health_only)?;
+
+    // Log human-readable dashboard to stderr
+    log_fleet_dashboard(&result);
+
+    let exit_code = if result.summary.servers.unreachable > 0
+        || result.summary.servers.services_down > 0
+    {
+        1
+    } else {
+        0
+    };
 
     Ok((
         FleetOutput {
             command: "fleet.status".to_string(),
             id: Some(id.to_string()),
             extra: FleetExtra {
-                status: Some(project_statuses),
+                status: Some(result),
                 ..Default::default()
             },
             ..Default::default()
         },
-        0,
+        exit_code,
     ))
+}
+
+/// Log a human-readable fleet status dashboard to stderr.
+fn log_fleet_dashboard(result: &FleetStatusResult) {
+    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return;
+    }
+
+    let summary = &result.summary;
+
+    // Fleet summary header
+    eprintln!("┌─── Fleet Status ───────────────────────────────────┐");
+    eprintln!(
+        "│ Servers: {} healthy, {} warning, {} unreachable      ",
+        summary.servers.healthy, summary.servers.warning, summary.servers.unreachable,
+    );
+    if summary.servers.services_up > 0 || summary.servers.services_down > 0 {
+        eprintln!(
+            "│ Services: {} up, {} down                             ",
+            summary.servers.services_up, summary.servers.services_down,
+        );
+    }
+    eprintln!(
+        "│ Components: {} current, {} outdated, {} need bump, {} unknown",
+        summary.components.current,
+        summary.components.needs_update,
+        summary.components.needs_bump,
+        summary.components.unknown,
+    );
+    eprintln!("└────────────────────────────────────────────────────┘");
+
+    // Per-project component table
+    for proj_status in &result.projects {
+        if proj_status.components.is_empty() {
+            continue;
+        }
+
+        let server_label = proj_status
+            .server_id
+            .as_deref()
+            .unwrap_or("unknown");
+
+        // Health indicator
+        let health_icon = match &proj_status.health {
+            Some(h) if h.warnings.is_empty() => "✅",
+            Some(_) => "⚠️ ",
+            None => "❌",
+        };
+
+        eprintln!(
+            "\n{} {} ({})",
+            health_icon, proj_status.project_id, server_label,
+        );
+
+        // Component rows
+        let id_width = proj_status
+            .components
+            .iter()
+            .map(|c| c.component_id.len())
+            .max()
+            .unwrap_or(9)
+            .max(9);
+
+        for comp in &proj_status.components {
+            let local = comp.local_version.as_deref().unwrap_or("-");
+            let remote = comp.remote_version.as_deref().unwrap_or("-");
+            let drift_icon = match &comp.drift {
+                FleetComponentDrift::Current => "✅ current",
+                FleetComponentDrift::NeedsUpdate => "⚠️  outdated",
+                FleetComponentDrift::BehindRemote => "🔙 behind",
+                FleetComponentDrift::NeedsBump => "🔶 needs bump",
+                FleetComponentDrift::DocsOnly => "📝 docs only",
+                FleetComponentDrift::Unknown => "❓ unknown",
+            };
+
+            eprintln!(
+                "  {:<w$}  {} → {}  ({} unreleased)  {}",
+                comp.component_id,
+                local,
+                remote,
+                comp.unreleased_commits,
+                drift_icon,
+                w = id_width,
+            );
+        }
+    }
+
+    // Warnings
+    if !summary.warnings.is_empty() {
+        eprintln!("\n⚠️  Warnings:");
+        for warning in &summary.warnings {
+            eprintln!(
+                "  {} ({}): {}",
+                warning.server_id, warning.project_id, warning.message,
+            );
+        }
+    }
 }
 
 fn check(id: &str, only_outdated: bool) -> CmdResult<FleetOutput> {

--- a/src/core/fleet/mod.rs
+++ b/src/core/fleet/mod.rs
@@ -10,7 +10,11 @@ pub mod status;
 
 pub use check::{collect_check, FleetCheckSummary, FleetComponentCheck, FleetProjectCheck};
 pub use exec::{collect_exec, FleetExecProjectResult, FleetExecSummary};
-pub use status::{collect_status, FleetComponentStatus, FleetProjectStatus};
+pub use status::{
+    collect_status, FleetComponentDrift, FleetComponentStatus, FleetComponentSummary,
+    FleetProjectStatus, FleetProjectSummary, FleetServerSummary, FleetStatusResult,
+    FleetStatusSummary, FleetWarning,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Fleet {

--- a/src/core/fleet/status.rs
+++ b/src/core/fleet/status.rs
@@ -1,14 +1,44 @@
-use crate::deploy::{self, DeployConfig};
+use std::collections::HashMap;
+
+use crate::deploy::{self, DeployConfig, ReleaseStateStatus};
 use crate::project;
 use crate::server::health::{self, ServerHealth};
 use crate::version;
 use serde::Serialize;
 
+// ============================================================================
+// Types
+// ============================================================================
+
 #[derive(Debug, Clone, Serialize)]
 pub struct FleetComponentStatus {
     pub component_id: String,
-    pub version: Option<String>,
-    pub version_source: Option<String>,
+    pub local_version: Option<String>,
+    pub remote_version: Option<String>,
+    /// Where the version was resolved from: "live" (SSH) or "cached" (local file)
+    pub version_source: String,
+    /// Component drift status
+    pub drift: FleetComponentDrift,
+    /// Number of unreleased commits since last version tag
+    pub unreleased_commits: u32,
+}
+
+/// Component drift status within the fleet.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetComponentDrift {
+    /// Local and remote versions match
+    Current,
+    /// Local version is ahead of remote (needs deploy)
+    NeedsUpdate,
+    /// Remote version is ahead of local
+    BehindRemote,
+    /// Has unreleased code commits (needs version bump)
+    NeedsBump,
+    /// Only docs changes since last tag
+    DocsOnly,
+    /// Cannot determine
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -19,119 +49,357 @@ pub struct FleetProjectStatus {
     pub health: Option<ServerHealth>,
 }
 
+/// Fleet-wide summary statistics.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FleetStatusSummary {
+    pub projects: FleetProjectSummary,
+    pub components: FleetComponentSummary,
+    pub servers: FleetServerSummary,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<FleetWarning>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FleetProjectSummary {
+    pub total: u32,
+    pub healthy: u32,
+    pub warning: u32,
+    pub unreachable: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FleetComponentSummary {
+    pub total: u32,
+    pub current: u32,
+    pub needs_update: u32,
+    pub needs_bump: u32,
+    pub docs_only: u32,
+    pub unknown: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FleetServerSummary {
+    pub total: u32,
+    pub healthy: u32,
+    pub warning: u32,
+    pub unreachable: u32,
+    pub services_up: u32,
+    pub services_down: u32,
+}
+
+/// A warning with its source context.
+#[derive(Debug, Clone, Serialize)]
+pub struct FleetWarning {
+    pub server_id: String,
+    pub project_id: String,
+    pub message: String,
+}
+
+/// Full fleet status result including per-project data and fleet-wide summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct FleetStatusResult {
+    pub projects: Vec<FleetProjectStatus>,
+    pub summary: FleetStatusSummary,
+}
+
+// ============================================================================
+// Collection
+// ============================================================================
+
 pub fn collect_status(
     fleet_id: &str,
     cached: bool,
     health_only: bool,
-) -> crate::Result<Vec<FleetProjectStatus>> {
+) -> crate::Result<FleetStatusResult> {
     let fl = super::load(fleet_id)?;
-    let mut project_statuses = Vec::new();
 
     if cached {
-        for project_id in &fl.project_ids {
-            let proj = match project::load(project_id) {
-                Ok(p) => p,
-                Err(_) => continue,
+        return collect_cached_status(&fl.project_ids);
+    }
+
+    // Deduplicate servers: collect health once per unique server
+    let mut server_health_cache: HashMap<String, Option<ServerHealth>> = HashMap::new();
+    let mut project_statuses = Vec::new();
+    let mut summary = FleetStatusSummary::default();
+    summary.projects.total = fl.project_ids.len() as u32;
+
+    for project_id in &fl.project_ids {
+        let proj = match project::load(project_id) {
+            Ok(p) => p,
+            Err(_) => {
+                summary.projects.unreachable += 1;
+                continue;
+            }
+        };
+
+        // Collect health (deduped by server_id)
+        let health = if let Some(ref server_id) = proj.server_id {
+            if let Some(cached_health) = server_health_cache.get(server_id) {
+                cached_health.clone()
+            } else {
+                let h = health::collect_project_health(&proj);
+                server_health_cache.insert(server_id.clone(), h.clone());
+                h
+            }
+        } else {
+            None
+        };
+
+        // Track server health in summary (only count each server once)
+        if let Some(ref server_id) = proj.server_id {
+            // Only count server stats on first encounter
+            if server_health_cache.len() as u32 > summary.servers.total
+                || !server_health_cache
+                    .keys()
+                    .take(summary.servers.total as usize)
+                    .any(|k| k == server_id)
+            {
+                // This is a newly seen server (we just inserted it above)
+            }
+        }
+
+        // Classify project health
+        match &health {
+            Some(h) if h.warnings.is_empty() => summary.projects.healthy += 1,
+            Some(h) => {
+                summary.projects.warning += 1;
+                // Aggregate warnings
+                if let Some(ref server_id) = proj.server_id {
+                    for warning_msg in &h.warnings {
+                        summary.warnings.push(FleetWarning {
+                            server_id: server_id.clone(),
+                            project_id: project_id.clone(),
+                            message: warning_msg.clone(),
+                        });
+                    }
+                }
+            }
+            None => summary.projects.unreachable += 1,
+        }
+
+        if health_only {
+            project_statuses.push(FleetProjectStatus {
+                project_id: project_id.clone(),
+                server_id: proj.server_id.clone(),
+                components: vec![],
+                health,
+            });
+            continue;
+        }
+
+        // Collect component status: version drift + release state
+        let component_statuses =
+            collect_project_component_statuses(project_id, &proj, &mut summary.components);
+
+        project_statuses.push(FleetProjectStatus {
+            project_id: project_id.clone(),
+            server_id: proj.server_id.clone(),
+            components: component_statuses,
+            health,
+        });
+    }
+
+    // Compute server summary from deduped cache
+    compute_server_summary(&server_health_cache, &project_statuses, &mut summary);
+
+    Ok(FleetStatusResult {
+        projects: project_statuses,
+        summary,
+    })
+}
+
+/// Collect cached status (local versions only, no SSH).
+fn collect_cached_status(project_ids: &[String]) -> crate::Result<FleetStatusResult> {
+    let mut project_statuses = Vec::new();
+    let mut summary = FleetStatusSummary::default();
+    summary.projects.total = project_ids.len() as u32;
+
+    for project_id in project_ids {
+        let proj = match project::load(project_id) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        summary.projects.healthy += 1; // Can't know health without SSH
+
+        let mut component_statuses = Vec::new();
+        for component_id in project::project_component_ids(&proj) {
+            let local_version = match project::resolve_project_component(&proj, &component_id) {
+                Ok(comp) => version::get_component_version(&comp),
+                Err(_) => None,
             };
 
-            let mut component_statuses = Vec::new();
-            for component_id in project::project_component_ids(&proj) {
-                let comp_version = match project::resolve_project_component(&proj, &component_id) {
+            summary.components.total += 1;
+            summary.components.unknown += 1;
+
+            component_statuses.push(FleetComponentStatus {
+                component_id,
+                local_version,
+                remote_version: None,
+                version_source: "cached".to_string(),
+                drift: FleetComponentDrift::Unknown,
+                unreleased_commits: 0,
+            });
+        }
+
+        project_statuses.push(FleetProjectStatus {
+            project_id: project_id.clone(),
+            server_id: proj.server_id.clone(),
+            components: component_statuses,
+            health: None,
+        });
+    }
+
+    Ok(FleetStatusResult {
+        projects: project_statuses,
+        summary,
+    })
+}
+
+/// Collect component statuses for a single project via deploy check mode.
+fn collect_project_component_statuses(
+    project_id: &str,
+    proj: &project::Project,
+    component_summary: &mut FleetComponentSummary,
+) -> Vec<FleetComponentStatus> {
+    let config = DeployConfig {
+        component_ids: vec![],
+        all: true,
+        outdated: false,
+        dry_run: false,
+        check: true,
+        force: false,
+        skip_build: true,
+        keep_deps: false,
+        expected_version: None,
+        no_pull: true,
+        head: true,
+    };
+
+    match deploy::run(project_id, &config) {
+        Ok(result) => {
+            let mut statuses = Vec::new();
+            for comp_result in &result.results {
+                // Get release state for this component
+                let (drift, unreleased) =
+                    resolve_component_drift(proj, &comp_result.id, &comp_result.component_status);
+
+                component_summary.total += 1;
+                match &drift {
+                    FleetComponentDrift::Current => component_summary.current += 1,
+                    FleetComponentDrift::NeedsUpdate | FleetComponentDrift::BehindRemote => {
+                        component_summary.needs_update += 1
+                    }
+                    FleetComponentDrift::NeedsBump => component_summary.needs_bump += 1,
+                    FleetComponentDrift::DocsOnly => component_summary.docs_only += 1,
+                    FleetComponentDrift::Unknown => component_summary.unknown += 1,
+                }
+
+                statuses.push(FleetComponentStatus {
+                    component_id: comp_result.id.clone(),
+                    local_version: comp_result.local_version.clone(),
+                    remote_version: comp_result.remote_version.clone(),
+                    version_source: "live".to_string(),
+                    drift,
+                    unreleased_commits: unreleased,
+                });
+            }
+            statuses
+        }
+        Err(_) => {
+            // SSH/deploy failed — fall back to local versions
+            let mut statuses = Vec::new();
+            for component_id in project::project_component_ids(proj) {
+                let local_version = match project::resolve_project_component(proj, &component_id) {
                     Ok(comp) => version::get_component_version(&comp),
                     Err(_) => None,
                 };
 
-                component_statuses.push(FleetComponentStatus {
-                    component_id: component_id.clone(),
-                    version: comp_version,
-                    version_source: Some("cached".to_string()),
+                component_summary.total += 1;
+                component_summary.unknown += 1;
+
+                statuses.push(FleetComponentStatus {
+                    component_id,
+                    local_version,
+                    remote_version: None,
+                    version_source: "cached".to_string(),
+                    drift: FleetComponentDrift::Unknown,
+                    unreleased_commits: 0,
                 });
             }
-
-            project_statuses.push(FleetProjectStatus {
-                project_id: project_id.clone(),
-                server_id: proj.server_id.clone(),
-                components: component_statuses,
-                health: None,
-            });
+            statuses
         }
-    } else {
-        for project_id in &fl.project_ids {
-            let proj = match project::load(project_id) {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
+    }
+}
 
-            let health = health::collect_project_health(&proj);
+/// Determine component drift by combining deploy status with release state.
+fn resolve_component_drift(
+    proj: &project::Project,
+    component_id: &str,
+    deploy_status: &Option<deploy::ComponentStatus>,
+) -> (FleetComponentDrift, u32) {
+    // Check release state (unreleased commits)
+    let release_info = project::resolve_project_component(proj, component_id)
+        .ok()
+        .and_then(|comp| {
+            let state = deploy::calculate_release_state(&comp)?;
+            Some((state.status(), state.commits_since_version))
+        });
 
-            if health_only {
-                project_statuses.push(FleetProjectStatus {
-                    project_id: project_id.clone(),
-                    server_id: proj.server_id.clone(),
-                    components: vec![],
-                    health,
-                });
-                continue;
+    if let Some((release_status, unreleased)) = release_info {
+        match release_status {
+            ReleaseStateStatus::NeedsBump => {
+                return (FleetComponentDrift::NeedsBump, unreleased);
             }
-
-            let config = DeployConfig {
-                component_ids: vec![],
-                all: true,
-                outdated: false,
-                dry_run: false,
-                check: true,
-                force: false,
-                skip_build: true,
-                keep_deps: false,
-                expected_version: None,
-                no_pull: true,
-                head: true,
-            };
-
-            match deploy::run(project_id, &config) {
-                Ok(result) => {
-                    let mut component_statuses = Vec::new();
-                    for comp_result in &result.results {
-                        component_statuses.push(FleetComponentStatus {
-                            component_id: comp_result.id.clone(),
-                            version: comp_result.remote_version.clone(),
-                            version_source: Some("live".to_string()),
-                        });
-                    }
-
-                    project_statuses.push(FleetProjectStatus {
-                        project_id: project_id.clone(),
-                        server_id: proj.server_id.clone(),
-                        components: component_statuses,
-                        health,
-                    });
-                }
-                Err(_) => {
-                    let mut component_statuses = Vec::new();
-                    for component_id in project::project_component_ids(&proj) {
-                        let comp_version =
-                            match project::resolve_project_component(&proj, &component_id) {
-                                Ok(comp) => version::get_component_version(&comp),
-                                Err(_) => None,
-                            };
-
-                        component_statuses.push(FleetComponentStatus {
-                            component_id: component_id.clone(),
-                            version: comp_version,
-                            version_source: Some("cached".to_string()),
-                        });
-                    }
-
-                    project_statuses.push(FleetProjectStatus {
-                        project_id: project_id.clone(),
-                        server_id: proj.server_id.clone(),
-                        components: component_statuses,
-                        health,
-                    });
-                }
+            ReleaseStateStatus::DocsOnly => {
+                return (FleetComponentDrift::DocsOnly, unreleased);
             }
+            ReleaseStateStatus::Uncommitted => {
+                // Uncommitted changes — still check deploy status
+                // but flag as needs_bump since there's local work
+                return (FleetComponentDrift::NeedsBump, unreleased);
+            }
+            _ => {}
         }
     }
 
-    Ok(project_statuses)
+    // Fall back to deploy status for drift detection
+    let drift = match deploy_status {
+        Some(deploy::ComponentStatus::UpToDate) => FleetComponentDrift::Current,
+        Some(deploy::ComponentStatus::NeedsUpdate) => FleetComponentDrift::NeedsUpdate,
+        Some(deploy::ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
+        Some(deploy::ComponentStatus::Unknown) | None => FleetComponentDrift::Unknown,
+    };
+
+    let unreleased = release_info.map(|(_, u)| u).unwrap_or(0);
+    (drift, unreleased)
+}
+
+/// Compute fleet-wide server summary from the deduped health cache.
+fn compute_server_summary(
+    health_cache: &HashMap<String, Option<ServerHealth>>,
+    _project_statuses: &[FleetProjectStatus],
+    summary: &mut FleetStatusSummary,
+) {
+    summary.servers.total = health_cache.len() as u32;
+
+    for health_opt in health_cache.values() {
+        match health_opt {
+            Some(h) => {
+                if h.warnings.is_empty() {
+                    summary.servers.healthy += 1;
+                } else {
+                    summary.servers.warning += 1;
+                }
+                for svc in &h.services {
+                    if svc.active {
+                        summary.servers.services_up += 1;
+                    } else {
+                        summary.servers.services_down += 1;
+                    }
+                }
+            }
+            None => summary.servers.unreachable += 1,
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #613

Upgrades `homeboy fleet status` from a flat version list to a full fleet observability dashboard — server health, component drift, release state, and fleet-wide summaries in one command.

## Before vs After

**Before:** `fleet status` returned `Vec<FleetProjectStatus>` with component versions and health. No summary, no drift detection, no release state, no deduplication.

**After:** Returns `FleetStatusResult` with per-project detail AND fleet-wide summary:

```json
{
  "projects": [{
    "project_id": "chubes-site",
    "server_id": "chubes-net",
    "health": { "uptime": "2 weeks", "load": {...}, "disk": {"percent": 58}, "memory": {"percent": 10} },
    "components": [{
      "component_id": "data-machine",
      "local_version": "0.55.2",
      "remote_version": "0.54.0",
      "drift": "needs_update",
      "unreleased_commits": 0,
      "version_source": "live"
    }]
  }],
  "summary": {
    "servers": { "total": 1, "healthy": 1, "warning": 0, "unreachable": 0, "services_up": 0, "services_down": 0 },
    "components": { "total": 1, "current": 0, "needs_update": 1, "needs_bump": 0, "unknown": 0 },
    "projects": { "total": 1, "healthy": 1, "warning": 0, "unreachable": 0 }
  }
}
```

### Human-readable table (stderr in terminals)
```
┌─── Fleet Status ───────────────────────────────────┐
│ Servers: 1 healthy, 0 warning, 0 unreachable
│ Services: 3 up, 0 down
│ Components: 2 current, 1 outdated, 0 need bump, 0 unknown
└────────────────────────────────────────────────────┘

✅ chubes-site (chubes-net)
  data-machine   0.55.2 → 0.54.0  (0 unreleased)  ⚠️  outdated
```

## What changed

### Core (`fleet/status.rs`)
- **Server dedup**: Health collected once per unique server_id, not per project
- **Version drift**: `FleetComponentDrift` enum (current, needs_update, behind_remote, needs_bump, docs_only, unknown)
- **Release state**: Unreleased commit count per component via `calculate_release_state()`
- **Fleet summary**: `FleetStatusSummary` with project, component, and server counts
- **Aggregated warnings**: `FleetWarning` with server_id + project_id context
- **`FleetStatusResult`**: New wrapper type combining projects + summary

### CLI (`commands/fleet.rs`)
- Removed shadow `FleetProjectStatus`/`FleetComponentStatus` types (used core types directly)
- Human-readable dashboard table to stderr
- Exit code 1 when servers unreachable or services down

### Modes preserved
- `fleet status <id>` — full live dashboard
- `fleet status <id> --cached` — local versions only, no SSH
- `fleet status <id> --health-only` — health metrics only, skip components

## Testing
- Build: ✅ clean
- Binary tests: ✅ 25/25
- Smoke tested all three modes (live, cached, health-only) against chubes-site