### PR TITLE
feat(rig): support shared dependency paths

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -11,6 +11,7 @@ JSON schema for `~/.config/homeboy/rigs/<id>.json`.
 | `components` | object | No | Map of component ID → `ComponentSpec`. |
 | `services` | object | No | Map of service ID → `ServiceSpec`. |
 | `symlinks` | array | No | List of `SymlinkSpec` entries. |
+| `shared_paths` | array | No | List of ephemeral dependency paths to borrow from another checkout. |
 | `pipeline` | object | No | Map of pipeline name → array of `PipelineStep`. |
 
 ## `ComponentSpec`
@@ -54,9 +55,25 @@ A symlink the rig maintains.
 
 `symlink ensure` creates or re-points the link; `symlink verify` checks it exists with the expected target.
 
+## `SharedPathSpec`
+
+An ephemeral dependency path the rig may borrow from another checkout. Common use: feature worktrees that do not have `node_modules`, while the primary checkout does.
+
+| Field | Type | Description |
+|---|---|---|
+| `link` | string | Path inside the active checkout. If missing, `shared-path ensure` creates a symlink here. Supports variable expansion. |
+| `target` | string | Existing path to borrow. Supports variable expansion. |
+
+Safety contract:
+
+- `ensure` creates a symlink only when `link` is missing.
+- If `link` already exists as a real file or directory, it is treated as local dependencies and left alone.
+- If `link` is a symlink to any other target, `ensure` fails instead of replacing it.
+- Cleanup removes only symlinks this rig created and recorded in rig state.
+
 ## `PipelineStep`
 
-Tagged union via the `kind` discriminator. Six shapes. **Prefer the typed primitives (`build`, `git`, `check`) over generic `command` wherever they fit — typed steps reuse homeboy's existing build/git plumbing, error mapping, and extension hooks rather than shelling out blindly.**
+Tagged union via the `kind` discriminator. **Prefer the typed primitives (`build`, `git`, `check`, `shared-path`) over generic `command` wherever they fit — typed steps reuse homeboy's existing build/git plumbing, error mapping, and extension hooks rather than shelling out blindly.**
 
 ### `service`
 
@@ -117,6 +134,16 @@ Runs via `sh -c`. `cwd`, `command`, and `env` values all support variable expans
 
 Operates on every symlink declared at the rig level. No per-step target — rig-wide intent.
 
