### PR TITLE
fix: deploy from clean tag clones — preserve remote_path, inherit extensions, stabilize component IDs

### DIFF
--- a/src/core/project/component/attachments.rs
+++ b/src/core/project/component/attachments.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use crate::error::{Error, Result};
 
-use super::discovery::infer_attached_component_id;
-use crate::project::{load, save, Project, ProjectComponentAttachment};
+use super::discovery::{discover_attached_component, infer_attached_component_id};
+use crate::project::{load, save, Project, ProjectComponentAttachment, ProjectComponentOverrides};
 
 fn component_ids_from_attachments(components: &[ProjectComponentAttachment]) -> Vec<String> {
     components
@@ -103,6 +103,16 @@ pub fn clear_component_attachments(project_id: &str) -> Result<Vec<String>> {
 pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &str) -> Result<()> {
     let mut project = load(project_id)?;
 
+    let is_update = project.components.iter().any(|c| c.id == component_id);
+
+    // When updating an existing component's path, preserve the current remote_path
+    // as a project override if the new path's homeboy.json doesn't provide one.
+    // This prevents clean tag clones (whose homeboy.json omits remote_path) from
+    // blanking the deploy target. (#932)
+    if is_update {
+        preserve_remote_path_on_reattach(&mut project, component_id, local_path);
+    }
+
     if let Some(component) = project.components.iter_mut().find(|c| c.id == component_id) {
         component.local_path = local_path.to_string();
     } else {
@@ -115,8 +125,181 @@ pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &
     save(&project)
 }
 
+/// When re-attaching a component to a new path, check whether the current remote_path
+/// would be lost. If the existing resolved component has a non-empty remote_path and the
+/// new path's homeboy.json doesn't provide one, store the current value as a project
+/// override so deploy config survives path changes.
+fn preserve_remote_path_on_reattach(
+    project: &mut Project,
+    component_id: &str,
+    new_local_path: &str,
+) {
+    // Already has a project-level remote_path override — nothing to preserve.
+    if let Some(overrides) = project.component_overrides.get(component_id) {
+        if overrides.remote_path.is_some() {
+            return;
+        }
+    }
+
+    // Resolve the current component to capture its remote_path.
+    let current_attachment = project.components.iter().find(|c| c.id == component_id);
+    let current_remote_path = current_attachment
+        .and_then(|a| discover_attached_component(Path::new(&a.local_path)))
+        .map(|c| c.remote_path.clone())
+        .unwrap_or_default();
+
+    if current_remote_path.trim().is_empty() {
+        return;
+    }
+
+    // Check whether the new path's homeboy.json provides a remote_path.
+    let new_remote_path = discover_attached_component(Path::new(new_local_path))
+        .map(|c| c.remote_path.clone())
+        .unwrap_or_default();
+
+    if !new_remote_path.trim().is_empty() {
+        return; // New path provides its own remote_path — no need to preserve.
+    }
+
+    // The new path would blank remote_path. Store the current value as an override.
+    crate::log_status!(
+        "project",
+        "Preserving remote_path '{}' as project override for '{}' (new path's homeboy.json omits it)",
+        current_remote_path,
+        component_id
+    );
+
+    let overrides = project
+        .component_overrides
+        .entry(component_id.to_string())
+        .or_insert_with(ProjectComponentOverrides::default);
+    overrides.remote_path = Some(current_remote_path);
+}
+
 pub fn attach_discovered_component_path(project_id: &str, local_path: &Path) -> Result<String> {
-    let component_id = infer_attached_component_id(local_path)?;
+    let inferred_id = infer_attached_component_id(local_path)?;
+
+    // When the inferred ID doesn't match any existing project component, check
+    // whether a directory-name fallback produced a version-stamped ID (e.g.
+    // "data-machine-v0402-clean" from a clone path). If an existing component
+    // whose ID is a prefix of the inferred ID exists, prefer the existing ID.
+    // This prevents component identity mutation from clone directory names. (#932)
+    let project = load(project_id)?;
+    let component_id = if has_component(&project, &inferred_id) {
+        inferred_id
+    } else {
+        find_prefix_match(&project, &inferred_id).unwrap_or(inferred_id)
+    };
+
     attach_component_path(project_id, &component_id, &local_path.to_string_lossy())?;
     Ok(component_id)
+}
+
+/// Find an existing project component whose ID is a prefix of the inferred ID.
+///
+/// When a clean clone directory name like "data-machine-v0.40.2-clean" gets slugified
+/// to "data-machine-v0402-clean", the real component ID "data-machine" is a prefix.
+/// This function detects that pattern and returns the existing component's ID.
+///
+/// Only matches if:
+/// - The existing ID is a proper prefix of the inferred ID
+/// - The character after the prefix is a separator (dash followed by 'v' + digit,
+///   or just a digit), suggesting a version/tag suffix
+fn find_prefix_match(project: &Project, inferred_id: &str) -> Option<String> {
+    let mut best_match: Option<&str> = None;
+
+    for attachment in &project.components {
+        let existing_id = &attachment.id;
+        if inferred_id.starts_with(existing_id.as_str()) && inferred_id.len() > existing_id.len() {
+            let suffix = &inferred_id[existing_id.len()..];
+            // The suffix should look like a version/clone qualifier: "-v...", "-0...", etc.
+            if suffix.starts_with('-') {
+                let after_dash = &suffix[1..];
+                let is_version_like = after_dash.starts_with('v')
+                    || after_dash.chars().next().is_some_and(|c| c.is_ascii_digit());
+                if is_version_like {
+                    // Prefer the longest matching prefix (most specific existing component)
+                    if best_match.is_none_or(|prev| existing_id.len() > prev.len()) {
+                        best_match = Some(existing_id);
+                    }
+                }
+            }
+        }
+    }
+
+    best_match.map(|id| {
+        crate::log_status!(
+            "project",
+            "Matched inferred ID '{}' to existing component '{}' (directory name appears version-stamped)",
+            inferred_id,
+            id
+        );
+        id.to_string()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project_with_components(ids: &[&str]) -> Project {
+        let mut project = Project::default();
+        for id in ids {
+            project.components.push(ProjectComponentAttachment {
+                id: id.to_string(),
+                local_path: format!("/workspace/{}", id),
+            });
+        }
+        project
+    }
+
+    #[test]
+    fn find_prefix_match_version_suffix() {
+        let project = project_with_components(&["data-machine", "chubes-theme"]);
+        // Clone dir "data-machine-v0402-clean" → slugified inferred ID
+        assert_eq!(
+            find_prefix_match(&project, "data-machine-v0402-clean"),
+            Some("data-machine".to_string()),
+        );
+    }
+
+    #[test]
+    fn find_prefix_match_numeric_suffix() {
+        let project = project_with_components(&["data-machine"]);
+        // Clone dir "data-machine-0402" → numeric version suffix
+        assert_eq!(
+            find_prefix_match(&project, "data-machine-0402"),
+            Some("data-machine".to_string()),
+        );
+    }
+
+    #[test]
+    fn find_prefix_match_no_match_non_version_suffix() {
+        let project = project_with_components(&["data-machine"]);
+        // "data-machine-socials" is NOT a version suffix, it's a different component
+        assert_eq!(find_prefix_match(&project, "data-machine-socials"), None);
+    }
+
+    #[test]
+    fn find_prefix_match_exact_match_not_prefix() {
+        let project = project_with_components(&["data-machine"]);
+        // Exact match — not a prefix scenario
+        assert_eq!(find_prefix_match(&project, "data-machine"), None);
+    }
+
+    #[test]
+    fn find_prefix_match_prefers_longest() {
+        let project = project_with_components(&["data", "data-machine"]);
+        // Both "data" and "data-machine" are prefixes, but "data-machine" is longer
+        assert_eq!(
+            find_prefix_match(&project, "data-machine-v1"),
+            Some("data-machine".to_string()),
+        );
+    }
+
+    #[test]
+    fn find_prefix_match_no_components() {
+        let project = project_with_components(&[]);
+        assert_eq!(find_prefix_match(&project, "anything-v1"), None);
+    }
 }

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -40,6 +40,18 @@ pub fn resolve_project_component(
 
     let mut resolved = apply_component_overrides(&component, project);
 
+    // Inherit project-level extensions when the component's homeboy.json doesn't
+    // declare any. This handles clean tag clones from older releases where
+    // extensions weren't yet in homeboy.json. (#932)
+    if resolved.extensions.is_none() || resolved.extensions.as_ref().is_some_and(|e| e.is_empty())
+    {
+        if let Some(project_extensions) = &project.extensions {
+            if !project_extensions.is_empty() {
+                resolved.extensions = Some(project_extensions.clone());
+            }
+        }
+    }
+
     // Auto-resolve remote_path if still empty after all config layers.
     // Repo homeboy.json intentionally omits remote_path (it's deploy config),
     // so auto-detect it from source files when possible (#812).


### PR DESCRIPTION
## Summary

Fixes #932 — three gaps in homeboy core that broke deploying from clean GitHub tag clones.

## Changes

### 1. Preserve `remote_path` on re-attach (`attachments.rs`)

When `attach_component_path` updates an existing component's `local_path`, it now checks whether the new path's `homeboy.json` would blank the `remote_path`. If so, it auto-creates a project-level `component_overrides` entry to preserve the existing value.

**Root cause**: `discover_from_portable` defaults `remote_path` to empty string when the repo's `homeboy.json` omits it. Clean tag clones intentionally omit `remote_path` (it's deploy config, not source config), so re-attaching a clone path silently blanked the deploy target.

### 2. Inherit project-level extensions (`resolution.rs`)

When a discovered component has no `extensions` field (or it's empty), `resolve_project_component` now inherits the project's `extensions` map.

**Root cause**: Older tag releases may predate the `extensions` field in `homeboy.json`. Without extensions, `resolve_build_command` can't find a build-capable extension, and the build fails.

### 3. Stabilize component ID on attach (`attachments.rs`)

When `attach_discovered_component_path` infers a component ID that doesn't match any existing project component, it now checks for version-stamped directory patterns (e.g., `data-machine-v0402-clean`) and matches against existing component IDs by prefix.

**Root cause**: `infer_portable_component_id` falls back to the directory name when `homeboy.json` has no `id` field. Clone directories like `/tmp/data-machine-v0.40.2-clean` get slugified to `data-machine-v0402-clean`, creating a phantom component instead of updating the existing `data-machine`.

## Tests

- Added 6 unit tests for `find_prefix_match` covering version suffixes, numeric suffixes, non-version suffixes, exact matches, longest-prefix preference, and empty project.
- `cargo check` passes clean (pre-existing warnings only).
- Pre-existing broken auto-generated tests in `conventions.rs`, `wrapper_inference.rs`, `version_overrides.rs` prevent `cargo test` from compiling — unrelated to this PR.