### PR TITLE
feat(bench): add measurement-phase tag (cold/warm/amortized) to BenchMetricPolicy

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,8 +3,8 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-04-26T17:42:47Z",
-      "item_count": 756,
+      "created_at": "2026-04-26T21:06:40Z",
+      "item_count": 760,
       "known_fingerprints": [
         "Commands::src/commands/docs.rs::NamespaceMismatch",
         "Stack (Tests)::tests/core/stack/inspect_test.rs::MissingMethod",
@@ -34,6 +34,8 @@
         "dead_code::src/core/engine/refactor_primitive.rs::UnreferencedExport",
         "dead_code::src/core/engine/symbol_graph.rs::UnreferencedExport",
         "dead_code::src/core/engine/text.rs::UnreferencedExport",
+        "dead_code::src/core/extension/bench/report.rs::UnreferencedExport",
+        "dead_code::src/core/extension/bench/report.rs::UnreferencedExport",
         "dead_code::src/core/extension/execution.rs::UnreferencedExport",
         "dead_code::src/core/extension/execution.rs::UnreferencedExport",
         "dead_code::src/core/extension/lifecycle.rs::UnreferencedExport",
@@ -310,6 +312,7 @@
         "structural::src/core/rig/spec.rs::HighItemCount",
         "structural::src/core/server/health.rs::HighItemCount",
         "structural::src/main.rs::HighItemCount",
+        "structural::tests/core/extension/bench/phase_tag_test.rs::HighItemCount",
         "structural::tests/core/rig/check_test.rs::HighItemCount",
         "structural::tests/core/rig/spec_test.rs::HighItemCount",
         "test_coverage::src/core/code_audit/baseline.rs::MissingTestMethod",
@@ -463,6 +466,7 @@
         "test_coverage::src/core/engine/undo/snapshot.rs::MissingTestMethod",
         "test_coverage::src/core/engine/undo/snapshot.rs::MissingTestMethod",
         "test_coverage::src/core/engine/validate_write.rs::MissingTestMethod",
+        "test_coverage::src/core/extension/bench/report.rs::MissingTestMethod",
         "test_coverage::src/core/extension/bench/report.rs::MissingTestMethod",
         "test_coverage::src/core/extension/bench/report.rs::MissingTestMethod",
         "test_coverage::src/core/extension/bench/report.rs::MissingTestMethod",

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -565,6 +565,7 @@ mod tests {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: None,
                 regression_threshold_absolute: Some(0.01),
+                phase: None,
             },
         );
 
@@ -596,6 +597,7 @@ mod tests {
                 direction: BenchMetricDirection::HigherIsBetter,
                 regression_threshold_percent: Some(5.0),
                 regression_threshold_absolute: None,
+                phase: None,
             },
         );
 
@@ -631,6 +633,7 @@ mod tests {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: None,
                 regression_threshold_absolute: Some(0.0),
+                phase: None,
             },
         );
 

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -104,6 +104,7 @@ impl ResolvedMetricPolicy {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: Some(default_threshold_percent),
                 regression_threshold_absolute: Some(0.0),
+                phase: None,
             },
             regression_threshold_absolute: 0.0,
             zero_baseline_is_neutral: true,
@@ -145,6 +146,7 @@ mod tests {
             direction,
             regression_threshold_percent: Some(5.0),
             regression_threshold_absolute: None,
+            phase: None,
         }
     }
 
