### PR TITLE
Remove pure planner artifacts (Phase 5a of #1041)

### DIFF
--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -13,7 +13,6 @@
 //!   test-results.json      ← test step output
 //!   test-failures.json     ← test failure details
 //!   coverage.json          ← test coverage data
-//!   fix-plan.json          ← planned fixes (autofix)
 //!   fix-results.json       ← applied fixes (autofix)
 //!   annotations/           ← CI annotation files
 //! ```
@@ -34,7 +33,6 @@ pub mod files {
     pub const TEST_RESULTS: &str = "test-results.json";
     pub const TEST_FAILURES: &str = "test-failures.json";
     pub const COVERAGE: &str = "coverage.json";
-    pub const FIX_PLAN: &str = "fix-plan.json";
     pub const FIX_RESULTS: &str = "fix-results.json";
     pub const ANNOTATIONS_DIR: &str = "annotations";
 }
@@ -126,12 +124,6 @@ impl RunDir {
             (
                 "HOMEBOY_COVERAGE_FILE".to_string(),
                 self.step_file(files::COVERAGE)
-                    .to_string_lossy()
-                    .to_string(),
-            ),
-            (
-                "HOMEBOY_FIX_PLAN_FILE".to_string(),
-                self.step_file(files::FIX_PLAN)
                     .to_string_lossy()
                     .to_string(),
             ),

--- a/src/core/refactor/auto/mod.rs
+++ b/src/core/refactor/auto/mod.rs
@@ -18,7 +18,7 @@ pub use outcome::{
     FixApplied, FixResultsSummary, RuleFixCount,
 };
 pub use policy::apply_fix_policy;
-pub use sidecar::{parse_fix_plan_file, parse_fix_results_file, read_fix_results};
+pub use sidecar::parse_fix_results_file;
 pub use summary::{
     primitive_name, summarize_audit_fix_result, summarize_fix_results,
     summarize_optional_fix_results,

--- a/src/core/refactor/auto/outcome.rs
+++ b/src/core/refactor/auto/outcome.rs
@@ -17,7 +17,6 @@ pub struct AutofixOutcome {
 #[derive(Debug, Clone)]
 pub struct AutofixSidecarFiles {
     pub results_file: PathBuf,
-    pub plan_file: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/refactor/auto/policy.rs
+++ b/src/core/refactor/auto/policy.rs
@@ -133,9 +133,12 @@ pub fn apply_fix_policy(result: &mut FixResult, write: bool, policy: &FixPolicy)
         .decompose_plans
         .retain(|p| !policy.exclude.contains(&p.source_finding));
 
-    // Structural decompose writes are still too risky for unattended autofix.
-    // Keep them visible in dry-run output, but do not auto-apply them in write
-    // mode until the engine is proven safe on real branches.
+    // Structural decompose writes are too risky for unattended autofix.
+    // In dry-run mode they remain visible for preview; in write mode they are
+    // dropped entirely. Because this clearing happens before `run_fix_iteration`
+    // clones `decompose_plans`, the decompose apply path in verify.rs is
+    // unreachable in write mode — any decompose application must go through
+    // explicit manual commands (e.g. `refactor decompose`).
     if write {
         summary.dropped_manual_only += result.decompose_plans.len();
         result.decompose_plans.clear();

--- a/src/core/refactor/auto/sidecar.rs
+++ b/src/core/refactor/auto/sidecar.rs
@@ -7,12 +7,11 @@ impl AutofixSidecarFiles {
     pub fn for_run_dir(run_dir: &RunDir) -> Self {
         Self {
             results_file: run_dir.step_file(run_dir::files::FIX_RESULTS),
-            plan_file: Some(run_dir.step_file(run_dir::files::FIX_PLAN)),
         }
     }
 
     pub fn consume_fix_results(&self) -> Vec<FixApplied> {
-        read_fix_results(&self.results_file, self.plan_file.as_deref())
+        parse_fix_results_file(&self.results_file)
     }
 }
 
@@ -31,19 +30,4 @@ pub fn parse_fix_results_file(path: &Path) -> Vec<FixApplied> {
     }
 
     serde_json::from_str(&content).unwrap_or_default()
-}
-
-pub fn parse_fix_plan_file(path: &Path) -> Vec<FixApplied> {
-    parse_fix_results_file(path)
-}
-
-pub fn read_fix_results(results_file: &Path, plan_file: Option<&Path>) -> Vec<FixApplied> {
-    if let Some(plan_file) = plan_file {
-        let planned_fix_results = parse_fix_plan_file(plan_file);
-        if !planned_fix_results.is_empty() {
-            return planned_fix_results;
-        }
-    }
-
-    parse_fix_results_file(results_file)
 }

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -748,7 +748,6 @@ fn plan_audit_stage(
             only,
             exclude,
             AuditConvergenceScoring::default(),
-            1,
             true,
         )?;
 
@@ -763,15 +762,10 @@ fn plan_audit_stage(
             .collect::<Vec<_>>();
 
         let warnings = outcome
-            .iterations
+            .iteration_summary
             .iter()
-            .filter(|iteration| iteration.status != "continued")
-            .map(|iteration| {
-                format!(
-                    "audit iteration {}: {}",
-                    iteration.iteration, iteration.status
-                )
-            })
+            .filter(|summary| summary.status != "continued")
+            .map(|summary| format!("audit refactor: {}", summary.status))
             .collect::<Vec<_>>();
 
         (
@@ -1386,7 +1380,7 @@ mod tests {
         assert!(audit_stage
             .warnings
             .iter()
-            .any(|warning| warning.starts_with("audit iteration ")));
+            .any(|warning| warning.starts_with("audit refactor: ")));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -61,7 +61,6 @@ pub(crate) fn rewrite_callers_after_dedup(fix: &fixer::Fix, root: &Path) {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AuditRefactorIterationSummary {
-    pub iteration: usize,
     pub findings_before: usize,
     pub findings_after: usize,
     pub weighted_score_before: usize,
@@ -78,7 +77,7 @@ pub struct AuditRefactorOutcome {
     pub current_result: CodeAuditResult,
     pub fix_result: fixer::FixResult,
     pub policy_summary: fixer::PolicySummary,
-    pub iterations: Vec<AuditRefactorIterationSummary>,
+    pub iteration_summary: Option<AuditRefactorIterationSummary>,
 }
 
 pub fn run_audit_refactor(
@@ -86,13 +85,12 @@ pub fn run_audit_refactor(
     only_kinds: &[crate::code_audit::AuditFinding],
     exclude_kinds: &[crate::code_audit::AuditFinding],
     scoring: AuditConvergenceScoring,
-    _max_iterations: usize,
     write: bool,
 ) -> crate::Result<AuditRefactorOutcome> {
     let current_result = initial_result;
-    let mut iterations = Vec::new();
     let final_fix_result;
     let final_policy_summary;
+    let final_iteration_summary;
 
     if write {
         // Single pass: take the provided findings, generate fixes, apply, validate.
@@ -107,7 +105,6 @@ pub fn run_audit_refactor(
         final_fix_result = fix_result;
         final_policy_summary = policy_summary;
 
-        iteration_summary.iteration = 1;
         iteration_summary.findings_after = current_result.findings.len();
         iteration_summary.weighted_score_after =
             weighted_finding_score_with(&current_result, scoring);
@@ -119,7 +116,7 @@ pub fn run_audit_refactor(
             iteration_summary.status = "completed".to_string();
         }
 
-        iterations.push(iteration_summary);
+        final_iteration_summary = Some(iteration_summary);
     } else {
         let policy = fixer::FixPolicy {
             only: (!only_kinds.is_empty()).then_some(only_kinds.to_vec()),
@@ -129,13 +126,14 @@ pub fn run_audit_refactor(
         let mut fix_result = super::generate::generate_audit_fixes(&current_result, root, &policy);
         final_policy_summary = fixer::apply_fix_policy(&mut fix_result, false, &policy);
         final_fix_result = fix_result;
+        final_iteration_summary = None;
     }
 
     Ok(AuditRefactorOutcome {
         current_result,
         fix_result: final_fix_result,
         policy_summary: final_policy_summary,
-        iterations,
+        iteration_summary: final_iteration_summary,
     })
 }
 
@@ -191,7 +189,9 @@ fn run_fix_iteration(
         .filter(|nf| nf.auto_apply)
         .cloned()
         .collect();
-    let mut auto_decompose_plans = fix_result.decompose_plans.clone();
+    // Note: decompose_plans are always cleared by apply_fix_policy() in write
+    // mode, so there are never any decompose plans to apply here. Decompose
+    // application goes through explicit manual commands (`refactor decompose`).
     let changed_files: Vec<String> = auto_fixes
         .iter()
         .map(|fix| fix.file.clone())
@@ -233,13 +233,6 @@ fn run_fix_iteration(
         fix_result.chunk_results.extend(chunk_results);
     }
 
-    // Decompose plans use their own apply path (out of scope for EditOp migration)
-    if !auto_decompose_plans.is_empty() {
-        let decompose_chunk_results =
-            fixer::apply_decompose_plans(&mut auto_decompose_plans, root);
-        fix_result.chunk_results.extend(decompose_chunk_results);
-    }
-
     for applied_fix in auto_fixes {
         if let Some(original) = fix_result
             .fixes
@@ -260,16 +253,6 @@ fn run_fix_iteration(
         }
     }
 
-    for plan in &auto_decompose_plans {
-        if let Some(original) = fix_result
-            .decompose_plans
-            .iter_mut()
-            .find(|candidate| candidate.file == plan.file)
-        {
-            original.applied = plan.applied;
-        }
-    }
-
     fix_result.files_modified = total_modified;
 
     let changed_files: Vec<String> = fix_result
@@ -283,7 +266,6 @@ fn run_fix_iteration(
         fix_result,
         policy_summary,
         AuditRefactorIterationSummary {
-            iteration: 0,
             findings_before: audit_result.findings.len(),
             findings_after: 0,
             weighted_score_before: weighted_finding_score_with(audit_result, scoring),

--- a/tests/utils/autofix_test.rs
+++ b/tests/utils/autofix_test.rs
@@ -1,5 +1,5 @@
 use homeboy::utils::autofix::{
-    read_fix_results, standard_outcome, summarize_optional_fix_results, AutofixMode,
+    parse_fix_results_file, standard_outcome, summarize_optional_fix_results, AutofixMode,
 };
 
 #[test]
@@ -49,17 +49,15 @@ fn test_standard_outcome_noop() {
 }
 
 #[test]
-fn test_read_fix_results_prefers_plan_file() {
+fn test_parse_fix_results_file() {
     let dir = tempfile::tempdir().expect("tempdir");
     let results = dir.path().join("results.json");
-    let plan = dir.path().join("plan.json");
 
     std::fs::write(&results, r#"[{"file":"src/results.rs","rule":"results"}]"#).expect("results");
-    std::fs::write(&plan, r#"[{"file":"src/plan.rs","rule":"plan"}]"#).expect("plan");
 
-    let parsed = read_fix_results(&results, Some(&plan));
+    let parsed = parse_fix_results_file(&results);
     assert_eq!(parsed.len(), 1);
-    assert_eq!(parsed[0].file, "src/plan.rs");
+    assert_eq!(parsed[0].file, "src/results.rs");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Removes dead planner-era code left over after the multi-iteration architecture was replaced with a single-pass pipeline. This is Phase 5a of #1041 — safe, zero-risk removals of unused code and parameters.

## Changes

- **Remove `parse_fix_plan_file()`** — trivial alias that just called `parse_fix_results_file()`; removed from `sidecar.rs` and its re-export from `auto/mod.rs`
- **Remove `plan_file` field** from `AutofixSidecarFiles` struct and stop populating it in `for_run_dir()`; also removed the `FIX_PLAN` constant and its legacy env var from `run_dir.rs`
- **Simplify `read_fix_results()`** — removed entirely; `consume_fix_results()` now calls `parse_fix_results_file()` directly instead of going through a plan-file-preference layer
- **Remove `_max_iterations` parameter** from `run_audit_refactor()` (always passed as 1) and update caller in `sources.rs`
- **Flatten `iterations` Vec** to `Option<AuditRefactorIterationSummary>` on `AuditRefactorOutcome` and remove the always-1 `iteration` field from the summary struct
- **Remove dead decompose-plan apply path** in `run_fix_iteration()` — `apply_fix_policy()` always clears decompose plans in write mode, so the apply/sync-back code was unreachable; added documentation in `policy.rs` explaining this behavior
- **Update test** for new warning format

## Stats

8 files changed, 24 insertions, 72 deletions — net reduction of 48 lines.

## Testing

All 1081 lib tests pass. Zero new compiler warnings (one pre-existing warning in `docs.rs` is unrelated).

Closes phase 5a of #1041.