### PR TITLE
fix(audit): route heuristic findings to review-only issues

### DIFF
--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -11,9 +11,10 @@ use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::PathBuf;
 
+use homeboy::code_audit::{AuditFinding, FindingConfidence};
 use homeboy::issues::{
-    apply_plan, reconcile, GithubTracker, IssueGroup, ReconcileConfig, ReconcilePlan,
-    ReconcileResult, Tracker,
+    apply_plan, reconcile, GithubTracker, IssueGroup, IssueGroupRouting, ReconcileConfig,
+    ReconcilePlan, ReconcileResult, Tracker,
 };
 
 use super::CmdResult;
@@ -53,7 +54,7 @@ enum IssuesCommand {
         ///   "command": "audit",
         ///   "groups": {
         ///     "unreferenced_export": { "count": 57, "label": "unreferenced export", "body": "..." },
-        ///     "god_file": { "count": 23, "label": "god file", "body": "..." }
+        ///     "god_file": { "count": 23, "label": "god file", "body": "...", "routing": "review_only" }
         ///   }
         /// }
         /// ```
@@ -222,6 +223,7 @@ struct GroupRow {
     count: usize,
     label: String,
     body: String,
+    routing: Option<IssueGroupRouting>,
 }
 
 impl FindingsInput {
@@ -231,6 +233,9 @@ impl FindingsInput {
             .map(|(category, row)| IssueGroup {
                 command: self.command.clone(),
                 component_id: component_id.to_string(),
+                routing: row
+                    .routing
+                    .unwrap_or_else(|| default_routing(&self.command, &category)),
                 category,
                 count: row.count,
                 label: row.label,
@@ -238,6 +243,21 @@ impl FindingsInput {
             })
             .collect()
     }
+}
+
+fn default_routing(command: &str, category: &str) -> IssueGroupRouting {
+    if command != "audit" {
+        return IssueGroupRouting::Actionable;
+    }
+
+    category
+        .parse::<AuditFinding>()
+        .ok()
+        .and_then(|finding| match finding.confidence() {
+            FindingConfidence::Heuristic => Some(IssueGroupRouting::ReviewOnly),
+            FindingConfidence::Structural | FindingConfidence::Graph => None,
+        })
+        .unwrap_or(IssueGroupRouting::Actionable)
 }
 
 fn read_findings(path: &str) -> homeboy::Result<FindingsInput> {
@@ -327,11 +347,41 @@ fn parse_findings_value(value: Value) -> homeboy::Result<FindingsInput> {
                 .and_then(|v| v.as_str())
                 .unwrap_or_default()
                 .to_string();
-            groups.insert(category.clone(), GroupRow { count, label, body });
+            let routing = row_obj
+                .get("routing")
+                .or_else(|| row_obj.get("issue_routing"))
+                .and_then(|v| v.as_str())
+                .map(parse_issue_routing)
+                .transpose()?;
+            groups.insert(
+                category.clone(),
+                GroupRow {
+                    count,
+                    label,
+                    body,
+                    routing,
+                },
+            );
         }
     }
 
     Ok(FindingsInput { command, groups })
+}
+
+fn parse_issue_routing(value: &str) -> homeboy::Result<IssueGroupRouting> {
+    match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+        "actionable" => Ok(IssueGroupRouting::Actionable),
+        "review_only" => Ok(IssueGroupRouting::ReviewOnly),
+        other => Err(homeboy::Error::validation_invalid_argument(
+            "findings.groups.*.routing",
+            &format!(
+                "unknown issue routing '{}'; expected 'actionable' or 'review_only'",
+                other
+            ),
+            None,
+            None,
+        )),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -486,5 +536,72 @@ fn summarize_plan(plan: &ReconcilePlan) -> PlanSummary {
         close: counts.close,
         close_duplicate: counts.close_duplicate,
         skip: counts.skip,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn audit_heuristic_categories_default_to_review_only_routing() {
+        let input = parse_findings_value(json!({
+            "command": "audit",
+            "groups": {
+                "god_file": { "count": 4 },
+                "repeated_field_pattern": { "count": 9 },
+                "compiler_warning": { "count": 1 },
+                "unreferenced_export": { "count": 2 }
+            }
+        }))
+        .expect("parse findings");
+
+        let groups = input.into_groups("homeboy");
+        let routing = groups
+            .iter()
+            .map(|g| (g.category.as_str(), g.routing))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(routing["god_file"], IssueGroupRouting::ReviewOnly);
+        assert_eq!(
+            routing["repeated_field_pattern"],
+            IssueGroupRouting::ReviewOnly
+        );
+        assert_eq!(routing["compiler_warning"], IssueGroupRouting::Actionable);
+        assert_eq!(
+            routing["unreferenced_export"],
+            IssueGroupRouting::Actionable
+        );
+    }
+
+    #[test]
+    fn explicit_routing_overrides_confidence_default() {
+        let input = parse_findings_value(json!({
+            "command": "audit",
+            "groups": {
+                "repeated_field_pattern": {
+                    "count": 9,
+                    "routing": "actionable"
+                },
+                "compiler_warning": {
+                    "count": 1,
+                    "routing": "review_only"
+                }
+            }
+        }))
+        .expect("parse findings");
+
+        let groups = input.into_groups("homeboy");
+        let routing = groups
+            .iter()
+            .map(|g| (g.category.as_str(), g.routing))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            routing["repeated_field_pattern"],
+            IssueGroupRouting::Actionable
+        );
+        assert_eq!(routing["compiler_warning"], IssueGroupRouting::ReviewOnly);
     }
 }

--- a/src/core/code_audit/field_patterns.rs
+++ b/src/core/code_audit/field_patterns.rs
@@ -98,11 +98,12 @@ fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
     // Find field GROUPS that co-occur — fields that appear together in
     // the same structs across multiple locations.
     // Strategy: for each pair of fields, check if they always appear together.
-    let repeated_fields: Vec<&FieldSignature> = field_locations
+    let mut repeated_fields: Vec<&FieldSignature> = field_locations
         .iter()
         .filter(|(_, locs)| locs.len() >= MIN_OCCURRENCES)
         .map(|(field, _)| field)
         .collect();
+    repeated_fields.sort_by(|a, b| a.name.cmp(&b.name).then(a.field_type.cmp(&b.field_type)));
 
     // Group repeated fields by the set of structs they appear in.
     // Fields that appear in the exact same set of structs form a co-occurring group.
@@ -122,7 +123,11 @@ fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
 
     let mut findings = Vec::new();
 
-    for (locations, fields) in &struct_set_to_fields {
+    let mut grouped_entries: Vec<(&Vec<(String, String)>, &Vec<FieldSignature>)> =
+        struct_set_to_fields.iter().collect();
+    grouped_entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (locations, fields) in grouped_entries {
         if fields.len() < MIN_GROUP_SIZE {
             continue;
         }
@@ -130,7 +135,9 @@ fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
             continue;
         }
 
-        let field_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+        let mut sorted_fields = fields.clone();
+        sorted_fields.sort_by(|a, b| a.name.cmp(&b.name).then(a.field_type.cmp(&b.field_type)));
+        let field_names: Vec<&str> = sorted_fields.iter().map(|f| f.name.as_str()).collect();
         let struct_names: Vec<String> = locations
             .iter()
             .map(|(file, name)| format!("{}::{}", file, name))
@@ -595,6 +602,46 @@ class {} {{
         assert!(findings
             .iter()
             .all(|f| f.kind == AuditFinding::RepeatedFieldPattern));
+    }
+
+    #[test]
+    fn repeated_pattern_description_orders_fields_deterministically() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        for name in &["alpha.rs", "beta.rs", "gamma.rs"] {
+            std::fs::write(
+                src.join(name),
+                format!(
+                    "struct {} {{\n    zebra: bool,\n    alpha: bool,\n    middle: bool,\n}}\n",
+                    name.replace(".rs", "").to_uppercase()
+                ),
+            )
+            .unwrap();
+        }
+
+        let findings = detect_repeated_field_patterns(dir.path());
+        assert!(
+            !findings.is_empty(),
+            "Should detect repeated [alpha, middle, zebra] pattern"
+        );
+        assert!(
+            findings.iter().all(|f| f
+                .description
+                .contains("Repeated field group [alpha, middle, zebra]")),
+            "field order in descriptions must be stable and lexical: {:?}",
+            findings
+                .iter()
+                .map(|f| f.description.clone())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.suggestion.contains("[alpha, middle, zebra]")),
+            "field order in suggestions must match descriptions"
+        );
     }
 
     #[test]

--- a/src/core/issues/mod.rs
+++ b/src/core/issues/mod.rs
@@ -41,8 +41,8 @@ pub mod tracker;
 
 pub use apply::{apply_plan, ReconcileExecution, ReconcileResult};
 pub use plan::{
-    IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
-    TrackedIssueState,
+    IssueGroup, IssueGroupRouting, ReconcileAction, ReconcileConfig, ReconcilePlan,
+    ReconcileSkipReason, TrackedIssue, TrackedIssueState,
 };
 pub use reconcile::reconcile;
 pub use tracker::{GithubTracker, Tracker};

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -32,6 +32,24 @@ pub struct IssueGroup {
     /// them in. Empty falls back to a minimal "<count> findings" body.
     #[serde(default)]
     pub body: String,
+    /// Whether this category is eligible for tracker issue filing by default.
+    /// Heuristic audit categories are review-only unless callers explicitly
+    /// opt the group into actionable routing.
+    #[serde(default)]
+    pub routing: IssueGroupRouting,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueGroupRouting {
+    Actionable,
+    ReviewOnly,
+}
+
+impl Default for IssueGroupRouting {
+    fn default() -> Self {
+        Self::Actionable
+    }
 }
 
 /// One issue from the tracker.
@@ -169,6 +187,9 @@ pub enum ReconcileSkipReason {
     ClosedNotPlannedNoRefresh,
     /// No findings AND no existing open issue → nothing to do.
     NoFindingsNoIssue,
+    /// Findings are still visible in reports, but this category defaults to
+    /// review-only routing and should not create or refresh tracker issues.
+    ReviewOnlyDefault,
 }
 
 /// The full reconciliation plan: every action, in execution order.

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -7,8 +7,8 @@
 use std::collections::BTreeMap;
 
 use super::plan::{
-    IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
-    TrackedIssueState,
+    IssueGroup, IssueGroupRouting, ReconcileAction, ReconcileConfig, ReconcilePlan,
+    ReconcileSkipReason, TrackedIssue, TrackedIssueState,
 };
 
 /// Run the 8-row behavior contract over every group.
@@ -105,6 +105,15 @@ pub fn reconcile(
         }
 
         // count > 0 from here.
+        if group.routing == IssueGroupRouting::ReviewOnly {
+            actions.push(ReconcileAction::Skip {
+                category: group.category.clone(),
+                component_id: group.component_id.clone(),
+                reason: ReconcileSkipReason::ReviewOnlyDefault,
+            });
+            continue;
+        }
+
         if !open_matches.is_empty() {
             // Update the lowest-numbered open match.
             let keep = open_matches[0].number;
@@ -285,6 +294,14 @@ mod tests {
             count,
             label: String::new(),
             body: format!("count={}", count),
+            routing: IssueGroupRouting::Actionable,
+        }
+    }
+
+    fn review_only_group(category: &str, count: usize) -> IssueGroup {
+        IssueGroup {
+            routing: IssueGroupRouting::ReviewOnly,
+            ..group(category, count)
         }
     }
 
@@ -500,6 +517,51 @@ mod tests {
         }
     }
 
+    #[test]
+    fn review_only_group_with_findings_skips_issue_actions() {
+        let groups = vec![review_only_group("repeated_field_pattern", 18)];
+        let existing = vec![issue(
+            1622,
+            "repeated field pattern",
+            TrackedIssueState::Open,
+            18,
+        )];
+
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            ReconcileAction::Skip {
+                reason, category, ..
+            } => {
+                assert_eq!(*reason, ReconcileSkipReason::ReviewOnlyDefault);
+                assert_eq!(category, "repeated_field_pattern");
+            }
+            other => panic!("expected review-only Skip, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn review_only_group_with_zero_findings_still_closes_existing_open_issue() {
+        let groups = vec![review_only_group("repeated_field_pattern", 0)];
+        let existing = vec![issue(
+            1622,
+            "repeated field pattern",
+            TrackedIssueState::Open,
+            18,
+        )];
+
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert_eq!(plan.actions.len(), 1);
+        assert!(matches!(
+            &plan.actions[0],
+            ReconcileAction::Close {
+                number: 1622,
+                category,
+                ..
+            } if category == "repeated_field_pattern"
+        ));
+    }
+
     // ----------------------------------------------- precedence ladder
 
     #[test]
@@ -624,6 +686,7 @@ mod tests {
             count: 1,
             label: String::new(),
             body: String::new(),
+            routing: IssueGroupRouting::Actionable,
         }];
         let plan = reconcile(&groups, &[], &cfg());
         match &plan.actions[0] {
@@ -643,6 +706,7 @@ mod tests {
             count: 3,
             label: "i18n / l10n".into(),
             body: String::new(),
+            routing: IssueGroupRouting::Actionable,
         }];
         let plan = reconcile(&groups, &[], &cfg());
         match &plan.actions[0] {


### PR DESCRIPTION
## Summary
- Route heuristic audit categories to review-only issue reconciliation by default so noisy threshold/similarity findings stay visible without auto-filing tracker debt.
- Stabilize `repeated_field_pattern` field ordering so JSON descriptions are deterministic across processes.

## Changes
- Adds `IssueGroupRouting` with `actionable` / `review_only` modes and a `ReviewOnlyDefault` reconcile skip reason.
- Defaults `homeboy issues reconcile` audit groups to `review_only` when the category's `FindingConfidence` is heuristic, while preserving explicit `routing` / `issue_routing` overrides.
- Sorts repeated-field groups before rendering descriptions and suggestions to remove HashMap-order nondeterminism.
- Adds regression coverage for routing defaults, routing overrides, review-only reconcile behavior, and deterministic repeated-field description ordering.

## Tests
- `cargo test core::code_audit::field_patterns`
- `cargo test core::issues::reconcile`
- `cargo test commands::issues`
- `cargo test --lib -- --test-threads=1`

Note: one parallel `cargo test --lib` run had three transient failures (`signature_check_majority_wins`, `signature_check_adds_to_existing_outliers`, `test_run_check`); each passed when rerun individually, and the full library suite passed serially.

## Closes
- Closes #1516
- Closes #1621
- Refs #1478
- Refs #1622
- Refs #1492

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the review-only issue routing slice, deterministic repeated-field ordering, and associated tests. Chris remains responsible for review and merge.