### PR TITLE
fix(audit): count_body_lines counts actual body lines + share is_trivial_method (#1517)

### DIFF
--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
+use super::idiomatic::is_trivial_method;
 
 /// Minimum number of locations for a function to count as duplicated.
 const MIN_DUPLICATE_LOCATIONS: usize = 2;
@@ -183,6 +184,10 @@ const GENERIC_NAMES: &[&str] = &[
 /// Minimum body line count — skip trivial functions (1-2 line bodies).
 /// Functions like `fn default_true() -> bool { true }` are too small
 /// to meaningfully refactor into shared code with a parameter.
+///
+/// Counted against `count_body_lines`, which returns the count of lines
+/// strictly between the opening and closing braces (so a single-line body
+/// is 0 and the standard three-line shape is 1).
 const MIN_BODY_LINES: usize = 3;
 
 /// Build structural hash groups from fingerprints.
@@ -224,8 +229,26 @@ fn is_command_file(path: &str) -> bool {
 
 /// Count the body lines of a function in a file's structural hash data.
 ///
-/// Uses heuristic: count lines in the content between `fn <name>` and the
-/// matching closing brace. Returns 0 if function not found or content empty.
+/// Returns the count of lines **strictly between** the line containing the
+/// opening `{` and the line containing the matching `}` — the actual body,
+/// not the wrapping span. So:
+///
+/// - `fn x() -> u32 { 0 }` (single-line body, both braces on the same line)
+///   returns **0** — there are no lines strictly between the braces.
+/// - The standard three-line shape
+///   ```text
+///   fn x() -> u32 {
+///       0
+///   }
+///   ```
+///   returns **1** — exactly the one body line.
+/// - A genuine N-statement body returns ~N.
+///
+/// Returns 0 if the function is not found or its content is empty. The
+/// previous implementation returned the **inclusive line span** from `fn`
+/// to the closing brace, which off-by-twoed three-line delegation methods
+/// like `pub fn len(&self) -> usize { self.inner.len() }` to a count of 3
+/// and slipped them past the `< MIN_BODY_LINES` filter (#1517).
 fn count_body_lines(fp: &FileFingerprint, method_name: &str) -> usize {
     let pattern = format!("fn {}", method_name);
     let lines: Vec<&str> = fp.content.lines().collect();
@@ -241,18 +264,22 @@ fn count_body_lines(fp: &FileFingerprint, method_name: &str) -> usize {
     let Some(start_idx) = start else { return 0 };
 
     let mut brace_depth = 0i32;
-    let mut found_open = false;
+    let mut open_line: Option<usize> = None;
     for (offset, line) in lines[start_idx..].iter().enumerate() {
+        let line_idx = start_idx + offset;
         for ch in line.chars() {
             if ch == '{' {
+                if open_line.is_none() {
+                    open_line = Some(line_idx);
+                }
                 brace_depth += 1;
-                found_open = true;
             } else if ch == '}' {
                 brace_depth -= 1;
+                if open_line.is_some() && brace_depth == 0 {
+                    let open = open_line.unwrap();
+                    return line_idx.saturating_sub(open).saturating_sub(1);
+                }
             }
-        }
-        if found_open && brace_depth == 0 {
-            return offset + 1;
         }
     }
 
@@ -269,8 +296,13 @@ fn count_body_lines(fp: &FileFingerprint, method_name: &str) -> usize {
 /// Filters out:
 /// - Functions already caught by exact-duplicate detection
 /// - Generic names (`run`, `list`, `show`, etc.)
+/// - Universally-idiomatic method names (`len`, `is_empty`, `iter`, `new`,
+///   `default`, `from`, `into`, `clone`, `fmt`, etc. — see
+///   `super::idiomatic::is_trivial_method`)
 /// - Command/core delegation pairs (command module ↔ core module)
-/// - Trivial functions (< 3 body lines)
+/// - Trivial functions (fewer than `MIN_BODY_LINES` body lines, where the
+///   body line count is *strictly between the braces* — so a single-line
+///   body is 0 and the standard three-line shape is 1)
 pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let structural_groups = build_structural_groups(fingerprints);
     let exact_groups = build_groups(fingerprints);
@@ -297,6 +329,18 @@ pub(crate) fn detect_near_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<F
 
         // Skip generic names
         if GENERIC_NAMES.contains(&method_name.as_str()) {
+            continue;
+        }
+
+        // Skip universally-idiomatic method names. `len`, `is_empty`, `iter`,
+        // `new`, `default`, `from`, `into`, `clone`, `fmt`, `as_str`,
+        // `to_string`, etc. are *expected* to have boilerplate-shaped bodies
+        // across unrelated types — every collection wrapper looks the same,
+        // and Clippy's `len_without_is_empty` lint actually *requires* you to
+        // pair `len` with `is_empty`. Flagging these as duplication is a
+        // false positive (#1517). Predicate is shared with `test_coverage`
+        // via `super::idiomatic::is_trivial_method`.
+        if is_trivial_method(method_name) {
             continue;
         }
 
@@ -1379,9 +1423,12 @@ mod tests {
 
     #[test]
     fn near_duplicate_detected_when_structural_match_but_exact_differs() {
-        // cache_path in two files: same structure, different constants
-        let content_a = "fn cache_path() -> Option<PathBuf> {\n    paths::homeboy().ok().map(|p| p.join(CACHE_A))\n}\n";
-        let content_b = "fn cache_path() -> Option<PathBuf> {\n    paths::homeboy().ok().map(|p| p.join(CACHE_B))\n}\n";
+        // cache_path in two files: same structure, different constants.
+        // Use a 3-body-line shape so the function clears MIN_BODY_LINES
+        // (the trivial-body filter); the structural twins differ only by
+        // the constant referenced.
+        let content_a = "fn cache_path() -> Option<PathBuf> {\n    let base = paths::homeboy().ok()?;\n    let file = base.join(CACHE_A);\n    Some(file)\n}\n";
+        let content_b = "fn cache_path() -> Option<PathBuf> {\n    let base = paths::homeboy().ok()?;\n    let file = base.join(CACHE_B);\n    Some(file)\n}\n";
 
         let fp1 = make_fp_with_content(
             "src/core/update_check.rs",
@@ -1534,6 +1581,128 @@ mod tests {
 
         let findings = detect_near_duplicates(&[&fp1, &fp2]);
         assert!(findings.is_empty(), "All-commands group should be skipped");
+    }
+
+    // ========================================================================
+    // count_body_lines — measures body lines strictly between braces (#1517)
+    // ========================================================================
+
+    #[test]
+    fn count_body_lines_zero_for_single_line_body() {
+        // `fn x() -> u32 { 0 }` — opening and closing brace on the same line.
+        // Zero lines strictly between them, so zero body lines.
+        let content = "fn x() -> u32 { 0 }\n";
+        let mut fp = make_fingerprint("src/x.rs", &["x"], &[]);
+        fp.content = content.to_string();
+
+        assert_eq!(
+            count_body_lines(&fp, "x"),
+            0,
+            "single-line body should report 0 body lines"
+        );
+    }
+
+    #[test]
+    fn count_body_lines_one_for_three_line_shape() {
+        // The standard formatter shape:
+        //   fn x() -> u32 {
+        //       0
+        //   }
+        // Exactly one line strictly between the braces.
+        let content = "fn x() -> u32 {\n    0\n}\n";
+        let mut fp = make_fingerprint("src/x.rs", &["x"], &[]);
+        fp.content = content.to_string();
+
+        assert_eq!(
+            count_body_lines(&fp, "x"),
+            1,
+            "three-line shape should report 1 body line"
+        );
+    }
+
+    #[test]
+    fn count_body_lines_counts_actual_body_statements() {
+        // Multi-line body with 4 statements between the braces.
+        let content = "fn process(items: &[Item]) -> Result {\n    let mut out = Vec::new();\n    for item in items {\n        out.push(item.clone());\n    }\n    Ok(out)\n}\n";
+        let mut fp = make_fingerprint("src/process.rs", &["process"], &[]);
+        fp.content = content.to_string();
+
+        // Lines strictly between `{` and `}`:
+        //   let mut out = Vec::new();
+        //   for item in items {
+        //       out.push(item.clone());
+        //   }
+        //   Ok(out)
+        // → 5 body lines.
+        assert_eq!(
+            count_body_lines(&fp, "process"),
+            5,
+            "should count actual body lines (5), not the wrapping span (7)"
+        );
+    }
+
+    #[test]
+    fn near_duplicate_skips_idiomatic_collection_methods() {
+        // The triggering case for #1517: every Vec/HashMap wrapper in the
+        // ecosystem defines `fn len(&self) -> usize { self.inner.len() }`,
+        // and Clippy's `len_without_is_empty` lint requires `is_empty`
+        // alongside it. Two structs each defining both methods must NOT
+        // produce near_duplicate findings.
+        let content_a = "struct A { inner: Vec<u8> }\nimpl A {\n    pub fn len(&self) -> usize {\n        self.inner.len()\n    }\n    pub fn is_empty(&self) -> bool {\n        self.inner.is_empty()\n    }\n}\n";
+        let content_b = "struct B { inner: HashMap<String, u32> }\nimpl B {\n    pub fn len(&self) -> usize {\n        self.inner.len()\n    }\n    pub fn is_empty(&self) -> bool {\n        self.inner.is_empty()\n    }\n}\n";
+
+        let fp1 = make_fp_with_content(
+            "src/core/a.rs",
+            content_a,
+            &[("len", "hash_a_len"), ("is_empty", "hash_a_emp")],
+            &[("len", "SAME_LEN"), ("is_empty", "SAME_EMP")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/b.rs",
+            content_b,
+            &[("len", "hash_b_len"), ("is_empty", "hash_b_emp")],
+            &[("len", "SAME_LEN"), ("is_empty", "SAME_EMP")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert!(
+            findings.is_empty(),
+            "idiomatic collection-wrapper methods (`len`, `is_empty`) must not be flagged as near-duplicates; got {} finding(s): {:?}",
+            findings.len(),
+            findings.iter().map(|f| &f.description).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn near_duplicate_still_flags_real_duplicates() {
+        // Regression guard against over-suppressing: a non-trivially-named
+        // method with identical structural hash but different body hashes
+        // across two files (and a 3+ body-line shape) MUST still be flagged.
+        let content_a = "fn compute_fixability(item: &Item) -> bool {\n    let score = item.score();\n    let threshold = THRESHOLD_A;\n    score > threshold\n}\n";
+        let content_b = "fn compute_fixability(item: &Item) -> bool {\n    let score = item.score();\n    let threshold = THRESHOLD_B;\n    score > threshold\n}\n";
+
+        let fp1 = make_fp_with_content(
+            "src/core/a.rs",
+            content_a,
+            &[("compute_fixability", "hash_a")],
+            &[("compute_fixability", "SAME_STRUCT")],
+        );
+        let fp2 = make_fp_with_content(
+            "src/core/b.rs",
+            content_b,
+            &[("compute_fixability", "hash_b")],
+            &[("compute_fixability", "SAME_STRUCT")],
+        );
+
+        let findings = detect_near_duplicates(&[&fp1, &fp2]);
+        assert_eq!(
+            findings.len(),
+            2,
+            "real near-duplicates (non-idiomatic name, multi-line body, distinct body hashes) must still be flagged",
+        );
+        assert!(findings
+            .iter()
+            .all(|f| f.description.contains("compute_fixability")));
     }
 
     // ========================================================================

--- a/src/core/code_audit/idiomatic.rs
+++ b/src/core/code_audit/idiomatic.rs
@@ -1,0 +1,134 @@
+//! Shared predicates for "this method name is idiomatic-shape across types."
+//!
+//! Some method names — `len`, `is_empty`, `iter`, `new`, `default`, `from`,
+//! `into`, `clone`, `fmt`, `as_str`, `to_string`, etc. — are **expected** to
+//! have boilerplate-shaped bodies across unrelated types. That's the language
+//! and stdlib doing what they're designed to do, not a code-smell.
+//!
+//! Two audit detectors care about this from different angles:
+//!
+//! - **test_coverage**: don't expect a dedicated test for a method whose name
+//!   is universally idiomatic. `len`/`is_empty`/`fmt` get tested transitively.
+//! - **near_duplicate (duplication.rs)**: don't flag a method whose name is
+//!   universally idiomatic — every collection wrapper in the Rust ecosystem
+//!   defines `fn len(&self) -> usize { self.inner.len() }`, and Clippy's
+//!   `len_without_is_empty` lint actually *requires* you to add `is_empty`
+//!   alongside it. Treating these as duplication findings is a false positive.
+//!
+//! Lifted from `test_coverage.rs` so both detectors consult the same predicate.
+
+/// Method names that are universally idiomatic-shape across types.
+///
+/// Returns true if the name is either:
+/// - in a curated list of stdlib-trait / common-accessor / lifecycle method
+///   names that are expected to look the same across unrelated types, or
+/// - prefixed with `get_`, `is_`, or `has_` (simple getters / predicates).
+pub(super) fn is_trivial_method(name: &str) -> bool {
+    let trivial = [
+        // Rust core trait methods
+        "new",
+        "default",
+        "from",
+        "into",
+        "clone",
+        "fmt",
+        "display",
+        "eq",
+        "hash",
+        "drop",
+        // Rust common conversions
+        "as_str",
+        "as_ref",
+        "as_mut",
+        "to_string",
+        "to_str",
+        "to_owned",
+        // Rust common accessors
+        "is_empty",
+        "len",
+        "iter",
+        // Serde
+        "serialize",
+        "deserialize",
+        // Builder pattern
+        "build",
+        "builder",
+        // PHP magic methods
+        "__construct",
+        "__destruct",
+        "__toString",
+        "__clone",
+        "get_instance",
+        "getInstance",
+        // Test lifecycle methods (PHPUnit / WP_UnitTestCase)
+        // These are optional overrides inherited from the base test class —
+        // not every test class needs to define them.
+        "set_up",
+        "tear_down",
+        "set_up_before_class",
+        "tear_down_after_class",
+        "setUp",
+        "tearDown",
+        "setUpBeforeClass",
+        "tearDownAfterClass",
+    ];
+    if trivial.contains(&name) {
+        return true;
+    }
+    // Prefix-based rules: simple getters/accessors/predicates
+    if name.starts_with("get_") || name.starts_with("is_") || name.starts_with("has_") {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_trivial_method_recognizes_collection_idioms() {
+        // The triggering case: standard collection-wrapper boilerplate.
+        // Every Vec/HashMap/String wrapper in the ecosystem looks the same
+        // for these names, and Clippy's `len_without_is_empty` lint requires
+        // them paired.
+        assert!(is_trivial_method("len"));
+        assert!(is_trivial_method("is_empty"));
+        assert!(is_trivial_method("iter"));
+    }
+
+    #[test]
+    fn is_trivial_method_recognizes_prefix_rules() {
+        // Simple getters / predicates / capability checks.
+        assert!(is_trivial_method("get_foo"));
+        assert!(is_trivial_method("is_bar"));
+        assert!(is_trivial_method("has_baz"));
+    }
+
+    #[test]
+    fn is_trivial_method_rejects_real_methods() {
+        // Domain methods with substantive bodies should not be considered
+        // trivial — they carry real logic that's worth testing and worth
+        // flagging if duplicated.
+        assert!(!is_trivial_method("compute_fixability"));
+        assert!(!is_trivial_method("from_snapshot"));
+    }
+
+    #[test]
+    fn is_trivial_method_recognizes_stdlib_trait_methods() {
+        // Core trait methods on the curated list.
+        assert!(is_trivial_method("new"));
+        assert!(is_trivial_method("default"));
+        assert!(is_trivial_method("from"));
+        assert!(is_trivial_method("into"));
+        assert!(is_trivial_method("clone"));
+        assert!(is_trivial_method("fmt"));
+    }
+
+    #[test]
+    fn is_trivial_method_recognizes_php_magic_methods() {
+        assert!(is_trivial_method("__construct"));
+        assert!(is_trivial_method("__toString"));
+        assert!(is_trivial_method("getInstance"));
+    }
+}

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -29,6 +29,7 @@ mod duplication;
 mod field_patterns;
 mod findings;
 pub mod fingerprint;
+mod idiomatic;
 pub(crate) mod impact;
 pub(crate) mod import_matching;
 mod layer_ownership;

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -19,6 +19,7 @@ use regex::Regex;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
+use super::idiomatic::is_trivial_method;
 use super::test_mapping::{
     build_source_name_index, partition_fingerprints, source_to_test_path, test_to_source_path,
 };
@@ -416,66 +417,6 @@ fn is_critical(path: &str, config: &TestMappingConfig) -> bool {
         .critical_patterns
         .iter()
         .any(|pattern| path.contains(pattern))
-}
-
-/// Trivial methods that don't warrant individual test coverage findings.
-fn is_trivial_method(name: &str) -> bool {
-    let trivial = [
-        // Rust core trait methods
-        "new",
-        "default",
-        "from",
-        "into",
-        "clone",
-        "fmt",
-        "display",
-        "eq",
-        "hash",
-        "drop",
-        // Rust common conversions
-        "as_str",
-        "as_ref",
-        "as_mut",
-        "to_string",
-        "to_str",
-        "to_owned",
-        // Rust common accessors
-        "is_empty",
-        "len",
-        "iter",
-        // Serde
-        "serialize",
-        "deserialize",
-        // Builder pattern
-        "build",
-        "builder",
-        // PHP magic methods
-        "__construct",
-        "__destruct",
-        "__toString",
-        "__clone",
-        "get_instance",
-        "getInstance",
-        // Test lifecycle methods (PHPUnit / WP_UnitTestCase)
-        // These are optional overrides inherited from the base test class —
-        // not every test class needs to define them.
-        "set_up",
-        "tear_down",
-        "set_up_before_class",
-        "tear_down_after_class",
-        "setUp",
-        "tearDown",
-        "setUpBeforeClass",
-        "tearDownAfterClass",
-    ];
-    if trivial.contains(&name) {
-        return true;
-    }
-    // Prefix-based rules: simple getters/accessors/predicates
-    if name.starts_with("get_") || name.starts_with("is_") || name.starts_with("has_") {
-        return true;
-    }
-    false
 }
 
 /// Check if a method should be flagged based on its visibility.


### PR DESCRIPTION
## Summary

- Fix `count_body_lines` off-by-one so it counts lines strictly between the braces (not the inclusive span), making one-statement delegation methods correctly measure as 0–1 body lines and trip the `< MIN_BODY_LINES` filter.
- Lift `is_trivial_method` from `test_coverage.rs` to a new shared `idiomatic.rs` module so `detect_near_duplicates` can short-circuit on the same curated list of universally-idiomatic method names (`len`, `is_empty`, `iter`, `new`, `default`, `from`, `into`, `clone`, `fmt`, …).
- Together these eliminate the false-positive `near_duplicate` findings on standard collection-wrapper boilerplate that prompted #1517 (observed on PR #1515).

## Root cause

Closes #1517.

`src/core/code_audit/duplication.rs::count_body_lines()` measured the full line span from the `fn <name>` line through the matching closing brace, **inclusive of both braces**. The standard three-line shape

```rust
pub fn len(&self) -> usize {     // line 1 — counted
    self.inner.len()             // line 2 — counted
}                                // line 3 — counted
```

returned **3**, so it slipped past the `< MIN_BODY_LINES` filter (`MIN_BODY_LINES = 3`). The docblock above `MIN_BODY_LINES` calls out the intent — *skip trivial 1–2 line bodies* — and that intent was being broken by the off-by-twoed measurement, not the constant.

A second contributing factor: `test_coverage.rs::is_trivial_method` already curates a list of names that are universally idiomatic-shape across unrelated types (`len`, `is_empty`, `iter`, `new`, `default`, `fmt`, etc.) — but `detect_near_duplicates` didn't consult it. Both detectors care about the same predicate from different angles ("don't expect a dedicated test for this name" vs "don't flag duplication on this name"), so the predicate belongs in a shared module.

## Changes

- **`src/core/code_audit/duplication.rs::count_body_lines`** — track the line index of the line containing the opening `{` and return `close_line.saturating_sub(open_line).saturating_sub(1)`. Returns 0 for single-line bodies (`fn x() -> u32 { 0 }`), 1 for the standard three-line shape, ~N for genuine N-statement bodies. Updated docblock spells out the new semantics and links #1517.
- **`src/core/code_audit/idiomatic.rs`** (new) — house for `is_trivial_method`, lifted verbatim from `test_coverage.rs`. Module docblock spells out *why* the predicate is shared and *which* detectors consume it.
- **`src/core/code_audit/mod.rs`** — register the new module.
- **`src/core/code_audit/test_coverage.rs`** — remove the local `is_trivial_method` definition; import from `super::idiomatic`. No call-site changes (no shim left behind, per house style).
- **`src/core/code_audit/duplication.rs::detect_near_duplicates`** — short-circuit on `is_trivial_method(method_name)` before the finding emit, with an inline comment explaining the false-positive class. Updated function-level docblock listing.
- One pre-existing test (`near_duplicate_detected_when_structural_match_but_exact_differs`) used a 2-body-line fixture that became correctly-trivial after the count fix; rewritten to a 3-body-line shape so it still tests what it advertises.

## Tests

New, all passing:

- `count_body_lines_zero_for_single_line_body` — `fn x() -> u32 { 0 }` returns 0.
- `count_body_lines_one_for_three_line_shape` — standard formatter shape returns 1.
- `count_body_lines_counts_actual_body_statements` — multi-line body returns body-statement count.
- `near_duplicate_skips_idiomatic_collection_methods` — fixture mirroring the #1517 reproduction case (two structs each defining `len` + `is_empty` as `self.inner.X()` delegation) produces 0 findings.
- `near_duplicate_still_flags_real_duplicates` — regression guard: a non-trivially-named method (`compute_fixability`) with identical structural hash but different body hashes across two files still produces findings.
- `is_trivial_method_recognizes_collection_idioms` / `_prefix_rules` / `_rejects_real_methods` / `_recognizes_stdlib_trait_methods` / `_recognizes_php_magic_methods` — coverage of the lifted predicate from its new home.

Pre-existing `test_coverage` tests for trivial-method behavior continue to pass without modification (the function moved, the call site didn't).

```
cargo test --lib -- --test-threads=1
test result: ok. 1414 passed; 0 failed; 1 ignored; 0 measured
```

## Verification

`homeboy audit homeboy --json-summary` on this branch vs `origin/main`:

| metric                               | main | branch | delta |
|--------------------------------------|-----:|-------:|------:|
| `near_duplicate` findings            |   16 |      8 |    -8 |
| `intra_method_duplicate` findings    |   58 |     55 |    -3 |
| total findings                       |  325 |    315 |   -10 |

The 8 `near_duplicate` reductions include the four flagged in #1517 (`CodebaseSnapshot::len`/`is_empty`, `FingerprintIndex::len`/`is_empty`) plus their structural twins in `engine/undo/rollback.rs`. The `intra_method_duplicate` drop is a side-effect of `count_body_lines` no longer over-counting trivial bodies inside the same method's siblings.

## Unblocks

- PR #1515 — slice 1 of #1492. The four CI-flagged false positives clear once this merges. PR #1515 itself is untouched by this change.
- #1492 bench parity gate — heuristic detectors that fire on idiomatic code defeat parity assertions; this is a structural fix, not a baseline refresh.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted the `count_body_lines` fix and the `is_trivial_method` lift; Chris caught the false positives on PR #1515 and pushed back on baseline-refresh muscle memory ("look at the audit mechanism that surfaced the false positives") — that reframe drove #1517 and this fix.