### PR TITLE
feat(review): scoped audit + lint + test umbrella (closes #1500)

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -23,6 +23,7 @@
 - [project](project.md)
 - [refactor](refactor.md)
 - [release](release.md) — local release pipeline
+- [review](review.md) — scoped audit + lint + test umbrella for PR-style changes
 - [rig](rig.md) — reproducible local dev environments ([spec](rig-spec.md))
 - [server](server.md)
 - [ssh](ssh.md)

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -1,0 +1,134 @@
+# Review Command
+
+Run scoped audit + lint + test in a single invocation against PR-style changes.
+
+## Synopsis
+
+```bash
+homeboy review [component] --changed-since=<ref>
+homeboy review [component] --changed-only
+homeboy review [component]
+```
+
+## Description
+
+`homeboy review` is a thin umbrella that fans out the existing scoped runs of
+`audit`, `lint`, and `test` against the same set of changed files, then prints a
+single consolidated report. It answers the question:
+
+> *"What would a reviewer see if I ran homeboy on just my PR diff?"*
+
+The umbrella owns no scoping logic of its own — every scope flag is forwarded to
+the underlying commands, which already share a common `--changed-since` plumbing
+(`core/git/changes.rs::get_files_changed_since`). Stages run **sequentially** in
+the order **audit → lint → test**, matching the canonical verification order.
+Output is deterministic and matches each command's per-stage output.
+
+## Arguments
+
+- `[component]`: Component ID. Optional — auto-discovered from the current
+  working directory via `homeboy.json`, just like `lint`, `audit`, and `test`.
+
+## Scope flags
+
+- `--changed-since <REF>`: Run audit, lint, and test only against files changed
+  since this git ref (branch, tag, or SHA). Triple-dot diff against `HEAD`,
+  excludes deletes, handles shallow CI clones automatically. Mutually exclusive
+  with `--changed-only`.
+- `--changed-only`: Run against files modified in the working tree (staged,
+  unstaged, untracked). **Only the lint stage scopes natively** — audit and test
+  do not currently accept working-tree-only scoping, so they run against the
+  full component when this flag is passed. The consolidated summary surfaces
+  this limitation as a hint. Use `--changed-since` for full umbrella scoping.
+
+If neither flag is passed, all three stages run against the entire component —
+equivalent to running `audit`, `lint`, and `test` back-to-back without scope.
+
+## Other flags
+
+- `--summary`: Forward the per-stage summary flag to each command (`--summary`
+  on lint, `--json-summary` on audit and test).
+- `--baseline` / `--ignore-baseline` / `--ratchet`: Forwarded to every stage
+  that participates in the baseline engine.
+
+## Examples
+
+```bash
+# CI pattern: review a feature branch against trunk
+homeboy review --changed-since=trunk
+
+# Review a specific component against a release tag
+homeboy review my-plugin --changed-since=v1.2.0
+
+# Quick local check of working-tree edits (lint only scopes)
+homeboy review --changed-only
+
+# Full sweep — equivalent to running audit + lint + test back-to-back
+homeboy review my-plugin
+```
+
+## Empty-changeset short-circuit
+
+When `--changed-since=<ref>` or `--changed-only` produces an empty file list,
+review prints a single line and exits cleanly:
+
+```text
+No files changed since trunk — skipping review
+```
+
+All three stages are reported as `ran: false` with `skipped_reason: "no files
+changed"` in the JSON envelope. No extension setup is performed.
+
+## Output
+
+Returns the standard CLI envelope `{success, data}`. The `data` payload
+consolidates all three stages:
+
+```json
+{
+  "success": true,
+  "data": {
+    "command": "review",
+    "summary": {
+      "passed": true,
+      "status": "passed",
+      "component": "my-plugin",
+      "scope": "changed-since",
+      "changed_since": "trunk",
+      "total_findings": 0,
+      "changed_file_count": 7,
+      "hints": []
+    },
+    "audit": {
+      "stage": "audit",
+      "ran": true,
+      "passed": true,
+      "exit_code": 0,
+      "finding_count": 0,
+      "hint": "Deep dive: homeboy audit my-plugin --changed-since=trunk",
+      "output": { "...": "full AuditCommandOutput" }
+    },
+    "lint": { "...": "full LintCommandOutput" },
+    "test": { "...": "full TestCommandOutput" }
+  }
+}
+```
+
+Each stage's `output` field carries the same structured payload that running
+`homeboy <stage>` directly would produce, so downstream consumers (the sectioned
+PR-comment primitive, CI wrappers) can render per-stage detail without needing
+a separate invocation.
+
+## Exit codes
+
+- `0`: Every stage that ran exited 0.
+- `1`: At least one stage reported findings or test failures (`exit_code == 1`).
+- `2`: At least one stage hit an infrastructure failure (`exit_code >= 2`).
+
+## Related
+
+- [audit](audit.md) — convention drift detection (run individually for deep dive)
+- [lint](lint.md) — code-style validation (only stage that natively supports `--changed-only`)
+- [test](test.md) — test execution + drift detection
+- [refactor](refactor.md) — apply automated fixes after review identifies issues
+- Issue [#1500](https://github.com/Extra-Chill/homeboy/issues/1500) — design and motivation

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -13,52 +13,52 @@ use super::{CmdResult, GlobalArgs};
 #[derive(Args)]
 pub struct LintArgs {
     #[command(flatten)]
-    comp: PositionalComponentArgs,
+    pub comp: PositionalComponentArgs,
 
     /// Show compact summary instead of full output
     #[arg(long)]
-    summary: bool,
+    pub summary: bool,
 
     /// Lint only a single file (path relative to component root)
     #[arg(long)]
-    file: Option<String>,
+    pub file: Option<String>,
 
     /// Lint only files matching glob pattern (e.g., "inc/**/*.php")
     #[arg(long)]
-    glob: Option<String>,
+    pub glob: Option<String>,
 
     /// Lint only files modified in the working tree (staged, unstaged, untracked)
     #[arg(long, conflicts_with = "changed_since")]
-    changed_only: bool,
+    pub changed_only: bool,
 
     /// Lint only files changed since a git ref (branch, tag, or SHA) — CI-friendly
     #[arg(long, conflicts_with = "changed_only")]
-    changed_since: Option<String>,
+    pub changed_since: Option<String>,
 
     /// Show only errors, suppress warnings
     #[arg(long)]
-    errors_only: bool,
+    pub errors_only: bool,
 
     /// Only check specific sniffs (comma-separated codes)
     #[arg(long)]
-    sniffs: Option<String>,
+    pub sniffs: Option<String>,
 
     /// Exclude sniffs from checking (comma-separated codes)
     #[arg(long)]
-    exclude_sniffs: Option<String>,
+    pub exclude_sniffs: Option<String>,
 
     /// Filter by category: security, i18n, yoda, whitespace
     #[arg(long)]
-    category: Option<String>,
+    pub category: Option<String>,
 
     #[command(flatten)]
-    setting_args: SettingArgs,
+    pub setting_args: SettingArgs,
 
     #[command(flatten)]
-    baseline_args: BaselineArgs,
+    pub baseline_args: BaselineArgs,
 
     #[command(flatten)]
-    _json: HiddenJsonArgs,
+    pub _json: HiddenJsonArgs,
 }
 
 pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -268,6 +268,7 @@ pub mod logs;
 pub mod project;
 pub mod refactor;
 pub mod release;
+pub mod review;
 pub mod rig;
 pub mod scaffold;
 pub mod server;
@@ -337,6 +338,7 @@ pub(crate) fn run_json(
         crate::Commands::Validate(args) => dispatch!(args, global, validate),
         crate::Commands::Changes(args) => dispatch!(args, global, changes),
         crate::Commands::Release(args) => dispatch!(args, global, release),
+        crate::Commands::Review(args) => dispatch!(args, global, review),
         crate::Commands::Scaffold(args) => dispatch!(args, global, scaffold),
         crate::Commands::Audit(args) => dispatch!(args, global, audit),
         crate::Commands::Refactor(args) => dispatch!(args, global, refactor),

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -1,0 +1,527 @@
+//! Review command — scoped audit + lint + test umbrella.
+//!
+//! `homeboy review --changed-since=<ref>` runs the same scoped checks a CI
+//! reviewer would run on a PR diff, fanning out to the existing
+//! `audit`, `lint`, and `test` commands and collapsing their structured
+//! results into a single consolidated report.
+//!
+//! The umbrella is deliberately thin: scoping logic lives in the underlying
+//! commands (and in `core/git/changes.rs::get_files_changed_since`). Review
+//! orchestrates ordering, short-circuits on empty changesets, and assembles
+//! the consolidated output envelope.
+//!
+//! See: https://github.com/Extra-Chill/homeboy/issues/1500
+
+use clap::Args;
+use serde::Serialize;
+
+use homeboy::code_audit::AuditCommandOutput;
+use homeboy::extension::lint::LintCommandOutput;
+use homeboy::extension::test::TestCommandOutput;
+use homeboy::git;
+
+use super::utils::args::{BaselineArgs, PositionalComponentArgs};
+use super::{audit, lint, test, CmdResult, GlobalArgs};
+
+#[derive(Args, Debug, Clone)]
+pub struct ReviewArgs {
+    #[command(flatten)]
+    pub comp: PositionalComponentArgs,
+
+    /// Run audit + lint + test only against files changed since this git ref
+    /// (branch, tag, or SHA). CI-friendly — mirrors the per-stage flag.
+    #[arg(long, value_name = "REF", conflicts_with = "changed_only")]
+    pub changed_since: Option<String>,
+
+    /// Run only against files modified in the working tree
+    /// (staged, unstaged, untracked). Only the lint stage scopes natively;
+    /// audit and test run on the full component with a hint noting the
+    /// limitation. Use `--changed-since` for full umbrella scoping.
+    #[arg(long, conflicts_with = "changed_since")]
+    pub changed_only: bool,
+
+    /// Show compact summary instead of full per-stage output
+    #[arg(long)]
+    pub summary: bool,
+
+    /// Hidden compatibility flag — the JSON envelope is always emitted at the
+    /// CLI layer (`{success, data}`); this exists so callers that pass
+    /// `--json` to other homeboy commands can pass it here too.
+    #[arg(long, hide = true)]
+    pub json: bool,
+
+    #[command(flatten)]
+    pub baseline_args: BaselineArgs,
+}
+
+/// Per-stage section of the consolidated review output.
+#[derive(Serialize)]
+pub struct ReviewStage<T: Serialize> {
+    /// Stage name (`"audit"`, `"lint"`, `"test"`).
+    pub stage: String,
+    /// Whether the stage ran or was skipped.
+    pub ran: bool,
+    /// Stage-level pass/fail (only meaningful when `ran` is true).
+    pub passed: bool,
+    /// Stage exit code (0 when skipped).
+    pub exit_code: i32,
+    /// Number of findings the stage reported (audit findings, lint findings,
+    /// test failures). Always 0 when skipped or stage-internal counts unavailable.
+    pub finding_count: usize,
+    /// Human-readable hint pointing to the per-stage command for deep dive.
+    pub hint: String,
+    /// Skip reason (only present when `ran` is false).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_reason: Option<String>,
+    /// Full structured output from the underlying command. None if skipped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<T>,
+}
+
+/// Top-level summary block — what a reviewer would skim first.
+#[derive(Serialize)]
+pub struct ReviewSummary {
+    /// True when every stage that ran exited 0.
+    pub passed: bool,
+    /// Top-line status string.
+    pub status: String,
+    /// Component label.
+    pub component: String,
+    /// Scope mode applied: `"changed-since"`, `"changed-only"`, or `"full"`.
+    pub scope: String,
+    /// The git ref passed to `--changed-since`, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_since: Option<String>,
+    /// Total findings across all stages that ran.
+    pub total_findings: usize,
+    /// Count of files in the changed set (None when not in scoped mode).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_file_count: Option<usize>,
+    /// Top-level hints (e.g., empty changeset, scope warnings).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub hints: Vec<String>,
+}
+
+/// Unified output envelope for the review command.
+#[derive(Serialize)]
+pub struct ReviewCommandOutput {
+    pub command: String,
+    pub summary: ReviewSummary,
+    pub audit: ReviewStage<AuditCommandOutput>,
+    pub lint: ReviewStage<LintCommandOutput>,
+    pub test: ReviewStage<TestCommandOutput>,
+}
+
+pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutput> {
+    // Resolve component ID (auto-discovers from CWD when omitted) and source
+    // path so we can probe git for the changed-file set ourselves.
+    let component = args.comp.load()?;
+    let component_label = component.id.clone();
+    let source_path = component.local_path.clone();
+
+    let scope = if args.changed_since.is_some() {
+        "changed-since"
+    } else if args.changed_only {
+        "changed-only"
+    } else {
+        "full"
+    }
+    .to_string();
+
+    // Probe the changed set once at the umbrella level so we can short-circuit
+    // before paying for any extension setup. Each stage will re-derive its
+    // own scope internally (and that's fine — `get_files_changed_since` is
+    // cheap, and lint/audit/test must remain independently invocable).
+    let changed_file_count = match (&args.changed_since, args.changed_only) {
+        (Some(git_ref), _) => Some(git::get_files_changed_since(&source_path, git_ref)?.len()),
+        (_, true) => Some(git::get_dirty_files(&source_path)?.len()),
+        _ => None,
+    };
+
+    if let Some(0) = changed_file_count {
+        let scope_label = if let Some(ref r) = args.changed_since {
+            format!("since {}", r)
+        } else {
+            "in working tree".to_string()
+        };
+        let message = format!("No files changed {} — skipping review", scope_label);
+        println!("{}", message);
+
+        let output = ReviewCommandOutput {
+            command: "review".to_string(),
+            summary: ReviewSummary {
+                passed: true,
+                status: "passed".to_string(),
+                component: component_label,
+                scope,
+                changed_since: args.changed_since.clone(),
+                total_findings: 0,
+                changed_file_count: Some(0),
+                hints: vec![message],
+            },
+            audit: stage_skipped("audit", "no files changed"),
+            lint: stage_skipped("lint", "no files changed"),
+            test: stage_skipped("test", "no files changed"),
+        };
+        return Ok((output, 0));
+    }
+
+    // ── Stage 1: audit ──────────────────────────────────────────────────────
+    // Audit scopes via --changed-since only (no --changed-only support today).
+    // When the user asked for --changed-only, audit runs against the full
+    // component; we surface that limitation in `summary.hints`.
+    let mut top_hints: Vec<String> = Vec::new();
+
+    let audit_args = audit::AuditArgs {
+        comp: args.comp.clone(),
+        conventions: false,
+        only: Vec::new(),
+        exclude: Vec::new(),
+        baseline_args: args.baseline_args.clone(),
+        changed_since: args.changed_since.clone(),
+        json_summary: args.summary,
+    };
+    let (audit_output, audit_exit) = audit::run(audit_args, global)?;
+    let audit_passed = audit_exit == 0;
+    let audit_findings = audit_finding_count(&audit_output);
+    let audit_stage = ReviewStage {
+        stage: "audit".to_string(),
+        ran: true,
+        passed: audit_passed,
+        exit_code: audit_exit,
+        finding_count: audit_findings,
+        hint: format!(
+            "Deep dive: homeboy audit {}{}",
+            component_label,
+            scope_flag_suffix(&args, /*include_changed_only=*/ false),
+        ),
+        skipped_reason: None,
+        output: Some(audit_output),
+    };
+
+    // ── Stage 2: lint ───────────────────────────────────────────────────────
+    let lint_args = lint::LintArgs {
+        comp: args.comp.clone(),
+        summary: args.summary,
+        file: None,
+        glob: None,
+        changed_only: args.changed_only,
+        changed_since: args.changed_since.clone(),
+        errors_only: false,
+        sniffs: None,
+        exclude_sniffs: None,
+        category: None,
+        setting_args: Default::default(),
+        baseline_args: args.baseline_args.clone(),
+        _json: Default::default(),
+    };
+    let (lint_output, lint_exit) = lint::run(lint_args, global)?;
+    let lint_passed = lint_exit == 0;
+    let lint_findings = lint_finding_count(&lint_output);
+    let lint_stage = ReviewStage {
+        stage: "lint".to_string(),
+        ran: true,
+        passed: lint_passed,
+        exit_code: lint_exit,
+        finding_count: lint_findings,
+        hint: format!(
+            "Deep dive: homeboy lint {}{}",
+            component_label,
+            scope_flag_suffix(&args, /*include_changed_only=*/ true),
+        ),
+        skipped_reason: None,
+        output: Some(lint_output),
+    };
+
+    // ── Stage 3: test ───────────────────────────────────────────────────────
+    // Test scopes via --changed-since only (same as audit). When the user
+    // passed --changed-only, test runs the full suite — surface as a hint.
+    let test_args = test::TestArgs {
+        comp: args.comp.clone(),
+        skip_lint: true, // lint already ran above; avoid double work
+        coverage: false,
+        coverage_min: None,
+        baseline_args: args.baseline_args.clone(),
+        analyze: false,
+        drift: false,
+        write: false,
+        since: "HEAD~10".to_string(),
+        changed_since: args.changed_since.clone(),
+        setting_args: Default::default(),
+        args: Vec::new(),
+        _json: Default::default(),
+        json_summary: args.summary,
+    };
+    let (test_output, test_exit) = test::run(test_args, global)?;
+    let test_passed = test_exit == 0;
+    let test_findings = test_finding_count(&test_output);
+    let test_stage = ReviewStage {
+        stage: "test".to_string(),
+        ran: true,
+        passed: test_passed,
+        exit_code: test_exit,
+        finding_count: test_findings,
+        hint: format!(
+            "Deep dive: homeboy test {}{}",
+            component_label,
+            scope_flag_suffix(&args, /*include_changed_only=*/ false),
+        ),
+        skipped_reason: None,
+        output: Some(test_output),
+    };
+
+    // Aggregate
+    let overall_passed = audit_passed && lint_passed && test_passed;
+    let overall_exit = if overall_passed {
+        0
+    } else if [audit_exit, lint_exit, test_exit].iter().any(|&c| c >= 2) {
+        2
+    } else {
+        1
+    };
+    let total_findings = audit_findings + lint_findings + test_findings;
+
+    if args.changed_only {
+        top_hints.push(
+            "--changed-only scopes lint only; audit and test ran on the full component".to_string(),
+        );
+    }
+
+    let summary = ReviewSummary {
+        passed: overall_passed,
+        status: if overall_passed { "passed" } else { "failed" }.to_string(),
+        component: component_label.clone(),
+        scope,
+        changed_since: args.changed_since.clone(),
+        total_findings,
+        changed_file_count,
+        hints: top_hints,
+    };
+
+    let output = ReviewCommandOutput {
+        command: "review".to_string(),
+        summary,
+        audit: audit_stage,
+        lint: lint_stage,
+        test: test_stage,
+    };
+
+    print_human_summary(&output);
+
+    Ok((output, overall_exit))
+}
+
+fn stage_skipped<T: Serialize>(stage: &str, reason: &str) -> ReviewStage<T> {
+    ReviewStage {
+        stage: stage.to_string(),
+        ran: false,
+        passed: true,
+        exit_code: 0,
+        finding_count: 0,
+        hint: format!("Run individually: homeboy {}", stage),
+        skipped_reason: Some(reason.to_string()),
+        output: None,
+    }
+}
+
+fn scope_flag_suffix(args: &ReviewArgs, include_changed_only: bool) -> String {
+    if let Some(ref r) = args.changed_since {
+        format!(" --changed-since={}", r)
+    } else if args.changed_only && include_changed_only {
+        " --changed-only".to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn audit_finding_count(output: &AuditCommandOutput) -> usize {
+    match output {
+        AuditCommandOutput::Full { result, .. } => result.findings.len(),
+        AuditCommandOutput::Compared { result, .. } => result.findings.len(),
+        AuditCommandOutput::Summary(summary) => summary.total_findings,
+        AuditCommandOutput::BaselineSaved { findings_count, .. } => *findings_count,
+        AuditCommandOutput::Conventions { .. } => 0,
+    }
+}
+
+fn lint_finding_count(output: &LintCommandOutput) -> usize {
+    output.lint_findings.as_ref().map(|f| f.len()).unwrap_or(0)
+}
+
+fn test_finding_count(output: &TestCommandOutput) -> usize {
+    output
+        .test_counts
+        .as_ref()
+        .map(|c| c.failed as usize)
+        .unwrap_or(0)
+}
+
+/// Print a compact human-readable summary to stderr so users running
+/// `homeboy review` interactively see a skim-friendly report on top of the
+/// JSON envelope. Mirrors the per-command stderr status hints.
+fn print_human_summary(output: &ReviewCommandOutput) {
+    use std::io::IsTerminal;
+    if !std::io::stderr().is_terminal() {
+        return;
+    }
+
+    eprintln!();
+    eprintln!(
+        "[review] {}: {} (component {}, scope {})",
+        if output.summary.passed {
+            "PASS"
+        } else {
+            "FAIL"
+        },
+        output.summary.status,
+        output.summary.component,
+        output.summary.scope,
+    );
+    print_stage_line(&output.audit);
+    print_stage_line(&output.lint);
+    print_stage_line(&output.test);
+    for hint in &output.summary.hints {
+        eprintln!("[review] hint: {}", hint);
+    }
+}
+
+fn print_stage_line<T: Serialize>(stage: &ReviewStage<T>) {
+    let marker = if !stage.ran {
+        "skipped"
+    } else if stage.passed {
+        "passed"
+    } else {
+        "failed"
+    };
+    eprintln!(
+        "[review]   {:<6} {:<7} findings={} exit={}",
+        stage.stage, marker, stage.finding_count, stage.exit_code,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::utils::args::{BaselineArgs, PositionalComponentArgs};
+    use clap::Parser;
+
+    /// Minimal CLI wrapper to exercise clap parsing of `ReviewArgs`.
+    #[derive(Parser, Debug)]
+    struct TestCli {
+        #[command(flatten)]
+        review: ReviewArgs,
+    }
+
+    #[test]
+    fn parses_changed_since() {
+        let cli = TestCli::try_parse_from(["test", "my-comp", "--changed-since", "trunk"])
+            .expect("should parse");
+        assert_eq!(cli.review.changed_since.as_deref(), Some("trunk"));
+        assert!(!cli.review.changed_only);
+        assert_eq!(cli.review.comp.component.as_deref(), Some("my-comp"));
+    }
+
+    #[test]
+    fn parses_changed_only() {
+        let cli = TestCli::try_parse_from(["test", "--changed-only"]).expect("should parse");
+        assert!(cli.review.changed_only);
+        assert!(cli.review.changed_since.is_none());
+    }
+
+    #[test]
+    fn parses_with_no_component() {
+        let cli = TestCli::try_parse_from(["test", "--changed-since", "main"])
+            .expect("should parse without positional component");
+        assert!(cli.review.comp.component.is_none());
+    }
+
+    #[test]
+    fn rejects_changed_since_with_changed_only() {
+        let result =
+            TestCli::try_parse_from(["test", "--changed-since", "trunk", "--changed-only"]);
+        assert!(result.is_err(), "clap must reject conflicting scope flags");
+    }
+
+    #[test]
+    fn rejects_changed_only_with_changed_since() {
+        let result =
+            TestCli::try_parse_from(["test", "--changed-only", "--changed-since", "trunk"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parses_summary_and_baseline_flags() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "my-comp",
+            "--changed-since=trunk",
+            "--summary",
+            "--ignore-baseline",
+        ])
+        .expect("should parse");
+        assert!(cli.review.summary);
+        assert!(cli.review.baseline_args.ignore_baseline);
+    }
+
+    #[test]
+    fn stage_skipped_helper_marks_not_ran() {
+        let stage: ReviewStage<serde_json::Value> = stage_skipped("audit", "no files changed");
+        assert!(!stage.ran);
+        assert!(stage.passed);
+        assert_eq!(stage.exit_code, 0);
+        assert_eq!(stage.skipped_reason.as_deref(), Some("no files changed"));
+    }
+
+    #[test]
+    fn scope_flag_suffix_renders_changed_since() {
+        let args = ReviewArgs {
+            comp: PositionalComponentArgs {
+                component: None,
+                path: None,
+            },
+            changed_since: Some("trunk".to_string()),
+            changed_only: false,
+            summary: false,
+            json: false,
+            baseline_args: BaselineArgs::default(),
+        };
+        assert_eq!(scope_flag_suffix(&args, true), " --changed-since=trunk");
+        assert_eq!(scope_flag_suffix(&args, false), " --changed-since=trunk");
+    }
+
+    #[test]
+    fn scope_flag_suffix_renders_changed_only_only_when_allowed() {
+        let args = ReviewArgs {
+            comp: PositionalComponentArgs {
+                component: None,
+                path: None,
+            },
+            changed_since: None,
+            changed_only: true,
+            summary: false,
+            json: false,
+            baseline_args: BaselineArgs::default(),
+        };
+        assert_eq!(scope_flag_suffix(&args, true), " --changed-only");
+        // audit/test do not support --changed-only, so the suffix is empty
+        // when the caller requests it not be included.
+        assert_eq!(scope_flag_suffix(&args, false), "");
+    }
+
+    #[test]
+    fn scope_flag_suffix_empty_for_full_run() {
+        let args = ReviewArgs {
+            comp: PositionalComponentArgs {
+                component: None,
+                path: None,
+            },
+            changed_since: None,
+            changed_only: false,
+            summary: false,
+            json: false,
+            baseline_args: BaselineArgs::default(),
+        };
+        assert_eq!(scope_flag_suffix(&args, true), "");
+        assert_eq!(scope_flag_suffix(&args, false), "");
+    }
+}

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -12,56 +12,56 @@ use super::{CmdResult, GlobalArgs};
 #[derive(Args)]
 pub struct TestArgs {
     #[command(flatten)]
-    comp: PositionalComponentArgs,
+    pub comp: PositionalComponentArgs,
 
     /// Skip linting before running tests
     #[arg(long)]
-    skip_lint: bool,
+    pub skip_lint: bool,
 
     /// Collect code coverage (requires xdebug/pcov for PHP, cargo-tarpaulin for Rust)
     #[arg(long)]
-    coverage: bool,
+    pub coverage: bool,
 
     /// Minimum coverage percentage — fail if below this threshold (implies --coverage)
     #[arg(long, value_name = "PERCENT")]
-    coverage_min: Option<f64>,
+    pub coverage_min: Option<f64>,
 
     #[command(flatten)]
-    baseline_args: BaselineArgs,
+    pub baseline_args: BaselineArgs,
 
     /// Analyze test failures — cluster by root cause and suggest fixes
     #[arg(long)]
-    analyze: bool,
+    pub analyze: bool,
 
     /// Detect test drift — cross-reference production changes with test files
     #[arg(long)]
-    drift: bool,
+    pub drift: bool,
 
     /// Write fixes to disk for workflows that support it
     #[arg(long)]
-    write: bool,
+    pub write: bool,
 
     /// Git ref to compare against for drift detection (tag, commit, branch)
     #[arg(long, value_name = "REF", default_value = "HEAD~10")]
-    since: String,
+    pub since: String,
 
     /// Limit test execution to files changed since this git ref (PR impact scope)
     #[arg(long, value_name = "REF")]
-    changed_since: Option<String>,
+    pub changed_since: Option<String>,
 
     #[command(flatten)]
-    setting_args: SettingArgs,
+    pub setting_args: SettingArgs,
 
     /// Additional arguments to pass to the test runner (must follow --)
     #[arg(last = true)]
-    args: Vec<String>,
+    pub args: Vec<String>,
 
     #[command(flatten)]
-    _json: HiddenJsonArgs,
+    pub _json: HiddenJsonArgs,
 
     /// Print compact machine-readable summary (for CI wrappers)
     #[arg(long)]
-    json_summary: bool,
+    pub json_summary: bool,
 }
 
 /// Filter out homeboy-owned flags from trailing args before passing to extension scripts.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ mod help_topics;
 use commands::utils::{args, entity_suggest, response as output, tty};
 use commands::{
     api, audit, auth, bench, build, changelog, changes, cli, component, config, db, deploy,
-    extension, file, fleet, git, init, lint, logs, project, refactor, release, rig, scaffold,
-    server, ssh, status, test, transfer, undo, upgrade, validate, version,
+    extension, file, fleet, git, init, lint, logs, project, refactor, release, review, rig,
+    scaffold, server, ssh, status, test, transfer, undo, upgrade, validate, version,
 };
 use homeboy::extension::load_all_extensions;
 
@@ -100,6 +100,8 @@ enum Commands {
     Changes(changes::ChangesArgs),
     /// Plan release workflows
     Release(release::ReleaseArgs),
+    /// Run scoped audit + lint + test umbrella against PR-style changes
+    Review(review::ReviewArgs),
     /// Scaffold files from project conventions
     Scaffold(scaffold::ScaffoldArgs),
     /// Audit code conventions and detect architectural drift


### PR DESCRIPTION
## Summary

- New `homeboy review [component] --changed-since=<ref>` (and `--changed-only`) umbrella that fans out the existing scoped runs of `audit`, `lint`, and `test` against the same set of changed files and prints a single consolidated report.
- Sequential canonical order (audit → lint → test); the umbrella owns no scoping logic of its own — every flag is forwarded to the underlying commands, which already share the `get_files_changed_since` plumbing in `core/git/changes.rs`.
- Empty-changeset short-circuit: prints `No files changed since <ref> — skipping review` once, exits 0, marks every stage as `ran: false`.

## What changed

- **`src/commands/review.rs` (new)** — `ReviewArgs` + orchestration. Resolves the component once, probes the changed set via `git::get_files_changed_since` / `git::get_dirty_files` for the short-circuit, then constructs `AuditArgs` / `LintArgs` / `TestArgs` and dispatches to the existing `audit::run` / `lint::run` / `test::run` functions in order. Aggregates each stage's `(output, exit_code)` into a `ReviewCommandOutput { command, summary, audit, lint, test }` payload. Test-skip is forced on for the inner `test` invocation since the umbrella already runs lint as its own stage. Includes a stderr-only human summary on TTYs (matches each per-command's own status hints).
- **`src/commands/mod.rs`** — register `pub mod review;` and dispatch `Commands::Review(args) => dispatch!(args, global, review)`.
- **`src/main.rs`** — register `Commands::Review(review::ReviewArgs)` with help text, add `review` to the `commands::` import list.
- **`src/commands/lint.rs`, `src/commands/test.rs`** — make `LintArgs` / `TestArgs` fields `pub` so the review command can build them programmatically. Audit's were already public. No logic changes.
- **`docs/commands/review.md` (new)** — usage, scope-flag semantics (including the `--changed-only` lint-only caveat), empty-changeset behaviour, JSON output shape with full nested `{audit, lint, test}` payloads, exit codes.
- **`docs/commands/commands-index.md`** — add the review entry alphabetically between `release` and `rig`.

## Acceptance criteria

- ✅ `homeboy review [component] --changed-since=<ref>` runs audit + lint + test in scoped mode against the same set of changed files (each stage receives `--changed-since=<ref>` directly, so they all hit `get_files_changed_since` with the same args).
- ✅ `--changed-only` also supported (working-tree mode). Lint scopes natively; audit and test don't accept working-tree mode today, so they run unscoped — the consolidated `summary.hints` makes this explicit. Documented in `review.md`.
- ✅ Stages run **sequentially** in fixed order (audit → lint → test) — matches `VerificationPhase::canonical_order()` and the existing per-command UX. No parallel execution.
- ✅ Single consolidated output: top-line `summary {passed, status, scope, total_findings, ...}` + per-stage section with `finding_count`, `exit_code`, and a deep-dive `hint` pointing at the individual command. Full `output` payload from each stage is embedded so downstream consumers (PR-comment primitive, CI wrappers) don't need a second invocation.
- ✅ Respects `--summary` (forwards to lint's `--summary` and audit/test's `--json-summary`), `--baseline` / `--ignore-baseline` / `--ratchet` (forwarded to every stage's `BaselineArgs`). Hidden `--json` accepted for parity with sibling commands.
- ✅ Component auto-discovery from CWD via `PositionalComponentArgs::load()` — same path lint / audit / test use today.
- ✅ Empty changeset → single `No files changed since <ref> — skipping review` line, clean exit 0, every stage reported as `ran: false` with `skipped_reason: "no files changed"`.

## Tests

- 10 new unit tests in `src/commands/review.rs::tests` covering arg parsing (positional + no-positional, `--changed-since`, `--changed-only`, mutual-exclusion in both directions, `--summary` and `--ignore-baseline` forwarding), the `stage_skipped` helper, and the `scope_flag_suffix` renderer for changed-since / changed-only / no-scope across both `include_changed_only` modes.
- `cargo test --bin homeboy` → 51/51 pass.
- `cargo build` clean. `cargo clippy --bin homeboy` clean (pre-existing clippy errors in `core/release/pipeline.rs` and `core/refactor/plan/mod.rs` are unrelated to this PR).
- `cargo fmt` applied.
- Smoke-tested end to end: `homeboy review homeboy --changed-since=HEAD` from inside the worktree correctly short-circuits with the expected one-line message and skipped-stage envelope.

## Out of scope (matches issue #1500)

- No new scoping primitives — the existing `get_files_changed_since` is sufficient.
- No PR comment posting — already owned by `homeboy git pr comment` (#1353) and `homeboy-action` #142.
- No parallel stage execution — sequential keeps output deterministic and matches existing UX.
- No cross-file PHPStan dependency expansion — already handled by PHPStan itself.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Sonnet 4.5)
- **Used for:** Drafted the full review command (`src/commands/review.rs`), the docs (`docs/commands/review.md`), the public-field tweaks to `LintArgs` / `TestArgs`, the registration plumbing in `main.rs` / `commands/mod.rs`, the test cases, and this PR description. Reviewed and tested by Chris before opening.