### PR TITLE
feat(bench): support generic metric policies

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -13,9 +13,9 @@ homeboy bench <component> [options] [-- <runner-args>]
 
 The `bench` command invokes the extension's bench runner, which measures
 one or more scenarios over N iterations and emits a structured JSON
-results file. Homeboy parses the results, compares p95 latency against
-a saved baseline, and returns a structured report plus an exit code
-suitable for CI gates.
+results file. Homeboy parses the results, compares declared numeric
+metrics against a saved baseline, and returns a structured report plus
+an exit code suitable for CI gates.
 
 `bench` is a sibling of `test`, `lint`, and `build` under homeboy's
 extension capability model. The runner contract, manifest shape, and
@@ -35,11 +35,11 @@ the other capabilities.
 - `--baseline`: Save the current run as the new baseline under
   `homeboy.json` → `baselines.bench`.
 - `--ignore-baseline`: Run without comparing to any saved baseline.
-- `--ratchet`: When scenarios improve (p95 got faster), auto-update the
-  saved baseline so the improvement "sticks". Ignored when the run
-  regresses.
-- `--regression-threshold <PERCENT>`: p95 regression tolerance (default
-  `5.0`). A scenario regresses when its current p95_ms exceeds
+- `--ratchet`: When scenarios improve, auto-update the saved baseline so
+  the improvement "sticks". Ignored when the run regresses.
+- `--regression-threshold <PERCENT>`: Legacy p95 regression tolerance
+  (default `5.0`) used when the runner does not declare `metric_policies`.
+  A p95 scenario regresses when its current `p95_ms` exceeds
   `baseline.p95_ms * (1 + threshold/100)`.
 - `--setting <key=value>`: Override component settings (may be repeated).
 - `--path <PATH>`: Override the component's `local_path` for this run.
@@ -72,25 +72,30 @@ homeboy bench my-component -- --filter=hot_path
 
 The bench baseline is a list of per-scenario snapshots stored in
 `homeboy.json` under the `baselines.bench` key. Each snapshot records
-`{ id, p95_ms, p50_ms, mean_ms }` plus the iteration count at capture
-time.
+`{ id, metrics }` plus the iteration count at capture time.
 
 On every run without `--baseline` or `--ignore-baseline`:
 
 1. Each current scenario is matched against the baseline by `id`.
-2. A scenario regresses when current `p95_ms > baseline.p95_ms * (1 + threshold/100)`.
-   Default threshold: 5%.
-3. A scenario improves when current `p95_ms < baseline.p95_ms`.
-4. Scenarios present in one run but not the other are flagged as
+2. If the runner declares `metric_policies`, only those metrics are
+   compared. Each policy declares whether lower or higher values are
+   better and optional percent/absolute tolerances.
+3. If the runner omits `metric_policies`, Homeboy keeps the historical
+   default: compare `p95_ms` as lower-is-better with the CLI threshold.
+4. A scenario improves when any compared metric moves in the better
+   direction.
+5. Scenarios present in one run but not the other are flagged as
    `new_scenario_ids` / `removed_scenario_ids`. Neither state triggers
    a regression by itself — they're informational.
-5. If any scenario regressed, the command exits `1` regardless of the
+6. If any scenario regressed, the command exits `1` regardless of the
    runner's own exit code.
-6. If any scenario improved and `--ratchet` is set, the baseline is
+7. If any scenario improved and `--ratchet` is set, the baseline is
    overwritten with the current snapshot.
 
-p95 was chosen as the regression signal over mean (too sensitive to
-one-off GC pauses) and p99 (too insensitive to real regressions).
+p95 remains the default for legacy latency benchmarks because it is less
+sensitive than mean to one-off GC pauses but more sensitive than p99 to
+genuine regressions. Runners that care about non-latency signals should
+declare `metric_policies` instead.
 
 ## Runner Contract
 
