### PR TITLE
docs: refresh homeboy command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Homeboy ships four pillars from one binary:
 
 - **Code Factory** — `audit` / `lint` / `test` / `refactor` / `release` with the autofix loop.
 - **Fleet & Ops** — `deploy`, `ssh`, `file`, `db`, `logs`, `transfer`, `server`, `project`, `component`, `fleet`.
-- **Dev Rig** — `rig` + `rig-spec` for reproducible, code-defined local dev environments.
+- **Dev Rig** — `rig`, `rig-spec`, and `stack` for reproducible, code-defined local dev environments and combined-fixes branches.
 - **Bench** — performance benchmarks with baseline ratchet, sibling of `lint` / `test` / `build`.
 
 ## How It Works
@@ -133,9 +133,10 @@ Structural improvements with safety tiers:
 
 Code-defined, reproducible local dev environments. A rig is a JSON spec at `~/.config/homeboy/rigs/<id>.json` that captures everything a dev setup needs — which components, which background services, which symlinks, which pre-flight invariants — and a linear pipeline that materializes it.
 
-- **Service supervision** — `http-static` and `command` service kinds run detached, tracked by PID, logs captured per service
-- **Pipeline steps** — `service`, `command`, `symlink`, `check`, `git`, `build`. Typed primitives reuse Homeboy's existing build/git plumbing instead of shelling out blindly.
-- **Git ops (MVP)** — `status`, `pull`, `fetch`, `checkout`, `current-branch`. `rebase` / `cherry-pick` are deferred.
+- **Service supervision** — `http-static` and `command` service kinds run detached, while `external` services let rigs adopt and stop processes they did not spawn.
+- **Pipeline steps** — `service`, `command`, `symlink`, `shared-path`, `check`, `git`, `build`, and `patch`. Typed primitives reuse Homeboy's existing build/git plumbing instead of shelling out blindly.
+- **Git ops** — `status`, `pull`, `push`, `fetch`, `checkout`, `current-branch`, `rebase`, and `cherry-pick`.
+- **Stack specs** — `stack` materializes combined-fixes branches from a base ref plus a declared PR list, with status/sync helpers for dropping merged PRs.
 - **Verbs** — `rig up` materializes the env, `rig check` reports health without fail-fast, `rig down` tears it down, `rig status` reports running services and last run timestamps.
 - **Variable expansion** — `${components.<id>.path}`, `${env.<NAME>}`, and `~` work across `cwd`, `command`, `link`, `target`, and check fields.
 
@@ -192,12 +193,15 @@ Deploy components to servers, manage SSH connections, run remote commands, tail 
 | `lint` | Format and static analysis with autofix. |
 | `test` | Run tests. Drift detection for renamed/deleted symbols. |
 | `refactor` | Structural renaming, decomposition, and auto-refactor with safety tiers. |
+| `review` | Scoped audit + lint + test umbrella for PR-style changes. |
 | `release` | Automated version bump + changelog + tag + push from conventional commits. |
 | `version` | Semantic version management with configurable file targets. |
 | `changelog` | Add/finalize categorized changelog entries. |
 | `changes` | Show commits and diffs since last version tag. |
 | `build` | Build a component using its configured build command. |
+| `validate` | Run extension parse/compile validation without a full test suite. |
 | `git` | Component-aware git operations. |
+| `issues` | Reconcile audit findings against an issue tracker. |
 | `status` | Repo state overview: uncommitted, needs-bump, ready, docs-only. |
 
 ### Fleet & Ops
@@ -221,6 +225,7 @@ Deploy components to servers, manage SSH connections, run remote commands, tail 
 |---------|-------------|
 | `rig` | Bring up / tear down / health-check reproducible local dev environments. |
 | `rig-spec` | Inspect and validate the JSON spec format used by `rig`. |
+| `stack` | Manage combined-fixes branches from base refs plus cherry-picked PRs. |
 
 ### Bench
 
@@ -239,7 +244,7 @@ Deploy components to servers, manage SSH connections, run remote commands, tail 
 | `extension` | Install, list, and update extensions. |
 | `list` | List registered components, projects, servers, fleets. |
 | `config` | Read and write Homeboy configuration. |
