### PR TITLE
fix: use positional arg for extension install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
         run: |
           chmod +x .homeboy-bin/homeboy
           sudo cp .homeboy-bin/homeboy /usr/local/bin/homeboy
-          homeboy extension install rust --source https://github.com/Extra-Chill/homeboy-extensions
+          homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id rust
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Fixes the **gate-refactor** (Auto-refactor) step failing in every release pipeline run since the CLI changed `extension install` to use a positional source argument
- Changes `homeboy extension install rust --source <url>` → `homeboy extension install <url> --id rust` to match the current CLI interface

## Context
The `homeboy extension install` command changed from `--source` as a named flag to a positional `<SOURCE>` argument. The homeboy-action was already updated (in `install-extension.sh`), but the release workflow's `gate-refactor` job had a hand-written install step that still used the old syntax.

**Error from CI:**
```
homeboy extension install rust --source https://github.com/Extra-Chill/homeboy-extensions
error: unexpected argument '--source' found

  tip: to pass '--source' as a value, use '-- --source'

Usage: homeboy extension install <SOURCE>
```

**Affected runs:** Every Release pipeline since the CLI change where `should-release == true`, including runs [23514052016](https://github.com/Extra-Chill/homeboy/actions/runs/23514052016) and [23512279281](https://github.com/Extra-Chill/homeboy/actions/runs/23512279281).

Closes #980
Closes #973