### PR TITLE
feat(cli): --setting-json flag for typed settings overrides

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -251,11 +251,12 @@ fn run_single(
         (None, None) => args.comp.resolve_id()?,
     };
 
-    let ctx = execution_context::resolve(&ResolveOptions::with_capability(
+    let ctx = execution_context::resolve(&ResolveOptions::with_capability_and_json(
         &effective_id,
         args.comp.path.clone(),
         ExtensionCapability::Bench,
         args.setting_args.setting.clone(),
+        args.setting_args.setting_json.clone(),
     ))?;
 
     let run_dir = RunDir::create()?;
@@ -267,17 +268,28 @@ fn run_single(
             component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
+            // Split ctx.settings by JSON shape: strings flow through the
+            // legacy `settings` channel (string-coerced for downstream
+            // consumers), non-string types (objects, arrays, numbers,
+            // bools, nulls) flow through `settings_json` so type is
+            // preserved end-to-end. Without the split, non-string values
+            // would be `.to_string()`'d into JSON literals and downstream
+            // `jq -c '.field'` extractions would surface a string-encoded
+            // JSON object instead of the actual object.
             settings: ctx
                 .settings
                 .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        match v {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        },
-                    )
+                .filter_map(|(k, v)| match v {
+                    serde_json::Value::String(s) => Some((k.clone(), s.clone())),
+                    _ => None,
+                })
+                .collect(),
+            settings_json: ctx
+                .settings
+                .iter()
+                .filter_map(|(k, v)| match v {
+                    serde_json::Value::String(_) => None,
+                    other => Some((k.clone(), other.clone())),
                 })
                 .collect(),
             iterations: args.iterations,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,35 @@ pub fn parse_key_val(s: &str) -> Result<(String, String), String> {
     Ok((s[..pos].to_string(), s[pos + 1..].to_string()))
 }
 
+/// Parse a `KEY=<json>` string into a (key, serde_json::Value) tuple.
+///
+/// Used by `--setting-json` for object/array/typed-scalar settings that
+/// `--setting`'s string-only coercion can't represent. JSON value can be
+/// any well-formed JSON: object, array, string (must be quoted), number,
+/// boolean, or null.
+///
+/// Examples:
+///
+///   --setting-json bench_env={"BENCH_CORPUS_SIZE":"1000"}
+///   --setting-json wp_config_defines={"MARKDOWN_DB_MODE":"primary","WP_DEBUG":true}
+///   --setting-json my_array=[1,2,3]
+///   --setting-json my_flag=true
+///   --setting-json my_string="literal"
+pub fn parse_key_json(s: &str) -> Result<(String, serde_json::Value), String> {
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=<json>: no `=` found in `{s}`"))?;
+    let key = s[..pos].to_string();
+    let raw = &s[pos + 1..];
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|e| {
+        format!(
+            "invalid JSON for setting `{key}`: {e}. Got `{raw}`. \
+             Strings must be quoted (`my_str=\"hello\"`); use --setting for unquoted strings."
+        )
+    })?;
+    Ok((key, value))
+}
+
 pub(crate) struct GlobalArgs {}
 
 /// Shared arguments for dynamic set commands.

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -138,11 +138,12 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     // Resolve component ID — auto-discover from CWD if omitted
     let effective_id = args.comp.resolve_id()?;
 
-    let ctx = execution_context::resolve(&ResolveOptions::with_capability(
+    let ctx = execution_context::resolve(&ResolveOptions::with_capability_and_json(
         &effective_id,
         args.comp.path.clone(),
         ExtensionCapability::Test,
         args.setting_args.setting.clone(),
+        args.setting_args.setting_json.clone(),
     ))?;
 
     // Drift detection mode — delegate to core drift workflow (read-only)

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -565,11 +565,49 @@ pub struct HiddenJsonArgs {
 }
 
 // ============================================================================
-// SettingArgs: --setting key=value pairs
+// SettingArgs: --setting key=value + --setting-json key=<json>
 // ============================================================================
 
+/// Settings overrides flattened into every command that runs an extension
+/// capability (test, bench, lint, build, validate).
+///
+/// Two flags by design:
+///
+/// - `--setting key=value` (string-coerced): the original "set this string
+///   override" path. Values are always strings, mirroring how operators
+///   typically configure settings interactively. Existing callers
+///   unchanged.
+///
+/// - `--setting-json key=<json>` (typed): for object/array/typed-scalar
+///   settings that `--setting`'s string-only coercion can't represent.
+///   Required for any setting whose dispatcher consumer expects a JSON
+///   object (the wordpress extension's `wp_config_defines` and `bench_env`
+///   are the motivating cases). String coercion of an object value
+///   produces `"{\"key\":\"value\"}"` — a string containing JSON, not a
+///   JSON object — which downstream `jq -c '.field'` extractions then
+///   pass through as a string, breaking the substitution that expects an
+///   object.
+///
+/// When both flags target the same key, `--setting-json` wins (it's
+/// strictly more expressive and was specified later in the merge order).
 #[derive(Args, Debug, Clone, Default)]
 pub struct SettingArgs {
     #[arg(long, value_parser = crate::commands::parse_key_val)]
     pub setting: Vec<(String, String)>,
+
+    /// Typed-JSON setting override. Repeatable.
+    ///
+    /// Format: `--setting-json key=<json>`, where `<json>` is any
+    /// well-formed JSON value (object, array, string [must be quoted],
+    /// number, boolean, null). For string values use `--setting`; this
+    /// flag exists for object/array/typed-scalar settings that string
+    /// coercion can't represent.
+    ///
+    /// Examples:
+    ///
+    ///   --setting-json bench_env='{"BENCH_CORPUS_SIZE":"1000"}'
+    ///   --setting-json wp_config_defines='{"MARKDOWN_DB_MODE":"primary"}'
+    ///   --setting-json my_flag=true
+    #[arg(long = "setting-json", value_parser = crate::commands::parse_key_json)]
+    pub setting_json: Vec<(String, serde_json::Value)>,
 }

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -66,8 +66,14 @@ pub struct ResolveOptions {
     /// When `None`, only component + source path are resolved — no extension lookup.
     pub capability: Option<ExtensionCapability>,
 
-    /// Additional settings from `--setting key=value` flags.
+    /// Additional settings from `--setting key=value` flags (string values).
     pub settings_overrides: Vec<(String, String)>,
+
+    /// Additional settings from `--setting-json key=<json>` flags (typed
+    /// values). Applied after `settings_overrides` so JSON wins on
+    /// conflict. Required for object-shaped settings whose dispatcher
+    /// consumers expect a JSON object, not a string-coerced JSON literal.
+    pub settings_json_overrides: Vec<(String, serde_json::Value)>,
 }
 
 impl ResolveOptions {
@@ -83,6 +89,26 @@ impl ResolveOptions {
             path_override,
             capability: Some(capability),
             settings_overrides: settings,
+            settings_json_overrides: Vec::new(),
+        }
+    }
+
+    /// Create options for a command that needs an extension capability AND
+    /// typed-JSON setting overrides. Mirrors `with_capability` but accepts
+    /// the JSON overrides too.
+    pub fn with_capability_and_json(
+        component_id: &str,
+        path_override: Option<String>,
+        capability: ExtensionCapability,
+        settings: Vec<(String, String)>,
+        settings_json: Vec<(String, serde_json::Value)>,
+    ) -> Self {
+        Self {
+            component_id: Some(component_id.to_string()),
+            path_override,
+            capability: Some(capability),
+            settings_overrides: settings,
+            settings_json_overrides: settings_json,
         }
     }
 
@@ -93,6 +119,7 @@ impl ResolveOptions {
             path_override,
             capability: None,
             settings_overrides: Vec::new(),
+            settings_json_overrides: Vec::new(),
         }
     }
 }
@@ -132,11 +159,20 @@ pub fn resolve(options: &ResolveOptions) -> Result<ExecutionContext> {
     let (extension_id, extension_path, settings) = if let Some(capability) = options.capability {
         let ext_context = extension::resolve_execution_context(&component, capability)?;
         let mut settings = ext_context.settings.clone();
-        // Merge CLI overrides on top (CLI values are always strings)
+        // Merge CLI string overrides on top (CLI string values stay strings).
         for (key, value) in &options.settings_overrides {
             // Remove existing key if present (override semantics)
             settings.retain(|(k, _)| k != key);
             settings.push((key.clone(), serde_json::Value::String(value.clone())));
+        }
+        // Then merge typed-JSON overrides — these win against both
+        // manifest defaults / component settings AND --setting string
+        // overrides. Strictly more expressive: an --setting-json on the
+        // same key represents intentional type preservation that string
+        // coercion can't represent.
+        for (key, value) in &options.settings_json_overrides {
+            settings.retain(|(k, _)| k != key);
+            settings.push((key.clone(), value.clone()));
         }
         (
             Some(ext_context.extension_id.clone()),
@@ -395,6 +431,7 @@ mod tests {
                 ("mode".to_string(), "strict".to_string()),
                 ("lang".to_string(), "rust".to_string()),
             ],
+            settings_json_overrides: Vec::new(),
         };
 
         let ctx = resolve(&options).expect("resolve should succeed");

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -22,6 +22,12 @@ pub struct BenchRunWorkflowArgs {
     pub component_id: String,
     pub path_override: Option<String>,
     pub settings: Vec<(String, String)>,
+    /// Typed-JSON setting overrides from `--setting-json key=<json>`.
+    /// Applied after `settings` (string overrides) so JSON wins on
+    /// conflict. Required for object-shaped settings like
+    /// `wp_config_defines` / `bench_env` whose dispatchers expect a JSON
+    /// object, not a JSON-string-of-an-object.
+    pub settings_json: Vec<(String, serde_json::Value)>,
     pub iterations: u64,
     pub baseline_flags: BaselineFlags,
     pub regression_threshold_percent: f64,
@@ -231,6 +237,7 @@ fn build_runner(
         .component(component.clone())
         .path_override(args.path_override.clone())
         .settings(&args.settings)
+        .settings_json(&args.settings_json)
         .with_run_dir(run_dir)
         .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
         .script_args(&args.passthrough_args);

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -411,6 +411,7 @@ pub(crate) fn build_settings_json_from_manifest(
     manifest: &serde_json::Value,
     extension_settings: &[(String, serde_json::Value)],
     settings_overrides: &[(String, String)],
+    settings_json_overrides: &[(String, serde_json::Value)],
 ) -> Result<String> {
     let mut settings = serde_json::json!({});
 
@@ -435,9 +436,17 @@ pub(crate) fn build_settings_json_from_manifest(
             obj.insert(key.clone(), value.clone());
         }
 
-        // CLI overrides are always strings (from --setting key=value).
+        // String overrides from `--setting key=value` (always strings).
         for (key, value) in settings_overrides {
             obj.insert(key.clone(), serde_json::Value::String(value.clone()));
+        }
+
+        // Typed-JSON overrides from `--setting-json key=<json>` (preserves
+        // object / array / typed-scalar). Applied AFTER string overrides
+        // so `--setting-json` wins when both target the same key —
+        // typed-JSON is strictly more expressive.
+        for (key, value) in settings_json_overrides {
+            obj.insert(key.clone(), value.clone());
         }
     }
 
@@ -577,6 +586,7 @@ pub(crate) fn prepare_capability_run(
     pre_loaded_component: Option<&Component>,
     path_override: Option<&str>,
     settings_overrides: &[(String, String)],
+    settings_json_overrides: &[(String, serde_json::Value)],
     skip_script_validation: bool,
 ) -> Result<PreparedCapabilityRun> {
     let component =
@@ -594,8 +604,12 @@ pub(crate) fn prepare_capability_run(
     }
 
     let manifest = load_extension_manifest_from_dir(&execution.extension_path)?;
-    let settings_json =
-        build_settings_json_from_manifest(&manifest, &execution.settings, settings_overrides)?;
+    let settings_json = build_settings_json_from_manifest(
+        &manifest,
+        &execution.settings,
+        settings_overrides,
+        settings_json_overrides,
+    )?;
 
     Ok(PreparedCapabilityRun {
         execution,
@@ -1093,9 +1107,15 @@ mod tests {
         ];
 
         let overrides: Vec<(String, String)> = vec![];
+        let json_overrides: Vec<(String, serde_json::Value)> = vec![];
 
-        let json = build_settings_json_from_manifest(&manifest, &extension_settings, &overrides)
-            .expect("should serialize");
+        let json = build_settings_json_from_manifest(
+            &manifest,
+            &extension_settings,
+            &overrides,
+            &json_overrides,
+        )
+        .expect("should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
 
         // Array from extension settings is preserved
@@ -1121,13 +1141,75 @@ mod tests {
         let extension_settings: Vec<(String, serde_json::Value)> =
             vec![("key".to_string(), serde_json::json!(["original"]))];
         let overrides = vec![("key".to_string(), "override_value".to_string())];
+        let json_overrides: Vec<(String, serde_json::Value)> = vec![];
 
-        let json = build_settings_json_from_manifest(&manifest, &extension_settings, &overrides)
-            .expect("should serialize");
+        let json = build_settings_json_from_manifest(
+            &manifest,
+            &extension_settings,
+            &overrides,
+            &json_overrides,
+        )
+        .expect("should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
 
         // CLI override replaces the array value with a string
         assert_eq!(parsed["key"], serde_json::json!("override_value"));
+    }
+
+    #[test]
+    fn build_settings_json_typed_overrides_preserve_objects() {
+        // The whole point of --setting-json: object values stay objects,
+        // unlike --setting which would coerce them to a JSON-string-of-an-
+        // object. Mirrors the wp_config_defines / bench_env use case
+        // (homeboy-extensions #248 / #250).
+        let manifest = serde_json::json!({
+            "settings": [
+                { "id": "bench_env", "default": {} }
+            ]
+        });
+        let extension_settings: Vec<(String, serde_json::Value)> = vec![];
+        let overrides: Vec<(String, String)> = vec![];
+        let json_overrides = vec![(
+            "bench_env".to_string(),
+            serde_json::json!({"BENCH_CORPUS_SIZE": "1000"}),
+        )];
+
+        let json = build_settings_json_from_manifest(
+            &manifest,
+            &extension_settings,
+            &overrides,
+            &json_overrides,
+        )
+        .expect("should serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
+
+        // The override is the actual JSON object, not a string-encoded one.
+        assert_eq!(
+            parsed["bench_env"],
+            serde_json::json!({"BENCH_CORPUS_SIZE": "1000"})
+        );
+        assert!(parsed["bench_env"].is_object());
+    }
+
+    #[test]
+    fn build_settings_json_typed_override_wins_on_conflict() {
+        // When the same key is targeted by both --setting and --setting-json,
+        // the typed override wins (strictly more expressive, applied later).
+        let manifest = serde_json::json!({});
+        let extension_settings: Vec<(String, serde_json::Value)> = vec![];
+        let overrides = vec![("key".to_string(), "string_value".to_string())];
+        let json_overrides = vec![("key".to_string(), serde_json::json!({"nested": true}))];
+
+        let json = build_settings_json_from_manifest(
+            &manifest,
+            &extension_settings,
+            &overrides,
+            &json_overrides,
+        )
+        .expect("should serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
+
+        assert_eq!(parsed["key"], serde_json::json!({"nested": true}));
     }
 
     #[test]

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -21,6 +21,10 @@ use super::ExtensionExecutionContext;
 pub struct ExtensionRunner {
     execution_context: ExtensionExecutionContext,
     settings_overrides: Vec<(String, String)>,
+    /// Typed-JSON setting overrides from `--setting-json key=<json>`.
+    /// Applied AFTER `settings_overrides` (so `--setting-json` wins on
+    /// conflict — strictly more expressive). See SettingArgs docstring.
+    settings_json_overrides: Vec<(String, serde_json::Value)>,
     env_vars: Vec<(String, String)>,
     script_args: Vec<String>,
     path_override: Option<String>,
@@ -49,6 +53,7 @@ impl ExtensionRunner {
         Self {
             execution_context,
             settings_overrides: Vec::new(),
+            settings_json_overrides: Vec::new(),
             env_vars: Vec::new(),
             script_args: Vec::new(),
             path_override: None,
@@ -70,6 +75,15 @@ impl ExtensionRunner {
     /// Add settings overrides from key=value pairs.
     pub fn settings(mut self, overrides: &[(String, String)]) -> Self {
         self.settings_overrides.extend(overrides.iter().cloned());
+        self
+    }
+
+    /// Add typed-JSON settings overrides from `--setting-json key=<json>`.
+    /// Preserves object/array/typed-scalar values; applied after string
+    /// overrides so JSON wins on conflict.
+    pub fn settings_json(mut self, overrides: &[(String, serde_json::Value)]) -> Self {
+        self.settings_json_overrides
+            .extend(overrides.iter().cloned());
         self
     }
 
@@ -143,6 +157,7 @@ impl ExtensionRunner {
             self.pre_loaded_component.as_ref(),
             self.path_override.as_deref(),
             &self.settings_overrides,
+            &self.settings_json_overrides,
             self.command_override.is_some(),
         )?;
 


### PR DESCRIPTION
## Summary

- Adds `--setting-json key=<json>` as a typed sibling to `--setting`. Parses the value as `serde_json::Value` so object/array/typed-scalar settings survive intact end-to-end.
- The existing `--setting key=value` flag string-coerces every value, which works for scalars but silently mangles structured settings — a downstream `jq -c '.field'` extraction would surface a JSON-encoded string literal instead of the actual structure.
- Required for any setting whose dispatcher consumer expects a JSON object (`wp_config_defines`, `bench_env`, etc. on the wordpress extension). String coercion of `{"BENCH_CORPUS_SIZE":"1000"}` produces `"\"{\\\"BENCH_CORPUS_SIZE\\\":\\\"1000\\\"}\""` which the dispatcher then sees as a string, not the object it expects.

## Behaviour

```bash
# String values — unchanged
homeboy bench <comp> --setting language=rust --setting strict=true

# Typed values (object, array, bool, int, null)
homeboy bench <comp> --setting-json bench_env='{"BENCH_CORPUS_SIZE":"1000"}'
homeboy bench <comp> --setting-json wp_config_defines='{"MARKDOWN_DB_MODE":"primary","WP_DEBUG":true}'
homeboy bench <comp> --setting-json my_array='[1,2,3]'
homeboy bench <comp> --setting-json my_flag=true

# Strings via --setting-json must be quoted (per JSON syntax)
homeboy bench <comp> --setting-json my_str='"hello"'
# Unquoted strings → use --setting (the error message says so)
```

When both flags target the same key, **`--setting-json` wins** (it's strictly more expressive — typed values can represent everything string coercion can, plus objects/arrays/typed scalars).

## Wiring

| Layer | Change |
|---|---|
| `commands/mod.rs` | New `parse_key_json` value parser. Mirrors `parse_key_val` but parses the value as `serde_json::Value` with a clear error on bad JSON. |
| `commands/utils/args.rs` | `SettingArgs.setting_json: Vec<(String, serde_json::Value)>` — new flattened field. |
| `core/engine/execution_context.rs` | `ResolveOptions.settings_json_overrides` + `with_capability_and_json` constructor. The `resolve()` function applies typed overrides AFTER string overrides in merge order. |
| `core/extension/execution.rs` | `build_settings_json_from_manifest` accepts a new `settings_json_overrides: &[(String, serde_json::Value)]` parameter, applied last so JSON wins on conflict. |
| `core/extension/runner.rs` | `ExtensionRunner.settings_json_overrides` field + `.settings_json()` builder method. |
| `core/extension/bench/run.rs` | `BenchRunWorkflowArgs.settings_json` typed pass-through. |
| `commands/bench.rs` | Splits `ctx.settings` by JSON shape: strings flow through legacy `settings`, non-strings flow through `settings_json` so type survives end-to-end. |
| `commands/{test,lint,build}.rs` | Switched from `with_capability` to `with_capability_and_json` so the typed-override channel is plumbed through (workflow-side wiring stays empty for now since their consumers don't yet need JSON-shape settings). |

## Tests

Two new unit tests in `core/extension/execution.rs`:

- `build_settings_json_typed_overrides_preserve_objects` — asserts an object passed via `--setting-json` round-trips as `Value::Object`, not a string.
- `build_settings_json_typed_override_wins_on_conflict` — asserts `--setting-json` wins when both flags target the same key.

Existing tests updated for the new `settings_json_overrides` parameter (purely additive — empty Vec preserves old behavior).

**Full lib suite: 1390/1390 pass.** `homeboy lint homeboy` passes (`cargo fmt --check` + `cargo clippy`).

## Why this PR

Fifth upstream PR in the MDI bench harness cook chain ([Automattic/markdown-database-integration#76](https://github.com/Automattic/markdown-database-integration/pull/76)). Without `--setting-json`, matrix drivers can't inject per-cell object-shaped settings cleanly:

- Parent-shell `HOMEBOY_SETTINGS_JSON` gets clobbered by `build_settings_json_from_manifest` (homeboy core builds the merged JSON from manifest + component settings, replacing whatever the parent shell set).
- `--setting key={"obj":1}` strips type — the dispatcher sees a string, breaks downstream `jq` extractions.

Concrete repro that surfaced this: MDI's `run-matrix.sh` synthesizes a `HOMEBOY_SETTINGS_JSON` per cell to vary `wp_config_defines.MARKDOWN_DB_MODE` and `bench_env.BENCH_CORPUS_SIZE`. Both got clobbered. Now expressible as `--setting-json wp_config_defines='{...}' --setting-json bench_env='{...}'`.

## Out of scope

- No CHANGELOG / version bumps. Homeboy owns release versioning.
- `test`/`lint`/`build` workflow args don't yet thread `settings_json` through to their respective `*RunWorkflowArgs` structs — only `bench` does today since its dispatcher is the one that needs JSON-shape consumers. The plumbing through `ResolveOptions` is in place; adding it to the other workflows is a one-liner-per-callsite when a consumer needs it.
- No CLI flag to disable parent-shell `HOMEBOY_SETTINGS_JSON` clobber. That's a separate design question; this PR sidesteps it by giving callers an explicit CLI mechanism instead.

## Related

- #1532 (--output post-position) — same MDI bench cook, same upstream-first pattern.
- Extra-Chill/homeboy-extensions#248 (wp_config_defines), #249 (PLUGIN_SLUG), #250 (bench_env) — sibling fixes in the wordpress extension.
- Automattic/markdown-database-integration#76 — the downstream bench harness this unblocks.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafting the parser, the SettingArgs / ResolveOptions / ExtensionRunner / BenchRunWorkflowArgs plumbing, the bench-side splitter that routes `ctx.settings` by JSON shape, and the unit tests. Chris reviewed the design choice (parallel typed flag vs respecting parent-shell `HOMEBOY_SETTINGS_JSON`; chose typed flag for grep-ability and to preserve existing parent-shell semantics for callers that don't want clobber-on-merge behaviour).