### PR TITLE
fix(rig): gate service supervisor behind #[cfg(unix)] so Windows builds

### DIFF
--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -12,20 +12,13 @@
 //! - `stop` sends SIGTERM, waits up to 5s, then SIGKILL.
 //! - `status` checks whether the recorded PID is alive.
 //!
-//! Everything runs via `sh -c` (POSIX). Windows is out of scope for MVP.
+//! Everything runs via `sh -c` (POSIX). Windows is out of scope for MVP —
+//! the Unix-only internals (`setsid`, `SIGTERM`/`SIGKILL`, `pre_exec`) live
+//! inside a `#[cfg(unix)]` module; on Windows the public API compiles but
+//! returns `RigServiceFailed` so the crate still builds everywhere.
 
-use std::fs::{File, OpenOptions};
-use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
-
-use super::expand::expand_vars;
-use super::spec::{RigSpec, ServiceKind, ServiceSpec};
-use super::state::{now_rfc3339, ServiceState};
-use crate::error::{Error, Result};
-use crate::paths;
+use super::spec::RigSpec;
+use crate::error::Result;
 
 /// Live status of a service as seen at probe time.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,203 +33,263 @@ pub enum ServiceStatus {
 ///
 /// Returns the PID of the running (or newly started) process.
 pub fn start(rig: &RigSpec, service_id: &str) -> Result<u32> {
-    let spec = rig.services.get(service_id).ok_or_else(|| {
-        Error::rig_service_failed(&rig.id, service_id, "service not declared in rig spec")
-    })?;
-
-    // Idempotency: if we have a PID and it's live, no-op.
-    let mut state = super::state::RigState::load(&rig.id)?;
-    if let Some(svc_state) = state.services.get(service_id) {
-        if let Some(pid) = svc_state.pid {
-            if pid_alive(pid) {
-                return Ok(pid);
-            }
-        }
-    }
-
-    let (program, args) = build_command(rig, service_id, spec)?;
-    let cwd = resolve_cwd(rig, spec)?;
-    let log_path = log_file_for(&rig.id, service_id)?;
-    let log_file = open_log(&log_path)?;
-    let err_file = log_file
-        .try_clone()
-        .map_err(|e| Error::internal_unexpected(format!("failed to clone log fd: {}", e)))?;
-
-    let mut command = Command::new(&program);
-    command
-        .args(&args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(log_file))
-        .stderr(Stdio::from(err_file));
-
-    if let Some(cwd) = cwd {
-        command.current_dir(cwd);
-    }
-
-    for (k, v) in &spec.env {
-        command.env(k, expand_vars(rig, v));
-    }
-
-    // Detach from homeboy — new session so Ctrl-C to `homeboy` doesn't kill it.
-    // Safe: setsid has no allocations and only touches the child.
-    unsafe {
-        command.pre_exec(|| {
-            libc::setsid();
-            Ok(())
-        });
-    }
-
-    let child = command.spawn().map_err(|e| {
-        Error::rig_service_failed(&rig.id, service_id, format!("spawn failed: {}", e))
-    })?;
-
-    let pid = child.id();
-
-    // We intentionally leak the Child handle — once detached, we track by PID
-    // in rig state, not by owning the handle. Dropping it without wait()
-    // leaves a zombie briefly until the next `rig down`, which is acceptable
-    // for a dev supervisor.
-    std::mem::forget(child);
-
-    state.services.insert(
-        service_id.to_string(),
-        ServiceState {
-            pid: Some(pid),
-            started_at: Some(now_rfc3339()),
-            status: "running".to_string(),
-        },
-    );
-    state.save(&rig.id)?;
-
-    Ok(pid)
+    platform::start(rig, service_id)
 }
 
 /// Stop a running service. Idempotent — if not running, returns immediately.
 pub fn stop(rig: &RigSpec, service_id: &str) -> Result<()> {
-    let mut state = super::state::RigState::load(&rig.id)?;
-    let pid = match state.services.get(service_id).and_then(|s| s.pid) {
-        Some(pid) => pid,
-        None => return Ok(()),
-    };
-
-    if !pid_alive(pid) {
-        state.services.remove(service_id);
-        state.save(&rig.id)?;
-        return Ok(());
-    }
-
-    unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGTERM);
-    }
-
-    // Grace period up to 5s.
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < deadline {
-        if !pid_alive(pid) {
-            break;
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    if pid_alive(pid) {
-        unsafe {
-            libc::kill(pid as libc::pid_t, libc::SIGKILL);
-        }
-        thread::sleep(Duration::from_millis(200));
-    }
-
-    state.services.remove(service_id);
-    state.save(&rig.id)?;
-    Ok(())
+    platform::stop(rig, service_id)
 }
 
 /// Report current service status, cross-referencing rig state with live PID.
 pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
-    let state = super::state::RigState::load(rig_id)?;
-    let pid = match state.services.get(service_id).and_then(|s| s.pid) {
-        Some(pid) => pid,
-        None => return Ok(ServiceStatus::Stopped),
-    };
-
-    if pid_alive(pid) {
-        Ok(ServiceStatus::Running(pid))
-    } else {
-        Ok(ServiceStatus::Stale(pid))
-    }
+    platform::status(rig_id, service_id)
 }
 
