### PR TITLE
feat(bench): add variance-aware metric comparisons

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -252,16 +252,20 @@ On every run without `--baseline` or `--ignore-baseline`:
 2. If the runner declares `metric_policies`, only those metrics are
    compared. Each policy declares whether lower or higher values are
    better and optional percent/absolute tolerances.
-3. If the runner omits `metric_policies`, Homeboy keeps the historical
+3. If a policy declares `variance_aware: true`, Homeboy compares the
+   metric's raw sample distributions instead of only the summary value.
+   The summary value still appears under `metrics.<name>` for reports;
+   the per-iteration samples live under `metrics.distributions.<name>`.
+4. If the runner omits `metric_policies`, Homeboy keeps the historical
    default: compare `p95_ms` as lower-is-better with the CLI threshold.
-4. A scenario improves when any compared metric moves in the better
+5. A scenario improves when any compared metric moves in the better
    direction.
-5. Scenarios present in one run but not the other are flagged as
+6. Scenarios present in one run but not the other are flagged as
    `new_scenario_ids` / `removed_scenario_ids`. Neither state triggers
    a regression by itself — they're informational.
-6. If any scenario regressed, the command exits `1` regardless of the
+7. If any scenario regressed, the command exits `1` regardless of the
    runner's own exit code.
-7. If any scenario improved and `--ratchet` is set, the baseline is
+8. If any scenario improved and `--ratchet` is set, the baseline is
    overwritten with the current snapshot.
 
 p95 remains the default for legacy latency benchmarks because it is less
@@ -292,6 +296,13 @@ The extension's bench script must:
     "requests_per_second": {
       "direction": "higher_is_better",
       "regression_threshold_percent": 5.0
+    },
+    "agent_loop_ms": {
+      "direction": "lower_is_better",
+      "regression_threshold_percent": 10.0,
+      "variance_aware": true,
+      "min_iterations_for_variance": 20,
+      "regression_test": "mann_whitney_u"
     }
   },
   "scenarios": [
@@ -308,7 +319,11 @@ The extension's bench script must:
         "max_ms": 172.0,
         "error_rate": 0.0,
         "requests_per_second": 180.5,
-        "status_500_count": 0
+        "status_500_count": 0,
+        "agent_loop_ms": 1200.0,
+        "distributions": {
+          "agent_loop_ms": [1100.0, 1200.0, 1300.0]
+        }
       },
       "memory": { "peak_bytes": 41943040 }
     }
@@ -328,6 +343,15 @@ The extension's bench script must:
   relative movement; `regression_threshold_absolute` compares raw numeric
   movement. If both are present, a metric must exceed both tolerances to
   regress.
+- Policy `variance_aware: true` requires a matching
+  `metrics.distributions.<metric>` array on every scenario that emits the
+  metric. If `min_iterations_for_variance` is set and the sample array is
+  smaller, parsing fails before baseline comparison.
+- Policy `regression_test` accepts `point_delta`, `mann_whitney_u`, and
+  `kolmogorov_smirnov`. `point_delta` is the legacy summary-value check.
+  Variance-aware metrics default to `mann_whitney_u` when the field is
+  omitted. Mann-Whitney uses a one-sided 95% normal approximation;
+  Kolmogorov-Smirnov uses the standard 5% two-sample critical value.
 - Scenario-level unknown keys are **tolerated**, so extensions can emit
   additional metadata (tags, environment info, warmup counts) without
   breaking parsing.

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -57,6 +57,8 @@ pub struct BenchScenarioSnapshot {
     pub id: String,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metrics: BTreeMap<String, f64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub distributions: BTreeMap<String, Vec<f64>>,
     /// Legacy fields from the first bench baseline shape. They remain
     /// readable so existing baselines keep working, but new baselines store
     /// metrics under the generic `metrics` map.
@@ -73,6 +75,7 @@ impl BenchScenarioSnapshot {
         Self {
             id: scenario.id.clone(),
             metrics: scenario.metrics.values.clone(),
+            distributions: scenario.metrics.distributions.clone(),
             p95_ms: None,
             p50_ms: None,
             mean_ms: None,
@@ -86,6 +89,10 @@ impl BenchScenarioSnapshot {
             "mean_ms" => self.mean_ms,
             _ => None,
         })
+    }
+
+    fn distribution(&self, name: &str) -> Option<&[f64]> {
+        self.distributions.get(name).map(Vec::as_slice)
     }
 }
 
