### PR TITLE
feat(lint): add --fix flag dispatching to the canonical refactor pipeline

### DIFF
--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -25,6 +25,7 @@ The `lint` command runs code style validation for a component using the linting 
 - `--changed-only`: Lint only files modified in the working tree (staged, unstaged, untracked)
 - `--errors-only`: Show only errors, suppress warnings
 - `--summary`: Show compact summary instead of full output
+- `--fix`: Apply auto-fixable lint findings in place. Thin alias for `homeboy refactor <component> --from lint --write` — dispatches to the existing fixer pipeline so a single ergonomic flag resolves the auto-fix CTA.
 - `--setting <key=value>`: Override extension settings (can be used multiple times)
 
 ## Examples
@@ -33,7 +34,10 @@ The `lint` command runs code style validation for a component using the linting 
 # Lint a WordPress component
 homeboy lint extrachill-api
 
-# Auto-fix formatting issues
+# Auto-fix formatting issues (ergonomic alias)
+homeboy lint extrachill-api --fix
+
+# Auto-fix formatting issues (canonical invocation, identical behavior)
 homeboy refactor extrachill-api --from lint --write
 
 # Lint only modified files in the working tree
@@ -81,11 +85,14 @@ Returns JSON with lint results:
   "component": "component-name",
   "output": "lint output...",
   "exit_code": 0,
-  "hints": ["Auto-fix: homeboy refactor <component> --from lint --write"]
+  "hints": ["Auto-fix: homeboy lint <component> --fix (or homeboy refactor <component> --from lint --write)"]
 }
 ```
 
-The `hints` field appears when linting fails, suggesting the refactor command for auto-fixing.
+The `hints` field appears when linting fails, suggesting the auto-fix CTA. Per the
+contract under [#1507](https://github.com/Extra-Chill/homeboy/issues/1507),
+autofixable findings never fail the run on their own — they nudge the user to
+run `homeboy lint --fix`.
 
 When extensions write `HOMEBOY_LINT_FINDINGS_FILE`, Homeboy exposes `lint_findings` in JSON output and
 supports baseline ratchet checks (`--baseline`, `--ignore-baseline`).

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -6,6 +6,7 @@ use homeboy::extension::lint::{
     report, run_main_lint_workflow, LintCommandOutput, LintRunWorkflowArgs,
 };
 use homeboy::extension::ExtensionCapability;
+use homeboy::refactor::plan::{run_lint_refactor, LintSourceOptions};
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
@@ -51,6 +52,14 @@ pub struct LintArgs {
     #[arg(long)]
     pub category: Option<String>,
 
+    /// Apply auto-fixable lint findings in place.
+    ///
+    /// Thin alias for `homeboy refactor <component> --from lint --write` —
+    /// dispatches to the existing fixer pipeline so a single ergonomic flag
+    /// resolves the auto-fix CTA without re-typing the canonical invocation.
+    #[arg(long)]
+    pub fix: bool,
+
     #[command(flatten)]
     pub setting_args: SettingArgs,
 
@@ -71,6 +80,29 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         ExtensionCapability::Lint,
         args.setting_args.setting.clone(),
     ))?;
+
+    let stringified_settings: Vec<(String, String)> = ctx
+        .settings
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.clone(),
+                match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                },
+            )
+        })
+        .collect();
+
+    // --fix dispatches to the canonical refactor sources pipeline.
+    // The fixer pipeline already exists; this flag connects the existing wire
+    // so users don't have to re-type `homeboy refactor <component> --from lint
+    // --write` to resolve the auto-fix CTA.
+    if args.fix {
+        return run_fix(args, &ctx, effective_id, stringified_settings);
+    }
+
     let run_dir = RunDir::create()?;
 
     let workflow = run_main_lint_workflow(
@@ -80,19 +112,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
-            settings: ctx
-                .settings
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        match v {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        },
-                    )
-                })
-                .collect(),
+            settings: stringified_settings,
             summary: args.summary,
             file: args.file.clone(),
             glob: args.glob.clone(),
@@ -114,12 +134,52 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     Ok(report::from_main_workflow(workflow))
 }
 
