### PR TITLE
fix(extension): clarify build and review setup guidance

### DIFF
--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -36,7 +36,7 @@ Release pipelines are defined in component configuration:
 
 #### `build`
 
-Build the component using configured `build_command`.
+Build the component using its linked extension's build support.
 
 ```json
 {
@@ -48,7 +48,7 @@ Build the component using configured `build_command`.
 }
 ```
 
-**Config options:** None (uses component build configuration)
+**Config options:** None (uses linked extension build configuration)
 
 #### `version_bump`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -263,18 +263,16 @@
 - `build_artifact` — Build artifact path relative to localPath
 - `version_targets` — Version targets in the form "file" or "file::pattern" (repeatable). For complex patterns, use --version-targets @file.json to avoid shell escaping
 - `version_targets_json`
-- `build_command` — Build command to run in localPath
 - `extract_command` — Extract command to run after upload (e.g., "unzip -o {artifact} && rm {artifact}")
 - `changelog_target` — Path to changelog file relative to localPath
 - `extensions` — Extension(s) this component uses (e.g., "wordpress"). Repeatable.
 - `Show` — Display component configuration
 - `id` — Component ID
-- `Set` — Update component configuration fields  Supports dedicated flags for common fields (e.g., --local-path, --build-command) as well as --json for arbitrary updates. When combining --json with dynamic trailing flags, use '--' separator.
+- `Set` — Update component configuration fields  Supports dedicated flags for common fields (e.g., --local-path, --changelog-target) as well as --json for arbitrary updates. When combining --json with dynamic trailing flags, use '--' separator.
 - `args`
 - `local_path` — Absolute path to local source directory
 - `remote_path` — Remote path relative to project basePath
 - `build_artifact` — Build artifact path relative to localPath
-- `build_command` — Build command to run in localPath
 - `extract_command` — Extract command to run after upload (e.g., "unzip -o {artifact} && rm {artifact}")
 - `changelog_target` — Path to changelog file relative to localPath
 - `version_targets` — Version targets in the form "file" or "file::pattern" (repeatable). Same format as `component create --version-target`.

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -10,7 +10,7 @@ homeboy build --json '<spec>'
 
 ## Description
 
-Runs a build command for the component in the component's `local_path`.
+Resolves a build command from the component's linked extension and runs it in the component's `local_path`.
 
 ## Path Override
 
@@ -27,7 +27,13 @@ This is useful for:
 
 The override is transient — it does not modify the stored component config.
 
-Requires `build_command` to be configured on the component, or a extension with build support. If neither is set, the command errors.
+Requires exactly one linked extension with build support. Component-level `build_command` is not supported; for one-off shell builds, define a rig `command` step instead.
+
+Useful remediation paths when a component is not buildable:
+
+- Link a build-capable extension: `homeboy component set <id> --extension <extension_id>`
+- Inspect installed extensions: `homeboy extension list`
+- Use a rig `command` step for local or private build workflows that do not belong in an extension.
 
 ## Pre-Build Validation
 

--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -27,7 +27,6 @@ Options:
 - `--remote-path <path>`: remote path relative to project `base_path` (required unless in `homeboy.json`)
 - `--build-artifact <path>`: build artifact path relative to `local_path` (required; must include a filename)
 - `--version-target <TARGET>`: version target in format `file` or `file::pattern` (repeatable)
-- `--build-command <command>`: build command to run in `local_path` (required for `homeboy build`)
 - `--extract-command <command>`: command to run after upload (optional; supports `{artifact}` and `{targetDir}`)
 
 #### Extract Command Execution Context
@@ -72,10 +71,10 @@ Options:
 
 ```sh
 # Correct: explicit separator before dynamic flags
-homeboy component set my-plugin --json '{"type":"plugin"}' -- --build_command "npm run build"
+homeboy component set my-plugin --json '{"type":"plugin"}' -- --docs_dir "docs"
 
 # Incorrect: will fail with "unexpected argument"
-homeboy component set my-plugin --json '{"type":"plugin"}' --build_command "npm run build"
+homeboy component set my-plugin --json '{"type":"plugin"}' --docs_dir "docs"
 ```
 
 Notes:
