### PR TITLE
feat(bench): --shared-state and --concurrency for multi-instance workloads

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -45,6 +45,15 @@ the other capabilities.
 - `--path <PATH>`: Override the component's `local_path` for this run.
 - `--json-summary`: Include a compact machine-readable summary in the
   JSON output envelope (for CI wrappers).
+- `--shared-state <DIR>`: Mount a stable storage directory across
+  iterations (and across parallel runner instances when combined with
+  `--concurrency`). Exposed to the runner as
+  `$HOMEBOY_BENCH_SHARED_STATE`. Created if it doesn't exist; never
+  cleaned up by homeboy. See "Shared State and Concurrency" below.
+- `--concurrency <N>`: Number of parallel runner instances to spawn
+  (default `1`). When `> 1`, `--shared-state` is required. Each instance
+  receives a distinct `$HOMEBOY_BENCH_INSTANCE_ID` (`0..N-1`) plus
+  `$HOMEBOY_BENCH_CONCURRENCY=N`.
 
 Arguments after `--` are passed verbatim to the extension's bench runner
 script (e.g., `--filter=scenario_id` for selective execution).
@@ -66,7 +75,61 @@ homeboy bench my-component --ratchet
 
 # Select a single scenario via passthrough args
 homeboy bench my-component -- --filter=hot_path
