### PR TITLE
feat(git): CWD detection + --path on every verb

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -27,12 +27,20 @@ enum GitCommand {
         #[arg(long)]
         json: Option<String>,
 
-        /// Component ID (non-JSON mode)
+        /// Component ID (non-JSON mode). When omitted, the component is
+        /// auto-detected from CWD via the registry or a portable
+        /// `homeboy.json`.
         component_id: Option<String>,
+
+        /// Workspace path to operate on directly. Useful for unregistered
+        /// checkouts (CI runners, ad-hoc clones, worktrees).
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Commit changes (by default stages all, use flags for granular control)
     Commit {
-        /// Component ID (optional if provided in JSON body)
+        /// Component ID (optional if provided in JSON body or auto-detected
+        /// from CWD).
         component_id: Option<String>,
 
         /// Commit message or JSON spec (auto-detected).
@@ -65,6 +73,11 @@ enum GitCommand {
         /// Explicit include list (repeatable)
         #[arg(long, num_args = 1.., conflicts_with = "exclude", conflicts_with = "files")]
         include: Option<Vec<String>>,
+
+        /// Workspace path to operate on directly. Useful for unregistered
+        /// checkouts (CI runners, ad-hoc clones, worktrees).
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Push local commits to remote
     Push {
@@ -73,12 +86,19 @@ enum GitCommand {
         #[arg(long)]
         json: Option<String>,
 
-        /// Component ID (non-JSON mode)
+        /// Component ID (non-JSON mode). When omitted, the component is
+        /// auto-detected from CWD via the registry or a portable
+        /// `homeboy.json`.
         component_id: Option<String>,
 
         /// Push tags as well
         #[arg(long)]
         tags: bool,
+
+        /// Workspace path to operate on directly. Useful for unregistered
+        /// checkouts (CI runners, ad-hoc clones, worktrees).
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Pull remote changes
     Pull {
@@ -87,12 +107,20 @@ enum GitCommand {
         #[arg(long)]
         json: Option<String>,
 
-        /// Component ID (non-JSON mode)
+        /// Component ID (non-JSON mode). When omitted, the component is
+        /// auto-detected from CWD via the registry or a portable
+        /// `homeboy.json`.
         component_id: Option<String>,
+
+        /// Workspace path to operate on directly. Useful for unregistered
+        /// checkouts (CI runners, ad-hoc clones, worktrees).
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Create a git tag
     Tag {
-        /// Component ID
+        /// Component ID. When omitted, the component is auto-detected from
+        /// CWD via the registry or a portable `homeboy.json`.
         component_id: Option<String>,
 
         /// Tag name (e.g., v0.1.2)
@@ -103,6 +131,11 @@ enum GitCommand {
         /// Tag message (creates annotated tag)
         #[arg(short, long)]
         message: Option<String>,
+
+        /// Workspace path to operate on directly. Useful for unregistered
+        /// checkouts (CI runners, ad-hoc clones, worktrees).
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
     },
     /// Manage GitHub issues for a component
     Issue(IssueArgs),
@@ -384,14 +417,18 @@ pub enum GitCommandOutput {
 
 pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<GitCommandOutput> {
     match args.command {
-        GitCommand::Status { json, component_id } => {
+        GitCommand::Status {
+            json,
+            component_id,
+            path,
+        } => {
             if let Some(spec) = json {
                 let output = git::status_bulk(&spec)?;
                 let exit_code = if output.summary.failed > 0 { 1 } else { 0 };
                 return Ok((GitCommandOutput::Bulk(output), exit_code));
             }
 
-            let output = git::status(component_id.as_deref())?;
+            let output = git::status_at(component_id.as_deref(), path.as_deref())?;
             let exit_code = output.exit_code;
             Ok((GitCommandOutput::Single(output), exit_code))
         }
@@ -404,6 +441,7 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
             files,
             exclude,
             include,
+            path,
         } => {
             // Explicit --json flag always uses JSON mode
             if let Some(json_spec) = json {
@@ -467,7 +505,12 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
                 exclude,
                 amend: false,
             };
-            let output = git::commit(component_id.as_deref(), final_message.as_deref(), options)?;
+            let output = git::commit_at(
+                component_id.as_deref(),
+                final_message.as_deref(),
+                options,
+                path.as_deref(),
+            )?;
             let exit_code = output.exit_code;
             Ok((GitCommandOutput::Single(output), exit_code))
         }
@@ -475,6 +518,7 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
             json,
             component_id,
             tags,
+            path,
         } => {
             if let Some(spec) = json {
                 let output = git::push_bulk(&spec)?;
@@ -482,18 +526,22 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
                 return Ok((GitCommandOutput::Bulk(output), exit_code));
             }
 
-            let output = git::push(component_id.as_deref(), tags)?;
+            let output = git::push_at(component_id.as_deref(), tags, path.as_deref())?;
             let exit_code = output.exit_code;
             Ok((GitCommandOutput::Single(output), exit_code))
         }
-        GitCommand::Pull { json, component_id } => {
+        GitCommand::Pull {
+            json,
+            component_id,
+            path,
+        } => {
             if let Some(spec) = json {
                 let output = git::pull_bulk(&spec)?;
                 let exit_code = if output.summary.failed > 0 { 1 } else { 0 };
                 return Ok((GitCommandOutput::Bulk(output), exit_code));
             }
 
-            let output = git::pull(component_id.as_deref())?;
+            let output = git::pull_at(component_id.as_deref(), path.as_deref())?;
             let exit_code = output.exit_code;
             Ok((GitCommandOutput::Single(output), exit_code))
         }
@@ -501,6 +549,7 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
             component_id,
             tag_name,
             message,
+            path,
         } => {
             // Derive tag from version if not provided
             let final_tag = match tag_name {
@@ -525,10 +574,11 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
                 }
             };
 
-            let output = git::tag(
+            let output = git::tag_at(
                 component_id.as_deref(),
                 Some(&final_tag),
                 message.as_deref(),
+                path.as_deref(),
             )?;
             let exit_code = output.exit_code;
             Ok((GitCommandOutput::Single(output), exit_code))

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -77,28 +77,62 @@ pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::R
     Ok(())
 }
 
+/// Resolve a (component_id, path) pair for a git operation.
+///
+/// Resolution order:
+/// 1. **Both `component_id` and `path_override` provided** — trust both;
+///    no registry lookup. Used by rig pipelines + workflows that already
+///    know the path they want to operate on.
+/// 2. **`path_override` only** — use the path; derive the ID from a
+///    portable `homeboy.json` at the path or its git root, falling back
+///    to the directory basename.
+/// 3. **`component_id` only** — look the component up in the registry,
+///    use its configured `local_path`.
+/// 4. **Neither** — fall through to [`crate::component::resolve`], which
+///    detects from CWD via the registry first, then portable
+///    `homeboy.json` at CWD or git root. This is what makes
+///    `homeboy git status` (and friends) work without arguments when
+///    run from inside a checkout.
 pub(super) fn resolve_target(
     component_id: Option<&str>,
     path_override: Option<&str>,
 ) -> crate::error::Result<(String, String)> {
-    let id = component_id.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "componentId",
-            "Missing componentId",
-            None,
-            Some(vec![
-                "Provide a component ID: homeboy git <command> <component-id>".to_string(),
-                "List available components: homeboy component list".to_string(),
-            ]),
-        )
-    })?;
-    let path = if let Some(p) = path_override {
-        p.to_string()
-    } else {
+    // Case 1 & 2: explicit path given.
+    if let Some(path) = path_override {
+        if let Some(id) = component_id {
+            return Ok((id.to_string(), path.to_string()));
+        }
+        // Discover ID from path or its git root via portable homeboy.json.
+        let dir = std::path::Path::new(path);
+        if let Some(comp) = crate::component::discover_from_portable(dir) {
+            return Ok((comp.id, path.to_string()));
+        }
+        if let Some(git_root) = crate::component::resolution::detect_git_root(dir) {
+            if git_root != dir {
+                if let Some(comp) = crate::component::discover_from_portable(&git_root) {
+                    return Ok((comp.id, path.to_string()));
+                }
+            }
+        }
+        // No portable config — synthesize an ID from the path basename so
+        // downstream output still has a meaningful identifier.
+        let basename = dir
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("(unknown)")
+            .to_string();
+        return Ok((basename, path.to_string()));
+    }
+
+    // Case 3: ID without path — look it up in the registry.
+    if let Some(id) = component_id {
         let comp = crate::component::resolve_effective(Some(id), None, None)?;
-        comp.local_path
-    };
-    Ok((id.to_string(), path))
+        return Ok((id.to_string(), comp.local_path));
+    }
+
+    // Case 4: neither — CWD detection.
+    let comp = crate::component::resolve(None)?;
+    Ok((comp.id, comp.local_path))
 }
 
 #[cfg(test)]
@@ -131,5 +165,104 @@ mod identity_tests {
         let id = parse_git_identity(Some("My Service"));
         assert_eq!(id.name, "My Service");
         assert_eq!(id.email, BOT_EMAIL);
+    }
+}
+
+#[cfg(test)]
+mod resolve_target_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Returns (TempDir, repo_path) where repo_path has a homeboy.json with
+    /// the given component id.
+    fn make_portable_repo(id: &str) -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        let repo = dir.path().join(id);
+        fs::create_dir_all(&repo).expect("Failed to create repo dir");
+
+        let portable = serde_json::json!({ "id": id });
+        fs::write(
+            repo.join("homeboy.json"),
+            serde_json::to_string_pretty(&portable).unwrap(),
+        )
+        .expect("Failed to write homeboy.json");
+
+        // Capture path before moving dir.
+        let path = repo.clone();
+        (dir, path)
+    }
+
+    #[test]
+    fn path_only_discovers_id_from_portable_config() {
+        let (_dir, repo) = make_portable_repo("my-plugin");
+
+        let (id, path) = resolve_target(None, Some(repo.to_str().unwrap()))
+            .expect("resolve_target should succeed with --path pointing at portable config");
+
+        assert_eq!(id, "my-plugin");
+        assert_eq!(path, repo.to_string_lossy());
+    }
+
+    #[test]
+    fn path_only_falls_back_to_basename_when_no_portable_config() {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path().join("bare-checkout");
+        fs::create_dir_all(&repo).unwrap();
+
+        let (id, path) = resolve_target(None, Some(repo.to_str().unwrap()))
+            .expect("resolve_target should succeed with --path even without portable config");
+
+        assert_eq!(id, "bare-checkout");
+        assert_eq!(path, repo.to_string_lossy());
+    }
+
+    #[test]
+    fn path_and_id_both_provided_skips_discovery() {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path().join("anywhere");
+        fs::create_dir_all(&repo).unwrap();
+
+        let (id, path) = resolve_target(Some("explicit-id"), Some(repo.to_str().unwrap()))
+            .expect("resolve_target should succeed with both args");
+
+        // Trusts both inputs verbatim — no registry lookup, no discovery.
+        assert_eq!(id, "explicit-id");
+        assert_eq!(path, repo.to_string_lossy());
+    }
+
+    #[test]
+    fn path_only_walks_up_to_git_root_for_portable_config() {
+        // Layout:
+        //   <tmp>/repo/                  (homeboy.json lives here)
+        //   <tmp>/repo/.git/
+        //   <tmp>/repo/subdir/
+        //
+        // Calling with path=<tmp>/repo/subdir should find homeboy.json at
+        // the git root via the existing detect_git_root walk.
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join("subdir")).unwrap();
+
+        let portable = serde_json::json!({ "id": "monorepo-thing" });
+        fs::write(
+            repo.join("homeboy.json"),
+            serde_json::to_string_pretty(&portable).unwrap(),
+        )
+        .unwrap();
+
+        // git init so detect_git_root can find the root.
+        std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .output()
+            .expect("git init");
+
+        let subdir = repo.join("subdir");
+        let (id, path) = resolve_target(None, Some(subdir.to_str().unwrap()))
+            .expect("resolve_target should walk up to git root for portable config");
+
+        assert_eq!(id, "monorepo-thing");
+        assert_eq!(path, subdir.to_string_lossy());
     }
 }

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -781,7 +781,12 @@ pub fn push_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
 
 /// Pull remote changes for a component.
 pub fn pull(component_id: Option<&str>) -> Result<GitOutput> {
-    let (id, path) = resolve_target(component_id, None)?;
+    pull_at(component_id, None)
+}
+
+/// Like [`pull`] but with an explicit path override for git operations.
+pub fn pull_at(component_id: Option<&str>, path_override: Option<&str>) -> Result<GitOutput> {
+    let (id, path) = resolve_target(component_id, path_override)?;
     let output =
         execute_git(&path, &["pull"]).map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "pull", output))


### PR DESCRIPTION
## Summary

`homeboy git status / pull / push / commit / tag` now work without arguments when run from any directory that's part of a registered component, a worktree, or a checkout containing a portable `homeboy.json`. They also accept `--path <dir>` for unregistered checkouts (CI runners, ad-hoc clones, worktrees that aren't a registered component path).

Before this PR:

```
$ cd ~/Developer/data-machine
$ homeboy git status
{ "error": { "code": "validation.invalid_argument",
             "message": "Invalid argument 'componentId': Missing componentId" } }
```

`component_id` was `Option<String>` at the surface, but `resolve_target` errored when it was `None` instead of falling back to CWD detection. `--path` existed on `git issue` / `git pr` (from #1368) but not on the core verbs.

## Behaviour

`resolve_target()` resolves a `(component_id, path)` pair through four explicit cases:

1. **Both `component_id` and `path_override` provided** — trust both, no registry lookup. Used by rig pipelines and workflows that already know the path they want.
2. **`path_override` only** — derive `id` from a portable `homeboy.json` at the path, then at its git root. Falls back to the directory basename if no portable config exists.
3. **`component_id` only** — registry lookup via `resolve_effective` (existing behaviour).
4. **Neither** — delegate to `component::resolve(None)`, which handles registered-component CWD detection, then portable `homeboy.json` discovery at CWD or git root.

This means:

```
$ cd ~/Developer/data-machine          # registered component
$ homeboy git status                    # works

$ cd ~/Developer/homeboy@feat-X         # worktree with portable homeboy.json
$ homeboy git status                    # works, reports the WORKTREE path
                                        # (not the registered local_path)

$ cd /tmp                               # unrelated directory
$ homeboy git status                    # clear error with hints
$ homeboy git status --path /opt/checkout
                                        # works, derives id from portable
                                        # config at /opt/checkout, or falls
                                        # back to basename "checkout"
```

The worktree case is particularly important — homeboy's own worktree workflow (and `data-machine-code workspace worktree`) inject portable `homeboy.json` files into worktree dirs. Before this PR, `git status` from inside a worktree returned the registered `local_path` of the primary checkout, which was wrong; now it correctly returns the worktree path.

## Why split from the rebase / cherry-pick / stack PR

While scoping `homeboy git rebase` + `homeboy git cherry-pick` + `--force-with-lease` (planned follow-up), I discovered the existing verbs already had this CWD-detection gap. Rather than ship the new verbs with the same gap or fix the gap as a side-effect inside a verb-addition PR, this is the foundation: get the resolution layer right first. The verb-addition PR will stack on this one.

## CLI surface

`--path <PATH>` added to:

- `homeboy git status`
- `homeboy git commit`
- `homeboy git push`
- `homeboy git pull`
- `homeboy git tag`

Already present on `homeboy git issue` / `homeboy git pr` from #1368.

`pull_at(component_id, path_override)` added to `core/git/operations.rs` — closes the inconsistency where every other write verb (`status_at`, `commit_at`, `push_at`, `tag_at`) had a `_at` sibling but `pull` did not. `pull()` is now `pull_at(_, None)`.

## Tests

New module: `core::git::resolve_target_tests`

- `path_only_discovers_id_from_portable_config` — `--path` to a dir with `homeboy.json` resolves the id from it.
- `path_only_falls_back_to_basename_when_no_portable_config` — `--path` to a bare dir uses the basename as id.
- `path_and_id_both_provided_skips_discovery` — explicit pair is trusted verbatim, no lookup, no discovery.
- `path_only_walks_up_to_git_root_for_portable_config` — `git init`'d subdir resolves to the parent's `homeboy.json`.

Smoke-tested live against:

- A registered component dir (`~/Developer/data-machine`) — resolves correctly.
- A homeboy worktree (`~/Developer/homeboy@feat-git-cwd-detection`) — reports worktree path, not registered `local_path`.
- The homeboy primary dir — resolves correctly.
- A `git init`'d /tmp dir without portable config — basename fallback works.
- `--path` to each of the above — works.
- An unregistered, no-config /tmp dir without `--path` — returns the existing helpful error from `component::resolve()`.

Test suite (serial): **1393 passed, 0 failed.** Two pre-existing parallel-test flakes (`write_standalone_creates_and_reads_back` and `build_exec_env_includes_runtime_runner_helper_path`) reproduce on `main` under default parallel `cargo test` and pass under `--test-threads=1` — they're concurrency artifacts of `set_var("HOME", ...)` in pre-existing tests, not introduced here.

`cargo fmt --check` clean. `cargo clippy --lib`: zero new warnings on changed files. `homeboy lint homeboy`: passed. `homeboy audit homeboy --changed-since main`: zero findings on changed files.

## Backwards compatibility

- Explicit component-id usage works exactly as before.
- `--json` bulk modes are untouched (bulk operations key by id by construction; `--path` on bulk wouldn't make sense and isn't added).
- Error messages from CWD-fallback come from the existing `component::resolve(None)` error path with its existing hints.

## Out of scope

- **No new verbs.** `rebase`, `cherry-pick`, `--force-with-lease`, and `git stack` (read-only inspection with PR-status decoration via `gh`) are the planned follow-up PR. They will stack on this one, since they need the same CWD detection.
- **No `path` on `--json` bulk modes.** Bulk operations resolve per-id by definition; a single `--path` doesn't apply to a multi-component bulk run.
- **No interactive elision.** Errors when CWD has no resolvable component still tell the user to provide an id, run from a config dir, or initialize one — same hints as before.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the four-case resolution order, identified that `pull` lacked an `_at` sibling, surveyed `--path` coverage on the CLI, wrote the code, wrote the tests, ran `cargo fmt`/`clippy`/`test`/`homeboy lint`/`homeboy audit`, and drafted this description. Chris caught the original scoping mistake (was about to fold this into the rebase/cherry-pick PR) and made the call to split into two PRs so each is small and reviewable. Chris also drove the architectural decision that synthesizing an id from path basename was acceptable when no portable config existed (vs. erroring out).