-| `supports` | Machine-readable CLI capability checks for shell wrappers. |
+| `undo` | Roll back the last Homeboy write operation when an undo snapshot exists. |
 | `upgrade` | Self-upgrade the homeboy binary. |
 | `docs` | Browse embedded documentation. All docs ship in the binary. |
 

--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -18,9 +18,9 @@ Each extension declares scripts per-capability in its manifest
 
 | Capability | Manifest field | Typical script | Invoked by |
 |------------|---------------|----------------|------------|
-| `lint` | `lint.extension_script` | `scripts/lint/lint-runner.sh` | `homeboy lint` |
-| `test` | `test.extension_script` | `scripts/test/test-runner.sh` | `homeboy test` |
-| `build` | `build.extension_script` | `scripts/build/build.sh` | `homeboy build`, `homeboy release` |
+| `lint` | `lint.extension_script` | extension-owned lint runner | `homeboy lint` |
+| `test` | `test.extension_script` | extension-owned test runner | `homeboy test` |
+| `build` | `build.extension_script` | extension-owned build runner | `homeboy build`, `homeboy release` |
 | `audit` | *built-in to core* | n/a | `homeboy audit` |
 
 `lint`, `test`, and `build` are shell-script capabilities: extensions own

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -179,6 +179,10 @@
 - `docs_only` — Show only components with docs-only changes
 - `all` — Show all components regardless of current directory context
 
+### `StackArgs`
+
+- `command`
+
 ### `TestArgs`
 
 - `component` — Component name to test
@@ -592,6 +596,41 @@
 
 - `List` — List configured SSH server targets
 
+### `StackCommand`
+
+- `List` — List all installed stack specs
+- `Show` — Show a stack spec
+- `stack_id` — Stack ID
+- `Create` — Create a new stack spec
+- `stack_id` — Stack ID
+- `component` — Component identifier
+- `component_path` — Local checkout path
+- `base` — Upstream ref as `<remote>/<branch>`
+- `target` — Target branch as `<remote>/<branch>`
+- `description` — Optional human-readable description
+- `AddPr` — Append a PR entry to a stack
+- `stack_id` — Stack ID
+- `repo` — GitHub repo coordinate (`owner/name`)
+- `number` — PR number
+- `note` — Optional human-readable note
+- `RemovePr` — Remove a PR entry from a stack
+- `stack_id` — Stack ID
+- `number` — PR number
+- `repo` — Optional repo disambiguator
+- `Apply` — Materialize a stack target branch
+- `stack_id` — Stack ID
+- `Status` — Report upstream PR state and local target state
+- `stack_id` — Stack ID
+- `Sync` — Rebuild target and auto-drop merged PRs
+- `stack_id` — Stack ID
+- `dry_run` — Preview without mutating the spec or target branch
+- `Inspect` — Inspect the current branch as a stack of commits
+- `component_id` — Optional component ID, auto-detected from CWD when omitted
+- `base` — Base ref to compare against
+- `no_pr` — Skip GitHub PR lookup
+- `repo` — Scope PR lookup to one GitHub repo
+- `path` — Workspace path override
+
 ### `VersionCommand`
 
 - `Show` — Show current version (default: homeboy binary)
@@ -613,6 +652,7 @@
 - `Ssh` — SSH into a project server or configured server
 - `Server` — Manage SSH server configurations
 - `Test` — Run tests for a component
+- `Bench` — Run performance benchmarks for a component
 - `Lint` — Lint a component
 - `Db` — Database operations
 - `File` — Remote file operations
@@ -628,12 +668,18 @@
 - `Docs` — Display CLI documentation
 - `Changelog` — Changelog operations
 - `Git` — Git operations for components
+- `Issues` — Reconcile findings against an issue tracker
 - `Version` — Version management for components
 - `Build` — Build a component
+- `Validate` — Validate that code compiles/parses through extension scripts
 - `Changes` — Show changes since last version tag
 - `Release` — Plan release workflows
+- `Review` — Run scoped audit + lint + test umbrella against PR-style changes
 - `Audit` — Audit code conventions and detect architectural drift
 - `Refactor` — Structural refactoring (rename terms across codebase)
+- `Rig` — Manage local dev rigs
+- `Stack` — Manage combined-fixes branch stacks
+- `Undo` — Undo the last write operation when a snapshot exists
 - `Auth` — Authenticate with a project's API
 - `Api` — Make API requests to a project
 - `Upgrade` — Upgrade Homeboy to the latest version

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -27,8 +27,8 @@
 - [rig](rig.md) — reproducible local dev environments ([spec](rig-spec.md))
 - [server](server.md)
 - [ssh](ssh.md)
