### PR TITLE
Phases 3-6: RefactorPrimitive cleanup, EditOp alignment, serde reporting (#1041)

### DIFF
--- a/src/core/engine/edit_op.rs
+++ b/src/core/engine/edit_op.rs
@@ -376,6 +376,41 @@ pub fn transform_result_to_edit_ops(
         .collect()
 }
 
+// ============================================================================
+// Rename command conversions
+// ============================================================================
+
+/// Translate a `FileRename` into a `TaggedEditOp`.
+pub fn file_rename_to_edit_op(
+    rename: &crate::refactor::FileRename,
+) -> TaggedEditOp {
+    TaggedEditOp {
+        op: EditOp::MoveFile {
+            from: rename.from.clone(),
+            to: rename.to.clone(),
+        },
+        primitive: None,
+        finding: None,
+        description: format!("Rename: {} → {}", rename.from, rename.to),
+        manual_only: false,
+    }
+}
+
+/// Translate the file renames from a `RenameResult` into `TaggedEditOp`s.
+///
+/// Only converts file/directory renames (→ `MoveFile`), not content edits.
+/// Content edits operate at whole-file granularity and are applied directly
+/// by the rename engine.
+pub fn rename_file_moves_to_edit_ops(
+    result: &crate::refactor::RenameResult,
+) -> Vec<TaggedEditOp> {
+    result
+        .file_renames
+        .iter()
+        .map(file_rename_to_edit_op)
+        .collect()
+}
+
 // Apply logic lives in `edit_op_apply` — see that module for:
 // resolve_anchor(), apply_edit_ops_to_content(), apply_edit_ops().
 

--- a/src/core/engine/refactor_primitive.rs
+++ b/src/core/engine/refactor_primitive.rs
@@ -165,8 +165,102 @@ pub fn tagged_visibility_change(
     )
 }
 
