### PR TITLE
feat(audit): dead-guard detector

### DIFF
--- a/docs/audit/dead-guard.md
+++ b/docs/audit/dead-guard.md
@@ -1,0 +1,43 @@
+# Dead Guard Detection
+
+Homeboy audit flags `function_exists('…')`, `class_exists('…')`, and `defined('…')` guards whose
+checked symbol is guaranteed to exist at runtime. Such guards are reachable-but-dead: the `else`
+branch can never fire, the code becomes harder to read, and refactors keep carrying forward stale
+defensive scaffolding.
+
+## How the detector decides a symbol is guaranteed
+
+A symbol is considered guaranteed when any of the following hold:
+
+- The plugin declares `Requires at least: X.Y` in its main-file header and the symbol shipped in
+  Core at or before that version (table covers common symbols such as `WP_Ability` @ 6.9,
+  `wp_generate_uuid4` @ 4.7, `wp_timezone` @ 5.3).
+- The plugin's main file contains an **unconditional** `require` / `require_once` of a well-known
+  vendor bootstrap (e.g. `vendor/woocommerce/action-scheduler/action-scheduler.php`). Requires
+  inside an `if ( ! class_exists(…) ) { … }` block are ignored.
+- `composer.json` lists a known package under `require` or `require-dev` whose symbols the detector
+  recognizes (e.g. `woocommerce/action-scheduler`).
+
+Both direct and negated guards are reported:
+
+```php
+if ( ! class_exists( 'WP_Ability' ) ) { return; } // flagged
+if ( function_exists( 'as_schedule_single_action' ) ) { … }  // flagged when AS is bootstrapped
+```
+
+## Finding output
+
+- `convention`: `dead_guard`
+- `kind`: `dead_guard`
+- `severity`: `warning`
+
+Dead-guard findings participate in baseline comparisons like any other audit finding.
+
+## Extending the symbol table
+
+The WP-core symbol table lives in `src/core/code_audit/requirements.rs`. Add new rows as
+`(symbol_name, introduced_in_encoded_version, kind)` — `kind` is `'f'` for functions, `'c'` for
+classes, `'k'` for constants. Version is encoded as `major * 100 + minor` (e.g. 6.9 → 609).
+
+Vendor packages are seeded via `seed_vendor_symbols_from_path` (bootstrap-require match) and
+`apply_composer_requires` (composer.json match). Add new packages there.

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -177,6 +177,10 @@ pub enum AuditFinding {
     /// Docblock `@deprecated X.Y.Z` tag is older than the configured age
     /// threshold relative to the component's current version.
     DeprecationAge,
+    /// `function_exists` / `class_exists` / `defined` guard on a symbol that is
+    /// guaranteed to exist given plugin requirements, explicit bootstrap
+    /// `require`s, or the WordPress core version baseline.
+    DeadGuard,
 }
 
 impl AuditFinding {
@@ -221,6 +225,7 @@ impl AuditFinding {
             "repeated_field_pattern",
             "repeated_literal_shape",
             "deprecation_age",
+            "dead_guard",
         ]
     }
 }

