### PR TITLE
feat(git): sectioned PR comment primitive (closes #1348)

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 
 use homeboy::git::{
     self, GithubFindOutput, GithubIssueOutput, GithubPrOutput, GitOutput, IssueCreateOptions,
-    IssueFindOptions, IssueState, PrCommentOptions, PrCreateOptions, PrEditOptions, PrFindOptions,
-    PrState,
+    IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions,
+    PrFindOptions, PrState,
 };
 use homeboy::BulkResult;
 
@@ -266,7 +266,21 @@ enum PrCommand {
         #[arg(long, default_value_t = 30)]
         limit: usize,
     },
-    /// Post a comment on a PR (supports sticky-comment keys)
+    /// Post a comment on a PR. Three modes:
+    ///
+    /// 1. Plain: no marker flags — a fresh comment is appended.
+    /// 2. Sticky single-section (#1334): `--key <k>` finds-or-updates the one
+    ///    comment tagged `<!-- homeboy:key=<k> -->`. The whole `--body` becomes
+    ///    the comment body.
+    /// 3. Sectioned (#1348): `--comment-key <outer> --section-key <inner>`
+    ///    merges `--body` into section `<inner>` of the shared comment tagged
+    ///    `<!-- homeboy:comment-key=<outer> -->`. Other sections are preserved.
+    ///    `--header` sets the line printed after the outer marker on new
+    ///    comments. `--section-order` pins section ordering (CSV of keys);
+    ///    default is alphabetical.
+    ///
+    /// Modes 2 and 3 are mutually exclusive. `--key` with `--comment-key` or
+    /// `--section-key` is an error.
     Comment {
         /// Component ID
         component_id: String,
@@ -283,10 +297,33 @@ enum PrCommand {
         #[arg(long, value_name = "PATH")]
         body_file: Option<String>,
 
-        /// Optional sticky-comment key. When set, an existing comment with this
-        /// marker is updated in place instead of a new one being posted.
-        #[arg(short, long)]
+        /// Sticky whole-body key (mode 2, PR #1334).
+        /// Mutually exclusive with --comment-key / --section-key.
+        #[arg(short, long, conflicts_with_all = ["comment_key", "section_key"])]
         key: Option<String>,
+
+        /// Sectioned mode: outer shared-comment key (mode 3, #1348).
+        /// Must be combined with --section-key.
+        #[arg(long, requires = "section_key")]
+        comment_key: Option<String>,
+
+        /// Sectioned mode: inner per-section key (mode 3, #1348).
+        /// Must be combined with --comment-key.
+        #[arg(long, requires = "comment_key")]
+        section_key: Option<String>,
+
+        /// Sectioned mode: optional header line written after the outer
+        /// marker on freshly-created shared comments (e.g.
+        /// "## Homeboy Results — `<component>`"). Existing comment headers
+        /// are preserved on merge.
+        #[arg(long, requires = "comment_key")]
+        header: Option<String>,
+
+        /// Sectioned mode: CSV of section keys in desired order. Sections
+        /// listed here come first in the given order; others are appended
+        /// alphabetically. Example: `--section-order lint,test,audit`.
+        #[arg(long, requires = "comment_key", value_delimiter = ',')]
+        section_order: Option<Vec<String>>,
     },
 }
 
@@ -590,6 +627,10 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             body,
             body_file,
             key,
+            comment_key,
+            section_key,
+            header,
+            section_order,
         } => {
             let body = resolve_body(body, body_file)?.ok_or_else(|| {
                 homeboy::Error::validation_invalid_argument(
@@ -599,9 +640,34 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
                     None,
                 )
             })?;
+
+            let mode = match (key, comment_key, section_key) {
+                (Some(k), None, None) => PrCommentMode::StickyWholeBody { key: k },
+                (None, Some(ck), Some(sk)) => PrCommentMode::Sectioned {
+                    comment_key: ck,
+                    section_key: sk,
+                    header,
+                    section_order,
+                },
+                (None, None, None) => {
+                    // Header / section_order without the pair — clap already
+                    // caught this via `requires = "comment_key"`, but double-check.
+                    PrCommentMode::Fresh
+                }
+                // Remaining cases are impossible due to clap `requires` /
+                // `conflicts_with_all`, but keep the match exhaustive.
+                _ => unreachable!(
+                    "clap argument parsing should have rejected incompatible --key / --comment-key / --section-key combos"
+                ),
+            };
+
             let output = git::pr_comment(
                 Some(&component_id),
-                PrCommentOptions { number, body, key },
+                PrCommentOptions {
+                    number,
+                    body,
+                    mode,
+                },
             )?;
             Ok((GitCommandOutput::Pr(output), 0))
         }

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -52,7 +52,7 @@ pub struct GithubIssueOutput {
 }
 
 /// Result of a GitHub PR operation (create, edit, find-one, comment).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct GithubPrOutput {
     pub component_id: String,
     pub owner: String,
@@ -71,6 +71,14 @@ pub struct GithubPrOutput {
     pub base: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub head: Option<String>,
+    /// Canonical comment id (sectioned flow). Omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment_id: Option<u64>,
+    /// Non-fatal warnings. Currently used for duplicate-comment deletes that
+    /// failed during race consolidation — the canonical comment was still
+    /// updated successfully, so we report the stuck ids and exit 0.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<String>,
 }
 
 /// Result of a find-many operation (list of matches).
@@ -184,15 +192,65 @@ impl PrState {
 }
 
 /// Parameters for posting a (potentially sticky) PR comment.
