### PR TITLE
fix: unblock release by applying rustfmt cleanups

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -1122,7 +1122,10 @@ mod tests {
             expected_interfaces: vec![],
             expected_namespace: None,
             expected_imports: vec![],
-            conforming: vec!["undo/snapshot.rs".to_string(), "undo/rollback.rs".to_string()],
+            conforming: vec![
+                "undo/snapshot.rs".to_string(),
+                "undo/rollback.rs".to_string(),
+            ],
             outliers: vec![],
             total_files: 2,
             confidence: 1.0,

--- a/src/core/code_audit/import_matching.rs
+++ b/src/core/code_audit/import_matching.rs
@@ -197,9 +197,8 @@ fn is_only_in_attribute_string(line: &str, name: &str) -> bool {
     let trimmed = line.trim();
 
     // Must be an attribute line or a field with an attribute
-    let is_attribute_context = trimmed.starts_with("#[")
-        || trimmed.starts_with("#![")
-        || trimmed.contains("#[");
+    let is_attribute_context =
+        trimmed.starts_with("#[") || trimmed.starts_with("#![") || trimmed.contains("#[");
 
     if !is_attribute_context {
         return false;
@@ -220,10 +219,12 @@ fn is_only_in_attribute_string(line: &str, name: &str) -> bool {
             i += 1;
             continue;
         }
-        if i + name_bytes.len() <= line_bytes.len() && &line_bytes[i..i + name_bytes.len()] == name_bytes {
+        if i + name_bytes.len() <= line_bytes.len()
+            && &line_bytes[i..i + name_bytes.len()] == name_bytes
+        {
             // Check word boundaries
-            let before_ok = i == 0
-                || (!line_bytes[i - 1].is_ascii_alphanumeric() && line_bytes[i - 1] != b'_');
+            let before_ok =
+                i == 0 || (!line_bytes[i - 1].is_ascii_alphanumeric() && line_bytes[i - 1] != b'_');
             let after = i + name_bytes.len();
             let after_ok = after >= line_bytes.len()
                 || (!line_bytes[after].is_ascii_alphanumeric() && line_bytes[after] != b'_');

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -459,8 +459,7 @@ pub fn move_items_with_options(
             } else if prev.is_empty() && start >= 2 {
                 // Allow one blank line gap if an attribute is above it
                 let above = lines[start - 2].trim();
-                if above.starts_with("#[") || above.starts_with("///") || above.starts_with("//!")
-                {
+                if above.starts_with("#[") || above.starts_with("///") || above.starts_with("//!") {
                     start -= 1;
                 } else {
                     break;

--- a/src/core/refactor/plan/generate/test_gen_fixes.rs
+++ b/src/core/refactor/plan/generate/test_gen_fixes.rs
@@ -124,8 +124,8 @@ pub(crate) fn generate_test_file_fixes(
         };
 
         // Downgrade to PlanOnly when generated tests use unresolved type fallbacks
-        let has_unresolved_types = test_module.contains("Default::default()")
-            || test_module.contains("::default()");
+        let has_unresolved_types =
+            test_module.contains("Default::default()") || test_module.contains("::default()");
         let safety_tier = if has_unresolved_types {
             FixSafetyTier::PlanOnly
         } else {
@@ -374,8 +374,8 @@ pub(crate) fn generate_test_method_fixes(
         // If the generated test code uses Default::default() fallbacks, the
         // type wasn't properly resolved and the test is likely meaningless.
         // Downgrade to PlanOnly so it requires human review instead of auto-applying.
-        let has_unresolved_types = append_code.contains("Default::default()")
-            || append_code.contains("::default()");
+        let has_unresolved_types =
+            append_code.contains("Default::default()") || append_code.contains("::default()");
         let safety_tier = if has_unresolved_types {
             FixSafetyTier::PlanOnly
         } else {


### PR DESCRIPTION
## Summary
- apply rustfmt-clean formatting changes to the files blocking CI and release
- keep the change set minimal and non-functional so the release gate can pass again

## Validation
- cargo fmt --check
- cargo build