### PR TITLE
feat: add --context filter to refactor rename (#586)

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use homeboy::code_audit::{AuditFinding, CodeAuditResult};
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::refactor::{
-    self, auto, AddResult, MoveResult, RenameScope, RenameSpec, RenameTargeting,
+    self, auto, AddResult, MoveResult, RenameContext, RenameScope, RenameSpec, RenameTargeting,
 };
 use serde::Serialize;
 
@@ -73,6 +73,10 @@ enum RefactorCommand {
         /// Disable file/directory path renames (content edits only)
         #[arg(long)]
         no_file_renames: bool,
+        /// Syntactic context filter: key (strings/property access), variable/var,
+        /// parameter/param, all (default — match everything)
+        #[arg(long, default_value = "all")]
+        context: String,
         #[command(flatten)]
         write_mode: WriteModeArgs,
     },
@@ -236,6 +240,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             files,
             exclude,
             no_file_renames,
+            context,
             write_mode,
         }) => run_rename(
             &from,
@@ -247,6 +252,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             &files,
             &exclude,
             no_file_renames,
+            &context,
             write_mode.write,
         ),
 
@@ -528,17 +534,20 @@ fn run_rename(
     include_globs: &[String],
     exclude_globs: &[String],
     no_file_renames: bool,
+    context: &str,
     write: bool,
 ) -> CmdResult<RefactorOutput> {
     let scope = RenameScope::from_str(scope)?;
+    let rename_context = RenameContext::from_str(context)?;
 
     let root = refactor::move_items::resolve_root(component_id, path)?;
 
-    let spec = if literal {
+    let mut spec = if literal {
         RenameSpec::literal(from, to, scope.clone())
     } else {
         RenameSpec::new(from, to, scope.clone())
     };
+    spec.rename_context = rename_context;
     let targeting = RenameTargeting {
         include_globs: include_globs.to_vec(),
         exclude_globs: exclude_globs.to_vec(),

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -78,8 +78,8 @@ pub use plan::{
 pub use propagate::{propagate, PropagateConfig, PropagateEdit, PropagateField, PropagateResult};
 pub use rename::{
     apply_renames, find_references, find_references_with_targeting, generate_renames,
-    generate_renames_with_targeting, CaseVariant, FileEdit, FileRename, Reference, RenameResult,
-    RenameScope, RenameSpec, RenameTargeting, RenameWarning,
+    generate_renames_with_targeting, CaseVariant, FileEdit, FileRename, Reference, RenameContext,
+    RenameResult, RenameScope, RenameSpec, RenameTargeting, RenameWarning,
 };
 pub use transform::{
     ad_hoc_transform, apply_transforms, load_transform_set, TransformResult, TransformRule,

--- a/src/core/refactor/rename/mod.rs
+++ b/src/core/refactor/rename/mod.rs
@@ -47,6 +47,162 @@ impl RenameScope {
     }
 }
 
+/// Syntactic context filter for rename matches.
+///
+/// Restricts which occurrences of a term get renamed based on their
+/// syntactic position in the source code. Useful for selective renames
+/// where only certain usages should change (e.g., rename an array key
+/// but not a variable with the same name).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenameContext {
+    /// Only match inside string literals (`'term'`, `"term"`) and
+    /// property access (`.term`, `->term`, `::term`).
+    Key,
+    /// Only match variable references (`$term` in PHP, standalone identifiers
+    /// NOT inside strings or property access).
+    Variable,
+    /// Only match function parameter definitions (inside parentheses
+    /// following a function/fn keyword).
+    Parameter,
+    /// Match everything — current default behavior.
+    All,
+}
+
+impl RenameContext {
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "key" => Ok(RenameContext::Key),
+            "variable" | "var" => Ok(RenameContext::Variable),
+            "parameter" | "param" => Ok(RenameContext::Parameter),
+            "all" => Ok(RenameContext::All),
+            _ => Err(Error::validation_invalid_argument(
+                "context",
+                format!(
+                    "Unknown context '{}'. Use: key, variable (var), parameter (param), all",
+                    s
+                ),
+                None,
+                None,
+            )),
+        }
+    }
+
+    /// Check whether a match at the given position in a line passes this context filter.
+    ///
+    /// - `line`: the full line content
+    /// - `col`: 0-indexed byte offset of the match start within the line
+    /// - `match_len`: byte length of the matched text
+    pub fn matches(&self, line: &str, col: usize, match_len: usize) -> bool {
+        match self {
+            RenameContext::All => true,
+            RenameContext::Key => is_key_context(line, col, match_len),
+            RenameContext::Variable => is_variable_context(line, col),
+            RenameContext::Parameter => is_parameter_context(line, col),
+        }
+    }
+}
+
+/// Check if match is inside a string literal or follows a property accessor.
+fn is_key_context(line: &str, col: usize, match_len: usize) -> bool {
+    let bytes = line.as_bytes();
+
+    // Check if preceded by `.`, `->`, or `::` (property/method access)
+    let before = &line[..col];
+    let trimmed = before.trim_end();
+    if trimmed.ends_with('.') || trimmed.ends_with("->") || trimmed.ends_with("::") {
+        return true;
+    }
+
+    // Check if inside string quotes: count unescaped quotes before the match position.
+    // If an odd number of single or double quotes precede us, we're inside a string.
+    let match_end = col + match_len;
+    for quote in [b'\'', b'"'] {
+        let mut count = 0;
+        let mut i = 0;
+        while i < col {
+            if bytes[i] == b'\\' {
+                i += 2; // skip escaped char
+                continue;
+            }
+            if bytes[i] == quote {
+                count += 1;
+            }
+            i += 1;
+        }
+        if count % 2 == 1 {
+            // Verify the closing quote is after the match
+            let mut j = match_end;
+            while j < bytes.len() {
+                if bytes[j] == b'\\' {
+                    j += 2;
+                    continue;
+                }
+                if bytes[j] == quote {
+                    return true; // Inside a quoted string
+                }
+                j += 1;
+            }
+        }
+    }
+
+    false
+}
+
+/// Check if match is a variable reference (`$term` in PHP, or a standalone identifier
+/// not inside strings or property access).
+fn is_variable_context(line: &str, col: usize) -> bool {
+    // PHP variable: preceded by `$`
+    if col > 0 && line.as_bytes()[col - 1] == b'$' {
+        return true;
+    }
+
+    // Standalone identifier: NOT inside quotes and NOT after `.`, `->`, `::`
+    let before = &line[..col];
+    let trimmed = before.trim_end();
+    if trimmed.ends_with('.') || trimmed.ends_with("->") || trimmed.ends_with("::") {
+        return false; // Property access — not a variable
+    }
+
+    // Not inside a string (simple odd-quote check)
+    for quote in ['\'', '"'] {
+        let count = before.chars().filter(|&c| c == quote).count();
+        if count % 2 == 1 {
+            return false; // Inside a string
+        }
+    }
+
+    true
+}
+
+/// Check if match is inside a function parameter list.
+fn is_parameter_context(line: &str, col: usize) -> bool {
+    let before = &line[..col];
+
+    // Look for an unclosed `(` that follows a function keyword
+    let mut paren_depth: i32 = 0;
+    for ch in before.chars().rev() {
+        match ch {
+            ')' => paren_depth += 1,
+            '(' => {
+                paren_depth -= 1;
+                if paren_depth < 0 {
+                    // We're inside an opening paren — check if it follows a function keyword
+                    let before_paren = before[..before.rfind('(').unwrap_or(0)].trim_end();
+                    return before_paren.ends_with("function")
+                        || before_paren.ends_with("fn")
+                        || before_paren.ends_with(')')  // return type: fn foo() -> Type
+                        || before_paren.contains("function ")
+                        || before_paren.contains("fn ");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
 /// A case variant of a rename term.
 #[derive(Debug, Clone, Serialize)]
 pub struct CaseVariant {
@@ -64,6 +220,8 @@ pub struct RenameSpec {
     pub variants: Vec<CaseVariant>,
     /// When true, use exact string matching (no boundary detection).
     pub literal: bool,
+    /// Syntactic context filter — restricts which occurrences get renamed.
+    pub rename_context: RenameContext,
 }
 
 /// Optional file-targeting controls for rename operations.
@@ -178,6 +336,7 @@ impl RenameSpec {
             scope,
             variants,
             literal: false,
+            rename_context: RenameContext::All,
         }
     }
 
@@ -196,6 +355,7 @@ impl RenameSpec {
             scope,
             variants,
             literal: true,
+            rename_context: RenameContext::All,
         }
     }
 }
@@ -543,6 +703,10 @@ pub fn find_references_with_targeting(
                     if claimed.iter().any(|&(s, e)| pos < e && end > s) {
                         continue;
                     }
+                    // Apply syntactic context filter
+                    if !spec.rename_context.matches(line, pos, variant.from.len()) {
+                        continue;
+                    }
                     claimed.push((pos, end));
                     references.push(Reference {
                         file: relative.clone(),
@@ -646,6 +810,16 @@ pub fn generate_renames_with_targeting(
                 // Skip if overlapping with an already-claimed longer match
                 if all_matches.iter().any(|&(s, e, _)| pos < e && end > s) {
                     continue;
+                }
+                // Apply syntactic context filter on the line containing this match
+                if spec.rename_context != RenameContext::All {
+                    let line_start = content[..pos].rfind('\n').map_or(0, |p| p + 1);
+                    let line_end = content[pos..].find('\n').map_or(content.len(), |p| pos + p);
+                    let line = &content[line_start..line_end];
+                    let col = pos - line_start;
+                    if !spec.rename_context.matches(line, col, variant.from.len()) {
+                        continue;
+                    }
                 }
                 all_matches.push((pos, end, variant.to.clone()));
             }
@@ -1905,6 +2079,97 @@ mod tests {
         assert!(
             result.file_renames.is_empty(),
             "File renames should be disabled when rename_files=false"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn context_key_filters_to_string_keys_only() {
+        let dir = std::env::temp_dir().join("homeboy_context_key_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let content = r#"
+$handler_config = [];
+$input['handler_config'] = 'value';
+function foo($handler_config) {}
+echo "handler_config";
+$obj->handler_config = true;
+"#;
+        std::fs::write(dir.join("test.php"), content).unwrap();
+
+        let mut spec = RenameSpec::literal("handler_config", "handler_configs", RenameScope::All);
+        spec.rename_context = RenameContext::Key;
+
+        let refs = find_references_with_targeting(&spec, &dir, &RenameTargeting::default());
+
+        // Should match: 'handler_config' (string key), "handler_config" (string),
+        // ->handler_config (property access)
+        // Should NOT match: $handler_config (variable), $handler_config (parameter)
+        let matched_lines: Vec<usize> = refs.iter().map(|r| r.line).collect();
+        assert!(
+            !matched_lines.contains(&2), // $handler_config = [] — variable
+            "Should not match variable assignment, got matches at lines: {:?}",
+            matched_lines
+        );
+        assert!(
+            matched_lines.contains(&3), // $input['handler_config'] — string key
+            "Should match string key, got matches at lines: {:?}",
+            matched_lines
+        );
+        assert!(
+            !matched_lines.contains(&4), // function foo($handler_config) — parameter
+            "Should not match function parameter, got matches at lines: {:?}",
+            matched_lines
+        );
+        assert!(
+            matched_lines.contains(&5), // "handler_config" — string
+            "Should match string literal, got matches at lines: {:?}",
+            matched_lines
+        );
+        assert!(
+            matched_lines.contains(&6), // ->handler_config — property access
+            "Should match property access, got matches at lines: {:?}",
+            matched_lines
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn context_variable_filters_to_variables_only() {
+        let dir = std::env::temp_dir().join("homeboy_context_var_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let content = r#"
+$handler_config = [];
+$input['handler_config'] = 'value';
+$obj->handler_config = true;
+"#;
+        std::fs::write(dir.join("test.php"), content).unwrap();
+
+        let mut spec = RenameSpec::literal("handler_config", "handler_configs", RenameScope::All);
+        spec.rename_context = RenameContext::Variable;
+
+        let refs = find_references_with_targeting(&spec, &dir, &RenameTargeting::default());
+
+        let matched_lines: Vec<usize> = refs.iter().map(|r| r.line).collect();
+        assert!(
+            matched_lines.contains(&2), // $handler_config — variable
+            "Should match PHP variable, got matches at lines: {:?}",
+            matched_lines
+        );
+        assert!(
+            !matched_lines.contains(&3), // 'handler_config' — string key, not variable
+            "Should not match string key, got matches at lines: {:?}",
+            matched_lines
+        );
+        assert!(
+            !matched_lines.contains(&4), // ->handler_config — property access, not variable
+            "Should not match property access, got matches at lines: {:?}",
+            matched_lines
         );
 
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

Add a `--context` flag to `refactor rename` for selective renames based on syntactic position.

### Problem

`refactor rename --from handler_config --to handler_configs` produces 679 matches — every occurrence including variables, parameters, string keys, and property access. Most are false positives when you only want to rename the array key.

### Solution

```bash
# Only rename string keys and property access
homeboy refactor rename --from handler_config --to handler_configs --literal --context key
# 88 matches instead of 679
```

### Contexts

| Value | Matches | Skips |
|---|---|---|
| `key` | `'handler_config'`, `"handler_config"`, `->handler_config`, `::handler_config` | `$handler_config`, function params |
| `variable` / `var` | `$handler_config` (PHP variables), standalone identifiers | String literals, property access |
| `parameter` / `param` | `function foo($handler_config)` | Everything outside function signatures |
| `all` | Everything (default, current behavior) | Nothing |

### Implementation

- `RenameContext` enum on `RenameSpec` — applied at both match sites (reference discovery + edit generation)
- Context classification uses character-level analysis: quote counting for strings, accessor prefix detection for properties, paren tracking for parameters
- Filter applied per-match, not per-file — a single line can have both key and variable matches, only the matching context is renamed

### Tests

- `context_key_filters_to_string_keys_only` — verifies key context matches strings/properties, skips variables/params
- `context_variable_filters_to_variables_only` — verifies variable context matches `$var`, skips strings/properties

```
test result: ok. 926 passed; 0 failed
```

Closes #586.