### PR TITLE
fix: CSS in rename, stale deploy, release --deploy skip

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -115,8 +115,8 @@ pub(super) fn deploy_components(
         Vec::new()
     };
 
-    // Warn about HEAD-vs-tag gap before the tag checkout.
-    // Skip warning for components that will reuse their build artifact.
+    // Check for HEAD-vs-tag gap before the tag checkout.
+    // Skip check for components that will reuse their build artifact.
     if !config.head && !config.skip_build {
         let non_reuse: Vec<_> = components
             .iter()
@@ -124,7 +124,7 @@ pub(super) fn deploy_components(
             .cloned()
             .collect();
         if !non_reuse.is_empty() {
-            warn_unreleased_commits(&non_reuse, config);
+            check_unreleased_commits(&non_reuse, config)?;
         }
     }
 
@@ -523,34 +523,55 @@ fn restore_branches(checkouts: &[TagCheckout]) {
     }
 }
 
-/// Warn about unreleased commits ahead of the latest tag.
+/// Check for unreleased commits ahead of the latest tag.
 ///
 /// Checks each component for commits between the latest tag and HEAD.
-/// When found, logs a warning with the commit count and subjects so
-/// the user knows their recent work won't be in this deploy.
-fn warn_unreleased_commits(components: &[Component], config: &DeployConfig) {
-    let mut any_gap = false;
+/// When found and `--force` is not set, returns an error to prevent
+/// silently deploying stale code. Use `deploy --head` to deploy
+/// unreleased commits, or `homeboy release` to tag them first.
+fn check_unreleased_commits(
+    components: &[Component],
+    config: &DeployConfig,
+) -> crate::Result<()> {
+    let mut gaps = Vec::new();
 
     for component in components {
         if let Some(gap) = super::provenance::detect_tag_gap(component) {
             super::provenance::warn_tag_gap(&component.id, &gap, "deploy");
-            any_gap = true;
+            gaps.push((component.id.clone(), gap));
         }
     }
 
-    if any_gap {
-        if config.force {
-            log_status!(
-                "deploy",
-                "Deploying from tagged releases. Use `deploy --head` to include unreleased commits, or `homeboy release` to tag them."
-            );
-        } else {
-            log_status!(
-                "deploy",
-                "Deploy will use tagged releases (not HEAD). Use `deploy --head` to include unreleased commits, or `homeboy release` to tag them."
-            );
-        }
+    if gaps.is_empty() {
+        return Ok(());
     }
+
+    if config.force {
+        log_status!(
+            "deploy",
+            "Deploying from tagged releases (--force). Use `deploy --head` to include unreleased commits, or `homeboy release` to tag them."
+        );
+        return Ok(());
+    }
+
+    let component_list: Vec<String> = gaps
+        .iter()
+        .map(|(id, gap)| format!("{} ({} commits ahead of {})", id, gap.ahead, gap.tag))
+        .collect();
+
+    Err(crate::Error::validation_invalid_argument(
+        "deploy",
+        format!(
+            "Refusing to deploy: HEAD has unreleased commits for: {}",
+            component_list.join(", ")
+        ),
+        None,
+        Some(vec![
+            "Run `homeboy release` to tag the commits first".to_string(),
+            "Use `deploy --head` to deploy unreleased commits directly".to_string(),
+            "Use `deploy --force` to deploy the stale tag anyway".to_string(),
+        ]),
+    ))
 }
 
 /// Detect components with reusable build artifacts.

--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -182,28 +182,30 @@ pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
 }
 
 /// Log a warning about the HEAD-vs-tag gap for a component.
-/// Used by both `build` and `deploy` commands.
+/// Format a tag gap as a human-readable warning string.
 ///
-/// Uses `eprintln` directly because `log_status!` requires literal prefixes
-/// and this function accepts a runtime `context` parameter.
-pub fn warn_tag_gap(component_id: &str, gap: &TagGap, context: &str) {
-    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-        return;
-    }
-    eprintln!(
-        "[{}] ⚠️  '{}': HEAD is {} commit(s) ahead of latest tag {}",
+/// Used by both `build` and `deploy` commands.
+pub fn format_tag_gap(component_id: &str, gap: &TagGap, context: &str) -> String {
+    let mut lines = vec![format!(
+        "[{}] '{}': HEAD is {} commit(s) ahead of latest tag {}",
         context, component_id, gap.ahead, gap.tag
-    );
+    )];
     for commit in &gap.commits {
-        eprintln!("[{}]      {}", context, commit);
+        lines.push(format!("[{}]      {}", context, commit));
     }
     if gap.ahead > 10 {
-        eprintln!(
+        lines.push(format!(
             "[{}]      ... and {} more",
             context,
             gap.ahead - gap.commits.len() as u32
-        );
+        ));
     }
+    lines.join("\n")
+}
+
+/// Print a tag gap warning to stderr. Always prints regardless of TTY.
+pub fn warn_tag_gap(component_id: &str, gap: &TagGap, context: &str) {
+    eprintln!("{}", format_tag_gap(component_id, gap, context));
 }
 
 #[cfg(test)]

--- a/src/core/engine/codebase_scan.rs
+++ b/src/core/engine/codebase_scan.rs
@@ -29,6 +29,7 @@ pub const ROOT_ONLY_SKIP_DIRS: &[&str] = &["build", "dist", "target", "cache", "
 pub const SOURCE_EXTENSIONS: &[&str] = &[
     "rs", "php", "js", "jsx", "ts", "tsx", "mjs", "json", "toml", "yaml", "yml", "md", "txt", "sh",
     "bash", "py", "rb", "go", "swift", "kt", "java", "c", "cpp", "h", "lock",
+    "css", "scss", "sass", "less", "html", "vue", "svelte",
 ];
 
 // ============================================================================

--- a/src/core/refactor/rename/mod.rs
+++ b/src/core/refactor/rename/mod.rs
@@ -620,7 +620,16 @@ pub fn find_references_with_targeting(
     root: &Path,
     targeting: &RenameTargeting,
 ) -> Vec<Reference> {
-    let config = scan_config_for_scope(&spec.scope);
+    // When --files globs are provided, bypass the default extension filter
+    // so any file type can be targeted explicitly.
+    let config = if !targeting.include_globs.is_empty() {
+        ScanConfig {
+            extensions: ExtensionFilter::All,
+            ..ScanConfig::default()
+        }
+    } else {
+        scan_config_for_scope(&spec.scope)
+    };
     let files = target_files(codebase_scan::walk_files(root, &config), root, targeting);
 
     // Build the working variant list — may be extended by discovery

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -885,11 +885,12 @@ fn build_release_steps(
         missing: vec![],
     });
 
+    let mut publish_step_ids: Vec<String> = Vec::new();
+
     if !publish_targets.is_empty() && !options.skip_publish {
         // 6. Publish steps (all run independently after git.push)
         // Package already ran before tagging; publish needs the push to have
         // completed (e.g., crates.io/Homebrew need the tag on the remote).
-        let mut publish_step_ids: Vec<String> = Vec::new();
         for target in &publish_targets {
             let step_id = format!("publish.{}", target);
             let step_type = format!("publish.{}", target);
@@ -915,7 +916,7 @@ fn build_release_steps(
                 id: "cleanup".to_string(),
                 step_type: "cleanup".to_string(),
                 label: Some("Clean up release artifacts".to_string()),
-                needs: publish_step_ids,
+                needs: publish_step_ids.clone(),
                 config: std::collections::HashMap::new(),
                 status: ReleasePlanStatus::Ready,
                 missing: vec![],
@@ -933,7 +934,14 @@ fn build_release_steps(
         crate::engine::hooks::resolve_hooks(component, crate::engine::hooks::events::POST_RELEASE);
     if !post_release_hooks.is_empty() {
         let post_release_needs = if !options.skip_publish && !publish_targets.is_empty() {
-            vec!["cleanup".to_string()]
+            if options.deploy {
+                // When --deploy is set, cleanup was removed from the pipeline
+                // (deploy needs the build artifact). Depend on the last publish
+                // steps directly.
+                publish_step_ids.clone()
+            } else {
+                vec!["cleanup".to_string()]
+            }
         } else {
             vec!["git.push".to_string()]
         };


### PR DESCRIPTION
## Summary

Three bug fixes in one PR. All are user-reported regressions.

## 1. refactor rename skips .css files (#1080)

**Root cause:** `SOURCE_EXTENSIONS` in `codebase_scan.rs` didn't include CSS or other styling/template extensions. The `--files` glob couldn't recover them because it narrowed the already-filtered file list instead of replacing the filter.

**Fix:**
- Added `css`, `scss`, `sass`, `less`, `html`, `vue`, `svelte` to `SOURCE_EXTENSIONS`
- When `--files` globs are provided, the extension filter is bypassed entirely (`ExtensionFilter::All`) so any file type can be explicitly targeted

## 2. deploy silently deploys stale tag (#1069)

**Root cause:** `warn_tag_gap()` had a TTY gate (`IsTerminal::is_terminal(&stderr)`) that silently suppressed the warning in CI, piped output, or any non-interactive context. The deploy proceeded to check out and deploy a stale tag with no indication.

**Fix:**
- Removed the TTY gate — warnings always print
- Changed from warning to **error**: deploy now refuses when HEAD has unreleased commits
- Three escape hatches: `--head` (deploy HEAD), `--force` (deploy stale tag anyway), or `homeboy release` (tag the commits first)

## 3. release --deploy silently skips deploy (#1070)

**Root cause:** When `--deploy` is set, the pipeline removes the `cleanup` step (deploy needs the build artifact). But `post_release` hooks still declared a dependency on `cleanup`, causing a pipeline validation error. The error propagated as a cryptic failure, not as "deploy was skipped."

**Fix:**
- Hoisted `publish_step_ids` to outer scope
- When `--deploy` removes cleanup, `post_release` depends on the publish steps directly instead of the missing cleanup step

## Files changed (5)

| File | Lines | What |
|---|---|---|
| `src/core/engine/codebase_scan.rs` | +1 | Added CSS/styling extensions |
| `src/core/refactor/rename/mod.rs` | +11 -1 | Bypass extension filter when --files is set |
| `src/core/deploy/provenance.rs` | +15 -13 | Remove TTY gate, extract format helper |
| `src/core/deploy/orchestration.rs` | +40 -23 | Error on stale tag instead of warning |
| `src/core/release/pipeline.rs` | +12 -2 | Fix post_release dependency when --deploy removes cleanup |

Closes #1080, #1069, #1070