### PR TITLE
feat(git): rebase, cherry-pick, --force-with-lease + rig GitOps

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -2,9 +2,10 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::git::{
-    self, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput, IssueCommentOptions,
-    IssueCreateOptions, IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions,
-    PrCreateOptions, PrEditOptions, PrFindOptions, PrState,
+    self, CherryPickOptions, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput,
+    IssueCommentOptions, IssueCreateOptions, IssueFindOptions, IssueState, PrCommentMode,
+    PrCommentOptions, PrCreateOptions, PrEditOptions, PrFindOptions, PrState, PushOptions,
+    RebaseOptions,
 };
 use homeboy::BulkResult;
 
@@ -95,8 +96,84 @@ enum GitCommand {
         #[arg(long)]
         tags: bool,
 
+        /// Use `--force-with-lease` for safe force-pushes (e.g. after a
+        /// rebase). Refuses to overwrite the remote if it has commits the
+        /// local ref hasn't seen. Plain `--force` is intentionally not
+        /// exposed.
+        #[arg(long)]
+        force_with_lease: bool,
+
         /// Workspace path to operate on directly. Useful for unregistered
         /// checkouts (CI runners, ad-hoc clones, worktrees).
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Rebase the current branch onto another ref.
+    ///
+    /// Default (no `--onto`) rebases onto the current branch's tracked
+    /// upstream (`@{upstream}`), same semantics as `git pull --rebase`.
+    /// Git's default rebase drops commits whose patch-id matches a commit
+    /// already in upstream — squash-merged PRs are NOT dropped (different
+    /// patch-id); that case will land in a follow-up.
+    ///
+    /// On conflict, the operation returns a failed result with git's
+    /// stderr. Resolve manually, then re-run with `--continue` or
+    /// `--abort`.
+    Rebase {
+        /// Component ID. When omitted, auto-detected from CWD.
+        component_id: Option<String>,
+
+        /// Target ref to rebase onto. Defaults to the current branch's
+        /// tracked upstream (`@{upstream}`).
+        #[arg(long, value_name = "REF")]
+        onto: Option<String>,
+
+        /// Continue an in-progress rebase after manual conflict resolution.
+        /// Mutually exclusive with `--abort`.
+        #[arg(long, conflicts_with = "abort")]
+        r#continue: bool,
+
+        /// Abort an in-progress rebase and return to the pre-rebase state.
+        #[arg(long)]
+        abort: bool,
+
+        /// Workspace path to operate on directly.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Cherry-pick one or more commits onto the current branch.
+    ///
+    /// Accepts SHAs, branch names, and ranges (`<a>..<b>`) as positional
+    /// args. Use `--pr <n>` to pick all commits from a GitHub PR via `gh`.
+    /// Both can be combined.
+    ///
+    /// On conflict, returns a failed result. Resolve manually, then
+    /// re-run with `--continue` or `--abort`.
+    CherryPick {
+        /// Component ID. When omitted, auto-detected from CWD.
+        #[arg(long, short)]
+        component_id: Option<String>,
+
+        /// Commit refs to pick: SHAs, branches, ranges (`<a>..<b>`).
+        /// Multiple positional args allowed.
+        #[arg(value_name = "REF")]
+        refs: Vec<String>,
+
+        /// Cherry-pick all commits from a GitHub PR (repeatable).
+        /// Resolved via `gh pr view <n> --json commits`.
+        #[arg(long, value_name = "NUMBER")]
+        pr: Vec<u64>,
+
+        /// Continue an in-progress cherry-pick after manual conflict
+        /// resolution. Mutually exclusive with `--abort`.
+        #[arg(long, conflicts_with = "abort")]
+        r#continue: bool,
+
+        /// Abort an in-progress cherry-pick.
+        #[arg(long)]
+        abort: bool,
+
+        /// Workspace path to operate on directly.
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
     },
@@ -518,6 +595,7 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
             json,
             component_id,
             tags,
+            force_with_lease,
             path,
         } => {
             if let Some(spec) = json {
@@ -526,7 +604,14 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
                 return Ok((GitCommandOutput::Bulk(output), exit_code));
             }
 
-            let output = git::push_at(component_id.as_deref(), tags, path.as_deref())?;
+            let output = git::push_at(
+                component_id.as_deref(),
+                PushOptions {
+                    tags,
+                    force_with_lease,
+                },
+                path.as_deref(),
+            )?;
             let exit_code = output.exit_code;
             Ok((GitCommandOutput::Single(output), exit_code))
         }
@@ -578,6 +663,46 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
                 component_id.as_deref(),
                 Some(&final_tag),
                 message.as_deref(),
+                path.as_deref(),
+            )?;
+            let exit_code = output.exit_code;
+            Ok((GitCommandOutput::Single(output), exit_code))
+        }
+        GitCommand::Rebase {
+            component_id,
+            onto,
+            r#continue,
+            abort,
+            path,
+        } => {
+            let output = git::rebase_at(
+                component_id.as_deref(),
+                RebaseOptions {
+                    onto,
+                    continue_: r#continue,
+                    abort,
+                },
+                path.as_deref(),
+            )?;
+            let exit_code = output.exit_code;
+            Ok((GitCommandOutput::Single(output), exit_code))
+        }
+        GitCommand::CherryPick {
+            component_id,
+            refs,
+            pr,
+            r#continue,
+            abort,
+            path,
+        } => {
+            let output = git::cherry_pick_at(
+                component_id.as_deref(),
+                CherryPickOptions {
+                    refs,
+                    prs: pr,
+                    continue_: r#continue,
+                    abort,
+                },
                 path.as_deref(),
             )?;
             let exit_code = output.exit_code;

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -265,6 +265,8 @@ struct BulkIdsInput {
     component_ids: Vec<String>,
     #[serde(default)]
     tags: bool,
+    #[serde(default)]
+    force_with_lease: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -742,23 +744,35 @@ pub fn commit_from_json(id: Option<&str>, json_spec: &str) -> Result<CommitJsonO
     Ok(CommitJsonOutput::Single(output))
 }
 
+/// Options for [`push`].
+#[derive(Debug, Clone, Default)]
+pub struct PushOptions {
+    /// Push tags as well (`--follow-tags`).
+    pub tags: bool,
+    /// Use `--force-with-lease` for safe force-pushes (e.g. after a rebase).
+    /// Deliberately the only force flavour exposed — never plain `--force`.
+    pub force_with_lease: bool,
+}
+
 /// Push local commits for a component.
-pub fn push(component_id: Option<&str>, tags: bool) -> Result<GitOutput> {
-    push_at(component_id, tags, None)
+pub fn push(component_id: Option<&str>, options: PushOptions) -> Result<GitOutput> {
+    push_at(component_id, options, None)
 }
 
 /// Like [`push`] but with an explicit path override for git operations.
 pub fn push_at(
     component_id: Option<&str>,
-    tags: bool,
+    options: PushOptions,
     path_override: Option<&str>,
 ) -> Result<GitOutput> {
     let (id, path) = resolve_target(component_id, path_override)?;
-    let args: Vec<&str> = if tags {
-        vec!["push", "--follow-tags"]
-    } else {
-        vec!["push"]
-    };
+    let mut args: Vec<&str> = vec!["push"];
+    if options.tags {
+        args.push("--follow-tags");
+    }
+    if options.force_with_lease {
+        args.push("--force-with-lease");
+    }
     let output = execute_git(&path, &args).map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "push", output))
 }