@@ -96,6 +95,8 @@ Components also define extension usage via `extensions`:
 ```sh
 homeboy component set <id> --json '{"extensions": {"github": {"settings": {}}, "rust": {"settings": {}}}}'
 ```
+
+`homeboy build`, `homeboy lint`, `homeboy test`, and `homeboy review` run through linked extensions. Components do not support a standalone `build_command` field; use an extension for component workflows or a rig `command` step for one-off shell commands.
 
 ```json
 {

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -73,7 +73,6 @@ Then read workspace docs (CLAUDE.md, README.md) for project context.
         "local_path": "...",
         "remote_path": "...",
         "build_artifact": "...",
-        "build_command": "./build.sh",
         "version_targets": [{ "file": "plugin.php", "pattern": "..." }]
       }
     ],
@@ -172,8 +171,8 @@ Repo is configured. Check for gaps and complete setup.
 
 ```bash
 # Gaps include remediation commands - run them
-homeboy component set <id> --build-command "./build.sh"
-homeboy component set <id> --changelog-targets '["CHANGELOG.md"]'
+homeboy component set <id> --extension <extension_id>
+homeboy component set <id> --changelog-target "CHANGELOG.md"
 ```
 
 ### If `managed: false` with `containedComponents`
@@ -189,15 +188,15 @@ homeboy project create "<name>" <domain> --server <server_id> --extension <exten
 
 **Component** (buildable/deployable unit):
 ```bash
-homeboy component create "<name>" --local-path "." --remote-path "<path>" --project <project_id>
-homeboy component set <id> --build-command "./build.sh" --build-artifact "build/<name>.zip"
+homeboy component create --local-path "." --remote-path "<path>" --project <project_id>
+homeboy component set <id> --extension <extension_id> --build-artifact "build/<name>.zip"
 ```
 
 ## Derivation Rules
 
 1. **name**: Directory name or from workspace docs
 2. **remotePath**: Match existing component patterns in target project
-3. **buildArtifact/buildCommand**: From build.sh, Makefile, or workspace docs
+3. **buildArtifact/extensions**: From build.sh, Makefile, or workspace docs
 4. **domain**: ASK (cannot derive locally)
 5. **server_id**: Auto-select if only one exists
 

--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -44,6 +44,16 @@ Output is deterministic and matches each command's per-stage output.
 If neither flag is passed, all three stages run against the entire component —
 equivalent to running `audit`, `lint`, and `test` back-to-back without scope.
 
+## Component Requirements
+
+`review` delegates to `audit`, `lint`, and `test`. Lint and test stages require linked extensions that provide those capabilities; review does not run arbitrary component shell commands.
+
+Useful remediation paths when review reports missing extensions:
+
+- Link the relevant extension: `homeboy component set <id> --extension <extension_id>`
+- Inspect installed extensions: `homeboy extension list`
+- Use a rig `command` step for one-off checks that do not belong in an extension.
+
 ## Other flags
 
 - `--summary`: Forward the per-stage summary flag to each command (`--summary`

--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -11,7 +11,6 @@ Component configuration defines buildable and deployable units stored in `compon
   "local_path": "string",
   "remote_path": "string",
   "build_artifact": "string",