+/// Dispatch `homeboy lint --fix` to the canonical refactor sources pipeline.
+///
+/// `homeboy lint --fix` is a thin alias for `homeboy refactor <component>
+/// --from lint --write`. Under the hood we invoke the same
+/// `run_lint_refactor` primitive that the refactor command uses, then wrap
+/// the result in a `LintCommandOutput` so the lint command surface returns a
+/// stable shape regardless of which mode was requested.
+///
+/// Exit code semantics: autofixable findings should never fail the run, so
+/// this path returns exit 0 unless the underlying fixer actually errored.
+fn run_fix(
+    args: LintArgs,
+    ctx: &homeboy::engine::execution_context::ExecutionContext,
+    component_label: String,
+    settings: Vec<(String, String)>,
+) -> CmdResult<LintCommandOutput> {
+    let lint_options = LintSourceOptions {
+        selected_files: None,
+        file: args.file.clone(),
+        glob: args.glob.clone(),
+        errors_only: args.errors_only,
+        sniffs: args.sniffs.clone(),
+        exclude_sniffs: args.exclude_sniffs.clone(),
+        category: args.category.clone(),
+    };
+
+    let run = run_lint_refactor(
+        ctx.component.clone(),
+        ctx.source_path.clone(),
+        settings,
+        lint_options,
+        true,
+    )?;
+
+    Ok(report::from_lint_fix(component_label, run))
+}
+
 #[cfg(test)]
 mod tests {
     use homeboy::component::Component;
     use homeboy::extension::lint as extension_lint;
     use homeboy::extension::lint::baseline::{self as lint_baseline, LintFinding};
-    use homeboy::refactor::plan::{lint_refactor_request, LintSourceOptions};
+    use homeboy::extension::lint::report;
+    use homeboy::refactor::plan::{
+        lint_refactor_request, LintSourceOptions, RefactorSourceRun, SourceTotals,
+    };
     use std::path::Path;
 
     #[test]
@@ -176,6 +236,72 @@ mod tests {
             Component::new("test".to_string(), "/tmp".to_string(), "".to_string(), None);
         let result = extension_lint::resolve_lint_command(&component);
         assert!(result.is_err());
+    }
+
+    fn fixture_refactor_run(applied: bool, files_modified: usize) -> RefactorSourceRun {
+        RefactorSourceRun {
+            component_id: "demo".to_string(),
+            source_path: "/tmp/demo".to_string(),
+            sources: vec!["lint".to_string()],
+            dry_run: !applied,
+            applied,
+            merge_strategy: "sequential_source_merge".to_string(),
+            collected_edits: Vec::new(),
+            stages: Vec::new(),
+            source_totals: SourceTotals {
+                stages_with_edits: if files_modified > 0 { 1 } else { 0 },
+                total_edits: files_modified,
+                total_files_selected: files_modified,
+            },
+            overlaps: Vec::new(),
+            files_modified,
+            changed_files: (0..files_modified)
+                .map(|i| format!("src/file_{}.rs", i))
+                .collect(),
+            fix_summary: None,
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            guard_block: None,
+        }
+    }
+
+    #[test]
+    fn lint_fix_report_passes_with_zero_exit_when_fixes_applied() {
+        // The contract under #1507: autofixable findings never fail the run.
+        // Even when --fix actually modifies files, the lint command exits 0.
+        let run = fixture_refactor_run(true, 3);
+        let (output, exit_code) = report::from_lint_fix("demo".to_string(), run);
+
+        assert_eq!(exit_code, 0);
+        assert!(output.passed);
+        assert_eq!(output.status, "passed");
+        assert!(output.failure.is_none());
+
+        let autofix = output.autofix.as_ref().expect("autofix populated");
+        assert_eq!(autofix.files_modified, 3);
+        assert!(autofix.rerun_recommended);
+        assert_eq!(autofix.changed_files.len(), 3);
+
+        let hints = output.hints.as_ref().expect("hints populated");
+        assert!(
+            hints.iter().any(|h| h.contains("homeboy lint demo")),
+            "expected re-run hint pointing back at lint, got {:?}",
+            hints
+        );
+    }
+
+    #[test]
+    fn lint_fix_report_passes_when_no_fixes_needed() {
+        // When no autofixable findings exist, --fix is a clean no-op:
+        // exit 0, no autofix changes reported, friendly hint.
+        let run = fixture_refactor_run(false, 0);
+        let (output, exit_code) = report::from_lint_fix("demo".to_string(), run);
+
+        assert_eq!(exit_code, 0);
+        assert!(output.passed);
+        let autofix = output.autofix.as_ref().expect("autofix populated");
+        assert_eq!(autofix.files_modified, 0);
+        assert!(!autofix.rerun_recommended);
     }
 
     #[test]

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -226,6 +226,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         sniffs: None,
         exclude_sniffs: None,
         category: None,
+        fix: false,
         setting_args: Default::default(),
         baseline_args: args.baseline_args.clone(),
         _json: Default::default(),

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -175,6 +175,7 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
                 "--sniffs",
                 "--exclude-sniffs",
                 "--category",
+                "--fix",
                 "--setting",
                 "--path",
                 "--json",

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -8,6 +8,7 @@ use crate::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, VerificationPhase,
 };
