### PR TITLE
ci(release): pass expected-commands to stop orphan-reconciliation churn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           source: '.'
           commands: release
+          expected-commands: audit,lint,test
           release-dry-run: 'true'
 
       - name: Decide whether to release
@@ -144,6 +145,7 @@ jobs:
         with:
           binary-path: .homeboy-bin/homeboy
           commands: audit
+          expected-commands: audit,lint,test
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
@@ -178,6 +180,7 @@ jobs:
         with:
           binary-path: .homeboy-bin/homeboy
           commands: lint
+          expected-commands: audit,lint,test
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
@@ -212,6 +215,7 @@ jobs:
         with:
           binary-path: .homeboy-bin/homeboy
           commands: test
+          expected-commands: audit,lint,test
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
@@ -259,6 +263,7 @@ jobs:
         with:
           binary-path: .homeboy-bin/homeboy
           commands: audit,lint,test
+          expected-commands: audit,lint,test
           autofix: 'true'
           autofix-mode: always
           autofix-open-pr: 'true'
@@ -303,6 +308,7 @@ jobs:
         with:
           source: '.'
           commands: release
+          expected-commands: audit,lint,test
           release-dry-run: ${{ inputs.dry-run || 'false' }}
           app-token: ${{ steps.app-token.outputs.token || '' }}
 


### PR DESCRIPTION
## Summary

The release workflow invokes `homeboy-action` six times in sequence:

| Step | `commands:` |
|---|---|
| Dry-run release check | `release` |
| gate-audit | `audit` |
| gate-lint | `lint` |
| gate-test | `test` |
| gate-refactor / autofix | `audit,lint,test` |
| Release | `release` |

Every **single-command** invocation treated all other command types as orphaned during the auto-issue reconciliation block, closing them seconds after a sibling step had just created or updated them.

## Evidence

On `Extra-Chill/homeboy` this produced 15+ open-then-close events per run, with **byte-identical finding bodies modulo timestamps**:

| Bucket | Refiles | Same count each time? |
|---|---:|---|
| `audit: near duplicate (18)` | 12 in 26h | yes |
| `audit: god file (22)` | 10 in 26h | yes |
| `audit: missing test method` | 14 | no — drifts 305→466→482 |
| `lint: lint failure (exit 1)` | 21 since March | yes |

Example run log for `24867610666` (2026-04-24):
```
01:43:42 Filing categorized audit issues   ← updates 13 audit issues
01:43:55 Filing categorized lint issues
01:43:55 Reconciling orphaned audit issues ← WRONG, audit ran earlier this workflow
01:43:58 Closed issue #1384 \"zero findings remaining\"
...13 fresh audit issues closed...
```

## Changes

Every `Extra-Chill/homeboy-action@v2` invocation in `release.yml` now passes `expected-commands: audit,lint,test` so the action knows which command types to leave alone during reconciliation — even when the current invocation is only running one of them.

## Dependency

Requires the new `expected-commands` input on homeboy-action:

- Extra-Chill/homeboy-action#140 — `fix(issues): scope orphan reconciliation to expected-commands`

Until #140 merges and is cut as a new `v2.x.y`, this PR is a no-op (the input is ignored as unknown).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Traced the bug via the bot-filed issue stream, wrote the fix on homeboy-action, and wired `expected-commands` through `release.yml`. Chris approved the approach before implementation.