### PR TITLE
docs(component): remove unsupported from-repo examples

### DIFF
--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -15,17 +15,15 @@ homeboy component [OPTIONS] <COMMAND>
 
 ```sh
 homeboy component create [OPTIONS] --local-path <path> --remote-path <path> --build-artifact <path>
-homeboy component create --from-repo <path> [--remote-path <path>]
 ```
 
-The component ID is derived from the `--local-path` (or `--from-repo`) directory name (lowercased). For example, `--local-path /path/to/extrachill-api` creates a component with ID `extrachill-api`.
+The component ID is derived from the `--local-path` directory name (lowercased). For example, `--local-path /path/to/extrachill-api` creates a component with ID `extrachill-api`.
 
 Options:
 
-- `--from-repo <path>`: create from a repo containing `homeboy.json` ([portable config](../schemas/portable-config.md)). Reads version targets, extensions, changelog, etc. from the file. CLI flags override `homeboy.json` values.
 - `--json <spec>`: JSON input spec for create/update (supports single or bulk)
 - `--skip-existing`: skip items that already exist (JSON mode only)
-- `--local-path <path>`: absolute path to local **source / git checkout** directory (required unless `--from-repo`; ID derived from directory name; `~` is expanded). Must be a git repo — not the production deploy target (see [component schema](../schemas/component-schema.md#local_path-vs-remote_path))
+- `--local-path <path>`: absolute path to local **source / git checkout** directory (required; ID derived from directory name; `~` is expanded). Must be a git repo — not the production deploy target (see [component schema](../schemas/component-schema.md#local_path-vs-remote_path))
 - `--remote-path <path>`: remote path relative to project `base_path` (required unless in `homeboy.json`)
 - `--build-artifact <path>`: build artifact path relative to `local_path` (required; must include a filename)
 - `--version-target <TARGET>`: version target in format `file` or `file::pattern` (repeatable)

--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -45,17 +45,17 @@ All fields are optional. The component `id` is derived from the directory name, 
 
 ## Usage
 
-### Register from repo
+### Initialize or refresh repo config
 
 ```bash
-# Read config from homeboy.json, only need to provide machine-specific path
-homeboy component create --from-repo /path/to/repo --remote-path wp-content/plugins/my-plugin
+# Initialize repo-owned homeboy.json from supported create flags
+homeboy component create --local-path /path/to/repo --remote-path wp-content/plugins/my-plugin
 
-# If homeboy.json already includes remote_path:
-homeboy component create --from-repo /path/to/repo
+# If homeboy.json already exists, preserve unknown fields and refresh known fields
+homeboy component create --local-path /path/to/repo
 
-# Override any field from the CLI:
-homeboy component create --from-repo /path/to/repo --build-command "npm run build"
+# Override any supported field from the CLI:
+homeboy component create --local-path /path/to/repo --changelog-target "CHANGELOG.md"
 ```
 
 ### What stays local (not in homeboy.json)


### PR DESCRIPTION
## Summary
- Remove stale `homeboy component create --from-repo` examples from the component command docs.
- Update portable config usage examples to show the current `--local-path` create flow.

## Tests
- `git diff --check`

Closes #1587

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated the docs examples to match the current CLI surface; Chris reviewed through the PR workflow.