### PR TITLE
fix: filter release commits from changelog + auto-discover changelog path

### DIFF
--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -68,6 +68,7 @@ pub enum CommitCategory {
     Docs,
     Chore,
     Merge,
+    Release,
     Other,
 }
 
@@ -115,12 +116,13 @@ impl CommitCategory {
             CommitCategory::Docs => Some("docs"),
             CommitCategory::Chore => Some("chore"),
             CommitCategory::Merge => None,
+            CommitCategory::Release => None,
             CommitCategory::Other => None,
         }
     }
 
     /// Map commit category to changelog entry type.
-    /// Returns None for categories that should be skipped (docs, chore, merge).
+    /// Returns None for categories that should be skipped (docs, chore, merge, release).
     pub fn to_changelog_entry_type(&self) -> Option<&'static str> {
         match self {
             CommitCategory::Feature => Some("added"),
@@ -129,6 +131,7 @@ impl CommitCategory {
             CommitCategory::Docs => None,
             CommitCategory::Chore => None,
             CommitCategory::Merge => None,
+            CommitCategory::Release => None,
             CommitCategory::Other => Some("changed"),
         }
     }
@@ -152,6 +155,12 @@ pub(crate) fn classify_commit(subject: &str, body: Option<&str>) -> CommitCatego
         || lower.starts_with("merge remote-tracking")
     {
         return CommitCategory::Merge;
+    }
+
+    // Detect version bump / release commits - these are release infrastructure noise.
+    // Uses the same patterns as find_version_commit() and find_version_release_commit().
+    if is_release_commit(&lower) {
+        return CommitCategory::Release;
     }
 
     // Check subject for breaking change markers
@@ -179,6 +188,55 @@ pub(crate) fn classify_commit(subject: &str, body: Option<&str>) -> CommitCatego
         CommitCategory::Other
     }
 }
+
+/// Check if a lowercased commit subject looks like a version bump or release commit.
+/// Matches patterns like: "v0.2.3", "bump version to 0.2.3", "release: v1.0.0",
+/// "version 0.2.2", "release v0.4.0", "chore(release): v1.0.0".
+fn is_release_commit(lower: &str) -> bool {
+    // Bare version tag: "v0.2.3" or "0.2.3" (entire subject is just a version)
+    if BARE_VERSION_RE
+        .is_match(lower)
+    {
+        return true;
+    }
+
+    // "bump version to 0.2.3", "bump to v0.2.3", "version bump to 0.2.3"
+    if lower.starts_with("bump") || lower.starts_with("version bump") || lower.starts_with("version ") {
+        if VERSION_NUMBER_RE.is_match(lower) {
+            return true;
+        }
+    }
+
+    // "release: v0.2.3", "release v0.2.3", "chore(release): v0.2.3"
+    if RELEASE_PREFIX_RE.is_match(lower) {
+        return true;
+    }
+
+    false
+}
+
+// Lazy regex patterns for release commit detection.
+// These mirror the patterns in find_version_commit() and find_version_release_commit()
+// but are compiled once for use in the hot path of classify_commit().
+use std::sync::LazyLock;
+
+/// Matches a subject that is just a version number: "v0.2.3", "0.2.3"
+static BARE_VERSION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^v?\d+\.\d+(?:\.\d+)?$").expect("Invalid regex")
+});
+
+/// Matches any string containing a semver-like version number
+static VERSION_NUMBER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\d+\.\d+(?:\.\d+)?").expect("Invalid regex")
+});
+
+/// Matches release-prefixed subjects: "release: v0.2.3", "release v0.2.3",
+/// "chore(release): v0.2.3"
+static RELEASE_PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^(?:chore\([^)]*\):\s*v?\d+\.\d+(?:\.\d+)?|release:?\s*v?\d+\.\d+(?:\.\d+)?)"
+    ).expect("Invalid regex")
+});
 
 /// Parse raw git log output that uses FIELD_SEP / RECORD_SEP delimiters
 /// into a list of CommitInfo structs with body-aware category classification.
@@ -479,7 +537,10 @@ pub fn recommended_bump_from_commits(commits: &[CommitInfo]) -> Option<SemverBum
             CommitCategory::Breaking => SemverBump::Major,
             CommitCategory::Feature => SemverBump::Minor,
             CommitCategory::Fix | CommitCategory::Other => SemverBump::Patch,
