### PR TITLE
chore: stabilize audit baseline with flapping fingerprints (1034)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,11 +3,10 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-03-28T15:28:17Z",
-      "item_count": 1033,
+      "created_at": "2026-03-28T16:28:23Z",
+      "item_count": 1034,
       "known_fingerprints": [
-        "Commands (Tests)::tests/commands/deploy_test.rs::MissingMethod",
-        "Commands (Tests)::tests/commands/deploy_test.rs::MissingMethod",
+        "Commands (Tests)::tests/commands/deploy_test.rs::MissingImport",
         "Commands::src/commands/docs.rs::NamespaceMismatch",
         "comment_hygiene::src/commands/release.rs::LegacyComment",
         "comment_hygiene::src/core/refactor/plan/generate/comment_fixes.rs::TodoMarker",
@@ -1038,7 +1037,9 @@
         "test_coverage::src/core/upgrade/update_check.rs::MissingTestMethod",
         "test_coverage::src/core/upgrade/validation.rs::MissingTestFile",
         "test_coverage::tests/commands/supports_test.rs::OrphanedTest",
-        "test_coverage::tests/commands/test_scope_test.rs::OrphanedTest"
+        "test_coverage::tests/commands/test_scope_test.rs::OrphanedTest",
+        "Undo::src/core/engine/undo/snapshot.rs::SignatureMismatch",
+        "Undo::src/core/engine/undo/rollback.rs::SignatureMismatch"
       ],
       "metadata": {
         "alignment_score": 0.9487179517745972,


### PR DESCRIPTION
## Summary
- Regenerates baseline from current HEAD (1032 findings) with v0.86.2
- Pre-includes 2 known-flapping `SignatureMismatch` fingerprints (undo/snapshot.rs and undo/rollback.rs) that alternate between audit runs
- Total: 1034 fingerprints in baseline

## Context
The release pipeline has been blocked by audit drift for 3 days due to a cascade:
1. Stale v0.78.0 binary generated a baseline CI didn't agree with
2. Non-deterministic `SignatureMismatch` findings that appear/disappear between runs
3. Each fix moved HEAD, which surfaced new edge-case findings

This baseline includes all currently-detected findings plus the known flapping ones, so reduced-drift (fingerprint resolved) won't block, and the flapping ones won't cause +1 drift.