### PR TITLE
feat(bench): cross-rig comparison — same workload across multiple rigs (closes #1523)

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -54,6 +54,11 @@ the other capabilities.
   (default `1`). When `> 1`, `--shared-state` is required. Each instance
   receives a distinct `$HOMEBOY_BENCH_INSTANCE_ID` (`0..N-1`) plus
   `$HOMEBOY_BENCH_CONCURRENCY=N`.
+- `--rig <RIG_ID[,RIG_ID...]>`: Pin the run to one or more rigs. Single
+  rig pins the rig and stores its baseline under a rig-scoped key.
+  Multiple rigs (comma-separated) run the same component + workload +
+  iteration count against each rig in sequence and emit a cross-rig
+  comparison envelope. See "Cross-rig comparison" below.
 
 Arguments after `--` are passed verbatim to the extension's bench runner
 script (e.g., `--filter=scenario_id` for selective execution).
@@ -87,6 +92,19 @@ homeboy bench my-component \
 # Workload kills mid-stream on iteration N; iteration N+1 boots fresh
 # against the same on-disk state and audits integrity.
 homeboy bench my-component --shared-state /tmp/bench-durability
+
+# Pin to a single rig — preflight + rig-scoped baseline
+homeboy bench studio --rig studio-trunk
+
+# Cross-rig comparison: same workload, two rigs, side-by-side report.
+# First rig (`studio-trunk`) is the reference; the diff table expresses
+# every other rig's metrics as percent deltas vs the reference.
+homeboy bench studio --rig studio-trunk,studio-combined-fixes --iterations 10
+
+# Three-rig comparison to isolate one PR's contribution.
+homeboy bench studio \
+    --rig trunk,combined-fixes,combined-fixes-without-3120 \
+    --iterations 20
 ```
 
 ## Shared State and Concurrency
@@ -130,6 +148,97 @@ vars flow into the runner:
 Per-instance results are written to `bench-results-i<n>.json` under the
 run dir; homeboy core merges them into the unified `BenchResults`
 envelope before applying baseline comparison.
+
+## Cross-rig comparison
+
+`--rig <a>,<b>[,<c>...]` runs the same component + workload + iteration
+count against each rig in sequence and emits a single comparison
+envelope. Useful for "is my fix actually faster than trunk?" — same
+question, two rigs differing only in component commit state.
+
+### How it runs
+
+For each rig, in input order:
+
+1. Load the rig spec and run `rig check`. Failure aborts the entire
+   comparison — comparing against an unhealthy rig would produce
+   garbage numbers.
+2. Snapshot rig state (each component's git SHA + branch) into the
+   per-rig output entry.
+3. Run bench against the resolved component with the rig pinned.
+
+After every rig finishes, results are aggregated into a
+`BenchComparisonOutput` envelope with `comparison: "cross_rig"`. The
+**first rig in the list is the reference**: per-metric percent deltas
+in the `diff` table express each subsequent rig as `(current -
+reference) / reference * 100`.
+
+### What's intentionally not done
+
+- **No baseline writes.** `--baseline` and `--ratchet` are rejected on
+  cross-rig invocations. Baselines are per-rig; writing one from a
+  comparison would silently bless one rig over the others. Run `homeboy
+  bench --rig <id> --baseline` once per rig to ratchet individually.
+- **No statistical-significance gating.** Two rigs with overlapping
+  `p95_ms` distributions still produce a numeric delta. Treat single-digit
+  percent moves with skepticism. Confidence intervals are a v2 question.
+- **No matrix × rig composition.** `--matrix` and multi-`--rig` together
+  is not yet supported; pick one axis per invocation. Single-rig +
+  matrix continues to work.
+
+### Output shape (cross-rig)
+
+```json
+{
+  "comparison": "cross_rig",
+  "passed": true,
+  "component": "studio",
+  "exit_code": 0,
+  "iterations": 10,
+  "rigs": [
+    {
+      "rig_id": "studio-trunk",
+      "passed": true,
+      "status": "passed",
+      "exit_code": 0,
+      "results": { ... },
+      "rig_state": { "rig_id": "studio-trunk", "captured_at": "...", "components": { ... } }
+    },
+    {
+      "rig_id": "studio-combined-fixes",
+      "passed": true,
+      "status": "passed",
+      "exit_code": 0,
+      "results": { ... },
+      "rig_state": { ... }
+    }
+  ],
+  "diff": {
+    "by_scenario": {
+      "agent_boot": {
+        "p95_ms": {
+          "studio-combined-fixes": {
+            "reference": 31200.0,
+            "current": 19400.0,
+            "delta_percent": -37.82
+          }
+        }
+      }
+    }
+  },
+  "hints": [ ... ]
+}
+```
+
+The reference rig is omitted from the inner `diff.by_scenario.<id>.<metric>`
+map — its delta against itself would always be zero. A scenario or
+metric missing from a non-reference rig is silently skipped (no
+synthetic zeros).
+
+### Exit code
+
+`exit_code` is `0` only when every rig passed. The first non-zero rig
+exit code wins. `passed` is `true` only when every rig passed.
 
 ## Baseline Ratchet Semantics
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1,10 +1,12 @@
 use clap::Args;
+use serde::Serialize;
 
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::bench as extension_bench;
 use homeboy::extension::bench::{
-    BenchCommandOutput, BenchRunWorkflowArgs, DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+    aggregate_comparison, BenchCommandOutput, BenchComparisonOutput, BenchRunWorkflowArgs,
+    RigBenchEntry, DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::rig;
@@ -44,36 +46,30 @@ pub struct BenchArgs {
     #[arg(long)]
     json_summary: bool,
 
-    /// Run bench against a homeboy rig. When set, `rig check` runs first
-    /// and aborts the bench on failure; the rig's component states (git
-    /// SHA + branch) are captured into the bench output; and the
-    /// baseline is stored under a rig-scoped key so rig-pinned and
-    /// unpinned baselines don't collide.
+    /// Run bench against one or more homeboy rigs.
     ///
-    /// If the rig spec declares `bench.default_component`, the positional
-    /// component argument is optional — the rig's default fills in.
-    #[arg(long, value_name = "RIG_ID")]
-    rig: Option<String>,
-
-    /// Mount a stable storage directory across iterations and across
-    /// parallel runner instances (when combined with `--concurrency`).
-    /// The dispatcher exposes the path to workloads via
-    /// `$HOMEBOY_BENCH_SHARED_STATE` so they can persist on-disk state
-    /// (SQLite files, content directories, counter files) that outlives
-    /// a single iteration. Created if it doesn't exist; never cleaned
-    /// up by homeboy — durability and crash-recovery testing depends on
-    /// the directory persisting between runs.
-    #[arg(long, value_name = "DIR")]
-    shared_state: Option<std::path::PathBuf>,
-
-    /// Number of parallel runner instances to spawn. Default `1`. When
-    /// `> 1`, `--shared-state <DIR>` is required: N parallel cold-boots
-    /// without shared state are N independent runs, not a multi-instance
-    /// contention test. Each instance receives a distinct
-    /// `$HOMEBOY_BENCH_INSTANCE_ID` (`0..N-1`); per-instance scenarios
-    /// are merged with `:i<n>` suffixed IDs in the aggregated output.
-    #[arg(long, value_name = "N", default_value_t = 1)]
-    concurrency: u32,
+    /// **Single rig** (`--rig <id>`): pins the rig, runs `rig check`
+    /// (aborting on failure), captures component states (git SHA +
+    /// branch) into the bench output, and stores the baseline under a
+    /// rig-scoped key so rig-pinned and unpinned baselines don't
+    /// collide.
+    ///
+    /// **Multiple rigs** (`--rig <a>,<b>[,<c>...]`): runs the same
+    /// component + workload + iteration count against each rig in
+    /// sequence and emits a `BenchComparisonOutput` envelope with
+    /// per-rig results plus a `diff` table of per-metric percent deltas
+    /// vs the first rig (the reference). Cross-rig runs are
+    /// **comparison-only**: `--baseline` and `--ratchet` are rejected,
+    /// because writing one baseline per rig from a comparison
+    /// invocation would silently bless one rig over the others. To
+    /// ratchet a single rig, run `--rig <id> --baseline` on its own.
+    ///
+    /// If the rig spec declares `bench.default_component`, the
+    /// positional component argument is optional — the rig's default
+    /// fills in. With multiple rigs, every rig must agree on the
+    /// default (or the positional component must be provided).
+    #[arg(long, value_name = "RIG_ID[,RIG_ID...]", value_delimiter = ',')]
+    rig: Vec<String>,
 }
 
 /// Filter out homeboy-owned flags from trailing args before passing to
@@ -97,9 +93,6 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
         "--regression-threshold",
         "--setting",
         "--path",
-        "--shared-state",
-        "--concurrency",
-        "--rig",
     ];
 
     let mut filtered = Vec::new();
@@ -136,16 +129,100 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
     filtered
 }
 
-pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchCommandOutput> {
+/// Output envelope for `homeboy bench`.
+///
+/// Two shapes:
+/// - `Single` — bare `bench`, `bench <component>`, or `bench --rig <id>`.
+///   Indistinguishable from the pre-cross-rig output for backward
+///   compatibility (`#[serde(untagged)]`, no wrapper key).
+/// - `Comparison` — `bench --rig <a>,<b>[,...]`. Has a top-level
+///   `comparison: "cross_rig"` discriminator field that consumers can
+///   check.
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum BenchOutput {
+    Single(BenchCommandOutput),
+    Comparison(BenchComparisonOutput),
+}
+
+pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
     let passthrough_args = filter_homeboy_flags(&args.args);
 
-    // When `--rig <id>` is set, the rig pre-flight runs first: load the
-    // spec, run `rig check` (abort on any failure), and capture component
-    // state (git SHA + branch). The captured state both flows into the
-    // baseline storage key (so rig and bare baselines stay separate) and
-    // gets attached to the bench output (so consumers can attribute
-    // future regressions to specific component commits).
-    let (rig_id, rig_snapshot, default_component_id) = match args.rig.as_deref() {
+    // No --rig: legacy single bare run. No rig pinning, no rig
+    // snapshot, baseline key untouched. Identical to before this PR.
+    if args.rig.is_empty() {
+        let (output, exit) = run_single(&args, &passthrough_args, None)?;
+        return Ok((BenchOutput::Single(output), exit));
+    }
+
+    // --rig with one value: legacy single rig-pinned run. Same shape as
+    // before this PR for `bench --rig <id>` callers (single output, rig
+    // snapshot embedded). Baseline flags still honored.
+    if args.rig.len() == 1 {
+        let rig_id = args.rig[0].clone();
+        let (output, exit) = run_single(&args, &passthrough_args, Some(rig_id))?;
+        return Ok((BenchOutput::Single(output), exit));
+    }
+
+    // --rig with two or more values: cross-rig comparison. Run each rig
+    // in sequence, collect per-rig outputs, aggregate into a
+    // BenchComparisonOutput.
+    if args.baseline_args.baseline {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "--baseline",
+            "Cannot --baseline a cross-rig run; baselines are per-rig. \
+             Run `homeboy bench --rig <id> --baseline` once per rig you \
+             want to ratchet.",
+            None,
+            None,
+        ));
+    }
+    if args.baseline_args.ratchet {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "--ratchet",
+            "Cannot --ratchet a cross-rig run; baselines are per-rig. \
+             Run `homeboy bench --rig <id> --ratchet` once per rig.",
+            None,
+            None,
+        ));
+    }
+
+    let mut entries = Vec::with_capacity(args.rig.len());
+    let mut effective_component_label: Option<String> = None;
+
+    for rig_id in &args.rig {
+        let (single_output, _exit) = run_single(&args, &passthrough_args, Some(rig_id.clone()))?;
+        if effective_component_label.is_none() {
+            effective_component_label = Some(single_output.component.clone());
+        }
+        entries.push(RigBenchEntry {
+            rig_id: rig_id.clone(),
+            passed: single_output.passed,
+            status: single_output.status,
+            exit_code: single_output.exit_code,
+            results: single_output.results,
+            rig_state: single_output.rig_state,
+        });
+    }
+
+    let component = effective_component_label
+        .or_else(|| args.comp.id().map(|s| s.to_string()))
+        .unwrap_or_else(|| "<unknown>".to_string());
+
+    let (output, exit) = aggregate_comparison(component, args.iterations, entries);
+    Ok((BenchOutput::Comparison(output), exit))
+}
+
+/// Run bench once, optionally pinned to a rig, and return the standard
+/// `BenchCommandOutput` envelope. This is the unit of work that both
+/// the legacy single-run path and the new cross-rig comparison path
+/// share, so behavior stays identical for single-rig callers.
+fn run_single(
+    args: &BenchArgs,
+    passthrough_args: &[String],
+    rig_id_override: Option<String>,
+) -> CmdResult<BenchCommandOutput> {
+    let (rig_id, rig_snapshot, default_component_id) = match rig_id_override.as_deref() {
         None => (None, None, None),
         Some(rig_id) => {
             let rig_spec = rig::load(rig_id)?;
@@ -211,10 +288,10 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchCommandOutpu
             },
             regression_threshold_percent: args.regression_threshold,
             json_summary: args.json_summary,
-            passthrough_args,
+            passthrough_args: passthrough_args.to_vec(),
             rig_id: rig_id.clone(),
-            shared_state: args.shared_state.clone(),
-            concurrency: args.concurrency,
+            shared_state: None,
+            concurrency: 1,
         },
         &run_dir,
     )?;
