### PR TITLE
feat(git): --footer / --footer-file on sectioned pr comment (closes #1470)

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -301,8 +301,11 @@ enum PrCommand {
     ///    merges `--body` into section `<inner>` of the shared comment tagged
     ///    `<!-- homeboy:comment-key=<outer> -->`. Other sections are preserved.
     ///    `--header` sets the line printed after the outer marker on new
-    ///    comments. `--section-order` pins section ordering (CSV of keys);
-    ///    default is alphabetical.
+    ///    comments; `--footer` / `--footer-file` sets a block printed after
+    ///    the last section (e.g. a tooling-versions <details> block). Both
+    ///    are preserved from existing comments on merge when omitted.
+    ///    `--section-order` pins section ordering (CSV of keys); default is
+    ///    alphabetical.
     ///
     /// Modes 2 and 3 are mutually exclusive. `--key` with `--comment-key` or
     /// `--section-key` is an error.
@@ -343,6 +346,19 @@ enum PrCommand {
         /// are preserved on merge.
         #[arg(long, requires = "comment_key")]
         header: Option<String>,
+
+        /// Sectioned mode: optional footer block written after the last
+        /// section (e.g. a tooling-versions <details> block). Existing
+        /// footers are preserved on merge when this is omitted; passing
+        /// --footer or --footer-file overwrites the preserved footer.
+        /// Mutually exclusive with --footer-file.
+        #[arg(long, requires = "comment_key", conflicts_with = "footer_file")]
+        footer: Option<String>,
+
+        /// Sectioned mode: read footer content from a file ("-" for stdin).
+        /// Mutually exclusive with --footer.
+        #[arg(long, requires = "comment_key", value_name = "PATH")]
+        footer_file: Option<String>,
 
         /// Sectioned mode: CSV of section keys in desired order. Sections
         /// listed here come first in the given order; others are appended
@@ -673,6 +689,8 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             comment_key,
             section_key,
             header,
+            footer,
+            footer_file,
             section_order,
             path,
         } => {
@@ -685,17 +703,23 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
                 )
             })?;
 
+            // --footer / --footer-file share resolve_body; clap guarantees at
+            // most one is set. `None` → preserve existing footer on merge.
+            let footer = resolve_body(footer, footer_file)?;
+
             let mode = match (key, comment_key, section_key) {
                 (Some(k), None, None) => PrCommentMode::StickyWholeBody { key: k },
                 (None, Some(ck), Some(sk)) => PrCommentMode::Sectioned {
                     comment_key: ck,
                     section_key: sk,
                     header,
+                    footer,
                     section_order,
                 },
                 (None, None, None) => {
-                    // Header / section_order without the pair — clap already
-                    // caught this via `requires = "comment_key"`, but double-check.
+                    // Header / footer / section_order without the pair — clap
+                    // already caught this via `requires = "comment_key"`, but
+                    // double-check.
                     PrCommentMode::Fresh
                 }
                 // Remaining cases are impossible due to clap `requires` /

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -255,6 +255,11 @@ pub enum PrCommentMode {
         /// comments (e.g. `## Homeboy Results — \`<component>\``). Preserved
         /// from existing comments on merge.
         header: Option<String>,
+        /// Optional footer block written after the last section on fresh
+        /// comments (e.g. a `<details><summary>Tooling versions</summary>`
+        /// block). Preserved from existing comments on merge when the caller
+        /// does not pass one explicitly; overwritten when the caller does.
+        footer: Option<String>,
         /// Optional explicit section ordering. Sections listed here come first
         /// in the given order; any other sections are appended alphabetically.
         /// `None` = pure alphabetical.
@@ -592,6 +597,7 @@ pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Resu
             comment_key,
             section_key,
             header,
+            footer,
             section_order,
         } => pr_comment_sectioned(
             id,
@@ -601,6 +607,7 @@ pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Resu
             comment_key,
             section_key,
             header,
+            footer,
             section_order,
         ),
     }
