### PR TITLE
fix(bench): preserve shared-state CLI flags

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -41,6 +41,11 @@ the other capabilities.
   (default `5.0`) used when the runner does not declare `metric_policies`.
   A p95 scenario regresses when its current `p95_ms` exceeds
   `baseline.p95_ms * (1 + threshold/100)`.
+- `--shared-state <DIR>`: Directory shared across iterations and concurrent
+  runner instances. Forwarded to workloads via
+  `$HOMEBOY_BENCH_SHARED_STATE`.
+- `--concurrency <N>`: Number of parallel bench runner instances to spawn
+  (default `1`). Values greater than `1` require `--shared-state`.
 - `--setting <key=value>`: Override component settings (may be repeated).
 - `--setting-json <key=json>`: Override component settings with typed JSON
   values for arrays, objects, numbers, booleans, or null.
@@ -75,6 +80,9 @@ homeboy bench my-component --ratchet
 
 # Select a single scenario via passthrough args
 homeboy bench my-component -- --filter=hot_path
+
+# Share warm state across invocations and run four instances in parallel
+homeboy bench my-component --shared-state /tmp/homeboy-bench --concurrency 4
 
 # Pin to a single rig — preflight + rig-scoped baseline
 homeboy bench studio --rig studio-trunk

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -148,6 +148,8 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
                 "--ignore-default-baseline",
                 "--ratchet",
                 "--regression-threshold",
+                "--shared-state",
+                "--concurrency",
                 "--rig",
                 "--setting",
                 "--path",
@@ -436,6 +438,22 @@ mod normalize_tests {
             "--iterations",
             "1",
             "--ignore-default-baseline",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// `bench` owns shared-state/concurrency. They must remain named CLI
+    /// flags even when placed after the positional component.
+    #[test]
+    fn bench_shared_state_flags_after_component_are_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--shared-state",
+            "/tmp/homeboy-bench",
+            "--concurrency=4",
         ]);
         let expected = input.clone();
         assert_eq!(normalize_trailing_flags(input), expected);


### PR DESCRIPTION
## Summary
- Keeps `--shared-state` and `--concurrency` on the `homeboy bench` named-argument path when they appear after the component.
- Documents the restored bench shared-state/concurrency flags and adds a normalizer regression test.

## Tests
- `cargo fmt --check`
- `cargo test commands::bench`
- `cargo test commands::utils::args::normalize_tests`
- `cargo test -- --test-threads=1`

Closes #1604

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the CLI normalizer/doc update, rebasing after upstream restored the core bench args, and running verification.