### PR TITLE
fix: improve autofix fixer quality — prevent 4 classes of broken output

### DIFF
--- a/src/core/code_audit/import_matching.rs
+++ b/src/core/code_audit/import_matching.rs
@@ -161,18 +161,83 @@ pub(crate) fn content_defines_name(content: &str, name: &str) -> bool {
 }
 
 /// Check if file content references a name outside of import/use statements.
+///
+/// Skips references that only appear inside string literals within attribute macros
+/// (e.g., `#[serde(default = "default_true")]`), since those are resolved by the
+/// macro at compile time, not by Rust's import system.
 pub(crate) fn content_references_name(content: &str, name: &str) -> bool {
+    let mut found_real_reference = false;
+
     for line in content.lines() {
         let trimmed = line.trim();
         // Skip import/use lines — we're looking for usage, not declarations
         if trimmed.starts_with("use ") || trimmed.starts_with("import ") {
             continue;
         }
-        if contains_word(trimmed, name) {
-            return true;
+        if !contains_word(trimmed, name) {
+            continue;
         }
+        // If the name only appears inside a string literal on an attribute line,
+        // it's a macro-resolved reference (serde, clap, etc.), not a real import.
+        if is_only_in_attribute_string(trimmed, name) {
+            continue;
+        }
+        found_real_reference = true;
+        break;
     }
-    false
+    found_real_reference
+}
+
+/// Check if `name` only appears inside string literals on an attribute line.
+///
+/// Catches patterns like `#[serde(default = "default_true")]` where the name
+/// is referenced by a proc macro (serde, clap, etc.) via a string path, not
+/// by Rust's module/import system. These don't need a `use` statement.
+fn is_only_in_attribute_string(line: &str, name: &str) -> bool {
+    let trimmed = line.trim();
+
+    // Must be an attribute line or a field with an attribute
+    let is_attribute_context = trimmed.starts_with("#[")
+        || trimmed.starts_with("#![")
+        || trimmed.contains("#[");
+
+    if !is_attribute_context {
+        return false;
+    }
+
+    // Check if ALL occurrences of `name` on this line are inside quoted strings.
+    // Walk through the line tracking whether we're inside a string literal.
+    let name_bytes = name.as_bytes();
+    let line_bytes = trimmed.as_bytes();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut all_in_string = true;
+    let mut found_any = false;
+
+    while i < line_bytes.len() {
+        if line_bytes[i] == b'"' && (i == 0 || line_bytes[i - 1] != b'\\') {
+            in_string = !in_string;
+            i += 1;
+            continue;
+        }
+        if i + name_bytes.len() <= line_bytes.len() && &line_bytes[i..i + name_bytes.len()] == name_bytes {
+            // Check word boundaries
+            let before_ok = i == 0
+                || (!line_bytes[i - 1].is_ascii_alphanumeric() && line_bytes[i - 1] != b'_');
+            let after = i + name_bytes.len();
+            let after_ok = after >= line_bytes.len()
+                || (!line_bytes[after].is_ascii_alphanumeric() && line_bytes[after] != b'_');
+            if before_ok && after_ok {
+                found_any = true;
+                if !in_string {
+                    all_in_string = false;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    found_any && all_in_string
 }
 
 /// Check if `text` contains `word` as a standalone word (not a substring).
@@ -380,6 +445,49 @@ fn default_true() -> bool {
         assert!(!contains_word("SerializeMe", "Serialize"));
         assert!(!contains_word("MySerialize", "Serialize"));
         assert!(!contains_word("_Serialize_ext", "Serialize"));
+    }
+
+    #[test]
+    fn serde_attribute_string_not_a_real_reference() {
+        // The name "default_true" only appears inside a serde attribute string —
+        // not a real code reference, so missing import should not be flagged.
+        let content = r#"    #[serde(default = "default_true")]
+    pub enabled: bool,
+"#;
+        assert!(!content_references_name(content, "default_true"));
+    }
+
+    #[test]
+    fn serde_attribute_string_with_real_usage_is_flagged() {
+        // Name appears both in a serde attribute string AND as a real call
+        let content = r#"    #[serde(default = "default_true")]
+    pub enabled: bool,
+    let x = default_true();
+"#;
+        assert!(content_references_name(content, "default_true"));
+    }
+
+    #[test]
+    fn non_attribute_reference_is_flagged() {
+        let content = "let x = default_true();\n";
+        assert!(content_references_name(content, "default_true"));
+    }
+
+    #[test]
+    fn attribute_string_detection_basics() {
+        assert!(is_only_in_attribute_string(
+            r#"#[serde(default = "default_true")]"#,
+            "default_true"
+        ));
+        assert!(!is_only_in_attribute_string(
+            "let x = default_true();",
+            "default_true"
+        ));
+        // Name outside quotes on an attribute line
+        assert!(!is_only_in_attribute_string(
+            r#"#[derive(default_true)]"#,
+            "default_true"
+        ));
     }
 
     #[test]

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -220,6 +220,10 @@ fn run_moves(plan: &DecomposePlan, root: &Path, write: bool) -> Result<Vec<MoveR
             write,
             MoveOptions {
                 move_related_tests: false,
+                // Decompose generates pub use re-exports in the source file,
+                // so callers importing from the original module path still work.
+                // Rewriting sibling imports would produce incorrect submodule paths.
+                skip_caller_rewrites: true,
             },
         )?;
         results.push(result);

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -482,10 +482,15 @@ pub fn move_items_with_options(
     };
 
     // ── Phase 7: Update caller imports across the codebase ──────────────
+    // Skip caller rewrites when the source file will generate pub use re-exports
+    // (e.g., decompose operations). The re-exports keep the original import paths
+    // valid, so rewriting siblings would produce incorrect paths.
     let mut imports_updated: usize = 0;
     let mut caller_rewrites: Vec<(PathBuf, Vec<ImportRewrite>)> = Vec::new();
 
-    if let Some(ref ext) = ext {
+    if options.skip_caller_rewrites {
+        // Decompose mode: source file gets pub use re-exports, callers don't need changes
+    } else if let Some(ref ext) = ext {
         // Walk source files to find callers that import the moved items
         let source_module = module_path_from_file(from);
         let dest_module = module_path_from_file(to);

--- a/src/core/refactor/move_items/move_options.rs
+++ b/src/core/refactor/move_items/move_options.rs
@@ -5,12 +5,21 @@
 pub struct MoveOptions {
     /// Whether related test functions should be moved alongside requested items.
     pub move_related_tests: bool,
+    /// Skip rewriting import paths in caller files across the codebase.
+    ///
+    /// Set this to `true` when the source file will generate `pub use *` re-exports
+    /// (e.g., decompose operations), making caller rewrites unnecessary — the
+    /// re-exports ensure callers can still find moved items via the original path.
+    /// Without this, the rewriter incorrectly changes sibling imports to point at
+    /// submodule paths that aren't directly accessible from the sibling's scope.
+    pub skip_caller_rewrites: bool,
 }
 
 impl Default for MoveOptions {
     fn default() -> Self {
         Self {
             move_related_tests: true,
+            skip_caller_rewrites: false,
         }
     }
 }

--- a/src/core/refactor/plan/generate/orphaned_test_fixes.rs
+++ b/src/core/refactor/plan/generate/orphaned_test_fixes.rs
@@ -385,7 +385,10 @@ pub(crate) fn generate_orphaned_test_fixes(
             }
         }
 
-        // Fallback: delete the orphaned test if no rename candidate found
+        // Fallback: delete the orphaned test if no rename candidate found.
+        // Use PlanOnly tier so deletions require human review — the orphan
+        // detection can produce false positives for behavioral tests that
+        // don't follow the test_<method> naming convention exactly.
         let mut ins = insertion(
             InsertionKind::FunctionRemoval {
                 start_line,
@@ -398,7 +401,7 @@ pub(crate) fn generate_orphaned_test_fixes(
                 test_method
             ),
         );
-        ins.safety_tier = FixSafetyTier::Safe;
+        ins.safety_tier = FixSafetyTier::PlanOnly;
 
         fixes.push(Fix {
             file: finding.file.clone(),

--- a/src/core/refactor/plan/generate/test_gen_fixes.rs
+++ b/src/core/refactor/plan/generate/test_gen_fixes.rs
@@ -123,6 +123,15 @@ pub(crate) fn generate_test_file_fixes(
             }
         };
 
+        // Downgrade to PlanOnly when generated tests use unresolved type fallbacks
+        let has_unresolved_types = test_module.contains("Default::default()")
+            || test_module.contains("::default()");
+        let safety_tier = if has_unresolved_types {
+            FixSafetyTier::PlanOnly
+        } else {
+            FixSafetyTier::Safe
+        };
+
         fixes.push(Fix {
             file: source_file.clone(),
             required_methods: vec![],
@@ -130,9 +139,13 @@ pub(crate) fn generate_test_file_fixes(
             insertions: vec![Insertion {
                 kind: InsertionKind::TestModule,
                 finding: AuditFinding::MissingTestFile,
-                safety_tier: FixSafetyTier::Safe,
-                auto_apply: true,
-                blocked_reason: None,
+                safety_tier,
+                auto_apply: !has_unresolved_types,
+                blocked_reason: if has_unresolved_types {
+                    Some("Generated test uses Default::default() fallback — types not resolved, test may be meaningless".to_string())
+                } else {
+                    None
+                },
                 preflight: None,
                 code: test_module,
                 description: format!(
@@ -358,12 +371,27 @@ pub(crate) fn generate_test_method_fixes(
             }
         };
 
+        // If the generated test code uses Default::default() fallbacks, the
+        // type wasn't properly resolved and the test is likely meaningless.
+        // Downgrade to PlanOnly so it requires human review instead of auto-applying.
+        let has_unresolved_types = append_code.contains("Default::default()")
+            || append_code.contains("::default()");
+        let safety_tier = if has_unresolved_types {
+            FixSafetyTier::PlanOnly
+        } else {
+            FixSafetyTier::Safe
+        };
+
         let insertions = vec![Insertion {
             kind: InsertionKind::MethodStub,
             finding: AuditFinding::MissingTestMethod,
-            safety_tier: FixSafetyTier::Safe,
-            auto_apply: true,
-            blocked_reason: None,
+            safety_tier,
+            auto_apply: !has_unresolved_types,
+            blocked_reason: if has_unresolved_types {
+                Some("Generated test uses Default::default() fallback — types not resolved, test may be meaningless".to_string())
+            } else {
+                None
+            },
             preflight: None,
             code: append_code,
             description: format!(


### PR DESCRIPTION
## Summary

Fixes four distinct autofix fixer bugs that caused non-compiling commits on PR #999. Each fix targets the root cause algorithmically rather than patching symptoms.

## Changes

### 1. `import_add`: skip serde attribute string references (#1001)

`content_references_name()` now detects when a symbol only appears inside string literals on attribute lines (e.g., `#[serde(default = "default_true")]`). These are proc-macro-resolved paths, not Rust import references.

**New function:** `is_only_in_attribute_string()` — walks the line tracking quote state to determine if all occurrences of the name are inside quoted strings on an attribute line.

**Before:** Added bogus `use crate::core::defaults::default_true;` → `error[E0603]: function is private`
**After:** Skips the finding entirely — no import needed for serde path strings.

### 2. `decompose`: skip caller import rewrites (#1002)

Added `skip_caller_rewrites: bool` to `MoveOptions`. When decompose splits a file into a directory, it generates `pub use *` re-exports in the parent module. Sibling files can still import from the original path — no rewriting needed.

**Before:** Rewrote `executor.rs` imports from `super::types::ReleaseStepType` → `super::release_step_type::ReleaseStepType` → `error[E0432]: unresolved import`
**After:** Skips Phase 7 (caller rewrites) entirely for decompose operations.

### 3. `orphanedtest`: downgrade deletion to PlanOnly (#1003)

`FunctionRemoval` for orphaned tests now uses `FixSafetyTier::PlanOnly` instead of `Safe`. The orphan detection produces false positives for behavioral tests that don't strictly follow the `test_<method>` convention.

**Before:** Auto-deleted `recommended_bump_prefers_highest_severity` (a valid, hand-written test) and replaced it with empty stubs.
**After:** Deletions require human review. Renames (when a source method was renamed) remain `Safe`.

### 4. `missingtestmethod`: downgrade `Default::default()` tests to PlanOnly (#1004)

Generated tests that fall back to `Default::default()` or `::default()` are now `PlanOnly` with a `blocked_reason` explaining why. Applied to both `generate_test_method_fixes` and `generate_test_file_fixes`.

**Before:** Auto-inserted 15+ tests like `let input = Default::default(); let _result = run_command(input);` — no assertions, no value.
**After:** These tests are plan-only and won't auto-apply.

## Tests

- 4 new tests for `is_only_in_attribute_string` and serde-aware reference detection
- All 973 existing tests pass (3 pre-existing failures in `git::changes` — unrelated auto-generated stubs)
- Clean `cargo build --release`

## Files changed

| File | What |
|------|------|
| `code_audit/import_matching.rs` | Serde attribute string detection in `content_references_name` |
| `refactor/move_items/move_options.rs` | `skip_caller_rewrites` field |
| `refactor/move_items.rs` | Honor `skip_caller_rewrites` in Phase 7 |
| `refactor/decompose.rs` | Set `skip_caller_rewrites: true` |
| `refactor/plan/generate/orphaned_test_fixes.rs` | `PlanOnly` for deletions |
| `refactor/plan/generate/test_gen_fixes.rs` | `PlanOnly` for unresolved-type tests |

Fixes #1001, fixes #1002, fixes #1003, fixes #1004