### PR TITLE
feat: make component ID optional for audit/lint/test/refactor/scaffold

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -63,32 +63,37 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
     // Run extension audit reference setup if configured.
     // This resolves framework dependencies (e.g. WordPress core) so their
     // fingerprints are included in cross-reference analysis (dead code detection).
-    run_audit_reference_setup(&args.comp.component);
+    if let Some(ref component_id) = args.comp.component {
+        run_audit_reference_setup(component_id);
+    }
 
-    // Resolve component ID and source path
-    let (resolved_id, resolved_path) = if Path::new(&args.comp.component).is_dir() {
-        // Bare directory path — no registered component
-        let effective = args
-            .comp
-            .path
-            .as_deref()
-            .unwrap_or(&args.comp.component)
-            .to_string();
-        let name = Path::new(&effective)
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-        (name, effective)
+    // Resolve component ID and source path.
+    // When component is omitted, auto-discover from CWD via homeboy.json.
+    let (resolved_id, resolved_path) = if let Some(ref comp_arg) = args.comp.component {
+        if Path::new(comp_arg).is_dir() {
+            // Bare directory path — no registered component
+            let effective = args.comp.path.as_deref().unwrap_or(comp_arg).to_string();
+            let name = Path::new(&effective)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            (name, effective)
+        } else {
+            // Registered component — use unified resolver
+            let ctx = execution_context::resolve(&ResolveOptions::source_only(
+                comp_arg,
+                args.comp.path.clone(),
+            ))?;
+            (
+                ctx.component_id,
+                ctx.source_path.to_string_lossy().to_string(),
+            )
+        }
     } else {
-        // Registered component — use unified resolver
-        let ctx = execution_context::resolve(&ResolveOptions::source_only(
-            &args.comp.component,
-            args.comp.path.clone(),
-        ))?;
-        (
-            ctx.component_id,
-            ctx.source_path.to_string_lossy().to_string(),
-        )
+        // No component specified — auto-discover from CWD
+        let component = args.comp.load()?;
+        let source_path = component.local_path.clone();
+        (component.id, source_path)
     };
 
     let workflow = run_main_audit_workflow(AuditRunWorkflowArgs {
@@ -234,7 +239,7 @@ mod tests {
 
         let args = AuditArgs {
             comp: PositionalComponentArgs {
-                component: root.to_string_lossy().to_string(),
+                component: Some(root.to_string_lossy().to_string()),
                 path: None,
             },
             conventions: false,

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -62,8 +62,11 @@ pub struct LintArgs {
 }
 
 pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput> {
+    // Resolve component ID — auto-discover from CWD if omitted
+    let effective_id = args.comp.resolve_id()?;
+
     let ctx = execution_context::resolve(&ResolveOptions::with_capability(
-        args.comp.id(),
+        &effective_id,
         args.comp.path.clone(),
         ExtensionCapability::Lint,
         args.setting_args.setting.clone(),
@@ -74,7 +77,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         &ctx.component,
         &ctx.source_path,
         LintRunWorkflowArgs {
-            component_label: args.comp.component.clone(),
+            component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
             settings: ctx

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -567,26 +567,33 @@ fn resolve_top_level_targets(
     let flagged_ids = collect_component_ids(component_ids, components);
 
     if let Some(comp) = comp {
-        if !flagged_ids.is_empty() {
-            return Err(homeboy::Error::validation_invalid_argument(
-                "component",
-                "Use either positional component syntax or --component/--components, not both",
-                None,
-                None,
-            ));
-        }
+        if let Some(ref component_id) = comp.component {
+            if !flagged_ids.is_empty() {
+                return Err(homeboy::Error::validation_invalid_argument(
+                    "component",
+                    "Use either positional component syntax or --component/--components, not both",
+                    None,
+                    None,
+                ));
+            }
 
-        return Ok(vec![RefactorTarget {
-            component_id: Some(comp.component.clone()),
-            path: comp.path.clone(),
-            label: comp.component.clone(),
-        }]);
+            return Ok(vec![RefactorTarget {
+                component_id: Some(component_id.clone()),
+                path: comp.path.clone(),
+                label: component_id.clone(),
+            }]);
+        }
+        // Component omitted — fall through to flagged_ids or CWD auto-discovery
     }
 
     if flagged_ids.is_empty() {
-        return Err(homeboy::Error::validation_missing_argument(vec![
-            "component".to_string(),
-        ]));
+        // No component specified anywhere — try CWD auto-discovery
+        let component = homeboy::component::resolution::resolve(None)?;
+        return Ok(vec![RefactorTarget {
+            label: component.id.clone(),
+            component_id: Some(component.id),
+            path: None,
+        }]);
     }
 
     Ok(flagged_ids

--- a/src/commands/scaffold.rs
+++ b/src/commands/scaffold.rs
@@ -41,13 +41,15 @@ pub fn run(args: ScaffoldArgs, _global: &GlobalArgs) -> CmdResult<ScaffoldWorkfl
 }
 
 fn run_test_scaffold(args: TestScaffoldArgs) -> CmdResult<ScaffoldWorkflowOutput> {
+    let effective_id = args.comp.resolve_id()?;
+
     let ctx = execution_context::resolve(&ResolveOptions::source_only(
-        args.comp.id(),
+        &effective_id,
         args.comp.path.clone(),
     ))?;
 
     let result = run_scaffold_workflow(
-        args.comp.id(),
+        &effective_id,
         &ctx.component,
         args.file.as_deref(),
         args.write,

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -139,8 +139,11 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 }
 
 pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput> {
+    // Resolve component ID — auto-discover from CWD if omitted
+    let effective_id = args.comp.resolve_id()?;
+
     let ctx = execution_context::resolve(&ResolveOptions::with_capability(
-        args.comp.id(),
+        &effective_id,
         args.comp.path.clone(),
         ExtensionCapability::Test,
         args.setting_args.setting.clone(),
@@ -149,7 +152,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     // Drift detection mode — delegate to core drift workflow (read-only)
     // Fixes are owned by `homeboy refactor --from test --write`.
     if args.drift {
-        let result = detect_test_drift(args.comp.id(), &ctx.component, &args.since)?;
+        let result = detect_test_drift(&effective_id, &ctx.component, &args.since)?;
         return Ok(report::from_drift_workflow(result));
     }
 
@@ -160,7 +163,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         &ctx.component,
         &ctx.source_path,
         TestRunWorkflowArgs {
-            component_label: args.comp.component.clone(),
+            component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
             settings: ctx

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -261,20 +261,31 @@ impl ComponentArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct PositionalComponentArgs {
-    pub component: String,
+    /// Component ID (optional — auto-detected from CWD if omitted)
+    pub component: Option<String>,
 
     #[arg(long)]
     pub path: Option<String>,
 }
 
+#[allow(dead_code)]
 impl PositionalComponentArgs {
-    #[cfg(test)]
     pub fn load(&self) -> homeboy::Result<Component> {
-        component::resolve_effective(Some(&self.component), self.path.as_deref(), None)
+        component::resolve_effective(self.component.as_deref(), self.path.as_deref(), None)
     }
 
-    pub fn id(&self) -> &str {
-        &self.component
+    pub fn id(&self) -> Option<&str> {
+        self.component.as_deref()
+    }
+
+    /// Resolve the component ID, falling back to CWD auto-discovery.
+    /// Returns the effective component ID string for display/logging.
+    pub fn resolve_id(&self) -> homeboy::Result<String> {
+        if let Some(ref id) = self.component {
+            return Ok(id.clone());
+        }
+        let component = self.load()?;
+        Ok(component.id)
     }
 }
 
@@ -285,7 +296,7 @@ mod positional_tests {
     #[test]
     fn load_uses_path_when_component_missing() {
         let args = PositionalComponentArgs {
-            component: "missing-component".to_string(),
+            component: Some("missing-component".to_string()),
             path: Some("/tmp/homeboy-missing-component".to_string()),
         };
 
@@ -296,6 +307,24 @@ mod positional_tests {
         assert_eq!(loaded.id, "missing-component");
         assert_eq!(loaded.local_path, "/tmp/homeboy-missing-component");
         assert_eq!(loaded.remote_path, "");
+    }
+
+    #[test]
+    fn id_returns_none_when_omitted() {
+        let args = PositionalComponentArgs {
+            component: None,
+            path: None,
+        };
+        assert!(args.id().is_none());
+    }
+
+    #[test]
+    fn id_returns_some_when_provided() {
+        let args = PositionalComponentArgs {
+            component: Some("my-comp".to_string()),
+            path: None,
+        };
+        assert_eq!(args.id(), Some("my-comp"));
     }
 }
 


### PR DESCRIPTION
## Summary

- **Component ID is now optional** in all positional-component commands: `audit`, `lint`, `test`, `refactor`, `scaffold`
- When omitted, auto-discovers from `homeboy.json` in CWD or git root
- Existing explicit component ID usage still works unchanged

## Before/After

```bash
# Before — component ID always required
cd /path/to/my-plugin
homeboy audit my-plugin
homeboy lint my-plugin
homeboy test my-plugin
homeboy refactor my-plugin --from all

# After — auto-discovers from CWD
cd /path/to/my-plugin
homeboy audit
homeboy lint
homeboy test
homeboy refactor --from all

# Explicit ID still works
homeboy audit my-plugin
homeboy audit /path/to/some/dir
```

## Resolution chain

1. Explicit component ID (if provided)
2. Registered component matching CWD path
3. `homeboy.json` in CWD
4. `homeboy.json` in git root
5. Error with actionable hints

## Changes

- `PositionalComponentArgs.component` changed from `String` to `Option<String>`
- Added `resolve_id()` method for commands that need the effective ID as a string
- Updated all 5 commands to handle the optional component with CWD fallback
- The `refactor` command additionally falls back to CWD when neither positional nor `--component` flags are provided

## Impact on CI

CI workflows that pass explicit component IDs are unaffected. The `homeboy-action` uses `homeboy component show --path .` for discovery which is a separate code path.

Closes #1074