### PR TITLE
feat(bench): pass rig-declared workloads to runners

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 use serde::Serialize;
+use std::path::PathBuf;
 
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
@@ -9,7 +10,7 @@ use homeboy::extension::bench::{
     RigBenchEntry, DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
 use homeboy::extension::ExtensionCapability;
-use homeboy::rig;
+use homeboy::rig::{self, RigSpec};
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
@@ -292,8 +293,8 @@ fn run_single(
     passthrough_args: &[String],
     rig_id_override: Option<String>,
 ) -> CmdResult<BenchCommandOutput> {
-    let (rig_id, rig_snapshot, default_component_id) = match rig_id_override.as_deref() {
-        None => (None, None, None),
+    let (rig_id, rig_snapshot, default_component_id, rig_spec) = match rig_id_override.as_deref() {
+        None => (None, None, None, None),
         Some(rig_id) => {
             let rig_spec = rig::load(rig_id)?;
             let check_report = rig::run_check(&rig_spec)?;
@@ -309,7 +310,12 @@ fn run_single(
                 .bench
                 .as_ref()
                 .and_then(|b| b.default_component.clone());
-            (Some(rig_spec.id.clone()), Some(snapshot), default)
+            (
+                Some(rig_spec.id.clone()),
+                Some(snapshot),
+                default,
+                Some(rig_spec),
+            )
         }
     };
 
@@ -330,6 +336,15 @@ fn run_single(
     ))?;
 
     let run_dir = RunDir::create()?;
+
+    let extra_workloads = rig_spec
+        .as_ref()
+        .and_then(|spec| {
+            ctx.extension_id
+                .as_deref()
+                .map(|id| bench_workloads_for_extension(spec, id))
+        })
+        .unwrap_or_default();
 
     let workflow = extension_bench::run_main_bench_workflow(
         &ctx.component,
@@ -374,6 +389,7 @@ fn run_single(
             rig_id: rig_id.clone(),
             shared_state: None,
             concurrency: 1,
+            extra_workloads,
         },
         &run_dir,
     )?;
@@ -382,6 +398,16 @@ fn run_single(
         workflow,
         rig_snapshot,
     ))
+}
+
+fn bench_workloads_for_extension(rig_spec: &RigSpec, extension_id: &str) -> Vec<PathBuf> {
+    rig_spec
+        .bench_workloads
+        .get(extension_id)
+        .into_iter()
+        .flat_map(|paths| paths.iter())
+        .map(|path| PathBuf::from(rig::expand::expand_vars(rig_spec, path)))
+        .collect()
 }
 
 #[cfg(test)]
@@ -393,6 +419,38 @@ mod tests {
         let args = vec!["--ratchet".to_string(), "--filter=Scenario".to_string()];
         let result = filter_homeboy_flags(&args);
         assert_eq!(result, vec!["--filter=Scenario"]);
+    }
+
+    #[test]
+    fn bench_workloads_for_extension_filters_and_expands_paths() {
+        std::env::set_var("HOMEBOY_TEST_BENCH_ROOT", "/tmp/private-benches");
+        let rig_spec: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "studio",
+                "components": {
+                    "playground": { "path": "/tmp/playground" }
+                },
+                "bench_workloads": {
+                    "wordpress": [
+                        "${env.HOMEBOY_TEST_BENCH_ROOT}/cold-boot.php",
+                        "${components.playground.path}/fixtures/wc-loaded.php"
+                    ],
+                    "nodejs": ["/tmp/node-only.bench.ts"]
+                }
+            }"#,
+        )
+        .expect("parse rig spec");
+
+        let workloads = bench_workloads_for_extension(&rig_spec, "wordpress");
+
+        assert_eq!(
+            workloads,
+            vec![
+                PathBuf::from("/tmp/private-benches/cold-boot.php"),
+                PathBuf::from("/tmp/playground/fixtures/wc-loaded.php"),
+            ]
+        );
+        assert!(bench_workloads_for_extension(&rig_spec, "rust").is_empty());
     }
 
     #[test]

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -301,6 +301,7 @@ mod tests {
         BenchScenario {
             id: id.to_string(),
             file: None,
+            source: None,
             iterations: 10,
             metrics: BenchMetrics { values: metrics },
             memory: None,

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -157,6 +157,7 @@ mod tests {
             scenarios: vec![BenchScenario {
                 id: "scenario".to_string(),
                 file: None,
+                source: None,
                 iterations: 10,
                 metrics: BenchMetrics { values: metrics },
                 memory: None,

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -56,6 +56,10 @@ pub struct BenchScenario {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
+    /// Scenario origin. Dispatchers use `in_tree` for component-owned
+    /// workloads and `rig` for out-of-tree workloads supplied by a rig spec.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     pub iterations: u64,
     pub metrics: BenchMetrics,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -367,6 +367,7 @@ mod tests {
         BenchScenario {
             id: id.to_string(),
             file: None,
+            source: None,
             iterations: 10,
             metrics: BenchMetrics { values },
             memory: None,

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -49,6 +49,9 @@ pub struct BenchRunWorkflowArgs {
     /// to be set — N independent cold-boots without shared state would
     /// be N independent runs, not a multi-instance contention test.
     pub concurrency: u32,
+    /// Rig-declared out-of-tree workloads to run alongside in-tree discovery.
+    /// Exported to dispatchers as `HOMEBOY_BENCH_EXTRA_WORKLOADS`.
+    pub extra_workloads: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -242,6 +245,13 @@ fn build_runner(
         .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
         .script_args(&args.passthrough_args);
 
+    if !args.extra_workloads.is_empty() {
+        runner = runner.env(
+            "HOMEBOY_BENCH_EXTRA_WORKLOADS",
+            &extra_workloads_env_value(&args.extra_workloads)?,
+        );
+    }
+
     if let Some(ref shared) = args.shared_state {
         runner = runner.env("HOMEBOY_BENCH_SHARED_STATE", &shared.to_string_lossy());
     }
@@ -258,6 +268,21 @@ fn build_runner(
     }
 
     Ok(runner)
+}
+
+fn extra_workloads_env_value(paths: &[PathBuf]) -> Result<String> {
+    let joined = std::env::join_paths(paths)
+        .map_err(|e| {
+            Error::validation_invalid_argument(
+                "bench_workloads",
+                format!("bench workload path cannot be exported: {}", e),
+                None,
+                None,
+            )
+        })?
+        .to_string_lossy()
+        .to_string();
+    Ok(joined)
 }
 
 /// Spawn N runner instances in parallel, wait for all, aggregate.
@@ -375,5 +400,18 @@ mod tests {
         assert_eq!(instance_results_filename(0), "bench-results-i0.json");
         assert_eq!(instance_results_filename(7), "bench-results-i7.json");
         assert_ne!(instance_results_filename(0), instance_results_filename(1));
+    }
+
+    #[test]
+    fn extra_workloads_env_value_joins_paths_for_runner_contract() {
+        let paths = vec![
+            PathBuf::from("/tmp/bench-one.php"),
+            PathBuf::from("/tmp/bench-two.php"),
+        ];
+
+        assert_eq!(
+            extra_workloads_env_value(&paths).unwrap(),
+            "/tmp/bench-one.php:/tmp/bench-two.php"
+        );
     }
 }

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -39,6 +39,15 @@ pub struct RigSpec {
     /// populated when the rig is meant to drive a benchmark.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bench: Option<BenchSpec>,
+
+    /// Out-of-tree bench workloads keyed by extension id.
+    ///
+    /// These are private, rig-owned workloads that should run alongside the
+    /// component's in-tree bench discovery when `homeboy bench --rig <id>` is
+    /// invoked. Values support the same `~`, `${env.NAME}`, and
+    /// `${components.<id>.path}` expansion as other rig path fields.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub bench_workloads: HashMap<String, Vec<String>>,
 }
 
 /// Bench composition for a rig. Currently minimal — pins which component

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -48,6 +48,7 @@ fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
     BenchScenario {
         id: id.to_string(),
         file: None,
+        source: None,
         iterations: 10,
         metrics: BenchMetrics { values },
         memory: None,
@@ -147,6 +148,34 @@ fn policy_without_phase_field_parses_as_none() {
         "missing phase field should deserialize as None"
     );
     assert_eq!(pol.direction, BenchMetricDirection::LowerIsBetter);
+}
+
+#[test]
+fn scenario_source_round_trips_for_rig_workload_origin() {
+    let raw = r#"{
+        "component_id": "demo",
+        "iterations": 1,
+        "scenarios": [
+            {
+                "id": "cold-boot",
+                "file": "/private/benches/cold-boot.php",
+                "source": "rig",
+                "iterations": 1,
+                "metrics": { "p95_ms": 100.0 }
+            }
+        ]
+    }"#;
+
+    let parsed = parse_bench_results_str(raw).unwrap();
+    let scenario = parsed.scenarios.first().expect("scenario");
+    assert_eq!(scenario.source.as_deref(), Some("rig"));
+
+    let serialized = serde_json::to_string(&parsed).unwrap();
+    assert!(
+        serialized.contains("\"source\":\"rig\""),
+        "scenario source should serialize for report consumers: {}",
+        serialized
+    );
 }
 
 // 3. None phase is omitted entirely from the wire form (back-compat

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -29,6 +29,39 @@ fn test_bench_spec_deserializes_both_fields() {
 }
 
 #[test]
+fn test_rig_spec_deserializes_bench_workloads_by_extension() {
+    let spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "studio",
+            "bench_workloads": {
+                "wordpress": [
+                    "/private/benches/cold-boot.php",
+                    "~/benches/wc-loaded.php"
+                ],
+                "nodejs": ["/private/benches/electron-startup.bench.ts"]
+            }
+        }"#,
+    )
+    .expect("parse RigSpec");
+
+    assert_eq!(
+        spec.bench_workloads
+            .get("wordpress")
+            .expect("wordpress workloads"),
+        &vec![
+            "/private/benches/cold-boot.php".to_string(),
+            "~/benches/wc-loaded.php".to_string(),
+        ]
+    );
+    assert_eq!(
+        spec.bench_workloads
+            .get("nodejs")
+            .expect("nodejs workloads"),
+        &vec!["/private/benches/electron-startup.bench.ts".to_string()]
+    );
+}
+
+#[test]
 fn test_bench_spec_default_component_only_back_compat() {
     // Pre-PR specs declare only `default_component`; the new field
     // must default to None so existing rigs keep parsing.
@@ -63,6 +96,7 @@ fn test_rig_spec_without_bench_block_back_compat() {
     let json = r#"{ "id": "no-bench" }"#;
     let spec: RigSpec = serde_json::from_str(json).expect("parse");
     assert!(spec.bench.is_none());
+    assert!(spec.bench_workloads.is_empty());
 }
 
 #[test]

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -16,6 +16,7 @@ fn minimal_rig() -> RigSpec {
         symlinks: Vec::new(),
         pipeline: Default::default(),
         bench: None,
+        bench_workloads: Default::default(),
     }
 }
 

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -16,6 +16,7 @@ fn rig_with(id: &str, components: HashMap<String, ComponentSpec>) -> RigSpec {
         symlinks: Vec::new(),
         pipeline: Default::default(),
         bench: None,
+        bench_workloads: Default::default(),
     }
 }
 

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -90,6 +90,7 @@ mod patch {
             symlinks: Vec::new(),
             pipeline,
             bench: None,
+            bench_workloads: Default::default(),
         }
     }
 

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -43,6 +43,7 @@ fn minimal_spec(id: &str) -> RigSpec {
         symlinks: Vec::new(),
         pipeline: HashMap::new(),
         bench: None,
+        bench_workloads: HashMap::new(),
     }
 }
 
@@ -241,6 +242,7 @@ fn test_snapshot_state() {
         symlinks: Vec::new(),
         pipeline: HashMap::new(),
         bench: None,
+        bench_workloads: HashMap::new(),
     };
 
     let snapshot = snapshot_state(&rig);


### PR DESCRIPTION
## Summary
- Add `bench_workloads` to rig specs, keyed by extension id, for private out-of-tree bench scripts.
- Resolve rig workload paths with existing rig expansion (`~`, `${env.NAME}`, `${components.<id>.path}`) and pass them to bench runners via `HOMEBOY_BENCH_EXTRA_WORKLOADS`.
- Add optional `source` metadata on bench scenarios so dispatchers can distinguish `in_tree` and `rig` workloads.

## Tests
- `cargo test bench_workloads --lib`
- `cargo test bench_workloads --bin homeboy`
- `cargo test extension::bench --lib`
- `cargo test --lib --bins -- --test-threads=1`

## Notes
- Part of #1576. The core runner contract is now in place; homeboy-extensions still needs dispatcher support for WordPress and Node workloads before the issue is end-to-end complete.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the core rig/bench plumbing, tests, and verification; Chris remains responsible for review and merge.