### PR TITLE
feat(extension): add verification phase contract

### DIFF
--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -7,6 +7,10 @@ are expected to write, and what exit codes mean.
 This is the authoritative reference for extension authors wiring a new
 runner and for core maintainers improving the cross-extension surface.
 
+For the cross-command verification phase model (`syntax`, `lint`, `typecheck`,
+`audit`, `test`), see
+[`docs/development/contracts/verification-phases.md`](../development/contracts/verification-phases.md).
+
 ## Capability model
 
 Each extension declares scripts per-capability in its manifest
@@ -14,7 +18,7 @@ Each extension declares scripts per-capability in its manifest
 
 | Capability | Manifest field | Typical script | Invoked by |
 |------------|---------------|----------------|------------|
-| `lint` | `lint.extension_script` | `scripts/lint/lint-runner.sh` | `homeboy lint`, also chained by `test` |
+| `lint` | `lint.extension_script` | `scripts/lint/lint-runner.sh` | `homeboy lint` |
 | `test` | `test.extension_script` | `scripts/test/test-runner.sh` | `homeboy test` |
 | `build` | `build.extension_script` | `scripts/build/build.sh` | `homeboy build`, `homeboy release` |
 | `audit` | *built-in to core* | n/a | `homeboy audit` |
@@ -228,12 +232,14 @@ yet — this is a follow-up deliverable, not a current reference.
 Invokes the extension's `test.extension_script` with context env vars
 set. The script is expected to:
 
-1. Run lint as a prerequisite (unless `HOMEBOY_SKIP_LINT=1` or
-   `--skip-lint`). Most runners dispatch to `lint-runner.sh` internally.
-2. Run the test tool (PHPUnit, cargo test, etc.).
-3. Write results sidecar if `HOMEBOY_TEST_RESULTS_FILE` is set.
-4. Write failures sidecar if `HOMEBOY_TEST_FAILURES_FILE` is set.
-5. Exit per the convention above.
+1. Run the test harness only (PHPUnit, cargo test, npm test, etc.).
+2. Write results sidecar if `HOMEBOY_TEST_RESULTS_FILE` is set.
+3. Write failures sidecar if `HOMEBOY_TEST_FAILURES_FILE` is set.
+4. Exit per the convention above.
+
+`homeboy test` does not run lint or audit. Those are separate primitive
+commands (`homeboy lint`, `homeboy audit`) that composed workflows can run
+alongside test when they need a full verification sequence.
 
 Core handles baseline comparison, coverage threshold enforcement,
 test-drift detection, and analysis mode — extensions don't implement

--- a/docs/development/contracts/verification-phases.md
+++ b/docs/development/contracts/verification-phases.md
@@ -1,0 +1,87 @@
+# Verification phase contract
+
+Homeboy's verification surface is deliberately split into isolated primitive
+commands that can be composed by higher-level workflows.
+
+## Primitive phases
+
+The shared phase vocabulary is:
+
+1. `syntax` — parser-level validation such as `php -l`, `rustc --emit=metadata`, or equivalent
+2. `lint` — static lint findings from PHPCS, ESLint, clippy, rustfmt, etc.
+3. `typecheck` — type/system checks such as PHPStan, `tsc --noEmit`, or `cargo check`
+4. `audit` — Homeboy structural analysis such as duplicates, orphaned tests, and code smells
+5. `test` — behavioral test harness execution such as PHPUnit, cargo test, or npm test
+
+These phases are a contract, not a requirement that one command runs all of
+them. `homeboy test` runs only the `test` phase. `homeboy lint` runs only the
+`lint` phase. `homeboy audit` runs only the `audit` phase. A composed command
+or CI wrapper can run the phases in canonical order when it needs a full check.
+
+## Exit codes
+
+Every primitive command uses the same exit code convention:
+
+- `0`: clean
+- `1`: findings, lint violations, audit findings, or test failures
+- `2` or higher: infrastructure failure such as missing dependencies, harness bootstrap failure, or runtime crash
+
+This distinction matters because code findings should fail CI differently from
+broken tooling. Composed workflows can stop early on infrastructure failures and
+still report normal findings as actionable code work.
+
+## Structured output
+
+Primitive command output should include a phase report:
+
+```json
+{
+  "phase": {
+    "phase": "test",
+    "status": "failed",
+    "exit_code": 1,
+    "summary": "test phase reported 2 failure(s) out of 120 test(s)"
+  },
+  "failure": {
+    "phase": "test",
+    "category": "findings",
+    "summary": "2 test failure(s) detected"
+  }
+}
+```
+
+`status` is one of:
+
+- `passed`
+- `failed`
+- `error`
+- `skipped`
+- `not-run`
+
+`failure.category` is one of:
+
+- `findings`
+- `infrastructure`
+
+The core Rust contract lives in `src/core/extension/runner_contract.rs`:
+
+- `VerificationPhase`
+- `PhaseStatus`
+- `PhaseFailureCategory`
+- `PhaseReport`
+- `PhaseFailure`
+
+## Composition
+
+Composed workflows should treat primitive commands as independent inputs:
+
+```text
+syntax     -> optional primitive / extension runner
+lint       -> homeboy lint
+typecheck  -> optional primitive / extension runner
+audit      -> homeboy audit
+test       -> homeboy test
+```
+
+This keeps each command debuggable on its own while giving CI, future `check`
+commands, and rig workflows one stable shape to aggregate.

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -4,6 +4,10 @@
 //! builder function to convert a workflow result into the command output tuple.
 
 use crate::extension::lint::baseline::{BaselineComparison, LintFinding};
