### PR TITLE
fix(audit): apply --only / --exclude to read-only audit findings

### DIFF
--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -41,7 +41,7 @@ pub fn run_main_audit_workflow(
     let result = run_audit(&args)?;
 
     // Early return: no-change shortcut already handled by run_audit returning None
-    let result = match result {
+    let mut result = match result {
         Some(r) => r,
         None => {
             return Ok(AuditRunWorkflowResult {
@@ -82,13 +82,49 @@ pub fn run_main_audit_workflow(
         });
     }
 
-    // --baseline: save current state
+    // --baseline: save current state. Saved baselines record the *full* finding
+    // set so they remain a complete reference; --only / --exclude intentionally
+    // do not narrow what gets persisted.
     if args.baseline_flags.baseline {
         return run_baseline_save(result, &args);
     }
 
+    // --only / --exclude: scope this run's findings before comparison and
+    // report assembly. The CLI flags are parsed in `parse_finding_kinds` and
+    // surfaced here as `only_kinds` / `exclude_kinds`; any filter activity
+    // also recomputes `summary.outliers_found` so the exit-code logic in
+    // `default_audit_exit_code` reflects the filtered view.
+    apply_finding_filters(&mut result, &args.only_kinds, &args.exclude_kinds);
+
     // Default: compare against baseline or return full result
     run_comparison_workflow(result, &args)
+}
+
+/// Filter `result.findings` by kind allow/deny lists and refresh
+/// `summary.outliers_found` so downstream exit-code and fixability logic
+/// agrees with what the user sees.
+///
+/// No-op when both lists are empty (the common case).
+fn apply_finding_filters(
+    result: &mut CodeAuditResult,
+    only_kinds: &[code_audit::AuditFinding],
+    exclude_kinds: &[code_audit::AuditFinding],
+) {
+    if only_kinds.is_empty() && exclude_kinds.is_empty() {
+        return;
+    }
+
+    result.findings.retain(|f| {
+        let allowed = only_kinds.is_empty() || only_kinds.contains(&f.kind);
+        let denied = exclude_kinds.contains(&f.kind);
+        allowed && !denied
+    });
+
+    // Recompute outliers_found from the filtered set. Findings count is the
+    // closest proxy available without re-running the per-convention check —
+    // this keeps `default_audit_exit_code(...) -> outliers_found > 0`
+    // honest under filtering.
+    result.summary.outliers_found = result.findings.len();
 }
 
 /// Run the audit scan (scoped or full). Returns None if changed-since found no files.

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -1,1 +1,123 @@
+//! Unit tests for the audit workflow filtering primitive.
+//!
+//! Wired into `src/core/code_audit/run.rs` via `#[cfg(test)] #[path = ...] mod run_test`.
 
+use super::apply_finding_filters;
+use crate::code_audit::findings::{Finding, Severity};
+use crate::code_audit::{AuditFinding, AuditSummary, CodeAuditResult};
+
+fn make_finding(kind: AuditFinding, file: &str) -> Finding {
+    Finding {
+        convention: "test".to_string(),
+        severity: Severity::Warning,
+        file: file.to_string(),
+        description: format!("{:?} on {}", kind, file),
+        suggestion: "fix it".to_string(),
+        kind,
+    }
+}
+
+fn make_result(findings: Vec<Finding>) -> CodeAuditResult {
+    let outliers = findings.len();
+    CodeAuditResult {
+        component_id: "test".to_string(),
+        source_path: "/tmp/test".to_string(),
+        summary: AuditSummary {
+            files_scanned: 1,
+            conventions_detected: 0,
+            outliers_found: outliers,
+            alignment_score: None,
+            files_skipped: 0,
+            warnings: vec![],
+        },
+        conventions: vec![],
+        directory_conventions: vec![],
+        findings,
+        duplicate_groups: vec![],
+    }
+}
+
+#[test]
+fn filter_noop_when_both_lists_empty() {
+    // The common case: no flags → no-op, untouched findings AND untouched summary.
+    let mut result = make_result(vec![
+        make_finding(AuditFinding::TodoMarker, "a.rs"),
+        make_finding(AuditFinding::LegacyComment, "b.rs"),
+    ]);
+
+    apply_finding_filters(&mut result, &[], &[]);
+
+    assert_eq!(result.findings.len(), 2);
+    assert_eq!(result.summary.outliers_found, 2);
+}
+
+#[test]
+fn only_keeps_listed_kinds_and_refreshes_outliers_count() {
+    // Regression for the silent-no-op `--only` bug: the filter was parsed but
+    // never applied to the read-only audit path. This is the round-trip test.
+    let mut result = make_result(vec![
+        make_finding(AuditFinding::TodoMarker, "a.rs"),
+        make_finding(AuditFinding::LegacyComment, "b.rs"),
+        make_finding(AuditFinding::GodFile, "c.rs"),
+    ]);
+
+    apply_finding_filters(&mut result, &[AuditFinding::LegacyComment], &[]);
+
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(result.findings[0].kind, AuditFinding::LegacyComment);
+    // outliers_found drives default_audit_exit_code; must reflect the filtered view.
+    assert_eq!(result.summary.outliers_found, 1);
+}
+
+#[test]
+fn exclude_drops_listed_kinds_and_refreshes_outliers_count() {
+    let mut result = make_result(vec![
+        make_finding(AuditFinding::TodoMarker, "a.rs"),
+        make_finding(AuditFinding::LegacyComment, "b.rs"),
+        make_finding(AuditFinding::GodFile, "c.rs"),
+    ]);
+
+    apply_finding_filters(&mut result, &[], &[AuditFinding::TodoMarker]);
+
+    assert_eq!(result.findings.len(), 2);
+    assert!(result
+        .findings
+        .iter()
+        .all(|f| f.kind != AuditFinding::TodoMarker));
+    assert_eq!(result.summary.outliers_found, 2);
+}
+
+#[test]
+fn exclude_takes_precedence_over_only() {
+    // If a kind appears in both lists, exclude wins — the user explicitly
+    // asked for it to be dropped.
+    let mut result = make_result(vec![
+        make_finding(AuditFinding::TodoMarker, "a.rs"),
+        make_finding(AuditFinding::LegacyComment, "b.rs"),
+    ]);
+
+    apply_finding_filters(
+        &mut result,
+        &[AuditFinding::TodoMarker, AuditFinding::LegacyComment],
+        &[AuditFinding::TodoMarker],
+    );
+
+    assert_eq!(result.findings.len(), 1);
+    assert_eq!(result.findings[0].kind, AuditFinding::LegacyComment);
+    assert_eq!(result.summary.outliers_found, 1);
+}
+
+#[test]
+fn only_with_no_matches_leaves_zero_findings_and_clean_exit() {
+    // Filtering down to a kind that has no findings → empty findings AND
+    // outliers_found == 0, so default_audit_exit_code returns 0 (clean).
+    let mut result = make_result(vec![
+        make_finding(AuditFinding::TodoMarker, "a.rs"),
+        make_finding(AuditFinding::LegacyComment, "b.rs"),
+    ]);
+
+    apply_finding_filters(&mut result, &[AuditFinding::DeadGuard], &[]);
+
+    assert!(result.findings.is_empty());
+    assert_eq!(result.summary.outliers_found, 0);
+}


### PR DESCRIPTION
## Summary
The `--only` and `--exclude` flags on `homeboy audit` were parsed into `AuditRunWorkflowArgs.only_kinds` / `exclude_kinds` but never applied to filter `result.findings` on the read-only audit path. The fields only flowed through `homeboy refactor --from audit` (see `src/core/refactor/plan/verify.rs`). From the user's perspective the flags silently did nothing.

Discovered while live-firing #1529 (`feat(audit): upstream_workaround`): running `homeboy audit homeboy --only upstream_workaround` returned the full finding set instead of the scoped slice. Fixing it as a sibling PR per the fix-upstream-first rule rather than papering over it inside the rule PR.

## Behaviour
Wires a small `apply_finding_filters()` helper into `run_main_audit_workflow`, called between the `--conventions` / `--baseline` branches and the comparison workflow. The filter:

- **No-op when both lists are empty** (the common case — zero overhead for normal runs).
- **Retains findings whose kind is in `only_kinds`** (or any kind, when `only` is empty) **AND not in `exclude_kinds`**. Exclude wins over only when a kind appears in both — explicit deny beats explicit allow.
- **Recomputes `summary.outliers_found`** from the filtered set so `default_audit_exit_code` (which keys off `outliers_found > 0`) returns a clean `0` when `--only` narrows down to a kind with zero findings.

## What's intentionally untouched
- **Baseline saves bypass the filter.** Saved baselines must record the *full* finding set so they remain a complete reference for future comparisons. Filter applies on the comparison / report path only — never on `--baseline`.
- **`result.conventions` / `result.directory_conventions` / `result.duplicate_groups`.** These are convention metadata, not findings; filtering them by kind doesn't make semantic sense.

## Tests
5 new unit tests in `tests/core/code_audit/run_test.rs` (wired via `#[path]` from `src/core/code_audit/run.rs`):

- `filter_noop_when_both_lists_empty` — hot path, no allocation, no mutation.
- `only_keeps_listed_kinds_and_refreshes_outliers_count` — round-trip regression for the silent-no-op bug.
- `exclude_drops_listed_kinds_and_refreshes_outliers_count` — same for `--exclude`.
- `exclude_takes_precedence_over_only` — both lists, deny wins.
- `only_with_no_matches_leaves_zero_findings_and_clean_exit` — guards the `default_audit_exit_code(...) -> 0` path.

All pre-existing tests still pass: **1435 / 0 lib serial** (`cargo test --lib -- --test-threads=1`). Two `signature_check_*` tests are flaky in parallel (HOME-touching tests, pre-existing condition documented in MEMORY.md). Clippy clean for the changed files.

## Out of scope (follow-ups)
- Surfacing the filter in eprintln summary output (e.g. `[audit] --only upstream_workaround: 0 finding(s)` instead of the silent shape change). Cosmetic, and the JSON `findings` array already reflects the filter.
- Filter equivalents on baselines themselves (e.g. `--baseline --only X` to save a kind-scoped baseline). Different semantic — would need a design pass on how kind-scoped baselines compose with full baselines on the same component. Not blocking the immediate bug fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Discovered the bug while verifying #1529, designed the minimal patch (filter helper + summary refresh + baseline-save bypass), wrote the implementation and the five unit tests, and confirmed the fix with serial test runs. Chris approved the parallel-PR plan before I cooked.