@@ -774,8 +788,15 @@ pub fn push_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
         )
     })?;
     let push_tags = input.tags;
+    let force_with_lease = input.force_with_lease;
     Ok(run_bulk_ids(&input.component_ids, "push", |id| {
-        push(Some(id), push_tags)
+        push(
+            Some(id),
+            PushOptions {
+                tags: push_tags,
+                force_with_lease,
+            },
+        )
     }))
 }
 
@@ -790,6 +811,189 @@ pub fn pull_at(component_id: Option<&str>, path_override: Option<&str>) -> Resul
     let output =
         execute_git(&path, &["pull"]).map_err(|e| Error::git_command_failed(e.to_string()))?;
     Ok(GitOutput::from_output(id, path, "pull", output))
+}
+
+/// Options for [`rebase`].
+#[derive(Debug, Clone, Default)]
+pub struct RebaseOptions {
+    /// Upstream / target ref to rebase onto. `None` defaults to the
+    /// current branch's tracked upstream (`@{upstream}`), matching
+    /// `git pull --rebase` semantics.
+    pub onto: Option<String>,
+    /// `git rebase --continue` after manual conflict resolution. Mutually
+    /// exclusive with `abort` at the CLI layer.
+    pub continue_: bool,
+    /// `git rebase --abort` to bail out of an in-progress rebase.
+    pub abort: bool,
+}
+
+/// Rebase the current branch onto another ref.
+///
+/// Default behaviour (no `onto`) is `git rebase @{upstream}`, which drops
+/// commits whose patch-id matches a commit already in upstream — the
+/// standard rebase merged-commit dedup. Squash-merged PRs (different
+/// patch-id) are NOT dropped by default; that case will land in a
+/// follow-up via `gh`-aware PR drop.
+///
+/// On conflict, the operation returns a `GitOutput { success: false }`
+/// with stderr from git. The caller resolves with raw `git`, then runs
+/// `homeboy git rebase --continue` or `--abort`. No state-machine
+/// orchestration in MVP.
+pub fn rebase(component_id: Option<&str>, options: RebaseOptions) -> Result<GitOutput> {
+    rebase_at(component_id, options, None)
+}
+
+/// Like [`rebase`] but with an explicit path override.
+pub fn rebase_at(
+    component_id: Option<&str>,
+    options: RebaseOptions,
+    path_override: Option<&str>,
+) -> Result<GitOutput> {
+    let (id, path) = resolve_target(component_id, path_override)?;
+
+    let args: Vec<String> = if options.abort {
+        vec!["rebase".into(), "--abort".into()]
+    } else if options.continue_ {
+        vec!["rebase".into(), "--continue".into()]
+    } else {
+        let mut a = vec!["rebase".into()];
+        if let Some(onto) = options.onto.as_deref() {
+            a.push(onto.to_string());
+        }
+        // No `onto` arg → bare `git rebase` rebases onto @{upstream}.
+        a
+    };
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let output =
+        execute_git(&path, &arg_refs).map_err(|e| Error::git_command_failed(e.to_string()))?;
+    Ok(GitOutput::from_output(id, path, "rebase", output))
+}
+
+/// Options for [`cherry_pick`].
+#[derive(Debug, Clone, Default)]
+pub struct CherryPickOptions {
+    /// Commit refs to cherry-pick. Accepts SHAs, branches, ranges
+    /// (`<sha1>..<sha2>`). Empty when `continue_` or `abort` is set.
+    pub refs: Vec<String>,
+    /// Cherry-pick all commits from a GitHub PR (one or more). Resolved
+    /// via `gh pr view <n> --json commits`. Each PR's commits are picked
+    /// in oldest-to-newest order. Combinable with `refs`; PR commits are
+    /// expanded first and then concatenated with explicit refs.
+    pub prs: Vec<u64>,
+    /// `git cherry-pick --continue` after manual conflict resolution.
+    pub continue_: bool,
+    /// `git cherry-pick --abort` to bail out of an in-progress pick.
+    pub abort: bool,
+}
+
+/// Cherry-pick one or more commits onto the current branch.
+///
+/// On conflict, returns `GitOutput { success: false }` with git's stderr.
+/// Resolve manually, then run with `--continue` or `--abort`.
+pub fn cherry_pick(component_id: Option<&str>, options: CherryPickOptions) -> Result<GitOutput> {
+    cherry_pick_at(component_id, options, None)
+}
+
+/// Like [`cherry_pick`] but with an explicit path override.
+pub fn cherry_pick_at(
+    component_id: Option<&str>,
+    options: CherryPickOptions,
+    path_override: Option<&str>,
+) -> Result<GitOutput> {
+    let (id, path) = resolve_target(component_id, path_override)?;
+
+    if options.abort {
+        let output = execute_git(&path, &["cherry-pick", "--abort"])
+            .map_err(|e| Error::git_command_failed(e.to_string()))?;
+        return Ok(GitOutput::from_output(id, path, "cherry-pick", output));
+    }
+    if options.continue_ {
+        let output = execute_git(&path, &["cherry-pick", "--continue"])
+            .map_err(|e| Error::git_command_failed(e.to_string()))?;
+        return Ok(GitOutput::from_output(id, path, "cherry-pick", output));
+    }
+
+    // Expand any PR numbers into commit SHAs via `gh`. PR commits come
+    // before explicit refs in argv order so the user's positional args
+    // can fine-tune ordering by interleaving — but in practice most
+    // callers pass either `--pr` or `<refs>`, not both.
+    let mut refs: Vec<String> = Vec::new();
+    for pr in &options.prs {
+        let pr_commits = resolve_pr_commits(&path, *pr)?;
+        refs.extend(pr_commits);
+    }
+    refs.extend(options.refs.iter().cloned());
+
+    if refs.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "refs",
+            "cherry-pick requires at least one commit ref or --pr <number>",
+            None,
+            Some(vec![
+                "Provide a commit ref: homeboy git cherry-pick <sha>".to_string(),
+                "Or pick a PR: homeboy git cherry-pick --pr <number>".to_string(),
+            ]),
+        ));
+    }
+
+    let mut args: Vec<String> = vec!["cherry-pick".into()];
+    args.extend(refs);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let output =
+        execute_git(&path, &arg_refs).map_err(|e| Error::git_command_failed(e.to_string()))?;
+    Ok(GitOutput::from_output(id, path, "cherry-pick", output))
+}
+
+/// Resolve a GitHub PR number to its list of commit SHAs (oldest first)
+/// using `gh pr view`. Used by [`cherry_pick`] to expand `--pr <n>`.
+fn resolve_pr_commits(path: &str, pr: u64) -> Result<Vec<String>> {
+    let output = std::process::Command::new("gh")
+        .args(["pr", "view", &pr.to_string(), "--json", "commits"])
+        .current_dir(path)
+        .output()
+        .map_err(|e| {
+            Error::git_command_failed(format!(
+                "gh pr view {}: {} (is `gh` installed and authenticated?)",
+                pr, e
+            ))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "gh pr view {} failed: {}",
+            pr,
+            stderr.trim()
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse `gh pr view {} --json commits`", pr)),
+            Some(stdout.chars().take(200).collect()),
+        )
+    })?;
+
+    let commits = parsed
+        .get("commits")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            Error::git_command_failed(format!(
+                "gh pr view {} returned JSON without a `commits` array",
+                pr
+            ))
+        })?;
+
+    let mut shas = Vec::with_capacity(commits.len());
+    for commit in commits {
+        let oid = commit.get("oid").and_then(|v| v.as_str()).ok_or_else(|| {
+            Error::git_command_failed(format!("gh pr view {} returned a commit without `oid`", pr))
+        })?;
+        shas.push(oid.to_string());
+    }
+    Ok(shas)
 }
 
 /// Pull multiple components from JSON spec.
