### PR TITLE
Promote more autofix findings from manual to automated

### DIFF
--- a/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
@@ -270,9 +270,11 @@ fn classify_relation(
     }
 
     // Same indent with code in the gap.
-    // Small gap (≤ 3 lines of real code): likely copy-paste with minor context between.
-    // Large gap: different enough to need human review.
-    if code_lines_in_gap <= 3 {
+    // Small gap (≤ 8 lines of real code): likely copy-paste with minor context between.
+    // The brace-balance check in the caller prevents corrupted output even for
+    // larger gap removals, so we can safely promote more cases to automation.
+    // Large gap (> 8): different enough to need human review.
+    if code_lines_in_gap <= 8 {
         DupRelation::SameIndentSmallGap
     } else {
         DupRelation::SameIndentLargeGap
@@ -345,7 +347,9 @@ mod tests {
     }
 
     #[test]
-    fn classify_same_indent_large_gap() {
+    fn classify_same_indent_medium_gap_now_promoted() {
+        // 4 lines of code in gap — was SameIndentLargeGap at threshold 3,
+        // now SameIndentSmallGap at threshold 8 (automation-eligible).
         let lines = vec![
             "    let x = 1;", // line 1
             "    let y = 2;", // line 2
@@ -357,6 +361,28 @@ mod tests {
             "    let y = 2;", // line 8
         ];
         let rel = classify_relation(&lines, 1, 7, 2);
+        assert!(matches!(rel, DupRelation::SameIndentSmallGap));
+    }
+
+    #[test]
+    fn classify_same_indent_large_gap() {
+        // 9 lines of code in gap — exceeds threshold of 8, stays manual.
+        let lines = vec![
+            "    let x = 1;", // line 1
+            "    let y = 2;", // line 2
+            "    a();",       // line 3
+            "    b();",       // line 4
+            "    c();",       // line 5
+            "    d();",       // line 6
+            "    e();",       // line 7
+            "    f();",       // line 8
+            "    g();",       // line 9
+            "    h();",       // line 10
+            "    i();",       // line 11  — 9 lines of code in gap
+            "    let x = 1;", // line 12
+            "    let y = 2;", // line 13
+        ];
+        let rel = classify_relation(&lines, 1, 12, 2);
         assert!(matches!(rel, DupRelation::SameIndentLargeGap));
     }
 

--- a/src/core/refactor/plan/generate/orphaned_test_fixes.rs
+++ b/src/core/refactor/plan/generate/orphaned_test_fixes.rs
@@ -386,8 +386,19 @@ pub(crate) fn generate_orphaned_test_fixes(
         }
 
         // Fallback: delete the orphaned test if no rename candidate found.
-        // Mark manual-only so automation via `refactor --from` cannot execute it.
-        let ins = manual_only(insertion_with_primitive(
+        //
+        // Safety gate: if the corresponding source file no longer exists at all,
+        // the test is unambiguously orphaned — there's no source to reference.
+        // In that case, skip the manual_only gate and allow automated removal.
+        //
+        // If the source file still exists (method was deleted but file remains),
+        // the test might be testing behavior via other code paths, so keep it
+        // manual-only for human review.
+        let source_file_exists = test_file_to_source_path(&finding.file)
+            .map(|p| root.join(p).exists())
+            .unwrap_or(false);
+
+        let ins = insertion_with_primitive(
             RefactorPrimitive::RemoveOrphanedTest,
             InsertionKind::FunctionRemoval {
                 start_line,
@@ -396,10 +407,20 @@ pub(crate) fn generate_orphaned_test_fixes(
             AuditFinding::OrphanedTest,
             String::new(),
             format!(
-                "Remove orphaned test `{}` — referenced source method no longer exists",
-                test_method
+                "Remove orphaned test `{}` — referenced source method no longer exists{}",
+                test_method,
+                if source_file_exists {
+                    ""
+                } else {
+                    " (source file deleted)"
+                },
             ),
-        ));
+        );
+        let ins = if source_file_exists {
+            manual_only(ins)
+        } else {
+            ins
+        };
 
         fixes.push(Fix {
             file: finding.file.clone(),
@@ -658,5 +679,94 @@ mod tests {
             Some("src/core/code_audit/bar.rs".to_string())
         );
         assert_eq!(test_file_to_source_path("src/foo.rs"), None);
+    }
+
+    // ── Integration tests: source-file-deleted promotion ──────────────
+
+    use crate::code_audit::test_helpers::empty_result;
+    use crate::code_audit::{Finding, Severity};
+    use crate::refactor::auto::{Fix, SkippedFile};
+
+    fn test_content() -> &'static str {
+        r#"#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_data() {
+        assert_eq!(1, 1);
+    }
+}
+"#
+    }
+
+    fn orphaned_finding(file: &str) -> Finding {
+        Finding {
+            convention: "test_coverage".to_string(),
+            severity: Severity::Warning,
+            file: file.to_string(),
+            description: "Test method 'test_process_data' references 'process_data' which no longer exists in the source".to_string(),
+            suggestion: "Remove orphaned test".to_string(),
+            kind: AuditFinding::OrphanedTest,
+        }
+    }
+
+    #[test]
+    fn orphaned_test_automated_when_source_file_deleted() {
+        // Source file does not exist → test is unambiguously orphaned → automated.
+        let dir = tempfile::tempdir().unwrap();
+        let test_file = dir.path().join("tests/core/process_test.rs");
+        std::fs::create_dir_all(test_file.parent().unwrap()).unwrap();
+        std::fs::write(&test_file, test_content()).unwrap();
+        // Deliberately do NOT create src/core/process.rs
+
+        let mut result = empty_result();
+        result.source_path = dir.path().to_string_lossy().to_string();
+        result.findings.push(orphaned_finding("tests/core/process_test.rs"));
+
+        let mut fixes: Vec<Fix> = Vec::new();
+        let mut skipped: Vec<SkippedFile> = Vec::new();
+        generate_orphaned_test_fixes(&result, dir.path(), &mut fixes, &mut skipped);
+
+        assert_eq!(fixes.len(), 1, "Expected 1 fix, got {}", fixes.len());
+        assert_eq!(fixes[0].insertions.len(), 1);
+        assert!(
+            !fixes[0].insertions[0].manual_only,
+            "Should be automated when source file is deleted"
+        );
+        assert!(
+            fixes[0].insertions[0].description.contains("source file deleted"),
+            "Description should note source file was deleted"
+        );
+    }
+
+    #[test]
+    fn orphaned_test_manual_when_source_file_exists() {
+        // Source file still exists → method might have been deliberately removed
+        // but test could still test valid behavior → manual-only.
+        let dir = tempfile::tempdir().unwrap();
+        let test_file = dir.path().join("tests/core/process_test.rs");
+        std::fs::create_dir_all(test_file.parent().unwrap()).unwrap();
+        std::fs::write(&test_file, test_content()).unwrap();
+
+        // Create the source file (without the referenced method)
+        let source_file = dir.path().join("src/core/process.rs");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "pub fn other_method() {}\n").unwrap();
+
+        let mut result = empty_result();
+        result.source_path = dir.path().to_string_lossy().to_string();
+        result.findings.push(orphaned_finding("tests/core/process_test.rs"));
+
+        let mut fixes: Vec<Fix> = Vec::new();
+        let mut skipped: Vec<SkippedFile> = Vec::new();
+        generate_orphaned_test_fixes(&result, dir.path(), &mut fixes, &mut skipped);
+
+        assert_eq!(fixes.len(), 1, "Expected 1 fix, got {}", fixes.len());
+        assert_eq!(fixes[0].insertions.len(), 1);
+        assert!(
+            fixes[0].insertions[0].manual_only,
+            "Should be manual-only when source file still exists"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Safely increases the number of findings the autorefactor engine can fix autonomously in CI, moving from **30 auto-fixable → estimated 65-95** without compromising the "never produce non-compiling code" guarantee.

### Phase 1: intra_method_duplicate threshold raise

- Raises the `SameIndentSmallGap` threshold from **3 → 8** lines of code in the gap between duplicate blocks
- Same-indent duplicates with a moderate gap (4-8 lines) are still copy-paste errors — the existing **balanced brace/paren guardrail** prevents corrupted output even for larger removals
- `CrossBranch` duplicates (different indent levels) remain manual-only — these require structural refactoring

### Phase 2: orphaned_test source-file-deleted heuristic

- When the corresponding source file **no longer exists at all**, the test is unambiguously orphaned — promotes to automated removal
- When the source file **still exists** (method deleted but file remains), keeps manual-only — the test might still exercise valid behavior through other code paths
- Added integration tests for both cases

### What stays manual (correctly)

- `CrossBranch` intra-duplicates (different control flow branches)
- `SameIndentLargeGap` with >8 lines of gap code
- Orphaned tests where the source file still exists
- `legacy_comment` else-branch/code-section removals
- `todo_marker` (always manual — TODOs need human resolution)