### PR TITLE
refactor(release): complete changelog automation transition

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -294,9 +294,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
     // Fetch upstream drift for all components
     let upstream_drift_map: std::collections::HashMap<String, UpstreamDrift> = components
         .iter()
-        .filter_map(|c| {
-            fetch_upstream_drift_for(&c.local_path, &c.id).map(|d| (c.id.clone(), d))
-        })
+        .filter_map(|c| fetch_upstream_drift_for(&c.local_path, &c.id).map(|d| (c.id.clone(), d)))
         .collect();
 
     // Build per-component rows
@@ -451,7 +449,11 @@ fn get_latest_tag_overall(path: &str) -> Option<String> {
         &["tag", "-l", "--sort=-v:refname"],
     )?;
 
-    output.lines().next().map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+    output
+        .lines()
+        .next()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Like `fetch_upstream_drift` but sets the component ID in the result.

--- a/src/core/engine/undo/rollback.rs
+++ b/src/core/engine/undo/rollback.rs
@@ -19,7 +19,7 @@
 //! }
 //! ```
 
-use super::entry::{restore_entries, is_tracked, FileStateEntry};
+use super::entry::{is_tracked, restore_entries, FileStateEntry};
 use std::path::Path;
 
 #[derive(Debug, Clone, Default)]

