### PR TITLE
docs(release): remove phantom changelog add references and dead code

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -248,13 +248,6 @@
 
 - `Show` — Show a changelog (Homeboy's own if no component specified)
 - `component_id` — Component ID to show changelog for
-- `EXAMPLES` — Add changelog items to the configured "next" section  Examples: homeboy changelog add my-plugin "Fixed login bug" homeboy changelog add my-plugin "Removed legacy API" --type Removed homeboy changelog add my-plugin -m "Added search" -m "Added filters"
-- `Add`
-- `json` — JSON input spec for batch operations.  Use "-" to read from stdin, "@file.json" to read from a file, or an inline JSON string.
-- `component_id` — Component ID (non-JSON mode)
-- `positional_message` — Changelog item content (positional, for backward compatibility)
-- `messages` — Changelog message (repeatable: -m "first" -m "second")
-- `entry_type` — Changelog subsection type (Added, Changed, Deprecated, Removed, Fixed, Security, Refactored)
 - `Init` — Initialize a new changelog file
 - `path` — Path for the changelog file (relative to component)
 - `configure` — Also update component config to add changelogTargets

--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -12,6 +12,8 @@ homeboy changelog [COMMAND]
 
 In JSON output mode, the default `show` output is returned as JSON (with a `content` field containing the markdown).
 
+> **Note:** Homeboy generates changelog entries automatically from conventional-prefixed commits (`feat:` / `fix:` / etc.) at release time. There is no `changelog add` command — users don't hand-curate changelog bullets. See `homeboy release` and the commits since the last tag.
+
 ## Subcommands
 
 ### Default (show)
@@ -19,37 +21,17 @@ In JSON output mode, the default `show` output is returned as JSON (with a `cont
 ```sh
 homeboy changelog
 homeboy changelog --self
+homeboy changelog show
+homeboy changelog show <component_id>
 ```
 
-Shows the embedded Homeboy CLI changelog documentation (from `docs/changelog.md`).
+Shows the embedded Homeboy CLI changelog documentation (from `docs/changelog.md`), or a specific component's changelog when a component ID is provided.
 
 Options:
 
 - `--self`: Show Homeboy's own changelog (release notes) instead of a component's changelog
 
 This prints raw markdown to stdout.
-
-### `add`
-
-```sh
-homeboy changelog add <component_id> <message>
-homeboy changelog add <component_id> -m "first" -m "second"
-homeboy changelog add <component_id> -m "Bug fix" --type fixed
-homeboy changelog add <component_id> -m "New feature" -t added
-homeboy changelog add --json <spec>
-```
-
-Options:
-
-- `-m, --message <message>`: Changelog message (repeatable)
-- `-t, --type <type>`: Changelog subsection type for Keep a Changelog format. Valid values: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security` (case-insensitive)
-
-Notes:
-
-- The changelog entry is the positional `<message>` value. Use `--json` for multiple messages in one run.
-- Changelog messages are intended to be user-facing release notes (capture anything impacting user or developer experience), not a 1:1 copy of commit subjects.
-- When `--json` is provided, other args are ignored and the payload's `messages` array is applied in order.
-- When `--type` is provided, items are placed under the corresponding Keep a Changelog subsection (e.g., `### Fixed`). If the subsection doesn't exist, it's created in canonical order.
 
 ### `init`
 
@@ -73,21 +55,17 @@ Requirements:
 
 ## Prerequisites
 
-Before using `changelog add`, configure the changelog path:
+Configure the changelog path:
 
 ```sh
 homeboy component set <id> --changelog-target "CHANGELOG.md"
 ```
 
-This is required for both `changelog add` and `version bump`.
+This is required for `version bump` and `release`.
 
 ## Changelog Resolution
 
-For `add`, Homeboy resolves the changelog from the component's `changelog_target` configuration.
-
-Adds one or more changelog items to the configured "next" section in the component's changelog file.
-
-`--json` for this command is an `add` subcommand option (not a root/global flag).
+Homeboy resolves the changelog from the component's `changelog_target` configuration for `show` (when a component ID is given) and for release-time finalization.
 
 Configuration / defaults (strict by default):
 
@@ -102,7 +80,7 @@ Configuration / defaults (strict by default):
 
 Notes:
 
-- Homeboy does not auto-fix existing changelogs. If the next section is missing or empty, commands will error with hints to fix it manually.
+- Homeboy does not auto-fix existing changelogs. If the next section is missing or malformed, commands will error with hints to fix it manually.
 
 
 ## JSON output
@@ -111,9 +89,9 @@ Notes:
 
 `homeboy changelog` returns a tagged union:
 
-- `command`: `show` (default) | `add` | `init`
+- `command`: `show` (default) | `init`
 
-### JSON output (default)
+### JSON output (default / show)
 
 This section applies only when JSON output is used.
 
@@ -123,29 +101,6 @@ This section applies only when JSON output is used.
   "topic_label": "changelog",
   "content": "<markdown content>"
 }
-```
-
-### JSON output (add)
-
-```json
-{
-  "command": "add",
-  "component_id": "<component_id>",
-  "changelog_path": "<absolute/or/resolved/path.md>",
-  "next_section_label": "<label>",
-  "messages": ["<message>", "<message>"],
-  "items_added": 2,
-  "changed": true,
-  "subsection_type": "fixed"
-}
-```
-
-Note: `subsection_type` is only present when `--type` was specified.
-
-Bulk JSON input uses a single object (not an array):
-
-```json
-{ "component_id": "<component_id>", "messages": ["<message>"] }
 ```
 
 ### JSON output (init)
@@ -164,11 +119,11 @@ Bulk JSON input uses a single object (not an array):
 
 ## Errors
 
-- `show`: errors if embedded docs do not contain `changelog`
-- `add`: errors if changelog path cannot be resolved, or if `messages` is empty / contains empty strings
+- `show`: errors if embedded docs do not contain `changelog`, or if the component's changelog path cannot be resolved (when a component ID is provided)
 - `init`: errors if changelog already exists, if component not found, or if no version targets configured
 
 ## Related
 
+- [Release command](release.md) — owns changelog entry generation from commits
 - [Docs command](docs.md)
-- [Changelog content](../changelog.md)
+- [Changelog content](../changelog.md) — homeboy's own historical changelog

--- a/docs/commands/changes.md
+++ b/docs/commands/changes.md
@@ -37,7 +37,7 @@ Release workflow note:
 
 - `commits[]` is intended as input to help you author complete release notes.
 - `uncommitted`/`uncommitted_diff` is a reminder that you have local edits; if they are intended for the release, commit them as scoped changes before version bumping. If they are not intended for the release, resolve them before version bumping.
-- Use `homeboy changelog add` to capture release notes before running `homeboy version bump` or `homeboy release`.
+- Commit your changes with conventional prefixes (`feat:`, `fix:`, etc.) before running `homeboy version bump` or `homeboy release`. Changelog entries are generated automatically from commits at release time.
 
 ## Options
 

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -69,7 +69,7 @@ Commits release changes (version bumps, changelog updates) before tagging.
 
 Release requires a clean working tree, with two exceptions:
 
-- **Changelog**: May have uncommitted entries from `homeboy changelog add`
+- **Changelog**: May have uncommitted entries (these will be finalized during release)
 - **Version targets**: May be staged (though unusual)
 
 These files are modified during the release anyway and included in the release commit.

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -50,16 +50,14 @@ Alias for `homeboy release`. Delegates to the release command for full release p
 
 - Writes the new version directly to targets without touching the changelog.
 
-Changelog entries must be added *before* running `version bump` (recommended: `homeboy changelog add --json ...`). Make sure the changelog includes ALL changes since the last update, not just the ones you personally worked on. 
+Changelog entries are generated automatically from conventional-prefixed commits (`feat:` / `fix:` / etc.) at release time — no hand-curation needed.
 
-Recommended release workflow (non-enforced):
+Recommended release workflow:
 
-- Land work as scoped feature/fix commits first.
+- Land work as scoped conventional-prefixed commits (`feat:`, `fix:`, etc.) first.
 - Use `homeboy changes <component_id>` to review everything since the last tag.
-- Add changelog items as user-facing release notes that capture anything impacting user or developer experience (not a copy of commit subjects).
-- Run `homeboy version bump ...` when the only remaining local changes are release metadata (changelog + version).
-
-Note: `--json` for changelog entries is on `homeboy changelog add` (not `homeboy changelog`).
+- Run `homeboy version bump <component_id> <patch|minor|major>` when the only remaining local changes are release metadata.
+- Homeboy generates the changelog section from the commit trail and finalizes it as `## [X.Y.Z] - YYYY-MM-DD` in one shot.
 
 Arguments:
 
@@ -130,11 +128,12 @@ To bypass changelog finalization entirely, use `version set` instead of `version
 
 ### Auto-Generation from Commits
 
-`version bump` can auto-generate changelog entries from commits since the last tag, **but only if:**
+`version bump` generates changelog entries from commits since the last tag. There is no manual entry path — all entries come from commits.
 
-1. All changes are **committed** (uncommitted changes are invisible to auto-gen)
-2. The Unreleased section is **empty** (existing entries skip auto-gen)
-3. At least one commit has an entry-producing prefix
+Requirements:
+
+1. All changes are **committed** (uncommitted changes don't contribute entries).
+2. At least one commit has an entry-producing prefix (see table below).
 
 | Commit prefix | Changelog section |
 |---------------|------------------|
@@ -144,18 +143,9 @@ To bypass changelog finalization entirely, use `version set` instead of `version
 | Other (non-conventional) | Changed |
 | `docs:`, `chore:` | **Skipped**  |
 
-**Important:** If ALL commits are `docs:` or `chore:`, auto-generation produces nothing and you'll get an error.
-
-To manually add entries: `homeboy changelog add <id> "message" --type fixed`
+**Important:** If all commits are `docs:` or `chore:`, no entries get generated and the release errors out. Commit at least one user-facing change with a `feat:`/`fix:`/conventional prefix before releasing.
 
 ## Related Workflows
-
-Before bumping, add changelog entries:
-
-```sh
-homeboy changelog add <component_id> "Added: new feature"
-homeboy changelog add <component_id> -m "Fixed: bug" -m "Changed: behavior"
-```
 
 After bumping, push and optionally tag:
 

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -412,7 +412,7 @@ pub(crate) fn build_untracked_hint(path: &str, untracked_count: usize) -> Option
 
 fn resolve_changelog_info(
     component: &crate::component::Component,
-    commits: &[CommitInfo],
+    _commits: &[CommitInfo],
 ) -> Option<ChangelogInfo> {
     let changelog_path = changelog::resolve_changelog_path(component).ok()?;
     let content = std::fs::read_to_string(&changelog_path).ok()?;
@@ -420,19 +420,14 @@ fn resolve_changelog_info(
     let unreleased_entries =
         changelog::count_unreleased_entries(&content, &settings.next_section_aliases);
 
-    let hint = if unreleased_entries == 0 && !commits.is_empty() {
-        Some(format!(
-            "Run `homeboy changelog add {}` before bumping version",
-            component.id
-        ))
-    } else {
-        None
-    };
-
+    // No hint: homeboy auto-generates changelog entries from commits at
+    // release time, so an empty `## Unreleased` section no longer implies
+    // the user needs to do anything. The count itself is still useful
+    // context for `homeboy changes` output.
     Some(ChangelogInfo {
         unreleased_entries,
         path: Some(changelog_path.to_string_lossy().to_string()),
-        hint,
+        hint: None,
     })
 }
 

--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -41,8 +41,9 @@ pub fn finalize_next_section(
                 .join(", ")
         ),
         vec![
-            "Add entries: `homeboy changelog add <componentId> -m \"...\"`".to_string(),
-            "Or create section manually: add a `## Unreleased` heading to your changelog"
+            "Homeboy generates entries from conventional-prefixed commits (feat:/fix:/...) at release time."
+                .to_string(),
+            "If the section is missing entirely, add a `## Unreleased` heading manually to your changelog."
                 .to_string(),
         ],
     )?;
@@ -70,8 +71,7 @@ pub fn finalize_next_section(
             None,
             None,
         )
-        .with_hint("Commit all changes before running version bump (changelog auto-generates from commits).")
-        .with_hint("Or add entries manually: `homeboy changelog add <componentId> -m \"...\"`"));
+        .with_hint("Commit all changes before running version bump — homeboy generates changelog entries from conventional-prefixed commits (feat:/fix:/...) at release time."));
     }
 
     let mut out_lines: Vec<String> = Vec::new();
