### PR TITLE
fix(refactor): collapse backslash escapes in replacement templates

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -187,6 +187,11 @@ enum RefactorCommand {
     /// Replacement templates support capture group refs ($1, $2, ${name}),
     /// case transforms ($1:lower, $1:upper, $1:kebab, $1:snake, $1:pascal, $1:camel),
     /// and literal $ via $$ (important for PHP code where every variable starts with $).
+    ///
+    /// Backslash escapes collapse before regex replacement: `\\` → one literal
+    /// backslash, `\n` → newline, `\t` → tab, `\r` → CR, `\"` / `\'` → the quote.
+    /// Write `\\WP_Foo` in JSON to emit `\WP_Foo` on disk (useful for PHP
+    /// fully-qualified class names). Unknown `\X` sequences pass through as-is.
     Transform {
         /// Transform set name (from homeboy.json transforms key)
         #[arg(value_name = "NAME")]
@@ -200,6 +205,8 @@ enum RefactorCommand {
         /// Supports $1, $2 capture group refs, ${name} named groups,
         /// $1:lower/:upper/:kebab/:snake/:pascal/:camel case transforms,
         /// and $$ for a literal dollar sign.
+        /// Backslash escapes are collapsed: \\ → one literal backslash,
+        /// \n/\t/\r/\0 → the control character, \" / \' → the quote.
         #[arg(long, value_name = "TEMPLATE")]
         replace: Option<String>,
 

--- a/src/core/refactor/transform.rs
+++ b/src/core/refactor/transform.rs
@@ -43,6 +43,13 @@ pub struct TransformRule {
     /// Replacement template. Supports `$1`, `$2`, `${name}` capture group refs,
     /// `$1:lower`/`:upper`/`:kebab`/`:snake`/`:pascal`/`:camel` case transforms,
     /// and `$$` for a literal dollar sign.
+    ///
+    /// Backslash escapes are collapsed before the template is handed to the
+    /// regex engine: `\\` → one literal backslash, `\n` → newline, `\t` → tab,
+    /// `\r` → CR, `\0` → nul, `\"` → `"`, `\'` → `'`. Unknown escapes pass
+    /// through verbatim. This means that to emit a PHP fully-qualified name
+    /// like `\WP_Foo` on disk, write `\\WP_Foo` in JSON (which decodes to
+    /// `\WP_Foo` in memory — the literal `\` you want). See #1277.
     pub replace: String,
     /// Glob pattern for files to apply to (e.g., `tests/**/*.php`).
     #[serde(default = "default_files_glob")]
@@ -103,6 +110,63 @@ pub struct TransformMatch {
     pub before: String,
     /// Replacement text.
     pub after: String,
+}
+
+// ============================================================================
+// Replacement template unescape
+// ============================================================================
+
+/// Unescape backslash sequences in a replacement template.
+///
+/// Users writing regex-replace rules in `homeboy.json` (or on the CLI) think of
+/// the `replace` value the way they think of sed, shell, or `String.replace` —
+/// `\\` means one literal backslash, `\n` means a newline, `\t` means a tab.
+/// The regex crate's native replacement syntax, on the other hand, passes
+/// backslashes through verbatim and only recognizes `$1`/`${name}`/`$$`. That
+/// left users with no ergonomic way to emit a single literal backslash without
+/// over-escaping in JSON and then hand-collapsing the result.
+///
+/// This helper closes the gap: it runs a single pass over the input and
+/// collapses common C-style escapes so that by the time the regex crate sees
+/// the template, `\\` is already one backslash.
+///
+/// Rules:
+/// - `\\` → one literal backslash
+/// - `\n` → newline, `\t` → tab, `\r` → carriage return, `\0` → nul
+/// - `\"` → `"`, `\'` → `'`
+/// - Any other `\X` is passed through unchanged (so stray escapes don't eat
+///   characters silently — regex-crate `$` syntax keeps working via `$$`).
+///
+/// `$` handling (`$1`, `$$`, `${name}`) is intentionally left to the regex
+/// crate. This pass only touches backslashes.
+///
+/// See: https://github.com/Extra-Chill/homeboy/issues/1277
+pub(crate) fn unescape_replacement_template(template: &str) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut chars = template.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('\\') => out.push('\\'),
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('0') => out.push('\0'),
+            Some('"') => out.push('"'),
+            Some('\'') => out.push('\''),
+            // Unknown escape — preserve both characters so users aren't
+            // surprised by silent character loss.
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 // ============================================================================
@@ -247,6 +311,11 @@ pub fn apply_transforms(
 
         let mut matches = Vec::new();
 
+        // Collapse C-style backslash escapes in the replacement template once
+        // per rule so `\\` in JSON → one literal backslash on disk, matching
+        // sed/shell/String.replace conventions. See #1277.
+        let replace_unescaped = unescape_replacement_template(&rule.replace);
+
         for file_path in matching_files {
             // Read from accumulated edits or original file
             let content = if let Some(edited) = file_edits.get(file_path) {
@@ -265,11 +334,11 @@ pub fn apply_transforms(
                 .to_string();
 
             let (new_content, file_matches) = if rule.context == "file" {
-                apply_file_context(regex, &rule.replace, &content, &relative)
+                apply_file_context(regex, &replace_unescaped, &content, &relative)
             } else if rule.context == "hoist_static" {
-                apply_hoist_static_context(regex, &rule.replace, &content, &relative)
+                apply_hoist_static_context(regex, &replace_unescaped, &content, &relative)
             } else {
-                apply_line_context(regex, &rule.replace, &content, &relative)
+                apply_line_context(regex, &replace_unescaped, &content, &relative)
             };
 
             if !file_matches.is_empty() {
@@ -788,6 +857,96 @@ fn replace_with_case_transforms(regex: &Regex, replace: &str, text: &str) -> Str
 mod tests {
     use super::*;
     use std::fs;
+
+    // --- Replacement unescape tests (regression for #1277) ---
+
+    #[test]
+    fn unescape_collapses_double_backslash_to_one() {
+        // User wrote `\\X` in JSON source → `\\X` (2 bs) after JSON decode.
+        // In Rust source, `"\\\\X"` is that same 2-bs-then-X string.
+        // After unescape, we want 1 bs + X — ready to emit as a literal on disk.
+        assert_eq!(unescape_replacement_template("\\\\X"), "\\X");
+    }
+
+    #[test]
+    fn unescape_preserves_single_literal_backslash_escape_in_php_namespace() {
+        // Reproducer from #1277: ternary_registry_guard rule.
+        // JSON source:        "\\\\WP_Abilities_Registry::get_instance()"
+        // In-memory (Rust):   "\\\\WP_Abilities_Registry::get_instance()" — 2 bs
+        // Want on disk:       "\\WP_Abilities_Registry::get_instance()"   — 1 bs
+        let input = "\\\\WP_Abilities_Registry::get_instance()";
+        let expected = "\\WP_Abilities_Registry::get_instance()";
+        assert_eq!(unescape_replacement_template(input), expected);
+    }
+
+    #[test]
+    fn unescape_handles_control_sequences() {
+        assert_eq!(unescape_replacement_template("a\\nb"), "a\nb");
+        assert_eq!(unescape_replacement_template("a\\tb"), "a\tb");
+        assert_eq!(unescape_replacement_template("a\\rb"), "a\rb");
+        assert_eq!(unescape_replacement_template("a\\0b"), "a\0b");
+    }
+
+    #[test]
+    fn unescape_handles_quote_escapes() {
+        assert_eq!(unescape_replacement_template("\\\""), "\"");
+        assert_eq!(unescape_replacement_template("\\'"), "'");
+    }
+
+    #[test]
+    fn unescape_leaves_dollar_captures_alone() {
+        // `$` syntax is the regex crate's territory; we don't touch it.
+        assert_eq!(unescape_replacement_template("$1"), "$1");
+        assert_eq!(unescape_replacement_template("$$"), "$$");
+        assert_eq!(unescape_replacement_template("${name}"), "${name}");
+    }
+
+    #[test]
+    fn unescape_preserves_unknown_escape_sequences() {
+        // Unknown \X should pass through unchanged — no silent character loss.
+        assert_eq!(unescape_replacement_template("\\q"), "\\q");
+        assert_eq!(unescape_replacement_template("\\!"), "\\!");
+    }
+
+    #[test]
+    fn unescape_handles_trailing_backslash() {
+        assert_eq!(unescape_replacement_template("abc\\"), "abc\\");
+    }
+
+    #[test]
+    fn unescape_is_idempotent_over_single_backslash_runs() {
+        // Triple-backslash in JSON (`\\\`) is invalid JSON, so we never see it.
+        // But `\\\\\\\\` in JSON = 4 bs in memory → should collapse to 2 bs.
+        assert_eq!(unescape_replacement_template("\\\\\\\\"), "\\\\");
+    }
+
+    #[test]
+    fn end_to_end_php_namespace_ternary_replacement() {
+        // Full reproducer from #1277: replacing a class_exists ternary with
+        // a direct \\WP_Abilities_Registry::get_instance() call. Before this
+        // fix, 2 bs in memory → 2 bs on disk (PHP parse error). Now: 2 bs in
+        // memory → 1 bs on disk (valid PHP FQN).
+        let find = r"class_exists\( 'WP_Abilities_Registry' \) \? \\WP_Abilities_Registry::get_instance\(\) : null";
+        // Simulates the in-memory value after JSON decode of `"\\\\WP_Abilities_Registry::get_instance()"`
+        let replace_in_memory = "\\\\WP_Abilities_Registry::get_instance()";
+        let content =
+            "$r = class_exists( 'WP_Abilities_Registry' ) ? \\WP_Abilities_Registry::get_instance() : null;";
+
+        let regex = Regex::new(find).unwrap();
+        let unescaped = unescape_replacement_template(replace_in_memory);
+        let (out, matches) = apply_line_context(&regex, &unescaped, content, "t.php");
+
+        assert_eq!(matches.len(), 1);
+        // One literal backslash before WP_ — the PHP FQN the user intended.
+        assert!(
+            out.contains("= \\WP_Abilities_Registry::get_instance()"),
+            "expected single backslash PHP FQN, got: {out:?}"
+        );
+        assert!(
+            !out.contains("\\\\WP_Abilities_Registry"),
+            "should not emit double backslashes: {out:?}"
+        );
+    }
 
     // --- Rule model tests ---
 


### PR DESCRIPTION
## Summary

`homeboy refactor transform` passed the `replace` field straight through to `regex::Regex::replace_all`, which treats `$` as capture-group syntax but passes every `\` through verbatim. That left users with no ergonomic way to emit a single literal backslash: writing `\\WP_Foo` in JSON (the natural escape for "one backslash") decoded to one bs in memory, which the regex crate passed through as one bs on disk — but every user's mental model from sed/shell/`String.replace` is that `\\` means one bs *at the source layer too*, so they tended to over-escape as `\\\\WP_Foo`, land on "two backslashes on disk", and produce PHP parse errors.

Caught in the wild during the `drop_wp_ability_dead_guards` mechanical sweep on Extra-Chill/data-machine — 4 files ended up with `\\WP_Abilities_Registry::get_instance()` (two literal backslashes) on disk, unparseable by PHP. Would have been caught by the `validate_write` gate except that's itself broken on macOS (see #1276 — separately fixed).

## Fix

Added a single-pass `unescape_replacement_template()` helper that collapses C-style escapes **before** the template is handed to the regex engine:

| Input    | Output                          |
|----------|---------------------------------|
| `\\`     | one literal backslash           |
| `\n`     | newline                         |
| `\t`     | tab                             |
| `\r`     | carriage return                 |
| `\0`     | nul                             |
| `\"` `\'` | the quote                      |
| any other `\X` | passed through unchanged  |

Dollar syntax (`$1`, `${name}`, `$$`) is deliberately left alone — the regex crate still owns that layer. Unknown `\X` sequences pass through instead of silently eating the character, so stray escapes don't corrupt output.

This is the escape convention every major tool in this space uses (sed, shell, Python `str.replace`, JavaScript RegExp replacement). CLI `--help` and `TransformRule::replace` docstring updated to document the behavior.

## Validation

**9 new unit tests** in `core::refactor::transform::tests`:

- `unescape_collapses_double_backslash_to_one`
- `unescape_preserves_single_literal_backslash_escape_in_php_namespace` — exact `#1277` reproducer
- `unescape_handles_control_sequences` — `\n`, `\t`, `\r`, `\0`
- `unescape_handles_quote_escapes`
- `unescape_leaves_dollar_captures_alone` — `$1`, `$$`, `${name}` passthrough
- `unescape_preserves_unknown_escape_sequences` — `\q`, `\!`
- `unescape_handles_trailing_backslash`
- `unescape_is_idempotent_over_single_backslash_runs`
- `end_to_end_php_namespace_ternary_replacement` — full ternary transform from the issue

**End-to-end manual test** using the real `ternary_registry_guard` rule from Extra-Chill/data-machine's `drop_wp_ability_dead_guards` transform set:

Before fix (homeboy 0.89.1):
```
$ xxd test.php | head -1
00000000: ... 5c5c 5750 5f41 6269 6c69 7469 6573 ...   (two backslashes)
$ php -l test.php
PHP Parse error:  syntax error, unexpected token "\"
```

After fix:
```
$ xxd test.php | head -1
00000000: ... 5c57 505f 4162 696c 6974 6965 7320 ...   (one backslash)
$ php -l test.php
No syntax errors detected
```

All 257 `refactor` unit tests pass. The 4 pre-existing test failures on main (`signature_check_*`, `write_standalone_creates_and_reads_back`) are unrelated — reproduced on clean `main` with no changes.

Fixes #1277

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Claude traced the replacement pipeline end-to-end (confirmed via standalone `regex`-crate test that the backslash passthrough is faithful — no doubling was happening, the user's mental model just expected a pre-pass that didn't exist). Drafted the unescape helper, wired it into the apply loop, wrote all 9 unit tests including the end-to-end PHP ternary case, and ran the real data-machine transform set against a scratch PHP file with `php -l` before and after. Chris filed the issue, picked the unescape-at-input-time approach over the document-only / opt-in-flag alternatives, and reviewed the patch before merge.