-#[derive(Debug, Clone, Default)]
+///
+/// Three shapes are supported, selected by `mode`:
+/// - [`PrCommentMode::Fresh`] — plain append, no marker, no find-or-update.
+/// - [`PrCommentMode::StickyWholeBody`] — single-section sticky (PR #1334
+///   semantics): prepend `<!-- homeboy:key=<key> -->` marker and update the
+///   one matching comment in place.
+/// - [`PrCommentMode::Sectioned`] — multi-section aggregation: a single shared
+///   comment carries `<!-- homeboy:comment-key=<outer> -->` and N section
+///   blocks delimited by `<!-- homeboy:section-key=<inner>:start|end -->`.
+///   Each invocation replaces its own inner section and leaves the others
+///   untouched. Handles race consolidation when parallel jobs raced to create
+///   the shared comment.
+#[derive(Debug, Clone)]
 pub struct PrCommentOptions {
     pub number: u64,
     pub body: String,
-    /// Optional marker key. When set, the body is prefixed with an HTML comment
-    /// (`<!-- homeboy:key=<key> -->`) and the function looks for an existing
-    /// comment carrying that marker — if found, updates it in place. Otherwise
-    /// a new comment is posted. This is the mechanism behind sticky CI comments.
-    pub key: Option<String>,
+    pub mode: PrCommentMode,
+}
+
+impl Default for PrCommentOptions {
+    fn default() -> Self {
+        Self {
+            number: 0,
+            body: String::new(),
+            mode: PrCommentMode::Fresh,
+        }
+    }
+}
+
+/// Which comment-posting flow to run. Mutually exclusive shapes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrCommentMode {
+    /// Plain append. No marker. No find-or-update.
+    Fresh,
+    /// Single-section sticky comment (PR #1334). The `body` is treated as the
+    /// whole comment body; the marker `<!-- homeboy:key=<key> -->` is prepended.
+    StickyWholeBody { key: String },
+    /// Multi-section aggregated sticky comment. `body` is ONE section's body;
+    /// it is merged under `section_key` into the comment carrying `comment_key`.
+    Sectioned {
+        /// Outer marker (one shared comment per PR per outer key).
+        comment_key: String,
+        /// Inner marker (one section per inner key within the shared comment).
+        section_key: String,
+        /// Optional header line written just after the outer marker on fresh
+        /// comments (e.g. `## Homeboy Results — \`<component>\``). Preserved
+        /// from existing comments on merge.
+        header: Option<String>,
+        /// Optional explicit section ordering. Sections listed here come first
+        /// in the given order; any other sections are appended alphabetically.
+        /// `None` = pure alphabetical.
+        section_order: Option<Vec<String>>,
+    },
+}
+
+impl Default for PrCommentMode {
+    fn default() -> Self {
+        PrCommentMode::Fresh
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -394,6 +452,7 @@ pub fn pr_create(
         state: Some("open".to_string()),
         base: Some(options.base),
         head: Some(options.head),
+        ..Default::default()
     })
 }
 
@@ -438,9 +497,7 @@ pub fn pr_edit(component_id: Option<&str>, options: PrEditOptions) -> Result<Git
         number: Some(options.number),
         url: Some(output.trim().to_string()),
         title: options.title,
-        state: None,
-        base: None,
-        head: None,
+        ..Default::default()
     })
 }
 
@@ -485,48 +542,50 @@ pub fn pr_find(component_id: Option<&str>, options: PrFindOptions) -> Result<Git
     })
 }
 