+- [stack](stack.md) — combined-fixes branches from base refs plus cherry-picked PRs
 - status — actionable component overview (`--uncommitted`, `--needs-bump`, `--ready`, `--docs-only`, `--all`, `--full`)
-- [supports](supports.md) — machine-readable CLI capability checks
 - [test](test.md)
 - transfer — transfer files between servers (`<source> <destination>`, supports `-r`, `-c`, `--dry-run`, `--exclude`)
 - [upgrade](upgrade.md)

--- a/docs/commands/git.md
+++ b/docs/commands/git.md
@@ -14,12 +14,16 @@ Note: some subcommands accept a `--json` flag for bulk operations.
 
 ### Single Component Mode
 
-- `status <component_id>`
-- `commit <component_id> [message-or-spec] [--json <spec>] [-m <message>] [--staged-only] [--files <paths>...] [--include <paths>...] [--exclude <paths>...]`
-- `push <component_id> [--tags]`
-- `pull <component_id>`
-- `tag <component_id> [tag_name] [-m <message>]`
+- `status [component_id] [--path <path>]`
+- `commit [component_id] [message-or-spec] [--json <spec>] [-m <message>] [--staged-only] [--files <paths>...] [--include <paths>...] [--exclude <paths>...] [--path <path>]`
+- `push [component_id] [--tags] [--force-with-lease] [--path <path>]`
+- `pull [component_id] [--path <path>]`
+- `rebase [component_id] [--onto <ref>] [--continue | --abort] [--path <path>]`
+- `cherry-pick [--component-id <id>] [refs...] [--pr <number>...] [--continue | --abort] [--path <path>]`
+- `tag [component_id] [tag_name] [-m <message>] [--path <path>]`
   - If `tag_name` is omitted, Homeboy tags `v<component version>` (from `homeboy version show`).
+
+When `component_id` is omitted, Homeboy auto-detects the component from the current directory using the registry or a portable `homeboy.json`. `--path` overrides the checkout path for unregistered clones, worktrees, or CI temp directories.
 
 ### Commit Options
 
@@ -30,6 +34,13 @@ By default, `commit` stages all changes before committing. Use these flags for g
 - `--files <paths>...`: Stage and commit only the specified files.
 - `--include <paths>...`: Alias for `--files` (repeatable).
 - `--exclude <paths>...`: Stage all files except the specified paths.
+
+### Rebase and Cherry-pick
+
+- `rebase` defaults to the current branch's tracked upstream (`@{upstream}`), matching `git pull --rebase` semantics. Use `--onto <ref>` to choose a target explicitly.
+- `cherry-pick` accepts positional refs, ranges, and repeatable `--pr <number>` flags. PR numbers are resolved with `gh pr view <n> --json commits`.
+- Both subcommands support `--continue` and `--abort` after manual conflict resolution.
+- `push --force-with-lease` is exposed for the common post-rebase push path. Plain `--force` is intentionally not exposed.
 
 ### JSON Spec Mode (commit)
 
@@ -47,7 +58,7 @@ Homeboy auto-detects **single vs bulk** by checking for a top-level `components`
 
 ### Bulk Mode (--json)
 
-All subcommands except `tag` support a `--json` flag for bulk operations across multiple components.
+The status, commit, push, and pull subcommands support a `--json` flag for bulk operations across multiple components.
 
 - `status --json '<bulk_ids_input>'`
 - `commit --json '<bulk_commit_input>'` (or positional spec)
@@ -98,6 +109,7 @@ Notes:
 
 Notes:
 - `tags` field is optional (defaults to false), only used for `push`
+- `force_with_lease` is optional (defaults to false), only used for `push`
 
 ## JSON Output
 