@@ -215,13 +222,26 @@ pub fn compare(
         let mut metric_deltas = Vec::new();
 
         for policy in &metric_policies {
-            let Some(baseline_value) = prior.metric_value(policy.name()) else {
-                continue;
-            };
-            let Some(current_value) = scenario.metrics.get(policy.name()) else {
-                continue;
-            };
-            metric_deltas.push(policy.compare(baseline_value, current_value));
+            if policy.variance_aware() {
+                let Some(baseline_samples) = prior.distribution(policy.name()) else {
+                    continue;
+                };
+                let Some(current_samples) = scenario.metrics.distribution(policy.name()) else {
+                    continue;
+                };
+                if let Some(delta) = policy.compare_distribution(baseline_samples, current_samples)
+                {
+                    metric_deltas.push(delta);
+                }
+            } else {
+                let Some(baseline_value) = prior.metric_value(policy.name()) else {
+                    continue;
+                };
+                let Some(current_value) = scenario.metrics.get(policy.name()) else {
+                    continue;
+                };
+                metric_deltas.push(policy.compare(baseline_value, current_value));
+            }
         }
 
         let regression = metric_deltas.iter().any(|d| d.regression);
@@ -283,6 +303,7 @@ pub fn compare(
 mod tests {
     use super::super::parsing::{
         BenchMetricDirection, BenchMetricPolicy, BenchMetrics, BenchResults, BenchScenario,
+        RegressionTest,
     };
     use super::*;
 
@@ -303,8 +324,42 @@ mod tests {
             file: None,
             source: None,
             iterations: 10,
-            metrics: BenchMetrics { values: metrics },
+            metrics: BenchMetrics {
+                values: metrics,
+                distributions: BTreeMap::new(),
+            },
             memory: None,
+        }
+    }
+
+    fn distribution_scenario(id: &str, metric: &str, samples: Vec<f64>) -> BenchScenario {
+        let value = samples.iter().sum::<f64>() / samples.len() as f64;
+        let mut values = BTreeMap::new();
+        values.insert(metric.to_string(), value);
+        let mut distributions = BTreeMap::new();
+        distributions.insert(metric.to_string(), samples);
+        BenchScenario {
+            id: id.to_string(),
+            file: None,
+            source: None,
+            iterations: 10,
+            metrics: BenchMetrics {
+                values,
+                distributions,
+            },
+            memory: None,
+        }
+    }
+
+    fn variance_policy(direction: BenchMetricDirection, test: RegressionTest) -> BenchMetricPolicy {
+        BenchMetricPolicy {
+            direction,
+            regression_threshold_percent: Some(5.0),
+            regression_threshold_absolute: None,
+            variance_aware: true,
+            min_iterations_for_variance: Some(5),
+            regression_test: Some(test),
+            phase: None,
         }
     }
 
@@ -566,6 +621,9 @@ mod tests {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: None,
                 regression_threshold_absolute: Some(0.01),
+                variance_aware: false,
+                min_iterations_for_variance: None,
+                regression_test: None,
                 phase: None,
             },
         );
@@ -598,6 +656,9 @@ mod tests {
                 direction: BenchMetricDirection::HigherIsBetter,
                 regression_threshold_percent: Some(5.0),
                 regression_threshold_absolute: None,
+                variance_aware: false,
+                min_iterations_for_variance: None,
+                regression_test: None,
                 phase: None,
             },
         );
@@ -634,6 +695,9 @@ mod tests {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: None,
                 regression_threshold_absolute: Some(0.0),
+                variance_aware: false,
+                min_iterations_for_variance: None,
+                regression_test: None,
                 phase: None,
             },
         );