-            CommitCategory::Docs | CommitCategory::Chore | CommitCategory::Merge => continue,
+            CommitCategory::Docs
+            | CommitCategory::Chore
+            | CommitCategory::Merge
+            | CommitCategory::Release => continue,
         };
 
         recommended = match recommended {
@@ -713,10 +774,123 @@ mod tests {
     }
 
     #[test]
-    fn merge_category_skipped_in_changelog() {
+    fn classify_release_bare_version() {
+        // Bare version tags: "v0.2.3", "0.2.3"
+        assert_eq!(
+            parse_conventional_commit("v0.2.3"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("0.2.3"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("v1.0.0"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("1.0"),
+            CommitCategory::Release
+        );
+    }
+
+    #[test]
+    fn classify_release_bump_patterns() {
+        // "Bump version to X.Y.Z" and variants
+        assert_eq!(
+            parse_conventional_commit("Bump version to 0.2.2"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("bump to v0.3.0"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("Bump version to 0.2.2 and add error logging"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("version bump to 0.2.1"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("Version 0.4.0"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("Bump version to 0.2.1"),
+            CommitCategory::Release
+        );
+    }
+
+    #[test]
+    fn classify_release_prefix_patterns() {
+        // "release: vX.Y.Z" and variants
+        assert_eq!(
+            parse_conventional_commit("release: v0.2.3"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("release v0.4.0"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("chore(release): v1.0.0"),
+            CommitCategory::Release
+        );
+        assert_eq!(
+            parse_conventional_commit("Release 0.5.0"),
+            CommitCategory::Release
+        );
+    }
+
+    #[test]
+    fn classify_release_does_not_match_feature_commits() {
+        // These should NOT be classified as Release
+        assert_eq!(
+            parse_conventional_commit("feat: add version display"),
+            CommitCategory::Feature
+        );
+        assert_eq!(
+            parse_conventional_commit("fix: version parsing bug"),
+            CommitCategory::Fix
+        );
+        assert_eq!(
+            parse_conventional_commit("Update plugin URI"),
+            CommitCategory::Other
+        );
+        assert_eq!(
+            parse_conventional_commit("added claude.md"),
+            CommitCategory::Other
+        );
+        assert_eq!(
+            parse_conventional_commit("Initial plan"),
+            CommitCategory::Other
+        );
+        // chore: without a version number should still be Chore
+        assert_eq!(
+            parse_conventional_commit("chore: cleanup"),
+            CommitCategory::Chore
+        );
+        // chore(deps) with a version-like number should still be Chore
+        // (only chore(release)-style with a bare version after colon is Release)
+        assert_eq!(
+            parse_conventional_commit("chore(deps): bump lodash to 4.17.21"),
+            CommitCategory::Chore
+        );
+    }
+
+    #[test]
+    fn release_category_skipped_in_changelog() {
+        assert!(CommitCategory::Release.to_changelog_entry_type().is_none());
+    }
+
+    #[test]
+    fn merge_and_release_categories_skipped_in_changelog() {
         assert!(CommitCategory::Merge.to_changelog_entry_type().is_none());
         assert!(CommitCategory::Docs.to_changelog_entry_type().is_none());
         assert!(CommitCategory::Chore.to_changelog_entry_type().is_none());
+        assert!(CommitCategory::Release.to_changelog_entry_type().is_none());
         assert!(CommitCategory::Feature.to_changelog_entry_type().is_some());
     }
 

--- a/src/core/release/changelog/io.rs
+++ b/src/core/release/changelog/io.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::component::{self, Component};
 use crate::engine::local_files;
@@ -8,6 +8,17 @@ use crate::paths::resolve_path;
 
 use super::sections::*;
 use super::settings::*;
+
+/// Common changelog file locations to check when the configured path doesn't exist.
+/// Ordered by convention preference.
+const CHANGELOG_CANDIDATES: &[&str] = &[
+    "CHANGELOG.md",
+    "docs/CHANGELOG.md",
+    "changelog.md",
+    "docs/changelog.md",
+    "doc/CHANGELOG.md",
+    "CHANGES.md",
+];
 
 pub fn resolve_changelog_path(component: &Component) -> Result<PathBuf> {
     // Validate local_path is absolute and exists before any file operations
@@ -30,11 +41,33 @@ pub fn resolve_changelog_path(component: &Component) -> Result<PathBuf> {
         ],
     )?;
 
-    resolve_target_path(&component.local_path, target)
-}
+    let configured_path = resolve_path(&component.local_path, target);
 
-fn resolve_target_path(local_path: &str, file: &str) -> Result<PathBuf> {
-    Ok(resolve_path(local_path, file))
+    // If the configured path exists, use it directly
+    if configured_path.exists() {
+        return Ok(configured_path);
+    }
+
+    // Configured path doesn't exist — try common fallback locations
+    let local_path = Path::new(&component.local_path);
+    for candidate in CHANGELOG_CANDIDATES {
+        let candidate_path = local_path.join(candidate);
+        if candidate_path.exists() && candidate_path != configured_path {
+            log_status!(
+                "changelog",
+                "Configured changelog_target '{}' not found, using discovered '{}'. Fix with:\n  homeboy component set {} --changelog-target \"{}\"",
+                target,
+                candidate,
+                component.id,
+                candidate
+            );
+            return Ok(candidate_path);
+        }
+    }
+
+    // Nothing found — return the configured path (will fail downstream with a
+    // clear "file not found" error from the caller that tries to read it)
+    Ok(configured_path)
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -275,6 +275,7 @@ fn build_semver_recommendation(
                 git::CommitCategory::Docs => "docs",
                 git::CommitCategory::Chore => "chore",
                 git::CommitCategory::Merge => "merge",
+                git::CommitCategory::Release => "release",
                 git::CommitCategory::Other => "other",
             }
             .to_string(),
@@ -709,7 +710,7 @@ fn group_commits_for_changelog(
         }
     }
 
-    // If no entries generated (all docs/chore/merge), use first non-skip commit or fallback
+    // If no entries generated (all docs/chore/merge/release), use first non-skip commit or fallback
     if entries_by_type.is_empty() {
         let fallback = commits
             .iter()
@@ -719,6 +720,7 @@ fn group_commits_for_changelog(
                     git::CommitCategory::Docs
                         | git::CommitCategory::Chore
                         | git::CommitCategory::Merge
+                        | git::CommitCategory::Release
                 )
             })
             .map(|c| strip_pr_reference(git::strip_conventional_prefix(&c.subject)))

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -272,50 +272,23 @@ pub(crate) fn validate_and_finalize_changelog(
     let settings = changelog::resolve_effective_settings(Some(component));
     let changelog_path = changelog::resolve_changelog_path(component)?;
 
+    // resolve_changelog_path() already handles fallback discovery when the
+    // configured path doesn't exist, so the path here should be valid.
     let changelog_content = match local_files::local().read(&changelog_path) {
         Ok(content) => content,
         Err(e) => {
-            // When the configured changelog_target doesn't exist, search for
-            // the file in common locations and suggest a config fix.
             let error_str = e.to_string();
             if error_str.contains("File not found") || error_str.contains("No such file") {
-                let mut hints = vec![format!(
-                    "Configured changelog_target resolved to: {}",
-                    changelog_path.display()
-                )];
-
-                let common_locations = [
-                    "CHANGELOG.md",
-                    "docs/CHANGELOG.md",
-                    "changelog.md",
-                    "docs/changelog.md",
-                    "CHANGES.md",
-                ];
-
-                for location in &common_locations {
-                    let candidate = std::path::Path::new(&component.local_path).join(location);
-                    if candidate.exists() && candidate != changelog_path {
-                        hints.push(format!(
-                            "Found changelog at {}. Fix with:\n  homeboy component set {} --changelog-target \"{}\"",
-                            location, component.id, location
-                        ));
-                        break;
-                    }
-                }
-
-                if hints.len() == 1 {
-                    // No existing file found — suggest creating one
-                    hints.push(format!(
-                        "Create a new changelog:\n  homeboy changelog init {} --configure",
-                        component.id
-                    ));
-                }
-
                 return Err(Error::validation_invalid_argument(
                     "changelog",
                     format!("Changelog file not found: {}", changelog_path.display()),
                     None,
-                    Some(hints),
+                    Some(vec![
+                        format!(
+                            "Create a new changelog:\n  homeboy changelog init {} --configure",
+                            component.id
+                        ),
+                    ]),
                 ));
             }
             return Err(e);


### PR DESCRIPTION
## Summary

Fixes #1127 and #1128.

- **#1127 — Changelog noise filtering:** Adds `CommitCategory::Release` to the commit classifier, detecting version bump commits (`v0.2.3`, `Bump version to X.Y.Z`, `release: vX.Y.Z`, `chore(release): vX.Y.Z`) and excluding them from changelog generation and semver bump calculation. Reuses the same patterns already present in `find_version_commit()` and `find_version_release_commit()`.
- **#1128 — Changelog path auto-discovery:** When the configured `changelog_target` doesn't exist on disk, `resolve_changelog_path()` now checks common fallback locations (`CHANGELOG.md`, `docs/CHANGELOG.md`, etc.) and uses the first match — logging a warning with the `homeboy component set` fix command. Removes duplicate discovery logic from `version.rs` since it's now centralized.

## Files changed

| File | Change |
|------|--------|
| `src/core/git/commits.rs` | New `Release` variant + `is_release_commit()` with lazy regex patterns; wired into `to_changelog_entry_type()` (→ `None`), `recommended_bump_from_commits()` (→ `continue`), `prefix()` (→ `None`); 6 new test cases |
| `src/core/release/changelog/io.rs` | `resolve_changelog_path()` now checks fallback locations before returning a nonexistent path; `CHANGELOG_CANDIDATES` constant; removed unused `resolve_target_path()` |
| `src/core/release/pipeline.rs` | Added `Release` to category→string mapping and fallback exclusion list in `group_commits_for_changelog()` |
| `src/core/release/version.rs` | Simplified error handling — removed duplicate discovery logic (now handled upstream) |

## Testing

All 1086 library tests pass (0 failures, 1 ignored).