### PR TITLE
fix: set restart_required only for source installs

### DIFF
--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -83,7 +83,7 @@ homeboy upgrade --force
 - `new_version`: Version after upgrade (may be null)
 - `upgraded`: Boolean indicating if upgrade was performed
 - `message`: Human-readable status message
-- `restart_required`: Boolean indicating if a restart is needed
+- `restart_required`: Boolean indicating if a restart is needed (true only for source installs)
 
 ## Exit code
 
@@ -94,8 +94,7 @@ homeboy upgrade --force
 
 - The `update` command is an alias for `upgrade` with identical behavior.
 - Version checking queries the crates.io API. Network failures are handled gracefully.
-- On Unix platforms, successful upgrades automatically restart into the new binary.
-- On non-Unix platforms, Homeboy prints a message to restart manually.
+- On Unix platforms, successful source installs automatically restart into the new binary. Binary and package-manager installs do not require a restart.
 
 ## Related
 

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -217,7 +217,7 @@ pub fn run_upgrade_with_method(
         } else {
             "Upgrade command completed but version unchanged".to_string()
         },
-        restart_required: success,
+        restart_required: success && matches!(install_method, InstallMethod::Source),
         extensions_updated,
         extensions_skipped,
         projects_migrated,


### PR DESCRIPTION
## Summary

- `restart_required` was unconditionally set to `true` on successful upgrade, regardless of install method
- For binary, homebrew, and cargo installs, the executable is replaced on disk — the next invocation picks up the new version automatically, no restart needed
- Only source installs (`cargo install` replacing the running binary in-place) actually need a process restart

Fixes #1581