### PR TITLE
feat(release): add --git-identity flag for CI bot commits

### DIFF
--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -57,6 +57,12 @@ pub struct ReleaseArgs {
     /// Use when CI handles publishing after the tag is pushed.
     #[arg(long)]
     skip_publish: bool,
+
+    /// Git identity for release commits and tags.
+    /// Use "bot" for the default CI bot identity, or "Name <email>" for custom.
+    /// When set, configures git user.name and user.email before committing.
+    #[arg(long)]
+    git_identity: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -106,6 +112,7 @@ impl ReleaseArgs {
             bump,
             major,
             skip_publish,
+            git_identity: None,
         }
     }
 }
@@ -132,6 +139,7 @@ pub fn run(
             skip_checks: args.skip_checks,
             bump_override: bump_override.clone(),
             skip_publish: args.skip_publish,
+            git_identity: args.git_identity.clone(),
         })?;
 
         return Ok((
@@ -167,6 +175,7 @@ pub fn run(
         skip_checks: args.skip_checks,
         bump_override,
         skip_publish: args.skip_publish,
+        git_identity: args.git_identity.clone(),
     };
 
     let batch_result = release::run_batch(&component_ids, &input_template);

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -59,7 +59,10 @@ pub fn parse_git_identity(identity: Option<&str>) -> GitIdentity {
 
 /// Configure git user.name and user.email in a repository.
 pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::Result<()> {
-    for (key, value) in [("user.name", identity.name.as_str()), ("user.email", identity.email.as_str())] {
+    for (key, value) in [
+        ("user.name", identity.name.as_str()),
+        ("user.email", identity.email.as_str()),
+    ] {
         let output = execute_git(path, &["config", key, value])
             .map_err(|e| Error::git_command_failed(format!("git config {key}: {e}")))?;
         if !output.status.success() {
@@ -70,6 +73,30 @@ pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::R
         }
     }
     Ok(())
+}
+
+fn resolve_target(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+) -> crate::error::Result<(String, String)> {
+    let id = component_id.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "componentId",
+            "Missing componentId",
+            None,
+            Some(vec![
+                "Provide a component ID: homeboy git <command> <component-id>".to_string(),
+                "List available components: homeboy component list".to_string(),
+            ]),
+        )
+    })?;
+    let path = if let Some(p) = path_override {
+        p.to_string()
+    } else {
+        let comp = crate::component::resolve_effective(Some(id), None, None)?;
+        comp.local_path
+    };
+    Ok((id.to_string(), path))
 }
 
 #[cfg(test)]
@@ -103,28 +130,4 @@ mod identity_tests {
         assert_eq!(id.name, "My Service");
         assert_eq!(id.email, BOT_EMAIL);
     }
-}
-
-fn resolve_target(
-    component_id: Option<&str>,
-    path_override: Option<&str>,
-) -> crate::error::Result<(String, String)> {
-    let id = component_id.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "componentId",
-            "Missing componentId",
-            None,
-            Some(vec![
-                "Provide a component ID: homeboy git <command> <component-id>".to_string(),
-                "List available components: homeboy component list".to_string(),
-            ]),
-        )
-    })?;
-    let path = if let Some(p) = path_override {
-        p.to_string()
-    } else {
-        let comp = crate::component::resolve_effective(Some(id), None, None)?;
-        comp.local_path
-    };
-    Ok((id.to_string(), path))
 }

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -16,6 +16,95 @@ fn execute_git(path: &str, args: &[&str]) -> std::io::Result<std::process::Outpu
     Command::new("git").args(args).current_dir(path).output()
 }
 
