### PR TITLE
fix(audit): split inline test methods from production methods in fingerprint (closes #1471)

### DIFF
--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -288,6 +288,17 @@ pub fn fingerprint_from_grammar(
     let functions = extract_functions(&symbols, &lines, &impl_contexts, test_range, grammar);
 
     // --- Methods list ---
+    //
+    // Production methods and inline test methods are kept in SEPARATE lists so
+    // a production method whose name begins with the test prefix (e.g.
+    // `ExtensionManifest::test_script()`) is never confused with an inline
+    // `#[test] fn test_script()`. See Extra-Chill/homeboy#1471 for the bug
+    // this separation prevents.
+    //
+    // `methods` holds non-test functions. `test_methods` holds test functions
+    // (those with an explicit `#[test]` attribute) with the test prefix
+    // normalized on — this is the canonical form the test-coverage detector
+    // expects.
     let mut methods = Vec::new();
     let mut seen_methods = HashSet::new();
     for f in &functions {
@@ -299,13 +310,16 @@ pub fn fingerprint_from_grammar(
             seen_methods.insert(f.name.clone());
         }
     }
-    // Add test methods with test_ prefix.
+
+    // Collect test methods separately.
     //
-    // Only include functions that have an explicit #[test] attribute.
-    // Functions inside #[cfg(test)] modules without #[test] are helpers
-    // (factories, fixtures, grammar builders) — not actual tests. Including
-    // them causes the orphaned test detector to flag them when no matching
-    // source method exists.
+    // Only functions with an explicit `#[test]` attribute qualify. Helpers
+    // inside `#[cfg(test)]` modules without `#[test]` (factories, fixtures,
+    // grammar builders) are deliberately excluded — including them would
+    // cause the orphaned-test detector to flag them when no matching source
+    // method exists.
+    let mut test_methods = Vec::new();
+    let mut seen_test_methods = HashSet::new();
     for f in &functions {
         if f.is_test && f.has_test_attr {
             let prefixed = if f.name.starts_with("test_") {
@@ -313,9 +327,9 @@ pub fn fingerprint_from_grammar(
             } else {
                 format!("test_{}", f.name)
             };
-            if !seen_methods.contains(&prefixed) {
-                methods.push(prefixed.clone());
-                seen_methods.insert(prefixed);
+            if !seen_test_methods.contains(&prefixed) {
+                test_methods.push(prefixed.clone());
+                seen_test_methods.insert(prefixed);
             }
         }
     }
@@ -421,6 +435,7 @@ pub fn fingerprint_from_grammar(
         relative_path: relative_path.to_string(),
         language,
         methods,
+        test_methods,
         registrations,
         type_name,
         type_names,
@@ -1708,8 +1723,13 @@ mod tests {
             !fp.method_hashes.contains_key("test_real_fn"),
             "Test functions should not be in method_hashes"
         );
-        // Test method should still be in the methods list
-        assert!(fp.methods.contains(&"test_real_fn".to_string()));
+        // Test method lives in `test_methods`, not `methods`, so a production
+        // method named `test_*` can't be confused with an inline `#[test]`.
+        assert!(fp.test_methods.contains(&"test_real_fn".to_string()));
+        assert!(
+            !fp.methods.contains(&"test_real_fn".to_string()),
+            "Inline #[test] functions must not leak into `methods`"
+        );
     }
 
     #[test]
@@ -2021,25 +2041,43 @@ mod tests {
         let fp = fingerprint_from_grammar(content, &grammar, "src/core/engine/edit_op.rs")
             .expect("fingerprint should succeed");
 
-        // test_from_insertion has #[test] → should be in methods as "test_from_insertion"
+        // test_from_insertion has #[test] → should be in `test_methods`,
+        // and NOT in `methods` (production methods list).
         assert!(
-            fp.methods.contains(&"test_from_insertion".to_string()),
-            "Actual #[test] function should be in methods list. Methods: {:?}",
+            fp.test_methods.contains(&"test_from_insertion".to_string()),
+            "Actual #[test] function should be in test_methods. test_methods: {:?}",
+            fp.test_methods
+        );
+        assert!(
+            !fp.methods.contains(&"test_from_insertion".to_string()),
+            "Inline #[test] functions must not leak into `methods`. Methods: {:?}",
             fp.methods
         );
 
-        // test_insertion is a helper (no #[test]) → should NOT be in methods list
+        // test_insertion is a helper (no #[test]) → should NOT be in either
+        // list; it's neither a production method nor an inline test.
         assert!(
             !fp.methods.contains(&"test_insertion".to_string()),
             "Helper fn test_insertion() without #[test] should NOT be in methods. Methods: {:?}",
             fp.methods
         );
+        assert!(
+            !fp.test_methods.contains(&"test_insertion".to_string()),
+            "Helper fn test_insertion() without #[test] should NOT be in test_methods. test_methods: {:?}",
+            fp.test_methods
+        );
 
-        // rust_grammar is a helper (no #[test]) → should NOT be in methods as test_rust_grammar
+        // rust_grammar is a helper (no #[test]) → should NOT appear with or
+        // without a test_ prefix in either list.
         assert!(
             !fp.methods.contains(&"test_rust_grammar".to_string()),
             "Helper fn rust_grammar() without #[test] should NOT be in methods. Methods: {:?}",
             fp.methods
+        );
+        assert!(
+            !fp.test_methods.contains(&"test_rust_grammar".to_string()),
+            "Helper fn rust_grammar() without #[test] should NOT be in test_methods. test_methods: {:?}",
+            fp.test_methods
         );
 
         // from_insertion is a real source method → should be in methods list

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -13,7 +13,27 @@ pub struct FileFingerprint {
     /// Language detected from extension.
     pub language: Language,
     /// Method/function names found in the file.
+    ///
+    /// Excludes inline test functions — those that have a `#[test]` (or
+    /// framework-specific test) attribute are tracked separately in
+    /// `test_methods`. A production method whose name happens to start with
+    /// a test-convention prefix (e.g. `ExtensionManifest::test_script()`)
+    /// still lives here, where it belongs.
     pub methods: Vec<String>,
+    /// Inline test method names, prefixed per `TestMappingConfig.method_prefix`.
+    ///
+    /// Populated ONLY for functions with an explicit test attribute (e.g.
+    /// `#[test]` in Rust) when the core grammar engine fingerprints the file.
+    /// Extension-script fingerprinting (PHP/JS/TS) leaves this empty because
+    /// those languages have no structural test marker — callers that care
+    /// about the non-inline case fall back to filtering `methods` by prefix.
+    ///
+    /// This exists so a production method named `test_foo()` is never
+    /// confused with an inline `#[test] fn test_foo()`. Without this field
+    /// the orphaned-test detector emitted source-file findings that
+    /// downstream autofix treated as deletable test functions — see
+    /// Extra-Chill/homeboy#1471.
+    pub test_methods: Vec<String>,
     /// Registration calls found (e.g., add_action, register_rest_route).
     pub registrations: Vec<String>,
     /// Class or struct name if found.
@@ -107,6 +127,10 @@ fn fingerprint_via_extension(
         relative_path: relative_path.to_string(),
         language,
         methods: output.methods,
+        // Extension-script fingerprinting does not distinguish test methods
+        // structurally — callers fall back to prefix-filter on `methods` when
+        // `test_methods` is empty and `inline_tests` is false.
+        test_methods: Vec::new(),
         registrations: output.registrations,
         type_name: output.type_name,
         type_names: output.type_names,

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -142,6 +142,9 @@ pub(crate) fn fingerprint_from_git_ref(
         relative_path: relative_path.to_string(),
         language,
         methods: output.methods,
+        // Extension-script fingerprinting does not structurally distinguish
+        // test methods — callers fall back to prefix filtering on `methods`.
+        test_methods: Vec::new(),
         registrations: output.registrations,
         type_name: output.type_name,
         type_names: output.type_names,

--- a/src/core/code_audit/shadow_modules.rs
+++ b/src/core/code_audit/shadow_modules.rs
@@ -248,6 +248,7 @@ mod tests {
             relative_path: path.to_string(),
             language: super::super::conventions::Language::Rust,
             methods: methods.iter().map(|s| s.to_string()).collect(),
+            test_methods: vec![],
             registrations: vec![],
             type_name: None,
             type_names: vec![],

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -685,7 +685,6 @@ mod tests {
     }
 
     /// Build a fingerprint with explicit `methods` and `test_methods` splits.
-    #[allow(dead_code)]
     fn make_fp_split(path: &str, methods: Vec<&str>, test_methods: Vec<&str>) -> FileFingerprint {
         FileFingerprint {
             relative_path: path.to_string(),

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -77,13 +77,13 @@ pub(crate) fn analyze_test_coverage(
         // For inline test languages (Rust), check for #[cfg(test)] in the source file itself
         if config.inline_tests {
             // Rust convention: tests can be inline in the same file.
-            // The fingerprint script extracts test methods from #[cfg(test)] modules
-            // and includes them in the methods list with their original names.
-            // Test methods matching method_prefix (e.g., "test_") indicate inline tests.
-            let has_inline_tests = source_fp
-                .methods
-                .iter()
-                .any(|m| m.starts_with(&config.method_prefix));
+            // The core grammar engine extracts functions with `#[test]` into the
+            // fingerprint's `test_methods` list (prefix normalized on). Reading
+            // the structural list rather than filtering `.methods` by name is
+            // what prevents production methods named `test_*` (like
+            // `ExtensionManifest::test_script`) from being classified as tests
+            // — see Extra-Chill/homeboy#1471.
+            let has_inline_tests = !source_fp.test_methods.is_empty();
 
             if !test_file_exists && !has_inline_tests {
                 if let Some(ref test_path) = expected_test_path {
@@ -108,35 +108,40 @@ pub(crate) fn analyze_test_coverage(
             // Check method coverage: combine inline test methods + dedicated test file methods
             let mut covered_methods: HashSet<&str> = HashSet::new();
 
-            // Inline test methods in the source file
-            for method in &source_fp.methods {
+            // Inline test methods — authored with `#[test]`, tracked separately
+            // from production methods so prefix-string ambiguity can't leak.
+            for method in &source_fp.test_methods {
                 if let Some(source_method) = method.strip_prefix(&config.method_prefix) {
                     covered_methods.insert(source_method);
                 }
             }
 
-            // Methods from dedicated test file
-            if let Some(test_fingerprint) = test_fp {
-                for method in &test_fingerprint.methods {
-                    if let Some(source_method) = method.strip_prefix(&config.method_prefix) {
-                        covered_methods.insert(source_method);
-                    }
-                }
+            // Methods from dedicated test file — for Rust, these are also
+            // structural (top-level `#[test]` functions in `tests/`). For
+            // extension-fingerprinted languages the core list is empty so we
+            // fall back to the prefix filter on `.methods`.
+            let dedicated_test_methods: Vec<&str> = if let Some(test_fingerprint) = test_fp {
+                collect_test_method_refs(test_fingerprint, config)
             } else if let Some(test_methods) = &disk_test_methods {
-                for method in test_methods {
-                    if let Some(source_method) = method.strip_prefix(&config.method_prefix) {
-                        covered_methods.insert(source_method);
-                    }
+                test_methods
+                    .iter()
+                    .filter(|m| m.starts_with(&config.method_prefix))
+                    .map(|m| m.as_str())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            for method in dedicated_test_methods {
+                if let Some(source_method) = method.strip_prefix(&config.method_prefix) {
+                    covered_methods.insert(source_method);
                 }
             }
 
-            // Build set of non-test source method names for orphaned test detection
-            let source_methods: HashSet<&str> = source_fp
-                .methods
-                .iter()
-                .filter(|m| !m.starts_with(&config.method_prefix))
-                .map(|m| m.as_str())
-                .collect();
+            // Build set of source method names for orphaned test detection.
+            // Test methods already live in `source_fp.test_methods` — `.methods`
+            // contains only non-test functions, so no prefix filter needed.
+            let source_methods: HashSet<&str> =
+                source_fp.methods.iter().map(|m| m.as_str()).collect();
 
             // Find source methods without tests (Check 2: MissingTestMethod)
             for method in &source_methods {
@@ -167,10 +172,15 @@ pub(crate) fn analyze_test_coverage(
             // Check 4a: Orphaned test methods (inline) — test methods whose
             // source method no longer exists. This catches tests left behind
             // when a function is deleted from the source.
+            //
+            // We pass `source_fp.test_methods` directly rather than filtering
+            // `source_fp.methods` by prefix. The detector historically used the
+            // prefix filter and emitted source-file findings for production
+            // methods named `test_*` — see Extra-Chill/homeboy#1471.
             find_orphaned_test_methods(
                 &mut findings,
                 &source_fp.relative_path,
-                &collect_test_methods_from_fp(source_fp, config),
+                &source_fp.test_methods,
                 &source_methods,
                 config,
             );
@@ -491,11 +501,39 @@ fn is_skipped_path(path: &str, config: &TestMappingConfig) -> bool {
 }
 
 /// Collect test method names from a fingerprint.
+///
+/// Prefers the structural `test_methods` list populated by the core grammar
+/// engine (Rust `#[test]` functions). Falls back to filtering `.methods` by
+/// the configured test prefix for extension-script fingerprints (PHP/JS/TS)
+/// that don't distinguish test functions structurally.
+///
+/// A production method named `test_foo()` in a source file is NOT considered
+/// a test method by this helper, because only the structural list is consulted
+/// when it's populated.
 fn collect_test_methods_from_fp(fp: &FileFingerprint, config: &TestMappingConfig) -> Vec<String> {
+    if !fp.test_methods.is_empty() {
+        return fp.test_methods.clone();
+    }
     fp.methods
         .iter()
         .filter(|m| m.starts_with(&config.method_prefix))
         .cloned()
+        .collect()
+}
+
+/// Collect test method names as borrowed `&str`s (same semantics as
+/// `collect_test_methods_from_fp`, borrowed for coverage-set building).
+fn collect_test_method_refs<'a>(
+    fp: &'a FileFingerprint,
+    config: &TestMappingConfig,
+) -> Vec<&'a str> {
+    if !fp.test_methods.is_empty() {
+        return fp.test_methods.iter().map(|m| m.as_str()).collect();
+    }
+    fp.methods
+        .iter()
+        .filter(|m| m.starts_with(&config.method_prefix))
+        .map(|m| m.as_str())
         .collect()
 }
 
@@ -613,11 +651,47 @@ mod tests {
         }
     }
 
+    /// Build a fingerprint for tests.
+    ///
+    /// For **source-file paths** (not under `tests/`), methods that start
+    /// with the conventional test prefix are split into `test_methods`,
+    /// mirroring what the core grammar engine does with `#[test]` functions.
+    /// This preserves backwards-compatibility with existing fixtures that mix
+    /// source methods and inline test methods into a single vec.
+    ///
+    /// For **test-file paths** (under `tests/` / `__tests__/` / matching
+    /// language-specific test suffixes), all methods stay in `.methods`. This
+    /// mirrors the extension-script fingerprint protocol (PHP/JS/TS) which
+    /// does not distinguish `#[test]`-attributed functions.
+    ///
+    /// For tests that need to model the specific case "production method with
+    /// a `test_` prefixed name" (e.g. `ExtensionManifest::test_script`), use
+    /// `make_fp_split` and pass an empty `test_methods` vec.
     fn make_fp(path: &str, methods: Vec<&str>) -> FileFingerprint {
+        let mut fp = FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Rust,
+            ..Default::default()
+        };
+        let is_test_file = crate::core::code_audit::walker::is_test_path(path);
+        for m in methods {
+            if !is_test_file && m.starts_with("test_") {
+                fp.test_methods.push(m.to_string());
+            } else {
+                fp.methods.push(m.to_string());
+            }
+        }
+        fp
+    }
+
+    /// Build a fingerprint with explicit `methods` and `test_methods` splits.
+    #[allow(dead_code)]
+    fn make_fp_split(path: &str, methods: Vec<&str>, test_methods: Vec<&str>) -> FileFingerprint {
         FileFingerprint {
             relative_path: path.to_string(),
             language: Language::Rust,
             methods: methods.into_iter().map(String::from).collect(),
+            test_methods: test_methods.into_iter().map(String::from).collect(),
             ..Default::default()
         }
     }
@@ -1257,6 +1331,74 @@ mod tests {
             orphaned.is_empty(),
             "Scenario test names should NOT be flagged as orphaned. Flagged: {:?}",
             orphaned.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn production_method_with_test_prefix_not_flagged_orphaned() {
+        // Regression for Extra-Chill/homeboy#1471: `ExtensionManifest::test_script()`
+        // and `test_mapping()` are production accessors on a manifest struct —
+        // public methods whose names happen to start with `test_`. They are
+        // NOT `#[test]` functions. The detector used to flag them as orphaned
+        // because `collect_test_methods_from_fp` filtered `.methods` by name
+        // prefix, ignoring the structural `has_test_attr` signal. The
+        // generator then auto-deleted them. Bug occurred three times in 26
+        // hours (#1176 → #1183 → bench PR #1385 force-push reverts) until
+        // this fix split test methods into their own `test_methods` vec.
+        let config = make_rust_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_prod_test_prefix");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/core/extension")).unwrap();
+
+        // Model ExtensionManifest: production methods with `test_` names, no
+        // inline tests. `test_methods` is empty (these are NOT #[test]).
+        let source = make_fp_split(
+            "src/core/extension/manifest.rs",
+            vec![
+                "lint_script",
+                "build_script",
+                "test_script",  // production accessor, looks like a test prefix
+                "test_mapping", // production accessor, looks like a test prefix
+                "autofix_verify",
+            ],
+            vec![], // no inline #[test] functions
+        );
+
+        let findings = analyze_test_coverage(&dir, &[&source], &config);
+
+        let orphaned: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| {
+                f.kind == AuditFinding::OrphanedTest && f.description.contains("no longer exists")
+            })
+            .collect();
+
+        assert!(
+            orphaned.is_empty(),
+            "Production methods named test_* must not be flagged as orphaned tests. \
+             Flagged: {:?}",
+            orphaned.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+
+        // They should also not show up as missing-test findings for the
+        // *nonexistent* source methods `script` / `mapping`.
+        let missing_methods_referencing_stub: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| {
+                f.kind == AuditFinding::MissingTestMethod
+                    && (f.description.contains("'script'") || f.description.contains("'mapping'"))
+            })
+            .collect();
+        assert!(
+            missing_methods_referencing_stub.is_empty(),
+            "test_script and test_mapping must not be interpreted as covering \
+             source methods named 'script' / 'mapping'. Found: {:?}",
+            missing_methods_referencing_stub
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/core/refactor/plan/generate/orphaned_test_fixes.rs
+++ b/src/core/refactor/plan/generate/orphaned_test_fixes.rs
@@ -472,16 +472,32 @@ pub(crate) fn generate_orphaned_test_fixes(
 
         // Fallback: delete the orphaned test if no rename candidate found.
         //
-        // Safety gate: if the corresponding source file no longer exists at all,
-        // the test is unambiguously orphaned — there's no source to reference.
-        // In that case, skip the manual_only gate and allow automated removal.
+        // Safety gate: we only auto-delete when we can confirm the finding
+        // refers to a real test file whose matching source file no longer
+        // exists. When `test_file_to_source_path` returns `None`, the
+        // finding's file is not shaped like a test path — which historically
+        // happened when the detector emitted a source-file finding for a
+        // production method named `test_*` (see Extra-Chill/homeboy#1471).
+        // In that case we refuse to act and surface the anomaly via
+        // `skipped` rather than silently auto-deleting a production method.
         //
-        // If the source file still exists (method was deleted but file remains),
-        // the test might be testing behavior via other code paths, so keep it
-        // manual-only for human review.
-        let source_file_exists = test_file_to_source_path(&finding.file)
-            .map(|p| root.join(p).exists())
-            .unwrap_or(false);
+        // If the derived source path exists, the test might still be
+        // exercising valid behavior through another code path → manual-only.
+        // If the derived source path is absent, the test is unambiguously
+        // orphaned → auto-delete.
+        let Some(derived_source_path) = test_file_to_source_path(&finding.file) else {
+            skipped.push(SkippedFile {
+                file: finding.file.clone(),
+                reason: format!(
+                    "Orphaned-test finding has non-test path shape `{}` — refusing to \
+                     auto-delete `{}`. Detector may be emitting source-file findings; \
+                     see Extra-Chill/homeboy#1471.",
+                    finding.file, test_method
+                ),
+            });
+            continue;
+        };
+        let source_file_exists = root.join(&derived_source_path).exists();
 
         let ins = insertion_with_primitive(
             RefactorPrimitive::RemoveOrphanedTest,
@@ -858,6 +874,74 @@ mod tests {
         assert!(
             fixes[0].insertions[0].manual_only,
             "Should be manual-only when source file still exists"
+        );
+    }
+
+    #[test]
+    fn generate_orphaned_test_fixes_refuses_source_path_finding() {
+        // Regression for Extra-Chill/homeboy#1471: the detector historically
+        // emitted findings whose `.file` was a SOURCE path (e.g.
+        // `src/core/extension/manifest.rs`) when a production method was
+        // named with the test prefix. The generator's `test_file_to_source_path`
+        // returned `None` on the source path, the previous `unwrap_or(false)`
+        // safety gate collapsed to "source doesn't exist → auto-delete", and
+        // the production method got deleted.
+        //
+        // After the fix the generator must refuse to act on findings whose
+        // file shape isn't recognisable as a test path. Upstream detector
+        // fix (production methods split into `test_methods`) makes such
+        // findings impossible in practice, but this backstop protects
+        // against any future detector regression emitting the same shape.
+        let dir = tempfile::tempdir().unwrap();
+        let source_file = dir.path().join("src/core/extension/manifest.rs");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_file,
+            "impl Foo {\n    pub fn test_script(&self) -> Option<&str> { None }\n}\n",
+        )
+        .unwrap();
+
+        let mut result = empty_result();
+        result.source_path = dir.path().to_string_lossy().to_string();
+        result.findings.push(Finding {
+            convention: "test_coverage".to_string(),
+            severity: Severity::Warning,
+            file: "src/core/extension/manifest.rs".to_string(),
+            description:
+                "Test method 'test_script' references 'script' which no longer exists in the source"
+                    .to_string(),
+            suggestion: "Remove".to_string(),
+            kind: AuditFinding::OrphanedTest,
+        });
+
+        let mut fixes: Vec<Fix> = Vec::new();
+        let mut skipped: Vec<SkippedFile> = Vec::new();
+        generate_orphaned_test_fixes(&result, dir.path(), &mut fixes, &mut skipped);
+
+        assert!(
+            fixes.is_empty(),
+            "Generator MUST NOT emit a fix for a source-file finding. Got: {:?}",
+            fixes
+                .iter()
+                .flat_map(|f| &f.insertions)
+                .map(|i| &i.description)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            skipped.len(),
+            1,
+            "Generator must record the refusal in `skipped`"
+        );
+        assert!(
+            skipped[0].reason.contains("non-test path shape"),
+            "Skip reason should explain the refusal. Got: {}",
+            skipped[0].reason
+        );
+        assert!(
+            skipped[0].reason.contains("#1471"),
+            "Skip reason should reference the tracking issue so future \
+             regressions are traceable. Got: {}",
+            skipped[0].reason
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #1471 (detector bug that has made the autofix bot delete `ExtensionManifest::test_script()` / `test_mapping()` three times in 26 hours). Also addresses #1478's narrower finding that the only real `manual_only` inconsistency in the autofix pipeline was the fail-open safety gate in `generate_orphaned_test_fixes`.

**Plumbing is complete, not half-migrated** — the full reconnaissance (wiki: `projects/homeboy-cli/autofix-safety-plumbing` on intelligence-chubes4) walked every detector in `src/core/code_audit/` and every generator in `src/core/refactor/plan/generate/`. The only Category-B (fragile-heuristic) generator was the orphaned-test path. Every other generator either correctly sets `manual_only` per-case or has sound upstream guards. No `FindingConfidence` enum needed.

## Root cause

`FileFingerprint.methods: Vec<String>` carried both production methods and (prefix-normalized) inline `#[test]` methods. `collect_test_methods_from_fp` filtered by name prefix — which cannot distinguish a production `test_script()` accessor from an inline `#[test] fn test_script()`. The core grammar engine computes `has_test_attr` at `core_fingerprint.rs:612-616` but that signal was discarded at the `Vec<String>` boundary.

Flow of the destruction:

```
core_fingerprint.rs     fn test_script (production)  →  methods += "test_script"
test_coverage.rs:494    .filter(|m| m.starts_with("test_"))  →  treated as test method
find_orphaned_test...   "test_script" doesn't map to source fn "script" → OrphanedTest finding
                        finding.file = "src/core/extension/manifest.rs"   ← SOURCE PATH
orphaned_test_fixes.rs  test_file_to_source_path("src/...") → None
                        .unwrap_or(false)  ←  fail OPEN
                        → auto-apply FunctionRemoval
                        → production method deleted
```

## P0 — detector fix

- New field `FileFingerprint.test_methods: Vec<String>`, populated **only** from functions with an explicit `#[test]` attribute in the core grammar engine. Production methods stay in `.methods`.
- Extension-script fingerprinting (PHP/JS/TS) leaves `test_methods` empty. Those languages have no structural test marker, so callers fall back to the prefix filter on `.methods` — unchanged behavior for PHPUnit / Vitest / Jest.
- `test_coverage.rs` rewired: `has_inline_tests` → check `!source_fp.test_methods.is_empty()`; the inline orphaned-test detector now reads `source_fp.test_methods` directly; `source_methods` no longer needs a prefix-exclusion filter.

## P1 — fail-closed backstop

- `generate_orphaned_test_fixes` now refuses to act when `test_file_to_source_path(finding.file)` returns `None` (the finding's file is not shaped like a test path). Records the refusal in `skipped` with a diagnostic that cites #1471, so future detector regressions are immediately visible in refactor reports instead of silently destroying code.

## Regression tests

- **`test_coverage::production_method_with_test_prefix_not_flagged_orphaned`** — models `ExtensionManifest`: production methods named `test_script` / `test_mapping`, no inline tests. Must not emit OrphanedTest findings and must not mark nonexistent source methods `script` / `mapping` as uncovered.
- **`orphaned_test_fixes::generate_orphaned_test_fixes_refuses_source_path_finding`** — verifies the backstop: when a malformed source-path finding reaches the generator, no fix is emitted and the refusal is traced with an #1471 citation.
- Two existing `core_fingerprint` tests updated to assert the new invariant (`#[test]` functions land in `.test_methods`, never in `.methods`).

## Tests

- `cargo test --lib test_coverage` — **23/23 pass** (up from 22, new regression test added)
- `cargo test --lib orphaned_test` — **30/30 pass** (up from 29, new regression test added)
- `cargo test --lib core_fingerprint` — **22/22 pass**
- Full `cargo test --lib` — 1337 passing vs 1334 on main. The 4 remaining failures (`signature_check_*`, `write_standalone_creates_and_reads_back`) all reproduce on `main` and predate this branch.
- `cargo build` clean; no new clippy warnings.

## Three-time recurrence, now closed

| PR | SHA | Outcome |
|---|---|---|
| #1176 | `9c13c518` | bot deleted `test_script()` + `test_mapping()` during ExtensionManifest rewrite |
| #1183 | `a76f51ed` | methods restored verbatim, detector untouched |
| bench #1385 stack | today | bot deleted them twice more, hand-reverted |

Historical pattern: every time autofix runs against the manifest, the latent detector bug re-flags these production methods and the fail-open safety gate lets the deletion through. This PR fixes both halves (detector says the truth; generator fails closed).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** read-only reconnaissance across every detector in `src/core/code_audit/` and every generator in `src/core/refactor/plan/generate/` to classify `manual_only` behavior; tracing the canary bug from fingerprint → detector → generator → filesystem write; drafting the structural split and backstop; writing the two regression tests. Chris reviewed the recon summary (wiki + #1478 comment) and chose the P0 shape (separate `test_methods` vec) + P0+P1 same-PR delivery before implementation began.