+
+# Concurrent-writer stress test: 4 parallel instances against a shared
+# on-disk state directory. All four runners see the same SQLite +
+# markdown files, surfacing lock contention and write loss.
+homeboy bench my-component \
+    --shared-state /tmp/bench-shared \
+    --concurrency 4
+
+# Crash-recovery / durability test: single instance, persistent state.
+# Workload kills mid-stream on iteration N; iteration N+1 boots fresh
+# against the same on-disk state and audits integrity.
+homeboy bench my-component --shared-state /tmp/bench-durability
 ```
+
+## Shared State and Concurrency
+
+Two workload classes need state shared across runtime instances or
+surviving a kill:
+
+- **Concurrent writers** — N parallel processes writing against the
+  same site, surfacing lock contention and write loss under load.
+- **Crash recovery** — Start a write stream, kill mid-stream, boot a
+  fresh runtime against the same on-disk state, audit integrity.
+
+Both fit cleanly under `--shared-state <DIR>`:
+
+| Mode | `--concurrency` | `--shared-state` | Behaviour |
+|---|---|---|---|
+| Cold-iteration (default) | `1` | unset | Per-iteration cold boot, no shared state. The original bench design. |
+| Persistent single | `1` | `<DIR>` | Single runtime, but state in `<DIR>` survives across iterations. Crash-recovery workloads. |
+| Concurrent | `> 1` | `<DIR>` (required) | N parallel runners, all pointed at `<DIR>`. Lock-contention workloads. |
+| Concurrent without state | `> 1` | unset | **Rejected** — N parallel cold-boots without shared state are N independent runs. The validation error points you at `--shared-state`. |
+
+Per-instance scenarios are merged with `:i<n>` suffixed IDs in the
+aggregated output (`shared_counter:i0`, `shared_counter:i1`, …) so each
+instance's measurements stay distinguishable. The baseline ratchet works
+unchanged — a regression in instance 2 surfaces as a regression on
+`<id>:i2`, not as silent averaging across instances.
+
+### Runner contract additions
+
+When shared-state and concurrency flags are set, three additional env
+vars flow into the runner:
+
+- `HOMEBOY_BENCH_SHARED_STATE` — absolute path to the shared directory
+  (or empty string when not set). Workloads that opt into shared state
+  read or write files under this path.
+- `HOMEBOY_BENCH_INSTANCE_ID` — `0..N-1` for parallel runs, `0` for
+  single-instance.
+- `HOMEBOY_BENCH_CONCURRENCY` — `N` for parallel runs, `1` for
+  single-instance.
+
+Per-instance results are written to `bench-results-i<n>.json` under the
+run dir; homeboy core merges them into the unified `BenchResults`
+envelope before applying baseline comparison.
 
 ## Baseline Ratchet Semantics
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -54,6 +54,26 @@ pub struct BenchArgs {
     /// component argument is optional — the rig's default fills in.
     #[arg(long, value_name = "RIG_ID")]
     rig: Option<String>,
+
+    /// Mount a stable storage directory across iterations and across
+    /// parallel runner instances (when combined with `--concurrency`).
+    /// The dispatcher exposes the path to workloads via
+    /// `$HOMEBOY_BENCH_SHARED_STATE` so they can persist on-disk state
+    /// (SQLite files, content directories, counter files) that outlives
+    /// a single iteration. Created if it doesn't exist; never cleaned
+    /// up by homeboy — durability and crash-recovery testing depends on
+    /// the directory persisting between runs.
+    #[arg(long, value_name = "DIR")]
+    shared_state: Option<std::path::PathBuf>,
+
+    /// Number of parallel runner instances to spawn. Default `1`. When
+    /// `> 1`, `--shared-state <DIR>` is required: N parallel cold-boots
+    /// without shared state are N independent runs, not a multi-instance
+    /// contention test. Each instance receives a distinct
+    /// `$HOMEBOY_BENCH_INSTANCE_ID` (`0..N-1`); per-instance scenarios
+    /// are merged with `:i<n>` suffixed IDs in the aggregated output.
+    #[arg(long, value_name = "N", default_value_t = 1)]
+    concurrency: u32,
 }
 
 /// Filter out homeboy-owned flags from trailing args before passing to
@@ -77,6 +97,9 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
         "--regression-threshold",
         "--setting",
         "--path",
+        "--shared-state",
+        "--concurrency",
+        "--rig",
     ];
 
     let mut filtered = Vec::new();
@@ -190,6 +213,8 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchCommandOutpu
             json_summary: args.json_summary,
             passthrough_args,
             rig_id: rig_id.clone(),
+            shared_state: args.shared_state.clone(),
+            concurrency: args.concurrency,
         },
         &run_dir,
     )?;

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1,16 +1,20 @@
 //! Bench main workflow: invoke extension runner, load JSON, apply baseline.
 
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
 
 use serde::Serialize;
 
 use crate::component::Component;
 use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::extension::bench::baseline::{self, BenchBaselineComparison};
-use crate::extension::bench::parsing::{self, BenchResults};
-use crate::extension::{resolve_execution_context, ExtensionCapability, ExtensionRunner};
+use crate::extension::bench::parsing::{self, BenchResults, BenchScenario};
+use crate::extension::{
+    resolve_execution_context, ExtensionCapability, ExtensionExecutionContext, ExtensionRunner,
+};
 
 #[derive(Debug, Clone)]
 pub struct BenchRunWorkflowArgs {
@@ -28,6 +32,17 @@ pub struct BenchRunWorkflowArgs {
     /// unpinned baselines stay in separate slots inside `homeboy.json`.
     /// `None` preserves the original baseline shape exactly.
     pub rig_id: Option<String>,
+    /// Optional shared-state directory mounted across iterations and
+    /// instances. When set, the dispatcher exposes the path to workloads
+    /// via `$HOMEBOY_BENCH_SHARED_STATE` so they can persist on-disk
+    /// state (SQLite files, content directories, counter files) that
+    /// outlives a single iteration. Required when `concurrency > 1`.
+    pub shared_state: Option<PathBuf>,
+    /// Number of parallel runner instances to spawn. `1` (default)
+    /// preserves single-instance behaviour. `> 1` requires `shared_state`
+    /// to be set — N independent cold-boots without shared state would
+    /// be N independent runs, not a multi-instance contention test.
+    pub concurrency: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -47,35 +62,78 @@ pub struct BenchRunWorkflowResult {
 /// envelope to `$HOMEBOY_BENCH_RESULTS_FILE`. Iteration count is passed
 /// via `$HOMEBOY_BENCH_ITERATIONS`. Runner exit code is taken as the
 /// primary signal; baseline regressions can override to 1.
+///
+/// ## Shared state and concurrency
+///
+/// When `args.shared_state` is set, the path is exported as
+/// `$HOMEBOY_BENCH_SHARED_STATE` so workloads can persist on-disk state
+/// across iterations.
+///
+/// When `args.concurrency > 1`, N runner instances are spawned in
+/// parallel threads. Each gets a distinct `$HOMEBOY_BENCH_INSTANCE_ID`
+/// (`0..N-1`), `$HOMEBOY_BENCH_CONCURRENCY` (`N`), and a per-instance
+/// results file (`bench-results-i<n>.json` under the run dir). After all
+/// instances finish, their `BenchResults` are merged: scenario IDs are
+/// suffixed with `:i<n>` so each instance's measurements stay
+/// distinguishable in the aggregated envelope and the baseline. This
+/// keeps the regression checker working unchanged — a regression in
+/// instance 2 surfaces as a regression on `<id>:i2`, not as silent
+/// averaging.
 pub fn run_main_bench_workflow(
     component: &Component,
     source_path: &PathBuf,
     args: BenchRunWorkflowArgs,
     run_dir: &RunDir,
 ) -> Result<BenchRunWorkflowResult> {
-    let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+    if args.concurrency == 0 {
+        return Err(Error::validation_invalid_argument(
+            "concurrency",
+            "must be >= 1",
+            None,
+            None,
+        ));
+    }
+    if args.concurrency > 1 && args.shared_state.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "concurrency",
+            "--concurrency > 1 requires --shared-state <DIR>; \
+             N parallel cold-boots without shared state are N independent \
+             runs, not a multi-instance contention test",
+            None,
+            None,
+        ));
+    }
+
+    if let Some(ref shared) = args.shared_state {
+        std::fs::create_dir_all(shared).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to create shared-state dir {}: {}",
+                    shared.display(),
+                    e
+                ),
+                Some("bench.run.shared_state".to_string()),
+            )
+        })?;
+    }
+
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
 
-    let runner_output = ExtensionRunner::for_context(execution_context)
-        .component(component.clone())
-        .path_override(args.path_override.clone())
-        .settings(&args.settings)
-        .with_run_dir(run_dir)
-        .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
-        .script_args(&args.passthrough_args)
-        .run()?;
-
-    let parsed = if results_file.exists() {
-        parsing::parse_bench_results_file(&results_file).ok()
+    let (parsed, runner_success, runner_exit_code) = if args.concurrency <= 1 {
+        let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+        let runner_output =
+            build_runner(&execution_context, component, &args, run_dir, None)?.run()?;
+        let parsed = if results_file.exists() {
+            parsing::parse_bench_results_file(&results_file).ok()
+        } else {
+            None
+        };
+        (parsed, runner_output.success, runner_output.exit_code)
     } else {
-        None
+        run_concurrent_instances(&execution_context, component, &args, run_dir)?
     };
 
-    let status = if runner_output.success {
-        "passed"
-    } else {
-        "failed"
-    };
+    let status = if runner_success { "passed" } else { "failed" };
 
     let rig_id = args.rig_id.as_deref();
 
@@ -134,7 +192,7 @@ pub fn run_main_bench_workflow(
 
     let hints = if hints.is_empty() { None } else { Some(hints) };
 
-    let exit_code = baseline_exit_override.unwrap_or(runner_output.exit_code);
+    let exit_code = baseline_exit_override.unwrap_or(runner_exit_code);
 
     Ok(BenchRunWorkflowResult {
         status: status.to_string(),
@@ -145,4 +203,170 @@ pub fn run_main_bench_workflow(
         baseline_comparison,
         hints,
     })
+}
+
+/// Per-instance results filename within the run dir.
+///
+/// Single source of truth so the runner-side override and the parent
+/// reader agree on the path. Single-instance runs keep the legacy
+/// `bench-results.json` filename for backward compatibility with any
+/// extension that hardcodes it.
+fn instance_results_filename(instance_id: u32) -> String {
+    format!("bench-results-i{}.json", instance_id)
+}
+
+/// Build the `ExtensionRunner` for a single bench invocation.
+///
+/// `instance` is `Some((id, total))` for multi-instance runs (each gets
+/// its own results file + instance/concurrency env vars), or `None` for
+/// the legacy single-instance path.
+fn build_runner(
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: &BenchRunWorkflowArgs,
+    run_dir: &RunDir,
+    instance: Option<(u32, u32)>,
+) -> Result<ExtensionRunner> {
+    let mut runner = ExtensionRunner::for_context(execution_context.clone())
+        .component(component.clone())
+        .path_override(args.path_override.clone())
+        .settings(&args.settings)
+        .with_run_dir(run_dir)
+        .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
+        .script_args(&args.passthrough_args);
+
+    if let Some(ref shared) = args.shared_state {
+        runner = runner.env("HOMEBOY_BENCH_SHARED_STATE", &shared.to_string_lossy());
+    }
+
+    if let Some((instance_id, concurrency)) = instance {
+        let results_path = run_dir.step_file(&instance_results_filename(instance_id));
+        runner = runner
+            .env(
+                "HOMEBOY_BENCH_RESULTS_FILE",
+                &results_path.to_string_lossy(),
+            )
+            .env("HOMEBOY_BENCH_INSTANCE_ID", &instance_id.to_string())
+            .env("HOMEBOY_BENCH_CONCURRENCY", &concurrency.to_string());
+    }
+
+    Ok(runner)
+}
+
+/// Spawn N runner instances in parallel, wait for all, aggregate.
+///
+/// Returns `(merged_results, all_succeeded, exit_code)`. Per-instance
+/// scenarios are merged with `:i<n>` suffixed IDs so each instance's
+/// measurements stay distinct in the envelope and the baseline. If any
+/// instance failed, the aggregate run reports failure with that
+/// instance's exit code (first failure wins).
+fn run_concurrent_instances(
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: &BenchRunWorkflowArgs,
+    run_dir: &RunDir,
+) -> Result<(Option<BenchResults>, bool, i32)> {
+    let concurrency = args.concurrency;
+    let execution_context = Arc::new(execution_context.clone());
+    let component = Arc::new(component.clone());
+    let args_arc = Arc::new(args.clone());
+    let run_dir = Arc::new(run_dir.clone());
+
+    let mut handles = Vec::with_capacity(concurrency as usize);
+    for instance_id in 0..concurrency {
+        let ctx = Arc::clone(&execution_context);
+        let comp = Arc::clone(&component);
+        let a = Arc::clone(&args_arc);
+        let rd = Arc::clone(&run_dir);
+        handles.push(thread::spawn(move || -> Result<(u32, _)> {
+            let runner = build_runner(&ctx, &comp, &a, &rd, Some((instance_id, concurrency)))?;
+            let output = runner.run()?;
+            Ok((instance_id, output))
+        }));
+    }
+
+    let mut per_instance: Vec<(u32, crate::extension::RunnerOutput)> =
+        Vec::with_capacity(concurrency as usize);
+    for h in handles {
+        match h.join() {
+            Ok(Ok(pair)) => per_instance.push(pair),
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Err(Error::internal_unexpected("bench instance thread panicked")),
+        }
+    }
+
+    per_instance.sort_by_key(|(id, _)| *id);
+
+    // First failure wins for the exit code surface; status is "all-or-nothing".
+    let mut all_success = true;
+    let mut first_failure_exit: Option<i32> = None;
+    for (_, output) in &per_instance {
+        if !output.success {
+            all_success = false;
+            if first_failure_exit.is_none() {
+                first_failure_exit = Some(output.exit_code);
+            }
+        }
+    }
+    let exit_code = if all_success {
+        0
+    } else {
+        first_failure_exit.unwrap_or(1)
+    };
+
+    // Read & merge per-instance results files.
+    let mut merged_scenarios: Vec<BenchScenario> = Vec::new();
+    let mut component_id_seen: Option<String> = None;
+    let mut iterations_seen: Option<u64> = None;
+    let mut metric_policies_seen: std::collections::BTreeMap<String, parsing::BenchMetricPolicy> =
+        std::collections::BTreeMap::new();
+
+    for (instance_id, _) in &per_instance {
+        let path = run_dir.step_file(&instance_results_filename(*instance_id));
+        if !path.exists() {
+            continue;
+        }
+        let parsed = match parsing::parse_bench_results_file(&path) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if component_id_seen.is_none() {
+            component_id_seen = Some(parsed.component_id.clone());
+        }
+        if iterations_seen.is_none() {
+            iterations_seen = Some(parsed.iterations);
+        }
+        for (k, v) in parsed.metric_policies.into_iter() {
+            metric_policies_seen.entry(k).or_insert(v);
+        }
+        for mut scenario in parsed.scenarios {
+            scenario.id = format!("{}:i{}", scenario.id, instance_id);
+            merged_scenarios.push(scenario);
+        }
+    }
+
+    let merged = if merged_scenarios.is_empty() && component_id_seen.is_none() {
+        None
+    } else {
+        Some(BenchResults {
+            component_id: component_id_seen.unwrap_or_else(|| args.component_id.clone()),
+            iterations: iterations_seen.unwrap_or(args.iterations),
+            scenarios: merged_scenarios,
+            metric_policies: metric_policies_seen,
+        })
+    };
+
+    Ok((merged, all_success, exit_code))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instance_results_filename_is_distinct_per_instance() {
+        assert_eq!(instance_results_filename(0), "bench-results-i0.json");
+        assert_eq!(instance_results_filename(7), "bench-results-i7.json");
+        assert_ne!(instance_results_filename(0), instance_results_filename(1));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1508. Adds two flags to `homeboy bench` so the dispatcher can express workload classes that can't run under the existing per-iteration cold-boot model:

- **Concurrent writers** — N parallel runtime instances pointed at the same on-disk state, surfacing lock contention and write loss (the bug class behind MDI #47, #70).
- **Crash recovery** — Persistent state surviving a kill, audited by a different fresh runtime.

## Shape

Picked Option 1 from the issue (`--shared-state <DIR>` + `--concurrency N`). Closest to the existing CLI shape, composes cleanly with `--rig`, `--baseline`, `--ratchet`, and the existing matrix axes. Option 2 (`--mode persistent | cold-iter`) was rejected because it makes results non-comparable to cold-boot runs by default; Option 3 (component-owned host runner) was rejected because it blurs the "Playground is the substrate" story.

## Behaviour

| Mode | `--concurrency` | `--shared-state` | Behaviour |
|---|---|---|---|
| Cold-iteration (default) | `1` | unset | Existing per-iteration cold boot, no shared state. **Unchanged.** |
| Persistent single | `1` | `<DIR>` | Single runtime, state in `<DIR>` survives across iterations. Crash-recovery workloads. |
| Concurrent | `> 1` | `<DIR>` (required) | N parallel runners, all pointed at `<DIR>`. Lock-contention workloads. |
| Concurrent without state | `> 1` | unset | **Rejected at validation** — N parallel cold-boots without shared state are N independent runs. |

Per-instance scenarios are merged with `:i<n>` suffixed IDs (`shared_counter:i0`, `shared_counter:i1`, …) so each instance's measurements stay distinguishable in the aggregated envelope and the baseline. The regression checker works unchanged — a regression in instance 2 surfaces as a regression on `<id>:i2`, not as silent averaging across instances.

## CLI surface

```
--shared-state <DIR>     Mount a stable storage directory across iterations and instances.
                          Created if missing; never cleaned up.