-/// Build (program, args) for a service kind.
-fn build_command(
-    rig: &RigSpec,
-    service_id: &str,
-    spec: &ServiceSpec,
-) -> Result<(String, Vec<String>)> {
-    match spec.kind {
-        ServiceKind::HttpStatic => {
-            let port = spec.port.ok_or_else(|| {
-                Error::rig_service_failed(&rig.id, service_id, "http-static requires `port`")
-            })?;
-            Ok((
-                "python3".to_string(),
-                vec![
-                    "-m".to_string(),
-                    "http.server".to_string(),
-                    port.to_string(),
-                ],
+#[cfg(unix)]
+mod platform {
+    use std::fs::{File, OpenOptions};
+    use std::os::unix::process::CommandExt;
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use super::super::expand::expand_vars;
+    use super::super::spec::{RigSpec, ServiceKind, ServiceSpec};
+    use super::super::state::{now_rfc3339, ServiceState};
+    use super::ServiceStatus;
+    use crate::error::{Error, Result};
+    use crate::paths;
+
+    pub fn start(rig: &RigSpec, service_id: &str) -> Result<u32> {
+        let spec = rig.services.get(service_id).ok_or_else(|| {
+            Error::rig_service_failed(&rig.id, service_id, "service not declared in rig spec")
+        })?;
+
+        // Idempotency: if we have a PID and it's live, no-op.
+        let mut state = super::super::state::RigState::load(&rig.id)?;
+        if let Some(svc_state) = state.services.get(service_id) {
+            if let Some(pid) = svc_state.pid {
+                if pid_alive(pid) {
+                    return Ok(pid);
+                }
+            }
+        }
+
+        let (program, args) = build_command(rig, service_id, spec)?;
+        let cwd = resolve_cwd(rig, spec)?;
+        let log_path = log_file_for(&rig.id, service_id)?;
+        let log_file = open_log(&log_path)?;
+        let err_file = log_file
+            .try_clone()
+            .map_err(|e| Error::internal_unexpected(format!("failed to clone log fd: {}", e)))?;
+
+        let mut command = Command::new(&program);
+        command
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(log_file))
+            .stderr(Stdio::from(err_file));
+
+        if let Some(cwd) = cwd {
+            command.current_dir(cwd);
+        }
+
+        for (k, v) in &spec.env {
+            command.env(k, expand_vars(rig, v));
+        }
+
+        // Detach from homeboy — new session so Ctrl-C to `homeboy` doesn't kill it.
+        // Safe: setsid has no allocations and only touches the child.
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+
+        let child = command.spawn().map_err(|e| {
+            Error::rig_service_failed(&rig.id, service_id, format!("spawn failed: {}", e))
+        })?;
+
+        let pid = child.id();
+
+        // We intentionally leak the Child handle — once detached, we track by PID
+        // in rig state, not by owning the handle. Dropping it without wait()
+        // leaves a zombie briefly until the next `rig down`, which is acceptable
+        // for a dev supervisor.
+        std::mem::forget(child);
+
+        state.services.insert(
+            service_id.to_string(),
+            ServiceState {
+                pid: Some(pid),
+                started_at: Some(now_rfc3339()),
+                status: "running".to_string(),
+            },
+        );
+        state.save(&rig.id)?;
+
+        Ok(pid)
+    }
+
+    pub fn stop(rig: &RigSpec, service_id: &str) -> Result<()> {
+        let mut state = super::super::state::RigState::load(&rig.id)?;
+        let pid = match state.services.get(service_id).and_then(|s| s.pid) {
+            Some(pid) => pid,
+            None => return Ok(()),
+        };
+
+        if !pid_alive(pid) {
+            state.services.remove(service_id);
+            state.save(&rig.id)?;
+            return Ok(());
+        }
+
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+
+        // Grace period up to 5s.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !pid_alive(pid) {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        if pid_alive(pid) {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+
+        state.services.remove(service_id);
+        state.save(&rig.id)?;
+        Ok(())
+    }
+
+    pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
+        let state = super::super::state::RigState::load(rig_id)?;
+        let pid = match state.services.get(service_id).and_then(|s| s.pid) {
+            Some(pid) => pid,
+            None => return Ok(ServiceStatus::Stopped),
+        };
+
+        if pid_alive(pid) {
+            Ok(ServiceStatus::Running(pid))
+        } else {
+            Ok(ServiceStatus::Stale(pid))
+        }
+    }
+
+    /// Build (program, args) for a service kind.
+    fn build_command(
+        rig: &RigSpec,
+        service_id: &str,
+        spec: &ServiceSpec,
+    ) -> Result<(String, Vec<String>)> {
+        match spec.kind {
+            ServiceKind::HttpStatic => {
+                let port = spec.port.ok_or_else(|| {
+                    Error::rig_service_failed(&rig.id, service_id, "http-static requires `port`")
+                })?;
+                Ok((
+                    "python3".to_string(),
+                    vec![
+                        "-m".to_string(),
+                        "http.server".to_string(),
+                        port.to_string(),
+                    ],
+                ))
+            }
+            ServiceKind::Command => {
+                let cmd = spec.command.as_ref().ok_or_else(|| {
+                    Error::rig_service_failed(
+                        &rig.id,
+                        service_id,
+                        "command kind requires `command`",
+                    )
+                })?;
+                let expanded = expand_vars(rig, cmd);
+                Ok(("sh".to_string(), vec!["-c".to_string(), expanded]))
+            }
+        }
+    }
+
+    fn resolve_cwd(rig: &RigSpec, spec: &ServiceSpec) -> Result<Option<PathBuf>> {
+        match &spec.cwd {
+            None => Ok(None),
+            Some(cwd) => {
+                let expanded = expand_vars(rig, cwd);
+                let path = shellexpand::tilde(&expanded).into_owned();
+                Ok(Some(PathBuf::from(path)))
+            }
+        }
+    }
+
+    fn log_file_for(rig_id: &str, service_id: &str) -> Result<PathBuf> {
+        let dir = paths::rig_logs_dir(rig_id)?;
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to create logs dir {}: {}",
+                dir.display(),
+                e
             ))
+        })?;
+        Ok(dir.join(format!("{}.log", service_id)))
+    }
+
+    fn open_log(path: &PathBuf) -> Result<File> {
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| {
+                Error::internal_unexpected(format!("Failed to open log {}: {}", path.display(), e))
+            })
+    }
+
+    /// Cheap liveness probe — `kill(pid, 0)` returns 0 if the process exists and
+    /// we have permission to signal it. Matches what `ps` and most supervisors do.
+    fn pid_alive(pid: u32) -> bool {
+        if pid == 0 {
+            return false;
         }
-        ServiceKind::Command => {
-            let cmd = spec.command.as_ref().ok_or_else(|| {
-                Error::rig_service_failed(&rig.id, service_id, "command kind requires `command`")
-            })?;
-            let expanded = expand_vars(rig, cmd);
-            Ok(("sh".to_string(), vec!["-c".to_string(), expanded]))
-        }
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
     }
 }
 
