### PR TITLE
feat(issues): homeboy issues reconcile + git issue close/edit primitives

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -3,9 +3,9 @@ use serde::Serialize;
 
 use homeboy::git::{
     self, CherryPickOptions, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput,
-    IssueCommentOptions, IssueCreateOptions, IssueFindOptions, IssueState, PrCommentMode,
-    PrCommentOptions, PrCreateOptions, PrEditOptions, PrFindOptions, PrState, PushOptions,
-    RebaseOptions, StackOptions, StackOutput,
+    IssueCloseOptions, IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions,
+    IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions,
+    PrFindOptions, PrState, PushOptions, RebaseOptions, StackOptions, StackOutput,
 };
 use homeboy::BulkResult;
 
@@ -332,6 +332,67 @@ enum IssueCommand {
         /// Max results (default 30)
         #[arg(long, default_value_t = 30)]
         limit: usize,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Close an existing issue with a typed reason
+    Close {
+        /// Component ID
+        component_id: String,
+
+        /// Issue number
+        #[arg(short, long)]
+        number: u64,
+
+        /// Close reason: completed (default) or not-planned. Use
+        /// `not-planned` to suppress re-filing by `homeboy issues reconcile`
+        /// — the GitHub-native signal for "we have decided not to fix this."
+        #[arg(short, long, default_value = "completed")]
+        reason: String,
+
+        /// Optional closing comment (markdown). Posted before the state
+        /// transition. Prefer --comment-file for long content.
+        #[arg(short, long, conflicts_with = "comment_file")]
+        comment: Option<String>,
+
+        /// Read closing comment from a file ("-" for stdin)
+        #[arg(long, value_name = "PATH")]
+        comment_file: Option<String>,
+
+        /// Workspace path to discover the component from a portable homeboy.json
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Edit an existing issue's title, body, or labels
+    Edit {
+        /// Component ID
+        component_id: String,
+
+        /// Issue number
+        #[arg(short, long)]
+        number: u64,
+
+        /// New title (optional)
+        #[arg(short, long)]
+        title: Option<String>,
+
+        /// New body (markdown). Prefer --body-file for long content.
+        #[arg(short, long, conflicts_with = "body_file")]
+        body: Option<String>,
+
+        /// Read body from a file ("-" for stdin)
+        #[arg(long, value_name = "PATH")]
+        body_file: Option<String>,
+
+        /// Add labels (repeatable)
+        #[arg(long = "add-label", value_name = "LABEL")]
+        add_labels: Vec<String>,
+
+        /// Remove labels (repeatable)
+        #[arg(long = "remove-label", value_name = "LABEL")]
+        remove_labels: Vec<String>,
 
         /// Workspace path to discover the component from a portable homeboy.json
         #[arg(long, value_name = "PATH")]
@@ -830,6 +891,51 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             )?;
             Ok((GitCommandOutput::Find(output), 0))
         }
+        IssueCommand::Close {
+            component_id,
+            number,
+            reason,
+            comment,
+            comment_file,
+            path,
+        } => {
+            let reason = parse_issue_close_reason(&reason)?;
+            let comment = resolve_body(comment, comment_file)?;
+            let output = git::issue_close(
+                Some(&component_id),
+                IssueCloseOptions {
+                    number,
+                    reason,
+                    comment,
+                    path,
+                },
+            )?;
+            Ok((GitCommandOutput::Issue(output), 0))
+        }
+        IssueCommand::Edit {
+            component_id,
+            number,
+            title,
+            body,
+            body_file,
+            add_labels,
+            remove_labels,
+            path,
+        } => {
+            let body = resolve_body(body, body_file)?;
+            let output = git::issue_edit(
+                Some(&component_id),
+                IssueEditOptions {
+                    number,
+                    title,
+                    body,
+                    add_labels,
+                    remove_labels,
+                    path,
+                },
+            )?;
+            Ok((GitCommandOutput::Issue(output), 0))
+        }
     }
 }
 