--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -1,0 +1,304 @@
+//! Reachability-aware dead-guard detector.
+//!
+//! Scans PHP file content for `function_exists('name')`, `class_exists('Name')`,
+//! and `defined('CONST')` guards (and their negations) and emits a finding
+//! when the checked symbol is guaranteed to exist given:
+//!
+//! 1. The plugin's declared requirements (`Requires at least:`).
+//! 2. Unconditional `require` calls from the plugin main file.
+//! 3. Known vendor packages declared in `composer.json`.
+//!
+//! The symbol-availability table is built by [`super::requirements`].
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::conventions::{AuditFinding, Language};
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+use super::requirements::{known_available_symbols, KnownSymbols};
+
+/// Kinds of guards we detect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuardKind {
+    Function,
+    Class,
+    Constant,
+}
+
+impl GuardKind {
+    fn label(self) -> &'static str {
+        match self {
+            GuardKind::Function => "function_exists",
+            GuardKind::Class => "class_exists",
+            GuardKind::Constant => "defined",
+        }
+    }
+}
+
+struct Guard {
+    kind: GuardKind,
+    symbol: String,
+    line: usize,
+}
+
+pub(super) fn run(fingerprints: &[&FileFingerprint], root: &Path) -> Vec<Finding> {
+    let known = known_available_symbols(root);
+    if known.functions.is_empty() && known.classes.is_empty() && known.constants.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for fp in fingerprints {
+        if fp.language != Language::Php {
+            continue;
+        }
+        for guard in extract_guards(&fp.content) {
+            if symbol_is_known(&known, &guard) {
+                findings.push(Finding {
+                    convention: "dead_guard".to_string(),
+                    severity: Severity::Warning,
+                    file: fp.relative_path.clone(),
+                    description: format!(
+                        "Dead guard on line {}: {}('{}') — symbol is guaranteed to exist at runtime",
+                        guard.line,
+                        guard.kind.label(),
+                        guard.symbol
+                    ),
+                    suggestion: format!(
+                        "Remove the {}('{}') guard; the symbol is guaranteed by plugin requirements, composer.json, or the plugin bootstrap",
+                        guard.kind.label(),
+                        guard.symbol
+                    ),
+                    kind: AuditFinding::DeadGuard,
+                });
+            }
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn symbol_is_known(known: &KnownSymbols, guard: &Guard) -> bool {
+    match guard.kind {
+        GuardKind::Function => known.has_function(&guard.symbol),
+        GuardKind::Class => known.has_class(&guard.symbol),
+        GuardKind::Constant => known.has_constant(&guard.symbol),
+    }
+}
+
+/// Regex matching any of the three guard calls plus a quoted symbol argument.
+///
+/// Examples matched:
+/// - `function_exists('foo_bar')`
+/// - `! class_exists( "WP_Ability" )`
+/// - `defined('REST_REQUEST')`
+///
+/// Group 1: guard name. Group 2 or 3: quoted symbol (without quotes).
+fn guards_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?x)
+            \b(function_exists|class_exists|defined)\s*
+            \(\s*
+            (?:'([^'\\]+)'|"([^"\\]+)")
+            \s*\)
+            "#,
+        )
+        .expect("dead_guard regex compiles")
+    })
+}
+
+fn extract_guards(content: &str) -> Vec<Guard> {
+    let re = guards_regex();
+    let mut out = Vec::new();
+    for cap in re.captures_iter(content) {
+        let guard_name = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let symbol = cap
+            .get(2)
+            .or_else(|| cap.get(3))
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if symbol.is_empty() {
+            continue;
+        }
+        let kind = match guard_name {
+            "function_exists" => GuardKind::Function,
+            "class_exists" => GuardKind::Class,
+            "defined" => GuardKind::Constant,
+            _ => continue,
+        };
+        let line = line_of_offset(content, cap.get(0).map(|m| m.start()).unwrap_or(0));
+        out.push(Guard {
+            kind,
+            symbol,
+            line,
+        });
+    }
+    out
+}
+
+fn line_of_offset(content: &str, offset: usize) -> usize {
+    content[..offset.min(content.len())]
+        .bytes()
+        .filter(|b| *b == b'\n')
+        .count()
+        + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code_audit::conventions::Language;
+    use crate::code_audit::fingerprint::FileFingerprint;
+    use std::fs;
+
+    fn make_fp(path: &str, content: &str) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Php,
+            content: content.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn write_plugin_main(root: &Path, requires_at_least: Option<&str>, body: &str) {
+        let header = requires_at_least
+            .map(|v| format!(" * Requires at least: {}\n", v))
+            .unwrap_or_default();
+        let content = format!(
+            "<?php\n/**\n * Plugin Name: Demo\n{} */\n\n{}",
+            header, body
+        );
+        fs::write(root.join("plugin.php"), content).unwrap();
+    }
+
+    #[test]
+    fn extract_guards_finds_all_three_kinds() {
+        let content = r#"<?php
+if ( function_exists('wp_timezone') ) {}
+if ( ! class_exists( 'WP_Ability' ) ) {}
+if ( defined("REST_REQUEST") ) {}
+"#;
+        let guards = extract_guards(content);
+        assert_eq!(guards.len(), 3);
+        assert_eq!(guards[0].kind, GuardKind::Function);
+        assert_eq!(guards[0].symbol, "wp_timezone");
+        assert_eq!(guards[1].kind, GuardKind::Class);
+        assert_eq!(guards[1].symbol, "WP_Ability");
+        assert_eq!(guards[2].kind, GuardKind::Constant);
+        assert_eq!(guards[2].symbol, "REST_REQUEST");
+    }
+
+    #[test]
+    fn flags_dead_class_exists_for_wp_ability() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.9"), "");
+
+        let fp = make_fp(
+            "inc/Abilities/Register.php",
+            r#"<?php
+if ( ! class_exists( 'WP_Ability' ) ) {
+    return;
+}
+
+class Register {}
+"#,
+        );
+
+        let findings = run(&[&fp], tmp.path());
+        assert_eq!(findings.len(), 1, "expected one dead-guard finding");
+        assert_eq!(findings[0].kind, AuditFinding::DeadGuard);
+        assert_eq!(findings[0].severity, Severity::Warning);
+        assert!(findings[0].description.contains("WP_Ability"));
+        assert!(findings[0].description.contains("class_exists"));
+    }
+
+    #[test]
+    fn does_not_flag_unknown_function() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.9"), "");
+
+        let fp = make_fp(
+            "inc/Bootstrap.php",
+            r#"<?php
+if ( ! function_exists('my_plugin_helper') ) {
+    function my_plugin_helper() {}
+}
+"#,
+        );
+
+        let findings = run(&[&fp], tmp.path());
+        assert!(
+            findings.is_empty(),
+            "unknown symbol should not be flagged, got: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn action_scheduler_guard_becomes_dead_when_bootstrap_requires_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("vendor/woocommerce/action-scheduler")).unwrap();
+        fs::write(
+            tmp.path()
+                .join("vendor/woocommerce/action-scheduler/action-scheduler.php"),
+            "<?php\n",
+        )
+        .unwrap();
+
+        write_plugin_main(
+            tmp.path(),
+            Some("6.0"),
+            "require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';\n",
+        );
+
+        let fp = make_fp(
+            "inc/Scheduler.php",
+            r#"<?php
+if ( function_exists('as_schedule_single_action') ) {
+    as_schedule_single_action( time(), 'my_hook' );
+}
+"#,
+        );
+
+        let findings = run(&[&fp], tmp.path());
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0]
+            .description
+            .contains("as_schedule_single_action"));
+    }
+
+    #[test]
+    fn non_php_files_are_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.9"), "");
+
+        let fp = FileFingerprint {
+            relative_path: "src/lib.rs".to_string(),
+            language: Language::Rust,
+            content: "function_exists('WP_Ability')".to_string(),
+            ..Default::default()
+        };
+
+        let findings = run(&[&fp], tmp.path());
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn empty_known_symbols_short_circuits() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No plugin main, no composer.json → known is empty.
+        let fp = make_fp(
+            "inc/X.php",
+            r#"<?php if ( class_exists('WP_Ability') ) {} "#,
+        );
+
+        let findings = run(&[&fp], tmp.path());
+        assert!(findings.is_empty());
+    }
+}

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -20,6 +20,7 @@ mod compiler_warnings;
 pub(crate) mod conventions;
 pub(crate) mod core_fingerprint;
 mod dead_code;
