### PR TITLE
Migrate fixers to shared builder helpers (Phase A of #1041)

### DIFF
--- a/src/core/engine/refactor_primitive.rs
+++ b/src/core/engine/refactor_primitive.rs
@@ -165,8 +165,28 @@ pub fn tagged_visibility_change(
     )
 }
 
+pub fn doc_line_removal(
+    finding: AuditFinding,
+    line: usize,
+    description: String,
+) -> Insertion {
+    insertion(
+        InsertionKind::DocLineRemoval { line },
+        finding,
+        String::new(),
+        description,
+    )
+}
+
 pub fn manual_only(mut insertion: Insertion) -> Insertion {
     insertion.manual_only = true;
+    insertion
+}
+
+/// Mark an insertion as manual-only with a specific blocked reason.
+pub fn manual_blocked(mut insertion: Insertion, reason: String) -> Insertion {
+    insertion.manual_only = true;
+    insertion.blocked_reason = Some(reason);
     insertion
 }
 

--- a/src/core/refactor/plan/generate/builders.rs
+++ b/src/core/refactor/plan/generate/builders.rs
@@ -1,5 +1,5 @@
 pub(crate) use crate::core::engine::refactor_primitive::{
-    insertion, manual_only, new_file, tagged_import_add,
-    tagged_insertion as insertion_with_primitive, tagged_line_replacement, tagged_range_removal,
-    tagged_visibility_change,
+    doc_line_removal, insertion, manual_blocked, manual_only, new_file, range_removal,
+    tagged_import_add, tagged_insertion as insertion_with_primitive, tagged_line_replacement,
+    tagged_range_removal, tagged_visibility_change,
 };

--- a/src/core/refactor/plan/generate/comment_fixes.rs
+++ b/src/core/refactor/plan/generate/comment_fixes.rs
@@ -21,7 +21,9 @@ use std::path::Path;
 use regex::Regex;
 
 use crate::code_audit::{AuditFinding, CodeAuditResult};
-use crate::refactor::auto::{Fix, Insertion, InsertionKind, SkippedFile};
+use crate::refactor::auto::{Fix, SkippedFile};
+
+use super::{doc_line_removal, manual_blocked, range_removal};
 
 /// Classification of the code block a legacy comment annotates.
 #[derive(Debug, PartialEq)]
