### PR TITLE
feat(rig): order pipeline steps by dependency graph

### DIFF
--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -1,12 +1,12 @@
-//! Linear pipeline executor.
+//! Rig pipeline executor.
 //!
-//! MVP is a straight for-loop over `PipelineStep`s. DAG + caching is
-//! explicitly Phase 3 (tracked in Extra-Chill/homeboy#1464).
+//! Optional step IDs plus `depends_on` edges are topologically ordered before
+//! sequential execution. Caching and parallelism are later #1464 phases.
 //!
 //! Every step emits a `PipelineStepOutcome`. The runner aggregates them into
 //! a `PipelineOutcome` with overall success/failure.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -36,7 +36,6 @@ pub struct PipelineStepOutcome {
     pub error: Option<String>,
 }
 
-/// Aggregate result of a pipeline run.
 #[derive(Debug, Clone, Serialize)]
 pub struct PipelineOutcome {
     pub name: String,
@@ -51,19 +50,16 @@ impl PipelineOutcome {
     }
 }
 
-/// Run a named pipeline from a rig spec.
-///
-/// `fail_fast = true` means the pipeline aborts on first failure (good for
-/// `up` — later steps usually depend on earlier ones). `fail_fast = false`
-/// runs every step (good for `check` — report everything wrong at once).
 pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<PipelineOutcome> {
     let steps = rig.pipeline.get(name).cloned().unwrap_or_default();
-    let mut outcomes = Vec::with_capacity(steps.len());
+    let ordered_indices = order_pipeline_steps(rig, name, &steps)?;
+    let mut outcomes = Vec::with_capacity(ordered_indices.len());
     let mut failed = 0;
     let mut passed = 0;
     let mut aborted = false;
 
-    for (idx, step) in steps.iter().enumerate() {
+    for idx in ordered_indices {
+        let step = &steps[idx];
         if aborted {
             outcomes.push(PipelineStepOutcome {
                 kind: step_kind(step).to_string(),
@@ -117,7 +113,7 @@ pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<Pipeli
 
 fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
     match step {
-        PipelineStep::Service { id, op } => run_service_step(rig, id, *op),
+        PipelineStep::Service { id, op, .. } => run_service_step(rig, id, *op),
         PipelineStep::Build { component, .. } => run_build_step(rig, component),
         PipelineStep::Git {
             component,
@@ -130,9 +126,10 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
             cwd,
             env,
             label: _,
+            ..
         } => run_command_step(rig, cmd, cwd.as_deref(), env),
-        PipelineStep::Symlink { op } => run_symlink_step(rig, *op),
-        PipelineStep::SharedPath { op } => run_shared_path_step(rig, *op),
+        PipelineStep::Symlink { op, .. } => run_symlink_step(rig, *op),
+        PipelineStep::SharedPath { op, .. } => run_shared_path_step(rig, *op),
         PipelineStep::Patch {
             component,
             file,
@@ -146,17 +143,130 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
     }
 }
 
-/// Cleanup shared paths created by this rig.
-///
-/// `run_down` calls this unconditionally as a safety net, even when a spec
-/// author forgets to include an explicit `shared-path cleanup` step.
+fn order_pipeline_steps(
+    rig: &RigSpec,
+    pipeline_name: &str,
+    steps: &[PipelineStep],
+) -> Result<Vec<usize>> {
+    if steps.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut id_to_index = HashMap::new();
+    for (idx, step) in steps.iter().enumerate() {
+        if let Some(id) = step_id(step) {
+            if let Some(previous_idx) = id_to_index.insert(id, idx) {
+                return Err(Error::rig_pipeline_failed(
+                    &rig.id,
+                    pipeline_name,
+                    format!(
+                        "duplicate pipeline step id '{}' at positions {} and {}",
+                        id, previous_idx, idx
+                    ),
+                ));
+            }
+        }
+    }
+
+    let mut indegree = vec![0usize; steps.len()];
+    let mut dependents = vec![Vec::<usize>::new(); steps.len()];
+
+    for (idx, step) in steps.iter().enumerate() {
+        for dependency_id in step_dependencies(step) {
+            let Some(&dependency_idx) = id_to_index.get(dependency_id.as_str()) else {
+                return Err(Error::rig_pipeline_failed(
+                    &rig.id,
+                    pipeline_name,
+                    format!(
+                        "pipeline step {} depends on missing step id '{}'",
+                        step_node_label(step, idx),
+                        dependency_id
+                    ),
+                ));
+            };
+            indegree[idx] += 1;
+            dependents[dependency_idx].push(idx);
+        }
+    }
+
+    for child_indices in &mut dependents {
+        child_indices.sort_unstable();
+    }
+
+    let mut ready = VecDeque::new();
+    for (idx, count) in indegree.iter().enumerate() {
+        if *count == 0 {
+            ready.push_back(idx);
+        }
+    }
+
+    let mut ordered = Vec::with_capacity(steps.len());
+    while let Some(idx) = ready.pop_front() {
+        ordered.push(idx);
+        for dependent_idx in dependents[idx].iter().copied() {
+            indegree[dependent_idx] -= 1;
+            if indegree[dependent_idx] == 0 {
+                ready.push_back(dependent_idx);
+            }
+        }
+    }
+
+    if ordered.len() != steps.len() {
+        let cycle_members = steps
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, step)| (indegree[idx] > 0).then(|| step_node_label(step, idx)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(Error::rig_pipeline_failed(
+            &rig.id,
+            pipeline_name,
+            format!(
+                "pipeline dependency cycle detected involving {}",
+                cycle_members
+            ),
+        ));
+    }
+
+    Ok(ordered)
+}
+
+fn step_id(step: &PipelineStep) -> Option<&str> {
+    match step {
+        PipelineStep::Service { step_id, .. }
+        | PipelineStep::Build { step_id, .. }
+        | PipelineStep::Git { step_id, .. }
+        | PipelineStep::Command { step_id, .. }
+        | PipelineStep::Symlink { step_id, .. }
+        | PipelineStep::SharedPath { step_id, .. }
+        | PipelineStep::Patch { step_id, .. }
+        | PipelineStep::Check { step_id, .. } => step_id.as_deref(),
+    }
+}
+
+fn step_dependencies(step: &PipelineStep) -> &[String] {
+    match step {
+        PipelineStep::Service { depends_on, .. }
+        | PipelineStep::Build { depends_on, .. }
+        | PipelineStep::Git { depends_on, .. }
+        | PipelineStep::Command { depends_on, .. }
+        | PipelineStep::Symlink { depends_on, .. }
+        | PipelineStep::SharedPath { depends_on, .. }
+        | PipelineStep::Patch { depends_on, .. }
+        | PipelineStep::Check { depends_on, .. } => depends_on,
+    }
+}
+
+fn step_node_label(step: &PipelineStep, idx: usize) -> String {
+    step_id(step)
+        .map(|id| format!("'{}'", id))
+        .unwrap_or_else(|| format!("at position {}", idx))
+}
+
 pub fn cleanup_shared_paths(rig: &RigSpec) -> Result<()> {
     run_shared_path_step(rig, SharedPathOp::Cleanup)
 }
 
-/// Resolve a component reference from the rig spec and return its expanded
-/// absolute path. Centralized so `build` and `git` steps share the error
-/// surface and spec validation.
 fn resolve_component_path(rig: &RigSpec, component_id: &str) -> Result<(ComponentSpec, String)> {
     let component = rig.components.get(component_id).ok_or_else(|| {
         Error::rig_pipeline_failed(
@@ -210,7 +320,6 @@ fn run_build_step(rig: &RigSpec, component_id: &str) -> Result<()> {
 fn run_git_step(rig: &RigSpec, component_id: &str, op: GitOp, extra_args: &[String]) -> Result<()> {
     let (_, path) = resolve_component_path(rig, component_id)?;
 
-    // Build the argv — op-specific base plus user-supplied extras.
     let base_args: Vec<String> = match op {
         GitOp::Status => vec!["status".into(), "--porcelain=v1".into()],
         GitOp::Pull => vec!["pull".into()],
@@ -348,7 +457,6 @@ fn ensure_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<()> {
         })?;
     }
 
-    // If the link exists pointing at the right target, no-op.
     if link_path.exists() || link_path.is_symlink() {
         if let Ok(current) = std::fs::read_link(&link_path) {
             if current == target_path {
@@ -386,9 +494,6 @@ fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
 
 #[cfg(not(unix))]
 fn create_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
-    // Rigs are Unix-only by design (see core/rig/service.rs). Windows users
-    // who reach this path get a clear error from rig_pipeline_failed instead
-    // of a compile failure.
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "rig symlinks are not supported on this platform (Unix only)",
@@ -501,8 +606,6 @@ fn ensure_shared_path(
             ))
         }
         Ok(_) => {
-            // Local dependencies already exist in this checkout. Leave them
-            // alone and forget any stale ownership marker for this path.
             if state.shared_paths.remove(&key).is_some() {
                 *state_changed = true;
             }
@@ -791,8 +894,10 @@ fn step_kind(step: &PipelineStep) -> &'static str {
 
 fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
     match step {
-        PipelineStep::Service { id, op } => format!("service {} {}", id, serialize_op(*op)),
-        PipelineStep::Build { component, label } => label
+        PipelineStep::Service { id, op, .. } => format!("service {} {}", id, serialize_op(*op)),
+        PipelineStep::Build {
+            component, label, ..
+        } => label
             .clone()
             .unwrap_or_else(|| format!("build {}", component)),
         PipelineStep::Git {
@@ -800,6 +905,7 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
             op,
             args,
             label,
+            ..
         } => label.clone().unwrap_or_else(|| {
             let joined = if args.is_empty() {
                 String::new()
@@ -811,8 +917,10 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
         PipelineStep::Command { cmd, label, .. } => label
             .clone()
             .unwrap_or_else(|| truncate(&expand_vars(rig, cmd), 80)),
-        PipelineStep::Symlink { op } => format!("symlink {}", serialize_symlink_op(*op)),
-        PipelineStep::SharedPath { op } => format!("shared-path {}", serialize_shared_path_op(*op)),
+        PipelineStep::Symlink { op, .. } => format!("symlink {}", serialize_symlink_op(*op)),
+        PipelineStep::SharedPath { op, .. } => {
+            format!("shared-path {}", serialize_shared_path_op(*op))
+        }
         PipelineStep::Patch {
             component,
             file,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -216,6 +216,12 @@ pub struct SharedPathSpec {
 pub enum PipelineStep {
     /// Start/stop/health-check a declared service.
     Service {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Service ID (must exist in `services`).
         id: String,
         /// Operation: `start`, `stop`, or `health`.
@@ -230,6 +236,12 @@ pub enum PipelineStep {
     /// path is resolved from the rig's `components` map, so the component
     /// doesn't need to be registered in homeboy's global registry.
     Build {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Component ID — must exist in the rig's `components` map.
         component: String,
         /// Human-readable label shown during execution.
@@ -244,6 +256,12 @@ pub enum PipelineStep {
     /// rigs actually need (MVP): `status`, `pull`, `fetch`, `checkout`,
     /// `current-branch`. More can land as follow-up.
     Git {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Component ID — must exist in the rig's `components` map.
         component: String,
         /// Operation name.
@@ -264,6 +282,12 @@ pub enum PipelineStep {
     /// typed steps pick up homeboy's existing error mapping, extension
     /// hooks, and registry awareness for free.
     Command {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Shell command to execute. Runs via `sh -c` (or `cmd /C` on Windows).
         #[serde(rename = "command")]
         cmd: String,
@@ -280,12 +304,24 @@ pub enum PipelineStep {
 
     /// Ensure a declared symlink exists (or verify it in `check` pipelines).
     Symlink {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Operation: `ensure` or `verify`.
         op: SymlinkOp,
     },
 
     /// Ensure, verify, or clean up declared shared dependency paths.
     SharedPath {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Operation: `ensure`, `verify`, or `cleanup`.
         op: SharedPathOp,
     },
@@ -307,6 +343,12 @@ pub enum PipelineStep {
     /// for it. Use this in `check` pipelines so a stale or unpatched
     /// checkout is reported as a failure, not silently re-patched.
     Patch {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Component ID — must exist in the rig's `components` map.
         component: String,
         /// File to patch, relative to the component's path. Tilde +
@@ -336,6 +378,12 @@ pub enum PipelineStep {
 
     /// Pre-flight / health check. Non-fatal in `up` (warns), fatal in `check`.
     Check {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
         /// Human-readable label.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         label: Option<String>,

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -56,6 +56,209 @@ fn test_pipeline_step_outcome_omits_error_when_absent() {
     assert!(!json.contains("\"error\""));
 }
 
+// ---- Dependency-aware ordering ---------------------------------------------
+
+mod dag {
+    use std::collections::HashMap;
+    use std::fs;
+
+    use crate::rig::pipeline::run_pipeline;
+    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+
+    fn command(id: &str, depends_on: &[&str], cmd: String, cwd: Option<String>) -> PipelineStep {
+        PipelineStep::Command {
+            step_id: Some(id.to_string()),
+            depends_on: depends_on.iter().map(|s| s.to_string()).collect(),
+            cmd,
+            cwd,
+            env: HashMap::new(),
+            label: Some(id.to_string()),
+        }
+    }
+
+    fn rig_with_steps(
+        steps: Vec<PipelineStep>,
+        components: HashMap<String, ComponentSpec>,
+    ) -> RigSpec {
+        let mut pipeline = HashMap::new();
+        pipeline.insert("up".to_string(), steps);
+        RigSpec {
+            id: "dag-test".to_string(),
+            description: String::new(),
+            components,
+            services: Default::default(),
+            symlinks: Vec::new(),
+            shared_paths: Vec::new(),
+            pipeline,
+            bench: None,
+            bench_workloads: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_pipeline_orders_steps_by_dependencies() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let log = tmp.path().join("order.txt");
+        let log_arg = log.to_string_lossy();
+        let rig = rig_with_steps(
+            vec![
+                command(
+                    "studio-build",
+                    &["studio-install"],
+                    format!("printf 'build\\n' >> {}", log_arg),
+                    None,
+                ),
+                command(
+                    "playground-build",
+                    &[],
+                    format!("printf 'playground\\n' >> {}", log_arg),
+                    None,
+                ),
+                command(
+                    "studio-install",
+                    &["playground-build"],
+                    format!("printf 'install\\n' >> {}", log_arg),
+                    None,
+                ),
+            ],
+            HashMap::new(),
+        );
+
+        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        assert!(out.is_success(), "outcomes: {:?}", out.steps);
+        assert_eq!(
+            fs::read_to_string(&log).expect("read log"),
+            "playground\ninstall\nbuild\n"
+        );
+        assert_eq!(
+            out.steps
+                .iter()
+                .map(|s| s.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["playground-build", "studio-install", "studio-build"]
+        );
+    }
+
+    #[test]
+    fn test_pipeline_errors_on_missing_dependency() {
+        let rig = rig_with_steps(
+            vec![command(
+                "studio-build",
+                &["missing-step"],
+                "true".to_string(),
+                None,
+            )],
+            HashMap::new(),
+        );
+
+        let err = run_pipeline(&rig, "up", true).expect_err("missing dependency errors");
+        let msg = err.to_string();
+        assert!(msg.contains("missing step id 'missing-step'"), "{msg}");
+    }
+
+    #[test]
+    fn test_pipeline_errors_on_dependency_cycle() {
+        let rig = rig_with_steps(
+            vec![
+                command("a", &["b"], "true".to_string(), None),
+                command("b", &["a"], "true".to_string(), None),
+            ],
+            HashMap::new(),
+        );
+
+        let err = run_pipeline(&rig, "up", true).expect_err("cycle errors");
+        let msg = err.to_string();
+        assert!(msg.contains("dependency cycle"), "{msg}");
+        assert!(msg.contains("'a'"), "{msg}");
+        assert!(msg.contains("'b'"), "{msg}");
+    }
+
+    #[test]
+    fn test_pipeline_preserves_linear_order_without_dependencies() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let log = tmp.path().join("linear.txt");
+        let log_arg = log.to_string_lossy();
+        let rig = rig_with_steps(
+            vec![
+                command("one", &[], format!("printf 'one\\n' >> {}", log_arg), None),
+                command("two", &[], format!("printf 'two\\n' >> {}", log_arg), None),
+                command(
+                    "three",
+                    &[],
+                    format!("printf 'three\\n' >> {}", log_arg),
+                    None,
+                ),
+            ],
+            HashMap::new(),
+        );
+
+        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        assert!(out.is_success());
+        assert_eq!(
+            fs::read_to_string(&log).expect("read log"),
+            "one\ntwo\nthree\n"
+        );
+    }
+
+    #[test]
+    fn test_pipeline_keeps_cross_component_path_expansion_after_reordering() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let component_a = tmp.path().join("component-a");
+        let component_b = tmp.path().join("component-b");
+        fs::create_dir_all(&component_a).expect("component a");
+        fs::create_dir_all(&component_b).expect("component b");
+
+        let mut components = HashMap::new();
+        components.insert(
+            "a".to_string(),
+            ComponentSpec {
+                path: component_a.to_string_lossy().into_owned(),
+                remote_url: None,
+                stack: None,
+                branch: None,
+            },
+        );
+        components.insert(
+            "b".to_string(),
+            ComponentSpec {
+                path: component_b.to_string_lossy().into_owned(),
+                remote_url: None,
+                stack: None,
+                branch: None,
+            },
+        );
+
+        let rig = rig_with_steps(
+            vec![
+                command(
+                    "write-from-a",
+                    &["prepare-b"],
+                    "printf 'from-a' > ${components.b.path}/from-a.txt".to_string(),
+                    Some("${components.a.path}".to_string()),
+                ),
+                command(
+                    "prepare-b",
+                    &[],
+                    "printf 'ready' > ready.txt".to_string(),
+                    Some("${components.b.path}".to_string()),
+                ),
+            ],
+            components,
+        );
+
+        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        assert!(out.is_success(), "outcomes: {:?}", out.steps);
+        assert_eq!(
+            fs::read_to_string(component_b.join("ready.txt")).expect("ready"),
+            "ready"
+        );
+        assert_eq!(
+            fs::read_to_string(component_b.join("from-a.txt")).expect("from-a"),
+            "from-a"
+        );
+    }
+}
+
 // ---- Patch step end-to-end -------------------------------------------------
 //
 // The patch step is the smallest of the three new pipeline kinds and the
@@ -103,6 +306,8 @@ mod patch {
         fs::write(&file, "original\n").expect("write");
 
         let step = PipelineStep::Patch {
+            step_id: None,
+            depends_on: Vec::new(),
             component: "c".to_string(),
             file: "x.c".to_string(),
             marker: "MARKER-XYZ".to_string(),
@@ -128,6 +333,8 @@ mod patch {
         let before = fs::read_to_string(&file).expect("read before");
 
         let step = PipelineStep::Patch {
+            step_id: None,
+            depends_on: Vec::new(),
             component: "c".to_string(),
             file: "x.c".to_string(),
             marker: "MARKER-XYZ".to_string(),
@@ -150,6 +357,8 @@ mod patch {
         fs::write(&file, "line1\n/* ANCHOR */\nline3\n").expect("write");
 
         let step = PipelineStep::Patch {
+            step_id: None,
+            depends_on: Vec::new(),
             component: "c".to_string(),
             file: "x.c".to_string(),
             marker: "MARKER-INSERTED".to_string(),
@@ -174,6 +383,8 @@ mod patch {
         fs::write(&file, "no anchor here\n").expect("write");
 
         let step = PipelineStep::Patch {
+            step_id: None,
+            depends_on: Vec::new(),
             component: "c".to_string(),
             file: "x.c".to_string(),
             marker: "MARKER".to_string(),
@@ -197,6 +408,8 @@ mod patch {
 
         // Marker not in content ⇒ would re-apply forever.
         let step = PipelineStep::Patch {
+            step_id: None,
+            depends_on: Vec::new(),
             component: "c".to_string(),
             file: "x.c".to_string(),
             marker: "M".to_string(),
@@ -217,6 +430,8 @@ mod patch {
         fs::write(&file, "/* ALREADY-PATCHED */\n").expect("write");
 
         let step = PipelineStep::Patch {
+            step_id: None,
+            depends_on: Vec::new(),
             component: "c".to_string(),
             file: "x.c".to_string(),
             marker: "ALREADY-PATCHED".to_string(),
@@ -238,6 +453,8 @@ mod patch {
         let before = fs::read_to_string(&file).expect("read before");
 
         let step = PipelineStep::Patch {
+            step_id: None,
+            depends_on: Vec::new(),
             component: "c".to_string(),
             file: "x.c".to_string(),
             marker: "M-MISSING".to_string(),
@@ -271,7 +488,14 @@ mod shared_path {
 
     fn rig_with_shared_path(id: &str, shared: SharedPathSpec, op: SharedPathOp) -> RigSpec {
         let mut pipeline = HashMap::new();
-        pipeline.insert("up".to_string(), vec![PipelineStep::SharedPath { op }]);
+        pipeline.insert(
+            "up".to_string(),
+            vec![PipelineStep::SharedPath {
+                step_id: None,
+                depends_on: Vec::new(),
+                op,
+            }],
+        );
         RigSpec {
             id: id.to_string(),
             description: String::new(),

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -206,6 +206,8 @@ fn test_run_down_cleans_state_owned_shared_paths() {
         pipeline.insert(
             "up".to_string(),
             vec![PipelineStep::SharedPath {
+                step_id: None,
+                depends_on: Vec::new(),
                 op: SharedPathOp::Ensure,
             }],
         );

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -154,7 +154,7 @@ fn test_spec_check_step_with_command_probe() {
     let steps = spec.pipeline.get("check").unwrap();
     assert_eq!(steps.len(), 1);
     match &steps[0] {
-        PipelineStep::Check { label, spec } => {
+        PipelineStep::Check { label, spec, .. } => {
             assert_eq!(label.as_deref(), Some("docker daemon running"));
             assert_eq!(spec.command.as_deref(), Some("docker info"));
             assert_eq!(spec.expect_exit, Some(0));
@@ -177,9 +177,48 @@ fn test_spec_build_step_parses() {
     let spec: RigSpec = serde_json::from_str(json).expect("parse");
     let steps = spec.pipeline.get("up").unwrap();
     match &steps[0] {
-        PipelineStep::Build { component, label } => {
+        PipelineStep::Build {
+            component, label, ..
+        } => {
             assert_eq!(component, "studio");
             assert_eq!(label.as_deref(), Some("compile studio"));
+        }
+        other => panic!("expected Build, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_spec_pipeline_step_id_and_dependencies_parse() {
+    let json = r#"{
+        "id": "r",
+        "components": {
+            "studio": { "path": "/tmp/studio" },
+            "playground": { "path": "/tmp/playground" }
+        },
+        "pipeline": {
+            "up": [
+                { "kind": "build", "id": "playground-build", "component": "playground" },
+                {
+                    "kind": "build",
+                    "id": "studio-install",
+                    "component": "studio",
+                    "depends_on": ["playground-build"]
+                }
+            ]
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+    let steps = spec.pipeline.get("up").unwrap();
+    match &steps[1] {
+        PipelineStep::Build {
+            step_id,
+            depends_on,
+            component,
+            ..
+        } => {
+            assert_eq!(step_id.as_deref(), Some("studio-install"));
+            assert_eq!(depends_on, &vec!["playground-build".to_string()]);
+            assert_eq!(component, "studio");
         }
         other => panic!("expected Build, got {:?}", other),
     }
@@ -279,6 +318,7 @@ fn test_spec_patch_step_parses_full_shape() {
             content,
             op,
             label,
+            ..
         } => {
             assert_eq!(component, "playground");
             assert_eq!(file, "packages/php-wasm/compile/dns_polyfill.c");


### PR DESCRIPTION
## Summary
- Adds optional pipeline step IDs plus `depends_on` edges and topologically orders rig pipelines before execution.
- Surfaces clear errors for duplicate IDs, missing dependencies, and dependency cycles.
- Covers dependency ordering, missing dependency errors, cycle detection, unchanged linear order, cross-component path expansion, and spec parsing.

## Tests
- `cargo test dag -- --test-threads=1`
- `cargo test test_spec_pipeline_step_id_and_dependencies_parse -- --test-threads=1`
- `cargo fmt --check`
- `cargo test --release -- --test-threads=1`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@rig-build-dag --json-summary` — reports existing baseline drift (`DRIFT INCREASED: 6 new finding(s) since baseline`), but no findings on changed files after trimming `src/core/rig/pipeline.rs` below the god-file threshold. Baseline was not refreshed because the remaining drift is unrelated to this PR.

Closes #1464.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / `openai/gpt-5.5`)
- **Used for:** Implemented the dependency-ordering slice, added tests, ran validation, and drafted this PR description. Chris remains responsible for review and merge.