+use crate::refactor::plan::RefactorSourceRun;
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
 
@@ -90,6 +91,70 @@ fn lint_phase_report(exit_code: i32, status: &str, finding_count: usize) -> Phas
             format!("lint phase {} (exit {})", status, exit_code)
         },
     }
+}
+
+/// Build a [`LintCommandOutput`] from a `homeboy lint --fix` dispatch.
+///
+/// `--fix` is a thin alias for `homeboy refactor <component> --from lint
+/// --write`, so the fix path receives a `RefactorSourceRun` rather than the
+/// usual lint workflow result. We surface the applied autofix via the existing
+/// `autofix` field on `LintCommandOutput` so consumers see a consistent shape
+/// regardless of which mode was requested.
+///
+/// Exit code semantics: autofixable findings should never fail the run, so
+/// the fix dispatch returns exit 0 even when fixes were applied. Real fixer
+/// errors propagate through `Result` and never reach this builder.
+pub fn from_lint_fix(component_label: String, run: RefactorSourceRun) -> (LintCommandOutput, i32) {
+    let exit_code = 0;
+    let phase = PhaseReport {
+        phase: VerificationPhase::Lint,
+        status: phase_status_from_exit_code(exit_code),
+        exit_code: Some(exit_code),
+        summary: if run.applied {
+            format!(
+                "lint phase auto-fix applied to {} file(s)",
+                run.files_modified
+            )
+        } else if run.files_modified > 0 {
+            "lint phase auto-fix dry run".to_string()
+        } else {
+            "lint phase auto-fix found no autofixable findings".to_string()
+        },
+    };
+
+    let mut hints = run.hints.clone();
+    if run.applied {
+        hints.push(format!(
+            "Re-run lint to confirm clean: homeboy lint {}",
+            component_label
+        ));
+    } else if run.files_modified == 0 && run.warnings.is_empty() {
+        hints.push("No autofixable findings detected.".to_string());
+    }
+    let hints = if hints.is_empty() { None } else { Some(hints) };
+
+    let autofix = AppliedRefactor {
+        files_modified: run.files_modified,
+        rerun_recommended: run.applied,
+        changed_files: run.changed_files.clone(),
+        fix_summary: run.fix_summary.clone(),
+    };
+
+    (
+        LintCommandOutput {
+            passed: true,
+            status: "passed".to_string(),
+            component: component_label,
+            exit_code,
+            phase,
+            failure: None,
+            autofix: Some(autofix),
+            hints,
+            baseline_comparison: None,
+            lint_findings: None,
+        },
+        exit_code,
+    )
 }
 
 fn lint_phase_failure(exit_code: i32, finding_count: usize) -> PhaseFailure {

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -114,11 +114,18 @@ pub fn run_main_lint_workflow(
     let (baseline_comparison, baseline_exit_override) =
         process_baseline(source_path, &args, &lint_findings)?;
 
-    // Hint assembly — point to refactor for fixes
+    // Hint assembly — point to the auto-fix CTA for autofixable findings.
+    //
+    // Per the contract under #1459 (issue #1507), autofixable findings never
+    // fail the run; they nudge. The CTA is rendered here in core, not by each
+    // extension's runner, so every language extension benefits from a single
+    // consistent prose. `homeboy lint --fix` is the ergonomic alias and is
+    // listed first; the canonical `homeboy refactor --from lint --write`
+    // invocation follows for users who want the longer form.
     if !lint_clean {
         hints.push(format!(
-            "Auto-fix: homeboy refactor {} --from lint --write",
-            args.component_label
+            "Auto-fix: homeboy lint {} --fix (or homeboy refactor {} --from lint --write)",
+            args.component_label, args.component_label
         ));
         hints.push("Some issues may require manual fixes".to_string());
     }


### PR DESCRIPTION
Closes #1507.

## Summary

`homeboy lint --fix` is now a thin alias for `homeboy refactor <component> --from lint --write`. The flag connects an existing wire — the refactor sources pipeline (`homeboy::refactor::plan::run_lint_refactor`, built on top of the `lint_refactor_request` primitive that was already imported in `src/commands/lint.rs` for tests but never wired to the runtime command) — instead of inventing a parallel autofix orchestration.

The auto-fix CTA is rendered in core (in `src/core/extension/lint/run.rs`) so every language extension benefits from a single consistent prose, and the CTA now leads with the ergonomic `homeboy lint --fix` form with the canonical `homeboy refactor --from lint --write` invocation as the longer alternative.

## The toggle dissolves

Per the discussion on #1507 (specifically [comment 4320297523](https://github.com/Extra-Chill/homeboy/issues/1507#issuecomment-4320297523)), the design evolved through:

1. `fail_on_autofixable` (original sketch) — fail the run mid-flight on autofixable findings.
2. `on_autofixable: warn|block|auto` (first revision) — escalate exit code without short-circuiting.
3. **Delete the toggle entirely** (final position, this PR).

Autofixable findings should never fail the run, period. By definition autofixable = the fixer knows the right answer. The right move is always "run the fixer," never "block CI." The interesting design surface is **how** the fix gets applied (pre-commit hook, agent loop, ergonomic alias), not whether to escalate the exit code on something the user obviously wants fixed.

This PR therefore:

- Adds **no** `fail_on_autofixable` / `on_autofixable` config field.
- Adds **no** `HOMEBOY_LINT_FAIL_ON_AUTOFIXABLE` / `HOMEBOY_LINT_ON_AUTOFIXABLE` env var.
- Adds **no** policy-level CLI flag.
- Keeps the lint phase exit code at 0 for autofixable-only runs. Real errors still fail.

Per the no-shim rule: the toggle never shipped, so there's nothing to deprecate. We just connect the ergonomic alias to the existing fixer pipeline and move on.

## What changes

- `src/commands/lint.rs` — adds `--fix` to `LintArgs`. When set, dispatches to `run_lint_refactor` and wraps the resulting `RefactorSourceRun` in a `LintCommandOutput` via the new `report::from_lint_fix` builder, populating the existing `autofix: Option<AppliedRefactor>` field.
- `src/core/extension/lint/report.rs` — adds `from_lint_fix(component_label, run)` builder. Always returns `passed: true` and `exit_code: 0`; surfaces files modified, changed files, and fix summary through `AppliedRefactor`. Real fixer errors propagate through `Result` and never reach this builder.
- `src/core/extension/lint/run.rs` — updates the auto-fix CTA hint to lead with `homeboy lint <component> --fix`, with `homeboy refactor <component> --from lint --write` as the canonical longer form. The CTA only renders when `lint_clean` is false (i.e., findings exist), so clean runs stay quiet.
- `src/commands/utils/args.rs` — adds `--fix` to the lint command's known-flag list in `normalize_trailing_flags`. Without this, the trailing-arg normalizer would insert a `--` separator before `--fix` and clap would reject it.
- `src/commands/review/mod.rs` — sets `fix: false` when constructing `LintArgs` for the review umbrella so it stays in dry-run mode.
- `docs/commands/lint.md` — documents `--fix` and the updated CTA prose.

## Out of scope

- `wordpress/scripts/lint/lint-runner.sh` (in `homeboy-extensions`, separate repo) currently renders its own CTA. That's tracked separately — this PR focuses on homeboy core.
- Per-finding `fixable` field on `LintFinding` and `total_fixable` rollup on the totals envelope (the rest of the #1459 contract). Worth shipping once extensions emit the data; this PR keeps the surface area minimal and focused on the CTA + ergonomic alias.

## Validation

- `cargo test --release` — 1404 unittests + 67 bin tests + 1 integration test, all green.
- `cargo build --release` — clean.
- Live runs from the worktree:
  - `homeboy lint --path .` → exit 0, no findings, no autofix CTA (clean run).
  - `homeboy lint --fix --path .` → exit 0, autofix capture in JSON output (`files_modified: 0`, `rerun_recommended: false`), phase summary `lint phase auto-fix found no autofixable findings`.
- `homeboy audit homeboy --path .` → no baseline drift; existing baseline unchanged.

New tests:
- `lint_fix_report_passes_with_zero_exit_when_fixes_applied` — asserts that even when `--fix` modifies files, the lint command exits 0 (the contract under #1507).
- `lint_fix_report_passes_when_no_fixes_needed` — asserts the no-op path is a clean exit 0 with `rerun_recommended: false`.
- The pre-existing `lint_fix_builds_canonical_refactor_request` test covers the request shape end-to-end.

## AI assistance disclosure

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Sonnet 4.5)
- **Used for:** Authoring the implementation, tests, docs, and PR body. Decision shape (delete the toggle entirely) was set by Chris in [#1507 comment 4320297523](https://github.com/Extra-Chill/homeboy/issues/1507#issuecomment-4320297523) before any code was written.