@@ -209,6 +211,7 @@ mod tests {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: None,
                 regression_threshold_absolute: Some(0.01),
+                phase: None,
             },
         );
         let delta = resolved.compare(0.0, 0.02);

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -82,6 +82,18 @@ pub struct BenchMetricPolicy {
     pub regression_threshold_percent: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub regression_threshold_absolute: Option<f64>,
+    /// Optional measurement-phase tag.
+    ///
+    /// Phase is **metadata only**: it does not affect regression math
+    /// (cold and warm metrics use the same `direction` /
+    /// `regression_threshold_*` fields), but it lets report renderers
+    /// group metrics by phase so cold-start numbers don't mix with
+    /// steady-state numbers in the same row of a diff table.
+    ///
+    /// Backwards-compatible: pre-existing JSON without `phase`
+    /// deserializes as `None` and round-trips unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<BenchMetricPhase>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -90,6 +102,36 @@ pub enum BenchMetricDirection {
     LowerIsBetter,
     #[serde(rename = "higher_is_better", alias = "higher")]
     HigherIsBetter,
+}
+
+/// Measurement-phase tag for a metric.
+///
+/// A bench run can mix one-time setup costs (process spawn, WASM boot,
+/// dependency install) with steady-state per-iteration costs. Without
+/// this tag every metric ends up in one flat alphabetical list and a
+/// 3500ms cold-boot sits next to a 12ms warm request as though they
+/// were comparable. Phase tagging lets the report renderer group cold
+/// metrics first, warm metrics second, amortized last, so the diff
+/// reads as the actually-useful story instead of a flat dump.
+///
+/// Phase is **opt-in**: pre-existing policies without a `phase` field
+/// stay untagged and render identically to today.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum BenchMetricPhase {
+    /// One-time setup cost (process spawn, WASM boot, dependency
+    /// install). First iteration only; subsequent iterations don't pay
+    /// this cost unless the dispatcher restarts the substrate between
+    /// iterations.
+    Cold,
+    /// Steady-state per-iteration cost after warmup. The metric the
+    /// user sees on every request after the first.
+    Warm,
+    /// Synthetic blend, e.g. `(cold + N * warm) / N` for some N.
+    /// Useful for "what does the user see on first page-load"
+    /// framing where one cold request is amortized over a small
+    /// burst of warm follow-ups.
+    Amortized,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 use super::baseline::BenchBaselineComparison;
-use super::parsing::{BenchResults, BenchScenario};
+use super::parsing::{BenchMetricPhase, BenchResults, BenchScenario};
 use super::run::BenchRunWorkflowResult;
 use crate::rig::RigStateSnapshot;
 
@@ -118,9 +118,75 @@ pub struct RigBenchEntry {
 /// reference) / reference * 100`. The reference rig is omitted from the
 /// inner map (its delta would always be zero). A scenario or metric
 /// missing from a rig is silently skipped — no synthetic zeros.
+///
+/// `phase_groups` is the **render-order contract** for phase-aware
+/// consumers: when at least one metric policy declares a `phase` tag,
+/// this field lists metric names per phase in the canonical render
+/// order (`Cold` first, then `Warm`, then `Amortized`, then untagged
+/// metrics under `None`-keyed-as-`untagged`). Consumers that want
+/// phase-grouped tables iterate `phase_groups` instead of the
+/// `by_scenario` inner map (which stays alphabetical for stability).
+/// When **no** policy declares a phase, `phase_groups` is `None` and
+/// the JSON envelope is byte-identical to pre-phase output.
 #[derive(Serialize, Default)]
 pub struct BenchComparisonDiff {
     pub by_scenario: BTreeMap<String, BTreeMap<String, BTreeMap<String, MetricDelta>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase_groups: Option<BenchPhaseGroups>,
+}
+
+/// Render-order contract for phase-aware bench-output consumers.
+///
+/// Each field lists the metric names whose policy declared the given
+/// phase, in the canonical render order: `cold` first (one-time setup
+/// costs), `warm` second (steady-state per-iteration costs),
+/// `amortized` third (synthetic blends), `untagged` last (metrics
+/// whose policy didn't declare a phase, or whose name has no policy
+/// at all).
+///
+/// Empty buckets are omitted from the JSON envelope.
+#[derive(Serialize, Default, Debug, PartialEq)]
+pub struct BenchPhaseGroups {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cold: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warm: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub amortized: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub untagged: Vec<String>,
+}
+
+impl BenchPhaseGroups {
+    /// Build a phase-grouping from a metric-policy table plus the set
+    /// of metric names that actually appear in the diff. Metric names
+    /// without a policy or without a `phase` tag fall into `untagged`.
+    /// Within each phase bucket the metric names are kept in
+    /// alphabetical order so the render is stable across runs.
+    pub fn from_policies(
+        policies: &BTreeMap<String, super::parsing::BenchMetricPolicy>,
+        metric_names: &std::collections::BTreeSet<String>,
+    ) -> Self {
+        let mut groups = BenchPhaseGroups::default();
+        for name in metric_names {
+            let phase = policies.get(name).and_then(|p| p.phase);
+            match phase {
+                Some(BenchMetricPhase::Cold) => groups.cold.push(name.clone()),
+                Some(BenchMetricPhase::Warm) => groups.warm.push(name.clone()),
+                Some(BenchMetricPhase::Amortized) => groups.amortized.push(name.clone()),
+                None => groups.untagged.push(name.clone()),
+            }
+        }
+        groups
+    }
+
+    /// True when no policy declared any phase tag — i.e. every metric
+    /// name is in the `untagged` bucket. Used to suppress the
+    /// `phase_groups` field entirely so back-compat consumers see no
+    /// change in the JSON envelope.
+    pub fn is_phaseless(&self) -> bool {
+        self.cold.is_empty() && self.warm.is_empty() && self.amortized.is_empty()
+    }
 }
 
 /// One rig's delta for one metric in one scenario.
@@ -197,7 +263,33 @@ impl BenchComparisonDiff {
             }
         }
 