-/// Post a comment on a PR. When `options.key` is set, existing comments with
-/// the same marker are updated in place (sticky-comment semantics) instead of
-/// being appended. Returns a `GithubPrOutput` describing the resulting action.
+/// Post a comment on a PR.
+///
+/// Dispatches on [`PrCommentOptions::mode`]:
+/// - [`PrCommentMode::Fresh`] — plain append, no marker.
+/// - [`PrCommentMode::StickyWholeBody`] — find-or-update the one comment
+///   tagged `<!-- homeboy:key=<key> -->` (single-section sticky, PR #1334).
+/// - [`PrCommentMode::Sectioned`] — multi-section aggregation: merge this
+///   invocation's section under `section_key` into the shared comment tagged
+///   `<!-- homeboy:comment-key=<comment_key> -->`.
 pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Result<GithubPrOutput> {
     let (id, repo) = resolve_component_github(component_id)?;
     ensure_gh_ready()?;
 
-    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-    let body = match &options.key {
-        Some(key) => format!("{}\n{}", marker_for_key(key), options.body),
-        None => options.body.clone(),
-    };
-
-    // Sticky comment flow: find-or-update.
-    if let Some(key) = &options.key {
-        if let Some(existing_id) = find_sticky_comment_id(&repo, options.number, key)? {
-            let args: Vec<String> = vec![
-                "api".into(),
-                format!("repos/{}/{}/issues/comments/{}", repo.owner, repo.repo, existing_id),
-                "--method".into(),
-                "PATCH".into(),
-                "-f".into(),
-                format!("body={}", body),
-            ];
-            run_gh(&args)?;
-            return Ok(GithubPrOutput {
-                component_id: id,
-                owner: repo.owner,
-                repo: repo.repo,
-                action: "pr.comment.update".to_string(),
-                success: true,
-                number: Some(options.number),
-                url: None,
-                title: None,
-                state: None,
-                base: None,
-                head: None,
-            });
+    match options.mode.clone() {
+        PrCommentMode::Fresh => pr_comment_fresh(id, repo, options),
+        PrCommentMode::StickyWholeBody { key } => {
+            pr_comment_sticky_whole(id, repo, options.number, options.body, key)
         }
+        PrCommentMode::Sectioned {
+            comment_key,
+            section_key,
+            header,
+            section_order,
+        } => pr_comment_sectioned(
+            id,
+            repo,
+            options.number,
+            options.body,
+            comment_key,
+            section_key,
+            header,
+            section_order,
+        ),
     }
+}
 
-    // Fresh-comment flow.
+/// Plain append flow. Shared by `Fresh` mode and the "no existing comment"
+/// branch of the sticky flow.
+fn pr_comment_fresh(
+    id: String,
+    repo: GitHubRepo,
+    options: PrCommentOptions,
+) -> Result<GithubPrOutput> {
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let args: Vec<String> = vec![
         "pr".into(),
         "comment".into(),
@@ -534,7 +593,7 @@ pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Resu
         "-R".into(),
         repo_flag,
         "--body".into(),
-        body,
+        options.body,
     ];
     let output = run_gh(&args)?;
     Ok(GithubPrOutput {
@@ -545,10 +604,217 @@ pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Resu
         success: true,
         number: Some(options.number),
         url: Some(output.trim().to_string()),
-        title: None,
-        state: None,
-        base: None,
-        head: None,
+        ..Default::default()
+    })
+}
+
+/// Sticky single-section flow (PR #1334 semantics).
+fn pr_comment_sticky_whole(
+    id: String,
+    repo: GitHubRepo,
+    pr_number: u64,
+    body: String,
+    key: String,
+) -> Result<GithubPrOutput> {
+    let full_body = format!("{}\n{}", marker_for_key(&key), body);
+
+    if let Some(existing_id) = find_sticky_comment_id(&repo, pr_number, &key)? {
+        let args: Vec<String> = vec![
+            "api".into(),
+            format!(
+                "repos/{}/{}/issues/comments/{}",
+                repo.owner, repo.repo, existing_id
+            ),
+            "--method".into(),
+            "PATCH".into(),
+            "-f".into(),
+            format!("body={}", full_body),
+        ];
+        run_gh(&args)?;
+        return Ok(GithubPrOutput {
+            component_id: id,
+            owner: repo.owner,
+            repo: repo.repo,
+            action: "pr.comment.update".to_string(),
+            success: true,
+            number: Some(pr_number),
+            comment_id: Some(existing_id),
+            ..Default::default()
+        });
+    }
+
+    // Fall through to fresh-comment.
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+    let args: Vec<String> = vec![
+        "pr".into(),
+        "comment".into(),
+        pr_number.to_string(),
+        "-R".into(),
+        repo_flag,
+        "--body".into(),
+        full_body,
+    ];
+    let output = run_gh(&args)?;
+    Ok(GithubPrOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: "pr.comment.create".to_string(),
+        success: true,
+        number: Some(pr_number),
+        url: Some(output.trim().to_string()),
+        ..Default::default()
+    })
+}
+
+/// Sectioned-comment flow.
+///
+/// Flow:
+/// 1. List the PR's issue-comments, filter to those carrying the comment-key
+///    marker (new OR legacy format — see [`parse_comment_sections`] contract).
+/// 2. If none: create one with a single section block.
+/// 3. If one: parse existing sections, merge this invocation's section, render.
+///    Byte-compare to the existing body — if equal, emit `pr.comment.section.noop`
+///    and skip the PATCH. Otherwise PATCH.
+/// 4. If many (race): pick lowest id as canonical, merge sections from ALL
+///    matching comments (current invocation wins last for duplicate keys),
+///    PATCH canonical, DELETE the rest. Failed DELETEs become warnings, not
+///    hard errors — the next invocation will consolidate.
+#[allow(clippy::too_many_arguments)]
+fn pr_comment_sectioned(
+    id: String,
+    repo: GitHubRepo,
+    pr_number: u64,
+    section_body: String,
+    comment_key: String,
+    section_key: String,
+    header: Option<String>,
+    section_order: Option<Vec<String>>,
+) -> Result<GithubPrOutput> {
+    // 1. Fetch every matching comment (with bodies) — we need the bodies to
+    //    merge the race case. `gh api --paginate` returns a stream of JSON
+    //    arrays concatenated with no separator; we parse each array
+    //    independently and flatten the results.
+    let matches = list_matching_comments(&repo, pr_number, &comment_key)?;
+
+    if matches.is_empty() {
+        // 2. No existing comment — create fresh with a single section.
+        let mut sections: Vec<(String, String)> = Vec::new();
+        sections.push((section_key.clone(), section_body.clone()));
+        let rendered = render_comment(
+            &comment_key,
+            header.as_deref(),
+            &sections,
+            section_order.as_deref(),
+        );
+        let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+        let args: Vec<String> = vec![
+            "pr".into(),
+            "comment".into(),
+            pr_number.to_string(),
+            "-R".into(),
+            repo_flag,
+            "--body".into(),
+            rendered,
+        ];
+        let output = run_gh(&args)?;
+        return Ok(GithubPrOutput {
+            component_id: id,
+            owner: repo.owner,
+            repo: repo.repo,
+            action: "pr.comment.section.create".to_string(),
+            success: true,
+            number: Some(pr_number),
+            url: Some(output.trim().to_string()),
+            ..Default::default()
+        });
+    }
+
+    // 3/4. Canonical = lowest id. Merge sections from every matching comment
+    //      (ascending id order so later comments override earlier ones), then
+    //      overwrite this invocation's section last.
+    let mut matches = matches;
+    matches.sort_by_key(|m| m.id);
+    let canonical_id = matches[0].id;
+    let canonical_body = matches[0].body.clone();
+
+    let mut merged: Vec<(String, String)> = Vec::new();
+    let mut discovered_header: Option<String> = header.clone();
+    for comment in &matches {
+        let parsed = parse_comment_sections(&comment.body);
+        for (k, v) in parsed {
+            merged = merge_section(merged, &k, v);
+        }
+        // First comment wins the header (in ascending id order = lowest id),
+        // but only if caller didn't pass one explicitly.
+        if discovered_header.is_none() {
+            discovered_header = extract_header(&comment.body);
+        }
+    }
+    // Current invocation wins last.
+    merged = merge_section(merged, &section_key, section_body);
+
+    let rendered = render_comment(
+        &comment_key,
+        discovered_header.as_deref(),
+        &merged,
+        section_order.as_deref(),
+    );
+
+    // Idempotency: byte-compare rendered to canonical's existing body.
+    let patch_needed = rendered.trim_end() != canonical_body.trim_end();
+    let mut warnings: Vec<String> = Vec::new();
+
+    if patch_needed {
+        let args: Vec<String> = vec![
+            "api".into(),
+            format!(
+                "repos/{}/{}/issues/comments/{}",
+                repo.owner, repo.repo, canonical_id
+            ),
+            "--method".into(),
+            "PATCH".into(),
+            "-f".into(),
+            format!("body={}", rendered),
+        ];
+        run_gh(&args)?;
+    }
+
+    // Delete duplicates (best-effort — warn instead of failing).
+    for comment in matches.iter().skip(1) {
+        let args: Vec<String> = vec![
+            "api".into(),
+            format!(
+                "repos/{}/{}/issues/comments/{}",
+                repo.owner, repo.repo, comment.id
+            ),
+            "--method".into(),
+            "DELETE".into(),
+        ];
+        if run_gh(&args).is_err() {
+            warnings.push(format!(
+                "failed to delete duplicate comment id={} — next invocation will retry",
+                comment.id
+            ));
+        }
+    }
+
+    let action = if patch_needed {
+        "pr.comment.section.update"
+    } else {
+        "pr.comment.section.noop"
+    };
+
+    Ok(GithubPrOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: action.to_string(),
+        success: true,
+        number: Some(pr_number),
+        comment_id: Some(canonical_id),
+        warnings,
+        ..Default::default()
     })
 }
 
