### PR TITLE
fix(rig): wait-ready loop in service.health http_check (#1537)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,8 +3,8 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-04-26T00:57:08Z",
-      "item_count": 718,
+      "created_at": "2026-04-26T01:39:27Z",
+      "item_count": 721,
       "known_fingerprints": [
         "Commands::src/commands/docs.rs::NamespaceMismatch",
         "comment_hygiene::src/commands/release.rs::LegacyComment",
@@ -35,6 +35,7 @@
         "dead_code::src/core/extension/lifecycle.rs::UnreferencedExport",
         "dead_code::src/core/extension/lifecycle.rs::UnreferencedExport",
         "dead_code::src/core/extension/runner.rs::UnreferencedExport",
+        "dead_code::src/core/extension/runner.rs::UnusedParameter",
         "dead_code::src/core/extension/runner_contract.rs::UnreferencedExport",
         "dead_code::src/core/extension/runner_contract.rs::UnreferencedExport",
         "dead_code::src/core/git/github.rs::UnreferencedExport",
@@ -295,6 +296,7 @@
         "structural::src/core/rig/spec.rs::HighItemCount",
         "structural::src/core/server/health.rs::HighItemCount",
         "structural::src/main.rs::HighItemCount",
+        "structural::tests/core/rig/check_test.rs::HighItemCount",
         "structural::tests/core/rig/spec_test.rs::HighItemCount",
         "test_coverage::src/core/code_audit/baseline.rs::MissingTestMethod",
         "test_coverage::src/core/code_audit/checks.rs::MissingTestMethod",
@@ -410,6 +412,7 @@
         "test_coverage::src/core/engine/edit_op.rs::MissingTestMethod",
         "test_coverage::src/core/engine/edit_op.rs::MissingTestMethod",
         "test_coverage::src/core/engine/edit_op_apply.rs::MissingTestMethod",
+        "test_coverage::src/core/engine/execution_context.rs::MissingTestMethod",
         "test_coverage::src/core/engine/execution_context.rs::MissingTestMethod",
         "test_coverage::src/core/engine/execution_context.rs::MissingTestMethod",
         "test_coverage::src/core/engine/execution_context.rs::MissingTestMethod",

--- a/src/core/rig/check.rs
+++ b/src/core/rig/check.rs
@@ -64,6 +64,24 @@ pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {
     Ok(())
 }
 
+/// Total wait budget for an HTTP probe to converge on a TCP listener.
+///
+/// Closes Extra-Chill/homeboy#1537: `service.start` returns once the child
+/// is forked, but the kernel may not have called `bind()`/`listen()` yet
+/// when the next pipeline step (`service.health`) fires. Connect-refused
+/// is a clear "not ready yet" signal — we retry the request, bounded by
+/// this ceiling, before giving up. Any HTTP-level response (even 5xx)
+/// counts as "the listener is up" and short-circuits the loop, because
+/// the question this probe answers is "is the port serving?", not "is
+/// the application happy?". Application-level health belongs in a
+/// separate `command` check.
+const HTTP_WAIT_READY_BUDGET: Duration = Duration::from_secs(10);
+
+/// Per-attempt sleep between connect-refused retries. Short enough that
+/// a service that comes up in <100ms still feels instant; long enough
+/// that we don't spin the CPU against a slow-starting daemon.
+const HTTP_RETRY_INTERVAL: Duration = Duration::from_millis(200);
+
 fn http_check(rig: &RigSpec, url: &str, expect_status: u16) -> Result<()> {
     let resolved = expand_vars(rig, url);
     let client = reqwest::blocking::Client::builder()
@@ -71,28 +89,46 @@ fn http_check(rig: &RigSpec, url: &str, expect_status: u16) -> Result<()> {
         .build()
         .map_err(|e| Error::internal_unexpected(format!("build http client: {}", e)))?;
 
-    let response = client.get(&resolved).send().map_err(|e| {
-        Error::validation_invalid_argument(
-            "check.http",
-            format!("HTTP GET {} failed: {}", resolved, e),
-            None,
-            None,
-        )
-    })?;
+    let deadline = std::time::Instant::now() + HTTP_WAIT_READY_BUDGET;
 
-    let actual = response.status().as_u16();
-    if actual != expect_status {
-        return Err(Error::validation_invalid_argument(
-            "check.http",
-            format!(
-                "HTTP GET {} returned {} (expected {})",
-                resolved, actual, expect_status
-            ),
-            None,
-            None,
-        ));
+    loop {
+        match client.get(&resolved).send() {
+            Ok(response) => {
+                let actual = response.status().as_u16();
+                if actual != expect_status {
+                    return Err(Error::validation_invalid_argument(
+                        "check.http",
+                        format!(
+                            "HTTP GET {} returned {} (expected {})",
+                            resolved, actual, expect_status
+                        ),
+                        None,
+                        None,
+                    ));
+                }
+                return Ok(());
+            }
+            Err(e) if e.is_connect() && std::time::Instant::now() < deadline => {
+                // Listener not up yet — keep waiting until the budget runs out.
+                // We deliberately do NOT retry on DNS, TLS, or read-timeout
+                // errors: those aren't startup races, they're real problems
+                // a retry loop would just paper over.
+                std::thread::sleep(HTTP_RETRY_INTERVAL);
+            }
+            Err(e) => {
+                // Either a non-connect error (DNS, TLS, read-timeout —
+                // surface verbatim) or the wait-ready budget exhausted on
+                // a still-refused connection. Either way the latest error
+                // is the most accurate diagnostic.
+                return Err(Error::validation_invalid_argument(
+                    "check.http",
+                    format!("HTTP GET {} failed: {}", resolved, e),
+                    None,
+                    None,
+                ));
+            }
+        }
     }
-    Ok(())
 }
 
 fn file_check(rig: &RigSpec, path: &str, contains: Option<&str>) -> Result<()> {

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -211,3 +211,207 @@ fn test_evaluate_check_with_no_probe_set_lists_newer_than() {
     // so users see `newer_than` in the suggestion.
     assert!(err.message.contains("newer_than"));
 }
+
+// ─── HTTP wait-ready (Extra-Chill/homeboy#1537) ──────────────────────────────
+//
+// `service.start` returns once the child is forked, but the kernel may not
+// have called `bind()`/`listen()` yet when the next pipeline step
+// (`service.health`) fires. `http_check` retries connect-refused failures
+// for a bounded budget so single-pass `rig up` doesn't race the listener.
+// The four tests below pin both the wait-loop semantics and what we
+// deliberately do NOT retry on.
+
+/// Reserve a free TCP port by binding then dropping. Used only by tests
+/// that want to assert connect-refused behavior on an unbound port. Tests
+/// that intend to actually serve a response should use `bind_serving` so
+/// the port is held continuously and parallel tests can't steal it
+/// between reserve and serve.
+fn reserve_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+/// Bind a listener on an ephemeral port and return both the bound
+/// listener and its port. Caller is responsible for accepting on it
+/// (typically by passing the listener into `serve_once`). Eliminates
+/// the reserve→bind race that plagues `bind ephemeral; drop; rebind`.
+fn bind_serving() -> (std::net::TcpListener, u16) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    (listener, port)
+}
+
+/// Spawn a one-shot HTTP/1.0 server that answers a single connection
+/// with `status` and a tiny body, then exits.
+fn serve_once(listener: std::net::TcpListener, status: u16) -> std::thread::JoinHandle<()> {
+    use std::io::{Read, Write};
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            // Drain request just enough that the client doesn't see RST.
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            let body = "ok";
+            let response = format!(
+                "HTTP/1.0 {} OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                status,
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    })
+}
+
+#[test]
+fn test_http_check_retries_until_listener_appears() {
+    // Real-world race shape: pipeline runs `service.start` then `service.health`
+    // back-to-back. The fix's job is to absorb the bind() gap.
+    //
+    // We deliberately use `reserve_port` here (not `bind_serving`) so the
+    // port is genuinely closed at probe time — that's what reproduces the
+    // bind() race the fix targets. The handler thread re-binds after a
+    // delay; the retry loop must absorb the gap.
+    let port = reserve_port();
+    let url = format!("http://127.0.0.1:{}/", port);
+
+    let handle = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let listener =
+            std::net::TcpListener::bind(("127.0.0.1", port)).expect("rebind listener for race");
+        let server = serve_once(listener, 200);
+        // Block until the request is served so the test thread's drop
+        // doesn't kill the listener mid-handshake.
+        let _ = server.join();
+    });
+
+    let rig = minimal_rig();
+    let spec = CheckSpec {
+        http: Some(url),
+        expect_status: Some(200),
+        ..Default::default()
+    };
+    let start = std::time::Instant::now();
+    evaluate(&rig, &spec).expect("listener came up within budget");
+    let elapsed = start.elapsed();
+
+    // Sanity bounds: must have actually waited (>=400ms) and must not
+    // have run anywhere near the 10s ceiling.
+    assert!(
+        elapsed >= std::time::Duration::from_millis(400),
+        "expected to wait for the listener; elapsed = {:?}",
+        elapsed
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "should converge well before budget exhaustion; elapsed = {:?}",
+        elapsed
+    );
+
+    let _ = handle.join();
+}
+
+#[test]
+fn test_http_check_exhausts_budget_when_nothing_ever_listens() {
+    // Inverse case: confirm we DO give up. Without a bounded budget this
+    // would hang forever; without a budget AT ALL we'd return immediately
+    // and re-introduce the original race.
+    let port = reserve_port();
+    let url = format!("http://127.0.0.1:{}/", port);
+
+    let rig = minimal_rig();
+    let spec = CheckSpec {
+        http: Some(url),
+        expect_status: Some(200),
+        ..Default::default()
+    };
+    let start = std::time::Instant::now();
+    let err = evaluate(&rig, &spec).expect_err("no listener => fail");
+    let elapsed = start.elapsed();
+
+    // Budget is 10s; allow generous slack for slow CI but cap below a
+    // pathological hang.
+    assert!(
+        elapsed >= std::time::Duration::from_secs(9),
+        "must exhaust the wait-ready budget; elapsed = {:?}",
+        elapsed
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(20),
+        "must not hang past the budget; elapsed = {:?}",
+        elapsed
+    );
+    // Final error should still surface as a connect failure, not a fake
+    // success or a confusing fallback.
+    assert!(
+        err.message.contains("HTTP GET") && err.message.contains("failed"),
+        "expected HTTP failure message, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn test_http_check_passes_when_listener_already_up() {
+    // No race in this case — listener is bound before the probe fires.
+    // Should return effectively instantly with no retries.
+    let (listener, port) = bind_serving();
+    let url = format!("http://127.0.0.1:{}/", port);
+    let server = serve_once(listener, 200);
+
+    let rig = minimal_rig();
+    let spec = CheckSpec {
+        http: Some(url),
+        expect_status: Some(200),
+        ..Default::default()
+    };
+    let start = std::time::Instant::now();
+    evaluate(&rig, &spec).expect("listener up => pass");
+    let elapsed = start.elapsed();
+
+    // Should be sub-second; the retry loop must not idle when the very
+    // first attempt succeeds.
+    assert!(
+        elapsed < std::time::Duration::from_secs(1),
+        "no-race path must be near-instant; elapsed = {:?}",
+        elapsed
+    );
+
+    let _ = server.join();
+}
+
+#[test]
+fn test_http_check_does_not_retry_on_unexpected_status() {
+    // Critical contract: an HTTP-level response — even a 5xx — means the
+    // listener IS up and answering. Retrying on status mismatch would
+    // turn `http_check` into an application-level health waiter, which is
+    // a different probe (use `command` checks for that). The wait loop is
+    // strictly for the bind() race.
+    let (listener, port) = bind_serving();
+    let url = format!("http://127.0.0.1:{}/", port);
+    let server = serve_once(listener, 503); // listener up, wrong status
+
+    let rig = minimal_rig();
+    let spec = CheckSpec {
+        http: Some(url),
+        expect_status: Some(200),
+        ..Default::default()
+    };
+    let start = std::time::Instant::now();
+    let err = evaluate(&rig, &spec).expect_err("wrong status => fail immediately");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < std::time::Duration::from_secs(1),
+        "status mismatch must not enter the wait loop; elapsed = {:?}",
+        elapsed
+    );
+    assert!(
+        err.message.contains("returned 503") && err.message.contains("expected 200"),
+        "expected status-mismatch message, got: {}",
+        err.message
+    );
+
+    let _ = server.join();
+}


### PR DESCRIPTION
## Summary
- Closes #1537. `service.start` returns once the child is forked, but the kernel may not have called `bind()`/`listen()` yet when the next pipeline step (`service.health`) fires. Connect-refused is a clear "not ready yet" signal, but reqwest's 5s timeout doesn't help (refused is immediate, not a timeout). Single-pass `rig up` was racing the listener.
- `http_check` now retries on connect-refused, bounded by a 10s wait-ready budget with 200ms intervals. Any HTTP response (even 5xx) short-circuits the loop because that proves the listener is up — application-level health belongs in a separate `command` check.
- DNS / TLS / read-timeout errors are NOT retried; a retry loop on those would just paper over real problems.

## Behaviour
- No spec change, no new field, no new knob (Option A from the issue).
- Wait-ready budget is internal to `http_check`. Per-attempt request timeout is unchanged at 5s; the retry loop sits on top of it.
- Constants are documented inline so the next reader sees the contract:
  - `HTTP_WAIT_READY_BUDGET = 10s` — total wait ceiling.
  - `HTTP_RETRY_INTERVAL = 200ms` — sleep between connect-refused retries.

## Live verification
Minimal repro rig (`http-static` service on port 9939, `start` immediately followed by `health`):

| Build | Result |
|---|---|
| **Pre-fix** (homeboy 0.97.3) | 5/5 single-shot `up` failures with `HTTP GET ... failed: error sending request` |
| **Post-fix** | 5/5 single-shot passes, ~365ms each (Python `http.server` bind latency dominates) |
| **Post-fix budget exhaustion** | 10149ms total when no listener ever binds; connect-refused error preserved verbatim |

## Tests
4 new in `tests/core/rig/check_test.rs`:
- `test_http_check_retries_until_listener_appears` — listener bound 500ms after probe starts; converges within 5s
- `test_http_check_exhausts_budget_when_nothing_ever_listens` — must take 9-20s and surface connect-refused
- `test_http_check_passes_when_listener_already_up` — no-race path stays sub-second (retry loop must not idle when first attempt succeeds)
- `test_http_check_does_not_retry_on_unexpected_status` — **critical contract**: a 503 response means the listener IS up; status mismatch must not enter the wait loop

Helpers `bind_serving()` / `serve_once(listener, status)` hold the bound listener continuously to avoid the reserve→bind→rebind race that would flake parallel tests.

1472/0 release tests serial (`cargo test --release`).

## Audit
Baseline refreshed (+3 findings):
- 1 self-inflicted `HighItemCount` on `tests/core/rig/check_test.rs` — file grew past the 15-item threshold by adding 4 tests + 3 helpers. Tests cover distinct contracts; not collapsing them just to dodge the threshold.
- 2 pre-existing drift items on `src/core/extension/runner.rs` (unrelated to this PR — surfaced by the rebuild).

## Out of scope
- Changing `service::start` to block on socket-bind (ties supervisor to spec port, breaks non-HTTP services). Discussed and rejected in #1537.
- Cross-service health waits ("wait for foo before starting bar") — different problem.
- A configurable wait budget. Not needed yet; a 10s fixed ceiling fits every real service we've seen. Adding a knob the moment a service genuinely needs it is cheap.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafted the implementation, tests, and live verification against a minimal repro rig; Chris reviewed the wait-ready contract (retry on connect-refused only; HTTP responses including 5xx prove the listener is up) before commit.