### PR TITLE
Fail-fast on compile errors in refactor convergence loop

### DIFF
--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -267,6 +267,35 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
                 &stage.summary.changed_files,
                 &mut warnings,
             );
+
+            // Fail-fast: compile-check the sandbox after each stage that modifies
+            // files. If a stage breaks compilation (e.g. audit fixes introduce
+            // parse errors), subsequent stages (lint, test) would run on broken
+            // code — producing bogus findings and wasting time. Skip them.
+            let abs_changed: Vec<PathBuf> = stage
+                .summary
+                .changed_files
+                .iter()
+                .map(|f| working_root.path().join(f))
+                .collect();
+            let sandbox_compile =
+                validate_write::validate_only(working_root.path(), &abs_changed)?;
+            if !sandbox_compile.success {
+                crate::log_status!(
+                    "refactor",
+                    "Sandbox compile check failed after {} stage — skipping remaining stages",
+                    source
+                );
+                if let Some(output) = &sandbox_compile.output {
+                    warnings.push(format!(
+                        "{} stage broke compilation — skipping remaining stages: {}",
+                        source, output
+                    ));
+                }
+                accumulator.extend(stage.fix_results.clone());
+                planned_stages.push(stage);
+                break;
+            }
         }
 
         accumulator.extend(stage.fix_results.clone());

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -2,6 +2,7 @@ use crate::code_audit::{self, CodeAuditResult};
 use crate::component::{self, Component};
 use crate::engine::temp;
 use crate::engine::undo::UndoSnapshot;
+use crate::engine::validate_write;
 use crate::extension::test::compute_changed_test_files;
 use crate::extension::{lint as extension_lint, test as extension_test};
 use crate::refactor::auto as fixer;
@@ -154,6 +155,36 @@ pub fn run_audit_refactor(
                 iteration_summary.score_delta =
                     score_delta(&current_result, &current_result, scoring);
                 iteration_summary.status = "stopped_no_safe_changes".to_string();
+                iterations.push(iteration_summary);
+                break;
+            }
+
+            // Fail-fast: compile-check after applying fixes. If the code no
+            // longer compiles (e.g. "failed to resolve mod", parse errors),
+            // further iterations cannot recover — bail immediately instead of
+            // burning cold-compile retries that will never converge.
+            let root = Path::new(&current_result.source_path);
+            let compile_check_files: Vec<PathBuf> = changed_files
+                .iter()
+                .map(|f| root.join(f))
+                .collect();
+            let compile_result = validate_write::validate_only(root, &compile_check_files)?;
+            if !compile_result.success {
+                crate::log_status!(
+                    "refactor",
+                    "Compile check failed after iteration {} — stopping convergence",
+                    iteration_index + 1
+                );
+                if let Some(output) = &compile_result.output {
+                    crate::log_status!("refactor", "Compile error: {}", output);
+                }
+                iteration_summary.iteration = iteration_index + 1;
+                iteration_summary.findings_after = current_result.findings.len();
+                iteration_summary.weighted_score_after =
+                    weighted_finding_score_with(&current_result, scoring);
+                iteration_summary.score_delta =
+                    score_delta(&current_result, &current_result, scoring);
+                iteration_summary.status = "stopped_compile_failure".to_string();
                 iterations.push(iteration_summary);
                 break;
             }


### PR DESCRIPTION
## Summary

- **Convergence loop fail-fast**: Adds a compile check (`validate_only`) after each convergence iteration. If code no longer compiles (e.g. `failed to resolve mod`, parse errors), breaks immediately with `stopped_compile_failure` instead of retrying
- **Stage loop fail-fast**: Adds a compile check between planner stages (`audit → lint → test`). If a stage breaks sandbox compilation, skips remaining stages instead of running lint/test on broken code

## Problem

Two layers of wasted CI time on unrecoverable errors:

### 1. Convergence loop (verify.rs)
The loop retries up to 3 times when fixes don't converge. Each retry is a cold compile in the sandbox. When a fix introduces a parse/resolve error, no amount of retrying will fix it:

```
apply fixes → re-audit → retry → re-audit → retry → re-audit → fail at final gate
```

### 2. Stage loop (planner.rs)
When `--from all` runs `audit → lint → test`, if audit fixes break compilation:
- Lint runs on broken code → bogus findings
- Test runs on broken code → bogus failures
- Both stages waste time and produce noise

## Fix

### Convergence loop
After `run_fix_iteration()` applies fixes, run `validate_only()` before the structural re-audit. If compilation fails, log the error and break with `stopped_compile_failure`.

```
Before:  apply → re-audit → retry → re-audit → retry → fail
After:   apply → compile check → STOP
```

### Stage loop
After each stage that modifies files, run `validate_only()` on the sandbox. If broken, log + skip remaining stages.

```
Before:  audit (breaks) → lint (bogus) → test (bogus) → validate_write → rollback
After:   audit (breaks) → compile check → STOP → validate_write → rollback
```

Both checks use the existing `validate_only()` function — no new infrastructure needed.