### PR TITLE
fix: sanitize condition text in test template variables + cargo fmt (#818)

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -608,8 +608,7 @@ fn list() -> CmdResult<ComponentOutput> {
                 // Always surface remote_owner so missing config is visible (#602).
                 // Serde skips None fields, but for list output we want explicit null
                 // so users can audit which components are missing this critical config.
-                map.entry("remote_owner".to_string())
-                    .or_insert(Value::Null);
+                map.entry("remote_owner".to_string()).or_insert(Value::Null);
             }
             Ok(value)
         })

--- a/src/core/engine/contract_extract.rs
+++ b/src/core/engine/contract_extract.rs
@@ -1126,10 +1126,7 @@ mod tests {
 
     #[test]
     fn extract_propagation_call_no_match() {
-        assert_eq!(
-            extract_propagation_call("    let x = 42;"),
-            "operation"
-        );
+        assert_eq!(extract_propagation_call("    let x = 42;"), "operation");
     }
 
     #[test]
@@ -1162,11 +1159,7 @@ mod tests {
         };
 
         let mut branches = Vec::new();
-        detect_error_propagation(
-            &body_lines,
-            &contract,
-            &mut branches,
-        );
+        detect_error_propagation(&body_lines, &contract, &mut branches);
 
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].returns.variant, "err");
@@ -1214,11 +1207,7 @@ mod tests {
             line: Some(5),
         }];
 
-        detect_error_propagation(
-            &body_lines,
-            &contract,
-            &mut branches,
-        );
+        detect_error_propagation(&body_lines, &contract, &mut branches);
 
         // Should NOT add another err branch
         assert_eq!(branches.len(), 1);

--- a/src/core/engine/contract_testgen.rs
+++ b/src/core/engine/contract_testgen.rs
@@ -149,7 +149,10 @@ pub(crate) fn generate_test_plan_with_types(
                 type_defaults,
                 &contract_grammar.fallback_default,
             );
-            vars.insert("condition".to_string(), branch.condition.clone());
+            vars.insert(
+                "condition".to_string(),
+                sanitize_for_string_literal(&branch.condition),
+            );
             vars.insert("condition_slug".to_string(), slugify(&branch.condition));
 
             // Behavioral inference: derive setup overrides from branch condition,
@@ -206,7 +209,8 @@ pub(crate) fn generate_test_plan_with_types(
                     &contract.signature.return_type,
                     &branch.condition,
                     &contract_grammar.assertion_templates,
-                ).unwrap_or(assertion)
+                )
+                .unwrap_or(assertion)
             } else {
                 assertion
             };
@@ -2237,10 +2241,7 @@ mod tests {
         };
 
         let mut templates = HashMap::new();
-        templates.insert(
-            "default".to_string(),
-            "fn {test_name}() {{}}\n".to_string(),
-        );
+        templates.insert("default".to_string(), "fn {test_name}() {{}}\n".to_string());
 
         let output = render_test_plan(&plan, &templates);
 