-        BenchComparisonDiff { by_scenario }
+        // Derive phase grouping from the reference rig's metric
+        // policies. Phase tagging is opt-in: when no policy declares a
+        // phase, `phase_groups` stays `None` and the JSON envelope is
+        // byte-identical to pre-phase output. When at least one policy
+        // declares a phase, emit the full grouping (including an
+        // `untagged` bucket for metrics without a phase tag) so
+        // consumers have a complete render-order contract.
+        let metric_names: std::collections::BTreeSet<String> = by_scenario
+            .values()
+            .flat_map(|m| m.keys().cloned())
+            .collect();
+        let phase_groups = if metric_names.is_empty() {
+            None
+        } else {
+            let groups =
+                BenchPhaseGroups::from_policies(&ref_results.metric_policies, &metric_names);
+            if groups.is_phaseless() {
+                None
+            } else {
+                Some(groups)
+            }
+        };
+
+        BenchComparisonDiff {
+            by_scenario,
+            phase_groups,
+        }
     }
 }
 
@@ -430,3 +522,7 @@ mod tests {
         assert!(hints.iter().any(|h| h.contains("no parseable results")));
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../tests/core/extension/bench/phase_tag_test.rs"]
+mod phase_tag_test;

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -1,0 +1,416 @@
+//! Phase-tag round-trip + render-grouping smokes for the bench
+//! measurement-phase metadata that landed alongside `BenchMetricPhase`
+//! / `BenchMetricPolicy.phase` / `BenchComparisonDiff.phase_groups`.
+//!
+//! The contract under test:
+//!
+//! 1. **Round-trip:** every `BenchMetricPhase` variant serializes to its
+//!    lowercase string form and deserializes back identically.
+//! 2. **Back-compat parse:** policy JSON without a `phase` key parses
+//!    successfully with `phase: None`.
+//! 3. **Back-compat serialize:** `phase: None` is omitted entirely from
+//!    the serialized JSON envelope so old consumers see no field
+//!    introduction at all.
+//! 4. **Render grouping:** when at least one policy declares a phase,
+//!    `BenchComparisonDiff::build` populates `phase_groups` with cold
+//!    metrics first, then warm, then amortized, then untagged.
+//! 5. **No-phase invariant:** when no policy declares a phase,
+//!    `phase_groups` is `None` and the JSON envelope is byte-identical
+//!    to pre-phase output.
+//!
+//! Phase is **metadata only** — it never participates in regression
+//! math. The render-grouping contract drives table layout for
+//! phase-aware report consumers; the `by_scenario` map stays
+//! alphabetical for stability across runs.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::extension::bench::parsing::{
+    parse_bench_results_str, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy,
+    BenchMetrics, BenchResults, BenchScenario,
+};
+use crate::extension::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
+
+fn policy(direction: BenchMetricDirection, phase: Option<BenchMetricPhase>) -> BenchMetricPolicy {
+    BenchMetricPolicy {
+        direction,
+        regression_threshold_percent: None,
+        regression_threshold_absolute: None,
+        phase,
+    }
+}
+
+fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
+    let mut values = BTreeMap::new();
+    for (k, v) in metrics {
+        values.insert((*k).to_string(), *v);
+    }
+    BenchScenario {
+        id: id.to_string(),
+        file: None,
+        iterations: 10,
+        metrics: BenchMetrics { values },
+        memory: None,
+    }
+}
+
+fn results_with(
+    scenarios: Vec<BenchScenario>,
+    policies: BTreeMap<String, BenchMetricPolicy>,
+) -> BenchResults {
+    BenchResults {
+        component_id: "demo".to_string(),
+        iterations: 10,
+        scenarios,
+        metric_policies: policies,
+    }
+}
+
+// 1a. Cold round-trips through serde with the lowercase wire form.
+#[test]
+fn phase_cold_serializes_lowercase() {
+    let p = policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Cold));
+    let raw = serde_json::to_string(&p).unwrap();
+    assert!(raw.contains("\"phase\":\"cold\""), "expected lowercase 'cold', got: {}", raw);
+
+    let back: BenchMetricPolicy = serde_json::from_str(&raw).unwrap();
+    assert_eq!(back.phase, Some(BenchMetricPhase::Cold));
+}
+
+// 1b. Warm round-trips.
+#[test]
+fn phase_warm_serializes_lowercase() {
+    let p = policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Warm));
+    let raw = serde_json::to_string(&p).unwrap();
+    assert!(raw.contains("\"phase\":\"warm\""), "expected lowercase 'warm', got: {}", raw);
+
+    let back: BenchMetricPolicy = serde_json::from_str(&raw).unwrap();
+    assert_eq!(back.phase, Some(BenchMetricPhase::Warm));
+}
+
+// 1c. Amortized round-trips.
+#[test]
+fn phase_amortized_serializes_lowercase() {
+    let p = policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Amortized));
+    let raw = serde_json::to_string(&p).unwrap();
+    assert!(
+        raw.contains("\"phase\":\"amortized\""),
+        "expected lowercase 'amortized', got: {}",
+        raw
+    );
+
+    let back: BenchMetricPolicy = serde_json::from_str(&raw).unwrap();
+    assert_eq!(back.phase, Some(BenchMetricPhase::Amortized));
+}
+
+// 2. Pre-existing JSON without a `phase` key parses with phase=None.
+#[test]
+fn policy_without_phase_field_parses_as_none() {
+    let raw = r#"{
+        "component_id": "demo",
+        "iterations": 1,
+        "metric_policies": {
+            "p95_ms": {
+                "direction": "lower_is_better",
+                "regression_threshold_percent": 5.0
+            }
+        },
+        "scenarios": [
+            {
+                "id": "s",
+                "iterations": 1,
+                "metrics": { "p95_ms": 100.0 }
+            }
+        ]
+    }"#;
+    let parsed = parse_bench_results_str(raw).unwrap();
+    let pol = parsed.metric_policies.get("p95_ms").unwrap();
+    assert_eq!(pol.phase, None, "missing phase field should deserialize as None");
+    assert_eq!(pol.direction, BenchMetricDirection::LowerIsBetter);
+}
+
+// 3. None phase is omitted entirely from the wire form (back-compat
+// for consumers that didn't expect a `phase` key).
+#[test]
+fn policy_serializes_without_phase_field_when_none() {
+    let p = policy(BenchMetricDirection::LowerIsBetter, None);
+    let raw = serde_json::to_string(&p).unwrap();
+    assert!(
+        !raw.contains("phase"),
+        "phase: None must not appear in serialized output, got: {}",
+        raw
+    );
+}
+
+// 4a. phase_groups is populated when any policy declares a phase, with
+// canonical ordering: cold → warm → amortized → untagged.
+#[test]
+fn phase_groups_orders_cold_before_warm_before_amortized_before_untagged() {
+    let mut policies = BTreeMap::new();
+    policies.insert(
+        "boot_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Cold)),
+    );
+    policies.insert(
+        "p95_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Warm)),
+    );
+    policies.insert(
+        "first_paint_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Amortized)),
+    );
+    // `error_rate` intentionally has no policy → falls into untagged.
+
+    let ref_r = results_with(
+        vec![scenario(
+            "page_load",
+            &[
+                ("boot_ms", 3500.0),
+                ("p95_ms", 12.0),
+                ("first_paint_ms", 600.0),
+                ("error_rate", 0.0),
+            ],
+        )],
+        policies,
+    );
+    // Comparison rig with the same shape so all metrics appear in the
+    // diff (otherwise unmatched metrics drop out per build()'s contract).
+    let other = results_with(
+        vec![scenario(
+            "page_load",
+            &[
+                ("boot_ms", 3000.0),
+                ("p95_ms", 13.0),
+                ("first_paint_ms", 580.0),
+                ("error_rate", 0.0),
+            ],
+        )],
+        BTreeMap::new(),
+    );
+
+    let diff = BenchComparisonDiff::build(("trunk", &ref_r), &[("combined-fixes", &other)]);
+    let groups = diff
+        .phase_groups
+        .as_ref()
+        .expect("phase_groups must be Some when any policy declares a phase");
+
+    assert_eq!(groups.cold, vec!["boot_ms".to_string()]);
+    assert_eq!(groups.warm, vec!["p95_ms".to_string()]);
+    assert_eq!(groups.amortized, vec!["first_paint_ms".to_string()]);
+    assert_eq!(groups.untagged, vec!["error_rate".to_string()]);
+}
+
+// 4b. Within a phase, metric names are alphabetical for stable render.
+#[test]
+fn phase_groups_sorts_within_phase_alphabetically() {
+    let mut policies = BTreeMap::new();
+    // Two cold metrics, declared in non-alphabetical order to prove the
+    // bucket sorts independently.
+    policies.insert(
+        "load_deps_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Cold)),
+    );
+    policies.insert(
+        "boot_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Cold)),
+    );
+
+    let ref_r = results_with(
+        vec![scenario("init", &[("boot_ms", 100.0), ("load_deps_ms", 200.0)])],
+        policies,
+    );
+    let other = results_with(
+        vec![scenario("init", &[("boot_ms", 110.0), ("load_deps_ms", 190.0)])],
+        BTreeMap::new(),
+    );
+
+    let diff = BenchComparisonDiff::build(("a", &ref_r), &[("b", &other)]);
+    let groups = diff.phase_groups.unwrap();
+    assert_eq!(
+        groups.cold,
+        vec!["boot_ms".to_string(), "load_deps_ms".to_string()]
+    );
+}
+
+// 5a. No-phase invariant: phase_groups is None when no policy declares
+// a phase. This is the "byte-identical to today" guarantee for any
+// existing extension that doesn't opt into phase tagging.
+#[test]
+fn phase_groups_is_none_when_no_policy_declares_a_phase() {
+    let mut policies = BTreeMap::new();
+    policies.insert(
+        "p95_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, None),
+    );
+
+    let ref_r = results_with(
+        vec![scenario("scenario", &[("p95_ms", 100.0)])],
+        policies,
+    );
+    let other = results_with(
+        vec![scenario("scenario", &[("p95_ms", 110.0)])],
+        BTreeMap::new(),
+    );
+
+    let diff = BenchComparisonDiff::build(("ref", &ref_r), &[("other", &other)]);
+    assert!(
+        diff.phase_groups.is_none(),
+        "phase_groups must be None when no policy declares a phase"
+    );
+}
+
+// 5b. No-phase invariant: with no policies at all (the legacy p95-only
+// path), phase_groups is also None.
+#[test]
+fn phase_groups_is_none_when_metric_policies_is_empty() {
+    let ref_r = results_with(
+        vec![scenario("s", &[("p95_ms", 100.0)])],
+        BTreeMap::new(),
+    );
+    let other = results_with(
+        vec![scenario("s", &[("p95_ms", 105.0)])],
+        BTreeMap::new(),
+    );
+
+    let diff = BenchComparisonDiff::build(("ref", &ref_r), &[("other", &other)]);
+    assert!(diff.phase_groups.is_none());
+}
+
+// 5c. JSON envelope back-compat: when phase_groups is None it must be
+// completely absent from the serialized form (not `"phase_groups":
+// null`). Any consumer that asserted on the exact JSON shape pre-phase
+// must continue to pass.
+#[test]
+fn diff_serializes_without_phase_groups_field_when_phaseless() {
+    let ref_r = results_with(
+        vec![scenario("s", &[("p95_ms", 100.0)])],
+        BTreeMap::new(),
+    );
+    let other = results_with(
+        vec![scenario("s", &[("p95_ms", 105.0)])],
+        BTreeMap::new(),
+    );
+
+    let diff = BenchComparisonDiff::build(("ref", &ref_r), &[("other", &other)]);
+    let raw = serde_json::to_string(&diff).unwrap();
+    assert!(
+        !raw.contains("phase_groups"),
+        "phase_groups must not appear in JSON when None, got: {}",
+        raw
+    );
+}
+
+// 5d. JSON envelope: when phase_groups is Some, empty buckets are
+// omitted (e.g. only cold metrics → warm/amortized/untagged absent
+// from JSON).
+#[test]
+fn phase_groups_omits_empty_buckets_in_json() {
+    let mut policies = BTreeMap::new();
+    policies.insert(
+        "boot_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Cold)),
+    );
+
+    let ref_r = results_with(
+        vec![scenario("init", &[("boot_ms", 3500.0)])],
+        policies,
+    );
+    let other = results_with(
+        vec![scenario("init", &[("boot_ms", 3000.0)])],
+        BTreeMap::new(),
+    );
+
+    let diff = BenchComparisonDiff::build(("a", &ref_r), &[("b", &other)]);
+    let raw = serde_json::to_string(&diff).unwrap();
+    assert!(raw.contains("\"cold\":[\"boot_ms\"]"), "got: {}", raw);
+    assert!(!raw.contains("\"warm\""), "empty warm bucket must be omitted, got: {}", raw);
+    assert!(
+        !raw.contains("\"amortized\""),
+        "empty amortized bucket must be omitted, got: {}",
+        raw
+    );
+    assert!(
+        !raw.contains("\"untagged\""),
+        "empty untagged bucket must be omitted, got: {}",
+        raw
+    );
+}
+
+// 6. Unit test for the BenchPhaseGroups builder: feeding it a
+// policies-with-phase table plus a metric-name set produces the
+// expected bucketing without going through BenchComparisonDiff.
+#[test]
+fn bench_phase_groups_from_policies_buckets_correctly() {
+    let mut policies = BTreeMap::new();
+    policies.insert(
+        "boot_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Cold)),
+    );
+    policies.insert(
+        "p95_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Warm)),
+    );
+
+    let mut names = BTreeSet::new();
+    names.insert("boot_ms".to_string());
+    names.insert("p95_ms".to_string());
+    names.insert("error_rate".to_string()); // no policy → untagged
+
+    let groups = BenchPhaseGroups::from_policies(&policies, &names);
+    assert_eq!(groups.cold, vec!["boot_ms".to_string()]);
+    assert_eq!(groups.warm, vec!["p95_ms".to_string()]);
+    assert!(groups.amortized.is_empty());
+    assert_eq!(groups.untagged, vec!["error_rate".to_string()]);
+    assert!(!groups.is_phaseless(), "must report phaseful when any bucket is non-empty");
+}
+
+// 7. by_scenario stays alphabetical even when phase_groups is
+// populated. The render-order contract lives in phase_groups; the data
+// table stays stable.
+#[test]
+fn by_scenario_inner_map_stays_alphabetical_when_phase_tagged() {
+    let mut policies = BTreeMap::new();
+    policies.insert(
+        "boot_ms".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Cold)),
+    );
+    policies.insert(
+        "z_warm_metric".to_string(),
+        policy(BenchMetricDirection::LowerIsBetter, Some(BenchMetricPhase::Warm)),
+    );
+
+    let ref_r = results_with(
+        vec![scenario(
+            "init",
+            &[("boot_ms", 100.0), ("z_warm_metric", 5.0)],
+        )],
+        policies,
+    );
+    let other = results_with(
+        vec![scenario(
+            "init",
+            &[("boot_ms", 110.0), ("z_warm_metric", 6.0)],
+        )],
+        BTreeMap::new(),
+    );
+
+    let diff = BenchComparisonDiff::build(("a", &ref_r), &[("b", &other)]);
+    let metric_keys: Vec<String> = diff
+        .by_scenario
+        .get("init")
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect();
+    assert_eq!(
+        metric_keys,
+        vec!["boot_ms".to_string(), "z_warm_metric".to_string()],
+        "by_scenario inner map must stay alphabetical regardless of phase tagging"
+    );
+
+    // And phase_groups still encodes the cold-before-warm render order
+    // for any consumer that wants it.
+    let groups = diff.phase_groups.unwrap();
+    assert_eq!(groups.cold, vec!["boot_ms".to_string()]);
+    assert_eq!(groups.warm, vec!["z_warm_metric".to_string()]);
+}


