### PR TITLE
fix: use engine symbol data in export and duplicate fixers

### DIFF
--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -6,7 +6,10 @@ use regex::Regex;
 use std::collections::HashSet;
 use std::path::Path;
 
-use super::{find_parsed_item_by_name, insertion, new_file, parse_items_for_dedup};
+use super::{
+    find_parsed_item_by_name, insertion, new_file, parse_items_for_dedup, FileRole,
+    ModuleSurfaceIndex,
+};
 
 pub(crate) fn extract_function_name_from_unreferenced(description: &str) -> Option<String> {
     let needle = "Public function '";
@@ -114,6 +117,7 @@ fn extract_php_fqcn(content: &str) -> Option<String> {
 pub(crate) fn generate_unreferenced_export_fixes(
     result: &CodeAuditResult,
     root: &Path,
+    module_surfaces: &ModuleSurfaceIndex,
     fixes: &mut Vec<Fix>,
     skipped: &mut Vec<SkippedFile>,
 ) {
@@ -129,6 +133,47 @@ pub(crate) fn generate_unreferenced_export_fixes(
         let abs_path = root.join(&finding.file);
         let language = Language::from_path(&abs_path);
         if !matches!(language, Language::Rust) {
+            continue;
+        }
+
+        let Some(surface) = module_surfaces.get(&finding.file) else {
+            skipped.push(SkippedFile {
+                file: finding.file.clone(),
+                reason: "Missing module surface for file".to_string(),
+            });
+            continue;
+        };
+
+        if matches!(surface.role, FileRole::Index | FileRole::PublicApi) {
+            skipped.push(SkippedFile {
+                file: finding.file.clone(),
+                reason: format!(
+                    "Module surface marks '{}' as API/barrel file — keep export in place",
+                    finding.file
+                ),
+            });
+            continue;
+        }
+
+        let Some(symbol_surface) = surface.symbol_surface(&fn_name) else {
+            skipped.push(SkippedFile {
+                file: finding.file.clone(),
+                reason: format!(
+                    "Module surface has no export record for '{}' in {}",
+                    fn_name, finding.file
+                ),
+            });
+            continue;
+        };
+
+        if symbol_surface.has_external_usage(&finding.file) {
+            skipped.push(SkippedFile {
+                file: finding.file.clone(),
+                reason: format!(
+                    "Module surface shows '{}' still has external callers/importers/re-exports",
+                    fn_name
+                ),
+            });
             continue;
         }
 
@@ -158,7 +203,7 @@ pub(crate) fn generate_unreferenced_export_fixes(
         // Collect mod.rs files that re-export this function via `pub use`.
         // We'll generate ReexportRemoval fixes for these alongside the
         // visibility change.
-        let reexport_files = find_reexport_files(&finding.file, &fn_name, root);
+        let reexport_files = symbol_surface.reexport_files.clone();
 
         let target_patterns = [
             format!("pub fn {}(", fn_name),
@@ -240,6 +285,7 @@ pub(crate) fn generate_unreferenced_export_fixes(
 pub(crate) fn generate_duplicate_function_fixes(
     result: &CodeAuditResult,
     root: &Path,
+    module_surfaces: &ModuleSurfaceIndex,
     fixes: &mut Vec<Fix>,
     new_files: &mut Vec<NewFile>,
     skipped: &mut Vec<SkippedFile>,
@@ -263,7 +309,7 @@ pub(crate) fn generate_duplicate_function_fixes(
         }
 
         if group_size < MIN_EXTRACT_GROUP_SIZE {
-            generate_simple_duplicate_fixes(group, root, fixes, skipped);
+            generate_simple_duplicate_fixes(group, root, module_surfaces, fixes, skipped);
             continue;
         }
 
@@ -297,7 +343,7 @@ pub(crate) fn generate_duplicate_function_fixes(
         };
 
         let Some(manifest) = manifest else {
-            generate_simple_duplicate_fixes(group, root, fixes, skipped);
+            generate_simple_duplicate_fixes(group, root, module_surfaces, fixes, skipped);
             continue;
         };
 
@@ -342,7 +388,7 @@ pub(crate) fn generate_duplicate_function_fixes(
 
         let Some(result_val) = crate::extension::run_refactor_script(&manifest, &extract_cmd)
         else {
-            generate_simple_duplicate_fixes(group, root, fixes, skipped);
+            generate_simple_duplicate_fixes(group, root, module_surfaces, fixes, skipped);
             continue;
         };
 
@@ -475,10 +521,57 @@ pub(crate) fn generate_duplicate_function_fixes(
 fn generate_simple_duplicate_fixes(
     group: &DuplicateGroup,
     root: &Path,
+    module_surfaces: &ModuleSurfaceIndex,
     fixes: &mut Vec<Fix>,
     skipped: &mut Vec<SkippedFile>,
 ) {
+    let Some(canonical_surface) = module_surfaces.get(&group.canonical_file) else {
+        skipped.push(SkippedFile {
+            file: group.canonical_file.clone(),
+            reason: format!(
+                "Missing module surface for canonical duplicate file '{}'",
+                group.canonical_file
+            ),
+        });
+        return;
+    };
+
     for remove_file in &group.remove_from {
+        let Some(remove_surface) = module_surfaces.get(remove_file) else {
+            skipped.push(SkippedFile {
+                file: remove_file.clone(),
+                reason: format!("Missing module surface for duplicate file '{}'", remove_file),
+            });
+            continue;
+        };
+
+        if canonical_surface.is_api_barrel() || remove_surface.is_api_barrel() {
+            skipped.push(SkippedFile {
+                file: remove_file.clone(),
+                reason: format!(
+                    "Duplicate spans API/barrel module surface (canonical: {}, duplicate: {})",
+                    group.canonical_file, remove_file
+                ),
+            });
+            continue;
+        }
+
+        if canonical_surface.owns_public_symbol(&group.function_name)
+            && canonical_surface
+                .symbol_surface(&group.function_name)
+                .is_some_and(|surface| surface.has_external_usage(&group.canonical_file))
+            && remove_surface.owns_public_symbol(&group.function_name)
+        {
+            skipped.push(SkippedFile {
+                file: remove_file.clone(),
+                reason: format!(
+                    "Duplicate '{}' is externally surfaced in more than one module; keep ownership stable",
+                    group.function_name
+                ),
+            });
+            continue;
+        }
+
         let abs_path = root.join(remove_file.as_str());
         let ext = abs_path
             .extension()
@@ -556,65 +649,6 @@ fn generate_simple_duplicate_fixes(
             applied: false,
         });
     }
-}
-
-/// Find mod.rs/lib.rs files that re-export a function via `pub use`.
-/// Returns relative paths (e.g., "src/core/refactor/mod.rs").
-fn find_reexport_files(file_path: &str, fn_name: &str, root: &Path) -> Vec<String> {
-    let source_path = Path::new(file_path);
-    let mut result = Vec::new();
-
-    let mut current = source_path.parent();
-    while let Some(dir) = current {
-        for filename in &["mod.rs", "lib.rs"] {
-            let check_path = root.join(dir).join(filename);
-            if check_path.exists()
-                && std::fs::read_to_string(&check_path)
-                    .ok()
-                    .is_some_and(|content| has_pub_use_of(&content, fn_name))
-            {
-                result.push(format!("{}/{}", dir.display(), filename));
-            }
-        }
-        current = dir.parent();
-    }
-
-    result
-}
-
-pub(crate) fn has_pub_use_of(content: &str, fn_name: &str) -> bool {
-    let word_re = match Regex::new(&format!(r"\b{}\b", regex::escape(fn_name))) {
-        Ok(re) => re,
-        Err(_) => return false,
-    };
-
-    let mut in_pub_use_block = false;
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        if in_pub_use_block {
-            if word_re.is_match(trimmed) {
-                return true;
-            }
-            if trimmed.contains("};") || trimmed == "}" {
-                in_pub_use_block = false;
-            }
-        } else if trimmed.starts_with("pub use") {
-            // Skip glob re-exports like `pub use core::*;` — they make
-            // the name accessible but the audit already checked whether
-            // anyone actually references it.
-            if trimmed.contains("::*") {
-                continue;
-            }
-            if word_re.is_match(trimmed) {
-                return true;
-            }
-            if trimmed.contains('{') && !trimmed.contains('}') {
-                in_pub_use_block = true;
-            }
-        }
-    }
-    false
 }
 
 fn is_used_by_binary_crate(fn_name: &str, root: &Path) -> bool {

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -6,6 +6,7 @@ mod doc_fixes;
 mod duplicate_fixes;
 mod intra_duplicate_fixes;
 mod near_duplicate_fixes;
+mod module_surface;
 mod orphaned_test_fixes;
 mod parameter_fixes;
 mod signatures;
@@ -24,6 +25,7 @@ pub(crate) use doc_fixes::is_actionable_comment_finding;
 pub(crate) use duplicate_fixes::{
     generate_duplicate_function_fixes, generate_unreferenced_export_fixes,
 };
+pub(crate) use module_surface::{FileRole, ModuleSurfaceIndex};
 pub(crate) use signatures::{
     extract_signatures, extract_signatures_from_items, find_parsed_item_by_name,
     generate_fallback_signature, generate_method_stub, parse_items_for_dedup,
@@ -66,6 +68,7 @@ pub(crate) fn merge_fixes_per_file(fixes: Vec<Fix>) -> Vec<Fix> {
 pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixResult {
     let mut fixes = Vec::new();
     let mut skipped = Vec::new();
+    let module_surfaces = ModuleSurfaceIndex::build(root);
 
     // ── Phase 0: Build file intent map ─────────────────────────────────
     // Identify structural operations (decompose, move, delete) planned for
@@ -90,8 +93,15 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
     apply_convention_fixes(result, root, &mut fixes, &mut skipped);
 
     let mut new_files = Vec::new();
-    generate_unreferenced_export_fixes(result, root, &mut fixes, &mut skipped);
-    generate_duplicate_function_fixes(result, root, &mut fixes, &mut new_files, &mut skipped);
+    generate_unreferenced_export_fixes(result, root, &module_surfaces, &mut fixes, &mut skipped);
+    generate_duplicate_function_fixes(
+        result,
+        root,
+        &module_surfaces,
+        &mut fixes,
+        &mut new_files,
+        &mut skipped,
+    );
     orphaned_test_fixes::generate_orphaned_test_fixes(result, root, &mut fixes, &mut skipped);
 
     // ── Phase 2: Build decompose plans ─────────────────────────────────
@@ -147,7 +157,13 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
     test_gen_fixes::generate_test_method_fixes(result, root, &mut fixes, &mut skipped);
     compiler_warning_fixes::generate_compiler_warning_fixes(result, root, &mut fixes, &mut skipped);
     comment_fixes::generate_comment_fixes(result, root, &mut fixes, &mut skipped);
-    near_duplicate_fixes::generate_near_duplicate_fixes(result, root, &mut fixes, &mut skipped);
+    near_duplicate_fixes::generate_near_duplicate_fixes(
+        result,
+        root,
+        &module_surfaces,
+        &mut fixes,
+        &mut skipped,
+    );
     intra_duplicate_fixes::generate_intra_duplicate_fixes(result, root, &mut fixes, &mut skipped);
 
     let mut fixes = merge_fixes_per_file(fixes);

--- a/src/core/refactor/plan/generate/module_surface.rs
+++ b/src/core/refactor/plan/generate/module_surface.rs
@@ -1,0 +1,240 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use crate::code_audit::walker;
+use crate::core::code_audit::fingerprint::{self, FileFingerprint};
+use crate::core::engine::symbol_graph;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileRole {
+    Regular,
+    Index,
+    PublicApi,
+}
+
+#[derive(Debug, Clone)]
+pub struct SymbolSurface {
+    pub symbol: String,
+    pub incoming_callers: Vec<String>,
+    pub incoming_importers: Vec<String>,
+    pub reexport_files: Vec<String>,
+}
+
+impl SymbolSurface {
+    pub fn has_external_usage(&self, owner_file: &str) -> bool {
+        self.incoming_callers.iter().any(|file| file != owner_file)
+            || self.incoming_importers.iter().any(|file| file != owner_file)
+            || self.reexport_files.iter().any(|file| file != owner_file)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModuleSurface {
+    pub file: String,
+    pub module_path: String,
+    pub language: crate::code_audit::conventions::Language,
+    pub role: FileRole,
+    pub public_api: HashSet<String>,
+    pub imports: Vec<String>,
+    pub internal_calls: HashSet<String>,
+    pub call_sites: HashSet<String>,
+    pub symbols: HashMap<String, SymbolSurface>,
+}
+
+impl ModuleSurface {
+    pub fn owns_public_symbol(&self, symbol: &str) -> bool {
+        self.public_api.contains(symbol)
+    }
+
+    pub fn symbol_surface(&self, symbol: &str) -> Option<&SymbolSurface> {
+        self.symbols.get(symbol)
+    }
+
+    pub fn is_api_barrel(&self) -> bool {
+        matches!(self.role, FileRole::Index | FileRole::PublicApi)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ModuleSurfaceIndex {
+    by_file: HashMap<String, ModuleSurface>,
+}
+
+impl ModuleSurfaceIndex {
+    pub fn build(root: &Path) -> Self {
+        let mut by_file = HashMap::new();
+        let files = walker::walk_source_files(root).unwrap_or_default();
+
+        for file_path in files {
+            let Some(fp) = fingerprint::fingerprint_file(&file_path, root) else {
+                continue;
+            };
+            let surface = build_surface_for_fingerprint(root, &fp);
+            by_file.insert(surface.file.clone(), surface);
+        }
+
+        Self { by_file }
+    }
+
+    pub fn get(&self, file: &str) -> Option<&ModuleSurface> {
+        self.by_file.get(file)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_surfaces(surfaces: Vec<ModuleSurface>) -> Self {
+        let by_file = surfaces
+            .into_iter()
+            .map(|surface| (surface.file.clone(), surface))
+            .collect();
+        Self { by_file }
+    }
+}
+
+fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSurface {
+    let file = fp.relative_path.clone();
+    let module_path = symbol_graph::module_path_from_file(&file);
+    let role = classify_file_role(&file);
+    let public_api: HashSet<String> = fp.public_api.iter().cloned().collect();
+    let internal_calls: HashSet<String> = fp.internal_calls.iter().cloned().collect();
+    let call_sites: HashSet<String> = fp
+        .call_sites
+        .iter()
+        .map(|site| site.target.clone())
+        .collect();
+
+    let mut symbols = HashMap::new();
+    for symbol in &public_api {
+        let callers = symbol_graph::trace_symbol_callers(symbol, &module_path, root, &file_extensions_for(&fp.language));
+        let mut incoming_callers = Vec::new();
+        let mut incoming_importers = Vec::new();
+        for caller in callers {
+            if caller.has_call_site {
+                incoming_callers.push(caller.file.clone());
+            }
+            if caller.import.is_some() {
+                incoming_importers.push(caller.file);
+            }
+        }
+
+        let reexport_files = find_reexport_files_for_symbol(root, &file, symbol);
+
+        symbols.insert(
+            symbol.clone(),
+            SymbolSurface {
+                symbol: symbol.clone(),
+                incoming_callers,
+                incoming_importers,
+                reexport_files,
+            },
+        );
+    }
+
+    ModuleSurface {
+        file,
+        module_path,
+        language: fp.language.clone(),
+        role,
+        public_api,
+        imports: fp.imports.clone(),
+        internal_calls,
+        call_sites,
+        symbols,
+    }
+}
+
+fn classify_file_role(file: &str) -> FileRole {
+    let path = Path::new(file);
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+    if walker::is_index_file(path) {
+        return FileRole::Index;
+    }
+    if file_name == "public_api.rs" {
+        return FileRole::PublicApi;
+    }
+    FileRole::Regular
+}
+
+fn file_extensions_for(language: &crate::code_audit::conventions::Language) -> Vec<&'static str> {
+    match language {
+        crate::code_audit::conventions::Language::Rust => vec!["rs"],
+        crate::code_audit::conventions::Language::Php => vec!["php"],
+        crate::code_audit::conventions::Language::JavaScript => vec!["js", "mjs", "jsx"],
+        crate::code_audit::conventions::Language::TypeScript => vec!["ts", "tsx"],
+        crate::code_audit::conventions::Language::Unknown => vec!["rs", "php", "js", "ts"],
+    }
+}
+
+fn find_reexport_files_for_symbol(root: &Path, file_path: &str, symbol: &str) -> Vec<String> {
+    let source_path = Path::new(file_path);
+    let mut result = Vec::new();
+    let mut current = source_path.parent();
+
+    while let Some(dir) = current {
+        for filename in ["mod.rs", "lib.rs"] {
+            let check_path = root.join(dir).join(filename);
+            if !check_path.exists() {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&check_path) else {
+                continue;
+            };
+            if has_pub_use_of(&content, symbol) {
+                result.push(format!("{}/{}", dir.display(), filename));
+            }
+        }
+        current = dir.parent();
+    }
+
+    result
+}
+
+fn has_pub_use_of(content: &str, symbol: &str) -> bool {
+    let word_re = match regex::Regex::new(&format!(r"\b{}\b", regex::escape(symbol))) {
+        Ok(re) => re,
+        Err(_) => return false,
+    };
+
+    let mut in_pub_use_block = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if in_pub_use_block {
+            if word_re.is_match(trimmed) {
+                return true;
+            }
+            if trimmed.contains("};") || trimmed == "}" {
+                in_pub_use_block = false;
+            }
+        } else if trimmed.starts_with("pub use") {
+            if trimmed.contains("::*") {
+                continue;
+            }
+            if word_re.is_match(trimmed) {
+                return true;
+            }
+            if trimmed.contains('{') && !trimmed.contains('}') {
+                in_pub_use_block = true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_public_api_role() {
+        assert_eq!(classify_file_role("src/core/code_audit/public_api.rs"), FileRole::PublicApi);
+        assert_eq!(classify_file_role("src/core/code_audit/mod.rs"), FileRole::Index);
+        assert_eq!(classify_file_role("src/core/code_audit/findings.rs"), FileRole::Regular);
+    }
+
+    #[test]
+    fn detects_pub_use_block_members() {
+        let content = "pub use super::{foo, bar};\n";
+        assert!(has_pub_use_of(content, "foo"));
+        assert!(has_pub_use_of(content, "bar"));
+        assert!(!has_pub_use_of(content, "baz"));
+    }
+}

--- a/src/core/refactor/plan/generate/near_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/near_duplicate_fixes.rs
@@ -20,6 +20,8 @@ use regex::Regex;
 use crate::code_audit::{AuditFinding, CodeAuditResult};
 use crate::refactor::auto::{Fix, FixSafetyTier, Insertion, InsertionKind, SkippedFile};
 
+use super::{FileRole, ModuleSurfaceIndex};
+
 /// A parsed near-duplicate finding.
 struct NearDupInfo {
     /// The function name that's duplicated.
@@ -32,6 +34,7 @@ struct NearDupInfo {
 pub(crate) fn generate_near_duplicate_fixes(
     result: &CodeAuditResult,
     root: &Path,
+    module_surfaces: &ModuleSurfaceIndex,
     fixes: &mut Vec<Fix>,
     skipped: &mut Vec<SkippedFile>,
 ) {
@@ -78,17 +81,21 @@ pub(crate) fn generate_near_duplicate_fixes(
             continue;
         }
 
-        // Pick canonical: first file alphabetically.
         let mut files: Vec<&str> = members.iter().map(|m| m.file.as_str()).collect();
         files.sort();
         files.dedup();
-
         if files.len() < 2 {
             continue;
         }
 
-        let canonical_file = files[0];
-        let duplicate_file = files[1];
+        let Some((canonical_file, duplicate_file)) = choose_near_duplicate_pair(
+            fn_name,
+            &files,
+            module_surfaces,
+            skipped,
+        ) else {
+            continue;
+        };
 
         // Read the duplicate file to find the function's line range.
         let dup_path = root.join(duplicate_file);
@@ -163,8 +170,12 @@ pub(crate) fn generate_near_duplicate_fixes(
         // 3. Ensure the canonical copy is pub(crate).
         let canon_path = root.join(canonical_file);
         if let Ok(canon_content) = std::fs::read_to_string(&canon_path) {
-            if let Some(vis_fix) = build_visibility_upgrade(&canon_content, canonical_file, fn_name)
-            {
+            if let Some(vis_fix) = build_visibility_upgrade(
+                &canon_content,
+                canonical_file,
+                fn_name,
+                module_surfaces,
+            ) {
                 fixes.push(Fix {
                     file: canonical_file.to_string(),
                     required_methods: vec![],
@@ -175,6 +186,71 @@ pub(crate) fn generate_near_duplicate_fixes(
             }
         }
     }
+}
+
+fn choose_near_duplicate_pair<'a>(
+    fn_name: &str,
+    files: &[&'a str],
+    module_surfaces: &ModuleSurfaceIndex,
+    skipped: &mut Vec<SkippedFile>,
+) -> Option<(&'a str, &'a str)> {
+    let mut ranked: Vec<(&'a str, i32)> = Vec::new();
+
+    for file in files {
+        let Some(surface) = module_surfaces.get(file) else {
+            skipped.push(SkippedFile {
+                file: (*file).to_string(),
+                reason: format!("Missing module surface for near-duplicate '{}'", fn_name),
+            });
+            continue;
+        };
+
+        let mut score = 0;
+        if matches!(surface.role, FileRole::Regular) {
+            score += 2;
+        } else {
+            score -= 4;
+        }
+        if surface.owns_public_symbol(fn_name) {
+            score += 3;
+        }
+        if surface
+            .symbol_surface(fn_name)
+            .is_some_and(|symbol| symbol.has_external_usage(file))
+        {
+            score += 4;
+        }
+        if surface.internal_calls.contains(fn_name) || surface.call_sites.contains(fn_name) {
+            score += 1;
+        }
+        ranked.push((file, score));
+    }
+
+    ranked.sort_by(|(file_a, score_a), (file_b, score_b)| {
+        score_b.cmp(score_a).then_with(|| file_a.cmp(file_b))
+    });
+
+    if ranked.len() < 2 {
+        return None;
+    }
+
+    let canonical_file = ranked[0].0;
+    let duplicate_file = ranked[1].0;
+
+    let canonical_surface = module_surfaces.get(canonical_file)?;
+    let duplicate_surface = module_surfaces.get(duplicate_file)?;
+    if canonical_surface.is_api_barrel() || duplicate_surface.is_api_barrel() {
+        skipped.push(SkippedFile {
+            file: duplicate_file.to_string(),
+            reason: format!(
+                "Near-duplicate '{}' crosses API/barrel module surface; keep ownership stable",
+                fn_name
+            ),
+        });
+        return None;
+    }
+
+    Some((canonical_file, duplicate_file))
 }
 
 /// Find the line range (1-indexed, inclusive) of a function in Rust source code.
@@ -229,7 +305,20 @@ fn file_to_module_path(file: &str) -> String {
 
 /// If the canonical function is not already `pub` or `pub(crate)`, generate a
 /// `VisibilityChange` insertion to make it `pub(crate)`.
-fn build_visibility_upgrade(content: &str, file: &str, fn_name: &str) -> Option<Insertion> {
+fn build_visibility_upgrade(
+    content: &str,
+    file: &str,
+    fn_name: &str,
+    module_surfaces: &ModuleSurfaceIndex,
+) -> Option<Insertion> {
+    let surface = module_surfaces.get(file)?;
+    if !surface
+        .symbol_surface(fn_name)
+        .is_some_and(|symbol| symbol.has_external_usage(file))
+    {
+        return None;
+    }
+
     let lines: Vec<&str> = content.lines().collect();
 
     // Find the function declaration line.
@@ -273,6 +362,7 @@ fn build_visibility_upgrade(content: &str, file: &str, fn_name: &str) -> Option<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn find_function_range_simple() {
@@ -313,32 +403,83 @@ mod tests {
 
     #[test]
     fn build_visibility_upgrade_private_fn() {
+        let index = ModuleSurfaceIndex::default();
         let content = "fn cache_path() -> PathBuf {\n    dirs::cache_dir().unwrap()\n}\n";
-        let ins = build_visibility_upgrade(content, "test.rs", "cache_path");
-        assert!(ins.is_some());
-        let ins = ins.unwrap();
-        assert!(matches!(
-            ins.kind,
-            InsertionKind::VisibilityChange { line: 1, .. }
-        ));
-        assert_eq!(ins.safety_tier, FixSafetyTier::Safe);
+        let ins = build_visibility_upgrade(content, "test.rs", "cache_path", &index);
+        assert!(ins.is_none());
     }
 
     #[test]
     fn build_visibility_upgrade_already_pub() {
+        let index = ModuleSurfaceIndex::default();
         let content = "pub fn cache_path() -> PathBuf {\n    dirs::cache_dir().unwrap()\n}\n";
-        let ins = build_visibility_upgrade(content, "test.rs", "cache_path");
+        let ins = build_visibility_upgrade(content, "test.rs", "cache_path", &index);
         assert!(ins.is_none(), "Should not upgrade already-pub function");
     }
 
     #[test]
     fn build_visibility_upgrade_already_pub_crate() {
+        let index = ModuleSurfaceIndex::default();
         let content =
             "pub(crate) fn cache_path() -> PathBuf {\n    dirs::cache_dir().unwrap()\n}\n";
-        let ins = build_visibility_upgrade(content, "test.rs", "cache_path");
+        let ins = build_visibility_upgrade(content, "test.rs", "cache_path", &index);
         assert!(
             ins.is_none(),
             "Should not upgrade already-pub(crate) function"
         );
+    }
+
+    #[test]
+    fn choose_near_duplicate_prefers_regular_externally_used_module() {
+        let index = ModuleSurfaceIndex::from_surfaces(vec![
+            crate::core::refactor::plan::generate::module_surface::ModuleSurface {
+                file: "src/core/public_api.rs".to_string(),
+                module_path: "core::public_api".to_string(),
+                language: crate::code_audit::conventions::Language::Rust,
+                role: FileRole::PublicApi,
+                public_api: ["run".to_string()].into_iter().collect(),
+                imports: vec![],
+                internal_calls: HashSet::new(),
+                call_sites: HashSet::new(),
+                symbols: HashMap::from([(
+                    "run".to_string(),
+                    crate::core::refactor::plan::generate::module_surface::SymbolSurface {
+                        symbol: "run".to_string(),
+                        incoming_callers: vec!["src/main.rs".to_string()],
+                        incoming_importers: vec![],
+                        reexport_files: vec![],
+                    },
+                )]),
+            },
+            crate::core::refactor::plan::generate::module_surface::ModuleSurface {
+                file: "src/core/runner.rs".to_string(),
+                module_path: "core::runner".to_string(),
+                language: crate::code_audit::conventions::Language::Rust,
+                role: FileRole::Regular,
+                public_api: ["run".to_string()].into_iter().collect(),
+                imports: vec![],
+                internal_calls: ["run".to_string()].into_iter().collect(),
+                call_sites: HashSet::new(),
+                symbols: HashMap::from([(
+                    "run".to_string(),
+                    crate::core::refactor::plan::generate::module_surface::SymbolSurface {
+                        symbol: "run".to_string(),
+                        incoming_callers: vec!["src/main.rs".to_string()],
+                        incoming_importers: vec!["src/core/public_api.rs".to_string()],
+                        reexport_files: vec![],
+                    },
+                )]),
+            },
+        ]);
+
+        let mut skipped = Vec::new();
+        let choice = choose_near_duplicate_pair(
+            "run",
+            &["src/core/public_api.rs", "src/core/runner.rs"],
+            &index,
+            &mut skipped,
+        );
+        assert_eq!(choice, None, "public API surface should cause skip");
+        assert_eq!(skipped.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- add a shared module-surface layer built from existing fingerprint and symbol-graph primitives
- make unreferenced-export fixes respect API/barrel file roles and actual caller/import/re-export usage
- make near-duplicate fixes choose ownership from module surface data instead of alphabetical filename heuristics

## Validation
- cargo test classify_public_api_role -- --nocapture
- cargo test detects_pub_use_block_members -- --nocapture
- cargo test choose_near_duplicate_prefers_regular_externally_used_module -- --nocapture
- cargo test test_generate_duplicate_import_rust -- --nocapture
- cargo test find_function_range_simple -- --nocapture