@@ -229,135 +229,6 @@ pub(super) fn ensure_next_section(content: &str, aliases: &[String]) -> Result<(
     Ok((out, true))
 }
 
-pub(crate) fn add_next_section_items(
-    changelog_content: &str,
-    next_section_aliases: &[String],
-    messages: &[String],
-) -> Result<(String, bool, usize)> {
-    if messages.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "messages",
-            "Changelog messages cannot be empty",
-            None,
-            None,
-        ));
-    }
-
-    let (mut content, mut changed) = ensure_next_section(changelog_content, next_section_aliases)?;
-    let mut items_added = 0;
-
-    for message in messages {
-        let trimmed_message = message.trim();
-        if trimmed_message.is_empty() {
-            return Err(Error::validation_invalid_argument(
-                "messages",
-                "Changelog messages cannot include empty values",
-                None,
-                None,
-            ));
-        }
-
-        let (next, item_changed) =
-            append_item_to_next_section(&content, next_section_aliases, trimmed_message)?;
-        if item_changed {
-            items_added += 1;
-            changed = true;
-        }
-        content = next;
-    }
-
-    Ok((content, changed, items_added))
-}
-
-fn append_item_to_next_section(
-    content: &str,
-    aliases: &[String],
-    message: &str,
-) -> Result<(String, bool)> {
-    let lines: Vec<&str> = content.lines().collect();
-    let start = find_next_section_start(&lines, aliases).ok_or_else(|| {
-        Error::internal_unexpected("Next changelog section not found (unexpected)".to_string())
-    })?;
-
-    let section_end = find_section_end(&lines, start);
-    let bullet = format!("- {}", message);
-
-    // Check for duplicates
-    for line in &lines[start + 1..section_end] {
-        if line.trim() == bullet {
-            return Ok((content.to_string(), false));
-        }
-    }
-
-    // Detect if section uses Keep a Changelog subsections
-    let has_subsections = lines[start + 1..section_end].iter().any(|l| {
-        KEEP_A_CHANGELOG_SUBSECTIONS
-            .iter()
-            .any(|h| l.trim().starts_with(h))
-    });
-
-    // Find where to insert
-    let mut insert_after = start;
-    let mut has_bullets = false;
-    let mut first_subsection_idx: Option<usize> = None;
-
-    for (i, line) in lines.iter().enumerate().take(section_end).skip(start + 1) {
-        let trimmed = line.trim();
-
-        // Track first subsection header (for fallback insertion point)
-        if first_subsection_idx.is_none()
-            && KEEP_A_CHANGELOG_SUBSECTIONS
-                .iter()
-                .any(|h| trimmed.starts_with(h))
-        {
-            first_subsection_idx = Some(i);
-        }
-
-        if trimmed.starts_with('-') || trimmed.starts_with('*') {
-            insert_after = i;
-            has_bullets = true;
-        } else if !has_bullets && !has_subsections && trimmed.is_empty() {
-            // No bullets yet and no subsections, insert after blank line following header
-            insert_after = i;
-        }
-    }
-
-    // If subsections exist but no bullets found, insert after the first subsection header
-    if has_subsections && !has_bullets {
-        if let Some(idx) = first_subsection_idx {
-            insert_after = idx;
-        }
-    }
-
-    let mut out = String::new();
-    for (idx, line) in lines.iter().enumerate() {
-        // Skip trailing blank lines after bullets (we'll add one at the end)
-        // Only skip if there are actual bullets and we're in the simple (non-subsection) case
-        if has_bullets
-            && !has_subsections
-            && idx > insert_after
-            && idx < section_end
-            && lines[idx].trim().is_empty()
-        {
-            continue;
-        }
-
-        out.push_str(line);
-        out.push('\n');
-
-        // Insert new bullet at the insertion point
-        if idx == insert_after {
-            out.push_str(&bullet);
-            out.push('\n');
-            // Add blank line after bullets (before next section) only in simple case
-            if !has_subsections && section_end < lines.len() {
-                out.push('\n');
-            }
-        }
-    }
-
-    Ok((out, true))
-}
 
 pub(super) fn append_item_to_subsection(
     content: &str,
@@ -519,33 +390,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn add_next_section_items_appends_multiple_in_order() {
-        let content = "# Changelog\n\n## Unreleased\n\n## 0.1.0\n";
-        let aliases = vec!["Unreleased".to_string(), "[Unreleased]".to_string()];
-        let messages = vec!["First".to_string(), "Second".to_string()];
-
-        let (out, changed, items_added) =
-            add_next_section_items(content, &aliases, &messages).unwrap();
-        assert!(changed);
-        assert_eq!(items_added, 2);
-        assert!(out.contains("## Unreleased\n\n- First\n- Second\n\n## 0.1.0"));
-    }
-
-    #[test]
-    fn add_next_section_items_dedupes_exact_bullets() {
-        let content = "# Changelog\n\n## Unreleased\n\n- First\n\n## 0.1.0\n";
-        let aliases = vec!["Unreleased".to_string(), "[Unreleased]".to_string()];
-        let messages = vec!["First".to_string(), "Second".to_string()];
-
-        let (out, changed, items_added) =
-            add_next_section_items(content, &aliases, &messages).unwrap();
-        assert!(changed);
-        assert_eq!(items_added, 1);
-        assert!(out.contains("- First"));
-        assert!(out.contains("- Second"));
-    }
-
-    #[test]
     fn finalize_moves_body_to_new_version_and_omits_empty_next_section() {
         let content = "# Changelog\n\n## Unreleased\n\n- First\n- Second\n\n## 0.1.0\n\n- Old\n";
         let aliases = vec!["Unreleased".to_string(), "[Unreleased]".to_string()];
@@ -682,46 +526,6 @@ mod tests {
             "Error should mention subsection headers: {}",
             problem
         );
-    }
-
-    #[test]
-    fn append_item_works_with_subsection_structure() {
-        let content = "# Changelog\n\n## Unreleased\n\n### Added\n\n- Existing\n\n## 0.1.0\n";
-        let aliases = vec!["Unreleased".to_string()];
-        let (out, changed) = append_item_to_next_section(content, &aliases, "New item").unwrap();
-
-        assert!(changed);
-        assert!(out.contains("- New item"));
-        // Item should be inserted after "- Existing"
-        assert!(out.contains("- Existing\n- New item"));
-    }
-
-    #[test]
-    fn append_item_to_empty_subsection() {
-        let content = "# Changelog\n\n## Unreleased\n\n### Added\n\n### Fixed\n\n## 0.1.0\n";
-        let aliases = vec!["Unreleased".to_string()];
-        let (out, changed) = append_item_to_next_section(content, &aliases, "New item").unwrap();
-
-        assert!(changed);
-        assert!(out.contains("- New item"));
-        // Item should be inserted after the first subsection header
-        assert!(out.contains("### Added\n- New item"));
-    }
-
-    #[test]
-    fn append_item_preserves_multiple_subsections() {
-        let content =
-            "# Changelog\n\n## Unreleased\n\n### Added\n\n- Feature 1\n\n### Fixed\n\n- Bug 1\n\n## 0.1.0\n";
-        let aliases = vec!["Unreleased".to_string()];
-        let (out, changed) = append_item_to_next_section(content, &aliases, "New item").unwrap();
-
-        assert!(changed);
-        assert!(out.contains("- New item"));
-        // Should preserve subsection structure
-        assert!(out.contains("### Added"));
-        assert!(out.contains("### Fixed"));
-        assert!(out.contains("- Feature 1"));
-        assert!(out.contains("- Bug 1"));
     }
 
     #[test]

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -508,7 +508,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
                 );
             } else if uncommitted.has_changes && !options.dry_run {
                 // Only changelog/version files are uncommitted — auto-stage them
-                // so the release commit includes them (e.g., after `homeboy changelog add`).
+                // so the release commit includes them (auto-generated from commits).
                 // Skip in dry-run mode to avoid mutating working tree.
                 log_status!(
                     "release",
@@ -695,6 +695,7 @@ pub(super) fn resolve_tag_and_commits(
         }
     }
 }
+
 
 /// Fetch from remote and fast-forward if behind.
 ///


### PR DESCRIPTION
## Summary

Removes all remaining references to the already-removed `homeboy changelog add` command from docs, error messages, and inline hints.

## Changes

- **docs/commands/changelog.md** — remove `add` subcommand docs
- **docs/cli-reference.md** — remove `Add` variant from `ChangelogCommand`
- **docs/commands/release.md** — update working-tree exception wording
- **docs/commands/changes.md** — replace `changelog add` reference with conventional-commit workflow
- **docs/commands/version.md** — clean up related workflow section
- **src/core/release/pipeline.rs** — remove `changelog add` hints from error strings
- **src/core/release/changelog/sections.rs** — remove dead `add_next_section_items()`, `append_item_to_next_section()`, and their tests; remove `changelog add` hints
- **src/core/git/operations.rs** — remove obsolete `changelog add` hint

Net: -264 lines of dead code and stale docs.

## Testing

- `cargo check --all-targets` ✅
- `cargo test --lib core::release` — 70 passed, 0 failed ✅

## Related

Closes #1205