### PR TITLE
fix: auto-detect deploy ownership from parent directory instead of target

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -529,10 +529,7 @@ fn restore_branches(checkouts: &[TagCheckout]) {
 /// When found and `--force` is not set, returns an error to prevent
 /// silently deploying stale code. Use `deploy --head` to deploy
 /// unreleased commits, or `homeboy release` to tag them first.
-fn check_unreleased_commits(
-    components: &[Component],
-    config: &DeployConfig,
-) -> crate::Result<()> {
+fn check_unreleased_commits(components: &[Component], config: &DeployConfig) -> crate::Result<()> {
     let mut gaps = Vec::new();
 
     for component in components {

--- a/src/core/deploy/permissions.rs
+++ b/src/core/deploy/permissions.rs
@@ -68,7 +68,7 @@ pub(crate) fn fix_deployed_permissions(
 }
 
 /// Fix ownership of deployed files via chown.
-/// Uses configured remote_owner if provided, otherwise auto-detects from existing ownership.
+/// Uses configured remote_owner if provided, otherwise auto-detects from the parent directory.
 fn fix_deployed_ownership(
     ssh_client: &SshClient,
     remote_path: &str,
@@ -78,22 +78,46 @@ fn fix_deployed_ownership(
     let owner = if let Some(configured) = remote_owner {
         configured.to_string()
     } else {
-        // Auto-detect: stat the remote_path to get current owner:group
-        let stat_cmd = format!("stat -c '%U:%G' {} 2>/dev/null", quoted_path);
+        // Auto-detect ownership from the PARENT directory, not the target itself.
+        // After deployment, the target dir is owned by whoever ran the deploy (usually root).
+        // The parent directory (e.g. wp-content/plugins/) retains the correct web server
+        // ownership (e.g. www-data:www-data) and is the reliable source of truth.
+        let parent_path = remote_path
+            .trim_end_matches('/')
+            .rsplit_once('/')
+            .map(|(parent, _)| parent)
+            .unwrap_or(remote_path);
+        let quoted_parent = shell::quote_path(parent_path);
+        let stat_cmd = format!(
+            "stat -c '%U:%G' {} 2>/dev/null || stat -f '%Su:%Sg' {} 2>/dev/null",
+            quoted_parent, quoted_parent
+        );
         let stat_output = ssh_client.execute(&stat_cmd);
         if !stat_output.success || stat_output.stdout.trim().is_empty() {
             log_status!(
                 "deploy",
-                "Could not detect ownership of {}, skipping chown",
-                remote_path
+                "Could not detect ownership of parent {}, skipping chown",
+                parent_path
             );
             return;
         }
         let detected = stat_output.stdout.trim().to_string();
-        // Skip chown if already root:root (no point changing to same)
+        // If the parent is root:root, there's nothing meaningful to inherit —
+        // the web server ownership is unknown, so skip chown.
         if detected == "root:root" {
+            log_status!(
+                "deploy",
+                "Parent directory {} is root:root — set remote_owner on the component to fix ownership",
+                parent_path
+            );
             return;
         }
+        log_status!(
+            "deploy",
+            "Auto-detected ownership {} from parent {}",
+            detected,
+            parent_path
+        );
         detected
     };
 

--- a/src/core/engine/codebase_scan.rs
+++ b/src/core/engine/codebase_scan.rs
@@ -28,8 +28,8 @@ pub const ROOT_ONLY_SKIP_DIRS: &[&str] = &["build", "dist", "target", "cache", "
 /// Common source file extensions across languages.
 pub const SOURCE_EXTENSIONS: &[&str] = &[
     "rs", "php", "js", "jsx", "ts", "tsx", "mjs", "json", "toml", "yaml", "yml", "md", "txt", "sh",
-    "bash", "py", "rb", "go", "swift", "kt", "java", "c", "cpp", "h", "lock",
-    "css", "scss", "sass", "less", "html", "vue", "svelte",
+    "bash", "py", "rb", "go", "swift", "kt", "java", "c", "cpp", "h", "lock", "css", "scss",
+    "sass", "less", "html", "vue", "svelte",
 ];
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Fix ownership auto-detection** to stat the parent directory (e.g. `wp-content/plugins/`) instead of the target directory itself
- After deployment as root, the target dir is `root:root` — the old logic saw that and silently skipped chown, leaving files inaccessible to the web server
- Add macOS `stat -f` fallback for cross-platform support
- When parent is also `root:root`, log an actionable message telling the user to set `remote_owner` on the component

## Before

```
deploy → stat target (root:root) → "already root:root, skip chown" → files stay root:root ❌
```

## After

```
deploy → stat parent (www-data:www-data) → chown -R www-data:www-data target → ✅
```

Fixes #1086