### PR TITLE
fix: deploy trio — resolver, Studio cli_path, --head branch warning (#1137, #1138, #1139)

### DIFF
--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -143,6 +143,9 @@ pub struct Component {
     pub docs_dir: Option<String>,
     pub docs_dirs: Vec<String>,
     pub scopes: Option<ScopeConfig>,
+    /// Override the CLI path used by extension deploy install steps.
+    /// For example, Studio sites need "studio wp" instead of the default "wp".
+    pub cli_path: Option<String>,
 }
 
 /// Raw JSON shape for Component — handles backward-compatible deserialization
@@ -200,6 +203,8 @@ struct RawComponent {
     docs_dirs: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     scopes: Option<ScopeConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cli_path: Option<String>,
 }
 
 /// Insert legacy commands into hooks map if the event key doesn't already exist.
@@ -245,6 +250,7 @@ impl From<RawComponent> for Component {
             docs_dir: raw.docs_dir,
             docs_dirs: raw.docs_dirs,
             scopes: raw.scopes,
+            cli_path: raw.cli_path,
         }
     }
 }
@@ -275,6 +281,7 @@ impl From<Component> for RawComponent {
             docs_dir: c.docs_dir,
             docs_dirs: c.docs_dirs,
             scopes: c.scopes,
+            cli_path: c.cli_path,
         }
     }
 }