+mod dead_guard;
 mod deprecation_age;
 mod discovery;
 pub mod docs;
@@ -34,6 +35,7 @@ mod layer_ownership;
 pub(crate) mod naming;
 mod repeated_literal_shape;
 pub mod report;
+mod requirements;
 pub mod run;
 mod shadow_modules;
 mod signatures;
@@ -559,6 +561,19 @@ fn audit_internal(
             deprecation_findings.len()
         );
         all_findings.extend(deprecation_findings);
+    }
+
+    // Phase 4q: Dead guard detection — flag function_exists/class_exists/defined
+    // guards on symbols guaranteed to exist given plugin requirements, composer
+    // dependencies, and bootstrap requires.
+    let dead_guard_findings = dead_guard::run(&all_fingerprints, root);
+    if !dead_guard_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Dead guards: {} finding(s) (guards on guaranteed-available symbols)",
+            dead_guard_findings.len()
+        );
+        all_findings.extend(dead_guard_findings);
     }
 
     // Phase 4p: Impact-scoped filtering — when auditing changed files only,

--- a/src/core/code_audit/requirements.rs
+++ b/src/core/code_audit/requirements.rs
@@ -1,0 +1,433 @@
+//! Plugin requirement + bootstrap parser — collects symbols that are guaranteed
+//! to exist at runtime so downstream detectors (e.g. `dead_guard`) can skip
+//! `function_exists` / `class_exists` / `defined` guards on them.
+//!
+//! Sources of "guaranteed available" symbols:
+//! 1. The WordPress plugin header's `Requires at least: X.Y` value, mapped
+//!    against a hard-coded WP-core symbol-availability table.
+//! 2. `composer.json` `require` and `require-dev` entries — when a known
+//!    vendor package is present, its public symbols are considered available.
+//! 3. Unconditional `require` / `require_once` calls from the plugin main
+//!    file — anything pulled in at bootstrap is guaranteed loaded.
+//!
+//! The parser is lenient: every source is optional and a missing / malformed
+//! file yields an empty contribution rather than an error.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Symbols guaranteed to be defined at runtime given the plugin's declared
+/// requirements and its explicit bootstrap wiring.
+#[derive(Debug, Default, Clone)]
+pub struct KnownSymbols {
+    pub functions: HashSet<String>,
+    pub classes: HashSet<String>,
+    pub constants: HashSet<String>,
+}
+
+impl KnownSymbols {
+    pub fn has_function(&self, name: &str) -> bool {
+        self.functions.contains(name)
+    }
+
+    pub fn has_class(&self, name: &str) -> bool {
+        // Case-insensitive lookup: PHP class names are case-insensitive.
+        let lower = name.to_ascii_lowercase();
+        self.classes.iter().any(|c| c.to_ascii_lowercase() == lower)
+    }
+
+    pub fn has_constant(&self, name: &str) -> bool {
+        self.constants.contains(name)
+    }
+}
+
+/// Entry point: inspect a plugin root and return the set of guaranteed symbols.
+pub fn known_available_symbols(root: &Path) -> KnownSymbols {
+    let mut symbols = KnownSymbols::default();
+
+    let main_file = find_plugin_main_file(root);
+    let wp_baseline = main_file
+        .as_ref()
+        .and_then(|p| parse_wp_requires_at_least(p))
+        .unwrap_or(0);
+
+    seed_wp_core_symbols(&mut symbols, wp_baseline);
+
+    if let Some(ref main) = main_file {
+        let required_paths = parse_bootstrap_requires(main, root);
+        for path in &required_paths {
+            seed_vendor_symbols_from_path(&mut symbols, path);
+        }
+    }
+
+    apply_composer_requires(&mut symbols, root);
+
+    symbols
+}
+
+/// Locate the plugin main file: a `*.php` file in `root` whose content contains
+/// `Plugin Name:` in the header comment.
+pub fn find_plugin_main_file(root: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(root).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("php") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        // Check first ~50 lines for "Plugin Name:" marker.
+        if content
+            .lines()
+            .take(50)
+            .any(|l| l.contains("Plugin Name:"))
+        {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Parse `Requires at least: X.Y` from the plugin header. Returns the WP core
+/// version encoded as `major * 100 + minor` (e.g. 5.3 → 503) for easy
+/// comparison, or `None` if absent.
+pub fn parse_wp_requires_at_least(main_file: &Path) -> Option<u32> {
+    let content = std::fs::read_to_string(main_file).ok()?;
+    for line in content.lines().take(80) {
+        if let Some(rest) = line.split_once("Requires at least:") {
+            let value = rest.1.trim().trim_end_matches('*').trim();
+            return parse_version_encoded(value);
+        }
+    }
+    None
+}
+
+fn parse_version_encoded(v: &str) -> Option<u32> {
+    let mut parts = v.split('.');
+    let major: u32 = parts.next()?.trim().parse().ok()?;
+    let minor: u32 = parts
+        .next()
+        .and_then(|m| m.trim().parse().ok())
+        .unwrap_or(0);
+    Some(major * 100 + minor)
+}
+
+/// Seed a minimum set of WP-core symbols known to exist when the plugin
+/// declares a floor of WP version `wp_baseline` (encoded as major*100+minor).
+///
+/// The table is intentionally small and conservative — the intent is to catch
+/// guards that are obviously dead given the plugin's declared floor, not to
+/// enumerate every WP symbol.
+fn seed_wp_core_symbols(symbols: &mut KnownSymbols, wp_baseline: u32) {
+    // (symbol_name, introduced_in_encoded_version, kind)
+    // kind: 'f' = function, 'c' = class, 'k' = constant
+    const WP_SYMBOLS: &[(&str, u32, char)] = &[
+        // Functions
+        ("wp_generate_uuid4", 407, 'f'),
+        ("wp_timezone", 503, 'f'),
+        ("wp_timezone_string", 501, 'f'),
+        ("wp_get_environment_type", 505, 'f'),
+        ("wp_date", 503, 'f'),
+        ("wp_json_encode", 404, 'f'),
+        ("get_post_type_object", 300, 'f'),
+        ("register_rest_route", 404, 'f'),
+        ("register_block_type", 500, 'f'),
+        ("has_blocks", 500, 'f'),
+        ("parse_blocks", 500, 'f'),
+        // Classes
+        ("WP_Ability", 609, 'c'),
+        ("WP_REST_Server", 404, 'c'),
+        ("WP_REST_Request", 404, 'c'),
+        ("WP_REST_Response", 404, 'c'),
+        ("WP_Block_Type_Registry", 500, 'c'),
+        ("WP_Block", 501, 'c'),
+        ("WP_HTML_Tag_Processor", 602, 'c'),
+        // Constants
+        ("REST_REQUEST", 404, 'k'),
+    ];
+
+    if wp_baseline == 0 {
+        return;
+    }
+
+    for (name, introduced, kind) in WP_SYMBOLS {
+        if *introduced <= wp_baseline {
+            match kind {
+                'f' => {
+                    symbols.functions.insert((*name).to_string());
+                }
+                'c' => {
+                    symbols.classes.insert((*name).to_string());
+                }
+                'k' => {
+                    symbols.constants.insert((*name).to_string());
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Parse unconditional `require` / `require_once` / `include` / `include_once`
+/// calls from the plugin main file and return resolved absolute paths that
+/// live under `root`.
+///
+/// "Unconditional" means: not inside an `if (!class_exists(...))` or similar
+/// guard. We use a simple heuristic: the `require` is skipped if the previous
+/// non-blank line opens a guard block (`if (...) {` mentioning `class_exists`,
+/// `function_exists`, or `defined`).
+pub fn parse_bootstrap_requires(main_file: &Path, root: &Path) -> Vec<PathBuf> {
+    let Ok(content) = std::fs::read_to_string(main_file) else {
+        return Vec::new();
+    };
+
+    let mut paths = Vec::new();
+    let main_dir = main_file.parent().unwrap_or(root);
+
+    let lines: Vec<&str> = content.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let requires_kind = ["require_once", "require", "include_once", "include"]
+            .iter()
+            .find(|k| trimmed.starts_with(*k) && !is_identifier_continuation(trimmed, k.len()));
+        if requires_kind.is_none() {
+            continue;
+        }
+
+        // Skip if the previous non-blank line opens a guard block.
+        let mut guarded = false;
+        for j in (0..i).rev() {
+            let prev = lines[j].trim();
+            if prev.is_empty() {
+                continue;
+            }
+            if prev.ends_with('{')
+                && (prev.contains("if ") || prev.contains("if("))
+                && (prev.contains("class_exists")
+                    || prev.contains("function_exists")
+                    || prev.contains("defined"))
+            {
+                guarded = true;
+            }
+            break;
+        }
+        if guarded {
+            continue;
+        }
+
+        if let Some(path_str) = extract_require_path(trimmed) {
+            let resolved = resolve_require_path(&path_str, main_dir);
+            if let Some(p) = resolved {
+                paths.push(p);
+            }
+        }
+    }
+
+    paths
+}
+
+fn is_identifier_continuation(line: &str, offset: usize) -> bool {
+    line.as_bytes()
+        .get(offset)
+        .map(|b| b.is_ascii_alphanumeric() || *b == b'_')
+        .unwrap_or(false)
+}
+
+/// Extract a quoted path from a `require[_once] ...;` statement. Returns the
+/// path string as-is (caller resolves `__DIR__ .` prefixes by stripping the
+/// leading `/`).
+fn extract_require_path(line: &str) -> Option<String> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\'' || c == b'"' {
+            let quote = c;
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && bytes[end] != quote {
+                end += 1;
+            }
+            if end <= bytes.len() {
+                let raw = &line[start..end];
+                return Some(raw.to_string());
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn resolve_require_path(raw: &str, main_dir: &Path) -> Option<PathBuf> {
+    let cleaned = raw.trim_start_matches('/');
+    Some(main_dir.join(cleaned))
+}
+
+/// Inspect a bootstrap `require`d path and seed vendor-specific symbols when
+/// the path matches a known library bootstrap.
+fn seed_vendor_symbols_from_path(symbols: &mut KnownSymbols, path: &Path) {
+    let p = path.to_string_lossy().replace('\\', "/");
+
+    // Action Scheduler — loaded by `vendor/woocommerce/action-scheduler/action-scheduler.php`.
+    if p.contains("action-scheduler/action-scheduler.php")
+        || p.ends_with("/action-scheduler.php")
+    {
+        seed_action_scheduler_symbols(symbols);
+    }
+}
+
+fn seed_action_scheduler_symbols(symbols: &mut KnownSymbols) {
+    const AS_FUNCTIONS: &[&str] = &[
+        "as_schedule_single_action",
+        "as_schedule_recurring_action",
+        "as_schedule_cron_action",
+        "as_enqueue_async_action",
+        "as_unschedule_action",
+        "as_unschedule_all_actions",
+        "as_next_scheduled_action",
+        "as_has_scheduled_action",
+        "as_get_scheduled_actions",
+    ];
+    const AS_CLASSES: &[&str] = &[
+        "ActionScheduler",
+        "ActionScheduler_Action",
+        "ActionScheduler_Store",
+        "ActionScheduler_Versions",
+    ];
+    for f in AS_FUNCTIONS {
+        symbols.functions.insert((*f).to_string());
+    }
+    for c in AS_CLASSES {
+        symbols.classes.insert((*c).to_string());
+    }
+}
+
+/// Inspect `composer.json` and seed symbols for well-known packages.
+fn apply_composer_requires(symbols: &mut KnownSymbols, root: &Path) {
+    let composer = root.join("composer.json");
+    let Ok(content) = std::fs::read_to_string(&composer) else {
+        return;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return;
+    };
+
+    let mut packages: HashSet<String> = HashSet::new();
+    for key in &["require", "require-dev"] {
+        if let Some(obj) = json.get(*key).and_then(|v| v.as_object()) {
+            for name in obj.keys() {
+                packages.insert(name.to_string());
+            }
+        }
+    }
+
+    if packages.contains("woocommerce/action-scheduler") {
+        seed_action_scheduler_symbols(symbols);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_plugin_main(dir: &Path, requires_at_least: Option<&str>, body: &str) -> PathBuf {
+        let header_line = requires_at_least
+            .map(|v| format!(" * Requires at least: {}\n", v))
+            .unwrap_or_default();
+        let content = format!(
+            "<?php\n/**\n * Plugin Name: Test Plugin\n{} */\n\n{}",
+            header_line, body
+        );
+        let path = dir.join("plugin.php");
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn parses_requires_at_least() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main = write_plugin_main(tmp.path(), Some("6.9"), "");
+        let baseline = parse_wp_requires_at_least(&main).unwrap();
+        assert_eq!(baseline, 609);
+    }
+
+    #[test]
+    fn seeds_wp_core_symbols_up_to_baseline() {
+        let mut syms = KnownSymbols::default();
+        seed_wp_core_symbols(&mut syms, 609);
+        assert!(syms.has_class("WP_Ability"));
+        assert!(syms.has_function("wp_timezone"));
+        assert!(syms.has_function("wp_generate_uuid4"));
+    }
+
+    #[test]
+    fn does_not_seed_symbols_introduced_later_than_baseline() {
+        let mut syms = KnownSymbols::default();
+        seed_wp_core_symbols(&mut syms, 500);
+        assert!(!syms.has_class("WP_Ability"));
+        assert!(syms.has_function("wp_generate_uuid4"));
+    }
+
+    #[test]
+    fn missing_plugin_main_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let syms = known_available_symbols(tmp.path());
+        assert!(syms.functions.is_empty());
+        assert!(syms.classes.is_empty());
+    }
+
+    #[test]
+    fn detects_action_scheduler_bootstrap_require() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("vendor/woocommerce/action-scheduler")).unwrap();
+        fs::write(
+            tmp.path()
+                .join("vendor/woocommerce/action-scheduler/action-scheduler.php"),
+            "<?php\n",
+        )
+        .unwrap();
+
+        let main = write_plugin_main(
+            tmp.path(),
+            Some("6.0"),
+            "require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';\n",
+        );
+        let requires = parse_bootstrap_requires(&main, tmp.path());
+        assert_eq!(requires.len(), 1);
+
+        let syms = known_available_symbols(tmp.path());
+        assert!(syms.has_function("as_schedule_single_action"));
+        assert!(syms.has_function("as_unschedule_action"));
+    }
+
+    #[test]
+    fn composer_require_seeds_action_scheduler() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("composer.json"),
+            r#"{"require":{"woocommerce/action-scheduler":"^3.0"}}"#,
+        )
+        .unwrap();
+        let mut syms = KnownSymbols::default();
+        apply_composer_requires(&mut syms, tmp.path());
+        assert!(syms.has_function("as_schedule_single_action"));
+    }
+
+    #[test]
+    fn guarded_require_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main = write_plugin_main(
+            tmp.path(),
+            Some("6.0"),
+            "if ( ! class_exists( 'ActionScheduler' ) ) {\n    require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';\n}\n",
+        );
+        let requires = parse_bootstrap_requires(&main, tmp.path());
+        assert!(
+            requires.is_empty(),
+            "guarded require should be skipped, got: {:?}",
+            requires
+        );
+    }
+}


### PR DESCRIPTION
Closes #1270.

## Summary

New reachability-aware detector in `src/core/code_audit/dead_guard.rs` that flags `function_exists()`, `class_exists()`, and `defined()` guards where the checked symbol is guaranteed to exist at runtime — the else branch is unreachable, so the guard is dead code.

## How it works

A companion parser in `src/core/code_audit/requirements.rs` computes `KnownSymbols` from three sources:

1. **`Requires at least: X.Y`** from the plugin main-file header, mapped against a small curated WP-core symbol-availability table (`WP_Ability` @ 6.9, `wp_generate_uuid4` @ 4.7, `wp_timezone` @ 5.3, `register_rest_route` @ 4.4, etc.).
2. **Unconditional `require` / `require_once`** calls in the plugin main file. Requires inside an `if ( ! class_exists(…) ) { … }` block are skipped. When the required path matches a known vendor bootstrap (currently `vendor/woocommerce/action-scheduler/action-scheduler.php`), the detector seeds that library's public API into `KnownSymbols`.
3. **`composer.json`** `require` / `require-dev` entries — known packages (currently `woocommerce/action-scheduler`) seed their symbols.

The detector walks every PHP fingerprint, regex-matches `function_exists('…')` / `class_exists('…')` / `defined('…')` (including negated forms like `! class_exists(…)`), and emits a `Severity::Warning` finding when the symbol is in `KnownSymbols`. Class lookups are case-insensitive (matching PHP semantics).

## Files

- `src/core/code_audit/requirements.rs` — new, ~400 lines. Plugin header parser, bootstrap-require parser, composer.json parser, curated WP-core symbol table, Action-Scheduler symbol seed. 7 inline tests.
- `src/core/code_audit/dead_guard.rs` — new, ~300 lines. Regex-driven guard extractor, finding emitter. 6 inline tests covering: dead `class_exists('WP_Ability')` flagged, unknown function NOT flagged, Action-Scheduler guard becoming dead when bootstrap requires it, non-PHP files ignored, short-circuit when no symbols are known, extraction of all three guard kinds.
- `src/core/code_audit/conventions.rs` — `DeadGuard` variant on `AuditFinding` + entry in `all_names()`.
- `src/core/code_audit/mod.rs` — `mod dead_guard;` / `mod requirements;` + Phase 4q invocation in `audit_internal`.
- `docs/audit/dead-guard.md` — short doc matching `docs/commands/audit-rules.md` style.

## Validation

- `cargo test --release --lib dead_guard` — **6/6 pass**.
- `cargo test --release --lib requirements` — **7/7 pass**.
- `cargo build --release -p homeboy` — clean.
- Full `cargo test --release`: all 1186 tests that pass on `main` still pass. The 5 pre-existing failures (`signature_check_*`, `standalone_prefers_portable_config_when_available`, `write_standalone_creates_and_reads_back`) are confirmed to fail on untouched `main` prior to this change — unrelated.
- **E2E against data-machine v0.78.0** (`cargo run --release -p homeboy -- audit /Users/chubes/Developer/data-machine --only dead_guard`):
  - **131 total `dead_guard` findings**.
  - **95 matches in `inc/Abilities/`** for `class_exists('WP_Ability')` — squarely in the "~92" range the issue predicted.
  - Action-Scheduler guards in `data-machine.php` also flagged (composer.json declares `woocommerce/action-scheduler`, so `class_exists('ActionScheduler')` and `function_exists('as_unschedule_all_actions')` are correctly identified as dead).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude (Sonnet 4.5) via Claude Code
- **Used for:** Implementation, tests, and documentation.