### PR TITLE
feat: directory-based config hierarchy — fleet, project, and component levels

### DIFF
--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -82,6 +82,11 @@ enum ProjectCommand {
         /// Project ID
         project_id: String,
     },
+    /// Initialize a project directory (migrate from flat file to directory layout)
+    Init {
+        /// Project ID
+        project_id: String,
+    },
     /// Show live server health and component versions for a project
     Status {
         /// Project ID
@@ -237,6 +242,7 @@ pub fn run(args: ProjectArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
         ProjectCommand::Components { command } => components(command),
         ProjectCommand::Pin { command } => pin(command),
         ProjectCommand::Delete { project_id } => delete(&project_id),
+        ProjectCommand::Init { project_id } => init(&project_id),
         ProjectCommand::Status {
             project_id,
             health_only,
@@ -291,6 +297,12 @@ fn delete(project_id: &str) -> CmdResult<ProjectOutput> {
     project::delete(project_id)?;
 
     Ok((project::build_delete_output(project_id), 0))
+}
+
+fn init(project_id: &str) -> CmdResult<ProjectOutput> {
+    let dir = project::init_project_dir(project_id)?;
+
+    Ok((project::build_init_output(project_id, &dir), 0))
 }
 
 fn components(command: ProjectComponentsCommand) -> CmdResult<ProjectOutput> {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -872,6 +872,11 @@ pub(crate) fn save<T: ConfigEntity>(entity: &T) -> Result<()> {
 
     let path = T::config_path(entity.id())?;
     local_files::ensure_app_dirs()?;
+    // Ensure parent directory exists (supports directory-based entities like
+    // projects and extensions where config_path is {dir}/{id}/{id}.json)
+    if let Some(parent) = path.parent() {
+        local_files::local().ensure_dir(parent)?;
+    }
     let content = to_string_pretty(entity)?;
     local_files::local().write(&path, &content)?;
     Ok(())
@@ -896,6 +901,9 @@ fn create_single<T: ConfigEntity>(entity: T) -> Result<CreateResult<T>> {
 
     let path = T::config_path(entity.id())?;
     local_files::ensure_app_dirs()?;
+    if let Some(parent) = path.parent() {
+        local_files::local().ensure_dir(parent)?;
+    }
     let content = to_string_pretty(&entity)?;
     local_files::local().write(&path, &content)?;
 
@@ -946,6 +954,22 @@ pub(crate) fn delete<T: ConfigEntity>(id: &str) -> Result<()> {
         return Err(T::not_found_error(id.to_string(), suggestions));
     }
     local_files::local().delete(&path)?;
+
+    // For directory-based entities, clean up the parent directory if it's
+    // now empty (e.g., projects/{id}/ after removing {id}.json).
+    if let Some(parent) = path.parent() {
+        if parent
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy() == id)
+        {
+            if let Ok(mut entries) = std::fs::read_dir(parent) {
+                if entries.next().is_none() {
+                    let _ = std::fs::remove_dir(parent);
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -1225,12 +1249,51 @@ pub(crate) fn rename<T: ConfigEntity>(id: &str, new_id: &str) -> Result<()> {
     entity.set_id(new_id.clone());
 
     local_files::ensure_app_dirs()?;
-    std::fs::rename(&old_path, &new_path).map_err(|e| {
-        Error::internal_io(e.to_string(), Some(format!("rename {}", T::entity_type())))
-    })?;
+
+    // For directory-based entities (where the config file lives inside a
+    // named directory, e.g. projects/{id}/{id}.json), rename the directory
+    // first, then save the updated entity into the new location.
+    let old_parent = old_path.parent().map(|p| p.to_path_buf());
+    let new_parent = new_path.parent().map(|p| p.to_path_buf());
+    let is_directory_based = old_parent.as_ref().is_some_and(|p| {
+        p.file_name()
+            .is_some_and(|name| name.to_string_lossy() == id)
+    });
+
+    if is_directory_based {
+        if let (Some(old_dir), Some(new_dir)) = (&old_parent, &new_parent) {
+            std::fs::rename(old_dir, new_dir).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("rename {} directory", T::entity_type())),
+                )
+            })?;
+            // Rename the JSON file inside the new directory
+            let old_json_in_new_dir = new_dir.join(format!("{}.json", id));
+            if old_json_in_new_dir.exists() {
+                std::fs::rename(&old_json_in_new_dir, &new_path).map_err(|e| {
+                    Error::internal_io(
+                        e.to_string(),
+                        Some(format!("rename {} config file", T::entity_type())),
+                    )
+                })?;
+            }
+        }
+    } else {
+        std::fs::rename(&old_path, &new_path).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("rename {}", T::entity_type())))
+        })?;
+    }
 
     if let Err(error) = save(&entity) {
-        let _ = std::fs::rename(&new_path, &old_path);
+        // Rollback: move back
+        if is_directory_based {
+            if let (Some(old_dir), Some(new_dir)) = (&old_parent, &new_parent) {
+                let _ = std::fs::rename(new_dir, old_dir);
+            }
+        } else {
+            let _ = std::fs::rename(&new_path, &old_path);
+        }
         return Err(error);
     }
 

--- a/src/core/fleet/mod.rs
+++ b/src/core/fleet/mod.rs
@@ -2,7 +2,9 @@ use crate::config::{self, ConfigEntity};
 use crate::error::{Error, Result};
 use crate::output::{CreateOutput, MergeOutput, RemoveResult};
 use crate::project;
+use crate::project::ProjectComponentOverrides;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub mod check;
 pub mod exec;
@@ -26,6 +28,11 @@ pub struct Fleet {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Fleet-level component overrides applied as defaults when no project-level
+    /// override exists. Resolution order: component (repo) → project → fleet.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub component_overrides: HashMap<String, ProjectComponentOverrides>,
 }
 
 impl Fleet {
@@ -34,6 +41,7 @@ impl Fleet {
             id,
             project_ids,
             description: None,
+            component_overrides: HashMap::new(),
         }
     }
 }
@@ -129,3 +137,53 @@ pub fn component_usage(fleet_id: &str) -> Result<std::collections::HashMap<Strin
 // Fleet Sync was removed in #101 — it had OpenClaw-specific logic hardcoded
 // in core, violating homeboy's platform-agnostic design. Use `homeboy deploy`
 // to sync files across servers instead.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fleet_new_has_empty_component_overrides() {
+        let fleet = Fleet::new("test-fleet".to_string(), vec!["project-a".to_string()]);
+        assert!(fleet.component_overrides.is_empty());
+    }
+
+    #[test]
+    fn fleet_component_overrides_serialization_roundtrip() {
+        let mut fleet = Fleet::new("test-fleet".to_string(), vec![]);
+        fleet.component_overrides.insert(
+            "my-plugin".to_string(),
+            ProjectComponentOverrides {
+                remote_path: Some("wp-content/plugins/my-plugin".to_string()),
+                remote_owner: Some("www-data:www-data".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let json = serde_json::to_string(&fleet).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // component_overrides should be present in serialized output
+        let overrides = parsed.get("component_overrides").unwrap();
+        let plugin = overrides.get("my-plugin").unwrap();
+        assert_eq!(
+            plugin.get("remote_path").unwrap().as_str(),
+            Some("wp-content/plugins/my-plugin")
+        );
+        assert_eq!(
+            plugin.get("remote_owner").unwrap().as_str(),
+            Some("www-data:www-data")
+        );
+    }
+
+    #[test]
+    fn fleet_empty_component_overrides_not_serialized() {
+        let fleet = Fleet::new("test-fleet".to_string(), vec![]);
+
+        let json = serde_json::to_string(&fleet).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // component_overrides should be omitted when empty (skip_serializing_if)
+        assert!(parsed.get("component_overrides").is_none());
+    }
+}

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -35,6 +35,16 @@ pub fn projects() -> Result<PathBuf> {
     Ok(homeboy()?.join("projects"))
 }
 
+/// Project directory path (e.g., ~/.config/homeboy/projects/{id}/)
+pub fn project_dir(id: &str) -> Result<PathBuf> {
+    Ok(projects()?.join(id))
+}
+
+/// Project config file path (e.g., ~/.config/homeboy/projects/{id}/{id}.json)
+pub fn project_config(id: &str) -> Result<PathBuf> {
+    Ok(projects()?.join(id).join(format!("{}.json", id)))
+}
+
 /// Servers directory
 pub fn servers() -> Result<PathBuf> {
     Ok(homeboy()?.join("servers"))

--- a/src/core/project/component/overrides.rs
+++ b/src/core/project/component/overrides.rs
@@ -1,39 +1,217 @@
-use crate::project::Project;
+use crate::project::{Project, ProjectComponentOverrides};
 
+/// Apply a single layer of component overrides to a component.
+///
+/// Fields from the overrides are applied only when present (Some), allowing
+/// each config layer to selectively override specific settings.
+fn apply_overrides_layer(
+    component: &mut crate::component::Component,
+    overrides: &ProjectComponentOverrides,
+) {
+    if let Some(remote_path) = &overrides.remote_path {
+        component.remote_path = remote_path.clone();
+    }
+    if let Some(build_artifact) = &overrides.build_artifact {
+        component.build_artifact = Some(build_artifact.clone());
+    }
+    if let Some(extract_command) = &overrides.extract_command {
+        component.extract_command = Some(extract_command.clone());
+    }
+    if let Some(remote_owner) = &overrides.remote_owner {
+        component.remote_owner = Some(remote_owner.clone());
+    }
+    if let Some(deploy_strategy) = &overrides.deploy_strategy {
+        component.deploy_strategy = Some(deploy_strategy.clone());
+    }
+    if let Some(git_deploy) = &overrides.git_deploy {
+        component.git_deploy = Some(git_deploy.clone());
+    }
+    if !overrides.hooks.is_empty() {
+        component.hooks = overrides.hooks.clone();
+    }
+    if let Some(scopes) = &overrides.scopes {
+        component.scopes = Some(scopes.clone());
+    }
+}
+
+/// Apply component overrides with fleet → project cascade.
+///
+/// Resolution order: component (repo portable config) → fleet defaults → project overrides.
+/// Fleet-level overrides provide defaults, project-level overrides take precedence.
 pub fn apply_component_overrides(
     component: &crate::component::Component,
     project: &Project,
 ) -> crate::component::Component {
-    let Some(overrides) = project.component_overrides.get(&component.id) else {
+    let fleet_overrides = resolve_fleet_overrides(project, &component.id);
+    let project_overrides = project.component_overrides.get(&component.id);
+
+    if fleet_overrides.is_none() && project_overrides.is_none() {
         return component.clone();
-    };
+    }
 
     let mut merged = component.clone();
 
-    if let Some(remote_path) = &overrides.remote_path {
-        merged.remote_path = remote_path.clone();
+    // Apply fleet-level overrides first (lowest precedence in the cascade)
+    if let Some(overrides) = &fleet_overrides {
+        apply_overrides_layer(&mut merged, overrides);
     }
-    if let Some(build_artifact) = &overrides.build_artifact {
-        merged.build_artifact = Some(build_artifact.clone());
-    }
-    if let Some(extract_command) = &overrides.extract_command {
-        merged.extract_command = Some(extract_command.clone());
-    }
-    if let Some(remote_owner) = &overrides.remote_owner {
-        merged.remote_owner = Some(remote_owner.clone());
-    }
-    if let Some(deploy_strategy) = &overrides.deploy_strategy {
-        merged.deploy_strategy = Some(deploy_strategy.clone());
-    }
-    if let Some(git_deploy) = &overrides.git_deploy {
-        merged.git_deploy = Some(git_deploy.clone());
-    }
-    if !overrides.hooks.is_empty() {
-        merged.hooks = overrides.hooks.clone();
-    }
-    if let Some(scopes) = &overrides.scopes {
-        merged.scopes = Some(scopes.clone());
+
+    // Apply project-level overrides on top (highest precedence)
+    if let Some(overrides) = project_overrides {
+        apply_overrides_layer(&mut merged, overrides);
     }
 
     merged
+}
+
+/// Look up fleet-level component overrides for a project's component.
+///
+/// Finds the fleet(s) containing this project and returns the first matching
+/// fleet-level override for the given component ID. If the project belongs
+/// to multiple fleets, the first fleet with an override wins.
+fn resolve_fleet_overrides(
+    project: &Project,
+    component_id: &str,
+) -> Option<ProjectComponentOverrides> {
+    let fleets = crate::fleet::list().ok()?;
+
+    for fleet in &fleets {
+        if fleet.project_ids.contains(&project.id) {
+            if let Some(overrides) = fleet.component_overrides.get(component_id) {
+                return Some(overrides.clone());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::Component;
+    use std::collections::HashMap;
+
+    fn base_component(id: &str) -> Component {
+        Component {
+            id: id.to_string(),
+            remote_path: "original/path".to_string(),
+            ..Component::default()
+        }
+    }
+
+    fn project_with_overrides(
+        id: &str,
+        overrides: HashMap<String, ProjectComponentOverrides>,
+    ) -> Project {
+        Project {
+            id: id.to_string(),
+            component_overrides: overrides,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_overrides_layer_sets_remote_path() {
+        let mut component = base_component("my-plugin");
+        let overrides = ProjectComponentOverrides {
+            remote_path: Some("wp-content/plugins/my-plugin".to_string()),
+            ..Default::default()
+        };
+
+        apply_overrides_layer(&mut component, &overrides);
+        assert_eq!(component.remote_path, "wp-content/plugins/my-plugin");
+    }
+
+    #[test]
+    fn apply_overrides_layer_sets_deploy_strategy() {
+        let mut component = base_component("my-plugin");
+        let overrides = ProjectComponentOverrides {
+            deploy_strategy: Some("git".to_string()),
+            ..Default::default()
+        };
+
+        apply_overrides_layer(&mut component, &overrides);
+        assert_eq!(component.deploy_strategy, Some("git".to_string()));
+    }
+
+    #[test]
+    fn apply_overrides_layer_skips_none_fields() {
+        let mut component = base_component("my-plugin");
+        component.deploy_strategy = Some("rsync".to_string());
+        let overrides = ProjectComponentOverrides::default();
+
+        apply_overrides_layer(&mut component, &overrides);
+        // deploy_strategy should remain unchanged
+        assert_eq!(component.deploy_strategy, Some("rsync".to_string()));
+        // remote_path should remain unchanged
+        assert_eq!(component.remote_path, "original/path");
+    }
+
+    #[test]
+    fn apply_overrides_layer_replaces_hooks() {
+        let mut component = base_component("my-plugin");
+        component
+            .hooks
+            .insert("pre:deploy".to_string(), vec!["echo old".to_string()]);
+
+        let mut hooks = HashMap::new();
+        hooks.insert("post:deploy".to_string(), vec!["echo new".to_string()]);
+        let overrides = ProjectComponentOverrides {
+            hooks,
+            ..Default::default()
+        };
+
+        apply_overrides_layer(&mut component, &overrides);
+        // Hooks should be replaced entirely
+        assert!(component.hooks.contains_key("post:deploy"));
+        assert!(!component.hooks.contains_key("pre:deploy"));
+    }
+
+    #[test]
+    fn no_overrides_returns_clone() {
+        let component = base_component("my-plugin");
+        let project = project_with_overrides("my-project", HashMap::new());
+
+        let result = apply_component_overrides(&component, &project);
+        assert_eq!(result.remote_path, "original/path");
+    }
+
+    #[test]
+    fn project_overrides_applied() {
+        let component = base_component("my-plugin");
+
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "my-plugin".to_string(),
+            ProjectComponentOverrides {
+                remote_path: Some("wp-content/plugins/my-plugin".to_string()),
+                remote_owner: Some("www-data:www-data".to_string()),
+                ..Default::default()
+            },
+        );
+        let project = project_with_overrides("my-project", overrides);
+
+        let result = apply_component_overrides(&component, &project);
+        assert_eq!(result.remote_path, "wp-content/plugins/my-plugin");
+        assert_eq!(result.remote_owner, Some("www-data:www-data".to_string()));
+    }
+
+    #[test]
+    fn unmatched_component_id_not_applied() {
+        let component = base_component("my-plugin");
+
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "other-plugin".to_string(),
+            ProjectComponentOverrides {
+                remote_path: Some("wp-content/plugins/other".to_string()),
+                ..Default::default()
+            },
+        );
+        let project = project_with_overrides("my-project", overrides);
+
+        let result = apply_component_overrides(&component, &project);
+        assert_eq!(result.remote_path, "original/path");
+    }
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -1,10 +1,13 @@
 use crate::component::ScopedExtensionConfig;
 use crate::config::{self, ConfigEntity};
+use crate::engine::local_files::{self, FileSystem};
 use crate::error::{Error, Result};
 use crate::output::{CreateOutput, MergeOutput, RemoveResult};
+use crate::paths;
 use crate::server;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub mod component;
 pub mod files;
@@ -28,10 +31,10 @@ pub use pins::{
 };
 pub use readiness::calculate_deploy_readiness;
 pub use report::{
-    build_components_output, build_create_output, build_delete_output, build_list_output,
-    build_pin_output, build_remove_output, build_rename_output, build_set_output,
-    build_show_output, build_status_output, list_report, show_report, status_report,
-    ProjectComponentVersion, ProjectListItem, ProjectListReport, ProjectReportExtra,
+    build_components_output, build_create_output, build_delete_output, build_init_output,
+    build_list_output, build_pin_output, build_remove_output, build_rename_output,
+    build_set_output, build_show_output, build_status_output, list_report, show_report,
+    status_report, ProjectComponentVersion, ProjectListItem, ProjectListReport, ProjectReportExtra,
     ProjectReportOutput, ProjectShowReport, ProjectStatusReport,
 };
 pub use status::{collect_status, ProjectComponentStatus, ProjectStatusSnapshot};
@@ -131,6 +134,27 @@ impl ConfigEntity for Project {
     }
     fn not_found_error(id: String, suggestions: Vec<String>) -> Error {
         Error::project_not_found(id, suggestions)
+    }
+
+    /// Directory-based config: `~/.config/homeboy/projects/{id}/{id}.json`.
+    ///
+    /// Falls back to legacy flat file `~/.config/homeboy/projects/{id}.json`
+    /// if the directory-based path doesn't exist yet. This allows transparent
+    /// migration — existing projects keep working, new projects use directories.
+    fn config_path(id: &str) -> Result<PathBuf> {
+        let dir_path = paths::project_config(id)?;
+        if dir_path.exists() {
+            return Ok(dir_path);
+        }
+
+        // Check for legacy flat file
+        let flat_path = Self::config_dir()?.join(format!("{}.json", id));
+        if flat_path.exists() {
+            return Ok(flat_path);
+        }
+
+        // Default to directory-based for new projects
+        Ok(dir_path)
     }
 
     fn validate(&self) -> Result<()> {
@@ -355,6 +379,95 @@ pub struct NewsletterConfig {
 // ============================================================================
 
 entity_crud!(Project; list_ids, merge, slugify_id);
+
+// ============================================================================
+// Project directory operations
+// ============================================================================
+
+/// Initialize a project directory at `~/.config/homeboy/projects/{id}/`.
+///
+/// Creates the directory structure and an initial `{id}.json` config file.
+/// If the project already exists as a flat file, migrates it to directory form.
+pub fn init_project_dir(id: &str) -> Result<PathBuf> {
+    let dir = paths::project_dir(id)?;
+    let config_path = paths::project_config(id)?;
+
+    // If directory config already exists, nothing to do
+    if config_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!("Project directory '{}' already exists", id),
+            Some(id.to_string()),
+            None,
+        ));
+    }
+
+    // Check if a flat-file project exists that should be migrated
+    let flat_path = paths::projects()?.join(format!("{}.json", id));
+    if flat_path.exists() {
+        return migrate_to_directory(id);
+    }
+
+    // Check the project exists in the registry
+    if !exists(id) {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!(
+                "Project '{}' does not exist. Create it first with `homeboy project create`",
+                id
+            ),
+            Some(id.to_string()),
+            None,
+        ));
+    }
+
+    // Load, then re-save — save() now creates the directory via config_path()
+    let project = load(id)?;
+    // Delete the old flat file if it exists
+    if flat_path.exists() {
+        let _ = std::fs::remove_file(&flat_path);
+    }
+    // Force the directory path for the new save
+    local_files::local().ensure_dir(&dir)?;
+    let content = config::to_string_pretty(&project)?;
+    local_files::local().write(&config_path, &content)?;
+
+    Ok(dir)
+}
+
+/// Migrate a project from flat file `{id}.json` to directory `{id}/{id}.json`.
+fn migrate_to_directory(id: &str) -> Result<PathBuf> {
+    let flat_path = paths::projects()?.join(format!("{}.json", id));
+    let dir = paths::project_dir(id)?;
+    let config_path = paths::project_config(id)?;
+
+    // Create the project directory
+    local_files::local().ensure_dir(&dir)?;
+
+    // Move the flat file into the directory with the correct name
+    std::fs::rename(&flat_path, &config_path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("migrate project '{}' to directory", id)),
+        )
+    })?;
+
+    Ok(dir)
+}
+
+/// Check if a project is using the directory-based config layout.
+pub fn is_directory_based(id: &str) -> bool {
+    paths::project_config(id)
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Get the project directory path for a given project ID.
+/// Returns the directory path regardless of whether the project uses
+/// directory-based or flat-file config.
+pub fn project_dir_path(id: &str) -> Result<PathBuf> {
+    paths::project_dir(id)
+}
 
 pub fn pin(project_id: &str, pin_type: PinType, path: &str, options: PinOptions) -> Result<()> {
     let mut project = load(project_id)?;

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -462,6 +462,45 @@ pub fn is_directory_based(id: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Check if a project is still using the legacy flat-file layout.
+pub fn needs_directory_migration(id: &str) -> bool {
+    let flat_exists = paths::projects()
+        .map(|p| p.join(format!("{}.json", id)).exists())
+        .unwrap_or(false);
+    flat_exists && !is_directory_based(id)
+}
+
+/// Migrate all flat-file projects to directory-based layout.
+///
+/// Called during `homeboy upgrade` to transparently move projects from
+/// `projects/{id}.json` to `projects/{id}/{id}.json`. Returns a list
+/// of (project_id, success) tuples.
+pub fn migrate_all_to_directories() -> Vec<(String, bool, String)> {
+    let project_ids = match list_ids() {
+        Ok(ids) => ids,
+        Err(_) => return vec![],
+    };
+
+    let mut results = Vec::new();
+
+    for id in &project_ids {
+        if !needs_directory_migration(id) {
+            continue;
+        }
+
+        match migrate_to_directory(id) {
+            Ok(dir) => {
+                results.push((id.clone(), true, format!("migrated to {}", dir.display())));
+            }
+            Err(e) => {
+                results.push((id.clone(), false, e.message.clone()));
+            }
+        }
+    }
+
+    results
+}
+
 /// Get the project directory path for a given project ID.
 /// Returns the directory path regardless of whether the project uses
 /// directory-based or flat-file config.

--- a/src/core/project/report.rs
+++ b/src/core/project/report.rs
@@ -302,3 +302,16 @@ pub fn build_status_output(project_id: &str, report: ProjectStatusReport) -> Pro
         ..Default::default()
     }
 }
+
+pub fn build_init_output(project_id: &str, dir: &std::path::Path) -> ProjectReportOutput {
+    ProjectReportOutput {
+        command: "project.init".to_string(),
+        id: Some(project_id.to_string()),
+        entity: load(project_id).ok(),
+        hint: Some(format!(
+            "Project directory initialized at {}",
+            dir.display()
+        )),
+        ..Default::default()
+    }
+}

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -165,6 +165,9 @@ pub fn run_upgrade_with_method(
     if !force {
         let check = check_for_updates()?;
         if !check.update_available {
+            // Even when no binary update is needed, still run config migrations
+            // and extension updates — these are independent of the binary version.
+            let projects_migrated = migrate_all_projects();
             return Ok(UpgradeResult {
                 command: "upgrade".to_string(),
                 install_method,
@@ -175,6 +178,7 @@ pub fn run_upgrade_with_method(
                 restart_required: false,
                 extensions_updated: vec![],
                 extensions_skipped: vec![],
+                projects_migrated,
             });
         }
     }
@@ -191,6 +195,11 @@ pub fn run_upgrade_with_method(
         (vec![], vec![])
     };
 
+    // Migrate flat-file projects to directory-based layout.
+    // Runs on every upgrade (even failed ones) since this is a config-only
+    // operation that doesn't depend on the binary version.
+    let projects_migrated = migrate_all_projects();
+
     Ok(UpgradeResult {
         command: "upgrade".to_string(),
         install_method,
@@ -205,7 +214,40 @@ pub fn run_upgrade_with_method(
         restart_required: success,
         extensions_updated,
         extensions_skipped,
+        projects_migrated,
     })
+}
+
+/// Migrate all flat-file projects to directory-based layout.
+/// Best-effort — failures are logged and returned in the result.
+fn migrate_all_projects() -> Vec<ProjectMigrationEntry> {
+    let results = crate::project::migrate_all_to_directories();
+
+    if results.is_empty() {
+        return vec![];
+    }
+
+    log_status!(
+        "upgrade",
+        "Migrating {} project(s) to directory layout...",
+        results.len()
+    );
+
+    let mut entries = Vec::new();
+    for (id, success, detail) in results {
+        if success {
+            log_status!("upgrade", "  {} migrated", id);
+        } else {
+            log_status!("upgrade", "  {} failed: {}", id, detail);
+        }
+        entries.push(ProjectMigrationEntry {
+            project_id: id,
+            success,
+            detail,
+        });
+    }
+
+    entries
 }
 
 /// Update all installed extensions. Best-effort — failures are logged and

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -35,6 +35,8 @@ pub struct UpgradeResult {
     pub extensions_updated: Vec<ExtensionUpgradeEntry>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extensions_skipped: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub projects_migrated: Vec<ProjectMigrationEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,6 +44,13 @@ pub struct ExtensionUpgradeEntry {
     pub extension_id: String,
     pub old_version: String,
     pub new_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectMigrationEntry {
+    pub project_id: String,
+    pub success: bool,
+    pub detail: String,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

Implements #969 — adds a three-tier config cascade for component overrides and migrates projects to directory-based config layout.

- **Directory-based project config**: Projects now live at `~/.config/homeboy/projects/{id}/{id}.json` instead of flat `{id}.json` files. This gives each project a directory for scripts, docs, and automation alongside its config. Legacy flat files continue to work transparently via fallback resolution.
- **Fleet → Project → Component cascade**: `component_overrides` can now be defined at the fleet level as defaults. Resolution order: component (repo `homeboy.json`) → fleet overrides → project overrides. Most specific wins.
- **`homeboy project init`**: New CLI command migrates existing flat-file projects to directory layout.

## Changes

| File | What |
|------|------|
| `config.rs` | Parent dir creation in save/create; directory-aware rename/delete |
| `paths.rs` | `project_dir()` and `project_config()` helpers |
| `project/mod.rs` | Directory-based `config_path()`, `init_project_dir()`, migration |
| `fleet/mod.rs` | `component_overrides` field on Fleet struct |
| `project/component/overrides.rs` | Cascade resolution with `apply_overrides_layer()` |
| `project/report.rs` | `build_init_output()` for init command |
| `commands/project.rs` | `project init` subcommand |

## Testing

- `cargo check` ✅
- `cargo test --lib` — 936 passed (10 new), 0 failed ✅
- `cargo fmt -- --check` ✅