### PR TITLE
fix: dead code cleanup + fast brace pre-check + intra-duplicate safety

### DIFF
--- a/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
@@ -130,6 +130,37 @@ pub(crate) fn generate_intra_duplicate_fixes(
                     second_line
                 };
 
+                // Check that the lines being removed have balanced braces.
+                // Duplicated blocks inside closures or match arms may contain
+                // only half of a brace pair (e.g., the opening `{` is above
+                // the block, the closing `}` is inside it). Removing such a
+                // block corrupts the file's delimiter structure.
+                let removal_lines =
+                    &lines[removal_start.saturating_sub(1)..second_end.min(lines.len())];
+                let mut brace_depth: i32 = 0;
+                let mut paren_depth: i32 = 0;
+                for line in removal_lines {
+                    for ch in line.chars() {
+                        match ch {
+                            '{' => brace_depth += 1,
+                            '}' => brace_depth -= 1,
+                            '(' => paren_depth += 1,
+                            ')' => paren_depth -= 1,
+                            _ => {}
+                        }
+                    }
+                }
+                if brace_depth != 0 || paren_depth != 0 {
+                    skipped.push(SkippedFile {
+                        file: finding.file.clone(),
+                        reason: format!(
+                            "Duplicate block in `{}` (lines {}-{}) has unbalanced delimiters (braces: {}, parens: {}) — removal would corrupt file",
+                            method_name, second_line, second_end, brace_depth, paren_depth,
+                        ),
+                    });
+                    continue;
+                }
+
                 fixes.push(Fix {
                     file: finding.file.clone(),
                     required_methods: vec![],

--- a/src/core/refactor/plan/generate/test_gen_fixes.rs
+++ b/src/core/refactor/plan/generate/test_gen_fixes.rs
@@ -13,7 +13,6 @@ use crate::code_audit::{AuditFinding, CodeAuditResult};
 use crate::core::engine::contract_testgen::{
     generate_tests_for_file_with_types, generate_tests_for_methods_with_types, GeneratedTestOutput,
 };
-use crate::core::engine::symbol_graph::module_path_from_file;
 use crate::core::extension::grammar_items;
 use crate::core::refactor::auto::{
     Fix, FixSafetyTier, Insertion, InsertionKind, NewFile, SkippedFile,
@@ -213,43 +212,6 @@ fn build_inline_test_module(generated: &GeneratedTestOutput, ext: &str) -> Optio
     }
 
     Some(content)
-}
-
-/// Build the complete test file content with module declaration, imports, and test functions.
-/// Used as fallback for non-inline test file generation.
-fn build_test_file_content(
-    source_file: &str,
-    generated: &GeneratedTestOutput,
-    ext: &str,
-) -> String {
-    let mut content = String::new();
-
-    match ext {
-        "rs" => {
-            let module_path = module_path_from_file(source_file);
-            content.push_str(&format!("use crate::{}::*;\n", module_path));
-
-            for imp in &generated.extra_imports {
-                content.push_str(imp);
-                content.push('\n');
-            }
-
-            content.push('\n');
-            content.push_str(&generated.test_source);
-        }
-        _ => {
-            for imp in &generated.extra_imports {
-                content.push_str(imp);
-                content.push('\n');
-            }
-            if !generated.extra_imports.is_empty() {
-                content.push('\n');
-            }
-            content.push_str(&generated.test_source);
-        }
-    }
-
-    content
 }
 
 /// Generate test methods for `MissingTestMethod` findings.
@@ -501,15 +463,6 @@ fn find_inline_test_module_end(content: &str) -> Option<usize> {
 }
 
 /// Extract the expected test path from a MissingTestFile finding description.
-///
-/// The description format is: "No test file found (expected 'tests/core/engine/foo_test.rs') ..."
-fn extract_test_path_from_description(description: &str) -> Option<String> {
-    let start = description.find("expected '")?;
-    let after_quote = &description[start + "expected '".len()..];
-    let end = after_quote.find('\'')?;
-    Some(after_quote[..end].to_string())
-}
-
 /// Build a project-wide type registry for a set of audit findings.
 ///
 /// Determines the dominant file extension from the findings, loads the
@@ -557,20 +510,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extract_test_path_from_description_typical() {
-        let desc = "No test file found (expected 'tests/core/engine/validate_write_test.rs') and no inline tests";
-        assert_eq!(
-            extract_test_path_from_description(desc),
-            Some("tests/core/engine/validate_write_test.rs".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_test_path_from_description_bad_format() {
-        assert_eq!(extract_test_path_from_description("no test file"), None);
-    }
-
-    #[test]
     fn test_extract_method_name_from_description_typical() {
         let desc =
             "Method 'validate_write' has no corresponding test (expected 'test_validate_write')";
@@ -596,19 +535,5 @@ mod tests {
             format!("tests/{}_test.rs", without_src)
         };
         assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn build_test_file_content_includes_imports() {
-        let generated = GeneratedTestOutput {
-            test_source: "#[test]\nfn test_foo() {}\n".to_string(),
-            extra_imports: vec!["use std::path::Path;".to_string()],
-            tested_functions: vec!["foo".to_string()],
-        };
-
-        let content = build_test_file_content("src/core/engine/foo.rs", &generated, "rs");
-        assert!(content.contains("use crate::core::engine::foo::*;"));
-        assert!(content.contains("use std::path::Path;"));
-        assert!(content.contains("#[test]"));
     }
 }

--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -278,6 +278,50 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
                 .iter()
                 .map(|f| working_root.path().join(f))
                 .collect();
+
+            // Fast brace-balance check before expensive sandbox compile.
+            // Catches fixer-induced brace corruption in milliseconds.
+            let mut brace_broken = false;
+            for file_path in &abs_changed {
+                if let Ok(content) = std::fs::read_to_string(file_path) {
+                    let ext = file_path
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .unwrap_or_default();
+                    if let Some(grammar) =
+                        crate::code_audit::core_fingerprint::load_grammar_for_ext(ext)
+                    {
+                        if !crate::extension::grammar_items::validate_brace_balance(
+                            &content, &grammar,
+                        ) {
+                            let rel = file_path
+                                .strip_prefix(working_root.path())
+                                .unwrap_or(file_path)
+                                .display()
+                                .to_string();
+                            crate::log_status!(
+                                "refactor",
+                                "Brace corruption in {} after {} stage — skipping compile",
+                                rel,
+                                source
+                            );
+                            warnings.push(format!(
+                                "{} stage produced unbalanced braces in {} — skipping",
+                                source, rel
+                            ));
+                            brace_broken = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if brace_broken {
+                accumulator.extend(stage.fix_results.clone());
+                planned_stages.push(stage);
+                break;
+            }
+
             let sandbox_compile = validate_write::validate_only(working_root.path(), &abs_changed)?;
             if !sandbox_compile.success {
                 crate::log_status!(

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -159,13 +159,62 @@ pub fn run_audit_refactor(
                 break;
             }
 
-            // Fail-fast: compile-check after applying fixes. If the code no
-            // longer compiles (e.g. "failed to resolve mod", parse errors),
-            // further iterations cannot recover — bail immediately instead of
-            // burning cold-compile retries that will never converge.
+            // Fail-fast: quick brace-balance check on changed files BEFORE
+            // the expensive compile. Catches fixer-induced brace corruption
+            // (mismatched delimiters from template expansion, bad line removals)
+            // in milliseconds instead of waiting for a 20+ minute cold compile.
             let root = Path::new(&current_result.source_path);
             let compile_check_files: Vec<PathBuf> =
                 changed_files.iter().map(|f| root.join(f)).collect();
+
+            let mut brace_error = None;
+            for file_path in &compile_check_files {
+                if let Ok(content) = std::fs::read_to_string(file_path) {
+                    let ext = file_path
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .unwrap_or_default();
+                    if let Some(grammar) =
+                        crate::code_audit::core_fingerprint::load_grammar_for_ext(ext)
+                    {
+                        if !crate::extension::grammar_items::validate_brace_balance(
+                            &content, &grammar,
+                        ) {
+                            let rel = file_path
+                                .strip_prefix(root)
+                                .unwrap_or(file_path)
+                                .display()
+                                .to_string();
+                            brace_error = Some(format!(
+                                "Unbalanced braces in {} after applying fixes — fixer produced broken code",
+                                rel
+                            ));
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if let Some(err_msg) = brace_error {
+                crate::log_status!(
+                    "refactor",
+                    "Brace check failed after iteration {} — stopping immediately",
+                    iteration_index + 1
+                );
+                crate::log_status!("refactor", "{}", err_msg);
+                iteration_summary.iteration = iteration_index + 1;
+                iteration_summary.findings_after = current_result.findings.len();
+                iteration_summary.weighted_score_after =
+                    weighted_finding_score_with(&current_result, scoring);
+                iteration_summary.score_delta =
+                    score_delta(&current_result, &current_result, scoring);
+                iteration_summary.status = "stopped_brace_corruption".to_string();
+                iterations.push(iteration_summary);
+                break;
+            }
+
+            // Full compile-check. If the code no longer compiles (e.g. type
+            // errors, missing imports), further iterations cannot recover.
             let compile_result = validate_write::validate_only(root, &compile_check_files)?;
             if !compile_result.success {
                 crate::log_status!(


### PR DESCRIPTION
## Summary

Three fixes addressing autorefactor reliability:

### 1. Remove dead code from test_gen_fixes.rs (#902)

Remove `build_test_file_content()` and `extract_test_path_from_description()` — orphaned from the separate-file test generation that was replaced by inline test modules. Resolves the 2 compiler warnings in #902.

### 2. Fast brace-balance pre-check before sandbox compile

Add a millisecond-level brace-balance check on changed files BEFORE running `cargo check` in both the convergence loop (`verify.rs`) and sandbox planner (`planner.rs`).

**Before**: fixer produces broken code → 20+ minute cold compile → discovers error → CI hangs
**After**: fixer produces broken code → instant brace check → bail with `stopped_brace_corruption`

### 3. Intra-duplicate fixer: skip removals with unbalanced delimiters

The `intra_method_duplicate` fixer was removing duplicate blocks inside closures and match arms without checking delimiter balance. When a block contains only one side of a brace pair (e.g., the error-handling body inside a `.filter_map` closure), removing it corrupts the file.

This was the direct cause of the recurring `config.rs` and `component.rs` breakage:
```
error: mismatched closing delimiter: `}`
  --> config.rs:794:32
  |
760 | .filter_map(|e| {
  |                  - closing delimiter possibly meant for this
```

Fix: count braces and parens in the removal range. If unbalanced, skip the removal and log a reason.

## Verification

```
cargo check: 0 warnings
test result: ok. 923 passed; 0 failed
cargo fmt: clean
```