### PR TITLE
fix(rig): cfg-gate symlink call in pipeline.rs (round 2 of #1496)

### DIFF
--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -7,7 +7,7 @@
 //! a `PipelineOutcome` with overall success/failure.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde::Serialize;
@@ -339,7 +339,7 @@ fn ensure_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<()> {
         })?;
     }
 
-    std::os::unix::fs::symlink(&target_path, &link_path).map_err(|e| {
+    create_symlink(&target_path, &link_path).map_err(|e| {
         Error::rig_pipeline_failed(
             &rig.id,
             "symlink",
@@ -352,6 +352,22 @@ fn ensure_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<()> {
         )
     })?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(not(unix))]
+fn create_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
+    // Rigs are Unix-only by design (see core/rig/service.rs). Windows users
+    // who reach this path get a clear error from rig_pipeline_failed instead
+    // of a compile failure.
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "rig symlinks are not supported on this platform (Unix only)",
+    ))
 }
 
 fn verify_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<()> {


### PR DESCRIPTION
## Summary

#1496 caught the unix-only APIs in `service.rs` but missed `std::os::unix::fs::symlink(...)` at `pipeline.rs:342`. v0.90.1's release pipeline failed Windows MSVC build with the exact same error class:

```
error[E0433]: failed to resolve: could not find `unix` in `os`
  --> src\core\rig\pipeline.rs:342:14
342 |     std::os::unix::fs::symlink(&target_path, &link_path).map_err(|e| {
```

Should have caught this in #1496 — apologies for the round-trip.

## Coverage check

After this fix, ran `grep -rn 'std::os::unix' src/`:

| File | Status |
|---|---|
| `src/core/rig/pipeline.rs` | **fixed in this PR** (was bare) |
| `src/core/rig/service.rs` | already cfg-gated (#1496) |
| `src/core/code_audit/test_topology.rs` | already cfg-gated |
| `src/core/upgrade/helpers.rs` | already cfg-gated |
| `src/core/extension/lifecycle.rs` | already cfg-gated |
| `src/core/server/keys.rs` | already cfg-gated |
| `src/core/engine/validate_write.rs` | already cfg-gated |

This is the **last bare reference**.

## Fix

Extracted `create_symlink(target, link) -> io::Result<()>` with cfg arms:
- Unix → delegates to `std::os::unix::fs::symlink`
- Windows → returns `io::ErrorKind::Unsupported` with `"rig symlinks are not supported on this platform (Unix only)"`

The existing `rig_pipeline_failed` map_err picks up the error, so Windows users get a clean runtime error instead of a compile failure (consistent with how #1496 handled `service::start`/`stop`/`status`).

Imported `std::path::Path` (was only `PathBuf`).

## Verification

- `cargo build --release` on macOS arm64 → clean
- `cargo fmt --check` → clean
- `cargo test --lib core::rig::pipeline` → **4 passed**
- `homeboy audit` → `drift_increased: false`, exit 0
- `cargo check --target x86_64-pc-windows-gnu --lib` → reaches the homeboy crate, **zero Rust errors from our code**. (Transitive C deps `ring`/`zstd-sys`/`bzip2-sys` fail at build-script time without mingw-w64; that's the local harness limitation, not a homeboy issue.)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Watched v0.90.1's release pipeline fail Windows MSVC build after #1496 merged, traced to the missed bare unix symlink call in `pipeline.rs:342`, ran `grep -rn 'std::os::unix' src/` to confirm no other surprises lurk, applied the cfg-gated helper pattern matching #1496's structure, verified locally with `cargo check --target x86_64-pc-windows-gnu` (homeboy crate Rust errors: 0), drafted commit + PR body. Chris directed the follow-up.