@@ -1012,6 +1118,21 @@ fn parse_issue_state(s: &str) -> homeboy::Result<IssueState> {
             format!("Unknown issue state '{}'", other),
             None,
             Some(vec!["Use one of: open, closed, all".into()]),
+        )),
+    }
+}
+
+fn parse_issue_close_reason(s: &str) -> homeboy::Result<IssueCloseReason> {
+    // Accept both kebab-case (CLI ergonomic) and snake_case (matches GitHub
+    // GraphQL state_reason values for symmetry with `--json stateReason`).
+    match s {
+        "completed" => Ok(IssueCloseReason::Completed),
+        "not-planned" | "not_planned" => Ok(IssueCloseReason::NotPlanned),
+        other => Err(homeboy::Error::validation_invalid_argument(
+            "reason",
+            format!("Unknown close reason '{}'", other),
+            None,
+            Some(vec!["Use one of: completed, not-planned".into()]),
         )),
     }
 }

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -1,0 +1,490 @@
+//! `homeboy issues reconcile` — finding-stream → tracker reconciliation.
+//!
+//! See homeboy issue #1551 for the architectural framing. This is the CLI
+//! surface that the action's `auto-file-categorized-issues.sh` collapses
+//! to a single call against.
+
+use clap::{Args, Subcommand};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::PathBuf;
+
+use homeboy::issues::{
+    apply_plan, reconcile, GithubTracker, IssueGroup, ReconcileConfig, ReconcilePlan,
+    ReconcileResult, Tracker,
+};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct IssuesArgs {
+    #[command(subcommand)]
+    command: IssuesCommand,
+}
+
+#[derive(Subcommand)]
+enum IssuesCommand {
+    /// Reconcile a finding stream against an issue tracker.
+    ///
+    /// Reads structured findings (from `homeboy audit --json-summary` or
+    /// `homeboy lint --json` or any equivalent), inspects open and closed
+    /// issues on the tracker, and produces a deterministic plan: file new,
+    /// update, close, dedupe, or skip per category.
+    ///
+    /// Defaults to dry-run; pass `--apply` to actually call the tracker.
+    Reconcile {
+        /// Component ID. Tracker repo is resolved from this component's
+        /// `remote_url` (or git remote, when --path is set).
+        component_id: String,
+
+        /// Tracker URI. Currently only `github://owner/repo` is supported.
+        /// When omitted, defaults to the component's GitHub remote — the
+        /// common case.
+        #[arg(long, value_name = "URI")]
+        tracker: Option<String>,
+
+        /// Path to a JSON findings file. Use `-` to read from stdin. The
+        /// file's shape:
+        ///
+        /// ```json
+        /// {
+        ///   "command": "audit",
+        ///   "groups": {
+        ///     "unreferenced_export": { "count": 57, "label": "unreferenced export", "body": "..." },
+        ///     "god_file": { "count": 23, "label": "god file", "body": "..." }
+        ///   }
+        /// }
+        /// ```
+        ///
+        /// Categories with `count: 0` drive close-on-resolved transitions.
+        /// `body` is rendered as-is into new or updated issues — callers
+        /// own the finding-table format.
+        #[arg(long, value_name = "PATH")]
+        findings: String,
+
+        /// Read suppressions from `homeboy.json`'s `audit.suppressed_categories`
+        /// and `issues.suppression_labels`. When false, suppression must be
+        /// passed explicitly via the flags below.
+        #[arg(long, default_value_t = true)]
+        suppress_from_config: bool,
+
+        /// Override category suppressions (repeatable). Replaces the
+        /// homeboy.json list when both are set.
+        #[arg(long, value_name = "CATEGORY")]
+        suppress_category: Vec<String>,
+
+        /// Override label suppressions (repeatable). Replaces the
+        /// homeboy.json list when both are set.
+        #[arg(long, value_name = "LABEL")]
+        suppress_label: Vec<String>,
+
+        /// Don't refresh the body of closed-not_planned issues with the
+        /// latest finding count. Default is to refresh (so the closed
+        /// issue stays useful as a "current state" reference).
+        #[arg(long)]
+        no_refresh_closed: bool,
+
+        /// Cap the number of issues fetched from the tracker for dedup
+        /// analysis. Defaults to 200 — high enough for normal repos, but
+        /// avoids paginating the entire tracker.
+        #[arg(long, default_value_t = 200)]
+        list_limit: usize,
+
+        /// Actually perform the reconcile actions. Default is dry-run.
+        #[arg(long)]
+        apply: bool,
+
+        /// Workspace path to discover the component from a portable
+        /// homeboy.json (CI runners, ad-hoc clones).
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum IssuesCommandOutput {
+    Reconcile(ReconcileOutput),
+}
+
+/// What the CLI emits for `homeboy issues reconcile`. Both dry-run and
+/// apply runs share this shape; `applied = false` means dry-run, no
+/// tracker calls were made.
+#[derive(Serialize)]
+pub struct ReconcileOutput {
+    pub component_id: String,
+    pub command: String,
+    pub applied: bool,
+    /// Always populated — same shape regardless of dry-run vs apply.
+    pub plan_summary: PlanSummary,
+    /// Only populated when `applied = true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<ReconcileResult>,
+    /// Always populated — full plan as a list of human-readable lines.
+    pub plan_lines: Vec<String>,
+}
+
+#[derive(Serialize, Default)]
+pub struct PlanSummary {
+    pub total_actions: usize,
+    pub file_new: usize,
+    pub update: usize,
+    pub update_closed: usize,
+    pub close: usize,
+    pub close_duplicate: usize,
+    pub skip: usize,
+}
+
+pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCommandOutput> {
+    match args.command {
+        IssuesCommand::Reconcile {
+            component_id,
+            tracker: _tracker,
+            findings,
+            suppress_from_config,
+            suppress_category,
+            suppress_label,
+            no_refresh_closed,
+            list_limit,
+            apply,
+            path,
+        } => {
+            let findings_input = read_findings(&findings)?;
+            let command_label = findings_input.command.clone();
+            let groups = findings_input.into_groups(&component_id);
+
+            // Build reconcile config: CLI overrides take priority; otherwise
+            // read homeboy.json when the flag is set; otherwise empty.
+            let config = build_reconcile_config(
+                &component_id,
+                path.as_deref(),
+                suppress_from_config,
+                suppress_category,
+                suppress_label,
+                no_refresh_closed,
+            )?;
+
+            // Default tracker = GitHub against the component's remote.
+            let tracker_impl = GithubTracker::new(component_id.clone()).with_path(path.clone());
+
+            // Fetch existing issues for label-scoping.
+            let existing = tracker_impl.list_issues(&command_label, list_limit)?;
+
+            // Pure decision.
+            let plan = reconcile(&groups, &existing, &config);
+            let plan_lines = render_plan_lines(&plan);
+            let plan_summary = summarize_plan(&plan);
+
+            if apply {
+                let result = apply_plan(plan, &tracker_impl)?;
+                let exit = if result.failed_count > 0 { 1 } else { 0 };
+                let output = ReconcileOutput {
+                    component_id,
+                    command: command_label,
+                    applied: true,
+                    plan_summary,
+                    result: Some(result),
+                    plan_lines,
+                };
+                Ok((IssuesCommandOutput::Reconcile(output), exit))
+            } else {
+                let output = ReconcileOutput {
+                    component_id,
+                    command: command_label,
+                    applied: false,
+                    plan_summary,
+                    result: None,
+                    plan_lines,
+                };
+                Ok((IssuesCommandOutput::Reconcile(output), 0))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Findings input parsing
+// ---------------------------------------------------------------------------
+
+/// Findings input shape. Designed to be a minimal superset of the JSON the
+/// action's bash already produces, so the migration path doesn't require
+/// changing the audit/lint/test output formats.
+#[derive(Debug)]
+struct FindingsInput {
+    command: String,
+    groups: BTreeMap<String, GroupRow>,
+}
+
+#[derive(Debug, Default)]
+struct GroupRow {
+    count: usize,
+    label: String,
+    body: String,
+}
+
+impl FindingsInput {
+    fn into_groups(self, component_id: &str) -> Vec<IssueGroup> {
+        self.groups
+            .into_iter()
+            .map(|(category, row)| IssueGroup {
+                command: self.command.clone(),
+                component_id: component_id.to_string(),
+                category,
+                count: row.count,
+                label: row.label,
+                body: row.body,
+            })
+            .collect()
+    }
+}
+
+fn read_findings(path: &str) -> homeboy::Result<FindingsInput> {
+    let raw = if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            homeboy::Error::internal_io(
+                format!("read findings from stdin: {}", e),
+                Some("stdin".into()),
+            )
+        })?;
+        buf
+    } else {
+        std::fs::read_to_string(path).map_err(|e| {
+            homeboy::Error::internal_io(
+                format!("read findings file: {}", e),
+                Some(path.to_string()),
+            )
+        })?
+    };
+
+    let value: Value = serde_json::from_str(&raw).map_err(|e| {
+        homeboy::Error::validation_invalid_json(
+            e,
+            Some("parse findings JSON".to_string()),
+            Some(raw.chars().take(200).collect()),
+        )
+    })?;
+
+    parse_findings_value(value)
+}
+
+fn parse_findings_value(value: Value) -> homeboy::Result<FindingsInput> {
+    let obj = value.as_object().ok_or_else(|| {
+        homeboy::Error::validation_invalid_argument(
+            "findings",
+            "Findings JSON must be an object with a `command` and `groups` field",
+            None,
+            None,
+        )
+    })?;
+
+    let command = obj
+        .get("command")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "findings.command",
+                "Missing or non-string `command` field (e.g. \"audit\")",
+                None,
+                None,
+            )
+        })?
+        .to_string();
+
+    let mut groups: BTreeMap<String, GroupRow> = BTreeMap::new();
+    if let Some(groups_value) = obj.get("groups") {
+        let groups_obj = groups_value.as_object().ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "findings.groups",
+                "`groups` must be a JSON object keyed by category",
+                None,
+                None,
+            )
+        })?;
+        for (category, row_value) in groups_obj {
+            let row_obj = row_value.as_object().ok_or_else(|| {
+                homeboy::Error::validation_invalid_argument(
+                    &format!("findings.groups.{}", category),
+                    "Each group must be a JSON object with `count`, optional `label`, optional `body`",
+                    None,
+                    None,
+                )
+            })?;
+            let count = row_obj
+                .get("count")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize)
+                .unwrap_or(0);
+            let label = row_obj
+                .get("label")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let body = row_obj
+                .get("body")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            groups.insert(category.clone(), GroupRow { count, label, body });
+        }
+    }
+
+    Ok(FindingsInput { command, groups })
+}
+
+// ---------------------------------------------------------------------------
+// homeboy.json suppression read
+// ---------------------------------------------------------------------------
+
+fn build_reconcile_config(
+    component_id: &str,
+    path: Option<&str>,
+    suppress_from_config: bool,
+    cli_categories: Vec<String>,
+    cli_labels: Vec<String>,
+    no_refresh_closed: bool,
+) -> homeboy::Result<ReconcileConfig> {
+    let mut config = ReconcileConfig {
+        suppressed_categories: Vec::new(),
+        suppression_labels: Vec::new(),
+        refresh_closed_not_planned: !no_refresh_closed,
+    };
+
+    if suppress_from_config {
+        if let Some((suppressed, labels)) = read_suppressions(component_id, path)? {
+            config.suppressed_categories = suppressed;
+            config.suppression_labels = labels;
+        }
+    }
+
+    // CLI flags override homeboy.json when present.
+    if !cli_categories.is_empty() {
+        config.suppressed_categories = cli_categories;
+    }
+    if !cli_labels.is_empty() {
+        config.suppression_labels = cli_labels;
+    }
+
+    // Sane default for suppression_labels when neither config nor CLI set
+    // them. Mirrors the documented defaults in #1551.
+    if config.suppression_labels.is_empty() {
+        config.suppression_labels = vec![
+            "wontfix".into(),
+            "upstream-bug".into(),
+            "audit-suppressed".into(),
+        ];
+    }
+
+    Ok(config)
+}
+
+fn read_suppressions(
+    component_id: &str,
+    path: Option<&str>,
+) -> homeboy::Result<Option<(Vec<String>, Vec<String>)>> {
+    let component_dir = match path {
+        Some(p) => PathBuf::from(p),
+        None => match homeboy::component::resolve_effective(Some(component_id), None, None) {
+            Ok(c) => PathBuf::from(c.local_path),
+            Err(_) => return Ok(None),
+        },
+    };
+
+    let raw = match homeboy::component::read_portable_config(&component_dir)? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    let categories = raw
+        .pointer("/audit/suppressed_categories")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let labels = raw
+        .pointer("/issues/suppression_labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if categories.is_empty() && labels.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some((categories, labels)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plan rendering helpers (also used by apply path for symmetry)
+// ---------------------------------------------------------------------------
+
+fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
+    plan.actions
+        .iter()
+        .map(|a| match a {
+            homeboy::issues::ReconcileAction::FileNew {
+                command,
+                component_id,
+                category,
+                count,
+                ..
+            } => format!(
+                "file_new      {}: {} in {} ({})",
+                command, category, component_id, count
+            ),
+            homeboy::issues::ReconcileAction::Update {
+                number,
+                category,
+                count,
+                ..
+            } => format!("update        {} ({}) → #{}", category, count, number),
+            homeboy::issues::ReconcileAction::UpdateClosed {
+                number,
+                category,
+                count,
+                ..
+            } => format!(
+                "update_closed {} ({}) → #{} (stays closed)",
+                category, count, number
+            ),
+            homeboy::issues::ReconcileAction::Close {
+                number, category, ..
+            } => format!("close         {} → #{}", category, number),
+            homeboy::issues::ReconcileAction::CloseDuplicate {
+                number,
+                keep,
+                category,
+                ..
+            } => format!(
+                "dedupe        {} → keep #{}, close #{}",
+                category, keep, number
+            ),
+            homeboy::issues::ReconcileAction::Skip {
+                category, reason, ..
+            } => format!("skip          {} ({:?})", category, reason),
+        })
+        .collect()
+}
+
+fn summarize_plan(plan: &ReconcilePlan) -> PlanSummary {
+    let counts = plan.counts();
+    PlanSummary {
+        total_actions: plan.actions.len(),
+        file_new: counts.file_new,
+        update: counts.update,
+        update_closed: counts.update_closed,
+        close: counts.close,
+        close_duplicate: counts.close_duplicate,
+        skip: counts.skip,
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -292,6 +292,7 @@ pub mod file;
 pub mod fleet;
 pub mod git;
 pub mod init;
+pub mod issues;
 pub mod lint;
 pub mod logs;
 pub mod project;
@@ -362,6 +363,7 @@ pub(crate) fn run_json(
         crate::Commands::Docs(args) => dispatch!(args, global, docs),
         crate::Commands::Changelog(args) => dispatch!(args, global, changelog),
         crate::Commands::Git(args) => dispatch!(args, global, git),
+        crate::Commands::Issues(args) => dispatch!(args, global, issues),
         crate::Commands::Version(args) => dispatch!(args, global, version),
         crate::Commands::Build(args) => dispatch!(args, global, build),
         crate::Commands::Validate(args) => dispatch!(args, global, validate),

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -99,6 +99,17 @@ pub struct GithubFindItem {
     pub title: String,
     pub url: String,
     pub state: String,
+    /// GitHub `stateReason` (issues only). One of `completed`, `not_planned`,
+    /// `reopened`, or `null`. Empty string when absent or for PRs.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub state_reason: String,
+    /// GitHub `closedAt` ISO-8601 timestamp (issues only). Empty when absent
+    /// (open issues) or for PRs.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub closed_at: String,
+    /// Labels attached to the issue/PR. Used for label-based suppression.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -268,7 +279,72 @@ pub enum PrCommentMode {
     },
 }
 
-/// Parameters for commenting on an existing issue.
+/// Parameters for closing an existing issue with a reason.
+///
+/// `reason` defaults to `Completed` (the GitHub-native signal for "the
+/// underlying problem was resolved"). `NotPlanned` is preserved across CI
+/// runs by `homeboy issues reconcile` as the "do not re-file" signal.
+#[derive(Debug, Clone, Default)]
+pub struct IssueCloseOptions {
+    pub number: u64,
+    /// Close-reason. `Completed` (default) is the GitHub-native signal for
+    /// "the underlying problem was resolved." `NotPlanned` is the GitHub-native
+    /// signal for "we've decided not to fix this" — used by `homeboy issues
+    /// reconcile` to suppress re-filing on subsequent runs.
+    pub reason: IssueCloseReason,
+    /// Optional closing comment posted before the state transition. Useful
+    /// for explaining why the issue is being closed (e.g. "All findings have
+    /// been resolved" / "Closed as duplicate of #N" / "Closed as upstream bug").
+    pub comment: Option<String>,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum IssueCloseReason {
+    #[default]
+    Completed,
+    NotPlanned,
+}
+
+impl IssueCloseReason {
+    /// Render for the `gh issue close --reason` flag. GitHub's CLI uses the
+    /// space-form (`"not planned"`) but the underlying GraphQL `state_reason`
+    /// uses the underscore form (`not_planned`). `IssueState::Reason` parsing
+    /// reads the underscore form from `gh ... --json stateReason`.
+    fn as_gh_flag(self) -> &'static str {
+        match self {
+            IssueCloseReason::Completed => "completed",
+            IssueCloseReason::NotPlanned => "not planned",
+        }
+    }
+
+    /// Parse from the GraphQL `state_reason` field on a closed issue.
+    /// Returns `None` when the value is unknown or absent (open issues).
+    pub fn from_graphql(s: &str) -> Option<Self> {
+        match s {
+            "completed" | "COMPLETED" => Some(IssueCloseReason::Completed),
+            "not_planned" | "NOT_PLANNED" => Some(IssueCloseReason::NotPlanned),
+            _ => None,
+        }
+    }
+}
+
+/// Parameters for editing an existing issue.
+#[derive(Debug, Clone, Default)]
+pub struct IssueEditOptions {
+    pub number: u64,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    /// Labels to add. Mirrors `gh issue edit --add-label` (repeatable).
+    pub add_labels: Vec<String>,
+    /// Labels to remove. Mirrors `gh issue edit --remove-label`.
+    pub remove_labels: Vec<String>,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
+}
+
+/// Parameters for posting a comment on an existing issue.
 #[derive(Debug, Clone, Default)]
 pub struct IssueCommentOptions {
     pub number: u64,
@@ -364,11 +440,120 @@ pub fn issue_comment(
     })
 }
 
+/// Close an existing issue with a typed reason.
+///
+/// `gh issue close --reason` accepts `completed | not planned | duplicate`.
+/// We expose the two semantically-meaningful values via [`IssueCloseReason`];
+/// `duplicate` is a special-case of "not planned" and not modeled here. Use
+/// [`IssueCloseOptions::comment`] to leave a closing comment in the same
+/// invocation (mirrors `gh issue close --comment`).
+pub fn issue_close(
+    component_id: Option<&str>,
+    options: IssueCloseOptions,
+) -> Result<GithubIssueOutput> {
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
+    ensure_gh_ready()?;
+
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+    let mut args: Vec<String> = vec![
+        "issue".into(),
+        "close".into(),
+        options.number.to_string(),
+        "-R".into(),
+        repo_flag,
+        "--reason".into(),
+        options.reason.as_gh_flag().to_string(),
+    ];
+    if let Some(comment) = &options.comment {
+        args.push("--comment".into());
+        args.push(comment.clone());
+    }
+
+    let _ = run_gh(&args)?;
+    Ok(GithubIssueOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: "issue.close".to_string(),
+        success: true,
+        number: Some(options.number),
+        url: None,
+        title: None,
+        state: Some("closed".to_string()),
+    })
+}
+
+/// Edit an existing issue's title, body, or labels.
+///
+/// At least one of `title`, `body`, `add_labels`, or `remove_labels` must be
+/// provided. Mirrors `gh issue edit <n> [--title ...] [--body ...]
+/// [--add-label ...] [--remove-label ...]`. Used by `homeboy issues reconcile`
+/// to refresh the body of existing issues (open OR closed) so the latest
+/// finding count and run link stay visible without duplicating the issue.
+pub fn issue_edit(
+    component_id: Option<&str>,
+    options: IssueEditOptions,
+) -> Result<GithubIssueOutput> {
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
+    ensure_gh_ready()?;
+
+    if options.title.is_none()
+        && options.body.is_none()
+        && options.add_labels.is_empty()
+        && options.remove_labels.is_empty()
+    {
+        return Err(Error::validation_invalid_argument(
+            "title/body/labels",
+            "At least one of --title, --body, --add-label, or --remove-label must be provided",
+            None,
+            None,
+        ));
+    }
+
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+    let mut args: Vec<String> = vec![
+        "issue".into(),
+        "edit".into(),
+        options.number.to_string(),
+        "-R".into(),
+        repo_flag,
+    ];
+    if let Some(title) = &options.title {
+        args.push("--title".into());
+        args.push(title.clone());
+    }
+    if let Some(body) = &options.body {
+        args.push("--body".into());
+        args.push(body.clone());
+    }
+    for label in &options.add_labels {
+        args.push("--add-label".into());
+        args.push(label.clone());
+    }
+    for label in &options.remove_labels {
+        args.push("--remove-label".into());
+        args.push(label.clone());
+    }
+
+    let output = run_gh(&args)?;
+    Ok(GithubIssueOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: "issue.edit".to_string(),
+        success: true,
+        number: Some(options.number),
+        url: Some(output.trim().to_string()),
+        title: options.title,
+        state: None,
+    })
+}
+
 /// Find issues matching the given filter. Useful for dedup before creating.
 ///
