### PR TITLE
fix: apply cargo fmt to resolve CI lint failures

### DIFF
--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -199,9 +199,7 @@ mod tests {
 
         // Legacy env vars
         let env_vars = run_dir.legacy_env_vars();
-        assert!(env_vars
-            .iter()
-            .any(|(k, _)| k == "HOMEBOY_RUN_DIR"));
+        assert!(env_vars.iter().any(|(k, _)| k == "HOMEBOY_RUN_DIR"));
         assert!(env_vars
             .iter()
             .any(|(k, _)| k == "HOMEBOY_LINT_FINDINGS_FILE"));
@@ -223,8 +221,7 @@ mod tests {
     fn read_step_output_present() {
         let run_dir = RunDir::create().expect("should create run dir");
         let path = run_dir.step_file(files::TEST_RESULTS);
-        std::fs::write(&path, r#"{"total":10,"passed":10,"failed":0}"#)
-            .expect("write test file");
+        std::fs::write(&path, r#"{"total":10,"passed":10,"failed":0}"#).expect("write test file");
 
         let output = run_dir
             .read_step_output(files::TEST_RESULTS)

--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -235,7 +235,10 @@ mod tests {
     fn test_get_dirty_files_ok_files_into_iter_collect() {
         let path = "";
         let result = get_dirty_files(&path);
-        assert!(result.is_ok(), "expected Ok for: Ok(files.into_iter().collect())");
+        assert!(
+            result.is_ok(),
+            "expected Ok for: Ok(files.into_iter().collect())"
+        );
     }
 
     #[test]
@@ -283,7 +286,9 @@ mod tests {
         let path = "";
         let baseline_ref = "";
         let result = get_range_diff(&path, &baseline_ref);
-        assert!(result.is_ok(), "expected Ok for: Ok(String::from_utf8_lossy(&output.stdout).to_string())");
+        assert!(
+            result.is_ok(),
+            "expected Ok for: Ok(String::from_utf8_lossy(&output.stdout).to_string())"
+        );
     }
-
 }

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -67,12 +67,10 @@ pub use decompose::{
 };
 pub use move_items::{move_items, ImportRewrite, ItemKind, MoveResult, MovedItem};
 pub use plan::{
-    build_refactor_plan, finding_fingerprint, lint_refactor_request,
-    run_audit_refactor, score_delta,
-    test_refactor_request, weighted_finding_score_with,
-    AuditConvergenceScoring, AuditRefactorIterationSummary, AuditRefactorOutcome,
-    LintSourceOptions, PlanOverlap, PlanStageSummary, RefactorPlan, RefactorPlanRequest,
-    TestSourceOptions, KNOWN_PLAN_SOURCES,
+    build_refactor_plan, finding_fingerprint, lint_refactor_request, run_audit_refactor,
+    score_delta, test_refactor_request, weighted_finding_score_with, AuditConvergenceScoring,
+    AuditRefactorIterationSummary, AuditRefactorOutcome, LintSourceOptions, PlanOverlap,
+    PlanStageSummary, RefactorPlan, RefactorPlanRequest, TestSourceOptions, KNOWN_PLAN_SOURCES,
 };
 pub use propagate::{propagate, PropagateConfig, PropagateEdit, PropagateField, PropagateResult};
 pub use rename::{

--- a/src/core/refactor/plan/generate/near_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/near_duplicate_fixes.rs
@@ -341,5 +341,4 @@ mod tests {
             "Should not upgrade already-pub(crate) function"
         );
     }
-
 }

--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -258,7 +258,11 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
                 snap.capture_file(file);
             }
             if let Err(e) = snap.save() {
-                crate::log_status!("undo", "Warning: failed to save pre-refactor undo snapshot: {}", e);
+                crate::log_status!(
+                    "undo",
+                    "Warning: failed to save pre-refactor undo snapshot: {}",
+                    e
+                );
             }
         }
     }
@@ -299,11 +303,7 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
         // Format generated/modified files so subsequent stages (especially lint)
         // see properly formatted code.
         if stage.summary.files_modified > 0 {
-            format_changed_files(
-                &request.root,
-                &stage.summary.changed_files,
-                &mut warnings,
-            );
+            format_changed_files(&request.root, &stage.summary.changed_files, &mut warnings);
         }
 
         accumulator.extend(stage.fix_results.clone());
@@ -360,9 +360,7 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
             .map(|source| format!("Re-run checks: homeboy {} {}", source, request.component.id))
             .collect()
     } else if files_modified > 0 {
-        vec![
-            "Dry run. Re-run with --write to apply fixes to the working tree.".to_string(),
-        ]
+        vec!["Dry run. Re-run with --write to apply fixes to the working tree.".to_string()]
     } else {
         Vec::new()
     };
@@ -692,7 +690,10 @@ fn run_lint_stage(
     let stage_changed_files = if write {
         let after_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
         let before_set: HashSet<&str> = before_dirty.iter().map(|s| s.as_str()).collect();
-        after_dirty.into_iter().filter(|f| !before_set.contains(f.as_str())).collect()
+        after_dirty
+            .into_iter()
+            .filter(|f| !before_set.contains(f.as_str()))
+            .collect()
     } else {
         Vec::new()
     };
@@ -759,7 +760,10 @@ fn run_test_stage(
     let stage_changed_files = if write {
         let after_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
         let before_set: HashSet<&str> = before_dirty.iter().map(|s| s.as_str()).collect();
-        after_dirty.into_iter().filter(|f| !before_set.contains(f.as_str())).collect()
+        after_dirty
+            .into_iter()
+            .filter(|f| !before_set.contains(f.as_str()))
+            .collect()
     } else {
         Vec::new()
     };


### PR DESCRIPTION
## Summary

- Runs `cargo fmt` on 5 files with pre-existing formatting violations
- These violations came from previous autofix commits that generated code without running the formatter
- Fixes lint gate failures in the release pipeline (issues #992, #980, #973)

## Root cause

The auto-refactor step generates code (test stubs, refactored sources) that isn't always `rustfmt`-compliant. When these get committed, subsequent CI runs fail `cargo fmt --check` on the _existing_ code before they even evaluate new fixes.

## Larger issue

The release pipeline's auto-refactor step (`gate-refactor`) runs `refactor --from all` as a dry-run first, then `refactor --from all --write` as autofix. This is redundant — audit, lint, and test gates already reported fixability via `--output`. The refactor step should just apply fixes directly, not re-discover them. That's a separate homeboy-action change.

Fixes #992
Related: #980, #973