@@ -717,6 +724,7 @@ fn pr_comment_sectioned(
     comment_key: String,
     section_key: String,
     header: Option<String>,
+    footer: Option<String>,
     section_order: Option<Vec<String>>,
 ) -> Result<GithubPrOutput> {
     // 1. Fetch every matching comment (with bodies) — we need the bodies to
@@ -734,6 +742,7 @@ fn pr_comment_sectioned(
             header.as_deref(),
             &sections,
             section_order.as_deref(),
+            footer.as_deref(),
         );
         let repo_flag = format!("{}/{}", repo.owner, repo.repo);
         let args: Vec<String> = vec![
@@ -768,15 +777,19 @@ fn pr_comment_sectioned(
 
     let mut merged: Vec<(String, String)> = Vec::new();
     let mut discovered_header: Option<String> = header.clone();
+    let mut discovered_footer: Option<String> = footer.clone();
     for comment in &matches {
         let parsed = parse_comment_sections(&comment.body);
         for (k, v) in parsed {
             merged = merge_section(merged, &k, v);
         }
-        // First comment wins the header (in ascending id order = lowest id),
-        // but only if caller didn't pass one explicitly.
+        // First comment wins the header / footer (in ascending id order =
+        // lowest id), but only if caller didn't pass one explicitly.
         if discovered_header.is_none() {
             discovered_header = extract_header(&comment.body);
+        }
+        if discovered_footer.is_none() {
+            discovered_footer = extract_footer(&comment.body);
         }
     }
     // Current invocation wins last.
@@ -787,6 +800,7 @@ fn pr_comment_sectioned(
         discovered_header.as_deref(),
         &merged,
         section_order.as_deref(),
+        discovered_footer.as_deref(),
     );
 
     // Idempotency: byte-compare rendered to canonical's existing body.
@@ -1085,6 +1099,27 @@ fn extract_header(body: &str) -> Option<String> {
     }
 }
 
+/// Extract the footer block of a comment — content between
+/// `<!-- homeboy:footer:start -->` and `<!-- homeboy:footer:end -->`.
+///
+/// Used to preserve an existing footer when merging. Only the NEW marker
+/// format is recognized; legacy `homeboy-action-*` bodies have no footer
+/// convention, so legacy-parse → `None` (no regression — footer is simply
+/// absent and the next render will omit it unless the caller opts in).
+fn extract_footer(body: &str) -> Option<String> {
+    const START: &str = "<!-- homeboy:footer:start -->";
+    const END: &str = "<!-- homeboy:footer:end -->";
+    let start_idx = body.find(START)?;
+    let after_start = &body[start_idx + START.len()..];
+    let end_idx = after_start.find(END)?;
+    let inner = after_start[..end_idx].trim_matches('\n');
+    if inner.is_empty() {
+        None
+    } else {
+        Some(inner.to_string())
+    }
+}
+
 /// Merge `(section_key, body)` into `sections`. Replaces any existing entry
 /// for `section_key`, preserving the original position; otherwise appends.
 pub fn merge_section(
@@ -1109,6 +1144,8 @@ pub fn merge_section(
 /// - `sections` → section map. Insertion order is preserved only when
 ///   `explicit_order` is `None`; otherwise explicit-ordered keys come first
 ///   in the given order, and any remaining keys follow alphabetically.
+/// - `footer` → optional block written after the last section, wrapped in
+///   dedicated `<!-- homeboy:footer:start|end -->` markers.
 /// - Output is always newline-normalized with a trailing newline and uses the
 ///   **new** marker format. Re-rendering a legacy-parsed body produces
 ///   new-format output (migration path).
@@ -1117,6 +1154,7 @@ pub fn render_comment(
     header: Option<&str>,
     sections: &[(String, String)],
     explicit_order: Option<&[String]>,
+    footer: Option<&str>,
 ) -> String {
     let ordered = order_sections(sections, explicit_order);
 
@@ -1131,6 +1169,10 @@ pub fn render_comment(
         }
     }
 
+    let has_footer = footer
+        .map(|f| !f.trim_matches('\n').is_empty())
+        .unwrap_or(false);
+
     for (idx, (key, body)) in ordered.iter().enumerate() {
         out.push_str(&format!("<!-- homeboy:section-key={}:start -->\n", key));
         let body_trimmed = body.trim_matches('\n');
@@ -1139,10 +1181,24 @@ pub fn render_comment(
             out.push('\n');
         }
         out.push_str(&format!("<!-- homeboy:section-key={}:end -->", key));
+        // Blank line between sections, and between the last section and a
+        // footer block. Trailing newline on the last line of the comment.
         if idx + 1 < ordered.len() {
+            out.push_str("\n\n");
+        } else if has_footer {
             out.push_str("\n\n");
         } else {
             out.push('\n');
+        }
+    }
+
+    if let Some(f) = footer {
+        let f = f.trim_matches('\n');
+        if !f.is_empty() {
+            out.push_str("<!-- homeboy:footer:start -->\n");
+            out.push_str(f);
+            out.push('\n');
+            out.push_str("<!-- homeboy:footer:end -->\n");
         }
     }
 
@@ -1497,7 +1553,7 @@ never-ends
             ("lint".to_string(), "lint body".to_string()),
             ("test".to_string(), "test body".to_string()),
         ];
-        let out = render_comment("ci:homeboy", Some("## Header"), &sections, None);
+        let out = render_comment("ci:homeboy", Some("## Header"), &sections, None, None);
         assert!(out.starts_with("<!-- homeboy:comment-key=ci:homeboy -->\n"));
         assert!(out.contains("## Header"));
         assert!(out.contains("<!-- homeboy:section-key=lint:start -->"));
@@ -1514,7 +1570,7 @@ never-ends
             ("audit".to_string(), "audit body\nmulti-line".to_string()),
             ("lint".to_string(), "lint body".to_string()),
         ];
-        let rendered = render_comment("ci:x", None, &sections, None);
+        let rendered = render_comment("ci:x", None, &sections, None, None);
         let reparsed = parse_comment_sections(&rendered);
 
         // Alphabetical default → audit before lint.
@@ -1531,7 +1587,7 @@ never-ends
             ("audit".to_string(), "a".to_string()),
             ("lint".to_string(), "l".to_string()),
         ];
-        let out = render_comment("k", None, &sections, None);
+        let out = render_comment("k", None, &sections, None, None);
         let audit_pos = out.find("section-key=audit:start").unwrap();
         let lint_pos = out.find("section-key=lint:start").unwrap();
         let test_pos = out.find("section-key=test:start").unwrap();
@@ -1547,7 +1603,7 @@ never-ends
             ("test".to_string(), "t".to_string()),
         ];
         let order = vec!["lint".to_string(), "test".to_string(), "audit".to_string()];