-/// Uses `gh issue list --json number,title,url,state,labels` and filters
-/// locally (title and label conjunctions are simpler to enforce client-side
-/// than via the gh search syntax).
+/// Uses `gh issue list --json number,title,url,state,stateReason,closedAt,labels`
+/// and filters locally (title and label conjunctions are simpler to enforce
+/// client-side than via the gh search syntax).
 pub fn issue_find(
     component_id: Option<&str>,
     options: IssueFindOptions,
@@ -392,7 +577,7 @@ pub fn issue_find(
         "--limit".into(),
         limit.to_string(),
         "--json".into(),
-        "number,title,url,state,labels".into(),
+        "number,title,url,state,stateReason,closedAt,labels".into(),
     ];
     // Pass labels through gh to narrow the server-side result set; we still
     // enforce the exact label-set conjunction locally in case gh changes the
@@ -1297,6 +1482,10 @@ fn parse_issue_list_json(raw: &str, options: &IssueFindOptions) -> Result<Vec<Gi
         title: String,
         url: String,
         state: String,
+        #[serde(default, rename = "stateReason")]
+        state_reason: Option<String>,
+        #[serde(default, rename = "closedAt")]
+        closed_at: Option<String>,
         #[serde(default)]
         labels: Vec<RawLabel>,
     }
@@ -1325,6 +1514,9 @@ fn parse_issue_list_json(raw: &str, options: &IssueFindOptions) -> Result<Vec<Gi
             title: i.title,
             url: i.url,
             state: i.state,
+            state_reason: i.state_reason.unwrap_or_default(),
+            closed_at: i.closed_at.unwrap_or_default(),
+            labels: i.labels.into_iter().map(|l| l.name).collect(),
         })
         .collect();
     Ok(out)
@@ -1348,6 +1540,9 @@ fn parse_pr_list_json(raw: &str) -> Result<Vec<GithubFindItem>> {
             title: p.title,
             url: p.url,
             state: p.state,
+            state_reason: String::new(),
+            closed_at: String::new(),
+            labels: Vec::new(),
         })
         .collect())
 }
@@ -1453,6 +1648,121 @@ mod tests {
     fn pr_state_gh_flag() {
         assert_eq!(PrState::Open.as_gh_flag(), "open");
         assert_eq!(PrState::Merged.as_gh_flag(), "merged");
+    }
+
+    #[test]
+    fn issue_close_reason_gh_flag() {
+        assert_eq!(IssueCloseReason::Completed.as_gh_flag(), "completed");
+        assert_eq!(IssueCloseReason::NotPlanned.as_gh_flag(), "not planned");
+    }
+
+    #[test]
+    fn issue_close_reason_from_graphql_completed() {
+        assert_eq!(
+            IssueCloseReason::from_graphql("completed"),
+            Some(IssueCloseReason::Completed)
+        );
+        assert_eq!(
+            IssueCloseReason::from_graphql("COMPLETED"),
+            Some(IssueCloseReason::Completed)
+        );
+    }
+
+    #[test]
+    fn issue_close_reason_from_graphql_not_planned() {
+        assert_eq!(
+            IssueCloseReason::from_graphql("not_planned"),
+            Some(IssueCloseReason::NotPlanned)
+        );
+        assert_eq!(
+            IssueCloseReason::from_graphql("NOT_PLANNED"),
+            Some(IssueCloseReason::NotPlanned)
+        );
+    }
+
+    #[test]
+    fn issue_close_reason_from_graphql_unknown_returns_none() {
+        assert!(IssueCloseReason::from_graphql("").is_none());
+        assert!(IssueCloseReason::from_graphql("reopened").is_none());
+        assert!(IssueCloseReason::from_graphql("nonsense").is_none());
+    }
+
+    #[test]
+    fn parse_issue_list_extracts_state_reason_and_closed_at() {
+        // gh issue list --json includes stateReason + closedAt fields when
+        // requested. Closed-completed, closed-not_planned, and open issues
+        // are represented in this fixture.
+        let raw = r#"[
+            {
+                "number": 100,
+                "title": "audit: thing in repo (3)",
+                "url": "https://github.com/o/r/issues/100",
+                "state": "OPEN",
+                "stateReason": null,
+                "closedAt": null,
+                "labels": [{"name":"audit"}]
+            },
+            {
+                "number": 101,
+                "title": "audit: other in repo (5)",
+                "url": "https://github.com/o/r/issues/101",
+                "state": "CLOSED",
+                "stateReason": "completed",
+                "closedAt": "2026-04-25T12:00:00Z",
+                "labels": [{"name":"audit"}]
+            },
+            {
+                "number": 102,
+                "title": "audit: muted in repo (12)",
+                "url": "https://github.com/o/r/issues/102",
+                "state": "CLOSED",
+                "stateReason": "not_planned",
+                "closedAt": "2026-04-26T03:00:00Z",
+                "labels": [{"name":"audit"},{"name":"wontfix"}]
+            }
+        ]"#;
+        let opts = IssueFindOptions {
+            state: IssueState::All,
+            ..Default::default()
+        };
+        let items = parse_issue_list_json(raw, &opts).unwrap();
+        assert_eq!(items.len(), 3);
+
+        // Open issue: empty state_reason and closed_at, single label.
+        assert_eq!(items[0].number, 100);
+        assert_eq!(items[0].state, "OPEN");
+        assert_eq!(items[0].state_reason, "");
+        assert_eq!(items[0].closed_at, "");
+        assert_eq!(items[0].labels, vec!["audit".to_string()]);
+
+        // Closed completed: state_reason populated, closed_at populated.
+        assert_eq!(items[1].number, 101);
+        assert_eq!(items[1].state, "CLOSED");
+        assert_eq!(items[1].state_reason, "completed");
+        assert_eq!(items[1].closed_at, "2026-04-25T12:00:00Z");
+
+        // Closed not_planned with suppression label.
+        assert_eq!(items[2].number, 102);
+        assert_eq!(items[2].state_reason, "not_planned");
+        assert_eq!(
+            items[2].labels,
+            vec!["audit".to_string(), "wontfix".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_issue_list_handles_missing_optional_fields() {
+        // Older gh versions or projects without state-reason support emit
+        // payloads without those fields. Default-deserialize to empty.
+        let raw = r#"[
+            {"number":1,"title":"x","url":"u","state":"open","labels":[]}
+        ]"#;
+        let opts = IssueFindOptions::default();
+        let items = parse_issue_list_json(raw, &opts).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].state_reason, "");
+        assert_eq!(items[0].closed_at, "");
+        assert!(items[0].labels.is_empty());
     }
 
     // -----------------------------------------------------------------------