@@ -168,6 +180,12 @@ Notes:
 ```sh
 homeboy git status extra-chill-multisite
 
+# Auto-detect from current directory or a portable homeboy.json
+homeboy git status
+
+# Operate on an unregistered worktree
+homeboy git status --path /tmp/my-worktree
+
 # CLI mode
 homeboy git commit extra-chill-multisite -m "Update docs"
 
@@ -184,7 +202,10 @@ homeboy git commit extra-chill-multisite -m "Update docs" --exclude Cargo.lock
 homeboy git commit extra-chill-multisite '{"message":"Update docs","files":["README.md"]}'
 
 homeboy git push extra-chill-multisite --tags
+homeboy git push --force-with-lease
 homeboy git pull extra-chill-multisite
+homeboy git rebase --onto origin/main
+homeboy git cherry-pick --pr 123
 homeboy git tag extra-chill-multisite v1.0.0 -m "Release 1.0.0"
 ```
 

--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -21,7 +21,7 @@ Reference to a local checkout of a component. Decoupled from homeboy's global co
 | Field | Type | Description |
 |---|---|---|
 | `path` | string | Filesystem path to the checkout. Supports `~` and `${env.VAR}` expansion. |
-| `stack` | string | Stack ID (Phase 2 — reserved, currently informational). |
+| `stack` | string | Stack ID associated with the component. Used by `homeboy stack`; rig pipeline integration is still explicit. |
 | `branch` | string | Expected branch hint. Documentation only in MVP. |
 
 ## `ServiceSpec`
@@ -30,7 +30,7 @@ A background process the rig manages.
 
 | Field | Type | Description |
 |---|---|---|
-| `kind` | enum | `"http-static"` or `"command"`. |
+| `kind` | enum | `"http-static"`, `"command"`, or `"external"`. |
 | `cwd` | string | Working directory. Supports variable expansion. |
 | `port` | integer | TCP port. Required for `http-static`; surfaced in status for `command`. |
 | `command` | string | Shell command for `kind: "command"`. |
@@ -41,6 +41,7 @@ A background process the rig manages.
 
 - **`http-static`** — runs `python3 -m http.server <port>` in `cwd`. The common case for dev envs that need to serve tarballs or static assets locally.
 - **`command`** — runs `sh -c <command>`. Use for anything else (docker, redis, custom dev servers, SSH tunnels).
+- **`external`** — adopts a process the rig did not spawn. Only `service.stop` is meaningful; it discovers the newest process whose command line contains `discover.pattern` and signals it. Use for stale daemons that need recycling after a build.
 
 Services are started detached (new session via `setsid`), tracked by PID in state, and logged to `~/.config/homeboy/rigs/<id>.state/logs/<service-id>.log`.
 
@@ -105,9 +106,26 @@ Delegates to `homeboy build`, using the component's path from the rig's `compone
 }
 ```
 
-Delegates to homeboy's git primitive (`git::execute_git_for_release` under the hood). Operation set: `status`, `pull`, `fetch`, `checkout`, `current-branch`. `args` are appended after the op-specific base args, so `op: pull` with `args: ["origin", "trunk"]` runs `git pull origin trunk`. Variable expansion applies to `args` entries.
+Delegates to homeboy's git primitive (`git::execute_git_for_release` under the hood). Operation set: `status`, `pull`, `push`, `fetch`, `checkout`, `current-branch`, `rebase`, and `cherry-pick`. `args` are appended after the op-specific base args, so `op: pull` with `args: ["origin", "trunk"]` runs `git pull origin trunk`. Variable expansion applies to `args` entries.
 
