### PR TITLE
fix(extension): restore test_script() and test_mapping() accessors

### DIFF
--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -356,6 +356,18 @@ impl ExtensionManifest {
             .and_then(|c| c.extension_script.as_deref())
     }
 
+    pub fn test_script(&self) -> Option<&str> {
+        self.test
+            .as_ref()
+            .and_then(|c| c.extension_script.as_deref())
+    }
+
+    /// Convenience accessor for the optional test mapping config
+    /// declared under the audit capability.
+    pub fn test_mapping(&self) -> Option<&TestMappingConfig> {
+        self.audit.as_ref().and_then(|a| a.test_mapping.as_ref())
+    }
+
     /// Convenience: autofix verify config, if this extension declares one.
     /// See [`AutofixVerifyConfig`] for the contract.
     pub fn autofix_verify(&self) -> Option<&AutofixVerifyConfig> {


### PR DESCRIPTION
## Summary

`cargo build` on `main` has been failing since 9c13c5 (#1176 "post-write verify gate for automated refactor"). That commit removed the `test_script()` and `test_mapping()` accessor methods on `ExtensionManifest` while adding `autofix_verify()` and `effective_timeout_secs()`. Four callers still rely on the removed methods:

```
error[E0599]: no method named `test_mapping` found for struct `ExtensionManifest`
  --> src/core/code_audit/mod.rs:439
  --> src/core/extension/mod.rs:108

error[E0599]: no method named `test_script` found for struct `ExtensionManifest`
  --> src/core/engine/execution_context.rs:200
  --> src/core/extension/mod.rs:261
```

Every CI run on `main` in the last few days is red for this reason. Example: https://github.com/Extra-Chill/homeboy/actions/runs/24759461975

## Fix

Restore both methods on `ExtensionManifest` with their original implementations:

- `test_script()` mirrors `lint_script()` and `build_script()` — pulls `extension_script` off `self.test`.
- `test_mapping()` pulls the `TestMappingConfig` off `self.audit` (where it lives as a field on `AuditCapability`).

No caller changes needed.

## Verification

- `cargo build` — green
- `cargo test --lib core::extension` — **128 passed, 0 failed**

Full `cargo test --lib` shows 4 pre-existing failures in `code_audit/conventions` (3 signature-check tests) and `component/inventory` (1 write-standalone test) that are unrelated to this change and appear to be flaky / cwd-dependent. Worth investigating separately.

## Unblocks

- This PR
- #1182 (my other open PR, which is currently blocked on this same compile failure)
- Any future PRs touching the tree

12-line diff, surgical restoration. No behavior change for any callers — they get the same accessor methods back that 9c13c5 removed.