### PR TITLE
Refactor direct source-driven automation flow

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -113,8 +113,7 @@ mod tests {
     use homeboy::component::Component;
     use homeboy::extension::lint as extension_lint;
     use homeboy::extension::lint::baseline::{self as lint_baseline, LintFinding};
-    use homeboy::refactor::lint_refactor_request;
-    use homeboy::refactor::LintSourceOptions;
+    use homeboy::refactor::plan::{lint_refactor_request, LintSourceOptions};
     use std::path::Path;
 
     #[test]

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -380,8 +380,8 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
 #[derive(Serialize)]
 #[serde(tag = "command")]
 pub enum RefactorOutput {
-    #[serde(rename = "refactor.plan")]
-    Plan(homeboy::refactor::RefactorPlan),
+    #[serde(rename = "refactor.sources")]
+    Sources(homeboy::refactor::plan::RefactorSourceRun),
 
     #[serde(rename = "refactor.rename")]
     Rename {
@@ -712,7 +712,7 @@ fn run_refactor_sources_single(
     let requested_sources = from.to_vec();
     let only_findings = parse_audit_findings(only)?;
     let exclude_findings = parse_audit_findings(exclude)?;
-    let plan = homeboy::refactor::build_refactor_plan(homeboy::refactor::RefactorPlanRequest {
+    let sources = homeboy::refactor::plan::collect_refactor_sources(homeboy::refactor::plan::RefactorSourceRequest {
         component: ctx.component,
         root: ctx.source_path,
         sources: requested_sources,
@@ -720,14 +720,14 @@ fn run_refactor_sources_single(
         only: only_findings,
         exclude: exclude_findings,
         settings: settings.to_vec(),
-        lint: homeboy::refactor::LintSourceOptions::default(),
-        test: homeboy::refactor::TestSourceOptions::default(),
+        lint: homeboy::refactor::plan::LintSourceOptions::default(),
+        test: homeboy::refactor::plan::TestSourceOptions::default(),
         write,
         force,
     })?;
-    let exit_code = if plan.files_modified > 0 { 1 } else { 0 };
+    let exit_code = if sources.files_modified > 0 { 1 } else { 0 };
 
-    Ok((RefactorOutput::Plan(plan), exit_code))
+    Ok((RefactorOutput::Sources(sources), exit_code))
 }
 
 fn parse_audit_findings(values: &[String]) -> homeboy::Result<Vec<AuditFinding>> {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -197,8 +197,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
 mod tests {
     use super::*;
     use homeboy::component::Component;
-    use homeboy::refactor::test_refactor_request;
-    use homeboy::refactor::TestSourceOptions;
+    use homeboy::refactor::plan::{test_refactor_request, TestSourceOptions};
     use std::path::PathBuf;
 
     #[test]

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -57,15 +57,7 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
         (
             "component",
             "edit",
-            &[
-                "--json",
-                "--base64",
-                "--replace",
-                "--version-target",
-                "--extension",
-                "--help",
-                "-h",
-            ],
+            &["--json", "--base64", "--replace", "--help", "-h"],
         ),
         (
             "component",

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -191,8 +191,8 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
         only: None,
         exclude: Vec::new(),
     };
-    let context = crate::refactor::auto::PreflightContext { root: source_path };
-    crate::refactor::auto::apply_fix_policy(&mut fix_result, false, &policy, &context);
+    let _ = source_path;
+    crate::refactor::auto::apply_fix_policy(&mut fix_result, false, &policy);
 
     // Count by automation eligibility
     let mut automated_count = 0usize;

--- a/src/core/refactor/auto/apply.rs
+++ b/src/core/refactor/auto/apply.rs
@@ -1145,19 +1145,19 @@ mod tests {
     #[test]
     fn remove_from_single_line_pub_use() {
         let mut lines: Vec<String> = vec![
-            "pub use planner::{analyze_stage_overlaps, build_refactor_plan, normalize_sources};"
+            "pub use sources::{analyze_stage_overlaps, collect_refactor_sources, normalize_sources};"
                 .into(),
         ];
         remove_from_pub_use_block(&mut lines, "analyze_stage_overlaps");
         assert_eq!(lines.len(), 1);
         assert!(!lines[0].contains("analyze_stage_overlaps"));
-        assert!(lines[0].contains("build_refactor_plan"));
+        assert!(lines[0].contains("collect_refactor_sources"));
         assert!(lines[0].contains("normalize_sources"));
     }
 
     #[test]
     fn remove_last_item_deletes_entire_line() {
-        let mut lines: Vec<String> = vec!["pub use planner::{only_function};".into()];
+        let mut lines: Vec<String> = vec!["pub use sources::{only_function};".into()];
         remove_from_pub_use_block(&mut lines, "only_function");
         assert!(lines.is_empty(), "Empty pub use should be removed entirely");
     }

--- a/src/core/refactor/auto/contracts.rs
+++ b/src/core/refactor/auto/contracts.rs
@@ -1,6 +1,5 @@
 use crate::code_audit::conventions::AuditFinding;
 use crate::core::refactor::decompose;
-use std::path::Path;
 
 /// Callback that verifies an applied chunk, returning Ok(message) or Err(reason).
 pub type ChunkVerifier<'a> = &'a dyn Fn(&ApplyChunkResult) -> Result<String, String>;
@@ -277,11 +276,6 @@ pub struct ApplyOptions<'a> {
 pub struct FixPolicy {
     pub only: Option<Vec<AuditFinding>>,
     pub exclude: Vec<AuditFinding>,
-}
-
-#[derive(Debug, Clone)]
-pub struct PreflightContext<'a> {
-    pub root: &'a Path,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/core/refactor/auto/mod.rs
+++ b/src/core/refactor/auto/mod.rs
@@ -12,8 +12,7 @@ pub use apply::{
 };
 pub use contracts::{
     ApplyChunkResult, ApplyOptions, ChunkStatus, ChunkVerifier, DecomposeFixPlan, Fix, FixPolicy,
-    FixResult, Insertion, InsertionKind, NewFile, PolicySummary, PreflightContext,
-    RefactorPrimitive, SkippedFile,
+    FixResult, Insertion, InsertionKind, NewFile, PolicySummary, RefactorPrimitive, SkippedFile,
 };
 pub use outcome::{
     standard_outcome, AppliedAutofixCapture, AutofixMode, AutofixOutcome, AutofixSidecarFiles,

--- a/src/core/refactor/auto/policy.rs
+++ b/src/core/refactor/auto/policy.rs
@@ -1,5 +1,5 @@
 use crate::code_audit::AuditFinding;
-use crate::refactor::auto::{FixPolicy, FixResult, Insertion, NewFile, PolicySummary, PreflightContext};
+use crate::refactor::auto::{FixPolicy, FixResult, Insertion, NewFile, PolicySummary};
 
 fn finding_allowed(finding: &AuditFinding, policy: &FixPolicy) -> bool {
     let included = policy
@@ -27,12 +27,7 @@ fn blocked_reason(manual_only: bool) -> String {
     }
 }
 
-fn annotate_insertion_for_policy(
-    insertion: &mut Insertion,
-    write: bool,
-    policy: &FixPolicy,
-    _context: &PreflightContext<'_>,
-) -> bool {
+fn annotate_insertion_for_policy(insertion: &mut Insertion, write: bool, policy: &FixPolicy) -> bool {
     if !finding_allowed(&insertion.finding, policy) {
         return false;
     }
@@ -47,12 +42,7 @@ fn annotate_insertion_for_policy(
     true
 }
 
-fn annotate_new_file_for_policy(
-    new_file: &mut NewFile,
-    write: bool,
-    policy: &FixPolicy,
-    _context: &PreflightContext<'_>,
-) -> bool {
+fn annotate_new_file_for_policy(new_file: &mut NewFile, write: bool, policy: &FixPolicy) -> bool {
     if !finding_allowed(&new_file.finding, policy) {
         return false;
     }
@@ -67,21 +57,15 @@ fn annotate_new_file_for_policy(
     true
 }
 
-pub fn apply_fix_policy(
-    result: &mut FixResult,
-    write: bool,
-    policy: &FixPolicy,
-    context: &PreflightContext<'_>,
-) -> PolicySummary {
+pub fn apply_fix_policy(result: &mut FixResult, write: bool, policy: &FixPolicy) -> PolicySummary {
     let mut summary = PolicySummary::default();
 
     result.fixes = result
         .fixes
         .drain(..)
         .filter_map(|mut fix| {
-            fix.insertions.retain_mut(|insertion| {
-                annotate_insertion_for_policy(insertion, write, policy, context)
-            });
+            fix.insertions
+                .retain_mut(|insertion| annotate_insertion_for_policy(insertion, write, policy));
 
             for insertion in &mut fix.insertions {
                 insertion.auto_apply = should_auto_apply(insertion.manual_only, write);
@@ -116,7 +100,7 @@ pub fn apply_fix_policy(
         .new_files
         .drain(..)
         .filter_map(|mut pending| {
-            if !annotate_new_file_for_policy(&mut pending, write, policy, context) {
+            if !annotate_new_file_for_policy(&mut pending, write, policy) {
                 return None;
             }
 

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -44,22 +44,14 @@ impl AppliedRefactor {
         }
     }
 
-    pub fn from_plan(plan: &RefactorPlan, rerun_recommended: bool) -> Self {
-        Self {
-            files_modified: plan.files_modified,
-            rerun_recommended,
-            changed_files: plan.changed_files.clone(),
-            fix_summary: plan.fix_summary.clone(),
-        }
-    }
 }
 
 pub use add::{add_import, fixes_from_audit, AddResult};
 pub use auto::{
     apply_decompose_plans, apply_fix_policy, apply_fixes, apply_fixes_chunked,
     apply_new_files_chunked, auto_apply_subset, ApplyChunkResult, ApplyOptions, ChunkStatus, Fix,
-    FixPolicy, FixResult, Insertion, InsertionKind, NewFile, PolicySummary, PreflightContext,
-    RefactorPrimitive, SkippedFile,
+    FixPolicy, FixResult, Insertion, InsertionKind, NewFile, PolicySummary, RefactorPrimitive,
+    SkippedFile,
 };
 pub use decompose::{
     apply_plan, apply_plan_skeletons, build_plan, DecomposeAuditImpact, DecomposeGroup,
@@ -67,10 +59,8 @@ pub use decompose::{
 };
 pub use move_items::{move_items, ImportRewrite, ItemKind, MoveResult, MovedItem};
 pub use plan::{
-    build_refactor_plan, finding_fingerprint, lint_refactor_request, run_audit_refactor,
-    score_delta, test_refactor_request, weighted_finding_score_with, AuditConvergenceScoring,
-    AuditRefactorIterationSummary, AuditRefactorOutcome, LintSourceOptions, PlanOverlap,
-    PlanStageSummary, RefactorPlan, RefactorPlanRequest, TestSourceOptions, KNOWN_PLAN_SOURCES,
+    finding_fingerprint, run_audit_refactor, score_delta, weighted_finding_score_with,
+    AuditConvergenceScoring, AuditRefactorIterationSummary, AuditRefactorOutcome,
 };
 pub use propagate::{propagate, PropagateConfig, PropagateEdit, PropagateField, PropagateResult};
 pub use rename::{

--- a/src/core/refactor/plan/generate/near_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/near_duplicate_fixes.rs
@@ -18,8 +18,7 @@ use std::path::Path;
 use regex::Regex;
 
 use crate::code_audit::{AuditFinding, CodeAuditResult};
-use crate::refactor::auto::{Fix, Insertion, InsertionKind, RefactorPrimitive, SkippedFile};
-
+use crate::refactor::auto::{Fix, Insertion, RefactorPrimitive, SkippedFile};
 use super::{tagged_import_add, tagged_range_removal, tagged_visibility_change};
 
 use super::{FileRole, ModuleSurfaceIndex};
@@ -343,6 +342,7 @@ fn build_visibility_upgrade(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::refactor::InsertionKind;
     use std::collections::{HashMap, HashSet};
 
     #[test]

--- a/src/core/refactor/plan/mod.rs
+++ b/src/core/refactor/plan/mod.rs
@@ -1,14 +1,15 @@
 pub mod file_intent;
 pub mod generate;
-pub mod planner;
+pub mod sources;
 pub mod verify;
 
 pub use generate::generate_audit_fixes;
-pub use planner::{
-    analyze_stage_overlaps, build_refactor_plan, lint_refactor_request, normalize_sources,
-    run_lint_refactor, run_test_refactor, summarize_plan_totals, test_refactor_request,
-    LintSourceOptions, PlanOverlap, PlanStageSummary, RefactorPlan, RefactorPlanRequest,
-    TestSourceOptions, KNOWN_PLAN_SOURCES,
+pub use sources::{
+    analyze_stage_overlaps, collect_refactor_sources, lint_refactor_request, normalize_sources,
+    run_lint_refactor, run_test_refactor, summarize_source_totals, test_refactor_request,
+    CollectedEdit, LintSourceOptions, RefactorSourceRequest, RefactorSourceRun,
+    SourceOverlap, SourceStageSummary, SourceTotals, TestSourceOptions,
+    KNOWN_REFACTOR_SOURCES,
 };
 pub use verify::{
     finding_fingerprint, run_audit_refactor, score_delta, weighted_finding_score_with,

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use super::verify::AuditConvergenceScoring;
 
-pub const KNOWN_PLAN_SOURCES: &[&str] = &["audit", "lint", "test"];
+pub const KNOWN_REFACTOR_SOURCES: &[&str] = &["audit", "lint", "test"];
 
 /// Name of the env var pointing to previous command output files.
 ///
@@ -24,7 +24,7 @@ pub const KNOWN_PLAN_SOURCES: &[&str] = &["audit", "lint", "test"];
 const OUTPUT_DIR_ENV: &str = "HOMEBOY_OUTPUT_DIR";
 
 #[derive(Debug, Clone)]
-pub struct RefactorPlanRequest {
+pub struct RefactorSourceRequest {
     pub component: Component,
     pub root: PathBuf,
     pub sources: Vec<String>,
@@ -45,8 +45,8 @@ pub fn lint_refactor_request(
     settings: Vec<(String, String)>,
     options: LintSourceOptions,
     write: bool,
-) -> RefactorPlanRequest {
-    RefactorPlanRequest {
+) -> RefactorSourceRequest {
+    RefactorSourceRequest {
         component,
         root,
         sources: vec!["lint".to_string()],
@@ -67,8 +67,8 @@ pub fn test_refactor_request(
     settings: Vec<(String, String)>,
     options: TestSourceOptions,
     write: bool,
-) -> RefactorPlanRequest {
-    RefactorPlanRequest {
+) -> RefactorSourceRequest {
+    RefactorSourceRequest {
         component,
         root,
         sources: vec!["test".to_string()],
@@ -89,8 +89,8 @@ pub fn run_lint_refactor(
     settings: Vec<(String, String)>,
     options: LintSourceOptions,
     write: bool,
-) -> crate::Result<RefactorPlan> {
-    build_refactor_plan(lint_refactor_request(
+) -> crate::Result<RefactorSourceRun> {
+    collect_refactor_sources(lint_refactor_request(
         component, root, settings, options, write,
     ))
 }
@@ -101,8 +101,8 @@ pub fn run_test_refactor(
     settings: Vec<(String, String)>,
     options: TestSourceOptions,
     write: bool,
-) -> crate::Result<RefactorPlan> {
-    build_refactor_plan(test_refactor_request(
+) -> crate::Result<RefactorSourceRun> {
+    collect_refactor_sources(test_refactor_request(
         component, root, settings, options, write,
     ))
 }
@@ -126,17 +126,17 @@ pub struct TestSourceOptions {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct RefactorPlan {
+pub struct RefactorSourceRun {
     pub component_id: String,
     pub source_path: String,
     pub sources: Vec<String>,
     pub dry_run: bool,
     pub applied: bool,
     pub merge_strategy: String,
-    pub proposals: Vec<FixProposal>,
-    pub stages: Vec<PlanStageSummary>,
-    pub plan_totals: PlanTotals,
-    pub overlaps: Vec<PlanOverlap>,
+    pub collected_edits: Vec<CollectedEdit>,
+    pub stages: Vec<SourceStageSummary>,
+    pub source_totals: SourceTotals,
+    pub overlaps: Vec<SourceOverlap>,
     pub files_modified: usize,
     pub changed_files: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -146,11 +146,11 @@ pub struct RefactorPlan {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct PlanStageSummary {
+pub struct SourceStageSummary {
     pub stage: String,
-    pub planned: bool,
+    pub collected: bool,
     pub applied: bool,
-    pub fixes_proposed: usize,
+    pub edit_count: usize,
     pub files_modified: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detected_findings: Option<usize>,
@@ -163,7 +163,7 @@ pub struct PlanStageSummary {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct PlanOverlap {
+pub struct SourceOverlap {
     pub file: String,
     pub earlier_stage: String,
     pub later_stage: String,
@@ -171,14 +171,14 @@ pub struct PlanOverlap {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct PlanTotals {
-    pub stages_with_proposals: usize,
-    pub total_fixes_proposed: usize,
+pub struct SourceTotals {
+    pub stages_with_edits: usize,
+    pub total_edits: usize,
     pub total_files_selected: usize,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct FixProposal {
+pub struct CollectedEdit {
     pub source: String,
     pub file: String,
     pub rule_id: String,
@@ -207,11 +207,11 @@ impl FixAccumulator {
 
 struct PlannedStage {
     source: String,
-    summary: PlanStageSummary,
+    summary: SourceStageSummary,
     fix_results: Vec<FixApplied>,
 }
 
-pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<RefactorPlan> {
+pub fn collect_refactor_sources(request: RefactorSourceRequest) -> crate::Result<RefactorSourceRun> {
     let sources = normalize_sources(&request.sources)?;
     let root_str = request.root.to_string_lossy().to_string();
     let original_changes = git::get_uncommitted_changes(&root_str).ok();
@@ -305,7 +305,7 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
                 request.write,
                 &run_dir,
             )?,
-            _ => unreachable!("sources are normalized before planning"),
+            _ => unreachable!("sources are normalized before orchestration"),
         };
 
         // Format generated/modified files so subsequent stages (especially lint)
@@ -318,8 +318,8 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
         planned_stages.push(stage);
     }
 
-    let proposals = collect_fix_proposals(&planned_stages);
-    let mut stage_summaries: Vec<PlanStageSummary> = planned_stages
+    let collected_edits = collect_collected_edits(&planned_stages);
+    let mut stage_summaries: Vec<SourceStageSummary> = planned_stages
         .into_iter()
         .map(|stage| stage.summary)
         .collect();
@@ -333,7 +333,7 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
         ));
     }
 
-    let plan_totals = summarize_plan_totals(&stage_summaries, changed_files.len());
+    let source_totals = summarize_source_totals(&stage_summaries, changed_files.len());
     let files_modified = changed_files.len();
     let applied = request.write && files_modified > 0;
 
@@ -373,16 +373,16 @@ pub fn build_refactor_plan(request: RefactorPlanRequest) -> crate::Result<Refact
         Vec::new()
     };
 
-    Ok(RefactorPlan {
+    Ok(RefactorSourceRun {
         component_id: request.component.id,
         source_path: root_str,
         sources,
         dry_run: !request.write,
         applied,
         merge_strategy: "sequential_source_merge".to_string(),
-        proposals,
+        collected_edits,
         stages: stage_summaries,
-        plan_totals,
+        source_totals,
         overlaps,
         files_modified,
         changed_files,
@@ -396,7 +396,7 @@ pub fn normalize_sources(sources: &[String]) -> crate::Result<Vec<String>> {
     let lowered: Vec<String> = sources.iter().map(|source| source.to_lowercase()).collect();
 
     if lowered.iter().any(|source| source == "all") {
-        return Ok(KNOWN_PLAN_SOURCES
+        return Ok(KNOWN_REFACTOR_SOURCES
             .iter()
             .map(|source| source.to_string())
             .collect());
@@ -404,7 +404,7 @@ pub fn normalize_sources(sources: &[String]) -> crate::Result<Vec<String>> {
 
     let unknown: Vec<String> = lowered
         .iter()
-        .filter(|source| !KNOWN_PLAN_SOURCES.contains(&source.as_str()))
+        .filter(|source| !KNOWN_REFACTOR_SOURCES.contains(&source.as_str()))
         .cloned()
         .collect();
 
@@ -415,13 +415,13 @@ pub fn normalize_sources(sources: &[String]) -> crate::Result<Vec<String>> {
             None,
             Some(vec![format!(
                 "Known sources: {}",
-                KNOWN_PLAN_SOURCES.join(", ")
+                KNOWN_REFACTOR_SOURCES.join(", ")
             )]),
         ));
     }
 
     let mut ordered = Vec::new();
-    for known in KNOWN_PLAN_SOURCES {
+    for known in KNOWN_REFACTOR_SOURCES {
         if lowered.iter().any(|source| source == known) {
             ordered.push((*known).to_string());
         }
@@ -478,12 +478,12 @@ fn format_changed_files(root: &Path, changed_files: &[String], warnings: &mut Ve
     }
 }
 
-fn collect_fix_proposals(stages: &[PlannedStage]) -> Vec<FixProposal> {
-    let mut proposals = Vec::new();
+fn collect_collected_edits(stages: &[PlannedStage]) -> Vec<CollectedEdit> {
+    let mut edits = Vec::new();
 
     for stage in stages {
         for fix in &stage.fix_results {
-            proposals.push(FixProposal {
+            edits.push(CollectedEdit {
                 source: stage.source.clone(),
                 file: fix.file.clone(),
                 rule_id: fix.rule.clone(),
@@ -492,17 +492,17 @@ fn collect_fix_proposals(stages: &[PlannedStage]) -> Vec<FixProposal> {
         }
     }
 
-    proposals.sort_by(|a, b| {
+    edits.sort_by(|a, b| {
         a.source
             .cmp(&b.source)
             .then(a.file.cmp(&b.file))
             .then(a.rule_id.cmp(&b.rule_id))
     });
 
-    proposals
+    edits
 }
 
-fn collect_stage_changed_files(stages: &[PlanStageSummary]) -> Vec<String> {
+fn collect_stage_changed_files(stages: &[SourceStageSummary]) -> Vec<String> {
     let mut final_changed_files = BTreeSet::new();
     for stage in stages {
         for file in &stage.changed_files {
@@ -594,7 +594,6 @@ fn plan_audit_stage(
         exclude: exclude.to_vec(),
     };
     let mut fix_result = super::generate::generate_audit_fixes(&result, root, &policy);
-    let policy_context = fixer::PreflightContext { root };
     let (fix_result, policy_summary, changed_files, stage_warnings): (
         fixer::FixResult,
         fixer::PolicySummary,
@@ -644,22 +643,21 @@ fn plan_audit_stage(
             warnings,
         )
     } else {
-        let policy_summary =
-            fixer::apply_fix_policy(&mut fix_result, false, &policy, &policy_context);
+        let policy_summary = fixer::apply_fix_policy(&mut fix_result, false, &policy);
         let changed_files = collect_audit_changed_files(&fix_result);
         (fix_result, policy_summary, changed_files, Vec::new())
     };
 
     let fix_results = summarize_audit_fix_result_entries(&fix_result);
-    let fixes_proposed = fix_results.len();
+    let edit_count = fix_results.len();
 
     Ok(PlannedStage {
         source: "audit".to_string(),
-        summary: PlanStageSummary {
+        summary: SourceStageSummary {
             stage: "audit".to_string(),
-            planned: true,
+            collected: true,
             applied: write && !changed_files.is_empty(),
-            fixes_proposed,
+            edit_count,
             files_modified: changed_files.len(),
             detected_findings: Some(result.findings.len()),
             changed_files,
@@ -746,17 +744,17 @@ fn run_lint_stage(
     };
 
     let fix_results = fix_sidecars.consume_fix_results();
-    let fixes_proposed = fix_results.len();
+    let edit_count = fix_results.len();
     let lint_findings =
         crate::extension::lint::baseline::parse_findings_file(&findings_file).unwrap_or_default();
 
     Ok(PlannedStage {
         source: "lint".to_string(),
-        summary: PlanStageSummary {
+        summary: SourceStageSummary {
             stage: "lint".to_string(),
-            planned: true,
+            collected: true,
             applied: write && !stage_changed_files.is_empty(),
-            fixes_proposed,
+            edit_count,
             files_modified: stage_changed_files.len(),
             detected_findings: Some(lint_findings.len()),
             changed_files: stage_changed_files,
@@ -816,14 +814,14 @@ fn run_test_stage(
     };
 
     let fix_results = fix_sidecars.consume_fix_results();
-    let fixes_proposed = fix_results.len();
+    let edit_count = fix_results.len();
     Ok(PlannedStage {
         source: "test".to_string(),
-        summary: PlanStageSummary {
+        summary: SourceStageSummary {
             stage: "test".to_string(),
-            planned: true,
+            collected: true,
             applied: write && !stage_changed_files.is_empty(),
-            fixes_proposed,
+            edit_count,
             files_modified: stage_changed_files.len(),
             detected_findings: None,
             changed_files: stage_changed_files,
@@ -875,7 +873,7 @@ fn summarize_audit_fix_result_entries(fix_result: &fixer::FixResult) -> Vec<FixA
     entries
 }
 
-pub fn analyze_stage_overlaps(stages: &[PlanStageSummary]) -> Vec<PlanOverlap> {
+pub fn analyze_stage_overlaps(stages: &[SourceStageSummary]) -> Vec<SourceOverlap> {
     let mut overlaps = Vec::new();
 
     for (later_index, later_stage) in stages.iter().enumerate() {
@@ -896,7 +894,7 @@ pub fn analyze_stage_overlaps(stages: &[PlanStageSummary]) -> Vec<PlanOverlap> {
 
             for file in earlier_stage.changed_files.iter().map(String::as_str) {
                 if later_files.contains(file) {
-                    overlaps.push(PlanOverlap {
+                    overlaps.push(SourceOverlap {
                         file: file.to_string(),
                         earlier_stage: earlier_stage.stage.clone(),
                         later_stage: later_stage.stage.clone(),
@@ -920,16 +918,16 @@ pub fn analyze_stage_overlaps(stages: &[PlanStageSummary]) -> Vec<PlanOverlap> {
     overlaps
 }
 
-pub fn summarize_plan_totals(
-    stages: &[PlanStageSummary],
+pub fn summarize_source_totals(
+    stages: &[SourceStageSummary],
     total_files_selected: usize,
-) -> PlanTotals {
-    PlanTotals {
-        stages_with_proposals: stages
+) -> SourceTotals {
+    SourceTotals {
+        stages_with_edits: stages
             .iter()
-            .filter(|stage| stage.fixes_proposed > 0)
+            .filter(|stage| stage.edit_count > 0)
             .count(),
-        total_fixes_proposed: stages.iter().map(|stage| stage.fixes_proposed).sum(),
+        total_edits: stages.iter().map(|stage| stage.edit_count).sum(),
         total_files_selected,
     }
 }
@@ -946,7 +944,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("homeboy-refactor-planner-{name}-{nanos}"))
+        std::env::temp_dir().join(format!("homeboy-refactor-sources-{name}-{nanos}"))
     }
 
     fn test_component(root: &Path) -> Component {
@@ -961,33 +959,33 @@ mod tests {
     #[test]
     fn analyze_stage_overlaps_reports_later_stage_precedence() {
         let stages = vec![
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "audit".to_string(),
-                planned: true,
+                collected: true,
                 applied: true,
-                fixes_proposed: 1,
+                edit_count: 1,
                 files_modified: 1,
                 detected_findings: Some(1),
                 changed_files: vec!["src/lib.rs".to_string()],
                 fix_summary: None,
                 warnings: Vec::new(),
             },
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "lint".to_string(),
-                planned: true,
+                collected: true,
                 applied: true,
-                fixes_proposed: 1,
+                edit_count: 1,
                 files_modified: 2,
                 detected_findings: Some(2),
                 changed_files: vec!["src/lib.rs".to_string(), "src/main.rs".to_string()],
                 fix_summary: None,
                 warnings: Vec::new(),
             },
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "test".to_string(),
-                planned: true,
+                collected: true,
                 applied: true,
-                fixes_proposed: 1,
+                edit_count: 1,
                 files_modified: 1,
                 detected_findings: None,
                 changed_files: vec!["src/main.rs".to_string()],
@@ -1001,13 +999,13 @@ mod tests {
         assert_eq!(
             overlaps,
             vec![
-                PlanOverlap {
+                SourceOverlap {
                     file: "src/lib.rs".to_string(),
                     earlier_stage: "audit".to_string(),
                     later_stage: "lint".to_string(),
                     resolution: "lint pass ran after audit in pipeline sequence".to_string(),
                 },
-                PlanOverlap {
+                SourceOverlap {
                     file: "src/main.rs".to_string(),
                     earlier_stage: "lint".to_string(),
                     later_stage: "test".to_string(),
@@ -1020,22 +1018,22 @@ mod tests {
     #[test]
     fn analyze_stage_overlaps_ignores_disjoint_files() {
         let stages = vec![
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "audit".to_string(),
-                planned: true,
+                collected: true,
                 applied: true,
-                fixes_proposed: 1,
+                edit_count: 1,
                 files_modified: 1,
                 detected_findings: Some(1),
                 changed_files: vec!["src/lib.rs".to_string()],
                 fix_summary: None,
                 warnings: Vec::new(),
             },
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "lint".to_string(),
-                planned: true,
+                collected: true,
                 applied: true,
-                fixes_proposed: 1,
+                edit_count: 1,
                 files_modified: 1,
                 detected_findings: Some(1),
                 changed_files: vec!["src/main.rs".to_string()],
@@ -1048,35 +1046,35 @@ mod tests {
     }
 
     #[test]
-    fn summarize_plan_totals_counts_stage_and_fix_totals() {
+    fn summarize_source_totals_counts_stage_and_fix_totals() {
         let stages = vec![
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "audit".to_string(),
-                planned: true,
+                collected: true,
                 applied: false,
-                fixes_proposed: 2,
+                edit_count: 2,
                 files_modified: 1,
                 detected_findings: Some(2),
                 changed_files: vec!["src/lib.rs".to_string()],
                 fix_summary: None,
                 warnings: Vec::new(),
             },
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "lint".to_string(),
-                planned: true,
+                collected: true,
                 applied: false,
-                fixes_proposed: 0,
+                edit_count: 0,
                 files_modified: 0,
                 detected_findings: Some(1),
                 changed_files: Vec::new(),
                 fix_summary: None,
                 warnings: Vec::new(),
             },
-            PlanStageSummary {
+            SourceStageSummary {
                 stage: "test".to_string(),
-                planned: true,
+                collected: true,
                 applied: false,
-                fixes_proposed: 3,
+                edit_count: 3,
                 files_modified: 2,
                 detected_findings: None,
                 changed_files: vec!["tests/foo.rs".to_string(), "tests/bar.rs".to_string()],
@@ -1085,15 +1083,15 @@ mod tests {
             },
         ];
 
-        let totals = summarize_plan_totals(&stages, 3);
+        let totals = summarize_source_totals(&stages, 3);
 
-        assert_eq!(totals.stages_with_proposals, 2);
-        assert_eq!(totals.total_fixes_proposed, 5);
+        assert_eq!(totals.stages_with_edits, 2);
+        assert_eq!(totals.total_edits, 5);
         assert_eq!(totals.total_files_selected, 3);
     }
 
     #[test]
-    fn build_refactor_plan_audit_write_uses_audit_refactor_engine() {
+    fn collect_refactor_sources_audit_write_uses_audit_refactor_engine() {
         let root = tmp_dir("audit-write");
         fs::create_dir_all(root.join("commands")).unwrap();
         fs::write(
@@ -1109,7 +1107,7 @@ mod tests {
         fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
 
         let component = test_component(&root);
-        let plan = build_refactor_plan(RefactorPlanRequest {
+        let sources_run = collect_refactor_sources(RefactorSourceRequest {
             component,
             root: root.clone(),
             sources: vec!["audit".to_string()],
@@ -1124,15 +1122,15 @@ mod tests {
         })
         .unwrap();
 
-        let audit_stage = plan
+        let audit_stage = sources_run
             .stages
             .iter()
             .find(|stage| stage.stage == "audit")
             .expect("audit stage present");
 
-        assert!(audit_stage.planned);
-        assert!(plan.proposals.is_empty());
-        assert!(audit_stage.planned);
+        assert!(audit_stage.collected);
+        assert!(sources_run.collected_edits.is_empty());
+        assert!(audit_stage.collected);
         assert!(audit_stage
             .warnings
             .iter()
@@ -1143,6 +1141,7 @@ mod tests {
 
     #[test]
     fn try_load_cached_audit_reads_output_dir() {
+        std::env::remove_var(OUTPUT_DIR_ENV);
         let dir = tmp_dir("cached-audit");
         fs::create_dir_all(&dir).unwrap();
         let audit_result = CodeAuditResult {
@@ -1187,6 +1186,7 @@ mod tests {
 
     #[test]
     fn try_load_cached_audit_skips_failed_envelope() {
+        std::env::remove_var(OUTPUT_DIR_ENV);
         let dir = tmp_dir("cached-audit-fail");
         fs::create_dir_all(&dir).unwrap();
         let envelope = serde_json::json!({

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -127,9 +127,7 @@ pub fn run_audit_refactor(
         };
         let root = Path::new(&current_result.source_path);
         let mut fix_result = super::generate::generate_audit_fixes(&current_result, root, &policy);
-        let policy_context = fixer::PreflightContext { root };
-        final_policy_summary =
-            fixer::apply_fix_policy(&mut fix_result, false, &policy, &policy_context);
+        final_policy_summary = fixer::apply_fix_policy(&mut fix_result, false, &policy);
         final_fix_result = fix_result;
     }
 
@@ -157,9 +155,7 @@ fn run_fix_iteration(
     };
     let root = Path::new(&audit_result.source_path);
     let mut fix_result = super::generate::generate_audit_fixes(audit_result, root, &policy);
-    let policy_context = fixer::PreflightContext { root };
-    let policy_summary =
-        fixer::apply_fix_policy(&mut fix_result, true, &policy, &policy_context);
+    let policy_summary = fixer::apply_fix_policy(&mut fix_result, true, &policy);
 
     let mut applied_chunks = 0;
     let mut reverted_chunks = 0;


### PR DESCRIPTION
## Summary
- remove more planner-era naming and indirection by renaming the source orchestration layer from `planner` to `sources`
- align refactor source execution with the direct model: collect edits from existing audit/lint/test reports and gate `--from` writes only with `manual_only`
- clean up the leftover guard-shell plumbing and cached-audit test setup around the source orchestration path

## Testing
- `cargo test commands::refactor::tests --bin homeboy`
- `cargo test core::refactor::plan::sources --lib`
- `cargo test core::refactor --lib`
- `cargo test core::code_audit::report --lib`