+pub fn function_removal(
+    finding: AuditFinding,
+    start_line: usize,
+    end_line: usize,
+    code: String,
+    description: String,
+) -> Insertion {
+    insertion(
+        InsertionKind::FunctionRemoval {
+            start_line,
+            end_line,
+        },
+        finding,
+        code,
+        description,
+    )
+}
+
+pub fn tagged_function_removal(
+    primitive: RefactorPrimitive,
+    finding: AuditFinding,
+    start_line: usize,
+    end_line: usize,
+    description: String,
+) -> Insertion {
+    tagged_insertion(
+        primitive,
+        InsertionKind::FunctionRemoval {
+            start_line,
+            end_line,
+        },
+        finding,
+        String::new(),
+        description,
+    )
+}
+
+pub fn doc_reference_update(
+    finding: AuditFinding,
+    line: usize,
+    old_ref: String,
+    new_ref: String,
+    code: String,
+    description: String,
+) -> Insertion {
+    insertion(
+        InsertionKind::DocReferenceUpdate {
+            line,
+            old_ref,
+            new_ref,
+        },
+        finding,
+        code,
+        description,
+    )
+}
+
+pub fn tagged_doc_reference_update(
+    primitive: RefactorPrimitive,
+    finding: AuditFinding,
+    line: usize,
+    old_ref: String,
+    new_ref: String,
+    code: String,
+    description: String,
+) -> Insertion {
+    tagged_insertion(
+        primitive,
+        InsertionKind::DocReferenceUpdate {
+            line,
+            old_ref,
+            new_ref,
+        },
+        finding,
+        code,
+        description,
+    )
+}
+
 pub fn doc_line_removal(finding: AuditFinding, line: usize, description: String) -> Insertion {
     insertion(
+        InsertionKind::DocLineRemoval { line },
+        finding,
+        String::new(),
+        description,
+    )
+}
+
+pub fn tagged_doc_line_removal(
+    primitive: RefactorPrimitive,
+    finding: AuditFinding,
+    line: usize,
+    description: String,
+) -> Insertion {
+    tagged_insertion(
+        primitive,
         InsertionKind::DocLineRemoval { line },
         finding,
         String::new(),

--- a/src/core/refactor/auto/apply.rs
+++ b/src/core/refactor/auto/apply.rs
@@ -2,9 +2,7 @@ use crate::core::refactor::decompose;
 use crate::core::refactor::plan::verify::rewrite_callers_after_dedup;
 
 use crate::engine::undo::InMemoryRollback;
-use crate::refactor::auto::{
-    ApplyChunkResult, ApplyOptions, ChunkStatus, DecomposeFixPlan, Fix, NewFile,
-};
+use crate::refactor::auto::{ApplyChunkResult, ChunkStatus, DecomposeFixPlan, Fix, NewFile};
 use std::path::Path;
 
 // ============================================================================
@@ -215,7 +213,6 @@ fn merge_same_file_insertions(fixes: &mut [Fix]) {
 pub fn apply_decompose_plans(
     plans: &mut [DecomposeFixPlan],
     root: &Path,
-    options: ApplyOptions<'_>,
 ) -> Vec<ApplyChunkResult> {
     let mut results = Vec::new();
     for (index, dfp) in plans.iter_mut().enumerate() {
@@ -261,7 +258,7 @@ pub fn apply_decompose_plans(
         match decompose::apply_plan(&dfp.plan, root, true) {
             Ok(move_results) => {
                 let files_modified = move_results.iter().filter(|r| r.applied).count();
-                let mut chunk = ApplyChunkResult {
+                let chunk = ApplyChunkResult {
                     chunk_id: format!("decompose:{}", index + 1),
                     files: all_files,
                     status: ChunkStatus::Applied,
@@ -270,22 +267,6 @@ pub fn apply_decompose_plans(
                     verification: Some("decompose_applied".to_string()),
                     error: None,
                 };
-                if let Some(verifier) = options.verifier {
-                    match verifier(&chunk) {
-                        Ok(verification) => {
-                            chunk.verification = Some(verification);
-                        }
-                        Err(error) => {
-                            rollback.restore_all();
-                            chunk.status = ChunkStatus::Reverted;
-                            chunk.reverted_files = files_modified;
-                            chunk.error = Some(error);
-                            dfp.applied = false;
-                            results.push(chunk);
-                            continue;
-                        }
-                    }
-                }
                 dfp.applied = true;
                 log_status!(
                     "fix",
@@ -317,6 +298,22 @@ mod tests {
     use super::*;
     use crate::code_audit::AuditFinding;
     use crate::refactor::auto::{Insertion, InsertionKind};
+
+    fn removal_insertion(start_line: usize, end_line: usize, description: &str) -> Insertion {
+        Insertion {
+            primitive: None,
+            kind: InsertionKind::FunctionRemoval {
+                start_line,
+                end_line,
+            },
+            finding: AuditFinding::OrphanedTest,
+            manual_only: false,
+            auto_apply: false,
+            blocked_reason: None,
+            code: String::new(),
+            description: description.to_string(),
+        }
+    }
 
     #[test]
     fn merge_same_file_insertions_combines_removals() {

--- a/src/core/refactor/auto/contracts.rs
+++ b/src/core/refactor/auto/contracts.rs
@@ -1,9 +1,6 @@
 use crate::code_audit::conventions::AuditFinding;
 use crate::core::refactor::decompose;
 
-/// Callback that verifies an applied chunk, returning Ok(message) or Err(reason).
-pub type ChunkVerifier<'a> = &'a dyn Fn(&ApplyChunkResult) -> Result<String, String>;
-
 /// A planned fix for a single file.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Fix {
@@ -265,11 +262,6 @@ pub struct ApplyChunkResult {
 pub enum ChunkStatus {
     Applied,
     Reverted,
-}
-
-#[derive(Clone)]
-pub struct ApplyOptions<'a> {
-    pub verifier: Option<ChunkVerifier<'a>>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/core/refactor/auto/mod.rs
+++ b/src/core/refactor/auto/mod.rs
@@ -9,8 +9,8 @@ pub mod tracking;
 
 pub use apply::{apply_decompose_plans, apply_fixes_via_edit_ops};
 pub use contracts::{
-    ApplyChunkResult, ApplyOptions, ChunkStatus, ChunkVerifier, DecomposeFixPlan, Fix, FixPolicy,
-    FixResult, Insertion, InsertionKind, NewFile, PolicySummary, RefactorPrimitive, SkippedFile,
+    ApplyChunkResult, ChunkStatus, DecomposeFixPlan, Fix, FixPolicy, FixResult, Insertion,
+    InsertionKind, NewFile, PolicySummary, RefactorPrimitive, SkippedFile,
 };
 pub use guard::{GuardBlock, GuardConfig, GuardResult};
 pub use outcome::{

--- a/src/core/refactor/auto/summary.rs
+++ b/src/core/refactor/auto/summary.rs
@@ -106,36 +106,48 @@ pub fn summarize_audit_fix_result(fix_result: &FixResult) -> FixResultsSummary {
     }
 }
 
+/// Derive the primitive name from serde's `#[serde(tag = "type", rename_all = "snake_case")]`
+/// attribute on `RefactorPrimitive`. This eliminates manual match arms — adding a new
+/// variant to the enum automatically works for reporting.
 pub fn primitive_name(primitive: &crate::refactor::RefactorPrimitive) -> String {
-    match primitive {
-        crate::refactor::RefactorPrimitive::MoveTestFile => "move_test_file".to_string(),
-        crate::refactor::RefactorPrimitive::RenameTestMethod => "rename_test_method".to_string(),
-        crate::refactor::RefactorPrimitive::RemoveOrphanedTest => {
-            "remove_orphaned_test".to_string()
-        }
-        crate::refactor::RefactorPrimitive::RemoveCompilerDeadCode => {
-            "remove_compiler_dead_code".to_string()
-        }
-        crate::refactor::RefactorPrimitive::ApplyCompilerReplacement => {
-            "apply_compiler_replacement".to_string()
-        }
-        crate::refactor::RefactorPrimitive::RemoveUnusedParameter => {
-            "remove_unused_parameter".to_string()
-        }
-        crate::refactor::RefactorPrimitive::RemoveNearDuplicateImplementation => {
-            "remove_near_duplicate_implementation".to_string()
-        }
-        crate::refactor::RefactorPrimitive::ImportCanonicalImplementation => {
-            "import_canonical_implementation".to_string()
-        }
-        crate::refactor::RefactorPrimitive::WidenCanonicalVisibility => {
-            "widen_canonical_visibility".to_string()
-        }
-        crate::refactor::RefactorPrimitive::UpdateStaleDocReference => {
-            "update_stale_doc_reference".to_string()
-        }
-        crate::refactor::RefactorPrimitive::RemoveBrokenDocReferenceLine => {
-            "remove_broken_doc_reference_line".to_string()
-        }
+    // RefactorPrimitive uses `#[serde(tag = "type", rename_all = "snake_case")]`.
+    // Serializing to JSON gives `{"type": "snake_case_name", ...}`.
+    // Extract the "type" field value.
+    serde_json::to_value(primitive)
+        .ok()
+        .and_then(|v| v.get("type").and_then(|t| t.as_str()).map(String::from))
+        .unwrap_or_else(|| format!("{:?}", primitive).to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::refactor::RefactorPrimitive;
+
+    #[test]
+    fn primitive_name_derives_from_serde() {
+        // Verify serde-derived names match the expected snake_case format.
+        // Adding a new variant to RefactorPrimitive automatically works —
+        // no manual match arm needed.
+        assert_eq!(
+            primitive_name(&RefactorPrimitive::MoveTestFile),
+            "move_test_file"
+        );
+        assert_eq!(
+            primitive_name(&RefactorPrimitive::RemoveOrphanedTest),
+            "remove_orphaned_test"
+        );
+        assert_eq!(
+            primitive_name(&RefactorPrimitive::RemoveNearDuplicateImplementation),
+            "remove_near_duplicate_implementation"
+        );
+        assert_eq!(
+            primitive_name(&RefactorPrimitive::UpdateStaleDocReference),
+            "update_stale_doc_reference"
+        );
+        assert_eq!(
+            primitive_name(&RefactorPrimitive::RemoveBrokenDocReferenceLine),
+            "remove_broken_doc_reference_line"
+        );
     }
 }

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -48,8 +48,8 @@ impl AppliedRefactor {
 pub use add::{add_import, fixes_from_audit, AddResult};
 pub use auto::{
     apply_decompose_plans, apply_fix_policy, apply_fixes_via_edit_ops, ApplyChunkResult,
-    ApplyOptions, ChunkStatus, Fix, FixPolicy, FixResult, Insertion, InsertionKind, NewFile,
-    PolicySummary, RefactorPrimitive, SkippedFile,
+    ChunkStatus, Fix, FixPolicy, FixResult, Insertion, InsertionKind, NewFile, PolicySummary,
+    RefactorPrimitive, SkippedFile,
 };
 pub use decompose::{
     apply_plan, apply_plan_skeletons, build_plan, DecomposeAuditImpact, DecomposeGroup,

--- a/src/core/refactor/plan/generate/builders.rs
+++ b/src/core/refactor/plan/generate/builders.rs
@@ -1,5 +1,6 @@
 pub(crate) use crate::core::engine::refactor_primitive::{
-    doc_line_removal, insertion, manual_blocked, manual_only, new_file, range_removal,
-    tagged_import_add, tagged_insertion as insertion_with_primitive, tagged_line_replacement,
-    tagged_range_removal, tagged_visibility_change,
+    doc_line_removal, function_removal, insertion, manual_blocked, manual_only, new_file,
+    range_removal, tagged_doc_line_removal, tagged_doc_reference_update, tagged_import_add,
+    tagged_insertion as insertion_with_primitive, tagged_line_replacement, tagged_range_removal,
+    tagged_visibility_change,
 };

--- a/src/core/refactor/plan/generate/doc_fixes.rs
+++ b/src/core/refactor/plan/generate/doc_fixes.rs
@@ -2,7 +2,7 @@ use crate::code_audit::{AuditFinding, CodeAuditResult};
 use crate::core::refactor::auto::{Fix, RefactorPrimitive};
 use std::path::Path;
 
-use super::insertion_with_primitive;
+use super::{tagged_doc_line_removal, tagged_doc_reference_update};
 
 pub(crate) fn extract_suggested_path(suggestion: &str) -> Option<String> {
     // Support both suggestion formats:
@@ -66,14 +66,12 @@ pub(super) fn apply_stale_doc_reference_fixes(result: &CodeAuditResult, fixes: &
             file: finding.file.clone(),
             required_methods: vec![],
             required_registrations: vec![],
-            insertions: vec![insertion_with_primitive(
+            insertions: vec![tagged_doc_reference_update(
                 RefactorPrimitive::UpdateStaleDocReference,
-                crate::core::refactor::auto::InsertionKind::DocReferenceUpdate {
-                    line: line_num,
-                    old_ref: old_path.clone(),
-                    new_ref: new_path.clone(),
-                },
                 AuditFinding::StaleDocReference,
+                line_num,
+                old_path.clone(),
+                new_path.clone(),
                 format!("{} → {}", old_path, new_path),
                 format!(
                     "Update stale reference: `{}` → `{}` (line {})",
@@ -118,11 +116,10 @@ pub(super) fn apply_broken_doc_reference_fixes(
             file: finding.file.clone(),
             required_methods: vec![],
             required_registrations: vec![],
-            insertions: vec![insertion_with_primitive(
+            insertions: vec![tagged_doc_line_removal(
                 RefactorPrimitive::RemoveBrokenDocReferenceLine,
-                crate::core::refactor::auto::InsertionKind::DocLineRemoval { line: line_num },
                 AuditFinding::BrokenDocReference,
-                dead_path.clone(),
+                line_num,
                 format!(
                     "Remove dead documentation reference line for `{}` (line {})",
                     dead_path, line_num

--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use super::{
-    find_parsed_item_by_name, insertion, new_file, parse_items_for_dedup, FileRole,
-    ModuleSurfaceIndex,
+    find_parsed_item_by_name, function_removal, insertion, new_file, parse_items_for_dedup,
+    FileRole, ModuleSurfaceIndex,
 };
 
 pub(crate) fn extract_function_name_from_unreferenced(description: &str) -> Option<String> {
@@ -520,12 +520,10 @@ pub(crate) fn generate_duplicate_function_fixes(
                             continue;
                         }
 
-                        insertions.push(insertion(
-                            InsertionKind::FunctionRemoval {
-                                start_line: start as usize,
-                                end_line: end as usize,
-                            },
+                        insertions.push(function_removal(
                             AuditFinding::DuplicateFunction,
+                            start as usize,
+                            end as usize,
                             String::new(),
                             format!(
                                 "Remove duplicate `{}` (extracted to shared trait)",
@@ -688,12 +686,10 @@ fn generate_simple_duplicate_fixes(
         let import_stmt =
             generate_duplicate_import(&group.canonical_file, &group.function_name, &language, root);
 
-        let mut insertions = vec![insertion(
-            InsertionKind::FunctionRemoval {
-                start_line: item.start_line,
-                end_line: item.end_line,
-            },
+        let mut insertions = vec![function_removal(
             AuditFinding::DuplicateFunction,
+            item.start_line,
+            item.end_line,
             String::new(),
             format!(
                 "Remove duplicate `{}` (canonical copy in {})",

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -20,9 +20,9 @@ use std::path::Path;
 use convention_fixes::apply_convention_fixes;
 
 pub(crate) use builders::{
-    doc_line_removal, insertion, insertion_with_primitive, manual_blocked, manual_only, new_file,
-    range_removal, tagged_import_add, tagged_line_replacement, tagged_range_removal,
-    tagged_visibility_change,
+    doc_line_removal, function_removal, insertion, insertion_with_primitive, manual_blocked,
+    manual_only, new_file, range_removal, tagged_doc_line_removal, tagged_doc_reference_update,
+    tagged_import_add, tagged_line_replacement, tagged_range_removal, tagged_visibility_change,
 };
 pub(crate) use doc_fixes::is_actionable_comment_finding;
 pub(crate) use duplicate_fixes::{

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -235,11 +235,8 @@ fn run_fix_iteration(
 
     // Decompose plans use their own apply path (out of scope for EditOp migration)
     if !auto_decompose_plans.is_empty() {
-        let decompose_chunk_results = fixer::apply_decompose_plans(
-            &mut auto_decompose_plans,
-            root,
-            fixer::ApplyOptions { verifier: None },
-        );
+        let decompose_chunk_results =
+            fixer::apply_decompose_plans(&mut auto_decompose_plans, root);
         fix_result.chunk_results.extend(decompose_chunk_results);
     }
 

--- a/src/core/refactor/rename/mod.rs
+++ b/src/core/refactor/rename/mod.rs
@@ -1107,8 +1107,16 @@ fn extract_field_identifier(trimmed: &str) -> Option<String> {
 // ============================================================================
 
 /// Apply rename edits and file renames to disk.
+///
+/// Content edits are written directly (whole-file replacement). File/directory
+/// renames are routed through `apply_edit_ops()` so they share the same
+/// execution path as the fixer pipeline and other manual commands.
 pub fn apply_renames(result: &mut RenameResult, root: &Path) -> Result<()> {
-    // Apply content edits first
+    use crate::engine::edit_op::rename_file_moves_to_edit_ops;
+    use crate::engine::edit_op_apply::apply_edit_ops;
+
+    // Apply content edits first (whole-file replacement — rename operates at
+    // full-content granularity, not line-level, so these bypass EditOp).
     for edit in &result.edits {
         let path = root.join(&edit.file);
         std::fs::write(&path, &edit.new_content).map_err(|e| {
@@ -1116,31 +1124,40 @@ pub fn apply_renames(result: &mut RenameResult, root: &Path) -> Result<()> {
         })?;
     }
 
-    // Apply file renames (sort by path depth descending so children rename before parents)
-    let mut renames = result.file_renames.clone();
-    renames.sort_by(|a, b| {
-        b.from
-            .matches('/')
-            .count()
-            .cmp(&a.from.matches('/').count())
-    });
+    // Apply file/directory renames through the shared EditOp engine.
+    // apply_edit_ops() handles parent directory creation and error reporting.
+    if !result.file_renames.is_empty() {
+        // Sort by path depth descending so children rename before parents.
+        let mut sorted_renames = result.file_renames.clone();
+        sorted_renames.sort_by(|a, b| {
+            b.from
+                .matches('/')
+                .count()
+                .cmp(&a.from.matches('/').count())
+        });
 
-    for rename in &renames {
-        let from = root.join(&rename.from);
-        let to = root.join(&rename.to);
+        // Temporarily replace file_renames with the sorted order for conversion.
+        let original_renames = std::mem::replace(&mut result.file_renames, sorted_renames);
+        let ops = rename_file_moves_to_edit_ops(result);
+        result.file_renames = original_renames;
 
-        // Create parent dirs if needed
-        if let Some(parent) = to.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
+        let report = apply_edit_ops(&ops, root).map_err(|e| {
+            Error::internal_io(
+                format!("apply_edit_ops failed for file renames: {}", e),
+                Some("rename.apply".to_string()),
+            )
+        })?;
 
-        if from.exists() {
-            std::fs::rename(&from, &to).map_err(|e| {
-                Error::internal_io(
-                    e.to_string(),
-                    Some(format!("rename {} → {}", from.display(), to.display())),
-                )
-            })?;
+        if !report.errors.is_empty() {
+            let error_messages: Vec<String> = report
+                .errors
+                .iter()
+                .map(|e| format!("{}: {}", e.file, e.message))
+                .collect();
+            return Err(Error::internal_io(
+                format!("File rename errors: {}", error_messages.join("; ")),
+                Some("rename.apply".to_string()),
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary

Phases 3 through 6 of #1041 — cleans up the primitive/helper layer, aligns manual command surfaces with the shared `EditOp` engine, and replaces hand-written reporting with serde-derived serialization.

### Phase 3: Engine helper cleanup
- **New engine builders** — `function_removal()`, `tagged_function_removal()`, `doc_reference_update()`, `tagged_doc_reference_update()`, `tagged_doc_line_removal()`
- **Standardized fixer construction** — `duplicate_fixes.rs` and `doc_fixes.rs` migrated from manual `InsertionKind` struct construction to engine builder helpers
- **Removed dead code** — `ApplyOptions` struct, `ChunkVerifier` type alias, and the verification branch in `apply_decompose_plans()` (verifier was always `None`)
- **Fixed pre-existing test breakage** — added missing `removal_insertion()` test helper in `apply.rs`

### Phase 4: Align rename with EditOp engine
- **New converters** — `file_rename_to_edit_op()` and `rename_file_moves_to_edit_ops()` translate `FileRename` → `EditOp::MoveFile`
- **Wired rename file moves** through `apply_edit_ops()` — gains parent dir creation, error reporting, and shared execution path
- Content edits remain as whole-file writes (rename operates at full-content granularity, not line-level)

### Phase 6: Serde-derived reporting
- **Replaced `primitive_name()` match arms** with `serde_json::to_value()` extraction — the enum already has `#[serde(tag = "type", rename_all = "snake_case")]`, so the 11 hand-written match arms were pure duplication
- Adding new `RefactorPrimitive` variants now automatically works for reporting with zero match arm maintenance
- Added test verifying serde-derived names match expected format

### EditOp alignment status after this PR

| Surface | EditOp Execution | EditOp Reporting |
|---|---|---|
| Fixer pipeline | `apply_edit_ops()` ✅ | `fix_to_edit_ops()` ✅ |
| Propagate | `apply_edit_ops()` ✅ | `propagate_result_to_edit_ops()` ✅ |
| Rename file moves | `apply_edit_ops()` ✅ | `rename_file_moves_to_edit_ops()` ✅ |
| Rename content | Direct write (whole-file) | N/A (full-content granularity) |
| Transform | Direct write (regex engine) | `transform_result_to_edit_ops()` ✅ |

### Phase 5 (planner removal) — out of scope
The `refactor --from` orchestration layer is still in active use across the codebase. Full planner removal is the eventual goal but requires a dedicated effort beyond this PR. Comments referencing `refactor --from` are documentation, not dead code.

## Test Results

- 1081 tests passing, 0 failures
- Zero new compiler warnings