-        let out = render_comment("k", None, &sections, Some(&order));
+        let out = render_comment("k", None, &sections, Some(&order), None);
         let lint_pos = out.find("section-key=lint:start").unwrap();
         let test_pos = out.find("section-key=test:start").unwrap();
         let audit_pos = out.find("section-key=audit:start").unwrap();
@@ -1565,7 +1621,7 @@ never-ends
         ];
         // Only lint+test in explicit order — zeta and alpha are "unknown".
         let order = vec!["lint".to_string(), "test".to_string()];
-        let out = render_comment("k", None, &sections, Some(&order));
+        let out = render_comment("k", None, &sections, Some(&order), None);
 
         let lint_pos = out.find("section-key=lint:start").unwrap();
         let test_pos = out.find("section-key=test:start").unwrap();
@@ -1585,7 +1641,7 @@ never-ends
         // `test` is in the order but not present in sections — should not appear
         // in output.
         let order = vec!["test".to_string(), "lint".to_string()];
-        let out = render_comment("k", None, &sections, Some(&order));
+        let out = render_comment("k", None, &sections, Some(&order), None);
         assert!(!out.contains("section-key=test:start"));
         assert!(out.contains("section-key=lint:start"));
     }
@@ -1637,6 +1693,7 @@ never-ends
             "ci:homeboy",
             Some("## Homeboy Results — `homeboy`"),
             &sections,
+            None,
             None,
         );
 
