### PR TITLE
feat: homeboy upgrade now updates all extensions including linked ones

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -56,7 +56,8 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         })
         .transpose()?;
 
-    let result = upgrade::run_upgrade_with_method(args.force, method_override, args.skip_extensions)?;
+    let result =
+        upgrade::run_upgrade_with_method(args.force, method_override, args.skip_extensions)?;
     let json = serde_json::to_value(&result)
         .map_err(|e| homeboy::Error::internal_json(e.to_string(), None))?;
 

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -19,6 +19,10 @@ pub struct UpgradeArgs {
     #[arg(long)]
     pub no_restart: bool,
 
+    /// Skip extension updates (only upgrade the binary)
+    #[arg(long)]
+    pub skip_extensions: bool,
+
     /// Override install method detection (homebrew|cargo|source|binary)
     #[arg(long)]
     pub method: Option<String>,
@@ -52,7 +56,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         })
         .transpose()?;
 
-    let result = upgrade::run_upgrade_with_method(args.force, method_override)?;
+    let result = upgrade::run_upgrade_with_method(args.force, method_override, args.skip_extensions)?;
     let json = serde_json::to_value(&result)
         .map_err(|e| homeboy::Error::internal_json(e.to_string(), None))?;
 

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -529,10 +529,7 @@ fn restore_branches(checkouts: &[TagCheckout]) {
 /// When found and `--force` is not set, returns an error to prevent
 /// silently deploying stale code. Use `deploy --head` to deploy
 /// unreleased commits, or `homeboy release` to tag them first.
-fn check_unreleased_commits(
-    components: &[Component],
-    config: &DeployConfig,
-) -> crate::Result<()> {
+fn check_unreleased_commits(components: &[Component], config: &DeployConfig) -> crate::Result<()> {
     let mut gaps = Vec::new();
 
     for component in components {

--- a/src/core/engine/codebase_scan.rs
+++ b/src/core/engine/codebase_scan.rs
@@ -28,8 +28,8 @@ pub const ROOT_ONLY_SKIP_DIRS: &[&str] = &["build", "dist", "target", "cache", "
 /// Common source file extensions across languages.
 pub const SOURCE_EXTENSIONS: &[&str] = &[
     "rs", "php", "js", "jsx", "ts", "tsx", "mjs", "json", "toml", "yaml", "yml", "md", "txt", "sh",
-    "bash", "py", "rb", "go", "swift", "kt", "java", "c", "cpp", "h", "lock",
-    "css", "scss", "sass", "less", "html", "vue", "svelte",
+    "bash", "py", "rb", "go", "swift", "kt", "java", "c", "cpp", "h", "lock", "css", "scss",
+    "sass", "less", "html", "vue", "svelte",
 ];
 
 // ============================================================================

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -521,14 +521,7 @@ fn update_linked_extension(
 /// Checks `refs/remotes/origin/HEAD` first, then tries `main` and `master`.
 fn detect_default_branch(repo_dir: &Path) -> Option<String> {
     // Try symbolic-ref first (most reliable)
-    let output = Command::new("git")
-        .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
-        .current_dir(repo_dir)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-
+    let output = git_silent(repo_dir, &["symbolic-ref", "refs/remotes/origin/HEAD"])?;
     if output.status.success() {
         let refname = String::from_utf8_lossy(&output.stdout).trim().to_string();
         // refs/remotes/origin/main → main
@@ -537,19 +530,24 @@ fn detect_default_branch(repo_dir: &Path) -> Option<String> {
 
     // Fallback: check if main or master exist as local branches
     for branch in &["main", "master"] {
-        let check = Command::new("git")
-            .args(["rev-parse", "--verify", branch])
-            .current_dir(repo_dir)
-            .stdin(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .output()
-            .ok()?;
+        let check = git_silent(repo_dir, &["rev-parse", "--verify", branch])?;
         if check.status.success() {
             return Some(branch.to_string());
         }
     }
 
     None
+}
+
+/// Run a git command silently (no stdin/stderr) and return the output.
+fn git_silent(dir: &Path, args: &[&str]) -> Option<std::process::Output> {
+    Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()
 }
 
 /// Uninstall a extension. Automatically detects symlinks vs cloned directories.

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -379,17 +379,11 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
         return Err(Error::extension_not_found(extension_id.to_string(), vec![]));
     }
 
-    // Linked extensions are managed externally
+    // Linked extensions: resolve the symlink target and pull the source repo.
+    // The target may be a subdirectory of a larger repo (e.g. homeboy-extensions/wordpress),
+    // so we find the git root and pull from there.
     if is_extension_linked(extension_id) {
-        return Err(Error::validation_invalid_argument(
-            "extension_id",
-            format!(
-                "Extension '{}' is linked. Update the source directory directly.",
-                extension_id
-            ),
-            Some(extension_id.to_string()),
-            None,
-        ));
+        return update_linked_extension(extension_id, &extension_dir, force);
     }
 
     if !force && !is_workdir_clean(&extension_dir) {
@@ -438,6 +432,124 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
         url: source_url,
         path: extension_dir,
     })
+}
+
+/// Update a linked extension by pulling the source repository.
+///
+/// Linked extensions are symlinks pointing to a source directory, which may be
+/// a subdirectory of a monorepo (e.g. `homeboy-extensions/wordpress`). This
+/// function resolves the git root, checks out the default branch, and pulls.
+fn update_linked_extension(
+    extension_id: &str,
+    extension_dir: &Path,
+    force: bool,
+) -> Result<UpdateResult> {
+    // Resolve symlink to actual source directory
+    let source_dir = std::fs::read_link(extension_dir).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read symlink for {}", extension_id)),
+        )
+    })?;
+
+    // Find the git root (source may be a subdirectory of a larger repo)
+    let git_root_str = git::get_git_root(&source_dir.to_string_lossy())?;
+    let git_root = PathBuf::from(&git_root_str);
+
+    if !force && !is_workdir_clean(&git_root) {
+        return Err(Error::validation_invalid_argument(
+            "extension_id",
+            format!(
+                "Linked extension '{}' source repo has uncommitted changes. Use --force to proceed.",
+                extension_id,
+            ),
+            Some(extension_id.to_string()),
+            None,
+        ));
+    }
+
+    // Checkout the default branch before pulling.
+    // Try main first, fall back to master.
+    let default_branch = detect_default_branch(&git_root).unwrap_or_else(|| "main".to_string());
+    let checkout_output = Command::new("git")
+        .args(["checkout", &default_branch])
+        .current_dir(&git_root)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .output();
+
+    if let Ok(output) = &checkout_output {
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            log_status!(
+                "extension",
+                "Warning: could not checkout {} for {}: {}",
+                default_branch,
+                extension_id,
+                stderr.trim()
+            );
+            // Continue anyway — pull on current branch is better than nothing
+        }
+    }
+
+    git::pull_repo(&git_root)?;
+
+    // Update .source-revision on the extension symlink target
+    if let Some(rev) = get_short_head_revision(&source_dir) {
+        let _ = std::fs::write(extension_dir.join(".source-revision"), &rev);
+    }
+
+    // Auto-run setup if extension defines a setup_command
+    if let Ok(extension) = load_extension(extension_id) {
+        if extension
+            .runtime()
+            .is_some_and(|r| r.setup_command.is_some())
+        {
+            let _ = run_setup(extension_id);
+        }
+    }
+
+    let url = format!("linked:{}", source_dir.display());
+    Ok(UpdateResult {
+        extension_id: extension_id.to_string(),
+        url,
+        path: source_dir,
+    })
+}
+
+/// Detect the default branch of a git repository.
+/// Checks `refs/remotes/origin/HEAD` first, then tries `main` and `master`.
+fn detect_default_branch(repo_dir: &Path) -> Option<String> {
+    // Try symbolic-ref first (most reliable)
+    let output = Command::new("git")
+        .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
+        .current_dir(repo_dir)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let refname = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        // refs/remotes/origin/main → main
+        return refname.rsplit('/').next().map(|s| s.to_string());
+    }
+
+    // Fallback: check if main or master exist as local branches
+    for branch in &["main", "master"] {
+        let check = Command::new("git")
+            .args(["rev-parse", "--verify", branch])
+            .current_dir(repo_dir)
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
+        if check.status.success() {
+            return Some(branch.to_string());
+        }
+    }
+
+    None
 }
 
 /// Uninstall a extension. Automatically detects symlinks vs cloned directories.

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -145,6 +145,7 @@ pub(crate) fn version_is_newer(latest: &str, current: &str) -> bool {
 pub fn run_upgrade_with_method(
     force: bool,
     method_override: Option<InstallMethod>,
+    skip_extensions: bool,
 ) -> Result<UpgradeResult> {
     let install_method = method_override.unwrap_or_else(detect_install_method);
     let previous_version = current_version().to_string();
@@ -165,8 +166,13 @@ pub fn run_upgrade_with_method(
     if !force {
         let check = check_for_updates()?;
         if !check.update_available {
-            // Even when no binary update is needed, still run config migrations
-            // and extension updates — these are independent of the binary version.
+            // Even when no binary update is needed, still run extension updates
+            // and config migrations — these are independent of the binary version.
+            let (extensions_updated, extensions_skipped) = if skip_extensions {
+                (vec![], vec![])
+            } else {
+                update_all_extensions()
+            };
             let projects_migrated = migrate_all_projects();
             return Ok(UpgradeResult {
                 command: "upgrade".to_string(),
@@ -176,8 +182,8 @@ pub fn run_upgrade_with_method(
                 upgraded: false,
                 message: "Already at latest version".to_string(),
                 restart_required: false,
-                extensions_updated: vec![],
-                extensions_skipped: vec![],
+                extensions_updated,
+                extensions_skipped,
                 projects_migrated,
             });
         }
@@ -189,7 +195,7 @@ pub fn run_upgrade_with_method(
     // Auto-update all installed extensions after a successful upgrade.
     // This prevents CI/local extension version drift that causes baseline
     // mismatches and inconsistent audit findings.
-    let (extensions_updated, extensions_skipped) = if success {
+    let (extensions_updated, extensions_skipped) = if success && !skip_extensions {
         update_all_extensions()
     } else {
         (vec![], vec![])
@@ -270,12 +276,6 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
     let mut skipped = Vec::new();
 
     for id in &extension_ids {
-        // Skip linked extensions (they're managed externally)
-        if extension::is_extension_linked(id) {
-            skipped.push(id.clone());
-            continue;
-        }
-
         let old_version = extension::load_extension(id)
             .ok()
             .map(|m| m.version.clone())


### PR DESCRIPTION
## Summary

- **`homeboy upgrade` now updates all extensions** — including linked ones that were previously silently skipped
- **Extensions update even when no binary update is available** — they're independent
- **New `--skip-extensions` flag** for when you only want the binary

## What changed

### `extension update()` handles linked extensions

Linked extensions are symlinks to source directories (often subdirectories of a monorepo like `homeboy-extensions/wordpress`). The update now:
1. Resolves the symlink target
2. Finds the git root (handles monorepo subdirs)
3. Detects and checks out the default branch (`main`/`master`)
4. Pulls latest
5. Updates `.source-revision`

### Extension updates run on every upgrade

Previously, when `homeboy upgrade` found no binary update available, it returned early without touching extensions. Now it always runs `update_all_extensions()`.

### Before/After

```
Before:
  homeboy upgrade → binary only, linked extensions silently skipped
  Result: WordPress extension stuck at v2.9.0 for weeks

After:
  homeboy upgrade → binary + all extensions (linked and installed)
  homeboy upgrade --skip-extensions → binary only
```

## Context

This caused the WordPress extension on chubes.net to stay at v2.9.0 while the repo had v2.10.4 with critical build/deploy fixes (#1085, #1086). The stale extension was only discovered by accident.

Closes #1088