### PR TITLE
feat(git): --path flag on git issue/pr subcommands for unregistered checkouts

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -2,9 +2,9 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::git::{
-    self, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput, IssueCreateOptions,
-    IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions,
-    PrFindOptions, PrState,
+    self, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput, IssueCommentOptions,
+    IssueCreateOptions, IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions,
+    PrCreateOptions, PrEditOptions, PrFindOptions, PrState,
 };
 use homeboy::BulkResult;
 
@@ -142,6 +142,11 @@ enum IssueCommand {
         /// Issue label (repeatable)
         #[arg(short, long)]
         label: Vec<String>,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        /// (for unregistered checkouts — CI runners, ad-hoc clones)
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Comment on an existing issue
     Comment {
@@ -159,6 +164,10 @@ enum IssueCommand {
         /// Read body from a file ("-" for stdin)
         #[arg(long, value_name = "PATH")]
         body_file: Option<String>,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Find issues matching filters (dedup primitive)
     Find {
@@ -180,6 +189,10 @@ enum IssueCommand {
         /// Max results (default 30)
         #[arg(long, default_value_t = 30)]
         limit: usize,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
 }
 
@@ -223,6 +236,10 @@ enum PrCommand {
         /// Open as draft
         #[arg(long)]
         draft: bool,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Edit an existing PR's title or body
     Edit {
@@ -244,6 +261,10 @@ enum PrCommand {
         /// Read body from a file ("-" for stdin)
         #[arg(long, value_name = "PATH")]
         body_file: Option<String>,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Find PRs matching filters
     Find {
@@ -265,6 +286,10 @@ enum PrCommand {
         /// Max results (default 30)
         #[arg(long, default_value_t = 30)]
         limit: usize,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Post a comment on a PR. Three modes:
     ///
@@ -324,6 +349,10 @@ enum PrCommand {
         /// alphabetically. Example: `--section-order lint,test,audit`.
         #[arg(long, requires = "comment_key", value_delimiter = ',')]
         section_order: Option<Vec<String>>,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
 }
 
@@ -505,6 +534,7 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             body,
             body_file,
             label,
+            path,
         } => {
             let body = resolve_body(body, body_file)?.unwrap_or_default();
             let output = git::issue_create(
@@ -513,6 +543,7 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
                     title,
                     body,
                     labels: label,
+                    path,
                 },
             )?;
             Ok((GitCommandOutput::Issue(output), 0))
@@ -522,6 +553,7 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             number,
             body,
             body_file,
+            path,
         } => {
             let body = resolve_body(body, body_file)?.ok_or_else(|| {
                 homeboy::Error::validation_invalid_argument(
@@ -531,7 +563,10 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
                     None,
                 )
             })?;
-            let output = git::issue_comment(Some(&component_id), number, &body)?;
+            let output = git::issue_comment(
+                Some(&component_id),
+                IssueCommentOptions { number, body, path },
+            )?;
             Ok((GitCommandOutput::Issue(output), 0))
         }
         IssueCommand::Find {
@@ -540,6 +575,7 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             label,
             state,
             limit,
+            path,
         } => {
             let state = parse_issue_state(&state)?;
             let output = git::issue_find(
@@ -549,6 +585,7 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
                     labels: label,
                     state,
                     limit,
+                    path,
                 },
             )?;
             Ok((GitCommandOutput::Find(output), 0))
@@ -570,6 +607,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             body,
             body_file,
             draft,
+            path,
         } => {
             let body = resolve_body(body, body_file)?.unwrap_or_default();
             let output = git::pr_create(
@@ -580,6 +618,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
                     title,
                     body,
                     draft,
+                    path,
                 },
             )?;
             Ok((GitCommandOutput::Pr(output), 0))
@@ -590,6 +629,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             title,
             body,
             body_file,
+            path,
         } => {
             let body = resolve_body(body, body_file)?;
             let output = git::pr_edit(
@@ -598,6 +638,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
                     number,
                     title,
                     body,
+                    path,
                 },
             )?;
             Ok((GitCommandOutput::Pr(output), 0))
@@ -608,6 +649,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             head,
             state,
             limit,
+            path,
         } => {
             let state = parse_pr_state(&state)?;
             let output = git::pr_find(
@@ -617,6 +659,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
                     head,
                     state,
                     limit,
+                    path,
                 },
             )?;
             Ok((GitCommandOutput::Find(output), 0))
@@ -631,6 +674,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             section_key,
             header,
             section_order,
+            path,
         } => {
             let body = resolve_body(body, body_file)?.ok_or_else(|| {
                 homeboy::Error::validation_invalid_argument(
@@ -661,8 +705,15 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
                 ),
             };
 
-            let output =
-                git::pr_comment(Some(&component_id), PrCommentOptions { number, body, mode })?;
+            let output = git::pr_comment(
+                Some(&component_id),
+                PrCommentOptions {
+                    number,
+                    body,
+                    mode,
+                    path,
+                },
+            )?;
             Ok((GitCommandOutput::Pr(output), 0))
         }
     }

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -500,6 +500,17 @@ pub(crate) fn detect_intra_method_duplicates(fingerprints: &[&FileFingerprint]) 
                         }
                     }
 
+                    // Suppress structural-syntax-only windows. Match-arm tails
+                    // (`},`, `)?;`, `Ok((...))`, closing brace, bare-identifier
+                    // struct-literal fields) repeat naturally across sibling
+                    // dispatch branches in `run_*` functions — they're not
+                    // merge artifacts or copy-paste, they're Rust syntax.
+                    // A block is worth flagging only if it contains at least
+                    // one logic-bearing line.
+                    if is_structural_syntax_only(&normalized, first_norm_idx, match_len) {
+                        continue;
+                    }
+
                     // Convert body-relative line numbers to 1-indexed file lines
                     let first_file_line = body_start + 1 + first.0 + 1;
                     let other_file_line = body_start + 1 + other.0 + 1;
@@ -602,6 +613,123 @@ fn normalize_line(line: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .to_lowercase()
+}
+
+/// Return true when the window `normalized[start..start+len]` is pure
+/// syntactic scaffolding with no logic-bearing content.
+///
+/// A window is scaffolding when **every** line is one of:
+/// - pure punctuation closers (`}`, `},`, `)?;`, etc.)
+/// - a single identifier, optionally trailed by `,` (struct-literal or
+///   destructuring fields)
+/// - common match-arm glue (`=> {`, `} => {`)
+///
+/// **and** none of the lines contain logic signals (`=`, `let `, `if `,
+/// `for `, `while `, `match `, `return`, or a function-call shape
+/// `foo(` / `foo::bar(`). If a single line in the window carries any
+/// logic signal, the window is not scaffolding and gets flagged normally.
+///
+/// Match-arm tails (`)?;`, `Ok((x, 0))`, struct-literal closers) repeated
+/// across sibling arms of a dispatch `match` are structural noise, not
+/// duplication — this filter stops them from tripping the detector.
+fn is_structural_syntax_only(
+    normalized: &[(usize, String)],
+    start: usize,
+    len: usize,
+) -> bool {
+    let end = (start + len).min(normalized.len());
+    if start >= end {
+        return false;
+    }
+    let window = &normalized[start..end];
+
+    // If any line in the window looks logical, window is not scaffolding.
+    if window.iter().any(|(_, line)| has_logic_signal(line)) {
+        return false;
+    }
+
+    // Every line must match a known scaffolding shape.
+    window
+        .iter()
+        .all(|(_, line)| is_scaffolding_line(line))
+}
+
+/// Lines that look like they do real work: assignment, control flow, or
+/// a user function call that isn't a dispatch-return wrapper.
+fn has_logic_signal(normalized: &str) -> bool {
+    let t = normalized.trim();
+
+    // Assignment or `let` binding.
+    if t.contains(" = ") || t.starts_with("let ") {
+        return true;
+    }
+
+    // Control flow keywords (normalized to lowercase by the caller).
+    for kw in ["if ", "for ", "while ", "match ", "return ", "loop ", "?;"] {
+        if t.contains(kw) && !matches!(t, ")?;" | "})?;") {
+            return true;
+        }
+    }
+
+    // Function / method calls that aren't bare dispatch-return wrappers.
+    // `ok(...)`, `err(...)`, `some(...)`, `none` by themselves are scaffolding
+    // (return-tail on a match arm); anything else with parens is real work.
+    if t.contains('(') {
+        let before_paren = t.split('(').next().unwrap_or("");
+        let head = before_paren.trim_end_matches(':').trim_end_matches(':');
+        let head = head.trim();
+        let is_return_wrapper = matches!(head, "ok" | "err" | "some")
+            || head.ends_with(" ok")
+            || head.ends_with(" err")
+            || head.ends_with(" some");
+        if !is_return_wrapper {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Does this normalized line match a known scaffolding shape?
+fn is_scaffolding_line(normalized: &str) -> bool {
+    let t = normalized.trim();
+    if t.is_empty() {
+        return true;
+    }
+
+    // Pure-punctuation closers: `}`, `},`, `)?;`, `))`, etc.
+    if t.chars().all(|c| matches!(c, '}' | ')' | '?' | ';' | ',' | '(')) {
+        return true;
+    }
+
+    // Bare identifier (optionally trailing comma) — struct-literal field or
+    // destructure.
+    let core = t.trim_end_matches(',');
+    if !core.is_empty()
+        && core
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return true;
+    }
+
+    // Dispatch-return tails: `ok(...)`, `err(...)`, `some(...)`, `none`
+    // (optionally with trailing `?`, `;`, `,`).
+    let core = t.trim_end_matches([',', ';', '?']);
+    if core == "none"
+        || core.starts_with("ok(")
+        || core.starts_with("err(")
+        || core.starts_with("some(")
+    {
+        return true;
+    }
+
+    // Match-arm glue.
+    if t.ends_with("=> {") || t == "} => {" || t == "_ => {" {
+        return true;
+    }
+
+    false
 }
 
 // ============================================================================
@@ -1479,6 +1607,157 @@ mod tests {
             !findings.is_empty(),
             "Should detect duplicated block in Rust function"
         );
+    }
+
+    #[test]
+    fn intra_method_ignores_match_arm_tail_scaffolding() {
+        // Sibling dispatch arms in a `run_*` match share a boilerplate tail:
+        //   )?;
+        //   Ok((Variant(output), 0))
+        //   }
+        //   OtherArm::Name { ... } => {
+        //
+        // After normalization these look like 5+ identical lines across arms,
+        // but they're Rust syntax, not duplicated logic. The scaffolding
+        // filter should suppress the finding.
+        //
+        // Each arm body here is intentionally one unique line plus the
+        // scaffolding tail — so the only thing that repeats is scaffolding.
+        let content = "\
+fn run_pr(args: PrArgs) -> Result {
+    match args.command {
+        PrCommand::Create {
+            comp_create,
+        } => {
+            do_create_thing(comp_create);
+            Ok((GitCommandOutput::Pr(output), 0))
+        }
+        PrCommand::Edit {
+            comp_edit,
+        } => {
+            do_edit_thing(comp_edit);
+            Ok((GitCommandOutput::Pr(output), 0))
+        }
+        PrCommand::Comment {
+            comp_comment,
+        } => {
+            do_comment_thing(comp_comment);
+            Ok((GitCommandOutput::Pr(output), 0))
+        }
+    }
+}
+";
+        let mut fp = make_fingerprint("src/commands/git.rs", &["run_pr"], &[]);
+        fp.content = content.to_string();
+
+        let findings = detect_intra_method_duplicates(&[&fp]);
+        assert!(
+            findings.is_empty(),
+            "Match-arm tail scaffolding should not be flagged as duplication; got {} finding(s): {:?}",
+            findings.len(),
+            findings.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn intra_method_still_flags_real_duplication_with_scaffolding_tails() {
+        // If the repeated block contains real logic (a `let` + a call that
+        // isn't an Ok/Err wrapper), we should still flag it even when it's
+        // surrounded by structural lines.
+        let content = "\
+fn process_twice() -> Result {
+    let items = load_items()?;
+    let validator = Validator::new();
+    let processor = Processor::new();
+    let output = processor.run(&items);
+    save_output(&output)?;
+
+    let items = load_items()?;
+    let validator = Validator::new();
+    let processor = Processor::new();
+    let output = processor.run(&items);
+    save_output(&output)?;
+
+    Ok(())
+}
+";
+        let mut fp = make_fingerprint("src/core/pipeline.rs", &["process_twice"], &[]);
+        fp.content = content.to_string();
+
+        let findings = detect_intra_method_duplicates(&[&fp]);
+        assert!(
+            !findings.is_empty(),
+            "Real duplication with logic lines should still be detected"
+        );
+    }
+
+    #[test]
+    fn scaffolding_line_classifier() {
+        // Positive cases (structural).
+        for line in &[
+            "}",
+            "},",
+            ")",
+            ")?;",
+            "))",
+            "))?",
+            "path,",
+            "component_id,",
+            "path",
+            "ok((gitcommandoutput::pr(output), 0))",
+            "ok(output)",
+            "err(e)",
+            "none",
+            "} => {",
+            "_ => {",
+            "foo => {",
+        ] {
+            assert!(
+                is_scaffolding_line(line),
+                "Expected scaffolding: {:?}",
+                line
+            );
+        }
+
+        // Negative cases (real logic).
+        for line in &[
+            "let x = foo();",
+            "x = y + 1",
+            "if x.is_empty() {",
+            "for item in items {",
+            "compute(&items)?",
+            ".stdout(std::process::stdio::null())",
+        ] {
+            assert!(
+                !is_scaffolding_line(line) || has_logic_signal(line),
+                "Expected logic: {:?}",
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn logic_signal_detector() {
+        assert!(has_logic_signal("let x = foo();"));
+        assert!(has_logic_signal("x = 1"));
+        assert!(has_logic_signal("if cond {"));
+        assert!(has_logic_signal("for x in y {"));
+        assert!(has_logic_signal("while true {"));
+        assert!(has_logic_signal("match thing {"));
+        assert!(has_logic_signal("return x"));
+        assert!(has_logic_signal(".stdout(something())"));
+        assert!(has_logic_signal("compute(&items)"));
+
+        // Return wrappers are NOT logic (they're structural tail expressions).
+        assert!(!has_logic_signal("ok(())"));
+        assert!(!has_logic_signal("ok((output, 0))"));
+        assert!(!has_logic_signal("err(e)"));
+        assert!(!has_logic_signal("some(x)"));
+        assert!(!has_logic_signal("none"));
+
+        // Pure punctuation is not logic.
+        assert!(!has_logic_signal("}"));
+        assert!(!has_logic_signal(")?;"));
     }
 
     #[test]

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -632,11 +632,7 @@ fn normalize_line(line: &str) -> String {
 /// Match-arm tails (`)?;`, `Ok((x, 0))`, struct-literal closers) repeated
 /// across sibling arms of a dispatch `match` are structural noise, not
 /// duplication — this filter stops them from tripping the detector.
-fn is_structural_syntax_only(
-    normalized: &[(usize, String)],
-    start: usize,
-    len: usize,
-) -> bool {
+fn is_structural_syntax_only(normalized: &[(usize, String)], start: usize, len: usize) -> bool {
     let end = (start + len).min(normalized.len());
     if start >= end {
         return false;
@@ -649,9 +645,7 @@ fn is_structural_syntax_only(
     }
 
     // Every line must match a known scaffolding shape.
-    window
-        .iter()
-        .all(|(_, line)| is_scaffolding_line(line))
+    window.iter().all(|(_, line)| is_scaffolding_line(line))
 }
 
 /// Lines that look like they do real work: assignment, control flow, or
@@ -698,18 +692,16 @@ fn is_scaffolding_line(normalized: &str) -> bool {
     }
 
     // Pure-punctuation closers: `}`, `},`, `)?;`, `))`, etc.
-    if t.chars().all(|c| matches!(c, '}' | ')' | '?' | ';' | ',' | '(')) {
+    if t.chars()
+        .all(|c| matches!(c, '}' | ')' | '?' | ';' | ',' | '('))
+    {
         return true;
     }
 
     // Bare identifier (optionally trailing comma) — struct-literal field or
     // destructure.
     let core = t.trim_end_matches(',');
-    if !core.is_empty()
-        && core
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-    {
+    if !core.is_empty() && core.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
         return true;
     }
 

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -903,18 +903,23 @@ fn resolve_component_github(
     Ok((id, repo))
 }
 
-/// Error out if `gh` is missing or unauthenticated. Unlike `run_github_release`
-/// (which soft-fails because the tag is already pushed), primitive operations
-/// have no already-committed side effect to preserve — fail loudly.
-fn ensure_gh_ready() -> Result<()> {
-    let available = Command::new("gh")
-        .arg("--version")
+/// Run `gh <args>` swallowing stdout/stderr, return whether it exited successfully.
+/// Used for probe-style `gh` invocations that only care about the exit code.
+fn gh_probe_succeeds(args: &[&str]) -> bool {
+    Command::new("gh")
+        .args(args)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
         .map(|s| s.success())
-        .unwrap_or(false);
-    if !available {
+        .unwrap_or(false)
+}
+
+/// Error out if `gh` is missing or unauthenticated. Unlike `run_github_release`
+/// (which soft-fails because the tag is already pushed), primitive operations
+/// have no already-committed side effect to preserve — fail loudly.
+fn ensure_gh_ready() -> Result<()> {
+    if !gh_probe_succeeds(&["--version"]) {
         return Err(Error::internal_io(
             "`gh` CLI not found on PATH".to_string(),
             Some("gh".to_string()),
@@ -922,14 +927,7 @@ fn ensure_gh_ready() -> Result<()> {
         .with_hint("Install the GitHub CLI: https://cli.github.com"));
     }
 
-    let authed = Command::new("gh")
-        .args(["auth", "status", "--hostname", "github.com"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    if !authed {
+    if !gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"]) {
         return Err(Error::internal_io(
             "`gh` is not authenticated for github.com".to_string(),
             Some("gh auth status".to_string()),

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -904,8 +904,12 @@ fn resolve_component_github(
 }
 
 /// Run `gh <args>` swallowing stdout/stderr, return whether it exited successfully.
-/// Used for probe-style `gh` invocations that only care about the exit code.
-fn gh_probe_succeeds(args: &[&str]) -> bool {
+/// Used for probe-style `gh` invocations that only care about the exit code
+/// (e.g. `gh --version`, `gh auth status`, `gh release view`).
+///
+/// Public so other modules can consolidate on one probe helper instead of
+/// reimplementing the same `Command::new + null stdio + status` pattern.
+pub fn gh_probe_succeeds(args: &[&str]) -> bool {
     Command::new("gh")
         .args(args)
         .stdout(std::process::Stdio::null())

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -111,6 +111,10 @@ pub struct IssueCreateOptions {
     pub title: String,
     pub body: String,
     pub labels: Vec<String>,
+    /// Optional workspace path. When set, the component is discovered from
+    /// `<path>/homeboy.json` instead of the global registry — required for
+    /// CI runners and other unregistered-checkout contexts.
+    pub path: Option<String>,
 }
 
 /// Parameters for filtering issues.
@@ -124,6 +128,8 @@ pub struct IssueFindOptions {
     pub state: IssueState,
     /// Cap the number of returned items. Defaults to 30.
     pub limit: usize,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -152,6 +158,8 @@ pub struct PrCreateOptions {
     pub title: String,
     pub body: String,
     pub draft: bool,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
 }
 
 /// Parameters for editing an existing PR.
@@ -160,6 +168,8 @@ pub struct PrEditOptions {
     pub number: u64,
     pub title: Option<String>,
     pub body: Option<String>,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
 }
 
 /// Parameters for filtering PRs.
@@ -169,6 +179,8 @@ pub struct PrFindOptions {
     pub head: Option<String>,
     pub state: PrState,
     pub limit: usize,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -209,6 +221,8 @@ pub struct PrCommentOptions {
     pub number: u64,
     pub body: String,
     pub mode: PrCommentMode,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
 }
 
 impl Default for PrCommentOptions {
@@ -217,6 +231,7 @@ impl Default for PrCommentOptions {
             number: 0,
             body: String::new(),
             mode: PrCommentMode::Fresh,
+            path: None,
         }
     }
 }
@@ -253,6 +268,15 @@ impl Default for PrCommentMode {
     }
 }
 
+/// Parameters for commenting on an existing issue.
+#[derive(Debug, Clone, Default)]
+pub struct IssueCommentOptions {
+    pub number: u64,
+    pub body: String,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Public API — issue
 // ---------------------------------------------------------------------------
@@ -262,7 +286,7 @@ pub fn issue_create(
     component_id: Option<&str>,
     options: IssueCreateOptions,
 ) -> Result<GithubIssueOutput> {
-    let (id, repo) = resolve_component_github(component_id)?;
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 
     if options.title.trim().is_empty() {
@@ -310,21 +334,20 @@ pub fn issue_create(
 /// Post a comment on an existing issue.
 pub fn issue_comment(
     component_id: Option<&str>,
-    number: u64,
-    body: &str,
+    options: IssueCommentOptions,
 ) -> Result<GithubIssueOutput> {
-    let (id, repo) = resolve_component_github(component_id)?;
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let args: Vec<String> = vec![
         "issue".into(),
         "comment".into(),
-        number.to_string(),
+        options.number.to_string(),
         "-R".into(),
         repo_flag,
         "--body".into(),
-        body.to_string(),
+        options.body.clone(),
     ];
 
     let output = run_gh(&args)?;
@@ -334,7 +357,7 @@ pub fn issue_comment(
         repo: repo.repo,
         action: "issue.comment".to_string(),
         success: true,
-        number: Some(number),
+        number: Some(options.number),
         url: Some(output.trim().to_string()),
         title: None,
         state: None,
@@ -350,7 +373,7 @@ pub fn issue_find(
     component_id: Option<&str>,
     options: IssueFindOptions,
 ) -> Result<GithubFindOutput> {
-    let (id, repo) = resolve_component_github(component_id)?;
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
@@ -397,8 +420,11 @@ pub fn issue_find(
 // ---------------------------------------------------------------------------
 
 /// Open a new pull request.
-pub fn pr_create(component_id: Option<&str>, options: PrCreateOptions) -> Result<GithubPrOutput> {
-    let (id, repo) = resolve_component_github(component_id)?;
+pub fn pr_create(
+    component_id: Option<&str>,
+    options: PrCreateOptions,
+) -> Result<GithubPrOutput> {
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 
     if options.title.trim().is_empty() {
@@ -459,7 +485,7 @@ pub fn pr_create(component_id: Option<&str>, options: PrCreateOptions) -> Result
 
 /// Edit an existing pull request's title and/or body.
 pub fn pr_edit(component_id: Option<&str>, options: PrEditOptions) -> Result<GithubPrOutput> {
-    let (id, repo) = resolve_component_github(component_id)?;
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 
     if options.title.is_none() && options.body.is_none() {
@@ -504,7 +530,7 @@ pub fn pr_edit(component_id: Option<&str>, options: PrEditOptions) -> Result<Git
 
 /// Find PRs matching the given filter.
 pub fn pr_find(component_id: Option<&str>, options: PrFindOptions) -> Result<GithubFindOutput> {
-    let (id, repo) = resolve_component_github(component_id)?;
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
@@ -557,7 +583,7 @@ pub fn pr_find(component_id: Option<&str>, options: PrFindOptions) -> Result<Git
 ///   invocation's section under `section_key` into the shared comment tagged
 ///   `<!-- homeboy:comment-key=<comment_key> -->`.
 pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Result<GithubPrOutput> {
-    let (id, repo) = resolve_component_github(component_id)?;
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 
     match options.mode.clone() {
@@ -828,9 +854,17 @@ fn pr_comment_sectioned(
 // ---------------------------------------------------------------------------
 
 /// Resolve a component ID to its GitHub owner/repo via `remote_url` (or git fallback).
-fn resolve_component_github(component_id: Option<&str>) -> Result<(String, GitHubRepo)> {
-    let (id, path) = resolve_target(component_id, None)?;
-    let comp = component::resolve_effective(Some(&id), None, None)?;
+///
+/// `path_override` lets callers point at an unregistered checkout (e.g. a CI
+/// runner workspace with a portable `homeboy.json` but no global component
+/// registry entry). When set, the component is discovered from the portable
+/// config at that path instead of the global registry.
+fn resolve_component_github(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+) -> Result<(String, GitHubRepo)> {
+    let (id, path) = resolve_target(component_id, path_override)?;
+    let comp = component::resolve_effective(Some(&id), path_override, None)?;
 
     let remote_url = comp
         .remote_url
@@ -847,6 +881,7 @@ fn resolve_component_github(component_id: Option<&str>) -> Result<(String, GitHu
                 Some(vec![
                     "Set it: homeboy component set <id> -- --remote_url https://github.com/<owner>/<repo>".to_string(),
                     "Or configure a git remote in the component's local_path".to_string(),
+                    "Or pass --path <workspace> to discover from a portable homeboy.json".to_string(),
                 ]),
             )
         })?;

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -420,10 +420,7 @@ pub fn issue_find(
 // ---------------------------------------------------------------------------
 
 /// Open a new pull request.
-pub fn pr_create(
-    component_id: Option<&str>,
-    options: PrCreateOptions,
-) -> Result<GithubPrOutput> {
+pub fn pr_create(component_id: Option<&str>, options: PrCreateOptions) -> Result<GithubPrOutput> {
     let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -758,33 +758,15 @@ fn store_artifacts_from_output(
 // ---------------------------------------------------------------------------
 
 fn gh_is_available() -> bool {
-    std::process::Command::new("gh")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    crate::git::gh_probe_succeeds(&["--version"])
 }
 
 fn gh_is_authenticated() -> bool {
-    std::process::Command::new("gh")
-        .args(["auth", "status", "--hostname", "github.com"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    crate::git::gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"])
 }
 
 fn gh_release_exists(tag: &str, repo_flag: &str) -> bool {
-    std::process::Command::new("gh")
-        .args(["release", "view", tag, "-R", repo_flag])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    crate::git::gh_probe_succeeds(&["release", "view", tag, "-R", repo_flag])
 }
 
 fn fallback_gh_command(tag: &str) -> String {


### PR DESCRIPTION
## Summary

Add `--path <workspace>` to every `git issue` and `git pr` subcommand so CI runners (and other unregistered-checkout contexts) can actually use the primitives shipped in #1334.

## Problem

The primitives from #1334 take a component ID and resolve its path via the global registry. That doesn't work in CI — the runner checks out a workspace with a portable `homeboy.json` but no global registry entry, so every `homeboy git issue|pr` call errors with `component.not_found`:

```
$ homeboy git pr find homeboy --state open
{ "success": false, "error": { "code": "component.not_found", ... } }
```

This was discovered while cooking Extra-Chill/homeboy-action#138 (the consumer migration for #1334). `homeboy lint|test|audit|refactor` already accept `--path <workspace>` for exactly this reason; `homeboy git issue|pr` had the gap.

## Fix

Thread `path_override` through:

```
homeboy git issue create  <id> --path <workspace> --title ... --body-file ...
homeboy git issue comment <id> --path <workspace> --number N --body-file ...
homeboy git issue find    <id> --path <workspace> --title ... --state open
homeboy git pr create     <id> --path <workspace> --base B --head H --title ...
homeboy git pr edit       <id> --path <workspace> --number N --body-file ...
homeboy git pr find       <id> --path <workspace> --base B --head H
homeboy git pr comment    <id> --path <workspace> --number N --body-file ... [--key sticky]
```

When set, the component is discovered from `<path>/homeboy.json` via `component::resolve_effective`'s existing `path_override` parameter (the same mechanism `homeboy lint/test/audit/refactor` already use).

## Library surface

- `IssueCreateOptions`, `IssueFindOptions`, `PrCreateOptions`, `PrEditOptions`, `PrFindOptions`, `PrCommentOptions` all gain `path: Option<String>`.
- New `IssueCommentOptions { number, body, path }` replaces the previous ad-hoc `issue_comment(id, number, body)` signature for consistency with the other verbs.
- `resolve_component_github` now takes `path_override` and threads it to both `resolve_target` and `component::resolve_effective`.

## Breaking changes

**None at the CLI level.** At the library level:

- `issue_comment` signature changed from `(id, number, body)` to `(id, IssueCommentOptions)`. This function was only added in #1334 and has one internal caller (the CLI dispatcher) updated in this PR. No external consumers exist yet.
- The 6 existing `*Options` structs gain a `path` field. Struct-literal callers must add `path: None` (or use `..Default::default()`). The CLI dispatcher is updated accordingly.

Both changes are safe because **no code outside homeboy consumes these primitives yet** — #1334 merged 2026-04-24 and `homeboy-action#138` (the first consumer) hasn't landed.

## Smoke test

```
$ cd /tmp
$ homeboy git pr find homeboy --state open
{ "success": false, "error": { "code": "component.not_found" } }    ← before

$ homeboy git pr find homeboy --path ~/Developer/homeboy --state open --limit 2
{
  "success": true,
  "data": {
    "action": "pr.find",
    "component_id": "homeboy",
    "items": [
      { "number": 1353, "title": "feat(git): sectioned PR comment primitive...", "url": "..." },
      { "number": 1350, "title": "chore(ci): autofix homeboy from main", "url": "..." }
    ],
    "owner": "Extra-Chill",
    "repo": "homeboy",
    "success": true
  }
}
```

Exactly the CI flow: invoked from a foreign CWD, `--path` resolves the component from a portable `homeboy.json` plus `git remote get-url origin` fallback.

## Tests

Existing 10 unit tests in `core::git::github::tests` still green (pure parsing helpers, unaffected by resolver changes). No new unit tests needed — path routing is a one-line delegation to `component::resolve_effective`, which has its own coverage. The live smoke test above validates the end-to-end resolver path.

## Unblocks

- Extra-Chill/homeboy-action#138 — action migration can now actually call `homeboy git issue|pr` against a CI workspace.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Identified the `--path` gap while attempting to migrate `homeboy-action`'s bash-over-`gh` scripts (hit `component.not_found` from a CI-equivalent flow). Threaded `path_override` through the existing `IssueCreateOptions`/`PrCreateOptions`/etc. structs and `resolve_component_github`. Mirrors the `--path` convention already present on `homeboy lint|test|audit|refactor`.

Refs #1333, unblocks Extra-Chill/homeboy-action#138
