### PR TITLE
chore: fix cargo fmt formatting

### DIFF
--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -1961,10 +1961,7 @@ fn parse_hunk() {}
     #[test]
     fn truncate_module_name_drops_stop_words() {
         // Stop words like "for", "from", "to", "in" are dropped, not counted
-        assert_eq!(
-            truncate_module_name("items_for_display"),
-            "items_display"
-        );
+        assert_eq!(truncate_module_name("items_for_display"), "items_display");
         assert_eq!(
             truncate_module_name("data_from_source_to_target"),
             "data_source_target"

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -72,8 +72,8 @@ pub use plan::{
     normalize_sources, run_audit_refactor, run_lint_refactor, run_test_refactor, score_delta,
     summarize_plan_totals, test_refactor_request, weighted_finding_score_with,
     AuditConvergenceScoring, AuditRefactorIterationSummary, AuditRefactorOutcome,
-    LintSourceOptions, PlanOverlap, PlanStageSummary, RefactorPlan,
-    RefactorPlanRequest, TestSourceOptions, KNOWN_PLAN_SOURCES,
+    LintSourceOptions, PlanOverlap, PlanStageSummary, RefactorPlan, RefactorPlanRequest,
+    TestSourceOptions, KNOWN_PLAN_SOURCES,
 };
 pub use propagate::{propagate, PropagateConfig, PropagateEdit, PropagateField, PropagateResult};
 pub use rename::{

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -100,12 +100,8 @@ pub fn run_audit_refactor(
         // it does not re-run the audit internally. The convergence loop
         // (audit → fix → PR → merge → re-audit) belongs in the orchestration
         // pipeline, not inside a single refactor invocation.
-        let (fix_result, policy_summary, mut iteration_summary) = run_fix_iteration(
-            &current_result,
-            only_kinds,
-            exclude_kinds,
-            scoring,
-        )?;
+        let (fix_result, policy_summary, mut iteration_summary) =
+            run_fix_iteration(&current_result, only_kinds, exclude_kinds, scoring)?;
 
         let changed_files = iteration_summary.changed_files.clone();
         final_fix_result = fix_result;
@@ -144,8 +140,6 @@ pub fn run_audit_refactor(
         iterations,
     })
 }
-
-
 
 fn run_fix_iteration(
     audit_result: &CodeAuditResult,
@@ -323,5 +317,3 @@ fn run_fix_iteration(
         },
     ))
 }
-
-


### PR DESCRIPTION
Fixes formatting violations in decompose.rs, mod.rs, and verify.rs left over from the autofix revert.