### PR TITLE
fix: harden autofix structural parsing and import application

### DIFF
--- a/src/core/refactor/auto/apply.rs
+++ b/src/core/refactor/auto/apply.rs
@@ -488,6 +488,10 @@ fn insert_inline_type_conformance(content: &str, declaration: &str, language: &L
 }
 
 pub(crate) fn insert_import(content: &str, import_line: &str, language: &Language) -> String {
+    if import_already_present(content, import_line, language) {
+        return content.to_string();
+    }
+
     let lines: Vec<&str> = content.lines().collect();
 
     let import_prefix = match language {
@@ -587,6 +591,32 @@ pub(crate) fn insert_import(content: &str, import_line: &str, language: &Languag
     }
 
     result
+}
+
+fn import_already_present(content: &str, import_line: &str, language: &Language) -> bool {
+    let normalized_candidate = normalize_import_line(import_line);
+    if normalized_candidate.is_empty() {
+        return true;
+    }
+
+    content.lines().any(|line| {
+        let trimmed = line.trim();
+        if !is_import_line(trimmed, language) {
+            return false;
+        }
+        normalize_import_line(trimmed) == normalized_candidate
+    })
+}
+
+fn is_import_line(line: &str, language: &Language) -> bool {
+    match language {
+        Language::Rust | Language::Php | Language::Unknown => line.starts_with("use "),
+        Language::JavaScript | Language::TypeScript => line.starts_with("import "),
+    }
+}
+
+fn normalize_import_line(line: &str) -> String {
+    line.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 pub(crate) fn insert_before_closing_brace(
@@ -1153,6 +1183,24 @@ mod tests {
         let mut lines: Vec<String> = vec!["pub use other::{foo, bar};".into()];
         remove_from_pub_use_block(&mut lines, "baz");
         assert_eq!(lines[0], "pub use other::{foo, bar};");
+    }
+
+    #[test]
+    fn insert_import_skips_identical_existing_rust_import() {
+        let content = "use std::collections::HashMap;\n\npub fn run() {}\n";
+        let result = insert_import(content, "use std::collections::HashMap;", &Language::Rust);
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn insert_import_skips_equivalent_rust_import_with_spacing_differences() {
+        let content = "use std::path::{Path, PathBuf};\n\npub fn run() {}\n";
+        let result = insert_import(
+            content,
+            "use  std::path::{Path,   PathBuf};",
+            &Language::Rust,
+        );
+        assert_eq!(result, content);
     }
 
     #[test]

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -322,8 +322,27 @@ fn source_to_test_file(target: &str) -> Option<String> {
 fn parse_items(file: &str, content: &str) -> Option<Vec<ParsedItem>> {
     let ext = Path::new(file).extension()?.to_str()?;
 
-    // Try core grammar engine first — faster and more robust than extension scripts
+    // Prefer the language extension's structural parser when available.
+    // For decomposition quality, the language-aware parser should be the
+    // authoritative source of item boundaries/source extraction. The core
+    // grammar parser remains the fallback for languages without a dedicated
+    // refactor parser.
     if let Some(manifest) = extension::find_extension_for_file_ext(ext, "refactor") {
+        // Try extension script first
+        let command = serde_json::json!({
+            "command": "parse_items",
+            "file_path": file,
+            "content": content,
+        });
+        if let Some(result) = extension::run_refactor_script(&manifest, &command) {
+            if let Some(items) = result.get("items").and_then(|value| serde_json::from_value::<Vec<ParsedItem>>(value.clone()).ok()) {
+                if !items.is_empty() {
+                    return Some(items);
+                }
+            }
+        }
+
+        // Fall back to core grammar parser
         if let Some(ext_path) = &manifest.extension_path {
             let grammar = load_extension_grammar(Path::new(ext_path), ext);
             if let Some(grammar) = grammar {
@@ -333,15 +352,6 @@ fn parse_items(file: &str, content: &str) -> Option<Vec<ParsedItem>> {
                 }
             }
         }
-
-        // Fall back to extension script
-        let command = serde_json::json!({
-            "command": "parse_items",
-            "file_path": file,
-            "content": content,
-        });
-        let result = extension::run_refactor_script(&manifest, &command)?;
-        return serde_json::from_value(result.get("items")?.clone()).ok();
     }
 
     None

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -220,10 +220,15 @@ pub fn move_items_with_options(
     let mut warnings: Vec<String> = Vec::new();
 
     // ── Phase 1: Parse items ────────────────────────────────────────────
-    // Try core grammar engine first (faster, more robust), fall back to extension script
+    // Prefer the language extension's structural parser when available.
+    // Structural move/decompose quality depends on language-specific item
+    // boundaries and source extraction being authoritative. The core grammar
+    // parser remains the fallback for languages without a dedicated refactor
+    // parser, but broad autofix showed that for Rust structural splits the
+    // extension parser is currently more trustworthy.
     let all_items: Vec<ParsedItem> = if let Some(ref ext) = ext {
-        core_parse_items(ext, &content).unwrap_or_else(|| {
-            ext_parse_items(ext, &content, from).unwrap_or_else(|| {
+        ext_parse_items(ext, &content, from).unwrap_or_else(|| {
+            core_parse_items(ext, &content).unwrap_or_else(|| {
                 warnings.push("Extension parse_items failed, using fallback parser".to_string());
                 Vec::new()
             })

--- a/src/core/refactor/move_items/whole_file_move.rs
+++ b/src/core/refactor/move_items/whole_file_move.rs
@@ -83,8 +83,8 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
             // callers might import individually
             let source_content = std::fs::read_to_string(&source_abs).unwrap_or_default();
             let pub_item_names: Vec<String> = if let Some(items) =
-                core_parse_items(ext, &source_content)
-                    .or_else(|| ext_parse_items(ext, &source_content, from))
+                ext_parse_items(ext, &source_content, from)
+                    .or_else(|| core_parse_items(ext, &source_content))
             {
                 items
                     .iter()


### PR DESCRIPTION
## Summary
- make structural refactor paths prefer the language-specific parser when available instead of trusting the generic parser first
- make import insertion idempotent so autofix stops re-adding equivalent imports
- keep the changes focused on generation/apply algorithms, not validation hooks or autofix restrictions

## Validation
- cargo test parse_items_braces_in_string -- --nocapture
- cargo test find_matching_brace_skips_raw_strings -- --nocapture
- cargo test insert_import_skips_identical_existing_rust_import -- --nocapture
- cargo test insert_import_skips_equivalent_rust_import_with_spacing_differences -- --nocapture