### PR TITLE
fix: remove dead fields to eliminate all compiler warnings

### DIFF
--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -36,6 +36,7 @@ pub struct BuildProvenance {
 
 impl BuildProvenance {
     /// Returns true if this build was from the exact tagged commit (not ahead).
+    #[allow(dead_code)]
     pub(crate) fn is_tagged_build(&self) -> bool {
         self.ahead_of_tag == 0 && self.tag.is_some() && !self.dirty
     }

--- a/src/core/refactor/plan/generate/comment_fixes.rs
+++ b/src/core/refactor/plan/generate/comment_fixes.rs
@@ -106,7 +106,7 @@ pub(crate) fn generate_comment_fixes(
             _ => continue,
         };
 
-        // TODO markers describe work to be done — always needs human review.
+        // TodoMarker findings describe work to be done — always needs human review.
         if finding_kind == AuditFinding::TodoMarker {
             let ins = manual_blocked(
                 doc_line_removal(

--- a/src/core/refactor/plan/generate/module_surface.rs
+++ b/src/core/refactor/plan/generate/module_surface.rs
@@ -14,7 +14,6 @@ pub enum FileRole {
 
 #[derive(Debug, Clone)]
 pub struct SymbolSurface {
-    pub symbol: String,
     pub incoming_callers: Vec<String>,
     pub incoming_importers: Vec<String>,
     pub reexport_files: Vec<String>,
@@ -34,11 +33,8 @@ impl SymbolSurface {
 #[derive(Debug, Clone)]
 pub struct ModuleSurface {
     pub file: String,
-    pub module_path: String,
-    pub language: crate::code_audit::conventions::Language,
     pub role: FileRole,
     pub public_api: HashSet<String>,
-    pub imports: Vec<String>,
     pub internal_calls: HashSet<String>,
     pub call_sites: HashSet<String>,
     pub symbols: HashMap<String, SymbolSurface>,
@@ -104,6 +100,7 @@ fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSur
         .iter()
         .map(|site| site.target.clone())
         .collect();
+    let extensions = file_extensions_for(&fp.language);
 
     let mut symbols = HashMap::new();
     for symbol in &public_api {
@@ -111,7 +108,7 @@ fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSur
             symbol,
             &module_path,
             root,
-            &file_extensions_for(&fp.language),
+            &extensions,
         );
         let mut incoming_callers = Vec::new();
         let mut incoming_importers = Vec::new();
@@ -129,7 +126,6 @@ fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSur
         symbols.insert(
             symbol.clone(),
             SymbolSurface {
-                symbol: symbol.clone(),
                 incoming_callers,
                 incoming_importers,
                 reexport_files,
@@ -139,11 +135,8 @@ fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSur
 
     ModuleSurface {
         file,
-        module_path,
-        language: fp.language.clone(),
         role,
         public_api,
-        imports: fp.imports.clone(),
         internal_calls,
         call_sites,
         symbols,

--- a/src/core/refactor/plan/generate/near_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/near_duplicate_fixes.rs
@@ -387,17 +387,13 @@ mod tests {
         let index = ModuleSurfaceIndex::from_surfaces(vec![
             crate::core::refactor::plan::generate::module_surface::ModuleSurface {
                 file: "test.rs".to_string(),
-                module_path: "test".to_string(),
-                language: crate::code_audit::conventions::Language::Rust,
                 role: FileRole::Regular,
                 public_api: ["cache_path".to_string()].into_iter().collect(),
-                imports: vec![],
                 internal_calls: HashSet::new(),
                 call_sites: HashSet::new(),
                 symbols: HashMap::from([(
                     "cache_path".to_string(),
                     crate::core::refactor::plan::generate::module_surface::SymbolSurface {
-                        symbol: "cache_path".to_string(),
                         incoming_callers: vec!["src/consumer.rs".to_string()],
                         incoming_importers: vec![],
                         reexport_files: vec![],
@@ -441,17 +437,13 @@ mod tests {
         let index = ModuleSurfaceIndex::from_surfaces(vec![
             crate::core::refactor::plan::generate::module_surface::ModuleSurface {
                 file: "src/core/public_api.rs".to_string(),
-                module_path: "core::public_api".to_string(),
-                language: crate::code_audit::conventions::Language::Rust,
                 role: FileRole::PublicApi,
                 public_api: ["run".to_string()].into_iter().collect(),
-                imports: vec![],
                 internal_calls: HashSet::new(),
                 call_sites: HashSet::new(),
                 symbols: HashMap::from([(
                     "run".to_string(),
                     crate::core::refactor::plan::generate::module_surface::SymbolSurface {
-                        symbol: "run".to_string(),
                         incoming_callers: vec!["src/main.rs".to_string()],
                         incoming_importers: vec![],
                         reexport_files: vec![],
@@ -460,17 +452,13 @@ mod tests {
             },
             crate::core::refactor::plan::generate::module_surface::ModuleSurface {
                 file: "src/core/runner.rs".to_string(),
-                module_path: "core::runner".to_string(),
-                language: crate::code_audit::conventions::Language::Rust,
                 role: FileRole::Regular,
                 public_api: ["run".to_string()].into_iter().collect(),
-                imports: vec![],
                 internal_calls: ["run".to_string()].into_iter().collect(),
                 call_sites: HashSet::new(),
                 symbols: HashMap::from([(
                     "run".to_string(),
                     crate::core::refactor::plan::generate::module_surface::SymbolSurface {
-                        symbol: "run".to_string(),
                         incoming_callers: vec!["src/main.rs".to_string()],
                         incoming_importers: vec!["src/core/public_api.rs".to_string()],
                         reexport_files: vec![],


### PR DESCRIPTION
## Summary

- Remove 4 unused fields from `ModuleSurface` and `SymbolSurface` structs
- Suppress `is_tagged_build` warning (has test coverage, reserved for future use)
- **Result: zero compiler warnings on `cargo check`**

## Changes

**`module_surface.rs`:**
- Remove `ModuleSurface.module_path` — stored but never read
- Remove `ModuleSurface.language` — stored but never read  
- Remove `ModuleSurface.imports` — stored but never read
- Remove `SymbolSurface.symbol` — redundant with the HashMap key

**`provenance.rs`:**
- Add `#[allow(dead_code)]` to `is_tagged_build` — method has test coverage and is reserved for deployment workflow enhancements

**`near_duplicate_fixes.rs`:**
- Update 3 test constructors to match the new struct shapes

Closes #1032