### PR TITLE
fix: deploy cluster — component set id round-trip + non-git local_path (#1140, #1141)

### DIFF
--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -36,13 +36,20 @@ pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Re
         ));
     }
 
-    let patch: Value = config::from_str(&raw)?;
+    let mut patch: Value = config::from_str(&raw)?;
 
     if let Some(json_id) = patch.get("id").and_then(|v| v.as_str()) {
         if json_id != id {
             rename(id, json_id)?;
             return merge(Some(json_id), json_spec, replace_fields);
         }
+    }
+
+    // `id` does not survive the `merge_config` serde round-trip (RawComponent.id
+    // is `skip_serializing`) and would surface as a spurious "Unknown field 'id'"
+    // error. Strip it here — any rename intent has already been handled above. (#1140)
+    if let Value::Object(ref mut map) = patch {
+        map.remove("id");
     }
 
     let component = mutate_portable(id, |component| {

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -201,6 +201,15 @@ where
     }
 
     mutator(&mut component)?;
+
+    // Defensive: if the mutator wiped `id` (for example via `config::merge_config`,
+    // which round-trips through serde and `RawComponent.id` is `skip_serializing`),
+    // restore it from the caller-provided id. Legitimate rename mutations set a
+    // non-empty new id inside the closure, so this check does not clobber them. (#1140)
+    if component.id.trim().is_empty() {
+        component.id = id.to_string();
+    }
+
     write_portable_config(&local_path, &component)?;
     Ok(component)
 }
@@ -344,6 +353,32 @@ mod tests {
         );
         let result = portable_json(&component);
         assert!(result.is_err(), "blank id should be rejected");
+    }
+
+    #[test]
+    fn merge_config_roundtrip_wipes_id_regression() {
+        // Regression test for #1140: `Component` serializes via `RawComponent`
+        // which has `#[serde(skip_serializing)]` on `id`. A `merge_config` round
+        // trip (serialize → deep_merge → deserialize) therefore drops `id`,
+        // leaving the component with a blank string. Callers like
+        // `mutate_portable` must restore the caller-provided id before writing
+        // to homeboy.json, or `portable_json` will refuse the write with
+        // "Cannot write portable config with a blank component ID".
+        let mut component = Component::new(
+            "intelligence".to_string(),
+            "/tmp/intelligence".to_string(),
+            "wp-content/plugins/intelligence".to_string(),
+            None,
+        );
+
+        let patch = serde_json::json!({ "local_path": "/new/path" });
+        crate::config::merge_config(&mut component, patch, &[]).expect("merge should succeed");
+
+        assert!(
+            component.id.trim().is_empty(),
+            "documented failure mode — remove this assert and the restore hack in mutate_portable if serde behavior changes"
+        );
+        assert_eq!(component.local_path, "/new/path");
     }
 
     #[test]

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -337,12 +337,57 @@ fn warn_non_default_branch(components: &[Component], config: &DeployConfig) -> R
 }
 
 fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
