### PR TITLE
Add file-level component deploy strategy

### DIFF
--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -315,6 +315,11 @@ impl Component {
     ///
     /// Returns `Some(path)` if auto-resolved, `None` if not applicable or not detectable.
     pub fn auto_resolve_remote_path(&self) -> Option<String> {
+        // File components cannot auto-resolve — they must have explicit remote_path.
+        if std::path::Path::new(&self.local_path).is_file() {
+            return None;
+        }
+
         // Only applies to components with the wordpress extension.
         let extensions = self.extensions.as_ref()?;
         if !extensions.contains_key("wordpress") {
@@ -354,6 +359,16 @@ impl Component {
         }
 
         None
+    }
+
+    /// Check if this component's local_path points to a file (not a directory).
+    ///
+    /// File components use `deploy_strategy: "file"` and are deployed via
+    /// atomic SCP instead of rsync. They skip build, git sync, and tag checkout.
+    pub fn is_file_component(&self) -> bool {
+        self.deploy_strategy.as_deref() == Some("file")
+            || (std::path::Path::new(&self.local_path).is_file()
+                && self.deploy_strategy.is_none())
     }
 
     /// Ensure `remote_path` is populated. If empty, attempt auto-resolution.

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -367,8 +367,7 @@ impl Component {
     /// atomic SCP instead of rsync. They skip build, git sync, and tag checkout.
     pub fn is_file_component(&self) -> bool {
         self.deploy_strategy.as_deref() == Some("file")
-            || (std::path::Path::new(&self.local_path).is_file()
-                && self.deploy_strategy.is_none())
+            || (std::path::Path::new(&self.local_path).is_file() && self.deploy_strategy.is_none())
     }
 
     /// Ensure `remote_path` is populated. If empty, attempt auto-resolution.

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -28,10 +28,12 @@ pub(super) fn execute_component_deploy(
     remote_version: Option<String>,
 ) -> ComponentDeployResult {
     let is_git_deploy = component.deploy_strategy.as_deref() == Some("git");
+    let is_file_deploy = component.deploy_strategy.as_deref() == Some("file");
 
     // Try downloading release artifact from GitHub instead of building locally.
     // This is the preferred path when the component has remote_url set.
     let release_artifact: Option<PathBuf> = if !is_git_deploy
+        && !is_file_deploy
         && !config.skip_build
         && release_download::supports_release_deploy(component)
     {
@@ -40,9 +42,9 @@ pub(super) fn execute_component_deploy(
         None
     };
 
-    // Build (git-deploy, skip-build, and release-download skip this step)
+    // Build (git-deploy, file-deploy, skip-build, and release-download skip this step)
     let (build_exit_code, build_error) =
-        if is_git_deploy || config.skip_build || release_artifact.is_some() {
+        if is_git_deploy || is_file_deploy || config.skip_build || release_artifact.is_some() {
             (Some(0), None)
         } else {
             build::build_component(component)
@@ -129,6 +131,17 @@ pub(super) fn execute_component_deploy(
         );
     }
 
+    if strategy == "file" {
+        return execute_file_deploy(
+            component,
+            ctx,
+            base_path,
+            &install_dir,
+            local_version,
+            remote_version,
+        );
+    }
+
     execute_artifact_deploy(
         component,
         config,
@@ -179,6 +192,132 @@ fn execute_git_deploy(
                 .with_deploy_exit_code(Some(exit_code))
         }
         Ok(DeployResult {
+            error, exit_code, ..
+        }) => ComponentDeployResult::failed(
+            component,
+            base_path,
+            local_version,
+            remote_version,
+            error.unwrap_or_default(),
+        )
+        .with_remote_path(install_dir.to_string())
+        .with_deploy_exit_code(Some(exit_code)),
+        Err(err) => ComponentDeployResult::failed(
+            component,
+            base_path,
+            local_version,
+            remote_version,
+            err.to_string(),
+        )
+        .with_remote_path(install_dir.to_string()),
+    }
+}
+
+/// Deploy a single file component via atomic SCP.
+///
+/// File components (`deploy_strategy: "file"`) skip build entirely — the
+/// `local_path` IS the artifact. The `remote_path` (resolved into `install_dir`)
+/// is treated as the full destination file path, not a directory.
+///
+/// The parent directory is created on the remote if it doesn't exist.
+/// Upload uses atomic SCP (temp file + mv) to prevent partial writes.
+fn execute_file_deploy(
+    component: &Component,
+    ctx: &RemoteProjectContext,
+    base_path: &str,
+    install_dir: &str,
+    local_version: Option<String>,
+    remote_version: Option<String>,
+) -> ComponentDeployResult {
+    let local_path = Path::new(&component.local_path);
+
+    if !local_path.exists() {
+        return ComponentDeployResult::failed(
+            component,
+            base_path,
+            local_version,
+            remote_version,
+            format!("Source file does not exist: {}", component.local_path),
+        );
+    }
+
+    if !local_path.is_file() {
+        return ComponentDeployResult::failed(
+            component,
+            base_path,
+            local_version,
+            remote_version,
+            format!(
+                "Component '{}' has deploy_strategy 'file' but local_path is not a file: {}",
+                component.id, component.local_path
+            ),
+        );
+    }
+
+    // Create the parent directory on the remote (not the file path itself!)
+    let remote_parent = Path::new(install_dir)
+        .parent()
+        .and_then(|p| p.to_str())
+        .unwrap_or(".");
+
+    let mkdir_cmd = format!("mkdir -p {}", crate::engine::shell::quote_path(remote_parent));
+    log_status!("deploy", "Ensuring remote directory: {}", remote_parent);
+    let mkdir_output = ctx.client.execute(&mkdir_cmd);
+    if !mkdir_output.success {
+        return ComponentDeployResult::failed(
+            component,
+            base_path,
+            local_version,
+            remote_version,
+            format!("Failed to create remote directory: {}", mkdir_output.stderr),
+        );
+    }
+
+    // Upload via atomic SCP (temp file + mv)
+    log_status!(
+        "deploy",
+        "Deploying file: {} -> {}",
+        local_path.display(),
+        install_dir
+    );
+
+    let deploy_result = super::transfer::upload_file(&ctx.client, local_path, install_dir);
+
+    match deploy_result {
+        Ok(super::types::DeployResult {
+            success: true,
+            exit_code,
+            ..
+        }) => {
+            // Fix ownership if configured
+            if let Some(owner) = component.remote_owner.as_deref() {
+                let chown_cmd = format!(
+                    "chown {} {}",
+                    crate::engine::shell::quote_arg(owner),
+                    crate::engine::shell::quote_path(install_dir)
+                );
+                let chown_output = ctx.client.execute(&chown_cmd);
+                if !chown_output.success {
+                    log_status!(
+                        "deploy",
+                        "Warning: could not set ownership to {}: {}",
+                        owner,
+                        chown_output.stderr
+                    );
+                }
+            }
+
+            super::version_overrides::run_post_deploy_hooks(
+                &ctx.client, component, install_dir, base_path,
+            );
+
+            ComponentDeployResult::new(component, base_path)
+                .with_status("deployed")
+                .with_versions(local_version.clone(), local_version)
+                .with_remote_path(install_dir.to_string())
+                .with_deploy_exit_code(Some(exit_code))
+        }
+        Ok(super::types::DeployResult {
             error, exit_code, ..
         }) => ComponentDeployResult::failed(
             component,

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -260,7 +260,10 @@ fn execute_file_deploy(
         .and_then(|p| p.to_str())
         .unwrap_or(".");
 
-    let mkdir_cmd = format!("mkdir -p {}", crate::engine::shell::quote_path(remote_parent));
+    let mkdir_cmd = format!(
+        "mkdir -p {}",
+        crate::engine::shell::quote_path(remote_parent)
+    );
     log_status!("deploy", "Ensuring remote directory: {}", remote_parent);
     let mkdir_output = ctx.client.execute(&mkdir_cmd);
     if !mkdir_output.success {
@@ -308,7 +311,10 @@ fn execute_file_deploy(
             }
 
             super::version_overrides::run_post_deploy_hooks(
-                &ctx.client, component, install_dir, base_path,
+                &ctx.client,
+                component,
+                install_dir,
+                base_path,
             );
 
             ComponentDeployResult::new(component, base_path)

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -268,6 +268,7 @@ fn run_dry_run_mode(
 fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
     let dirty: Vec<&str> = components
         .iter()
+        .filter(|c| !c.is_file_component())
         .filter(|c| !git::is_workdir_clean(Path::new(&c.local_path)))
         .map(|c| c.id.as_str())
         .collect();
@@ -294,6 +295,11 @@ fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
 /// Aborts if pull fails (e.g., merge conflicts).
 fn sync_components(components: &[Component]) -> Result<()> {
     for component in components {
+        // File components are not git repos — skip sync
+        if component.is_file_component() {
+            continue;
+        }
+
         let path = &component.local_path;
 
         // Check if behind remote
@@ -351,6 +357,11 @@ fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
     let mut checkouts = Vec::new();
 
     for component in components {
+        // File components don't have tags — skip
+        if component.is_file_component() {
+            continue;
+        }
+
         let path = &component.local_path;
 
         // Get the latest tag

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -297,11 +297,12 @@ pub(super) fn load_project_components(
         // Resolve effective artifact (component value OR extension pattern)
         let effective_artifact = component::resolve_artifact(&loaded);
 
-        // Git-deploy components don't need a build artifact
+        // Git-deploy and file-deploy components don't need a build artifact
         let is_git_deploy = loaded.deploy_strategy.as_deref() == Some("git");
+        let is_file_deploy = loaded.deploy_strategy.as_deref() == Some("file");
 
         match effective_artifact {
-            Some(artifact) if !is_git_deploy => {
+            Some(artifact) if !is_git_deploy && !is_file_deploy => {
                 let resolved_artifact =
                     crate::paths::resolve_path_string(&loaded.local_path, &artifact);
                 loaded.build_artifact = Some(resolved_artifact);
@@ -309,6 +310,10 @@ pub(super) fn load_project_components(
             }
             _ if is_git_deploy => {
                 // Git-deploy components are deployable without an artifact
+                deployable.push(loaded);
+            }
+            _ if is_file_deploy => {
+                // File-deploy components use local_path as the artifact — no build needed
                 deployable.push(loaded);
             }
             Some(_) | None => {

--- a/src/core/refactor/auto/guard.rs
+++ b/src/core/refactor/auto/guard.rs
@@ -263,7 +263,7 @@ fn check_cap(path: &str, config: &GuardConfig) -> Option<GuardBlock> {
     let output = Command::new("git")
         .args([
             "log",
-            &format!("--format=%s"),
+            "--format=%s",
             &format!("-n{}", config.max_commits + 1),
         ])
         .current_dir(path)


### PR DESCRIPTION
## Summary

- Adds `deploy_strategy: "file"` for deploying individual files (configs, binaries, agent memory files) instead of directories
- File components skip build, git sync, and tag checkout — the file IS the artifact
- Deploy uses existing atomic SCP (`upload_file()` → temp file + `mv -f`)
- Parent directory is created on remote, not the file path itself (fixes the critical `mkdir -p` gap)
- Works with `--shared` and fleet deploy out of the box

## Usage

```bash
# Register a file component
homeboy component create \
  --local-path /var/lib/datamachine/agent-configs/USER.md \
  --remote-path wp-content/uploads/datamachine/agents/chubes-bot/USER.md

homeboy component set user-md --json '{"deploy_strategy": "file"}'

# Deploy to one project
homeboy deploy chubes-site user-md

# Deploy to all projects using it
homeboy deploy --shared user-md

# Deploy across a fleet
homeboy deploy -f my-fleet user-md
```

## How it works

File deploy is a new strategy alongside `rsync` (default) and `git`:

| Strategy | Source | Upload | Build | Git sync |
|----------|--------|--------|-------|----------|
| `rsync` | Directory | rsync --delete | Yes | Yes |
| `git` | Remote repo | git pull | No | N/A |
| **`file`** | **Single file** | **Atomic SCP** | **No** | **No** |

The deploy pipeline already had `upload_file()` with atomic replace — this PR just adds the routing to get file components to it.

## Changes

| File | What |
|------|------|
| `component/mod.rs` | `is_file_component()` helper + guard `auto_resolve_remote_path()` for file paths |
| `deploy/planning.rs` | Recognize `"file"` strategy as deployable without `build_artifact` |
| `deploy/execution.rs` | New `execute_file_deploy()` — parent-dir `mkdir -p`, atomic upload, ownership fix |
| `deploy/orchestration.rs` | Skip git sync, uncommitted checks, and tag checkout for file components |

## Test results

All 1039 existing tests pass. No regressions.

## Related

- Extra-Chill/data-machine#1006 / Extra-Chill/data-machine#1007 — Context-aware memory file injection (the Data Machine side)
- `fleet sync` was deprecated with guidance to "register shared configs as components" — this completes that vision

Closes #1102