### PR TITLE
feat(release): auto-create GitHub Release after tag push

### DIFF
--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -58,6 +58,11 @@ pub struct ReleaseArgs {
     #[arg(long)]
     skip_publish: bool,
 
+    /// Skip the GitHub Release creation step (tag + notes on github.com).
+    /// Use when CI or another pipeline already creates GitHub Releases.
+    #[arg(long)]
+    no_github_release: bool,
+
     /// Git identity for release commits and tags.
     /// Use "bot" for the default CI bot identity, or "Name <email>" for custom.
     /// When set, configures git user.name and user.email before committing.
@@ -112,6 +117,7 @@ impl ReleaseArgs {
             bump,
             major,
             skip_publish,
+            no_github_release: false,
             git_identity: None,
         }
     }
@@ -139,6 +145,7 @@ pub fn run(
             skip_checks: args.skip_checks,
             bump_override: bump_override.clone(),
             skip_publish: args.skip_publish,
+            skip_github_release: args.no_github_release,
             git_identity: args.git_identity.clone(),
         })?;
 
@@ -175,6 +182,7 @@ pub fn run(
         skip_checks: args.skip_checks,
         bump_override,
         skip_publish: args.skip_publish,
+        skip_github_release: args.no_github_release,
         git_identity: args.git_identity.clone(),
     };
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -63,6 +63,7 @@ impl ReleaseStepExecutor {
             ReleaseStepType::Publish(target) => self.run_publish(step, &target),
             ReleaseStepType::Cleanup => self.run_cleanup(step),
             ReleaseStepType::PostRelease => self.run_post_release(step),
+            ReleaseStepType::GitHubRelease => self.run_github_release(step),
         }
     }
 
@@ -527,6 +528,240 @@ impl ReleaseStepExecutor {
         ))
     }
 
