### PR TITLE
fix(validate): invoke extension validate scripts with bash, not sh (#1276)

### DIFF
--- a/src/core/engine/validate_write.rs
+++ b/src/core/engine/validate_write.rs
@@ -243,9 +243,15 @@ fn resolve_validate_command(root: &Path, changed_files: &[PathBuf]) -> Option<St
             let script_path = std::path::Path::new(ext_path).join(script_rel);
 
             if script_path.exists() {
-                // Build the command: pass root and changed files as JSON on stdin
+                // Invoke via `bash` rather than `sh`: the bundled
+                // extension scripts (e.g. validate-syntax.sh) declare
+                // `#!/usr/bin/env bash` and use bash-only constructs
+                // like `< <(...)` process substitution. On macOS
+                // /bin/sh is bash in sh-compat mode, which disables
+                // those constructs and fails with a syntax error.
+                // See https://github.com/Extra-Chill/homeboy/issues/1276.
                 return Some(format!(
-                    "sh {}",
+                    "bash {}",
                     crate::engine::shell::quote_path(&script_path.to_string_lossy())
                 ));
             }


### PR DESCRIPTION
## Summary

`resolve_validate_command` built the validation command as `sh <script>`, and `validate_write` then wrapped that in another `sh -c`, so bundled scripts like `validate-syntax.sh` were ultimately executed by `/bin/sh`. On macOS `/bin/sh` is bash in sh-compat mode, which disables bash-only constructs such as `< <(...)` process substitution. The scripts already declare `#!/usr/bin/env bash`, but that shebang is ignored when an explicit interpreter is passed.

The failure reported in #1276:

```
/Users/.../validate-syntax.sh: line 27: syntax error near unexpected token `<`
/Users/.../validate-syntax.sh: line 27: `done < <(find "$ROOT" \'
```

## Fix

Swap the prefix from `sh` to `bash`. All bundled extension scripts require bash anyway; this keeps the call via `Command::new("sh").args(["-c", ...])` shape (so quoting semantics are unchanged) while honouring the bash contract the scripts actually depend on.

Fixes #1276

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib engine::validate_write` — all 7 existing tests pass (only the one-line format! change is in scope; no existing test asserts the exact "sh" prefix, and adding an extension-fixture test would require a full installed extension, which is out of scope for a trivial interpreter swap)