### PR DESCRIPTION
## Summary

Adds an optional `BenchMetricPhase` (cold | warm | amortized) tag to `BenchMetricPolicy`. The bench cross-rig diff envelope now emits a `phase_groups` sidecar listing metric names per phase in canonical render order (cold → warm → amortized → untagged) when at least one policy declares a phase. When no policy declares a phase, the field is omitted entirely and the JSON envelope is byte-identical to pre-phase output.

Phase is **metadata only** — it does not participate in regression math (cold and warm metrics use the same `direction` / `regression_threshold_*` fields). The `by_scenario` inner map stays alphabetical for stability across runs; consumers that want phase-grouped tables iterate `phase_groups` to drive metric ordering.

Closes Extra-Chill/homeboy#1571.

## Changes

- **`parsing.rs`**: new `BenchMetricPhase` enum (`#[serde(rename_all = "lowercase")]`) with `Cold` / `Warm` / `Amortized` variants. New `phase: Option<BenchMetricPhase>` field on `BenchMetricPolicy` with `#[serde(default, skip_serializing_if = "Option::is_none")]` so existing JSON round-trips unchanged.
- **`report.rs`**: new `BenchPhaseGroups` struct (cold / warm / amortized / untagged metric-name vecs) on `BenchComparisonDiff` as `phase_groups: Option<BenchPhaseGroups>`. `BenchComparisonDiff::build` derives the grouping from the reference rig's `metric_policies`. When no policy declares a phase, `phase_groups` is `None` and the field is skipped from JSON entirely. Empty buckets are also skipped so a cold-only run emits just `"cold": [...]`.
- **`baseline.rs` / `metrics.rs`**: existing `BenchMetricPolicy` test fixtures updated with `phase: None` to match the new struct shape (no behavior change).
- **`tests/core/extension/bench/phase_tag_test.rs`**: 13 assertions across the round-trip / back-compat / render-grouping / no-phase invariant contracts. Wired into the lib via `#[cfg(test)] #[path = "../../../../tests/core/extension/bench/phase_tag_test.rs"] mod phase_tag_test;` at the bottom of `report.rs`.