@@ -679,6 +945,257 @@ fn find_sticky_comment_id(repo: &GitHubRepo, pr_number: u64, key: &str) -> Resul
     ];
     let raw = run_gh(&args)?;
     Ok(raw.lines().next().and_then(|l| l.trim().parse().ok()))
+}
+
+// ---------------------------------------------------------------------------
+// Sectioned-comment primitive: pure parser / renderer / merger
+// ---------------------------------------------------------------------------
+//
+// Marker contract recognized by the parser (both formats, for rollout compat):
+//
+//   NEW (written on render):
+//     <!-- homeboy:comment-key=<outer> -->
+//     <!-- homeboy:section-key=<inner>:start -->
+//     ...
+//     <!-- homeboy:section-key=<inner>:end -->
+//
+//   LEGACY (homeboy-action scripts wrote these before the primitive shipped):
+//     <!-- homeboy-action-results:key=<outer> -->
+//     <!-- homeboy-action-section:key=<inner>:start -->
+//     ...
+//     <!-- homeboy-action-section:key=<inner>:end -->
+//
+// The parser accepts both so the primitive can adopt in-flight comments that
+// the action wrote under legacy markers. The renderer writes only new markers;
+// re-parsing the output migrates legacy → new on the next invocation.
+
+/// Minimal shape for a fetched PR comment (id + body).
+struct FetchedComment {
+    id: u64,
+    body: String,
+}
+
+/// Outer-key marker formats (start-of-body anchor for the shared comment).
+fn comment_key_markers(comment_key: &str) -> [String; 2] {
+    [
+        format!("<!-- homeboy:comment-key={} -->", comment_key),
+        format!("<!-- homeboy-action-results:key={} -->", comment_key),
+    ]
+}
+
+/// Does `body` carry the comment-key marker under either format?
+fn comment_matches_key(body: &str, comment_key: &str) -> bool {
+    let markers = comment_key_markers(comment_key);
+    markers.iter().any(|m| body.contains(m.as_str()))
+}
+
+/// Parse section blocks out of a comment body. Honors BOTH new and legacy
+/// marker formats.
+///
+/// Returns an ordered `Vec<(key, body)>` in the order encountered. Keys are
+/// trimmed; bodies have leading/trailing newlines stripped. Unpaired or
+/// malformed markers are skipped silently (no panic, no error) so the merge
+/// loop can always make forward progress even if a comment body was hand-
+/// edited.
+pub fn parse_comment_sections(body: &str) -> Vec<(String, String)> {
+    // Single regex that matches either marker format. The `regex` crate does
+    // not support backreferences, so we capture both start-key and end-key
+    // and verify equality post-match. Both formats:
+    //   <!-- homeboy:section-key=KEY:start -->       (new)
+    //   <!-- homeboy-action-section:key=KEY:start --> (legacy)
+    let re = regex::Regex::new(
+        r"(?s)<!-- homeboy(?:-action-section:key|:section-key)=([^:]*?):start -->\n?(.*?)\n?<!-- homeboy(?:-action-section:key|:section-key)=([^:]*?):end -->",
+    )
+    .expect("section-marker regex is valid");
+
+    let mut out: Vec<(String, String)> = Vec::new();
+    for caps in re.captures_iter(body) {
+        let start_key = caps.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+        let end_key = caps.get(3).map(|m| m.as_str().trim()).unwrap_or("");
+        if start_key.is_empty() || start_key != end_key {
+            // Unmatched or unnamed — skip.
+            continue;
+        }
+        let inner = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+        let inner = inner.trim_matches('\n').to_string();
+        out.push((start_key.to_string(), inner));
+    }
+    out
+}
+
+/// Extract the header line(s) of a comment — everything between the outer
+/// marker and the first section marker, minus the outer marker itself.
+///
+/// Used to preserve an existing header when merging (so we don't clobber
+/// `## Homeboy Results — <component>` that an earlier invocation wrote).
+fn extract_header(body: &str) -> Option<String> {
+    // Find the end of the outer marker line. Either format.
+    let outer_end = body.find("-->\n")?;
+    let after_outer = &body[outer_end + 4..];
+    // First section marker (either format).
+    let first_section_idx = after_outer
+        .find("<!-- homeboy:section-key=")
+        .or_else(|| after_outer.find("<!-- homeboy-action-section:key="))?;
+    let header = after_outer[..first_section_idx].trim_matches('\n').trim();
+    if header.is_empty() {
+        None
+    } else {
+        Some(header.to_string())
+    }
+}
+
+/// Merge `(section_key, body)` into `sections`. Replaces any existing entry
+/// for `section_key`, preserving the original position; otherwise appends.
+pub fn merge_section(
+    mut sections: Vec<(String, String)>,
+    section_key: &str,
+    body: String,
+) -> Vec<(String, String)> {
+    for entry in sections.iter_mut() {
+        if entry.0 == section_key {
+            entry.1 = body;
+            return sections;
+        }
+    }
+    sections.push((section_key.to_string(), body));
+    sections
+}
+
+/// Render a comment body from a set of sections.
+///
+/// - `comment_key` → outer marker (new format).
+/// - `header` → optional line(s) written after the outer marker.
+/// - `sections` → section map. Insertion order is preserved only when
+///   `explicit_order` is `None`; otherwise explicit-ordered keys come first
+///   in the given order, and any remaining keys follow alphabetically.
+/// - Output is always newline-normalized with a trailing newline and uses the
+///   **new** marker format. Re-rendering a legacy-parsed body produces
+///   new-format output (migration path).
+pub fn render_comment(
+    comment_key: &str,
+    header: Option<&str>,
+    sections: &[(String, String)],
+    explicit_order: Option<&[String]>,
+) -> String {
+    let ordered = order_sections(sections, explicit_order);
+
+    let mut out = String::new();
+    out.push_str(&format!("<!-- homeboy:comment-key={} -->\n", comment_key));
+    if let Some(h) = header {
+        let h = h.trim_matches('\n');
+        if !h.is_empty() {
+            out.push_str(h);
+            out.push('\n');
+            out.push('\n');
+        }
+    }
+
+    for (idx, (key, body)) in ordered.iter().enumerate() {
+        out.push_str(&format!("<!-- homeboy:section-key={}:start -->\n", key));
+        let body_trimmed = body.trim_matches('\n');
+        if !body_trimmed.is_empty() {
+            out.push_str(body_trimmed);
+            out.push('\n');
+        }
+        out.push_str(&format!("<!-- homeboy:section-key={}:end -->", key));
+        if idx + 1 < ordered.len() {
+            out.push_str("\n\n");
+        } else {
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+/// Apply the ordering rule: explicit-ordered keys first (in given order),
+/// remaining keys alphabetically. Unknown keys in `explicit_order` are
+/// silently dropped (nothing to render).
+fn order_sections<'a>(
+    sections: &'a [(String, String)],
+    explicit_order: Option<&[String]>,
+) -> Vec<&'a (String, String)> {
+    match explicit_order {
+        Some(order) => {
+            let mut out: Vec<&(String, String)> = Vec::new();
+            let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
+            // 1. Keys in explicit order (only if present in sections).
+            for key in order {
+                if let Some(entry) = sections.iter().find(|(k, _)| k == key) {
+                    out.push(entry);
+                    seen.insert(entry.0.as_str());
+                }
+            }
+
+            // 2. Remaining keys, alphabetical.
+            let mut leftovers: Vec<&(String, String)> = sections
+                .iter()
+                .filter(|(k, _)| !seen.contains(k.as_str()))
+                .collect();
+            leftovers.sort_by(|a, b| a.0.cmp(&b.0));
+            out.extend(leftovers);
+
+            out
+        }
+        None => {
+            // Pure alphabetical.
+            let mut out: Vec<&(String, String)> = sections.iter().collect();
+            out.sort_by(|a, b| a.0.cmp(&b.0));
+            out
+        }
+    }
+}
+
+/// List all PR issue-comments that carry the given comment-key marker (either
+/// format). Returns `(id, body)` pairs so the merge step can parse each body.
+fn list_matching_comments(
+    repo: &GitHubRepo,
+    pr_number: u64,
+    comment_key: &str,
+) -> Result<Vec<FetchedComment>> {
+    let args: Vec<String> = vec![
+        "api".into(),
+        format!(
+            "repos/{}/{}/issues/{}/comments?per_page=100",
+            repo.owner, repo.repo, pr_number
+        ),
+        "--paginate".into(),
+    ];
+    let raw = run_gh(&args)?;
+    parse_comments_list_json(&raw, comment_key)
+}
+
+/// Parse `gh api --paginate issues/:n/comments` output and filter to those
+/// carrying the outer marker. With `--paginate`, `gh` concatenates JSON
+/// arrays (no separator between pages) — we re-parse as a stream.
+fn parse_comments_list_json(raw: &str, comment_key: &str) -> Result<Vec<FetchedComment>> {
+    #[derive(serde::Deserialize)]
+    struct RawComment {
+        id: u64,
+        body: Option<String>,
+    }
+
+    let mut out: Vec<FetchedComment> = Vec::new();
+
+    // `--paginate` output is one or more JSON arrays concatenated. Use a
+    // streaming deserializer to eat them in order.
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(out);
+    }
+    let de = serde_json::Deserializer::from_str(trimmed);
+    for value in de.into_iter::<Vec<RawComment>>() {
+        let page = value
+            .map_err(|e| Error::internal_json(e.to_string(), Some("gh api comments".into())))?;
+        for c in page {
+            let body = c.body.unwrap_or_default();
+            if comment_matches_key(&body, comment_key) {
+                out.push(FetchedComment { id: c.id, body });
+            }
+        }
+    }
+    Ok(out)
 }
 
 fn parse_issue_list_json(raw: &str, options: &IssueFindOptions) -> Result<Vec<GithubFindItem>> {
@@ -841,5 +1358,334 @@ mod tests {
     fn pr_state_gh_flag() {
         assert_eq!(PrState::Open.as_gh_flag(), "open");
         assert_eq!(PrState::Merged.as_gh_flag(), "merged");
+    }
+
+    // -----------------------------------------------------------------------
+    // Sectioned-comment primitive tests (#1348)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_sections_new_markers() {
+        let body = "\
+<!-- homeboy:comment-key=ci:homeboy -->
+## Homeboy Results — `homeboy`
+
+<!-- homeboy:section-key=lint:start -->
+:white_check_mark: **lint**
+<!-- homeboy:section-key=lint:end -->
+
+<!-- homeboy:section-key=test:start -->
+:x: **test**
+1 failure
+<!-- homeboy:section-key=test:end -->
+";
+        let sections = parse_comment_sections(body);
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].0, "lint");
+        assert_eq!(sections[0].1, ":white_check_mark: **lint**");
+        assert_eq!(sections[1].0, "test");
+        assert!(sections[1].1.contains(":x: **test**"));
+        assert!(sections[1].1.contains("1 failure"));
+    }
+
+    #[test]
+    fn parse_sections_legacy_markers() {
+        // Body shape written by homeboy-action today (merge-pr-comment.py).
+        let body = "\
+<!-- homeboy-action-results:key=ci:homeboy -->
+## Homeboy Results — `homeboy`
+
+<!-- homeboy-action-section:key=lint:start -->
+:white_check_mark: **lint**
+<!-- homeboy-action-section:key=lint:end -->
+
+<!-- homeboy-action-section:key=test:start -->
+:x: **test**
+<!-- homeboy-action-section:key=test:end -->
+";
+        let sections = parse_comment_sections(body);
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].0, "lint");
+        assert!(sections[0].1.contains("white_check_mark"));
+        assert_eq!(sections[1].0, "test");
+    }
+
+    #[test]
+    fn parse_sections_mixed_markers() {
+        // Edge: a body that was rendered half-new, half-legacy (shouldn't
+        // happen in practice, but the parser must not die if it does).
+        let body = "\
+<!-- homeboy:comment-key=ci:homeboy -->
+
+<!-- homeboy:section-key=lint:start -->
+new-style lint
+<!-- homeboy:section-key=lint:end -->
+
+<!-- homeboy-action-section:key=test:start -->
+legacy-style test
+<!-- homeboy-action-section:key=test:end -->
+";
+        let sections = parse_comment_sections(body);
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].1, "new-style lint");
+        assert_eq!(sections[1].1, "legacy-style test");
+    }
+
+    #[test]
+    fn parse_sections_returns_empty_for_unmarkered_body() {
+        let body = "Just a regular PR comment.\n\nNo markers here.\n";
+        assert!(parse_comment_sections(body).is_empty());
+    }
+
+    #[test]
+    fn parse_sections_skips_malformed_blocks() {
+        // Start without matching end — should be ignored, not panic.
+        let body = "\
+<!-- homeboy:section-key=lint:start -->
+never-ends
+";
+        assert!(parse_comment_sections(body).is_empty());
+    }
+
+    #[test]
+    fn render_comment_writes_new_markers() {
+        let sections = vec![
+            ("lint".to_string(), "lint body".to_string()),
+            ("test".to_string(), "test body".to_string()),
+        ];
+        let out = render_comment("ci:homeboy", Some("## Header"), &sections, None);
+        assert!(out.starts_with("<!-- homeboy:comment-key=ci:homeboy -->\n"));
+        assert!(out.contains("## Header"));
+        assert!(out.contains("<!-- homeboy:section-key=lint:start -->"));
+        assert!(out.contains("<!-- homeboy:section-key=lint:end -->"));
+        assert!(out.contains("<!-- homeboy:section-key=test:start -->"));
+        // No legacy markers in rendered output.
+        assert!(!out.contains("homeboy-action-results"));
+        assert!(!out.contains("homeboy-action-section"));
+    }
+
+    #[test]
+    fn render_comment_round_trips_through_parse() {
+        let sections = vec![
+            ("audit".to_string(), "audit body\nmulti-line".to_string()),
+            ("lint".to_string(), "lint body".to_string()),
+        ];
+        let rendered = render_comment("ci:x", None, &sections, None);
+        let reparsed = parse_comment_sections(&rendered);
+
+        // Alphabetical default → audit before lint.
+        assert_eq!(reparsed.len(), 2);
+        assert_eq!(reparsed[0].0, "audit");
+        assert_eq!(reparsed[0].1, "audit body\nmulti-line");
+        assert_eq!(reparsed[1].0, "lint");
+    }
+
+    #[test]
+    fn render_comment_alphabetical_by_default() {
+        let sections = vec![
+            ("test".to_string(), "t".to_string()),
+            ("audit".to_string(), "a".to_string()),
+            ("lint".to_string(), "l".to_string()),
+        ];
+        let out = render_comment("k", None, &sections, None);
+        let audit_pos = out.find("section-key=audit:start").unwrap();
+        let lint_pos = out.find("section-key=lint:start").unwrap();
+        let test_pos = out.find("section-key=test:start").unwrap();
+        assert!(audit_pos < lint_pos);
+        assert!(lint_pos < test_pos);
+    }
+
+    #[test]
+    fn render_comment_honors_explicit_order() {
+        let sections = vec![
+            ("audit".to_string(), "a".to_string()),
+            ("lint".to_string(), "l".to_string()),
+            ("test".to_string(), "t".to_string()),
+        ];
+        let order = vec!["lint".to_string(), "test".to_string(), "audit".to_string()];
+        let out = render_comment("k", None, &sections, Some(&order));
+        let lint_pos = out.find("section-key=lint:start").unwrap();
+        let test_pos = out.find("section-key=test:start").unwrap();
+        let audit_pos = out.find("section-key=audit:start").unwrap();
+        assert!(lint_pos < test_pos);
+        assert!(test_pos < audit_pos);
+    }
+
+    #[test]
+    fn render_comment_unknown_keys_appended_alphabetically() {
+        let sections = vec![
+            ("zeta".to_string(), "z".to_string()),
+            ("alpha".to_string(), "a".to_string()),
+            ("lint".to_string(), "l".to_string()),
+            ("test".to_string(), "t".to_string()),
+        ];
+        // Only lint+test in explicit order — zeta and alpha are "unknown".
+        let order = vec!["lint".to_string(), "test".to_string()];
+        let out = render_comment("k", None, &sections, Some(&order));
+
+        let lint_pos = out.find("section-key=lint:start").unwrap();
+        let test_pos = out.find("section-key=test:start").unwrap();
+        let alpha_pos = out.find("section-key=alpha:start").unwrap();
+        let zeta_pos = out.find("section-key=zeta:start").unwrap();
+
+        // Explicit-order keys come first in their listed order.
+        assert!(lint_pos < test_pos);
+        // Unknown keys appended after, alphabetical among themselves.
+        assert!(test_pos < alpha_pos);
+        assert!(alpha_pos < zeta_pos);
+    }
+
+    #[test]
+    fn render_comment_explicit_order_ignores_missing_keys() {
+        let sections = vec![("lint".to_string(), "l".to_string())];
+        // `test` is in the order but not present in sections — should not appear
+        // in output.
+        let order = vec!["test".to_string(), "lint".to_string()];
+        let out = render_comment("k", None, &sections, Some(&order));
+        assert!(!out.contains("section-key=test:start"));
+        assert!(out.contains("section-key=lint:start"));
+    }
+
+    #[test]
+    fn merge_section_replaces_existing_preserves_position() {
+        let sections = vec![
+            ("lint".to_string(), "old lint".to_string()),
+            ("test".to_string(), "old test".to_string()),
+        ];
+        let merged = merge_section(sections, "lint", "new lint".to_string());
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].0, "lint");
+        assert_eq!(merged[0].1, "new lint");
+        assert_eq!(merged[1].0, "test");
+        assert_eq!(merged[1].1, "old test");
+    }
+
+    #[test]
+    fn merge_section_appends_when_absent() {
+        let sections = vec![("lint".to_string(), "lint".to_string())];
+        let merged = merge_section(sections, "test", "test".to_string());
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[1].0, "test");
+        assert_eq!(merged[1].1, "test");
+    }
+
+    #[test]
+    fn legacy_markers_rerender_as_new_markers() {
+        // This is the rollout compat path: an existing homeboy-action comment
+        // is read, parsed, re-rendered. The output must use ONLY new markers
+        // so subsequent reads are self-consistent.
+        let legacy_body = "\
+<!-- homeboy-action-results:key=ci:homeboy -->
+## Homeboy Results — `homeboy`
+
+<!-- homeboy-action-section:key=lint:start -->
+:white_check_mark: lint passed
+<!-- homeboy-action-section:key=lint:end -->
+
+<!-- homeboy-action-section:key=test:start -->
+:x: 1 test failure
+<!-- homeboy-action-section:key=test:end -->
+";
+        let sections = parse_comment_sections(legacy_body);
+        assert_eq!(sections.len(), 2);
+
+        let rendered = render_comment(
+            "ci:homeboy",
+            Some("## Homeboy Results — `homeboy`"),
+            &sections,
+            None,
+        );
+
+        // New markers only.
+        assert!(rendered.contains("<!-- homeboy:comment-key=ci:homeboy -->"));
+        assert!(rendered.contains("<!-- homeboy:section-key=lint:start -->"));
+        assert!(rendered.contains("<!-- homeboy:section-key=test:end -->"));
+        assert!(!rendered.contains("homeboy-action-results"));
+        assert!(!rendered.contains("homeboy-action-section"));
+
+        // Content preserved.
+        assert!(rendered.contains(":white_check_mark: lint passed"));
+        assert!(rendered.contains(":x: 1 test failure"));
+    }
+
+    #[test]
+    fn comment_matches_key_recognizes_both_marker_formats() {
+        let new_body = "<!-- homeboy:comment-key=ci:x -->\nbody\n";
+        let legacy_body = "<!-- homeboy-action-results:key=ci:x -->\nbody\n";
+        let unrelated = "<!-- homeboy:comment-key=ci:y -->\nbody\n";
+        let unmarked = "just a comment\n";
+
+        assert!(comment_matches_key(new_body, "ci:x"));
+        assert!(comment_matches_key(legacy_body, "ci:x"));
+        assert!(!comment_matches_key(unrelated, "ci:x"));
+        assert!(!comment_matches_key(unmarked, "ci:x"));
+    }
+
+    #[test]
+    fn extract_header_reads_between_markers() {
+        let body = "\
+<!-- homeboy:comment-key=ci:x -->
+## Homeboy Results — `homeboy`
+
+<!-- homeboy:section-key=lint:start -->
+body
+<!-- homeboy:section-key=lint:end -->
+";
+        assert_eq!(
+            extract_header(body),
+            Some("## Homeboy Results — `homeboy`".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_header_empty_when_no_header_text() {
+        let body = "\
+<!-- homeboy:comment-key=ci:x -->
+<!-- homeboy:section-key=lint:start -->
+body
+<!-- homeboy:section-key=lint:end -->
+";
+        assert_eq!(extract_header(body), None);
+    }
+
+    #[test]
+    fn extract_header_legacy_markers() {
+        let body = "\
+<!-- homeboy-action-results:key=ci:x -->
+## Legacy Header
+
+<!-- homeboy-action-section:key=lint:start -->
+body
+<!-- homeboy-action-section:key=lint:end -->
+";
+        assert_eq!(extract_header(body), Some("## Legacy Header".to_string()));
+    }
+
+    #[test]
+    fn parse_comments_list_filters_by_key_and_handles_pagination() {
+        // Two pages: gh --paginate concatenates JSON arrays with no separator.
+        let raw = r#"[
+            {"id": 1, "body": "<!-- homeboy:comment-key=ci:x -->\nsection"},
+            {"id": 2, "body": "unrelated"}
+        ][
+            {"id": 3, "body": "<!-- homeboy-action-results:key=ci:x -->\nlegacy section"},
+            {"id": 4, "body": "<!-- homeboy:comment-key=other -->\nother"}
+        ]"#;
+        let got = parse_comments_list_json(raw, "ci:x").unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].id, 1);
+        assert_eq!(got[1].id, 3);
+    }
+
+    #[test]
+    fn parse_comments_list_empty_input_is_ok() {
+        let got = parse_comments_list_json("", "ci:x").unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn pr_comment_mode_default_is_fresh() {
+        let opts = PrCommentOptions::default();
+        assert_eq!(opts.mode, PrCommentMode::Fresh);
     }
 }


