### PR TITLE
arch: refactor engine owns all fix application (lint + test)

### DIFF
--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -63,7 +63,7 @@ The following environment variables are set for lint runners:
 - `HOMEBOY_MODULE_PATH`: Absolute path to extension directory
 - `HOMEBOY_COMPONENT_PATH`: Absolute path to component directory
 - `HOMEBOY_PLUGIN_PATH`: Same as component path
-- `HOMEBOY_AUTO_FIX`: Set to `1` when running via `refactor --from lint --write`
+- `HOMEBOY_FIX_ONLY`: Set to `1` when running in fix-only mode (refactor --from lint --write) — extension should apply fixes without re-running diagnostics
 - `HOMEBOY_SUMMARY_MODE`: Set to `1` when `--summary` flag is used
 - `HOMEBOY_LINT_FILE`: Single file path when `--file` is used
 - `HOMEBOY_LINT_GLOB`: Glob pattern when `--glob` or `--changed-only` is used

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -200,7 +200,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
 mod tests {
     use super::*;
     use homeboy::component::Component;
-    use homeboy::refactor::plan::{test_refactor_request, TestSourceOptions};
+    use homeboy::refactor::plan::{build_test_refactor_request, TestSourceOptions};
     use std::path::PathBuf;
 
     #[test]
@@ -341,7 +341,7 @@ mod tests {
             None,
         );
 
-        let request = test_refactor_request(
+        let request = build_test_refactor_request(
             component.clone(),
             PathBuf::from("/tmp/demo"),
             vec![("runner".to_string(), "ci".to_string())],

--- a/src/core/refactor/plan/mod.rs
+++ b/src/core/refactor/plan/mod.rs
@@ -5,10 +5,11 @@ pub mod verify;
 
 pub use generate::generate_audit_fixes;
 pub use sources::{
-    analyze_stage_overlaps, collect_refactor_sources, lint_refactor_request, normalize_sources,
-    run_lint_refactor, run_test_refactor, summarize_source_totals, test_refactor_request,
-    CollectedEdit, LintSourceOptions, RefactorSourceRequest, RefactorSourceRun, SourceOverlap,
-    SourceStageSummary, SourceTotals, TestSourceOptions, KNOWN_REFACTOR_SOURCES,
+    analyze_stage_overlaps, build_test_refactor_request, collect_refactor_sources,
+    lint_refactor_request, normalize_sources, run_lint_refactor, run_test_refactor,
+    summarize_source_totals, CollectedEdit, LintSourceOptions, RefactorSourceRequest,
+    RefactorSourceRun, SourceOverlap, SourceStageSummary, SourceTotals, TestSourceOptions,
+    KNOWN_REFACTOR_SOURCES,
 };
 pub use verify::{
     finding_fingerprint, run_audit_refactor, score_delta, weighted_finding_score_with,

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -598,10 +598,11 @@ fn try_load_cached_audit() -> Option<CodeAuditResult> {
 /// Try to load cached lint findings from a previous `homeboy lint` run.
 ///
 /// Checks `HOMEBOY_OUTPUT_DIR/lint.json` for a `CliResponse<LintCommandOutput>`
-/// envelope. If found and the run passed (zero findings), returns an empty
-/// finding list — the fix stage can be skipped entirely since there's nothing
-/// to fix. If findings exist, returns None so the fix stage runs normally
-/// (fixes require actual file modification that can't be cached).
+/// envelope. If found and the run passed (zero findings), returns `Clean`
+/// — the fix stage can be skipped entirely.
+///
+/// If findings exist, returns `HasFindings(count)` so the fix stage knows
+/// to invoke fix-only mode without re-running the diagnostic pass.
 fn try_load_cached_lint() -> Option<CachedLintResult> {
     let output_dir = std::env::var(OUTPUT_DIR_ENV).ok()?;
     let lint_file = PathBuf::from(&output_dir).join("lint.json");
@@ -618,7 +619,11 @@ fn try_load_cached_lint() -> Option<CachedLintResult> {
         .map(|a| a.len())
         .unwrap_or(0);
 
-    if success && passed && finding_count == 0 {
+    if !success {
+        return None;
+    }
+
+    if passed && finding_count == 0 {
         crate::log_status!(
             "refactor",
             "Cached lint result is clean (0 findings from {}) — skipping lint fix stage",
@@ -627,11 +632,15 @@ fn try_load_cached_lint() -> Option<CachedLintResult> {
         return Some(CachedLintResult::Clean);
     }
 
-    crate::log_status!(
-        "refactor",
-        "Cached lint result has {} findings — fix stage will re-run linter with auto-fix",
-        finding_count
-    );
+    if finding_count > 0 {
+        crate::log_status!(
+            "refactor",
+            "Cached lint result has {} findings — fix stage will invoke fix-only mode",
+            finding_count
+        );
+        return Some(CachedLintResult::HasFindings(finding_count));
+    }
+
     None
 }
 
@@ -669,6 +678,8 @@ fn try_load_cached_test() -> Option<CachedTestResult> {
 enum CachedLintResult {
     /// Lint passed with zero findings — nothing to fix.
     Clean,
+    /// Lint had findings — the fix stage should invoke fix-only mode.
+    HasFindings(usize),
 }
 
 enum CachedTestResult {
@@ -814,9 +825,11 @@ fn run_lint_stage(
     write: bool,
     run_dir: &RunDir,
 ) -> crate::Result<PlannedStage> {
-    // Check for cached lint results — if the quality gate already passed clean,
-    // there's nothing to fix and we can skip re-running the linter entirely.
-    if let Some(CachedLintResult::Clean) = try_load_cached_lint() {
+    // Check for cached lint results from the quality gate.
+    let cached = try_load_cached_lint();
+
+    // If clean, nothing to fix — skip entirely.
+    if let Some(CachedLintResult::Clean) = cached {
         return Ok(PlannedStage {
             source: "lint".to_string(),
             summary: SourceStageSummary {
@@ -837,11 +850,6 @@ fn run_lint_stage(
     let root_str = root.to_string_lossy().to_string();
     let findings_file = run_dir.step_file(run_dir::files::LINT_FINDINGS);
     let fix_sidecars = auto::AutofixSidecarFiles::for_run_dir(run_dir);
-    let before_dirty = if write {
-        git::get_dirty_files(&root_str).unwrap_or_default()
-    } else {
-        Vec::new()
-    };
 
     let selected_files = options.selected_files.as_deref().or(changed_files);
     let effective_glob = if let Some(changed_files) = selected_files {
@@ -862,38 +870,103 @@ fn run_lint_stage(
         options.glob.clone()
     };
 
-    let runner = extension::lint::build_lint_runner(
-        component,
-        None,
-        settings,
-        false,
-        options.file.as_deref(),
-        effective_glob.as_deref(),
-        options.errors_only,
-        options.sniffs.as_deref(),
-        options.exclude_sniffs.as_deref(),
-        options.category.as_deref(),
-        run_dir,
-    )?
-    .env_if(write, "HOMEBOY_AUTO_FIX", "1");
-
-    runner.run()?;
-
-    let stage_changed_files = if write {
-        let after_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
-        let before_set: HashSet<&str> = before_dirty.iter().map(|s| s.as_str()).collect();
-        after_dirty
-            .into_iter()
-            .filter(|f| !before_set.contains(f.as_str()))
-            .collect()
+    // ── Phase 1: Diagnose ──────────────────────────────────────────────
+    // Run the linter WITHOUT auto-fix. The extension reports findings but
+    // does NOT modify files. This separates diagnosis from fix application
+    // so the engine controls the full lifecycle.
+    //
+    // When cached findings exist from the quality gate, skip the diagnostic
+    // pass entirely — the engine already knows what needs fixing.
+    let lint_findings = if let Some(CachedLintResult::HasFindings(count)) = cached {
+        crate::log_status!(
+            "refactor",
+            "Using {} cached lint findings — skipping diagnostic pass",
+            count
+        );
+        // Parse cached findings for reporting
+        let output_dir = std::env::var(OUTPUT_DIR_ENV).ok();
+        let cached_findings = output_dir
+            .and_then(|dir| {
+                let file = PathBuf::from(&dir).join("lint.json");
+                let content = std::fs::read_to_string(&file).ok()?;
+                let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+                let data = json.get("data")?;
+                let findings: Vec<crate::extension::lint::LintFinding> =
+                    serde_json::from_value(data.get("lint_findings")?.clone()).ok()?;
+                Some(findings)
+            })
+            .unwrap_or_default();
+        cached_findings
     } else {
-        Vec::new()
+        // No cached findings — run the diagnostic pass.
+        let runner = extension::lint::build_lint_runner(
+            component,
+            None,
+            settings,
+            false,
+            options.file.as_deref(),
+            effective_glob.as_deref(),
+            options.errors_only,
+            options.sniffs.as_deref(),
+            options.exclude_sniffs.as_deref(),
+            options.category.as_deref(),
+            run_dir,
+        )?;
+
+        runner.run()?;
+
+        crate::extension::lint::baseline::parse_findings_file(&findings_file).unwrap_or_default()
     };
 
-    let fix_results = fix_sidecars.consume_fix_results();
+    // ── Phase 2: Apply fixes (only when --write) ───────────────────────
+    // The engine controls fix application. The extension's fix-mode
+    // invocation runs ONLY the fixers, not the diagnostic pass. The engine
+    // tracks what changed via undo snapshots and git diff.
+    let (stage_changed_files, fix_results) = if write && !lint_findings.is_empty() {
+        let before_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
+
+        // Save undo snapshot before applying lint fixes.
+        let mut snap = UndoSnapshot::new(root, "lint fix");
+        for file in &before_dirty {
+            snap.capture_file(file);
+        }
+        if let Err(error) = snap.save() {
+            crate::log_status!("undo", "Warning: failed to save undo snapshot: {}", error);
+        }
+
+        // Invoke the extension in fix-only mode — runs fixers without
+        // re-running the diagnostic pass.
+        let fix_runner = extension::lint::build_lint_runner(
+            component,
+            None,
+            settings,
+            false,
+            options.file.as_deref(),
+            effective_glob.as_deref(),
+            options.errors_only,
+            options.sniffs.as_deref(),
+            options.exclude_sniffs.as_deref(),
+            options.category.as_deref(),
+            run_dir,
+        )?
+        .env("HOMEBOY_FIX_ONLY", "1");
+
+        fix_runner.run()?;
+
+        let after_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
+        let before_set: HashSet<&str> = before_dirty.iter().map(|s| s.as_str()).collect();
+        let changed: Vec<String> = after_dirty
+            .into_iter()
+            .filter(|f| !before_set.contains(f.as_str()))
+            .collect();
+
+        let fix_results = fix_sidecars.consume_fix_results();
+        (changed, fix_results)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
     let edit_count = fix_results.len();
-    let lint_findings =
-        crate::extension::lint::baseline::parse_findings_file(&findings_file).unwrap_or_default();
 
     Ok(PlannedStage {
         source: "lint".to_string(),
@@ -943,15 +1016,12 @@ fn run_test_stage(
 
     let root_str = root.to_string_lossy().to_string();
     let fix_sidecars = auto::AutofixSidecarFiles::for_run_dir(run_dir);
-    let before_dirty = if write {
-        git::get_dirty_files(&root_str).unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-
     let selected_test_files = options.selected_files.as_deref().or(changed_test_files);
 
-    let mut runner = extension::test::build_test_runner(
+    // ── Phase 1: Diagnose ──────────────────────────────────────────────
+    // Run tests WITHOUT auto-fix. The extension reports failures but does
+    // NOT modify files. This separates diagnosis from fix application.
+    let runner = extension::test::build_test_runner(
         component,
         None,
         settings,
@@ -960,27 +1030,63 @@ fn run_test_stage(
         None,
         selected_test_files,
         run_dir,
-    )?
-    .env_if(write, "HOMEBOY_AUTO_FIX", "1");
+    )?;
 
+    let mut runner = runner;
     if !options.script_args.is_empty() {
         runner = runner.script_args(&options.script_args);
     }
 
     runner.run()?;
 
-    let stage_changed_files = if write {
+    // ── Phase 2: Apply fixes (only when --write) ───────────────────────
+    // The engine controls fix application. The extension's fix-mode
+    // invocation runs ONLY the fixers, not the diagnostic pass.
+    let (stage_changed_files, fix_results) = if write {
+        let before_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
+
+        // Save undo snapshot before applying test fixes.
+        let mut snap = UndoSnapshot::new(root, "test fix");
+        for file in &before_dirty {
+            snap.capture_file(file);
+        }
+        if let Err(error) = snap.save() {
+            crate::log_status!("undo", "Warning: failed to save undo snapshot: {}", error);
+        }
+
+        // Invoke the extension in fix-only mode.
+        let fix_runner = extension::test::build_test_runner(
+            component,
+            None,
+            settings,
+            options.skip_lint,
+            false,
+            None,
+            selected_test_files,
+            run_dir,
+        )?
+        .env("HOMEBOY_FIX_ONLY", "1");
+
+        let mut fix_runner = fix_runner;
+        if !options.script_args.is_empty() {
+            fix_runner = fix_runner.script_args(&options.script_args);
+        }
+
+        fix_runner.run()?;
+
         let after_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
         let before_set: HashSet<&str> = before_dirty.iter().map(|s| s.as_str()).collect();
-        after_dirty
+        let changed: Vec<String> = after_dirty
             .into_iter()
             .filter(|f| !before_set.contains(f.as_str()))
-            .collect()
+            .collect();
+
+        let fix_results = fix_sidecars.consume_fix_results();
+        (changed, fix_results)
     } else {
-        Vec::new()
+        (Vec::new(), Vec::new())
     };
 
-    let fix_results = fix_sidecars.consume_fix_results();
     let edit_count = fix_results.len();
     Ok(PlannedStage {
         source: "test".to_string(),

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -61,28 +61,6 @@ pub fn lint_refactor_request(
     }
 }
 
-pub fn test_refactor_request(
-    component: Component,
-    root: PathBuf,
-    settings: Vec<(String, String)>,
-    options: TestSourceOptions,
-    write: bool,
-) -> RefactorSourceRequest {
-    RefactorSourceRequest {
-        component,
-        root,
-        sources: vec!["test".to_string()],
-        changed_since: None,
-        only: Vec::new(),
-        exclude: Vec::new(),
-        settings,
-        lint: LintSourceOptions::default(),
-        test: options,
-        write,
-        force: false,
-    }
-}
-
 pub fn run_lint_refactor(
     component: Component,
     root: PathBuf,

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -61,6 +61,28 @@ pub fn lint_refactor_request(
     }
 }
 
+pub fn build_test_refactor_request(
+    component: Component,
+    root: PathBuf,
+    settings: Vec<(String, String)>,
+    options: TestSourceOptions,
+    write: bool,
+) -> RefactorSourceRequest {
+    RefactorSourceRequest {
+        component,
+        root,
+        sources: vec!["test".to_string()],
+        changed_since: None,
+        only: Vec::new(),
+        exclude: Vec::new(),
+        settings,
+        lint: LintSourceOptions::default(),
+        test: options,
+        write,
+        force: false,
+    }
+}
+
 pub fn run_lint_refactor(
     component: Component,
     root: PathBuf,
@@ -80,7 +102,7 @@ pub fn run_test_refactor(
     options: TestSourceOptions,
     write: bool,
 ) -> crate::Result<RefactorSourceRun> {
-    collect_refactor_sources(test_refactor_request(
+    collect_refactor_sources(build_test_refactor_request(
         component, root, settings, options, write,
     ))
 }

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -870,6 +870,24 @@ fn run_lint_stage(
         options.glob.clone()
     };
 
+    // Helper: build the lint runner with the current stage options.
+    // Used by both the diagnostic pass and the fix-only pass.
+    let build_lint_runner = || {
+        extension::lint::build_lint_runner(
+            component,
+            None,
+            settings,
+            false,
+            options.file.as_deref(),
+            effective_glob.as_deref(),
+            options.errors_only,
+            options.sniffs.as_deref(),
+            options.exclude_sniffs.as_deref(),
+            options.category.as_deref(),
+            run_dir,
+        )
+    };
+
     // ── Phase 1: Diagnose ──────────────────────────────────────────────
     // Run the linter WITHOUT auto-fix. The extension reports findings but
     // does NOT modify files. This separates diagnosis from fix application
@@ -899,21 +917,7 @@ fn run_lint_stage(
         cached_findings
     } else {
         // No cached findings — run the diagnostic pass.
-        let runner = extension::lint::build_lint_runner(
-            component,
-            None,
-            settings,
-            false,
-            options.file.as_deref(),
-            effective_glob.as_deref(),
-            options.errors_only,
-            options.sniffs.as_deref(),
-            options.exclude_sniffs.as_deref(),
-            options.category.as_deref(),
-            run_dir,
-        )?;
-
-        runner.run()?;
+        build_lint_runner()?.run()?;
 
         crate::extension::lint::baseline::parse_findings_file(&findings_file).unwrap_or_default()
     };
@@ -936,22 +940,7 @@ fn run_lint_stage(
 
         // Invoke the extension in fix-only mode — runs fixers without
         // re-running the diagnostic pass.
-        let fix_runner = extension::lint::build_lint_runner(
-            component,
-            None,
-            settings,
-            false,
-            options.file.as_deref(),
-            effective_glob.as_deref(),
-            options.errors_only,
-            options.sniffs.as_deref(),
-            options.exclude_sniffs.as_deref(),
-            options.category.as_deref(),
-            run_dir,
-        )?
-        .env("HOMEBOY_FIX_ONLY", "1");
-
-        fix_runner.run()?;
+        build_lint_runner()?.env("HOMEBOY_FIX_ONLY", "1").run()?;
 
         let after_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
         let before_set: HashSet<&str> = before_dirty.iter().map(|s| s.as_str()).collect();
@@ -1021,18 +1010,22 @@ fn run_test_stage(
     // ── Phase 1: Diagnose ──────────────────────────────────────────────
     // Run tests WITHOUT auto-fix. The extension reports failures but does
     // NOT modify files. This separates diagnosis from fix application.
-    let runner = extension::test::build_test_runner(
-        component,
-        None,
-        settings,
-        options.skip_lint,
-        false,
-        None,
-        selected_test_files,
-        run_dir,
-    )?;
+    //
+    // Helper: build the test runner with the current stage options.
+    let build_runner = || {
+        extension::test::build_test_runner(
+            component,
+            None,
+            settings,
+            options.skip_lint,
+            false,
+            None,
+            selected_test_files,
+            run_dir,
+        )
+    };
 
-    let mut runner = runner;
+    let mut runner = build_runner()?;
     if !options.script_args.is_empty() {
         runner = runner.script_args(&options.script_args);
     }
@@ -1054,20 +1047,9 @@ fn run_test_stage(
             crate::log_status!("undo", "Warning: failed to save undo snapshot: {}", error);
         }
 
-        // Invoke the extension in fix-only mode.
-        let fix_runner = extension::test::build_test_runner(
-            component,
-            None,
-            settings,
-            options.skip_lint,
-            false,
-            None,
-            selected_test_files,
-            run_dir,
-        )?
-        .env("HOMEBOY_FIX_ONLY", "1");
-
-        let mut fix_runner = fix_runner;
+        // Invoke the extension in fix-only mode. Reuses the same builder
+        // as the diagnostic pass with HOMEBOY_FIX_ONLY=1.
+        let mut fix_runner = build_runner()?.env("HOMEBOY_FIX_ONLY", "1");
         if !options.script_args.is_empty() {
             fix_runner = fix_runner.script_args(&options.script_args);
         }


### PR DESCRIPTION
## Summary

Closes #1077

The refactor engine now owns the full fix lifecycle for lint and test stages, matching the diagnose → plan → apply model that audit already uses.

### What changed

- **`run_lint_stage()`**: Split into two explicit phases — Phase 1 runs the linter WITHOUT `HOMEBOY_AUTO_FIX` (diagnosis only), Phase 2 invokes the extension with `HOMEBOY_FIX_ONLY=1` (fix-only, no re-diagnosis)
- **`run_test_stage()`**: Same two-phase pattern, wrapped with undo snapshots for rollback safety
- **`try_load_cached_lint()`**: Now returns `HasFindings(count)` when the quality gate already found issues, so the fix stage can skip re-running the diagnostic pass entirely
- **Replaced `HOMEBOY_AUTO_FIX`** with `HOMEBOY_FIX_ONLY` — extensions should recognize this to run fixers without re-running diagnostics
- Updated `docs/commands/lint.md` with the new env var

### Architecture

```
BEFORE (side-effect model):
  run_lint_stage() → HOMEBOY_AUTO_FIX=1 → extension fixes + diagnoses → git diff

AFTER (owned model):
  Phase 1: run_lint_stage() → lint WITHOUT auto-fix → collect findings (or use cached)
  Phase 2 (only when --write): → HOMEBOY_FIX_ONLY=1 → extension runs fixers only
                                    → engine tracks changes via undo snapshots + git diff
```

### Extension compatibility

Extension scripts need to recognize `HOMEBOY_FIX_ONLY=1` to run fixers without re-running diagnostics. Until they do, the fix-only invocation is a no-op (extensions ignore unknown env vars). The WordPress extension update is a follow-up.

### Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (33 unit tests + 1 integration test)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` — no new warnings
- [ ] CI pipeline passes