+    /// Create a GitHub Release for the just-pushed tag.
+    ///
+    /// Reuses the already-finalized changelog section (stored in
+    /// `ReleaseContext::notes` by the version step) as the release body, so the
+    /// notes on github.com match `CHANGELOG.md` exactly.
+    ///
+    /// Fails soft and returns Success with a warning when:
+    /// - `gh` is not installed on PATH
+    /// - `gh auth status` reports unauthenticated
+    /// - A release for the tag already exists (idempotent re-runs)
+    ///
+    /// The fallback `gh release create` command is always printed so the
+    /// operator can finish the release manually without re-deriving the notes.
+    fn run_github_release(&self, step: &PipelineStep) -> Result<PipelineStepResult> {
+        let (tag, notes) = {
+            let context = self.context.lock().map_err(|_| {
+                Error::internal_unexpected("Failed to lock release context".to_string())
+            })?;
+            let tag = context.tag.clone().ok_or_else(|| {
+                Error::internal_unexpected(
+                    "github.release: tag context not set (git.tag must run first)".to_string(),
+                )
+            })?;
+            let notes = context.notes.clone().unwrap_or_default();
+            (tag, notes)
+        };
+
+        let local_path = &self.component.local_path;
+
+        // Resolve owner/repo. Prefer the component's configured remote_url,
+        // falling back to `git remote get-url origin` in the local path.
+        let remote_url = self
+            .component
+            .remote_url
+            .clone()
+            .or_else(|| {
+                crate::deploy::release_download::detect_remote_url(std::path::Path::new(local_path))
+            })
+            .ok_or_else(|| {
+                Error::internal_unexpected(
+                    "github.release: no remote_url configured and git remote get-url origin failed"
+                        .to_string(),
+                )
+            })?;
+
+        let github = crate::deploy::release_download::parse_github_url(&remote_url)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "github.release",
+                    format!("Remote URL '{}' is not a GitHub URL", remote_url),
+                    None,
+                    Some(vec![
+                        "Only github.com remotes are supported for automatic GitHub Releases"
+                            .to_string(),
+                        "Use --no-github-release to skip this step".to_string(),
+                    ]),
+                )
+            })?;
+
+        // Check gh binary exists.
+        if !gh_is_available() {
+            let fallback = fallback_gh_command(&tag);
+            log_status!(
+                "release",
+                "⚠ `gh` CLI not found on PATH — skipping GitHub Release creation"
+            );
+            log_status!("release", "Manual fallback: {}", fallback);
+            return Ok(self.step_result(
+                step,
+                PipelineRunStatus::Success,
+                Some(serde_json::json!({
+                    "skipped": true,
+                    "reason": "gh-not-available",
+                    "tag": tag,
+                    "owner": github.owner,
+                    "repo": github.repo,
+                    "fallback_command": fallback,
+                })),
+                None,
+                Vec::new(),
+            ));
+        }
+
+        // Check gh auth. `gh auth status` exits non-zero when unauthenticated.
+        if !gh_is_authenticated() {
+            let fallback = fallback_gh_command(&tag);
+            log_status!(
+                "release",
+                "⚠ `gh` is not authenticated — skipping GitHub Release creation"
+            );
+            log_status!(
+                "release",
+                "Authenticate with `gh auth login`, then manual fallback: {}",
+                fallback
+            );
+            return Ok(self.step_result(
+                step,
+                PipelineRunStatus::Success,
+                Some(serde_json::json!({
+                    "skipped": true,
+                    "reason": "gh-not-authenticated",
+                    "tag": tag,
+                    "owner": github.owner,
+                    "repo": github.repo,
+                    "fallback_command": fallback,
+                })),
+                None,
+                Vec::new(),
+            ));
+        }
+
+        // Idempotency: if a release for this tag already exists, skip + warn.
+        // Uses `gh release view <tag> -R <owner>/<repo>` which exits 0 when the
+        // release exists, non-zero otherwise.
+        let repo_flag = format!("{}/{}", github.owner, github.repo);
+        if gh_release_exists(&tag, &repo_flag) {
+            log_status!(
+                "release",
+                "GitHub Release {} already exists for {} — skipping (idempotent)",
+                tag,
+                repo_flag
+            );
+            return Ok(self.step_result(
+                step,
+                PipelineRunStatus::Success,
+                Some(serde_json::json!({
+                    "skipped": true,
+                    "reason": "release-already-exists",
+                    "tag": tag,
+                    "owner": github.owner,
+                    "repo": github.repo,
+                })),
+                None,
+                Vec::new(),
+            ));
+        }
+
+        // Write the notes body to a temp file. `gh release create --notes-file`
+        // preserves the exact text, including markdown formatting, that we
+        // already computed for CHANGELOG.md.
+        let notes_body = if notes.trim().is_empty() {
+            format!("Release {}", tag)
+        } else {
+            notes
+        };
+
+        let tmp_dir = crate::engine::temp::runtime_temp_dir("github-release")?;
+        let notes_path = tmp_dir.join(format!("notes-{}.md", sanitize_tag_for_filename(&tag)));
+        std::fs::write(&notes_path, &notes_body).map_err(|e| {
+            Error::internal_io(
+                format!("Failed to write release notes file: {}", e),
+                Some(notes_path.display().to_string()),
+            )
+        })?;
+
+        log_status!(
+            "release",
+            "Creating GitHub Release {} on {}...",
+            tag,
+            repo_flag
+        );
+
+        let output = std::process::Command::new("gh")
+            .args([
+                "release",
+                "create",
+                &tag,
+                "--title",
+                &tag,
+                "--notes-file",
+                notes_path
+                    .to_str()
+                    .ok_or_else(|| {
+                        Error::internal_unexpected(
+                            "github.release: notes-file path is not valid UTF-8".to_string(),
+                        )
+                    })?,
+                "-R",
+                &repo_flag,
+            ])
+            .output()
+            .map_err(|e| {
+                Error::internal_io(
+                    format!("Failed to invoke gh: {}", e),
+                    Some("gh release create".to_string()),
+                )
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let fallback = fallback_gh_command(&tag);
+            log_status!(
+                "release",
+                "⚠ `gh release create` failed: {}",
+                stderr.trim()
+            );
+            log_status!("release", "Manual fallback: {}", fallback);
+            return Ok(self.step_result(
+                step,
+                PipelineRunStatus::Success,
+                Some(serde_json::json!({
+                    "skipped": true,
+                    "reason": "gh-command-failed",
+                    "tag": tag,
+                    "owner": github.owner,
+                    "repo": github.repo,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "fallback_command": fallback,
+                })),
+                None,
+                Vec::new(),
+            ));
+        }
+
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        log_status!("release", "Created GitHub Release: {}", url);
+
+        Ok(self.step_result(
+            step,
+            PipelineRunStatus::Success,
+            Some(serde_json::json!({
+                "action": "github.release",
+                "tag": tag,
+                "owner": github.owner,
+                "repo": github.repo,
+                "url": url,
+            })),
+            None,
+            Vec::new(),
+        ))
+    }
+
     fn default_commit_message(&self) -> String {
         let context = self.context.lock().ok();
         let version = context
@@ -672,5 +907,93 @@ impl ReleaseStepExecutor {
 impl PipelineStepExecutor for ReleaseStepExecutor {
     fn execute_step(&self, step: &PipelineStep) -> Result<PipelineStepResult> {
         self.execute_core_step(step)
+    }
+}
+
+/// Return true if the `gh` binary is on PATH.
+fn gh_is_available() -> bool {
+    std::process::Command::new("gh")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Return true if `gh auth status` reports an authenticated user for github.com.
+fn gh_is_authenticated() -> bool {
+    std::process::Command::new("gh")
+        .args(["auth", "status", "--hostname", "github.com"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Return true if a GitHub Release for the given tag already exists on the repo.
+fn gh_release_exists(tag: &str, repo_flag: &str) -> bool {
+    std::process::Command::new("gh")
+        .args(["release", "view", tag, "-R", repo_flag])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Build the manual-fallback `gh release create` command string shown to the
+/// operator when the automatic step can't run (no auth, no binary, command
+/// failed). The operator has the `CHANGELOG.md` section at the same version,
+/// so `--notes-file CHANGELOG.md` works if they just want the whole file;
+/// most teams copy the `## vX.Y.Z` block manually.
+fn fallback_gh_command(tag: &str) -> String {
+    format!(
+        "gh release create {} --title {} --notes-file <path-to-release-notes>",
+        tag, tag
+    )
+}
+
+/// Sanitize a tag into a safe filename component. Replaces anything that isn't
+/// alphanumeric, dash, underscore, or dot with '-'. Used only for the temp
+/// notes file name, so collisions aren't a correctness concern.
+fn sanitize_tag_for_filename(tag: &str) -> String {
+    tag.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fallback_gh_command, sanitize_tag_for_filename};
+
+    #[test]
+    fn sanitize_tag_for_filename_preserves_safe_chars() {
+        assert_eq!(sanitize_tag_for_filename("v1.2.3"), "v1.2.3");
+        assert_eq!(
+            sanitize_tag_for_filename("data-machine-v0.70.2"),
+            "data-machine-v0.70.2"
+        );
+    }
+
+    #[test]
+    fn sanitize_tag_for_filename_strips_unsafe_chars() {
+        assert_eq!(sanitize_tag_for_filename("v1.2.3 rc1"), "v1.2.3-rc1");
+        assert_eq!(sanitize_tag_for_filename("feat/foo@1"), "feat-foo-1");
+    }
+
+    #[test]
+    fn fallback_gh_command_includes_tag_twice() {
+        let cmd = fallback_gh_command("v1.2.3");
+        assert!(cmd.contains("gh release create v1.2.3"));
+        assert!(cmd.contains("--title v1.2.3"));
+        assert!(cmd.contains("--notes-file"));
     }
 }

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -777,6 +777,28 @@ pub(super) fn changelog_entries_from_json(
     serde_json::from_value(value.clone()).ok()
 }
 
+/// Return true if this component should get a GitHub Release created.
+///
+/// Resolves the remote URL from the component config (preferred) or from
+/// `git remote get-url origin` in the component's local_path, then parses
+/// it as a GitHub URL. Non-GitHub remotes (GitLab, self-hosted, etc.) fall
+/// through cleanly — the step simply isn't added to the plan.
+fn github_release_applies(component: &Component) -> bool {
+    let remote_url = component
+        .remote_url
+        .clone()
+        .or_else(|| {
+            crate::deploy::release_download::detect_remote_url(std::path::Path::new(
+                &component.local_path,
+            ))
+        });
+
+    remote_url
+        .as_deref()
+        .and_then(crate::deploy::release_download::parse_github_url)
+        .is_some()
+}
+
 /// Derive publish targets from extensions that have `release.publish` action.
 fn get_publish_targets(extensions: &[ExtensionManifest]) -> Vec<String> {
     extensions
@@ -917,6 +939,22 @@ fn build_release_steps(
         status: ReleasePlanStatus::Ready,
         missing: vec![],
     });
+
+    // 5a. GitHub Release (create tag+notes on github.com)
+    // Runs in parallel with publish/cleanup — it only needs the tag to be on
+    // the remote. Fails soft when `gh` isn't installed or authenticated.
+    // Skipped entirely for non-GitHub remotes (no remote_url, or non-github URL).
+    if !options.skip_github_release && github_release_applies(component) {
+        steps.push(ReleasePlanStep {
+            id: "github.release".to_string(),
+            step_type: "github.release".to_string(),
+            label: Some("Create GitHub Release".to_string()),
+            needs: vec!["git.push".to_string()],
+            config: std::collections::HashMap::new(),
+            status: ReleasePlanStatus::Ready,
+            missing: vec![],
+        });
+    }
 
     let mut publish_step_ids: Vec<String> = Vec::new();
 

--- a/src/core/release/resolver.rs
+++ b/src/core/release/resolver.rs
@@ -36,7 +36,8 @@ impl PipelineCapabilityResolver for ReleaseCapabilityResolver {
             | ReleaseStepType::GitTag
             | ReleaseStepType::GitPush
             | ReleaseStepType::Cleanup
-            | ReleaseStepType::PostRelease => true,
+            | ReleaseStepType::PostRelease
+            | ReleaseStepType::GitHubRelease => true,
             ReleaseStepType::Package => self.supports_package(),
             ReleaseStepType::Publish(ref target) => self.supports_publish_target(target),
         }

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -16,6 +16,7 @@ pub(crate) enum ReleaseStepType {
     Publish(String),
     Cleanup,
     PostRelease,
+    GitHubRelease,
 }
 
 impl ReleaseStepType {
@@ -28,6 +29,7 @@ impl ReleaseStepType {
             "package" => ReleaseStepType::Package,
             "cleanup" => ReleaseStepType::Cleanup,
             "post_release" => ReleaseStepType::PostRelease,
+            "github.release" => ReleaseStepType::GitHubRelease,
             other => {
                 // Strip "publish." prefix at source - single source of truth for format parsing
                 let target = other.strip_prefix("publish.").unwrap_or(other);
@@ -156,6 +158,10 @@ pub struct ReleaseOptions {
     /// Deploy after release — defers artifact cleanup until after deployment.
     #[serde(default)]
     pub deploy: bool,
+    /// Skip the GitHub Release creation step (tag + notes on github.com).
+    /// Use when another pipeline (CI, semantic-release, etc.) already owns that step.
+    #[serde(default)]
+    pub skip_github_release: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
@@ -177,6 +183,9 @@ pub struct ReleaseCommandInput {
     pub bump_override: Option<String>,
     #[serde(default)]
     pub skip_publish: bool,
+    /// Skip the GitHub Release creation step (tag + notes on github.com).
+    #[serde(default)]
+    pub skip_github_release: bool,
     /// Git identity for release commits: "bot", "Name <email>", or None (use existing config).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_identity: Option<String>,

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -193,6 +193,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         skip_checks: input.skip_checks,
         skip_publish: input.skip_publish,
         deploy: input.deploy,
+        skip_github_release: input.skip_github_release,
     };
 
     if options.dry_run {
@@ -697,6 +698,7 @@ pub fn run_batch(
             skip_checks: input_template.skip_checks,
             bump_override: input_template.bump_override.clone(),
             skip_publish: input_template.skip_publish,
+            skip_github_release: input_template.skip_github_release,
             git_identity: input_template.git_identity.clone(),
         };
 


### PR DESCRIPTION
## Summary

Closes #1184 — `homeboy release` now creates a GitHub Release automatically after it tags and pushes, so operators no longer need to follow every release with a manual `gh release create vX.Y.Z`.

## How it works

A new pipeline step, `github.release`, is inserted after `git.push` (and runs in parallel with any publish/cleanup steps). It reuses the already-finalized changelog section that the version step writes into the executor's `ReleaseContext` as the release body — so the notes on github.com match `CHANGELOG.md` exactly, no reimplementation of commit categorization.

Shell-out path:

```
gh release create <tag> --title <tag> --notes-file <tmp> -R <owner>/<repo>
```

`<owner>/<repo>` is resolved from the component's configured `remote_url`, falling back to `git remote get-url origin` in the component's `local_path`. Both HTTPS and SSH GitHub URL formats are handled via the existing `release_download::parse_github_url`.

## Behavior guarantees

- **Non-GitHub remotes unchanged.** The step is only added to the plan when the component's remote parses as a github.com URL. GitLab, self-hosted, or components with no `remote_url` see the same pipeline they had before.
- **Fails soft.** Missing `gh` binary, unauthenticated `gh auth status`, or a non-zero exit from `gh release create` all log a warning with the manual fallback command and return Success. The tag is already pushed by the time this step runs — we don't want to poison an otherwise-successful release.
- **Idempotent.** If a Release already exists for the tag (partial prior run, CI beat us to it), the step skips with a warning instead of failing.
- **Opt-out.** `--no-github-release` disables the step for environments where another pipeline owns GitHub Releases.

## Files changed

- `src/core/release/types.rs` — add `skip_github_release` to `ReleaseOptions` + `ReleaseCommandInput`, add `GitHubRelease` step-type variant, wire it through `from_str`.
- `src/core/release/pipeline.rs` — insert `github.release` step after `git.push` when the remote parses as GitHub; add `github_release_applies()` gate.
- `src/core/release/executor.rs` — implement `run_github_release()` with the fail-soft + idempotency logic, plus unit tests for the tag-to-filename sanitizer and fallback command builder.
- `src/core/release/resolver.rs` — declare the new step type as supported.
- `src/core/release/workflow.rs` — forward `skip_github_release` from `ReleaseCommandInput` into `ReleaseOptions` for both single and batch runs.
- `src/commands/release.rs` — add `--no-github-release` CLI flag.

## Tests

- Full `cargo test --lib core::release` suite passes (75 tests, 0 new failures).
- New unit tests cover `sanitize_tag_for_filename` (preserves safe chars, strips unsafe ones) and `fallback_gh_command` (shape check).
- `cargo check --all-targets` clean; pre-existing failing tests (`signature_check_*`, `write_standalone_creates_and_reads_back`) also fail on main — unrelated to this change.

## Follow-ups (out of scope)

- Draft-vs-published toggle (default is published, per the issue).
- Attaching release assets — #462 already covered the packaging action primitives and asset upload lives there, not here.