### PR TITLE
fix: validate trait extraction — PSR-4, body comparison, line validation (#1112)

### DIFF
--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -497,8 +497,7 @@ pub(crate) fn generate_duplicate_function_fixes(
                         // wrong, skip the entire edit for this file to avoid
                         // leaving orphaned trait-use statements (Bug 3).
                         let abs_path = root.join(&file);
-                        let file_content =
-                            std::fs::read_to_string(&abs_path).unwrap_or_default();
+                        let file_content = std::fs::read_to_string(&abs_path).unwrap_or_default();
                         let file_lines: Vec<&str> = file_content.lines().collect();
                         let start_idx = (start as usize).saturating_sub(1);
                         let end_idx = (end as usize).min(file_lines.len());

--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -384,6 +384,7 @@ pub(crate) fn generate_duplicate_function_fixes(
             "canonical_content": canonical_content,
             "files": file_entries,
             "all_file_paths": all_paths,
+            "project_root": root.to_string_lossy(),
         });
 
         let Some(result_val) = crate::extension::run_refactor_script(&manifest, &extract_cmd)
@@ -418,6 +419,28 @@ pub(crate) fn generate_duplicate_function_fixes(
                 reason: format!("Skipped `{}`: {}", group.function_name, reason),
             });
             continue;
+        }
+
+        // Record files that the extension skipped due to body mismatch.
+        if let Some(skipped_arr) = result_val
+            .get("skipped_files")
+            .and_then(|value| value.as_array())
+        {
+            for entry in skipped_arr {
+                let file = entry
+                    .get("file")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let reason = entry
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("body mismatch")
+                    .to_string();
+                if !file.is_empty() {
+                    skipped.push(SkippedFile { file, reason });
+                }
+            }
         }
 
         if let (Some(trait_file), Some(trait_content)) = (
@@ -469,6 +492,35 @@ pub(crate) fn generate_duplicate_function_fixes(
                             .get("end_line")
                             .and_then(|value| value.as_u64()),
                     ) {
+                        // Validate that the line range actually contains the
+                        // function declaration. If line numbers are stale or
+                        // wrong, skip the entire edit for this file to avoid
+                        // leaving orphaned trait-use statements (Bug 3).
+                        let abs_path = root.join(&file);
+                        let file_content =
+                            std::fs::read_to_string(&abs_path).unwrap_or_default();
+                        let file_lines: Vec<&str> = file_content.lines().collect();
+                        let start_idx = (start as usize).saturating_sub(1);
+                        let end_idx = (end as usize).min(file_lines.len());
+
+                        let fn_pattern = format!("function {}", group.function_name);
+                        let lines_contain_fn = (start_idx..end_idx)
+                            .any(|i| file_lines.get(i).is_some_and(|l| l.contains(&fn_pattern)));
+
+                        if !lines_contain_fn {
+                            skipped.push(SkippedFile {
+                                file: file.clone(),
+                                reason: format!(
+                                    "Line range {}–{} does not contain `function {}` — \
+                                     skipping trait extraction for this file",
+                                    start, end, group.function_name
+                                ),
+                            });
+                            // Skip the entire edit for this file — don't add
+                            // trait-use or import without the removal.
+                            continue;
+                        }
+
                         insertions.push(insertion(
                             InsertionKind::FunctionRemoval {
                                 start_line: start as usize,


### PR DESCRIPTION
## Summary

Fixes #1112 — `refactor --write` generated broken trait extractions that broke `data-machine-socials` in three ways.

### Bug 1: Traits placed in wrong directory
- The extension now receives `project_root` and reads `composer.json` `autoload.psr-4` to resolve namespace-to-directory mappings
- Falls back to the hardcoded `DataMachine` → `inc/` heuristic when no mappings found

### Bug 2: Non-duplicate methods treated as duplicates  
- The extension now compares normalized method bodies before generating edit instructions
- Files with different implementations are skipped with clear reason messages
- If all non-canonical files have different bodies, the entire extraction is skipped

### Bug 3: Original methods left behind after trait insertion
- The Rust caller now validates that `FunctionRemoval` line ranges actually contain the expected `function <name>` declaration
- If line numbers are stale/wrong, the entire edit (removal + trait-use + import) is skipped to prevent orphaned trait-use statements

### Companion PR
- Extension changes: Extra-Chill/homeboy-extensions — `fix/1112-psr4-trait-placement` branch

### Testing
- All existing Rust tests pass (`cargo test`)
- Python smoke tests covering PSR-4 resolution, body comparison, and the full `extract_shared` flow
- Simulated the `data-machine-socials` scenario: `remove_account` (different bodies) correctly skipped, `get_account_details` (identical bodies) correctly extracted to `inc/Handlers/Auth/Traits/HasGetAccountDetails.php`