### PR TITLE
feat(audit): CodebaseSnapshot + FingerprintIndex primitives (slice 1 of #1492)

### DIFF
--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -1,9 +1,10 @@
 //! fingerprint — extracted from conventions.rs.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::conventions::Language;
+use crate::core::engine::codebase_scan::CodebaseSnapshot;
 
 /// A structural fingerprint extracted from a single source file.
 #[derive(Debug, Clone, Default)]
@@ -83,14 +84,28 @@ pub struct FileFingerprint {
     pub trait_impl_methods: Vec<String>,
 }
 
-/// Extract a structural fingerprint from a source file.
+/// Extract a structural fingerprint from a source file on disk.
+///
+/// Reads `path` from disk, then delegates to [`fingerprint_content`]. Use
+/// `fingerprint_content` directly when content has already been loaded
+/// (e.g., from a [`CodebaseSnapshot`]) to avoid double-reads.
+pub fn fingerprint_file(path: &Path, root: &Path) -> Option<FileFingerprint> {
+    let content = std::fs::read_to_string(path).ok()?;
+    fingerprint_content(path, root, &content)
+}
+
+/// Extract a structural fingerprint from already-loaded file content.
 ///
 /// Tries the grammar-driven core engine first (no subprocess, faster, testable).
 /// Falls back to the extension fingerprint script if no grammar is available
 /// or the core engine can't handle the file.
-pub fn fingerprint_file(path: &Path, root: &Path) -> Option<FileFingerprint> {
+///
+/// This is the content-taking primitive used by [`FingerprintIndex::from_snapshot`]
+/// to avoid re-reading every file from disk after a [`CodebaseSnapshot`] has
+/// already loaded them. [`fingerprint_file`] is a convenience wrapper that
+/// reads from disk and delegates here so behavior stays identical.
+pub fn fingerprint_content(path: &Path, root: &Path, content: &str) -> Option<FileFingerprint> {
     let ext = path.extension()?.to_str()?;
-    let content = std::fs::read_to_string(path).ok()?;
     let relative_path = path
         .strip_prefix(root)
         .unwrap_or(path)
@@ -100,14 +115,14 @@ pub fn fingerprint_file(path: &Path, root: &Path) -> Option<FileFingerprint> {
     // Try core grammar engine first
     if let Some(grammar) = super::core_fingerprint::load_grammar_for_ext(ext) {
         if let Some(fp) =
-            super::core_fingerprint::fingerprint_from_grammar(&content, &grammar, &relative_path)
+            super::core_fingerprint::fingerprint_from_grammar(content, &grammar, &relative_path)
         {
             return Some(fp);
         }
     }
 
     // Fall back to extension fingerprint script
-    fingerprint_via_extension(ext, &content, &relative_path)
+    fingerprint_via_extension(ext, content, &relative_path)
 }
 
 /// Fingerprint using the extension script protocol (legacy path).
@@ -152,4 +167,177 @@ fn fingerprint_via_extension(
         hook_callbacks: output.hook_callbacks,
         trait_impl_methods: Vec::new(), // Extension scripts don't track this
     })
+}
+
+// ============================================================================
+// FingerprintIndex — built once from a CodebaseSnapshot
+// ============================================================================
+
+/// Pre-computed fingerprints for every file in a [`CodebaseSnapshot`].
+///
+/// Slice 1 of Extra-Chill/homeboy#1492. Built once via
+/// [`FingerprintIndex::from_snapshot`], shared by audit detectors,
+/// fixability planning, and refactor primitives instead of each consumer
+/// re-walking the tree and re-fingerprinting from disk.
+///
+/// Files whose extension has no grammar and no extension-script
+/// fingerprinter are silently dropped from the index — same semantics as
+/// [`fingerprint_file`] returning `None`.
+///
+/// This is opt-in scaffolding: existing callsites still use `fingerprint_file`
+/// directly. Consumer migration lands in subsequent slices.
+#[derive(Debug, Clone, Default)]
+pub struct FingerprintIndex {
+    inner: HashMap<PathBuf, FileFingerprint>,
+}
+
+impl FingerprintIndex {
+    /// Build an index by fingerprinting every file in `snapshot` once,
+    /// reusing the snapshot's already-loaded content (no disk re-reads).
+    pub fn from_snapshot(snapshot: &CodebaseSnapshot) -> Self {
+        let root = snapshot.root();
+        let mut inner = HashMap::with_capacity(snapshot.len());
+        for (path, content) in snapshot.iter() {
+            if let Some(fp) = fingerprint_content(path, root, content) {
+                inner.insert(path.to_path_buf(), fp);
+            }
+        }
+        Self { inner }
+    }
+
+    /// Look up the fingerprint for an absolute file path from the snapshot.
+    pub fn get(&self, path: &Path) -> Option<&FileFingerprint> {
+        self.inner.get(path)
+    }
+
+    /// Number of fingerprinted files (may be less than the source snapshot
+    /// if some extensions have no fingerprinter).
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Whether the index is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Iterate `(path, fingerprint)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&Path, &FileFingerprint)> {
+        self.inner.iter().map(|(p, fp)| (p.as_path(), fp))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::engine::codebase_scan::ScanConfig;
+
+    /// Sort a slice of strings into an owned Vec for set-equivalence asserts.
+    /// Used because some fingerprint vector fields come from HashMap iteration
+    /// and have non-deterministic order across runs.
+    fn sorted(v: &[String]) -> Vec<String> {
+        let mut out = v.to_vec();
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn fingerprint_content_matches_fingerprint_file() {
+        // Use the homeboy worktree's own source as a real-world Rust input.
+        let dir = std::env::temp_dir().join("homeboy_fingerprint_parity_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(dir.join("src"));
+
+        let src = "pub fn alpha() {}\npub fn beta(x: i32) -> i32 { x }\n";
+        let file = dir.join("src/lib.rs");
+        std::fs::write(&file, src).unwrap();
+
+        let from_disk = fingerprint_file(&file, &dir);
+        let from_content = fingerprint_content(&file, &dir, src);
+
+        // Either both produce a fingerprint, or both return None — and when
+        // both produce one, the structural fields must match. Vector fields
+        // come from HashMap iteration in some grammar paths, so compare as
+        // sorted sets rather than ordered sequences.
+        assert_eq!(from_disk.is_some(), from_content.is_some());
+        if let (Some(a), Some(b)) = (from_disk, from_content) {
+            assert_eq!(a.relative_path, b.relative_path);
+            assert_eq!(sorted(&a.methods), sorted(&b.methods));
+            assert_eq!(sorted(&a.public_api), sorted(&b.public_api));
+            assert_eq!(sorted(&a.imports), sorted(&b.imports));
+            assert_eq!(a.namespace, b.namespace);
+            assert_eq!(a.type_name, b.type_name);
+            assert_eq!(sorted(&a.type_names), sorted(&b.type_names));
+            assert_eq!(a.extends, b.extends);
+            assert_eq!(sorted(&a.implements), sorted(&b.implements));
+            assert_eq!(a.content, b.content);
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn from_snapshot_index_matches_per_file_get_calls() {
+        let dir = std::env::temp_dir().join("homeboy_fingerprint_index_parity_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(dir.join("src"));
+
+        std::fs::write(
+            dir.join("src/alpha.rs"),
+            "pub fn alpha_one() {}\npub fn alpha_two() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("src/beta.rs"),
+            "pub struct Beta;\nimpl Beta { pub fn new() -> Self { Self } }\n",
+        )
+        .unwrap();
+
+        let snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
+        let index = FingerprintIndex::from_snapshot(&snapshot);
+
+        // For every file the snapshot saw, the index either contains a
+        // fingerprint identical to the one fingerprint_file would produce,
+        // or both routes return None (extension with no fingerprinter).
+        for (path, _) in snapshot.iter() {
+            let from_index = index.get(path);
+            let from_file = fingerprint_file(path, snapshot.root());
+            assert_eq!(from_index.is_some(), from_file.is_some());
+            if let (Some(a), Some(b)) = (from_index, from_file.as_ref()) {
+                assert_eq!(a.relative_path, b.relative_path);
+                assert_eq!(sorted(&a.methods), sorted(&b.methods));
+                assert_eq!(sorted(&a.public_api), sorted(&b.public_api));
+                assert_eq!(sorted(&a.imports), sorted(&b.imports));
+                assert_eq!(a.content, b.content);
+            }
+        }
+
+        // The index should be non-empty for a tree with .rs files when a
+        // Rust grammar is available; if no grammar/extension is registered
+        // in this build, the test still passes (both routes return None).
+        assert_eq!(index.len(), index.iter().count());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn from_snapshot_get_returns_none_for_empty_snapshot() {
+        let dir = std::env::temp_dir().join("homeboy_fingerprint_index_empty_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+
+        let snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
+        let index = FingerprintIndex::from_snapshot(&snapshot);
+
+        assert!(index.is_empty());
+        assert_eq!(index.len(), 0);
+        assert_eq!(index.iter().count(), 0);
+        assert!(index.get(&dir.join("nope.rs")).is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -236,9 +236,9 @@ pub(crate) fn analyze_test_coverage(
                 // token-bounded substring matches (see `test_covers_method`).
                 let mut covered_methods: HashSet<&str> = HashSet::new();
                 for source_method in source_fp.methods.iter().map(|m| m.as_str()) {
-                    let covered = test_methods.iter().any(|test| {
-                        test_covers_method(test, source_method, &config.method_prefix)
-                    });
+                    let covered = test_methods
+                        .iter()
+                        .any(|test| test_covers_method(test, source_method, &config.method_prefix));
                     if covered {
                         covered_methods.insert(source_method);
                     }

--- a/src/core/engine/codebase_scan.rs
+++ b/src/core/engine/codebase_scan.rs
@@ -555,6 +555,71 @@ pub fn discover_casing(root: &Path, term: &str, config: &ScanConfig) -> Vec<(Str
 }
 
 // ============================================================================
+// In-memory snapshot — single-walk, single-read primitive
+// ============================================================================
+
+/// One-shot in-memory view of a codebase: a single walk + a single read pass.
+///
+/// Built by [`CodebaseSnapshot::build`] from a root directory and a [`ScanConfig`].
+/// Subsequent consumers (audit detectors, fingerprint indexes, symbol graphs, etc.)
+/// borrow content from this snapshot instead of re-walking the tree and re-reading
+/// each file. See Extra-Chill/homeboy#1492.
+///
+/// Files that fail to read as UTF-8 are silently dropped — same behavior as the
+/// pre-snapshot `walk_files` + `std::fs::read_to_string` callsites this replaces.
+///
+/// This is slice 1 of #1492 — pure addition, no consumer migration. The new
+/// type is opt-in primitive scaffolding; existing audit/fixability/refactor
+/// pipelines still go through `walk_files` + `fingerprint_file` directly.
+#[derive(Debug, Clone)]
+pub struct CodebaseSnapshot {
+    root: PathBuf,
+    files: Vec<(PathBuf, String)>,
+}
+
+impl CodebaseSnapshot {
+    /// Walk `root` once with `config`, read each matching file once, collect
+    /// (path, content) pairs in walk order. Files that fail to read as UTF-8
+    /// are skipped without erroring.
+    pub fn build(root: &Path, config: &ScanConfig) -> Self {
+        let paths = walk_files(root, config);
+        let mut files = Vec::with_capacity(paths.len());
+        for path in paths {
+            match std::fs::read_to_string(&path) {
+                Ok(content) => files.push((path, content)),
+                Err(_) => continue,
+            }
+        }
+        Self {
+            root: root.to_path_buf(),
+            files,
+        }
+    }
+
+    /// Root directory the snapshot was built from.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Number of files captured in the snapshot (post-read-filter).
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Whether the snapshot is empty.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    /// Iterate `(path, content)` pairs in walk order.
+    pub fn iter(&self) -> impl Iterator<Item = (&Path, &str)> {
+        self.files
+            .iter()
+            .map(|(path, content)| (path.as_path(), content.as_str()))
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -838,6 +903,80 @@ mod tests {
 
         assert_eq!(results.len(), 1); // Only "WPAgent" matches (WP_AGENT has an underscore)
         assert_eq!(results[0].matched, "WPAgent");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- CodebaseSnapshot tests ---
+
+    #[test]
+    fn snapshot_build_matches_walk_files() {
+        let dir = std::env::temp_dir().join("homeboy_snapshot_walk_parity_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(dir.join("src/sub"));
+        let _ = std::fs::create_dir_all(dir.join("node_modules"));
+
+        std::fs::write(dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(dir.join("src/sub/lib.rs"), "pub fn lib() {}\n").unwrap();
+        std::fs::write(dir.join("src/style.css"), "body{}\n").unwrap();
+        std::fs::write(dir.join("node_modules/skip.rs"), "skipped\n").unwrap();
+
+        let config = ScanConfig::default();
+        let walked = walk_files(&dir, &config);
+        let snapshot = CodebaseSnapshot::build(&dir, &config);
+
+        let walked_set: std::collections::HashSet<PathBuf> = walked.into_iter().collect();
+        let snapshot_set: std::collections::HashSet<PathBuf> =
+            snapshot.iter().map(|(p, _)| p.to_path_buf()).collect();
+
+        assert_eq!(snapshot_set, walked_set);
+        assert_eq!(snapshot.len(), snapshot_set.len());
+        assert_eq!(snapshot.root(), dir.as_path());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn snapshot_reads_each_file_exactly_once() {
+        let dir = std::env::temp_dir().join("homeboy_snapshot_content_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+
+        std::fs::write(dir.join("alpha.rs"), "alpha content\n").unwrap();
+        std::fs::write(dir.join("beta.rs"), "beta content\n").unwrap();
+        std::fs::write(dir.join("gamma.md"), "# gamma\n").unwrap();
+
+        let snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
+
+        // Collect (filename, content) pairs and verify each file's content
+        // is present exactly once — no duplicate reads, no missing files.
+        let mut by_name: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for (path, content) in snapshot.iter() {
+            let name = path.file_name().unwrap().to_string_lossy().to_string();
+            by_name.entry(name).or_default().push(content.to_string());
+        }
+
+        assert_eq!(by_name.get("alpha.rs").map(|v| v.len()), Some(1));
+        assert_eq!(by_name.get("beta.rs").map(|v| v.len()), Some(1));
+        assert_eq!(by_name.get("gamma.md").map(|v| v.len()), Some(1));
+        assert_eq!(by_name.get("alpha.rs").unwrap()[0], "alpha content\n");
+        assert_eq!(by_name.get("beta.rs").unwrap()[0], "beta content\n");
+        assert_eq!(by_name.get("gamma.md").unwrap()[0], "# gamma\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn snapshot_empty_for_empty_dir() {
+        let dir = std::env::temp_dir().join("homeboy_snapshot_empty_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+
+        let snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
+        assert!(snapshot.is_empty());
+        assert_eq!(snapshot.len(), 0);
+        assert_eq!(snapshot.iter().count(), 0);
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary

- Slice 1 of #1492. Pure addition — `CodebaseSnapshot` owns one walk + one read pass; `FingerprintIndex` builds once from a snapshot.
- New `fingerprint_content(path, root, content)` extracts the disk-free path from `fingerprint_file()`, which now delegates to it. Behavior is preserved byte-for-byte.
- Zero consumer migration in this PR. Audit detectors, fixability, refactor — all untouched. Subsequent slices will swap them onto the shared state and ratchet bench numbers will land then.

## What this is / what it isn't

This is **slice 1 of 7** from #1492. It's the in-memory shared-state scaffolding waiting for consumers. There is no behavior change in this PR — `homeboy audit homeboy --changed-since=v0.93.0 --json-summary` produces identical findings counts (9 / 3 warnings / 6 info / drift +1) before and after this change. The single line-level diff observed across runs is pre-existing nondeterminism in the `repeated_field_pattern` description string (HashMap iteration order), reproducible on `main` without these changes.

## API surface

`src/core/engine/codebase_scan.rs`:

```rust
pub struct CodebaseSnapshot { /* … */ }
impl CodebaseSnapshot {
    pub fn build(root: &Path, config: &ScanConfig) -> Self;
    pub fn root(&self) -> &Path;
    pub fn len(&self) -> usize;
    pub fn is_empty(&self) -> bool;
    pub fn iter(&self) -> impl Iterator<Item = (&Path, &str)>;
}
```

`src/core/code_audit/fingerprint.rs`:

```rust
pub fn fingerprint_content(path: &Path, root: &Path, content: &str) -> Option<FileFingerprint>;
// fingerprint_file() now delegates to fingerprint_content() after a single disk read.

pub struct FingerprintIndex { /* … */ }
impl FingerprintIndex {
    pub fn from_snapshot(snapshot: &CodebaseSnapshot) -> Self;
    pub fn get(&self, path: &Path) -> Option<&FileFingerprint>;
    pub fn len(&self) -> usize;
    pub fn is_empty(&self) -> bool;
    pub fn iter(&self) -> impl Iterator<Item = (&Path, &FileFingerprint)>;
}
```

No shims. `fingerprint_file` is a one-line convenience wrapper around `fingerprint_content`, not a deprecated path. Callers that already have content in hand (snapshot consumers) skip the disk read; callers that don't keep working unchanged.

## Tests

Six new unit tests, all green; full lib suite goes from 1403 → 1409 passing serial.

`codebase_scan` tests:
- `snapshot_build_matches_walk_files` — set-equivalence vs `walk_files` on a fixture with skip dirs, nested dirs, and an extension filter.
- `snapshot_reads_each_file_exactly_once` — every fixture file's content appears exactly once in the snapshot.
- `snapshot_empty_for_empty_dir` — empty / `is_empty` / iter count.

`fingerprint` tests:
- `fingerprint_content_matches_fingerprint_file` — same input via both code paths produces identical structural fields (compared as sorted sets where HashMap iteration is involved).
- `fingerprint_index_matches_per_file_calls` — every snapshot path resolves to the same fingerprint via `index.get(path)` and `fingerprint_file(path, root)`.
- `fingerprint_index_empty_for_empty_snapshot` — empty / `is_empty` / `get` miss.

## Validation

```
cargo build                                                    # clean
cargo test --lib -- --test-threads=1                           # 1409 passed; 0 failed
cargo test codebase_scan                                       # 19 passed (3 new)
cargo test fingerprint                                         # 40 passed (3 new)
homeboy audit homeboy --changed-since=v0.93.0 --json-summary   # parity vs main
```

## Out of scope

Tracked under #1492:
- Slice 2: migrate audit detectors to borrow from `AnalysisContext` (the wrapper struct lands when there's a consumer).
- Slice 3: batched `SymbolIndex` builder.
- Slice 4: `ModuleSurfaceIndex::from_fingerprints_and_symbols(...)`.
- Slice 5: `generate_audit_fixes_with_context(...)`.
- Slice 6: wire `report::compute_fixability()` to the shared context.
- Slice 7: ensure changed-scope audit keeps exact functionality with fewer scans.
- Bench baseline capture (lands when slice 2 has something measurable).

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted the slice-1 primitives + tests; Chris reviewed scope and approved the cook before I started.
