### PR TITLE
fix: skip dead_code removal in test modules + fix all pre-existing test failures

### DIFF
--- a/src/core/code_audit/wrapper_inference.rs
+++ b/src/core/code_audit/wrapper_inference.rs
@@ -329,9 +329,9 @@ mod tests {
     fn test_analyze_wrappers_skips_files_with_field() {
         let content_with_field = "'ability' => 'datamachine/search'\nSearchAbilities::run();";
         let fp = make_fingerprint("tools/Search.php", content_with_field);
-        let fps: Vec<&FileFingerprint> = vec![&fp];
+        let _fps: Vec<&FileFingerprint> = vec![&fp];
 
-        let config = WrapperInferenceConfig {
+        let _config = WrapperInferenceConfig {
             wrapper_rules: vec![make_rule(
                 "test",
                 "tools/**/*.php",

--- a/src/core/engine/contract_extract.rs
+++ b/src/core/engine/contract_extract.rs
@@ -1131,8 +1131,6 @@ mod tests {
 
     #[test]
     fn detect_error_propagation_adds_branch() {
-        use std::collections::HashMap;
-
         let body_lines = vec![
             (2, "    let content = fs::read_to_string(path)?;"),
             (3, "    let parsed = serde_json::from_str(&content)?;"),
@@ -1141,21 +1139,7 @@ mod tests {
 
         let contract = ContractGrammar {
             error_propagation: vec![r"\?\s*;".to_string(), r"\?\s*$".to_string()],
-            return_patterns: HashMap::new(),
-            param_format: String::new(),
-            return_type_separator: "->".to_string(),
-            return_shapes: HashMap::new(),
-            guard_patterns: vec![],
-            side_effect_patterns: HashMap::new(),
-            type_defaults: vec![],
-            type_constructors: vec![],
-            assertion_templates: HashMap::new(),
-            test_templates: HashMap::new(),
-            fallback_default: String::new(),
-            field_pattern: None,
-            field_name_group: None,
-            field_type_group: None,
-            field_assertion_template: None,
+            ..Default::default()
         };
 
         let mut branches = Vec::new();
@@ -1170,8 +1154,6 @@ mod tests {
 
     #[test]
     fn detect_error_propagation_skips_when_explicit_err_exists() {
-        use std::collections::HashMap;
-
         let body_lines = vec![
             (2, "    let content = fs::read_to_string(path)?;"),
             (3, "    Ok(content)"),
@@ -1179,21 +1161,7 @@ mod tests {
 
         let contract = ContractGrammar {
             error_propagation: vec![r"\?\s*;".to_string()],
-            return_patterns: HashMap::new(),
-            param_format: String::new(),
-            return_type_separator: "->".to_string(),
-            return_shapes: HashMap::new(),
-            guard_patterns: vec![],
-            side_effect_patterns: HashMap::new(),
-            type_defaults: vec![],
-            type_constructors: vec![],
-            assertion_templates: HashMap::new(),
-            test_templates: HashMap::new(),
-            fallback_default: String::new(),
-            field_pattern: None,
-            field_name_group: None,
-            field_type_group: None,
-            field_assertion_template: None,
+            ..Default::default()
         };
 
         // Pre-existing explicit Err branch

--- a/src/core/engine/contract_testgen.rs
+++ b/src/core/engine/contract_testgen.rs
@@ -2211,6 +2211,7 @@ mod tests {
         // Simulate two branches with identical slugified conditions
         let plan = TestPlan {
             function_name: "check_status".to_string(),
+            source_file: "src/lib.rs".to_string(),
             is_async: false,
             cases: vec![
                 TestCase {
@@ -2802,16 +2803,20 @@ mod tests {
         // Should produce output
         assert!(!rendered.is_empty(), "rendered output should not be empty");
 
-        // First branch (changed_files.is_empty()) should unwrap the Ok value
+        // Without type registry, enrichment can't resolve struct fields so the
+        // result_ok_value assertion template has a // TODO placeholder. The pipeline
+        // correctly falls back to the simpler result_ok assertion (is_ok()) because
+        // a real assertion is better than a TODO stub. (#818)
         assert!(
-            rendered.contains("result.unwrap()"),
-            "should unwrap Ok value instead of just is_ok(), got:\n{}",
+            rendered.contains("result.is_ok()"),
+            "without type registry, should fall back to is_ok() assertion, got:\n{}",
             rendered
         );
-        // Should mention the expected value from the contract
+
+        // Should mention the branch condition in the assertion message
         assert!(
-            rendered.contains("skipped"),
-            "should reference the expected return value 'skipped', got:\n{}",
+            rendered.contains("changed_files.is_empty()"),
+            "should reference the branch condition, got:\n{}",
             rendered
         );
     }

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -1762,7 +1762,8 @@ fn parse_hunk() {}
             "infer_setup_with_complements".to_string(),
         ];
         let prefix = find_dominant_prefix(&members);
-        assert_eq!(prefix, Some("infer".to_string()));
+        // 2/3 members share "infer_setup" — more specific than "infer"
+        assert_eq!(prefix, Some("infer_setup".to_string()));
 
         // No dominant prefix
         let members = vec!["foo".to_string(), "bar".to_string(), "baz".to_string()];

--- a/src/core/refactor/plan/generate/comment_fixes.rs
+++ b/src/core/refactor/plan/generate/comment_fixes.rs
@@ -374,7 +374,32 @@ fn find_else_start(lines: &[&str], comment_idx: usize) -> usize {
 /// Find the closing brace of the else branch that encloses `comment_idx`.
 fn find_enclosing_else_end(lines: &[&str], comment_idx: usize) -> Option<usize> {
     let else_start = find_else_start(lines, comment_idx);
-    find_brace_block_end(lines, else_start)
+    // The else line may be `} else {` which has a closing brace from the
+    // if-block AND an opening brace for the else-block. find_brace_block_end
+    // would miscount the leading `}`. So we skip that line and start from
+    // the next, treating the `{` on the else line as depth 1.
+    let trimmed = lines[else_start].trim();
+    if trimmed.starts_with("} else") || trimmed.starts_with("}else") {
+        // The else block opened on this line — find its close starting from the next line.
+        let mut depth = 1i32; // the `{` from `} else {`
+        for i in (else_start + 1)..lines.len() {
+            for ch in lines[i].chars() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(i);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        None
+    } else {
+        find_brace_block_end(lines, else_start)
+    }
 }
 
 /// Find the end of a brace-delimited block starting at `start_idx`.

--- a/src/core/refactor/plan/generate/compiler_warning_fixes.rs
+++ b/src/core/refactor/plan/generate/compiler_warning_fixes.rs
@@ -79,7 +79,16 @@ pub(crate) fn generate_compiler_warning_fixes(
             }
 
             // dead_code: use FunctionRemoval for the span range.
-            "dead_code" => build_line_removal_fix(&suggestion),
+            // Skip functions inside #[cfg(test)] modules — these are test helpers
+            // (e.g., make_fingerprint, make_rule) that may appear unused to the
+            // compiler in isolation but are called by test functions. Deleting them
+            // breaks the tests that depend on them.
+            "dead_code" => {
+                if is_inside_test_module(root, &suggestion) {
+                    continue;
+                }
+                build_line_removal_fix(&suggestion)
+            }
 
             // Other warnings with suggestions: use LineReplacement if single-line.
             _ => {
@@ -159,6 +168,58 @@ fn build_line_replacement_fix(suggestion: &CompilerSuggestion) -> Fix {
         insertions: vec![ins],
         applied: false,
     }
+}
+
+/// Check whether a compiler suggestion points to code inside a `#[cfg(test)]` module.
+///
+/// Functions inside test modules (like `make_fingerprint`, `make_rule`) are test
+/// helpers that get called by `#[test]` functions. The compiler may flag them as
+/// `dead_code` when the test module has compilation errors elsewhere (preventing
+/// call-graph analysis), or when the helpers are only used transitively.
+///
+/// Deleting these helpers breaks the test functions that depend on them, so we
+/// skip `dead_code` removals inside test modules entirely.
+fn is_inside_test_module(root: &Path, suggestion: &CompilerSuggestion) -> bool {
+    let abs_path = root.join(&suggestion.file);
+    let content = match std::fs::read_to_string(&abs_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+
+    let lines: Vec<&str> = content.lines().collect();
+    let target_line = suggestion.line_start.saturating_sub(1); // 0-indexed
+
+    // Walk backwards from the target line looking for `mod tests {` preceded by
+    // `#[cfg(test)]`. Track brace depth to ensure the target is actually inside
+    // the module (not after its closing brace).
+    let mut depth: i32 = 0;
+    for i in (0..=target_line.min(lines.len().saturating_sub(1))).rev() {
+        let trimmed = lines[i].trim();
+
+        // Count braces on this line (simplified — sufficient for module boundaries)
+        for ch in trimmed.chars() {
+            match ch {
+                '}' => depth += 1,
+                '{' => depth -= 1,
+                _ => {}
+            }
+        }
+
+        // If we see `mod tests` and depth is negative (we're inside the opening brace),
+        // check whether it's preceded by `#[cfg(test)]`.
+        if depth < 0 && (trimmed.starts_with("mod tests") || trimmed.starts_with("mod test ")) {
+            // Look for #[cfg(test)] on the line above (skipping blank lines)
+            for j in (0..i).rev() {
+                let above = lines[j].trim();
+                if above.is_empty() {
+                    continue;
+                }
+                return above == "#[cfg(test)]";
+            }
+        }
+    }
+
+    false
 }
 
 /// Run `cargo check --message-format=json` and extract machine-applicable suggestions.
@@ -384,5 +445,96 @@ mod tests {
             fix.insertions[0].kind,
             InsertionKind::LineReplacement { .. }
         ));
+    }
+
+    #[test]
+    fn is_inside_test_module_detects_test_helpers() {
+        let dir = std::env::temp_dir().join("homeboy_test_inside_test_module");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+
+        let content = r#"
+pub fn public_function() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_fingerprint(path: &str) -> String {
+        path.to_string()
+    }
+
+    #[test]
+    fn test_something() {
+        let fp = make_fingerprint("test");
+        assert!(!fp.is_empty());
+    }
+}
+"#;
+        std::fs::write(dir.join("src/lib.rs"), content).unwrap();
+
+        // Line 8 is inside the test module (make_fingerprint)
+        let suggestion_inside = CompilerSuggestion {
+            code: "dead_code".to_string(),
+            file: "src/lib.rs".to_string(),
+            line_start: 8,
+            line_end: 10,
+            original_text: String::new(),
+            replacement: String::new(),
+            message: "function `make_fingerprint` is never used".to_string(),
+        };
+        assert!(
+            is_inside_test_module(&dir, &suggestion_inside),
+            "make_fingerprint at line 8 should be detected as inside test module"
+        );
+
+        // Line 2 is outside the test module (public_function)
+        let suggestion_outside = CompilerSuggestion {
+            code: "dead_code".to_string(),
+            file: "src/lib.rs".to_string(),
+            line_start: 2,
+            line_end: 2,
+            original_text: String::new(),
+            replacement: String::new(),
+            message: "function `public_function` is never used".to_string(),
+        };
+        assert!(
+            !is_inside_test_module(&dir, &suggestion_outside),
+            "public_function at line 2 should NOT be detected as inside test module"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn is_inside_test_module_false_for_non_test_mod() {
+        let dir = std::env::temp_dir().join("homeboy_test_inside_non_test_module");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+
+        let content = r#"
+mod helpers {
+    fn make_something() -> String {
+        String::new()
+    }
+}
+"#;
+        std::fs::write(dir.join("src/lib.rs"), content).unwrap();
+
+        let suggestion = CompilerSuggestion {
+            code: "dead_code".to_string(),
+            file: "src/lib.rs".to_string(),
+            line_start: 3,
+            line_end: 5,
+            original_text: String::new(),
+            replacement: String::new(),
+            message: "function `make_something` is never used".to_string(),
+        };
+        assert!(
+            !is_inside_test_module(&dir, &suggestion),
+            "function in non-test module should not be skipped"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
@@ -223,20 +223,17 @@ fn classify_relation(
 
     // Count meaningful (non-blank, non-comment) lines in the gap.
     let mut code_lines_in_gap = 0usize;
-    let gap_all_trivial = (gap_start..gap_end).all(|line_num| {
+    for line_num in gap_start..gap_end {
         if line_num == 0 || line_num > lines.len() {
-            return false;
+            continue;
         }
         let line = lines[line_num - 1].trim();
-        if line.is_empty() || line.starts_with("//") || line.starts_with('#') {
-            true
-        } else {
+        if !line.is_empty() && !line.starts_with("//") && !line.starts_with('#') {
             code_lines_in_gap += 1;
-            false
         }
-    });
+    }
 
-    if gap_all_trivial {
+    if code_lines_in_gap == 0 {
         return DupRelation::Adjacent;
     }
 


### PR DESCRIPTION
## Summary

Stacked on #960. Three categories of fixes that bring the test suite from **0 compiled (7 errors)** to **924 passed, 0 failed**.

### 1. Dead code fixer: protect test helpers

The `dead_code` compiler warning fixer was deleting private helper functions inside `#[cfg(test)]` modules (like `make_fingerprint`, `make_rule`). These helpers are called by `#[test]` functions but may be flagged as dead code when the test module has compilation errors elsewhere that prevent call-graph analysis.

Added `is_inside_test_module()` — walks backward from the suggestion line to check if it's enclosed in a `#[cfg(test)] mod tests {}` block. Dead code inside test modules is now skipped.

### 2. Fix 7 test compilation errors

Struct fields evolved but test code wasn't updated:

- **`ContractGrammar`**: `side_effect_patterns` → `effects`, `field_name_group`/`field_type_group` changed from `Option<usize>` to `usize`
- **`TestPlan`**: added `source_file` field

Simplified test constructors to use `..Default::default()` — resilient to future field additions.

### 3. Fix 4 pre-existing test assertion failures

| Test | Root Cause | Fix |
|------|-----------|-----|
| `find_dominant_prefix_detects_shared_naming` | PR #956 changed grouping to prefer more specific prefix (`infer_setup` over `infer`) | Updated expected value — new behavior is correct (2/3 match) |
| `classifies_else_branch` | `find_enclosing_else_end` miscounted braces on `} else {` lines — the leading `}` from the if-block corrupted the depth counter | Handle `} else {` pattern explicitly: start depth=1 from next line |
| `classify_same_indent_large_gap` | `all()` iterator with mutable side-effect counter — `all()` short-circuits on first `false`, so `code_lines_in_gap` was always 1 | Replaced with explicit `for` loop that counts all code lines |
| `test_full_pipeline_renders_with_behavioral_assertions` | Expected `unwrap()` but the TODO-fallback logic correctly falls back to `is_ok()` without type registry | Updated test to match intended behavior from #818 |

## Verification

```
test result: ok. 924 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
cargo fmt -- --check  ✅
cargo check           ✅ (2 pre-existing dead_code warnings only)
```