### PR TITLE
docs: refresh command execution context docs

### DIFF
--- a/docs/architecture/execution-context.md
+++ b/docs/architecture/execution-context.md
@@ -1,202 +1,85 @@
 # Execution Context
 
-Execution context provides runtime information to extensions during execution via environment variables and template variable resolution.
+Execution context is the environment Homeboy passes to extension runners and extension-backed pipeline steps.
 
 ## Overview
 
-When Homeboy executes extensions (via `homeboy extension run` or release pipeline steps), it builds an execution context containing:
-
-- Extension metadata
-- Project and component information (when available)
-- Resolved settings
-- Template variables
-- Environment variables
+When Homeboy executes an extension, it builds context from the resolved extension, optional project, optional component, and merged settings. The context is exposed as environment variables and template variables.
 
 ## Environment Variables
 
-Homeboy sets the following environment variables before executing extensions:
+Homeboy sets these variables when the corresponding context exists:
 
-### Base Context Variables
-
-- **`HOMEBOY_EXEC_CONTEXT_VERSION`**: Execution context protocol version (currently `"1"`)
-
-### Extension Variables
-
-- **`HOMEBOY_MODULE_ID`**: Extension identifier
-- **`HOMEBOY_MODULE_PATH`**: Absolute path to extension directory
-
-### Project Context (when project is specified)
-
-- **`HOMEBOY_PROJECT_ID`**: Project identifier
-- **`HOMEBOY_DOMAIN`**: Project domain
-- **`HOMEBOY_SITE_PATH`**: Project site path (absolute)
-
-### Component Context (when component is resolved)
-
-- **`HOMEBOY_COMPONENT_ID`**: Component identifier
-- **`HOMEBOY_COMPONENT_PATH`**: Absolute path to component directory
-
-### Settings
-
-- **`HOMEBOY_SETTINGS_JSON`**: Merged effective settings as JSON string
+- `HOMEBOY_EXEC_CONTEXT_VERSION`: Execution context protocol version, currently `2`
+- `HOMEBOY_EXTENSION_ID`: Extension identifier
+- `HOMEBOY_EXTENSION_PATH`: Absolute path to the extension directory
+- `HOMEBOY_SETTINGS_JSON`: Merged effective settings as JSON
+- `HOMEBOY_PROJECT_ID`: Project identifier
+- `HOMEBOY_PROJECT_PATH`: Absolute path to the project directory
+- `HOMEBOY_COMPONENT_ID`: Component identifier
+- `HOMEBOY_COMPONENT_PATH`: Absolute path to the component directory
+- `HOMEBOY_STEP`: Comma-separated step filter
+- `HOMEBOY_SKIP`: Comma-separated skip filter
 
 ## Context Resolution Flow
 
-Homeboy resolves execution context in the following order:
+1. Extension is loaded from the installed extensions directory or an explicit development path.
+2. Project context is resolved when the command or action asks for one.
+3. Component context is resolved from an explicit component, project association, portable `homeboy.json`, or registered component metadata depending on the command.
+4. Settings are merged from available scopes, with narrower scopes and CLI overrides winning.
+5. Extension `runtime.env` values are resolved with template variables and added to the process environment.
 
-### 1. Extension Resolution
+## Template Variables
 
-Extension is loaded from:
-- Installed extensions directory (`~/.config/homeboy/extensions/<extension_id>/`)
-- Or directly referenced via path (for development)
+Common template variables include:
 
-Extension metadata is extracted from `<extension_id>.json` manifest.
+- `{{extensionPath}}`: Extension installation path
+- `{{entrypoint}}`: Extension entrypoint from the manifest
+- `{{args}}`: CLI arguments passed to the extension
+- `{{projectId}}`: Project ID when project context exists
+- `{{settings.<key>}}`: Merged setting value
+- `{{payload.<key>}}`: Action payload data
+- `{{release.<key>}}`: Release pipeline payload data
 
-### 2. Project Resolution (optional)
+Project-specific extension manifests may define additional variables through their runtime configuration.
 
-If `--project` is specified:
-- Project configuration is loaded (`projects/<project_id>.json`)
-- Server configuration is loaded (via `server_id`)
-- Database and API configuration is resolved
+## Examples
 