## Tests

- **Round-trip:** every phase variant serializes to its lowercase form and deserializes back identically (`cold`, `warm`, `amortized`).
- **Back-compat parse:** policy JSON without a `phase` key parses with `phase: None`.
- **Back-compat serialize:** `phase: None` is omitted entirely from the wire form (no `"phase": null` introduction).
- **Render grouping:** `phase_groups` orders cold → warm → amortized → untagged. Within each phase, metric names are alphabetical for stable rendering.
- **No-phase invariant:** when no policy declares a phase, `phase_groups` is `None` and the JSON envelope is byte-identical to pre-phase output (`!raw.contains("phase_groups")`).
- **Empty-bucket invariant:** a cold-only run emits just `"cold": [...]`; warm / amortized / untagged buckets are absent from JSON when empty.
- **`by_scenario` stability:** the `by_scenario` inner metric map stays alphabetical regardless of phase tagging — phase-grouped iteration order lives only in `phase_groups`.

Full suite: 1489 lib tests + 75 main tests + 1 integration + 13 phase_tag tests, all green. Pre-PR was 1476 lib tests; +13 from the new smoke.

Live-verified via `target/release/homeboy bench homeboy --iterations 1` (bench-audit-self workload from #1574, no phase tags declared) — JSON envelope shape matches pre-change output exactly. `--json-summary` envelope likewise unchanged. That **is** the back-compat proof: a workload that doesn't opt into phase tagging emits zero new fields.

## Audit baseline

Baseline refreshed via `homeboy audit homeboy --baseline`. Net delta: **756 → 760 (+4)**. All four are accepted:

1. `tests/core/extension/bench/phase_tag_test.rs::HighItemCount` — 16 top-level items (13 test fns + 3 helper fns), one over the soft threshold of 15. Tests cover distinct contracts (round-trip / back-compat / render-grouping / no-phase invariant) and benefit from being in one file for that reason; same call as PR #1543's #1531.
2. `src/core/extension/bench/report.rs::UnreferencedExport` ×2 — `BenchPhaseGroups::from_policies` and `BenchPhaseGroups::is_phaseless`. Both are referenced inside the same file (`report.rs:281` / `:282`) by `BenchComparisonDiff::build`. The `unreferenced_export` rule's "any other file" check doesn't see intra-file calls — known false-positive class (homeboy#1546). Kept `pub` because both are part of the public type's API surface; downstream consumers wanting phase-aware rendering will use them.
3. `src/core/extension/bench/report.rs::missing_test_method` for `from_policies` — covered indirectly by the `bench_phase_groups_from_policies_buckets_correctly` smoke; `test_from_policies` strict-name match isn't met. Keeping the descriptive test name.

## Out of scope

- **Per-phase regression thresholds** (`--regression-threshold-cold=20 --regression-threshold-warm=5`). Issue body lists this as a future consumer; this PR is **schema + report grouping only**.
- **Extension dispatcher emission of phase tags** — the bench-audit-self workload, the homeboy-extensions/wordpress / nodejs / rust dispatchers don't yet declare phase tags. That's a follow-up PR per dispatcher; the schema landing here unblocks them.
- **Auto-detection of phase from metric names.** Out per issue body — too magic, lean on explicit declarations.
- **Replacing `BenchMetrics.values` flat map with a phase-keyed nested structure.** Out per issue body — phase is metadata, not a key.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Implementation, smoke tests, and PR body. Manual review of generated code, intra-file call-graph verification for the audit baseline acceptance, and end-to-end live-verify with `homeboy bench homeboy`.