@@ -1213,6 +1417,225 @@ mod tests {
         assert!(
             !super::super::is_workdir_clean(path),
             "Expected invalid path to return false"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // rebase / cherry-pick / push --force-with-lease tests
+    //
+    // These shell out to real git in tempdirs. They exercise the wiring
+    // (option struct → argv → execute_git → GitOutput) end-to-end without
+    // touching the homeboy registry. `--path` keeps resolve_target out of
+    // the registry path so the tests don't need HOME isolation.
+    // ------------------------------------------------------------------
+
+    /// Create a fresh git repo with a single committed file. Returns the
+    /// TempDir (drop-cleanup) and the repo path as a String.
+    fn init_repo_with_initial_commit() -> (tempfile::TempDir, String) {
+        use std::fs;
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_string_lossy().to_string();
+
+        Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(&path)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+        fs::write(dir.path().join("README.md"), "initial\n").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "initial"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        (dir, path)
+    }
+
+    #[test]
+    fn rebase_against_self_is_a_noop_success() {
+        let (_dir, path) = init_repo_with_initial_commit();
+
+        // Rebase onto HEAD — always a no-op, exit 0.
+        let out = rebase_at(
+            None,
+            RebaseOptions {
+                onto: Some("HEAD".to_string()),
+                ..Default::default()
+            },
+            Some(&path),
+        )
+        .expect("rebase_at");
+
+        assert!(out.success, "rebase HEAD should succeed: {:?}", out.stderr);
+        assert_eq!(out.action, "rebase");
+        assert_eq!(out.path, path);
+    }
+
+    #[test]
+    fn rebase_abort_outside_of_rebase_is_an_error() {
+        let (_dir, path) = init_repo_with_initial_commit();
+
+        // git rebase --abort with no rebase in progress fails. We surface
+        // that via GitOutput { success: false, stderr } — NOT via Err —
+        // because the caller may want to inspect the message.
+        let out = rebase_at(
+            None,
+            RebaseOptions {
+                abort: true,
+                ..Default::default()
+            },
+            Some(&path),
+        )
+        .expect("rebase_at returns Ok with failed GitOutput");
+
+        assert!(!out.success);
+        assert_ne!(out.exit_code, 0);
+        assert!(
+            out.stderr.contains("rebase") || out.stderr.contains("No rebase"),
+            "expected stderr to mention rebase: {:?}",
+            out.stderr
+        );
+    }
+
+    #[test]
+    fn cherry_pick_picks_a_commit_from_another_branch() {
+        use std::fs;
+        let (dir, path) = init_repo_with_initial_commit();
+
+        // Create a side branch with a unique commit.
+        Command::new("git")
+            .args(["checkout", "-q", "-b", "side"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+        fs::write(dir.path().join("from-side.txt"), "side\n").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "side commit"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+        let side_sha = String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&path)
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        // Switch back to main; pick the side commit.
+        Command::new("git")
+            .args(["checkout", "-q", "main"])
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        let out = cherry_pick_at(
+            None,
+            CherryPickOptions {
+                refs: vec![side_sha.clone()],
+                ..Default::default()
+            },
+            Some(&path),
+        )
+        .expect("cherry_pick_at");
+
+        assert!(
+            out.success,
+            "cherry-pick should succeed: stderr={:?}",
+            out.stderr
+        );
+        assert!(
+            dir.path().join("from-side.txt").exists(),
+            "cherry-picked file should exist on main"
+        );
+    }
+
+    #[test]
+    fn cherry_pick_with_no_refs_and_no_pr_errors() {
+        let (_dir, path) = init_repo_with_initial_commit();
+
+        // Empty refs + no PR + not continue/abort → user-facing error,
+        // NOT a `git cherry-pick` invocation.
+        let err = cherry_pick_at(None, CherryPickOptions::default(), Some(&path))
+            .expect_err("cherry_pick with empty refs should Err");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("at least one commit ref") || msg.contains("--pr"),
+            "expected helpful error, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn cherry_pick_abort_outside_of_pick_is_a_failed_output() {
+        let (_dir, path) = init_repo_with_initial_commit();
+
+        let out = cherry_pick_at(
+            None,
+            CherryPickOptions {
+                abort: true,
+                ..Default::default()
+            },
+            Some(&path),
+        )
+        .expect("cherry_pick_at returns Ok with failed GitOutput");
+
+        assert!(!out.success);
+        assert_ne!(out.exit_code, 0);
+    }
+
+    #[test]
+    fn push_options_force_with_lease_includes_flag() {
+        // We can't test the real push (no remote) but we can verify that
+        // push_at with force_with_lease=true at least invokes git with
+        // the right argv. With no remote configured, git push fails —
+        // we check stderr to confirm the flag flowed through and the
+        // failure is the expected "no remote" failure, not a wiring bug.
+        let (_dir, path) = init_repo_with_initial_commit();
+
+        let out = push_at(
+            None,
+            PushOptions {
+                tags: false,
+                force_with_lease: true,
+            },
+            Some(&path),
+        )
+        .expect("push_at");
+
+        assert!(!out.success, "push without remote should fail");
+        // The failure message is from git, not us — but it should at
+        // least mention the absence of a remote / upstream rather than
+        // anything about an unknown flag.
+        assert!(
+            !out.stderr.contains("unknown option") && !out.stderr.contains("invalid argument"),
+            "--force-with-lease should be a known flag, got: {}",
+            out.stderr
         );
     }
 }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -253,7 +253,14 @@ pub(crate) fn run_git_tag(
 
 /// Push commits (and tags) to the remote.
 pub(crate) fn run_git_push(component: &Component, component_id: &str) -> Result<ReleaseStepResult> {
-    let output = crate::git::push_at(Some(component_id), true, Some(&component.local_path))?;
+    let output = crate::git::push_at(
+        Some(component_id),
+        crate::git::PushOptions {
+            tags: true,
+            force_with_lease: false,
+        },
+        Some(&component.local_path),
+    )?;
     let data = serde_json::to_value(output)
         .map_err(|e| Error::internal_json(e.to_string(), Some("git push output".to_string())))?;
     Ok(step_success("git.push", "git.push", Some(data), Vec::new()))

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -625,7 +625,13 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
 
     if !tag_exists_remote {
         log_status!("recover", "Pushing to remote...");
-        let push_result = git::push(Some(&input.component_id), true)?;
+        let push_result = git::push(
+            Some(&input.component_id),
+            git::PushOptions {
+                tags: true,
+                force_with_lease: false,
+            },
+        )?;
         if !push_result.success {
             return Err(Error::git_command_failed(format!(
                 "Failed to push: {}",

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -192,9 +192,12 @@ fn run_git_step(rig: &RigSpec, component_id: &str, op: GitOp, extra_args: &[Stri
     let base_args: Vec<String> = match op {
         GitOp::Status => vec!["status".into(), "--porcelain=v1".into()],
         GitOp::Pull => vec!["pull".into()],
+        GitOp::Push => vec!["push".into()],
         GitOp::Fetch => vec!["fetch".into()],
         GitOp::Checkout => vec!["checkout".into()],
         GitOp::CurrentBranch => vec!["rev-parse".into(), "--abbrev-ref".into(), "HEAD".into()],
+        GitOp::Rebase => vec!["rebase".into()],
+        GitOp::CherryPick => vec!["cherry-pick".into()],
     };
     let mut full_args: Vec<String> = base_args;
     for arg in extra_args {
@@ -447,9 +450,12 @@ fn serialize_git_op(op: GitOp) -> &'static str {
     match op {
         GitOp::Status => "status",
         GitOp::Pull => "pull",
+        GitOp::Push => "push",
         GitOp::Fetch => "fetch",
         GitOp::Checkout => "checkout",
         GitOp::CurrentBranch => "current-branch",
+        GitOp::Rebase => "rebase",
+        GitOp::CherryPick => "cherry-pick",
     }
 }
 

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -216,12 +216,26 @@ pub enum GitOp {
     Status,
     /// `git pull [args...]`.
     Pull,
+    /// `git push [args...]`. Use `args` for `--force-with-lease`,
+    /// `--follow-tags`, etc. Plain `--force` is intentionally NOT
+    /// blocked at the rig layer — rigs can be reproduced or reverted, so
+    /// the safety boundary lives at the CLI surface.
+    Push,
     /// `git fetch [args...]`.
     Fetch,
     /// `git checkout [args...]`.
     Checkout,
     /// `git rev-parse --abbrev-ref HEAD` — returns current branch in logs.
     CurrentBranch,
+    /// `git rebase [<onto>]`. Default with no `args` rebases onto
+    /// `@{upstream}`. Use `args` to specify the upstream ref or extra
+    /// rebase flags.
+    Rebase,
+    /// `git cherry-pick <refs...>`. `args` is the list of commit refs to
+    /// pick (SHAs, branches, ranges). PR-number expansion via `gh` is a
+    /// CLI-only convenience and not modelled at the rig step level —
+    /// resolve PR numbers to SHAs in the rig spec.
+    CherryPick,
 }
 
 /// Service operation in a pipeline step.


### PR DESCRIPTION
## Summary

Adds three per-component git primitive verbs that combined-fixes-style maintenance workflows need on top of #1498's CWD detection. Each verb follows the established `fn verb(component_id, options)` + `fn verb_at(component_id, options, path_override)` pattern and slots into `resolve_target` so all four resolution cases (id+path / path-only / id-only / neither) work identically.

## Verbs added

### `homeboy git rebase`

```
homeboy git rebase [<component>] [--onto <ref>] [--continue|--abort] [--path <dir>]
```

- `--onto <ref>` — target ref. Default: `@{upstream}` (same as `git pull --rebase`).
- `--continue` / `--abort` — passthrough for in-progress rebases. Mutually exclusive.
- Default rebase already drops commits whose patch-id matches a commit in upstream (git's standard merged-commit dedup). **Squash-merged PRs are NOT dropped** because their patch-ids differ from the local cherry-pick — that case will land in a follow-up via `gh`-aware PR detection.

### `homeboy git cherry-pick`

```
homeboy git cherry-pick [<refs>...] [--pr <n>] [--continue|--abort] [--path <dir>] [-c <component>]
```

- Variadic positional `<refs>` — SHAs, branch names, ranges (`<a>..<b>`).
- Repeatable `--pr <n>` — fetches PR commits via `gh pr view <n> --json commits` and expands oldest-first. Combinable with `<refs>`.
- `--continue` / `--abort` for in-progress picks.
- Empty-input (no refs, no PRs, no continue/abort) returns a helpful error instead of invoking `git cherry-pick` with no args.

### `homeboy git push --force-with-lease`

The push surface gains `PushOptions { tags, force_with_lease }`. Plain `--force` is intentionally NOT exposed; `--force-with-lease` is the safety primitive every rebase workflow needs (refuses the push if the remote has commits the local ref hasn't seen).

## Rig integration

Adds three variants to `core/rig/spec.rs::GitOp`:

- `GitOp::Push` — `git push [args...]`
- `GitOp::Rebase` — `git rebase [args...]`
- `GitOp::CherryPick` — `git cherry-pick [refs...]`

This unblocks declarative daily-rebase rituals at the rig layer:

```json
"sync": [
  { "kind": "git", "component": "studio", "op": "rebase" },
  { "kind": "git", "component": "studio", "op": "push",
    "args": ["--force-with-lease"] }
]
```

Push at the rig layer takes args directly rather than gating `--force-with-lease` behind a typed flag — rigs can be reproduced or reverted, so the safety boundary lives at the CLI surface, not the rig layer. PR-number expansion via `gh` is also a CLI-only convenience and not modelled at rig step level — resolve PR numbers to SHAs in the rig spec.

## Conflict semantics

When `git rebase` or `git cherry-pick` hits a conflict, the operation returns `GitOutput { success: false, stderr: ... }` rather than `Err`. The caller sees git's actual conflict output and resolves with raw `git`, then re-runs with `--continue` or `--abort`. No state-machine orchestration in MVP — that surface is bigger than this PR and would gain little over what users already do at the shell.

## Caller updates

The `push()` API change (`tags: bool` → `PushOptions { tags, force_with_lease }`) ripples to two existing call sites:

- `core/release/workflow.rs::recover_publish` — passes `PushOptions { tags: true, force_with_lease: false }`.
- `core/release/executor.rs::run_git_push` — same.

`BulkIdsInput` gains `#[serde(default)] force_with_lease: bool` so bulk push specs can opt in. Backwards-compatible at the JSON surface (defaults to false).

## Tests

6 new tests in `core::git::operations::tests`, all using real git in tempdirs (no homeboy registry interaction; `--path` keeps `resolve_target` out of the registry path so HOME isolation isn't needed):

- `rebase_against_self_is_a_noop_success` — `--onto HEAD` exits 0.
- `rebase_abort_outside_of_rebase_is_an_error` — surfaces git's "no rebase in progress" via `GitOutput { success: false }`.
- `cherry_pick_picks_a_commit_from_another_branch` — end-to-end: side-branch commit → main → file lands on main.
- `cherry_pick_with_no_refs_and_no_pr_errors` — empty input gets a helpful `Err`, not a bare `git cherry-pick` invocation.
- `cherry_pick_abort_outside_of_pick_is_a_failed_output` — same error-pass-through pattern as rebase.
- `push_options_force_with_lease_includes_flag` — verifies the flag flows through to argv (push fails for lack of remote, but stderr doesn't mention an unknown option).

**Full lib test suite (serial): 1399 passed, 0 failed.** Same pre-existing parallel-test flakes from #1498 still apply only under default parallel runs.

`cargo fmt --check` clean. `cargo clippy --lib`: zero new warnings on changed files. `homeboy lint homeboy`: passed. `homeboy audit homeboy --changed-since main`: `drift_increased: false`, `new_items: []` — 44 findings exist on this file (god_file, high_item_count, the missing_test_method swarm) but all are pre-existing baseline drift, not introduced here.

## Backwards compatibility

- **Rust API:** `push()` and `push_at()` signatures changed. homeboy is workspace-internal — no external Rust consumers exist.
- **CLI:** Purely additive. `homeboy git push` gains `--force-with-lease`. New subcommands `git rebase` and `git cherry-pick` are net-new surface.
- **Rig spec JSON:** `GitOp` enum gains three variants (`push`, `rebase`, `cherry-pick`); existing rig specs in the wild don't name these and are unaffected. Bulk push JSON gains optional `force_with_lease` field.

## Out of scope

- **`homeboy git stack`** — read-only commits-over-upstream view with PR-status decoration via `gh`. Planned for PR 3. Different concern (introspection vs. mutation), different testing surface (gh mocking), independent value.
- **Squash-merged-PR drop in rebase.** GitHub's default-merge case (different patch-id from local cherry-pick) requires a `gh`-aware diff. Will land alongside or after `git stack` once the GH surface is in place.
- **State-machine orchestration** of `--continue` / `--abort`. Today these are flag passthroughs. A real orchestrator would track in-flight rebase/pick state across invocations — not worth the complexity in MVP given users already navigate this with raw `git`.
- **Plain `--force`.** Intentionally never exposed at the CLI. Rigs can pass it via raw `args` if a workflow really needs it.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the verb shapes (`RebaseOptions` / `CherryPickOptions` / `PushOptions` refactor), wrote the implementations, identified external callers via grep and updated them, wrote the tests, ran the full validation pipeline (fmt / clippy / cargo test / homeboy lint / homeboy audit), and drafted this description. Chris drove the scope decisions: split `git stack` into PR 3, defer squash-merge drop to follow-up, no state-machine orchestration in MVP, no plain `--force`. The fluid-UX shape ("one command per workflow", `--continue`/`--abort` only on the verbs that can pause) was Chris's framing question that landed the design here instead of on a smaller verb-only scope.
