### PR TITLE
feat: add Bench capability — sibling of Lint/Test/Build with p95 regression ratchet

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,6 +241,7 @@
 - `build`
 - `lint`
 - `test`
+- `bench`
 - `actions`
 - `hooks`
 - `settings`

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -1,0 +1,179 @@
+# Bench Command
+
+Run performance benchmarks for a Homeboy component and surface regression
+deltas against a stored baseline.
+
+## Synopsis
+
+```bash
+homeboy bench <component> [options] [-- <runner-args>]
+```
+
+## Description
+
+The `bench` command invokes the extension's bench runner, which measures
+one or more scenarios over N iterations and emits a structured JSON
+results file. Homeboy parses the results, compares p95 latency against
+a saved baseline, and returns a structured report plus an exit code
+suitable for CI gates.
+
+`bench` is a sibling of `test`, `lint`, and `build` under homeboy's
+extension capability model. The runner contract, manifest shape, and
+baseline primitive (`homeboy.json` → `baselines.bench`) are shared with
+the other capabilities.
+
+## Arguments
+
+- `<component>`: Component to benchmark. Auto-detected from the current
+  working directory if omitted. The component must have a linked
+  extension that declares a `bench` capability.
+
+## Options
+
+- `--iterations <N>`: Iterations per scenario (default `10`). Forwarded
+  to the runner via `$HOMEBOY_BENCH_ITERATIONS`. Extensions may clamp.
+- `--baseline`: Save the current run as the new baseline under
+  `homeboy.json` → `baselines.bench`.
+- `--ignore-baseline`: Run without comparing to any saved baseline.
+- `--ratchet`: When scenarios improve (p95 got faster), auto-update the
+  saved baseline so the improvement "sticks". Ignored when the run
+  regresses.
+- `--regression-threshold <PERCENT>`: p95 regression tolerance (default
+  `5.0`). A scenario regresses when its current p95_ms exceeds
+  `baseline.p95_ms * (1 + threshold/100)`.
+- `--setting <key=value>`: Override component settings (may be repeated).
+- `--path <PATH>`: Override the component's `local_path` for this run.
+- `--json-summary`: Include a compact machine-readable summary in the
+  JSON output envelope (for CI wrappers).
+
+Arguments after `--` are passed verbatim to the extension's bench runner
+script (e.g., `--filter=scenario_id` for selective execution).
+
+## Examples
+
+```bash
+# Benchmark a component with defaults (10 iterations, 5% regression threshold)
+homeboy bench my-component
+
+# 50 iterations, stricter 2% regression threshold
+homeboy bench my-component --iterations 50 --regression-threshold 2.0
+
+# Save a new baseline
+homeboy bench my-component --baseline
+
+# Run with auto-ratchet on improvement
+homeboy bench my-component --ratchet
+
+# Select a single scenario via passthrough args
+homeboy bench my-component -- --filter=hot_path
+```
+
+## Baseline Ratchet Semantics
+
+The bench baseline is a list of per-scenario snapshots stored in
+`homeboy.json` under the `baselines.bench` key. Each snapshot records
+`{ id, p95_ms, p50_ms, mean_ms }` plus the iteration count at capture
+time.
+
+On every run without `--baseline` or `--ignore-baseline`:
+
+1. Each current scenario is matched against the baseline by `id`.
+2. A scenario regresses when current `p95_ms > baseline.p95_ms * (1 + threshold/100)`.
+   Default threshold: 5%.
+3. A scenario improves when current `p95_ms < baseline.p95_ms`.
+4. Scenarios present in one run but not the other are flagged as
+   `new_scenario_ids` / `removed_scenario_ids`. Neither state triggers
+   a regression by itself — they're informational.
+5. If any scenario regressed, the command exits `1` regardless of the
+   runner's own exit code.
+6. If any scenario improved and `--ratchet` is set, the baseline is
+   overwritten with the current snapshot.
+
+p95 was chosen as the regression signal over mean (too sensitive to
+one-off GC pauses) and p99 (too insensitive to real regressions).
+
+## Runner Contract
+
+The extension's bench script must:
+
+1. Read `$HOMEBOY_BENCH_ITERATIONS` to determine iteration count.
+2. Write its JSON output to `$HOMEBOY_BENCH_RESULTS_FILE`.
+3. Exit with a non-zero status only on runner-level failure (script
+   error, workload crash) — regressions are homeboy's domain.
+
+### JSON output schema
+
+```json
+{
+  "component_id": "string",
+  "iterations": 10,
+  "scenarios": [
+    {
+      "id": "scenario_slug",
+      "file": "tests/bench/some-workload.ext",
+      "iterations": 10,
+      "metrics": {
+        "mean_ms": 120.3,
+        "p50_ms": 118.0,
+        "p95_ms": 145.0,
+        "p99_ms": 160.0,
+        "min_ms": 110.0,
+        "max_ms": 172.0
+      },
+      "memory": { "peak_bytes": 41943040 }
+    }
+  ]
+}
+```
+
+- Top-level keys are strict — unknown top-level fields are rejected to
+  keep the contract honest.
+- Scenario-level unknown keys are **tolerated**, so extensions can emit
+  additional metadata (tags, environment info, warmup counts) without
+  breaking parsing.
+- `memory` is optional. Extensions that can't measure peak memory omit it.
+- `file` is optional but recommended for diagnostics.
+
+### Environment variables injected
+
+Bench scripts receive the standard runner contract plus bench-specific
+variables:
+
+- `HOMEBOY_BENCH_RESULTS_FILE` — where to write JSON output.
+- `HOMEBOY_BENCH_ITERATIONS` — iteration count to use.
+- `HOMEBOY_RUN_DIR` — per-run directory (shared with test/lint/build).
+- `HOMEBOY_EXTENSION_ID`, `HOMEBOY_COMPONENT_ID`, `HOMEBOY_COMPONENT_PATH`,
+  and the usual execution-context vars.
+- `HOMEBOY_SETTINGS_JSON` — component settings as JSON.
+
+## Component Requirements
+
+For a component to be benchmarkable, it must have:
+
+- A linked extension whose manifest declares a `bench` capability.
+- A bench-runner script provided by the extension.
+
+Extension manifest:
+
+```json
+{
+  "bench": {
+    "extension_script": "scripts/bench/bench-runner.sh"
+  }
+}
+```
+
+## Exit Codes
+
+- `0` — All scenarios passed, no regressions detected (or no baseline
+  exists yet).
+- `1` — At least one scenario regressed beyond the threshold, or the
+  runner itself failed.
+- Other non-zero — Runner exit code passthrough (extension-specific).
+
+## Related
+
+- [test](./test.md) — Test sibling capability; bench mirrors its flag
+  conventions for `--baseline`, `--ignore-baseline`, and `--ratchet`.
+- [lint](./lint.md) — Lint sibling capability.
+- [build](./build.md) — Build sibling capability.

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -3,6 +3,7 @@
 - [api](api.md)
 - [audit](audit.md) — code convention drift and structural analysis
 - [auth](auth.md)