--- a/src/core/issues/apply.rs
+++ b/src/core/issues/apply.rs
@@ -1,0 +1,408 @@
+//! Plan executor: walk a [`ReconcilePlan`] and call the [`Tracker`].
+//!
+//! Pure separation: the plan is decided in [`reconcile`](super::reconcile),
+//! the I/O is performed here. Each action's outcome is captured so dry-run
+//! and apply runs share the same output shape (the plan + per-action result).
+
+use serde::Serialize;
+
+use crate::error::{Error, Result};
+
+use super::plan::{ReconcileAction, ReconcilePlan, ReconcilePlanCounts};
+use super::tracker::{CloseReason, Tracker};
+
+/// Execute a [`ReconcilePlan`] against a [`Tracker`]. Returns a
+/// [`ReconcileResult`] with the original plan plus per-action outcomes.
+///
+/// Failure semantics: each action is best-effort. A failed action is recorded
+/// in the result and the run continues. The overall return is `Ok(...)` as
+/// long as we produced a result; callers inspect `failed_count` to decide
+/// whether to exit non-zero.
+pub fn apply_plan(plan: ReconcilePlan, tracker: &dyn Tracker) -> Result<ReconcileResult> {
+    let mut executions: Vec<ReconcileExecution> = Vec::with_capacity(plan.actions.len());
+
+    for action in &plan.actions {
+        let exec = execute_action(action, tracker);
+        executions.push(exec);
+    }
+
+    let counts = plan.counts();
+    let failed_count = executions
+        .iter()
+        .filter(|e| matches!(e.outcome, ExecutionOutcome::Failed { .. }))
+        .count();
+
+    Ok(ReconcileResult {
+        plan,
+        executions,
+        counts,
+        failed_count,
+    })
+}
+
+fn execute_action(action: &ReconcileAction, tracker: &dyn Tracker) -> ReconcileExecution {
+    let summary = summary_for(action);
+    let outcome = match action {
+        ReconcileAction::FileNew {
+            title,
+            body,
+            labels,
+            ..
+        } => match tracker.create_issue(title, body, labels) {
+            Ok(number) => ExecutionOutcome::Filed { number },
+            Err(e) => ExecutionOutcome::failed(&e),
+        },
+        ReconcileAction::Update {
+            number,
+            title,
+            body,
+            ..
+        } => match tracker.update_issue(*number, Some(title), Some(body)) {
+            Ok(()) => ExecutionOutcome::Updated { number: *number },
+            Err(e) => ExecutionOutcome::failed(&e),
+        },
+        ReconcileAction::UpdateClosed { number, body, .. } => {
+            match tracker.update_issue(*number, None, Some(body)) {
+                Ok(()) => ExecutionOutcome::UpdatedClosed { number: *number },
+                Err(e) => ExecutionOutcome::failed(&e),
+            }
+        }
+        ReconcileAction::Close {
+            number, comment, ..
+        } => match tracker.close_issue(*number, CloseReason::Completed, Some(comment)) {
+            Ok(()) => ExecutionOutcome::Closed { number: *number },
+            Err(e) => ExecutionOutcome::failed(&e),
+        },
+        ReconcileAction::CloseDuplicate {
+            number,
+            keep,
+            comment,
+            ..
+        } => match tracker.close_issue(*number, CloseReason::NotPlanned, Some(comment)) {
+            Ok(()) => ExecutionOutcome::ClosedDuplicate {
+                number: *number,
+                keep: *keep,
+            },
+            Err(e) => ExecutionOutcome::failed(&e),
+        },
+        ReconcileAction::Skip { .. } => ExecutionOutcome::Skipped,
+    };
+
+    ReconcileExecution { summary, outcome }
+}
+
+fn summary_for(action: &ReconcileAction) -> String {
+    match action {
+        ReconcileAction::FileNew {
+            command,
+            component_id,
+            category,
+            count,
+            ..
+        } => format!(
+            "file_new      {}: {} in {} ({})",
+            command, category, component_id, count
+        ),
+        ReconcileAction::Update {
+            number,
+            category,
+            count,
+            ..
+        } => format!("update        {} ({} → #{})", category, count, number),
+        ReconcileAction::UpdateClosed {
+            number,
+            category,
+            count,
+            ..
+        } => format!(
+            "update_closed {} ({} → #{}) [stays closed]",
+            category, count, number
+        ),
+        ReconcileAction::Close {
+            number, category, ..
+        } => format!("close         {} → #{}", category, number),
+        ReconcileAction::CloseDuplicate {
+            number,
+            keep,
+            category,
+            ..
+        } => format!(
+            "dedupe        {} → keep #{} close #{}",
+            category, keep, number
+        ),
+        ReconcileAction::Skip {
+            category, reason, ..
+        } => format!("skip          {} ({:?})", category, reason),
+    }
+}
+
+/// Per-action outcome. Pairs with the original action for traceability.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReconcileExecution {
+    pub summary: String,
+    pub outcome: ExecutionOutcome,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ExecutionOutcome {
+    Filed { number: u64 },
+    Updated { number: u64 },
+    UpdatedClosed { number: u64 },
+    Closed { number: u64 },
+    ClosedDuplicate { number: u64, keep: u64 },
+    Skipped,
+    Failed { error: String },
+}
+
+impl ExecutionOutcome {
+    fn failed(err: &Error) -> Self {
+        ExecutionOutcome::Failed {
+            error: err.to_string(),
+        }
+    }
+}
+
+/// Full reconcile output: plan + per-action results + summary counts.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReconcileResult {
+    pub plan: ReconcilePlan,
+    pub executions: Vec<ReconcileExecution>,
+    pub counts: ReconcilePlanCounts,
+    pub failed_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Tests — apply_plan with a mock Tracker
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::issues::plan::{ReconcileAction, ReconcileSkipReason};
+    use std::cell::RefCell;
+
+    /// Mock tracker: records every call, returns canned IDs for create_issue.
+    /// Each operation can be set to fail by toggling the matching flag.
+    struct MockTracker {
+        calls: RefCell<Vec<String>>,
+        fail_create: bool,
+        fail_close: bool,
+    }
+
+    impl MockTracker {
+        fn new() -> Self {
+            Self {
+                calls: RefCell::new(Vec::new()),
+                fail_create: false,
+                fail_close: false,
+            }
+        }
+    }
+
+    impl Tracker for MockTracker {
+        fn list_issues(
+            &self,
+            _label: &str,
+            _limit: usize,
+        ) -> Result<Vec<crate::core::issues::TrackedIssue>> {
+            unimplemented!("apply_plan does not call list_issues")
+        }
+        fn create_issue(&self, title: &str, _body: &str, _labels: &[String]) -> Result<u64> {
+            self.calls.borrow_mut().push(format!("create:{}", title));
+            if self.fail_create {
+                Err(Error::internal_io("create failed", None))
+            } else {
+                Ok(42)
+            }
+        }
+        fn update_issue(
+            &self,
+            number: u64,
+            title: Option<&str>,
+            _body: Option<&str>,
+        ) -> Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(format!("update:#{}:{}", number, title.unwrap_or("-")));
+            Ok(())
+        }
+        fn close_issue(
+            &self,
+            number: u64,
+            reason: CloseReason,
+            _comment: Option<&str>,
+        ) -> Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(format!("close:#{}:{:?}", number, reason));
+            if self.fail_close {
+                Err(Error::internal_io("close failed", None))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn file_new(category: &str) -> ReconcileAction {
+        ReconcileAction::FileNew {
+            command: "audit".into(),
+            component_id: "c".into(),
+            category: category.into(),
+            title: format!("audit: {} in c (5)", category),
+            body: "body".into(),
+            labels: vec!["audit".into()],
+            count: 5,
+        }
+    }
+
+    #[test]
+    fn applies_file_new_via_tracker() {
+        let plan = ReconcilePlan {
+            actions: vec![file_new("x")],
+        };
+        let tracker = MockTracker::new();
+        let result = apply_plan(plan, &tracker).unwrap();
+
+        assert_eq!(result.executions.len(), 1);
+        assert!(matches!(
+            result.executions[0].outcome,
+            ExecutionOutcome::Filed { number: 42 }
+        ));
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(tracker.calls.borrow().len(), 1);
+    }
+
+    #[test]
+    fn applies_update_close_dedupe_in_order() {
+        let plan = ReconcilePlan {
+            actions: vec![
+                ReconcileAction::Update {
+                    number: 100,
+                    title: "audit: x in c (3)".into(),
+                    body: "b".into(),
+                    category: "x".into(),
+                    count: 3,
+                },
+                ReconcileAction::Close {
+                    number: 200,
+                    category: "y".into(),
+                    comment: "resolved".into(),
+                },
+                ReconcileAction::CloseDuplicate {
+                    number: 300,
+                    keep: 100,
+                    category: "x".into(),
+                    comment: "dupe of #100".into(),
+                },
+            ],
+        };
+        let tracker = MockTracker::new();
+        let result = apply_plan(plan, &tracker).unwrap();
+
+        assert_eq!(result.executions.len(), 3);
+        assert!(matches!(
+            result.executions[0].outcome,
+            ExecutionOutcome::Updated { number: 100 }
+        ));
+        assert!(matches!(
+            result.executions[1].outcome,
+            ExecutionOutcome::Closed { number: 200 }
+        ));
+        assert!(matches!(
+            result.executions[2].outcome,
+            ExecutionOutcome::ClosedDuplicate {
+                number: 300,
+                keep: 100,
+            }
+        ));
+
+        let calls = tracker.calls.borrow();
+        assert_eq!(calls[0], "update:#100:audit: x in c (3)");
+        assert_eq!(calls[1], "close:#200:Completed");
+        assert_eq!(calls[2], "close:#300:NotPlanned");
+    }
+
+    #[test]
+    fn skip_actions_make_no_tracker_calls() {
+        let plan = ReconcilePlan {
+            actions: vec![
+                ReconcileAction::Skip {
+                    category: "x".into(),
+                    component_id: "c".into(),
+                    reason: ReconcileSkipReason::SuppressedByConfig,
+                },
+                ReconcileAction::Skip {
+                    category: "y".into(),
+                    component_id: "c".into(),
+                    reason: ReconcileSkipReason::SuppressedByLabel,
+                },
+            ],
+        };
+        let tracker = MockTracker::new();
+        let result = apply_plan(plan, &tracker).unwrap();
+
+        assert!(tracker.calls.borrow().is_empty());
+        assert!(matches!(
+            result.executions[0].outcome,
+            ExecutionOutcome::Skipped
+        ));
+        assert!(matches!(
+            result.executions[1].outcome,
+            ExecutionOutcome::Skipped
+        ));
+        assert_eq!(result.failed_count, 0);
+    }
+
+    #[test]
+    fn failed_actions_recorded_but_run_continues() {
+        let plan = ReconcilePlan {
+            actions: vec![
+                file_new("a"),
+                ReconcileAction::Close {
+                    number: 1,
+                    category: "b".into(),
+                    comment: "c".into(),
+                },
+                file_new("c"),
+            ],
+        };
+        let mut tracker = MockTracker::new();
+        tracker.fail_close = true;
+
+        let result = apply_plan(plan, &tracker).unwrap();
+        assert_eq!(result.executions.len(), 3);
+        assert_eq!(result.failed_count, 1);
+        // First and third (FileNew) succeed; second (Close) fails.
+        assert!(matches!(
+            result.executions[0].outcome,
+            ExecutionOutcome::Filed { .. }
+        ));
+        assert!(matches!(
+            result.executions[1].outcome,
+            ExecutionOutcome::Failed { .. }
+        ));
+        assert!(matches!(
+            result.executions[2].outcome,
+            ExecutionOutcome::Filed { .. }
+        ));
+    }
+
+    #[test]
+    fn update_closed_passes_no_title_to_tracker() {
+        // UpdateClosed should refresh body only — the title carrying
+        // an outdated count is fine because the issue is closed and the
+        // body holds the latest count + run link.
+        let plan = ReconcilePlan {
+            actions: vec![ReconcileAction::UpdateClosed {
+                number: 50,
+                body: "fresh".into(),
+                category: "x".into(),
+                count: 99,
+            }],
+        };
+        let tracker = MockTracker::new();
+        apply_plan(plan, &tracker).unwrap();
+        assert_eq!(tracker.calls.borrow()[0], "update:#50:-");
+    }
+}

