### PR TITLE
fix: scope refactor generation before planning fixes

### DIFF
--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -176,7 +176,11 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
     }
 
     // Generate fix plan (dry-run — never writes)
-    let mut fix_result = crate::refactor::plan::generate::generate_audit_fixes(result, source_path);
+    let mut fix_result = crate::refactor::plan::generate::generate_audit_fixes(
+        result,
+        source_path,
+        &crate::refactor::auto::FixPolicy::default(),
+    );
 
     if fix_result.fixes.is_empty() && fix_result.new_files.is_empty() {
         return None;

--- a/src/core/refactor/add.rs
+++ b/src/core/refactor/add.rs
@@ -48,7 +48,7 @@ pub fn fixes_from_audit(audit: &CodeAuditResult, write: bool) -> Result<FixResul
         ));
     }
 
-    let mut fix_result = plan::generate_audit_fixes(audit, root);
+    let mut fix_result = plan::generate_audit_fixes(audit, root, &auto::FixPolicy::default());
 
     if write && !fix_result.fixes.is_empty() {
         let applied = auto::apply_fixes(&mut fix_result.fixes, root);

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -336,7 +336,10 @@ fn parse_items(file: &str, content: &str) -> Option<Vec<ParsedItem>> {
             "content": content,
         });
         if let Some(result) = extension::run_refactor_script(&manifest, &command) {
-            if let Some(items) = result.get("items").and_then(|value| serde_json::from_value::<Vec<ParsedItem>>(value.clone()).ok()) {
+            if let Some(items) = result
+                .get("items")
+                .and_then(|value| serde_json::from_value::<Vec<ParsedItem>>(value.clone()).ok())
+            {
                 if !items.is_empty() {
                     return Some(items);
                 }
@@ -1115,7 +1118,8 @@ fn group_items(file: &str, items: &[ParsedItem], content: &str) -> Vec<Decompose
         }
     }
 
-    let final_buckets = rebalance_for_viable_parent_surface(file, content, &fn_items, final_buckets);
+    let final_buckets =
+        rebalance_for_viable_parent_surface(file, content, &fn_items, final_buckets);
 
     let ext = source.extension().and_then(|e| e.to_str()).unwrap_or("rs");
 
@@ -1491,7 +1495,8 @@ fn has_established_module_surface(content: &str) -> bool {
     let mut public_decl_count = 0usize;
 
     for line in content.lines().map(str::trim) {
-        if line.starts_with("pub use ") || line.starts_with("pub mod ") || line.starts_with("mod ") {
+        if line.starts_with("pub use ") || line.starts_with("pub mod ") || line.starts_with("mod ")
+        {
             return true;
         }
 
@@ -1668,7 +1673,10 @@ fn is_root_orchestrator_name(name: &str) -> bool {
 
 fn public_items_for_group(plan: &DecomposePlan, group: &DecomposeGroup) -> Vec<String> {
     let source_path = Path::new(&plan.file);
-    let ext = source_path.extension().and_then(|e| e.to_str()).unwrap_or("rs");
+    let ext = source_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("rs");
 
     let root = Path::new(".");
     let content = std::fs::read_to_string(source_path).unwrap_or_default();
@@ -1968,13 +1976,18 @@ macro_rules! entity_crud {
             kind: "function".to_string(),
             start_line: 3,
             end_line: 5,
-            source: "pub fn load(id: &str) -> Result<$Entity> {\n    config::load::<$Entity>(id)\n}"
-                .to_string(),
+            source:
+                "pub fn load(id: &str) -> Result<$Entity> {\n    config::load::<$Entity>(id)\n}"
+                    .to_string(),
             visibility: String::new(),
         }];
         let mut warnings = Vec::new();
-        let filtered = filter_extractable_items("src/core/config.rs", content, items, &mut warnings);
-        assert!(filtered.is_empty(), "macro template fragment should not be extractable");
+        let filtered =
+            filter_extractable_items("src/core/config.rs", content, items, &mut warnings);
+        assert!(
+            filtered.is_empty(),
+            "macro template fragment should not be extractable"
+        );
         assert_eq!(warnings.len(), 1);
     }
 
@@ -2086,7 +2099,10 @@ fn helper() {}
         let refs: Vec<&ParsedItem> = items.iter().collect();
         let mut buckets = BTreeMap::new();
         buckets.insert("alpha".to_string(), vec!["a".to_string()]);
-        buckets.insert("beta".to_string(), vec!["b".to_string(), "helper".to_string()]);
+        buckets.insert(
+            "beta".to_string(),
+            vec!["b".to_string(), "helper".to_string()],
+        );
 
         let rebalanced =
             rebalance_for_viable_parent_surface("src/core/config.rs", content, &refs, buckets);

--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -540,7 +540,10 @@ fn generate_simple_duplicate_fixes(
         let Some(remove_surface) = module_surfaces.get(remove_file) else {
             skipped.push(SkippedFile {
                 file: remove_file.clone(),
-                reason: format!("Missing module surface for duplicate file '{}'", remove_file),
+                reason: format!(
+                    "Missing module surface for duplicate file '{}'",
+                    remove_file
+                ),
             });
             continue;
         };

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -5,8 +5,8 @@ mod convention_fixes;
 mod doc_fixes;
 mod duplicate_fixes;
 mod intra_duplicate_fixes;
-mod near_duplicate_fixes;
 mod module_surface;
+mod near_duplicate_fixes;
 mod orphaned_test_fixes;
 mod parameter_fixes;
 mod signatures;
@@ -32,7 +32,11 @@ pub(crate) use signatures::{
     primary_type_name_from_declaration,
 };
 
-pub fn generate_audit_fixes(result: &CodeAuditResult, root: &Path, policy: &FixPolicy) -> FixResult {
+pub fn generate_audit_fixes(
+    result: &CodeAuditResult,
+    root: &Path,
+    policy: &FixPolicy,
+) -> FixResult {
     generate_fixes_impl(result, root, policy)
 }
 
@@ -65,7 +69,11 @@ pub(crate) fn merge_fixes_per_file(fixes: Vec<Fix>) -> Vec<Fix> {
         .collect()
 }
 
-pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path, policy: &FixPolicy) -> FixResult {
+pub(crate) fn generate_fixes_impl(
+    result: &CodeAuditResult,
+    root: &Path,
+    policy: &FixPolicy,
+) -> FixResult {
     let mut fixes = Vec::new();
     let mut skipped = Vec::new();
     let module_surfaces = ModuleSurfaceIndex::build(root);
@@ -106,7 +114,13 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path, policy:
 
     let mut new_files = Vec::new();
     if finding_enabled(&AuditFinding::UnreferencedExport) {
-        generate_unreferenced_export_fixes(result, root, &module_surfaces, &mut fixes, &mut skipped);
+        generate_unreferenced_export_fixes(
+            result,
+            root,
+            &module_surfaces,
+            &mut fixes,
+            &mut skipped,
+        );
     }
     if finding_enabled(&AuditFinding::DuplicateFunction) {
         generate_duplicate_function_fixes(
@@ -188,11 +202,14 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path, policy:
         test_gen_fixes::generate_test_method_fixes(result, root, &mut fixes, &mut skipped);
     }
     if finding_enabled(&AuditFinding::CompilerWarning) {
-        compiler_warning_fixes::generate_compiler_warning_fixes(result, root, &mut fixes, &mut skipped);
+        compiler_warning_fixes::generate_compiler_warning_fixes(
+            result,
+            root,
+            &mut fixes,
+            &mut skipped,
+        );
     }
-    if finding_enabled(&AuditFinding::TodoMarker)
-        || finding_enabled(&AuditFinding::LegacyComment)
-    {
+    if finding_enabled(&AuditFinding::TodoMarker) || finding_enabled(&AuditFinding::LegacyComment) {
         comment_fixes::generate_comment_fixes(result, root, &mut fixes, &mut skipped);
     }
     if finding_enabled(&AuditFinding::NearDuplicate) {
@@ -205,7 +222,12 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path, policy:
         );
     }
     if finding_enabled(&AuditFinding::IntraMethodDuplicate) {
-        intra_duplicate_fixes::generate_intra_duplicate_fixes(result, root, &mut fixes, &mut skipped);
+        intra_duplicate_fixes::generate_intra_duplicate_fixes(
+            result,
+            root,
+            &mut fixes,
+            &mut skipped,
+        );
     }
 
     let mut fixes = merge_fixes_per_file(fixes);

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -13,7 +13,7 @@ mod signatures;
 mod test_gen_fixes;
 
 use crate::code_audit::{AuditFinding, CodeAuditResult};
-use crate::core::refactor::auto::{DecomposeFixPlan, Fix, FixResult, SkippedFile};
+use crate::core::refactor::auto::{DecomposeFixPlan, Fix, FixPolicy, FixResult, SkippedFile};
 use crate::core::refactor::decompose;
 use crate::core::refactor::plan::file_intent::{FileIntent, FileIntentMap};
 use std::path::Path;
@@ -32,8 +32,8 @@ pub(crate) use signatures::{
     primary_type_name_from_declaration,
 };
 
-pub fn generate_audit_fixes(result: &CodeAuditResult, root: &Path) -> FixResult {
-    generate_fixes_impl(result, root)
+pub fn generate_audit_fixes(result: &CodeAuditResult, root: &Path, policy: &FixPolicy) -> FixResult {
+    generate_fixes_impl(result, root, policy)
 }
 
 pub(crate) fn merge_fixes_per_file(fixes: Vec<Fix>) -> Vec<Fix> {
@@ -65,10 +65,17 @@ pub(crate) fn merge_fixes_per_file(fixes: Vec<Fix>) -> Vec<Fix> {
         .collect()
 }
 
-pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixResult {
+pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path, policy: &FixPolicy) -> FixResult {
     let mut fixes = Vec::new();
     let mut skipped = Vec::new();
     let module_surfaces = ModuleSurfaceIndex::build(root);
+    let finding_enabled = |finding: &AuditFinding| {
+        policy
+            .only
+            .as_ref()
+            .is_none_or(|only| only.contains(finding))
+            && !policy.exclude.contains(finding)
+    };
 
     // ── Phase 0: Build file intent map ─────────────────────────────────
     // Identify structural operations (decompose, move, delete) planned for
@@ -78,6 +85,9 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
     // declarative conflict rules.
     let mut intent_map = FileIntentMap::new();
     for finding in &result.findings {
+        if !finding_enabled(&finding.kind) {
+            continue;
+        }
         if matches!(
             finding.kind,
             AuditFinding::GodFile | AuditFinding::HighItemCount
@@ -90,81 +100,113 @@ pub(crate) fn generate_fixes_impl(result: &CodeAuditResult, root: &Path) -> FixR
     // ── Phase 1: Generate all content fixes ────────────────────────────
     // Fixers run freely against the audit data. Conflicts with structural
     // intents are resolved after generation, not during.
-    apply_convention_fixes(result, root, &mut fixes, &mut skipped);
+    if policy.only.is_none() && policy.exclude.is_empty() {
+        apply_convention_fixes(result, root, &mut fixes, &mut skipped);
+    }
 
     let mut new_files = Vec::new();
-    generate_unreferenced_export_fixes(result, root, &module_surfaces, &mut fixes, &mut skipped);
-    generate_duplicate_function_fixes(
-        result,
-        root,
-        &module_surfaces,
-        &mut fixes,
-        &mut new_files,
-        &mut skipped,
-    );
-    orphaned_test_fixes::generate_orphaned_test_fixes(result, root, &mut fixes, &mut skipped);
+    if finding_enabled(&AuditFinding::UnreferencedExport) {
+        generate_unreferenced_export_fixes(result, root, &module_surfaces, &mut fixes, &mut skipped);
+    }
+    if finding_enabled(&AuditFinding::DuplicateFunction) {
+        generate_duplicate_function_fixes(
+            result,
+            root,
+            &module_surfaces,
+            &mut fixes,
+            &mut new_files,
+            &mut skipped,
+        );
+    }
+    if finding_enabled(&AuditFinding::OrphanedTest) {
+        orphaned_test_fixes::generate_orphaned_test_fixes(result, root, &mut fixes, &mut skipped);
+    }
 
     // ── Phase 2: Build decompose plans ─────────────────────────────────
     let mut decompose_plans = Vec::new();
     let mut decompose_seen = std::collections::HashSet::new();
-    for finding in &result.findings {
-        if !matches!(
-            finding.kind,
-            AuditFinding::GodFile | AuditFinding::HighItemCount
-        ) {
-            continue;
-        }
-        // A file can trigger both GodFile and HighItemCount — only plan once.
-        if decompose_seen.contains(&finding.file) {
-            continue;
-        }
-        let is_test = crate::code_audit::walker::is_test_path(&finding.file);
-        if is_test {
-            continue;
-        }
-        match decompose::build_plan(&finding.file, root, "grouped") {
-            Ok(plan) => {
-                if plan.groups.len() > 1 {
+    if finding_enabled(&AuditFinding::GodFile) || finding_enabled(&AuditFinding::HighItemCount) {
+        for finding in &result.findings {
+            if !finding_enabled(&finding.kind) {
+                continue;
+            }
+            if !matches!(
+                finding.kind,
+                AuditFinding::GodFile | AuditFinding::HighItemCount
+            ) {
+                continue;
+            }
+            if decompose_seen.contains(&finding.file) {
+                continue;
+            }
+            let is_test = crate::code_audit::walker::is_test_path(&finding.file);
+            if is_test {
+                continue;
+            }
+            match decompose::build_plan(&finding.file, root, "grouped") {
+                Ok(plan) => {
+                    if plan.groups.len() > 1 {
+                        decompose_seen.insert(finding.file.clone());
+                        decompose_plans.push(DecomposeFixPlan {
+                            file: finding.file.clone(),
+                            plan,
+                            source_finding: finding.kind.clone(),
+                            applied: false,
+                        });
+                    }
+                }
+                Err(error) => {
                     decompose_seen.insert(finding.file.clone());
-                    decompose_plans.push(DecomposeFixPlan {
+                    skipped.push(SkippedFile {
                         file: finding.file.clone(),
-                        plan,
-                        source_finding: finding.kind.clone(),
-                        applied: false,
+                        reason: format!("Decompose plan failed: {}", error),
                     });
                 }
-            }
-            Err(error) => {
-                decompose_seen.insert(finding.file.clone());
-                skipped.push(SkippedFile {
-                    file: finding.file.clone(),
-                    reason: format!("Decompose plan failed: {}", error),
-                });
             }
         }
     }
 
-    doc_fixes::apply_stale_doc_reference_fixes(result, &mut fixes);
-    doc_fixes::apply_broken_doc_reference_fixes(result, root, &mut fixes);
-    parameter_fixes::generate_parameter_fixes(result, root, &mut fixes, &mut skipped);
-    test_gen_fixes::generate_test_file_fixes(
-        result,
-        root,
-        &mut new_files,
-        &mut fixes,
-        &mut skipped,
-    );
-    test_gen_fixes::generate_test_method_fixes(result, root, &mut fixes, &mut skipped);
-    compiler_warning_fixes::generate_compiler_warning_fixes(result, root, &mut fixes, &mut skipped);
-    comment_fixes::generate_comment_fixes(result, root, &mut fixes, &mut skipped);
-    near_duplicate_fixes::generate_near_duplicate_fixes(
-        result,
-        root,
-        &module_surfaces,
-        &mut fixes,
-        &mut skipped,
-    );
-    intra_duplicate_fixes::generate_intra_duplicate_fixes(result, root, &mut fixes, &mut skipped);
+    if finding_enabled(&AuditFinding::StaleDocReference) {
+        doc_fixes::apply_stale_doc_reference_fixes(result, &mut fixes);
+    }
+    if finding_enabled(&AuditFinding::BrokenDocReference) {
+        doc_fixes::apply_broken_doc_reference_fixes(result, root, &mut fixes);
+    }
+    if finding_enabled(&AuditFinding::UnusedParameter) {
+        parameter_fixes::generate_parameter_fixes(result, root, &mut fixes, &mut skipped);
+    }
+    if finding_enabled(&AuditFinding::MissingTestFile) {
+        test_gen_fixes::generate_test_file_fixes(
+            result,
+            root,
+            &mut new_files,
+            &mut fixes,
+            &mut skipped,
+        );
+    }
+    if finding_enabled(&AuditFinding::MissingTestMethod) {
+        test_gen_fixes::generate_test_method_fixes(result, root, &mut fixes, &mut skipped);
+    }
+    if finding_enabled(&AuditFinding::CompilerWarning) {
+        compiler_warning_fixes::generate_compiler_warning_fixes(result, root, &mut fixes, &mut skipped);
+    }
+    if finding_enabled(&AuditFinding::TodoMarker)
+        || finding_enabled(&AuditFinding::LegacyComment)
+    {
+        comment_fixes::generate_comment_fixes(result, root, &mut fixes, &mut skipped);
+    }
+    if finding_enabled(&AuditFinding::NearDuplicate) {
+        near_duplicate_fixes::generate_near_duplicate_fixes(
+            result,
+            root,
+            &module_surfaces,
+            &mut fixes,
+            &mut skipped,
+        );
+    }
+    if finding_enabled(&AuditFinding::IntraMethodDuplicate) {
+        intra_duplicate_fixes::generate_intra_duplicate_fixes(result, root, &mut fixes, &mut skipped);
+    }
 
     let mut fixes = merge_fixes_per_file(fixes);
 

--- a/src/core/refactor/plan/generate/module_surface.rs
+++ b/src/core/refactor/plan/generate/module_surface.rs
@@ -23,7 +23,10 @@ pub struct SymbolSurface {
 impl SymbolSurface {
     pub fn has_external_usage(&self, owner_file: &str) -> bool {
         self.incoming_callers.iter().any(|file| file != owner_file)
-            || self.incoming_importers.iter().any(|file| file != owner_file)
+            || self
+                .incoming_importers
+                .iter()
+                .any(|file| file != owner_file)
             || self.reexport_files.iter().any(|file| file != owner_file)
     }
 }
@@ -104,7 +107,12 @@ fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSur
 
     let mut symbols = HashMap::new();
     for symbol in &public_api {
-        let callers = symbol_graph::trace_symbol_callers(symbol, &module_path, root, &file_extensions_for(&fp.language));
+        let callers = symbol_graph::trace_symbol_callers(
+            symbol,
+            &module_path,
+            root,
+            &file_extensions_for(&fp.language),
+        );
         let mut incoming_callers = Vec::new();
         let mut incoming_importers = Vec::new();
         for caller in callers {
@@ -144,7 +152,10 @@ fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSur
 
 fn classify_file_role(file: &str) -> FileRole {
     let path = Path::new(file);
-    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
     if walker::is_index_file(path) {
         return FileRole::Index;
     }
@@ -225,9 +236,18 @@ mod tests {
 
     #[test]
     fn classify_public_api_role() {
-        assert_eq!(classify_file_role("src/core/code_audit/public_api.rs"), FileRole::PublicApi);
-        assert_eq!(classify_file_role("src/core/code_audit/mod.rs"), FileRole::Index);
-        assert_eq!(classify_file_role("src/core/code_audit/findings.rs"), FileRole::Regular);
+        assert_eq!(
+            classify_file_role("src/core/code_audit/public_api.rs"),
+            FileRole::PublicApi
+        );
+        assert_eq!(
+            classify_file_role("src/core/code_audit/mod.rs"),
+            FileRole::Index
+        );
+        assert_eq!(
+            classify_file_role("src/core/code_audit/findings.rs"),
+            FileRole::Regular
+        );
     }
 
     #[test]

--- a/src/core/refactor/plan/generate/near_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/near_duplicate_fixes.rs
@@ -88,12 +88,9 @@ pub(crate) fn generate_near_duplicate_fixes(
             continue;
         }
 
-        let Some((canonical_file, duplicate_file)) = choose_near_duplicate_pair(
-            fn_name,
-            &files,
-            module_surfaces,
-            skipped,
-        ) else {
+        let Some((canonical_file, duplicate_file)) =
+            choose_near_duplicate_pair(fn_name, &files, module_surfaces, skipped)
+        else {
             continue;
         };
 
@@ -170,12 +167,9 @@ pub(crate) fn generate_near_duplicate_fixes(
         // 3. Ensure the canonical copy is pub(crate).
         let canon_path = root.join(canonical_file);
         if let Ok(canon_content) = std::fs::read_to_string(&canon_path) {
-            if let Some(vis_fix) = build_visibility_upgrade(
-                &canon_content,
-                canonical_file,
-                fn_name,
-                module_surfaces,
-            ) {
+            if let Some(vis_fix) =
+                build_visibility_upgrade(&canon_content, canonical_file, fn_name, module_surfaces)
+            {
                 fixes.push(Fix {
                     file: canonical_file.to_string(),
                     required_methods: vec![],

--- a/src/core/refactor/plan/planner.rs
+++ b/src/core/refactor/plan/planner.rs
@@ -589,11 +589,11 @@ fn plan_audit_stage(
         crate::code_audit::audit_path_with_id(component_id, &root.to_string_lossy())?
     };
 
-    let mut fix_result = super::generate::generate_audit_fixes(&result, root);
     let policy = fixer::FixPolicy {
         only: (!only.is_empty()).then_some(only.to_vec()),
         exclude: exclude.to_vec(),
     };
+    let mut fix_result = super::generate::generate_audit_fixes(&result, root, &policy);
     let preflight_context = fixer::PreflightContext { root };
     let (fix_result, policy_summary, changed_files, stage_warnings): (
         fixer::FixResult,

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -121,12 +121,12 @@ pub fn run_audit_refactor(
 
         iterations.push(iteration_summary);
     } else {
-        let root = Path::new(&current_result.source_path);
-        let mut fix_result = super::generate::generate_audit_fixes(&current_result, root);
         let policy = fixer::FixPolicy {
             only: (!only_kinds.is_empty()).then_some(only_kinds.to_vec()),
             exclude: exclude_kinds.to_vec(),
         };
+        let root = Path::new(&current_result.source_path);
+        let mut fix_result = super::generate::generate_audit_fixes(&current_result, root, &policy);
         let preflight_context = fixer::PreflightContext { root };
         final_policy_summary =
             fixer::apply_fix_policy(&mut fix_result, false, &policy, &preflight_context);
@@ -151,12 +151,12 @@ fn run_fix_iteration(
     fixer::PolicySummary,
     AuditRefactorIterationSummary,
 )> {
-    let root = Path::new(&audit_result.source_path);
-    let mut fix_result = super::generate::generate_audit_fixes(audit_result, root);
     let policy = fixer::FixPolicy {
         only: (!only_kinds.is_empty()).then_some(only_kinds.to_vec()),
         exclude: exclude_kinds.to_vec(),
     };
+    let root = Path::new(&audit_result.source_path);
+    let mut fix_result = super::generate::generate_audit_fixes(audit_result, root, &policy);
     let preflight_context = fixer::PreflightContext { root };
     let policy_summary =
         fixer::apply_fix_policy(&mut fix_result, true, &policy, &preflight_context);


### PR DESCRIPTION
## Summary
- apply `only`/`exclude` policy during audit fix generation instead of generating unrelated fixers and decompose plans first
- stop scoped local refactor runs from being contaminated by unrelated structural planning
- keep `apply_fix_policy()` for final filtering, but make isolated repros truly isolated at generation time

## Why
Running:

`homeboy refactor ... --from audit --only duplicate_function --write`

was still generating unrelated decompose plans before policy filtering, which produced misleading conflict logs like `dominated by Decompose` and sent debugging in the wrong direction.

After this change, the same isolated repro now touches only:
- `src/core/extension/grammar.rs`

instead of building unrelated structural plans.

## Validation
- `cargo build`
- `./target/debug/homeboy --output /tmp/homeboy-duplicate_function-repro-scoped.json refactor homeboy --path /var/lib/datamachine/workspace/homeboy-fixer-repro --from audit --only duplicate_function --force --write`