+- [bench](bench.md) — performance benchmarks + p95 regression ratchet
 - [build](build.md)
 - [changelog](changelog.md)
 - [changes](changes.md)

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1,0 +1,238 @@
+use clap::Args;
+
+use homeboy::engine::execution_context::{self, ResolveOptions};
+use homeboy::engine::run_dir::RunDir;
+use homeboy::extension::bench as extension_bench;
+use homeboy::extension::bench::{
+    from_main_workflow, BenchCommandOutput, BenchRunWorkflowArgs,
+    DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+};
+use homeboy::extension::ExtensionCapability;
+
+use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
+use super::{CmdResult, GlobalArgs};
+
+#[derive(Args)]
+pub struct BenchArgs {
+    #[command(flatten)]
+    comp: PositionalComponentArgs,
+
+    /// Iterations per scenario (default 10). Forwarded to the runner via
+    /// HOMEBOY_BENCH_ITERATIONS. Individual extensions may clamp.
+    #[arg(long, default_value_t = 10)]
+    iterations: u64,
+
+    #[command(flatten)]
+    baseline_args: BaselineArgs,
+
+    /// Auto-update the baseline when scenarios improve (p95 got faster)
+    #[arg(long)]
+    ratchet: bool,
+
+    /// p95 regression tolerance as a percentage. A scenario regresses when
+    /// its current p95_ms exceeds baseline.p95_ms * (1 + threshold/100).
+    #[arg(long, value_name = "PERCENT", default_value_t = DEFAULT_REGRESSION_THRESHOLD_PERCENT)]
+    regression_threshold: f64,
+
+    #[command(flatten)]
+    setting_args: SettingArgs,
+
+    /// Additional arguments to pass to the bench runner (must follow --)
+    #[arg(last = true)]
+    args: Vec<String>,
+
+    #[command(flatten)]
+    _json: HiddenJsonArgs,
+
+    /// Print compact machine-readable summary (for CI wrappers)
+    #[arg(long)]
+    json_summary: bool,
+}
+
+/// Filter out homeboy-owned flags from trailing args before passing to
+/// extension scripts.
+///
+/// Same pattern as `test.rs::filter_homeboy_flags` — clap's
+/// `trailing_var_arg` captures everything after the positional component,
+/// including flags that also got parsed into named fields. Without
+/// filtering, homeboy-owned flags leak into the extension runner script.
+fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
+    const HOMEBOY_FLAGS: &[&str] = &[
+        "--baseline",
+        "--ignore-baseline",
+        "--ratchet",
+        "--json-summary",
+        "--json",
+    ];
+
+    const HOMEBOY_VALUE_FLAGS: &[&str] = &[
+        "--iterations",
+        "--regression-threshold",
+        "--setting",
+        "--path",
+    ];
+
+    let mut filtered = Vec::new();
+    let mut skip_next = false;
+
+    for arg in args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+
+        if HOMEBOY_FLAGS.contains(&arg.as_str()) {
+            continue;
+        }
+
+        let is_value_flag = HOMEBOY_VALUE_FLAGS.iter().any(|f| {
+            if arg.starts_with(&format!("{}=", f)) {
+                return true;
+            }
+            if arg == *f {
+                skip_next = true;
+                return true;
+            }
+            false
+        });
+
+        if is_value_flag {
+            continue;
+        }
+
+        filtered.push(arg.clone());
+    }
+
+    filtered
+}
+
+pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchCommandOutput> {
+    let effective_id = args.comp.resolve_id()?;
+
+    let ctx = execution_context::resolve(&ResolveOptions::with_capability(
+        &effective_id,
+        args.comp.path.clone(),
+        ExtensionCapability::Bench,
+        args.setting_args.setting.clone(),
+    ))?;
+
+    let run_dir = RunDir::create()?;
+    let passthrough_args = filter_homeboy_flags(&args.args);
+
+    let workflow = extension_bench::run_main_bench_workflow(
+        &ctx.component,
+        &ctx.source_path,
+        BenchRunWorkflowArgs {
+            component_label: effective_id.clone(),
+            component_id: ctx.component_id.clone(),
+            path_override: args.comp.path.clone(),
+            settings: ctx
+                .settings
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        match v {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        },
+                    )
+                })
+                .collect(),
+            iterations: args.iterations,
+            baseline: args.baseline_args.baseline,
+            ignore_baseline: args.baseline_args.ignore_baseline,
+            ratchet: args.ratchet,
+            regression_threshold_percent: args.regression_threshold,
+            json_summary: args.json_summary,
+            passthrough_args,
+        },
+        &run_dir,
+    )?;
+
+    Ok(from_main_workflow(workflow))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_strips_boolean_flags() {
+        let args = vec!["--ratchet".to_string(), "--filter=Scenario".to_string()];
+        let result = filter_homeboy_flags(&args);
+        assert_eq!(result, vec!["--filter=Scenario"]);
+    }
+
+    #[test]
+    fn filter_strips_all_boolean_flags() {
+        let args = vec![
+            "--baseline".to_string(),
+            "--ignore-baseline".to_string(),
+            "--ratchet".to_string(),
+            "--json-summary".to_string(),
+            "--json".to_string(),
+        ];
+        assert!(filter_homeboy_flags(&args).is_empty());
+    }
+
+    #[test]
+    fn filter_strips_iterations_space_form() {
+        let args = vec![
+            "--iterations".to_string(),
+            "50".to_string(),
+            "--filter=Scenario".to_string(),
+        ];
+        assert_eq!(filter_homeboy_flags(&args), vec!["--filter=Scenario"]);
+    }
+
+    #[test]
+    fn filter_strips_iterations_equals_form() {
+        let args = vec!["--iterations=50".to_string(), "--keep".to_string()];
+        assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+    }
+
+    #[test]
+    fn filter_strips_regression_threshold_forms() {
+        let args = vec![
+            "--regression-threshold".to_string(),
+            "10".to_string(),
+            "--keep".to_string(),
+        ];
+        assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+
+        let args = vec!["--regression-threshold=10".to_string(), "--keep".to_string()];
+        assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+    }
+
+    #[test]
+    fn filter_preserves_unknown_flags() {
+        let args = vec![
+            "--filter=Scenario".to_string(),
+            "--verbose".to_string(),
+            "extra".to_string(),
+        ];
+        assert_eq!(filter_homeboy_flags(&args), args);
+    }
+
+    #[test]
+    fn filter_handles_empty() {
+        assert!(filter_homeboy_flags(&[]).is_empty());
+    }
+
+    #[test]
+    fn filter_handles_mixed() {
+        let args = vec![
+            "--ratchet".to_string(),
+            "--iterations".to_string(),
+            "25".to_string(),
+            "--filter=hot_path".to_string(),
+            "--regression-threshold=7.5".to_string(),
+            "--verbose".to_string(),
+        ];
+        assert_eq!(
+            filter_homeboy_flags(&args),
+            vec!["--filter=hot_path", "--verbose"]
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -248,6 +248,7 @@ pub fn finalize_set_spec(
 pub mod api;
 pub mod audit;
 pub mod auth;
+pub mod bench;
 pub mod build;
 pub mod changelog;
 pub mod changes;
@@ -313,6 +314,7 @@ pub(crate) fn run_json(
         crate::Commands::Init(args) => dispatch!(args, global, init),
         crate::Commands::Status(args) => dispatch!(args, global, status),
         crate::Commands::Test(args) => dispatch!(args, global, test),
+        crate::Commands::Bench(args) => dispatch!(args, global, bench),
         crate::Commands::Lint(args) => dispatch!(args, global, lint),
         crate::Commands::Project(args) => dispatch!(args, global, project),
         crate::Commands::Ssh(args) => dispatch!(args, global, ssh),

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -126,6 +126,23 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
             ],
         ),
         (
+            "bench",
+            "",
+            &[
+                "--iterations",
+                "--baseline",
+                "--ignore-baseline",
+                "--ratchet",
+                "--regression-threshold",
+                "--setting",
+                "--path",
+                "--json-summary",
+                "--json",
+                "--help",
+                "-h",
+            ],
+        ),
+        (
             "scaffold",
             "test",
             &["--file", "--write", "--path", "--json", "--help", "-h"],

--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -362,6 +362,7 @@ JSON
             build: None,
             lint: None,
             test: None,
+            bench: None,
             actions: vec![],
             hooks: std::collections::HashMap::new(),
             settings: vec![],

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -199,6 +199,7 @@ impl ExecutionContext {
             ExtensionCapability::Lint => manifest.lint_script(),
             ExtensionCapability::Test => manifest.test_script(),
             ExtensionCapability::Build => manifest.build_script(),
+            ExtensionCapability::Bench => manifest.bench_script(),
         }
         .map(|s| s.to_string())
         .or_else(|| {
@@ -218,6 +219,7 @@ impl ExecutionContext {
                         ExtensionCapability::Lint => "lint",
                         ExtensionCapability::Test => "test",
                         ExtensionCapability::Build => "build",
+                        ExtensionCapability::Bench => "bench",
                     }
                 ),
                 None,

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -34,6 +34,7 @@ pub mod files {
     pub const TEST_FAILURES: &str = "test-failures.json";
     pub const COVERAGE: &str = "coverage.json";
     pub const FIX_RESULTS: &str = "fix-results.json";
+    pub const BENCH_RESULTS: &str = "bench-results.json";
     pub const ANNOTATIONS_DIR: &str = "annotations";
 }
 
@@ -130,6 +131,12 @@ impl RunDir {
             (
                 "HOMEBOY_FIX_RESULTS_FILE".to_string(),
                 self.step_file(files::FIX_RESULTS)
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+            (
+                "HOMEBOY_BENCH_RESULTS_FILE".to_string(),
+                self.step_file(files::BENCH_RESULTS)
                     .to_string_lossy()
                     .to_string(),
             ),

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -1,0 +1,397 @@
+//! Bench baseline — ratchet for scenario latency (p95) regressions.
+//!
+//! Stored under `homeboy.json` → `baselines.bench` via the generic
+//! `engine::baseline` primitive, alongside `baselines.test` and
+//! `baselines.audit`. Each scenario appears as a `Fingerprintable` item
+//! with fingerprint = `scenario_id`, so adding or removing scenarios
+//! tracks through the generic `new_items` / `resolved_fingerprints`
+//! lanes automatically.
+//!
+//! On top of that, bench adds a **threshold-based regression check**:
+//! a scenario regresses when its current `p95_ms` exceeds its baseline
+//! `p95_ms` by more than the configured percentage. Improvements (p95
+//! got faster) are celebrated and only written back to the baseline
+//! when `--ratchet` is set.
+//!
+//! Default threshold is 5%. p95 was chosen as the signal over mean
+//! because p95 is less sensitive than mean to one-off GC pauses but
+//! more sensitive than p99 to genuine regressions. Callers can pass
+//! any threshold per run via the command flag.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::baseline::{self as generic, BaselineConfig};
+use crate::error::Result;
+
+use super::parsing::{BenchResults, BenchScenario};
+
+const BASELINE_KEY: &str = "bench";
+
+/// Default regression threshold: 5% p95_ms slowdown flags a regression.
+pub const DEFAULT_REGRESSION_THRESHOLD_PERCENT: f64 = 5.0;
+
+/// Per-scenario snapshot persisted in the baseline metadata.
+///
+/// Only the metrics that participate in comparisons + the ones useful
+/// for human diffs are stored. The runner can emit more per-scenario
+/// data in each run (that's in `BenchResults`); the baseline stores a
+/// canonical compact form.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BenchScenarioSnapshot {
+    pub id: String,
+    pub p95_ms: f64,
+    pub p50_ms: f64,
+    pub mean_ms: f64,
+}
+
+impl BenchScenarioSnapshot {
+    pub fn from_scenario(scenario: &BenchScenario) -> Self {
+        Self {
+            id: scenario.id.clone(),
+            p95_ms: scenario.metrics.p95_ms,
+            p50_ms: scenario.metrics.p50_ms,
+            mean_ms: scenario.metrics.mean_ms,
+        }
+    }
+}
+
+impl generic::Fingerprintable for BenchScenarioSnapshot {
+    fn fingerprint(&self) -> String {
+        self.id.clone()
+    }
+    fn description(&self) -> String {
+        format!("p95 {:.2}ms (p50 {:.2}ms, mean {:.2}ms)", self.p95_ms, self.p50_ms, self.mean_ms)
+    }
+    fn context_label(&self) -> String {
+        self.id.clone()
+    }
+}
+
+/// Metadata stored alongside the fingerprint list in the baseline file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BenchBaselineMetadata {
+    pub scenarios: Vec<BenchScenarioSnapshot>,
+    /// Total iterations used when the baseline was captured. Stored for
+    /// human context; comparisons don't require matching iteration
+    /// counts.
+    pub iterations: u64,
+}
+
+pub type BenchBaseline = generic::Baseline<BenchBaselineMetadata>;
+
+/// Per-scenario delta vs baseline.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ScenarioDelta {
+    pub id: String,
+    pub baseline_p95_ms: f64,
+    pub current_p95_ms: f64,
+    /// Current minus baseline in ms. Negative = faster.
+    pub p95_delta_ms: f64,
+    /// (current - baseline) / baseline * 100. Negative = faster.
+    pub p95_delta_pct: f64,
+    pub regression: bool,
+    pub improvement: bool,
+}
+
+/// Summary of comparing a current run against a stored baseline.
+#[derive(Debug, Clone, Serialize)]
+pub struct BenchBaselineComparison {
+    pub threshold_percent: f64,
+    pub scenarios: Vec<ScenarioDelta>,
+    /// Scenarios present in the current run but not the baseline.
+    pub new_scenario_ids: Vec<String>,
+    /// Scenarios present in the baseline but not the current run.
+    pub removed_scenario_ids: Vec<String>,
+    pub regression: bool,
+    pub has_improvements: bool,
+    /// Short human-readable reasons, one per regressed scenario.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}
+
+pub fn save_baseline(
+    source_path: &Path,
+    component_id: &str,
+    results: &BenchResults,
+) -> Result<std::path::PathBuf> {
+    let snapshots: Vec<BenchScenarioSnapshot> = results
+        .scenarios
+        .iter()
+        .map(BenchScenarioSnapshot::from_scenario)
+        .collect();
+    let metadata = BenchBaselineMetadata {
+        scenarios: snapshots.clone(),
+        iterations: results.iterations,
+    };
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    generic::save(&config, component_id, &snapshots, metadata)
+}
+
+pub fn load_baseline(source_path: &Path) -> Option<BenchBaseline> {
+    let config = BaselineConfig::new(source_path, BASELINE_KEY);
+    generic::load::<BenchBaselineMetadata>(&config)
+        .ok()
+        .flatten()
+}
+
+/// Compare a current run against a loaded baseline at the given p95
+/// regression threshold (as a percentage, e.g. `5.0` = 5%).
+pub fn compare(
+    current: &BenchResults,
+    baseline: &BenchBaseline,
+    threshold_percent: f64,
+) -> BenchBaselineComparison {
+    let baseline_by_id: HashMap<&str, &BenchScenarioSnapshot> = baseline
+        .metadata
+        .scenarios
+        .iter()
+        .map(|snap| (snap.id.as_str(), snap))
+        .collect();
+
+    let current_ids: std::collections::HashSet<&str> =
+        current.scenarios.iter().map(|s| s.id.as_str()).collect();
+
+    let mut scenario_deltas = Vec::new();
+    let mut new_scenario_ids = Vec::new();
+    let mut reasons = Vec::new();
+    let mut has_improvements = false;
+    let mut any_regression = false;
+
+    for scenario in &current.scenarios {
+        let Some(prior) = baseline_by_id.get(scenario.id.as_str()) else {
+            new_scenario_ids.push(scenario.id.clone());
+            continue;
+        };
+
+        let baseline_p95 = prior.p95_ms;
+        let current_p95 = scenario.metrics.p95_ms;
+        let delta_ms = current_p95 - baseline_p95;
+
+        // Guard against zero-valued baselines — anything-over-zero is
+        // infinite % regression, which is noise for a micro-benchmark
+        // that legitimately measured 0ms. Treat them as no-delta.
+        let delta_pct = if baseline_p95 > 0.0 {
+            (delta_ms / baseline_p95) * 100.0
+        } else {
+            0.0
+        };
+
+        let threshold_ratio = 1.0 + (threshold_percent / 100.0);
+        let regression = baseline_p95 > 0.0 && current_p95 > baseline_p95 * threshold_ratio;
+        let improvement = delta_ms < 0.0;
+
+        if regression {
+            any_regression = true;
+            reasons.push(format!(
+                "{}: p95 {:.2}ms → {:.2}ms ({:+.1}%)",
+                scenario.id, baseline_p95, current_p95, delta_pct
+            ));
+        }
+        if improvement {
+            has_improvements = true;
+        }
+
+        scenario_deltas.push(ScenarioDelta {
+            id: scenario.id.clone(),
+            baseline_p95_ms: baseline_p95,
+            current_p95_ms: current_p95,
+            p95_delta_ms: delta_ms,
+            p95_delta_pct: delta_pct,
+            regression,
+            improvement,
+        });
+    }
+
+    let removed_scenario_ids: Vec<String> = baseline
+        .metadata
+        .scenarios
+        .iter()
+        .filter(|s| !current_ids.contains(s.id.as_str()))
+        .map(|s| s.id.clone())
+        .collect();
+
+    BenchBaselineComparison {
+        threshold_percent,
+        scenarios: scenario_deltas,
+        new_scenario_ids,
+        removed_scenario_ids,
+        regression: any_regression,
+        has_improvements,
+        reasons,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::parsing::{BenchMetrics, BenchResults, BenchScenario};
+    use super::*;
+
+    fn scenario(id: &str, p95_ms: f64) -> BenchScenario {
+        BenchScenario {
+            id: id.to_string(),
+            file: None,
+            iterations: 10,
+            metrics: BenchMetrics {
+                mean_ms: p95_ms * 0.9,
+                p50_ms: p95_ms * 0.85,
+                p95_ms,
+                p99_ms: p95_ms * 1.05,
+                min_ms: p95_ms * 0.7,
+                max_ms: p95_ms * 1.1,
+            },
+            memory: None,
+        }
+    }
+
+    fn results(scenarios: Vec<BenchScenario>) -> BenchResults {
+        BenchResults {
+            component_id: "demo".to_string(),
+            iterations: 10,
+            scenarios,
+        }
+    }
+
+    #[test]
+    fn save_and_load_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = results(vec![scenario("a", 100.0), scenario("b", 200.0)]);
+        save_baseline(dir.path(), "demo", &run).unwrap();
+
+        let loaded = load_baseline(dir.path()).unwrap();
+        assert_eq!(loaded.context_id, "demo");
+        assert_eq!(loaded.metadata.iterations, 10);
+        assert_eq!(loaded.metadata.scenarios.len(), 2);
+        assert_eq!(loaded.metadata.scenarios[0].id, "a");
+        assert_eq!(loaded.metadata.scenarios[0].p95_ms, 100.0);
+    }
+
+    #[test]
+    fn no_regression_when_flat() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_run = results(vec![scenario("a", 100.0)]);
+        save_baseline(dir.path(), "demo", &baseline_run).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = results(vec![scenario("a", 100.0)]);
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(!comparison.regression);
+        assert!(!comparison.has_improvements);
+        assert_eq!(comparison.scenarios.len(), 1);
+        assert_eq!(comparison.scenarios[0].p95_delta_ms, 0.0);
+    }
+
+    #[test]
+    fn four_percent_slower_does_not_regress_at_five_percent_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(dir.path(), "demo", &results(vec![scenario("a", 100.0)])).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = results(vec![scenario("a", 104.0)]);
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(!comparison.regression);
+        assert!(!comparison.scenarios[0].regression);
+        assert_eq!(comparison.reasons, Vec::<String>::new());
+    }
+
+    #[test]
+    fn six_percent_slower_regresses_at_five_percent_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(dir.path(), "demo", &results(vec![scenario("a", 100.0)])).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = results(vec![scenario("a", 106.0)]);
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(comparison.regression);
+        assert!(comparison.scenarios[0].regression);
+        assert_eq!(comparison.reasons.len(), 1);
+        assert!(comparison.reasons[0].contains("a:"));
+        assert!(comparison.reasons[0].contains("100.00ms"));
+        assert!(comparison.reasons[0].contains("106.00ms"));
+    }
+
+    #[test]
+    fn improvement_is_flagged_not_regression() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(dir.path(), "demo", &results(vec![scenario("a", 100.0)])).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = results(vec![scenario("a", 80.0)]);
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(!comparison.regression);
+        assert!(comparison.has_improvements);
+        assert!(comparison.scenarios[0].improvement);
+        assert_eq!(comparison.scenarios[0].p95_delta_ms, -20.0);
+    }
+
+    #[test]
+    fn new_scenario_is_tracked() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(dir.path(), "demo", &results(vec![scenario("a", 100.0)])).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = results(vec![scenario("a", 100.0), scenario("b", 50.0)]);
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(!comparison.regression);
+        assert_eq!(comparison.new_scenario_ids, vec!["b".to_string()]);
+        assert_eq!(comparison.scenarios.len(), 1); // only "a" has a baseline delta
+    }
+
+    #[test]
+    fn removed_scenario_is_tracked() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(
+            dir.path(),
+            "demo",
+            &results(vec![scenario("a", 100.0), scenario("b", 50.0)]),
+        )
+        .unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        let current = results(vec![scenario("a", 100.0)]);
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(!comparison.regression);
+        assert_eq!(comparison.removed_scenario_ids, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn threshold_percent_is_configurable() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(dir.path(), "demo", &results(vec![scenario("a", 100.0)])).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        // 8% slower: passes at 10% threshold, fails at 5%.
+        let current = results(vec![scenario("a", 108.0)]);
+        assert!(!compare(&current, &baseline, 10.0).regression);
+        assert!(compare(&current, &baseline, 5.0).regression);
+    }
+
+    #[test]
+    fn zero_baseline_p95_does_not_panic_or_always_regress() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(dir.path(), "demo", &results(vec![scenario("a", 0.0)])).unwrap();
+        let baseline = load_baseline(dir.path()).unwrap();
+
+        // Even a non-trivial current p95 should not be flagged as a
+        // regression when the baseline was effectively zero — that
+        // almost certainly means the baseline was miscaptured.
+        let current = results(vec![scenario("a", 5.0)]);
+        let comparison = compare(&current, &baseline, 5.0);
+        assert!(!comparison.regression);
+        assert_eq!(comparison.scenarios[0].p95_delta_pct, 0.0);
+    }
+
+    #[test]
+    fn load_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_baseline(dir.path()).is_none());
+    }
+}

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -1,0 +1,44 @@
+//! Extension bench capability — run performance workloads inside an
+//! extension's runtime and surface regression deltas vs a stored baseline.
+//!
+//! Bench is a sibling of `lint` / `test` / `build` under `ExtensionCapability`.
+//! It shares the runner contract (env-var-driven, JSON-output-file), the
+//! manifest shape (`bench: { extension_script: "..." }`), and the baseline
+//! ratchet primitive (`engine::baseline`). What makes bench distinct is the
+//! **threshold-based regression check on p95 latency** — see
+//! [`baseline::compare`] for the logic and [`baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT`]
+//! for the default.
+//!
+//! Contract with extension scripts:
+//! - `$HOMEBOY_BENCH_RESULTS_FILE` — path to write the JSON envelope to.
+//! - `$HOMEBOY_BENCH_ITERATIONS` — iterations per scenario.
+//! - `$HOMEBOY_RUN_DIR` — the per-run directory (same as test/lint/build).
+//! - Passthrough args after `--` forwarded verbatim to the script.
+//!
+//! See `docs/commands/bench.md` for the end-user view.
+
+pub mod baseline;
+pub mod parsing;
+pub mod report;
+pub mod run;
+
+use crate::component::Component;
+use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
+
+pub use baseline::{
+    compare as compare_baseline, load_baseline, save_baseline, BenchBaseline,
+    BenchBaselineComparison, BenchBaselineMetadata, BenchScenarioSnapshot, ScenarioDelta,
+    DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+};
+pub use parsing::{
+    parse_bench_results_file, parse_bench_results_str, BenchMemory, BenchMetrics, BenchResults,
+    BenchScenario,
+};
+pub use report::{from_main_workflow, BenchCommandOutput};
+pub use run::{run_main_bench_workflow, BenchRunWorkflowArgs, BenchRunWorkflowResult};
+
+pub fn resolve_bench_command(
+    component: &Component,
+) -> crate::error::Result<ExtensionExecutionContext> {
+    crate::extension::resolve_execution_context(component, ExtensionCapability::Bench)
+}

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -1,0 +1,230 @@
+//! Bench runner JSON output parsing.
+//!
+//! The extension's bench runner writes a JSON envelope to the path in
+//! `$HOMEBOY_BENCH_RESULTS_FILE`. The schema is strict on top-level keys
+//! (unknown top-level fields are rejected) but tolerant of unknown
+//! scenario-level keys so extensions can emit extra metadata without
+//! breaking forward compatibility.
+//!
+//! # Schema
+//!
+//! ```json
+//! {
+//!   "component_id": "string",
+//!   "iterations": 10,
+//!   "scenarios": [
+//!     {
+//!       "id": "scenario_slug",
+//!       "file": "tests/bench/some-workload.ext",
+//!       "iterations": 10,
+//!       "metrics": {
+//!         "mean_ms": 120.3,
+//!         "p50_ms": 118.0,
+//!         "p95_ms": 145.0,
+//!         "p99_ms": 160.0,
+//!         "min_ms": 110.0,
+//!         "max_ms": 172.0
+//!       },
+//!       "memory": { "peak_bytes": 41943040 }
+//!     }
+//!   ]
+//! }
+//! ```
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// Full bench run output from an extension script.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchResults {
+    pub component_id: String,
+    pub iterations: u64,
+    pub scenarios: Vec<BenchScenario>,
+}
+
+/// One scenario's measurements.
+///
+/// Scenario-level unknown keys are accepted to keep the contract
+/// forward-compatible: a runner can emit extra metadata (tags, warmup
+/// counts, environment info) without breaking parsers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BenchScenario {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    pub iterations: u64,
+    pub metrics: BenchMetrics,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<BenchMemory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchMetrics {
+    pub mean_ms: f64,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub p99_ms: f64,
+    pub min_ms: f64,
+    pub max_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchMemory {
+    pub peak_bytes: u64,
+}
+
+/// Read and parse a `$HOMEBOY_BENCH_RESULTS_FILE` written by an extension.
+pub fn parse_bench_results_file(path: &Path) -> Result<BenchResults> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read bench results file {}: {}",
+                path.display(),
+                e
+            ),
+            Some("bench.parsing.read".to_string()),
+        )
+    })?;
+    parse_bench_results_str(&content)
+}
+
+/// Parse a raw JSON string into a `BenchResults`.
+pub fn parse_bench_results_str(raw: &str) -> Result<BenchResults> {
+    serde_json::from_str(raw).map_err(|e| {
+        Error::internal_json(
+            format!("Failed to parse bench results JSON: {}", e),
+            Some("bench.parsing.deserialize".to_string()),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_RESULTS: &str = r#"{
+        "component_id": "example",
+        "iterations": 10,
+        "scenarios": [
+            {
+                "id": "scenario_one",
+                "file": "bench/one.ext",
+                "iterations": 10,
+                "metrics": {
+                    "mean_ms": 120.5,
+                    "p50_ms": 118.0,
+                    "p95_ms": 145.0,
+                    "p99_ms": 160.0,
+                    "min_ms": 110.0,
+                    "max_ms": 172.5
+                },
+                "memory": { "peak_bytes": 41943040 }
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn parses_valid_results() {
+        let parsed = parse_bench_results_str(VALID_RESULTS).unwrap();
+        assert_eq!(parsed.component_id, "example");
+        assert_eq!(parsed.iterations, 10);
+        assert_eq!(parsed.scenarios.len(), 1);
+        let scenario = &parsed.scenarios[0];
+        assert_eq!(scenario.id, "scenario_one");
+        assert_eq!(scenario.file.as_deref(), Some("bench/one.ext"));
+        assert_eq!(scenario.metrics.p95_ms, 145.0);
+        assert_eq!(scenario.memory.as_ref().unwrap().peak_bytes, 41943040);
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_keys() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 10,
+            "scenarios": [],
+            "unexpected_top_level": true
+        }"#;
+        let err = parse_bench_results_str(raw).unwrap_err();
+        let inner = err
+            .details
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            inner.contains("unexpected_top_level") || inner.contains("unknown field"),
+            "expected unknown-field error, got details: {}",
+            inner
+        );
+    }
+
+    #[test]
+    fn tolerates_unknown_scenario_level_keys() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 10,
+            "scenarios": [
+                {
+                    "id": "scenario_one",
+                    "iterations": 10,
+                    "metrics": {
+                        "mean_ms": 120.5,
+                        "p50_ms": 118.0,
+                        "p95_ms": 145.0,
+                        "p99_ms": 160.0,
+                        "min_ms": 110.0,
+                        "max_ms": 172.5
+                    },
+                    "extra_metadata": "tolerated",
+                    "tags": ["warmup", "cold"]
+                }
+            ]
+        }"#;
+        let parsed = parse_bench_results_str(raw).unwrap();
+        assert_eq!(parsed.scenarios.len(), 1);
+        assert_eq!(parsed.scenarios[0].id, "scenario_one");
+    }
+
+    #[test]
+    fn rejects_missing_required_metric() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 10,
+            "scenarios": [
+                {
+                    "id": "scenario_one",
+                    "iterations": 10,
+                    "metrics": {
+                        "mean_ms": 120.5,
+                        "p50_ms": 118.0,
+                        "p95_ms": 145.0,
+                        "p99_ms": 160.0,
+                        "min_ms": 110.0
+                    }
+                }
+            ]
+        }"#;
+        let err = parse_bench_results_str(raw).unwrap_err();
+        let inner = err
+            .details
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            inner.contains("max_ms") || inner.contains("missing field"),
+            "expected missing-field error, got details: {}",
+            inner
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let raw = "not json at all";
+        assert!(parse_bench_results_str(raw).is_err());
+    }
+}

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -1,0 +1,39 @@
+//! Bench command output — unified envelope for the `homeboy bench` command.
+
+use serde::Serialize;
+
+use super::baseline::BenchBaselineComparison;
+use super::parsing::BenchResults;
+use super::run::BenchRunWorkflowResult;
+
+#[derive(Serialize)]
+pub struct BenchCommandOutput {
+    pub passed: bool,
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    pub iterations: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub results: Option<BenchResults>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<BenchBaselineComparison>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
+}
+
+pub fn from_main_workflow(result: BenchRunWorkflowResult) -> (BenchCommandOutput, i32) {
+    let exit_code = result.exit_code;
+    (
+        BenchCommandOutput {
+            passed: exit_code == 0,
+            status: result.status,
+            component: result.component,
+            exit_code,
+            iterations: result.iterations,
+            results: result.results,
+            baseline_comparison: result.baseline_comparison,
+            hints: result.hints,
+        },
+        exit_code,
+    )
+}

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1,0 +1,140 @@
+//! Bench main workflow: invoke extension runner, load JSON, apply baseline.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::component::Component;
+use crate::engine::run_dir::{self, RunDir};
+use crate::extension::bench::baseline::{self, BenchBaselineComparison};
+use crate::extension::bench::parsing::{self, BenchResults};
+use crate::extension::{
+    resolve_execution_context, ExtensionCapability, ExtensionRunner,
+};
+use crate::error::Result;
+
+#[derive(Debug, Clone)]
+pub struct BenchRunWorkflowArgs {
+    pub component_label: String,
+    pub component_id: String,
+    pub path_override: Option<String>,
+    pub settings: Vec<(String, String)>,
+    pub iterations: u64,
+    pub baseline: bool,
+    pub ignore_baseline: bool,
+    pub ratchet: bool,
+    pub regression_threshold_percent: f64,
+    pub json_summary: bool,
+    pub passthrough_args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BenchRunWorkflowResult {
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    pub iterations: u64,
+    pub results: Option<BenchResults>,
+    pub baseline_comparison: Option<BenchBaselineComparison>,
+    pub hints: Option<Vec<String>>,
+}
+
+/// Runs the extension's bench script and produces a structured result.
+///
+/// Same runner contract as test/lint/build: the script writes a JSON
+/// envelope to `$HOMEBOY_BENCH_RESULTS_FILE`. Iteration count is passed
+/// via `$HOMEBOY_BENCH_ITERATIONS`. Runner exit code is taken as the
+/// primary signal; baseline regressions can override to 1.
+pub fn run_main_bench_workflow(
+    component: &Component,
+    source_path: &PathBuf,
+    args: BenchRunWorkflowArgs,
+    run_dir: &RunDir,
+) -> Result<BenchRunWorkflowResult> {
+    let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+    let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
+
+    let runner_output = ExtensionRunner::for_context(execution_context)
+        .component(component.clone())
+        .path_override(args.path_override.clone())
+        .settings(&args.settings)
+        .with_run_dir(run_dir)
+        .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
+        .script_args(&args.passthrough_args)
+        .run()?;
+
+    let parsed = if results_file.exists() {
+        parsing::parse_bench_results_file(&results_file).ok()
+    } else {
+        None
+    };
+
+    let status = if runner_output.success {
+        "passed"
+    } else {
+        "failed"
+    };
+
+    if args.baseline {
+        if let Some(ref r) = parsed {
+            let _ = baseline::save_baseline(source_path, &args.component_id, r)?;
+        }
+    }
+
+    let mut baseline_comparison = None;
+    let mut baseline_exit_override = None;
+
+    if !args.baseline && !args.ignore_baseline {
+        if let Some(ref r) = parsed {
+            if let Some(existing) = baseline::load_baseline(source_path) {
+                let comparison =
+                    baseline::compare(r, &existing, args.regression_threshold_percent);
+
+                if comparison.regression {
+                    baseline_exit_override = Some(1);
+                } else if comparison.has_improvements && args.ratchet {
+                    let _ = baseline::save_baseline(source_path, &args.component_id, r);
+                }
+
+                baseline_comparison = Some(comparison);
+            }
+        }
+    }
+
+    let mut hints = Vec::new();
+    if parsed.is_some() && !args.baseline && baseline_comparison.is_none() {
+        hints.push(format!(
+            "Save bench baseline: homeboy bench {} --baseline",
+            args.component_id
+        ));
+    }
+    if baseline_comparison.is_some() && !args.ratchet {
+        hints.push(format!(
+            "Auto-update baseline on improvement: homeboy bench {} --ratchet",
+            args.component_id
+        ));
+    }
+    if let Some(ref cmp) = baseline_comparison {
+        if cmp.regression {
+            hints.push(format!(
+                "Regression threshold: {}%. Raise it with --regression-threshold=<PCT> if expected.",
+                cmp.threshold_percent
+            ));
+        }
+    }
+    hints.push("Full options: homeboy docs commands/bench".to_string());
+
+    let hints = if hints.is_empty() { None } else { Some(hints) };
+
+    let exit_code = baseline_exit_override.unwrap_or(runner_output.exit_code);
+
+    Ok(BenchRunWorkflowResult {
+        status: status.to_string(),
+        component: args.component_label,
+        exit_code,
+        iterations: args.iterations,
+        results: parsed,
+        baseline_comparison,
+        hints,
+    })
+}

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -455,6 +455,7 @@ pub(crate) fn validate_capability_script_exists(
             super::ExtensionCapability::Lint => "lint",
             super::ExtensionCapability::Test => "test",
             super::ExtensionCapability::Build => "build",
+            super::ExtensionCapability::Bench => "bench",
         };
 
         return Err(Error::validation_invalid_argument(

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -291,6 +291,8 @@ pub struct ExtensionManifest {
     pub lint: Option<LintConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<TestConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bench: Option<BenchConfig>,
     /// Post-write verify command used as a safety gate after `refactor --from ...`
     /// autofix writes to disk. If the command exits non-zero, the written files
     /// are reverted and the fixes are reclassified as declined. See #1167.
@@ -344,6 +346,13 @@ impl ExtensionManifest {
             .is_some()
     }
 
+    pub fn has_bench(&self) -> bool {
+        self.bench
+            .as_ref()
+            .and_then(|c| c.extension_script.as_ref())
+            .is_some()
+    }
+
     pub fn lint_script(&self) -> Option<&str> {
         self.lint
             .as_ref()
@@ -358,6 +367,12 @@ impl ExtensionManifest {
 
     pub fn test_script(&self) -> Option<&str> {
         self.test
+            .as_ref()
+            .and_then(|c| c.extension_script.as_deref())
+    }
+
+    pub fn bench_script(&self) -> Option<&str> {
+        self.bench
             .as_ref()
             .and_then(|c| c.extension_script.as_deref())
     }
@@ -682,6 +697,12 @@ pub struct LintConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension_script: Option<String>,
 }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -1,3 +1,4 @@
+pub mod bench;
 pub mod build;
 mod execution;
 pub mod grammar;
@@ -22,12 +23,13 @@ pub use runtime_helper::RUNNER_STEPS_ENV;
 
 // Re-export manifest types
 pub use manifest::{
-    ActionConfig, ActionType, AuditCapability, AutofixVerifyConfig, BuildConfig, CliConfig,
-    DatabaseCliConfig, DatabaseConfig, DeployCapability, DeployOverride, DeployVerification,
-    DiscoveryConfig, DocTarget, ExecutableCapability, ExtensionManifest, FeatureContextRule,
-    HttpMethod, InputConfig, LintConfig, OutputConfig, OutputSchema, PlatformCapability,
-    ProvidesConfig, RequirementsConfig, RuntimeConfig, ScriptsConfig, SelectOption, SettingConfig,
-    SinceTagConfig, TestConfig, TestMappingConfig, VersionPatternConfig,
+    ActionConfig, ActionType, AuditCapability, AutofixVerifyConfig, BenchConfig, BuildConfig,
+    CliConfig, DatabaseCliConfig, DatabaseConfig, DeployCapability, DeployOverride,
+    DeployVerification, DiscoveryConfig, DocTarget, ExecutableCapability, ExtensionManifest,
+    FeatureContextRule, HttpMethod, InputConfig, LintConfig, OutputConfig, OutputSchema,
+    PlatformCapability, ProvidesConfig, RequirementsConfig, RuntimeConfig, ScriptsConfig,
+    SelectOption, SettingConfig, SinceTagConfig, TestConfig, TestMappingConfig,
+    VersionPatternConfig,
 };
 
 // Re-export version types
@@ -117,6 +119,7 @@ pub enum ExtensionCapability {
     Lint,
     Test,
     Build,
+    Bench,
 }
 
 #[derive(Debug, Clone)]
@@ -147,6 +150,7 @@ fn capability_label(capability: ExtensionCapability) -> &'static str {
         ExtensionCapability::Lint => "lint",
         ExtensionCapability::Test => "test",
         ExtensionCapability::Build => "build",
+        ExtensionCapability::Bench => "bench",
     }
 }
 
@@ -155,6 +159,7 @@ fn manifest_has_capability(manifest: &ExtensionManifest, capability: ExtensionCa
         ExtensionCapability::Lint => manifest.has_lint(),
         ExtensionCapability::Test => manifest.has_test(),
         ExtensionCapability::Build => manifest.has_build(),
+        ExtensionCapability::Bench => manifest.has_bench(),
     }
 }
 
@@ -260,10 +265,11 @@ pub fn resolve_execution_context(
         ExtensionCapability::Lint => manifest.lint_script(),
         ExtensionCapability::Test => manifest.test_script(),
         ExtensionCapability::Build => manifest.build_script(),
+        ExtensionCapability::Bench => manifest.bench_script(),
     }
     .map(|s| s.to_string())
     // Build's extension_script is optional (builds can use local scripts or command templates),
-    // so we allow an empty script_path for Build. Lint/Test require it.
+    // so we allow an empty script_path for Build. Lint/Test/Bench require it.
     .or_else(|| {
         if capability == ExtensionCapability::Build {
             Some(String::new())

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,9 @@ mod help_topics;
 
 use commands::utils::{args, entity_suggest, response as output, tty};
 use commands::{
-    api, audit, auth, build, changelog, changes, cli, component, config, db, deploy, extension,
-    file, fleet, git, init, lint, logs, project, refactor, release, scaffold, server, ssh, status,
-    test, transfer, undo, upgrade, validate, version,
+    api, audit, auth, bench, build, changelog, changes, cli, component, config, db, deploy,
+    extension, file, fleet, git, init, lint, logs, project, refactor, release, scaffold, server,
+    ssh, status, test, transfer, undo, upgrade, validate, version,
 };
 use homeboy::extension::load_all_extensions;
 
@@ -54,6 +54,8 @@ enum Commands {
     Server(server::ServerArgs),
     /// Run tests for a component
     Test(test::TestArgs),
+    /// Run performance benchmarks for a component
+    Bench(bench::BenchArgs),
     /// Lint a component
     Lint(lint::LintArgs),
     /// Database operations


### PR DESCRIPTION
## Summary

Adds `Bench` as a fourth extension capability under homeboy core, sibling to `Lint`, `Test`, and `Build`. Extensions declare a `bench` capability in their manifest, homeboy invokes the runner with the standard contract (env-var-driven, JSON-output-file), parses the results, compares p95 latency against a saved baseline, and emits a structured report plus an exit code suitable for CI gates.

The whole PR is pure core plumbing — zero references to any specific extension, runtime, or language. A follow-up PR on `homeboy-extensions` will add a WordPress-Playground-backed bench runner that consumes this capability.

## Why bench belongs in core

The initial framing was "add bench to the WordPress extension." Reading the `test` command made it clear bench is the same shape as every other capability homeboy already owns:

- **Same manifest shape** — `bench: { extension_script: "..." }` mirrors `test`, `lint`, `build`.
- **Same runner contract** — env vars + a JSON output file path, same as `$HOMEBOY_TEST_RESULTS_FILE`.
- **Same baseline substrate** — `engine::baseline` is already generic over `Fingerprintable` and stores baselines in `homeboy.json → baselines.*`. `test/baseline.rs` and `code_audit/baseline.rs` are thin adapters on top of it. `bench/baseline.rs` is a fourth thin adapter, not a reimplementation.

Building bench into a single extension would have welded a capability into one consumer that every future extension (Rust/Go/Python/etc.) would eventually want to reproduce from scratch.

## The three commits

### 1. `feat(extension): add Bench capability to the extension surface`

Pure plumbing. Adds `BenchConfig` to the manifest, a `Bench` variant to `ExtensionCapability`, and threads it through every match arm (`capability_label`, `manifest_has_capability`, script-path resolution in both `extension/mod.rs` and `engine/execution_context.rs`, script-existence validation in `extension/execution.rs`). Also adds `files::BENCH_RESULTS` + `HOMEBOY_BENCH_RESULTS_FILE` to the run-dir legacy-env-vars map. No workflow logic, no user-visible behaviour change from this commit alone.

### 2. `feat(extension): bench workflow — runner, parsing, baseline adapter`

The `extension::bench` module:

- **`parsing.rs`** — runner JSON schema. Strict top-level keys (`deny_unknown_fields`) so the contract can't silently drift. Tolerant per-scenario keys so extensions can emit metadata (tags, warmup counts, environment info) without breaking parsers.
- **`baseline.rs`** — fourth consumer of `engine::baseline`, with a **threshold-based regression check on p95**: a scenario regresses when current `p95_ms` exceeds `baseline.p95_ms * (1 + threshold_percent/100)`. Default threshold is 5% (configurable per run via `--regression-threshold`). p95 was chosen over mean (too sensitive to one-off GC pauses) and p99 (too insensitive to real regressions). Zero-valued baselines are handled explicitly to avoid the infinite-percent-change noise.
- **`run.rs`** — main workflow: resolve execution context, invoke runner with `HOMEBOY_BENCH_ITERATIONS`, parse results, save baseline if `--baseline`, compare + ratchet if applicable, assemble hints.
- **`report.rs`** — `BenchCommandOutput` envelope mirroring `TestCommandOutput` shape.
- **`mod.rs`** — public entry + re-exports.

**15 unit tests** cover the baseline threshold math (flat run, 4% slower passes at 5% threshold, 6% slower fails, improvements flagged as non-regression, new/removed scenarios tracked, configurable thresholds, zero-baseline guard) and JSON parsing (valid round-trip, unknown top-level keys rejected, unknown scenario-level keys tolerated, missing required metrics rejected, malformed JSON rejected).

### 3. `feat(commands): wire homeboy bench subcommand + docs`

`homeboy bench [COMPONENT]` with flags that mirror `test` conventions where they overlap:

- `--iterations N` (default 10) → `HOMEBOY_BENCH_ITERATIONS`
- `--baseline` / `--ignore-baseline` via the shared `BaselineArgs`
- `--ratchet` to auto-update the baseline on improvement
- `--regression-threshold PERCENT` (default `5.0`)
- `--setting`, `--path`, `--json-summary`, passthrough `-- ARGS`

`filter_homeboy_flags` strips homeboy-owned flags from trailing args before they reach the extension script, same pattern as `test.rs`. **9 unit tests** cover space-separated and equals-form value flags, the pre-existing clap `trailing_var_arg + allow_hyphen_values` capture-everything behaviour, and the mixed-flag case.

New doc at `docs/commands/bench.md` covering synopsis, options, baseline ratchet semantics, runner contract, JSON schema, environment variables, manifest shape, and exit codes. `commands-index.md` and `architecture.md` updated.

## Runner contract

Extension scripts:

1. Read `$HOMEBOY_BENCH_ITERATIONS` to determine iteration count.
2. Write JSON output to `$HOMEBOY_BENCH_RESULTS_FILE`.
3. Exit non-zero only on runner-level failure (script error, workload crash) — regressions are homeboy's domain.

### JSON schema

```json
{
  "component_id": "string",
  "iterations": 10,
  "scenarios": [
    {
      "id": "scenario_slug",
      "file": "tests/bench/some-workload.ext",
      "iterations": 10,
      "metrics": {
        "mean_ms": 120.3,
        "p50_ms": 118.0,
        "p95_ms": 145.0,
        "p99_ms": 160.0,
        "min_ms": 110.0,
        "max_ms": 172.0
      },
      "memory": { "peak_bytes": 41943040 }
    }
  ]
}
```

## Baseline storage

Stored under `homeboy.json → baselines.bench`, alongside `baselines.test` and `baselines.audit`. No new config files — the existing single-root-file invariant is preserved.

## Verification

- `cargo build` — clean
- `cargo test --lib extension::bench` — **15/15 pass**
- `cargo test --lib` full suite — **1212 pass, 5 pre-existing failures on `main` unchanged by this PR** (3 in `code_audit/conventions`, 1 in `code_audit/test_topology`, 1 flaky filesystem test in `component::inventory` that passes when run in isolation)
- `homeboy bench --help` — renders all flags
- `homeboy --help` — bench appears between `test` and `lint` in the subcommand list

## Out of scope (deferred)

- **WordPress Playground bench runner** — follow-up PR on `homeboy-extensions`, consuming this capability.
- **`lint --ratchet` parity** — `lint` currently has `--baseline` / `--ignore-baseline` but no `--ratchet`, while `test` and `audit` do. Brought up in planning; separable and not in scope for this PR.
- **`--analyze` / `--drift` for bench** — those are test-shaped concepts that don't map cleanly onto benchmarks. Not included in v1.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Scaffolded the Bench capability module as a sibling of Test/Lint/Build. Implemented the threshold-based ratchet adapter on top of `engine/baseline.rs`. Wrote the 24 new unit tests (15 for baseline/parsing, 9 for command-layer flag filter). Chris reviewed the contract design (additive-only repair vs full reconcile, p95 as the regression signal, 5% default threshold, lint ratchet scope deferred to a separate PR) in the planning session before implementation.