@@ -647,6 +711,83 @@ mod tests {
         assert!(!comparison.regression);
         assert_eq!(comparison.scenarios[0].metric_deltas.len(), 0);
         assert_eq!(comparison.scenarios[0].p95_delta_ms, Some(100.0));
+    }
+
+    #[test]
+    fn variance_aware_metric_uses_mann_whitney_distribution_comparison() {
+        let dir = tempfile::tempdir().unwrap();
+        let metric = "agent_loop_ms";
+        let baseline_run = results(vec![distribution_scenario(
+            "agent",
+            metric,
+            vec![100.0, 101.0, 102.0, 103.0, 104.0, 105.0],
+        )]);
+        save_baseline(dir.path(), "demo", &baseline_run, None).unwrap();
+        let baseline = load_baseline(dir.path(), None).unwrap();
+
+        let mut policies = BTreeMap::new();
+        policies.insert(
+            metric.to_string(),
+            variance_policy(
+                BenchMetricDirection::LowerIsBetter,
+                RegressionTest::MannWhitneyU,
+            ),
+        );
+        let current = results_with_policies(
+            vec![distribution_scenario(
+                "agent",
+                metric,
+                vec![140.0, 141.0, 142.0, 143.0, 144.0, 145.0],
+            )],
+            policies,
+        );
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(comparison.regression);
+        let delta = &comparison.scenarios[0].metric_deltas[0];
+        assert_eq!(delta.regression_test, Some(RegressionTest::MannWhitneyU));
+        assert_eq!(delta.baseline_samples, Some(6));
+        assert_eq!(delta.current_samples, Some(6));
+        assert!(delta.statistic.unwrap() > 1.645);
+    }
+
+    #[test]
+    fn variance_aware_metric_uses_ks_distribution_comparison() {
+        let dir = tempfile::tempdir().unwrap();
+        let metric = "quality_score";
+        let baseline_run = results(vec![distribution_scenario(
+            "agent",
+            metric,
+            vec![90.0, 91.0, 92.0, 93.0, 94.0, 95.0],
+        )]);
+        save_baseline(dir.path(), "demo", &baseline_run, None).unwrap();
+        let baseline = load_baseline(dir.path(), None).unwrap();
+
+        let mut policies = BTreeMap::new();
+        policies.insert(
+            metric.to_string(),
+            variance_policy(
+                BenchMetricDirection::HigherIsBetter,
+                RegressionTest::KolmogorovSmirnov,
+            ),
+        );
+        let current = results_with_policies(
+            vec![distribution_scenario(
+                "agent",
+                metric,
+                vec![70.0, 71.0, 72.0, 73.0, 74.0, 75.0],
+            )],
+            policies,
+        );
+        let comparison = compare(&current, &baseline, 5.0);
+
+        assert!(comparison.regression);
+        let delta = &comparison.scenarios[0].metric_deltas[0];
+        assert_eq!(
+            delta.regression_test,
+            Some(RegressionTest::KolmogorovSmirnov)
+        );
+        assert!(delta.statistic.unwrap() > 0.7);
     }
 
     #[test]

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use super::parsing::{BenchMetricDirection, BenchMetricPolicy, BenchResults};
+use super::parsing::{BenchMetricDirection, BenchMetricPolicy, BenchResults, RegressionTest};
 
 /// Per-metric delta vs baseline. Extensions can opt into comparing any
 /// numeric metric by declaring a policy in the bench results JSON.
@@ -17,6 +17,16 @@ pub struct MetricDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delta_pct: Option<f64>,
     pub direction: BenchMetricDirection,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regression_test: Option<RegressionTest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_samples: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_samples: Option<usize>,
+    /// Test statistic for distribution comparisons: z-score for
+    /// Mann-Whitney U, D statistic for Kolmogorov-Smirnov.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statistic: Option<f64>,
     pub regression: bool,
     pub improvement: bool,
 }
@@ -83,9 +93,97 @@ impl ResolvedMetricPolicy {
             delta,
             delta_pct,
             direction: self.policy.direction,
+            regression_test: None,
+            baseline_samples: None,
+            current_samples: None,
+            statistic: None,
             regression,
             improvement: bad_delta < 0.0,
         }
