### PR TITLE
fix(ci): auto-refactor should run even when quality gates fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,9 +240,10 @@ jobs:
     needs:
       - check
       - gate-build
+      - gate-audit
+      - gate-lint
       - gate-test
-      - prepare
-    if: ${{ always() && needs.gate-test.result == 'success' }}
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Auto-refactor has never run in the release pipeline because it was gated on `gate-test.result == 'success'`:

```
audit fails (868 findings, always exit 1)
  → lint skipped (depends on audit)
    → test skipped (depends on lint)
      → auto-refactor skipped (requires test success)
```

The whole point of auto-refactor is to **fix what the quality gates found**. Gating it on their success means it can never run when there's work to do.

## Fix

```yaml
# Before
needs: [check, gate-build, gate-test, prepare]
if: always() && needs.gate-test.result == 'success'

# After
needs: [check, gate-build, gate-audit, gate-lint, gate-test]
if: always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success'
```

- **Only requires build success** (needs the homeboy binary)
- **Waits for all quality gates** to finish (via `needs`) but doesn't require they pass
- **Removes `prepare` dependency** — auto-refactor shouldn't wait for the release step
- Uses `always()` so skipped/failed upstream jobs don't block it

## Impact

After this merge, the next scheduled release run will actually run auto-refactor for the first time, attempting to fix audit findings automatically.