### PR TITLE
fix(audit): suppress unreferenced_export false positives on hook callbacks and same-file references (#1149)

### DIFF
--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -439,6 +439,7 @@ pub fn fingerprint_from_grammar(
         internal_calls,
         call_sites: Vec::new(), // Core grammar engine doesn't extract call sites yet
         public_api,
+        hook_callbacks: Vec::new(), // Core grammar engine doesn't extract hook callbacks yet
         trait_impl_methods,
     })
 }

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -115,7 +115,40 @@ pub(crate) fn analyze_dead_code(
         // Skip test files — test methods are invoked by the test runner via
         // reflection/convention, not by direct calls from other source files.
         if !is_test_path(&fp.relative_path) {
+            // For languages without finer-grained visibility than "public" (PHP
+            // top-level functions, for example), a public function called from
+            // anywhere in its own file IS referenced — the "make it private"
+            // suggestion doesn't apply, because PHP top-level functions are
+            // always globally accessible. Rust, by contrast, supports
+            // `pub(crate)` / `pub(super)` narrowing, so a self-only public
+            // function IS actionably dead code.
+            let language_allows_self_reference = matches!(
+                fp.language,
+                super::conventions::Language::Php
+                    | super::conventions::Language::JavaScript
+                    | super::conventions::Language::TypeScript
+            );
+
             for export in &fp.public_api {
+                // Skip if this function is registered as a hook/callback target
+                // from within this same file. Such functions ARE referenced —
+                // just by the framework runtime (WordPress hook system, REST
+                // route callbacks, activation hooks, block render callbacks,
+                // etc.) rather than by direct calls from other source files.
+                // (homeboy#1149 — WP plugin bootstrap files)
+                if fp.hook_callbacks.contains(export) {
+                    continue;
+                }
+
+                // For languages without finer visibility, same-file direct
+                // calls count as references. This catches WP plugin bootstrap
+                // patterns where a top-level helper is called from the main
+                // plugin file (e.g., the top-level WPINC guard that runs
+                // `datamachine_check_requirements()` before continuing).
+                if language_allows_self_reference && fp.internal_calls.contains(export) {
+                    continue;
+                }
+
                 // Check if any OTHER file (owned or reference) references this export.
                 let referenced_elsewhere = owned.iter().chain(reference.iter()).any(|other| {
                     // Skip self
@@ -716,6 +749,94 @@ mod tests {
             findings.is_empty(),
             "Reference fingerprints should not produce findings, got: {:?}",
             findings.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn php_hook_callback_suppresses_unreferenced_export() {
+        // data-machine.php pattern: function is defined and registered as a
+        // WordPress hook callback in the same file. The hook system invokes
+        // it, but no other file has a direct call. This is NOT dead code.
+        let mut fp = make_fingerprint(
+            "data-machine.php",
+            vec!["datamachine_activate_plugin"],
+            vec!["datamachine_activate_plugin"],
+            vec![], // no self-calls
+            vec![],
+        );
+        fp.language = Language::Php;
+        fp.hook_callbacks = vec!["datamachine_activate_plugin".to_string()];
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "Hook-callback registrations should suppress unreferenced_export, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn php_same_file_internal_call_suppresses_unreferenced_export() {
+        // data-machine.php pattern: top-level bootstrap file calls its own
+        // helper functions directly. PHP has no finer visibility than
+        // "public" for top-level functions, so "make it private" is not
+        // actionable advice — the reference IS the justification for export.
+        let mut fp = make_fingerprint(
+            "data-machine.php",
+            vec!["datamachine_check_requirements"],
+            vec!["datamachine_check_requirements"],
+            // Same-file call (e.g., line-20 WPINC guard)
+            vec!["datamachine_check_requirements"],
+            vec![],
+        );
+        fp.language = Language::Php;
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "PHP same-file internal calls should suppress unreferenced_export, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rust_same_file_internal_call_still_flags_unreferenced_export() {
+        // Rust has pub(crate) / pub(super) for narrowing visibility. A
+        // public function only called from its own file IS actionable dead
+        // code: the suggestion to narrow visibility is concrete and useful.
+        // This test guards against overcorrection from the PHP fix above.
+        let fp = make_fingerprint(
+            "src/foo.rs",
+            vec!["compute"],
+            vec!["compute"],
+            vec!["compute"], // same-file call
+            vec![],
+        );
+        // language defaults to Rust in make_fingerprint
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert_eq!(
+            unreferenced.len(),
+            1,
+            "Rust public functions called only from their own file should still be flagged for visibility narrowing"
         );
     }
 }

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -53,6 +53,12 @@ pub struct FileFingerprint {
     pub call_sites: Vec<crate::extension::CallSite>,
     /// Public functions/methods exported from this file.
     pub public_api: Vec<String>,
+    /// Functions/methods registered as hook/callback targets from WITHIN
+    /// this file (populated by extension fingerprint scripts). Used by the
+    /// dead-code check to recognize that a function defined and
+    /// hook-registered in the same file IS live code — invoked by the
+    /// framework runtime rather than direct calls from other files.
+    pub hook_callbacks: Vec<String>,
     /// Method names that are trait implementations (called via trait dispatch).
     pub trait_impl_methods: Vec<String>,
 }
@@ -119,6 +125,7 @@ fn fingerprint_via_extension(
         internal_calls: output.internal_calls,
         call_sites: output.call_sites,
         public_api: output.public_api,
+        hook_callbacks: output.hook_callbacks,
         trait_impl_methods: Vec::new(), // Extension scripts don't track this
     })
 }

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -644,18 +644,23 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diff_fingerprints_detects_removed_hook() {
-        let base = make_fingerprint(
+    /// Helper for hook-diff tests: minimal fingerprint carrying only a single hook.
+    fn fingerprint_with_hook(hook_type: &str, hook_name: &str) -> FileFingerprint {
+        make_fingerprint(
             "Foo.php",
             vec![],
             vec![],
             vec![],
             None,
             None,
-            vec![("action", "my_custom_action")],
-        );
-        let current = make_fingerprint(vec![("action", "my_renamed_action")]);
+            vec![(hook_type, hook_name)],
+        )
+    }
+
+    #[test]
+    fn test_diff_fingerprints_detects_removed_hook() {
+        let base = fingerprint_with_hook("action", "my_custom_action");
+        let current = fingerprint_with_hook("action", "my_renamed_action");
 
         let diff = diff_fingerprints("Foo.php", &base, &current);
         assert!(diff.removed_hooks.contains(&"my_custom_action".to_string()));

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -117,7 +117,7 @@ impl std::fmt::Display for AffectReason {
 ///
 /// Uses `git show <ref>:<path>` to get the base version without checkout,
 /// then runs the extension fingerprint script on that content.
-pub fn fingerprint_from_git_ref(
+pub(crate) fn fingerprint_from_git_ref(
     source_path: &str,
     git_ref: &str,
     relative_path: &str,
@@ -173,7 +173,7 @@ pub fn fingerprint_from_git_ref(
 ///
 /// For each changed file, retrieves the base version, fingerprints it, and
 /// produces a `SymbolDiff` describing what symbols changed.
-pub fn diff_changed_files(
+pub(crate) fn diff_changed_files(
     source_path: &str,
     git_ref: &str,
     changed_files: &[String],
@@ -361,7 +361,7 @@ fn similarity(a: &str, b: &str) -> f64 {
 /// - `hooks` matching removed hook names
 ///
 /// Returns only files NOT already in the changed set.
-pub fn find_affected_files(
+pub(crate) fn find_affected_files(
     diffs: &[SymbolDiff],
     all_fingerprints: &[&FileFingerprint],
     changed_files: &HashSet<&str>,

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -160,6 +160,7 @@ pub fn fingerprint_from_git_ref(
         internal_calls: output.internal_calls,
         call_sites: output.call_sites,
         public_api: output.public_api,
+        hook_callbacks: output.hook_callbacks,
         trait_impl_methods: Vec::new(),
     })
 }

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -117,7 +117,7 @@ impl std::fmt::Display for AffectReason {
 ///
 /// Uses `git show <ref>:<path>` to get the base version without checkout,
 /// then runs the extension fingerprint script on that content.
-pub(crate) fn fingerprint_from_git_ref(
+pub fn fingerprint_from_git_ref(
     source_path: &str,
     git_ref: &str,
     relative_path: &str,
@@ -173,7 +173,7 @@ pub(crate) fn fingerprint_from_git_ref(
 ///
 /// For each changed file, retrieves the base version, fingerprints it, and
 /// produces a `SymbolDiff` describing what symbols changed.
-pub(crate) fn diff_changed_files(
+pub fn diff_changed_files(
     source_path: &str,
     git_ref: &str,
     changed_files: &[String],
@@ -361,7 +361,7 @@ fn similarity(a: &str, b: &str) -> f64 {
 /// - `hooks` matching removed hook names
 ///
 /// Returns only files NOT already in the changed set.
-pub(crate) fn find_affected_files(
+pub fn find_affected_files(
     diffs: &[SymbolDiff],
     all_fingerprints: &[&FileFingerprint],
     changed_files: &HashSet<&str>,
@@ -655,7 +655,15 @@ mod tests {
             None,
             vec![("action", "my_custom_action")],
         );
-        let current = make_fingerprint(vec![("action", "my_renamed_action")]);
+        let current = make_fingerprint(
+            "Foo.php",
+            vec![],
+            vec![],
+            vec![],
+            None,
+            None,
+            vec![("action", "my_renamed_action")],
+        );
 
         let diff = diff_fingerprints("Foo.php", &base, &current);
         assert!(diff.removed_hooks.contains(&"my_custom_action".to_string()));

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -117,7 +117,7 @@ impl std::fmt::Display for AffectReason {
 ///
 /// Uses `git show <ref>:<path>` to get the base version without checkout,
 /// then runs the extension fingerprint script on that content.
-pub fn fingerprint_from_git_ref(
+pub(crate) fn fingerprint_from_git_ref(
     source_path: &str,
     git_ref: &str,
     relative_path: &str,
@@ -173,7 +173,7 @@ pub fn fingerprint_from_git_ref(
 ///
 /// For each changed file, retrieves the base version, fingerprints it, and
 /// produces a `SymbolDiff` describing what symbols changed.
-pub fn diff_changed_files(
+pub(crate) fn diff_changed_files(
     source_path: &str,
     git_ref: &str,
     changed_files: &[String],
@@ -361,7 +361,7 @@ fn similarity(a: &str, b: &str) -> f64 {
 /// - `hooks` matching removed hook names
 ///
 /// Returns only files NOT already in the changed set.
-pub fn find_affected_files(
+pub(crate) fn find_affected_files(
     diffs: &[SymbolDiff],
     all_fingerprints: &[&FileFingerprint],
     changed_files: &HashSet<&str>,
@@ -655,15 +655,7 @@ mod tests {
             None,
             vec![("action", "my_custom_action")],
         );
-        let current = make_fingerprint(
-            "Foo.php",
-            vec![],
-            vec![],
-            vec![],
-            None,
-            None,
-            vec![("action", "my_renamed_action")],
-        );
+        let current = make_fingerprint(vec![("action", "my_renamed_action")]);
 
         let diff = diff_fingerprints("Foo.php", &base, &current);
         assert!(diff.removed_hooks.contains(&"my_custom_action".to_string()));

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -655,15 +655,7 @@ mod tests {
             None,
             vec![("action", "my_custom_action")],
         );
-        let current = make_fingerprint(
-            "Foo.php",
-            vec![],
-            vec![],
-            vec![],
-            None,
-            None,
-            vec![("action", "my_renamed_action")],
-        );
+        let current = make_fingerprint(vec![("action", "my_renamed_action")]);
 
         let diff = diff_fingerprints("Foo.php", &base, &current);
         assert!(diff.removed_hooks.contains(&"my_custom_action".to_string()));

--- a/src/core/code_audit/shadow_modules.rs
+++ b/src/core/code_audit/shadow_modules.rs
@@ -272,6 +272,7 @@ mod tests {
             internal_calls: vec![],
             call_sites: vec![],
             public_api: vec![],
+            hook_callbacks: vec![],
             trait_impl_methods: vec![],
         }
     }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -476,6 +476,22 @@ pub struct FingerprintOutput {
     /// Public functions/methods exported from this file (the file's API surface).
     #[serde(default)]
     pub public_api: Vec<String>,
+    /// Functions/methods registered as hook/callback targets from WITHIN
+    /// this file. These names are invoked by the framework runtime (e.g.,
+    /// WordPress's hook system, `register_activation_hook`, REST callbacks,
+    /// block render callbacks), not by direct calls from other source files.
+    ///
+    /// When a file both defines a function AND registers it as a hook
+    /// callback, the function IS live code — it's just invoked through the
+    /// framework rather than through a direct function call. The dead-code
+    /// check uses this field to suppress false positives on such functions.
+    ///
+    /// Populated by extension fingerprint scripts; older scripts may not
+    /// emit it (defaults to empty Vec). Extensions should populate this for
+    /// ALL framework-runtime invocation patterns they can detect in the
+    /// language/framework they support — not just WordPress hooks.
+    #[serde(default)]
+    pub hook_callbacks: Vec<String>,
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #1149

## What

Two complementary structural fixes that together drop the `unreferenced_export` false-positive rate to ~0% on WordPress plugin bootstrap files. Verified against the canonical fixture (`extra-chill/data-machine`'s `data-machine.php`): **17 of 17** public functions go from flagged to clean.

### 1. Recognize same-file hook-callback registrations as references

The check counts a public function as referenced only if some OTHER file calls or imports it. That's right for direct-call languages, but it breaks down when the function is invoked by the framework runtime (WP hooks, REST callbacks, activation hooks, block render callbacks, etc.) **from the same file that defines it** — the standard pattern in plugin bootstrap files.

The `wordpress` extension already extracts these registrations into a `hook_callbacks` set in its fingerprint output, but homeboy core was discarding the field. Now we deserialize and use it.

### 2. PHP/JS/TS: same-file internal calls count as references

For languages that don't have finer visibility than `public` for top-level functions (PHP, JavaScript, TypeScript), a public function called anywhere in its own file IS live code — there's no actionable "narrow visibility" suggestion. The original "skip self" behavior was designed for Rust where `pub(crate)` / `pub(super)` give the suggestion concrete force.

Rust still gets the original behavior. New test `rust_same_file_internal_call_still_flags_unreferenced_export` guards against overcorrection.

## Plumbing

- New `hook_callbacks: Vec<String>` on `FingerprintOutput` (`#[serde(default)]` for backward compatibility)
- Matching field on `FileFingerprint`, propagated through both fingerprint paths (extension script + grammar engine) plus `impact.rs`
- Grammar engine emits empty Vec for now; can populate when grammar-driven PHP fingerprinting matures

## Tests

3 new dead_code tests:
- `php_hook_callback_suppresses_unreferenced_export`
- `php_same_file_internal_call_suppresses_unreferenced_export`
- `rust_same_file_internal_call_still_flags_unreferenced_export`

All 16 dead_code tests pass. Two pre-existing flakes elsewhere (`write_standalone_creates_and_reads_back`, `try_load_cached_audit_reads_output_dir`) are unchanged by this PR — verified pre-existing on main.

## End-to-end verification

Ran the updated fingerprint + suppression logic against `data-machine.php` directly:

| Logic | Functions flagged |
|---|---|
| Old | 17 of 17 public functions |
| New | **0 of 17** public functions |

All 10 functions enumerated in #1149 verified suppressed:

| Function | Suppressed by |
|---|---|
| `datamachine_activate_plugin` | hook + self-call |
| `datamachine_deactivate_plugin` | hook + self-call |
| `datamachine_register_capabilities` | self-call |
| `datamachine_activate_plugin_defaults` | hook + self-call |
| `datamachine_activate_defaults_for_site` | self-call |
| `datamachine_on_new_site` | hook + self-call |
| `datamachine_check_requirements` | self-call |
| `datamachine_run_datamachine_plugin` | hook + self-call |
| `datamachine_scan_and_instantiate` | self-call |
| `datamachine_allow_json_upload` | hook + self-call |

## Companion PR

Extra-Chill/homeboy-extensions#212 extends the wordpress extension's `hook_callbacks` regex set to cover `register_rest_route`, `register_block_type` `render_callback`, `add_shortcode`, `register_uninstall_hook`, and the generic `'callback' / '*_callback'` array key family.

The two PRs compose:

- **This PR alone is safe to land:** no FP regression, just new suppressions on extensions that emit `hook_callbacks`. The wordpress extension already emits that field for the patterns its existing regex set covers.
- **The companion extension PR adds new pattern coverage** — without this core PR it has no effect, with this core PR it widens the set of suppressed FPs even further.