+    }
+
+    pub(crate) fn compare_distribution(
+        &self,
+        baseline_samples: &[f64],
+        current_samples: &[f64],
+    ) -> Option<MetricDelta> {
+        if baseline_samples.is_empty() || current_samples.is_empty() {
+            return None;
+        }
+
+        let baseline_value = median(baseline_samples);
+        let current_value = median(current_samples);
+        let delta = current_value - baseline_value;
+        let bad_delta = match self.policy.direction {
+            BenchMetricDirection::LowerIsBetter => delta,
+            BenchMetricDirection::HigherIsBetter => -delta,
+        };
+        let delta_pct = if baseline_value != 0.0 {
+            Some((delta / baseline_value) * 100.0)
+        } else {
+            None
+        };
+        let bad_delta_pct = if baseline_value != 0.0 {
+            Some((bad_delta / baseline_value.abs()) * 100.0)
+        } else {
+            None
+        };
+
+        let worse = bad_delta > 0.0;
+        let exceeds_absolute = bad_delta > self.regression_threshold_absolute;
+        let exceeds_percent = match self.policy.regression_threshold_percent {
+            Some(threshold) => bad_delta_pct.map(|pct| pct > threshold).unwrap_or(worse),
+            None => true,
+        };
+        let regression_test = self
+            .policy
+            .regression_test
+            .unwrap_or(RegressionTest::MannWhitneyU);
+        let statistic = match regression_test {
+            RegressionTest::PointDelta => None,
+            RegressionTest::MannWhitneyU => Some(mann_whitney_worse_z(
+                baseline_samples,
+                current_samples,
+                self.policy.direction,
+            )),
+            RegressionTest::KolmogorovSmirnov => Some(kolmogorov_smirnov_worse_d(
+                baseline_samples,
+                current_samples,
+                self.policy.direction,
+            )),
+        };
+        let significant = match regression_test {
+            RegressionTest::PointDelta => true,
+            // One-sided 95% normal approximation.
+            RegressionTest::MannWhitneyU => statistic.map(|z| z > 1.645).unwrap_or(false),
+            RegressionTest::KolmogorovSmirnov => statistic
+                .map(|d| {
+                    d > kolmogorov_smirnov_critical_value(
+                        baseline_samples.len(),
+                        current_samples.len(),
+                    )
+                })
+                .unwrap_or(false),
+        };
+
+        Some(MetricDelta {
+            name: self.name.clone(),
+            baseline_value,
+            current_value,
+            delta,
+            delta_pct,
+            direction: self.policy.direction,
+            regression_test: Some(regression_test),
+            baseline_samples: Some(baseline_samples.len()),
+            current_samples: Some(current_samples.len()),
+            statistic,
+            regression: worse && exceeds_absolute && exceeds_percent && significant,
+            improvement: bad_delta < 0.0,
+        })
+    }
+
+    pub(crate) fn variance_aware(&self) -> bool {
+        self.policy.variance_aware
     }
 
     fn custom(name: &str, policy: &BenchMetricPolicy) -> Self {
@@ -104,12 +202,96 @@ impl ResolvedMetricPolicy {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: Some(default_threshold_percent),
                 regression_threshold_absolute: Some(0.0),
+                variance_aware: false,
+                min_iterations_for_variance: None,
+                regression_test: None,
                 phase: None,
             },
             regression_threshold_absolute: 0.0,
             zero_baseline_is_neutral: true,
         }
     }
