### PR TITLE
Remove all internal validation from refactor command

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -587,28 +587,7 @@ fn run_rename(
             &affected_files,
         );
 
-        let abs_changed: Vec<std::path::PathBuf> =
-            affected_files.iter().map(|f| root.join(f)).collect();
-        let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
-        for file in &abs_changed {
-            validation_rollback.capture(file);
-        }
-
         refactor::apply_renames(&mut result, &root)?;
-
-        // Validate that renamed code compiles
-        let validation = homeboy::engine::validate_write::validate_write(
-            &root,
-            &abs_changed,
-            &validation_rollback,
-        )?;
-        if !validation.success {
-            homeboy::log_status!(
-                "validate",
-                "Post-write validation failed — changes rolled back"
-            );
-            result.applied = false;
-        }
     }
 
     let scope_str = match scope {
@@ -820,34 +799,12 @@ fn run_move(
 ) -> CmdResult<RefactorOutput> {
     let root = refactor::move_items::resolve_root(component_id, path)?;
 
-    let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
     if write {
         homeboy::engine::undo::UndoSnapshot::capture_and_save(&root, "refactor move", [from, to]);
-        validation_rollback.capture(&root.join(from));
-        validation_rollback.capture(&root.join(to));
     }
 
     let item_refs: Vec<&str> = items.iter().map(|s| s.as_str()).collect();
     let result = refactor::move_items(&item_refs, from, to, &root, write)?;
-
-    // Post-write validation gate
-    if write && !result.items_moved.is_empty() {
-        let changed_files = vec![root.join(from), root.join(to)];
-        let validation = homeboy::engine::validate_write::validate_write(
-            &root,
-            &changed_files,
-            &validation_rollback,
-        )?;
-        if !validation.success {
-            homeboy::log_status!(
-                "validate",
-                "Move output failed validation — changes rolled back"
-            );
-            if let Some(ref output) = validation.output {
-                homeboy::log_status!("validate", "{}", output);
-            }
-        }
-    }
 
     let exit_code = if result.items_moved.is_empty() { 1 } else { 0 };
 
@@ -909,37 +866,15 @@ fn run_move_file(
 ) -> CmdResult<RefactorOutput> {
     let root = refactor::move_items::resolve_root(component_id, path)?;
 
-    let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
     if write {
         homeboy::engine::undo::UndoSnapshot::capture_and_save(
             &root,
             "refactor move --file",
             [file, to],
         );
-        validation_rollback.capture(&root.join(file));
-        validation_rollback.capture(&root.join(to));
     }
 
     let result = refactor::move_items::move_file(file, to, &root, write)?;
-
-    // Post-write validation gate
-    if write && (result.imports_updated > 0 || result.mod_declarations_updated) {
-        let changed_files = vec![root.join(file), root.join(to)];
-        let validation = homeboy::engine::validate_write::validate_write(
-            &root,
-            &changed_files,
-            &validation_rollback,
-        )?;
-        if !validation.success {
-            homeboy::log_status!(
-                "validate",
-                "Move-file output failed validation — changes rolled back"
-            );
-            if let Some(ref output) = validation.output {
-                homeboy::log_status!("validate", "{}", output);
-            }
-        }
-    }
 
     let exit_code = if result.imports_updated > 0 || result.mod_declarations_updated {
         0
@@ -1002,15 +937,6 @@ fn run_propagate(
         );
     }
 
-    // Capture pre-write state for validation rollback
-    let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
-    if write {
-        let preview = refactor::propagate(&config)?;
-        for edit in &preview.edits {
-            validation_rollback.capture(&root.join(&edit.file));
-        }
-    }
-
     // Run the actual propagation (with write mode as requested)
     let write_config = refactor::PropagateConfig {
         struct_name,
@@ -1018,25 +944,7 @@ fn run_propagate(
         root: &root,
         write,
     };
-    let mut result = refactor::propagate(&write_config)?;
-
-    // Validate written code compiles
-    if write && result.applied {
-        let abs_changed: Vec<std::path::PathBuf> =
-            result.edits.iter().map(|e| root.join(&e.file)).collect();
-        let validation = homeboy::engine::validate_write::validate_write(
-            &root,
-            &abs_changed,
-            &validation_rollback,
-        )?;
-        if !validation.success {
-            homeboy::log_status!(
-                "validate",
-                "Post-write validation failed — changes rolled back"
-            );
-            result.applied = false;
-        }
-    }
+    let result = refactor::propagate(&write_config)?;
 
     // Log results to stderr
     homeboy::log_status!(
@@ -1128,7 +1036,6 @@ fn run_transform(
         homeboy::log_status!("info", "{}", set.description);
     }
 
-    let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
     if write {
         // Dry-run to discover affected files for the undo snapshot
         if let Ok(preview) = refactor::apply_transforms(&root, &set_name, &set, false, rule_filter)
@@ -1143,38 +1050,11 @@ fn run_transform(
                 "refactor transform",
                 &affected_files,
             );
-            // Capture for validation rollback
-            for rel_path in &affected_files {
-                validation_rollback.capture(&root.join(rel_path));
-            }
         }
     }
 
     // Apply transforms
     let result = refactor::apply_transforms(&root, &set_name, &set, write, rule_filter)?;
-
-    // Post-write validation gate
-    if write && result.total_replacements > 0 {
-        let changed_files: Vec<std::path::PathBuf> = result
-            .rules
-            .iter()
-            .flat_map(|r| r.matches.iter().map(|m| root.join(&m.file)))
-            .collect();
-        let validation = homeboy::engine::validate_write::validate_write(
-            &root,
-            &changed_files,
-            &validation_rollback,
-        )?;
-        if !validation.success {
-            homeboy::log_status!(
-                "validate",
-                "Transform output failed validation — changes rolled back"
-            );
-            if let Some(ref output) = validation.output {
-                homeboy::log_status!("validate", "{}", output);
-            }
-        }
-    }
 
     // Report results to stderr
     for rule_result in &result.rules {
@@ -1249,8 +1129,6 @@ fn run_decompose(
     let root = refactor::move_items::resolve_root(component_id, path)?;
     let plan = refactor::build_plan(file, &root, strategy)?;
 
-    // Capture rollback state before writes for validation gate
-    let mut validation_rollback = homeboy::engine::undo::InMemoryRollback::new();
     if write {
         let affected: Vec<&str> = std::iter::once(file)
             .chain(plan.groups.iter().map(|g| g.suggested_target.as_str()))
@@ -1260,10 +1138,6 @@ fn run_decompose(
             "refactor decompose",
             &affected,
         );
-        // Also capture for in-memory rollback (validation gate)
-        for rel_path in &affected {
-            validation_rollback.capture(&root.join(rel_path));
-        }
     }
 
     let move_results = refactor::apply_plan(&plan, &root, write)?;
@@ -1271,34 +1145,6 @@ fn run_decompose(
         .iter()
         .filter(|result| !result.items_moved.is_empty())
         .count();
-
-    // Post-write validation gate
-    if write && groups_applied > 0 {
-        let changed_files: Vec<std::path::PathBuf> = move_results
-            .iter()
-            .flat_map(|r| {
-                r.items_moved
-                    .iter()
-                    .map(|_| root.join(file))
-                    .chain(std::iter::once(root.join(file)))
-            })
-            .chain(plan.groups.iter().map(|g| root.join(&g.suggested_target)))
-            .collect();
-        let validation = homeboy::engine::validate_write::validate_write(
-            &root,
-            &changed_files,
-            &validation_rollback,
-        )?;
-        if !validation.success {
-            homeboy::log_status!(
-                "validate",
-                "Decompose output failed validation — changes rolled back"
-            );
-            if let Some(ref output) = validation.output {
-                homeboy::log_status!("validate", "{}", output);
-            }
-        }
-    }
 
     homeboy::log_status!(
         "decompose",

--- a/src/core/refactor/add.rs
+++ b/src/core/refactor/add.rs
@@ -51,32 +51,8 @@ pub fn fixes_from_audit(audit: &CodeAuditResult, write: bool) -> Result<FixResul
     let mut fix_result = plan::generate_audit_fixes(audit, root);
 
     if write && !fix_result.fixes.is_empty() {
-        // Capture pre-write state for rollback on validation failure
-        let affected_files: Vec<PathBuf> = fix_result
-            .fixes
-            .iter()
-            .map(|f| root.join(&f.file))
-            .collect();
-        let mut rollback = crate::engine::undo::InMemoryRollback::new();
-        for file in &affected_files {
-            rollback.capture(file);
-        }
-
         let applied = auto::apply_fixes(&mut fix_result.fixes, root);
         fix_result.files_modified = applied;
-
-        // Validate written code compiles
-        if applied > 0 {
-            let validation =
-                crate::engine::validate_write::validate_write(root, &affected_files, &rollback)?;
-            if !validation.success {
-                crate::log_status!(
-                    "validate",
-                    "Post-write validation failed — changes rolled back"
-                );
-                fix_result.files_modified = 0;
-            }
-        }
     }
 
     Ok(fix_result)
@@ -147,27 +123,7 @@ pub fn add_import(
     let mut files_modified = 0;
 
     if write && !fixes.is_empty() {
-        // Capture pre-write state for rollback on validation failure
-        let affected_files: Vec<PathBuf> = fixes.iter().map(|f| root.join(&f.file)).collect();
-        let mut rollback = crate::engine::undo::InMemoryRollback::new();
-        for file in &affected_files {
-            rollback.capture(file);
-        }
-
         files_modified = auto::apply_fixes(&mut fixes, &root);
-
-        // Validate written code compiles
-        if files_modified > 0 {
-            let validation =
-                crate::engine::validate_write::validate_write(&root, &affected_files, &rollback)?;
-            if !validation.success {
-                crate::log_status!(
-                    "validate",
-                    "Post-write validation failed — changes rolled back"
-                );
-                files_modified = 0;
-            }
-        }
     }
 
     Ok(AddResult {

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -68,12 +68,12 @@ pub use decompose::{
 };
 pub use move_items::{move_items, ImportRewrite, ItemKind, MoveResult, MovedItem};
 pub use plan::{
-    analyze_stage_overlaps, build_chunk_verifier, build_refactor_plan, finding_fingerprint,
-    lint_refactor_request, normalize_sources, run_audit_refactor, run_lint_refactor,
-    run_test_refactor, score_delta, summarize_plan_totals, test_refactor_request,
-    weighted_finding_score_with, AuditConvergenceScoring, AuditRefactorIterationSummary,
-    AuditRefactorOutcome, AuditVerificationToggles, LintSourceOptions, PlanOverlap,
-    PlanStageSummary, RefactorPlan, RefactorPlanRequest, TestSourceOptions, KNOWN_PLAN_SOURCES,
+    analyze_stage_overlaps, build_refactor_plan, finding_fingerprint, lint_refactor_request,
+    normalize_sources, run_audit_refactor, run_lint_refactor, run_test_refactor, score_delta,
+    summarize_plan_totals, test_refactor_request, weighted_finding_score_with,
+    AuditConvergenceScoring, AuditRefactorIterationSummary, AuditRefactorOutcome,
+    LintSourceOptions, PlanOverlap, PlanStageSummary, RefactorPlan,
+    RefactorPlanRequest, TestSourceOptions, KNOWN_PLAN_SOURCES,
 };
 pub use propagate::{propagate, PropagateConfig, PropagateEdit, PropagateField, PropagateResult};
 pub use rename::{

--- a/src/core/refactor/plan/mod.rs
+++ b/src/core/refactor/plan/mod.rs
@@ -10,7 +10,6 @@ pub use planner::{
     TestSourceOptions, KNOWN_PLAN_SOURCES,
 };
 pub use verify::{
-    build_chunk_verifier, finding_fingerprint, run_audit_refactor, score_delta,
-    weighted_finding_score_with, AuditConvergenceScoring, AuditRefactorIterationSummary,
-    AuditRefactorOutcome, AuditVerificationToggles,
+    finding_fingerprint, run_audit_refactor, score_delta, weighted_finding_score_with,
+    AuditConvergenceScoring, AuditRefactorIterationSummary, AuditRefactorOutcome,
 };

--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -1,7 +1,6 @@
 use crate::component::Component;
 use crate::engine::temp;
-use crate::engine::undo::{InMemoryRollback, UndoSnapshot};
-use crate::engine::validate_write;
+use crate::engine::undo::UndoSnapshot;
 use crate::extension;
 use crate::extension::test::compute_changed_test_files;
 use crate::git;
@@ -12,7 +11,7 @@ use serde::Serialize;
 use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
-use super::verify::{AuditConvergenceScoring, AuditVerificationToggles};
+use super::verify::AuditConvergenceScoring;
 use crate::refactor::sandbox::{
     clone_tree, copy_changed_files, diff_tree_snapshots, resolve_build_exclusions, snapshot_tree,
     SandboxDir,
@@ -267,78 +266,6 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
                 &stage.summary.changed_files,
                 &mut warnings,
             );
-
-            // Fail-fast: compile-check the sandbox after each stage that modifies
-            // files. If a stage breaks compilation (e.g. audit fixes introduce
-            // parse errors), subsequent stages (lint, test) would run on broken
-            // code — producing bogus findings and wasting time. Skip them.
-            let abs_changed: Vec<PathBuf> = stage
-                .summary
-                .changed_files
-                .iter()
-                .map(|f| working_root.path().join(f))
-                .collect();
-
-            // Fast brace-balance check before expensive sandbox compile.
-            // Catches fixer-induced brace corruption in milliseconds.
-            let mut brace_broken = false;
-            for file_path in &abs_changed {
-                if let Ok(content) = std::fs::read_to_string(file_path) {
-                    let ext = file_path
-                        .extension()
-                        .and_then(|e| e.to_str())
-                        .unwrap_or_default();
-                    if let Some(grammar) =
-                        crate::code_audit::core_fingerprint::load_grammar_for_ext(ext)
-                    {
-                        if !crate::extension::grammar_items::validate_brace_balance(
-                            &content, &grammar,
-                        ) {
-                            let rel = file_path
-                                .strip_prefix(working_root.path())
-                                .unwrap_or(file_path)
-                                .display()
-                                .to_string();
-                            crate::log_status!(
-                                "refactor",
-                                "Brace corruption in {} after {} stage — skipping compile",
-                                rel,
-                                source
-                            );
-                            warnings.push(format!(
-                                "{} stage produced unbalanced braces in {} — skipping",
-                                source, rel
-                            ));
-                            brace_broken = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if brace_broken {
-                accumulator.extend(stage.fix_results.clone());
-                planned_stages.push(stage);
-                break;
-            }
-
-            let sandbox_compile = validate_write::validate_only(working_root.path(), &abs_changed)?;
-            if !sandbox_compile.success {
-                crate::log_status!(
-                    "refactor",
-                    "Sandbox compile check failed after {} stage — skipping remaining stages",
-                    source
-                );
-                if let Some(output) = &sandbox_compile.output {
-                    warnings.push(format!(
-                        "{} stage broke compilation — skipping remaining stages: {}",
-                        source, output
-                    ));
-                }
-                accumulator.extend(stage.fix_results.clone());
-                planned_stages.push(stage);
-                break;
-            }
         }
 
         accumulator.extend(stage.fix_results.clone());
@@ -382,13 +309,8 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
             }
         }
 
-        // Capture pre-write state for rollback if validation fails
         let abs_changed: Vec<PathBuf> =
             changed_files.iter().map(|f| request.root.join(f)).collect();
-        let mut validation_rollback = InMemoryRollback::new();
-        for file in &abs_changed {
-            validation_rollback.capture(file);
-        }
 
         copy_changed_files(working_root.path(), &request.root, &changed_files)?;
 
@@ -405,43 +327,6 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
             Err(e) => {
                 crate::log_status!("format", "Warning: post-write format failed: {}", e);
             }
-        }
-
-        // Validate that written code compiles. If validation fails, roll back
-        // all changes and report as dry-run (no files modified).
-        let validation =
-            validate_write::validate_write(&request.root, &abs_changed, &validation_rollback)?;
-        if !validation.success {
-            crate::log_status!(
-                "validate",
-                "Post-write validation failed — all changes rolled back"
-            );
-            if let Some(output) = &validation.output {
-                warnings.push(format!("Validation failed: {}", output));
-            }
-            // Reset: no files were modified (rolled back by validate_write)
-            for stage in &mut stage_summaries {
-                stage.applied = false;
-            }
-            return Ok(RefactorPlan {
-                component_id: request.component.id.clone(),
-                source_path: request.root.to_string_lossy().to_string(),
-                sources: sources.clone(),
-                dry_run: false,
-                applied: false,
-                merge_strategy: merge_order.clone(),
-                proposals,
-                stages: stage_summaries,
-                plan_totals,
-                overlaps,
-                files_modified: 0,
-                changed_files: vec![],
-                fix_summary: None,
-                warnings,
-                hints: vec![
-                    "Validation failed — changes were rolled back. Fix compilation errors and retry.".to_string(),
-                ],
-            });
         }
     }
 
@@ -667,10 +552,6 @@ fn plan_audit_stage(
             only,
             exclude,
             AuditConvergenceScoring::default(),
-            AuditVerificationToggles {
-                lint_smoke: true,
-                test_smoke: true,
-            },
             1,
             true,
         )?;

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -1,14 +1,8 @@
-use crate::code_audit::{self, CodeAuditResult};
-use crate::component::{self, Component};
-use crate::engine::temp;
+use crate::code_audit::CodeAuditResult;
 use crate::engine::undo::UndoSnapshot;
-use crate::engine::validate_write;
-use crate::extension::test::compute_changed_test_files;
-use crate::extension::{lint as extension_lint, test as extension_test};
 use crate::refactor::auto as fixer;
 use serde::Serialize;
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub use crate::code_audit::{
     finding_fingerprint, score_delta, weighted_finding_score_with, AuditConvergenceScoring,
@@ -65,12 +59,6 @@ pub(crate) fn rewrite_callers_after_dedup(fix: &fixer::Fix, root: &Path) {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct AuditVerificationToggles {
-    pub lint_smoke: bool,
-    pub test_smoke: bool,
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct AuditRefactorIterationSummary {
     pub iteration: usize,
@@ -98,7 +86,6 @@ pub fn run_audit_refactor(
     only_kinds: &[crate::code_audit::AuditFinding],
     exclude_kinds: &[crate::code_audit::AuditFinding],
     scoring: AuditConvergenceScoring,
-    verification: AuditVerificationToggles,
     _max_iterations: usize,
     write: bool,
 ) -> crate::Result<AuditRefactorOutcome> {
@@ -118,86 +105,25 @@ pub fn run_audit_refactor(
             only_kinds,
             exclude_kinds,
             scoring,
-            verification,
         )?;
 
         let changed_files = iteration_summary.changed_files.clone();
         final_fix_result = fix_result;
         final_policy_summary = policy_summary;
 
+        iteration_summary.iteration = 1;
+        iteration_summary.findings_after = current_result.findings.len();
+        iteration_summary.weighted_score_after =
+            weighted_finding_score_with(&current_result, scoring);
+        iteration_summary.score_delta = 0;
+
         if changed_files.is_empty() {
-            iteration_summary.iteration = 1;
-            iteration_summary.findings_after = current_result.findings.len();
-            iteration_summary.weighted_score_after =
-                weighted_finding_score_with(&current_result, scoring);
-            iteration_summary.score_delta = 0;
             iteration_summary.status = "no_safe_changes".to_string();
-            iterations.push(iteration_summary);
         } else {
-            // Quick brace-balance check before expensive compile.
-            // Catches fixer-induced brace corruption in milliseconds.
-            let root = Path::new(&current_result.source_path);
-            let compile_check_files: Vec<PathBuf> =
-                changed_files.iter().map(|f| root.join(f)).collect();
-
-            let mut brace_error = None;
-            for file_path in &compile_check_files {
-                if let Ok(content) = std::fs::read_to_string(file_path) {
-                    let ext = file_path
-                        .extension()
-                        .and_then(|e| e.to_str())
-                        .unwrap_or_default();
-                    if let Some(grammar) =
-                        crate::code_audit::core_fingerprint::load_grammar_for_ext(ext)
-                    {
-                        if !crate::extension::grammar_items::validate_brace_balance(
-                            &content, &grammar,
-                        ) {
-                            let rel = file_path
-                                .strip_prefix(root)
-                                .unwrap_or(file_path)
-                                .display()
-                                .to_string();
-                            brace_error = Some(format!(
-                                "Unbalanced braces in {} — fixer produced broken code",
-                                rel
-                            ));
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if let Some(err_msg) = brace_error {
-                crate::log_status!("refactor", "Brace check failed — {}", err_msg);
-                iteration_summary.iteration = 1;
-                iteration_summary.findings_after = current_result.findings.len();
-                iteration_summary.weighted_score_after =
-                    weighted_finding_score_with(&current_result, scoring);
-                iteration_summary.score_delta = 0;
-                iteration_summary.status = "brace_corruption".to_string();
-            } else {
-                // Compile check
-                let compile_result = validate_write::validate_only(root, &compile_check_files)?;
-                iteration_summary.iteration = 1;
-                iteration_summary.findings_after = current_result.findings.len();
-                iteration_summary.weighted_score_after =
-                    weighted_finding_score_with(&current_result, scoring);
-                iteration_summary.score_delta = 0;
-
-                if !compile_result.success {
-                    crate::log_status!("refactor", "Compile check failed after applying fixes");
-                    if let Some(output) = &compile_result.output {
-                        crate::log_status!("refactor", "{}", output);
-                    }
-                    iteration_summary.status = "compile_failure".to_string();
-                } else {
-                    iteration_summary.status = "completed".to_string();
-                }
-            }
-
-            iterations.push(iteration_summary);
+            iteration_summary.status = "completed".to_string();
         }
+
+        iterations.push(iteration_summary);
     } else {
         let root = Path::new(&current_result.source_path);
         let mut fix_result = super::generate::generate_audit_fixes(&current_result, root);
@@ -219,145 +145,13 @@ pub fn run_audit_refactor(
     })
 }
 
-fn load_or_discover(component_id: &str, source_path: &str) -> Option<Component> {
-    component::load(component_id).ok().or_else(|| {
-        let mut comp = component::discover_from_portable(Path::new(source_path))?;
-        comp.id = component_id.to_string();
-        comp.local_path = source_path.to_string();
-        Some(comp)
-    })
-}
 
-fn build_smoke_verifier<'a>(
-    component_id: &'a str,
-    source_path: &'a str,
-    changed_files: &'a [String],
-) -> Option<impl Fn(&fixer::ApplyChunkResult) -> Result<String, String> + 'a> {
-    let component = load_or_discover(component_id, source_path)?;
-    extension_lint::resolve_lint_command(&component).ok()?;
-    let root = PathBuf::from(source_path);
-    Some(move |chunk: &fixer::ApplyChunkResult| {
-        if changed_files.is_empty() {
-            return Ok("lint_smoke_skipped_no_files".to_string());
-        }
-
-        if chunk.files.is_empty() {
-            return Ok("lint_smoke_skipped_no_chunk_files".to_string());
-        }
-
-        let target_files: Vec<String> = changed_files
-            .iter()
-            .filter(|file| chunk.files.contains(file))
-            .cloned()
-            .collect();
-
-        if target_files.is_empty() {
-            return Ok("lint_smoke_skipped_no_overlap".to_string());
-        }
-
-        let glob = if target_files.len() == 1 {
-            root.join(&target_files[0]).to_string_lossy().to_string()
-        } else {
-            let joined = target_files
-                .iter()
-                .map(|file| root.join(file).to_string_lossy().to_string())
-                .collect::<Vec<_>>()
-                .join(",");
-            format!("{{{}}}", joined)
-        };
-
-        let output = extension_lint::build_lint_runner(
-            &component,
-            Some(source_path.to_string()),
-            &[],
-            false,
-            None,
-            Some(&glob),
-            false,
-            None,
-            None,
-            None,
-            "/dev/null",
-        )
-        .and_then(|runner| runner.run())
-        .map_err(|error| format!("lint smoke run failed: {}", error))?;
-
-        if output.success {
-            Ok("lint_smoke_passed".to_string())
-        } else {
-            Err("lint smoke failed".to_string())
-        }
-    })
-}
-
-fn build_test_smoke_verifier<'a>(
-    component_id: &'a str,
-    source_path: &'a str,
-    changed_files: &'a [String],
-) -> Option<impl Fn(&fixer::ApplyChunkResult) -> Result<String, String> + 'a> {
-    let component = load_or_discover(component_id, source_path)?;
-    extension_test::resolve_test_command(&component).ok()?;
-    let changed_test_files = compute_changed_test_files(&component, "HEAD~1")
-        .ok()
-        .and_then(|files| (!files.is_empty()).then_some(files.join("\n")));
-
-    Some(move |chunk: &fixer::ApplyChunkResult| {
-        if chunk.files.is_empty() || changed_files.is_empty() {
-            return Ok("test_smoke_skipped_no_files".to_string());
-        }
-
-        let overlapping_files: Vec<String> = changed_files
-            .iter()
-            .filter(|file| chunk.files.contains(file))
-            .cloned()
-            .collect();
-
-        if overlapping_files.is_empty() {
-            return Ok("test_smoke_skipped_no_overlap".to_string());
-        }
-
-        let results_file = temp::runtime_temp_file("homeboy-audit-test-smoke", ".json")
-            .map_err(|error| format!("create test smoke temp file failed: {}", error))?;
-        let results_file_str = results_file.to_string_lossy().to_string();
-        let selected_test_files = changed_test_files.as_ref().map(|files| {
-            files
-                .split('\n')
-                .filter(|file| !file.is_empty())
-                .map(|file| file.to_string())
-                .collect::<Vec<_>>()
-        });
-
-        let output = extension_test::build_test_runner(
-            &component,
-            Some(source_path.to_string()),
-            &[],
-            true,
-            false,
-            &results_file_str,
-            None,
-            None,
-            None,
-            selected_test_files.as_deref(),
-        )
-        .and_then(|runner| runner.run())
-        .map_err(|error| format!("test smoke run failed: {}", error))?;
-
-        let _ = std::fs::remove_file(&results_file);
-
-        if output.success {
-            Ok("test_smoke_passed".to_string())
-        } else {
-            Err("test smoke failed".to_string())
-        }
-    })
-}
 
 fn run_fix_iteration(
     audit_result: &CodeAuditResult,
     only_kinds: &[crate::code_audit::AuditFinding],
     exclude_kinds: &[crate::code_audit::AuditFinding],
     scoring: AuditConvergenceScoring,
-    verification: AuditVerificationToggles,
 ) -> crate::Result<(
     fixer::FixResult,
     fixer::PolicySummary,
@@ -399,111 +193,35 @@ fn run_fix_iteration(
         }
     }
 
-    let smoke_verifier = build_smoke_verifier(
-        &audit_result.component_id,
-        &audit_result.source_path,
-        &changed_files,
-    )
-    .filter(|_| verification.lint_smoke);
-    let test_smoke_verifier = build_test_smoke_verifier(
-        &audit_result.component_id,
-        &audit_result.source_path,
-        &changed_files,
-    )
-    .filter(|_| verification.test_smoke);
-    let mut extra_smokes: Vec<fixer::ChunkVerifier> = Vec::new();
-    if let Some(verifier) = smoke_verifier.as_ref() {
-        extra_smokes.push(verifier);
-    }
-    if let Some(verifier) = test_smoke_verifier.as_ref() {
-        extra_smokes.push(verifier);
-    }
-    let verifier = build_chunk_verifier(root, &audit_result.findings, extra_smokes);
-
+    // Apply all fixes without per-chunk verification. Validation belongs
+    // downstream (PR CI pipeline), not inside the refactor command.
     if !auto_apply_result.fixes.is_empty() {
-        // Partition fixes into three tiers based on verification needs:
-        //
-        // 1. Full verification (lint smoke + re-audit): fixes that change
-        //    production code and aren't compiler-guaranteed safe.
-        // 2. Re-audit only: Safe-tier fixes (compiler-suggested, guaranteed
-        //    correct) and test-only fixes (TestModule insertions). Skipping
-        //    lint smoke avoids redundant cargo fmt/clippy runs — these fixes
-        //    are already formatted by format_after_write() before verification.
-        let (mut light_fixes, mut full_fixes): (Vec<_>, Vec<_>) =
-            auto_apply_result.fixes.drain(..).partition(|fix| {
-                fix.insertions.iter().all(|ins| {
-                    matches!(ins.kind, fixer::InsertionKind::TestModule)
-                        || ins.safety_tier == fixer::FixSafetyTier::Safe
-                })
-            });
-
-        // Apply fixes that need full verification (lint smoke + re-audit).
-        if !full_fixes.is_empty() {
-            let chunk_results = fixer::apply_fixes_chunked(
-                &mut full_fixes,
-                root,
-                fixer::ApplyOptions {
-                    verifier: Some(&verifier),
-                },
-            );
-            applied_chunks += chunk_results
-                .iter()
-                .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Applied))
-                .count();
-            reverted_chunks += chunk_results
-                .iter()
-                .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Reverted))
-                .count();
-            total_modified += chunk_results
-                .iter()
-                .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Applied))
-                .map(|chunk| chunk.applied_files)
-                .sum::<usize>();
-            fix_result.chunk_results.extend(chunk_results);
-        }
-
-        // Apply Safe-tier and test-only fixes with just the re-audit verifier.
-        // These skip lint smoke because:
-        // - Compiler-suggested fixes are guaranteed correct by the compiler.
-        // - Test module insertions don't affect production code.
-        // The scoped re-audit still validates no new audit findings are introduced.
-        if !light_fixes.is_empty() {
-            let light_verifier = build_chunk_verifier(root, &audit_result.findings, vec![]);
-            let chunk_results = fixer::apply_fixes_chunked(
-                &mut light_fixes,
-                root,
-                fixer::ApplyOptions {
-                    verifier: Some(&light_verifier),
-                },
-            );
-            applied_chunks += chunk_results
-                .iter()
-                .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Applied))
-                .count();
-            reverted_chunks += chunk_results
-                .iter()
-                .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Reverted))
-                .count();
-            total_modified += chunk_results
-                .iter()
-                .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Applied))
-                .map(|chunk| chunk.applied_files)
-                .sum::<usize>();
-            fix_result.chunk_results.extend(chunk_results);
-        }
-
-        // Reassemble for downstream processing
-        auto_apply_result.fixes = full_fixes;
-        auto_apply_result.fixes.extend(light_fixes);
+        let chunk_results = fixer::apply_fixes_chunked(
+            &mut auto_apply_result.fixes,
+            root,
+            fixer::ApplyOptions { verifier: None },
+        );
+        applied_chunks += chunk_results
+            .iter()
+            .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Applied))
+            .count();
+        reverted_chunks += chunk_results
+            .iter()
+            .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Reverted))
+            .count();
+        total_modified += chunk_results
+            .iter()
+            .filter(|chunk| matches!(chunk.status, fixer::ChunkStatus::Applied))
+            .map(|chunk| chunk.applied_files)
+            .sum::<usize>();
+        fix_result.chunk_results.extend(chunk_results);
     }
 
     if !auto_apply_result.new_files.is_empty() {
         let chunk_results = fixer::apply_new_files_chunked(
             &mut auto_apply_result.new_files,
             root,
-            fixer::ApplyOptions {
-                verifier: Some(&verifier),
-            },
+            fixer::ApplyOptions { verifier: None },
         );
         applied_chunks += chunk_results
             .iter()
@@ -525,9 +243,7 @@ fn run_fix_iteration(
         let decompose_chunk_results = fixer::apply_decompose_plans(
             &mut auto_apply_result.decompose_plans,
             root,
-            fixer::ApplyOptions {
-                verifier: Some(&verifier),
-            },
+            fixer::ApplyOptions { verifier: None },
         );
         fix_result.chunk_results.extend(decompose_chunk_results);
     }
@@ -608,94 +324,4 @@ fn run_fix_iteration(
     ))
 }
 