-fn resolve_cwd(rig: &RigSpec, spec: &ServiceSpec) -> Result<Option<PathBuf>> {
-    match &spec.cwd {
-        None => Ok(None),
-        Some(cwd) => {
-            let expanded = expand_vars(rig, cwd);
-            let path = shellexpand::tilde(&expanded).into_owned();
-            Ok(Some(PathBuf::from(path)))
-        }
+#[cfg(not(unix))]
+mod platform {
+    //! Non-Unix stub. Rig services rely on POSIX process groups, SIGTERM/
+    //! SIGKILL, and `pre_exec` for detached supervision — none of which map
+    //! cleanly to Windows job objects. Every entry point returns
+    //! `RigServiceFailed` with the same message so callers get a clear
+    //! reason instead of a compile error.
+    use super::super::spec::RigSpec;
+    use super::ServiceStatus;
+    use crate::error::{Error, Result};
+
+    const UNSUPPORTED: &str = "rig services are not supported on this platform (Unix only)";
+
+    pub fn start(rig: &RigSpec, service_id: &str) -> Result<u32> {
+        Err(Error::rig_service_failed(&rig.id, service_id, UNSUPPORTED))
     }
-}
 
-fn log_file_for(rig_id: &str, service_id: &str) -> Result<PathBuf> {
-    let dir = paths::rig_logs_dir(rig_id)?;
-    std::fs::create_dir_all(&dir).map_err(|e| {
-        Error::internal_unexpected(format!(
-            "Failed to create logs dir {}: {}",
-            dir.display(),
-            e
-        ))
-    })?;
-    Ok(dir.join(format!("{}.log", service_id)))
-}
-
-fn open_log(path: &PathBuf) -> Result<File> {
-    OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|e| {
-            Error::internal_unexpected(format!("Failed to open log {}: {}", path.display(), e))
-        })
-}
-
-/// Cheap liveness probe — `kill(pid, 0)` returns 0 if the process exists and
-/// we have permission to signal it. Matches what `ps` and most supervisors do.
-fn pid_alive(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
+    pub fn stop(rig: &RigSpec, service_id: &str) -> Result<()> {
+        Err(Error::rig_service_failed(&rig.id, service_id, UNSUPPORTED))
     }
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+
+    pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
+        Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
+    }
 }
 
 #[cfg(test)]