-Stacked combined-fixes workflows are a future phase (see Homeboy #1462 `homeboy stack`) — for MVP, use repeated `git checkout` + `git pull` + `git` with `args: ["cherry-pick", "<sha>"]` as a workaround.
+For long-lived combined-fixes branches, prefer a `homeboy stack` spec plus explicit `stack` invocations over hand-maintaining a long sequence of raw cherry-pick steps in the rig.
+
+### `patch`
+
+```jsonc
+{
+  "kind": "patch",
+  "component": "wordpress-playground",
+  "file": "packages/php-wasm/compile/php/patches/local.h",
+  "marker": "TSRMLS_CC fallback",
+  "after": "#include <php.h>",
+  "content": "/* TSRMLS_CC fallback */\n#ifndef TSRMLS_CC\n#define TSRMLS_CC\n#endif",
+  "op": "apply",
+  "label": "local TSRMLS fallback"
+}
+```
+
+Applies or verifies an idempotent local-only file patch. `marker` must appear in `content`; if the marker is already present, `apply` is a no-op. If `after` is set and missing from the file, the step fails instead of guessing where to insert. Use `op: "verify"` in `check` pipelines.
 
 ### `command`
 
@@ -159,7 +177,7 @@ Embeds a `CheckSpec` (see below). Non-fatal in `up` pipelines; fatal in `check` 
 
 ## `CheckSpec`
 
-A single declarative probe. Exactly one of the three probe fields must be set.
+A single declarative probe. Exactly one of the four probe fields must be set.
 
 ### HTTP probe
 
@@ -186,6 +204,19 @@ Passes if the file exists. If `contains` is set, also requires the file contents
 
 Runs via `sh -c`. Passes if exit code matches `expect_exit` (default `0`).
 
+### Staleness probe
+
+```jsonc
+{
+  "newer_than": {
+    "left": { "process_start": "wordpress-server-child.mjs" },
+    "right": { "file_mtime": "${components.studio.path}/dist/cli/index.js" }
+  }
+}
+```
+
+Passes when `left` is newer than `right`. Each side chooses one time source: `file_mtime` or `process_start`. If the left side is a `process_start` source and no matching process exists, the check passes because there is no stale process to flag. Other missing sources are errors.
+
 ## Variable expansion
 
 Three substitutions apply to `cwd`, `command`, `link`, `target`, shared paths, and `CheckSpec` fields:
@@ -202,7 +233,7 @@ Unknown `${...}` patterns are left literal so failures are loud and localized.
 - `check` — runs every step regardless of failures so you see every problem at once.
 - `down` — fail-fast through `down` pipeline, then stops every declared service unconditionally (belt + suspenders).
 
-MVP pipelines are linear lists. DAG pipelines with cross-component dependencies + caching land in Phase 3 (tracked as Automattic/homeboy #1464).
+Pipelines are linear lists. DAG pipelines with cross-component dependencies + caching are still a future phase (tracked as Extra-Chill/homeboy #1464).
 
 ## Example rigs
 

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -16,7 +16,7 @@ Rigs are the missing piece between individual components (one repo, one version)
 
 **Typical consumer:** a cross-repo setup that today lives as a wiki runbook (Studio + Playground with combined-fixes, WordPress core + Gutenberg dev, a sandbox + tunnel, etc).
 
-**MVP scope (Phase 1):** linear pipelines, `http-static` and `command` service kinds, `up` / `check` / `down` / `status` / `list` / `show` verbs. See Automattic/homeboy #1461 for the phased roadmap (stack integration, DAG pipelines, extension-registered service kinds, `.app` wrappers, bench composition, spec sharing).
+**Current scope:** linear pipelines, `http-static`, `command`, and `external` service kinds, shared dependency paths, idempotent local patch steps, typed git/build/check primitives, and `up` / `check` / `down` / `status` / `list` / `show` verbs. See Extra-Chill/homeboy #1461 for the broader phased roadmap (DAG pipelines, extension-registered service kinds, `.app` wrappers, bench composition, spec sharing).
 
 ## Subcommands
 
@@ -143,5 +143,6 @@ State is ephemeral — deleting it means `rig up` will re-probe on next invocati
 ## See also
 
 - [rig-spec.md](./rig-spec.md) — full spec schema reference
+- [stack.md](./stack.md) — combined-fixes branch specs that rigs can reference
 - [fleet.md](./fleet.md) — remote multi-project equivalent (rigs are local, fleets are remote)
-- Automattic/homeboy #1461 — design + phased roadmap
+- Extra-Chill/homeboy #1461 — design + phased roadmap

--- a/docs/commands/stack.md
+++ b/docs/commands/stack.md
@@ -1,0 +1,120 @@
+# `homeboy stack`
+
+Manage **combined-fixes branches** as JSON specs instead of hand-maintained cherry-pick lists.
+
+## Synopsis
+
+```sh
+homeboy stack <COMMAND>
+```
+
+Stack specs live at `~/.config/homeboy/stacks/<id>.json`. A stack declares one checkout path, a base ref to rebuild from, a target branch to materialize, and an ordered list of GitHub PRs to cherry-pick.
+
+## Spec format
+
+```jsonc
+{
+  "id": "studio-combined",
+  "description": "Studio dev/combined-fixes branch",
+  "component": "studio",
+  "component_path": "~/Developer/studio",
+  "base": { "remote": "origin", "branch": "trunk" },
+  "target": { "remote": "fork", "branch": "dev/combined-fixes" },
+  "prs": [
+    { "repo": "Automattic/studio", "number": 3120, "note": "proc_open cwd fix" },
+    { "repo": "Automattic/studio", "number": 3211 }
+  ]
+}
+```
+
+`component_path` supports `~` and `${env.VAR}` expansion. `base` and `target` are split into `{ remote, branch }` so Homeboy can fetch and rebuild without reparsing slash-joined refs.
+
+## Subcommands
+
+### `list`
+
+```sh
+homeboy stack list
+```
+
+List installed stack specs.
+
+### `show`
+
+```sh
+homeboy stack show <stack-id>
+```
+
+Print the resolved stack spec.
+
+### `create`
+
+```sh
+homeboy stack create <stack-id> \
+  --component studio \
+  --component-path ~/Developer/studio \
+  --base origin/trunk \
+  --target fork/dev/combined-fixes \
+  --description "Studio combined fixes"
+```
+
+Create a spec file under `~/.config/homeboy/stacks/`.
+
+### `add-pr`
+
+```sh
+homeboy stack add-pr <stack-id> Automattic/studio 3120 --note "proc_open cwd fix"
+```
+
+Append a PR entry to the stack's `prs` array.
+
+### `remove-pr`
+
+```sh
+homeboy stack remove-pr <stack-id> 3120
+homeboy stack remove-pr <stack-id> 3120 --repo Automattic/studio
+```
+
+Remove a PR entry. Use `--repo` when the same number appears for multiple repos in one stack.
+
+### `apply`
+
+```sh
+homeboy stack apply <stack-id>
+```
+
+Fetches the base, recreates the local target branch from the base, then cherry-picks every PR head in order. `apply` stops on the first conflict, aborts the in-progress pick, and prints a manual-resolution hint. It does not push.
+
+### `status`
+
+```sh
+homeboy stack status <stack-id>
+```
+
+Read-only report combining upstream PR state from GitHub with local target-branch state. Use it to spot merged PRs, missing local picks, and review status without mutating the checkout.
+
+### `sync`
+
+```sh
+homeboy stack sync <stack-id>
+homeboy stack sync <stack-id> --dry-run
+```
+
+Rebuilds the target branch from the fresh base and removes PRs whose content is already in the base. `--dry-run` reports what would be dropped and picked without mutating the spec or target branch.
+
+### `inspect`
+
+```sh
+homeboy stack inspect [component-id] [--base <ref>] [--repo <owner/name>] [--no-pr] [--path <path>]
+```
+
+Spec-less inspection of the current branch as a stack of commits over a base ref. This replaces the older `homeboy git stack` surface.
+
+## GitHub dependency
+
+`apply`, `status`, `sync`, and `inspect` PR lookup paths call the GitHub CLI (`gh`). Authenticate `gh` for private repositories before relying on stack reports.
+
+## Related
+
+- [rig](rig.md) — local dev environments that can reference stack IDs in component specs
+- [git](git.md) — lower-level component-aware git primitives

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Homeboy is a config-driven automation engine for development and deployment auto
 - Changes summary: [changes](commands/changes.md)
 - Reproducible local dev environments: [rig](commands/rig.md)
 - Rig spec JSON schema: [rig-spec](commands/rig-spec.md)
+- Combined-fixes branch specs: [stack](commands/stack.md)
 - Performance benchmarks with baseline ratchet: [bench](commands/bench.md)
 - API authentication scoped per project: [auth](commands/auth.md)
 - JSON output envelope: [JSON output contract](architecture/output-system.md)


### PR DESCRIPTION
## Summary
- Refresh README and command docs for the current `rig`, `git`, and `stack` surfaces.
- Add a dedicated `homeboy stack` command page and link it from the docs index.
- Remove a stale `supports` command reference and clear broken runner-contract file references flagged by the docs audit.

## Tests
- `cargo check`
- `homeboy audit homeboy --path "/Users/chubes/Developer/homeboy@docs-audit" --only broken_doc_reference --only stale_doc_reference --only undocumented_feature --ignore-baseline`
- `cargo run --quiet --bin homeboy -- docs commands/stack`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited documentation drift against the current CLI/source surface, drafted the documentation updates, and ran verification. Chris remains responsible for review and merge.