+/// Well-known bot identity for CI commits.
+pub const BOT_NAME: &str = "homeboy-ci[bot]";
+/// Well-known bot email for CI commits (GitHub noreply address).
+pub const BOT_EMAIL: &str = "266378653+homeboy-ci[bot]@users.noreply.github.com";
+
+/// Parsed git identity (name + email).
+pub struct GitIdentity {
+    pub name: String,
+    pub email: String,
+}
+
+/// Parse a `--git-identity` value into name + email.
+///
+/// - `None` or `"bot"` → default CI bot identity
+/// - `"Name <email>"` → parsed
+/// - `"Name"` → name with bot email
+pub fn parse_git_identity(identity: Option<&str>) -> GitIdentity {
+    match identity {
+        None | Some("bot") => GitIdentity {
+            name: BOT_NAME.to_string(),
+            email: BOT_EMAIL.to_string(),
+        },
+        Some(custom) => {
+            if let Some(angle_start) = custom.find('<') {
+                let name = custom[..angle_start].trim().to_string();
+                let email = custom[angle_start + 1..]
+                    .trim_end_matches('>')
+                    .trim()
+                    .to_string();
+                if !name.is_empty() && !email.is_empty() {
+                    return GitIdentity { name, email };
+                }
+            }
+            GitIdentity {
+                name: custom.to_string(),
+                email: BOT_EMAIL.to_string(),
+            }
+        }
+    }
+}
+
+/// Configure git user.name and user.email in a repository.
+pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::Result<()> {
+    for (key, value) in [("user.name", identity.name.as_str()), ("user.email", identity.email.as_str())] {
+        let output = execute_git(path, &["config", key, value])
+            .map_err(|e| Error::git_command_failed(format!("git config {key}: {e}")))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::git_command_failed(format!(
+                "git config {key} failed: {stderr}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod identity_tests {
+    use super::*;
+
+    #[test]
+    fn bot_shorthand() {
+        let id = parse_git_identity(Some("bot"));
+        assert_eq!(id.name, BOT_NAME);
+        assert_eq!(id.email, BOT_EMAIL);
+    }
+
+    #[test]
+    fn none_defaults_to_bot() {
+        let id = parse_git_identity(None);
+        assert_eq!(id.name, BOT_NAME);
+        assert_eq!(id.email, BOT_EMAIL);
+    }
+
+    #[test]
+    fn custom_name_and_email() {
+        let id = parse_git_identity(Some("Deploy Bot <deploy@example.com>"));
+        assert_eq!(id.name, "Deploy Bot");
+        assert_eq!(id.email, "deploy@example.com");
+    }
+
+    #[test]
+    fn name_only_uses_bot_email() {
+        let id = parse_git_identity(Some("My Service"));
+        assert_eq!(id.name, "My Service");
+        assert_eq!(id.email, BOT_EMAIL);
+    }
+}
+
 fn resolve_target(
     component_id: Option<&str>,
     path_override: Option<&str>,

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -177,6 +177,9 @@ pub struct ReleaseCommandInput {
     pub bump_override: Option<String>,
     #[serde(default)]
     pub skip_publish: bool,
+    /// Git identity for release commits: "bot", "Name <email>", or None (use existing config).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_identity: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -26,6 +26,18 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
 
     if !input.dry_run {
         ensure_release_on_default_branch(&component.local_path)?;
+
+        // Configure git identity for release commits/tags
+        if let Some(ref identity_str) = input.git_identity {
+            let identity = git::parse_git_identity(Some(identity_str));
+            git::configure_identity(&component.local_path, &identity)?;
+            log_status!(
+                "release",
+                "Git identity: {} <{}>",
+                identity.name,
+                identity.email
+            );
+        }
     }
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
@@ -552,6 +564,13 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             ..Default::default()
         },
     )?;
+
+    // Configure git identity for recovery commits/tags
+    if let Some(ref identity_str) = input.git_identity {
+        let identity = git::parse_git_identity(Some(identity_str));
+        git::configure_identity(&component.local_path, &identity)?;
+    }
+
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
     let version_info = crate::version::read_component_version(&component)?;
     let current_version = &version_info.version;
@@ -678,6 +697,7 @@ pub fn run_batch(
             skip_checks: input_template.skip_checks,
             bump_override: input_template.bump_override.clone(),
             skip_publish: input_template.skip_publish,
+            git_identity: input_template.git_identity.clone(),
         };
 
         match run_command(input) {


### PR DESCRIPTION
## Summary

Adds `--git-identity` to `homeboy release` so CI doesn't need to configure git identity externally. The action's release wrapper currently has 8 lines of git config + env vars for this.

Closes #1073

## Usage

```bash
# Default CI bot identity
homeboy release my-component --git-identity bot

# Custom identity
homeboy release my-component --git-identity "Deploy Bot <deploy@example.com>"

# Use existing git config (omit flag)
homeboy release my-component
```

## What changed

### `src/core/git/mod.rs` (+89 lines)
- `parse_git_identity()` — shared parser: "bot" → default, "Name <email>" → parsed, name-only → bot email
- `configure_identity()` — runs `git config user.name` + `user.email`
- `BOT_NAME` / `BOT_EMAIL` constants
- 4 unit tests

### `src/commands/release.rs` (+9 lines)
- New `--git-identity` flag on `ReleaseArgs`
- Wired through to `ReleaseCommandInput`

### `src/core/release/types.rs` (+3 lines)
- `git_identity: Option<String>` field on `ReleaseCommandInput`

### `src/core/release/workflow.rs` (+20 lines)
- Calls `configure_identity()` before release commits in both `run_command` and `run_recover`
- Logs the identity being used

## What this replaces in the action

From `run-release.sh` lines 158-165:
```bash
BOT_NAME="homeboy-ci[bot]"
BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
git config user.name "${BOT_NAME}"
git config user.email "${BOT_EMAIL}"
export GIT_AUTHOR_NAME="${BOT_NAME}"
export GIT_AUTHOR_EMAIL="${BOT_EMAIL}"
export GIT_COMMITTER_NAME="${BOT_NAME}"
export GIT_COMMITTER_EMAIL="${BOT_EMAIL}"
```

Becomes:
```bash
homeboy release "${COMP_ID}" --git-identity bot --skip-checks --skip-publish --path "${WORKSPACE}"
```

The shared `git::parse_git_identity()` and `git::configure_identity()` functions will also be used by `refactor --commit` (PR #1076) once it merges.