@@ -107,6 +112,16 @@ The extension's bench script must:
 {
   "component_id": "string",
   "iterations": 10,
+  "metric_policies": {
+    "error_rate": {
+      "direction": "lower_is_better",
+      "regression_threshold_absolute": 0.01
+    },
+    "requests_per_second": {
+      "direction": "higher_is_better",
+      "regression_threshold_percent": 5.0
+    }
+  },
   "scenarios": [
     {
       "id": "scenario_slug",
@@ -118,7 +133,10 @@ The extension's bench script must:
         "p95_ms": 145.0,
         "p99_ms": 160.0,
         "min_ms": 110.0,
-        "max_ms": 172.0
+        "max_ms": 172.0,
+        "error_rate": 0.0,
+        "requests_per_second": 180.5,
+        "status_500_count": 0
       },
       "memory": { "peak_bytes": 41943040 }
     }
@@ -128,6 +146,16 @@ The extension's bench script must:
 
 - Top-level keys are strict — unknown top-level fields are rejected to
   keep the contract honest.
+- `metrics` is an arbitrary map of numeric values. Homeboy core does not
+  attach domain meaning to metric names.
+- `metric_policies` is optional. If omitted, Homeboy compares `p95_ms`
+  using the legacy lower-is-better latency policy.
+- Policy `direction` accepts `lower_is_better` / `lower` and
+  `higher_is_better` / `higher`.
+- Policy thresholds are optional. `regression_threshold_percent` compares
+  relative movement; `regression_threshold_absolute` compares raw numeric
+  movement. If both are present, a metric must exceed both tolerances to
+  regress.
 - Scenario-level unknown keys are **tolerated**, so extensions can emit
   additional metadata (tags, environment info, warmup counts) without
   breaking parsing.

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -329,6 +329,55 @@ mod tests {
     }
 
     #[test]
+    fn test_from_scenario() {
+        let scenario = scenario("snapshot", 123.0);
+        let snapshot = BenchScenarioSnapshot::from_scenario(&scenario);
+
+        assert_eq!(snapshot.id, "snapshot");
+        assert_eq!(snapshot.metric_value("p95_ms"), Some(123.0));
+        assert!(snapshot.metric_value("mean_ms").unwrap() > 110.0);
+    }
+
+    #[test]
+    fn test_save_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = results(vec![scenario("a", 100.0)]);
+        let path = save_baseline(dir.path(), "demo", &run, None).unwrap();
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_load_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = results(vec![scenario("a", 100.0)]);
+        save_baseline(dir.path(), "demo", &run, None).unwrap();
+
+        let loaded = load_baseline(dir.path(), None).unwrap();
+
+        assert_eq!(loaded.context_id, "demo");
+        assert_eq!(loaded.metadata.scenarios.len(), 1);
+    }
+
+    #[test]
+    fn test_compare() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(
+            dir.path(),
+            "demo",
+            &results(vec![scenario("a", 100.0)]),
+            None,
+        )
+        .unwrap();
+        let baseline = load_baseline(dir.path(), None).unwrap();
+
+        let comparison = compare(&results(vec![scenario("a", 106.0)]), &baseline, 5.0);
+
+        assert!(comparison.regression);
+        assert_eq!(comparison.scenarios.len(), 1);
+    }
+
+    #[test]
     fn save_and_load_roundtrips() {
         let dir = tempfile::tempdir().unwrap();
         let run = results(vec![scenario("a", 100.0), scenario("b", 200.0)]);

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -1,4 +1,4 @@
-//! Bench baseline — ratchet for scenario latency (p95) regressions.
+//! Bench baseline — ratchet for scenario metric regressions.
 //!
 //! Stored under `homeboy.json` → `baselines.bench` via the generic
 //! `engine::baseline` primitive, alongside `baselines.test` and
@@ -7,18 +7,16 @@
 //! tracks through the generic `new_items` / `resolved_fingerprints`
 //! lanes automatically.
 //!
-//! On top of that, bench adds a **threshold-based regression check**:
-//! a scenario regresses when its current `p95_ms` exceeds its baseline
-//! `p95_ms` by more than the configured percentage. Improvements (p95
-//! got faster) are celebrated and only written back to the baseline
-//! when `--ratchet` is set.
+//! On top of that, bench adds a **threshold-based regression check**.
+//! Runners may declare metric policies for arbitrary numeric metrics
+//! (lower-is-better error rates, higher-is-better throughput, etc.). If
+//! they do not, Homeboy preserves the original p95 latency behavior.
 //!
-//! Default threshold is 5%. p95 was chosen as the signal over mean
-//! because p95 is less sensitive than mean to one-off GC pauses but
-//! more sensitive than p99 to genuine regressions. Callers can pass
-//! any threshold per run via the command flag.
+//! Default p95 threshold is 5%. Callers can pass any threshold per run
+//! via the command flag, while runner-declared policies can carry their
+//! own percent or absolute tolerances.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -26,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use crate::engine::baseline::{self as generic, BaselineConfig};
 use crate::error::Result;
 
-use super::parsing::{BenchResults, BenchScenario};
+use super::parsing::{BenchMetricDirection, BenchMetricPolicy, BenchResults, BenchScenario};
 
 const BASELINE_KEY: &str = "bench";
 
@@ -56,19 +54,37 @@ pub const DEFAULT_REGRESSION_THRESHOLD_PERCENT: f64 = 5.0;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BenchScenarioSnapshot {
     pub id: String,
-    pub p95_ms: f64,
-    pub p50_ms: f64,
-    pub mean_ms: f64,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metrics: BTreeMap<String, f64>,
+    /// Legacy fields from the first bench baseline shape. They remain
+    /// readable so existing baselines keep working, but new baselines store
+    /// metrics under the generic `metrics` map.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p95_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p50_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mean_ms: Option<f64>,
 }
 
 impl BenchScenarioSnapshot {
     pub(crate) fn from_scenario(scenario: &BenchScenario) -> Self {
         Self {
             id: scenario.id.clone(),
-            p95_ms: scenario.metrics.p95_ms,
-            p50_ms: scenario.metrics.p50_ms,
-            mean_ms: scenario.metrics.mean_ms,
+            metrics: scenario.metrics.values.clone(),
+            p95_ms: None,
+            p50_ms: None,
+            mean_ms: None,
         }
+    }
+
+    fn metric_value(&self, name: &str) -> Option<f64> {
+        self.metrics.get(name).copied().or_else(|| match name {
+            "p95_ms" => self.p95_ms,
+            "p50_ms" => self.p50_ms,
+            "mean_ms" => self.mean_ms,
+            _ => None,
+        })
     }
 }
 
@@ -77,10 +93,13 @@ impl generic::Fingerprintable for BenchScenarioSnapshot {
         self.id.clone()
     }
     fn description(&self) -> String {
-        format!(
-            "p95 {:.2}ms (p50 {:.2}ms, mean {:.2}ms)",
-            self.p95_ms, self.p50_ms, self.mean_ms
-        )
+        if let Some(p95) = self.metric_value("p95_ms") {
+            return format!("p95 {:.2}ms", p95);
+        }
+        if let Some((name, value)) = self.metrics.iter().next() {
+            return format!("{} {:.2}", name, value);
+        }
+        "no metrics".to_string()
     }
     fn context_label(&self) -> String {
         self.id.clone()
@@ -103,14 +122,48 @@ pub type BenchBaseline = generic::Baseline<BenchBaselineMetadata>;
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ScenarioDelta {
     pub id: String,
-    pub baseline_p95_ms: f64,
-    pub current_p95_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_p95_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_p95_ms: Option<f64>,
     /// Current minus baseline in ms. Negative = faster.
-    pub p95_delta_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p95_delta_ms: Option<f64>,
     /// (current - baseline) / baseline * 100. Negative = faster.
-    pub p95_delta_pct: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p95_delta_pct: Option<f64>,
+    pub metric_deltas: Vec<MetricDelta>,
     pub regression: bool,
     pub improvement: bool,
+}
+
+/// Per-metric delta vs baseline. Extensions can opt into comparing any
+/// numeric metric by declaring a policy in the bench results JSON.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct MetricDelta {
+    pub name: String,
+    pub baseline_value: f64,
+    pub current_value: f64,
+    /// Current minus baseline. Positive is not always bad — consult
+    /// `direction` to know whether larger or smaller is better.
+    pub delta: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta_pct: Option<f64>,
+    pub direction: BenchMetricDirection,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regression_threshold_percent: Option<f64>,
+    pub regression_threshold_absolute: f64,
+    pub regression: bool,
+    pub improvement: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedMetricPolicy {
+    name: String,
+    direction: BenchMetricDirection,
+    regression_threshold_percent: Option<f64>,
+    regression_threshold_absolute: f64,
+    zero_baseline_is_neutral: bool,
 }
 
 /// Summary of comparing a current run against a stored baseline.
@@ -179,6 +232,7 @@ pub fn compare(
     let mut reasons = Vec::new();
     let mut has_improvements = false;
     let mut any_regression = false;
+    let metric_policies = resolve_metric_policies(current, threshold_percent);
 
     for scenario in &current.scenarios {
         let Some(prior) = baseline_by_id.get(scenario.id.as_str()) else {
@@ -186,40 +240,49 @@ pub fn compare(
             continue;
         };
 
-        let baseline_p95 = prior.p95_ms;
-        let current_p95 = scenario.metrics.p95_ms;
-        let delta_ms = current_p95 - baseline_p95;
+        let mut metric_deltas = Vec::new();
 
-        // Guard against zero-valued baselines — anything-over-zero is
-        // infinite % regression, which is noise for a micro-benchmark
-        // that legitimately measured 0ms. Treat them as no-delta.
-        let delta_pct = if baseline_p95 > 0.0 {
-            (delta_ms / baseline_p95) * 100.0
-        } else {
-            0.0
-        };
+        for policy in &metric_policies {
+            let Some(baseline_value) = prior.metric_value(&policy.name) else {
+                continue;
+            };
+            let Some(current_value) = scenario.metrics.get(&policy.name) else {
+                continue;
+            };
+            metric_deltas.push(compare_metric(policy, baseline_value, current_value));
+        }
 
-        let threshold_ratio = 1.0 + (threshold_percent / 100.0);
-        let regression = baseline_p95 > 0.0 && current_p95 > baseline_p95 * threshold_ratio;
-        let improvement = delta_ms < 0.0;
+        let regression = metric_deltas.iter().any(|d| d.regression);
+        let improvement = metric_deltas.iter().any(|d| d.improvement);
 
         if regression {
             any_regression = true;
-            reasons.push(format!(
-                "{}: p95 {:.2}ms → {:.2}ms ({:+.1}%)",
-                scenario.id, baseline_p95, current_p95, delta_pct
-            ));
+            for delta in metric_deltas.iter().filter(|d| d.regression) {
+                reasons.push(format_metric_reason(&scenario.id, delta));
+            }
         }
         if improvement {
             has_improvements = true;
         }
 
+        let baseline_p95 = prior.metric_value("p95_ms");
+        let current_p95 = scenario.metrics.get("p95_ms");
+        let p95_delta_ms = baseline_p95.zip(current_p95).map(|(b, c)| c - b);
+        let p95_delta_pct = baseline_p95.zip(current_p95).and_then(|(b, c)| {
+            if b > 0.0 {
+                Some(((c - b) / b) * 100.0)
+            } else {
+                None
+            }
+        });
+
         scenario_deltas.push(ScenarioDelta {
             id: scenario.id.clone(),
             baseline_p95_ms: baseline_p95,
             current_p95_ms: current_p95,
-            p95_delta_ms: delta_ms,
-            p95_delta_pct: delta_pct,
+            p95_delta_ms,
+            p95_delta_pct,
+            metric_deltas,
             regression,
             improvement,
         });
@@ -244,24 +307,124 @@ pub fn compare(
     }
 }
 
+fn resolve_metric_policies(
+    current: &BenchResults,
+    default_threshold_percent: f64,
+) -> Vec<ResolvedMetricPolicy> {
+    if current.metric_policies.is_empty() {
+        let has_p95 = current
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.metrics.get("p95_ms").is_some());
+        if !has_p95 {
+            return Vec::new();
+        }
+        return vec![ResolvedMetricPolicy {
+            name: "p95_ms".to_string(),
+            direction: BenchMetricDirection::LowerIsBetter,
+            regression_threshold_percent: Some(default_threshold_percent),
+            regression_threshold_absolute: 0.0,
+            zero_baseline_is_neutral: true,
+        }];
+    }
+
+    current
+        .metric_policies
+        .iter()
+        .map(|(name, policy)| resolve_metric_policy(name, policy))
+        .collect()
+}
+
+fn resolve_metric_policy(name: &str, policy: &BenchMetricPolicy) -> ResolvedMetricPolicy {
+    ResolvedMetricPolicy {
+        name: name.to_string(),
+        direction: policy.direction,
+        regression_threshold_percent: policy.regression_threshold_percent,
+        regression_threshold_absolute: policy.regression_threshold_absolute.unwrap_or(0.0),
+        zero_baseline_is_neutral: false,
+    }
+}
+
+fn compare_metric(
+    policy: &ResolvedMetricPolicy,
+    baseline_value: f64,
+    current_value: f64,
+) -> MetricDelta {
+    let delta = current_value - baseline_value;
+    let bad_delta = match policy.direction {
+        BenchMetricDirection::LowerIsBetter => delta,
+        BenchMetricDirection::HigherIsBetter => -delta,
+    };
+    let delta_pct = if baseline_value != 0.0 {
+        Some((delta / baseline_value) * 100.0)
+    } else {
+        None
+    };
+    let bad_delta_pct = if baseline_value != 0.0 {
+        Some((bad_delta / baseline_value.abs()) * 100.0)
+    } else {
+        None
+    };
+
+    let worse = bad_delta > 0.0;
+    let regression = if policy.zero_baseline_is_neutral && baseline_value == 0.0 {
+        false
+    } else {
+        let exceeds_absolute = bad_delta > policy.regression_threshold_absolute;
+        let exceeds_percent = match policy.regression_threshold_percent {
+            Some(threshold) => bad_delta_pct.map(|pct| pct > threshold).unwrap_or(worse),
+            None => true,
+        };
+        worse && exceeds_absolute && exceeds_percent
+    };
+
+    MetricDelta {
+        name: policy.name.clone(),
+        baseline_value,
+        current_value,
+        delta,
+        delta_pct,
+        direction: policy.direction,
+        regression_threshold_percent: policy.regression_threshold_percent,
+        regression_threshold_absolute: policy.regression_threshold_absolute,
+        regression,
+        improvement: bad_delta < 0.0,
+    }
+}
+
+fn format_metric_reason(scenario_id: &str, delta: &MetricDelta) -> String {
+    let pct = delta
+        .delta_pct
+        .map(|p| format!(" ({:+.1}%)", p))
+        .unwrap_or_default();
+    format!(
+        "{}: {} {:.2} → {:.2}{}",
+        scenario_id, delta.name, delta.baseline_value, delta.current_value, pct
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::parsing::{BenchMetrics, BenchResults, BenchScenario};
     use super::*;
 
     fn scenario(id: &str, p95_ms: f64) -> BenchScenario {
+        let mut values = BTreeMap::new();
+        values.insert("mean_ms".to_string(), p95_ms * 0.9);
+        values.insert("p50_ms".to_string(), p95_ms * 0.85);
+        values.insert("p95_ms".to_string(), p95_ms);
+        values.insert("p99_ms".to_string(), p95_ms * 1.05);
+        values.insert("min_ms".to_string(), p95_ms * 0.7);
+        values.insert("max_ms".to_string(), p95_ms * 1.1);
+        metric_scenario(id, values)
+    }
+
+    fn metric_scenario(id: &str, metrics: BTreeMap<String, f64>) -> BenchScenario {
         BenchScenario {
             id: id.to_string(),
             file: None,
             iterations: 10,
-            metrics: BenchMetrics {
-                mean_ms: p95_ms * 0.9,
-                p50_ms: p95_ms * 0.85,
-                p95_ms,
-                p99_ms: p95_ms * 1.05,
-                min_ms: p95_ms * 0.7,
-                max_ms: p95_ms * 1.1,
-            },
+            metrics: BenchMetrics { values: metrics },
             memory: None,
         }
     }
@@ -271,6 +434,19 @@ mod tests {
             component_id: "demo".to_string(),
             iterations: 10,
             scenarios,
+            metric_policies: BTreeMap::new(),
+        }
+    }
+
+    fn results_with_policies(
+        scenarios: Vec<BenchScenario>,
+        metric_policies: BTreeMap<String, BenchMetricPolicy>,
+    ) -> BenchResults {
+        BenchResults {
+            component_id: "demo".to_string(),
+            iterations: 10,
+            scenarios,
+            metric_policies,
         }
     }
 
@@ -285,7 +461,10 @@ mod tests {
         assert_eq!(loaded.metadata.iterations, 10);
         assert_eq!(loaded.metadata.scenarios.len(), 2);
         assert_eq!(loaded.metadata.scenarios[0].id, "a");
-        assert_eq!(loaded.metadata.scenarios[0].p95_ms, 100.0);
+        assert_eq!(
+            loaded.metadata.scenarios[0].metric_value("p95_ms"),
+            Some(100.0)
+        );
     }
 
     #[test]
@@ -301,7 +480,7 @@ mod tests {
         assert!(!comparison.regression);
         assert!(!comparison.has_improvements);
         assert_eq!(comparison.scenarios.len(), 1);
-        assert_eq!(comparison.scenarios[0].p95_delta_ms, 0.0);
+        assert_eq!(comparison.scenarios[0].p95_delta_ms, Some(0.0));
     }
 
     #[test]
@@ -343,8 +522,9 @@ mod tests {
         assert!(comparison.scenarios[0].regression);
         assert_eq!(comparison.reasons.len(), 1);
         assert!(comparison.reasons[0].contains("a:"));
-        assert!(comparison.reasons[0].contains("100.00ms"));
-        assert!(comparison.reasons[0].contains("106.00ms"));
+        assert!(comparison.reasons[0].contains("p95_ms"));
+        assert!(comparison.reasons[0].contains("100.00"));
+        assert!(comparison.reasons[0].contains("106.00"));
     }
 
     #[test]
@@ -365,7 +545,7 @@ mod tests {
         assert!(!comparison.regression);
         assert!(comparison.has_improvements);
         assert!(comparison.scenarios[0].improvement);
-        assert_eq!(comparison.scenarios[0].p95_delta_ms, -20.0);
+        assert_eq!(comparison.scenarios[0].p95_delta_ms, Some(-20.0));
     }
 
     #[test]
@@ -437,7 +617,105 @@ mod tests {
         let current = results(vec![scenario("a", 5.0)]);
         let comparison = compare(&current, &baseline, 5.0);
         assert!(!comparison.regression);
-        assert_eq!(comparison.scenarios[0].p95_delta_pct, 0.0);
+        assert_eq!(comparison.scenarios[0].p95_delta_pct, None);
+    }
+
+    #[test]
+    fn lower_is_better_custom_metric_regresses_on_absolute_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut baseline_metrics = BTreeMap::new();
+        baseline_metrics.insert("error_rate".to_string(), 0.0);
+        let baseline_run = results(vec![metric_scenario("http", baseline_metrics)]);
+        save_baseline(dir.path(), "demo", &baseline_run, None).unwrap();
+        let baseline = load_baseline(dir.path(), None).unwrap();
+
+        let mut current_metrics = BTreeMap::new();
+        current_metrics.insert("error_rate".to_string(), 0.02);
+        let mut policies = BTreeMap::new();
+        policies.insert(
+            "error_rate".to_string(),
+            BenchMetricPolicy {
+                direction: BenchMetricDirection::LowerIsBetter,
+                regression_threshold_percent: None,
+                regression_threshold_absolute: Some(0.01),
+            },
+        );
+
+        let current =
+            results_with_policies(vec![metric_scenario("http", current_metrics)], policies);
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(comparison.regression);
+        assert_eq!(comparison.scenarios[0].metric_deltas[0].name, "error_rate");
+        assert!(comparison.scenarios[0].metric_deltas[0].regression);
+        assert!(comparison.reasons[0].contains("error_rate"));
+    }
+
+    #[test]
+    fn higher_is_better_custom_metric_regresses_on_percent_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut baseline_metrics = BTreeMap::new();
+        baseline_metrics.insert("requests_per_second".to_string(), 100.0);
+        let baseline_run = results(vec![metric_scenario("throughput", baseline_metrics)]);
+        save_baseline(dir.path(), "demo", &baseline_run, None).unwrap();
+        let baseline = load_baseline(dir.path(), None).unwrap();
+
+        let mut current_metrics = BTreeMap::new();
+        current_metrics.insert("requests_per_second".to_string(), 90.0);
+        let mut policies = BTreeMap::new();
+        policies.insert(
+            "requests_per_second".to_string(),
+            BenchMetricPolicy {
+                direction: BenchMetricDirection::HigherIsBetter,
+                regression_threshold_percent: Some(5.0),
+                regression_threshold_absolute: None,
+            },
+        );
+
+        let current = results_with_policies(
+            vec![metric_scenario("throughput", current_metrics)],
+            policies,
+        );
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(comparison.regression);
+        assert_eq!(comparison.scenarios[0].metric_deltas[0].delta, -10.0);
+        assert!(comparison.scenarios[0].metric_deltas[0].regression);
+    }
+
+    #[test]
+    fn custom_metric_policies_disable_implicit_p95_comparison() {
+        let dir = tempfile::tempdir().unwrap();
+        save_baseline(
+            dir.path(),
+            "demo",
+            &results(vec![scenario("mixed", 100.0)]),
+            None,
+        )
+        .unwrap();
+        let baseline = load_baseline(dir.path(), None).unwrap();
+
+        let mut current = scenario("mixed", 200.0);
+        current.metrics.values.insert("error_rate".to_string(), 0.0);
+        let mut policies = BTreeMap::new();
+        policies.insert(
+            "error_rate".to_string(),
+            BenchMetricPolicy {
+                direction: BenchMetricDirection::LowerIsBetter,
+                regression_threshold_percent: None,
+                regression_threshold_absolute: Some(0.0),
+            },
+        );
+
+        let comparison = compare(
+            &results_with_policies(vec![current], policies),
+            &baseline,
+            5.0,
+        );
+
+        assert!(!comparison.regression);
+        assert_eq!(comparison.scenarios[0].metric_deltas.len(), 0);
+        assert_eq!(comparison.scenarios[0].p95_delta_ms, Some(100.0));
     }
 
     #[test]
@@ -467,11 +745,17 @@ mod tests {
         .unwrap();
 
         let unpinned = load_baseline(dir.path(), None).expect("unpinned baseline present");
-        assert_eq!(unpinned.metadata.scenarios[0].p95_ms, 100.0);
+        assert_eq!(
+            unpinned.metadata.scenarios[0].metric_value("p95_ms"),
+            Some(100.0)
+        );
 
         let pinned = load_baseline(dir.path(), Some("studio-playground-dev"))
             .expect("rig-pinned baseline present");
-        assert_eq!(pinned.metadata.scenarios[0].p95_ms, 200.0);
+        assert_eq!(
+            pinned.metadata.scenarios[0].metric_value("p95_ms"),
+            Some(200.0)
+        );
 
         // Different rig identifier returns None — no cross-rig leakage.
         assert!(load_baseline(dir.path(), Some("other-rig")).is_none());

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -24,7 +24,8 @@ use serde::{Deserialize, Serialize};
 use crate::engine::baseline::{self as generic, BaselineConfig};
 use crate::error::Result;
 
-use super::parsing::{BenchMetricDirection, BenchMetricPolicy, BenchResults, BenchScenario};
+use super::metrics::{resolve_metric_policies, MetricDelta};
+use super::parsing::{BenchResults, BenchScenario};
 
 const BASELINE_KEY: &str = "bench";
 
@@ -137,35 +138,6 @@ pub struct ScenarioDelta {
     pub improvement: bool,
 }
 
-/// Per-metric delta vs baseline. Extensions can opt into comparing any
-/// numeric metric by declaring a policy in the bench results JSON.
-#[derive(Debug, Clone, Serialize, PartialEq)]
-pub struct MetricDelta {
-    pub name: String,
-    pub baseline_value: f64,
-    pub current_value: f64,
-    /// Current minus baseline. Positive is not always bad — consult
-    /// `direction` to know whether larger or smaller is better.
-    pub delta: f64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub delta_pct: Option<f64>,
-    pub direction: BenchMetricDirection,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub regression_threshold_percent: Option<f64>,
-    pub regression_threshold_absolute: f64,
-    pub regression: bool,
-    pub improvement: bool,
-}
-
-#[derive(Debug, Clone)]
-struct ResolvedMetricPolicy {
-    name: String,
-    direction: BenchMetricDirection,
-    regression_threshold_percent: Option<f64>,
-    regression_threshold_absolute: f64,
-    zero_baseline_is_neutral: bool,
-}
-
 /// Summary of comparing a current run against a stored baseline.
 #[derive(Debug, Clone, Serialize)]
 pub struct BenchBaselineComparison {
@@ -210,8 +182,8 @@ pub fn load_baseline(source_path: &Path, rig_id: Option<&str>) -> Option<BenchBa
         .flatten()
 }
 
-/// Compare a current run against a loaded baseline at the given p95
-/// regression threshold (as a percentage, e.g. `5.0` = 5%).
+/// Compare a current run against a loaded baseline. The threshold is used
+/// for the legacy p95 policy when the runner does not declare policies.
 pub fn compare(
     current: &BenchResults,
     baseline: &BenchBaseline,
@@ -243,13 +215,13 @@ pub fn compare(
         let mut metric_deltas = Vec::new();
 
         for policy in &metric_policies {
-            let Some(baseline_value) = prior.metric_value(&policy.name) else {
+            let Some(baseline_value) = prior.metric_value(policy.name()) else {
                 continue;
             };
-            let Some(current_value) = scenario.metrics.get(&policy.name) else {
+            let Some(current_value) = scenario.metrics.get(policy.name()) else {
                 continue;
             };
-            metric_deltas.push(compare_metric(policy, baseline_value, current_value));
+            metric_deltas.push(policy.compare(baseline_value, current_value));
         }
 
         let regression = metric_deltas.iter().any(|d| d.regression);
@@ -258,7 +230,7 @@ pub fn compare(
         if regression {
             any_regression = true;
             for delta in metric_deltas.iter().filter(|d| d.regression) {
-                reasons.push(format_metric_reason(&scenario.id, delta));
+                reasons.push(delta.reason(&scenario.id));
             }
         }
         if improvement {
@@ -307,105 +279,11 @@ pub fn compare(
     }
 }
 
-fn resolve_metric_policies(
-    current: &BenchResults,
-    default_threshold_percent: f64,
-) -> Vec<ResolvedMetricPolicy> {
-    if current.metric_policies.is_empty() {
-        let has_p95 = current
-            .scenarios
-            .iter()
-            .any(|scenario| scenario.metrics.get("p95_ms").is_some());
-        if !has_p95 {
-            return Vec::new();
-        }
-        return vec![ResolvedMetricPolicy {
-            name: "p95_ms".to_string(),
-            direction: BenchMetricDirection::LowerIsBetter,
-            regression_threshold_percent: Some(default_threshold_percent),
-            regression_threshold_absolute: 0.0,
-            zero_baseline_is_neutral: true,
-        }];
-    }
-
-    current
-        .metric_policies
-        .iter()
-        .map(|(name, policy)| resolve_metric_policy(name, policy))
-        .collect()
-}
-
-fn resolve_metric_policy(name: &str, policy: &BenchMetricPolicy) -> ResolvedMetricPolicy {
-    ResolvedMetricPolicy {
-        name: name.to_string(),
-        direction: policy.direction,
-        regression_threshold_percent: policy.regression_threshold_percent,
-        regression_threshold_absolute: policy.regression_threshold_absolute.unwrap_or(0.0),
-        zero_baseline_is_neutral: false,
-    }
-}
-
-fn compare_metric(
-    policy: &ResolvedMetricPolicy,
-    baseline_value: f64,
-    current_value: f64,
-) -> MetricDelta {
-    let delta = current_value - baseline_value;
-    let bad_delta = match policy.direction {
-        BenchMetricDirection::LowerIsBetter => delta,
-        BenchMetricDirection::HigherIsBetter => -delta,
-    };
-    let delta_pct = if baseline_value != 0.0 {
-        Some((delta / baseline_value) * 100.0)
-    } else {
-        None
-    };
-    let bad_delta_pct = if baseline_value != 0.0 {
-        Some((bad_delta / baseline_value.abs()) * 100.0)
-    } else {
-        None
-    };
-
-    let worse = bad_delta > 0.0;
-    let regression = if policy.zero_baseline_is_neutral && baseline_value == 0.0 {
-        false
-    } else {
-        let exceeds_absolute = bad_delta > policy.regression_threshold_absolute;
-        let exceeds_percent = match policy.regression_threshold_percent {
-            Some(threshold) => bad_delta_pct.map(|pct| pct > threshold).unwrap_or(worse),
-            None => true,
-        };
-        worse && exceeds_absolute && exceeds_percent
-    };
-
-    MetricDelta {
-        name: policy.name.clone(),
-        baseline_value,
-        current_value,
-        delta,
-        delta_pct,
-        direction: policy.direction,
-        regression_threshold_percent: policy.regression_threshold_percent,
-        regression_threshold_absolute: policy.regression_threshold_absolute,
-        regression,
-        improvement: bad_delta < 0.0,
-    }
-}
-
-fn format_metric_reason(scenario_id: &str, delta: &MetricDelta) -> String {
-    let pct = delta
-        .delta_pct
-        .map(|p| format!(" ({:+.1}%)", p))
-        .unwrap_or_default();
-    format!(
-        "{}: {} {:.2} → {:.2}{}",
-        scenario_id, delta.name, delta.baseline_value, delta.current_value, pct
-    )
-}
-
 #[cfg(test)]
 mod tests {
-    use super::super::parsing::{BenchMetrics, BenchResults, BenchScenario};
+    use super::super::parsing::{
+        BenchMetricDirection, BenchMetricPolicy, BenchMetrics, BenchResults, BenchScenario,
+    };
     use super::*;
 
     fn scenario(id: &str, p95_ms: f64) -> BenchScenario {

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -1,0 +1,134 @@
+//! Generic bench metric comparison policy.
+
+use serde::Serialize;
+
+use super::parsing::{BenchMetricDirection, BenchMetricPolicy, BenchResults};
+
+/// Per-metric delta vs baseline. Extensions can opt into comparing any
+/// numeric metric by declaring a policy in the bench results JSON.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct MetricDelta {
+    pub name: String,
+    pub baseline_value: f64,
+    pub current_value: f64,
+    /// Current minus baseline. Positive is not always bad — consult
+    /// `direction` to know whether larger or smaller is better.
+    pub delta: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta_pct: Option<f64>,
+    pub direction: BenchMetricDirection,
+    pub regression: bool,
+    pub improvement: bool,
+}
+
+impl MetricDelta {
+    pub(crate) fn reason(&self, scenario_id: &str) -> String {
+        let pct = self
+            .delta_pct
+            .map(|p| format!(" ({:+.1}%)", p))
+            .unwrap_or_default();
+        format!(
+            "{}: {} {:.2} → {:.2}{}",
+            scenario_id, self.name, self.baseline_value, self.current_value, pct
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedMetricPolicy {
+    name: String,
+    policy: BenchMetricPolicy,
+    regression_threshold_absolute: f64,
+    zero_baseline_is_neutral: bool,
+}
+
+impl ResolvedMetricPolicy {
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn compare(&self, baseline_value: f64, current_value: f64) -> MetricDelta {
+        let delta = current_value - baseline_value;
+        let bad_delta = match self.policy.direction {
+            BenchMetricDirection::LowerIsBetter => delta,
+            BenchMetricDirection::HigherIsBetter => -delta,
+        };
+        let delta_pct = if baseline_value != 0.0 {
+            Some((delta / baseline_value) * 100.0)
+        } else {
+            None
+        };
+        let bad_delta_pct = if baseline_value != 0.0 {
+            Some((bad_delta / baseline_value.abs()) * 100.0)
+        } else {
+            None
+        };
+
+        let worse = bad_delta > 0.0;
+        let regression = if self.zero_baseline_is_neutral && baseline_value == 0.0 {
+            false
+        } else {
+            let exceeds_absolute = bad_delta > self.regression_threshold_absolute;
+            let exceeds_percent = match self.policy.regression_threshold_percent {
+                Some(threshold) => bad_delta_pct.map(|pct| pct > threshold).unwrap_or(worse),
+                None => true,
+            };
+            worse && exceeds_absolute && exceeds_percent
+        };
+
+        MetricDelta {
+            name: self.name.clone(),
+            baseline_value,
+            current_value,
+            delta,
+            delta_pct,
+            direction: self.policy.direction,
+            regression,
+            improvement: bad_delta < 0.0,
+        }
+    }
+
+    fn custom(name: &str, policy: &BenchMetricPolicy) -> Self {
+        Self {
+            name: name.to_string(),
+            policy: policy.clone(),
+            regression_threshold_absolute: policy.regression_threshold_absolute.unwrap_or(0.0),
+            zero_baseline_is_neutral: false,
+        }
+    }
+
+    fn legacy_p95(default_threshold_percent: f64) -> Self {
+        Self {
+            name: "p95_ms".to_string(),
+            policy: BenchMetricPolicy {
+                direction: BenchMetricDirection::LowerIsBetter,
+                regression_threshold_percent: Some(default_threshold_percent),
+                regression_threshold_absolute: Some(0.0),
+            },
+            regression_threshold_absolute: 0.0,
+            zero_baseline_is_neutral: true,
+        }
+    }
+}
+
+pub(crate) fn resolve_metric_policies(
+    current: &BenchResults,
+    default_threshold_percent: f64,
+) -> Vec<ResolvedMetricPolicy> {
+    if current.metric_policies.is_empty() {
+        let has_p95 = current
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.metrics.get("p95_ms").is_some());
+        if !has_p95 {
+            return Vec::new();
+        }
+        return vec![ResolvedMetricPolicy::legacy_p95(default_threshold_percent)];
+    }
+
+    current
+        .metric_policies
+        .iter()
+        .map(|(name, policy)| ResolvedMetricPolicy::custom(name, policy))
+        .collect()
+}

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -132,3 +132,108 @@ pub(crate) fn resolve_metric_policies(
         .map(|(name, policy)| ResolvedMetricPolicy::custom(name, policy))
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::super::parsing::{BenchMetrics, BenchScenario};
+    use super::*;
+
+    fn policy(direction: BenchMetricDirection) -> BenchMetricPolicy {
+        BenchMetricPolicy {
+            direction,
+            regression_threshold_percent: Some(5.0),
+            regression_threshold_absolute: None,
+        }
+    }
+
+    fn results(metrics: BTreeMap<String, f64>) -> BenchResults {
+        BenchResults {
+            component_id: "demo".to_string(),
+            iterations: 10,
+            scenarios: vec![BenchScenario {
+                id: "scenario".to_string(),
+                file: None,
+                iterations: 10,
+                metrics: BenchMetrics { values: metrics },
+                memory: None,
+            }],
+            metric_policies: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_reason() {
+        let delta = MetricDelta {
+            name: "error_rate".to_string(),
+            baseline_value: 0.01,
+            current_value: 0.02,
+            delta: 0.01,
+            delta_pct: Some(100.0),
+            direction: BenchMetricDirection::LowerIsBetter,
+            regression: true,
+            improvement: false,
+        };
+
+        assert_eq!(
+            delta.reason("http"),
+            "http: error_rate 0.01 → 0.02 (+100.0%)"
+        );
+    }
+
+    #[test]
+    fn test_name() {
+        let resolved = ResolvedMetricPolicy::legacy_p95(5.0);
+
+        assert_eq!(resolved.name(), "p95_ms");
+    }
+
+    #[test]
+    fn test_compare() {
+        let resolved = ResolvedMetricPolicy::custom(
+            "requests_per_second",
+            &policy(BenchMetricDirection::HigherIsBetter),
+        );
+        let delta = resolved.compare(100.0, 90.0);
+
+        assert!(delta.regression);
+        assert_eq!(delta.delta, -10.0);
+    }
+
+    #[test]
+    fn test_custom() {
+        let resolved = ResolvedMetricPolicy::custom(
+            "error_rate",
+            &BenchMetricPolicy {
+                direction: BenchMetricDirection::LowerIsBetter,
+                regression_threshold_percent: None,
+                regression_threshold_absolute: Some(0.01),
+            },
+        );
+        let delta = resolved.compare(0.0, 0.02);
+
+        assert_eq!(resolved.name(), "error_rate");
+        assert!(delta.regression);
+    }
+
+    #[test]
+    fn test_legacy_p95() {
+        let resolved = ResolvedMetricPolicy::legacy_p95(5.0);
+        let delta = resolved.compare(0.0, 10.0);
+
+        assert_eq!(resolved.name(), "p95_ms");
+        assert!(!delta.regression);
+    }
+
+    #[test]
+    fn test_resolve_metric_policies() {
+        let mut metrics = BTreeMap::new();
+        metrics.insert("p95_ms".to_string(), 100.0);
+
+        let resolved = resolve_metric_policies(&results(metrics), 5.0);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name(), "p95_ms");
+    }
+}

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -5,9 +5,9 @@
 //! It shares the runner contract (env-var-driven, JSON-output-file), the
 //! manifest shape (`bench: { extension_script: "..." }`), and the baseline
 //! ratchet primitive (`engine::baseline`). What makes bench distinct is the
-//! **threshold-based regression check on p95 latency** — see
+//! **threshold-based regression check on numeric metrics** — see
 //! [`baseline::compare`] for the logic and [`baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT`]
-//! for the default.
+//! for the legacy p95 default.
 //!
 //! Contract with extension scripts:
 //! - `$HOMEBOY_BENCH_RESULTS_FILE` — path to write the JSON envelope to.
@@ -18,6 +18,7 @@
 //! See `docs/commands/bench.md` for the end-user view.
 
 pub mod baseline;
+pub mod metrics;
 pub mod parsing;
 pub mod report;
 pub mod run;
@@ -30,6 +31,7 @@ pub use baseline::{
     BenchBaselineComparison, BenchBaselineMetadata, BenchScenarioSnapshot, ScenarioDelta,
     DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
+pub use metrics::MetricDelta;
 pub use parsing::{
     parse_bench_results_file, parse_bench_results_str, BenchMemory, BenchMetrics, BenchResults,
     BenchScenario,

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -18,12 +18,9 @@
 //!       "file": "tests/bench/some-workload.ext",
 //!       "iterations": 10,
 //!       "metrics": {
-//!         "mean_ms": 120.3,
-//!         "p50_ms": 118.0,
 //!         "p95_ms": 145.0,
-//!         "p99_ms": 160.0,
-//!         "min_ms": 110.0,
-//!         "max_ms": 172.0
+//!         "status_500_count": 0,
+//!         "error_rate": 0.0
 //!       },
 //!       "memory": { "peak_bytes": 41943040 }
 //!     }
@@ -31,6 +28,7 @@
 //! }
 //! ```
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -44,6 +42,8 @@ pub struct BenchResults {
     pub component_id: String,
     pub iterations: u64,
     pub scenarios: Vec<BenchScenario>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metric_policies: BTreeMap<String, BenchMetricPolicy>,
 }
 
 /// One scenario's measurements.
@@ -62,15 +62,34 @@ pub struct BenchScenario {
     pub memory: Option<BenchMemory>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct BenchMetrics {
+    #[serde(flatten)]
+    pub values: BTreeMap<String, f64>,
+}
+
+impl BenchMetrics {
+    pub fn get(&self, key: &str) -> Option<f64> {
+        self.values.get(key).copied()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct BenchMetrics {
-    pub mean_ms: f64,
-    pub p50_ms: f64,
-    pub p95_ms: f64,
-    pub p99_ms: f64,
-    pub min_ms: f64,
-    pub max_ms: f64,
+pub struct BenchMetricPolicy {
+    pub direction: BenchMetricDirection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regression_threshold_percent: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regression_threshold_absolute: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum BenchMetricDirection {
+    #[serde(rename = "lower_is_better", alias = "lower")]
+    LowerIsBetter,
+    #[serde(rename = "higher_is_better", alias = "higher")]
+    HigherIsBetter,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -138,8 +157,52 @@ mod tests {
         let scenario = &parsed.scenarios[0];
         assert_eq!(scenario.id, "scenario_one");
         assert_eq!(scenario.file.as_deref(), Some("bench/one.ext"));
-        assert_eq!(scenario.metrics.p95_ms, 145.0);
+        assert_eq!(scenario.metrics.get("p95_ms"), Some(145.0));
         assert_eq!(scenario.memory.as_ref().unwrap().peak_bytes, 41943040);
+    }
+
+    #[test]
+    fn parses_arbitrary_numeric_metrics_and_policies() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 10,
+            "metric_policies": {
+                "error_rate": {
+                    "direction": "lower_is_better",
+                    "regression_threshold_absolute": 0.01
+                },
+                "requests_per_second": {
+                    "direction": "higher",
+                    "regression_threshold_percent": 5.0
+                }
+            },
+            "scenarios": [
+                {
+                    "id": "concurrent_http",
+                    "iterations": 10,
+                    "metrics": {
+                        "total_requests": 1200,
+                        "status_500_count": 0,
+                        "error_rate": 0.0,
+                        "requests_per_second": 180.5
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = parse_bench_results_str(raw).unwrap();
+        let scenario = &parsed.scenarios[0];
+
+        assert_eq!(scenario.metrics.get("status_500_count"), Some(0.0));
+        assert_eq!(scenario.metrics.get("requests_per_second"), Some(180.5));
+        assert_eq!(
+            parsed.metric_policies["error_rate"].direction,
+            BenchMetricDirection::LowerIsBetter
+        );
+        assert_eq!(
+            parsed.metric_policies["requests_per_second"].direction,
+            BenchMetricDirection::HigherIsBetter
+        );
     }
 
     #[test]
@@ -191,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_required_metric() {
+    fn rejects_non_numeric_metric_values() {
         let raw = r#"{
             "component_id": "example",
             "iterations": 10,
@@ -200,11 +263,7 @@ mod tests {
                     "id": "scenario_one",
                     "iterations": 10,
                     "metrics": {
-                        "mean_ms": 120.5,
-                        "p50_ms": 118.0,
-                        "p95_ms": 145.0,
-                        "p99_ms": 160.0,
-                        "min_ms": 110.0
+                        "error_rate": "bad"
                     }
                 }
             ]
@@ -216,8 +275,8 @@ mod tests {
             .and_then(|v| v.as_str())
             .unwrap_or("");
         assert!(
-            inner.contains("max_ms") || inner.contains("missing field"),
-            "expected missing-field error, got details: {}",
+            inner.contains("invalid type") || inner.contains("f64"),
+            "expected invalid-metric error, got details: {}",
             inner
         );
     }

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -162,6 +162,33 @@ mod tests {
     }
 
     #[test]
+    fn test_get() {
+        let parsed = parse_bench_results_str(VALID_RESULTS).unwrap();
+        let metrics = &parsed.scenarios[0].metrics;
+
+        assert_eq!(metrics.get("p95_ms"), Some(145.0));
+        assert_eq!(metrics.get("missing"), None);
+    }
+
+    #[test]
+    fn test_parse_bench_results_str() {
+        let parsed = parse_bench_results_str(VALID_RESULTS).unwrap();
+
+        assert_eq!(parsed.component_id, "example");
+    }
+
+    #[test]
+    fn test_parse_bench_results_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bench-results.json");
+        std::fs::write(&path, VALID_RESULTS).unwrap();
+
+        let parsed = parse_bench_results_file(&path).unwrap();
+
+        assert_eq!(parsed.scenarios.len(), 1);
+    }
+
+    #[test]
     fn parses_arbitrary_numeric_metrics_and_policies() {
         let raw = r#"{
             "component_id": "example",


### PR DESCRIPTION
## Summary
- Allows bench runners to emit arbitrary numeric metrics instead of forcing every benchmark into the p95 latency shape.
- Adds optional `metric_policies` so extensions declare lower/higher-is-better semantics plus percent/absolute regression tolerances.
- Keeps legacy behavior when no policies are declared: `p95_ms` remains lower-is-better and uses `--regression-threshold`.

## Why
This keeps Homeboy core agnostic. WordPress, Playground, HTTP fanout, throughput, error-rate, and future benchmark runners can all report domain-specific metrics without Homeboy hardcoding those domains.

## Testing
- `cargo check`
- `cargo test core::extension::bench`
- `cargo test core::rig`
- `cargo test -- --test-threads=1`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic bench metric-policy model, updating tests/docs, and drafting this PR description. The change was reviewed and verified locally before opening the PR.