+### `shared-path`
+
+```jsonc
+{ "kind": "shared-path", "op": "ensure" }
+{ "kind": "shared-path", "op": "verify" }
+{ "kind": "shared-path", "op": "cleanup" }
+```
+
+Operates on every `shared_paths` entry declared at the rig level. Use `ensure` before dependency-consuming commands, `verify` in `check`, and `cleanup` in `down` when you want explicit teardown. `rig down` also runs shared-path cleanup as a safety net.
+
 ### `check`
 
 ```jsonc
@@ -161,7 +188,7 @@ Runs via `sh -c`. Passes if exit code matches `expect_exit` (default `0`).
 
 ## Variable expansion
 
-Three substitutions apply to `cwd`, `command`, `link`, `target`, and `CheckSpec` fields:
+Three substitutions apply to `cwd`, `command`, `link`, `target`, shared paths, and `CheckSpec` fields:
 
 - `${components.<id>.path}` — component path from the rig spec
 - `${env.<NAME>}` — process environment variable (empty if unset)

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -10,7 +10,7 @@ homeboy rig <COMMAND>
 
 ## Overview
 
-A rig is a named bundle of components, local services, pre-flight checks, and a linear build pipeline, described as JSON at `~/.config/homeboy/rigs/<id>.json`. `rig up` materializes the env; `rig check` reports health; `rig down` tears it down.
+A rig is a named bundle of components, local services, shared dependency paths, pre-flight checks, and a linear build pipeline, described as JSON at `~/.config/homeboy/rigs/<id>.json`. `rig up` materializes the env; `rig check` reports health; `rig down` tears it down.
 
 Rigs are the missing piece between individual components (one repo, one version) and full deployments (many repos, remote servers) — they capture the setup a dev environment needs: which commits of which components, which background services are running, which pre-flight invariants must hold.
 
@@ -90,14 +90,23 @@ See [rig-spec.md](./rig-spec.md) for the full schema. Minimal example:
     { "link": "~/.local/bin/studio", "target": "~/.local/bin/studio-dev" }
   ],
 
+  "shared_paths": [
+    {
+      "link": "${components.studio.path}/node_modules",
+      "target": "~/Developer/studio/node_modules"
+    }
+  ],
+
   "pipeline": {
     "up":    [
       { "kind": "service", "id": "tarball-server", "op": "start" },
-      { "kind": "symlink", "op": "ensure" }
+      { "kind": "symlink", "op": "ensure" },
+      { "kind": "shared-path", "op": "ensure" }
     ],
     "check": [
       { "kind": "service", "id": "tarball-server", "op": "health" },
       { "kind": "symlink", "op": "verify" },
+      { "kind": "shared-path", "op": "verify" },
       {
         "kind": "check",
         "label": "MDI drop-in intact",
@@ -106,6 +115,7 @@ See [rig-spec.md](./rig-spec.md) for the full schema. Minimal example:
       }
     ],
     "down":  [
+      { "kind": "shared-path", "op": "cleanup" },
       { "kind": "service", "id": "tarball-server", "op": "stop" }
     ]
   }
@@ -116,7 +126,7 @@ See [rig-spec.md](./rig-spec.md) for the full schema. Minimal example:
 
 Rig runtime state lives at `~/.config/homeboy/rigs/<id>.state/`:
 
-- `state.json` — service PIDs, last `up`/`check` timestamps
+- `state.json` — service PIDs, shared-path ownership markers, last `up`/`check` timestamps
 - `logs/<service-id>.log` — captured stdout/stderr per service
 
 State is ephemeral — deleting it means `rig up` will re-probe on next invocation. Never treat it as source of truth.

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -5,10 +5,10 @@
 //! `rig check` reports health, `rig down` tears it down.
 //!
 //! Phase 1 scope:
-//! - Spec schema with components, services, symlinks, and linear pipelines
+//! - Spec schema with components, services, symlinks, shared paths, and linear pipelines
 //! - Service kinds: `http-static`, `command`, `external` (adopted)
 //! - Pipeline step kinds: `service`, `build`, `git`, `command`, `symlink`,
-//!   `patch`, `check`
+//!   `shared-path`, `patch`, `check`
 //! - Check probes: `http`, `file` (+ `contains`), `command`, `newer_than`
 //!   (mtime / process-start staleness)
 //! - State file at `~/.config/homeboy/rigs/{id}.state/state.json`
@@ -34,7 +34,7 @@ pub use runner::{
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use spec::{
     BenchSpec, CheckSpec, ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep,
-    RigSpec, ServiceKind, ServiceSpec, SymlinkSpec, TimeSource,
+    RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, SymlinkSpec, TimeSource,
 };
 pub use state::{RigState, ServiceState};
 

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -16,8 +16,10 @@ use super::check;
 use super::expand::expand_vars;
 use super::service;
 use super::spec::{
-    ComponentSpec, GitOp, PatchOp, PipelineStep, RigSpec, ServiceOp, SymlinkOp, SymlinkSpec,
+    ComponentSpec, GitOp, PatchOp, PipelineStep, RigSpec, ServiceOp, SharedPathOp, SharedPathSpec,
+    SymlinkOp, SymlinkSpec,
 };
+use super::state::{now_rfc3339, RigState, SharedPathState};
 use crate::error::{Error, Result};
 
 /// Result of one pipeline step.
@@ -130,6 +132,7 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
             label: _,
         } => run_command_step(rig, cmd, cwd.as_deref(), env),
         PipelineStep::Symlink { op } => run_symlink_step(rig, *op),
+        PipelineStep::SharedPath { op } => run_shared_path_step(rig, *op),
         PipelineStep::Patch {
             component,
             file,
@@ -141,6 +144,14 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
         } => run_patch_step(rig, component, file, marker, after.as_deref(), content, *op),
         PipelineStep::Check { spec, .. } => check::evaluate(rig, spec),
     }
+}
+
+/// Cleanup shared paths created by this rig.
+///
+/// `run_down` calls this unconditionally as a safety net, even when a spec
+/// author forgets to include an explicit `shared-path cleanup` step.
+pub fn cleanup_shared_paths(rig: &RigSpec) -> Result<()> {
+    run_shared_path_step(rig, SharedPathOp::Cleanup)
 }
 
 /// Resolve a component reference from the rig spec and return its expanded
@@ -417,6 +428,243 @@ fn verify_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<()> {
     Ok(())
 }
 
+fn run_shared_path_step(rig: &RigSpec, op: SharedPathOp) -> Result<()> {
+    if rig.shared_paths.is_empty() {
+        return Ok(());
+    }
+
+    if op == SharedPathOp::Verify {
+        for shared in &rig.shared_paths {
+            verify_shared_path(rig, shared)?;
+        }
+        return Ok(());
+    }
+
+    let mut state = RigState::load(&rig.id)?;
+    let mut state_changed = false;
+
+    for shared in &rig.shared_paths {
+        match op {
+            SharedPathOp::Ensure => {
+                ensure_shared_path(rig, shared, &mut state, &mut state_changed)?
+            }
+            SharedPathOp::Verify => verify_shared_path(rig, shared)?,
+            SharedPathOp::Cleanup => {
+                cleanup_shared_path(rig, shared, &mut state, &mut state_changed)?
+            }
+        }
+    }
+
+    if state_changed {
+        state.save(&rig.id)?;
+    }
+    Ok(())
+}
+
+fn ensure_shared_path(
+    rig: &RigSpec,
+    shared: &SharedPathSpec,
+    state: &mut RigState,
+    state_changed: &mut bool,
+) -> Result<()> {
+    let (link_path, target_path) = resolve_shared_paths(rig, shared);
+    let key = shared_path_key(&link_path);
+
+    match std::fs::symlink_metadata(&link_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let current = std::fs::read_link(&link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!("read {}: {}", link_path.display(), e),
+                )
+            })?;
+            if current == target_path {
+                if !target_path.exists() {
+                    return Err(Error::rig_pipeline_failed(
+                        &rig.id,
+                        "shared-path",
+                        format!("shared target {} does not exist", target_path.display()),
+                    ));
+                }
+                return Ok(());
+            }
+            Err(Error::rig_pipeline_failed(
+                &rig.id,
+                "shared-path",
+                format!(
+                    "{} points at {}, expected {} — refusing to replace an existing symlink",
+                    link_path.display(),
+                    current.display(),
+                    target_path.display()
+                ),
+            ))
+        }
+        Ok(_) => {
+            // Local dependencies already exist in this checkout. Leave them
+            // alone and forget any stale ownership marker for this path.
+            if state.shared_paths.remove(&key).is_some() {
+                *state_changed = true;
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if !target_path.exists() {
+                return Err(Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!(
+                        "shared target {} does not exist for {}",
+                        target_path.display(),
+                        link_path.display()
+                    ),
+                ));
+            }
+            let parent = link_path.parent().ok_or_else(|| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!("{} has no parent directory", link_path.display()),
+                )
+            })?;
+            if !parent.exists() {
+                return Err(Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!(
+                        "parent directory {} does not exist for {}",
+                        parent.display(),
+                        link_path.display()
+                    ),
+                ));
+            }
+
+            create_symlink(&target_path, &link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!(
+                        "create {} → {}: {}",
+                        link_path.display(),
+                        target_path.display(),
+                        e
+                    ),
+                )
+            })?;
+            state.shared_paths.insert(
+                key,
+                SharedPathState {
+                    target: target_path.to_string_lossy().into_owned(),
+                    created_at: now_rfc3339(),
+                },
+            );
+            *state_changed = true;
+            Ok(())
+        }
+        Err(e) => Err(Error::rig_pipeline_failed(
+            &rig.id,
+            "shared-path",
+            format!("stat {}: {}", link_path.display(), e),
+        )),
+    }
+}
+
+fn verify_shared_path(rig: &RigSpec, shared: &SharedPathSpec) -> Result<()> {
+    let (link_path, target_path) = resolve_shared_paths(rig, shared);
+    match std::fs::symlink_metadata(&link_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let current = std::fs::read_link(&link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!("read {}: {}", link_path.display(), e),
+                )
+            })?;
+            if current != target_path {
+                return Err(Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!(
+                        "{} points at {}, expected {}",
+                        link_path.display(),
+                        current.display(),
+                        target_path.display()
+                    ),
+                ));
+            }
+            if !target_path.exists() {
+                return Err(Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!("shared target {} does not exist", target_path.display()),
+                ));
+            }
+            Ok(())
+        }
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(Error::rig_pipeline_failed(
+            &rig.id,
+            "shared-path",
+            format!("{} is missing", link_path.display()),
+        )),
+        Err(e) => Err(Error::rig_pipeline_failed(
+            &rig.id,
+            "shared-path",
+            format!("stat {}: {}", link_path.display(), e),
+        )),
+    }
+}
+
+fn cleanup_shared_path(
+    rig: &RigSpec,
+    shared: &SharedPathSpec,
+    state: &mut RigState,
+    state_changed: &mut bool,
+) -> Result<()> {
+    let (link_path, _target_path) = resolve_shared_paths(rig, shared);
+    let key = shared_path_key(&link_path);
+    let Some(owned) = state.shared_paths.get(&key).cloned() else {
+        return Ok(());
+    };
+    let owned_target = PathBuf::from(&owned.target);
+
+    if let Ok(metadata) = std::fs::symlink_metadata(&link_path) {
+        if metadata.file_type().is_symlink() {
+            let current = std::fs::read_link(&link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "shared-path",
+                    format!("read {}: {}", link_path.display(), e),
+                )
+            })?;
+            if current == owned_target {
+                std::fs::remove_file(&link_path).map_err(|e| {
+                    Error::rig_pipeline_failed(
+                        &rig.id,
+                        "shared-path",
+                        format!("remove {}: {}", link_path.display(), e),
+                    )
+                })?;
+            }
+        }
+    }
+
+    state.shared_paths.remove(&key);
+    *state_changed = true;
+    Ok(())
+}
+
+fn resolve_shared_paths(rig: &RigSpec, shared: &SharedPathSpec) -> (PathBuf, PathBuf) {
+    (
+        PathBuf::from(expand_vars(rig, &shared.link)),
+        PathBuf::from(expand_vars(rig, &shared.target)),
+    )
+}
+
+fn shared_path_key(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
 /// Apply or verify an idempotent local-only patch.
 ///
 /// `apply` semantics:
@@ -535,6 +783,7 @@ fn step_kind(step: &PipelineStep) -> &'static str {
         PipelineStep::Git { .. } => "git",
         PipelineStep::Command { .. } => "command",
         PipelineStep::Symlink { .. } => "symlink",
+        PipelineStep::SharedPath { .. } => "shared-path",
         PipelineStep::Patch { .. } => "patch",
         PipelineStep::Check { .. } => "check",
     }
@@ -563,6 +812,7 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
             .clone()
             .unwrap_or_else(|| truncate(&expand_vars(rig, cmd), 80)),
         PipelineStep::Symlink { op } => format!("symlink {}", serialize_symlink_op(*op)),
+        PipelineStep::SharedPath { op } => format!("shared-path {}", serialize_shared_path_op(*op)),
         PipelineStep::Patch {
             component,
             file,
@@ -608,6 +858,14 @@ fn serialize_symlink_op(op: SymlinkOp) -> &'static str {
     match op {
         SymlinkOp::Ensure => "ensure",
         SymlinkOp::Verify => "verify",
+    }
+}
+
+fn serialize_shared_path_op(op: SharedPathOp) -> &'static str {
+    match op {
+        SharedPathOp::Ensure => "ensure",
+        SharedPathOp::Verify => "verify",
+        SharedPathOp::Cleanup => "cleanup",
     }
 }
 

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 use super::expand::expand_vars;
-use super::pipeline::{run_pipeline, PipelineOutcome};
+use super::pipeline::{cleanup_shared_paths, run_pipeline, PipelineOutcome};
 use super::service::{self, ServiceStatus};
 use super::spec::RigSpec;
 use super::state::{now_rfc3339, RigState};
@@ -105,6 +105,8 @@ pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
     } else {
         None
     };
+
+    cleanup_shared_paths(rig)?;
 
     let mut stopped = Vec::new();
     for service_id in rig.services.keys() {

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -30,6 +30,14 @@ pub struct RigSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub symlinks: Vec<SymlinkSpec>,
 
+    /// Ephemeral dependency paths a rig may borrow from another checkout.
+    ///
+    /// Unlike `symlinks`, these are safe-by-default: `ensure` only creates the
+    /// link when the path is missing, leaves real directories alone, and records
+    /// ownership so cleanup removes only links created by this rig.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shared_paths: Vec<SharedPathSpec>,
+
     /// Pipelines for `up`, `check`, `down`, and custom verbs. MVP uses `up`,
     /// `check`, and `down`; future phases will add `sync`, `bench`, etc.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -171,6 +179,17 @@ pub struct SymlinkSpec {
     pub target: String,
 }
 
+/// Ephemeral path borrowed from another checkout, usually dependencies such as
+/// `node_modules` that can be reused across worktrees.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SharedPathSpec {
+    /// Path inside the active checkout. If missing, `shared-path ensure` creates
+    /// a symlink here. If a real file/directory already exists, it is left alone.
+    pub link: String,
+    /// Existing path to borrow, usually the primary checkout's dependency dir.
+    pub target: String,
+}
+
 /// A pipeline step. Flat enum via `kind` discriminator so specs stay readable.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
@@ -243,6 +262,12 @@ pub enum PipelineStep {
     Symlink {
         /// Operation: `ensure` or `verify`.
         op: SymlinkOp,
+    },
+
+    /// Ensure, verify, or clean up declared shared dependency paths.
+    SharedPath {
+        /// Operation: `ensure`, `verify`, or `cleanup`.
+        op: SharedPathOp,
     },
 
     /// Apply (or verify) an idempotent local-only patch to a file in a
@@ -349,6 +374,18 @@ pub enum ServiceOp {
 pub enum SymlinkOp {
     Ensure,
     Verify,
+}
+
+/// Shared path operation in a pipeline step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SharedPathOp {
+    /// Create missing dependency paths as symlinks to their shared targets.
+    Ensure,
+    /// Check that each dependency path is available without mutating anything.
+    Verify,
+    /// Remove only symlinks this rig created and still owns.
+    Cleanup,
 }
 
 /// Patch operation in a pipeline step.

--- a/src/core/rig/state.rs
+++ b/src/core/rig/state.rs
@@ -28,6 +28,11 @@ pub struct RigState {
     /// Services the rig is managing.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub services: HashMap<String, ServiceState>,
+
+    /// Shared dependency symlinks created by this rig and safe to remove on
+    /// cleanup. Keyed by expanded link path.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub shared_paths: HashMap<String, SharedPathState>,
 }
 
 /// Per-service state: PID, start time, health.
@@ -43,6 +48,16 @@ pub struct ServiceState {
 
     /// Last observed status — `"running"` / `"stopped"` / `"unknown"`.
     pub status: String,
+}
+
+/// Per-shared-path ownership marker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SharedPathState {
+    /// Expanded target path the rig linked to when it created the symlink.
+    pub target: String,
+
+    /// Timestamp when the symlink was created, RFC3339.
+    pub created_at: String,
 }
 
 impl RigState {

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -14,6 +14,7 @@ fn minimal_rig() -> RigSpec {
         components: Default::default(),
         services: Default::default(),
         symlinks: Vec::new(),
+        shared_paths: Vec::new(),
         pipeline: Default::default(),
         bench: None,
     }

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -14,6 +14,7 @@ fn rig_with(id: &str, components: HashMap<String, ComponentSpec>) -> RigSpec {
         components,
         services: Default::default(),
         symlinks: Vec::new(),
+        shared_paths: Vec::new(),
         pipeline: Default::default(),
         bench: None,
     }

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -88,6 +88,7 @@ mod patch {
             components,
             services: Default::default(),
             symlinks: Vec::new(),
+            shared_paths: Vec::new(),
             pipeline,
             bench: None,
         }
@@ -249,5 +250,224 @@ mod patch {
 
         let after = fs::read_to_string(&file).expect("read after");
         assert_eq!(before, after, "verify must be read-only");
+    }
+}
+
+// ---- Shared path step end-to-end -------------------------------------------
+
+#[cfg(unix)]
+mod shared_path {
+    use std::collections::HashMap;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+
+    use tempfile::TempDir;
+
+    use crate::rig::pipeline::{cleanup_shared_paths, run_pipeline};
+    use crate::rig::spec::{PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
+    use crate::rig::state::RigState;
+
+    fn rig_with_shared_path(id: &str, shared: SharedPathSpec, op: SharedPathOp) -> RigSpec {
+        let mut pipeline = HashMap::new();
+        pipeline.insert("up".to_string(), vec![PipelineStep::SharedPath { op }]);
+        RigSpec {
+            id: id.to_string(),
+            description: String::new(),
+            components: Default::default(),
+            services: Default::default(),
+            symlinks: Vec::new(),
+            shared_paths: vec![shared],
+            pipeline,
+            bench: None,
+        }
+    }
+
+    fn home_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
+        let guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var("HOME").ok();
+        let dir = TempDir::new().expect("home tempdir");
+        std::env::set_var("HOME", dir.path());
+        let result = body(&dir);
+        match prior {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        drop(guard);
+        result
+    }
+
+    fn shared(link: &std::path::Path, target: &std::path::Path) -> SharedPathSpec {
+        SharedPathSpec {
+            link: link.to_string_lossy().into_owned(),
+            target: target.to_string_lossy().into_owned(),
+        }
+    }
+
+    #[test]
+    fn test_shared_path_ensure_creates_missing_symlink_and_records_state() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let target = tmp.path().join("primary-node_modules");
+            let link = tmp.path().join("worktree-node_modules");
+            fs::create_dir(&target).expect("target dir");
+
+            let rig = rig_with_shared_path(
+                "shared-create",
+                shared(&link, &target),
+                SharedPathOp::Ensure,
+            );
+            let out = run_pipeline(&rig, "up", true).expect("pipeline");
+            assert!(out.is_success(), "outcomes: {:?}", out.steps);
+            assert!(link.is_symlink(), "missing path becomes symlink");
+            assert_eq!(fs::read_link(&link).expect("read link"), target);
+
+            let state = RigState::load(&rig.id).expect("state");
+            let key = link.to_string_lossy().into_owned();
+            assert_eq!(
+                state.shared_paths.get(&key).unwrap().target,
+                target.to_string_lossy()
+            );
+        });
+    }
+
+    #[test]
+    fn test_shared_path_ensure_leaves_existing_local_directory_unowned() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let target = tmp.path().join("primary-node_modules");
+            let link = tmp.path().join("worktree-node_modules");
+            fs::create_dir(&target).expect("target dir");
+            fs::create_dir(&link).expect("local deps dir");
+
+            let rig =
+                rig_with_shared_path("shared-local", shared(&link, &target), SharedPathOp::Ensure);
+            let out = run_pipeline(&rig, "up", true).expect("pipeline");
+            assert!(out.is_success(), "existing local directory should pass");
+            assert!(link.is_dir());
+            assert!(!link.is_symlink());
+
+            let state = RigState::load(&rig.id).expect("state");
+            assert!(
+                state.shared_paths.is_empty(),
+                "local deps are not rig-owned"
+            );
+        });
+    }
+
+    #[test]
+    fn test_shared_path_cleanup_removes_only_state_owned_symlink() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let target = tmp.path().join("primary-node_modules");
+            let owned_link = tmp.path().join("owned-node_modules");
+            fs::create_dir(&target).expect("target dir");
+
+            let rig = rig_with_shared_path(
+                "shared-cleanup",
+                shared(&owned_link, &target),
+                SharedPathOp::Ensure,
+            );
+            run_pipeline(&rig, "up", true).expect("ensure");
+            assert!(owned_link.is_symlink());
+
+            cleanup_shared_paths(&rig).expect("cleanup");
+            assert!(!owned_link.exists(), "owned symlink removed");
+            let state = RigState::load(&rig.id).expect("state");
+            assert!(state.shared_paths.is_empty(), "ownership marker cleared");
+        });
+    }
+
+    #[test]
+    fn test_shared_path_cleanup_does_not_remove_unowned_matching_symlink() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let target = tmp.path().join("primary-node_modules");
+            let link = tmp.path().join("worktree-node_modules");
+            fs::create_dir(&target).expect("target dir");
+            std::os::unix::fs::symlink(&target, &link).expect("preexisting symlink");
+
+            let rig = rig_with_shared_path(
+                "shared-unowned",
+                shared(&link, &target),
+                SharedPathOp::Ensure,
+            );
+            run_pipeline(&rig, "up", true).expect("ensure sees existing symlink");
+            cleanup_shared_paths(&rig).expect("cleanup");
+            assert!(link.is_symlink(), "unowned symlink is left alone");
+        });
+    }
+
+    #[test]
+    fn test_shared_path_ensure_refuses_existing_symlink_to_other_target() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let target = tmp.path().join("primary-node_modules");
+            let other = tmp.path().join("other-node_modules");
+            let link = tmp.path().join("worktree-node_modules");
+            fs::create_dir(&target).expect("target dir");
+            fs::create_dir(&other).expect("other dir");
+            std::os::unix::fs::symlink(&other, &link).expect("preexisting symlink");
+
+            let rig = rig_with_shared_path(
+                "shared-wrong-symlink",
+                shared(&link, &target),
+                SharedPathOp::Ensure,
+            );
+            let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+            assert!(!out.is_success(), "wrong symlink should fail");
+            assert_eq!(fs::read_link(&link).expect("read link"), other);
+        });
+    }
+
+    #[test]
+    fn test_shared_path_ensure_rejects_broken_matching_symlink() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let target = tmp.path().join("missing-primary-node_modules");
+            let link = tmp.path().join("worktree-node_modules");
+            std::os::unix::fs::symlink(&target, &link).expect("preexisting symlink");
+
+            let rig = rig_with_shared_path(
+                "shared-broken-symlink",
+                shared(&link, &target),
+                SharedPathOp::Ensure,
+            );
+            let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+            assert!(!out.is_success(), "broken dependency symlink should fail");
+            assert!(link.is_symlink(), "ensure must not remove broken symlink");
+        });
+    }
+
+    #[test]
+    fn test_shared_path_verify_accepts_local_directory_and_rejects_missing() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let target = tmp.path().join("primary-node_modules");
+            let local = tmp.path().join("local-node_modules");
+            let missing = tmp.path().join("missing-node_modules");
+            fs::create_dir(&target).expect("target dir");
+            fs::create_dir(&local).expect("local dir");
+
+            let local_rig = rig_with_shared_path(
+                "shared-verify-local",
+                shared(&local, &target),
+                SharedPathOp::Verify,
+            );
+            let local_out = run_pipeline(&local_rig, "up", true).expect("local verify");
+            assert!(local_out.is_success(), "local deps satisfy verify");
+
+            let missing_rig = rig_with_shared_path(
+                "shared-verify-missing",
+                shared(&missing, &target),
+                SharedPathOp::Verify,
+            );
+            let missing_out = run_pipeline(&missing_rig, "up", true).expect("missing verify");
+            assert!(!missing_out.is_success(), "missing deps should fail verify");
+        });
     }
 }

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -23,7 +23,7 @@ use crate::rig::runner::{
     run_check, run_down, run_status, run_up, snapshot_state, CheckReport, RigStatusReport,
     ServiceStatusReport, UpReport,
 };
-use crate::rig::spec::{ComponentSpec, RigSpec};
+use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
 
 fn empty_pipeline(name: &str) -> PipelineOutcome {
     PipelineOutcome {
@@ -41,6 +41,7 @@ fn minimal_spec(id: &str) -> RigSpec {
         components: HashMap::new(),
         services: HashMap::new(),
         symlinks: Vec::new(),
+        shared_paths: Vec::new(),
         pipeline: HashMap::new(),
         bench: None,
     }
@@ -191,6 +192,46 @@ fn test_run_down() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn test_run_down_cleans_state_owned_shared_paths() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let target = tmp.path().join("primary-node_modules");
+        let link = tmp.path().join("worktree-node_modules");
+        std::fs::create_dir(&target).expect("target dir");
+
+        let mut pipeline = HashMap::new();
+        pipeline.insert(
+            "up".to_string(),
+            vec![PipelineStep::SharedPath {
+                op: SharedPathOp::Ensure,
+            }],
+        );
+        let rig = RigSpec {
+            id: "run-down-shared-path-fixture".to_string(),
+            description: String::new(),
+            components: HashMap::new(),
+            services: HashMap::new(),
+            symlinks: Vec::new(),
+            shared_paths: vec![SharedPathSpec {
+                link: link.to_string_lossy().into_owned(),
+                target: target.to_string_lossy().into_owned(),
+            }],
+            pipeline,
+            bench: None,
+        };
+
+        let up = crate::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");
+        assert!(up.is_success());
+        assert!(link.is_symlink());
+
+        let down = run_down(&rig).expect("run_down");
+        assert!(down.success);
+        assert!(!link.exists(), "run_down removes owned shared-path symlink");
+    });
+}
+
 #[test]
 fn test_run_status() {
     with_isolated_home(|_dir| {
@@ -239,6 +280,7 @@ fn test_snapshot_state() {
         components,
         services: HashMap::new(),
         symlinks: Vec::new(),
+        shared_paths: Vec::new(),
         pipeline: HashMap::new(),
         bench: None,
     };

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -1,7 +1,7 @@
 //! Spec parsing tests — serde round-trips, pipeline step discriminants,
 //! service-kind parsing. Covers `src/core/rig/spec.rs`.
 
-use crate::rig::{PipelineStep, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec};
+use crate::rig::{PipelineStep, RigSpec, ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec};
 
 /// Canonical fixture matching the studio-playground-dev shape used as the
 /// first real consumer of the rig primitive.
@@ -23,14 +23,22 @@ const STUDIO_PLAYGROUND_SPEC: &str = r#"{
     "symlinks": [
         { "link": "~/.local/bin/studio", "target": "~/.local/bin/studio-dev" }
     ],
+    "shared_paths": [
+        {
+            "link": "${components.studio.path}/node_modules",
+            "target": "~/Developer/studio/node_modules"
+        }
+    ],
     "pipeline": {
         "up": [
             { "kind": "service", "id": "tarball-server", "op": "start" },
-            { "kind": "symlink", "op": "ensure" }
+            { "kind": "symlink", "op": "ensure" },
+            { "kind": "shared-path", "op": "ensure" }
         ],
         "check": [
             { "kind": "service", "id": "tarball-server", "op": "health" },
             { "kind": "symlink", "op": "verify" },
+            { "kind": "shared-path", "op": "verify" },
             {
                 "kind": "check",
                 "label": "MDI db.php drop-in survived",
@@ -39,6 +47,7 @@ const STUDIO_PLAYGROUND_SPEC: &str = r#"{
             }
         ],
         "down": [
+            { "kind": "shared-path", "op": "cleanup" },
             { "kind": "service", "id": "tarball-server", "op": "stop" }
         ]
     }
@@ -51,9 +60,10 @@ fn test_spec_parses_studio_playground_fixture() {
     assert_eq!(spec.components.len(), 2);
     assert_eq!(spec.services.len(), 1);
     assert_eq!(spec.symlinks.len(), 1);
-    assert_eq!(spec.pipeline.get("up").unwrap().len(), 2);
-    assert_eq!(spec.pipeline.get("check").unwrap().len(), 3);
-    assert_eq!(spec.pipeline.get("down").unwrap().len(), 1);
+    assert_eq!(spec.shared_paths.len(), 1);
+    assert_eq!(spec.pipeline.get("up").unwrap().len(), 3);
+    assert_eq!(spec.pipeline.get("check").unwrap().len(), 4);
+    assert_eq!(spec.pipeline.get("down").unwrap().len(), 2);
 }
 
 #[test]
@@ -74,9 +84,10 @@ fn test_spec_pipeline_steps_discriminate_correctly() {
     let up = spec.pipeline.get("up").unwrap();
     assert!(matches!(up[0], PipelineStep::Service { .. }));
     assert!(matches!(up[1], PipelineStep::Symlink { .. }));
+    assert!(matches!(up[2], PipelineStep::SharedPath { .. }));
 
     let check = spec.pipeline.get("check").unwrap();
-    assert!(matches!(check[2], PipelineStep::Check { .. }));
+    assert!(matches!(check[3], PipelineStep::Check { .. }));
 }
 
 #[test]
@@ -88,6 +99,14 @@ fn test_spec_symlink_fields_parse() {
 }
 
 #[test]
+fn test_spec_shared_path_fields_parse() {
+    let spec: RigSpec = serde_json::from_str(STUDIO_PLAYGROUND_SPEC).expect("parse");
+    let shared: &SharedPathSpec = &spec.shared_paths[0];
+    assert_eq!(shared.link, "${components.studio.path}/node_modules");
+    assert_eq!(shared.target, "~/Developer/studio/node_modules");
+}
+
+#[test]
 fn test_spec_minimal_only_required_fields() {
     let json = r#"{"id": "tiny"}"#;
     let spec: RigSpec = serde_json::from_str(json).expect("parse");
@@ -95,6 +114,7 @@ fn test_spec_minimal_only_required_fields() {
     assert!(spec.components.is_empty());
     assert!(spec.services.is_empty());
     assert!(spec.symlinks.is_empty());
+    assert!(spec.shared_paths.is_empty());
     assert!(spec.pipeline.is_empty());
 }
 

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -4,7 +4,7 @@
 //! touching real user state), so this module exercises serde round-tripping
 //! which is the meaningful invariant.
 
-use crate::rig::state::{RigState, ServiceState};
+use crate::rig::state::{RigState, ServiceState, SharedPathState};
 
 #[test]
 fn test_state_round_trips_empty() {
@@ -13,6 +13,7 @@ fn test_state_round_trips_empty() {
     let parsed: RigState = serde_json::from_str(&json).expect("parse");
     assert!(parsed.last_up.is_none());
     assert!(parsed.services.is_empty());
+    assert!(parsed.shared_paths.is_empty());
 }
 
 #[test]
@@ -22,6 +23,7 @@ fn test_state_round_trips_with_service() {
         last_check: None,
         last_check_result: None,
         services: Default::default(),
+        shared_paths: Default::default(),
     };
     state.services.insert(
         "tarball".to_string(),
@@ -42,6 +44,24 @@ fn test_state_round_trips_with_service() {
         parsed.services.get("tarball").map(|s| s.status.as_str()),
         Some("running")
     );
+}
+
+#[test]
+fn test_state_round_trips_with_shared_path() {
+    let mut state = RigState::default();
+    state.shared_paths.insert(
+        "/worktree/node_modules".to_string(),
+        SharedPathState {
+            target: "/primary/node_modules".to_string(),
+            created_at: "2026-04-26T13:00:00Z".to_string(),
+        },
+    );
+
+    let json = serde_json::to_string(&state).expect("serialize");
+    let parsed: RigState = serde_json::from_str(&json).expect("parse");
+    let entry = parsed.shared_paths.get("/worktree/node_modules").unwrap();
+    assert_eq!(entry.target, "/primary/node_modules");
+    assert_eq!(entry.created_at, "2026-04-26T13:00:00Z");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add rig-level shared_paths declarations for borrowing dependency directories from another checkout.
- Add shared-path pipeline operations for ensure, verify, and cleanup with state-backed ownership markers.
- Document the spec and cover creation, verification, cleanup, and run_down safety behavior.

## Tests
- cargo fmt --check
- cargo test core::rig --lib -- --test-threads=1
- cargo test -- --test-threads=1
- homeboy lint homeboy --path .
- homeboy audit homeboy --path .

Closes #1586

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting the implementation, tests, documentation, and verification commands.