### PR TITLE
fix: component create auto-detects changelog path (#1128)

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -241,7 +241,12 @@ pub fn run(
             };
 
             new_component.extract_command = extract_command;
-            new_component.changelog_target = changelog_target;
+            // Respect an explicit --changelog-target flag; otherwise auto-detect
+            // the actual changelog location on disk so generated homeboy.json
+            // files don't ship with a path that doesn't exist. (#1128)
+            new_component.changelog_target = changelog_target.or_else(|| {
+                homeboy::release::changelog::discover_changelog_relative_path(repo_path)
+            });
 
             if !extensions.is_empty() {
                 let mut extension_map = std::collections::HashMap::new();

--- a/src/core/engine/edit_op_apply.rs
+++ b/src/core/engine/edit_op_apply.rs
@@ -82,7 +82,7 @@ fn extract_import_alias(import_line: &str) -> Option<String> {
 
     // Extract the last segment: `Foo\Bar\Baz` → `Baz`, `foo::bar::Baz` → `Baz`
     let last = path
-        .rsplit(|c: char| c == '\\' || c == ':')
+        .rsplit(['\\', ':'])
         .find(|s| !s.is_empty())?;
     if last.is_empty() {
         return None;
@@ -104,11 +104,10 @@ fn import_alias_collides(content: &str, import_line: &str, language: &Language) 
             continue;
         }
         if let Some(existing_alias) = extract_import_alias(trimmed) {
-            if existing_alias == candidate_alias {
-                if normalize_import_line(trimmed) != normalize_import_line(import_line) {
+            if existing_alias == candidate_alias
+                && normalize_import_line(trimmed) != normalize_import_line(import_line) {
                     return true;
                 }
-            }
         }
     }
 
@@ -170,14 +169,14 @@ fn is_type_declaration_line(line: &str, language: &Language) -> bool {
         Language::Php | Language::TypeScript => {
             regex::Regex::new(r"\b(?:class|interface|trait)\s+\w+")
                 .ok()
-                .map_or(false, |re| re.is_match(trimmed))
+                .is_some_and(|re| re.is_match(trimmed))
         }
         Language::Rust => regex::Regex::new(r"\b(?:pub\s+)?(?:struct|enum|trait)\s+\w+")
             .ok()
-            .map_or(false, |re| re.is_match(trimmed)),
+            .is_some_and(|re| re.is_match(trimmed)),
         Language::JavaScript => regex::Regex::new(r"\bclass\s+\w+")
             .ok()
-            .map_or(false, |re| re.is_match(trimmed)),
+            .is_some_and(|re| re.is_match(trimmed)),
         Language::Unknown => false,
     }
 }
@@ -546,7 +545,7 @@ pub fn apply_edit_ops_to_content(
         let idx = line_num.saturating_sub(1);
         if idx < lines.len() {
             if lines[idx].contains(*old_text) {
-                lines[idx] = lines[idx].replacen(*old_text, *new_text, 1);
+                lines[idx] = lines[idx].replacen(*old_text, new_text, 1);
             } else {
                 return Err(format!(
                     "ReplaceText: old_text {:?} not found on line {}",
@@ -772,7 +771,7 @@ pub fn apply_edit_ops(ops: &[TaggedEditOp], root: &Path) -> Result<ApplyReport> 
         };
 
         let language = Language::from_path(&abs_path);
-        let op_refs: Vec<&EditOp> = file_ops.iter().copied().collect();
+        let op_refs: Vec<&EditOp> = file_ops.to_vec();
 
         match apply_edit_ops_to_content(&content, &op_refs, &language) {
             Ok(modified) => {

--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -199,14 +199,12 @@ fn is_release_commit(lower: &str) -> bool {
     }
 
     // "bump version to 0.2.3", "bump to v0.2.3", "version bump to 0.2.3"
-    if lower.starts_with("bump")
+    if (lower.starts_with("bump")
         || lower.starts_with("version bump")
-        || lower.starts_with("version ")
-    {
-        if VERSION_NUMBER_RE.is_match(lower) {
+        || lower.starts_with("version "))
+        && VERSION_NUMBER_RE.is_match(lower) {
             return true;
         }
-    }
 
     // "release: v0.2.3", "release v0.2.3", "chore(release): v0.2.3"
     if RELEASE_PREFIX_RE.is_match(lower) {

--- a/src/core/release/changelog/io.rs
+++ b/src/core/release/changelog/io.rs
@@ -11,7 +11,7 @@ use super::settings::*;
 
 /// Common changelog file locations to check when the configured path doesn't exist.
 /// Ordered by convention preference.
-const CHANGELOG_CANDIDATES: &[&str] = &[
+pub const CHANGELOG_CANDIDATES: &[&str] = &[
     "CHANGELOG.md",
     "docs/CHANGELOG.md",
     "changelog.md",
@@ -19,6 +19,18 @@ const CHANGELOG_CANDIDATES: &[&str] = &[
     "doc/CHANGELOG.md",
     "CHANGES.md",
 ];
+
+/// Discover an existing changelog file under `repo_path` by checking the common
+/// candidate locations. Returns the relative path (as stored in `changelog_target`)
+/// of the first match, or `None` if no candidate exists on disk. (#1128)
+pub fn discover_changelog_relative_path(repo_path: &Path) -> Option<String> {
+    for candidate in CHANGELOG_CANDIDATES {
+        if repo_path.join(candidate).is_file() {
+            return Some((*candidate).to_string());
+        }
+    }
+    None
+}
 
 pub fn resolve_changelog_path(component: &Component) -> Result<PathBuf> {
     // Validate local_path is absolute and exists before any file operations
@@ -102,4 +114,44 @@ pub fn read_component_snapshots(
     });
 
     Ok((last_release, unreleased))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn discover_changelog_prefers_root_when_both_exist() {
+        let dir = TempDir::new().expect("temp dir");
+        fs::create_dir_all(dir.path().join("docs")).unwrap();
+        fs::write(dir.path().join("CHANGELOG.md"), "# Changelog\n").unwrap();
+        fs::write(dir.path().join("docs/CHANGELOG.md"), "# Changelog\n").unwrap();
+
+        assert_eq!(
+            discover_changelog_relative_path(dir.path()),
+            Some("CHANGELOG.md".to_string())
+        );
+    }
+
+    #[test]
+    fn discover_changelog_finds_docs_path_when_root_absent() {
+        // This is the html-to-blocks-converter scenario from #1128: the file
+        // lives at docs/CHANGELOG.md but nothing at the repo root.
+        let dir = TempDir::new().expect("temp dir");
+        fs::create_dir_all(dir.path().join("docs")).unwrap();
+        fs::write(dir.path().join("docs/CHANGELOG.md"), "# Changelog\n").unwrap();
+
+        assert_eq!(
+            discover_changelog_relative_path(dir.path()),
+            Some("docs/CHANGELOG.md".to_string())
+        );
+    }
+
+    #[test]
+    fn discover_changelog_returns_none_when_nothing_exists() {
+        let dir = TempDir::new().expect("temp dir");
+        assert_eq!(discover_changelog_relative_path(dir.path()), None);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the last gap on #1128.

Runtime `resolve_changelog_path()` already falls back to the discovered path and emits a warning/hint when the configured `changelog_target` is missing on disk (added in e13a61b). But `component create` still writes a bare `"CHANGELOG.md"` into `homeboy.json` regardless of what actually exists — the html-to-blocks-converter scenario the user hit.

Fix: when `component create` runs without `--changelog-target`, probe the repo for the same candidate set the runtime fallback checks (`CHANGELOG.md`, `docs/CHANGELOG.md`, `changelog.md`, etc.) and persist the first match. When no candidate exists, leave the field unset.

## Changes

- New `discover_changelog_relative_path(repo_path)` in `release::changelog::io`. Exposed alongside the pre-existing `CHANGELOG_CANDIDATES` list so the candidate ordering remains the single source of truth for runtime *and* create-time discovery.
- `component create` calls it when no `--changelog-target` flag is supplied.
- Tests: root-preferred ordering, docs-only (the #1128 scenario), none-found returns `None`.

## Test plan

- `cargo test --lib release::changelog::io` — 3/3
- Generated homeboy.json no longer needs post-create fix-up when the project uses `docs/CHANGELOG.md`.

Closes #1128