-### 3. Component Resolution (optional)
-
-If `--component` is specified:
-- Component configuration is loaded (`components/<component_id>.json`)
-- Component path is validated
-- Component extension associations are identified
-
-If `--component` is omitted:
-- Homeboy attempts to resolve component from project's `component_ids`
-- First matching component is used
-- Ambiguity is resolved via user prompt or explicit specification
-
-### 4. Settings Merge
-
-Extension settings are merged from multiple scopes in order (later scopes override earlier ones):
-
-1. **Project settings**: `projects/<project_id>.json` -> `extensions.<extension_id>.settings`
-2. **Component settings**: `components/<component_id>.json` -> `extensions.<extension_id>.settings`
-
-Merged settings are available as:
-- Environment variable: `HOMEBOY_SETTINGS_JSON`
-- Template variable: `{{settings.<key>}}`
-
-### 5. Template Variable Resolution
-
-Template variables are resolved from:
-- Execution context variables
-- Extension manifest `runtime.env` definitions
-- Extension `platform` configuration
-- CLI input parameters
-
-## Template Variables Available in Execution
-
-### Standard Variables
-
-Available in most contexts:
-- **`{{projectId}}`**: Project ID
-- **`{{domain}}`**: Project domain
-- **`{{sitePath}}`**: Site root path
-- **`{{cliPath}}`**: CLI executable path
-
-### Extension Runtime Variables
-
-Available in `runtime.run_command`:
-- **`{{extensionPath}}`**: Extension installation path
-- **`{{entrypoint}}`**: Extension entrypoint file
-- **`{{args}}`**: Command-line arguments
-
-### Project Context Variables
-
-Available when project is resolved:
-- **`{{db_host}}`**: Database host
-- **`{{db_port}}`**: Database port
-- **`{{db_name}}`**: Database name
-- **`{{db_user}}`**: Database user
-- **`{{db_password}}`**: Database password (from keychain)
-
-### Special Variables
-
-Available in specific contexts:
-- **`{{selected}}`**: Selected result rows (from `--data` flag)
-- **`{{settings.<key>}}`**: Extension settings value
-- **`{{payload.<key>}}`**: Action payload data
-- **`{{release.<key>}}`**: Release configuration data
-
-## CLI Command Resolution
-
-When extension provides top-level CLI commands, execution context is resolved similarly to `homeboy extension run`.
-
-### Extension Command Execution
-
-```bash
-homeboy wp <project_id> plugin list
-```
-
-Context resolution:
-1. Extension is loaded (wordpress)
-2. Project is resolved (`<project_id>`)
-3. Component is resolved (if component specified or project has single component)
-4. Settings are merged
-5. Environment variables are set
-6. Command is executed with template resolution
-
-## Extension Execution vs Release Pipeline Execution
-
-Both `homeboy extension run` and `extension.run` pipeline steps share the same execution context behavior:
-
-- Same template variable resolution
-- Same settings merge logic
-- Same environment variable setting
-- Same CLI output contract
-
-This ensures consistent behavior regardless of how extensions are invoked.
-
-## Example Contexts
-
-### Simple Extension Execution
+### Component-Scoped Extension Execution
 
 ```bash
 homeboy extension run rust --component mycomponent
 ```
 
-Environment variables:
+Environment variables include:
+
 ```bash
-HOMEBOY_EXEC_CONTEXT_VERSION=1
-HOMEBOY_MODULE_ID=rust
-HOMEBOY_MODULE_PATH=/home/user/.config/homeboy/extensions/rust
+HOMEBOY_EXEC_CONTEXT_VERSION=2
+HOMEBOY_EXTENSION_ID=rust
+HOMEBOY_EXTENSION_PATH=/home/user/.config/homeboy/extensions/rust
 HOMEBOY_COMPONENT_ID=mycomponent
 HOMEBOY_COMPONENT_PATH=/home/user/dev/mycomponent
 HOMEBOY_SETTINGS_JSON={}
 ```
 
-### Full Context with Project
+### Project and Component Context
 
 ```bash
 homeboy extension run wordpress --project mysite --component mytheme
 ```
 