-  "build_command": "string",
   "extract_command": "string",
   "version_targets": [
     {
@@ -33,7 +32,6 @@ Component configuration defines buildable and deployable units stored in `compon
 - **`local_path`** (string): Absolute path to local **source / git checkout** directory, `~` is expanded
 - **`remote_path`** (string): Remote path relative to project `base_path` (the **deploy target**)
 - **`build_artifact`** (string): Build artifact path relative to `local_path`, must include filename
-- **`build_command`** (string): Shell command to execute in `local_path` during builds
 
 > **Important:** `local_path` must point to a **git repository / source checkout**, not the production deploy target. The deploy target is derived from `project.base_path + component.remote_path`. If `local_path` points to the deployed directory, builds will run inside production and uncommitted-changes checks will fail (the directory isn't a git repo). This is a common misconfiguration after server migrations.
 
@@ -49,6 +47,7 @@ Component configuration defines buildable and deployable units stored in `compon
 - **`extensions`** (object): Extension-specific settings
   - Keys are extension IDs (e.g., `"wordpress"`, `"rust"`)
   - Values are extension setting objects
+  - Build, lint, test, bench, and review support comes from linked extensions; component-level `build_command` is not supported.
 - **`release`** (object): Component-scoped release configuration
   - **`enabled`** (boolean): Whether release pipeline is enabled
   - **`steps`** (array): Release step definitions
@@ -96,7 +95,6 @@ Setting `local_path` to the same directory as the deploy target is a misconfigur
   "local_path": "/Users/dev/extrachill-api",
   "remote_path": "wp-content/plugins/extrachill-api",
   "build_artifact": "build/extrachill-api.zip",
-  "build_command": "npm run build",
   "extract_command": "unzip -o {{artifact}} && rm {{artifact}}",
   "version_targets": [
     {

--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -8,7 +8,6 @@ A `homeboy.json` file in a repo root defines portable component configuration th
 {
   "remote_path": "string",
   "build_artifact": "string",
-  "build_command": "string",
   "extract_command": "string",
   "version_targets": [
     {
@@ -71,11 +70,12 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 |-------|-------------|
 | `remote_path` | Deploy target relative to project `base_path` |
 | `build_artifact` | Build output path relative to repo root |
-| `build_command` | Shell command to build the component |
 | `extract_command` | Post-upload command (supports `{artifact}`, `{targetDir}`) |
 | `version_targets` | Version detection patterns |
 | `changelog_target` | Path to changelog file |
 | `extensions` | Extension configuration (e.g., `{"wordpress": {}}`) |
+
+Build, lint, test, bench, and review behavior comes from linked extensions. For one-off shell commands, use a rig `command` step; component-level `build_command` is not supported.
 
 ## Precedence
 

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -69,7 +69,7 @@ enum ComponentCommand {
     },
     /// Update component configuration fields
     ///
-    /// Supports dedicated flags for common fields (e.g., --local-path, --build-command)
+    /// Supports dedicated flags for common fields (e.g., --local-path, --changelog-target)
     /// as well as --json for arbitrary updates. When combining --json with dynamic
     /// trailing flags, use '--' separator.
     #[command(visible_aliases = ["edit", "merge"])]

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -103,7 +103,7 @@ pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBui
         Err(Error::validation_invalid_argument(
             "buildCommand",
             format!(
-                "Component '{}' links a extension with build support, but no build script was found.\n\
+                "Component '{}' links an extension with build support, but no build script was found.\n\
                  Expected: extension's bundled script OR local script matching extension pattern.\n\
                  Check extension installation or add a local build.sh to the component directory.",
                 component.id
@@ -112,17 +112,22 @@ pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBui
             None,
         ))
     } else {
-        Err(Error::validation_invalid_argument(
+        let mut err = Error::validation_invalid_argument(
             "extensions",
             format!(
                 "Component '{}' has no linked extension with build support",
                 component.id
             ),
             Some(component.id.clone()),
-            Some(vec![
-                format!("Link an extension with build support: homeboy component set {} --extension <extension_id>", component.id),
-            ]),
-        ))
+            None,
+        );
+
+        for hint in extension::extension_guidance_hints(component, Some(ExtensionCapability::Build))
+        {
+            err = err.with_hint(hint);
+        }
+
+        Err(err)
     }
 }
 
@@ -495,5 +500,26 @@ mod tests {
         assert!(is_json_input(r#"  {"componentIds": ["a"]}"#));
         assert!(!is_json_input("extrachill-api"));
         assert!(!is_json_input("some-component-id"));
+    }
+
+    #[test]
+    fn resolve_build_command_guides_unconfigured_components() {
+        let component = Component {
+            id: "plain-package".to_string(),
+            ..Default::default()
+        };
+
+        let err = resolve_build_command(&component).unwrap_err();
+        assert!(err
+            .message
+            .contains("no linked extension with build support"));
+        assert!(err.hints.iter().any(|hint| {
+            hint.message
+                .contains("homeboy component set plain-package --extension")
+        }));
+        assert!(err.hints.iter().any(|hint| {
+            hint.message
+                .contains("component-level `build_command` is not supported")
+        }));
     }
 }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -136,16 +136,18 @@ pub struct ExtensionExecutionContext {
 }
 
 fn no_extensions_error(component: &Component) -> Error {
-    Error::validation_invalid_argument(
+    let mut err = Error::validation_invalid_argument(
         "component",
         format!("Component '{}' has no extensions configured", component.id),
         None,
         None,
-    )
-    .with_hint(format!(
-        "Add a extension: homeboy component set {} --extension <extension_id>",
-        component.id
-    ))
+    );
+
+    for hint in extension_guidance_hints(component, None) {
+        err = err.with_hint(hint);
+    }
+
+    err
 }
 
 fn capability_label(capability: ExtensionCapability) -> &'static str {
@@ -168,7 +170,7 @@ fn manifest_has_capability(manifest: &ExtensionManifest, capability: ExtensionCa
 
 fn capability_missing_error(component: &Component, capability: ExtensionCapability) -> Error {
     let capability_name = capability_label(capability);
-    Error::validation_invalid_argument(
+    let mut err = Error::validation_invalid_argument(
         "extension",
         format!(
             "Component '{}' has no linked extensions that provide {} support",
@@ -176,11 +178,36 @@ fn capability_missing_error(component: &Component, capability: ExtensionCapabili
         ),
         None,
         None,
-    )
-    .with_hint(format!(
-        "Link an extension with {} support: homeboy component set {} --extension <extension_id>",
-        capability_name, component.id
-    ))
+    );
+
+    for hint in extension_guidance_hints(component, Some(capability)) {
+        err = err.with_hint(hint);
+    }
+
+    err
+}
+
+pub(crate) fn extension_guidance_hints(
+    component: &Component,
+    capability: Option<ExtensionCapability>,
+) -> Vec<String> {
+    let link_hint = match capability {
+        Some(capability) => format!(
+            "Link an extension with {} support: homeboy component set {} --extension <extension_id>",
+            capability_label(capability),
+            component.id
+        ),
+        None => format!(
+            "Link an extension that provides the needed command support: homeboy component set {} --extension <extension_id>",
+            component.id
+        ),
+    };
+
+    vec![
+        link_hint,
+        "List installed extensions: homeboy extension list".to_string(),
+        "For one-off shell builds or checks, model the workflow as a rig `command` step; component-level `build_command` is not supported.".to_string(),
+    ]
 }
 
 fn capability_ambiguous_error(
@@ -1131,6 +1158,26 @@ mod tests {
         assert!(err.message.contains("missing-mod-b"));
         // Should have install hint for each + browse hint
         assert!(err.hints.len() >= 3);
+    }
+
+    #[test]
+    fn extension_guidance_hints_point_to_supported_paths() {
+        let comp = Component {
+            id: "plain-package".to_string(),
+            ..Default::default()
+        };
+
+        let hints = extension_guidance_hints(&comp, Some(ExtensionCapability::Build));
+
+        assert!(hints
+            .iter()
+            .any(|hint| { hint.contains("homeboy component set plain-package --extension") }));
+        assert!(hints
+            .iter()
+            .any(|hint| { hint.contains("component-level `build_command` is not supported") }));
+        assert!(hints
+            .iter()
+            .any(|hint| hint.contains("homeboy extension list")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Improve build/review missing-extension guidance with concrete supported paths: link an extension, inspect installed extensions, or use a rig `command` step for one-off shell workflows.
- Remove stale component-level `build_command` references from component schemas and command docs.
- Update `component set` help/docs examples away from unsupported `--build-command` usage.

## Tests
- `cargo test core::extension -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo run --quiet --bin homeboy -- component create --help`
- `cargo run --quiet --bin homeboy -- component set --help`

Closes #1584
Closes #1585

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the error guidance, docs cleanup, and regression tests; Chris reviewed through the PR workflow.