### PR TITLE
feat: add shadow module and repeated field pattern audit rules (#635, #441)

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -167,6 +167,9 @@ pub enum AuditFinding {
     /// Two directories contain overlapping file names with high content similarity.
     /// Indicates a copy-paste module that was never consolidated.
     ShadowModule,
+    /// Multiple structs define the same field group — candidates for extraction
+    /// into a shared type and flattening/embedding.
+    RepeatedFieldPattern,
 }
 
 impl AuditFinding {
@@ -208,6 +211,7 @@ impl AuditFinding {
             "compiler_warning",
             "missing_wrapper_declaration",
             "shadow_module",
+            "repeated_field_pattern",
         ]
     }
 }

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -164,6 +164,9 @@ pub enum AuditFinding {
     /// Wrapper file is missing an explicit declaration of what it wraps.
     /// Detected by tracing calls in the wrapper to infer the implementation target.
     MissingWrapperDeclaration,
+    /// Two directories contain overlapping file names with high content similarity.
+    /// Indicates a copy-paste module that was never consolidated.
+    ShadowModule,
 }
 
 impl AuditFinding {
@@ -204,6 +207,7 @@ impl AuditFinding {
             "stale_doc_reference",
             "compiler_warning",
             "missing_wrapper_declaration",
+            "shadow_module",
         ]
     }
 }

