### PR TITLE
ci: add concurrency group to cancel stale PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary

- Adds `concurrency` group keyed by PR number (or ref for non-PR events)
- `cancel-in-progress: true` — cancels stale runs on new pushes
- Especially important for the multi-job pipeline (build → audit → lint → test → refactor) — prevents 5 wasted jobs on outdated commits