### PR TITLE
feat: add --user override and per-server env to fleet exec/ssh (#763, #816)

### DIFF
--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -109,6 +109,10 @@ enum FleetCommand {
         #[arg(long)]
         check: bool,
 
+        /// Override the SSH user for this execution (instead of each server's configured user)
+        #[arg(long)]
+        user: Option<String>,
+
         /// Reserved for future parallel mode. Currently all execution is serial.
         #[arg(long, hide = true)]
         serial: bool,
@@ -161,8 +165,9 @@ pub fn run(args: FleetArgs, _global: &super::GlobalArgs) -> CmdResult<FleetOutpu
             id,
             command,
             check,
+            user,
             serial: _,
-        } => exec(&id, command, check),
+        } => exec(&id, command, check, user),
     }
 }
 
@@ -474,8 +479,13 @@ fn check(id: &str, only_outdated: bool) -> CmdResult<FleetOutput> {
     ))
 }
 
-fn exec(id: &str, command: Vec<String>, check: bool) -> CmdResult<FleetOutput> {
-    let (results, summary, exit_code) = fleet::collect_exec(id, command, check)?;
+fn exec(
+    id: &str,
+    command: Vec<String>,
+    check: bool,
+    user: Option<String>,
+) -> CmdResult<FleetOutput> {
+    let (results, summary, exit_code) = fleet::collect_exec(id, command, check, user)?;
 
     Ok((
         FleetOutput {

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -163,6 +163,7 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                     user,
                     port: port.unwrap_or(22),
                     identity_file: None,
+                    env: std::collections::HashMap::new(),
                 };
 
                 homeboy::config::to_json_string(&new_server)?

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -26,6 +26,10 @@ pub struct SshArgs {
     #[arg(long)]
     pub as_server: bool,
 
+    /// Override the SSH user (instead of the server's configured user)
+    #[arg(long)]
+    pub user: Option<String>,
+
     #[command(subcommand)]
     pub subcommand: Option<SshSubcommand>,
 }
@@ -108,7 +112,10 @@ pub fn run(args: SshArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Ss
                 _ => command_string.clone(),
             };
 
-            let client = SshClient::from_server(&result.server, &result.server_id)?;
+            let mut client = SshClient::from_server(&result.server, &result.server_id)?;
+            if let Some(ref user_override) = args.user {
+                client.user = user_override.clone();
+            }
 
             if !args.command.is_empty() {
                 // Non-interactive: capture output for JSON response

--- a/src/core/fleet/exec.rs
+++ b/src/core/fleet/exec.rs
@@ -29,6 +29,7 @@ pub fn collect_exec(
     fleet_id: &str,
     command: Vec<String>,
     check: bool,
+    user_override: Option<String>,
 ) -> crate::Result<(Vec<FleetExecProjectResult>, FleetExecSummary, i32)> {
     if command.is_empty() {
         return Err(
@@ -97,9 +98,9 @@ pub fn collect_exec(
             }
         };
 
-        let client = match SshClient::from_server(&resolve_result.server, &resolve_result.server_id)
-        {
-            Ok(c) => c,
+        let mut client =
+            match SshClient::from_server(&resolve_result.server, &resolve_result.server_id) {
+                Ok(c) => c,
             Err(e) => {
                 summary.failed += 1;
                 results.push(FleetExecProjectResult {
@@ -114,6 +115,10 @@ pub fn collect_exec(
                 continue;
             }
         };
+
+        if let Some(ref user) = user_override {
+            client.user = user.clone();
+        }
 
         let effective_cmd = match &resolve_result.base_path {
             Some(bp) => format!("cd {} && {}", shell::quote_path(bp), &command_string),

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::engine::shell;
 use crate::error::{Error, Result};
 
@@ -12,6 +14,9 @@ pub struct SshClient {
     /// When true, all commands run locally instead of over SSH.
     /// Set automatically when the server host is localhost/127.0.0.1/::1.
     pub is_local: bool,
+    /// Environment variables to inject before remote commands.
+    /// Values are passed through the shell, so `$PATH`-style expansion works.
+    pub env: HashMap<String, String>,
 }
 
 pub struct CommandOutput {
@@ -52,6 +57,7 @@ impl SshClient {
             port: server.port,
             identity_file,
             is_local,
+            env: server.env.clone(),
         })
     }
 
@@ -93,7 +99,22 @@ impl SshClient {
     }
 
     pub fn execute(&self, command: &str) -> CommandOutput {
-        self.execute_with_stdin(command, None)
+        let effective = self.prepend_env(command);
+        self.execute_with_stdin(&effective, None)
+    }
+
+    /// Build an env preamble that sets configured variables via `export`.
+    /// Values are quoted but allow shell expansion (e.g. `$PATH`).
+    fn prepend_env(&self, command: &str) -> String {
+        if self.env.is_empty() {
+            return command.to_string();
+        }
+        let exports: Vec<String> = self
+            .env
+            .iter()
+            .map(|(k, v)| format!("export {}={}", k, shell::quote_arg(v)))
+            .collect();
+        format!("{} && {}", exports.join(" && "), command)
     }
 
     pub fn upload_file(&self, local_path: &str, remote_path: &str) -> CommandOutput {
@@ -192,9 +213,12 @@ impl SshClient {
     }
 
     pub fn execute_interactive(&self, command: Option<&str>) -> i32 {
+        let effective = command.map(|c| self.prepend_env(c));
+        let effective_ref = effective.as_deref();
+
         // Local execution: run command directly instead of opening SSH session
         if self.is_local {
-            return match command {
+            return match effective_ref {
                 Some(cmd) => execute_local_command_interactive(cmd, None, None),
                 None => {
                     // Interactive shell on localhost — just open a shell
@@ -203,7 +227,7 @@ impl SshClient {
             };
         }
 
-        let args = self.build_ssh_args(command, true);
+        let args = self.build_ssh_args(effective_ref, true);
 
         let status = Command::new("ssh")
             .args(&args)

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -13,6 +13,8 @@ pub use health::*;
 pub use keys::*;
 pub use transfer::*;
 
+use std::collections::HashMap;
+
 use crate::config::{self, ConfigEntity};
 use crate::error::{Error, Result};
 use crate::output::{CreateOutput, MergeOutput, RemoveResult};
@@ -33,6 +35,10 @@ pub struct Server {
     pub port: u16,
     #[serde(default)]
     pub identity_file: Option<String>,
+    /// Environment variables to set before executing commands on this server.
+    /// Values support `$PATH`-style expansion — the shell handles it.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
 }
 
 fn default_port() -> u16 {


### PR DESCRIPTION
## Summary

### `--user` override (#763)
Override the SSH user for a single invocation:

```bash
homeboy fleet exec fleet-servers --user root -- homeboy update
homeboy ssh extra-chill --user root -- systemctl restart nginx
```

No more maintaining duplicate server entries for the same host. The configured user stays correct for deploys, `--user` overrides for admin ops.

### Per-server `env` config (#816)
Servers can declare environment variables that are injected before every SSH command:

```json
{
  "id": "extra-chill",
  "host": "178.156.238.82",
  "user": "opencode",
  "env": {
    "PATH": "/home/opencode/.local/bin:$PATH"
  }
}
```

Solves the non-interactive SSH PATH problem — `fleet exec` now finds user-local binaries.

### Implementation
- `Server` struct gets `env: HashMap<String, String>` (serde-defaulted, skip-if-empty)
- `SshClient` gets `env` field + `prepend_env()` method that wraps commands with `export K=V && ...`
- Applied transparently in `execute()` and `execute_interactive()` — all SSH consumers get env injection for free

Closes #763, #816