@@ -342,6 +349,7 @@ impl Component {
             docs_dir: None,
             docs_dirs: Vec::new(),
             scopes: None,
+            cli_path: None,
         }
     }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -986,8 +986,23 @@ pub(crate) fn list_ids<T: ConfigEntity>() -> Result<Vec<String>> {
     let entries = local_files::local().list(&dir)?;
     let mut ids: Vec<String> = entries
         .into_iter()
-        .filter(|e| e.is_json() && !e.is_dir)
-        .filter_map(|e| e.path.file_stem().map(|s| s.to_string_lossy().to_string()))
+        .filter_map(|e| {
+            if e.is_dir {
+                // For directories: check for {dir}/{dir}.json (same logic as list())
+                let dir_name = e.path.file_name()?.to_string_lossy().to_string();
+                let nested_json = e.path.join(format!("{}.json", dir_name));
+                if nested_json.exists() {
+                    Some(dir_name)
+                } else {
+                    None
+                }
+            } else if e.is_json() {
+                // For flat files: use existing behavior
+                e.path.file_stem().map(|s| s.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        })
         .collect();
     ids.sort();
     Ok(ids)

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -440,6 +440,7 @@ fn execute_artifact_deploy(
                 Some(base_path),
                 project.domain.as_deref(),
                 component.remote_owner.as_deref(),
+                component.cli_path.as_deref(),
             )
         } else {
             deploy_artifact(

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -102,6 +102,11 @@ pub(super) fn deploy_components(
         sync_components(&components)?;
     }
 
+    // Warn when --head deploys from a non-default branch (safety guardrail)
+    if config.head && !config.skip_build {
+        warn_non_default_branch(&components, config)?;
+    }
+
     if !config.force {
         check_uncommitted_changes(&components)?;
     }
@@ -265,6 +270,74 @@ fn run_dry_run_mode(
 }
 
 /// Verify no components have uncommitted changes before deployment.
+/// Warn when `--head` would deploy from a non-default branch.
+///
+/// Detects the current branch for each component and compares it against the
+/// default branch (via `git symbolic-ref refs/remotes/origin/HEAD`, falling
+/// back to "main"). If a component is on a feature branch, this is likely
+/// unintentional — the user probably meant to deploy the default branch.
+///
+/// With `--force`, this emits a log warning but proceeds. Without `--force`,
+/// it returns an error so the user can switch branches or confirm intent.
+fn warn_non_default_branch(components: &[Component], config: &DeployConfig) -> Result<()> {
+    for component in components {
+        if component.is_file_component() {
+            continue;
+        }
+
+        let path = &component.local_path;
+
+        // Get current branch
+        let current_branch = match crate::engine::command::run_in_optional(
+            path,
+            "git",
+            &["rev-parse", "--abbrev-ref", "HEAD"],
+        ) {
+            Some(branch) if branch != "HEAD" => branch, // "HEAD" means detached
+            _ => continue,                               // detached or error — skip
+        };
+
+        // Detect default branch from remote HEAD symref, fallback to "main"
+        let default_branch = crate::engine::command::run_in_optional(
+            path,
+            "git",
+            &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        )
+        .map(|s| {
+            // Output is like "origin/main" — strip the remote prefix
+            s.strip_prefix("origin/")
+                .unwrap_or(&s)
+                .to_string()
+        })
+        .unwrap_or_else(|| "main".to_string());
+
+        if current_branch != default_branch {
+            let message = format!(
+                "Component '{}' is on branch '{}', not '{}' (default)",
+                component.id, current_branch, default_branch
+            );
+
+            if config.force {
+                log_status!("deploy", "Warning: {}", message);
+            } else {
+                return Err(Error::validation_invalid_argument(
+                    "head",
+                    message,
+                    None,
+                    Some(vec![
+                        format!(
+                            "Switch to the default branch: git -C {} checkout {}",
+                            component.local_path, default_branch
+                        ),
+                        "Use --force to deploy from the current branch anyway".to_string(),
+                    ]),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
     let dirty: Vec<&str> = components
         .iter()

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -221,6 +221,7 @@ pub(super) fn deploy_with_override(
     site_root: Option<&str>,
     domain: Option<&str>,
     remote_owner: Option<&str>,
+    cli_path_override: Option<&str>,
 ) -> Result<DeployResult> {
     let artifact_filename = local_path
         .file_name()
@@ -269,10 +270,14 @@ pub(super) fn deploy_with_override(
     }
 
     // Step 3: Render and execute install command
-    let cli_path = extension
-        .cli
-        .as_ref()
-        .and_then(|c| c.default_cli_path.as_deref())
+    // Resolution order: component/project cli_path override → extension default → "wp"
+    let cli_path = cli_path_override
+        .or_else(|| {
+            extension
+                .cli
+                .as_ref()
+                .and_then(|c| c.default_cli_path.as_deref())
+        })
         .unwrap_or("wp");
 
     let mut vars = HashMap::new();

--- a/src/core/project/component/overrides.rs
+++ b/src/core/project/component/overrides.rs
@@ -32,6 +32,9 @@ fn apply_overrides_layer(
     if let Some(scopes) = &overrides.scopes {
         component.scopes = Some(scopes.clone());
     }
+    if let Some(cli_path) = &overrides.cli_path {
+        component.cli_path = Some(cli_path.clone());
+    }
 }
 
 /// Apply component overrides with fleet → project cascade.
@@ -213,5 +216,37 @@ mod tests {
 
         let result = apply_component_overrides(&component, &project);
         assert_eq!(result.remote_path, "original/path");
+    }
+
+    #[test]
+    fn apply_overrides_layer_sets_cli_path() {
+        let mut component = base_component("my-plugin");
+        assert_eq!(component.cli_path, None);
+
+        let overrides = ProjectComponentOverrides {
+            cli_path: Some("studio wp".to_string()),
+            ..Default::default()
+        };
+
+        apply_overrides_layer(&mut component, &overrides);
+        assert_eq!(component.cli_path, Some("studio wp".to_string()));
+    }
+
+    #[test]
+    fn cli_path_override_applied_via_project() {
+        let component = base_component("my-plugin");
+
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "my-plugin".to_string(),
+            ProjectComponentOverrides {
+                cli_path: Some("studio wp".to_string()),
+                ..Default::default()
+            },
+        );
+        let project = project_with_overrides("my-studio-site", overrides);
+
+        let result = apply_component_overrides(&component, &project);
+        assert_eq!(result.cli_path, Some("studio wp".to_string()));
     }
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -63,6 +63,10 @@ pub struct ProjectComponentOverrides {
     pub hooks: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scopes: Option<crate::component::ScopeConfig>,
+    /// Override the CLI path used by extension deploy install steps.
+    /// For example, Studio sites need "studio wp" instead of the default "wp".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cli_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

Three deploy fixes that came up during first week at Automattic deploying to Studio sites.

### #1137 — Two-arg deploy resolver

**Bug:** `homeboy deploy <project_id> <component_id>` fails with "not a known project" because `list_ids()` only scans flat `.json` files, skipping directory-based project configs (`projects/{id}/{id}.json`). The `list()` function handles both layouts correctly.

**Fix:** Updated `list_ids()` in `src/core/config.rs` to mirror the directory-handling logic from `list()` — check for `{dir}/{dir}.json` inside directory entries.

### #1138 — Studio `cli_path` override

**Bug:** Deploy install step hardcodes `wp` via the extension manifest's `default_cli_path`. Studio sites need `studio wp` — no per-project override existed.

**Fix:**
- Added `cli_path: Option<String>` to `Component` and `ProjectComponentOverrides`
- Wired through the override cascade (fleet → project → component)
- `deploy_with_override()` now checks component-level `cli_path` before falling back to extension default

**Usage:**
```bash
homeboy project set my-studio-site component_overrides.intelligence.cli_path "studio wp"
```

### #1139 — `--head` branch warning

**Bug:** `deploy --head` silently deploys whatever branch the workspace is on. If left on a feature branch from an earlier session, wrong code ships.

**Fix:** Added `warn_non_default_branch()` check in orchestration. Detects default branch via `git symbolic-ref refs/remotes/origin/HEAD` (fallback: `main`). Behavior:
- Not on default branch → **error** (switch branches or use `--force`)
- Not on default branch + `--force` → **warning**, proceeds
- On default branch → no-op

## Files Changed

| File | Change |
|------|--------|
| `src/core/config.rs` | `list_ids()` handles directory-based configs |
| `src/core/component/mod.rs` | Added `cli_path` field |
| `src/core/project/mod.rs` | Added `cli_path` to `ProjectComponentOverrides` |
| `src/core/project/component/overrides.rs` | Wire `cli_path` in cascade + 2 new tests |
| `src/core/deploy/version_overrides.rs` | Accept `cli_path_override` param, use in resolution |
| `src/core/deploy/execution.rs` | Pass `component.cli_path` to `deploy_with_override` |
| `src/core/deploy/orchestration.rs` | Add `warn_non_default_branch()` check |

## Testing

- `cargo check` — clean
- `cargo clippy` — no warnings in changed files  
- `cargo test --lib` — 1094 passed (1 pre-existing flaky failure in refactor plan sources, unrelated)
- 2 new unit tests for `cli_path` override cascade

Closes #1137, closes #1138, closes #1139