-    let dirty: Vec<&str> = components
-        .iter()
-        .filter(|c| !c.is_file_component())
-        .filter(|c| !git::is_workdir_clean(Path::new(&c.local_path)))
-        .map(|c| c.id.as_str())
-        .collect();
+    // Partition components into "non-git local_path" vs "dirty git repo" so we can
+    // emit the right diagnostic. Conflating the two leaves users chasing a
+    // nonexistent uncommitted-changes problem when the real issue is that
+    // local_path doesn't point at a git checkout. (#1141)
+    let mut non_git: Vec<&Component> = Vec::new();
+    let mut dirty: Vec<&str> = Vec::new();
+
+    for component in components {
+        if component.is_file_component() {
+            continue;
+        }
+        let path = Path::new(&component.local_path);
+        if !git::is_git_repo(&component.local_path) {
+            non_git.push(component);
+            continue;
+        }
+        if !git::is_workdir_clean(path) {
+            dirty.push(component.id.as_str());
+        }
+    }
+
+    if !non_git.is_empty() {
+        let ids: Vec<&str> = non_git.iter().map(|c| c.id.as_str()).collect();
+        let mut hints: Vec<String> = non_git
+            .iter()
+            .map(|c| {
+                format!(
+                    "Repoint '{}' at a git checkout: homeboy component set {} --local-path <path-to-git-workspace>",
+                    c.id, c.id
+                )
+            })
+            .collect();
+        hints.push(
+            "Initialize a git repo at the existing local_path if the contents are the source of truth: git -C <local_path> init && git add . && git commit -m 'initial'"
+                .to_string(),
+        );
+        hints.push("Or deploy with --force to bypass the git-clean check".to_string());
+        let paths: Vec<String> = non_git
+            .iter()
+            .map(|c| format!("{} ({})", c.id, c.local_path))
+            .collect();
+        return Err(Error::validation_invalid_argument(
+            "components",
+            format!(
+                "local_path is not a git repository for: {}. The uncommitted-changes check requires a git checkout.",
+                paths.join(", ")
+            ),
+            Some(ids.join(",")),
+            Some(hints),
+        ));
+    }
 
     if !dirty.is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -652,4 +697,64 @@ fn verify_expected_version(components: &[Component], expected: &str) -> Result<(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_component(id: &str, local_path: &str) -> Component {
+        Component::new(id.to_string(), local_path.to_string(), String::new(), None)
+    }
+
+    #[test]
+    fn check_uncommitted_changes_reports_non_git_local_path() {
+        // A directory exists but is not a git repo — the error must say so clearly
+        // instead of reporting "uncommitted changes". (#1141)
+        let dir = TempDir::new().expect("temp dir");
+        let component = make_component("test", &dir.path().to_string_lossy());
+
+        let result = check_uncommitted_changes(&[component]);
+        let err = result.expect_err("should fail for non-git local_path");
+        let message = format!("{}", err);
+        assert!(
+            message.contains("not a git repository"),
+            "error should identify the non-git local_path issue, got: {message}"
+        );
+        assert!(
+            !message.contains("uncommitted changes"),
+            "error must not conflate non-git with dirty git, got: {message}"
+        );
+    }
+
+    #[test]
+    fn check_uncommitted_changes_passes_for_clean_git_repo() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path();
+
+        // Initialize an empty git repo with one commit so the working dir is clean.
+        let run = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git command")
+        };
+        assert!(run(&["init", "-q"]).status.success());
+        assert!(
+            run(&["config", "user.email", "test@example.com"])
+                .status
+                .success()
+        );
+        assert!(run(&["config", "user.name", "Test"]).status.success());
+        assert!(
+            run(&["commit", "--allow-empty", "-q", "-m", "init"])
+                .status
+                .success()
+        );
+
+        let component = make_component("test", &path.to_string_lossy());
+        check_uncommitted_changes(&[component]).expect("clean git repo should pass");
+    }
 }

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -742,17 +742,13 @@ mod tests {
                 .expect("git command")
         };
         assert!(run(&["init", "-q"]).status.success());
-        assert!(
-            run(&["config", "user.email", "test@example.com"])
-                .status
-                .success()
-        );
+        assert!(run(&["config", "user.email", "test@example.com"])
+            .status
+            .success());
         assert!(run(&["config", "user.name", "Test"]).status.success());
-        assert!(
-            run(&["commit", "--allow-empty", "-q", "-m", "init"])
-                .status
-                .success()
-        );
+        assert!(run(&["commit", "--allow-empty", "-q", "-m", "init"])
+            .status
+            .success());
 
         let component = make_component("test", &path.to_string_lossy());
         check_uncommitted_changes(&[component]).expect("clean git repo should pass");

--- a/src/core/engine/edit_op_apply.rs
+++ b/src/core/engine/edit_op_apply.rs
@@ -82,7 +82,7 @@ fn extract_import_alias(import_line: &str) -> Option<String> {
 
     // Extract the last segment: `Foo\Bar\Baz` → `Baz`, `foo::bar::Baz` → `Baz`
     let last = path
-        .rsplit(|c: char| c == '\\' || c == ':')
+        .rsplit(['\\', ':'])
         .find(|s| !s.is_empty())?;
     if last.is_empty() {
         return None;
@@ -104,11 +104,10 @@ fn import_alias_collides(content: &str, import_line: &str, language: &Language) 
             continue;
         }
         if let Some(existing_alias) = extract_import_alias(trimmed) {
-            if existing_alias == candidate_alias {
-                if normalize_import_line(trimmed) != normalize_import_line(import_line) {
+            if existing_alias == candidate_alias
+                && normalize_import_line(trimmed) != normalize_import_line(import_line) {
                     return true;
                 }
-            }
         }
     }
 
@@ -170,14 +169,14 @@ fn is_type_declaration_line(line: &str, language: &Language) -> bool {
         Language::Php | Language::TypeScript => {
             regex::Regex::new(r"\b(?:class|interface|trait)\s+\w+")
                 .ok()
-                .map_or(false, |re| re.is_match(trimmed))
+                .is_some_and(|re| re.is_match(trimmed))
         }
         Language::Rust => regex::Regex::new(r"\b(?:pub\s+)?(?:struct|enum|trait)\s+\w+")
             .ok()
-            .map_or(false, |re| re.is_match(trimmed)),
+            .is_some_and(|re| re.is_match(trimmed)),
         Language::JavaScript => regex::Regex::new(r"\bclass\s+\w+")
             .ok()
-            .map_or(false, |re| re.is_match(trimmed)),
+            .is_some_and(|re| re.is_match(trimmed)),
         Language::Unknown => false,
     }
 }