### PR DESCRIPTION
## Summary

Adds multi-section aggregation to `homeboy git pr comment`. Parallel CI jobs can each write one section of a shared sticky comment without clobbering the others — the merge, race consolidation, idempotency, and marker parsing live in Rust instead of ~470 lines of bash + Python in `homeboy-action`.

Closes #1348. Builds on #1334.

## CLI surface

Three mutually-exclusive shapes on `homeboy git pr comment`:

| Mode | Flags | Behavior |
|---|---|---|
| 1. Plain | (none) | Fresh comment, no marker, no find-or-update. |
| 2. Sticky whole-body | `--key <k>` | PR #1334 semantics — unchanged. |
| 3. **Sectioned (new)** | `--comment-key <outer> --section-key <inner>` | Merge `--body` into section `<inner>` of the shared comment tagged `<!-- homeboy:comment-key=<outer> -->`. |

Sectioned mode also accepts:
- `--header "## Homeboy Results — \`<component>\`"` — set on fresh comments; preserved on merge.
- `--section-order lint,test,audit` — pin section ordering (default is alphabetical).

Clap enforces the mutex: `--key` with `--comment-key`/`--section-key` is rejected, and `--comment-key` requires `--section-key` and vice versa.

## Library surface

`PrCommentOptions` now carries a `PrCommentMode` enum (`Fresh`, `StickyWholeBody { key }`, `Sectioned { comment_key, section_key, header, section_order }`). The old bare `key: Option<String>` field is gone — an enum makes the modes explicit and rejects nonsense combinations at compile time.