+use crate::extension::{
+    phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
+    PhaseFailureCategory, PhaseReport, VerificationPhase,
+};
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
 
@@ -19,6 +23,9 @@ pub struct LintCommandOutput {
     pub status: String,
     pub component: String,
     pub exit_code: i32,
+    pub phase: PhaseReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<PhaseFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub autofix: Option<AppliedRefactor>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,12 +46,26 @@ pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, 
     } else {
         result.exit_code
     };
+    let finding_count = result
+        .lint_findings
+        .as_ref()
+        .map(|findings| findings.len())
+        .unwrap_or(0);
+    let phase = lint_phase_report(exit_code, &result.status, finding_count);
+    let failure = if exit_code == 0 {
+        None
+    } else {
+        Some(lint_phase_failure(exit_code, finding_count))
+    };
+
     (
         LintCommandOutput {
             passed: exit_code == 0,
             status: result.status,
             component: result.component,
             exit_code,
+            phase,
+            failure,
             autofix: result.autofix,
             hints: result.hints,
             baseline_comparison: result.baseline_comparison,
@@ -52,4 +73,41 @@ pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, 
         },
         exit_code,
     )
+}
+
+fn lint_phase_report(exit_code: i32, status: &str, finding_count: usize) -> PhaseReport {
+    PhaseReport {
+        phase: VerificationPhase::Lint,
+        status: phase_status_from_exit_code(exit_code),
+        exit_code: Some(exit_code),
+        summary: if exit_code == 0 {
+            "lint phase passed with no findings".to_string()
+        } else if exit_code >= 2 {
+            format!("lint phase infrastructure failure (exit {})", exit_code)
+        } else if finding_count > 0 {
+            format!("lint phase reported {} finding(s)", finding_count)
+        } else {
+            format!("lint phase {} (exit {})", status, exit_code)
+        },
+    }
+}
+
+fn lint_phase_failure(exit_code: i32, finding_count: usize) -> PhaseFailure {
+    let category = phase_failure_category_from_exit_code(exit_code);
+    PhaseFailure {
+        phase: VerificationPhase::Lint,
+        summary: match category {
+            PhaseFailureCategory::Infrastructure => {
+                format!("lint runner infrastructure failure (exit {})", exit_code)
+            }
+            PhaseFailureCategory::Findings => {
+                if finding_count > 0 {
+                    format!("{} lint finding(s) detected", finding_count)
+                } else {
+                    format!("lint phase reported findings (exit {})", exit_code)
+                }
+            }
+        },
+        category,
+    }
 }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -18,7 +18,10 @@ pub mod exec_context;
 
 // Re-export runner types
 pub use runner::{ExtensionRunner, RunnerOutput};
