### PR TITLE
feat(review): --report=pr-comment markdown renderer (closes #1509)

### DIFF
--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -65,6 +65,12 @@ homeboy review --changed-only
 
 # Full sweep — equivalent to running audit + lint + test back-to-back
 homeboy review my-plugin
+
+# Render a PR-comment markdown section directly to a file, then post it
+homeboy review my-plugin --changed-since=main --report=pr-comment > /tmp/section.md
+homeboy git pr comment my-plugin --number 42 --comment-key ci:my-plugin \
+  --section-key review --body-file /tmp/section.md \
+  --header "## Homeboy Results — \`my-plugin\`"
 ```
 
 ## Empty-changeset short-circuit
@@ -118,6 +124,75 @@ Each stage's `output` field carries the same structured payload that running
 `homeboy <stage>` directly would produce, so downstream consumers (the sectioned
 PR-comment primitive, CI wrappers) can render per-stage detail without needing
 a separate invocation.
+
+## Output formats
+
+`review` supports two output shapes, selected via `--report`.
+
+### Default — JSON envelope
+
+The default output is the structured `{success, data: ReviewCommandOutput}`
+envelope shown above. Suitable for programmatic consumers, CI wrappers, and
+the agent surface. Every field that a per-stage command would emit is
+preserved under `data.audit.output`, `data.lint.output`, `data.test.output`.
+
+### `--report=pr-comment` — markdown PR-comment section
+
+Renders the same envelope into a markdown PR-comment section, ready to pipe
+into `homeboy git pr comment --body-file`. The renderer emits **only the
+section body** — the consumer (`homeboy git pr comment --header`) owns the
+wrapping `### Title` heading.
+
+Per-stage shape:
+
+- Header line per stage: `:white_check_mark: **<stage>**` for pass,
+  `:x: **<stage>**` for fail, `:fast_forward: **<stage>** — skipped (<reason>)`
+  when the stage was skipped (e.g. empty changeset).
+- Audit body: top finding categories (by `convention`) with counts, capped at
+  10 categories with a `… N more` overflow line.
+- Lint body: top sniff codes (by `category`) with counts, same 10-cap.
+- Test body: failure summary line (`**N failed** out of M total`) plus pass
+  and skip counts. Per-test failure names are not surfaced — that data isn't
+  on `TestCommandOutput`.
+- Each ran stage ends with a `> Deep dive: homeboy <cmd> ...` blockquote
+  pointing the reviewer at the per-stage command for full detail.
+
+Above the stages, the renderer emits a scope banner
+(`:zap: Scope: **changed files only** (since \`<ref>\`)` or
+`:information_source: Scope: **full**`) and a total-findings line
+(`**N** finding(s) across M stage(s)`).
+
+**Out of scope for this renderer.** Action-level signals — autofix banners,
+fallback-binary warnings, tooling-version footers, scope-mode resolution
+notes — are not present in `ReviewCommandOutput` and are not rendered. The
+GitHub Action layer continues to emit those as separate sections (or via
+`--banner` flags in a future PR).
+
+Example:
+
+```bash
+homeboy review my-plugin --changed-since=main --report=pr-comment
+```
+
+```markdown
+:zap: Scope: **changed files only** (since `main`)
+
+**4** finding(s) across 3 stage(s)
+
+:x: **audit**
+- **ability-shape** — 3 finding(s)
+- **naming-convention** — 1 finding(s)
+- _Total: 4 finding(s)_
+> Deep dive: homeboy audit my-plugin --changed-since=main
+
+:white_check_mark: **lint**
+> Deep dive: homeboy lint my-plugin --changed-since=main
+
+:white_check_mark: **test**
+- 87 passed
+- 2 skipped
+> Deep dive: homeboy test my-plugin --changed-since=main
+```
 
 ## Exit codes
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -3,7 +3,7 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-04-25T18:23:58Z",
+      "created_at": "2026-04-25T18:32:43Z",
       "item_count": 894,
       "known_fingerprints": [
         "Commands::src/commands/docs.rs::NamespaceMismatch",
@@ -92,7 +92,7 @@
         "field_patterns::src/commands/lint.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/refactor.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/release.rs::RepeatedFieldPattern",
-        "field_patterns::src/commands/review.rs::RepeatedFieldPattern",
+        "field_patterns::src/commands/review/mod.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/ssh.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/status.rs::RepeatedFieldPattern",
         "field_patterns::src/commands/status.rs::RepeatedFieldPattern",
@@ -902,12 +902,12 @@
         "test_coverage::tests/commands/test_scope_test.rs::OrphanedTest"
       ],
       "metadata": {
-        "alignment_score": 0.9047619104385376,
+        "alignment_score": 0.9024389982223511,
         "known_outliers": [
           "src/commands/docs.rs",
-          "src/core/engine/undo/entry.rs",
+          "src/core/engine/undo/rollback.rs",
           "src/core/engine/undo/snapshot.rs",
-          "src/core/engine/undo/rollback.rs"
+          "src/core/engine/undo/entry.rs"
         ],
         "outliers_count": 4
       }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -284,11 +284,12 @@ pub mod version;
 
 pub(crate) fn run_markdown(
     command: crate::Commands,
-    _global: &GlobalArgs,
+    global: &GlobalArgs,
 ) -> homeboy::Result<(String, i32)> {
     match command {
         crate::Commands::Docs(args) => docs::run_markdown(args),
         crate::Commands::Changelog(args) => changelog::run_markdown(args),
+        crate::Commands::Review(args) => review::run_markdown(args, global),
         _ => Err(homeboy::Error::validation_invalid_argument(
             "output_mode",
             "Command does not support markdown output",

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -23,6 +23,8 @@ use homeboy::git;
 use super::utils::args::{BaselineArgs, PositionalComponentArgs};
 use super::{audit, lint, test, CmdResult, GlobalArgs};
 
+mod render;
+
 #[derive(Args, Debug, Clone)]
 pub struct ReviewArgs {
     #[command(flatten)]
@@ -50,8 +52,21 @@ pub struct ReviewArgs {
     #[arg(long, hide = true)]
     pub json: bool,
 
+    /// Output format. Default JSON envelope; `--report=pr-comment` emits a
+    /// markdown PR-comment section instead, suitable for piping to
+    /// `homeboy git pr comment --body-file`.
+    #[arg(long, value_name = "FORMAT", value_parser = ["pr-comment"])]
+    pub report: Option<String>,
+
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
+}
+
+/// True when the caller asked for a markdown PR-comment section instead of
+/// the structured JSON envelope. Used by the top-level dispatcher to route
+/// the response through `RawOutputMode::Markdown`.
+pub(crate) fn is_markdown_mode(args: &ReviewArgs) -> bool {
+    args.report.as_deref() == Some("pr-comment")
 }
 
 /// Per-stage section of the consolidated review output.
@@ -311,6 +326,16 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
     Ok((output, overall_exit))
 }
 
+/// Markdown output mode — runs the JSON path internally and renders the
+/// envelope into a PR-comment section. The body is just the section content;
+/// the consumer (`homeboy git pr comment --header`) owns the wrapping
+/// section header.
+pub fn run_markdown(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<String> {
+    let (output, exit_code) = run(args, global)?;
+    let md = render::render_pr_comment(&output);
+    Ok((md, exit_code))
+}
+
 fn stage_skipped<T: Serialize>(stage: &str, reason: &str) -> ReviewStage<T> {
     ReviewStage {
         stage: stage.to_string(),
@@ -429,6 +454,29 @@ mod tests {
     }
 
     #[test]
+    fn parses_report_pr_comment() {
+        let cli = TestCli::try_parse_from(["test", "my-comp", "--report=pr-comment"])
+            .expect("should parse");
+        assert_eq!(cli.review.report.as_deref(), Some("pr-comment"));
+        assert!(is_markdown_mode(&cli.review));
+    }
+
+    #[test]
+    fn rejects_unknown_report_format() {
+        let result = TestCli::try_parse_from(["test", "my-comp", "--report=slack"]);
+        assert!(
+            result.is_err(),
+            "clap whitelist must reject unknown report formats"
+        );
+    }
+
+    #[test]
+    fn is_markdown_mode_false_without_flag() {
+        let cli = TestCli::try_parse_from(["test", "my-comp"]).expect("should parse");
+        assert!(!is_markdown_mode(&cli.review));
+    }
+
+    #[test]
     fn parses_with_no_component() {
         let cli = TestCli::try_parse_from(["test", "--changed-since", "main"])
             .expect("should parse without positional component");
@@ -483,6 +531,7 @@ mod tests {
             changed_only: false,
             summary: false,
             json: false,
+            report: None,
             baseline_args: BaselineArgs::default(),
         };
         assert_eq!(scope_flag_suffix(&args, true), " --changed-since=trunk");
@@ -500,6 +549,7 @@ mod tests {
             changed_only: true,
             summary: false,
             json: false,
+            report: None,
             baseline_args: BaselineArgs::default(),
         };
         assert_eq!(scope_flag_suffix(&args, true), " --changed-only");
@@ -519,6 +569,7 @@ mod tests {
             changed_only: false,
             summary: false,
             json: false,
+            report: None,
             baseline_args: BaselineArgs::default(),
         };
         assert_eq!(scope_flag_suffix(&args, true), "");

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -1,0 +1,699 @@
+//! PR-comment markdown renderer for `homeboy review`.
+//!
+//! Pure function over `ReviewCommandOutput` — no I/O, no template engine.
+//! The renderer emits the *body* of a PR comment section; the consumer
+//! (`homeboy git pr comment --header`) owns the wrapping `### Title` heading.
+//!
+//! Shape (top-down):
+//!
+//! 1. Scope banner: `:zap:` for changed-since/changed-only, `:information_source:` for full.
+//! 2. Total findings line.
+//! 3. Three stage blocks in fixed order — audit, lint, test. Each stage:
+//!    - icon + name header (`:white_check_mark:`, `:x:`, `:fast_forward:`)
+//!    - up to 10 finding bullets (top categories / sniff codes / failure summary)
+//!    - blockquote with the deep-dive hint
+//!
+//! Action-level signals (autofix banners, binary-source warnings, tooling
+//! versions) are out of scope — those are not present in `ReviewCommandOutput`.
+//! See follow-up: `feat(review): --banner key=value for action-level signals`.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use homeboy::code_audit::AuditCommandOutput;
+use homeboy::extension::lint::LintCommandOutput;
+use homeboy::extension::test::TestCommandOutput;
+
+use super::{ReviewCommandOutput, ReviewStage};
+
+/// Maximum bullets shown per stage. Anything beyond is collapsed into a
+/// `(... N more)` hint so PR comments stay skim-friendly.
+const TOP_N: usize = 10;
+
+/// Render a `ReviewCommandOutput` into a PR-comment-ready markdown body.
+pub fn render_pr_comment(output: &ReviewCommandOutput) -> String {
+    let mut out = String::new();
+
+    render_scope_banner(&mut out, output);
+    render_total_findings(&mut out, output);
+    render_top_hints(&mut out, output);
+
+    render_audit_stage(&mut out, &output.audit);
+    out.push('\n');
+    render_lint_stage(&mut out, &output.lint);
+    out.push('\n');
+    render_test_stage(&mut out, &output.test);
+
+    out
+}
+
+// ── Top-level banners ───────────────────────────────────────────────────
+
+fn render_scope_banner(out: &mut String, output: &ReviewCommandOutput) {
+    match output.summary.scope.as_str() {
+        "changed-since" => {
+            let r = output.summary.changed_since.as_deref().unwrap_or("<base>");
+            let _ = writeln!(out, ":zap: Scope: **changed files only** (since `{}`)", r);
+        }
+        "changed-only" => {
+            let _ = writeln!(out, ":zap: Scope: **working tree changes only**");
+        }
+        _ => {
+            let _ = writeln!(out, ":information_source: Scope: **full**");
+        }
+    }
+    out.push('\n');
+}
+
+fn render_total_findings(out: &mut String, output: &ReviewCommandOutput) {
+    let ran = [&output.audit.ran, &output.lint.ran, &output.test.ran]
+        .iter()
+        .filter(|r| ***r)
+        .count();
+    let _ = writeln!(
+        out,
+        "**{}** finding(s) across {} stage(s)",
+        output.summary.total_findings, ran
+    );
+    out.push('\n');
+}
+
+fn render_top_hints(out: &mut String, output: &ReviewCommandOutput) {
+    if output.summary.hints.is_empty() {
+        return;
+    }
+    for hint in &output.summary.hints {
+        let _ = writeln!(out, "> :information_source: {}", hint);
+    }
+    out.push('\n');
+}
+
+// ── Stage rendering ─────────────────────────────────────────────────────
+
+fn stage_header_icon(stage_ran: bool, stage_passed: bool) -> &'static str {
+    if !stage_ran {
+        ":fast_forward:"
+    } else if stage_passed {
+        ":white_check_mark:"
+    } else {
+        ":x:"
+    }
+}
+
+fn render_stage_header<T: serde::Serialize>(out: &mut String, stage: &ReviewStage<T>) {
+    let icon = stage_header_icon(stage.ran, stage.passed);
+    if !stage.ran {
+        let reason = stage.skipped_reason.as_deref().unwrap_or("not run");
+        let _ = writeln!(out, "{} **{}** — skipped ({})", icon, stage.stage, reason);
+    } else {
+        let _ = writeln!(out, "{} **{}**", icon, stage.stage);
+    }
+}
+
+fn render_stage_hint<T: serde::Serialize>(out: &mut String, stage: &ReviewStage<T>) {
+    if stage.ran {
+        let _ = writeln!(out, "> {}", stage.hint);
+    }
+}
+
+fn render_audit_stage(out: &mut String, stage: &ReviewStage<AuditCommandOutput>) {
+    render_stage_header(out, stage);
+    if let Some(ref output) = stage.output {
+        render_audit_body(out, output);
+    }
+    render_stage_hint(out, stage);
+}
+
+fn render_lint_stage(out: &mut String, stage: &ReviewStage<LintCommandOutput>) {
+    render_stage_header(out, stage);
+    if let Some(ref output) = stage.output {
+        render_lint_body(out, output);
+    }
+    render_stage_hint(out, stage);
+}
+
+fn render_test_stage(out: &mut String, stage: &ReviewStage<TestCommandOutput>) {
+    render_stage_header(out, stage);
+    if let Some(ref output) = stage.output {
+        render_test_body(out, output);
+    }
+    render_stage_hint(out, stage);
+}
+
+// ── Per-stage bodies ────────────────────────────────────────────────────
+
+/// Render the audit stage body — top finding categories (by `convention`)
+/// with counts. Empty bodies mean no findings; we say nothing.
+fn render_audit_body(out: &mut String, output: &AuditCommandOutput) {
+    let findings = audit_findings(output);
+    if findings.is_empty() {
+        return;
+    }
+    let total = findings.len();
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for label in findings {
+        *counts.entry(label).or_insert(0) += 1;
+    }
+    // Sort by count desc, then alpha for stability.
+    let mut ordered: Vec<(String, usize)> = counts.into_iter().collect();
+    ordered.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let shown = ordered.len().min(TOP_N);
+    for (label, count) in ordered.iter().take(shown) {
+        let _ = writeln!(out, "- **{}** — {} finding(s)", label, count);
+    }
+    if ordered.len() > TOP_N {
+        let _ = writeln!(
+            out,
+            "- _… {} more categor{}_",
+            ordered.len() - TOP_N,
+            if ordered.len() - TOP_N == 1 {
+                "y"
+            } else {
+                "ies"
+            }
+        );
+    }
+    let _ = writeln!(out, "- _Total: {} finding(s)_", total);
+}
+
+/// Pull labels for grouping audit findings. We use the convention name when
+/// available; falls back to the kind for variants without conventions.
+fn audit_findings(output: &AuditCommandOutput) -> Vec<String> {
+    match output {
+        AuditCommandOutput::Full { result, .. } => result
+            .findings
+            .iter()
+            .map(|f| f.convention.clone())
+            .collect(),
+        AuditCommandOutput::Compared { result, .. } => result
+            .findings
+            .iter()
+            .map(|f| f.convention.clone())
+            .collect(),
+        AuditCommandOutput::Summary(summary) => summary
+            .top_findings
+            .iter()
+            .map(|f| f.convention.clone())
+            .collect(),
+        AuditCommandOutput::BaselineSaved { .. } => Vec::new(),
+        AuditCommandOutput::Conventions { .. } => Vec::new(),
+    }
+}
+
+/// Render the lint stage body — top sniff codes (by `category`) with counts.
+fn render_lint_body(out: &mut String, output: &LintCommandOutput) {
+    let findings = match output.lint_findings.as_ref() {
+        Some(f) if !f.is_empty() => f,
+        _ => return,
+    };
+    let total = findings.len();
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for f in findings {
+        *counts.entry(f.category.clone()).or_insert(0) += 1;
+    }
+    let mut ordered: Vec<(String, usize)> = counts.into_iter().collect();
+    ordered.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let shown = ordered.len().min(TOP_N);
+    for (code, count) in ordered.iter().take(shown) {
+        let _ = writeln!(out, "- `{}` — {} finding(s)", code, count);
+    }
+    if ordered.len() > TOP_N {
+        let _ = writeln!(out, "- _… {} more sniff(s)_", ordered.len() - TOP_N);
+    }
+    let _ = writeln!(out, "- _Total: {} finding(s)_", total);
+}
+
+/// Render the test stage body — failure count + pass-summary line. Per-test
+/// failure names are not surfaced in `TestCommandOutput` (no `failed_tests`
+/// field), so we summarize from `test_counts`.
+fn render_test_body(out: &mut String, output: &TestCommandOutput) {
+    let counts = match output.test_counts.as_ref() {
+        Some(c) => c,
+        None => return,
+    };
+
+    if counts.failed > 0 {
+        let _ = writeln!(
+            out,
+            "- **{} failed** out of {} total",
+            counts.failed, counts.total
+        );
+        if counts.passed > 0 {
+            let _ = writeln!(out, "- {} passed", counts.passed);
+        }
+        if counts.skipped > 0 {
+            let _ = writeln!(out, "- {} skipped", counts.skipped);
+        }
+    } else if counts.passed > 0 {
+        let _ = writeln!(out, "- {} passed", counts.passed);
+        if counts.skipped > 0 {
+            let _ = writeln!(out, "- {} skipped", counts.skipped);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use homeboy::code_audit::{
+        AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity,
+    };
+    use homeboy::extension::lint::{LintCommandOutput, LintFinding};
+    use homeboy::extension::test::{TestCommandOutput, TestCounts};
+    use homeboy::extension::{PhaseReport, PhaseStatus, VerificationPhase};
+
+    // ── Builders for fixture envelopes ──────────────────────────────────
+
+    fn passing_envelope() -> ReviewCommandOutput {
+        ReviewCommandOutput {
+            command: "review".to_string(),
+            summary: super::super::ReviewSummary {
+                passed: true,
+                status: "passed".to_string(),
+                component: "my-comp".to_string(),
+                scope: "full".to_string(),
+                changed_since: None,
+                total_findings: 0,
+                changed_file_count: None,
+                hints: Vec::new(),
+            },
+            audit: stage_audit_passing(),
+            lint: stage_lint_passing(),
+            test: stage_test_passing(0),
+        }
+    }
+
+    fn stage_audit_passing() -> ReviewStage<AuditCommandOutput> {
+        ReviewStage {
+            stage: "audit".to_string(),
+            ran: true,
+            passed: true,
+            exit_code: 0,
+            finding_count: 0,
+            hint: "Deep dive: homeboy audit my-comp".to_string(),
+            skipped_reason: None,
+            output: Some(audit_full_with_findings(Vec::new())),
+        }
+    }
+
+    fn stage_lint_passing() -> ReviewStage<LintCommandOutput> {
+        ReviewStage {
+            stage: "lint".to_string(),
+            ran: true,
+            passed: true,
+            exit_code: 0,
+            finding_count: 0,
+            hint: "Deep dive: homeboy lint my-comp".to_string(),
+            skipped_reason: None,
+            output: Some(lint_with_findings(Vec::new())),
+        }
+    }
+
+    fn stage_test_passing(passed: u64) -> ReviewStage<TestCommandOutput> {
+        ReviewStage {
+            stage: "test".to_string(),
+            ran: true,
+            passed: true,
+            exit_code: 0,
+            finding_count: 0,
+            hint: "Deep dive: homeboy test my-comp".to_string(),
+            skipped_reason: None,
+            output: Some(test_with_counts(passed, 0, 0)),
+        }
+    }
+
+    fn stage_skipped<T: serde::Serialize>(name: &str, reason: &str) -> ReviewStage<T> {
+        ReviewStage {
+            stage: name.to_string(),
+            ran: false,
+            passed: true,
+            exit_code: 0,
+            finding_count: 0,
+            hint: format!("Run individually: homeboy {}", name),
+            skipped_reason: Some(reason.to_string()),
+            output: None,
+        }
+    }
+
+    fn audit_full_with_findings(conventions: Vec<&str>) -> AuditCommandOutput {
+        let findings: Vec<Finding> = conventions
+            .into_iter()
+            .map(|c| Finding {
+                convention: c.to_string(),
+                severity: Severity::Warning,
+                file: "src/foo.rs".to_string(),
+                description: "deviates from convention".to_string(),
+                suggestion: "align with siblings".to_string(),
+                kind: AuditFinding::MissingMethod,
+            })
+            .collect();
+
+        let result = CodeAuditResult {
+            component_id: "my-comp".to_string(),
+            source_path: "/tmp/my-comp".to_string(),
+            summary: homeboy::code_audit::AuditSummary {
+                files_scanned: 0,
+                conventions_detected: 0,
+                outliers_found: 0,
+                alignment_score: Some(1.0),
+                files_skipped: 0,
+                warnings: Vec::new(),
+            },
+            conventions: Vec::new(),
+            directory_conventions: Vec::new(),
+            findings,
+            duplicate_groups: Vec::new(),
+        };
+
+        AuditCommandOutput::Full {
+            passed: result.findings.is_empty(),
+            result,
+            fixability: None,
+        }
+    }
+
+    fn lint_with_findings(items: Vec<(&str, &str)>) -> LintCommandOutput {
+        let findings: Vec<LintFinding> = items
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (category, msg))| LintFinding {
+                id: format!("lint-{}", idx),
+                message: msg.to_string(),
+                category: category.to_string(),
+            })
+            .collect();
+
+        let exit_code = if findings.is_empty() { 0 } else { 1 };
+
+        LintCommandOutput {
+            passed: exit_code == 0,
+            status: if exit_code == 0 { "passed" } else { "failed" }.to_string(),
+            component: "my-comp".to_string(),
+            exit_code,
+            phase: PhaseReport {
+                phase: VerificationPhase::Lint,
+                status: if exit_code == 0 {
+                    PhaseStatus::Passed
+                } else {
+                    PhaseStatus::Failed
+                },
+                exit_code: Some(exit_code),
+                summary: "lint phase".to_string(),
+            },
+            failure: None,
+            autofix: None,
+            hints: None,
+            baseline_comparison: None,
+            lint_findings: Some(findings),
+        }
+    }
+
+    fn test_with_counts(passed: u64, failed: u64, skipped: u64) -> TestCommandOutput {
+        let total = passed + failed + skipped;
+        let exit_code: i32 = if failed == 0 { 0 } else { 1 };
+        TestCommandOutput {
+            passed: exit_code == 0,
+            status: if exit_code == 0 { "passed" } else { "failed" }.to_string(),
+            component: "my-comp".to_string(),
+            exit_code,
+            phase: None,
+            failure: None,
+            test_counts: Some(TestCounts {
+                total,
+                passed,
+                failed,
+                skipped,
+            }),
+            coverage: None,
+            baseline_comparison: None,
+            analysis: None,
+            autofix: None,
+            hints: None,
+            drift: None,
+            auto_fix_drift: None,
+            test_scope: None,
+            summary: None,
+            raw_output: None,
+        }
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn renders_passing_review_with_full_scope() {
+        let env = passing_envelope();
+        let md = render_pr_comment(&env);
+        assert!(
+            md.contains(":information_source: Scope: **full**"),
+            "missing full-scope banner:\n{}",
+            md
+        );
+        assert!(
+            md.contains("**0** finding(s) across 3 stage(s)"),
+            "missing total-findings line:\n{}",
+            md
+        );
+        assert!(
+            md.contains(":white_check_mark: **audit**"),
+            "audit header: {}",
+            md
+        );
+        assert!(
+            md.contains(":white_check_mark: **lint**"),
+            "lint header: {}",
+            md
+        );
+        assert!(
+            md.contains(":white_check_mark: **test**"),
+            "test header: {}",
+            md
+        );
+        // No bullets when no findings.
+        assert!(
+            !md.contains("- **"),
+            "should not render bullets on a clean run:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn renders_failing_review_with_findings() {
+        let mut env = passing_envelope();
+        env.summary.passed = false;
+        env.summary.status = "failed".to_string();
+        env.summary.total_findings = 5;
+
+        // Audit fails with three convention buckets.
+        env.audit.passed = false;
+        env.audit.exit_code = 1;
+        env.audit.finding_count = 3;
+        env.audit.output = Some(audit_full_with_findings(vec![
+            "ability-shape",
+            "ability-shape",
+            "naming-convention",
+        ]));
+
+        // Lint fails with two sniffs.
+        env.lint.passed = false;
+        env.lint.exit_code = 1;
+        env.lint.finding_count = 2;
+        env.lint.output = Some(lint_with_findings(vec![
+            ("Squiz.Commenting.FunctionComment.Missing", "no docblock"),
+            ("Squiz.Commenting.FunctionComment.Missing", "no docblock"),
+        ]));
+
+        let md = render_pr_comment(&env);
+        assert!(md.contains(":x: **audit**"), "audit failed icon:\n{}", md);
+        assert!(md.contains(":x: **lint**"), "lint failed icon:\n{}", md);
+        assert!(
+            md.contains("- **ability-shape** — 2 finding(s)"),
+            "convention bucket count:\n{}",
+            md
+        );
+        assert!(
+            md.contains("- `Squiz.Commenting.FunctionComment.Missing` — 2 finding(s)"),
+            "lint sniff bucket count:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn renders_all_stages_skipped() {
+        let env = ReviewCommandOutput {
+            command: "review".to_string(),
+            summary: super::super::ReviewSummary {
+                passed: true,
+                status: "passed".to_string(),
+                component: "my-comp".to_string(),
+                scope: "changed-since".to_string(),
+                changed_since: Some("main".to_string()),
+                total_findings: 0,
+                changed_file_count: Some(0),
+                hints: vec!["No files changed since main — skipping review".to_string()],
+            },
+            audit: stage_skipped("audit", "no files changed"),
+            lint: stage_skipped("lint", "no files changed"),
+            test: stage_skipped("test", "no files changed"),
+        };
+        let md = render_pr_comment(&env);
+        assert!(
+            md.contains(":fast_forward: **audit** — skipped (no files changed)"),
+            "audit skipped header:\n{}",
+            md
+        );
+        assert!(
+            md.contains(":fast_forward: **lint**"),
+            "lint skipped: {}",
+            md
+        );
+        assert!(
+            md.contains(":fast_forward: **test**"),
+            "test skipped: {}",
+            md
+        );
+        assert!(
+            md.contains("**0** finding(s) across 0 stage(s)"),
+            "ran-stage count should reflect zero ran stages:\n{}",
+            md
+        );
+        assert!(
+            !md.contains("Deep dive:"),
+            "skipped stages must not emit deep-dive hints:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn renders_changed_since_scope_banner() {
+        let mut env = passing_envelope();
+        env.summary.scope = "changed-since".to_string();
+        env.summary.changed_since = Some("trunk".to_string());
+        let md = render_pr_comment(&env);
+        assert!(
+            md.contains(":zap: Scope: **changed files only** (since `trunk`)"),
+            "missing changed-since banner:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn renders_full_scope_banner() {
+        let env = passing_envelope();
+        let md = render_pr_comment(&env);
+        assert!(
+            md.contains(":information_source: Scope: **full**"),
+            "missing full-scope banner:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn renders_test_pass_count_when_no_failures() {
+        let mut env = passing_envelope();
+        env.test.output = Some(test_with_counts(42, 0, 1));
+        let md = render_pr_comment(&env);
+        assert!(
+            md.contains("- 42 passed"),
+            "missing passed count line:\n{}",
+            md
+        );
+        assert!(md.contains("- 1 skipped"), "missing skipped line:\n{}", md);
+    }
+
+    #[test]
+    fn renders_test_failure_summary() {
+        let mut env = passing_envelope();
+        env.test.passed = false;
+        env.test.exit_code = 1;
+        env.test.finding_count = 3;
+        env.test.output = Some(test_with_counts(10, 3, 0));
+        let md = render_pr_comment(&env);
+        assert!(
+            md.contains("- **3 failed** out of 13 total"),
+            "missing failure summary:\n{}",
+            md
+        );
+        assert!(md.contains("- 10 passed"), "missing passed line:\n{}", md);
+    }
+
+    #[test]
+    fn caps_lint_sniffs_at_top_10() {
+        // 15 distinct categories — expect 10 rendered + a "5 more" line.
+        let items: Vec<(String, String)> = (0..15)
+            .map(|i| (format!("Sniff.Code.{:02}", i), format!("msg {}", i)))
+            .collect();
+        let item_refs: Vec<(&str, &str)> = items
+            .iter()
+            .map(|(c, m)| (c.as_str(), m.as_str()))
+            .collect();
+
+        let mut env = passing_envelope();
+        env.lint.passed = false;
+        env.lint.exit_code = 1;
+        env.lint.finding_count = 15;
+        env.lint.output = Some(lint_with_findings(item_refs));
+
+        let md = render_pr_comment(&env);
+        let bullet_count = md.matches("- `Sniff.Code.").count();
+        assert_eq!(
+            bullet_count, TOP_N,
+            "should render exactly 10 sniff bullets, got {}:\n{}",
+            bullet_count, md
+        );
+        assert!(
+            md.contains("_… 5 more sniff(s)_"),
+            "missing overflow hint:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn caps_audit_categories_at_top_10() {
+        let conventions: Vec<String> = (0..15).map(|i| format!("convention-{:02}", i)).collect();
+        let conv_refs: Vec<&str> = conventions.iter().map(|s| s.as_str()).collect();
+
+        let mut env = passing_envelope();
+        env.audit.passed = false;
+        env.audit.exit_code = 1;
+        env.audit.finding_count = 15;
+        env.audit.output = Some(audit_full_with_findings(conv_refs));
+
+        let md = render_pr_comment(&env);
+        let bullet_count = md.matches("- **convention-").count();
+        assert_eq!(
+            bullet_count, TOP_N,
+            "should render exactly 10 audit category bullets:\n{}",
+            md
+        );
+        assert!(
+            md.contains("_… 5 more categories_"),
+            "missing overflow hint:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn renders_deep_dive_hints_for_ran_stages() {
+        let env = passing_envelope();
+        let md = render_pr_comment(&env);
+        assert!(md.contains("> Deep dive: homeboy audit my-comp"));
+        assert!(md.contains("> Deep dive: homeboy lint my-comp"));
+        assert!(md.contains("> Deep dive: homeboy test my-comp"));
+    }
+
+    #[test]
+    fn never_emits_top_level_section_heading() {
+        let env = passing_envelope();
+        let md = render_pr_comment(&env);
+        // The consumer (`homeboy git pr comment --header`) owns the wrapping
+        // `### Title` heading. Renderer must only emit the body.
+        assert!(
+            !md.starts_with("### "),
+            "renderer must not emit a section header:\n{}",
+            md
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,9 @@ fn response_mode(command: &Commands) -> ResponseMode {
         Commands::Changelog(args) if changelog::is_show_markdown(args) => {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
+        Commands::Review(args) if review::is_markdown_mode(args) => {
+            ResponseMode::Raw(RawOutputMode::Markdown)
+        }
         Commands::List => ResponseMode::Raw(RawOutputMode::Markdown),
         _ => ResponseMode::Json,
     }


### PR DESCRIPTION
## Summary

Adds a built-in markdown renderer to `homeboy review` so the GitHub Action layer can collapse `scripts/digest/render-command-summary.py` + the per-command branches in `scripts/pr/comment/sections.sh` onto a single `homeboy review --report=pr-comment` call.

The renderer plugs into the existing generic markdown CLI mode (`RawOutputMode::Markdown` + `commands::run_markdown` dispatch — already used by `homeboy docs`, `homeboy changelog show`, `homeboy list`). It is a pure function over `&ReviewCommandOutput`, no template engine, just `String::push_str` / `writeln!`.

Closes #1509.

## What changed

- **`ReviewArgs`** gains an `--report=<FORMAT>` flag with a `value_parser` whitelist (only `pr-comment` accepted today). New format values are trivial to add.
- **`review::run_markdown(args, global)`** runs the JSON path internally and renders the envelope. Wired into the existing `commands::run_markdown` dispatch.
- **`review::is_markdown_mode(args)`** predicate hooked into `main::response_mode` so `--report=pr-comment` routes through `RawOutputMode::Markdown` (suppresses the JSON envelope, prints raw body to stdout, returns the review's exit code).
- **`src/commands/review.rs`** converted to a directory module. Existing logic stays in `mod.rs`; the new renderer lives in `src/commands/review/render.rs`.
- **No version bump, no changelog edit** — homeboy owns those at release time.

## Markdown shape

Top-down:

- Scope banner — `:zap: Scope: **changed files only** (since \`<ref>\`)` for changed-since, `:zap: Scope: **working tree changes only**` for changed-only, `:information_source: Scope: **full**` otherwise.
- Total findings line — `**N** finding(s) across M stage(s)`.
- Three stage blocks in fixed audit → lint → test order. Each stage:
  - Icon header — `:white_check_mark: **<stage>**` (passed) / `:x: **<stage>**` (failed) / `:fast_forward: **<stage>** — skipped (<reason>)`.
  - Body bullets — top finding categories (audit, by `convention`), top sniff codes (lint, by `category`), or failure summary (test). Top-10 cap with `… N more` overflow line.
  - Blockquote `> Deep dive: homeboy <cmd> ...` hint pointing at the per-stage command.

The renderer emits the section body only — `homeboy git pr comment --header` owns the wrapping `### Title` heading.

## Out of scope

Action-level signals (autofix banners, fallback-binary warnings, tooling versions, scope-mode resolution notes) are not present in `ReviewCommandOutput` and are intentionally not rendered. The Action will continue to render those as separate sections (or via `--banner` flags in a future PR).

- Banner injection follow-up: #1510.
- homeboy-action migration to consume `--report=pr-comment`: Extra-Chill/homeboy-action#144.

## Tests

24 review tests pass (15 new in this PR + 9 pre-existing rebased onto the new module layout):

- `parses_report_pr_comment` — `--report=pr-comment` parses.
- `rejects_unknown_report_format` — `--report=slack` is rejected by the whitelist.
- `is_markdown_mode_false_without_flag` — predicate returns false when the flag isn't set.
- `renders_passing_review_with_full_scope` — clean run shows three green headers and no bullets.
- `renders_failing_review_with_findings` — failures flip the icon to `:x:` and bucket counts render.
- `renders_all_stages_skipped` — empty changeset renders three skipped headers, zero ran stages.
- `renders_changed_since_scope_banner` / `renders_full_scope_banner` — both banner variants.
- `renders_test_pass_count_when_no_failures` / `renders_test_failure_summary` — test body shape.
- `caps_lint_sniffs_at_top_10` / `caps_audit_categories_at_top_10` — synthesize 15 categories, expect 10 + `5 more` overflow.
- `renders_deep_dive_hints_for_ran_stages` — every ran stage emits its blockquote hint.
- `never_emits_top_level_section_heading` — body must not start with `### `.

Full bin test run: **65/65 pass** (`cargo test --bin homeboy -- --test-threads=1`). `cargo build` clean. `cargo clippy --bin homeboy` produces no review-related warnings.

## Live smoke test

Ran `./target/release/homeboy review homeboy --changed-since=main --report=pr-comment` against the worktree itself. Rendered output (post-stage stderr stripped):

\`\`\`markdown
:zap: Scope: **changed files only** (since \`main\`)

**68** finding(s) across 3 stage(s)

:white_check_mark: **audit**
- **test_coverage** — 49 finding(s)
- **structural** — 6 finding(s)
- **dead_code** — 4 finding(s)
- **field_patterns** — 4 finding(s)
- **intra-method-duplication** — 4 finding(s)
- **parallel-implementation** — 1 finding(s)
- _Total: 68 finding(s)_
> Deep dive: homeboy audit homeboy --changed-since=main

:white_check_mark: **lint**
> Deep dive: homeboy lint homeboy --changed-since=main

:x: **test**
> Deep dive: homeboy test homeboy --changed-since=main
\`\`\`

The audit stage shows `:white_check_mark:` because in `--changed-since` mode it passes when no NEW findings exist vs baseline; the bullets still surface the 68 findings present in the current run, which is exactly what a reviewer wants to see.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafting the renderer, the test fixtures, doc updates, and PR scaffolding from the design brief. Reviewed and live-smoke-tested by Chris.