--- a/src/core/issues/mod.rs
+++ b/src/core/issues/mod.rs
@@ -1,0 +1,48 @@
+//! Issue reconciliation: finding-stream → tracker.
+//!
+//! This module turns a structured stream of categorized findings (from
+//! `homeboy audit`, `homeboy lint`, `homeboy test`) into a deterministic
+//! plan against an issue tracker. The plan can then be printed (dry-run)
+//! or executed via a [`Tracker`] implementation.
+//!
+//! # Why this exists
+//!
+//! Before this module landed, `homeboy-action`'s `auto-file-categorized-issues.sh`
+//! (~809 lines of bash + jq + `gh api`) was the only place this logic lived.
+//! That meant:
+//!
+//! - The reconciliation contract had no real home, tests, or types.
+//! - The `gh api ?state=open` query threw away `state_reason` — so a human
+//!   closing an audit issue with `state_reason=not_planned` (the GitHub-native
+//!   "do not re-file" signal) was invisible to the next CI run, which would
+//!   re-file the same category as a brand-new issue.
+//! - Every consumer that wanted issue auto-filing (a cron job, a pre-commit
+//!   hook, a future `homeboy ci` command, an LLM agent) had to reimplement
+//!   the bash from scratch.
+//!
+//! See homeboy issue #1551 for the full architectural framing.
+//!
+//! # Module shape
+//!
+//! - [`plan`]: pure types — [`ReconcilePlan`], [`ReconcileAction`],
+//!   [`TrackedIssue`], [`IssueGroup`], [`ReconcileConfig`].
+//! - [`reconcile`]: the pure decision function — `(groups, issues, config) →
+//!   ReconcilePlan`. Pure means: no I/O, deterministic, fully testable.
+//! - [`tracker`]: the I/O seam — [`Tracker`] trait abstracts over GitHub /
+//!   future GitLab / future Linear. [`tracker::GithubTracker`] is the default
+//!   impl shelling out to `gh` via `core/git/github.rs`.
+//! - [`apply`]: walks a [`ReconcilePlan`] and asks the [`Tracker`] to perform
+//!   each action. Returns a [`ReconcileResult`] with per-action outcomes.
+
+pub mod apply;
+pub mod plan;
+pub mod reconcile;
+pub mod tracker;
+
+pub use apply::{apply_plan, ReconcileExecution, ReconcileResult};
+pub use plan::{
+    IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
+    TrackedIssueState,
+};
+pub use reconcile::reconcile;
+pub use tracker::{GithubTracker, Tracker};

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -1,0 +1,213 @@
+//! Pure types for the reconcile contract.
+//!
+//! Every type here is plain data with no I/O. The [`reconcile`](super::reconcile)
+//! function consumes them; [`apply_plan`](super::apply::apply_plan) turns the
+//! resulting [`ReconcilePlan`] into tracker calls.
+
+use serde::{Deserialize, Serialize};
+
+/// One row of incoming findings: "command produced N findings of category X
+/// for component Y." This is the input grain reconcile reasons over.
+///
+/// `command` is `"audit" | "lint" | "test"` etc. — used for label-scoping
+/// the tracker query (e.g. only consider open issues labeled `audit`) and
+/// for the issue title prefix.
+///
+/// `category` is the kind/key (e.g. `unreferenced_export`, `god_file`,
+/// `missing_test_method`). Empty findings counts (`count = 0`) for a category
+/// that previously had open issues drive the close-on-resolved transition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueGroup {
+    pub command: String,
+    pub component_id: String,
+    pub category: String,
+    pub count: usize,
+    /// Human-friendly category label (e.g. `unreferenced export` for
+    /// `unreferenced_export`). Used in issue titles. Empty falls back to a
+    /// straight `category.replace('_', ' ')` rendering at title time.
+    #[serde(default)]
+    pub label: String,
+    /// Pre-rendered body for new issues. The reconciler does NOT generate
+    /// finding tables — the action / caller renders them once and passes
+    /// them in. Empty falls back to a minimal "<count> findings" body.
+    #[serde(default)]
+    pub body: String,
+}
+
+/// One issue from the tracker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackedIssue {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub state: TrackedIssueState,
+    pub labels: Vec<String>,
+}
+
+/// Tracker-agnostic issue state. Maps directly onto GitHub's
+/// `state` + `stateReason` pair; future trackers (GitLab, Linear) implement
+/// their analogs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackedIssueState {
+    Open,
+    /// "Resolved." Findings re-appearing → file a new issue (the original
+    /// problem returned). GitHub: `state=closed, state_reason=completed`.
+    ClosedCompleted,
+    /// "We have decided not to fix this / this is a false positive."
+    /// Findings re-appearing → refresh the closed issue body, do NOT
+    /// re-file. GitHub: `state=closed, state_reason=not_planned`.
+    ClosedNotPlanned,
+}
+
+impl TrackedIssueState {
+    pub fn is_open(self) -> bool {
+        matches!(self, TrackedIssueState::Open)
+    }
+    pub fn is_closed(self) -> bool {
+        !self.is_open()
+    }
+}
+
+/// Configuration that affects reconcile decisions but not finding shape.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReconcileConfig {
+    /// Categories whose findings are unconditionally muted. No new issue is
+    /// filed; existing OPEN issues for these categories are left alone.
+    /// Existing CLOSED issues stay closed. Sourced from `homeboy.json`'s
+    /// `audit.suppressed_categories` (or a CLI override).
+    #[serde(default)]
+    pub suppressed_categories: Vec<String>,
+
+    /// Labels that, when present on a closed issue, suppress re-filing the
+    /// same category. Defaults to `["wontfix", "upstream-bug",
+    /// "audit-suppressed"]`. Sourced from `homeboy.json`'s
+    /// `issues.suppression_labels`.
+    #[serde(default)]
+    pub suppression_labels: Vec<String>,
+
+    /// When true, also refresh the body of closed-not_planned issues with
+    /// the latest finding count + run link. This keeps the closed issue
+    /// useful as a "current state" reference even though it stays closed.
+    /// Default: true.
+    #[serde(default = "default_refresh_closed")]
+    pub refresh_closed_not_planned: bool,
+}
+
+fn default_refresh_closed() -> bool {
+    true
+}
+
+/// One concrete action the reconciler decided on. Order matters in the plan:
+/// dedupe-closes run before file-new so race-condition duplicates don't
+/// inflate the new-issue count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ReconcileAction {
+    /// File a new issue.
+    FileNew {
+        command: String,
+        component_id: String,
+        category: String,
+        title: String,
+        body: String,
+        labels: Vec<String>,
+        count: usize,
+    },
+    /// Update an existing OPEN issue's title + body to reflect latest count.
+    Update {
+        number: u64,
+        title: String,
+        body: String,
+        category: String,
+        count: usize,
+    },
+    /// Refresh a closed-not_planned issue's body. Stays closed.
+    UpdateClosed {
+        number: u64,
+        body: String,
+        category: String,
+        count: usize,
+    },
+    /// Close an issue whose findings dropped to zero. Reason is always
+    /// `completed` for this action — caller intent is "the underlying
+    /// problem was resolved."
+    Close {
+        number: u64,
+        category: String,
+        comment: String,
+    },
+    /// Close a duplicate of another open issue for the same category.
+    /// Reason is always `not_planned` — caller intent is "this is the same
+    /// thing as #N." Caller keeps the lowest-numbered match.
+    CloseDuplicate {
+        number: u64,
+        keep: u64,
+        category: String,
+        comment: String,
+    },
+    /// Skip this group. Diagnostic — never produces a tracker call.
+    Skip {
+        category: String,
+        component_id: String,
+        reason: ReconcileSkipReason,
+    },
+}
+
+/// Why the reconciler decided to skip a group. Surfaces in dry-run output
+/// so the user can see whether suppression came from config, label, or
+/// close-state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconcileSkipReason {
+    /// Category was in `suppressed_categories`.
+    SuppressedByConfig,
+    /// A closed-not_planned issue carried a `suppression_labels` label.
+    SuppressedByLabel,
+    /// A closed-not_planned issue without a suppression label, AND
+    /// `refresh_closed_not_planned = false`. Less common.
+    ClosedNotPlannedNoRefresh,
+    /// No findings AND no existing open issue → nothing to do.
+    NoFindingsNoIssue,
+}
+
+/// The full reconciliation plan: every action, in execution order.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReconcilePlan {
+    pub actions: Vec<ReconcileAction>,
+}
+
+impl ReconcilePlan {
+    /// Count actions by variant (file_new, update, etc.). Used by the CLI
+    /// to render a one-line summary.
+    pub fn counts(&self) -> ReconcilePlanCounts {
+        let mut c = ReconcilePlanCounts::default();
+        for action in &self.actions {
+            match action {
+                ReconcileAction::FileNew { .. } => c.file_new += 1,
+                ReconcileAction::Update { .. } => c.update += 1,
+                ReconcileAction::UpdateClosed { .. } => c.update_closed += 1,
+                ReconcileAction::Close { .. } => c.close += 1,
+                ReconcileAction::CloseDuplicate { .. } => c.close_duplicate += 1,
+                ReconcileAction::Skip { .. } => c.skip += 1,
+            }
+        }
+        c
+    }
+
+    pub fn is_noop(&self) -> bool {
+        self.actions
+            .iter()
+            .all(|a| matches!(a, ReconcileAction::Skip { .. }))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ReconcilePlanCounts {
+    pub file_new: usize,
+    pub update: usize,
+    pub update_closed: usize,
+    pub close: usize,
+    pub close_duplicate: usize,
+    pub skip: usize,
+}

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -1,0 +1,696 @@
+//! The pure reconcile decision function.
+//!
+//! See homeboy issue #1551 for the full behavior contract. The decision
+//! table is encoded in [`reconcile_group`]; [`reconcile`] applies it across
+//! every input group and gathers the resulting actions into a single plan.
+
+use std::collections::BTreeMap;
+
+use super::plan::{
+    IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
+    TrackedIssueState,
+};
+
+/// Run the 8-row behavior contract over every group.
+///
+/// `groups` is the structured finding stream — one row per
+/// `(command, component, category)` tuple. `existing` is the tracker's
+/// matching issues for the same component+command label scope (caller
+/// fetches them with `state=all` so closed-not_planned is visible).
+///
+/// Pure: no I/O, no clock, no randomness. Same inputs → same plan.
+pub fn reconcile(
+    groups: &[IssueGroup],
+    existing: &[TrackedIssue],
+    config: &ReconcileConfig,
+) -> ReconcilePlan {
+    // Index existing issues by (command, component, category). The category
+    // key is parsed from the title shape `<command>: <label> in <component>`
+    // — this matches the convention `auto-file-categorized-issues.sh` has
+    // been writing for ~year. Future trackers may store the category in a
+    // structured field instead.
+    let mut by_category: BTreeMap<(String, String, String), Vec<&TrackedIssue>> = BTreeMap::new();
+    for issue in existing {
+        if let Some(key) = parse_category_key(&issue.title) {
+            by_category.entry(key).or_default().push(issue);
+        }
+    }
+
+    let mut actions: Vec<ReconcileAction> = Vec::new();
+
+    for group in groups {
+        // Phase 1: suppression by config (highest precedence — short-circuits
+        // every other consideration).
+        if config
+            .suppressed_categories
+            .iter()
+            .any(|c| c == &group.category)
+        {
+            actions.push(ReconcileAction::Skip {
+                category: group.category.clone(),
+                component_id: group.component_id.clone(),
+                reason: ReconcileSkipReason::SuppressedByConfig,
+            });
+            continue;
+        }
+
+        let key = (
+            group.command.clone(),
+            group.component_id.clone(),
+            group.category.clone(),
+        );
+        let matches = by_category.get(&key).cloned().unwrap_or_default();
+
+        // Phase 2: dispatch on (existing-issue-shape, count).
+        let (open_matches, closed_matches): (Vec<_>, Vec<_>) =
+            matches.into_iter().partition(|i| i.state.is_open());
+
+        // Sort opens by issue number so dedupe is deterministic (lowest kept).
+        let mut open_matches = open_matches;
+        open_matches.sort_by_key(|i| i.number);
+
+        // Pick a closed issue to consider for state-reason precedence:
+        // not_planned beats completed (the muting signal is more interesting
+        // than the resolved signal), then most-recent (highest number) wins.
+        let preferred_closed = pick_preferred_closed(&closed_matches);
+
+        if group.count == 0 {
+            // No findings remaining for this category.
+            if let Some((_, rest)) = open_matches.split_first() {
+                let keep = open_matches[0].number;
+                // Close every open match (no reason to keep one if there are
+                // no findings — fold dedupes in for free).
+                actions.push(ReconcileAction::Close {
+                    number: keep,
+                    category: group.category.clone(),
+                    comment: close_resolved_comment(&group.label_or_category()),
+                });
+                for dup in rest {
+                    actions.push(ReconcileAction::CloseDuplicate {
+                        number: dup.number,
+                        keep,
+                        category: group.category.clone(),
+                        comment: close_dedupe_comment(keep),
+                    });
+                }
+            } else {
+                // Nothing to do — no findings, no existing issue.
+                actions.push(ReconcileAction::Skip {
+                    category: group.category.clone(),
+                    component_id: group.component_id.clone(),
+                    reason: ReconcileSkipReason::NoFindingsNoIssue,
+                });
+            }
+            continue;
+        }
+
+        // count > 0 from here.
+        if !open_matches.is_empty() {
+            // Update the lowest-numbered open match.
+            let keep = open_matches[0].number;
+            actions.push(ReconcileAction::Update {
+                number: keep,
+                title: render_title(group),
+                body: group.body.clone(),
+                category: group.category.clone(),
+                count: group.count,
+            });
+            // Close any other open dupes (race-condition consolidation).
+            for dup in &open_matches[1..] {
+                actions.push(ReconcileAction::CloseDuplicate {
+                    number: dup.number,
+                    keep,
+                    category: group.category.clone(),
+                    comment: close_dedupe_comment(keep),
+                });
+            }
+            continue;
+        }
+
+        // No open match. Check the closed issues for suppression / refresh.
+        if let Some(closed) = preferred_closed {
+            match closed.state {
+                TrackedIssueState::ClosedNotPlanned => {
+                    let has_suppression_label = closed
+                        .labels
+                        .iter()
+                        .any(|l| config.suppression_labels.iter().any(|s| s == l));
+                    if has_suppression_label {
+                        // Phase 3 suppression — a label on a closed-not_planned
+                        // issue mutes re-filing.
+                        actions.push(ReconcileAction::Skip {
+                            category: group.category.clone(),
+                            component_id: group.component_id.clone(),
+                            reason: ReconcileSkipReason::SuppressedByLabel,
+                        });
+                        continue;
+                    }
+                    if !config.refresh_closed_not_planned {
+                        actions.push(ReconcileAction::Skip {
+                            category: group.category.clone(),
+                            component_id: group.component_id.clone(),
+                            reason: ReconcileSkipReason::ClosedNotPlannedNoRefresh,
+                        });
+                        continue;
+                    }
+                    actions.push(ReconcileAction::UpdateClosed {
+                        number: closed.number,
+                        body: group.body.clone(),
+                        category: group.category.clone(),
+                        count: group.count,
+                    });
+                    continue;
+                }
+                TrackedIssueState::ClosedCompleted => {
+                    // Resolved-then-returned: file a fresh issue.
+                    actions.push(ReconcileAction::FileNew {
+                        command: group.command.clone(),
+                        component_id: group.component_id.clone(),
+                        category: group.category.clone(),
+                        title: render_title(group),
+                        body: group.body.clone(),
+                        labels: vec![group.command.clone()],
+                        count: group.count,
+                    });
+                    continue;
+                }
+                TrackedIssueState::Open => unreachable!("partitioned above"),
+            }
+        }
+
+        // No issue ever existed (open or closed) for this category.
+        actions.push(ReconcileAction::FileNew {
+            command: group.command.clone(),
+            component_id: group.component_id.clone(),
+            category: group.category.clone(),
+            title: render_title(group),
+            body: group.body.clone(),
+            labels: vec![group.command.clone()],
+            count: group.count,
+        });
+    }
+
+    ReconcilePlan { actions }
+}
+
+fn pick_preferred_closed<'a>(closed: &[&'a TrackedIssue]) -> Option<&'a TrackedIssue> {
+    // not_planned beats completed; otherwise highest number (most recent).
+    closed
+        .iter()
+        .copied()
+        .max_by_key(|i| (i.state == TrackedIssueState::ClosedNotPlanned, i.number))
+}
+
+fn render_title(group: &IssueGroup) -> String {
+    format!(
+        "{}: {} in {} ({})",
+        group.command,
+        group.label_or_category(),
+        group.component_id,
+        group.count
+    )
+}
+
+fn close_resolved_comment(label: &str) -> String {
+    format!(
+        "All **{}** findings have been resolved. Closing automatically.\n\n\
+         Resolved by `homeboy issues reconcile`. If findings reappear, a new \
+         issue will be filed.",
+        label
+    )
+}
+
+fn close_dedupe_comment(keep: u64) -> String {
+    format!(
+        "Closing as duplicate of #{} — consolidated by `homeboy issues reconcile`.\n\n\
+         Going forward, a single issue per category is maintained and updated \
+         on each CI run.",
+        keep
+    )
+}
+
+/// Parse `<command>: <label> in <component>` (with optional `(N)` suffix)
+/// out of an issue title. Returns `(command, component, category_key)`.
+///
+/// `category_key` is the underscore-form (`unreferenced_export`) reconstructed
+/// from the human label (`unreferenced export`). This mirrors the title shape
+/// `auto-file-categorized-issues.sh` has been writing.
+fn parse_category_key(title: &str) -> Option<(String, String, String)> {
+    // Match `command: label in component(... maybe (N) ...)`.
+    let colon = title.find(':')?;
+    let command = title[..colon].trim().to_string();
+    let rest = title[colon + 1..].trim();
+
+    // Strip optional trailing `(N)` count.
+    let rest = match rest.rfind(" (") {
+        Some(idx) if rest.ends_with(')') => &rest[..idx],
+        _ => rest,
+    };
+
+    // Split off ` in <component>` from the right.
+    let in_idx = rest.rfind(" in ")?;
+    let label = rest[..in_idx].trim().to_string();
+    let component = rest[in_idx + 4..].trim().to_string();
+
+    if command.is_empty() || label.is_empty() || component.is_empty() {
+        return None;
+    }
+    let category = label.replace(' ', "_");
+    Some((command, component, category))
+}
+
+impl IssueGroup {
+    fn label_or_category(&self) -> String {
+        if self.label.is_empty() {
+            self.category.replace('_', " ")
+        } else {
+            self.label.clone()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the 8-row behavior table + suppression precedence
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn group(category: &str, count: usize) -> IssueGroup {
+        IssueGroup {
+            command: "audit".into(),
+            component_id: "data-machine".into(),
+            category: category.into(),
+            count,
+            label: String::new(),
+            body: format!("count={}", count),
+        }
+    }
+
+    fn issue(
+        number: u64,
+        category_label: &str,
+        state: TrackedIssueState,
+        count: usize,
+    ) -> TrackedIssue {
+        TrackedIssue {
+            number,
+            title: format!("audit: {} in data-machine ({})", category_label, count),
+            url: format!("https://github.com/o/r/issues/{}", number),
+            state,
+            labels: vec!["audit".into()],
+        }
+    }
+
+    fn issue_with_labels(
+        number: u64,
+        category_label: &str,
+        state: TrackedIssueState,
+        count: usize,
+        labels: &[&str],
+    ) -> TrackedIssue {
+        let mut iss = issue(number, category_label, state, count);
+        iss.labels = labels.iter().map(|s| s.to_string()).collect();
+        iss
+    }
+
+    fn cfg() -> ReconcileConfig {
+        ReconcileConfig {
+            suppressed_categories: vec![],
+            suppression_labels: vec!["wontfix".into(), "upstream-bug".into()],
+            refresh_closed_not_planned: true,
+        }
+    }
+
+    // --------------------------------------------------------------- ROW 1
+
+    #[test]
+    fn row1_no_issue_ever_with_findings_files_new() {
+        let groups = vec![group("unreferenced_export", 12)];
+        let plan = reconcile(&groups, &[], &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            ReconcileAction::FileNew {
+                title,
+                count,
+                labels,
+                ..
+            } => {
+                assert_eq!(*count, 12);
+                assert_eq!(title, "audit: unreferenced export in data-machine (12)");
+                assert_eq!(labels, &vec!["audit".to_string()]);
+            }
+            other => panic!("expected FileNew, got {:?}", other),
+        }
+    }
+
+    // --------------------------------------------------------------- ROW 2
+
+    #[test]
+    fn row2_open_issue_with_findings_updates() {
+        let groups = vec![group("god_file", 23)];
+        let existing = vec![issue(675, "god file", TrackedIssueState::Open, 17)];
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            ReconcileAction::Update {
+                number,
+                count,
+                title,
+                ..
+            } => {
+                assert_eq!(*number, 675);
+                assert_eq!(*count, 23);
+                assert_eq!(title, "audit: god file in data-machine (23)");
+            }
+            other => panic!("expected Update, got {:?}", other),
+        }
+    }
+
+    // --------------------------------------------------------------- ROW 3
+
+    #[test]
+    fn row3_open_issue_zero_findings_closes() {
+        let groups = vec![group("legacy_comment", 0)];
+        let existing = vec![issue(1449, "legacy comment", TrackedIssueState::Open, 1)];
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            ReconcileAction::Close {
+                number,
+                category,
+                comment,
+            } => {
+                assert_eq!(*number, 1449);
+                assert_eq!(category, "legacy_comment");
+                assert!(comment.contains("legacy comment"));
+                assert!(comment.contains("Resolved"));
+            }
+            other => panic!("expected Close, got {:?}", other),
+        }
+    }
+
+    // --------------------------------------------------------------- ROW 4
+
+    #[test]
+    fn row4_closed_completed_with_findings_files_new() {
+        // The original issue auto-resolved. Findings came back.
+        // Same shape as Row 1 but with a closed-completed issue in history.
+        let groups = vec![group("unreferenced_export", 5)];
+        let existing = vec![issue(
+            684,
+            "unreferenced export",
+            TrackedIssueState::ClosedCompleted,
+            0,
+        )];
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        assert!(matches!(&plan.actions[0], ReconcileAction::FileNew { count, .. } if *count == 5));
+    }
+
+    // --------------------------------------------------------------- ROW 5
+
+    #[test]
+    fn row5_closed_not_planned_with_findings_refreshes_body() {
+        // Human closed the issue saying "don't bug me about this, it's a
+        // false positive." Findings still produced. Refresh body, stay closed.
+        let groups = vec![group("missing_method", 164)];
+        let existing = vec![issue(
+            719,
+            "missing method",
+            TrackedIssueState::ClosedNotPlanned,
+            0,
+        )];
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            ReconcileAction::UpdateClosed { number, count, .. } => {
+                assert_eq!(*number, 719);
+                assert_eq!(*count, 164);
+            }
+            other => panic!("expected UpdateClosed, got {:?}", other),
+        }
+    }
+
+    // --------------------------------------------------------------- ROW 6
+
+    #[test]
+    fn row6_closed_not_planned_with_suppression_label_skips() {
+        let groups = vec![group("missing_test_method", 334)];
+        let existing = vec![issue_with_labels(
+            802,
+            "missing test method",
+            TrackedIssueState::ClosedNotPlanned,
+            0,
+            &["audit", "wontfix"],
+        )];
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            ReconcileAction::Skip { reason, .. } => {
+                assert_eq!(*reason, ReconcileSkipReason::SuppressedByLabel);
+            }
+            other => panic!("expected Skip(SuppressedByLabel), got {:?}", other),
+        }
+    }
+
+    // --------------------------------------------------------------- ROW 7
+
+    #[test]
+    fn row7_suppressed_categories_in_config_skips() {
+        let mut config = cfg();
+        config.suppressed_categories = vec!["god_file".into()];
+        let groups = vec![group("god_file", 99)];
+        // Even with an open issue present, config-level suppression wins.
+        let existing = vec![issue(675, "god file", TrackedIssueState::Open, 17)];
+        let plan = reconcile(&groups, &existing, &config);
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            ReconcileAction::Skip { reason, .. } => {
+                assert_eq!(*reason, ReconcileSkipReason::SuppressedByConfig);
+            }
+            other => panic!("expected Skip(SuppressedByConfig), got {:?}", other),
+        }
+    }
+
+    // --------------------------------------------------------------- ROW 8
+
+    #[test]
+    fn row8_multiple_open_for_same_category_dedupes() {
+        let groups = vec![group("high_item_count", 52)];
+        let existing = vec![
+            issue(676, "high item count", TrackedIssueState::Open, 50),
+            issue(1253, "high item count", TrackedIssueState::Open, 50),
+        ];
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 2);
+        // First action: update the lowest-numbered (676).
+        match &plan.actions[0] {
+            ReconcileAction::Update { number, .. } => assert_eq!(*number, 676),
+            other => panic!("expected Update on #676, got {:?}", other),
+        }
+        // Second action: close-as-duplicate the higher-numbered (1253).
+        match &plan.actions[1] {
+            ReconcileAction::CloseDuplicate { number, keep, .. } => {
+                assert_eq!(*number, 1253);
+                assert_eq!(*keep, 676);
+            }
+            other => panic!("expected CloseDuplicate, got {:?}", other),
+        }
+    }
+
+    // ----------------------------------------------- precedence ladder
+
+    #[test]
+    fn precedence_config_beats_open_issue() {
+        // Already covered by row7, but keeps the precedence story explicit.
+        let mut config = cfg();
+        config.suppressed_categories = vec!["x".into()];
+        let groups = vec![group("x", 5)];
+        let existing = vec![issue(1, "x", TrackedIssueState::Open, 5)];
+        let plan = reconcile(&groups, &existing, &config);
+        assert!(matches!(
+            &plan.actions[0],
+            ReconcileAction::Skip {
+                reason: ReconcileSkipReason::SuppressedByConfig,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn precedence_label_only_applies_when_closed_not_planned() {
+        // A `wontfix` label on an OPEN issue should NOT suppress — the
+        // label-precedence rule is gated on closed-not_planned per #1551
+        // (option 2). Open + label = update normally.
+        let groups = vec![group("x", 5)];
+        let existing = vec![issue_with_labels(
+            1,
+            "x",
+            TrackedIssueState::Open,
+            3,
+            &["audit", "wontfix"],
+        )];
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert!(matches!(&plan.actions[0], ReconcileAction::Update { .. }));
+    }
+
+    #[test]
+    fn precedence_refresh_disabled_for_closed_not_planned_skips() {
+        let mut config = cfg();
+        config.refresh_closed_not_planned = false;
+        let groups = vec![group("x", 5)];
+        let existing = vec![issue(1, "x", TrackedIssueState::ClosedNotPlanned, 0)];
+        let plan = reconcile(&groups, &existing, &config);
+        assert!(matches!(
+            &plan.actions[0],
+            ReconcileAction::Skip {
+                reason: ReconcileSkipReason::ClosedNotPlannedNoRefresh,
+                ..
+            }
+        ));
+    }
+
+    // ---------------------------------------------------- edge cases
+
+    #[test]
+    fn no_findings_no_issue_skips_silently() {
+        let groups = vec![group("x", 0)];
+        let plan = reconcile(&groups, &[], &cfg());
+        assert!(matches!(
+            &plan.actions[0],
+            ReconcileAction::Skip {
+                reason: ReconcileSkipReason::NoFindingsNoIssue,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn closed_not_planned_beats_closed_completed_when_both_exist() {
+        // Both closed in history. not_planned wins (the "do not re-file"
+        // signal is more specific than "we resolved it once").
+        let groups = vec![group("x", 5)];
+        let existing = vec![
+            issue(10, "x", TrackedIssueState::ClosedCompleted, 0),
+            issue(20, "x", TrackedIssueState::ClosedNotPlanned, 0),
+        ];
+        let plan = reconcile(&groups, &existing, &cfg());
+        match &plan.actions[0] {
+            ReconcileAction::UpdateClosed { number, .. } => assert_eq!(*number, 20),
+            other => panic!("expected UpdateClosed on #20, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_category_key_round_trips() {
+        let title = "audit: unreferenced export in data-machine (57)";
+        let (cmd, comp, cat) = parse_category_key(title).unwrap();
+        assert_eq!(cmd, "audit");
+        assert_eq!(comp, "data-machine");
+        assert_eq!(cat, "unreferenced_export");
+    }
+
+    #[test]
+    fn parse_category_key_handles_missing_count_suffix() {
+        // Aggregate issues don't always carry `(N)`.
+        let title = "test: failures in homeboy";
+        let (cmd, comp, cat) = parse_category_key(title).unwrap();
+        assert_eq!(cmd, "test");
+        assert_eq!(comp, "homeboy");
+        assert_eq!(cat, "failures");
+    }
+
+    #[test]
+    fn parse_category_key_returns_none_for_garbage() {
+        assert!(parse_category_key("not a homeboy issue").is_none());
+        assert!(parse_category_key("audit: missing component").is_none());
+    }
+
+    #[test]
+    fn empty_groups_produces_empty_plan() {
+        let plan = reconcile(&[], &[], &cfg());
+        assert!(plan.actions.is_empty());
+        assert!(plan.is_noop());
+    }
+
+    #[test]
+    fn label_falls_back_to_category_with_underscores_replaced() {
+        let groups = vec![IssueGroup {
+            command: "audit".into(),
+            component_id: "x".into(),
+            category: "snake_case_thing".into(),
+            count: 1,
+            label: String::new(),
+            body: String::new(),
+        }];
+        let plan = reconcile(&groups, &[], &cfg());
+        match &plan.actions[0] {
+            ReconcileAction::FileNew { title, .. } => {
+                assert!(title.contains("snake case thing"));
+            }
+            _ => panic!("expected FileNew"),
+        }
+    }
+
+    #[test]
+    fn explicit_label_used_in_title_when_provided() {
+        let groups = vec![IssueGroup {
+            command: "lint".into(),
+            component_id: "x".into(),
+            category: "i18n".into(),
+            count: 3,
+            label: "i18n / l10n".into(),
+            body: String::new(),
+        }];
+        let plan = reconcile(&groups, &[], &cfg());
+        match &plan.actions[0] {
+            ReconcileAction::FileNew { title, .. } => {
+                assert_eq!(title, "lint: i18n / l10n in x (3)");
+            }
+            _ => panic!("expected FileNew"),
+        }
+    }
+
+    #[test]
+    fn plan_counts_aggregate_correctly() {
+        let plan = ReconcilePlan {
+            actions: vec![
+                ReconcileAction::FileNew {
+                    command: "a".into(),
+                    component_id: "c".into(),
+                    category: "k".into(),
+                    title: "t".into(),
+                    body: "b".into(),
+                    labels: vec![],
+                    count: 1,
+                },
+                ReconcileAction::Update {
+                    number: 1,
+                    title: "t".into(),
+                    body: "b".into(),
+                    category: "k".into(),
+                    count: 1,
+                },
+                ReconcileAction::Update {
+                    number: 2,
+                    title: "t".into(),
+                    body: "b".into(),
+                    category: "k".into(),
+                    count: 1,
+                },
+                ReconcileAction::Skip {
+                    category: "k".into(),
+                    component_id: "c".into(),
+                    reason: ReconcileSkipReason::NoFindingsNoIssue,
+                },
+            ],
+        };
+        let c = plan.counts();
+        assert_eq!(c.file_new, 1);
+        assert_eq!(c.update, 2);
+        assert_eq!(c.skip, 1);
+        assert!(!plan.is_noop());
+    }
+}

--- a/src/core/issues/tracker.rs
+++ b/src/core/issues/tracker.rs
@@ -1,0 +1,273 @@
+//! Issue-tracker abstraction.
+//!
+//! [`Tracker`] is the I/O seam: list issues, create / update / close them.
+//! [`reconcile`](super::reconcile::reconcile) is generic over this trait
+//! through the [`apply_plan`](super::apply::apply_plan) executor — it never
+//! sees a `gh` shell command directly. This is what unlocks future GitLab,
+//! Linear, or local-file trackers without touching the decision logic.
+//!
+//! The default implementation [`GithubTracker`] wraps the existing
+//! `core/git/github.rs` primitives.
+
+use crate::error::Result;
+use crate::git::{
+    issue_close, issue_create, issue_edit, issue_find, IssueCloseOptions, IssueCloseReason,
+    IssueCreateOptions, IssueEditOptions, IssueFindOptions, IssueState,
+};
+
+use super::plan::{TrackedIssue, TrackedIssueState};
+
+/// Abstract issue-tracker contract. All operations are component-scoped:
+/// the tracker resolves which repo/project to talk to from the component
+/// at construction time, NOT per call. This matches the existing
+/// `core/git/github.rs` shape.
+pub trait Tracker {
+    /// Return every issue in the tracker matching the given label. Includes
+    /// open AND closed issues — reconcile needs `state_reason` on closed
+    /// issues to distinguish completed from not_planned.
+    ///
+    /// `command_label` is the reconciler's category-class label
+    /// (e.g. `"audit"`, `"lint"`, `"test"`). Implementations should restrict
+    /// the result set by this label so we don't paginate the entire tracker
+    /// for every reconcile run.
+    fn list_issues(&self, command_label: &str, limit: usize) -> Result<Vec<TrackedIssue>>;
+
+    /// File a new issue with the given title, body, and labels. Returns the
+    /// new issue number on success.
+    fn create_issue(&self, title: &str, body: &str, labels: &[String]) -> Result<u64>;
+
+    /// Update the title and/or body of an existing issue (open OR closed).
+    /// Closed issues stay closed — this is the "refresh closed-not_planned
+    /// body" path.
+    fn update_issue(&self, number: u64, title: Option<&str>, body: Option<&str>) -> Result<()>;
+
+    /// Close an issue with a typed reason. Reconcile uses `Completed` for
+    /// "no findings remaining" closes, and `NotPlanned` for race-condition
+    /// duplicate consolidation.
+    fn close_issue(&self, number: u64, reason: CloseReason, comment: Option<&str>) -> Result<()>;
+}
+
+/// Tracker-agnostic close reason. Maps onto GitHub's `state_reason` directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseReason {
+    Completed,
+    NotPlanned,
+}
+
+impl CloseReason {
+    fn to_github(self) -> IssueCloseReason {
+        match self {
+            CloseReason::Completed => IssueCloseReason::Completed,
+            CloseReason::NotPlanned => IssueCloseReason::NotPlanned,
+        }
+    }
+}
+
+/// Default tracker: GitHub via the `gh` CLI shellouts in `core/git/github.rs`.
+pub struct GithubTracker {
+    component_id: String,
+    /// Optional workspace path for unregistered checkouts (CI / ad-hoc clones).
+    /// Forwarded to every `core/git/github.rs` call. Mirrors the `--path` flag
+    /// every other `homeboy git *` command takes.
+    path: Option<String>,
+}
+
+impl GithubTracker {
+    pub fn new(component_id: impl Into<String>) -> Self {
+        Self {
+            component_id: component_id.into(),
+            path: None,
+        }
+    }
+
+    pub fn with_path(mut self, path: Option<String>) -> Self {
+        self.path = path;
+        self
+    }
+}
+
+impl Tracker for GithubTracker {
+    fn list_issues(&self, command_label: &str, limit: usize) -> Result<Vec<TrackedIssue>> {
+        let out = issue_find(
+            Some(&self.component_id),
+            IssueFindOptions {
+                title: None,
+                labels: vec![command_label.to_string()],
+                state: IssueState::All,
+                limit,
+                path: self.path.clone(),
+            },
+        )?;
+
+        let issues = out
+            .items
+            .into_iter()
+            .filter_map(|item| github_to_tracked(item))
+            .collect();
+        Ok(issues)
+    }
+
+    fn create_issue(&self, title: &str, body: &str, labels: &[String]) -> Result<u64> {
+        let out = issue_create(
+            Some(&self.component_id),
+            IssueCreateOptions {
+                title: title.to_string(),
+                body: body.to_string(),
+                labels: labels.to_vec(),
+                path: self.path.clone(),
+            },
+        )?;
+        out.number.ok_or_else(|| {
+            crate::error::Error::internal_io(
+                "issue.create succeeded but returned no number".to_string(),
+                Some("gh issue create".into()),
+            )
+        })
+    }
+
+    fn update_issue(&self, number: u64, title: Option<&str>, body: Option<&str>) -> Result<()> {
+        issue_edit(
+            Some(&self.component_id),
+            IssueEditOptions {
+                number,
+                title: title.map(|s| s.to_string()),
+                body: body.map(|s| s.to_string()),
+                add_labels: Vec::new(),
+                remove_labels: Vec::new(),
+                path: self.path.clone(),
+            },
+        )?;
+        Ok(())
+    }
+
+    fn close_issue(&self, number: u64, reason: CloseReason, comment: Option<&str>) -> Result<()> {
+        issue_close(
+            Some(&self.component_id),
+            IssueCloseOptions {
+                number,
+                reason: reason.to_github(),
+                comment: comment.map(|s| s.to_string()),
+                path: self.path.clone(),
+            },
+        )?;
+        Ok(())
+    }
+}
+
+/// Translate a GitHub `GithubFindItem` into the tracker-agnostic
+/// [`TrackedIssue`] shape. Returns `None` when the issue's state shape is
+/// unrecognized — defensive against future GitHub state additions.
+fn github_to_tracked(item: crate::git::GithubFindItem) -> Option<TrackedIssue> {
+    let state = match item.state.to_lowercase().as_str() {
+        "open" => TrackedIssueState::Open,
+        "closed" => match item.state_reason.as_str() {
+            "not_planned" | "NOT_PLANNED" => TrackedIssueState::ClosedNotPlanned,
+            // Empty state_reason on a closed issue happens for older issues
+            // closed before GitHub introduced state_reason. Treat as
+            // completed (the safer default — "we resolved this once").
+            "" | "completed" | "COMPLETED" => TrackedIssueState::ClosedCompleted,
+            // Unknown state_reason (e.g. "duplicate", future additions):
+            // treat as completed too. The reconcile policy on completed is
+            // "file new if findings return," which is the safer fallback
+            // for an unrecognized close.
+            _ => TrackedIssueState::ClosedCompleted,
+        },
+        _ => return None,
+    };
+
+    Some(TrackedIssue {
+        number: item.number,
+        title: item.title,
+        url: item.url,
+        state,
+        labels: item.labels,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests — github_to_tracked translation table
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::GithubFindItem;
+
+    fn item(state: &str, state_reason: &str) -> GithubFindItem {
+        GithubFindItem {
+            number: 1,
+            title: "t".into(),
+            url: "u".into(),
+            state: state.into(),
+            state_reason: state_reason.into(),
+            closed_at: String::new(),
+            labels: vec!["audit".into()],
+        }
+    }
+
+    #[test]
+    fn translates_open() {
+        assert_eq!(
+            github_to_tracked(item("OPEN", "")).unwrap().state,
+            TrackedIssueState::Open
+        );
+        assert_eq!(
+            github_to_tracked(item("open", "")).unwrap().state,
+            TrackedIssueState::Open
+        );
+    }
+
+    #[test]
+    fn translates_closed_completed() {
+        assert_eq!(
+            github_to_tracked(item("CLOSED", "completed"))
+                .unwrap()
+                .state,
+            TrackedIssueState::ClosedCompleted
+        );
+    }
+
+    #[test]
+    fn translates_closed_not_planned() {
+        assert_eq!(
+            github_to_tracked(item("closed", "not_planned"))
+                .unwrap()
+                .state,
+            TrackedIssueState::ClosedNotPlanned
+        );
+        assert_eq!(
+            github_to_tracked(item("CLOSED", "NOT_PLANNED"))
+                .unwrap()
+                .state,
+            TrackedIssueState::ClosedNotPlanned
+        );
+    }
+
+    #[test]
+    fn empty_state_reason_on_closed_defaults_to_completed() {
+        // Older GitHub issues closed before state_reason existed.
+        assert_eq!(
+            github_to_tracked(item("CLOSED", "")).unwrap().state,
+            TrackedIssueState::ClosedCompleted
+        );
+    }
+
+    #[test]
+    fn unknown_state_reason_falls_back_to_completed() {
+        // Future state_reason values we don't model yet (e.g. "duplicate")
+        // are safer treated as completed than as not_planned — completed
+        // means "file new if findings return."
+        assert_eq!(
+            github_to_tracked(item("CLOSED", "duplicate"))
+                .unwrap()
+                .state,
+            TrackedIssueState::ClosedCompleted
+        );
+    }
+
+    #[test]
+    fn unknown_state_returns_none() {
+        assert!(github_to_tracked(item("merged", "")).is_none());
+        assert!(github_to_tracked(item("draft", "")).is_none());
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod extension;
 pub mod fleet;
 pub mod git;
+pub mod issues;
 pub mod output;
 pub mod project;
 pub mod refactor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ mod help_topics;
 use commands::utils::{args, entity_suggest, response as output, tty};
 use commands::{
     api, audit, auth, bench, build, changelog, changes, cli, component, config, db, deploy,
-    extension, file, fleet, git, init, lint, logs, project, refactor, release, review, rig, server,
-    ssh, status, test, transfer, undo, upgrade, validate, version,
+    extension, file, fleet, git, init, issues, lint, logs, project, refactor, release, review, rig,
+    server, ssh, status, test, transfer, undo, upgrade, validate, version,
 };
 use homeboy::extension::load_all_extensions;
 
@@ -90,6 +90,8 @@ enum Commands {
     Changelog(changelog::ChangelogArgs),
     /// Git operations for components
     Git(git::GitArgs),
+    /// Reconcile findings against an issue tracker
+    Issues(issues::IssuesArgs),
     /// Version management for components
     Version(version::VersionArgs),
     /// Build a component


### PR DESCRIPTION
## Summary

Closes #1551.

Adds `homeboy issues reconcile` — a first-class reconciliation primitive that turns a structured finding stream into a deterministic plan against an issue tracker — plus the foundational `git issue close|edit` primitives that were missing from `core/git/github.rs`.

Together these collapse the 809-line bash reconciliation script in `homeboy-action/scripts/issues/auto-file-categorized-issues.sh` to a single `homeboy issues reconcile --apply --json` call, and finally honor `state_reason=not_planned` so closing a false-positive audit issue actually sticks across CI runs.

## What's new

### `homeboy issues reconcile` — new top-level command

Reads JSON findings (groups by category with counts + optional rendered body), inspects open AND closed tracker issues, and produces a plan with six action shapes covering the full 8-row behavior contract from #1551:

| Tracker state | Findings | Action |
|---|---|---|
| No issue ever | > 0 | `file_new` |
| Open | > 0 | `update` (refresh title + body + count) |
| Open | 0 | `close` (`state_reason=completed`) |
| Closed `completed` | > 0 | `file_new` (resolved-then-returned) |
| Closed `not_planned` | > 0 | `update_closed` (refresh body, stay closed) |
| Closed `not_planned` + suppression label | > 0 | `skip` |
| Category in `suppressed_categories` | any | `skip` |
| Multiple open for same category | any | `dedupe` (keep oldest, close rest) |

Three-level suppression precedence: `homeboy.json` config → labels on closed-not_planned issues → close-state semantics.

Defaults to dry-run; `--apply` performs the tracker calls. Both modes emit the same JSON shape with `plan_summary`, `plan_lines`, and (when applied) `result` containing per-action outcomes.

### Foundational primitives in `core/git/github.rs`

The reconciler needed three things the existing GitHub plumbing didn't expose:

- **`issue_close(number, reason, comment?)`** — wraps `gh issue close --reason completed|"not planned" --comment` with typed `IssueCloseReason::{Completed, NotPlanned}`.
- **`issue_edit(number, title?, body?, add_labels, remove_labels)`** — wraps `gh issue edit` so reconcile can refresh existing-issue bodies on each CI run without filing duplicates.
- **`state_reason` + `closed_at` + `labels` on `issue_find`** — closed issues now carry their GitHub `stateReason` field through to callers, so they can distinguish `completed` (re-file when findings return) from `not_planned` (do not re-file, this is a false positive / decided not to fix).

These also surface as `homeboy git issue close|edit` for ad-hoc use.

### `Tracker` trait — the architectural seam

`reconcile()` is generic over a `Tracker`. `GithubTracker` is the default impl wrapping the new `gh` primitives. Future GitLab, Linear, or local-file trackers can implement the same trait without touching the decision logic.

```rust
pub trait Tracker {
    fn list_issues(&self, command_label: &str, limit: usize) -> Result<Vec<TrackedIssue>>;
    fn create_issue(&self, title: &str, body: &str, labels: &[String]) -> Result<u64>;
    fn update_issue(&self, number: u64, title: Option<&str>, body: Option<&str>) -> Result<()>;
    fn close_issue(&self, number: u64, reason: CloseReason, comment: Option<&str>) -> Result<()>;
}
```

### `homeboy.json` schema additions

```json
{
  "audit": {
    "suppressed_categories": ["unreferenced_export", "missing_test_method"]
  },
  "issues": {
    "suppression_labels": ["wontfix", "upstream-bug", "audit-suppressed"]
  }
}
```

Read when `--suppress-from-config` is set (default: true). CLI flags `--suppress-category` and `--suppress-label` override. Sane defaults for `suppression_labels` apply when neither is set.

## Why this layering

Before this PR, the reconciliation contract lived as ~809 lines of bash + jq + `gh api` shellouts in `homeboy-action/scripts/issues/auto-file-categorized-issues.sh`. That layer:

1. **Couldn't see `state_reason`** — the `gh api ?state=open` query threw it away. Closing an audit issue with `state_reason=not_planned` was invisible to the next CI run, which would file a brand-new issue. This is the core bug from #1551 (17 closures / 17 re-filings on data-machine in one morning).
2. **Couldn't share state with the rest of homeboy** — audit fingerprint index, codebase scan, future confidence tiers (#1478) all blocked by the bash boundary.
3. **Was locked to one consumer** — cron jobs, pre-commit hooks, future `homeboy ci`, agent runners. Anyone wanting issue reconciliation had to reimplement 809 lines of bash from scratch.

After: the action collapses to ~30 lines: invoke `homeboy issues reconcile --apply --json` and render the structured output.

## Tests

42 new unit tests, all green serially:

- **6** in `core/git/github.rs` — `IssueCloseReason::as_gh_flag` / `from_graphql`, state_reason + closed_at + labels parsing, missing-field defaults.
- **31** in `core/issues/` — every row of the 8-row behavior contract, three-level suppression precedence, dedup ordering, edge cases (empty groups, garbage titles, label-only-applies-when-closed, refresh-disabled, not_planned-beats-completed when both exist), plan counts aggregation, mock-tracker apply with success/skip/fail outcomes.
- **5** in `core/issues/tracker.rs` — GitHub state translation table (open / closed_completed / closed_not_planned / unknown_state_reason fallback / unknown_state returns None).

```
cargo test --lib core::issues  -- --test-threads=1     # 31 / 0
cargo test --lib core::git::github -- --test-threads=1 # 49 / 0 (was 43)
cargo test --lib -- --test-threads=1                   # 1433 / 0 (was 1390)
```

(One pre-existing parallel-test flake in `core::code_audit::conventions::tests::signature_check_adds_to_existing_outliers` — passes serially, same `HOME`-touching pattern noted in MEMORY for prior PRs. Not introduced here.)

## Live verification against the real homeboy issue tracker

Hand-crafted a findings file with three categories (god_file=23, unreferenced_export=57, missing_test_method=0) and ran a dry-run against this very repo:

```
$ homeboy issues reconcile homeboy --findings smoke.json --path .
{
  "success": true,
  "data": {
    "applied": false,
    "command": "audit",
    "component_id": "homeboy",
    "plan_lines": [
      "update        god_file (23) → #1446",
      "close         missing_test_method → #1451",
      "update        unreferenced_export (57) → #1457"
    ],
    "plan_summary": {
      "close": 1, "file_new": 0, "skip": 0, "total_actions": 3,
      "update": 2, "update_closed": 0, "close_duplicate": 0
    }
  }
}
```

Cross-checked the issue numbers via `gh issue list --repo Extra-Chill/homeboy --label audit --state open`:
- #1446 — `audit: god file in homeboy (23)` ✓
- #1451 — `audit: missing test method in homeboy (334)` ✓
- #1457 — `audit: unreferenced export in homeboy (57)` ✓

Exact match. The reconciler correctly identifies open issues by parsing the existing `<command>: <label> in <component> (<count>)` title shape that the bash already writes — preserving compatibility with every existing audit issue out there.

## CLI surface

```
homeboy issues reconcile <component> --findings <path|-> [OPTIONS]
  --tracker <URI>              # github://owner/repo (default: component remote)
  --suppress-from-config       # read homeboy.json (default: true)
  --suppress-category <CAT>    # repeatable, overrides config
  --suppress-label <LABEL>     # repeatable, overrides config
  --no-refresh-closed          # skip body refresh on closed-not_planned
  --list-limit <N>             # cap tracker pagination (default 200)
  --apply                      # perform actions (default: dry-run)
  --path <PATH>                # workspace path for unregistered checkouts

homeboy git issue close <component> --number <N> [--reason completed|not-planned] [--comment ... | --comment-file ...]
homeboy git issue edit <component> --number <N> [--title ...] [--body ... | --body-file ...] [--add-label ...] [--remove-label ...]
```

## Migration plan (for follow-up PRs)

1. **Tag a homeboy release** with this PR. The action and consumer repos pick it up via the normal `homeboy@v...` install path.
2. **Rewrite the action's bash** — `homeboy-action/scripts/issues/auto-file-categorized-issues.sh` collapses from 809 lines to ~30: a `homeboy issues reconcile --apply --json` call plus a small renderer that turns the JSON output into the existing PR-comment shape.
3. **Sweep `homeboy.json` files** across consumer repos (data-machine, intelligence, MDI, etc.) to add `audit.suppressed_categories` for the speculative-cleanup detectors that were closed-not_planned during triage. The closed-not_planned issues themselves now stop being re-filed automatically; suppressed_categories is the more efficient long-term shape (no API call, no body refresh).

## Out of scope (deliberate)

- **Action migration itself.** Phase 2 lands in `homeboy-action` as a separate PR after this tag ships.
- **GitLab / Linear / local-file tracker impls.** The `Tracker` trait is the seam; concrete impls are follow-ups when there's a consumer that needs them.
- **Confidence tiers from #1478.** Reconcile decisions today are pure category-count; once Findings carry `Structural | Graph | Heuristic`, this module is the natural place to gate auto-apply by tier. Hooks are reachable but not wired.
- **Issue-grouping detector (#1275 facade).** Different concern — that's about cross-referencing a finding to an existing issue at audit time, not reconciling the post-audit summary against the tracker.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.7 (via Kimaki / Claude Code)
- **Used for:** Read `auto-file-categorized-issues.sh` end-to-end, identified the four-layer issue (contract has no home / state=open query / no shared state / locked to one consumer), designed the `Tracker` trait + reconcile contract + 8-row behavior table, implemented the primitives + module + CLI surface + 42 unit tests, ran live verification against the real GitHub tracker. Chris reviewed the architectural framing and the layering call (extract to homeboy core vs hot-fix in the action).