--- a/src/core/code_audit/field_patterns.rs
+++ b/src/core/code_audit/field_patterns.rs
@@ -1,0 +1,515 @@
+//! Repeated struct field pattern detection.
+//!
+//! Finds groups of fields that appear together in multiple struct definitions.
+//! When the same fields (same name + type) appear in 3+ structs, they're
+//! candidates for extraction into a shared type.
+//!
+//! Language-agnostic: parses struct field declarations from raw file content
+//! using brace-depth tracking and line-level pattern matching. No AST parsing.
+//!
+//! Examples of what this catches:
+//! - `path: Option<String>` with `#[arg(long)]` in 12 `#[derive(Args)]` structs
+//! - `verbose: bool` + `quiet: bool` appearing together in 8 CLI structs
+//! - Repeated config fields across multiple builder/options types
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+
+/// Minimum number of structs sharing a field group to report.
+const MIN_OCCURRENCES: usize = 3;
+
+/// Minimum number of fields in a group to report.
+const MIN_GROUP_SIZE: usize = 2;
+
+pub(super) fn run(root: &Path) -> Vec<Finding> {
+    detect_repeated_field_patterns(root)
+}
+
+/// A parsed field from a struct definition.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FieldSignature {
+    /// Field name (e.g., "verbose").
+    name: String,
+    /// Field type (e.g., "bool", "Option<String>").
+    field_type: String,
+}
+
+/// A struct and the fields it contains.
+struct StructDef {
+    /// File containing this struct.
+    file: String,
+    /// Struct name.
+    name: String,
+    /// Fields declared in this struct.
+    fields: Vec<FieldSignature>,
+}
+
+fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
+    let config = ScanConfig {
+        extensions: ExtensionFilter::Only(vec![
+            "rs".to_string(),
+            "php".to_string(),
+            "ts".to_string(),
+            "js".to_string(),
+            "go".to_string(),
+        ]),
+        ..Default::default()
+    };
+    let files = codebase_scan::walk_files(root, &config);
+
+    let mut all_structs: Vec<StructDef> = Vec::new();
+
+    for file_path in &files {
+        let relative = match file_path.strip_prefix(root) {
+            Ok(p) => p.to_string_lossy().replace('\\', "/"),
+            Err(_) => continue,
+        };
+
+        // Skip test files.
+        if is_test_path(&relative) {
+            continue;
+        }
+
+        let Ok(content) = std::fs::read_to_string(file_path) else {
+            continue;
+        };
+
+        let structs = extract_structs(&content, &relative);
+        all_structs.extend(structs);
+    }
+
+    // Build a map: field signature → set of (file, struct_name) locations.
+    let mut field_locations: HashMap<FieldSignature, Vec<(String, String)>> = HashMap::new();
+
+    for sd in &all_structs {
+        for field in &sd.fields {
+            field_locations
+                .entry(field.clone())
+                .or_default()
+                .push((sd.file.clone(), sd.name.clone()));
+        }
+    }
+
+    // Find field GROUPS that co-occur — fields that appear together in
+    // the same structs across multiple locations.
+    // Strategy: for each pair of fields, check if they always appear together.
+    let repeated_fields: Vec<&FieldSignature> = field_locations
+        .iter()
+        .filter(|(_, locs)| locs.len() >= MIN_OCCURRENCES)
+        .map(|(field, _)| field)
+        .collect();
+
+    // Group repeated fields by the set of structs they appear in.
+    // Fields that appear in the exact same set of structs form a co-occurring group.
+    let mut struct_set_to_fields: HashMap<Vec<(String, String)>, Vec<FieldSignature>> =
+        HashMap::new();
+
+    for field in &repeated_fields {
+        if let Some(locs) = field_locations.get(field) {
+            let mut sorted_locs = locs.clone();
+            sorted_locs.sort();
+            struct_set_to_fields
+                .entry(sorted_locs)
+                .or_default()
+                .push((*field).clone());
+        }
+    }
+
+    let mut findings = Vec::new();
+
+    for (locations, fields) in &struct_set_to_fields {
+        if fields.len() < MIN_GROUP_SIZE {
+            continue;
+        }
+        if locations.len() < MIN_OCCURRENCES {
+            continue;
+        }
+
+        let field_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+        let struct_names: Vec<String> = locations
+            .iter()
+            .map(|(file, name)| format!("{}::{}", file, name))
+            .collect();
+
+        // Emit one finding per file that contains the pattern.
+        let mut seen_files: HashSet<String> = HashSet::new();
+        for (file, _) in locations {
+            if seen_files.contains(file) {
+                continue;
+            }
+            seen_files.insert(file.clone());
+
+            findings.push(Finding {
+                convention: "field_patterns".to_string(),
+                severity: Severity::Info,
+                file: file.clone(),
+                description: format!(
+                    "Repeated field group [{}] appears in {} structs: {}",
+                    field_names.join(", "),
+                    locations.len(),
+                    struct_names.join(", ")
+                ),
+                suggestion: format!(
+                    "Extract fields [{}] into a shared struct and flatten/embed it",
+                    field_names.join(", ")
+                ),
+                kind: AuditFinding::RepeatedFieldPattern,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+/// Extract struct definitions and their fields from file content.
+///
+/// Language-agnostic: looks for patterns like:
+/// - Rust: `struct Name {` ... `field: Type,` ... `}`
+/// - PHP: `class Name {` ... `type $field;` or `public type $field;`
+/// - TS/JS: `interface Name {` or `type Name = {`
+fn extract_structs(content: &str, file: &str) -> Vec<StructDef> {
+    let mut result = Vec::new();
+    let lines: Vec<&str> = content.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        // Detect struct/class/interface start.
+        let name = extract_type_name(trimmed);
+        if let Some(type_name) = name {
+            // Find the opening brace (might be on same line or next).
+            let brace_line = if trimmed.contains('{') {
+                Some(i)
+            } else if i + 1 < lines.len() && lines[i + 1].trim().starts_with('{') {
+                Some(i + 1)
+            } else {
+                None
+            };
+
+            if let Some(start) = brace_line {
+                // Walk to closing brace, tracking depth.
+                let mut depth = 0i32;
+                let mut fields = Vec::new();
+                let mut j = start;
+
+                while j < lines.len() {
+                    for ch in lines[j].chars() {
+                        match ch {
+                            '{' => depth += 1,
+                            '}' => depth -= 1,
+                            _ => {}
+                        }
+                    }
+
+                    // Parse field declarations from lines inside the struct body.
+                    if j > start && depth > 0 {
+                        if let Some(field) = parse_field_line(lines[j]) {
+                            fields.push(field);
+                        }
+                    }
+
+                    if depth == 0 && j > start {
+                        break;
+                    }
+                    j += 1;
+                }
+
+                if !fields.is_empty() {
+                    result.push(StructDef {
+                        file: file.to_string(),
+                        name: type_name,
+                        fields,
+                    });
+                }
+
+                i = j + 1;
+                continue;
+            }
+        }
+
+        i += 1;
+    }
+
+    result
+}
+
+/// Try to extract a type name from a line that starts a struct/class/interface.
+fn extract_type_name(line: &str) -> Option<String> {
+    // Skip comments and attributes.
+    let trimmed = line.trim();
+    if trimmed.starts_with("//") || trimmed.starts_with('#') || trimmed.starts_with("/*") {
+        return None;
+    }
+
+    // Rust: pub struct Foo, struct Foo, pub(crate) struct Foo
+    if let Some(pos) = trimmed.find("struct ") {
+        let after = &trimmed[pos + 7..];
+        let name = after.split(|c: char| !c.is_alphanumeric() && c != '_').next()?;
+        if !name.is_empty() {
+            return Some(name.to_string());
+        }
+    }
+
+    // PHP/TS: class Foo, interface Foo
+    for keyword in &["class ", "interface "] {
+        if let Some(pos) = trimmed.find(keyword) {
+            let after = &trimmed[pos + keyword.len()..];
+            let name = after.split(|c: char| !c.is_alphanumeric() && c != '_').next()?;
+            if !name.is_empty() {
+                return Some(name.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+/// Try to parse a field declaration from a single line.
+///
+/// Returns `Some(FieldSignature)` for lines that look like field declarations.
+/// Handles multiple syntax styles:
+/// - Rust: `field_name: Type,` or `pub field_name: Type,`
+/// - PHP: `public Type $field_name;` or `$field_name;`
+/// - TS: `field_name: type;` or `readonly field_name: type;`
+fn parse_field_line(line: &str) -> Option<FieldSignature> {
+    let trimmed = line.trim();
+
+    // Skip comments, attributes, blank lines, braces.
+    if trimmed.is_empty()
+        || trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed == "{"
+        || trimmed == "}"
+        || trimmed == "},"
+    {
+        return None;
+    }
+
+    // Skip function/method declarations.
+    if trimmed.contains("fn ") || trimmed.contains("function ") || trimmed.contains("=>") {
+        return None;
+    }
+
+    // Rust-style: `[pub] name: Type[,]`
+    // Strip visibility prefix.
+    let content = trimmed
+        .strip_prefix("pub(crate) ")
+        .or_else(|| trimmed.strip_prefix("pub(super) "))
+        .or_else(|| trimmed.strip_prefix("pub "))
+        .unwrap_or(trimmed);
+
+    if let Some((name_part, type_part)) = content.split_once(':') {
+        let name = name_part.trim().to_string();
+        let field_type = type_part
+            .trim()
+            .trim_end_matches(',')
+            .trim_end_matches(';')
+            .trim()
+            .to_string();
+
+        // Validate name is a reasonable identifier.
+        if !name.is_empty()
+            && name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_')
+            && !field_type.is_empty()
+        {
+            return Some(FieldSignature {
+                name,
+                field_type,
+            });
+        }
+    }
+
+    None
+}
+
+fn is_test_path(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    lower.contains("/tests/")
+        || lower.contains("/test/")
+        || lower.starts_with("tests/")
+        || lower.starts_with("test/")
+        || lower.ends_with("_test.rs")
+        || lower.ends_with("_test.php")
+        || lower.ends_with(".test.ts")
+        || lower.ends_with(".test.js")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_rust_struct_fields() {
+        let content = r#"
+pub struct Config {
+    pub verbose: bool,
+    pub quiet: bool,
+    pub output: Option<String>,
+}
+"#;
+        let structs = extract_structs(content, "test.rs");
+        assert_eq!(structs.len(), 1);
+        assert_eq!(structs[0].name, "Config");
+        assert_eq!(structs[0].fields.len(), 3);
+        assert_eq!(structs[0].fields[0].name, "verbose");
+        assert_eq!(structs[0].fields[0].field_type, "bool");
+        assert_eq!(structs[0].fields[2].name, "output");
+        assert_eq!(structs[0].fields[2].field_type, "Option<String>");
+    }
+
+    #[test]
+    fn extracts_multiple_structs() {
+        let content = r#"
+struct Alpha {
+    x: i32,
+    y: i32,
+}
+
+struct Beta {
+    x: i32,
+    y: i32,
+    z: i32,
+}
+"#;
+        let structs = extract_structs(content, "test.rs");
+        assert_eq!(structs.len(), 2);
+        assert_eq!(structs[0].name, "Alpha");
+        assert_eq!(structs[1].name, "Beta");
+    }
+
+    #[test]
+    fn skips_methods_inside_struct() {
+        let content = r#"
+struct Foo {
+    name: String,
+}
+
+impl Foo {
+    fn new() -> Self {
+        Self { name: String::new() }
+    }
+}
+"#;
+        let structs = extract_structs(content, "test.rs");
+        assert_eq!(structs.len(), 1);
+        assert_eq!(structs[0].fields.len(), 1);
+        assert_eq!(structs[0].fields[0].name, "name");
+    }
+
+    #[test]
+    fn parse_field_line_rust() {
+        let field = parse_field_line("    pub verbose: bool,");
+        assert!(field.is_some());
+        let f = field.unwrap();
+        assert_eq!(f.name, "verbose");
+        assert_eq!(f.field_type, "bool");
+    }
+
+    #[test]
+    fn parse_field_line_with_option() {
+        let field = parse_field_line("    output: Option<PathBuf>,");
+        assert!(field.is_some());
+        let f = field.unwrap();
+        assert_eq!(f.name, "output");
+        assert_eq!(f.field_type, "Option<PathBuf>");
+    }
+
+    #[test]
+    fn parse_field_line_skips_comments() {
+        assert!(parse_field_line("    // a comment").is_none());
+        assert!(parse_field_line("    #[derive(Debug)]").is_none());
+        assert!(parse_field_line("").is_none());
+    }
+
+    #[test]
+    fn parse_field_line_skips_functions() {
+        assert!(parse_field_line("    fn new() -> Self {").is_none());
+        assert!(parse_field_line("    pub function run() {").is_none());
+    }
+
+    #[test]
+    fn extract_type_name_rust() {
+        assert_eq!(extract_type_name("pub struct Foo {"), Some("Foo".to_string()));
+        assert_eq!(
+            extract_type_name("pub(crate) struct Bar<T> {"),
+            Some("Bar".to_string())
+        );
+        assert_eq!(extract_type_name("struct Baz"), Some("Baz".to_string()));
+    }
+
+    #[test]
+    fn extract_type_name_other_langs() {
+        assert_eq!(
+            extract_type_name("class MyClass {"),
+            Some("MyClass".to_string())
+        );
+        assert_eq!(
+            extract_type_name("interface IFoo {"),
+            Some("IFoo".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_type_name_skips_comments() {
+        assert_eq!(extract_type_name("// struct Comment"), None);
+        assert_eq!(extract_type_name("# class PythonStyle"), None);
+    }
+
+    #[test]
+    fn detects_repeated_pattern() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        // Three files with the same field group.
+        for name in &["alpha.rs", "beta.rs", "gamma.rs"] {
+            std::fs::write(
+                src.join(name),
+                format!(
+                    "struct {} {{\n    verbose: bool,\n    quiet: bool,\n}}\n",
+                    name.replace(".rs", "").to_uppercase()
+                ),
+            )
+            .unwrap();
+        }
+
+        let findings = detect_repeated_field_patterns(dir.path());
+        assert!(
+            !findings.is_empty(),
+            "Should detect repeated [verbose, quiet] pattern"
+        );
+        assert!(findings
+            .iter()
+            .all(|f| f.kind == AuditFinding::RepeatedFieldPattern));
+    }
+
+    #[test]
+    fn ignores_below_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        // Only 2 files (below MIN_OCCURRENCES=3).
+        for name in &["alpha.rs", "beta.rs"] {
+            std::fs::write(
+                src.join(name),
+                "struct Foo {\n    x: i32,\n    y: i32,\n}\n",
+            )
+            .unwrap();
+        }
+
+        let findings = detect_repeated_field_patterns(dir.path());
+        assert!(findings.is_empty(), "Two occurrences should be below threshold");
+    }
+}

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -32,6 +32,7 @@ mod layer_ownership;
 pub(crate) mod naming;
 pub mod report;
 pub mod run;
+mod field_patterns;
 mod shadow_modules;
 mod signatures;
 mod structural;
@@ -525,7 +526,18 @@ fn audit_internal(
         all_findings.extend(shadow_findings);
     }
 
-    // Phase 4o: Impact-scoped filtering — when auditing changed files only,
+    // Phase 4o: Repeated struct field pattern detection.
+    let field_pattern_findings = field_patterns::run(root);
+    if !field_pattern_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Field patterns: {} finding(s) (repeated struct fields)",
+            field_pattern_findings.len()
+        );
+        all_findings.extend(field_pattern_findings);
+    }
+
+    // Phase 4p: Impact-scoped filtering — when auditing changed files only,
     // expand scope to include call sites affected by symbol changes, then
     // filter findings to that expanded scope.
     //

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -32,6 +32,7 @@ mod layer_ownership;
 pub(crate) mod naming;
 pub mod report;
 pub mod run;
+mod shadow_modules;
 mod signatures;
 mod structural;
 mod test_coverage;
@@ -513,7 +514,18 @@ fn audit_internal(
         all_findings.extend(wrapper_findings);
     }
 
-    // Phase 4n: Impact-scoped filtering — when auditing changed files only,
+    // Phase 4n: Shadow module detection — directories that are near-copies.
+    let shadow_findings = shadow_modules::run(&all_fingerprints);
+    if !shadow_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Shadow modules: {} finding(s) (duplicate directory structures)",
+            shadow_findings.len()
+        );
+        all_findings.extend(shadow_findings);
+    }
+
+    // Phase 4o: Impact-scoped filtering — when auditing changed files only,
     // expand scope to include call sites affected by symbol changes, then
     // filter findings to that expanded scope.
     //

--- a/src/core/code_audit/shadow_modules.rs
+++ b/src/core/code_audit/shadow_modules.rs
@@ -1,0 +1,447 @@
+//! Shadow module detection — find directories that are near-copies of each other.
+//!
+//! When two directories share 50%+ of file names and those files have high
+//! content similarity, one is likely a copy-paste of the other that was never
+//! consolidated. This is a stronger signal than individual DuplicateFunction
+//! findings because it indicates systemic duplication — an entire module was
+//! copied instead of properly refactored.
+//!
+//! Language-agnostic: operates on file names and structural hashes from
+//! fingerprinting. No language parsing.
+
+use std::collections::{HashMap, HashSet};
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+
+/// Minimum file name overlap ratio to consider two directories related.
+const MIN_NAME_OVERLAP: f64 = 0.5;
+
+/// Minimum method hash overlap ratio to confirm shadow module status.
+const MIN_CONTENT_OVERLAP: f64 = 0.5;
+
+/// Minimum number of shared file names to avoid false positives on tiny directories.
+const MIN_SHARED_FILES: usize = 2;
+
+pub(super) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    detect_shadow_modules(fingerprints)
+}
+
+/// Directory-level metadata aggregated from file fingerprints.
+struct DirInfo {
+    /// File names (stem only, no extension) in this directory.
+    file_names: HashSet<String>,
+    /// All method hashes across all files in this directory.
+    method_hashes: HashSet<String>,
+    /// All structural hashes across all files (for near-dup detection).
+    structural_hashes: HashSet<String>,
+    /// Relative directory path.
+    dir_path: String,
+}
+
+fn detect_shadow_modules(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    // Group fingerprints by parent directory.
+    let mut dir_files: HashMap<String, Vec<&FileFingerprint>> = HashMap::new();
+
+    for fp in fingerprints {
+        let dir = parent_dir(&fp.relative_path);
+        dir_files.entry(dir).or_default().push(fp);
+    }
+
+    // Build directory-level metadata.
+    let dirs: Vec<DirInfo> = dir_files
+        .into_iter()
+        .filter(|(_, files)| files.len() >= MIN_SHARED_FILES) // Skip tiny dirs
+        .map(|(dir_path, files)| {
+            let mut file_names = HashSet::new();
+            let mut method_hashes = HashSet::new();
+            let mut structural_hashes = HashSet::new();
+
+            for fp in &files {
+                if let Some(stem) = file_stem(&fp.relative_path) {
+                    file_names.insert(stem);
+                }
+                for hash in fp.method_hashes.values() {
+                    method_hashes.insert(hash.clone());
+                }
+                for hash in fp.structural_hashes.values() {
+                    structural_hashes.insert(hash.clone());
+                }
+            }
+
+            DirInfo {
+                file_names,
+                method_hashes,
+                structural_hashes,
+                dir_path,
+            }
+        })
+        .collect();
+
+    // Compare all directory pairs.
+    let mut findings = Vec::new();
+    let mut seen_pairs: HashSet<(String, String)> = HashSet::new();
+
+    for i in 0..dirs.len() {
+        for j in (i + 1)..dirs.len() {
+            let a = &dirs[i];
+            let b = &dirs[j];
+
+            // Skip if one directory is a subdirectory of the other.
+            if a.dir_path.starts_with(&format!("{}/", b.dir_path))
+                || b.dir_path.starts_with(&format!("{}/", a.dir_path))
+            {
+                continue;
+            }
+
+            // Skip test directory pairs — test dirs legitimately mirror source dirs.
+            if is_test_dir(&a.dir_path) || is_test_dir(&b.dir_path) {
+                continue;
+            }
+
+            // File name overlap.
+            let shared_names: HashSet<_> =
+                a.file_names.intersection(&b.file_names).cloned().collect();
+            if shared_names.len() < MIN_SHARED_FILES {
+                continue;
+            }
+
+            let smaller_dir_size = a.file_names.len().min(b.file_names.len());
+            let name_overlap = shared_names.len() as f64 / smaller_dir_size as f64;
+            if name_overlap < MIN_NAME_OVERLAP {
+                continue;
+            }
+
+            // Content overlap — check method hash similarity.
+            let content_overlap = if a.method_hashes.is_empty() && b.method_hashes.is_empty() {
+                // No methods — fall back to structural hash comparison.
+                if a.structural_hashes.is_empty() || b.structural_hashes.is_empty() {
+                    0.0
+                } else {
+                    let shared = a
+                        .structural_hashes
+                        .intersection(&b.structural_hashes)
+                        .count();
+                    let smaller = a.structural_hashes.len().min(b.structural_hashes.len());
+                    shared as f64 / smaller as f64
+                }
+            } else {
+                let shared = a.method_hashes.intersection(&b.method_hashes).count();
+                let smaller = a.method_hashes.len().min(b.method_hashes.len());
+                if smaller == 0 {
+                    0.0
+                } else {
+                    shared as f64 / smaller as f64
+                }
+            };
+
+            if content_overlap < MIN_CONTENT_OVERLAP {
+                continue;
+            }
+
+            // Deduplicate — only report each pair once, with the canonical (shorter path) first.
+            let (first, second) = if a.dir_path < b.dir_path {
+                (&a.dir_path, &b.dir_path)
+            } else {
+                (&b.dir_path, &a.dir_path)
+            };
+
+            let pair_key = (first.clone(), second.clone());
+            if seen_pairs.contains(&pair_key) {
+                continue;
+            }
+            seen_pairs.insert(pair_key);
+
+            let shared_list: Vec<&str> = shared_names.iter().map(|s| s.as_str()).collect();
+            let name_pct = (name_overlap * 100.0).round() as u32;
+            let content_pct = (content_overlap * 100.0).round() as u32;
+
+            // Emit finding for both directories.
+            findings.push(Finding {
+                convention: "shadow_module".to_string(),
+                severity: Severity::Warning,
+                file: first.to_string(),
+                description: format!(
+                    "Shadow module: `{}` and `{}` share {} files ({name_pct}% name overlap, \
+                     {content_pct}% content similarity) — shared: {}",
+                    first,
+                    second,
+                    shared_names.len(),
+                    shared_list.join(", ")
+                ),
+                suggestion: format!(
+                    "Consolidate `{}` and `{}` into a single module. \
+                     One is likely a copy-paste that was never cleaned up.",
+                    first, second
+                ),
+                kind: AuditFinding::ShadowModule,
+            });
+
+            findings.push(Finding {
+                convention: "shadow_module".to_string(),
+                severity: Severity::Warning,
+                file: second.to_string(),
+                description: format!(
+                    "Shadow module: `{}` and `{}` share {} files ({name_pct}% name overlap, \
+                     {content_pct}% content similarity) — shared: {}",
+                    second,
+                    first,
+                    shared_names.len(),
+                    shared_list.join(", ")
+                ),
+                suggestion: format!(
+                    "Consolidate into `{}` — this directory appears to be the shadow copy.",
+                    first
+                ),
+                kind: AuditFinding::ShadowModule,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+/// Extract the parent directory from a relative path.
+fn parent_dir(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    match normalized.rsplit_once('/') {
+        Some((dir, _)) => dir.to_string(),
+        None => ".".to_string(),
+    }
+}
+
+/// Extract the file stem (name without extension) from a path.
+fn file_stem(path: &str) -> Option<String> {
+    let normalized = path.replace('\\', "/");
+    let file_name = normalized.rsplit_once('/').map(|(_, f)| f).unwrap_or(&normalized);
+    file_name.rsplit_once('.').map(|(stem, _)| stem.to_string())
+}
+
+/// Check if a directory path looks like a test directory.
+fn is_test_dir(dir: &str) -> bool {
+    let lower = dir.to_lowercase();
+    lower.contains("/tests/")
+        || lower.contains("/test/")
+        || lower.ends_with("/tests")
+        || lower.ends_with("/test")
+        || lower.starts_with("tests/")
+        || lower.starts_with("test/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_fp(
+        path: &str,
+        methods: &[&str],
+        method_hashes: &[(&str, &str)],
+        structural_hashes: &[(&str, &str)],
+    ) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: super::super::conventions::Language::Rust,
+            methods: methods.iter().map(|s| s.to_string()).collect(),
+            registrations: vec![],
+            type_name: None,
+            type_names: vec![],
+            extends: None,
+            implements: vec![],
+            namespace: None,
+            imports: vec![],
+            content: String::new(),
+            method_hashes: method_hashes
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            structural_hashes: structural_hashes
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            visibility: HashMap::new(),
+            properties: vec![],
+            hooks: vec![],
+            unused_parameters: vec![],
+            dead_code_markers: vec![],
+            internal_calls: vec![],
+            call_sites: vec![],
+            public_api: vec![],
+            trait_impl_methods: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_shadow_modules() {
+        let fp1 = make_fp(
+            "src/module_a/claims.rs",
+            &["extract", "validate"],
+            &[("extract", "hash1"), ("validate", "hash2")],
+            &[],
+        );
+        let fp2 = make_fp(
+            "src/module_a/verify.rs",
+            &["check"],
+            &[("check", "hash3")],
+            &[],
+        );
+        let fp3 = make_fp(
+            "src/module_b/claims.rs",
+            &["extract", "validate"],
+            &[("extract", "hash1"), ("validate", "hash2")],
+            &[],
+        );
+        let fp4 = make_fp(
+            "src/module_b/verify.rs",
+            &["check"],
+            &[("check", "hash3")],
+            &[],
+        );
+
+        let fps: Vec<&FileFingerprint> = vec![&fp1, &fp2, &fp3, &fp4];
+        let findings = detect_shadow_modules(&fps);
+
+        assert_eq!(findings.len(), 2, "Should emit findings for both dirs");
+        assert!(findings.iter().all(|f| f.kind == AuditFinding::ShadowModule));
+        assert!(findings
+            .iter()
+            .any(|f| f.file == "src/module_a" && f.description.contains("src/module_b")));
+    }
+
+    #[test]
+    fn ignores_test_directories() {
+        let fp1 = make_fp(
+            "src/module_a/foo.rs",
+            &["run"],
+            &[("run", "hash1")],
+            &[],
+        );
+        let fp2 = make_fp(
+            "src/module_a/bar.rs",
+            &["exec"],
+            &[("exec", "hash2")],
+            &[],
+        );
+        let fp3 = make_fp(
+            "tests/module_a/foo.rs",
+            &["run"],
+            &[("run", "hash1")],
+            &[],
+        );
+        let fp4 = make_fp(
+            "tests/module_a/bar.rs",
+            &["exec"],
+            &[("exec", "hash2")],
+            &[],
+        );
+
+        let fps: Vec<&FileFingerprint> = vec![&fp1, &fp2, &fp3, &fp4];
+        let findings = detect_shadow_modules(&fps);
+
+        assert!(
+            findings.is_empty(),
+            "Test dirs should not be flagged as shadows"
+        );
+    }
+
+    #[test]
+    fn ignores_low_overlap() {
+        let fp1 = make_fp(
+            "src/alpha/common.rs",
+            &["shared"],
+            &[("shared", "hash1")],
+            &[],
+        );
+        let fp2 = make_fp(
+            "src/alpha/unique_a.rs",
+            &["only_a"],
+            &[("only_a", "hash2")],
+            &[],
+        );
+        let fp3 = make_fp(
+            "src/alpha/unique_b.rs",
+            &["only_b"],
+            &[("only_b", "hash3")],
+            &[],
+        );
+        let fp4 = make_fp(
+            "src/beta/common.rs",
+            &["shared"],
+            &[("shared", "hash1")],
+            &[],
+        );
+        let fp5 = make_fp(
+            "src/beta/different_a.rs",
+            &["diff_a"],
+            &[("diff_a", "hash4")],
+            &[],
+        );
+        let fp6 = make_fp(
+            "src/beta/different_b.rs",
+            &["diff_b"],
+            &[("diff_b", "hash5")],
+            &[],
+        );
+
+        let fps: Vec<&FileFingerprint> = vec![&fp1, &fp2, &fp3, &fp4, &fp5, &fp6];
+        let findings = detect_shadow_modules(&fps);
+
+        // Only 1 shared file name out of 3 = 33% < 50% threshold
+        assert!(
+            findings.is_empty(),
+            "Low overlap should not produce findings"
+        );
+    }
+
+    #[test]
+    fn ignores_subdirectory_relationship() {
+        let fp1 = make_fp(
+            "src/core/foo.rs",
+            &["run"],
+            &[("run", "hash1")],
+            &[],
+        );
+        let fp2 = make_fp(
+            "src/core/bar.rs",
+            &["exec"],
+            &[("exec", "hash2")],
+            &[],
+        );
+        let fp3 = make_fp(
+            "src/core/sub/foo.rs",
+            &["run"],
+            &[("run", "hash1")],
+            &[],
+        );
+        let fp4 = make_fp(
+            "src/core/sub/bar.rs",
+            &["exec"],
+            &[("exec", "hash2")],
+            &[],
+        );
+
+        let fps: Vec<&FileFingerprint> = vec![&fp1, &fp2, &fp3, &fp4];
+        let findings = detect_shadow_modules(&fps);
+
+        assert!(
+            findings.is_empty(),
+            "Parent/child dirs should not be flagged"
+        );
+    }
+
+    #[test]
+    fn parent_dir_extracts_correctly() {
+        assert_eq!(parent_dir("src/core/foo.rs"), "src/core");
+        assert_eq!(parent_dir("lib.rs"), ".");
+        assert_eq!(parent_dir("src\\win\\bar.rs"), "src/win");
+    }
+
+    #[test]
+    fn file_stem_extracts_correctly() {
+        assert_eq!(file_stem("src/core/foo.rs"), Some("foo".to_string()));
+        assert_eq!(file_stem("bar.php"), Some("bar".to_string()));
+        assert_eq!(file_stem("noext"), None);
+    }
+}


### PR DESCRIPTION
## Summary

Two new audit rules, both language-agnostic:

### Shadow Module Detection (#635)
Detects directories that are near-copies — overlapping file names with high content similarity. Stronger signal than individual `DuplicateFunction` findings because it indicates systemic duplication (an entire module was copy-pasted).

- Groups fingerprints by parent directory
- Compares all pairs for ≥50% file name overlap AND ≥50% method/structural hash overlap
- Filters out test directories and parent/child relationships
- New finding kind: `ShadowModule`

### Repeated Struct Field Pattern (#441)
Detects groups of fields that appear together in 3+ struct/class/interface definitions. Candidates for extraction into a shared type.

- Walks source files, extracts struct definitions using brace-depth tracking
- Parses field declarations (name + type) from line content
- Finds co-occurring field groups across multiple types
- New finding kind: `RepeatedFieldPattern`

### Also
- Closed #482 — layer ownership rules were already fully implemented

Addresses #635, #441