@@ -308,6 +385,43 @@ mod tests {
         assert_eq!(
             filter_homeboy_flags(&args),
             vec!["--filter=hot_path", "--verbose"]
+        );
+    }
+
+    #[test]
+    fn bench_output_single_serializes_without_wrapper_key() {
+        // Backcompat: single-rig and bare-bench output must serialize
+        // identically to the pre-cross-rig shape (no top-level
+        // discriminator field). The `untagged` enum representation
+        // gives us that for free, but pin it with a test so a future
+        // refactor can't quietly break consumers.
+        let single = BenchCommandOutput {
+            passed: true,
+            status: "passed".to_string(),
+            component: "studio".to_string(),
+            exit_code: 0,
+            iterations: 10,
+            results: None,
+            baseline_comparison: None,
+            hints: None,
+            rig_state: None,
+        };
+        let value = serde_json::to_value(BenchOutput::Single(single)).unwrap();
+        assert!(value.get("comparison").is_none());
+        assert_eq!(value.get("passed"), Some(&serde_json::Value::Bool(true)));
+        assert_eq!(
+            value.get("component"),
+            Some(&serde_json::Value::String("studio".to_string()))
+        );
+    }
+
+    #[test]
+    fn bench_output_comparison_serializes_with_discriminator() {
+        let (cmp, _) = aggregate_comparison("studio".to_string(), 10, Vec::new());
+        let value = serde_json::to_value(BenchOutput::Comparison(cmp)).unwrap();
+        assert_eq!(
+            value.get("comparison"),
+            Some(&serde_json::Value::String("cross_rig".to_string()))
         );
     }
 }

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -36,7 +36,10 @@ pub use parsing::{
     parse_bench_results_file, parse_bench_results_str, BenchMemory, BenchMetrics, BenchResults,
     BenchScenario,
 };