@@ -1731,5 +1788,185 @@ body
     fn pr_comment_mode_default_is_fresh() {
         let opts = PrCommentOptions::default();
         assert_eq!(opts.mode, PrCommentMode::Fresh);
+    }
+
+    // ---------------------------------------------------------------------
+    // Footer primitive tests (#1470)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn render_comment_writes_footer_block_after_last_section() {
+        let sections = vec![("lint".to_string(), "lint body".to_string())];
+        let out = render_comment(
+            "ci:x",
+            Some("## Header"),
+            &sections,
+            None,
+            Some("tooling versions block"),
+        );
+        // Footer markers present, one blank line before start marker, trailing
+        // newline after end marker.
+        assert!(out.contains("<!-- homeboy:footer:start -->\ntooling versions block\n<!-- homeboy:footer:end -->\n"));
+        // Footer appears after the last section's :end marker.
+        let last_section_end = out.find("<!-- homeboy:section-key=lint:end -->").unwrap();
+        let footer_start = out.find("<!-- homeboy:footer:start -->").unwrap();
+        assert!(last_section_end < footer_start);
+        // Exactly one blank line (=\n\n) between section end and footer start.
+        let between = &out[last_section_end..footer_start];
+        assert!(between.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn render_comment_without_footer_omits_footer_markers() {
+        let sections = vec![("lint".to_string(), "lint body".to_string())];
+        let out = render_comment("ci:x", None, &sections, None, None);
+        assert!(!out.contains("homeboy:footer:start"));
+        assert!(!out.contains("homeboy:footer:end"));
+    }
+
+    #[test]
+    fn render_comment_empty_footer_string_omits_footer_markers() {
+        // Passing Some("") or Some("\n") should behave like None — no footer.
+        let sections = vec![("lint".to_string(), "lint body".to_string())];
+        for probe in ["", "\n", "\n\n"] {
+            let out = render_comment("ci:x", None, &sections, None, Some(probe));
+            assert!(
+                !out.contains("homeboy:footer:start"),
+                "footer markers should be omitted for empty footer '{:?}'",
+                probe
+            );
+        }
+    }
+
+    #[test]
+    fn extract_footer_reads_block_between_markers() {
+        let body = "\
+<!-- homeboy:comment-key=ci:x -->
+## Header
+
+<!-- homeboy:section-key=lint:start -->
+lint body
+<!-- homeboy:section-key=lint:end -->
+
+<!-- homeboy:footer:start -->
+tooling block line 1
+tooling block line 2
+<!-- homeboy:footer:end -->
+";
+        assert_eq!(
+            extract_footer(body),
+            Some("tooling block line 1\ntooling block line 2".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_footer_returns_none_when_markers_absent() {
+        let body = "\
+<!-- homeboy:comment-key=ci:x -->
+<!-- homeboy:section-key=lint:start -->
+body
+<!-- homeboy:section-key=lint:end -->
+";
+        assert_eq!(extract_footer(body), None);
+    }
+
+    #[test]
+    fn extract_footer_returns_none_for_legacy_marker_bodies() {
+        // Legacy homeboy-action bodies had no footer convention. Parse →
+        // None so the renderer omits the footer block unless the caller opts in.
+        let body = "\
+<!-- homeboy-action-results:key=ci:x -->
+## Legacy Header
+
+<!-- homeboy-action-section:key=lint:start -->
+body
+<!-- homeboy-action-section:key=lint:end -->
+";
+        assert_eq!(extract_footer(body), None);
+    }
+
+    #[test]
+    fn extract_footer_empty_inner_returns_none() {
+        let body = "\
+<!-- homeboy:footer:start -->
+<!-- homeboy:footer:end -->
+";
+        assert_eq!(extract_footer(body), None);
+    }
+
+    #[test]
+    fn render_comment_round_trips_footer_through_parse() {
+        // Rendering with a footer, then extract_footer on the output, should
+        // return the same footer content.
+        let sections = vec![("lint".to_string(), "body".to_string())];
+        let footer = "- Homeboy CLI: `1.2.3`\n- Action: `repo@v1`";
+        let rendered = render_comment("ci:x", None, &sections, None, Some(footer));
+        assert_eq!(extract_footer(&rendered), Some(footer.to_string()));
+        // And sections should still round-trip.
+        let parsed = parse_comment_sections(&rendered);
+        assert_eq!(parsed, vec![("lint".to_string(), "body".to_string())]);
+    }
+
+    #[test]
+    fn render_comment_footer_with_multiple_sections_alphabetical() {
+        // Footer sits after the last section regardless of section ordering.
+        let sections = vec![
+            ("lint".to_string(), "l".to_string()),
+            ("audit".to_string(), "a".to_string()),
+            ("test".to_string(), "t".to_string()),
+        ];
+        let out = render_comment("ci:x", None, &sections, None, Some("FTR"));
+        // Alphabetical order: audit, lint, test; footer last.
+        let audit_pos = out.find("section-key=audit:end").unwrap();
+        let lint_pos = out.find("section-key=lint:end").unwrap();
+        let test_pos = out.find("section-key=test:end").unwrap();
+        let footer_pos = out.find("homeboy:footer:start").unwrap();
+        assert!(audit_pos < lint_pos);
+        assert!(lint_pos < test_pos);
+        assert!(test_pos < footer_pos);
+    }
+
+    #[test]
+    fn render_comment_footer_with_explicit_section_order() {
+        let sections = vec![
+            ("audit".to_string(), "a".to_string()),
+            ("lint".to_string(), "l".to_string()),
+        ];
+        let order = vec!["lint".to_string(), "audit".to_string()];
+        let out = render_comment("ci:x", None, &sections, Some(&order), Some("FTR"));
+        let lint_pos = out.find("section-key=lint:end").unwrap();
+        let audit_pos = out.find("section-key=audit:end").unwrap();
+        let footer_pos = out.find("homeboy:footer:start").unwrap();
+        assert!(lint_pos < audit_pos);
+        assert!(audit_pos < footer_pos);
+    }
+
+    #[test]
+    fn render_comment_footer_content_trimmed_of_surrounding_newlines() {
+        // A footer passed with leading/trailing newlines should render cleanly
+        // (no double blank lines).
+        let sections = vec![("lint".to_string(), "body".to_string())];
+        let out = render_comment("ci:x", None, &sections, None, Some("\n\nFTR\n\n"));
+        assert!(out.contains("<!-- homeboy:footer:start -->\nFTR\n<!-- homeboy:footer:end -->\n"));
+        assert!(!out.contains("start -->\n\nFTR"));
+        assert!(!out.contains("FTR\n\n<!-- homeboy:footer:end"));
+    }
+
+    #[test]
+    fn parse_sections_ignores_footer_block() {
+        // A comment with both sections and a footer should parse only the
+        // sections — the footer is not a section.
+        let body = "\
+<!-- homeboy:comment-key=ci:x -->
+<!-- homeboy:section-key=lint:start -->
+lint body
+<!-- homeboy:section-key=lint:end -->
+
+<!-- homeboy:footer:start -->
+tooling
+<!-- homeboy:footer:end -->
+";
+        let sections = parse_comment_sections(body);
+        assert_eq!(sections, vec![("lint".to_string(), "lint body".to_string())]);
     }
 }


### PR DESCRIPTION
## Summary

Adds `--footer` / `--footer-file` flags to `homeboy git pr comment` in sectioned mode, symmetric to the existing `--header` flag. Lets sectioned PR comments carry a block **after the last section** — tooling-versions boxes, signature lines, meta-info footers that belong at the bottom of an aggregated results comment, not inside any single section.

Closes #1470.

## Marker format — Option A from #1470

Dedicated pair, parallel to the section marker shape:

```
<!-- homeboy:footer:start -->
...footer body...
<!-- homeboy:footer:end -->
```

Written after the last section's `:end` marker with one blank line separator. Matches the renderer's existing between-section layout so the footer reads naturally as a final block. Option B (positional convention, no markers) was rejected — the marker discipline is load-bearing for hand-edit resilience and the idempotency byte-compare.

## Library surface

- `PrCommentMode::Sectioned` gains `footer: Option<String>`.
- `render_comment` takes a 5th arg `footer: Option<&str>`. All existing call sites updated.
- New pure function `extract_footer(body: &str) -> Option<String>`, symmetric to `extract_header`.
- `extract_footer` only recognizes the **new** marker format — legacy `homeboy-action-*` bodies never had a footer convention, so legacy-parse → `None`. No regression: the renderer omits the footer block unless the caller opts in.

## Merge semantics — mirrors header

| Caller | Merge outcome |
|---|---|
| Passes `--footer` / `--footer-file` | Overwrites the preserved footer (if any). |
| Omits | `extract_footer` on every matching comment in ascending id order; **first non-empty wins**. Preserves user-written footers on merges from callers that don't set one. |
| Omits + no existing footer | Fresh render with no footer block — identical to today's output. |

## Empty-footer handling

`Some("")`, `Some(\"\\n\")`, `Some(\"\\n\\n\")` all behave as `None` — footer markers are **not** emitted. Matches the existing treatment of `--header \"\"` and is the intuitive read of \"a blank footer is not a footer.\"

## CLI

Two new flags on `homeboy git pr comment`:

```
--footer <text>       inline footer text
--footer-file <path>  read footer from file ("-" = stdin)
```

Clap-enforced:

- Mutually exclusive with each other.
- `requires = \"comment_key\"` — sectioned mode only. Rejected in legacy whole-body sticky mode (2) and plain mode (1), where no footer concept exists.

`resolve_body` (existing helper) is reused for both body and footer, so file-reading and stdin semantics stay consistent across `--body` / `--body-file` / `--footer` / `--footer-file`.

### CLI constraint verification

```
$ homeboy git pr comment t -n 1 --comment-key k --section-key s \
    --body b --footer f --footer-file /tmp/f
error: the argument '--footer <FOOTER>' cannot be used with
       '--footer-file <PATH>'

$ homeboy git pr comment t -n 1 --body b --footer f
error: the following required arguments were not provided:
  --section-key <SECTION_KEY>
  --comment-key <COMMENT_KEY>
```

Both mutex + `requires` constraints fire correctly.

## Rollout compat

- **Existing sectioned comments without a footer** → parse cleanly. Next render emits the same body byte-for-byte (idempotency noop still triggers).
- **Legacy `homeboy-action-*` bodies** → same as before; sections migrated to new markers, footer remains absent unless caller opts in. No regression.
- **Consumer that starts passing `--footer` on an existing comment** → next CI run adds a footer block. Subsequent runs preserve it even if the caller stops passing the flag (because `extract_footer` on the existing comment finds it and retains it).

## Tests

12 new pure-Rust unit tests in `src/core/git/github.rs`:

- `render_comment_writes_footer_block_after_last_section` — markers present after last section, blank-line separator, trailing newline.
- `render_comment_without_footer_omits_footer_markers` — no footer markers when caller omits.
- `render_comment_empty_footer_string_omits_footer_markers` — `\"\"`, `\"\\n\"`, `\"\\n\\n\"` all treated as None.
- `extract_footer_reads_block_between_markers` — round-trip.
- `extract_footer_returns_none_when_markers_absent` — no false positives.
- `extract_footer_returns_none_for_legacy_marker_bodies` — legacy-compat negative.
- `extract_footer_empty_inner_returns_none` — empty markers treated as absent.
- `render_comment_round_trips_footer_through_parse` — render → extract_footer preserves bytes; sections still round-trip.
- `render_comment_footer_with_multiple_sections_alphabetical` — footer last regardless of section order.
- `render_comment_footer_with_explicit_section_order` — footer last with explicit `--section-order`.
- `render_comment_footer_content_trimmed_of_surrounding_newlines` — clean output for sloppy input.
- `parse_sections_ignores_footer_block` — the section regex doesn't accidentally consume the footer.

**All 43 tests in `core::git::github` pass.** Full `cargo test --lib` → 1275 passed / 7 failed — failures are the same pre-existing flakes documented in #1334 / #1415 (`signature_check_*`, `test_run_topology_script`, `write_standalone_*`, `passing_verify_leaves_files_and_chunks_alone`). Verified against stashed baseline: same 7-flake set, different shuffling between runs (known intermittent). Zero new regressions from this change.

## Consumer follow-up

[Extra-Chill/homeboy-action#142](https://github.com/Extra-Chill/homeboy-action/pull/142) currently renders a tooling-versions block as a dedicated `tooling` section, pinned last via `--section-order lint,build,test,audit,tooling`. Once this lands in a homeboy release, that action PR can collapse to:

```bash
homeboy git pr comment ... \
  --section-key \"\$SECTION_KEY\" \
  --body-file \"\$SECTION_FILE\" \
  --header \"...\" \
  --footer-file \"\$TOOLING_FILE\" \
  --section-order lint,build,test,audit
```

One `homeboy` call per invocation instead of two, no `tooling` section key, clean separation of job-output from presentation meta. I'll file that simplification as a separate follow-up PR on the action repo once this ships.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted the `PrCommentMode::Sectioned.footer` field, `extract_footer`, 5-arg `render_comment` signature, CLI flag wiring (`--footer` / `--footer-file` with clap mutex + `requires`), and 12 unit tests covering render / extract / round-trip / legacy-compat / empty-footer behavior. Validated all scenarios pass against baseline. Chris directed the design (Option A markers from #1470, footer-preserve-on-merge semantics matching header, reuse `resolve_body` for file resolution).

Closes #1470.