-pub use runner_contract::RunnerStepFilter;
+pub use runner_contract::{
+    phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
+    PhaseFailureCategory, PhaseReport, PhaseStatus, RunnerStepFilter, VerificationPhase,
+};
 pub use runtime_helper::RUNNER_STEPS_ENV;
 
 // Re-export manifest types

--- a/src/core/extension/runner_contract.rs
+++ b/src/core/extension/runner_contract.rs
@@ -1,5 +1,84 @@
 use std::collections::HashSet;
 
+use serde::{Deserialize, Serialize};
+
+/// Shared verification phase vocabulary for isolated commands and composed runners.
+///
+/// `homeboy lint`, `homeboy audit`, and `homeboy test` stay independent. A
+/// future composed command can run these phases in canonical order while reusing
+/// the same phase reports and exit-code semantics.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum VerificationPhase {
+    Syntax,
+    Lint,
+    Typecheck,
+    Audit,
+    Test,
+}
+
+impl VerificationPhase {
+    pub fn canonical_order() -> [Self; 5] {
+        [
+            Self::Syntax,
+            Self::Lint,
+            Self::Typecheck,
+            Self::Audit,
+            Self::Test,
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PhaseStatus {
+    Passed,
+    Failed,
+    Error,
+    Skipped,
+    NotRun,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PhaseFailureCategory {
+    Findings,
+    Infrastructure,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PhaseReport {
+    pub phase: VerificationPhase,
+    pub status: PhaseStatus,
+    pub exit_code: Option<i32>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PhaseFailure {
+    pub phase: VerificationPhase,
+    pub category: PhaseFailureCategory,
+    pub summary: String,
+}
+
+pub fn phase_status_from_exit_code(exit_code: i32) -> PhaseStatus {
+    if exit_code == 0 {
+        PhaseStatus::Passed
+    } else if exit_code >= 2 {
+        PhaseStatus::Error
+    } else {
+        PhaseStatus::Failed
+    }
+}
+
+pub fn phase_failure_category_from_exit_code(exit_code: i32) -> PhaseFailureCategory {
+    if exit_code >= 2 {
+        PhaseFailureCategory::Infrastructure
+    } else {
+        PhaseFailureCategory::Findings
+    }
+}
+
 /// Generic step filter contract for extension runner scripts.
 #[derive(Debug, Clone, Default)]
 pub struct RunnerStepFilter {
@@ -121,6 +200,35 @@ mod tests {
         let env = filter.to_env_pairs();
         assert!(env.iter().any(|(k, v)| k == "HOMEBOY_STEP" && v == "a"));
         assert!(env.iter().any(|(k, v)| k == "HOMEBOY_SKIP" && v == "b"));
+    }
+
+    #[test]
+    fn verification_phase_order_is_canonical() {
+        assert_eq!(
+            VerificationPhase::canonical_order(),
+            [
+                VerificationPhase::Syntax,
+                VerificationPhase::Lint,
+                VerificationPhase::Typecheck,
+                VerificationPhase::Audit,
+                VerificationPhase::Test,
+            ]
+        );
+    }
+
+    #[test]
+    fn phase_exit_codes_are_classified() {
+        assert_eq!(phase_status_from_exit_code(0), PhaseStatus::Passed);
+        assert_eq!(phase_status_from_exit_code(1), PhaseStatus::Failed);
+        assert_eq!(phase_status_from_exit_code(2), PhaseStatus::Error);
+        assert_eq!(
+            phase_failure_category_from_exit_code(1),
+            PhaseFailureCategory::Findings
+        );
+        assert_eq!(
+            phase_failure_category_from_exit_code(2),
+            PhaseFailureCategory::Infrastructure
+        );
     }
 }
 

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -8,6 +8,10 @@ use crate::extension::test::{
     CoverageOutput, DriftReport, TestAnalysis, TestBaselineComparison, TestCounts, TestScopeOutput,
     TestSummaryOutput,
 };
+use crate::extension::{
+    phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
+    PhaseFailureCategory, PhaseReport, VerificationPhase,
+};
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
 
@@ -24,6 +28,10 @@ pub struct TestCommandOutput {
     pub status: String,
     pub component: String,
     pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<PhaseReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<PhaseFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test_counts: Option<TestCounts>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -53,12 +61,21 @@ pub struct TestCommandOutput {
 /// Build output from a main test workflow result.
 pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, i32) {
     let exit_code = result.exit_code;
+    let phase = Some(test_phase_report(exit_code, result.test_counts.as_ref()));
+    let failure = if exit_code == 0 {
+        None
+    } else {
+        Some(test_phase_failure(exit_code, result.test_counts.as_ref()))
+    };
+
     (
         TestCommandOutput {
             passed: exit_code == 0,
             status: result.status,
             component: result.component,
             exit_code: result.exit_code,
+            phase,
+            failure,
             test_counts: result.test_counts,
             coverage: result.coverage,
             baseline_comparison: result.baseline_comparison,
@@ -84,6 +101,8 @@ pub fn from_drift_workflow(result: DriftWorkflowResult) -> (TestCommandOutput, i
             status: "drift".to_string(),
             component: result.component,
             exit_code: result.exit_code,
+            phase: None,
+            failure: None,
             test_counts: None,
             coverage: None,
             baseline_comparison: None,
@@ -121,6 +140,8 @@ pub fn from_auto_fix_drift_workflow(
             status,
             component: result.component,
             exit_code: 0,
+            phase: None,
+            failure: None,
             test_counts: None,
             coverage: None,
             baseline_comparison: None,
@@ -135,4 +156,54 @@ pub fn from_auto_fix_drift_workflow(
         },
         0,
     )
+}
+
+fn test_phase_report(exit_code: i32, counts: Option<&TestCounts>) -> PhaseReport {
+    PhaseReport {
+        phase: VerificationPhase::Test,
+        status: phase_status_from_exit_code(exit_code),
+        exit_code: Some(exit_code),
+        summary: if exit_code == 0 {
+            if let Some(counts) = counts {
+                format!(
+                    "test phase passed: {} passed, {} skipped",
+                    counts.passed, counts.skipped
+                )
+            } else {
+                "test phase passed".to_string()
+            }
+        } else if exit_code >= 2 {
+            format!("test harness infrastructure failure (exit {})", exit_code)
+        } else if let Some(counts) = counts {
+            format!(
+                "test phase reported {} failure(s) out of {} test(s)",
+                counts.failed, counts.total
+            )
+        } else {
+            format!(
+                "test phase failed without structured counts (exit {})",
+                exit_code
+            )
+        },
+    }
+}
+
+fn test_phase_failure(exit_code: i32, counts: Option<&TestCounts>) -> PhaseFailure {
+    let category = phase_failure_category_from_exit_code(exit_code);
+    PhaseFailure {
+        phase: VerificationPhase::Test,
+        summary: match category {
+            PhaseFailureCategory::Infrastructure => {
+                format!("test harness infrastructure failure (exit {})", exit_code)
+            }
+            PhaseFailureCategory::Findings => {
+                if let Some(counts) = counts {
+                    format!("{} test failure(s) detected", counts.failed)
+                } else {
+                    format!("test phase reported failures (exit {})", exit_code)
+                }
+            }
+        },
+        category,
+    }
 }


### PR DESCRIPTION
## Summary
- Add shared verification phase contract types for `syntax`, `lint`, `typecheck`, `audit`, and `test`.
- Include `phase` and classified `failure` metadata in isolated `homeboy lint` and `homeboy test` outputs.
- Document that `lint`, `audit`, and `test` are separate primitive commands that composed workflows can aggregate.

Refs #1459.

## Testing
- `cargo check`
- `cargo test runner_contract`
- `cargo test -- --test-threads=1`

Note: parallel `cargo test` still shows a race in `core::component::inventory` tests; the failing tests pass individually and the full suite passes serially.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the shared verification phase contract types, structured lint/test phase metadata, and documentation updates. Chris directed the architectural correction that `test` must remain isolated from `lint`/`audit`.