--- a/src/core/engine/undo/snapshot.rs
+++ b/src/core/engine/undo/snapshot.rs
@@ -112,7 +112,8 @@ impl UndoSnapshot {
         let state = FileStateEntry::capture(&abs);
 
         if let Some(ref content) = state.original_content {
-            self.contents.push((relative_path.to_string(), content.clone()));
+            self.contents
+                .push((relative_path.to_string(), content.clone()));
         }
 
         self.entries.push(SnapshotEntry {

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -715,8 +715,7 @@ mod tests {
         // installs (no `.git`) must be treated as clean, since there is no
         // working tree to be dirty in the first place.
         let temp = TempDir::new().expect("create tempdir");
-        std::fs::write(temp.path().join("some-file.txt"), "content")
-            .expect("write file");
+        std::fs::write(temp.path().join("some-file.txt"), "content").expect("write file");
 
         assert!(
             is_workdir_clean(temp.path()),
@@ -756,8 +755,7 @@ mod tests {
             return;
         }
 
-        std::fs::write(temp.path().join("untracked.txt"), "hi")
-            .expect("write untracked file");
+        std::fs::write(temp.path().join("untracked.txt"), "hi").expect("write untracked file");
 
         assert!(
             !is_workdir_clean(temp.path()),

--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -13,27 +13,6 @@ use crate::error::{Error, Result};
 
 use super::settings::*;
 
-pub fn check_next_section_content(
-    changelog_content: &str,
-    next_section_aliases: &[String],
-) -> Result<Option<String>> {
-    let lines: Vec<&str> = changelog_content.lines().collect();
-    let start = match find_next_section_start(&lines, next_section_aliases) {
-        Some(idx) => idx,
-        None => return Ok(None),
-    };
-
-    let end = find_section_end(&lines, start);
-    let body_lines = &lines[start + 1..end];
-    let content_status = validate_section_content(body_lines);
-
-    match content_status {
-        SectionContentStatus::Valid => Ok(None),
-        SectionContentStatus::SubsectionsOnly => Ok(Some(String::from("subsection_headers_only"))),
-        SectionContentStatus::Empty => Ok(Some(String::from("empty"))),
-    }
-}
-
 pub fn finalize_next_section(
     changelog_content: &str,
     next_section_aliases: &[String],

--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -229,7 +229,7 @@ pub(super) fn ensure_next_section(content: &str, aliases: &[String]) -> Result<(
     Ok((out, true))
 }
 
-pub fn add_next_section_items(
+pub(crate) fn add_next_section_items(
     changelog_content: &str,
     next_section_aliases: &[String],
     messages: &[String],

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -462,8 +462,8 @@ pub(crate) fn run_github_release(
             )
         })?;
 
-    let github = crate::deploy::release_download::parse_github_url(&remote_url).ok_or_else(
-        || {
+    let github =
+        crate::deploy::release_download::parse_github_url(&remote_url).ok_or_else(|| {
             Error::validation_invalid_argument(
                 "github.release",
                 format!("Remote URL '{}' is not a GitHub URL", remote_url),
@@ -474,8 +474,7 @@ pub(crate) fn run_github_release(
                     "Use --no-github-release to skip this step".to_string(),
                 ]),
             )
-        },
-    )?;
+        })?;
 
     if !gh_is_available() {
         let fallback = fallback_gh_command(&tag);
@@ -597,11 +596,7 @@ pub(crate) fn run_github_release(
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let fallback = fallback_gh_command(&tag);
-        log_status!(
-            "release",
-            "⚠ `gh release create` failed: {}",
-            stderr.trim()
-        );
+        log_status!("release", "⚠ `gh release create` failed: {}", stderr.trim());
         log_status!("release", "Manual fallback: {}", fallback);
         return Ok(step_success(
             "github.release",
@@ -652,9 +647,8 @@ fn load_release_notes(component: &Component) -> Result<String> {
 }
 
 fn should_amend_release_commit(local_path: &str) -> Result<bool> {
-    let log_output =
-        crate::git::execute_git_for_release(local_path, &["log", "-1", "--format=%s"])
-            .map_err(|e| Error::internal_io(e.to_string(), Some("git log".to_string())))?;
+    let log_output = crate::git::execute_git_for_release(local_path, &["log", "-1", "--format=%s"])
+        .map_err(|e| Error::internal_io(e.to_string(), Some("git log".to_string())))?;
     if !log_output.status.success() {
         return Ok(false);
     }
@@ -684,10 +678,7 @@ pub(crate) fn build_release_payload(
     extra_config: Option<&std::collections::HashMap<String, serde_json::Value>>,
 ) -> serde_json::Value {
     let version = state.version.clone().unwrap_or_default();
-    let tag = state
-        .tag
-        .clone()
-        .unwrap_or_else(|| format!("v{}", version));
+    let tag = state.tag.clone().unwrap_or_else(|| format!("v{}", version));
     let notes = state.notes.clone().unwrap_or_default();
 
     let mut payload = serde_json::json!({

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -453,25 +453,29 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let semver_recommendation =
         build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?;
 
-    // === Stage 1: Determine changelog entries from conventional commits ===
-    // Returns Some(entries) when commits need changelog entries generated.
-    // Never writes to disk — entries are passed to the executor via step config.
-    // When auto-generation will handle the changelog, skip downstream changelog
-    // validations (they would false-fail since entries don't exist on disk yet).
+    // === Stage 1: Generate changelog entries from conventional commits ===
+    //
+    // Homeboy owns the changelog end-to-end: entries come from commits, get
+    // finalized into a `## [X.Y.Z]` section by `bump_component_version`, and
+    // are written to disk in one shot. Users never hand-curate entries.
+    //
+    // An empty commit set is a clean gate — a zero-commit release makes no
+    // sense in the automation model, so the generator errors out.
     let pending_entries = v
         .capture(
-            validate_commits_vs_changelog(&component, options.dry_run, monorepo.as_ref()),
+            generate_changelog_entries(
+                &component,
+                component_id,
+                options.dry_run,
+                monorepo.as_ref(),
+            ),
             "commits",
         )
-        .flatten();
-    let will_auto_generate = pending_entries.is_some();
+        .unwrap_or_default();
 
-    if !will_auto_generate {
-        v.capture(validate_changelog(&component), "changelog");
-    }
     let version_info = v.capture(version::read_component_version(&component), "version");
 
-    // === Stage 2: Version-dependent validations ===
+    // === Stage 2: Version bump math ===
     let new_version = if let Some(ref info) = version_info {
         match version::increment_version(&info.version, &options.bump_type) {
             Some(ver) => Some(ver),
@@ -487,15 +491,6 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     } else {
         None
     };
-
-    if !will_auto_generate {
-        if let (Some(ref info), Some(ref new_ver)) = (&version_info, &new_version) {
-            v.capture(
-                version::validate_changelog_for_bump(&component, &info.version, new_ver),
-                "changelog_sync",
-            );
-        }
-    }
 
     // === Stage 3: Working tree check ===
     if let Some(ref info) = version_info {
@@ -570,13 +565,14 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         &mut hints,
     )?;
 
-    // Embed pending changelog entries in the version step config so the executor
-    // can generate and finalize them atomically — no ## Unreleased disk round-trip.
-    if let Some(ref entries) = pending_entries {
+    // Embed the generated changelog entries in the version step config so the
+    // executor can finalize them directly into a `## [X.Y.Z]` section — no
+    // `## Unreleased` round-trip.
+    if !pending_entries.is_empty() {
         if let Some(version_step) = steps.iter_mut().find(|s| s.id == "version") {
             version_step.config.insert(
                 "changelog_entries".to_string(),
-                changelog_entries_to_json(entries),
+                changelog_entries_to_json(&pending_entries),
             );
         }
     }
@@ -708,43 +704,6 @@ pub(super) fn resolve_tag_and_commits(
             Ok((latest_tag, commits))
         }
     }
-}
-
-fn validate_changelog(component: &Component) -> Result<()> {
-    let changelog_path = changelog::resolve_changelog_path(component)?;
-    let changelog_content = crate::engine::local_files::local().read(&changelog_path)?;
-    let settings = changelog::resolve_effective_settings(Some(component));
-
-    if let Some(status) =
-        changelog::check_next_section_content(&changelog_content, &settings.next_section_aliases)?
-    {
-        match status.as_str() {
-            "empty" => {
-                return Err(Error::validation_invalid_argument(
-                    "changelog",
-                    "Changelog has no unreleased entries",
-                    None,
-                    Some(vec![
-                        "Add changelog entries: homeboy changelog add <component> -m \"...\""
-                            .to_string(),
-                    ]),
-                ));
-            }
-            "subsection_headers_only" => {
-                return Err(Error::validation_invalid_argument(
-                    "changelog",
-                    "Changelog has subsection headers but no items",
-                    None,
-                    Some(vec![
-                        "Add changelog entries: homeboy changelog add <component> -m \"...\""
-                            .to_string(),
-                    ]),
-                ));
-            }
-            _ => {}
-        }
-    }
-    Ok(())
 }
 
 /// Fetch from remote and fast-forward if behind.
@@ -908,46 +867,56 @@ fn validate_code_quality(component: &Component) -> Result<()> {
     ))
 }
 
-/// Validate that commits since the last tag have corresponding changelog entries.
-/// Returns Ok(Some(entries)) when entries need to be auto-generated (passed to executor),
-/// Ok(None) if all entries already exist, or Err on failure.
-/// Never writes to disk — the executor handles writes via finalize_with_generated_entries.
-fn validate_commits_vs_changelog(
+/// Generate changelog entries from the commits since the last tag.
+///
+/// Returns `Ok(Some(entries))` when commits produced entries to finalize.
+/// Returns `Ok(Some(empty_map))` when the changelog is already ahead of the
+/// latest tag (fully-automated repos that commit the release *before* tagging)
+/// — nothing to generate but the release still proceeds.
+/// Returns `Err` when there are no commits since the last tag at all — a zero-
+/// commit release is a clean gate, no special cases.
+///
+/// Pure computation: never writes to disk. The writes happen in
+/// `bump_component_version` → `finalize_with_generated_entries`.
+fn generate_changelog_entries(
     component: &Component,
+    component_id: &str,
     dry_run: bool,
     monorepo: Option<&git::MonorepoContext>,
-) -> Result<Option<std::collections::HashMap<String, Vec<String>>>> {
-    // Get latest tag and commits (scoped to component in monorepo)
+) -> Result<std::collections::HashMap<String, Vec<String>>> {
     let (latest_tag, commits) = resolve_tag_and_commits(&component.local_path, monorepo)?;
 
-    // If no commits, nothing to validate
+    // Clean gate: no commits → no release. Users never hand-curate changelogs
+    // anymore (the homeboy changelog add path is deprecated — see #1205), so
+    // "commits = no release" is the only correct answer.
     if commits.is_empty() {
-        return Ok(None);
+        let tag_desc = latest_tag
+            .as_deref()
+            .map(|t| format!("tag '{}'", t))
+            .unwrap_or_else(|| "the initial commit".to_string());
+        return Err(Error::validation_invalid_argument(
+            "commits",
+            format!("No commits since {} — nothing to release", tag_desc),
+            Some(format!("Component: {}", component_id)),
+            Some(vec![
+                "Homeboy releases are driven by commits. Commit a change, then re-run."
+                    .to_string(),
+                format!(
+                    "Check status: git log {}..HEAD --oneline",
+                    latest_tag.as_deref().unwrap_or("")
+                )
+                .trim_end_matches(' ')
+                .to_string(),
+            ]),
+        ));
     }
 
-    // Read unreleased changelog entries
+    // If the changelog is already finalized ahead of the latest tag, the
+    // release commit was produced in a prior run that got interrupted before
+    // tagging. No new entries to generate; let the rest of the pipeline
+    // (tag + push) finish the job.
     let changelog_path = changelog::resolve_changelog_path(component)?;
     let changelog_content = crate::engine::local_files::local().read(&changelog_path)?;
-    let settings = changelog::resolve_effective_settings(Some(component));
-    let unreleased_entries =
-        changelog::get_unreleased_entries(&changelog_content, &settings.next_section_aliases);
-
-    let missing_commits = find_uncovered_commits(&commits, &unreleased_entries);
-
-    // If all relevant commits are already represented in the changelog, no new
-    // entries needed. Return an empty map (not None) so will_auto_generate stays
-    // true — this prevents changelog_sync from running and failing when there's
-    // no ## Unreleased section (fully automated changelogs never have one).
-    if missing_commits.is_empty() {
-        return Ok(Some(std::collections::HashMap::new()));
-    }
-
-    // Check if changelog is already finalized ahead of the latest tag.
-    // This handles fully automated changelogs where entries are generated from
-    // commits and finalized into a versioned section — no ## Unreleased section
-    // ever exists on disk. Return an empty entries map so will_auto_generate is
-    // true, which skips changelog_sync validation (it would fail looking for a
-    // non-existent ## Unreleased section).
     let latest_changelog_version = changelog::get_latest_finalized_version(&changelog_content);
     if let (Some(latest_tag), Some(changelog_ver_str)) = (&latest_tag, latest_changelog_version) {
         let tag_version = latest_tag.trim_start_matches('v');
@@ -962,43 +931,28 @@ fn validate_commits_vs_changelog(
                     changelog_ver_str,
                     latest_tag
                 );
-                return Ok(Some(std::collections::HashMap::new()));
+                return Ok(std::collections::HashMap::new());
             }
         }
     }
 
-    // Build entries from commits — pure computation, no disk writes.
-    let entries = group_commits_for_changelog(&missing_commits);
+    // Filter to commits that produce changelog entries (skip docs/chore/merge).
+    let releasable: Vec<git::CommitInfo> = commits
+        .into_iter()
+        .filter(|c| c.category.to_changelog_entry_type().is_some())
+        .collect();
+
+    let entries = group_commits_for_changelog(&releasable);
     let count: usize = entries.values().map(|v| v.len()).sum();
 
-    if dry_run {
-        log_status!(
-            "release",
-            "Would auto-generate {} changelog entries from commits (dry run)",
-            count
-        );
-    } else {
-        log_status!(
-            "release",
-            "Will auto-generate {} changelog entries from commits",
-            count
-        );
-    }
+    log_status!(
+        "release",
+        "{} auto-generate {} changelog entries from commits",
+        if dry_run { "Would" } else { "Will" },
+        count,
+    );
 
-    Ok(Some(entries))
-}
-
-fn normalize_changelog_text(value: &str) -> String {
-    // Strip trailing PR/issue references like (#123) before normalizing
-    let stripped = strip_pr_reference(value);
-    stripped
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
-        .collect::<String>()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+    Ok(entries)
 }
 
 /// Strip trailing PR/issue references like "(#123)" or "(#123, #456)" from text.
@@ -1016,35 +970,6 @@ fn strip_pr_reference(value: &str) -> String {
         }
     }
     trimmed.to_string()
-}
-
-fn find_uncovered_commits(
-    commits: &[git::CommitInfo],
-    unreleased_entries: &[String],
-) -> Vec<git::CommitInfo> {
-    let normalized_entries: Vec<String> = unreleased_entries
-        .iter()
-        .map(|entry| normalize_changelog_text(entry))
-        .collect();
-
-    commits
-        .iter()
-        .filter(|commit| commit.category.to_changelog_entry_type().is_some())
-        .filter(|commit| {
-            let normalized_subject =
-                normalize_changelog_text(git::strip_conventional_prefix(&commit.subject));
-
-            // Check both directions: entry contains subject OR subject contains entry.
-            // This handles cases where the manual changelog entry is a substring of the
-            // commit message or vice versa.
-            !normalized_entries.iter().any(|entry| {
-                !entry.is_empty()
-                    && (entry.contains(&normalized_subject)
-                        || normalized_subject.contains(entry.as_str()))
-            })
-        })
-        .cloned()
-        .collect()
 }
 
 /// Generate changelog entries from conventional commit messages.
@@ -1446,29 +1371,20 @@ fn validate_working_tree_fail_fast(component: &Component) -> Result<()> {
 }
 
 /// First-release bootstrap: if the component's configured `changelog_target`
-/// doesn't exist on disk (and no fallback candidate exists either), synthesize
-/// a minimal changelog so the downstream release stages have a file to read
-/// and finalize.
+/// doesn't exist on disk (and no fallback candidate exists), create an empty
+/// changelog scaffold so `resolve_changelog_path` + `finalize_with_generated_entries`
+/// downstream have a file to work with.
 ///
-/// Without this, three stages below all fail with the same `File not found`
-/// error — `commits`, `changelog`, and `changelog_sync` each read the
-/// changelog independently — and none of their hints point at
-/// `homeboy changelog init`. See #1172.
-///
-/// Writes a template matching `homeboy changelog init`: a `# Changelog` title
-/// and a `## Unreleased` section. The downstream `finalize_with_generated_entries`
-/// or `finalize_next_section` then replaces `## Unreleased` with the real
-/// `## [x.y.z] - YYYY-MM-DD` section, so the template is transient — it
-/// lands on disk only for the span of one release run.
+/// Writes only a `# Changelog` title — no `## Unreleased` section. The
+/// downstream `finalize_with_generated_entries` handles inserting the new
+/// `## [x.y.z] - YYYY-MM-DD` section directly. See #1172 + #1205.
 ///
 /// No-op when:
-/// - `changelog_target` is unset (resolver already fails with a teaching error),
+/// - `changelog_target` is unset (resolver emits a teaching error downstream),
 /// - the configured path exists,
 /// - a fallback candidate exists (resolver's discovery covers this case).
 fn ensure_changelog_initialized(component: &Component) -> Result<()> {
     let Some(ref target) = component.changelog_target else {
-        // No target configured — let resolve_changelog_path() emit its
-        // existing "No changelog configured" teaching error downstream.
         return Ok(());
     };
 
@@ -1477,22 +1393,18 @@ fn ensure_changelog_initialized(component: &Component) -> Result<()> {
         return Ok(());
     }
 
-    // If a fallback candidate exists, resolve_changelog_path() will pick
-    // it up — don't overwrite it with a fresh template.
     let repo_root = std::path::Path::new(&component.local_path);
     if changelog::discover_changelog_relative_path(repo_root).is_some() {
         return Ok(());
     }
 
-    // Create the parent directory (e.g. `docs/`) before writing the file.
     if let Some(parent) = configured_path.parent() {
         crate::engine::local_files::local().ensure_dir(parent)?;
     }
 
-    let settings = changelog::resolve_effective_settings(Some(component));
-    let template = format!("# Changelog\n\n## {}\n\n", settings.next_section_label,);
-
-    crate::engine::local_files::local().write(&configured_path, &template)?;
+    // Title only. `finalize_with_generated_entries` will create the
+    // `## [X.Y.Z]` section directly on top of this.
+    crate::engine::local_files::local().write(&configured_path, "# Changelog\n\n")?;
 
     log_status!(
         "release",
@@ -1561,9 +1473,8 @@ fn get_unexpected_uncommitted_files(
 #[cfg(test)]
 mod tests {
     use super::{
-        ensure_changelog_initialized, filter_homeboy_managed, find_uncovered_commits,
-        get_unexpected_uncommitted_files, is_homeboy_managed_path, normalize_changelog_text,
-        strip_pr_reference,
+        ensure_changelog_initialized, filter_homeboy_managed, get_unexpected_uncommitted_files,
+        is_homeboy_managed_path, strip_pr_reference,
     };
     use crate::component::Component;
     use crate::git::{CommitCategory, CommitInfo, UncommittedChanges};
@@ -1574,68 +1485,6 @@ mod tests {
             subject: subject.to_string(),
             category,
         }
-    }
-
-    #[test]
-    fn test_normalize_changelog_text() {
-        assert_eq!(
-            normalize_changelog_text(
-                "Fixed scoped audit exit codes to ignore unchanged legacy outliers"
-            ),
-            "fixed scoped audit exit codes to ignore unchanged legacy outliers"
-        );
-        assert_eq!(
-            normalize_changelog_text("fix(audit): use scoped findings for changed-since exit"),
-            "fix audit use scoped findings for changed since exit"
-        );
-    }
-
-    #[test]
-    fn test_find_uncovered_commits_ignores_covered_fix_commit() {
-        let commits = vec![commit(
-            "fix(audit): use scoped findings for changed-since exit",
-            CommitCategory::Fix,
-        )];
-        let unreleased = vec![
-            "use scoped findings for changed-since exit".to_string(),
-            "another manual note".to_string(),
-        ];
-
-        let uncovered = find_uncovered_commits(&commits, &unreleased);
-        assert!(uncovered.is_empty());
-    }
-
-    #[test]
-    fn test_find_uncovered_commits_requires_feature_coverage() {
-        let commits = vec![
-            commit(
-                "fix(audit): use scoped findings for changed-since exit",
-                CommitCategory::Fix,
-            ),
-            commit(
-                "feat(refactor): apply decompose plans with audit impact projection",
-                CommitCategory::Feature,
-            ),
-        ];
-        let unreleased = vec!["use scoped findings for changed-since exit".to_string()];
-
-        let uncovered = find_uncovered_commits(&commits, &unreleased);
-        assert_eq!(uncovered.len(), 1);
-        assert_eq!(
-            uncovered[0].subject,
-            "feat(refactor): apply decompose plans with audit impact projection"
-        );
-    }
-
-    #[test]
-    fn test_find_uncovered_commits_skips_docs_and_merge() {
-        let commits = vec![
-            commit("docs: update release notes", CommitCategory::Docs),
-            commit("Merge pull request #1 from branch", CommitCategory::Merge),
-        ];
-
-        let uncovered = find_uncovered_commits(&commits, &[]);
-        assert!(uncovered.is_empty());
     }
 
     #[test]
@@ -1652,43 +1501,6 @@ mod tests {
         assert_eq!(
             strip_pr_reference("has parens (not a pr ref)"),
             "has parens (not a pr ref)"
-        );
-    }
-
-    #[test]
-    fn test_normalize_strips_pr_reference() {
-        assert_eq!(
-            normalize_changelog_text("fix something (#526)"),
-            normalize_changelog_text("fix something")
-        );
-    }
-
-    #[test]
-    fn test_find_uncovered_commits_deduplicates_with_pr_suffix() {
-        // Scenario: manual changelog entry without PR ref, commit has PR ref
-        let commits = vec![commit(
-            "fix: version bump dry-run no longer mutates changelog (#526)",
-            CommitCategory::Fix,
-        )];
-        let unreleased = vec!["version bump dry-run no longer mutates changelog".to_string()];
-
-        let uncovered = find_uncovered_commits(&commits, &unreleased);
-        assert!(
-            uncovered.is_empty(),
-            "Should detect commit as covered by manual entry (PR ref stripped)"
-        );
-    }
-
-    #[test]
-    fn test_find_uncovered_commits_bidirectional_match() {
-        // Entry is longer/more descriptive than the commit message
-        let commits = vec![commit("feat: enable autofix", CommitCategory::Feature)];
-        let unreleased = vec!["enable autofix on PR and release CI workflows".to_string()];
-
-        let uncovered = find_uncovered_commits(&commits, &unreleased);
-        assert!(
-            uncovered.is_empty(),
-            "Should match when commit subject is contained in the entry"
         );
     }
 
@@ -1822,6 +1634,10 @@ mod tests {
     /// Regression for #1172: first release with `changelog_target` configured
     /// but no file on disk. The preflight must create the file so downstream
     /// stages don't all fail with "File not found".
+    ///
+    /// Post-#1205: the scaffold only contains the `# Changelog` title, not a
+    /// `## Unreleased` section. `finalize_with_generated_entries` inserts the
+    /// `## [X.Y.Z]` section directly.
     #[test]
     fn ensure_changelog_initialized_creates_missing_file() {
         let temp = tempfile::tempdir().unwrap();
@@ -1835,8 +1651,8 @@ mod tests {
         let content = std::fs::read_to_string(&changelog_path).expect("file created");
         assert!(content.contains("# Changelog"), "has title: {}", content);
         assert!(
-            content.contains("## Unreleased"),
-            "has unreleased: {}",
+            !content.contains("## Unreleased"),
+            "should NOT pre-create Unreleased section (legacy): {}",
             content
         );
     }

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -107,12 +107,7 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
     let has_publish_targets = !get_publish_targets(&extensions).is_empty();
     let want_publish = !options.skip_publish && has_publish_targets;
     if want_publish {
-        match executor::run_package(
-            &extensions,
-            &mut state,
-            component_id,
-            &component.local_path,
-        ) {
+        match executor::run_package(&extensions, &mut state, component_id, &component.local_path) {
             Ok(result) => results.push(result),
             Err(err) => results.push(failed_result("package", "package", err)),
         }
@@ -258,10 +253,7 @@ fn derive_overall_status(results: &[ReleaseStepResult]) -> ReleaseStepStatus {
     }
 }
 
-fn build_summary(
-    results: &[ReleaseStepResult],
-    status: &ReleaseStepStatus,
-) -> ReleaseRunSummary {
+fn build_summary(results: &[ReleaseStepResult], status: &ReleaseStepStatus) -> ReleaseRunSummary {
     let succeeded = results
         .iter()
         .filter(|r| matches!(r.status, ReleaseStepStatus::Success))
@@ -376,8 +368,6 @@ fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
         _ => None,
     }
 }
-
-
 
 /// Plan a release: run all preflight validations, then return a description
 /// of the steps the executor will run. Used by `--dry-run` to preview work
@@ -899,8 +889,7 @@ fn generate_changelog_entries(
             format!("No commits since {} — nothing to release", tag_desc),
             Some(format!("Component: {}", component_id)),
             Some(vec![
-                "Homeboy releases are driven by commits. Commit a change, then re-run."
-                    .to_string(),
+                "Homeboy releases are driven by commits. Commit a change, then re-run.".to_string(),
                 format!(
                     "Check status: git log {}..HEAD --oneline",
                     latest_tag.as_deref().unwrap_or("")
@@ -1028,14 +1017,11 @@ fn changelog_entries_to_json(
 /// it as a GitHub URL. Non-GitHub remotes (GitLab, self-hosted, etc.) fall
 /// through cleanly — the step simply isn't added to the plan.
 fn github_release_applies(component: &Component) -> bool {
-    let remote_url = component
-        .remote_url
-        .clone()
-        .or_else(|| {
-            crate::deploy::release_download::detect_remote_url(std::path::Path::new(
-                &component.local_path,
-            ))
-        });
+    let remote_url = component.remote_url.clone().or_else(|| {
+        crate::deploy::release_download::detect_remote_url(std::path::Path::new(
+            &component.local_path,
+        ))
+    });
 
     remote_url
         .as_deref()

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -185,72 +185,6 @@ fn pre_validate_version_targets(
     Ok(target_infos)
 }
 
-/// Read-only changelog validation for version bump operations.
-/// Validates that changelog can be finalized without making any changes.
-/// Returns the same validation results as validate_and_finalize_changelog but without modifying files.
-pub fn validate_changelog_for_bump(
-    component: &Component,
-    current_version: &str,
-    new_version: &str,
-) -> Result<ChangelogValidationResult> {
-    let settings = changelog::resolve_effective_settings(Some(component));
-    let changelog_path = changelog::resolve_changelog_path(component)?;
-
-    let changelog_content = local_files::local().read(&changelog_path)?;
-
-    // A changelog with no finalized versions is the **bootstrap case** (first
-    // release for this component). The release pipeline is about to write the
-    // first `## [x.y.z] - YYYY-MM-DD` section itself — there's no prior version
-    // to compare against, so the version-gap check below doesn't apply and
-    // requiring a pre-existing finalized section creates a chicken-and-egg
-    // loop. See #1172.
-    let latest_changelog_version = changelog::get_latest_finalized_version(&changelog_content);
-
-    // Check if changelog is already finalized for the target version.
-    if latest_changelog_version.as_deref() == Some(new_version) {
-        return Ok(ChangelogValidationResult {
-            changelog_path: changelog_path.to_string_lossy().to_string(),
-            changelog_finalized: true,
-            changelog_changed: false, // Already finalized, no changes needed
-        });
-    }
-
-    // Reject if changelog is ahead of files (version gap). Skipped on the
-    // bootstrap case (no prior finalized version).
-    if let Some(ref prev) = latest_changelog_version {
-        let changelog_ver = semver::Version::parse(prev);
-        let file_ver = semver::Version::parse(current_version);
-        if let (Ok(clv), Ok(fv)) = (changelog_ver, file_ver) {
-            if clv > fv {
-                return Err(Error::validation_invalid_argument(
-                    "version",
-                    format!(
-                        "Version mismatch: changelog is at {} but files are at {}. Setting version would create a version gap.",
-                        prev, current_version
-                    ),
-                    None,
-                    Some(vec![
-                        "Ensure changelog and version files are in sync before updating version.".to_string(),
-                    ]),
-                ));
-            }
-        }
-    }
-
-    let (_, changelog_changed) = changelog::finalize_next_section(
-        &changelog_content,
-        &settings.next_section_aliases,
-        new_version,
-        false,
-    )?;
-
-    Ok(ChangelogValidationResult {
-        changelog_path: changelog_path.to_string_lossy().to_string(),
-        changelog_finalized: true,
-        changelog_changed,
-    })
-}
-
 /// Validate and finalize changelog for a version operation.
 /// Ensures changelog is in sync with current version and has valid unreleased content.
 ///
@@ -290,9 +224,9 @@ pub(crate) fn validate_and_finalize_changelog(
         }
     };
 
-    // See validate_changelog_for_bump() for the bootstrap rationale — a fresh
-    // changelog with no finalized versions is a legitimate first-release state,
-    // not an error. The finalize step below writes the first version section.
+    // Bootstrap case: a fresh changelog with no finalized versions is a
+    // legitimate first-release state, not an error. The finalize step below
+    // writes the first version section. See #1172.
     let latest_changelog_version = changelog::get_latest_finalized_version(&changelog_content);
 
     // Reject if changelog is ahead of files (version gap). Skipped on the
@@ -579,28 +513,6 @@ mod tests {
         assert!(!unchanged.contains("0.4.17"));
     }
 
-    /// Regression for #1172: a changelog with only an `## Unreleased` section
-    /// and no prior finalized versions is the bootstrap case (first release),
-    /// not an error. `validate_changelog_for_bump` used to fail with
-    /// "Changelog has no finalized versions", blocking every first release.
-    #[test]
-    fn validate_changelog_for_bump_accepts_bootstrap_with_no_prior_versions() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let changelog_path = temp_dir.path().join("CHANGELOG.md");
-        fs::write(
-            &changelog_path,
-            "# Changelog\n\n## Unreleased\n- first feature\n",
-        )
-        .unwrap();
-
-        let component = make_test_component(&temp_dir);
-        let result = validate_changelog_for_bump(&component, "0.1.0", "0.2.0")
-            .expect("bootstrap changelog should validate");
-
-        assert!(result.changelog_finalized);
-        assert!(result.changelog_changed);
-    }
-
     /// Bootstrap with generated entries (the release pipeline's common path):
     /// no prior finalized version on disk, entries coming from conventional
     /// commits. `validate_and_finalize_changelog` should write the first
@@ -635,26 +547,5 @@ mod tests {
         );
     }
 
-    /// Even with no entries, `validate_changelog_for_bump` should not throw
-    /// the "no finalized versions" gate — downstream finalization handles the
-    /// empty-content case with its own error. This test just confirms the
-    /// bootstrap path no longer short-circuits at the version check.
-    #[test]
-    fn validate_changelog_for_bump_does_not_require_prior_version() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let changelog_path = temp_dir.path().join("CHANGELOG.md");
-        fs::write(&changelog_path, "# Changelog\n\n## Unreleased\n- seed\n").unwrap();
 
-        let component = make_test_component(&temp_dir);
-        let err = validate_changelog_for_bump(&component, "0.1.0", "0.2.0");
-
-        // Should NOT fail with the specific "no finalized versions" error.
-        if let Err(e) = &err {
-            assert!(
-                !e.message.contains("no finalized versions"),
-                "bootstrap case should not trip the finalized-versions gate; got: {}",
-                e.message
-            );
-        }
-    }
 }

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -546,6 +546,4 @@ mod tests {
             finalized
         );
     }
-
-
 }


### PR DESCRIPTION
Closes #1205.

## Summary

Finishes the transition from \"users hand-curate \`## Unreleased\`\" to \"homeboy generates everything from commits.\" Deletes the legacy validators that guarded the old manual-entry path, tightens the forced-bump gate with a sane teaching error, and drops the dedup machinery that only existed to diff manual entries against commit subjects.

## Symptom that triggered this

On a repo with no commits since the last tag:

\`\`\`
$ homeboy release intelligence --dry-run --bump patch --skip-checks
error: Invalid argument 'changelog_sync':
  No unreleased changelog section found
  (looked for: \"## Unreleased\", \"## Next\", \"## [Unreleased]\", \"## [Next]\")
\`\`\`

That error is nonsense in the automated world. \`## Unreleased\` is itself a legacy artifact — homeboy writes \`## [X.Y.Z]\` directly, skipping the round-trip. The real problem was \"no commits to release,\" leaked through a vestigial validator.

Post-this-PR:

\`\`\`
$ homeboy release intelligence --dry-run --bump patch --skip-checks
error: Invalid argument 'commits':
  No commits since tag 'v0.9.0' — nothing to release
  hint: Homeboy releases are driven by commits. Commit a change, then re-run.
\`\`\`

## What changed

### Renamed
- **\`validate_commits_vs_changelog\` → \`generate_changelog_entries\`.** The old name lied; the function is a generator, not a validator. The \"validate\" framing leaked the manual-entry model into the code names.

### Deleted
- **\`validate_changelog()\`** — guarded the hand-curation world by checking \`## Unreleased\` was non-empty. Already skipped on the auto-generation path; only fired in the forced-bump-no-commits edge case.
- **\`validate_changelog_for_bump()\` + the \`changelog_sync\` stage** — same story. Pure legacy.
- **\`check_next_section_content()\` in the changelog module** — \`validate_changelog()\` was its only caller.
- **\`find_uncovered_commits()\` + \`normalize_changelog_text()\`** — existed solely to diff manual entries against commit subjects for dedup. In the automated world nobody writes manual entries, so the diff collapses to \"every commit is uncovered.\" Replaced with a straight filter on \`c.category.to_changelog_entry_type().is_some()\`.
- **All three \`!will_auto_generate\` branches + the flag itself** — dead code after the deletions above.

### Tightened
- **Forced bump with zero commits rejects with a clean error.** \"No commits since tag 'vX.Y.Z' — nothing to release.\" No flag, no opt-out — zero-commit releases make no sense in the automation model.

### Updated
- **\`ensure_changelog_initialized\` no longer pre-creates \`## Unreleased\`.** Just writes the \`# Changelog\` title; \`finalize_with_generated_entries\` inserts the \`## [X.Y.Z]\` section directly. \`## Unreleased\` was a transient artifact we didn't need.

## What's unchanged

- Non-changelog validators (working-tree fail-fast, remote sync, lint/test gate, changelog bootstrap) untouched.
- \`--json\` output / plan shape / step-result shape identical.
- All CLI flags identical.
- \`homeboy changelog add\` command still exists. Full deprecation is explicitly step 6 in #1205 and is a separate concern (docs + possibly a warning + eventual removal).

## Stats

- **−314 lines** across 3 files (\`pipeline.rs\`, \`version.rs\`, \`changelog/sections.rs\`).
- **66 release unit tests pass** (down from 75 — 9 deleted tests covered the dedup + old-bootstrap machinery we just removed).
- **Zero new full-suite failures.** The 4 pre-existing failures (\`signature_check_*\`, \`write_standalone_creates_and_reads_back\`) are unchanged.
- **Zero new warnings.**

## Related

- #1186 — auto GitHub Release (closed the post-release manual step).
- #1187 — pipeline/executor/resolver simplification issue.
- #1189 — pipeline/executor/resolver refactor PR (the structural simplification this semantic cleanup builds on).
- #1205 — this issue.
- #1172 — first-release bootstrap, updated here.