-Environment variables:
+Environment variables include:
+
 ```bash
-HOMEBOY_EXEC_CONTEXT_VERSION=1
-HOMEBOY_MODULE_ID=wordpress
-HOMEBOY_MODULE_PATH=/home/user/.config/homeboy/extensions/wordpress
+HOMEBOY_EXEC_CONTEXT_VERSION=2
+HOMEBOY_EXTENSION_ID=wordpress
+HOMEBOY_EXTENSION_PATH=/home/user/.config/homeboy/extensions/wordpress
 HOMEBOY_PROJECT_ID=mysite
-HOMEBOY_DOMAIN=mysite.com
-HOMEBOY_SITE_PATH=/var/www/mysite
+HOMEBOY_PROJECT_PATH=/home/user/projects/mysite
 HOMEBOY_COMPONENT_ID=mytheme
 HOMEBOY_COMPONENT_PATH=/home/user/dev/mytheme
 HOMEBOY_SETTINGS_JSON={"php_version":"8.1"}
 ```
-
-Template variables in `run_command`:
-- `{{extensionPath}}` → `/home/user/.config/homeboy/extensions/wordpress`
-- `{{entrypoint}}` → `main.py` (from manifest)
-- `{{args}}` → CLI arguments passed to extension
-- `{{projectId}}` → `mysite`
-- `{{domain}}` → `mysite.com`
-- `{{settings.php_version}}` → `8.1`
 
 ## Extension Environment Variables
 
@@ -216,24 +99,8 @@ Extensions can define additional environment variables in their manifest:
 
 These are set alongside Homeboy's standard environment variables.
 
-## Context Limits and Validation
-
-### Validation Rules
-
-- **Required context**: Some commands require project or component context
-- **Ambiguity resolution**: Multiple components in project require explicit `--component`
-- **Path validation**: Component paths must exist and be directories
-- **Extension validation**: Extension must be installed or specified via path
-
-### Error Conditions
-
-- **Extension not found**: Extension ID not in extensions directory
-- **Project not found**: Project ID not in projects directory
-- **Component not found**: Component ID not in components directory
-- **Context missing**: Command requires project/component but none provided
-
 ## Related
 
-- [Extension command](../commands/extension.md) - Extension execution
-- [Extension manifest schema](../schemas/extension-manifest-schema.md) - Runtime configuration
-- [Template variables](../templates.md) - Template variable reference
+- [Extension command](../commands/extension.md)
+- [Extension manifest schema](../schemas/extension-manifest-schema.md)
+- [Template variables](../templates.md)

--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -122,12 +122,15 @@ Homeboy builds an **effective settings** map for each extension by merging setti
 
 When running a extension, Homeboy passes an execution context via environment variables:
 
-- `HOMEBOY_EXEC_CONTEXT_VERSION`: currently `1`
+- `HOMEBOY_EXEC_CONTEXT_VERSION`: currently `2`
 - `HOMEBOY_EXTENSION_ID`
 - `HOMEBOY_SETTINGS_JSON`: merged effective settings (JSON)
 - `HOMEBOY_PROJECT_ID` (optional; when a project context is used)
+- `HOMEBOY_EXTENSION_PATH`: absolute path to extension directory
+- `HOMEBOY_PROJECT_PATH` (optional; absolute path to project directory)
 - `HOMEBOY_COMPONENT_ID` (optional; when a component context is resolved)
 - `HOMEBOY_COMPONENT_PATH` (optional; absolute path to component directory)
+- `HOMEBOY_STEP` / `HOMEBOY_SKIP` (optional; comma-separated step filters)
 
 Extensions can define additional environment variables via `runtime.env` in their manifest.
 

--- a/docs/commands/lint.md
+++ b/docs/commands/lint.md
@@ -1,32 +1,38 @@
 # Lint Command
 
-Lint a component using its configured extension's linting infrastructure.
+Lint a component using its linked extension's linting infrastructure.
 
 ## Synopsis
 
 ```bash
-homeboy lint <component> [options]
+homeboy lint [component] [options]
 ```
 
 ## Description
 