--- a/src/core/project/component/attachments.rs
+++ b/src/core/project/component/attachments.rs
@@ -216,7 +216,10 @@ fn find_prefix_match(project: &Project, inferred_id: &str) -> Option<String> {
             if suffix.starts_with('-') {
                 let after_dash = &suffix[1..];
                 let is_version_like = after_dash.starts_with('v')
-                    || after_dash.chars().next().is_some_and(|c| c.is_ascii_digit());
+                    || after_dash
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c.is_ascii_digit());
                 if is_version_like {
                     // Prefer the longest matching prefix (most specific existing component)
                     if best_match.is_none_or(|prev| existing_id.len() > prev.len()) {

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -43,8 +43,7 @@ pub fn resolve_project_component(
     // Inherit project-level extensions when the component's homeboy.json doesn't
     // declare any. This handles clean tag clones from older releases where
     // extensions weren't yet in homeboy.json. (#932)
-    if resolved.extensions.is_none() || resolved.extensions.as_ref().is_some_and(|e| e.is_empty())
-    {
+    if resolved.extensions.is_none() || resolved.extensions.as_ref().is_some_and(|e| e.is_empty()) {
         if let Some(project_extensions) = &project.extensions {
             if !project_extensions.is_empty() {
                 resolved.extensions = Some(project_extensions.clone());

--- a/src/core/refactor/plan/generate/comment_fixes.rs
+++ b/src/core/refactor/plan/generate/comment_fixes.rs
@@ -155,8 +155,7 @@ pub(crate) fn generate_comment_fixes(
             continue;
         }
 
-        let (block_kind, start_line, end_line) =
-            classify_and_bound(&lines, comment_idx);
+        let (block_kind, start_line, end_line) = classify_and_bound(&lines, comment_idx);
 
         let (safety, blocked_reason) = match block_kind {
             BlockKind::Function | BlockKind::GuardClause | BlockKind::MatchArm => {
@@ -169,18 +168,20 @@ pub(crate) fn generate_comment_fixes(
                     Some("Removing else branch changes control flow — verify the if-branch is the canonical path".to_string()),
                 )
             }
-            BlockKind::CodeSection => {
-                (
-                    FixSafetyTier::PlanOnly,
-                    Some("Legacy code section boundaries detected heuristically — verify removal range".to_string()),
-                )
-            }
-            BlockKind::Unknown => {
-                (
-                    FixSafetyTier::PlanOnly,
-                    Some("Could not determine legacy code block boundaries — manual review required".to_string()),
-                )
-            }
+            BlockKind::CodeSection => (
+                FixSafetyTier::PlanOnly,
+                Some(
+                    "Legacy code section boundaries detected heuristically — verify removal range"
+                        .to_string(),
+                ),
+            ),
+            BlockKind::Unknown => (
+                FixSafetyTier::PlanOnly,
+                Some(
+                    "Could not determine legacy code block boundaries — manual review required"
+                        .to_string(),
+                ),
+            ),
         };
 
         let description = format!(
@@ -277,11 +278,7 @@ fn classify_and_bound(lines: &[&str], comment_idx: usize) -> (BlockKind, usize, 
     // Pattern: contiguous code section — runs until next blank line or de-indent
     let section_end = find_code_section_end(lines, comment_idx);
     if section_end > comment_idx {
-        return (
-            BlockKind::CodeSection,
-            comment_idx + 1,
-            section_end + 1,
-        );
+        return (BlockKind::CodeSection, comment_idx + 1, section_end + 1);
     }
 
     // Fallback: just the comment line
@@ -311,8 +308,7 @@ fn is_function_start(line: &str) -> bool {
         return true;
     }
     // PHP: function, public function, private function, etc.
-    let php_re =
-        Regex::new(r"^(?:public|private|protected|static|\s)*function\s+\w+").unwrap();
+    let php_re = Regex::new(r"^(?:public|private|protected|static|\s)*function\s+\w+").unwrap();
     php_re.is_match(line)
 }
 
@@ -551,7 +547,7 @@ mod tests {
         let (kind, start, end) = classify_and_bound(&src, 1);
         assert_eq!(kind, BlockKind::Function);
         assert_eq!(start, 2); // comment line (1-indexed)
-        assert_eq!(end, 5);   // closing brace of old_handler
+        assert_eq!(end, 5); // closing brace of old_handler
     }
 
     #[test]
@@ -582,7 +578,7 @@ mod tests {
         let (kind, start, end) = classify_and_bound(&src, 1);
         assert_eq!(kind, BlockKind::GuardClause);
         assert_eq!(start, 2); // comment
-        assert_eq!(end, 5);   // closing brace of if
+        assert_eq!(end, 5); // closing brace of if
     }
 
     #[test]
@@ -598,7 +594,7 @@ mod tests {
         let (kind, start, end) = classify_and_bound(&src, 3);
         assert_eq!(kind, BlockKind::ElseBranch);
         assert_eq!(start, 3); // `} else {` line (1-indexed)
-        assert_eq!(end, 6);   // closing brace
+        assert_eq!(end, 6); // closing brace
     }
 
     #[test]
@@ -614,7 +610,7 @@ mod tests {
         let (kind, start, end) = classify_and_bound(&src, 2);
         assert_eq!(kind, BlockKind::MatchArm);
         assert_eq!(start, 3); // comment
-        assert_eq!(end, 4);   // match arm line
+        assert_eq!(end, 4); // match arm line
     }
 
     #[test]
@@ -633,15 +629,12 @@ mod tests {
         let (kind, start, end) = classify_and_bound(&src, 3);
         assert_eq!(kind, BlockKind::CodeSection);
         assert_eq!(start, 4); // comment
-        assert_eq!(end, 6);   // last line before blank
+        assert_eq!(end, 6); // last line before blank
     }
 
     #[test]
     fn classifies_unknown_at_end_of_file() {
-        let src = vec![
-            "fn main() {}",
-            "// outdated: leftover note",
-        ];
+        let src = vec!["fn main() {}", "// outdated: leftover note"];
         let (kind, start, end) = classify_and_bound(&src, 1);
         // No code after the comment — Unknown.
         assert_eq!(kind, BlockKind::Unknown);
@@ -668,9 +661,8 @@ mod tests {
             convention: "comment_hygiene".to_string(),
             severity: Severity::Info,
             file: "src/old.rs".to_string(),
-            description:
-                "Potential legacy/stale comment on line 1: workaround for broken upstream"
-                    .to_string(),
+            description: "Potential legacy/stale comment on line 1: workaround for broken upstream"
+                .to_string(),
             suggestion: "Validate".to_string(),
             kind: AuditFinding::LegacyComment,
         });
@@ -795,12 +787,7 @@ mod tests {
 
     #[test]
     fn is_inside_else_branch_false_in_if() {
-        let lines = vec![
-            "if a {",
-            "    // workaround for bug",
-            "    x();",
-            "}",
-        ];
+        let lines = vec!["if a {", "    // workaround for bug", "    x();", "}"];
         assert!(!is_inside_else_branch(&lines, 1));
     }
 

--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -88,14 +88,11 @@ fn extract_php_fqcn(content: &str) -> Option<String> {
 
         if class_name.is_none() {
             // Match: class Foo, abstract class Foo, final class Foo
-            if let Some(rest) = trimmed
-                .strip_prefix("class ")
-                .or_else(|| {
-                    trimmed
-                        .strip_prefix("abstract class ")
-                        .or_else(|| trimmed.strip_prefix("final class "))
-                })
-            {
+            if let Some(rest) = trimmed.strip_prefix("class ").or_else(|| {
+                trimmed
+                    .strip_prefix("abstract class ")
+                    .or_else(|| trimmed.strip_prefix("final class "))
+            }) {
                 // Class name is the first word
                 let name = rest.split_whitespace().next()?;
                 class_name = Some(name.to_string());
@@ -526,7 +523,8 @@ fn generate_simple_duplicate_fixes(
         };
 
         let language = Language::from_path(&abs_path);
-        let import_stmt = generate_duplicate_import(&group.canonical_file, &group.function_name, &language, root);
+        let import_stmt =
+            generate_duplicate_import(&group.canonical_file, &group.function_name, &language, root);
 
         let mut insertions = vec![insertion(
             InsertionKind::FunctionRemoval {
@@ -702,7 +700,8 @@ mod tests {
 
     #[test]
     fn test_extract_php_fqcn_with_namespace() {
-        let content = "<?php\nnamespace DataMachine\\Abilities\\Fetch;\n\nclass FetchRssAbility {\n";
+        let content =
+            "<?php\nnamespace DataMachine\\Abilities\\Fetch;\n\nclass FetchRssAbility {\n";
         assert_eq!(
             extract_php_fqcn(content),
             Some("DataMachine\\Abilities\\Fetch\\FetchRssAbility".to_string())
@@ -711,8 +710,7 @@ mod tests {
 
     #[test]
     fn test_extract_php_fqcn_abstract_class() {
-        let content =
-            "<?php\nnamespace DataMachine\\Core;\n\nabstract class BaseHandler {\n";
+        let content = "<?php\nnamespace DataMachine\\Core;\n\nabstract class BaseHandler {\n";
         assert_eq!(
             extract_php_fqcn(content),
             Some("DataMachine\\Core\\BaseHandler".to_string())
@@ -722,10 +720,7 @@ mod tests {
     #[test]
     fn test_extract_php_fqcn_no_namespace() {
         let content = "<?php\nclass SimpleClass {\n";
-        assert_eq!(
-            extract_php_fqcn(content),
-            Some("SimpleClass".to_string())
-        );
+        assert_eq!(extract_php_fqcn(content), Some("SimpleClass".to_string()));
     }
 
     #[test]
@@ -742,7 +737,10 @@ mod tests {
             &Language::Rust,
             Path::new("/tmp"),
         );
-        assert_eq!(import, "use crate::core::engine::symbol_graph::parse_imports;");
+        assert_eq!(
+            import,
+            "use crate::core::engine::symbol_graph::parse_imports;"
+        );
     }
 
     #[test]
@@ -764,7 +762,10 @@ mod tests {
             &Language::Php,
             root,
         );
-        assert_eq!(import, "use DataMachine\\Abilities\\Fetch\\FetchRssAbility;");
+        assert_eq!(
+            import,
+            "use DataMachine\\Abilities\\Fetch\\FetchRssAbility;"
+        );
     }
 
     #[test]
@@ -776,7 +777,15 @@ mod tests {
             Path::new("/tmp"),
         );
         // JS imports derive the module name from the file path
-        assert!(import.starts_with("import {"), "Expected JS import, got: {}", import);
-        assert!(import.contains("helpers"), "Expected module name in import, got: {}", import);
+        assert!(
+            import.starts_with("import {"),
+            "Expected JS import, got: {}",
+            import
+        );
+        assert!(
+            import.contains("helpers"),
+            "Expected module name in import, got: {}",
+            import
+        );
     }
 }

--- a/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
@@ -280,10 +280,10 @@ mod tests {
     #[test]
     fn classify_adjacent_no_gap() {
         let lines = vec![
-            "    let x = 1;",  // line 1
-            "    let y = 2;",  // line 2
-            "    let x = 1;",  // line 3
-            "    let y = 2;",  // line 4
+            "    let x = 1;", // line 1
+            "    let y = 2;", // line 2
+            "    let x = 1;", // line 3
+            "    let y = 2;", // line 4
         ];
         let rel = classify_relation(&lines, 1, 3, 2);
         assert!(matches!(rel, DupRelation::Adjacent));
@@ -292,11 +292,11 @@ mod tests {
     #[test]
     fn classify_adjacent_blank_gap() {
         let lines = vec![
-            "    let x = 1;",  // line 1
-            "    let y = 2;",  // line 2
-            "",                // line 3
-            "    let x = 1;",  // line 4
-            "    let y = 2;",  // line 5
+            "    let x = 1;", // line 1
+            "    let y = 2;", // line 2
+            "",               // line 3
+            "    let x = 1;", // line 4
+            "    let y = 2;", // line 5
         ];
         let rel = classify_relation(&lines, 1, 4, 2);
         assert!(matches!(rel, DupRelation::Adjacent));
@@ -305,11 +305,11 @@ mod tests {
     #[test]
     fn classify_same_indent_small_gap() {
         let lines = vec![
-            "    let x = 1;",        // line 1
-            "    let y = 2;",        // line 2
-            "    let z = x + y;",    // line 3 — 1 line of code
-            "    let x = 1;",        // line 4
-            "    let y = 2;",        // line 5
+            "    let x = 1;",     // line 1
+            "    let y = 2;",     // line 2
+            "    let z = x + y;", // line 3 — 1 line of code
+            "    let x = 1;",     // line 4
+            "    let y = 2;",     // line 5
         ];
         let rel = classify_relation(&lines, 1, 4, 2);
         assert!(matches!(rel, DupRelation::SameIndentSmallGap));
@@ -318,14 +318,14 @@ mod tests {
     #[test]
     fn classify_same_indent_large_gap() {
         let lines = vec![
-            "    let x = 1;",        // line 1
-            "    let y = 2;",        // line 2
-            "    a();",              // line 3
-            "    b();",              // line 4
-            "    c();",              // line 5
-            "    d();",              // line 6  — 4 lines of code in gap
-            "    let x = 1;",        // line 7
-            "    let y = 2;",        // line 8
+            "    let x = 1;", // line 1
+            "    let y = 2;", // line 2
+            "    a();",       // line 3
+            "    b();",       // line 4
+            "    c();",       // line 5
+            "    d();",       // line 6  — 4 lines of code in gap
+            "    let x = 1;", // line 7
+            "    let y = 2;", // line 8
         ];
         let rel = classify_relation(&lines, 1, 7, 2);
         assert!(matches!(rel, DupRelation::SameIndentLargeGap));
@@ -334,13 +334,13 @@ mod tests {
     #[test]
     fn classify_cross_branch_different_indent() {
         let lines = vec![
-            "    if cond {",             // line 1
-            "        let x = 1;",        // line 2 — indent 8
-            "        let y = 2;",        // line 3
-            "    } else {",              // line 4
-            "            let x = 1;",    // line 5 — indent 12
-            "            let y = 2;",    // line 6
-            "    }",                     // line 7
+            "    if cond {",          // line 1
+            "        let x = 1;",     // line 2 — indent 8
+            "        let y = 2;",     // line 3
+            "    } else {",           // line 4
+            "            let x = 1;", // line 5 — indent 12
+            "            let y = 2;", // line 6
+            "    }",                  // line 7
         ];
         let rel = classify_relation(&lines, 2, 5, 2);
         assert!(matches!(rel, DupRelation::CrossBranch));
@@ -349,9 +349,9 @@ mod tests {
     #[test]
     fn median_indent_skips_blank() {
         let lines = vec![
-            "        code();",   // indent 8
-            "",                  // blank — skipped
-            "        more();",   // indent 8
+            "        code();", // indent 8
+            "",                // blank — skipped
+            "        more();", // indent 8
         ];
         assert_eq!(median_indent(&lines, 1, 3), 8);
     }
@@ -359,11 +359,11 @@ mod tests {
     #[test]
     fn median_indent_handles_outlier() {
         let lines = vec![
-            "        code();",       // indent 8
-            "    oddly();",          // indent 4
-            "        more();",       // indent 8
-            "        again();",      // indent 8
-            "        last();",       // indent 8
+            "        code();",  // indent 8
+            "    oddly();",     // indent 4
+            "        more();",  // indent 8
+            "        again();", // indent 8
+            "        last();",  // indent 8
         ];
         // Sorted: [4, 8, 8, 8, 8] → median at index 2 = 8
         assert_eq!(median_indent(&lines, 1, 5), 8);

--- a/src/core/refactor/plan/generate/near_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/near_duplicate_fixes.rs
@@ -70,10 +70,7 @@ pub(crate) fn generate_near_duplicate_fixes(
     // Group by function name to find pairs.
     let mut groups: HashMap<String, Vec<NearDupInfo>> = HashMap::new();
     for info in infos {
-        groups
-            .entry(info.fn_name.clone())
-            .or_default()
-            .push(info);
+        groups.entry(info.fn_name.clone()).or_default().push(info);
     }
 
     for (fn_name, members) in &groups {
@@ -167,8 +164,7 @@ pub(crate) fn generate_near_duplicate_fixes(
         // 3. Ensure the canonical copy is pub(crate).
         let canon_path = root.join(canonical_file);
         if let Ok(canon_content) = std::fs::read_to_string(&canon_path) {
-            if let Some(vis_fix) =
-                build_visibility_upgrade(&canon_content, canonical_file, fn_name)
+            if let Some(vis_fix) = build_visibility_upgrade(&canon_content, canonical_file, fn_name)
             {
                 fixes.push(Fix {
                     file: canonical_file.to_string(),
@@ -234,11 +230,7 @@ fn file_to_module_path(file: &str) -> String {
 
 /// If the canonical function is not already `pub` or `pub(crate)`, generate a
 /// `VisibilityChange` insertion to make it `pub(crate)`.
-fn build_visibility_upgrade(
-    content: &str,
-    file: &str,
-    fn_name: &str,
-) -> Option<Insertion> {
+fn build_visibility_upgrade(content: &str, file: &str, fn_name: &str) -> Option<Insertion> {
     let lines: Vec<&str> = content.lines().collect();
 
     // Find the function declaration line.


### PR DESCRIPTION
## Summary

- **Root cause**: `render_test_plan()` substitutes `{condition}` from the variables map into templates. The condition was inserted raw (`branch.condition.clone()`) bypassing `sanitize_for_string_literal()`. When a condition contained quotes or backticks (e.g. `format!("```{} block", language)`), the generated test had unescaped characters inside string literals — breaking compilation.
- **Fix**: Sanitize the condition at insertion into the variables map, matching what `resolve_assertion()` already does.
- **Also**: Runs `cargo fmt` across the codebase to fix pre-existing formatting violations that caused `cargo fmt --check` failures in CI sandbox.

### The CI error this fixes
```
error: prefix `block` is unknown
  --> claims.rs:708
   |
   assert!(!result.is_empty(), "expected non-empty collection for: context: Some(format!("```{} block", language)),");
                                                                                               ^^^^^ unknown prefix
```