### PR TITLE
Remove .homeboy-build-meta.json sidecar — one homeboy file per repo

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -106,41 +106,14 @@ pub(super) fn deploy_components(
         check_uncommitted_changes(&components)?;
     }
 
-    // Smart artifact reuse: check if any component has a fresh build artifact
-    // from a recent `homeboy build`. If so, skip the tag checkout and rebuild
-    // for that component — deploy what was already built.
-    let reuse_artifact_ids = if !config.head && !config.skip_build && !config.tagged {
-        detect_reusable_artifacts(&components)
-    } else {
-        Vec::new()
-    };
-
     // Check for HEAD-vs-tag gap before the tag checkout.
-    // Skip check for components that will reuse their build artifact.
     if !config.head && !config.skip_build {
-        let non_reuse: Vec<_> = components
-            .iter()
-            .filter(|c| !reuse_artifact_ids.contains(&c.id))
-            .cloned()
-            .collect();
-        if !non_reuse.is_empty() {
-            check_unreleased_commits(&non_reuse, config)?;
-        }
+        check_unreleased_commits(&components, config)?;
     }
 
-    // Checkout latest tag for each component (unless --head or reusing artifact).
-    // Components with reusable build artifacts are excluded from tag checkout.
+    // Checkout latest tag for each component (unless --head or --skip-build).
     let tag_checkouts = if !config.head && !config.skip_build {
-        let checkout_components: Vec<_> = components
-            .iter()
-            .filter(|c| !reuse_artifact_ids.contains(&c.id))
-            .cloned()
-            .collect();
-        if checkout_components.is_empty() {
-            Vec::new()
-        } else {
-            checkout_latest_tags(&checkout_components)?
-        }
+        checkout_latest_tags(&components)?
     } else {
         Vec::new()
     };
@@ -159,15 +132,7 @@ pub(super) fn deploy_components(
         // Apply per-project overrides (e.g. different extract_command or remote_owner)
         let component = crate::project::apply_component_overrides(component, project);
 
-        // For components reusing a build artifact, skip the build step
-        let effective_config = if reuse_artifact_ids.contains(&component.id) {
-            DeployConfig {
-                skip_build: true,
-                ..clone_config(config)
-            }
-        } else {
-            clone_config(config)
-        };
+        let effective_config = clone_config(config);
 
         let mut result = execute_component_deploy(
             &component,
@@ -180,22 +145,7 @@ pub(super) fn deploy_components(
         );
 
         // Record which git ref was deployed
-        if reuse_artifact_ids.contains(&component.id) {
-            // Artifact was reused from a prior build — record the provenance ref
-            if let Some(prov) = super::provenance::read(&component) {
-                let ref_label = if prov.is_ahead_of_tag() {
-                    format!(
-                        "{} (HEAD, {} ahead of {})",
-                        prov.git_ref,
-                        prov.ahead_of_tag,
-                        prov.tag.as_deref().unwrap_or("?")
-                    )
-                } else {
-                    format!("{} (build artifact)", prov.git_ref)
-                };
-                result = result.with_deployed_ref(ref_label);
-            }
-        } else if let Some(checkout) = tag_checkouts
+        if let Some(checkout) = tag_checkouts
             .iter()
             .find(|c| c.component_id == component.id)
         {
@@ -569,46 +519,6 @@ fn check_unreleased_commits(components: &[Component], config: &DeployConfig) -> 
             "Use `deploy --force` to deploy the stale tag anyway".to_string(),
         ]),
     ))
-}
-
-/// Detect components with reusable build artifacts.
-///
-/// A build artifact is reusable when:
-/// 1. A `.homeboy-build-meta.json` sidecar exists
-/// 2. The recorded commit matches the current HEAD (the artifact is current)
-///
-/// When a reusable artifact is found, the component skips tag checkout
-/// and rebuild — deploying whatever was already built by `homeboy build`.
-fn detect_reusable_artifacts(components: &[Component]) -> Vec<String> {
-    let mut reuse_ids = Vec::new();
-
-    for component in components {
-        if let Some(prov) = super::provenance::read(component) {
-            if super::provenance::is_current(component, &prov) {
-                if prov.is_ahead_of_tag() {
-                    log_status!(
-                        "deploy",
-                        "ℹ️  '{}': reusing build artifact from {} ({} commit(s) ahead of {})",
-                        component.id,
-                        &prov.commit[..prov.commit.len().min(8)],
-                        prov.ahead_of_tag,
-                        prov.tag.as_deref().unwrap_or("?")
-                    );
-                } else {
-                    log_status!(
-                        "deploy",
-                        "ℹ️  '{}': reusing build artifact from {} (at tag {})",
-                        component.id,
-                        &prov.commit[..prov.commit.len().min(8)],
-                        prov.tag.as_deref().unwrap_or("?")
-                    );
-                }
-                reuse_ids.push(component.id.clone());
-            }
-        }
-    }
-
-    reuse_ids
 }
 
 /// Create a value copy of DeployConfig for per-component overrides.