@@ -546,7 +545,7 @@ pub fn apply_edit_ops_to_content(
         let idx = line_num.saturating_sub(1);
         if idx < lines.len() {
             if lines[idx].contains(*old_text) {
-                lines[idx] = lines[idx].replacen(*old_text, *new_text, 1);
+                lines[idx] = lines[idx].replacen(*old_text, new_text, 1);
             } else {
                 return Err(format!(
                     "ReplaceText: old_text {:?} not found on line {}",
@@ -772,7 +771,7 @@ pub fn apply_edit_ops(ops: &[TaggedEditOp], root: &Path) -> Result<ApplyReport> 
         };
 
         let language = Language::from_path(&abs_path);
-        let op_refs: Vec<&EditOp> = file_ops.iter().copied().collect();
+        let op_refs: Vec<&EditOp> = file_ops.to_vec();
 
         match apply_edit_ops_to_content(&content, &op_refs, &language) {
             Ok(modified) => {

--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -199,14 +199,12 @@ fn is_release_commit(lower: &str) -> bool {
     }
 
     // "bump version to 0.2.3", "bump to v0.2.3", "version bump to 0.2.3"
-    if lower.starts_with("bump")
+    if (lower.starts_with("bump")
         || lower.starts_with("version bump")
-        || lower.starts_with("version ")
-    {
-        if VERSION_NUMBER_RE.is_match(lower) {
+        || lower.starts_with("version "))
+        && VERSION_NUMBER_RE.is_match(lower) {
             return true;
         }
-    }
 
     // "release: v0.2.3", "release v0.2.3", "chore(release): v0.2.3"
     if RELEASE_PREFIX_RE.is_match(lower) {


### PR DESCRIPTION
## Summary

Two clean, independent bug fixes in the deploy UX cluster.

### #1140 — `component set` positional ID argument ignored when updating via JSON spec

`homeboy component set <id> --json '<spec>'` failed with *Cannot write portable config with a blank component ID* even though `<id>` was explicitly provided, and rejected `{"id": "<id>"}` inside the JSON body with *Unknown field(s): 'id'*. Both paths were broken — there was no working way to update a component via JSON at all.

**Root cause.** `Component` is `#[serde(from = "RawComponent", into = "RawComponent")]` and `RawComponent.id` is annotated `#[serde(skip_serializing)]`. `config::merge_config` round-trips the typed struct (serialize → deep_merge patch → deserialize), which silently drops `id` and reinstantiates it as an empty `String` default. `write_portable_config` then calls `portable_json`, which correctly rejects the blank id with the #801 guard.

The `{"id": "<id>"}` form hit the same round-trip: `id` didn't survive re-serialization, so `merge_config`'s unknown-field detector flagged it as dropped.

**Fix.**
- `mutate_portable` restores the caller-provided id after the mutator if it came back blank. Legitimate rename mutations write a non-empty new id inside the closure, so the guard never clobbers them.
- `component::merge` strips `id` from the patch when it matches the target id, so `{"id": "<id>"}` no longer trips the unknown-field check. Renames to a *different* id are still handled by the pre-existing rename branch.

Regression test in `portable.rs` pins the documented serde behavior so the hack can be removed if the round-trip ever stops dropping `id`.

### #1141 — deploy reports "uncommitted changes" when `local_path` is not a git repo

`homeboy deploy <component>` failed with *Components have uncommitted changes* when `local_path` pointed at a directory that wasn't a git repository at all. `git::is_workdir_clean` returns `false` for any `git status` failure (conservative fallback), conflating "not a git repo" with "dirty". The suggested fixes (*Commit your changes* / *Use --force*) both assumed a git repo existed.

**Fix.** `check_uncommitted_changes` now partitions components into non-git vs dirty buckets and emits distinct errors:
- non-git: names the offending component + path, suggests repointing `local_path` at a git workspace, initializing the existing directory, or using `--force`
- dirty: unchanged error message

Two new tests in `core::deploy::orchestration` cover both the non-git error path and the clean-git happy path.

## Test plan

- `cargo test --lib` — all 1110 passing tests stay green; one pre-existing HOME-env flake in `component::inventory::tests::write_standalone_creates_and_reads_back` fails in parallel (unrelated, documented in the test module preamble, passes with `--test-threads=1`).
- `cargo test --lib component::portable` — 6/6 including new regression test.
- `cargo test --lib deploy::orchestration` — 2/2 new tests.
- Manual verification against a live component with `homeboy.json` — all three `component set` forms now succeed and the homeboy.json round-trip is clean:
  - `component set <id> --json '{"remote_url": "..."}'` ✅
  - `component set <id> --json '{"id": "<id>", "remote_path": "..."}'` ✅
  - `component set <id> --changelog-target "docs/CHANGELOG.md"` ✅

Closes #1140
Closes #1141