### PR TITLE
feat: add component.not_attached error for registered-but-unattached components

### DIFF
--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -126,6 +126,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         ErrorCode::ProjectNotFound
         | ErrorCode::ServerNotFound
         | ErrorCode::ComponentNotFound
+        | ErrorCode::ComponentNotAttached
         | ErrorCode::FleetNotFound
         | ErrorCode::ExtensionNotFound
         | ErrorCode::DocsTopicNotFound

--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -194,12 +194,63 @@ pub fn load(id: &str) -> Result<Component> {
         return Ok(component);
     }
 
+    // Component not in full inventory. Check if a standalone registration
+    // file exists — this means the component was created but isn't loaded
+    // into inventory (e.g., local_path doesn't exist or portable config
+    // is missing). Return a specific "not attached" error with guidance.
+    if let Some(standalone) = read_standalone_file(id) {
+        let project_suggestion = suggest_project_for_attachment();
+        return Err(Error::component_not_attached(
+            id.to_string(),
+            standalone.local_path,
+            project_suggestion,
+        ));
+    }
+
     let suggestions = list_ids().unwrap_or_default();
     Err(Error::component_not_found(id.to_string(), suggestions))
 }
 
 pub fn exists(id: &str) -> bool {
     load(id).is_ok()
+}
+
+/// Read a standalone registration file for a component ID without loading
+/// it into the full inventory. Returns a minimal struct with `local_path`
+/// for error messaging when the component exists on disk but isn't loadable.
+fn read_standalone_file(id: &str) -> Option<StandaloneFileInfo> {
+    let dir = match crate::paths::components() {
+        Ok(d) if d.exists() => d,
+        _ => return None,
+    };
+
+    let path = dir.join(format!("{}.json", id));
+    if !path.exists() {
+        return None;
+    }
+
+    let content = std::fs::read_to_string(&path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let local_path = json.get("local_path").and_then(|v| v.as_str())?;
+
+    Some(StandaloneFileInfo {
+        local_path: local_path.to_string(),
+    })
+}
+
+/// Minimal info extracted from a standalone registration file for error messages.
+struct StandaloneFileInfo {
+    local_path: String,
+}
+
+/// If exactly one project exists, return its ID for the attach hint.
+fn suggest_project_for_attachment() -> Option<String> {
+    let projects = project::list().unwrap_or_default();
+    if projects.len() == 1 {
+        Some(projects[0].id.clone())
+    } else {
+        None
+    }
 }
 
 /// Write a standalone component registration to `~/.config/homeboy/components/<id>.json`.

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -25,6 +25,7 @@ pub enum ErrorCode {
     ProjectNoActive,
     ServerNotFound,
     ComponentNotFound,
+    ComponentNotAttached,
     FleetNotFound,
     ExtensionNotFound,
     DocsTopicNotFound,
@@ -65,6 +66,7 @@ impl ErrorCode {
             ErrorCode::ProjectNoActive => "project.no_active",
             ErrorCode::ServerNotFound => "server.not_found",
             ErrorCode::ComponentNotFound => "component.not_found",
+            ErrorCode::ComponentNotAttached => "component.not_attached",
             ErrorCode::FleetNotFound => "fleet.not_found",
             ErrorCode::ExtensionNotFound => "extension.not_found",
             ErrorCode::DocsTopicNotFound => "docs.topic_not_found",
@@ -345,6 +347,42 @@ impl Error {
 
     pub fn component_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {
         Self::entity_not_found(ErrorCode::ComponentNotFound, "Component", id, suggestions)
+    }
+
+    pub fn component_not_attached(
+        id: impl Into<String>,
+        local_path: impl Into<String>,
+        project_suggestion: Option<String>,
+    ) -> Self {
+        let id = id.into();
+        let lp = local_path.into();
+        let details = to_details(NotFoundDetails { id: id.clone() });
+        let mut err = Self::new(
+            ErrorCode::ComponentNotAttached,
+            format!(
+                "Component '{}' is registered but not attached to any project. Release and deploy require project attachment.",
+                id
+            ),
+            details,
+        );
+        if let Some(proj) = project_suggestion {
+            err = err
+                .with_hint(format!(
+                    "Attach: homeboy project components attach-path {} {}",
+                    proj, lp
+                ))
+                .with_hint(format!(
+                    "If only one project exists, run: homeboy project components attach-path {} {}",
+                    proj, lp
+                ));
+        } else {
+            err = err.with_hint(format!(
+                "Attach to a project: homeboy project components attach-path <project> {}",
+                lp
+            ));
+        }
+        err = err.with_hint("List projects: homeboy project list".to_string());
+        err
     }
 
     pub fn extension_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {


### PR DESCRIPTION
## Summary

Add a specific `component.not_attached` error that fires when a component exists as a standalone registration but isn't attached to any project — instead of the generic `component.not_found` with misleading "Did you mean...?" hints.

## Problem (from #1156)

`homeboy release <id>` returns `component.not_found` with "Did you mean: data-machine, data-machine-code?" even when the component was successfully created via `component create`. The component exists on disk as a standalone registration, but isn't in the full inventory because it's not attached to a project. The error actively misleads the user about what's wrong.

## Solution

Three changes:

1. **`ErrorCode::ComponentNotAttached`** — new error code (`component.not_attached`) with exit code 4 (same family as `component.not_found`)

2. **`Error::component_not_attached()`** — builder that produces:
   - Clear message: "Component 'X' is registered but not attached to any project. Release and deploy require project attachment."
   - When exactly one project exists: `Attach: homeboy project components attach-path <project> <path>`
   - When multiple projects exist: `Attach to a project: homeboy project components attach-path <project> <path>`
   - Always: `List projects: homeboy project list`

3. **`inventory::load()` fallback** — when a component isn't in the full inventory, checks if a standalone registration file exists at `~/.config/homeboy/components/<id>.json`. If found, returns `component.not_attached` instead of `component.not_found`.

## Example output

**Before:**
```
Component not found
Did you mean: data-machine, data-machine-code?
Run 'homeboy component list' to see available components
```

**After:**
```
Component 'wp-coding-agents' is registered but not attached to any project.
  Release and deploy require project attachment.
Attach: homeboy project components attach-path chubes-site /path/to/wp-coding-agents
List projects: homeboy project list
```

## Testing

- `cargo check` — clean
- `cargo test` — 1176 passed, 0 new failures (2 pre-existing standalone registration test failures on main)
- Exit code mapping: `ComponentNotAttached` → exit code 4 (same as other not-found errors)

Refs #1156