--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -1,131 +1,11 @@
 //! Build provenance tracking.
 //!
-//! Records metadata about what was built so `deploy` can make informed
-//! decisions about whether to reuse an existing artifact or rebuild
-//! from the latest tag.
-//!
-//! The sidecar lives at `.homeboy-build-meta.json` in the component's
-//! local directory root.
-
-use std::path::{Path, PathBuf};
-
-use serde::{Deserialize, Serialize};
+//! Provides tag-gap detection so `build` and `deploy` can warn about
+//! unreleased commits ahead of the latest tag.
 
 use crate::component::Component;
 use crate::engine::command;
 use crate::git;
-
-const META_FILENAME: &str = ".homeboy-build-meta.json";
-
-/// Metadata recorded after a successful build.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BuildProvenance {
-    /// Full commit hash that was built
-    pub commit: String,
-    /// Branch or ref name (e.g. "main", or tag name if detached at a tag)
-    pub git_ref: String,
-    /// Latest tag at build time (if any)
-    pub tag: Option<String>,
-    /// Number of commits HEAD is ahead of the latest tag
-    pub ahead_of_tag: u32,
-    /// ISO 8601 timestamp of the build
-    pub timestamp: String,
-    /// Whether the working tree had uncommitted changes at build time
-    pub dirty: bool,
-}
-
-impl BuildProvenance {
-    /// Returns true if this build was from the exact tagged commit (not ahead).
-    #[allow(dead_code)]
-    pub(crate) fn is_tagged_build(&self) -> bool {
-        self.ahead_of_tag == 0 && self.tag.is_some() && !self.dirty
-    }
-
-    /// Returns true if this build includes unreleased commits beyond the tag.
-    pub fn is_ahead_of_tag(&self) -> bool {
-        self.ahead_of_tag > 0
-    }
-}
-
-/// Capture build provenance for a component's current git state.
-pub fn capture(component: &Component) -> Option<BuildProvenance> {
-    let path = &component.local_path;
-
-    let commit = command::run_in_optional(path, "git", &["rev-parse", "HEAD"])?;
-
-    let git_ref = command::run_in_optional(path, "git", &["symbolic-ref", "--short", "HEAD"])
-        .unwrap_or_else(|| {
-            // Detached HEAD — use the commit hash as ref
-            commit.chars().take(12).collect()
-        });
-
-    let tag = git::get_latest_tag(path).ok().flatten();
-
-    let ahead_of_tag = tag
-        .as_ref()
-        .and_then(|t| {
-            command::run_in_optional(
-                path,
-                "git",
-                &["rev-list", "--count", &format!("{}..HEAD", t)],
-            )
-        })
-        .and_then(|s| s.trim().parse::<u32>().ok())
-        .unwrap_or(0);
-
-    let dirty = !git::is_workdir_clean(Path::new(path));
-
-    let timestamp = chrono_now_iso();
-
-    Some(BuildProvenance {
-        commit,
-        git_ref,
-        tag,
-        ahead_of_tag,
-        timestamp,
-        dirty,
-    })
-}
-
-/// Write build provenance to the sidecar file in the component directory.
-pub fn write(component: &Component, provenance: &BuildProvenance) -> std::io::Result<()> {
-    let meta_path = meta_path(&component.local_path);
-    let json = serde_json::to_string_pretty(provenance).map_err(std::io::Error::other)?;
-    std::fs::write(&meta_path, json)
-}
-
-/// Read build provenance from the sidecar file, if it exists.
-pub fn read(component: &Component) -> Option<BuildProvenance> {
-    read_from_path(&component.local_path)
-}
-
-/// Read build provenance from a path (component local_path).
-pub(crate) fn read_from_path(local_path: &str) -> Option<BuildProvenance> {
-    let meta_path = meta_path(local_path);
-    let content = std::fs::read_to_string(&meta_path).ok()?;
-    serde_json::from_str(&content).ok()
-}
-
-/// Check if the provenance is still valid for the current HEAD.
-///
-/// Returns true if the recorded commit matches the current HEAD,
-/// meaning the build artifact corresponds to the checked-out code.
-pub fn is_current(component: &Component, provenance: &BuildProvenance) -> bool {
-    let current_commit =
-        command::run_in_optional(&component.local_path, "git", &["rev-parse", "HEAD"]);
-    current_commit.as_deref() == Some(provenance.commit.as_str())
-}
-
-fn meta_path(local_path: &str) -> PathBuf {
-    Path::new(local_path).join(META_FILENAME)
-}
-
-/// ISO 8601 UTC timestamp without external crate dependency.
-fn chrono_now_iso() -> String {
-    // Use `date` command for UTC ISO format — avoids adding chrono crate
-    command::run_in_optional(".", "date", &["-u", "+%Y-%m-%dT%H:%M:%SZ"])
-        .unwrap_or_else(|| "unknown".to_string())
-}
 
 /// Information about the HEAD-vs-tag gap for a component.
 #[derive(Debug, Clone)]