New pure functions (testable without shelling to `gh`):

- `parse_comment_sections` — honors BOTH new and legacy marker formats (rollout compat).
- `render_comment` — always writes new markers.
- `merge_section` — preserves section position on replace.
- `parse_comments_list_json` — handles `gh api --paginate` concatenated JSON arrays.
- `extract_header` — preserves an existing comment's title across merges.

## Race resolution + idempotency

On PATCH:
- **Multiple comments** with the outer marker → lowest id is canonical, sections merged from all (current invocation wins last for duplicate keys), canonical PATCHed, duplicates DELETEd.
- **Failed DELETEs** are warnings, not errors — next invocation consolidates. The output carries a `warnings: []` field listing stuck ids.
- **Byte-identical body** → skip the PATCH entirely and emit `action: "pr.comment.section.noop"`. Successful `run`, exit 0.

## Marker rollout compat

Parser accepts both formats so the primitive can adopt in-flight comments the action wrote:

```
NEW (written on render):
  <!-- homeboy:comment-key=<outer> -->
  <!-- homeboy:section-key=<inner>:start -->
  <!-- homeboy:section-key=<inner>:end -->

LEGACY (recognized only):
  <!-- homeboy-action-results:key=<outer> -->
  <!-- homeboy-action-section:key=<inner>:start -->
  <!-- homeboy-action-section:key=<inner>:end -->
```

