### PR TITLE
feat(refactor): add --commit and --git-identity flags

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -53,6 +53,16 @@ pub struct RefactorArgs {
     #[command(flatten)]
     write_mode: WriteModeArgs,
 
+    /// After applying fixes, stage all changes and commit.
+    /// Only effective with --write. The commit message is built from fix results.
+    #[arg(long, requires = "write")]
+    commit: bool,
+
+    /// Git identity for the commit (used with --commit).
+    /// Use "bot" for the default CI bot identity, or "Name <email>" for custom.
+    #[arg(long)]
+    git_identity: Option<String>,
+
     #[command(subcommand)]
     command: Option<RefactorCommand>,
 }
@@ -258,6 +268,8 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             &args.setting_args.setting,
             args.force,
             args.write_mode.write,
+            args.commit,
+            args.git_identity.as_deref(),
         ),
 
         Some(RefactorCommand::Rename {
@@ -663,6 +675,7 @@ where
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_refactor_sources(
     comp: Option<&PositionalComponentArgs>,
     component_ids: &[String],
@@ -674,6 +687,8 @@ fn run_refactor_sources(
     settings: &[(String, String)],
     force: bool,
     write: bool,
+    commit: bool,
+    git_identity: Option<&str>,
 ) -> CmdResult<RefactorOutput> {
     let targets = resolve_top_level_targets(comp, component_ids, components)?;
     run_across_targets("sources", targets, |component_id, path| {
@@ -687,10 +702,13 @@ fn run_refactor_sources(
             settings,
             force,
             write,
+            commit,
+            git_identity,
         )
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_refactor_sources_single(
     component_id: Option<&str>,
     path: Option<&str>,
@@ -701,6 +719,8 @@ fn run_refactor_sources_single(
     settings: &[(String, String)],
     force: bool,
     write: bool,
+    commit: bool,
+    git_identity: Option<&str>,
 ) -> CmdResult<RefactorOutput> {
     let component_id = component_id.ok_or_else(|| {
         homeboy::Error::validation_missing_argument(vec!["component".to_string()])
@@ -712,6 +732,7 @@ fn run_refactor_sources_single(
     let requested_sources = from.to_vec();
     let only_findings = parse_audit_findings(only)?;
     let exclude_findings = parse_audit_findings(exclude)?;
+    let source_path = ctx.source_path.clone();
     let sources = homeboy::refactor::plan::collect_refactor_sources(
         homeboy::refactor::plan::RefactorSourceRequest {
             component: ctx.component,
@@ -728,6 +749,12 @@ fn run_refactor_sources_single(
         },
     )?;
     let exit_code = if sources.files_modified > 0 { 1 } else { 0 };
+
+    // --commit: stage all changes and create a commit with a structured message
+    if commit && write && sources.applied {
+        let root_str = source_path.to_string_lossy();
+        autofix_commit(&root_str, &sources, git_identity)?;
+    }
 
     Ok((RefactorOutput::Sources(sources), exit_code))
 }
@@ -1528,6 +1555,164 @@ fn run_decompose_single(
     ))
 }
 
+// ── Autofix commit ──────────────────────────────────────────────────────────
+
+const BOT_NAME: &str = "homeboy-ci[bot]";
+const BOT_EMAIL: &str = "266378653+homeboy-ci[bot]@users.noreply.github.com";
+const AUTOFIX_PREFIX: &str = "chore(ci): homeboy autofix";
+
+/// Stage all changes and create a commit after refactor --write.
+fn autofix_commit(
+    path: &str,
+    sources: &homeboy::refactor::plan::RefactorSourceRun,
+    git_identity: Option<&str>,
+) -> homeboy::Result<()> {
+    use std::process::Command;
+
+    // Stage all changes
+    let add = Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(path)
+        .output()
+        .map_err(|e| homeboy::Error::git_command_failed(format!("git add: {e}")))?;
+    if !add.status.success() {
+        let stderr = String::from_utf8_lossy(&add.stderr);
+        return Err(homeboy::Error::git_command_failed(format!(
+            "git add -A failed: {stderr}"
+        )));
+    }
+
+    // Check if there's anything staged (fixes may have been no-ops after formatting)
+    let diff_check = Command::new("git")
+        .args(["diff", "--cached", "--quiet"])
+        .current_dir(path)
+        .output()
+        .map_err(|e| homeboy::Error::git_command_failed(format!("git diff: {e}")))?;
+    if diff_check.status.success() {
+        eprintln!("[refactor] No staged changes after git add — skipping commit");
+        return Ok(());
+    }
+
+    // Resolve git identity
+    let (name, email) = resolve_git_identity(git_identity);
+
+    // Configure git identity
+    for (key, value) in [("user.name", name.as_str()), ("user.email", email.as_str())] {
+        let config = Command::new("git")
+            .args(["config", key, value])
+            .current_dir(path)
+            .output()
+            .map_err(|e| homeboy::Error::git_command_failed(format!("git config: {e}")))?;
+        if !config.status.success() {
+            let stderr = String::from_utf8_lossy(&config.stderr);
+            return Err(homeboy::Error::git_command_failed(format!(
+                "git config {key} failed: {stderr}"
+            )));
+        }
+    }
+
+    // Build commit message
+    let message = build_autofix_commit_message(sources);
+
+    // Commit with explicit author to match the configured identity
+    let author = format!("{name} <{email}>");
+    let commit = Command::new("git")
+        .args(["commit", "-m", &message, "--author", &author])
+        .current_dir(path)
+        .output()
+        .map_err(|e| homeboy::Error::git_command_failed(format!("git commit: {e}")))?;
+    if !commit.status.success() {
+        let stderr = String::from_utf8_lossy(&commit.stderr);
+        return Err(homeboy::Error::git_command_failed(format!(
+            "git commit failed: {stderr}"
+        )));
+    }
+
+    eprintln!(
+        "[refactor] Committed autofix: {} files changed",
+        sources.files_modified
+    );
+    Ok(())
+}
+
+/// Resolve git identity from the --git-identity flag.
+/// "bot" → default CI bot. "Name <email>" → parsed. None → default bot.
+fn resolve_git_identity(identity: Option<&str>) -> (String, String) {
+    match identity {
+        None | Some("bot") => (BOT_NAME.to_string(), BOT_EMAIL.to_string()),
+        Some(custom) => {
+            // Parse "Name <email>" format
+            if let Some(angle_start) = custom.find('<') {
+                let name = custom[..angle_start].trim().to_string();
+                let email = custom[angle_start + 1..]
+                    .trim_end_matches('>')
+                    .trim()
+                    .to_string();
+                if !name.is_empty() && !email.is_empty() {
+                    return (name, email);
+                }
+            }
+            // Fallback: use the whole string as name, bot email
+            (custom.to_string(), BOT_EMAIL.to_string())
+        }
+    }
+}
+
+/// Build a structured commit message from refactor results.
+///
+/// Format matches the homeboy-action convention:
+/// ```text
+/// chore(ci): homeboy autofix — refactor (5 files, 12 fixes)
+///
+/// Unused imports removed: 5 fixes (3 files)
+/// Dead code removed: 4 fixes (2 files)
+/// ...
+/// ```
+fn build_autofix_commit_message(sources: &homeboy::refactor::plan::RefactorSourceRun) -> String {
+    let source_labels: Vec<&str> = sources.sources.iter().map(|s| s.as_str()).collect();
+    let source_desc = source_labels.join(", ");
+
+    let total_fixes = sources
+        .fix_summary
+        .as_ref()
+        .map(|s| s.fixes_applied)
+        .unwrap_or(0);
+
+    // Subject line
+    let subject = if total_fixes > 0 {
+        format!(
+            "{AUTOFIX_PREFIX} — {source_desc} ({} files, {total_fixes} fixes)",
+            sources.files_modified
+        )
+    } else {
+        format!(
+            "{AUTOFIX_PREFIX} — {source_desc} ({} files)",
+            sources.files_modified
+        )
+    };
+
+    // Body: per-rule breakdown from fix_summary
+    let mut body_lines = Vec::new();
+    if let Some(ref summary) = sources.fix_summary {
+        for rule in &summary.rules {
+            body_lines.push(format!("{}: {} fixes", rule.rule, rule.count));
+        }
+    }
+
+    // Fall back to changed file list if no rule breakdown
+    if body_lines.is_empty() {
+        for file in &sources.changed_files {
+            body_lines.push(file.clone());
+        }
+    }
+
+    if body_lines.is_empty() {
+        subject
+    } else {
+        format!("{subject}\n\n{}", body_lines.join("\n"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1569,5 +1754,33 @@ mod tests {
         let targets = args.resolve_targets().unwrap();
         let labels: Vec<_> = targets.into_iter().map(|target| target.label).collect();
         assert_eq!(labels, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn resolve_git_identity_bot_shorthand() {
+        let (name, email) = resolve_git_identity(Some("bot"));
+        assert_eq!(name, BOT_NAME);
+        assert_eq!(email, BOT_EMAIL);
+    }
+
+    #[test]
+    fn resolve_git_identity_none_defaults_to_bot() {
+        let (name, email) = resolve_git_identity(None);
+        assert_eq!(name, BOT_NAME);
+        assert_eq!(email, BOT_EMAIL);
+    }
+
+    #[test]
+    fn resolve_git_identity_custom_parsed() {
+        let (name, email) = resolve_git_identity(Some("My Bot <my-bot@example.com>"));
+        assert_eq!(name, "My Bot");
+        assert_eq!(email, "my-bot@example.com");
+    }
+
+    #[test]
+    fn resolve_git_identity_name_only_uses_bot_email() {
+        let (name, email) = resolve_git_identity(Some("Just A Name"));
+        assert_eq!(name, "Just A Name");
+        assert_eq!(email, BOT_EMAIL);
     }
 }


### PR DESCRIPTION
## Summary

Moves the fix → stage → commit atom from the homeboy-action's 373-line shell script into homeboy core. The action's autofix script can now delegate the commit to homeboy instead of reimplementing git add, identity config, and commit message building in bash.

Closes #1071

## New Flags

```bash
# Apply fixes, stage, and commit with default bot identity
homeboy refactor my-component --from all --write --commit

# Custom git identity
homeboy refactor my-component --from all --write --commit --git-identity "My Bot <bot@example.com>"

# Explicit "bot" shorthand (same as default)
homeboy refactor my-component --from all --write --commit --git-identity bot
```

## Commit Message Format

Matches the existing homeboy-action convention:

```
chore(ci): homeboy autofix — audit, lint, test (5 files, 12 fixes)

unused_parameter: 5 fixes
dead_code: 4 fixes
orphaned_test: 3 fixes
```

## What This Replaces in the Action

From `apply-autofix-commit.sh`:
- `stage_autofix_changes()` — `git add -A` + `git diff --cached --quiet`
- `commit_autofix_changes()` — git identity config, commit message building, `git commit`
- `build_autofix_commit_message()` — subject + body construction
- `extract_fix_details_from_output()` — jq-based category extraction

## What Stays in the Action

- Push with authentication (`git push` with GitHub App token)
- Push retry loop with conflict resolution
- Bot loop guards (HEAD author check, commit cap, revert detection)
- PR state checks (`pr_is_active()`)
- Baseline-only commit logic

These are all GitHub-specific or orchestration concerns.

## Tests

- 4 new tests for `resolve_git_identity` (bot, none, custom, name-only)
- All existing refactor tests pass
- Compiles clean (only pre-existing warnings)