@@ -106,26 +108,23 @@ pub(crate) fn generate_comment_fixes(
 
         // TODO markers describe work to be done — always needs human review.
         if finding_kind == AuditFinding::TodoMarker {
+            let ins = manual_blocked(
+                doc_line_removal(
+                    AuditFinding::TodoMarker,
+                    line_num,
+                    format!(
+                        "TODO marker on line {} in {} — resolve before removing",
+                        line_num, finding.file
+                    ),
+                ),
+                "TODO markers require human judgment — resolve the TODO, then remove".to_string(),
+            );
+
             fixes.push(Fix {
                 file: finding.file.clone(),
                 required_methods: vec![],
                 required_registrations: vec![],
-                insertions: vec![Insertion {
-                    primitive: None,
-                    kind: InsertionKind::DocLineRemoval { line: line_num },
-                    finding: AuditFinding::TodoMarker,
-                    manual_only: true,
-                    auto_apply: false,
-                    blocked_reason: Some(
-                        "TODO markers require human judgment — resolve the TODO, then remove"
-                            .to_string(),
-                    ),
-                    code: String::new(),
-                    description: format!(
-                        "TODO marker on line {} in {} — resolve before removing",
-                        line_num, finding.file
-                    ),
-                }],
+                insertions: vec![ins],
                 applied: false,
             });
             continue;
@@ -198,23 +197,23 @@ pub(crate) fn generate_comment_fixes(
             &finding.description
         );
 
+        let ins = range_removal(
+            AuditFinding::LegacyComment,
+            start_line,
+            end_line,
+            description,
+        );
+        let ins = if manual_only {
+            manual_blocked(ins, blocked_reason.unwrap_or_default())
+        } else {
+            ins
+        };
+
         fixes.push(Fix {
             file: finding.file.clone(),
             required_methods: vec![],
             required_registrations: vec![],
-            insertions: vec![Insertion {
-                primitive: None,
-                kind: InsertionKind::FunctionRemoval {
-                    start_line,
-                    end_line,
-                },
-                finding: AuditFinding::LegacyComment,
-                manual_only,
-                auto_apply: false,
-                blocked_reason,
-                code: String::new(),
-                description,
-            }],
+            insertions: vec![ins],
             applied: false,
         });
     }
@@ -558,6 +557,7 @@ mod tests {
     use super::*;
     use crate::code_audit::test_helpers::empty_result;
     use crate::code_audit::{Finding, Severity};
+    use crate::refactor::auto::InsertionKind;
 
     // ── classify_and_bound tests ──────────────────────────────────────
 

--- a/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
@@ -18,7 +18,9 @@ use std::path::Path;
 
 use crate::code_audit::{AuditFinding, CodeAuditResult};
 use crate::engine::local_files;
-use crate::refactor::auto::{Fix, Insertion, InsertionKind, SkippedFile};
+use crate::refactor::auto::{Fix, SkippedFile};
+
+use super::{manual_blocked, range_removal};
 
 /// Structural relationship between two duplicated blocks.
 enum DupRelation {
@@ -162,26 +164,21 @@ pub(crate) fn generate_intra_duplicate_fixes(
                     continue;
                 }
 
+                let ins = range_removal(
+                    AuditFinding::IntraMethodDuplicate,
+                    removal_start,
+                    second_end,
+                    format!(
+                        "Remove duplicate block in `{}` (lines {}-{}) — identical to lines {}-{}",
+                        method_name, second_line, second_end, first_line, first_end,
+                    ),
+                );
+
                 fixes.push(Fix {
                     file: finding.file.clone(),
                     required_methods: vec![],
                     required_registrations: vec![],
-                    insertions: vec![Insertion {
-                        primitive: None,
-                        kind: InsertionKind::FunctionRemoval {
-                            start_line: removal_start,
-                            end_line: second_end,
-                        },
-                        finding: AuditFinding::IntraMethodDuplicate,
-                        manual_only: false,
-                        auto_apply: false,
-                        blocked_reason: None,
-                        code: String::new(),
-                        description: format!(
-                            "Remove duplicate block in `{}` (lines {}-{}) — identical to lines {}-{}",
-                            method_name, second_line, second_end, first_line, first_end,
-                        ),
-                    }],
+                    insertions: vec![ins],
                     applied: false,
                 });
             }
@@ -200,26 +197,24 @@ pub(crate) fn generate_intra_duplicate_fixes(
                     ),
                 };
 
+                let ins = manual_blocked(
+                    range_removal(
+                        AuditFinding::IntraMethodDuplicate,
+                        second_line,
+                        second_end,
+                        format!(
+                            "Duplicate block in `{}`: lines {}-{} and lines {}-{} are identical",
+                            method_name, first_line, first_end, second_line, second_end,
+                        ),
+                    ),
+                    reason,
+                );
+
                 fixes.push(Fix {
                     file: finding.file.clone(),
                     required_methods: vec![],
                     required_registrations: vec![],
-                    insertions: vec![Insertion {
-                        primitive: None,
-                        kind: InsertionKind::FunctionRemoval {
-                            start_line: second_line,
-                            end_line: second_end,
-                        },
-                        finding: AuditFinding::IntraMethodDuplicate,
-                        manual_only: true,
-                        auto_apply: false,
-                        blocked_reason: Some(reason),
-                        code: String::new(),
-                        description: format!(
-                            "Duplicate block in `{}`: lines {}-{} and lines {}-{} are identical",
-                            method_name, first_line, first_end, second_line, second_end,
-                        ),
-                    }],
+                    insertions: vec![ins],
                     applied: false,
                 });
             }

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -20,8 +20,9 @@ use std::path::Path;
 use convention_fixes::apply_convention_fixes;
 
 pub(crate) use builders::{
-    insertion, insertion_with_primitive, manual_only, new_file, tagged_import_add,
-    tagged_line_replacement, tagged_range_removal, tagged_visibility_change,
+    doc_line_removal, insertion, insertion_with_primitive, manual_blocked, manual_only, new_file,
+    range_removal, tagged_import_add, tagged_line_replacement, tagged_range_removal,
+    tagged_visibility_change,
 };
 pub(crate) use doc_fixes::is_actionable_comment_finding;
 pub(crate) use duplicate_fixes::{


### PR DESCRIPTION
## Summary

Phase A of #1041 — consistency cleanup. Migrates the two fixers that bypassed builder helpers (`comment_fixes.rs` and `intra_duplicate_fixes.rs`) to use the shared builders in `engine/refactor_primitive.rs`.

### What changed

**New builders in `refactor_primitive.rs`:**
- `doc_line_removal(finding, line, description)` — shortcut for `InsertionKind::DocLineRemoval`
- `manual_blocked(insertion, reason)` — sets `manual_only: true` + `blocked_reason` in one call

**Re-exported existing builders:**
- `range_removal` — was defined but not exported through the builders module
- `doc_line_removal` — new

**Migrated fixers:**
- `comment_fixes.rs` — TodoMarker and LegacyComment insertions now use `doc_line_removal`, `range_removal`, and `manual_blocked` instead of raw `Insertion { ... }` construction
- `intra_duplicate_fixes.rs` — Adjacent/SmallGap and LargeGap/CrossBranch insertions now use `range_removal` and `manual_blocked`

### Why this matters for #1041

All 9 fixers now construct edits through the shared builder layer. This means:
1. No fixer directly imports `Insertion` or `InsertionKind` for construction
2. The builder layer is the single construction surface — future changes to edit representation only need to update builders
3. Phase B (introducing `EditOp` in `core/engine/`) can add a translation layer under the builders without touching any fixer code

### Tests

1009 lib tests pass. No new warnings.