+}
+
+fn median(values: &[f64]) -> f64 {
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let mid = sorted.len() / 2;
+    if sorted.len() % 2 == 0 {
+        (sorted[mid - 1] + sorted[mid]) / 2.0
+    } else {
+        sorted[mid]
+    }
+}
+
+fn worse_scale(value: f64, direction: BenchMetricDirection) -> f64 {
+    match direction {
+        BenchMetricDirection::LowerIsBetter => value,
+        BenchMetricDirection::HigherIsBetter => -value,
+    }
+}
+
+fn mann_whitney_worse_z(
+    baseline_samples: &[f64],
+    current_samples: &[f64],
+    direction: BenchMetricDirection,
+) -> f64 {
+    let mut u = 0.0;
+    for current in current_samples {
+        let current = worse_scale(*current, direction);
+        for baseline in baseline_samples {
+            let baseline = worse_scale(*baseline, direction);
+            if current > baseline {
+                u += 1.0;
+            } else if current == baseline {
+                u += 0.5;
+            }
+        }
+    }
+    let n1 = baseline_samples.len() as f64;
+    let n2 = current_samples.len() as f64;
+    let mean = n1 * n2 / 2.0;
+    let variance = n1 * n2 * (n1 + n2 + 1.0) / 12.0;
+    if variance == 0.0 {
+        0.0
+    } else {
+        (u - mean) / variance.sqrt()
+    }
+}
+
+fn kolmogorov_smirnov_worse_d(
+    baseline_samples: &[f64],
+    current_samples: &[f64],
+    direction: BenchMetricDirection,
+) -> f64 {
+    let mut points: Vec<f64> = baseline_samples
+        .iter()
+        .chain(current_samples.iter())
+        .map(|value| worse_scale(*value, direction))
+        .collect();
+    points.sort_by(|a, b| a.total_cmp(b));
+    points.dedup_by(|a, b| a == b);
+
+    let n1 = baseline_samples.len() as f64;
+    let n2 = current_samples.len() as f64;
+    let baseline: Vec<f64> = baseline_samples
+        .iter()
+        .map(|value| worse_scale(*value, direction))
+        .collect();
+    let current: Vec<f64> = current_samples
+        .iter()
+        .map(|value| worse_scale(*value, direction))
+        .collect();
+
+    points.into_iter().fold(0.0, |max_d, point| {
+        let f_baseline = baseline.iter().filter(|value| **value <= point).count() as f64 / n1;
+        let f_current = current.iter().filter(|value| **value <= point).count() as f64 / n2;
+        max_d.max(f_baseline - f_current)
+    })
+}
+
+fn kolmogorov_smirnov_critical_value(n1: usize, n2: usize) -> f64 {
+    1.36 * (((n1 + n2) as f64) / ((n1 * n2) as f64)).sqrt()
 }
 
 pub(crate) fn resolve_metric_policies(
@@ -146,6 +328,9 @@ mod tests {
             direction,
             regression_threshold_percent: Some(5.0),
             regression_threshold_absolute: None,
+            variance_aware: false,
+            min_iterations_for_variance: None,
+            regression_test: None,
             phase: None,
         }
     }
@@ -159,7 +344,10 @@ mod tests {
                 file: None,
                 source: None,
                 iterations: 10,
-                metrics: BenchMetrics { values: metrics },
+                metrics: BenchMetrics {
+                    values: metrics,
+                    distributions: BTreeMap::new(),
+                },
                 memory: None,
             }],
             metric_policies: BTreeMap::new(),
@@ -175,6 +363,10 @@ mod tests {
             delta: 0.01,
             delta_pct: Some(100.0),
             direction: BenchMetricDirection::LowerIsBetter,
+            regression_test: None,
+            baseline_samples: None,
+            current_samples: None,
+            statistic: None,
             regression: true,
             improvement: false,
         };
@@ -212,6 +404,9 @@ mod tests {
                 direction: BenchMetricDirection::LowerIsBetter,
                 regression_threshold_percent: None,
                 regression_threshold_absolute: Some(0.01),
+                variance_aware: false,
+                min_iterations_for_variance: None,
+                regression_test: None,
                 phase: None,
             },
         );

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -20,7 +20,10 @@
 //!       "metrics": {
 //!         "p95_ms": 145.0,
 //!         "status_500_count": 0,
-//!         "error_rate": 0.0
+//!         "error_rate": 0.0,
+//!         "distributions": {
+//!           "agent_loop_ms": [1000.0, 1200.0, 1400.0]
+//!         }
 //!       },
 //!       "memory": { "peak_bytes": 41943040 }
 //!     }