-/// Findings that are expected side effects of structural refactoring.
-///
-/// When decompose splits a god file into submodules, the new smaller files
-/// may trigger findings that weren't visible before (e.g., duplication
-/// patterns become detectable at the file level, or new files lack tests).
-/// These are the next step to fix, not a reason to rollback the refactor.
-fn is_cascading_finding_kind(kind: &crate::code_audit::AuditFinding) -> bool {
-    use crate::code_audit::AuditFinding;
 
-    matches!(
-        kind,
-        AuditFinding::GodFile
-            | AuditFinding::HighItemCount
-            | AuditFinding::DirectorySprawl
-            | AuditFinding::MissingTestFile
-            | AuditFinding::MissingTestMethod
-            | AuditFinding::IntraMethodDuplicate
-            | AuditFinding::NearDuplicate
-            | AuditFinding::ParallelImplementation
-            | AuditFinding::UnreferencedExport
-    )
-}
-
-pub fn build_chunk_verifier<'a>(
-    root: &'a Path,
-    baseline_findings: &'a [crate::code_audit::Finding],
-    extra_smokes: Vec<fixer::ChunkVerifier<'a>>,
-) -> impl Fn(&fixer::ApplyChunkResult) -> Result<String, String> + 'a {
-    move |chunk| {
-        let changed_files = chunk.files.clone();
-        if changed_files.is_empty() {
-            return Ok("no_files".to_string());
-        }
-
-        let baseline: HashSet<String> = baseline_findings
-            .iter()
-            .filter(|finding| changed_files.contains(&finding.file))
-            .map(finding_fingerprint)
-            .collect();
-
-        let audit_result = code_audit::audit_path_scoped(
-            "audit-fix-verify",
-            &root.to_string_lossy(),
-            &changed_files,
-            None,
-        )
-        .map_err(|error| format!("verification audit failed: {}", error))?;
-
-        let new_findings: Vec<&crate::code_audit::Finding> = audit_result
-            .findings
-            .iter()
-            .filter(|finding| changed_files.contains(&finding.file))
-            .filter(|finding| !baseline.contains(&finding_fingerprint(finding)))
-            .collect();
-
-        let hard_failures: Vec<String> = new_findings
-            .iter()
-            .filter(|finding| !is_cascading_finding_kind(&finding.kind))
-            .map(|finding| format!("{}: {:?}", finding.file, finding.kind))
-            .collect();
-        let cascading_count = new_findings.len() - hard_failures.len();
-
-        if !hard_failures.is_empty() {
-            Err(format!(
-                "scoped re-audit introduced new findings in changed files: {}",
-                hard_failures.join(", ")
-            ))
-        } else if cascading_count > 0 {
-            let mut verification = format!(
-                "scoped_reaudit_ok_with_{}_cascading_findings",
-                cascading_count
-            );
-            for smoke in &extra_smokes {
-                let smoke_result = smoke(chunk)?;
-                verification.push('+');
-                verification.push_str(&smoke_result);
-            }
-            Ok(verification)
-        } else if extra_smokes.is_empty() {
-            Ok("scoped_reaudit_no_new_findings".to_string())
-        } else {
-            let mut verification = "scoped_reaudit_no_new_findings".to_string();
-            for smoke in &extra_smokes {
-                let smoke_result = smoke(chunk)?;
-                verification.push('+');
-                verification.push_str(&smoke_result);
-            }
-            Ok(verification)
-        }
-    }
-}


