### PR TITLE
fix(cli): --output works at any position, not just pre-subcommand (closes #1532)

### DIFF
--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -38,6 +38,19 @@ pub(crate) fn normalize_version_show(args: Vec<String>) -> Vec<String> {
     result
 }
 
+/// Flags declared on the top-level `Cli` struct as `#[arg(global = true)]`.
+///
+/// These can appear at any position in the argv (clap routes them to the
+/// parent struct regardless), so the trailing-flag normalizer below must
+/// treat them as known — otherwise it inserts a `--` separator before them
+/// and the value gets eaten by a subcommand's `last = true` capture
+/// instead of binding to `Cli::output`. The bug surfaced as homeboy#1532
+/// for `--output`.
+///
+/// Adding a new global flag to `Cli` requires adding the long form here
+/// and the equals-form lookup happens automatically.
+const GLOBAL_FLAGS: &[&str] = &["--output", "-h", "--help"];
+
 /// Auto-insert '--' separator before unknown flags for trailing_var_arg commands.
 pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
     let commands: &[(&str, &str, &[&str])] = &[
@@ -207,16 +220,34 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
     let mut found_separator = false;
     let mut insert_position: Option<usize> = None;
 
+    // A flag is "known" if the per-subcommand list owns it, OR if it's a
+    // top-level Cli global (which clap routes to the parent struct
+    // regardless of position). Without the global merge, `--output PATH`
+    // placed after the subcommand triggers the `--` insertion and gets
+    // eaten by the subcommand's `last = true` capture (homeboy#1532).
+    let is_known = |flag: &str| -> bool {
+        if known_flags.contains(&flag)
+            || known_flags
+                .iter()
+                .any(|f| flag.starts_with(&format!("{}=", f)))
+        {
+            return true;
+        }
+        if GLOBAL_FLAGS.contains(&flag) {
+            return true;
+        }
+        GLOBAL_FLAGS
+            .iter()
+            .any(|f| flag.starts_with(&format!("{}=", f)))
+    };
+
     for (i, arg) in args.iter().enumerate() {
         if arg == "--" {
             found_separator = true;
         }
         if !found_separator
             && arg.starts_with("--")
-            && !known_flags.contains(&arg.as_str())
-            && !known_flags
-                .iter()
-                .any(|f| arg.starts_with(&format!("{}=", f)))
+            && !is_known(arg.as_str())
             && insert_position.is_none()
         {
             insert_position = Some(i);
@@ -343,6 +374,129 @@ mod positional_tests {
             path: None,
         };
         assert_eq!(args.id(), Some("my-comp"));
+    }
+}
+
+#[cfg(test)]
+mod normalize_tests {
+    use super::normalize_trailing_flags;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// `--output` placed AFTER a `last = true` subcommand must NOT trigger
+    /// the `--` separator insertion — it's a `global = true` flag on the
+    /// top-level Cli struct and clap routes it there directly. Inserting
+    /// `--` would cause the subcommand's trailing-arg capture to swallow
+    /// the value (homeboy#1532).
+    #[test]
+    fn output_after_subcommand_is_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--output",
+            "/tmp/x.json",
+            "--iterations",
+            "1",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// Equals form must round-trip the same way.
+    #[test]
+    fn output_equals_form_after_subcommand_is_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--output=/tmp/x.json",
+            "--iterations",
+            "1",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// Mirror the bench check for `test` (the other `last = true`
+    /// subcommand). Both consumers must accept post-position `--output`.
+    #[test]
+    fn output_after_test_subcommand_is_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "test",
+            "my-comp",
+            "--output",
+            "/tmp/y.json",
+            "--ratchet",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// A genuinely unknown flag (not on the per-subcommand allow-list,
+    /// not a Cli global) STILL triggers the `--` insertion. This is the
+    /// existing trailing-arg passthrough behaviour the normalizer was
+    /// designed for; the fix must not regress it.
+    #[test]
+    fn unknown_flag_after_bench_still_separated() {
+        let input = argv(&["homeboy", "bench", "my-comp", "--unknown-flag", "value"]);
+        let expected = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--",
+            "--unknown-flag",
+            "value",
+        ]);
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// `--output` mixed with an unknown flag: separator goes before the
+    /// unknown flag, NOT before `--output`. Captures the most realistic
+    /// repro from the MDI bench cook (driver script with `--output` plus
+    /// dispatcher passthrough flags).
+    #[test]
+    fn output_plus_unknown_flag_separator_before_unknown_only() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--output",
+            "/tmp/x.json",
+            "--unknown",
+            "v",
+        ]);
+        let expected = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--output",
+            "/tmp/x.json",
+            "--",
+            "--unknown",
+            "v",
+        ]);
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// Pre-subcommand position must continue to work — that's the path
+    /// the existing tests + production users have relied on.
+    #[test]
+    fn output_before_subcommand_is_unchanged() {
+        let input = argv(&[
+            "homeboy",
+            "--output",
+            "/tmp/x.json",
+            "bench",
+            "my-comp",
+            "--iterations",
+            "1",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
     }
 }
 


### PR DESCRIPTION
Closes #1532.

## Summary

- `--output PATH` placed AFTER a `last = true` subcommand (`bench`, `test`) was silently swallowed by the trailing-arg capture. The JSON envelope still reached stdout but the file was never written.
- Fix: introduce `GLOBAL_FLAGS` in `commands/utils/args.rs` as the single source of truth for `Cli`-level `#[arg(global = true)]` flags. The pre-parse normalizer treats them as known flags everywhere so they pass through to clap unmodified, and clap binds them to `Cli::output` per its global-arg semantics.

## Why

`bench --help` and `test --help` advertise `--output <PATH>` as a subcommand option. The post-subcommand position is the natural one to type. The normalizer in `commands/utils/args.rs::normalize_trailing_flags` saw `--output` as an unknown flag (not in any per-subcommand allow-list), inserted a `--` separator before it, and clap then routed the flag into the subcommand's `#[arg(last = true)] args: Vec<String>` instead of binding it to `Cli::output`. main.rs:387's file-write branch never fired.

Surfaced during the MDI bench harness cook ([Automattic/markdown-database-integration#76](https://github.com/Automattic/markdown-database-integration/pull/76)). The matrix driver script wrote `homeboy bench <component> --output results/<substrate>.json` — the exact pattern that didn't work. Worked around in the script with the documented global position (`homeboy --output ... bench ...`); filing this so the next consumer doesn't hit the same wall.

## Behaviour

```bash
# All four now write the file:
homeboy --output /tmp/x.json bench <comp>          # pre-subcommand (already worked)
homeboy bench <comp> --output /tmp/x.json          # post-subcommand (the bug)
homeboy bench <comp> --output=/tmp/x.json          # equals form
homeboy test <comp> --output /tmp/y.json           # mirror fix for `test` (same `last = true` shape)
```

The pre-parse normalizer's existing trailing-arg passthrough is unchanged: a genuinely unknown flag (`--my-extension-flag`) still gets a `--` inserted before it so the subcommand's `last = true` capture receives it. Mixed cases (`--output X --my-extension-flag Y`) insert `--` before the unknown flag only, not before `--output`.

## Plumbing

```rust
// New: source of truth for global flags on Cli.
const GLOBAL_FLAGS: &[&str] = &["--output", "-h", "--help"];

// In normalize_trailing_flags():
let is_known = |flag: &str| -> bool {
    if known_flags.contains(&flag) || /* equals form for per-subcommand */ {
        return true;
    }
    if GLOBAL_FLAGS.contains(&flag) {
        return true;
    }
    GLOBAL_FLAGS.iter().any(|f| flag.starts_with(&format!(\"{}=\", f)))
};
```

Adding a new `Cli` `global = true` flag in the future requires adding the long form to `GLOBAL_FLAGS`. The equals-form match is automatic.

## Tests

Six new unit tests in `commands::utils::args::normalize_tests`:

- `output_after_subcommand_is_not_separated`
- `output_equals_form_after_subcommand_is_not_separated`
- `output_after_test_subcommand_is_not_separated`
- `unknown_flag_after_bench_still_separated` (regression check)
- `output_plus_unknown_flag_separator_before_unknown_only` (the realistic mixed case)
- `output_before_subcommand_is_unchanged`

**Full lib suite: 1468/1468 pass.** No regressions.

`homeboy lint homeboy` passes (`cargo fmt --check` + `cargo clippy`).

## Out of scope

- No CHANGELOG / version bumps. Homeboy owns release versioning.
- No new global flags. Just plumbing for the existing one (`--output`).
- Help text is unchanged. The flag was already documented at the subcommand level via clap's `global = true`; the bug was that the documented behaviour didn't actually work at that position.

## Related

- #1532 (this issue, closed by this PR)
- Automattic/markdown-database-integration#76 (the downstream bench harness that surfaced the bug; matrix driver currently uses the pre-subcommand position)

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the fix, the tests, and the PR write-up. Chris reviewed the design choice (`GLOBAL_FLAGS` as centralized source of truth vs per-subcommand additions) and the no-shim rule that drove this PR — clean fix upstream, no `run-matrix.sh` workaround calcified in MDI's tree.