### PR TITLE
fix: surface PHPUnit/runner stdout+stderr on test failure (#1143)

### DIFF
--- a/src/core/engine/edit_op_apply.rs
+++ b/src/core/engine/edit_op_apply.rs
@@ -82,7 +82,7 @@ fn extract_import_alias(import_line: &str) -> Option<String> {
 
     // Extract the last segment: `Foo\Bar\Baz` → `Baz`, `foo::bar::Baz` → `Baz`
     let last = path
-        .rsplit(|c: char| c == '\\' || c == ':')
+        .rsplit(['\\', ':'])
         .find(|s| !s.is_empty())?;
     if last.is_empty() {
         return None;
@@ -104,11 +104,10 @@ fn import_alias_collides(content: &str, import_line: &str, language: &Language) 
             continue;
         }
         if let Some(existing_alias) = extract_import_alias(trimmed) {
-            if existing_alias == candidate_alias {
-                if normalize_import_line(trimmed) != normalize_import_line(import_line) {
+            if existing_alias == candidate_alias
+                && normalize_import_line(trimmed) != normalize_import_line(import_line) {
                     return true;
                 }
-            }
         }
     }
 
@@ -170,14 +169,14 @@ fn is_type_declaration_line(line: &str, language: &Language) -> bool {
         Language::Php | Language::TypeScript => {
             regex::Regex::new(r"\b(?:class|interface|trait)\s+\w+")
                 .ok()
-                .map_or(false, |re| re.is_match(trimmed))
+                .is_some_and(|re| re.is_match(trimmed))
         }
         Language::Rust => regex::Regex::new(r"\b(?:pub\s+)?(?:struct|enum|trait)\s+\w+")
             .ok()
-            .map_or(false, |re| re.is_match(trimmed)),
+            .is_some_and(|re| re.is_match(trimmed)),
         Language::JavaScript => regex::Regex::new(r"\bclass\s+\w+")
             .ok()
-            .map_or(false, |re| re.is_match(trimmed)),
+            .is_some_and(|re| re.is_match(trimmed)),
         Language::Unknown => false,
     }
 }
@@ -546,7 +545,7 @@ pub fn apply_edit_ops_to_content(
         let idx = line_num.saturating_sub(1);
         if idx < lines.len() {
             if lines[idx].contains(*old_text) {
-                lines[idx] = lines[idx].replacen(*old_text, *new_text, 1);
+                lines[idx] = lines[idx].replacen(*old_text, new_text, 1);
             } else {
                 return Err(format!(
                     "ReplaceText: old_text {:?} not found on line {}",
@@ -772,7 +771,7 @@ pub fn apply_edit_ops(ops: &[TaggedEditOp], root: &Path) -> Result<ApplyReport> 
         };
 
         let language = Language::from_path(&abs_path);
-        let op_refs: Vec<&EditOp> = file_ops.iter().copied().collect();
+        let op_refs: Vec<&EditOp> = file_ops.to_vec();
 
         match apply_edit_ops_to_content(&content, &op_refs, &language) {
             Ok(modified) => {

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -35,7 +35,7 @@ pub use parsing::{
     parse_test_results_text, CoverageOutput, TestSummaryOutput,
 };
 pub use report::TestCommandOutput;
-pub use run::{run_main_test_workflow, TestRunWorkflowArgs, TestRunWorkflowResult};
+pub use run::{run_main_test_workflow, RawTestOutput, TestRunWorkflowArgs, TestRunWorkflowResult};
 pub use workflow::{
     auto_fix_test_drift, detect_test_drift, AutoFixDriftOutput, AutoFixDriftWorkflowResult,
     DriftWorkflowResult, MainTestWorkflowResult,

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -11,7 +11,7 @@ use crate::extension::test::{
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
 
-use super::run::TestRunWorkflowResult;
+use super::run::{RawTestOutput, TestRunWorkflowResult};
 use super::workflow::{AutoFixDriftOutput, AutoFixDriftWorkflowResult, DriftWorkflowResult};
 
 /// Unified output envelope for all test command modes.
@@ -44,6 +44,10 @@ pub struct TestCommandOutput {
     pub test_scope: Option<TestScopeOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<TestSummaryOutput>,
+    /// Tail of runner stdout/stderr when tests fail — lets CI wrappers and
+    /// users see the actual PHPUnit/cargo output. (#1143)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_output: Option<RawTestOutput>,
 }
 
 /// Build output from a main test workflow result.
@@ -65,6 +69,7 @@ pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, 
             auto_fix_drift: None,
             test_scope: result.test_scope,
             summary: result.summary,
+            raw_output: result.raw_output,
         },
         exit_code,
     )
@@ -89,6 +94,7 @@ pub fn from_drift_workflow(result: DriftWorkflowResult) -> (TestCommandOutput, i
             auto_fix_drift: None,
             test_scope: None,
             summary: None,
+            raw_output: None,
         },
         exit_code,
     )
@@ -125,6 +131,7 @@ pub fn from_auto_fix_drift_workflow(
             auto_fix_drift: Some(result.output),
             test_scope: None,
             summary: None,
+            raw_output: None,
         },
         0,
     )

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -42,6 +42,39 @@ pub struct TestRunWorkflowResult {
     pub hints: Option<Vec<String>>,
     pub test_scope: Option<TestScopeOutput>,
     pub summary: Option<TestSummaryOutput>,
+    /// Tail of the runner's stdout/stderr, surfaced when tests fail so users
+    /// can see PHPUnit/cargo output (bootstrap errors, stack traces) without
+    /// having to re-run with a different flag. (#1143)
+    pub raw_output: Option<RawTestOutput>,
+}
+
+/// Captured tail of a test runner's stdout/stderr.
+///
+/// Surfaced on failure so the actual tool output (PHPUnit, cargo test, etc.)
+/// is visible in the structured JSON response. The tail is bounded by
+/// `RAW_OUTPUT_TAIL_LINES` to keep JSON payloads small while still showing
+/// the last error / stack frame, which is almost always the relevant part
+/// for bootstrap failures. (#1143)
+#[derive(Debug, Clone, Serialize)]
+pub struct RawTestOutput {
+    /// Last N lines of stdout. Empty string if the runner emitted no stdout.
+    pub stdout_tail: String,
+    /// Last N lines of stderr. Empty string if the runner emitted no stderr.
+    pub stderr_tail: String,
+    /// Whether either tail was truncated from the original output.
+    pub truncated: bool,
+}
+
+const RAW_OUTPUT_TAIL_LINES: usize = 80;
+
+fn tail_lines(s: &str, max_lines: usize) -> (String, bool) {
+    let lines: Vec<&str> = s.lines().collect();
+    if lines.len() <= max_lines {
+        (s.to_string(), false)
+    } else {
+        let start = lines.len() - max_lines;
+        (lines[start..].join("\n"), true)
+    }
 }
 
 pub fn run_main_test_workflow(
@@ -102,6 +135,7 @@ pub fn run_main_test_workflow(
                 } else {
                     None
                 },
+                raw_output: None,
             });
         }
     }
@@ -259,6 +293,46 @@ pub fn run_main_test_workflow(
         None
     };
 
+    // When the run failed, surface a tail of the runner's stdout/stderr so the
+    // user can see the actual PHPUnit / cargo / etc. output — including
+    // bootstrap errors like database connection failures that produce zero
+    // parsed test results. Without this, `status: failed, exit_code: 1, 0
+    // tests ran` leaves the user guessing. (#1143)
+    let raw_output = if status == "failed" {
+        let (stdout_tail, stdout_truncated) = tail_lines(&output.stdout, RAW_OUTPUT_TAIL_LINES);
+        let (stderr_tail, stderr_truncated) = tail_lines(&output.stderr, RAW_OUTPUT_TAIL_LINES);
+        if stdout_tail.is_empty() && stderr_tail.is_empty() {
+            None
+        } else {
+            Some(RawTestOutput {
+                stdout_tail,
+                stderr_tail,
+                truncated: stdout_truncated || stderr_truncated,
+            })
+        }
+    } else {
+        None
+    };
+
+    // When tests failed with no parseable counts, surface a dedicated hint so
+    // the user understands `raw_output` is the only signal about what went
+    // wrong (typically a bootstrap error). (#1143)
+    let mut hints_vec = hints.unwrap_or_default();
+    if status == "failed" && test_counts.is_none() && raw_output.is_some() {
+        hints_vec.insert(
+            0,
+            "No tests ran — the runner failed before producing results. \
+             See raw_output.stderr_tail / raw_output.stdout_tail for the underlying error \
+             (bootstrap failure, missing deps, DB connection, etc.)."
+                .to_string(),
+        );
+    }
+    let hints = if hints_vec.is_empty() {
+        None
+    } else {
+        Some(hints_vec)
+    };
+
     Ok(TestRunWorkflowResult {
         status: status.to_string(),
         component: args.component_label,
@@ -271,5 +345,47 @@ pub fn run_main_test_workflow(
         hints,
         test_scope: changed_scope,
         summary,
+        raw_output,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tail_lines_returns_full_text_when_under_limit() {
+        let input = "line 1\nline 2\nline 3";
+        let (tail, truncated) = tail_lines(input, 10);
+        assert_eq!(tail, input);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn tail_lines_trims_to_last_n_lines() {
+        let input: String = (1..=20)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (tail, truncated) = tail_lines(&input, 5);
+        assert!(truncated);
+        let kept: Vec<&str> = tail.lines().collect();
+        assert_eq!(kept, vec!["line 16", "line 17", "line 18", "line 19", "line 20"]);
+    }
+
+    #[test]
+    fn tail_lines_handles_empty_input() {
+        let (tail, truncated) = tail_lines("", 10);
+        assert_eq!(tail, "");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn tail_lines_at_exact_limit_is_not_truncated() {
+        let input = "a\nb\nc";
+        let (tail, truncated) = tail_lines(input, 3);
+        assert_eq!(tail, input);
+        assert!(!truncated);
+    }
+}
+

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -370,7 +370,10 @@ mod tests {
         let (tail, truncated) = tail_lines(&input, 5);
         assert!(truncated);
         let kept: Vec<&str> = tail.lines().collect();
-        assert_eq!(kept, vec!["line 16", "line 17", "line 18", "line 19", "line 20"]);
+        assert_eq!(
+            kept,
+            vec!["line 16", "line 17", "line 18", "line 19", "line 20"]
+        );
     }
 
     #[test]
@@ -388,4 +391,3 @@ mod tests {
         assert!(!truncated);
     }
 }
-

--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -199,14 +199,12 @@ fn is_release_commit(lower: &str) -> bool {
     }
 
     // "bump version to 0.2.3", "bump to v0.2.3", "version bump to 0.2.3"
-    if lower.starts_with("bump")
+    if (lower.starts_with("bump")
         || lower.starts_with("version bump")
-        || lower.starts_with("version ")
-    {
-        if VERSION_NUMBER_RE.is_match(lower) {
+        || lower.starts_with("version "))
+        && VERSION_NUMBER_RE.is_match(lower) {
             return true;
         }
-    }
 
     // "release: v0.2.3", "release v0.2.3", "chore(release): v0.2.3"
     if RELEASE_PREFIX_RE.is_match(lower) {

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -329,13 +329,22 @@ pub fn execute_local_command_interactive(
     }
 }
 
-/// Execute local command with stdout/stderr passed through to terminal.
-/// Returns only exit status, not captured output.
+/// Execute local command with stdout/stderr tee'd to terminal *and* captured.
+///
+/// Originally this function just inherited stdout/stderr and returned empty
+/// strings — which meant callers like the test runner had no way to surface
+/// PHPUnit output when tests failed (#1143). We now pipe both streams, copy
+/// each chunk to the parent's stdout/stderr as it arrives (so the user still
+/// sees live progress), and retain the full text in `CommandOutput` for
+/// downstream processing.
 pub fn execute_local_command_passthrough(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
 ) -> CommandOutput {
+    use std::io::{Read, Write};
+    use std::thread;
+
     #[cfg(windows)]
     let mut cmd = {
         let mut cmd = Command::new("cmd");
@@ -358,20 +367,71 @@ pub fn execute_local_command_passthrough(
         cmd.envs(env_pairs.iter().copied());
     }
 
-    // Passthrough to terminal instead of capturing
-    cmd.stdout(Stdio::inherit());
-    cmd.stderr(Stdio::inherit());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
 
-    match cmd.status() {
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            return CommandOutput {
+                stdout: String::new(),
+                stderr: format!("Command error: {}", e),
+                success: false,
+                exit_code: -1,
+            };
+        }
+    };
+
+    // Tee each stream: copy every chunk to the parent's stdout/stderr as it
+    // arrives (preserving the live-progress UX) while buffering it for the
+    // caller. Using 4 KiB reads keeps latency low without excess syscalls.
+    fn tee_to<R, W>(mut src: R, mut sink: W) -> String
+    where
+        R: Read,
+        W: Write,
+    {
+        let mut captured = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            match src.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = sink.write_all(&buf[..n]);
+                    let _ = sink.flush();
+                    captured.extend_from_slice(&buf[..n]);
+                }
+                Err(_) => break,
+            }
+        }
+        String::from_utf8_lossy(&captured).to_string()
+    }
+
+    let stdout_handle = child.stdout.take().map(|pipe| {
+        thread::spawn(move || tee_to(pipe, std::io::stdout()))
+    });
+    let stderr_handle = child.stderr.take().map(|pipe| {
+        thread::spawn(move || tee_to(pipe, std::io::stderr()))
+    });
+
+    let status = child.wait();
+
+    let stdout = stdout_handle
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr_handle
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
+
+    match status {
         Ok(status) => CommandOutput {
-            stdout: String::new(),
-            stderr: String::new(),
+            stdout,
+            stderr,
             success: status.success(),
             exit_code: status.code().unwrap_or(-1),
         },
         Err(e) => CommandOutput {
-            stdout: String::new(),
-            stderr: format!("Command error: {}", e),
+            stdout,
+            stderr: format!("{stderr}\nCommand error: {}", e),
             success: false,
             exit_code: -1,
         },

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -406,12 +406,14 @@ pub fn execute_local_command_passthrough(
         String::from_utf8_lossy(&captured).to_string()
     }
 
-    let stdout_handle = child.stdout.take().map(|pipe| {
-        thread::spawn(move || tee_to(pipe, std::io::stdout()))
-    });
-    let stderr_handle = child.stderr.take().map(|pipe| {
-        thread::spawn(move || tee_to(pipe, std::io::stderr()))
-    });
+    let stdout_handle = child
+        .stdout
+        .take()
+        .map(|pipe| thread::spawn(move || tee_to(pipe, std::io::stdout())));
+    let stderr_handle = child
+        .stderr
+        .take()
+        .map(|pipe| thread::spawn(move || tee_to(pipe, std::io::stderr())));
 
     let status = child.wait();
 


### PR DESCRIPTION
## Summary

`homeboy test <component>` returned a structured JSON envelope with `status: "failed"` and `exit_code: 1` but swallowed the actual runner output. Users (and agents) had to manually trace through extension shell scripts to discover what actually broke — MySQL connection failure, bootstrap error, PHP fatal, whatever PHPUnit or cargo actually printed.

## Root cause

`execute_local_command_passthrough` in `server::client` inherited stdout/stderr to the parent process for the live-progress UX, then returned **empty strings** for `stdout`/`stderr` in `CommandOutput`. By the time the test workflow tried to report anything, the output was already gone — inherited by the terminal, never captured.

## Fix

**1. Tee instead of inherit.** `execute_local_command_passthrough` now pipes the child's stdout/stderr, reads each chunk, and both copies it to the parent's stream (live-progress preserved) and buffers it into a `String` for `CommandOutput`. Two small threads, 4 KiB buffered reads, same UX as before but the output is now also available to callers.

**2. New `raw_output` field on the test envelope.** `TestRunWorkflowResult` and `TestCommandOutput` gain an optional `RawTestOutput { stdout_tail, stderr_tail, truncated }`. Populated only when `status == "failed"`, bounded to the last 80 lines per stream to keep JSON payloads small while preserving the bottom of the output — almost always where the relevant error message and stack frame live.

**3. Dedicated hint for bootstrap failures.** When a run fails *and* no test counts are parseable (the exact scenario the issue describes: *"0 tests ran"* but exit 1), a hint is inserted at the top of the hint list telling the caller to look at `raw_output.stderr_tail` / `raw_output.stdout_tail`.

## Verified end-to-end

`homeboy test data-machine --skip-lint -- --filter=ThisTestDoesNotExistXYZ`:
- Before: empty hints, no trace of PHPUnit output in JSON
- After: PHPUnit banner, "0 tests executed" warning block, and the PSR-4 validation stack trace all land inside `raw_output.stdout_tail` alongside the new hint

```json
"hints": [
  "No tests ran — the runner failed before producing results. See raw_output.stderr_tail / raw_output.stdout_tail for the underlying error (bootstrap failure, missing deps, DB connection, etc.).",
  ...
],
"raw_output": {
  "stdout_tail": "... WARNING: PHPUnit ran 0 tests ... BUILD FAILED: PHPUnit tests (zero tests executed)",
  "stderr_tail": "",
  "truncated": false
}
```

## Test plan

- `cargo test --lib extension::test::run` — 4 new `tail_lines` tests pass.
- `cargo test --lib` — all 1115 tests green (1 pre-existing HOME-env flake, unrelated).
- Manual end-to-end against data-machine with a deliberately-failing filter.

Closes #1143