@@ -70,11 +73,21 @@ pub struct BenchScenario {
 pub struct BenchMetrics {
     #[serde(flatten)]
     pub values: BTreeMap<String, f64>,
+    /// Raw per-iteration samples for variance-aware metrics.
+    ///
+    /// `values` remains the single-point summary contract; distributions
+    /// are opt-in data used by variance-aware regression checks.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub distributions: BTreeMap<String, Vec<f64>>,
 }
 
 impl BenchMetrics {
     pub fn get(&self, key: &str) -> Option<f64> {
         self.values.get(key).copied()
+    }
+
+    pub fn distribution(&self, key: &str) -> Option<&[f64]> {
+        self.distributions.get(key).map(Vec::as_slice)
     }
 }
 
@@ -86,6 +99,19 @@ pub struct BenchMetricPolicy {
     pub regression_threshold_percent: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub regression_threshold_absolute: Option<f64>,
+    /// True when this metric is expected to vary between iterations.
+    ///
+    /// Variance-aware metrics must emit a matching `metrics.distributions`
+    /// entry so regression checks can compare distribution shape instead
+    /// of a single summary point.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub variance_aware: bool,
+    /// Minimum sample count needed for a meaningful variance-aware run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_iterations_for_variance: Option<u64>,
+    /// Statistical test used for variance-aware regression detection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regression_test: Option<RegressionTest>,
     /// Optional measurement-phase tag.
     ///
     /// Phase is **metadata only**: it does not affect regression math
@@ -100,12 +126,27 @@ pub struct BenchMetricPolicy {
     pub phase: Option<BenchMetricPhase>,
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum BenchMetricDirection {
     #[serde(rename = "lower_is_better", alias = "lower")]
     LowerIsBetter,
     #[serde(rename = "higher_is_better", alias = "higher")]
     HigherIsBetter,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RegressionTest {
+    /// Legacy single-point threshold comparison.
+    PointDelta,
+    /// Non-parametric rank test, useful when distributions are not Normal.
+    MannWhitneyU,
+    /// Distribution-shape test sensitive to CDF shifts.
+    KolmogorovSmirnov,
 }
 
 /// Measurement-phase tag for a metric.
@@ -161,12 +202,66 @@ pub fn parse_bench_results_file(path: &Path) -> Result<BenchResults> {
 
 /// Parse a raw JSON string into a `BenchResults`.
 pub fn parse_bench_results_str(raw: &str) -> Result<BenchResults> {
-    serde_json::from_str(raw).map_err(|e| {
+    let parsed: BenchResults = serde_json::from_str(raw).map_err(|e| {
         Error::internal_json(
             format!("Failed to parse bench results JSON: {}", e),
             Some("bench.parsing.deserialize".to_string()),
         )
-    })
+    })?;
+    validate_variance_policies(&parsed)?;
+    Ok(parsed)
+}
+
+fn validate_variance_policies(results: &BenchResults) -> Result<()> {
+    for (name, policy) in &results.metric_policies {
+        if !policy.variance_aware {
+            continue;
+        }
+        for scenario in &results.scenarios {
+            if scenario.metrics.get(name).is_none() {
+                continue;
+            }
+            let Some(samples) = scenario.metrics.distribution(name) else {
+                return Err(Error::validation_invalid_argument(
+                    "metrics.distributions",
+                    format!(
+                        "variance-aware metric `{}` in scenario `{}` must emit metrics.distributions.{}",
+                        name, scenario.id, name
+                    ),
+                    None,
+                    None,
+                ));
+            };
+            if samples.iter().any(|value| !value.is_finite()) {
+                return Err(Error::validation_invalid_argument(
+                    "metrics.distributions",
+                    format!(
+                        "variance-aware metric `{}` in scenario `{}` contains a non-finite sample",
+                        name, scenario.id
+                    ),
+                    None,
+                    None,
+                ));
+            }
+            if let Some(min) = policy.min_iterations_for_variance {
+                if samples.len() < min as usize {
+                    return Err(Error::validation_invalid_argument(
+                        "metrics.distributions",
+                        format!(
+                            "variance-aware metric `{}` in scenario `{}` has {} samples; minimum is {}",
+                            name,
+                            scenario.id,
+                            samples.len(),
+                            min
+                        ),
+                        None,
+                        None,
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -324,6 +419,93 @@ mod tests {
         let parsed = parse_bench_results_str(raw).unwrap();
         assert_eq!(parsed.scenarios.len(), 1);
         assert_eq!(parsed.scenarios[0].id, "scenario_one");
+    }
+
+    #[test]
+    fn parses_variance_aware_metric_distributions() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 20,
+            "metric_policies": {
+                "agent_loop_ms": {
+                    "direction": "lower_is_better",
+                    "variance_aware": true,
+                    "min_iterations_for_variance": 3,
+                    "regression_test": "mann_whitney_u"
+                }
+            },
+            "scenarios": [
+                {
+                    "id": "agent_loop",
+                    "iterations": 20,
+                    "metrics": {
+                        "agent_loop_ms": 1200.0,
+                        "distributions": {
+                            "agent_loop_ms": [1000.0, 1200.0, 1400.0]
+                        }
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = parse_bench_results_str(raw).unwrap();
+        let policy = &parsed.metric_policies["agent_loop_ms"];
+        assert!(policy.variance_aware);
+        assert_eq!(policy.regression_test, Some(RegressionTest::MannWhitneyU));
+        assert_eq!(
+            parsed.scenarios[0].metrics.distribution("agent_loop_ms"),
+            Some(&[1000.0, 1200.0, 1400.0][..])
+        );
+    }
+
+    #[test]
+    fn rejects_variance_aware_metric_without_distribution() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 20,
+            "metric_policies": {
+                "agent_loop_ms": {
+                    "direction": "lower_is_better",
+                    "variance_aware": true
+                }
+            },
+            "scenarios": [
+                {
+                    "id": "agent_loop",
+                    "iterations": 20,
+                    "metrics": { "agent_loop_ms": 1200.0 }
+                }
+            ]
+        }"#;
+
+        assert!(parse_bench_results_str(raw).is_err());
+    }
+
+    #[test]
+    fn rejects_variance_aware_metric_below_minimum_samples() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 20,
+            "metric_policies": {
+                "agent_loop_ms": {
+                    "direction": "lower_is_better",
+                    "variance_aware": true,
+                    "min_iterations_for_variance": 5
+                }
+            },
+            "scenarios": [
+                {
+                    "id": "agent_loop",
+                    "iterations": 20,
+                    "metrics": {
+                        "agent_loop_ms": 1200.0,
+                        "distributions": { "agent_loop_ms": [1000.0, 1200.0] }
+                    }
+                }
+            ]
+        }"#;
+
+        assert!(parse_bench_results_str(raw).is_err());
     }
 
     #[test]

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -369,7 +369,10 @@ mod tests {
             file: None,
             source: None,
             iterations: 10,
-            metrics: BenchMetrics { values },
+            metrics: BenchMetrics {
+                values,
+                distributions: BTreeMap::new(),
+            },
             memory: None,
         }
     }

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -36,6 +36,9 @@ fn policy(direction: BenchMetricDirection, phase: Option<BenchMetricPhase>) -> B
         direction,
         regression_threshold_percent: None,
         regression_threshold_absolute: None,
+        variance_aware: false,
+        min_iterations_for_variance: None,
+        regression_test: None,
         phase,
     }
 }
@@ -50,7 +53,10 @@ fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
         file: None,
         source: None,
         iterations: 10,
-        metrics: BenchMetrics { values },
+        metrics: BenchMetrics {
+            values,
+            distributions: BTreeMap::new(),
+        },
         memory: None,
     }
 }

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -280,6 +280,7 @@ mod shared_path {
             shared_paths: vec![shared],
             pipeline,
             bench: None,
+            bench_workloads: Default::default(),
         }
     }
 

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -221,6 +221,7 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             }],
             pipeline,
             bench: None,
+            bench_workloads: HashMap::new(),
         };
 
         let up = crate::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");


### PR DESCRIPTION
## Summary
- Adds variance-aware bench metric policies with raw per-metric sample distributions.
- Persists distributions in bench baselines and compares them with Mann-Whitney U or Kolmogorov-Smirnov checks when opted in.
- Documents the runner schema and keeps deterministic metric comparison backward-compatible.

## Behaviour
- Existing deterministic metrics keep the current point-delta comparison path.
- `variance_aware: true` requires `metrics.distributions.<metric>` samples and honors `min_iterations_for_variance` before comparison.
- Variance-aware comparisons still require the configured percent/absolute threshold before a statistical shift is treated as a regression.

## Tests
- `cargo test core::extension::bench --lib --tests`
- `cargo test --lib --tests -- --test-threads=1`

Closes #1567

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the variance-aware bench schema, comparison logic, tests, and documentation; Chris reviews and owns the submitted change.