### PR DESCRIPTION
## Summary

- **Remove all internal validation from refactor** — the command now just writes fixes and moves on
- Sandbox cold compiles (`cargo check --tests` with no cache, 10-20min each) eliminated
- Per-chunk verification (scoped re-audit + lint/test smoke per fix) eliminated
- `validate_write()` calls removed from all refactor subcommands (rename, move, move-file, propagate, transform, decompose, and the `--from` source pipeline)
- `AuditVerificationToggles`, `build_chunk_verifier`, `build_smoke_verifier`, `build_test_smoke_verifier`, `is_cascading_finding_kind` — all removed

## What stays
- **Undo snapshots** — `homeboy undo` still works for local recovery
- **Formatter runs** — generated code still gets formatted before write
- **Sandbox for stage isolation** — lint still sees audit's changes in multi-source runs

## Why
The refactor command was duplicating what CI already does. In the autofix pipeline:
1. Refactor runs internally: sandbox cold compile (10-20min) × up to 3 stages
2. Per-chunk: scoped re-audit + lint smoke + test smoke per fix chunk
3. Post-write: `validate_write()` runs `cargo check --tests` again
4. CI action: `validate_autofix_changes()` runs `cargo check --tests` again
5. CI re-run: runs `audit`, `lint`, `test` all over again

That's **5+ compilation passes** for a single autofix run. Now it's just: generate fixes → apply → commit → push → let PR CI validate.

**-737 lines**

Companion PR: homeboy-action removes `validate_autofix_changes()` (same rationale).