### PR TITLE
fix: HOMEBOY_FIX_ONLY is the single auto-fix contract (#1145)

### DIFF
--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -932,8 +932,12 @@ fn run_lint_stage(
             crate::log_status!("undo", "Warning: failed to save undo snapshot: {}", error);
         }
 
-        // Invoke the extension in fix-only mode — runs fixers without
-        // re-running the diagnostic pass.
+        // Invoke the extension in fix-only mode.
+        //
+        // HOMEBOY_FIX_ONLY=1 is the single contract: the extension runs its
+        // fixers and skips its own validation pass (the engine validates
+        // separately via the diagnose phase). Auto-fixing lives exclusively
+        // under `homeboy refactor` — there is no other entry point.
         build_lint_runner()?.env("HOMEBOY_FIX_ONLY", "1").run()?;
 
         let after_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
@@ -1042,7 +1046,8 @@ fn run_test_stage(
         }
 
         // Invoke the extension in fix-only mode. Reuses the same builder
-        // as the diagnostic pass with HOMEBOY_FIX_ONLY=1.
+        // as the diagnostic pass with HOMEBOY_FIX_ONLY=1 — the single env-var
+        // contract for running fixers. See `run_lint_stage` for context.
         let mut fix_runner = build_runner()?.env("HOMEBOY_FIX_ONLY", "1");
         if !options.script_args.is_empty() {
             fix_runner = fix_runner.script_args(&options.script_args);


### PR DESCRIPTION
Companion to [homeboy-extensions#210](https://github.com/Extra-Chill/homeboy-extensions/pull/210).

## The bug

`homeboy refactor data-machine --from lint --write` detects all findings but applies **zero** fixes:

```
detected_findings: 586
edit_count: 0
files_modified: 0
Warning: "No automated fixes accumulated across audit/lint/test"
```

`phpcbf` would fix 439 of those in 29s. Homeboy just wasn't invoking it.

## Root cause

Commit 2d1ef26 (`arch: separate diagnosis from fix application`, #1077) renamed the env var the core sends to the extension:

```diff
- .env_if(write, "HOMEBOY_AUTO_FIX", "1");
+ .env("HOMEBOY_FIX_ONLY", "1");
```

The commit message promised:

> Extension scripts need to recognize HOMEBOY_FIX_ONLY=1 to run fixers

…but the extension-side change never landed. The wordpress runners still gate their auto-fix block on `HOMEBOY_AUTO_FIX=1`, so nothing ran.

## Fix

**Single env-var contract**: `HOMEBOY_FIX_ONLY=1` means "run fixers, skip validation". That's it. Auto-fixing lives exclusively under `homeboy refactor` — there is no other entry point.

The companion extensions PR rips `HOMEBOY_AUTO_FIX` out entirely and makes every runner gate on `HOMEBOY_FIX_ONLY`. This PR drops the belt-and-suspenders dual-env experiment and keeps the core clean: send just `HOMEBOY_FIX_ONLY=1` to the extension.

## Files changed

`src/core/refactor/plan/sources.rs`:
- `run_lint_stage()` Phase 2: sends `HOMEBOY_FIX_ONLY=1` to the extension.
- `run_test_stage()` Phase 2: same.
- Comment explains the single-contract design.

## Testing

All non-flaky library tests pass. The two failing `component::inventory::write_standalone_*` tests fail on main too (pre-existing test-isolation issue, unrelated).

The fix is an env-var contract change that's validated end-to-end by running `homeboy refactor <component> --from lint --write` against a dirty component — expect `edit_count > 0` and phpcbf output in the logs.

Closes #1145.