-The `lint` command runs code style validation for a component using the linting tools provided by its configured extension. For WordPress components, this uses PHPCS (PHP CodeSniffer) with WordPress coding standards.
+The `lint` command resolves the component's linked extension with `lint` capability and runs that extension's lint runner. Homeboy owns scoping flags, baseline / ratchet behavior, and structured output; the extension owns the language-specific tools.
 
 ## Arguments
 
-- `<component>`: Name of the component to lint
+- `[component]`: Component ID. Optional when Homeboy can auto-detect a portable `homeboy.json` or registered component from the current directory.
 
 ## Options
 
 - `--baseline`: Save current lint findings as baseline for future comparisons
 - `--ignore-baseline`: Skip baseline comparison even if baseline exists
+- `--path <PATH>`: Override component `local_path` for this run
 - `--file <path>`: Lint only a single file (path relative to component root)
 - `--glob <pattern>`: Lint only files matching glob pattern (e.g., "inc/**/*.php")
 - `--changed-only`: Lint only files modified in the working tree (staged, unstaged, untracked)
+- `--changed-since <REF>`: Lint only files changed since a git ref
 - `--errors-only`: Show only errors, suppress warnings
 - `--summary`: Show compact summary instead of full output
+- `--sniffs <SNIFFS>`: Restrict to comma-separated linter sniffs or rules when supported
+- `--exclude-sniffs <SNIFFS>`: Exclude comma-separated linter sniffs or rules when supported
+- `--category <CATEGORY>`: Restrict to a named linter category when supported
 - `--fix`: Apply auto-fixable lint findings in place. Thin alias for `homeboy refactor <component> --from lint --write` — dispatches to the existing fixer pipeline so a single ergonomic flag resolves the auto-fix CTA.
 - `--setting <key=value>`: Override extension settings (can be used multiple times)
+- `--setting-json <key=json>`: Override extension settings with typed JSON values
 
 ## Examples
 
@@ -57,16 +63,16 @@ homeboy lint extrachill-api --setting some_option=value
 
 For a component to be lintable, it must have:
 
-- A extension configured (e.g., `wordpress`)
-- The extension must provide a lint-runner script (at scripts/lint-runner.sh within the extension)
+- A linked extension that declares a `lint` capability
+- A lint runner declared by the extension's `lint.extension_script`
 
 ## Environment Variables
 
 The following environment variables are set for lint runners:
 
-- `HOMEBOY_MODULE_PATH`: Absolute path to extension directory
+- `HOMEBOY_EXTENSION_ID`: Extension identifier
+- `HOMEBOY_EXTENSION_PATH`: Absolute path to extension directory
 - `HOMEBOY_COMPONENT_PATH`: Absolute path to component directory
-- `HOMEBOY_PLUGIN_PATH`: Same as component path
 - `HOMEBOY_FIX_ONLY`: Set to `1` when running in fix-only mode (refactor --from lint --write) — extension should apply fixes without re-running diagnostics
 - `HOMEBOY_SUMMARY_MODE`: Set to `1` when `--summary` flag is used
 - `HOMEBOY_LINT_FILE`: Single file path when `--file` is used

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -3,24 +3,30 @@
 ## Synopsis
 
 ```sh
-homeboy release <COMPONENT> <BUMP_TYPE> [OPTIONS]
+homeboy release [OPTIONS] [COMPONENTS]...
 ```
 
-Where `<BUMP_TYPE>` is `patch`, `minor`, or `major`.
+By default Homeboy auto-detects the bump from commit history. Use `--bump <major|minor|patch|VERSION>` to force a bump type or explicit version.
 
-Also available as: `homeboy version bump <COMPONENT> <BUMP_TYPE> [OPTIONS]`
+Legacy positional bump syntax is still accepted for compatibility: `homeboy release <COMPONENT> <BUMP_TYPE>`.
 
 ## Options
 
 - `--dry-run`: Preview the release plan without executing
+- `--project <PROJECT>` / `-p <PROJECT>`: Release components from a project
+- `--outdated`: With `--project`, release only components with unreleased commits
+- `--path <PATH>`: Override local path for a single-component release
 - `--deploy`: Deploy this component to all projects that use it after release
 - `--recover`: Recover from an interrupted release
 - `--skip-checks`: Skip pre-release lint/test checks
