### PR TITLE
fix(deploy): always pass --allow-root to WP-CLI in WordPress deploy

### DIFF
--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -284,12 +284,7 @@ pub(super) fn deploy_with_override(
     vars.insert("domain".to_string(), domain.unwrap_or("").to_string());
     vars.insert(
         "allowRootFlag".to_string(),
-        if ssh_client.user == "root" {
-            "--allow-root"
-        } else {
-            ""
-        }
-        .to_string(),
+        "--allow-root".to_string(),
     );
 
     let install_cmd = render_map(&override_config.install_command, &vars);


### PR DESCRIPTION
## Summary
- Always pass `--allow-root` to WP-CLI in the WordPress extension's deploy override, instead of only when `ssh_client.user == "root"`
- `--allow-root` is a no-op when not running as root, so it's safe to always include
- Fixes root-context deploys (e.g., agent sessions, local server deploys) that fail with the "YIKES! It looks like you're running this as root" error

Closes Extra-Chill/homeboy-extensions#201