### PR TITLE
fix: always rebuild before deploy — remove stale artifact reuse

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -14,8 +14,8 @@ use super::release_download;
 use super::safety_and_artifact::{deploy_artifact, deploy_via_git, validate_deploy_target};
 use super::types::{ComponentDeployResult, DeployConfig, DeployResult};
 use super::version_overrides::{
-    artifact_is_fresh, deploy_with_override, find_deploy_override, find_deploy_verification,
-    is_self_deploy, prefer_installed_binary, run_post_deploy_hooks,
+    deploy_with_override, find_deploy_override, find_deploy_verification, is_self_deploy,
+    prefer_installed_binary, run_post_deploy_hooks,
 };
 
 pub(super) fn execute_component_deploy(
@@ -43,13 +43,6 @@ pub(super) fn execute_component_deploy(
     // Build (git-deploy, skip-build, and release-download skip this step)
     let (build_exit_code, build_error) =
         if is_git_deploy || config.skip_build || release_artifact.is_some() {
-            (Some(0), None)
-        } else if artifact_is_fresh(component) {
-            log_status!(
-                "deploy",
-                "Artifact for '{}' is up-to-date, skipping build",
-                component.id
-            );
             (Some(0), None)
         } else {
             build::build_component(component)

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::SystemTime;
 
 use super::permissions;
 use crate::component::Component;
@@ -8,7 +7,6 @@ use crate::engine::hooks::{self, HookFailureMode};
 use crate::engine::shell;
 use crate::engine::template::{render_map, TemplateVars};
 use crate::error::{Error, Result};
-use crate::extension::build::resolve_artifact_path;
 use crate::extension::{
     load_all_extensions, DeployOverride, DeployVerification, ExtensionManifest,
 };
@@ -18,43 +16,6 @@ use crate::version;
 
 use super::transfer::scp_file;
 use super::types::DeployResult;
-
-pub(super) fn artifact_is_fresh(component: &Component) -> bool {
-    let artifact_pattern = match component.build_artifact.as_ref() {
-        Some(p) => p,
-        None => return false,
-    };
-
-    let artifact_path = match resolve_artifact_path(artifact_pattern) {
-        Ok(p) => p,
-        Err(_) => return false, // artifact doesn't exist yet
-    };
-
-    let artifact_mtime = match artifact_path.metadata().and_then(|m| m.modified()) {
-        Ok(t) => t,
-        Err(_) => return false,
-    };
-
-    // Get HEAD commit timestamp as Unix epoch seconds
-    let commit_ts = crate::engine::command::run_in_optional(
-        &component.local_path,
-        "git",
-        &["log", "-1", "--format=%ct", "HEAD"],
-    );
-
-    let commit_time = match commit_ts {
-        Some(ts) => {
-            let secs: u64 = match ts.trim().parse() {
-                Ok(s) => s,
-                Err(_) => return false,
-            };
-            SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(secs)
-        }
-        None => return false,
-    };
-
-    artifact_mtime > commit_time
-}
 
 /// Detect if a component's artifact is a CLI binary matching the currently
 /// running process name. Used to print a post-deploy hint for self-deploy.

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -348,7 +348,9 @@ fn execute_deployment(
             // workspace is clean by definition. Skipping the uncommitted changes
             // check avoids false positives that silently block deployment.
             force: true,
-            skip_build: true,
+            // Always rebuild to guarantee the artifact matches the just-tagged
+            // commit. Reusing a stale artifact is a silent production bug (#991).
+            skip_build: false,
             keep_deps: false,
             expected_version: None,
             no_pull: true,


### PR DESCRIPTION
## Summary

Fixes #991 — `homeboy deploy` and `release --deploy` were silently deploying stale build artifacts because of a flawed time-based freshness check.

## Changes

- **Remove `artifact_is_fresh()`** from `version_overrides.rs` — this compared artifact mtime against HEAD commit timestamp, which failed when the artifact was built from a different commit than the deploy target
- **Remove `skip_build` from `release --deploy` path** — the release pipeline now always rebuilds after tagging, guaranteeing the deployed artifact matches the tagged commit
- **Multi-project optimization preserved** — `skip_build` on 2nd+ project in `run_multi()` still works correctly (same artifact, different servers)
- **Status/check callers unchanged** — fleet status, project status, and fleet check still use `skip_build: true` for read-only operations

## Root Cause

`artifact_is_fresh()` used `artifact_mtime > commit_time` which broke when:
1. An artifact was built from commit A
2. `homeboy deploy` checked out tag at commit B
3. The artifact was newer than commit B's timestamp → build skipped
4. Commit A's artifact shipped as if it were commit B

## Net change

-49 lines deleted, +5 lines added. Delete the cleverness, ship the correct code.