-- `--allow-underbump`: Override semver guardrail when requested bump is lower than commit-derived recommendation
+- `--bump <BUMP>`: Force `major`, `minor`, `patch`, or an explicit version like `2.0.0`
+- `--skip-publish`: Skip publish/package steps; useful when CI publishes after the tag is pushed
+- `--no-github-release`: Skip GitHub Release creation while still tagging and pushing
+- `--git-identity <IDENTITY>`: Configure git identity for release commits/tags; use `bot` or `Name <email>`
 
 ## Description
 
-`homeboy release` executes a component release: bumps version, finalizes changelog, commits, tags, and optionally pushes. Use `--dry-run` to preview the release plan without making changes.
+`homeboy release` executes component releases: detects or applies a version bump, finalizes generated changelog entries, commits, tags, pushes, and optionally publishes release artifacts. Use `--dry-run` to preview the release plan without making changes.
 
 ## Recommended Workflow
 
@@ -29,10 +35,10 @@ Also available as: `homeboy version bump <COMPONENT> <BUMP_TYPE> [OPTIONS]`
 homeboy changes <component_id>
 
 # 2. Preview the release (validates configuration, shows plan)
-homeboy release <component_id> patch --dry-run
+homeboy release <component_id> --dry-run
 
 # 3. Execute the release
-homeboy release <component_id> patch
+homeboy release <component_id>
 ```
 
 ## Release Pipeline
@@ -154,7 +160,7 @@ With `--dry-run`:
 For automation, run dry-run JSON and consume:
 
 ```sh
-homeboy release <component_id> patch --dry-run --json
+homeboy release <component_id> --dry-run --json
 ```
 
 Semver recommendation is exposed at:
@@ -184,7 +190,7 @@ Example payload:
 }
 ```
 
-Use this in CI to block accidental under-bumps before tagging/publish.
+Use this in CI to inspect Homeboy's commit-derived recommendation before tagging/publish. Pass `--bump` when automation or a maintainer needs to override the detected bump.
 
 Without `--dry-run`:
 
@@ -233,7 +239,6 @@ GitHub release CI publishes to crates.io when the repository has a `CARGO_REGIST
 secret configured.
 
 This allows safe retry after `partial_success` without manual cleanup.
-```
 
 ## Related
 

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -1,25 +1,34 @@
 # Test Command
 
-Run test suites for Homeboy components/extensions.
+Run a component's extension-backed test suite.
 
 ## Synopsis
 
 ```bash
-homeboy test <component> [options]
+homeboy test [component] [options] [-- <runner-args>]
 ```
 
 ## Description
 
-The `test` command executes test suites for specified Homeboy components. It automatically discovers and runs the appropriate test infrastructure for each component type.
+The `test` command resolves the component's linked extension with `test` capability, runs its configured test runner, and applies Homeboy's baseline / ratchet handling to structured test output when available.
 
 ## Arguments
 
-- `<component>`: Name of the component to test (must have a extension configured)
+- `[component]`: Component ID. Optional when Homeboy can auto-detect a portable `homeboy.json` or registered component from the current directory.
 
 ## Options
 
 - `--skip-lint`: Skip linting before running tests
+- `--coverage`: Collect code coverage when the runner supports it
+- `--coverage-min <PERCENT>`: Fail when coverage is below this threshold; implies `--coverage`
+- `--baseline`: Persist the current test result baseline
+- `--ignore-baseline`: Skip baseline comparison for this run
+- `--ratchet`: Auto-update the baseline when the current run improves on it
+- `--drift`: Cross-reference production changes with test files
+- `--write`: Write fixes to disk for workflows that support it
+- `--since <REF>`: Git ref for drift detection (default `HEAD~10`)
 - `--setting <key=value>`: Override component settings (can be used multiple times)
+- `--setting-json <key=json>`: Override component settings with typed JSON values
 - `--path <PATH>`: Override component `local_path` for this run
 - `--changed-since <REF>`: Limit execution to impacted tests since a git ref
 - `--analyze`: Cluster and summarize failures
