### PR TITLE
fix(audit): missing_test_method recognizes descriptive test names (#1518)

### DIFF
--- a/src/core/code_audit/idiomatic.rs
+++ b/src/core/code_audit/idiomatic.rs
@@ -1,11 +1,15 @@
-//! Shared predicates for "this method name is idiomatic-shape across types."
+//! Shared predicates for recognizing idiomatic Rust / PHP shape — names that
+//! are expected to have boilerplate bodies and test names that describe
+//! behavior rather than literally repeat the production method name.
+//!
+//! Two distinct concerns live here, both about "don't punish idiomatic code":
+//!
+//! ## `is_trivial_method` — universally idiomatic method names
 //!
 //! Some method names — `len`, `is_empty`, `iter`, `new`, `default`, `from`,
 //! `into`, `clone`, `fmt`, `as_str`, `to_string`, etc. — are **expected** to
 //! have boilerplate-shaped bodies across unrelated types. That's the language
 //! and stdlib doing what they're designed to do, not a code-smell.
-//!
-//! Two audit detectors care about this from different angles:
 //!
 //! - **test_coverage**: don't expect a dedicated test for a method whose name
 //!   is universally idiomatic. `len`/`is_empty`/`fmt` get tested transitively.
@@ -15,7 +19,19 @@
 //!   `len_without_is_empty` lint actually *requires* you to add `is_empty`
 //!   alongside it. Treating these as duplication findings is a false positive.
 //!
-//! Lifted from `test_coverage.rs` so both detectors consult the same predicate.
+//! ## `test_covers_method` — behavior-describing test names
+//!
+//! Behavior-describing test names — the dominant Rust idiom in serde, tokio,
+//! rayon, clippy, and homeboy itself — name the function under test inside
+//! a longer descriptive name (`fingerprint_content_matches_fingerprint_file`
+//! tests `fingerprint_content`). Strict literal-prefix matching
+//! (`test_<methodname>`) misses these. The token-bounded substring predicate
+//! recognizes them as coverage without false-matching `getrandom_works` to
+//! `get`.
+//!
+//! - **test_coverage**: used by `MissingTestMethod` to detect that a source
+//!   method is exercised by a behavior-describing test, even when the test
+//!   name doesn't literally start with `test_<methodname>`.
 
 /// Method names that are universally idiomatic-shape across types.
 ///
@@ -82,6 +98,69 @@ pub(super) fn is_trivial_method(name: &str) -> bool {
     false
 }
 
+/// Check if `test_name` covers `source_method` under the configured prefix.
+///
+/// Coverage is established when EITHER:
+/// 1. The test name matches the literal `{prefix}{source_method}` shape
+///    (the existing strict path — preserves PHPUnit-style conventions
+///    where every test is `test_<methodname>`), OR
+/// 2. The source method name appears as a snake_case-token-bounded
+///    substring within the test name. This handles behavior-describing
+///    test names — the dominant Rust idiom — like
+///    `fingerprint_content_matches_fingerprint_file` covering
+///    `fingerprint_content`.
+///
+/// Token boundary for snake_case identifiers: `_` is a separator, not part
+/// of a word. So a match is token-bounded when the byte before the match
+/// is start-of-string, `_`, or any non-alphanumeric byte; and the byte
+/// after the match is end-of-string, `_`, or any non-alphanumeric byte.
+/// This accepts `foo_handles_empty` covering `foo` (separator on the
+/// right) and rejects `getrandom_works` covering `get` (alphanumeric `r`
+/// on the right) or `foobar_test` covering `foo` (alphanumeric `b` on the
+/// right).
+///
+/// Used only by MissingTestMethod / coverage-presence checks. Orphaned-test
+/// detection (`find_orphaned_test_methods`) intentionally keeps the strict
+/// prefix match — it needs to know which test was supposed to map to which
+/// source method by name.
+pub(super) fn test_covers_method(test_name: &str, source_method: &str, prefix: &str) -> bool {
+    // Literal-prefix path
+    if let Some(stripped) = test_name.strip_prefix(prefix) {
+        if stripped == source_method {
+            return true;
+        }
+    }
+
+    // Token-bounded substring path
+    if source_method.is_empty() {
+        return false;
+    }
+    let bytes = test_name.as_bytes();
+    let needle = source_method.as_bytes();
+    let needle_len = needle.len();
+    if bytes.len() < needle_len {
+        return false;
+    }
+    let mut i = 0;
+    while i + needle_len <= bytes.len() {
+        if &bytes[i..i + needle_len] == needle {
+            let before_ok = i == 0 || !is_word_byte(bytes[i - 1]);
+            let after_ok = i + needle_len == bytes.len() || !is_word_byte(bytes[i + needle_len]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+/// True if `b` is part of a snake_case word (alphanumeric only). `_` is a
+/// separator, not part of a word, so it counts as a token boundary.
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +209,53 @@ mod tests {
         assert!(is_trivial_method("__construct"));
         assert!(is_trivial_method("__toString"));
         assert!(is_trivial_method("getInstance"));
+    }
+
+    // ========================================================================
+    // test_covers_method — substring matching for descriptive test names (#1518)
+    // ========================================================================
+
+    #[test]
+    fn test_covers_method_strict_prefix_match() {
+        // Existing literal-prefix path: `test_foo` covers `foo`.
+        assert!(test_covers_method("test_foo", "foo", "test_"));
+    }
+
+    #[test]
+    fn test_covers_method_descriptive_match() {
+        // Behavior-describing test name: `foo_handles_empty` covers `foo`.
+        // The source method appears at the start, followed by `_`.
+        assert!(test_covers_method("foo_handles_empty", "foo", "test_"));
+    }
+
+    #[test]
+    fn test_covers_method_descriptive_match_at_end() {
+        // Source method appears at the end of the test name.
+        assert!(test_covers_method("handles_empty_foo", "foo", "test_"));
+    }
+
+    #[test]
+    fn test_covers_method_descriptive_match_in_middle() {
+        // Source method appears in the middle, surrounded by underscores.
+        assert!(test_covers_method("handles_foo_empty", "foo", "test_"));
+    }
+
+    #[test]
+    fn test_covers_method_rejects_substring_inside_identifier() {
+        // Token-bounded substring: `getrandom_works` does NOT cover `get`
+        // because `get` is followed by `r` (an identifier byte).
+        assert!(!test_covers_method("getrandom_works", "get", "test_"));
+        // Same idea trailing: `foobar_test` does NOT cover `foo` because
+        // `foo` is followed by `b` (an identifier byte).
+        assert!(!test_covers_method("foobar_test", "foo", "test_"));
+        // Leading: `myfoo_test` does NOT cover `foo` because `foo` is
+        // preceded by `y` (an identifier byte).
+        assert!(!test_covers_method("myfoo_test", "foo", "test_"));
+    }
+
+    #[test]
+    fn test_covers_method_rejects_unrelated_test() {
+        // Test name doesn't contain the source method at all.
+        assert!(!test_covers_method("unrelated_test", "foo", "test_"));
     }
 }

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -19,7 +19,7 @@ use regex::Regex;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
-use super::idiomatic::is_trivial_method;
+use super::idiomatic::{is_trivial_method, test_covers_method};
 use super::test_mapping::{
     build_source_name_index, partition_fingerprints, source_to_test_path, test_to_source_path,
 };
@@ -106,17 +106,6 @@ pub(crate) fn analyze_test_coverage(
                 continue; // No tests at all — skip method-level checks
             }
 
-            // Check method coverage: combine inline test methods + dedicated test file methods
-            let mut covered_methods: HashSet<&str> = HashSet::new();
-
-            // Inline test methods — authored with `#[test]`, tracked separately
-            // from production methods so prefix-string ambiguity can't leak.
-            for method in &source_fp.test_methods {
-                if let Some(source_method) = method.strip_prefix(&config.method_prefix) {
-                    covered_methods.insert(source_method);
-                }
-            }
-
             // Methods from dedicated test file — for Rust, these are also
             // structural (top-level `#[test]` functions in `tests/`). For
             // extension-fingerprinted languages the core list is empty so we
@@ -132,17 +121,28 @@ pub(crate) fn analyze_test_coverage(
             } else {
                 Vec::new()
             };
-            for method in dedicated_test_methods {
-                if let Some(source_method) = method.strip_prefix(&config.method_prefix) {
-                    covered_methods.insert(source_method);
-                }
-            }
 
             // Build set of source method names for orphaned test detection.
             // Test methods already live in `source_fp.test_methods` — `.methods`
             // contains only non-test functions, so no prefix filter needed.
             let source_methods: HashSet<&str> =
                 source_fp.methods.iter().map(|m| m.as_str()).collect();
+
+            // Check method coverage: combine inline test methods + dedicated
+            // test file methods, accepting either literal-prefix matches or
+            // token-bounded substring matches (see `test_covers_method`).
+            let mut covered_methods: HashSet<&str> = HashSet::new();
+            for source_method in &source_methods {
+                let covered = source_fp
+                    .test_methods
+                    .iter()
+                    .map(|s| s.as_str())
+                    .chain(dedicated_test_methods.iter().copied())
+                    .any(|test| test_covers_method(test, source_method, &config.method_prefix));
+                if covered {
+                    covered_methods.insert(*source_method);
+                }
+            }
 
             // Find source methods without tests (Check 2: MissingTestMethod)
             for method in &source_methods {
@@ -232,10 +232,17 @@ pub(crate) fn analyze_test_coverage(
                 source_fp.methods.iter().map(|m| m.as_str()).collect();
 
             if !test_methods.is_empty() {
-                let covered_methods: HashSet<&str> = test_methods
-                    .iter()
-                    .filter_map(|m| m.strip_prefix(&config.method_prefix))
-                    .collect();
+                // Coverage accepts either literal-prefix matches or
+                // token-bounded substring matches (see `test_covers_method`).
+                let mut covered_methods: HashSet<&str> = HashSet::new();
+                for source_method in source_fp.methods.iter().map(|m| m.as_str()) {
+                    let covered = test_methods.iter().any(|test| {
+                        test_covers_method(test, source_method, &config.method_prefix)
+                    });
+                    if covered {
+                        covered_methods.insert(source_method);
+                    }
+                }
 
                 let test_file_label = test_fp
                     .map(|fp| fp.relative_path.clone())
@@ -1340,6 +1347,111 @@ mod tests {
                 .map(|f| &f.description)
                 .collect::<Vec<_>>()
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ========================================================================
+    // MissingTestMethod integration with substring matching (#1518)
+    //
+    // Unit tests for the `test_covers_method` predicate itself live in
+    // `super::idiomatic::tests`. These exercise the full
+    // `analyze_test_coverage` pipeline.
+    // ========================================================================
+
+    #[test]
+    fn missing_test_method_skipped_for_descriptive_test() {
+        // Regression for #1518: a behavior-describing test name should be
+        // recognized as coverage for the source method it references.
+        let config = make_rust_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_descriptive_inline");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/core")).unwrap();
+
+        // Source method: fingerprint_content. Inline test:
+        // fingerprint_content_matches_fingerprint_file (no `test_` prefix
+        // because it's a behavior-describing name, but #[test]-attributed
+        // upstream so it lives in `test_methods`).
+        let source = make_fp_split(
+            "src/core/fingerprint.rs",
+            vec!["fingerprint_content"],
+            vec!["fingerprint_content_matches_fingerprint_file"],
+        );
+
+        let findings = analyze_test_coverage(&dir, &[&source], &config);
+
+        let missing: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::MissingTestMethod)
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "Descriptive test name should be recognized as coverage. \
+             Findings: {:?}",
+            missing.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_test_method_still_emits_for_uncovered_method() {
+        // Regression guard: substring matching must not turn into a free pass.
+        // A source method with no test (literal or descriptive) still emits.
+        let config = make_rust_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_still_emits");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/core")).unwrap();
+
+        let source = make_fp_split(
+            "src/core/something.rs",
+            vec!["something_uncovered"],
+            vec!["totally_unrelated_test", "another_unrelated_one"],
+        );
+
+        let findings = analyze_test_coverage(&dir, &[&source], &config);
+
+        let missing: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::MissingTestMethod)
+            .collect();
+        assert_eq!(
+            missing.len(),
+            1,
+            "Uncovered source method must still emit. Findings: {:?}",
+            missing.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+        assert!(missing[0].description.contains("something_uncovered"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn orphaned_test_unaffected_by_substring_relaxation() {
+        // Orphaned-test detection still uses the strict prefix path. A
+        // `test_foo` with no `foo` source method emits an orphan finding,
+        // unaffected by the new substring relaxation in coverage detection.
+        let config = make_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_orphan_strict");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::create_dir_all(dir.join("tests")).unwrap();
+
+        // Source has `bar`. Test file has `test_foo` (orphan, foo doesn't
+        // exist) and `test_bar` (valid).
+        let source = make_fp("src/mod.rs", vec!["bar"]);
+        let test = make_fp("tests/mod_test.rs", vec!["test_foo", "test_bar"]);
+
+        let findings = analyze_test_coverage(&dir, &[&source, &test], &config);
+
+        let orphaned: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| {
+                f.kind == AuditFinding::OrphanedTest && f.description.contains("no longer exists")
+            })
+            .collect();
+        assert_eq!(orphaned.len(), 1);
+        assert!(orphaned[0].description.contains("test_foo"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary

Fixes #1518. The `MissingTestMethod` detector treated behavior-describing test names — the dominant Rust idiom — as missing coverage. This PR adds token-bounded substring matching alongside the existing literal-prefix path so descriptive tests count.

Rebased on top of #1521; the new predicate lives in the shared `idiomatic.rs` module that #1521 introduced, alongside `is_trivial_method`.

## Root cause

`src/core/code_audit/test_coverage.rs` (lines 113–138 pre-fix) built coverage by `strip_prefix(&config.method_prefix)`-ing every test method name and only inserting the result. A test named `fingerprint_content_matches_fingerprint_file` does not strip `test_`, so `fingerprint_content` was never inserted into `covered_methods` and showed up as missing — even though the test directly exercises it.

## Changes

### `src/core/code_audit/idiomatic.rs`

Module already housed `is_trivial_method` (from #1521) as a shared cross-detector predicate. Adds two new helpers and broadens the module-doc to reflect both concerns ("don't punish idiomatic code" → idiomatic *method names* and idiomatic *test names*):

- `pub(super) fn test_covers_method(test_name, source_method, prefix) -> bool` — coverage predicate. Returns true when EITHER the test equals `{prefix}{source_method}` (existing strict path) OR `source_method` appears as a token-bounded substring inside the test name (new fallback).
- `fn is_word_byte(b: u8) -> bool` — alphanumeric-only word-byte check. `_` is treated as a snake_case separator, not part of a word, so the boundary check accepts `foo_handles_empty` as covering `foo` while rejecting `getrandom_works` as covering `get`.

### `src/core/code_audit/test_coverage.rs`

- Imports `test_covers_method` from `idiomatic` (joins the existing `is_trivial_method` import).
- Coverage construction in **Check 2** (the post-strip-prefix block) now iterates source methods × test names and uses the predicate.
- Coverage construction in **Check 3** (source-file inline tests) — same refactor.

## What stays strict

`find_orphaned_test_methods` and `collect_test_methods_from_fp` (line 513) still use the literal `strip_prefix(&config.method_prefix)` path. Orphaned-test detection legitimately needs the strict prefix to know which test was supposed to map to which source method by name. The substring relaxation applies only to coverage-presence checks (`MissingTestMethod`).

## Tests

9 new tests, split between unit + integration:

**Unit (`idiomatic.rs::tests`)** — exercise the predicate directly:
1. `test_covers_method_strict_prefix_match` — `test_foo` covers `foo`.
2. `test_covers_method_descriptive_match` — `foo_handles_empty` covers `foo`.
3. `test_covers_method_descriptive_match_at_end` — `handles_empty_foo` covers `foo`.
4. `test_covers_method_descriptive_match_in_middle` — `handles_foo_empty` covers `foo`.
5. `test_covers_method_rejects_substring_inside_identifier` — `getrandom_works` does NOT cover `get`; `foobar_test` does NOT cover `foo`; `myfoo_test` does NOT cover `foo`.
6. `test_covers_method_rejects_unrelated_test` — `unrelated_test` does NOT cover `foo`.

**Integration (`test_coverage.rs::tests`)** — exercise the full `analyze_test_coverage` pipeline:

7. `missing_test_method_skipped_for_descriptive_test` — fingerprint with source method `fingerprint_content` and test `fingerprint_content_matches_fingerprint_file` produces 0 `MissingTestMethod` findings.
8. `missing_test_method_still_emits_for_uncovered_method` — regression guard: source method `something_uncovered` with only unrelated tests still emits a finding.
9. `orphaned_test_unaffected_by_substring_relaxation` — `test_foo` with no `foo` source method still emits an orphan finding (strict path preserved).

Full suite: `1423 passed; 0 failed; 1 ignored` (`cargo test --lib -- --test-threads=1`).

## Verification

`homeboy audit --changed-since=v0.93.0 --json-summary` on this worktree:

| | total | warnings | info |
|---|---|---|---|
| main (post-#1521) | 41 | 30 | 11 |
| branch | 37 | 26 | 11 |

4 false-positive `missing_test_method` findings drop. Methods like `from_extension`, `load`, and others that are exercised by descriptive test names no longer show as missing.

## Unblocks

PR #1515 — once rebased on this, the 4 `missing_test_method` false positives that failed CI will resolve.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted the substring-matching helper, the call-site refactors, the 9 new tests, and the move into the shared `idiomatic.rs` module after rebasing on #1521. Chris caught the false-positive on PR #1515 and pushed back on the baseline-refresh muscle memory — the right fix was in the detector, not the baseline.