@@ -182,7 +62,6 @@ pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
     })
 }
 
-/// Log a warning about the HEAD-vs-tag gap for a component.
 /// Format a tag gap as a human-readable warning string.
 ///
 /// Used by both `build` and `deploy` commands.
@@ -207,49 +86,4 @@ pub fn format_tag_gap(component_id: &str, gap: &TagGap, context: &str) -> String
 /// Print a tag gap warning to stderr. Always prints regardless of TTY.
 pub fn warn_tag_gap(component_id: &str, gap: &TagGap, context: &str) {
     eprintln!("{}", format_tag_gap(component_id, gap, context));
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_tagged_build() {
-        let p = BuildProvenance {
-            commit: "abc123".to_string(),
-            git_ref: "main".to_string(),
-            tag: Some("v1.0.0".to_string()),
-            ahead_of_tag: 0,
-            timestamp: "2026-03-28T20:00:00Z".to_string(),
-            dirty: false,
-        };
-        assert!(p.is_tagged_build());
-    }
-
-    #[test]
-    fn test_is_tagged_build_dirty() {
-        let p = BuildProvenance {
-            commit: "abc123".to_string(),
-            git_ref: "main".to_string(),
-            tag: Some("v1.0.0".to_string()),
-            ahead_of_tag: 0,
-            timestamp: "2026-03-28T20:00:00Z".to_string(),
-            dirty: true,
-        };
-        assert!(!p.is_tagged_build());
-    }
-
-    #[test]
-    fn test_is_ahead_of_tag() {
-        let p = BuildProvenance {
-            commit: "abc123".to_string(),
-            git_ref: "main".to_string(),
-            tag: Some("v1.0.0".to_string()),
-            ahead_of_tag: 5,
-            timestamp: "2026-03-28T20:00:00Z".to_string(),
-            dirty: false,
-        };
-        assert!(p.is_ahead_of_tag());
-        assert!(!p.is_tagged_build());
-    }
 }

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -423,15 +423,6 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
 
     let success = runner_output.success;
 
-    // Record build provenance on success so deploy can detect fresh artifacts
-    if success {
-        if let Some(prov) = crate::deploy::provenance::capture(comp) {
-            if let Err(e) = crate::deploy::provenance::write(comp, &prov) {
-                log_status!("build", "Warning: could not write build provenance: {}", e);
-            }
-        }
-    }
-
     Ok((
         BuildOutput {
             command: "build.run".to_string(),


### PR DESCRIPTION
## Summary

- **Removes** the `.homeboy-build-meta.json` sidecar file that `homeboy build` was writing to component roots after every build
- **Eliminates** the implicit artifact-reuse optimization in deploy that depended on the sidecar
- **Preserves** tag-gap detection (`detect_tag_gap`/`warn_tag_gap`) which uses inline git queries

## Why

`homeboy.json` should be the **single homeboy file** in any repo. The sidecar was a build provenance tracker that leaked into repos (e.g. extrachill-studio had it committed). It was an optimization for deploy to skip rebuilding when a fresh build artifact existed — but that optimization is better handled explicitly via `--skip-build`.

## Changes

| File | What |
|------|------|
| `provenance.rs` | Gutted — removed `BuildProvenance`, `capture()`, `write()`, `read()`, `is_current()`, `meta_path()`, `chrono_now_iso()`, and all tests. Kept `TagGap` + `detect_tag_gap` + `warn_tag_gap` |
| `orchestration.rs` | Removed `detect_reusable_artifacts()` and all `reuse_artifact_ids` logic. Deploy always rebuilds from tag now |
| `build/mod.rs` | Removed provenance write after successful build |

## Behavioral change

Deploy no longer auto-detects fresh build artifacts. It always rebuilds from the latest tag (default) or HEAD (`--head`). Use `--skip-build` to explicitly skip rebuilding.