Re-rendering a legacy body migrates it to new markers on the next invocation — no coordinated cutover required. The legacy branch of the parser can be dropped once downstream action consumers have rolled over.

## Tests

21 new pure-Rust unit tests on top of the existing 10 from #1334:

- parse on new / legacy / mixed / unmarkered / malformed bodies
- render round-trips through parse
- alphabetical default ordering
- explicit `--section-order` honored
- unknown keys in explicit order appended alphabetically at the end
- explicit order ignores keys missing from sections
- `merge_section` preserves position on replace / appends on insert
- **legacy-marker body → re-rendered as new-marker output (migration proof)**
- paginated `gh api` comment list parsing
- `comment_matches_key` recognizes both formats
- `extract_header` on new / legacy / empty bodies

All green. `cargo test --lib core::git::github` → **31 pass / 0 fail**.

Full `cargo test --lib` → 1229 pass, 5 fail — **the same 5 pre-existing flakes** documented in #1334 (`signature_check_*`, `test_run_topology_script`, `write_standalone_creates_and_reads_back`). Zero new regressions.

## Deliberately out of scope

- **Consumer migration of `homeboy-action`**. Belongs in Extra-Chill/homeboy-action#138 — swap the bash/Python merger for `homeboy git pr comment --comment-key --section-key`.
- **Dropping the legacy marker branch.** Kept for rollout safety. Delete once action consumers have flipped over (tracked in #1354).
- **Default rank map baked into core.** `lint:10, test:20, audit:30` etc. is action-specific presentation. Consumers pass `--section-order` if they want that order.

## Heads-up for the `homeboy-action` migration (Extra-Chill/homeboy-action#138)

`merge-pr-comment.py` currently sorts sections via a soft rank map:

```python
rank_map = { "lint": 10, "build": 15, "test": 20, "audit": 30, "legacy": 90 }
```

→ Rendered PR comments show sections in the order **`lint, build, test, audit`** today.

This primitive's default is **alphabetical** (`audit, build, lint, test`). To preserve the current UX across the migration, the action needs to pass:

```
homeboy git pr comment <component> \
  --comment-key "$COMMENT_KEY" \
  --section-key "$SECTION_KEY" \
  --body-file <section> \
  --section-order lint,build,test,audit
```

Otherwise reviewers will see sections visually shuffle on the first CI run after rollout. Keeping the explicit rank out of core was deliberate (core is generic, presentation is action-specific), but the migrator should not miss this one.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted the sectioned-comment module (`PrCommentMode` enum, `parse_comment_sections` / `render_comment` / `merge_section` / race-consolidation flow), CLI wiring in `commands/git.rs`, and the 21 new unit tests based on the Option A design in #1348. Reviewed `homeboy-action/scripts/pr/merge-pr-comment.py` to keep the parser byte-compatible with comments the action already wrote. Chris reviewed and directed the design.

Closes #1348.