@@ -28,17 +37,17 @@ The `test` command executes test suites for specified Homeboy components. It aut
 ## Examples
 
 ```bash
-# Test the wordpress component with default settings
-homeboy test wordpress
+# Test the current component from a repo with homeboy.json
+homeboy test
 
-# Test wordpress with MySQL instead of SQLite
-homeboy test wordpress --setting database_type=mysql --setting mysql_host=localhost
+# Test a registered component with setting overrides
+homeboy test my-component --setting database_type=mysql --setting mysql_host=localhost
 
 # Run tests only, skip linting
-homeboy test wordpress --skip-lint
+homeboy test my-component --skip-lint
 
 # Test with multiple setting overrides
-homeboy test wordpress --setting database_type=mysql --setting mysql_database=test_db
+homeboy test my-component --setting database_type=mysql --setting mysql_database=test_db
 ```
 
 ## Passthrough Arguments
@@ -60,24 +69,12 @@ Supported arguments depend on the underlying test framework.
 For a component to be testable, it must have:
 
 - A linked extension with test support
-- A manifest file for the extension (e.g., wordpress.json)
-- A test-runner script provided by the extension (at scripts/test-runner.sh within the extension)
-
-## Supported Components
-
-Currently supported:
-
-- **wordpress**: PHPUnit-based WordPress testing with SQLite/MySQL support
+- A manifest file for the extension
+- A test runner declared by the extension's `test.extension_script`
 
 ## Settings
 
-Settings vary by component. For WordPress:
-
-- `database_type`: `"sqlite"` (default) or `"mysql"`
-- `mysql_host`: MySQL hostname (default: `"localhost"`)
-- `mysql_database`: MySQL database name (default: `"wordpress_test"`)
-- `mysql_user`: MySQL username (default: `"root"`)
-- `mysql_password`: MySQL password (default: `""`)
+Settings are extension-defined. Use `--setting key=value` for string values and `--setting-json key=<json>` when the runner expects typed values such as objects, arrays, booleans, numbers, or null.
 
 ## Output
 
@@ -102,17 +99,17 @@ Returns JSON with test results:
 
 The following environment variables are set for test runners:
 
-- `HOMEBOY_EXEC_CONTEXT_VERSION`: Protocol version (`"1"`)
-- `HOMEBOY_MODULE_ID`: Component name
-- `HOMEBOY_MODULE_PATH`: Absolute path to extension directory
+- `HOMEBOY_EXEC_CONTEXT_VERSION`: Protocol version (`"2"`)
+- `HOMEBOY_EXTENSION_ID`: Extension identifier
+- `HOMEBOY_EXTENSION_PATH`: Absolute path to extension directory
 - `HOMEBOY_PROJECT_PATH`: Absolute path to project directory
 - `HOMEBOY_COMPONENT_ID`: Component identifier
 - `HOMEBOY_COMPONENT_PATH`: Absolute path to component directory
 - `HOMEBOY_SETTINGS_JSON`: Merged settings as JSON string
+- `HOMEBOY_TEST_RESULTS_FILE`: Path where runners can write structured test results
+- `HOMEBOY_TEST_FAILURES_FILE`: Path where runners can write structured failure summaries
 
 ## Notes
 
-- Tests run in the component's environment, not the project's
-- SQLite provides fastest in-memory testing
-- MySQL testing requires a running MySQL server
-- Component settings can be configured globally via `homeboy config`
+- Tests run in the component's source directory.
+- Component settings can live in `homeboy.json`, component config, or CLI overrides depending on how the component is resolved.


### PR DESCRIPTION
## Summary
- Refresh `test`, `lint`, and `release` command docs against the current CLI surface.
- Replace stale execution-context documentation with the current extension env vars and protocol version.
- Remove outdated runner-script, module env var, and release bump syntax references.

## Tests
- `cargo check`
- `homeboy audit homeboy --path "/Users/chubes/Developer/homeboy@docs-stale-pass-2" --only broken_doc_reference --only stale_doc_reference --only undocumented_feature --ignore-baseline`
- `cargo run --quiet --bin homeboy -- docs commands/test`
- `cargo run --quiet --bin homeboy -- docs commands/lint`
- `cargo run --quiet --bin homeboy -- docs commands/release`
- `cargo run --quiet --bin homeboy -- docs architecture/execution-context`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing stale documentation against CLI/source output, drafting the docs updates, and running verification; Chris remains responsible for review and merge.