### PR TITLE
fix: auto-init missing changelog on first release

### DIFF
--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -103,6 +103,22 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         v.capture(validate_code_quality(&component), "code_quality");
     }
 
+    // === Stage 0.7: Auto-initialize changelog (first-release bootstrap) ===
+    //
+    // If `changelog_target` is configured but the file doesn't exist on disk,
+    // synthesize a minimal changelog so downstream stages have something to
+    // read and finalize. Without this, three stages below all fail with
+    // "File not found" for the same root cause and none of their hints
+    // mention `homeboy changelog init`. See #1172.
+    //
+    // Skipped in dry-run to avoid mutating the working tree during a preview.
+    if !options.dry_run {
+        v.capture(
+            ensure_changelog_initialized(&component),
+            "changelog_bootstrap",
+        );
+    }
+
     // Detect monorepo context for path-scoped commits and component-prefixed tags.
     let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
 
@@ -1072,6 +1088,69 @@ fn validate_working_tree_fail_fast(component: &Component) -> Result<()> {
     ))
 }
 
+/// First-release bootstrap: if the component's configured `changelog_target`
+/// doesn't exist on disk (and no fallback candidate exists either), synthesize
+/// a minimal changelog so the downstream release stages have a file to read
+/// and finalize.
+///
+/// Without this, three stages below all fail with the same `File not found`
+/// error — `commits`, `changelog`, and `changelog_sync` each read the
+/// changelog independently — and none of their hints point at
+/// `homeboy changelog init`. See #1172.
+///
+/// Writes a template matching `homeboy changelog init`: a `# Changelog` title
+/// and a `## Unreleased` section. The downstream `finalize_with_generated_entries`
+/// or `finalize_next_section` then replaces `## Unreleased` with the real
+/// `## [x.y.z] - YYYY-MM-DD` section, so the template is transient — it
+/// lands on disk only for the span of one release run.
+///
+/// No-op when:
+/// - `changelog_target` is unset (resolver already fails with a teaching error),
+/// - the configured path exists,
+/// - a fallback candidate exists (resolver's discovery covers this case).
+fn ensure_changelog_initialized(component: &Component) -> Result<()> {
+    let Some(ref target) = component.changelog_target else {
+        // No target configured — let resolve_changelog_path() emit its
+        // existing "No changelog configured" teaching error downstream.
+        return Ok(());
+    };
+
+    let configured_path =
+        crate::paths::resolve_path(&component.local_path, target);
+    if configured_path.exists() {
+        return Ok(());
+    }
+
+    // If a fallback candidate exists, resolve_changelog_path() will pick
+    // it up — don't overwrite it with a fresh template.
+    let repo_root = std::path::Path::new(&component.local_path);
+    if changelog::discover_changelog_relative_path(repo_root).is_some() {
+        return Ok(());
+    }
+
+    // Create the parent directory (e.g. `docs/`) before writing the file.
+    if let Some(parent) = configured_path.parent() {
+        crate::engine::local_files::local().ensure_dir(parent)?;
+    }
+
+    let settings = changelog::resolve_effective_settings(Some(component));
+    let template = format!(
+        "# Changelog\n\n## {}\n\n",
+        settings.next_section_label,
+    );
+
+    crate::engine::local_files::local().write(&configured_path, &template)?;
+
+    log_status!(
+        "release",
+        "Initialized changelog at {} (first release for {})",
+        configured_path.display(),
+        component.id
+    );
+
+    Ok(())
+}
+
 /// Get list of files allowed to be dirty during release (relative paths).
 fn get_release_allowed_files(
     changelog_path: &std::path::Path,
@@ -1129,9 +1208,11 @@ fn get_unexpected_uncommitted_files(
 #[cfg(test)]
 mod tests {
     use super::{
-        filter_homeboy_managed, find_uncovered_commits, get_unexpected_uncommitted_files,
-        is_homeboy_managed_path, normalize_changelog_text, strip_pr_reference,
+        ensure_changelog_initialized, filter_homeboy_managed, find_uncovered_commits,
+        get_unexpected_uncommitted_files, is_homeboy_managed_path, normalize_changelog_text,
+        strip_pr_reference,
     };
+    use crate::component::Component;
     use crate::git::{CommitCategory, CommitInfo, UncommittedChanges};
 
     fn commit(subject: &str, category: CommitCategory) -> CommitInfo {
@@ -1370,6 +1451,113 @@ mod tests {
             "allowed files + homeboy scratch should yield clean result, got: {:?}",
             unexpected
         );
+    }
+
+    fn component_with_changelog_target(
+        temp_dir: &tempfile::TempDir,
+        target: Option<&str>,
+    ) -> Component {
+        Component {
+            id: "test-component".to_string(),
+            local_path: temp_dir.path().to_string_lossy().to_string(),
+            remote_path: String::new(),
+            changelog_target: target.map(|s| s.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Regression for #1172: first release with `changelog_target` configured
+    /// but no file on disk. The preflight must create the file so downstream
+    /// stages don't all fail with "File not found".
+    #[test]
+    fn ensure_changelog_initialized_creates_missing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let component = component_with_changelog_target(&temp, Some("CHANGELOG.md"));
+
+        let changelog_path = temp.path().join("CHANGELOG.md");
+        assert!(!changelog_path.exists(), "precondition: no changelog yet");
+
+        ensure_changelog_initialized(&component).expect("preflight should bootstrap");
+
+        let content = std::fs::read_to_string(&changelog_path).expect("file created");
+        assert!(content.contains("# Changelog"), "has title: {}", content);
+        assert!(content.contains("## Unreleased"), "has unreleased: {}", content);
+    }
+
+    /// Nested targets like `docs/CHANGELOG.md` must have the parent directory
+    /// created before the file is written.
+    #[test]
+    fn ensure_changelog_initialized_creates_parent_dir_for_nested_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let component = component_with_changelog_target(&temp, Some("docs/CHANGELOG.md"));
+
+        let docs_dir = temp.path().join("docs");
+        assert!(!docs_dir.exists(), "precondition: no docs/ yet");
+
+        ensure_changelog_initialized(&component).expect("preflight should bootstrap");
+
+        assert!(docs_dir.is_dir(), "docs/ parent should be created");
+        assert!(
+            temp.path().join("docs/CHANGELOG.md").exists(),
+            "changelog should land at docs/CHANGELOG.md"
+        );
+    }
+
+    /// Idempotent: if the configured path already exists, leave it alone.
+    /// A second release run must not overwrite an existing changelog.
+    #[test]
+    fn ensure_changelog_initialized_leaves_existing_file_untouched() {
+        let temp = tempfile::tempdir().unwrap();
+        let component = component_with_changelog_target(&temp, Some("CHANGELOG.md"));
+        let changelog_path = temp.path().join("CHANGELOG.md");
+        let original =
+            "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### Added\n- real release\n";
+        std::fs::write(&changelog_path, original).unwrap();
+
+        ensure_changelog_initialized(&component).expect("no-op on existing file");
+
+        let after = std::fs::read_to_string(&changelog_path).unwrap();
+        assert_eq!(after, original, "existing changelog must not be rewritten");
+    }
+
+    /// If a fallback candidate (e.g. `docs/CHANGELOG.md`) exists but the
+    /// configured target points elsewhere, prefer the fallback (the resolver
+    /// already does this) instead of creating a second changelog alongside.
+    #[test]
+    fn ensure_changelog_initialized_defers_to_existing_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let component = component_with_changelog_target(&temp, Some("CHANGELOG.md"));
+
+        // Create a fallback candidate at a different location.
+        std::fs::create_dir_all(temp.path().join("docs")).unwrap();
+        let fallback = temp.path().join("docs/CHANGELOG.md");
+        std::fs::write(&fallback, "# Changelog\n\n## [0.1.0] - 2026-01-01\n").unwrap();
+
+        ensure_changelog_initialized(&component).expect("defer to fallback");
+
+        // The configured target should NOT have been created — the resolver
+        // will pick up the fallback instead.
+        assert!(
+            !temp.path().join("CHANGELOG.md").exists(),
+            "should not create duplicate when fallback exists"
+        );
+    }
+
+    /// If no `changelog_target` is configured at all, the preflight is a
+    /// no-op — `resolve_changelog_path()` downstream emits its existing
+    /// "No changelog configured" teaching error.
+    #[test]
+    fn ensure_changelog_initialized_is_noop_without_configured_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let component = component_with_changelog_target(&temp, None);
+
+        ensure_changelog_initialized(&component).expect("no-op without target");
+
+        // No file created.
+        for entry in std::fs::read_dir(temp.path()).unwrap() {
+            let path = entry.unwrap().path();
+            panic!("should have created nothing, but found: {}", path.display());
+        }
     }
 
     #[test]

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -1115,8 +1115,7 @@ fn ensure_changelog_initialized(component: &Component) -> Result<()> {
         return Ok(());
     };
 
-    let configured_path =
-        crate::paths::resolve_path(&component.local_path, target);
+    let configured_path = crate::paths::resolve_path(&component.local_path, target);
     if configured_path.exists() {
         return Ok(());
     }
@@ -1134,10 +1133,7 @@ fn ensure_changelog_initialized(component: &Component) -> Result<()> {
     }
 
     let settings = changelog::resolve_effective_settings(Some(component));
-    let template = format!(
-        "# Changelog\n\n## {}\n\n",
-        settings.next_section_label,
-    );
+    let template = format!("# Changelog\n\n## {}\n\n", settings.next_section_label,);
 
     crate::engine::local_files::local().write(&configured_path, &template)?;
 
@@ -1481,7 +1477,11 @@ mod tests {
 
         let content = std::fs::read_to_string(&changelog_path).expect("file created");
         assert!(content.contains("# Changelog"), "has title: {}", content);
-        assert!(content.contains("## Unreleased"), "has unreleased: {}", content);
+        assert!(
+            content.contains("## Unreleased"),
+            "has unreleased: {}",
+            content
+        );
     }
 
     /// Nested targets like `docs/CHANGELOG.md` must have the parent directory
@@ -1510,8 +1510,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let component = component_with_changelog_target(&temp, Some("CHANGELOG.md"));
         let changelog_path = temp.path().join("CHANGELOG.md");
-        let original =
-            "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### Added\n- real release\n";
+        let original = "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### Added\n- real release\n";
         std::fs::write(&changelog_path, original).unwrap();
 
         ensure_changelog_initialized(&component).expect("no-op on existing file");

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -621,9 +621,8 @@ mod tests {
             vec!["initial public release".to_string()],
         );
 
-        let result =
-            validate_and_finalize_changelog(&component, "0.1.0", "0.1.0", Some(&entries))
-                .expect("bootstrap finalize should succeed");
+        let result = validate_and_finalize_changelog(&component, "0.1.0", "0.1.0", Some(&entries))
+            .expect("bootstrap finalize should succeed");
 
         assert!(result.changelog_finalized);
         assert!(result.changelog_changed);
@@ -644,11 +643,7 @@ mod tests {
     fn validate_changelog_for_bump_does_not_require_prior_version() {
         let temp_dir = tempfile::tempdir().unwrap();
         let changelog_path = temp_dir.path().join("CHANGELOG.md");
-        fs::write(
-            &changelog_path,
-            "# Changelog\n\n## Unreleased\n- seed\n",
-        )
-        .unwrap();
+        fs::write(&changelog_path, "# Changelog\n\n## Unreleased\n- seed\n").unwrap();
 
         let component = make_test_component(&temp_dir);
         let err = validate_changelog_for_bump(&component, "0.1.0", "0.2.0");

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -198,21 +198,16 @@ pub fn validate_changelog_for_bump(
 
     let changelog_content = local_files::local().read(&changelog_path)?;
 
-    let latest_changelog_version = changelog::get_latest_finalized_version(&changelog_content)
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "changelog",
-                "Changelog has no finalized versions".to_string(),
-                None,
-                Some(vec![
-                    "Add at least one finalized version section like '## [0.1.0] - YYYY-MM-DD'"
-                        .to_string(),
-                ]),
-            )
-        })?;
+    // A changelog with no finalized versions is the **bootstrap case** (first
+    // release for this component). The release pipeline is about to write the
+    // first `## [x.y.z] - YYYY-MM-DD` section itself — there's no prior version
+    // to compare against, so the version-gap check below doesn't apply and
+    // requiring a pre-existing finalized section creates a chicken-and-egg
+    // loop. See #1172.
+    let latest_changelog_version = changelog::get_latest_finalized_version(&changelog_content);
 
-    // Check if changelog is already finalized for the target version
-    if latest_changelog_version == new_version {
+    // Check if changelog is already finalized for the target version.
+    if latest_changelog_version.as_deref() == Some(new_version) {
         return Ok(ChangelogValidationResult {
             changelog_path: changelog_path.to_string_lossy().to_string(),
             changelog_finalized: true,
@@ -220,24 +215,26 @@ pub fn validate_changelog_for_bump(
         });
     }
 
-    // Reject if changelog is ahead of files (version gap)
-    let changelog_ver = semver::Version::parse(&latest_changelog_version);
-    let file_ver = semver::Version::parse(current_version);
-    match (changelog_ver, file_ver) {
-        (Ok(clv), Ok(fv)) if clv > fv => {
-            return Err(Error::validation_invalid_argument(
-                "version",
-                format!(
-                    "Version mismatch: changelog is at {} but files are at {}. Setting version would create a version gap.",
-                    latest_changelog_version, current_version
-                ),
-                None,
-                Some(vec![
-                    "Ensure changelog and version files are in sync before updating version.".to_string(),
-                ]),
-            ));
+    // Reject if changelog is ahead of files (version gap). Skipped on the
+    // bootstrap case (no prior finalized version).
+    if let Some(ref prev) = latest_changelog_version {
+        let changelog_ver = semver::Version::parse(prev);
+        let file_ver = semver::Version::parse(current_version);
+        if let (Ok(clv), Ok(fv)) = (changelog_ver, file_ver) {
+            if clv > fv {
+                return Err(Error::validation_invalid_argument(
+                    "version",
+                    format!(
+                        "Version mismatch: changelog is at {} but files are at {}. Setting version would create a version gap.",
+                        prev, current_version
+                    ),
+                    None,
+                    Some(vec![
+                        "Ensure changelog and version files are in sync before updating version.".to_string(),
+                    ]),
+                ));
+            }
         }
-        _ => {}
     }
 
     let (_, changelog_changed) = changelog::finalize_next_section(
@@ -293,37 +290,31 @@ pub(crate) fn validate_and_finalize_changelog(
         }
     };
 
-    let latest_changelog_version = changelog::get_latest_finalized_version(&changelog_content)
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "changelog",
-                "Changelog has no finalized versions".to_string(),
-                None,
-                Some(vec![
-                    "Add at least one finalized version section like '## [0.1.0] - YYYY-MM-DD'"
-                        .to_string(),
-                ]),
-            )
-        })?;
+    // See validate_changelog_for_bump() for the bootstrap rationale — a fresh
+    // changelog with no finalized versions is a legitimate first-release state,
+    // not an error. The finalize step below writes the first version section.
+    let latest_changelog_version = changelog::get_latest_finalized_version(&changelog_content);
 
-    // Reject if changelog is ahead of files (version gap)
-    let changelog_ver = semver::Version::parse(&latest_changelog_version);
-    let file_ver = semver::Version::parse(current_version);
-    match (changelog_ver, file_ver) {
-        (Ok(clv), Ok(fv)) if clv > fv => {
-            return Err(Error::validation_invalid_argument(
-                "version",
-                format!(
-                    "Version mismatch: changelog is at {} but files are at {}. Setting version would create a version gap.",
-                    latest_changelog_version, current_version
-                ),
-                None,
-                Some(vec![
-                    "Ensure changelog and version files are in sync before updating version.".to_string(),
-                ]),
-            ));
+    // Reject if changelog is ahead of files (version gap). Skipped on the
+    // bootstrap case (no prior finalized version).
+    if let Some(ref prev) = latest_changelog_version {
+        let changelog_ver = semver::Version::parse(prev);
+        let file_ver = semver::Version::parse(current_version);
+        if let (Ok(clv), Ok(fv)) = (changelog_ver, file_ver) {
+            if clv > fv {
+                return Err(Error::validation_invalid_argument(
+                    "version",
+                    format!(
+                        "Version mismatch: changelog is at {} but files are at {}. Setting version would create a version gap.",
+                        prev, current_version
+                    ),
+                    None,
+                    Some(vec![
+                        "Ensure changelog and version files are in sync before updating version.".to_string(),
+                    ]),
+                ));
+            }
         }
-        _ => {}
     }
 
     let (finalized_changelog, changelog_changed) = if let Some(entries) = generated_entries {
@@ -586,5 +577,89 @@ mod tests {
         let unchanged = fs::read_to_string(&changelog_path).unwrap();
         assert!(unchanged.contains("## [0.4.16] - 2026-03-01"));
         assert!(!unchanged.contains("0.4.17"));
+    }
+
+    /// Regression for #1172: a changelog with only an `## Unreleased` section
+    /// and no prior finalized versions is the bootstrap case (first release),
+    /// not an error. `validate_changelog_for_bump` used to fail with
+    /// "Changelog has no finalized versions", blocking every first release.
+    #[test]
+    fn validate_changelog_for_bump_accepts_bootstrap_with_no_prior_versions() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let changelog_path = temp_dir.path().join("CHANGELOG.md");
+        fs::write(
+            &changelog_path,
+            "# Changelog\n\n## Unreleased\n- first feature\n",
+        )
+        .unwrap();
+
+        let component = make_test_component(&temp_dir);
+        let result = validate_changelog_for_bump(&component, "0.1.0", "0.2.0")
+            .expect("bootstrap changelog should validate");
+
+        assert!(result.changelog_finalized);
+        assert!(result.changelog_changed);
+    }
+
+    /// Bootstrap with generated entries (the release pipeline's common path):
+    /// no prior finalized version on disk, entries coming from conventional
+    /// commits. `validate_and_finalize_changelog` should write the first
+    /// versioned section without complaining about the missing baseline.
+    #[test]
+    fn validate_and_finalize_changelog_bootstraps_first_release_with_generated_entries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let changelog_path = temp_dir.path().join("CHANGELOG.md");
+        // Minimal changelog produced by the pipeline's auto-init preflight.
+        fs::write(&changelog_path, "# Changelog\n\n## Unreleased\n\n").unwrap();
+
+        let component = make_test_component(&temp_dir);
+
+        let mut entries: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        entries.insert(
+            "added".to_string(),
+            vec!["initial public release".to_string()],
+        );
+
+        let result =
+            validate_and_finalize_changelog(&component, "0.1.0", "0.1.0", Some(&entries))
+                .expect("bootstrap finalize should succeed");
+
+        assert!(result.changelog_finalized);
+        assert!(result.changelog_changed);
+
+        let finalized = fs::read_to_string(&changelog_path).unwrap();
+        assert!(
+            finalized.contains("## [0.1.0]"),
+            "expected first version section, got: {}",
+            finalized
+        );
+    }
+
+    /// Even with no entries, `validate_changelog_for_bump` should not throw
+    /// the "no finalized versions" gate — downstream finalization handles the
+    /// empty-content case with its own error. This test just confirms the
+    /// bootstrap path no longer short-circuits at the version check.
+    #[test]
+    fn validate_changelog_for_bump_does_not_require_prior_version() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let changelog_path = temp_dir.path().join("CHANGELOG.md");
+        fs::write(
+            &changelog_path,
+            "# Changelog\n\n## Unreleased\n- seed\n",
+        )
+        .unwrap();
+
+        let component = make_test_component(&temp_dir);
+        let err = validate_changelog_for_bump(&component, "0.1.0", "0.2.0");
+
+        // Should NOT fail with the specific "no finalized versions" error.
+        if let Err(e) = &err {
+            assert!(
+                !e.message.contains("no finalized versions"),
+                "bootstrap case should not trip the finalized-versions gate; got: {}",
+                e.message
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1172.

First release of a new component used to hit a cluster of unhelpful failures when `changelog_target` was configured but no CHANGELOG.md existed yet. Three validation stages (`commits`, `changelog`, `changelog_sync`) all failed with the same `File not found` error for the same root cause, and none of their hints mentioned `homeboy changelog init`. Manually seeding CHANGELOG.md (against the docs, which say changelogs are auto-generated) then tripped a second error — `Changelog has no finalized versions` — because the version-gap check required a prior `## [x.y.z]` section to compare against.

Every new component's first release hit this wall. Chubes filed this after running into it on `markdown-database-integration` today and shipping two workaround commits to main (`chore: seed CHANGELOG.md for homeboy-managed releases`, `chore: seed 0.2.0 baseline entry for homeboy changelog`) that shouldn't exist.

## What changed

Two changes land together because they're the same bootstrap bug:

### 1. Auto-init preflight in `release::pipeline::plan`

If `changelog_target` is configured, the configured path doesn't exist on disk, and no fallback candidate (`CHANGELOG.md`, `docs/CHANGELOG.md`, etc.) exists either, the pipeline synthesizes a minimal template before the validation stages run:

```
# Changelog

## Unreleased

```

- Skipped in `--dry-run` (matches Stage 3 auto-staging precedent — dry-run never mutates).
- Logs the init so the user sees what happened.
- No-op when:
  - a changelog already exists at the configured path,
  - a fallback candidate exists elsewhere (the resolver picks that up),
  - no `changelog_target` is configured (the existing "No changelog configured" teaching error still fires downstream).

### 2. Treat "no finalized versions" as bootstrap, not error

Relaxed both `validate_changelog_for_bump` and `validate_and_finalize_changelog` so the absence of any prior `## [x.y.z]` section is a legitimate first-release state. The version-gap check still runs when a prior version exists — it just no-ops when there's no baseline to compare against. The finalize step writes the first versioned section, which is exactly what a first release should produce.

## Net UX

`homeboy release <new-component>` on a component with `changelog_target` configured but no on-disk changelog now Just Works:

```
$ homeboy release markdown-database-integration --skip-checks
Initialized changelog at /.../CHANGELOG.md (first release for markdown-database-integration)
Bumping version 0.2.0 → 0.3.0 (minor, 4 releasable commits)
...
```

The synthesized template is **transient** — it lives on disk only until `finalize_next_section` / `finalize_with_generated_entries` replaces `## Unreleased` with the real `## [x.y.z] - YYYY-MM-DD` section later in the same run. No intermediate `## Unreleased` commit is ever made.

## Tests

**Pipeline bootstrap** (`src/core/release/pipeline.rs`, 5 new tests):

- `ensure_changelog_initialized_creates_missing_file` — baseline bootstrap
- `ensure_changelog_initialized_creates_parent_dir_for_nested_target` — `docs/CHANGELOG.md` path
- `ensure_changelog_initialized_leaves_existing_file_untouched` — idempotent
- `ensure_changelog_initialized_defers_to_existing_fallback` — respects resolver fallback discovery
- `ensure_changelog_initialized_is_noop_without_configured_target` — no surprise writes

**Version gate** (`src/core/release/version.rs`, 3 new tests):

- `validate_changelog_for_bump_accepts_bootstrap_with_no_prior_versions` — primary regression
- `validate_changelog_for_bump_does_not_require_prior_version` — confirms the specific gate is gone
- `validate_and_finalize_changelog_bootstraps_first_release_with_generated_entries` — end-to-end first-release finalize with commit-derived entries

**Overall:** full release test tree (72 tests) passes. Full lib suite (`cargo test --lib -- --test-threads=1`, 1168 tests) passes.

## Not in scope

- The first-release UX issues in #1168 that live in the error surface (error messages that don't teach, docs drift) — separate, larger refactor.
- #1156 component-registration seam — separate UX cluster.
- Dry-run preview of a first release still fails at the `commits` read stage because the preflight skips the write. That's a smaller follow-up: either emit a preview-only hint ("would initialize CHANGELOG.md") or let dry-run create the file in a scratch location. Out of scope for this PR.

## Related

- #1168 — parent issue capturing the broader "errors don't teach" UX pattern. This closes a concrete instance.
- #1156 — sibling first-run friction (registration / attachment seam).