### PR TITLE
refactor(review): share top-N grouping

### DIFF
--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -17,12 +17,12 @@
 //! versions) are out of scope — those are not present in `ReviewCommandOutput`.
 //! See follow-up: `feat(review): --banner key=value for action-level signals`.
 
-use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use homeboy::code_audit::AuditCommandOutput;
 use homeboy::extension::lint::LintCommandOutput;
 use homeboy::extension::test::TestCommandOutput;
+use homeboy::top_n::top_n_by;
 
 use super::{ReviewCommandOutput, ReviewStage};
 
@@ -146,35 +146,23 @@ fn render_test_stage(out: &mut String, stage: &ReviewStage<TestCommandOutput>) {
 /// with counts. Empty bodies mean no findings; we say nothing.
 fn render_audit_body(out: &mut String, output: &AuditCommandOutput) {
     let findings = audit_findings(output);
-    if findings.is_empty() {
+    let buckets = top_n_by(findings, |label| label.clone(), TOP_N);
+    if buckets.is_empty() {
         return;
     }
-    let total = findings.len();
-    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
-    for label in findings {
-        *counts.entry(label).or_insert(0) += 1;
-    }
-    // Sort by count desc, then alpha for stability.
-    let mut ordered: Vec<(String, usize)> = counts.into_iter().collect();
-    ordered.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
-    let shown = ordered.len().min(TOP_N);
-    for (label, count) in ordered.iter().take(shown) {
+    for (label, count) in &buckets.items {
         let _ = writeln!(out, "- **{}** — {} finding(s)", label, count);
     }
-    if ordered.len() > TOP_N {
+    if buckets.remainder > 0 {
         let _ = writeln!(
             out,
             "- _… {} more categor{}_",
-            ordered.len() - TOP_N,
-            if ordered.len() - TOP_N == 1 {
-                "y"
-            } else {
-                "ies"
-            }
+            buckets.remainder,
+            if buckets.remainder == 1 { "y" } else { "ies" }
         );
     }
-    let _ = writeln!(out, "- _Total: {} finding(s)_", total);
+    let _ = writeln!(out, "- _Total: {} finding(s)_", buckets.total);
 }
 
 /// Pull labels for grouping audit findings. We use the convention name when
@@ -207,22 +195,15 @@ fn render_lint_body(out: &mut String, output: &LintCommandOutput) {
         Some(f) if !f.is_empty() => f,
         _ => return,
     };
-    let total = findings.len();
-    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
-    for f in findings {
-        *counts.entry(f.category.clone()).or_insert(0) += 1;
-    }
-    let mut ordered: Vec<(String, usize)> = counts.into_iter().collect();
-    ordered.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
-    let shown = ordered.len().min(TOP_N);
-    for (code, count) in ordered.iter().take(shown) {
+    let buckets = top_n_by(findings, |f| f.category.clone(), TOP_N);
+    for (code, count) in &buckets.items {
         let _ = writeln!(out, "- `{}` — {} finding(s)", code, count);
     }
-    if ordered.len() > TOP_N {
-        let _ = writeln!(out, "- _… {} more sniff(s)_", ordered.len() - TOP_N);
+    if buckets.remainder > 0 {
+        let _ = writeln!(out, "- _… {} more sniff(s)_", buckets.remainder);
     }
-    let _ = writeln!(out, "- _Total: {} finding(s)_", total);
+    let _ = writeln!(out, "- _Total: {} finding(s)_", buckets.total);
 }
 
 /// Render the test stage body — failure count + pass-summary line. Per-test

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -19,6 +19,7 @@ pub mod release;
 pub mod rig;
 pub mod server;
 pub mod stack;
+pub mod top_n;
 pub mod upgrade;
 
 // Internal extensions - not part of public API

--- a/src/core/top_n.rs
+++ b/src/core/top_n.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+
+/// Count items by key, keep the top buckets sorted by count desc then key asc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TopN<K> {
+    pub items: Vec<(K, usize)>,
+    pub remainder: usize,
+    pub total: usize,
+}
+
+impl<K> TopN<K> {
+    pub fn is_empty(&self) -> bool {
+        self.total == 0
+    }
+}
+
+/// Group `items` by `key`, sort buckets by count desc then key asc, and cap the list.
+pub fn top_n_by<T, K, F>(items: impl IntoIterator<Item = T>, mut key: F, cap: usize) -> TopN<K>
+where
+    K: Ord,
+    F: FnMut(&T) -> K,
+{
+    let mut counts: BTreeMap<K, usize> = BTreeMap::new();
+    let mut total = 0usize;
+
+    for item in items {
+        total += 1;
+        *counts.entry(key(&item)).or_insert(0) += 1;
+    }
+
+    let bucket_count = counts.len();
+    let mut ordered: Vec<(K, usize)> = counts.into_iter().collect();
+    ordered.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ordered.truncate(cap);
+
+    TopN {
+        items: ordered,
+        remainder: bucket_count.saturating_sub(cap),
+        total,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_sorts_and_caps_buckets() {
+        let buckets = top_n_by(
+            ["beta", "alpha", "beta", "gamma", "alpha", "alpha"],
+            |label| label.to_string(),
+            2,
+        );
+
+        assert_eq!(buckets.total, 6);
+        assert_eq!(buckets.remainder, 1);
+        assert_eq!(
+            buckets.items,
+            vec![("alpha".to_string(), 3), ("beta".to_string(), 2)]
+        );
+    }
+
+    #[test]
+    fn uses_key_order_as_tiebreaker() {
+        let buckets = top_n_by(["zeta", "alpha", "middle"], |label| label.to_string(), 10);
+
+        assert_eq!(
+            buckets.items,
+            vec![
+                ("alpha".to_string(), 1),
+                ("middle".to_string(), 1),
+                ("zeta".to_string(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn handles_zero_cap_without_losing_totals() {
+        let buckets = top_n_by(["a", "b", "b"], |label| label.to_string(), 0);
+
+        assert_eq!(buckets.total, 3);
+        assert_eq!(buckets.remainder, 2);
+        assert!(buckets.items.is_empty());
+        assert!(!buckets.is_empty());
+    }
+
+    #[test]
+    fn handles_empty_input() {
+        let buckets = top_n_by(Vec::<String>::new(), |label| label.clone(), 10);
+
+        assert_eq!(buckets.total, 0);
+        assert_eq!(buckets.remainder, 0);
+        assert!(buckets.items.is_empty());
+        assert!(buckets.is_empty());
+    }
+}

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -280,6 +280,7 @@ mod shared_path {
             shared_paths: vec![shared],
             pipeline,
             bench: None,
+            bench_workloads: Default::default(),
         }
     }
 

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -221,6 +221,7 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             }],
             pipeline,
             bench: None,
+            bench_workloads: HashMap::new(),
         };
 
         let up = crate::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");


### PR DESCRIPTION
## Summary
- Add a reusable `top_n_by` primitive for count/sort/cap grouping.
- Migrate the review PR-comment audit and lint renderers to use the shared primitive.
- Fill two stale `RigSpec` test fixtures with `bench_workloads` so fresh `main` compiles under the test suite.

## Tests
- `cargo test top_n --lib`
- `cargo test commands::review::render`
- `cargo test -- --test-threads=1`
- `homeboy audit homeboy --path .` (reports existing audit findings; no branch-specific failure isolated)

Closes #1514

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the shared grouping primitive, migrating the review renderer callsites, adding tests, and running verification. Chris remains responsible for review and merge.
