### PR TITLE
feat(test): expose failed tests in output

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,8 +3,8 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-04-27T01:17:47Z",
-      "item_count": 758,
+      "created_at": "2026-04-27T01:48:54Z",
+      "item_count": 761,
       "known_fingerprints": [
         "Commands::src/commands/docs.rs::NamespaceMismatch",
         "Stack (Tests)::tests/core/stack/inspect_test.rs::MissingMethod",
@@ -244,6 +244,7 @@
         "structural::src/commands/project.rs::HighItemCount",
         "structural::src/commands/refactor.rs::GodFile",
         "structural::src/commands/refactor.rs::HighItemCount",
+        "structural::src/commands/review/render.rs::HighItemCount",
         "structural::src/commands/server.rs::HighItemCount",
         "structural::src/commands/stack.rs::HighItemCount",
         "structural::src/commands/status.rs::HighItemCount",
@@ -524,7 +525,9 @@
         "test_coverage::src/core/extension/test/drift.rs::MissingTestMethod",
         "test_coverage::src/core/extension/test/drift.rs::MissingTestMethod",
         "test_coverage::src/core/extension/test/parsing.rs::MissingTestFile",
-        "test_coverage::src/core/extension/test/report.rs::MissingTestFile",
+        "test_coverage::src/core/extension/test/report.rs::MissingTestMethod",
+        "test_coverage::src/core/extension/test/report.rs::MissingTestMethod",
+        "test_coverage::src/core/extension/test/report.rs::MissingTestMethod",
         "test_coverage::src/core/extension/test/run.rs::MissingTestMethod",
         "test_coverage::src/core/extension/test/workflow.rs::MissingTestFile",
         "test_coverage::src/core/extension/update_check.rs::MissingTestMethod",

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -21,7 +21,7 @@ use std::fmt::Write as _;
 
 use homeboy::code_audit::AuditCommandOutput;
 use homeboy::extension::lint::LintCommandOutput;
-use homeboy::extension::test::TestCommandOutput;
+use homeboy::extension::test::{FailedTest, TestCommandOutput};
 use homeboy::top_n::top_n_by;
 
 use super::{ReviewCommandOutput, ReviewStage};
@@ -206,9 +206,8 @@ fn render_lint_body(out: &mut String, output: &LintCommandOutput) {
     let _ = writeln!(out, "- _Total: {} finding(s)_", buckets.total);
 }
 
-/// Render the test stage body — failure count + pass-summary line. Per-test
-/// failure names are not surfaced in `TestCommandOutput` (no `failed_tests`
-/// field), so we summarize from `test_counts`.
+/// Render the test stage body — structured failure names when present, with
+/// the aggregate-only fallback preserved for runners that only report counts.
 fn render_test_body(out: &mut String, output: &TestCommandOutput) {
     let counts = match output.test_counts.as_ref() {
         Some(c) => c,
@@ -221,6 +220,9 @@ fn render_test_body(out: &mut String, output: &TestCommandOutput) {
             "- **{} failed** out of {} total",
             counts.failed, counts.total
         );
+        if let Some(failed_tests) = output.failed_tests.as_ref() {
+            render_failed_tests(out, failed_tests);
+        }
         if counts.passed > 0 {
             let _ = writeln!(out, "- {} passed", counts.passed);
         }
@@ -235,6 +237,27 @@ fn render_test_body(out: &mut String, output: &TestCommandOutput) {
     }
 }
 
+fn render_failed_tests(out: &mut String, failed_tests: &[FailedTest]) {
+    for failed_test in failed_tests.iter().take(TOP_N) {
+        let _ = write!(out, "- `{}`", failed_test.name);
+        if let Some(detail) = failed_test.detail.as_deref() {
+            let _ = write!(out, " — {}", detail);
+        }
+        if let Some(location) = failed_test.location.as_deref() {
+            let _ = write!(out, " (`{}`)", location);
+        }
+        out.push('\n');
+    }
+
+    if failed_tests.len() > TOP_N {
+        let _ = writeln!(
+            out,
+            "- _… {} more failed test(s)_",
+            failed_tests.len() - TOP_N
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -243,7 +266,7 @@ mod tests {
         AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity,
     };
     use homeboy::extension::lint::{LintCommandOutput, LintFinding};
-    use homeboy::extension::test::{TestCommandOutput, TestCounts};
+    use homeboy::extension::test::{FailedTest, TestCommandOutput, TestCounts};
     use homeboy::extension::{PhaseReport, PhaseStatus, VerificationPhase};
 
     // ── Builders for fixture envelopes ──────────────────────────────────
@@ -408,6 +431,7 @@ mod tests {
                 failed,
                 skipped,
             }),
+            failed_tests: None,
             coverage: None,
             baseline_comparison: None,
             analysis: None,
@@ -419,6 +443,20 @@ mod tests {
             summary: None,
             raw_output: None,
         }
+    }
+
+    fn failed_test(idx: usize) -> FailedTest {
+        FailedTest {
+            name: format!("tests::suite::case_{:02}", idx),
+            detail: Some(format!("assertion {} failed", idx)),
+            location: Some(format!("tests/suite.rs:{}", idx + 10)),
+        }
+    }
+
+    fn test_with_failed_tests(total: usize) -> TestCommandOutput {
+        let mut output = test_with_counts(20, total as u64, 1);
+        output.failed_tests = Some((0..total).map(failed_test).collect());
+        output
     }
 
     // ── Tests ───────────────────────────────────────────────────────────
@@ -598,6 +636,59 @@ mod tests {
             md
         );
         assert!(md.contains("- 10 passed"), "missing passed line:\n{}", md);
+    }
+
+    #[test]
+    fn renders_top_failed_tests_when_present() {
+        let mut env = passing_envelope();
+        env.test.passed = false;
+        env.test.exit_code = 1;
+        env.test.finding_count = 3;
+        env.test.output = Some(test_with_failed_tests(3));
+
+        let md = render_pr_comment(&env);
+        assert!(
+            md.contains("- **3 failed** out of 24 total"),
+            "missing aggregate line:\n{}",
+            md
+        );
+        assert!(
+            md.contains("- `tests::suite::case_00` — assertion 0 failed (`tests/suite.rs:10`)"),
+            "missing failed-test detail line:\n{}",
+            md
+        );
+        assert!(
+            md.contains("- `tests::suite::case_02` — assertion 2 failed (`tests/suite.rs:12`)"),
+            "missing final failed-test detail line:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn caps_failed_tests_at_top_10() {
+        let mut env = passing_envelope();
+        env.test.passed = false;
+        env.test.exit_code = 1;
+        env.test.finding_count = 12;
+        env.test.output = Some(test_with_failed_tests(12));
+
+        let md = render_pr_comment(&env);
+        let bullet_count = md.matches("- `tests::suite::case_").count();
+        assert_eq!(
+            bullet_count, TOP_N,
+            "should render exactly 10 failed-test bullets:\n{}",
+            md
+        );
+        assert!(
+            md.contains("_… 2 more failed test(s)_"),
+            "missing failed-test overflow hint:\n{}",
+            md
+        );
+        assert!(
+            !md.contains("tests::suite::case_10"),
+            "should not render failed tests beyond top cap:\n{}",
+            md
+        );
     }
 
     #[test]

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -34,7 +34,7 @@ pub use parsing::{
     build_test_summary, parse_coverage_file, parse_failures_file, parse_test_results_file,
     parse_test_results_text, CoverageOutput, TestSummaryOutput,
 };
-pub use report::TestCommandOutput;
+pub use report::{FailedTest, TestCommandOutput};
 pub use run::{run_main_test_workflow, RawTestOutput, TestRunWorkflowArgs, TestRunWorkflowResult};
 pub use workflow::{
     auto_fix_test_drift, detect_test_drift, AutoFixDriftOutput, AutoFixDriftWorkflowResult,

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -18,6 +18,16 @@ use serde::Serialize;
 use super::run::{RawTestOutput, TestRunWorkflowResult};
 use super::workflow::{AutoFixDriftOutput, AutoFixDriftWorkflowResult, DriftWorkflowResult};
 
+/// A single structured test failure surfaced for renderer consumption.
+#[derive(Debug, Clone, Serialize)]
+pub struct FailedTest {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+}
+
 /// Unified output envelope for all test command modes.
 ///
 /// This is the single serialization target for the test command. Each sub-workflow
@@ -34,6 +44,8 @@ pub struct TestCommandOutput {
     pub failure: Option<PhaseFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test_counts: Option<TestCounts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_tests: Option<Vec<FailedTest>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coverage: Option<CoverageOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,6 +89,7 @@ pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, 
             phase,
             failure,
             test_counts: result.test_counts,
+            failed_tests: result.failed_tests,
             coverage: result.coverage,
             baseline_comparison: result.baseline_comparison,
             analysis: result.analysis,
@@ -104,6 +117,7 @@ pub fn from_drift_workflow(result: DriftWorkflowResult) -> (TestCommandOutput, i
             phase: None,
             failure: None,
             test_counts: None,
+            failed_tests: None,
             coverage: None,
             baseline_comparison: None,
             analysis: None,
@@ -143,6 +157,7 @@ pub fn from_auto_fix_drift_workflow(
             phase: None,
             failure: None,
             test_counts: None,
+            failed_tests: None,
             coverage: None,
             baseline_comparison: None,
             analysis: None,
@@ -205,5 +220,69 @@ fn test_phase_failure(exit_code: i32, counts: Option<&TestCounts>) -> PhaseFailu
             }
         },
         category,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workflow_result(failed_tests: Option<Vec<FailedTest>>) -> TestRunWorkflowResult {
+        TestRunWorkflowResult {
+            status: "failed".to_string(),
+            component: "homeboy".to_string(),
+            exit_code: 1,
+            test_counts: Some(TestCounts::new(3, 1, 2, 0)),
+            failed_tests,
+            coverage: None,
+            baseline_comparison: None,
+            analysis: None,
+            autofix: None,
+            hints: None,
+            test_scope: None,
+            summary: None,
+            raw_output: None,
+        }
+    }
+
+    #[test]
+    fn serializes_failed_tests_when_present() {
+        let (output, exit_code) = from_main_workflow(workflow_result(Some(vec![FailedTest {
+            name: "tests::fails".to_string(),
+            detail: Some("assertion failed".to_string()),
+            location: Some("tests/fails.rs:42".to_string()),
+        }])));
+
+        let json = serde_json::to_value(output).expect("serialize test command output");
+        assert_eq!(exit_code, 1);
+        assert_eq!(json["failed_tests"][0]["name"], "tests::fails");
+        assert_eq!(json["failed_tests"][0]["detail"], "assertion failed");
+        assert_eq!(json["failed_tests"][0]["location"], "tests/fails.rs:42");
+    }
+
+    #[test]
+    fn omits_failed_tests_when_absent() {
+        let (output, _) = from_main_workflow(workflow_result(None));
+        let json = serde_json::to_value(output).expect("serialize test command output");
+        assert!(
+            json.get("failed_tests").is_none(),
+            "failed_tests should be omitted when unavailable: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn omits_empty_failed_test_optional_fields() {
+        let (output, _) = from_main_workflow(workflow_result(Some(vec![FailedTest {
+            name: "tests::fails".to_string(),
+            detail: None,
+            location: None,
+        }])));
+
+        let json = serde_json::to_value(output).expect("serialize test command output");
+        let failed = &json["failed_tests"][0];
+        assert_eq!(failed["name"], "tests::fails");
+        assert!(failed.get("detail").is_none());
+        assert!(failed.get("location").is_none());
     }
 }

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -6,7 +6,7 @@ use crate::extension::test::baseline::{self, TestBaselineComparison, TestCounts}
 use crate::extension::test::{
     build_test_runner, build_test_summary, compute_changed_test_scope, parse_coverage_file,
     parse_failures_file, parse_test_results_file, parse_test_results_text, CoverageOutput,
-    TestScopeOutput, TestSummaryOutput,
+    FailedTest, TestScopeOutput, TestSummaryOutput,
 };
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
@@ -34,6 +34,7 @@ pub struct TestRunWorkflowResult {
     pub component: String,
     pub exit_code: i32,
     pub test_counts: Option<TestCounts>,
+    pub failed_tests: Option<Vec<FailedTest>>,
     pub coverage: Option<CoverageOutput>,
     pub baseline_comparison: Option<TestBaselineComparison>,
     pub analysis: Option<TestAnalysis>,
@@ -66,6 +67,44 @@ pub struct RawTestOutput {
 
 const RAW_OUTPUT_TAIL_LINES: usize = 80;
 
+fn failed_tests_from_analysis_input(input: &TestAnalysisInput) -> Option<Vec<FailedTest>> {
+    if input.failures.is_empty() {
+        return None;
+    }
+
+    Some(
+        input
+            .failures
+            .iter()
+            .map(|failure| {
+                let detail = if failure.error_type.is_empty() {
+                    failure.message.clone()
+                } else if failure.message.is_empty() {
+                    failure.error_type.clone()
+                } else {
+                    format!("{}: {}", failure.error_type, failure.message)
+                };
+
+                let location = if !failure.source_file.is_empty() {
+                    if failure.source_line > 0 {
+                        format!("{}:{}", failure.source_file, failure.source_line)
+                    } else {
+                        failure.source_file.clone()
+                    }
+                } else {
+                    failure.test_file.clone()
+                };
+
+                FailedTest {
+                    name: failure.test_name.clone(),
+                    detail: (!detail.is_empty()).then_some(detail),
+                    location: (!location.is_empty()).then_some(location),
+                }
+            })
+            .collect(),
+    )
+}
+
 fn tail_lines(s: &str, max_lines: usize) -> (String, bool) {
     let lines: Vec<&str> = s.lines().collect();
     if lines.len() <= max_lines {
@@ -95,11 +134,7 @@ pub fn run_main_test_workflow(
     } else {
         None
     };
-    let failures_file = if args.analyze {
-        Some(run_dir.step_file(run_dir::files::TEST_FAILURES))
-    } else {
-        None
-    };
+    let failures_file = run_dir.step_file(run_dir::files::TEST_FAILURES);
 
     let changed_test_files = changed_scope
         .as_ref()
@@ -123,6 +158,7 @@ pub fn run_main_test_workflow(
                 component: args.component_label,
                 exit_code: 0,
                 test_counts: None,
+                failed_tests: None,
                 coverage: None,
                 baseline_comparison: None,
                 analysis: None,
@@ -174,18 +210,20 @@ pub fn run_main_test_workflow(
         .as_ref()
         .and_then(|file| parse_coverage_file(file).ok());
 
+    let failure_analysis_input = parse_failures_file(&failures_file);
+    let failed_tests = failure_analysis_input
+        .as_ref()
+        .and_then(failed_tests_from_analysis_input);
+
     let analysis = if args.analyze {
-        let analysis_input = failures_file
-            .as_ref()
-            .and_then(|file| parse_failures_file(file))
-            .unwrap_or_else(|| TestAnalysisInput {
-                failures: Vec::new(),
-                total: test_counts.as_ref().map(|counts| counts.total).unwrap_or(0),
-                passed: test_counts
-                    .as_ref()
-                    .map(|counts| counts.passed)
-                    .unwrap_or(0),
-            });
+        let analysis_input = failure_analysis_input.unwrap_or_else(|| TestAnalysisInput {
+            failures: Vec::new(),
+            total: test_counts.as_ref().map(|counts| counts.total).unwrap_or(0),
+            passed: test_counts
+                .as_ref()
+                .map(|counts| counts.passed)
+                .unwrap_or(0),
+        });
 
         Some(analyze(&args.component_id, &analysis_input))
     } else {
@@ -337,6 +375,7 @@ pub fn run_main_test_workflow(
         component: args.component_label,
         exit_code,
         test_counts,
+        failed_tests,
         coverage,
         baseline_comparison,
         analysis,
@@ -351,6 +390,7 @@ pub fn run_main_test_workflow(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::test::TestFailure;
 
     #[test]
     fn tail_lines_returns_full_text_when_under_limit() {
@@ -388,5 +428,30 @@ mod tests {
         let (tail, truncated) = tail_lines(input, 3);
         assert_eq!(tail, input);
         assert!(!truncated);
+    }
+
+    #[test]
+    fn failed_tests_from_analysis_input_preserves_name_detail_and_location() {
+        let input = TestAnalysisInput {
+            failures: vec![TestFailure {
+                test_name: "tests::fails".to_string(),
+                test_file: "tests/fails.rs".to_string(),
+                error_type: "AssertionFailed".to_string(),
+                message: "expected true".to_string(),
+                source_file: "src/lib.rs".to_string(),
+                source_line: 42,
+            }],
+            total: 2,
+            passed: 1,
+        };
+
+        let failed_tests = failed_tests_from_analysis_input(&input).expect("failed tests");
+        assert_eq!(failed_tests.len(), 1);
+        assert_eq!(failed_tests[0].name, "tests::fails");
+        assert_eq!(
+            failed_tests[0].detail.as_deref(),
+            Some("AssertionFailed: expected true")
+        );
+        assert_eq!(failed_tests[0].location.as_deref(), Some("src/lib.rs:42"));
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `failed_tests` to `TestCommandOutput` so review renderers can show structured failing test details when runners provide them.
- Populate `failed_tests` from existing `test-failures.json` data without inventing new runner parsers, while keeping `--analyze` as the gate for clustered analysis.
- Update PR-comment rendering to show the top 10 failed test names/details with an overflow line and preserve aggregate-only fallback when `failed_tests` is absent.

## Tests
- `cargo fmt --check`
- `cargo test failed_tests --release -- --test-threads=1`
- `cargo test --release -- --test-threads=1`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@test-failed-tests-output --json-summary`

## Audit baseline
- Refreshed the audit baseline after the renderer tests pushed `src/commands/review/render.rs` over the `HighItemCount` threshold.
- After rebasing onto latest `origin/main`, final baseline is 761 findings with `No change from baseline` on the required audit command.

Closes #1513

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / `openai/gpt-5.5`)
- **Used for:** Implementing the additive output field, renderer updates, tests, validation, and PR preparation. Chris remains responsible for review and merge.