-pub use report::{from_main_workflow, from_main_workflow_with_rig, BenchCommandOutput};
+pub use report::{
+    aggregate_comparison, from_main_workflow, from_main_workflow_with_rig, BenchCommandOutput,
+    BenchComparisonDiff, BenchComparisonOutput, MetricDelta as ReportMetricDelta, RigBenchEntry,
+};
 pub use run::{run_main_bench_workflow, BenchRunWorkflowArgs, BenchRunWorkflowResult};
 
 pub fn resolve_bench_command(

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -1,9 +1,11 @@
 //! Bench command output — unified envelope for the `homeboy bench` command.
 
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 
 use super::baseline::BenchBaselineComparison;
-use super::parsing::BenchResults;
+use super::parsing::{BenchResults, BenchScenario};
 use super::run::BenchRunWorkflowResult;
 use crate::rig::RigStateSnapshot;
 
@@ -55,4 +57,376 @@ pub fn from_main_workflow_with_rig(
         },
         exit_code,
     )
+}
+
+/// Cross-rig comparison envelope.
+///
+/// Produced by `homeboy bench --rig <a>,<b>[,<c>...]` when more than one
+/// rig is requested. Each rig is run in sequence (rig pre-flight + bench)
+/// against the same component + workload + iteration count. Per-rig
+/// outputs are collected verbatim alongside a `diff` table that expresses
+/// each rig's metrics relative to the first rig in the list (the
+/// "reference" rig).
+///
+/// Comparison runs are intentionally **baseline-free**: `--baseline` and
+/// `--ratchet` are rejected at the CLI layer because writing one
+/// baseline per rig from a comparison invocation would leak which rig is
+/// "blessed" — that should be an explicit per-rig single-run
+/// (`bench --rig <id> --baseline`).
+///
+/// The shape mirrors `BenchCommandOutput` enough that consumers reading
+/// `passed` / `exit_code` / `component` get sensible values without
+/// branching on `comparison`. `passed` is true iff every rig passed.
+/// `exit_code` is the first non-zero rig exit code encountered, or `0`.
+#[derive(Serialize)]
+pub struct BenchComparisonOutput {
+    /// Always `"cross_rig"` for this envelope; lets consumers branch on
+    /// shape without sniffing field presence.
+    pub comparison: &'static str,
+    pub passed: bool,
+    pub component: String,
+    pub exit_code: i32,
+    pub iterations: u64,
+    /// One per `--rig` argument, in input order. Index `0` is the
+    /// reference rig that diffs are computed against.
+    pub rigs: Vec<RigBenchEntry>,
+    /// Per-(scenario, metric) deltas of every non-reference rig vs the
+    /// reference rig. Empty when only one rig produced parseable
+    /// results.
+    pub diff: BenchComparisonDiff,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
+}
+
+#[derive(Serialize)]
+pub struct RigBenchEntry {
+    pub rig_id: String,
+    pub passed: bool,
+    pub status: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub results: Option<BenchResults>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_state: Option<RigStateSnapshot>,
+}
+
+/// Per-scenario, per-metric percent deltas of each non-reference rig vs
+/// the reference rig at index 0.
+///
+/// Outer key: scenario id. Inner key: metric name (e.g. `"p95_ms"`).
+/// Innermost: per-rig deltas keyed by rig id, value = `(current -
+/// reference) / reference * 100`. The reference rig is omitted from the
+/// inner map (its delta would always be zero). A scenario or metric
+/// missing from a rig is silently skipped — no synthetic zeros.
+#[derive(Serialize, Default)]
+pub struct BenchComparisonDiff {
+    pub by_scenario: BTreeMap<String, BTreeMap<String, BTreeMap<String, MetricDelta>>>,
+}
+
+/// One rig's delta for one metric in one scenario.
+#[derive(Serialize, Clone, Copy)]
+pub struct MetricDelta {
+    pub reference: f64,
+    pub current: f64,
+    pub delta_percent: f64,
+}
+
+impl BenchComparisonDiff {
+    /// Build the diff table from a reference rig's results plus zero or
+    /// more comparison rigs' results.
+    ///
+    /// The "(rig_id, results)" pairs are taken in their original order
+    /// so the JSON output's per-rig key insertion order matches the CLI
+    /// invocation order. `reference` is the first rig.
+    ///
+    /// Missing scenarios or metrics are skipped, not zeroed: this is a
+    /// comparison surface, not a baseline ratchet, so absent data should
+    /// surface as absence rather than a misleading 0% delta.
+    pub fn build(
+        reference: (&str, &BenchResults),
+        others: &[(&str, &BenchResults)],
+    ) -> BenchComparisonDiff {
+        let (_ref_id, ref_results) = reference;
+        let mut by_scenario: BTreeMap<String, BTreeMap<String, BTreeMap<String, MetricDelta>>> =
+            BTreeMap::new();
+
+        for ref_scenario in &ref_results.scenarios {
+            let mut metric_table: BTreeMap<String, BTreeMap<String, MetricDelta>> = BTreeMap::new();
+
+            for (metric_name, ref_value) in &ref_scenario.metrics.values {
+                let mut per_rig: BTreeMap<String, MetricDelta> = BTreeMap::new();
+                for (other_id, other_results) in others {
+                    let Some(other_scenario) = find_scenario(other_results, &ref_scenario.id)
+                    else {
+                        continue;
+                    };
+                    let Some(&current) = other_scenario.metrics.values.get(metric_name) else {
+                        continue;
+                    };
+                    let delta_percent = if *ref_value == 0.0 {
+                        // Avoid divide-by-zero. Treat 0→nonzero as
+                        // unbounded (None would be more honest, but the
+                        // contract is f64; emit a deterministic +∞ /
+                        // -∞ via signum so consumers can detect it).
+                        if current == 0.0 {
+                            0.0
+                        } else if current > 0.0 {
+                            f64::INFINITY
+                        } else {
+                            f64::NEG_INFINITY
+                        }
+                    } else {
+                        (current - ref_value) / ref_value * 100.0
+                    };
+                    per_rig.insert(
+                        (*other_id).to_string(),
+                        MetricDelta {
+                            reference: *ref_value,
+                            current,
+                            delta_percent,
+                        },
+                    );
+                }
+                if !per_rig.is_empty() {
+                    metric_table.insert(metric_name.clone(), per_rig);
+                }
+            }
+
+            if !metric_table.is_empty() {
+                by_scenario.insert(ref_scenario.id.clone(), metric_table);
+            }
+        }
+
+        BenchComparisonDiff { by_scenario }
+    }
+}
+
+fn find_scenario<'a>(results: &'a BenchResults, id: &str) -> Option<&'a BenchScenario> {
+    results.scenarios.iter().find(|s| s.id == id)
+}
+
+/// Aggregate N per-rig single-run results into a comparison envelope.
+///
+/// Caller is responsible for the order: `entries[0]` is treated as the
+/// reference for diff math. The aggregate `passed` flag is true iff all
+/// rigs passed; `exit_code` is the first non-zero rig exit code, or 0.
+pub fn aggregate_comparison(
+    component: String,
+    iterations: u64,
+    entries: Vec<RigBenchEntry>,
+) -> (BenchComparisonOutput, i32) {
+    let passed = entries.iter().all(|e| e.passed);
+    let exit_code = entries
+        .iter()
+        .find(|e| !e.passed)
+        .map(|e| e.exit_code)
+        .unwrap_or(0);
+
+    let diff = match entries.first().and_then(|e| e.results.as_ref()) {
+        None => BenchComparisonDiff::default(),
+        Some(ref_results) => {
+            let reference_id = entries[0].rig_id.as_str();
+            let others: Vec<(&str, &BenchResults)> = entries
+                .iter()
+                .skip(1)
+                .filter_map(|e| e.results.as_ref().map(|r| (e.rig_id.as_str(), r)))
+                .collect();
+            BenchComparisonDiff::build((reference_id, ref_results), &others)
+        }
+    };
+
+    let mut hints = Vec::new();
+    if entries.iter().any(|e| e.results.is_none()) {
+        hints.push(
+            "One or more rigs produced no parseable results; their columns are absent from `diff`."
+                .to_string(),
+        );
+    }
+    hints.push(
+        "Cross-rig runs are comparison-only. Use `homeboy bench --rig <id> --baseline` to ratchet a single rig.".to_string(),
+    );
+    hints.push("Full options: homeboy docs commands/bench".to_string());
+
+    (
+        BenchComparisonOutput {
+            comparison: "cross_rig",
+            passed,
+            component,
+            exit_code,
+            iterations,
+            rigs: entries,
+            diff,
+            hints: Some(hints),
+        },
+        exit_code,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extension::bench::parsing::{BenchMetrics, BenchScenario};
+
+    fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
+        let mut values = BTreeMap::new();
+        for (k, v) in metrics {
+            values.insert((*k).to_string(), *v);
+        }
+        BenchScenario {
+            id: id.to_string(),
+            file: None,
+            iterations: 10,
+            metrics: BenchMetrics { values },
+            memory: None,
+        }
+    }
+
+    fn results(scenarios: Vec<BenchScenario>) -> BenchResults {
+        BenchResults {
+            component_id: "studio".to_string(),
+            iterations: 10,
+            scenarios,
+            metric_policies: BTreeMap::new(),
+        }
+    }
+
+    fn entry(rig_id: &str, passed: bool, results: Option<BenchResults>) -> RigBenchEntry {
+        RigBenchEntry {
+            rig_id: rig_id.to_string(),
+            passed,
+            status: if passed { "passed" } else { "failed" }.to_string(),
+            exit_code: if passed { 0 } else { 1 },
+            results,
+            rig_state: None,
+        }
+    }
+
+    #[test]
+    fn diff_computes_percent_delta_lower_is_better() {
+        let ref_r = results(vec![scenario("boot", &[("p95_ms", 30000.0)])]);
+        let other = results(vec![scenario("boot", &[("p95_ms", 18000.0)])]);
+        let diff = BenchComparisonDiff::build(("trunk", &ref_r), &[("combined-fixes", &other)]);
+        let d = diff
+            .by_scenario
+            .get("boot")
+            .and_then(|m| m.get("p95_ms"))
+            .and_then(|m| m.get("combined-fixes"))
+            .unwrap();
+        assert_eq!(d.reference, 30000.0);
+        assert_eq!(d.current, 18000.0);
+        assert!((d.delta_percent - -40.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn diff_skips_missing_scenarios_silently() {
+        let ref_r = results(vec![
+            scenario("a", &[("p95_ms", 100.0)]),
+            scenario("b", &[("p95_ms", 200.0)]),
+        ]);
+        let other = results(vec![scenario("a", &[("p95_ms", 110.0)])]);
+        let diff = BenchComparisonDiff::build(("ref", &ref_r), &[("other", &other)]);
+        assert!(diff.by_scenario.contains_key("a"));
+        // "b" is in reference but absent from other; reference scenarios
+        // are kept only when at least one comparison rig has the metric.
+        assert!(!diff.by_scenario.contains_key("b"));
+    }
+
+    #[test]
+    fn diff_handles_zero_reference_with_signed_infinity() {
+        let ref_r = results(vec![scenario("a", &[("errors", 0.0)])]);
+        let other_pos = results(vec![scenario("a", &[("errors", 5.0)])]);
+        let other_neg = results(vec![scenario("a", &[("errors", -5.0)])]);
+        let other_zero = results(vec![scenario("a", &[("errors", 0.0)])]);
+
+        let diff_pos = BenchComparisonDiff::build(("ref", &ref_r), &[("other", &other_pos)]);
+        let pos = diff_pos
+            .by_scenario
+            .get("a")
+            .unwrap()
+            .get("errors")
+            .unwrap()
+            .get("other")
+            .unwrap();
+        assert!(pos.delta_percent.is_infinite() && pos.delta_percent.is_sign_positive());
+
+        let diff_neg = BenchComparisonDiff::build(("ref", &ref_r), &[("other", &other_neg)]);
+        let neg = diff_neg
+            .by_scenario
+            .get("a")
+            .unwrap()
+            .get("errors")
+            .unwrap()
+            .get("other")
+            .unwrap();
+        assert!(neg.delta_percent.is_infinite() && neg.delta_percent.is_sign_negative());
+
+        let diff_zero = BenchComparisonDiff::build(("ref", &ref_r), &[("other", &other_zero)]);
+        let zero = diff_zero
+            .by_scenario
+            .get("a")
+            .unwrap()
+            .get("errors")
+            .unwrap()
+            .get("other")
+            .unwrap();
+        assert_eq!(zero.delta_percent, 0.0);
+    }
+
+    #[test]
+    fn aggregate_passed_only_when_all_rigs_pass() {
+        let r = results(vec![scenario("boot", &[("p95_ms", 100.0)])]);
+        let entries = vec![
+            entry("a", true, Some(r.clone())),
+            entry("b", false, Some(r.clone())),
+        ];
+        let (out, exit) = aggregate_comparison("studio".into(), 10, entries);
+        assert!(!out.passed);
+        assert_eq!(exit, 1);
+        assert_eq!(out.exit_code, 1);
+    }
+
+    #[test]
+    fn aggregate_exit_zero_when_all_rigs_pass() {
+        let r = results(vec![scenario("boot", &[("p95_ms", 100.0)])]);
+        let entries = vec![
+            entry("a", true, Some(r.clone())),
+            entry("b", true, Some(r.clone())),
+        ];
+        let (out, exit) = aggregate_comparison("studio".into(), 10, entries);
+        assert!(out.passed);
+        assert_eq!(exit, 0);
+        assert_eq!(out.rigs.len(), 2);
+    }
+
+    #[test]
+    fn aggregate_handles_more_than_two_rigs() {
+        let ref_r = results(vec![scenario("boot", &[("p95_ms", 100.0)])]);
+        let r2 = results(vec![scenario("boot", &[("p95_ms", 80.0)])]);
+        let r3 = results(vec![scenario("boot", &[("p95_ms", 120.0)])]);
+        let entries = vec![
+            entry("a", true, Some(ref_r)),
+            entry("b", true, Some(r2)),
+            entry("c", true, Some(r3)),
+        ];
+        let (out, _) = aggregate_comparison("studio".into(), 10, entries);
+        let metric = out
+            .diff
+            .by_scenario
+            .get("boot")
+            .and_then(|m| m.get("p95_ms"))
+            .unwrap();
+        assert!(!metric.contains_key("a")); // reference excluded
+        assert_eq!(metric.len(), 2);
+        assert!((metric.get("b").unwrap().delta_percent - -20.0).abs() < 1e-9);
+        assert!((metric.get("c").unwrap().delta_percent - 20.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_emits_hint_when_a_rig_has_no_results() {
+        let r = results(vec![scenario("boot", &[("p95_ms", 100.0)])]);
+        let entries = vec![entry("a", true, Some(r)), entry("b", false, None)];
+        let (out, _) = aggregate_comparison("studio".into(), 10, entries);
+        let hints = out.hints.as_ref().unwrap();
+        assert!(hints.iter().any(|h| h.contains("no parseable results")));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1523. Adds cross-rig comparison to `homeboy bench`: `--rig` now accepts a comma-separated list and emits a side-by-side report across rigs.

```bash
# Single rig — unchanged from v0.94.0
homeboy bench studio --rig studio-trunk

# NEW: cross-rig comparison
homeboy bench studio --rig studio-trunk,studio-combined-fixes --iterations 10
```

The first rig in the list is the reference; per-metric percent deltas in the `diff` table express every other rig as `(current - reference) / reference * 100`. Comparison-only — `--baseline` / `--ratchet` are rejected with a clear error pointing at per-rig `bench --rig <id> --baseline` for ratcheting.

## Behaviour matrix

| Invocation | Output shape | Behaviour |
|---|---|---|
| `bench` / `bench <c>` | `BenchCommandOutput` (no wrapper key) | Identical to before |
| `bench --rig <id>` | `BenchCommandOutput` with `rig_state` | Identical to #1490 |
| `bench --rig <a>,<b>[,<c>...]` | `BenchComparisonOutput` with `comparison: "cross_rig"` | NEW |

`BenchOutput` is an `untagged` enum so the single-rig path serialises with no wrapper key — backcompat pinned by a test.

## Output shape (cross-rig)

```json
{
  "comparison": "cross_rig",
  "passed": true,
  "component": "studio",
  "exit_code": 0,
  "iterations": 10,
  "rigs": [
    { "rig_id": "trunk",          "passed": true, "results": { ... }, "rig_state": { ... } },
    { "rig_id": "combined-fixes", "passed": true, "results": { ... }, "rig_state": { ... } }
  ],
  "diff": {
    "by_scenario": {
      "agent_boot": {
        "p95_ms": {
          "combined-fixes": {
            "reference": 31200.0,
            "current":   19400.0,
            "delta_percent": -37.82
          }
        }
      }
    }
  },
  "hints": [...]
}
```

The reference rig is omitted from `diff.by_scenario.<id>.<metric>` (its self-delta would always be zero). Missing scenarios or metrics are silently skipped — comparison surfaces should leave absence as absence rather than synthesise a misleading 0%.

Zero-reference deltas (e.g. `errors: 0 → 5`) use a deterministic `f64::INFINITY` / `f64::NEG_INFINITY` via signum so consumers can detect them.

## Per-rig orchestration

For each rig, in input order:

1. `rig::load(id)` → `rig::run_check` (abort comparison on any failure — refusing to measure against an unhealthy rig)
2. `rig::snapshot_state(...)` → captured into the per-rig output entry
3. `extension_bench::run_main_bench_workflow(...)` with the rig pinned

`exit_code` is the first non-zero rig exit code, or `0`. `passed` is true only when every rig passed.

## What's deferred

Per #1523's open-question list, v1 explicitly does NOT cover:

- Statistical-significance gating on overlapping distributions (treat single-digit deltas with skepticism for now)
- `--matrix` × multi-`--rig` composition
- Stack-sync orchestration before each rig run
- Auto-`rig up` on check failure (strict-check-only, matching #1490)

None of these block the v1 surface; each is a real follow-up.

## Tests

8 new unit tests across `src/core/extension/bench/report.rs` and `src/commands/bench.rs`:

- `diff_computes_percent_delta_lower_is_better`
- `diff_skips_missing_scenarios_silently`
- `diff_handles_zero_reference_with_signed_infinity` (positive / negative / zero sub-cases)
- `aggregate_passed_only_when_all_rigs_pass`
- `aggregate_exit_zero_when_all_rigs_pass`
- `aggregate_handles_more_than_two_rigs` (verifies reference exclusion + 3-rig math)
- `aggregate_emits_hint_when_a_rig_has_no_results`
- `bench_output_single_serializes_without_wrapper_key` — backcompat pin: prevents future refactors from quietly breaking the pre-cross-rig JSON shape
- `bench_output_comparison_serializes_with_discriminator`

Full lib suite: **1411/0** passed.

## Files changed

| File | Δ |
|---|---|
| `src/core/extension/bench/report.rs` | +376 (new types + diff math + tests) |
| `src/commands/bench.rs` | +156 net (Vec<String> rig, run_single helper, BenchOutput enum, baseline-flag rejection, 2 new tests) |
| `src/core/extension/bench/mod.rs` | +4 re-exports |
| `docs/commands/bench.md` | +109 (cross-rig section + examples) |

## CI

Audit baseline may need a refresh (a couple of new types in `report.rs` will likely be picked up as new public surface). I'll handle the refresh in a follow-up commit on this branch if CI flags it — pre-existing pattern from #1493 / #1506.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the implementation, the cross-rig output type, the diff math, the doc additions, and the tests after a design conversation with Chris in the #intelligence-chubes4 thread that produced issue #1523. Chris set the direction (cross-rig as a missing axis, comparison-only semantics, no statistical-significance gating in v1) and reviewed the output. The realisation that bench is the right home for "10-run side-by-side speed comparison across rigs" — vs. eval, vs. a new `compare` verb — came out of that conversation.
