### PR TITLE
Add build provenance tracking and deploy warning for unreleased commits

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -68,6 +68,9 @@ pub struct DeployArgs {
     /// Deploy from current branch HEAD instead of the latest tag
     #[arg(long)]
     pub head: bool,
+    /// Force tag-based deploy, ignoring any reusable build artifacts
+    #[arg(long)]
+    pub tagged: bool,
 }
 
 #[derive(Serialize)]
@@ -272,6 +275,7 @@ fn build_config(args: &DeployArgs, skip_build: bool) -> DeployConfig {
         expected_version: args.version.clone(),
         no_pull: args.no_pull,
         head: args.head,
+        tagged: args.tagged,
     }
 }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -355,6 +355,7 @@ fn fetch_project_remote_versions(project_id: &str) -> std::collections::HashMap<
         expected_version: None,
         no_pull: true,
         head: true,
+        tagged: false,
     };
 
     match deploy::run(project_id, &config) {

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -2,6 +2,7 @@ mod execution;
 mod orchestration;
 pub(crate) mod permissions;
 mod planning;
+pub(crate) mod provenance;
 pub mod release_download;
 mod safety_and_artifact;
 mod transfer;
@@ -142,6 +143,7 @@ pub fn run_multi(
             // Only pull on first project
             no_pull: config.no_pull || !first_project,
             head: config.head,
+            tagged: config.tagged,
         };
 
         match run(project_id, &project_config) {

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -106,10 +106,41 @@ pub(super) fn deploy_components(
         check_uncommitted_changes(&components)?;
     }
 
-    // Checkout latest tag for each component (unless --head)
-    // This ensures only released, tagged code reaches production.
+    // Smart artifact reuse: check if any component has a fresh build artifact
+    // from a recent `homeboy build`. If so, skip the tag checkout and rebuild
+    // for that component — deploy what was already built.
+    let reuse_artifact_ids = if !config.head && !config.skip_build && !config.tagged {
+        detect_reusable_artifacts(&components)
+    } else {
+        Vec::new()
+    };
+
+    // Warn about HEAD-vs-tag gap before the tag checkout.
+    // Skip warning for components that will reuse their build artifact.
+    if !config.head && !config.skip_build {
+        let non_reuse: Vec<_> = components
+            .iter()
+            .filter(|c| !reuse_artifact_ids.contains(&c.id))
+            .cloned()
+            .collect();
+        if !non_reuse.is_empty() {
+            warn_unreleased_commits(&non_reuse, config);
+        }
+    }
+
+    // Checkout latest tag for each component (unless --head or reusing artifact).
+    // Components with reusable build artifacts are excluded from tag checkout.
     let tag_checkouts = if !config.head && !config.skip_build {
-        checkout_latest_tags(&components)?
+        let checkout_components: Vec<_> = components
+            .iter()
+            .filter(|c| !reuse_artifact_ids.contains(&c.id))
+            .cloned()
+            .collect();
+        if checkout_components.is_empty() {
+            Vec::new()
+        } else {
+            checkout_latest_tags(&checkout_components)?
+        }
     } else {
         Vec::new()
     };
@@ -127,9 +158,20 @@ pub(super) fn deploy_components(
     for component in &components {
         // Apply per-project overrides (e.g. different extract_command or remote_owner)
         let component = crate::project::apply_component_overrides(component, project);
+
+        // For components reusing a build artifact, skip the build step
+        let effective_config = if reuse_artifact_ids.contains(&component.id) {
+            DeployConfig {
+                skip_build: true,
+                ..clone_config(config)
+            }
+        } else {
+            clone_config(config)
+        };
+
         let mut result = execute_component_deploy(
             &component,
-            config,
+            &effective_config,
             ctx,
             base_path,
             project,
@@ -138,7 +180,22 @@ pub(super) fn deploy_components(
         );
 
         // Record which git ref was deployed
-        if let Some(checkout) = tag_checkouts
+        if reuse_artifact_ids.contains(&component.id) {
+            // Artifact was reused from a prior build — record the provenance ref
+            if let Some(prov) = super::provenance::read(&component) {
+                let ref_label = if prov.is_ahead_of_tag() {
+                    format!(
+                        "{} (HEAD, {} ahead of {})",
+                        prov.git_ref,
+                        prov.ahead_of_tag,
+                        prov.tag.as_deref().unwrap_or("?")
+                    )
+                } else {
+                    format!("{} (build artifact)", prov.git_ref)
+                };
+                result = result.with_deployed_ref(ref_label);
+            }
+        } else if let Some(checkout) = tag_checkouts
             .iter()
             .find(|c| c.component_id == component.id)
         {
@@ -463,6 +520,94 @@ fn restore_branches(checkouts: &[TagCheckout]) {
                 );
             }
         }
+    }
+}
+
+/// Warn about unreleased commits ahead of the latest tag.
+///
+/// Checks each component for commits between the latest tag and HEAD.
+/// When found, logs a warning with the commit count and subjects so
+/// the user knows their recent work won't be in this deploy.
+fn warn_unreleased_commits(components: &[Component], config: &DeployConfig) {
+    let mut any_gap = false;
+
+    for component in components {
+        if let Some(gap) = super::provenance::detect_tag_gap(component) {
+            super::provenance::warn_tag_gap(&component.id, &gap, "deploy");
+            any_gap = true;
+        }
+    }
+
+    if any_gap {
+        if config.force {
+            log_status!(
+                "deploy",
+                "Deploying from tagged releases. Use `deploy --head` to include unreleased commits, or `homeboy release` to tag them."
+            );
+        } else {
+            log_status!(
+                "deploy",
+                "Deploy will use tagged releases (not HEAD). Use `deploy --head` to include unreleased commits, or `homeboy release` to tag them."
+            );
+        }
+    }
+}
+
+/// Detect components with reusable build artifacts.
+///
+/// A build artifact is reusable when:
+/// 1. A `.homeboy-build-meta.json` sidecar exists
+/// 2. The recorded commit matches the current HEAD (the artifact is current)
+///
+/// When a reusable artifact is found, the component skips tag checkout
+/// and rebuild — deploying whatever was already built by `homeboy build`.
+fn detect_reusable_artifacts(components: &[Component]) -> Vec<String> {
+    let mut reuse_ids = Vec::new();
+
+    for component in components {
+        if let Some(prov) = super::provenance::read(component) {
+            if super::provenance::is_current(component, &prov) {
+                if prov.is_ahead_of_tag() {
+                    log_status!(
+                        "deploy",
+                        "ℹ️  '{}': reusing build artifact from {} ({} commit(s) ahead of {})",
+                        component.id,
+                        &prov.commit[..prov.commit.len().min(8)],
+                        prov.ahead_of_tag,
+                        prov.tag.as_deref().unwrap_or("?")
+                    );
+                } else {
+                    log_status!(
+                        "deploy",
+                        "ℹ️  '{}': reusing build artifact from {} (at tag {})",
+                        component.id,
+                        &prov.commit[..prov.commit.len().min(8)],
+                        prov.tag.as_deref().unwrap_or("?")
+                    );
+                }
+                reuse_ids.push(component.id.clone());
+            }
+        }
+    }
+
+    reuse_ids
+}
+
+/// Create a value copy of DeployConfig for per-component overrides.
+fn clone_config(config: &DeployConfig) -> DeployConfig {
+    DeployConfig {
+        component_ids: config.component_ids.clone(),
+        all: config.all,
+        outdated: config.outdated,
+        dry_run: config.dry_run,
+        check: config.check,
+        force: config.force,
+        skip_build: config.skip_build,
+        keep_deps: config.keep_deps,
+        expected_version: config.expected_version.clone(),
+        no_pull: config.no_pull,
+        head: config.head,
+        tagged: config.tagged,
     }
 }
 

--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -1,0 +1,267 @@
+//! Build provenance tracking.
+//!
+//! Records metadata about what was built so `deploy` can make informed
+//! decisions about whether to reuse an existing artifact or rebuild
+//! from the latest tag.
+//!
+//! The sidecar lives at `.homeboy-build-meta.json` in the component's
+//! local directory root.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::component::Component;
+use crate::engine::command;
+use crate::git;
+
+const META_FILENAME: &str = ".homeboy-build-meta.json";
+
+/// Metadata recorded after a successful build.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildProvenance {
+    /// Full commit hash that was built
+    pub commit: String,
+    /// Branch or ref name (e.g. "main", or tag name if detached at a tag)
+    pub git_ref: String,
+    /// Latest tag at build time (if any)
+    pub tag: Option<String>,
+    /// Number of commits HEAD is ahead of the latest tag
+    pub ahead_of_tag: u32,
+    /// ISO 8601 timestamp of the build
+    pub timestamp: String,
+    /// Whether the working tree had uncommitted changes at build time
+    pub dirty: bool,
+}
+
+impl BuildProvenance {
+    /// Returns true if this build was from the exact tagged commit (not ahead).
+    pub fn is_tagged_build(&self) -> bool {
+        self.ahead_of_tag == 0 && self.tag.is_some() && !self.dirty
+    }
+
+    /// Returns true if this build includes unreleased commits beyond the tag.
+    pub fn is_ahead_of_tag(&self) -> bool {
+        self.ahead_of_tag > 0
+    }
+}
+
+/// Capture build provenance for a component's current git state.
+pub fn capture(component: &Component) -> Option<BuildProvenance> {
+    let path = &component.local_path;
+
+    let commit = command::run_in_optional(path, "git", &["rev-parse", "HEAD"])?;
+
+    let git_ref = command::run_in_optional(path, "git", &["symbolic-ref", "--short", "HEAD"])
+        .unwrap_or_else(|| {
+            // Detached HEAD — use the commit hash as ref
+            commit.chars().take(12).collect()
+        });
+
+    let tag = git::get_latest_tag(path).ok().flatten();
+
+    let ahead_of_tag = tag
+        .as_ref()
+        .and_then(|t| {
+            command::run_in_optional(
+                path,
+                "git",
+                &["rev-list", "--count", &format!("{}..HEAD", t)],
+            )
+        })
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(0);
+
+    let dirty = !git::is_workdir_clean(Path::new(path));
+
+    let timestamp = chrono_now_iso();
+
+    Some(BuildProvenance {
+        commit,
+        git_ref,
+        tag,
+        ahead_of_tag,
+        timestamp,
+        dirty,
+    })
+}
+
+/// Write build provenance to the sidecar file in the component directory.
+pub fn write(component: &Component, provenance: &BuildProvenance) -> std::io::Result<()> {
+    let meta_path = meta_path(&component.local_path);
+    let json = serde_json::to_string_pretty(provenance)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    std::fs::write(&meta_path, json)
+}
+
+/// Read build provenance from the sidecar file, if it exists.
+pub fn read(component: &Component) -> Option<BuildProvenance> {
+    read_from_path(&component.local_path)
+}
+
+/// Read build provenance from a path (component local_path).
+pub fn read_from_path(local_path: &str) -> Option<BuildProvenance> {
+    let meta_path = meta_path(local_path);
+    let content = std::fs::read_to_string(&meta_path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Check if the provenance is still valid for the current HEAD.
+///
+/// Returns true if the recorded commit matches the current HEAD,
+/// meaning the build artifact corresponds to the checked-out code.
+pub fn is_current(component: &Component, provenance: &BuildProvenance) -> bool {
+    let current_commit =
+        command::run_in_optional(&component.local_path, "git", &["rev-parse", "HEAD"]);
+    current_commit.as_deref() == Some(provenance.commit.as_str())
+}
+
+fn meta_path(local_path: &str) -> PathBuf {
+    Path::new(local_path).join(META_FILENAME)
+}
+
+/// ISO 8601 UTC timestamp without external crate dependency.
+fn chrono_now_iso() -> String {
+    // Use `date` command for UTC ISO format — avoids adding chrono crate
+    command::run_in_optional(".", "date", &["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Information about the HEAD-vs-tag gap for a component.
+#[derive(Debug, Clone)]
+pub struct TagGap {
+    /// The latest tag
+    pub tag: String,
+    /// Number of commits HEAD is ahead
+    pub ahead: u32,
+    /// Short commit subjects (newest first)
+    pub commits: Vec<String>,
+}
+
+/// Check if HEAD is ahead of the latest tag for a component.
+/// Returns None if HEAD is at or behind the tag, or if no tags exist.
+pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
+    let path = &component.local_path;
+    let tag = git::get_latest_tag(path).ok().flatten()?;
+
+    let ahead_str = command::run_in_optional(
+        path,
+        "git",
+        &["rev-list", "--count", &format!("{}..HEAD", tag)],
+    )?;
+    let ahead = ahead_str.trim().parse::<u32>().ok()?;
+
+    if ahead == 0 {
+        return None;
+    }
+
+    // Get commit subjects for the unreleased commits (max 10)
+    let log_output = command::run_in_optional(
+        path,
+        "git",
+        &[
+            "log",
+            "--oneline",
+            "--format=%h %s",
+            "-10",
+            &format!("{}..HEAD", tag),
+        ],
+    )
+    .unwrap_or_default();
+
+    let commits: Vec<String> = log_output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+
+    Some(TagGap {
+        tag,
+        ahead,
+        commits,
+    })
+}
+
+/// Log a warning about the HEAD-vs-tag gap for a component.
+/// Used by both `build` and `deploy` commands.
+///
+/// Uses `eprintln` directly because `log_status!` requires literal prefixes
+/// and this function accepts a runtime `context` parameter.
+pub fn warn_tag_gap(component_id: &str, gap: &TagGap, context: &str) {
+    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return;
+    }
+    eprintln!(
+        "[{}] ⚠️  '{}': HEAD is {} commit(s) ahead of latest tag {}",
+        context, component_id, gap.ahead, gap.tag
+    );
+    for commit in &gap.commits {
+        eprintln!("[{}]      {}", context, commit);
+    }
+    if gap.ahead > 10 {
+        eprintln!(
+            "[{}]      ... and {} more",
+            context,
+            gap.ahead - gap.commits.len() as u32
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_tagged_build() {
+        let p = BuildProvenance {
+            commit: "abc123".to_string(),
+            git_ref: "main".to_string(),
+            tag: Some("v1.0.0".to_string()),
+            ahead_of_tag: 0,
+            timestamp: "2026-03-28T20:00:00Z".to_string(),
+            dirty: false,
+        };
+        assert!(p.is_tagged_build());
+    }
+
+    #[test]
+    fn test_is_tagged_build_dirty() {
+        let p = BuildProvenance {
+            commit: "abc123".to_string(),
+            git_ref: "main".to_string(),
+            tag: Some("v1.0.0".to_string()),
+            ahead_of_tag: 0,
+            timestamp: "2026-03-28T20:00:00Z".to_string(),
+            dirty: true,
+        };
+        assert!(!p.is_tagged_build());
+    }
+
+    #[test]
+    fn test_is_ahead_of_tag() {
+        let p = BuildProvenance {
+            commit: "abc123".to_string(),
+            git_ref: "main".to_string(),
+            tag: Some("v1.0.0".to_string()),
+            ahead_of_tag: 5,
+            timestamp: "2026-03-28T20:00:00Z".to_string(),
+            dirty: false,
+        };
+        assert!(p.is_ahead_of_tag());
+        assert!(!p.is_tagged_build());
+    }
+
+    #[test]
+    fn test_no_tag() {
+        let p = BuildProvenance {
+            commit: "abc123".to_string(),
+            git_ref: "main".to_string(),
+            tag: None,
+            ahead_of_tag: 0,
+            timestamp: "2026-03-28T20:00:00Z".to_string(),
+            dirty: false,
+        };
+        assert!(!p.is_tagged_build());
+        assert!(!p.is_ahead_of_tag());
+    }
+}

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -53,6 +53,8 @@ pub struct DeployConfig {
     pub no_pull: bool,
     /// Deploy from current branch HEAD instead of latest tag
     pub head: bool,
+    /// Force tag-based deploy, ignoring any reusable build artifacts
+    pub tagged: bool,
 }
 
 /// Reason why a component was selected for deployment.

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -363,6 +363,16 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
     let validated_path = component::validate_local_path(comp)?;
     let local_path_str = validated_path.to_string_lossy().to_string();
 
+    // Warn when HEAD is ahead of the latest tag — the build will include
+    // unreleased commits that won't be deployed unless using `deploy --head`.
+    if let Some(gap) = crate::deploy::provenance::detect_tag_gap(comp) {
+        crate::deploy::provenance::warn_tag_gap(&comp.id, &gap, "build");
+        log_status!(
+            "build",
+            "Build uses current working tree. To deploy these commits: use `deploy --head` or run `homeboy release`."
+        );
+    }
+
     let resolved = resolve_build_command(comp)?;
     let build_cmd = resolved.command().to_string();
     let build_context = match &resolved {
@@ -411,13 +421,24 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
             .run()?
     };
 
+    let success = runner_output.success;
+
+    // Record build provenance on success so deploy can detect fresh artifacts
+    if success {
+        if let Some(prov) = crate::deploy::provenance::capture(comp) {
+            if let Err(e) = crate::deploy::provenance::write(comp, &prov) {
+                log_status!("build", "Warning: could not write build provenance: {}", e);
+            }
+        }
+    }
+
     Ok((
         BuildOutput {
             command: "build.run".to_string(),
             component_id: comp.id.clone(),
             build_command: build_cmd,
             output: CapturedOutput::new(runner_output.stdout, runner_output.stderr),
-            success: runner_output.success,
+            success,
         },
         runner_output.exit_code,
     ))

--- a/src/core/fleet/check.rs
+++ b/src/core/fleet/check.rs
@@ -53,6 +53,7 @@ pub fn collect_check(
             expected_version: None,
             no_pull: true,
             head: true,
+            tagged: false,
         };
 
         match deploy::run(project_id, &config) {

--- a/src/core/fleet/status.rs
+++ b/src/core/fleet/status.rs
@@ -274,6 +274,7 @@ fn collect_project_component_statuses(
         expected_version: None,
         no_pull: true,
         head: true,
+        tagged: false,
     };
 
     match deploy::run(project_id, &config) {

--- a/src/core/project/status.rs
+++ b/src/core/project/status.rs
@@ -51,6 +51,7 @@ fn collect_component_versions(project_id: &str) -> Option<Vec<ProjectComponentSt
         expected_version: None,
         no_pull: true,
         head: true,
+        tagged: false,
     };
 
     deploy::run(project_id, &config).ok().map(|result| {

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -466,6 +466,7 @@ fn execute_deployment(
             expected_version: None,
             no_pull: true,
             head: true,
+            tagged: true,
         };
 
         match deploy::run(project_id, &config) {


### PR DESCRIPTION
## Summary

- **Build provenance**: After a successful `homeboy build`, a `.homeboy-build-meta.json` sidecar records the commit, ref, tag distance, dirty state, and timestamp
- **Unreleased commits warning**: Both `build` and `deploy` now surface a prominent warning when HEAD is ahead of the latest tag, showing commit count and subjects
- **Smart artifact reuse**: `deploy` checks for a fresh build artifact before checking out the tag and rebuilding — if `homeboy build` already ran, it reuses that artifact instead of throwing it away
- **New `--tagged` flag**: Forces tag-based deploy, bypassing artifact reuse (for when you explicitly want the tagged version)

## Problem

When running `homeboy build && homeboy deploy`:
1. `build` compiles from HEAD (your latest commits ✅)
2. `deploy` throws that build away, checks out the latest tag, rebuilds from the tag, and deploys *that* 😐
3. Your HEAD commits are never deployed, with zero indication anything went wrong

This is the "prank on yourself" bug — you watch the build succeed, deploy reports success, and walk away thinking your fix is live.

## Changes

| File | Change |
|------|--------|
| `src/core/deploy/provenance.rs` | **New** — build provenance capture, write, read, tag gap detection, warning display |
| `src/core/extension/build/mod.rs` | Write provenance after successful build; warn when HEAD > tag |
| `src/core/deploy/orchestration.rs` | Smart artifact reuse, unreleased commits warning, `clone_config` helper |
| `src/core/deploy/types.rs` | Add `tagged: bool` to `DeployConfig` |
| `src/commands/deploy.rs` | Add `--tagged` CLI flag |
| `src/core/deploy/mod.rs` | Register `provenance` module |
| 5 other files | Add `tagged: false` to all `DeployConfig` construction sites |

## Behavior Matrix

| Workflow | Before | After |
|----------|--------|-------|
| `homeboy deploy` (no prior build) | Checkout tag, build, deploy | Same — unchanged |
| `homeboy build && homeboy deploy` | Build from HEAD, then throw it away and rebuild from tag | Build from HEAD (with warning), then deploy that artifact |
| `homeboy deploy --head` | Deploy from HEAD | Unchanged |
| `homeboy deploy --tagged` | N/A | Force tag-based deploy, ignore artifacts |
| `homeboy release --deploy` | Deploy just-tagged commit | Unchanged (`tagged: true` internally) |

## Tests

- 4 new unit tests for `BuildProvenance` methods
- Full test suite: **1027 passed, 0 failed**

Closes #1064