### PR TITLE
feat: surface remote_owner in component list + warn on WordPress deploy

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -605,6 +605,11 @@ fn list() -> CmdResult<ComponentOutput> {
             })?;
             if let Value::Object(ref mut map) = value {
                 map.insert("id".to_string(), Value::String(component.id.clone()));
+                // Always surface remote_owner so missing config is visible (#602).
+                // Serde skips None fields, but for list output we want explicit null
+                // so users can audit which components are missing this critical config.
+                map.entry("remote_owner".to_string())
+                    .or_insert(Value::Null);
             }
             Ok(value)
         })

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -81,6 +81,19 @@ pub(super) fn execute_component_deploy(
         component.remote_path.clone()
     };
 
+    // Warn when deploying to a WordPress path without remote_owner configured.
+    // Files will end up as root:root which breaks WordPress functionality (#602).
+    if component.remote_owner.is_none() && effective_remote_path.contains("wp-content/") {
+        log_status!(
+            "deploy",
+            "⚠ Component '{}' deploys to a WordPress path but has no remote_owner set. \
+             Files may deploy as root:root. \
+             Fix: homeboy component set {} --json '{{\"remote_owner\":\"www-data:www-data\"}}'",
+            component.id,
+            component.id
+        );
+    }
+
     // Resolve install directory
     let install_dir = match base_path::join_remote_path(Some(base_path), &effective_remote_path) {
         Ok(v) => v,


### PR DESCRIPTION
## Summary

Fixes #602 — makes `remote_owner` visible so missing config doesn't silently break WordPress deployments.

## Changes

### 1. `component list` always shows `remote_owner`

Before: `remote_owner` was omitted from JSON when `None` (serde `skip_serializing_if`).  
After: explicitly `null` in list output, making it easy to spot missing config:

```json
{
  "id": "data-machine",
  "remote_owner": null,          // ← now visible
  "remote_path": "wp-content/plugins/data-machine"
}
```

The `skip_serializing_if` on `RawComponent` is unchanged — `homeboy.json` files won't get polluted with `"remote_owner": null`.

### 2. Deploy warning for WordPress paths

When deploying to a `wp-content/` path without `remote_owner`, a warning is logged with the exact fix command:

```
⚠ Component 'data-machine' deploys to a WordPress path but has no remote_owner set.
  Files may deploy as root:root.
  Fix: homeboy component set data-machine --json '{"remote_owner":"www-data:www-data"}'
```

## Context

Root cause of the original issue: `fix_deployed_ownership()` auto-detects ownership from existing files, but on first deploy the directory doesn't exist yet — files end up as `root:root`, breaking WordPress.