+#[cfg(unix)]
 #[path = "../../../tests/core/rig/service_test.rs"]
 mod service_test;


### PR DESCRIPTION
## Summary

v0.90.0's release pipeline built 4/5 platform binaries cleanly but **x86_64-pc-windows-msvc failed to compile**, blocking the GitHub Release from publishing despite darwin (x64/arm64) and linux (x64/arm64) succeeding.

Root cause: #1468's new service supervisor in \`src/core/rig/service.rs\` uses Unix-only APIs (\`std::os::unix::process::CommandExt\`, \`libc::{setsid, kill, pid_t, SIGKILL}\`, \`Command::pre_exec\`) unconditionally. The module's own doc comment says \"Windows is out of scope for MVP\" — but without \`#[cfg]\` gates that intent didn't translate into compile-time reality, and the whole crate fails to build on Windows.

## The actual errors from the failed release build

From [run 24920458049 / build (x86_64-pc-windows-msvc)](https://github.com/Extra-Chill/homeboy/actions/runs/24920458049):

\`\`\`
error[E0433]: failed to resolve: could not find \`unix\` in \`os\`
error[E0425]: cannot find function \`setsid\` in crate \`libc\`
error[E0425]: cannot find function \`kill\` in crate \`libc\`
error[E0425]: cannot find type \`pid_t\` in crate \`libc\`
error[E0425]: cannot find value \`SIGKILL\` in crate \`libc\`
error[E0599]: no method named \`pre_exec\` found for struct \`Command\`
... (11 total)
\`\`\`

## Fix

Kept the public API (\`start\`, \`stop\`, \`status\`, \`ServiceStatus\`) **identical on all platforms** so callers in \`runner.rs\` and \`pipeline.rs\` don't need to sprinkle cfg gates.

Structure:

- \`#[cfg(unix)] mod platform { ... }\` — existing POSIX implementation (signals, pre_exec, setsid, kill)
- \`#[cfg(not(unix))] mod platform { ... }\` — stub that returns \`Error::rig_service_failed(rig_id, service_id, \"rig services are not supported on this platform (Unix only)\")\` from each entry point
- Public wrappers delegate to \`platform::\`
- \`service_test\` also gated \`#[cfg(unix)]\` since it exercises the live process supervisor

Windows users who try \`homeboy rig up\` will now get a clear runtime error instead of the crate failing to compile.

## Verification

- \`cargo build --release\` on macOS (arm64) → Finished clean
- \`cargo fmt --check\` → clean
- \`cargo test --lib core::rig\` → **43 passed**, 0 failed
- \`cargo test --lib core::rig::service\` → **3 passed**, 0 failed
- \`homeboy audit\` → \`drift_increased: false\`, exit 0 (refactor actually **resolved** 15 previously-baselined findings by tightening the public surface; no new findings introduced)

**Windows cross-check not possible locally** without mingw-w64 + MSVC linker, so leaning on CI's \`build (x86_64-pc-windows-msvc)\` job to verify. The fix is mechanical: Unix-only APIs are now unreachable on Windows at compile time, so the errors cannot recur.

## Follow-up

If you want Windows rig support eventually, it needs a Windows-native supervisor built on job objects (\`CreateJobObject\` + \`AssignProcessToJobObject\` + \`TerminateJobObject\` via \`windows-sys\`), not a port of the signal-based path. That's a bigger piece of work and belongs in its own issue.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Watched v0.90.0's release pipeline, traced the only remaining failure (after audit-baseline PRs #1491 and #1493 unblocked the gate) to #1468's service supervisor, read all 11 Windows build errors, split \`service.rs\` into cfg-gated \`platform\` submodules preserving the public API, ran local verification (Unix build, fmt, rig tests, audit), drafted commit + PR body. Chris reviewed the approach (cfg-gate over drop-Windows) and directed the split architecture.