### PR TITLE
test(audit): chmod +x topology script in test_run_topology_script

### DIFF
--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -337,8 +337,20 @@ JSON
         )
         .expect("script should be written");
 
-        // Keep the command invocation test deterministic by stubbing shell execution,
-        // not filesystem permissions. `sh -c <path>` works with readable script files.
+        // `run_topology_script` invokes the script directly (not via `sh <script>`)
+        // so the shebang resolves the interpreter — see #1276 / commit 343386a0.
+        // Direct invocation requires the execute bit on Unix; chmod +x or the
+        // spawn fails with EACCES and the assertion below sees 0 artifacts.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)
+                .expect("script metadata should be readable")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)
+                .expect("script should become executable");
+        }
 
         let extension = ExtensionManifest {
             id: "test-ext".to_string(),

--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -348,8 +348,7 @@ JSON
                 .expect("script metadata should be readable")
                 .permissions();
             perms.set_mode(0o755);
-            std::fs::set_permissions(&script_path, perms)
-                .expect("script should become executable");
+            std::fs::set_permissions(&script_path, perms).expect("script should become executable");
         }
 
         let extension = ExtensionManifest {


### PR DESCRIPTION
## Summary

Single-line root cause: the test writes a topology script to disk via `std::fs::write` and never chmods it executable. `run_topology_script` (the production code under test) invokes the script directly so its shebang resolves the interpreter — change introduced by **#1276** / commit `343386a0`. Direct invocation requires the execute bit on Unix; without it the spawn fails with `EACCES`, the function returns `Vec::new()`, and the test assertion sees **0 artifacts vs expected 1**.

The test's own comment betrayed its stale assumption:

> *"Keep the command invocation test deterministic by stubbing shell execution, not filesystem permissions. `sh -c <path>` works with readable script files."*

But production stopped using `sh -c <path>` in #1276. The test was never updated.

## Why this matters tonight

After PR #1369 merged the audit-baseline refresh + cargo fmt, the release pipeline progressed past the `Audit` and `Lint` gates for the first time in days. **`Test` is now the lone remaining release blocker** — and it fails on this single test, which I just confirmed is a real test bug, not flake.

Reproduces deterministically:

```bash
$ cargo test --lib core::code_audit::test_topology::tests::test_run_topology_script
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1213 filtered out
```

After the fix, the same command:

```bash
$ cargo test --lib core::code_audit::test_topology::tests::test_run_topology_script
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1265 filtered out
```

Full module: 8/8 pass.

## Fix

```rust
// `run_topology_script` invokes the script directly (not via `sh <script>`)
// so the shebang resolves the interpreter — see #1276 / commit 343386a0.
// Direct invocation requires the execute bit on Unix; chmod +x or the
// spawn fails with EACCES and the assertion below sees 0 artifacts.
#[cfg(unix)]
{
    use std::os::unix::fs::PermissionsExt;
    let mut perms = std::fs::metadata(&script_path)
        .expect("script metadata should be readable")
        .permissions();
    perms.set_mode(0o755);
    std::fs::set_permissions(&script_path, perms)
        .expect("script should become executable");
}
```

`#[cfg(unix)]` because Windows doesn't use POSIX exec bits — a future Windows test runner wouldn't need (or accept) this.

## Out of scope

Three other tests fail locally on macOS (`signature_check_*` in `core::code_audit::conventions`) but **PASS in CI on Linux** (verified against the Test job log from run `24868312108`) — environmental drift, not a release blocker. Filing a separate issue isn't urgent.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Diagnosed the EACCES failure mode by reading the test alongside the post-#1276 `run_topology_script` implementation, wrote the chmod fix, verified the full `core::code_audit::test_topology` module still passes (8/8). Chris reviewed and directed the cook.