--concurrency <N>        Number of parallel runner instances. Default 1. N>1 requires --shared-state.
```

Both threaded into `BenchRunWorkflowArgs`. `filter_homeboy_flags` updated to strip them from passthrough args.

## Runner contract additions

When the flags are set, three env vars flow into the runner script:

- `HOMEBOY_BENCH_SHARED_STATE` — absolute path to the shared dir (or empty when unset).
- `HOMEBOY_BENCH_INSTANCE_ID` — `0..N-1` for parallel runs, `0` for single-instance.
- `HOMEBOY_BENCH_CONCURRENCY` — `N` for parallel runs, `1` for single-instance.

Per-instance results go to `bench-results-i<n>.json` under the run dir; homeboy core merges them into the unified `BenchResults` envelope before applying baseline comparison.

The wordpress dispatcher PR ([Extra-Chill/homeboy-extensions#NNN](TBD) — link added once pushed) honors this contract.

## Tests

- New unit test `instance_results_filename_is_distinct_per_instance` covers the per-instance filename derivation.
- All 1404 lib tests pass under `--test-threads=1` (the 3 parallel-flake failures match the known HOME-touching pattern documented in the worktree's notes — pre-existing, unrelated).
- Audit: 566 fingerprints resolved, 1 new finding in `src/commands/review.rs` field-pattern (unrelated to this PR — co-existing files from main).
- End-to-end: smoke-tested via the wordpress extension dispatcher PR with the `bench-shared-state` fixture.

## Out of scope

- Component-owned host runner (Option 3) — left for a separate issue if it ever proves needed.
- Parallel matrix execution (mentioned in #1508 as adjacent) — independent unlock; the per-iteration cold-boot path can fan out cells without shared-state coordination, separately.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the workflow refactor (`build_runner` / `run_concurrent_instances` split, scenario-id suffix merge), the CLI surface, and the docs section. Chris reviewed and validated against the issue's three options before landing.