### PR TITLE
fix(rig): harden local service supervision

### DIFF
--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use super::expand::expand_vars;
 use super::pipeline::{cleanup_shared_paths, run_pipeline, PipelineOutcome};
 use super::service::{self, ServiceStatus};
-use super::spec::RigSpec;
+use super::spec::{RigSpec, ServiceKind};
 use super::state::{now_rfc3339, RigState};
 use crate::engine::command::run_in_optional;
 use crate::error::Result;
@@ -55,9 +55,13 @@ pub struct RigStatusReport {
 #[derive(Debug, Clone, Serialize)]
 pub struct ServiceStatusReport {
     pub id: String,
+    pub kind: String,
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    pub log_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub started_at: Option<String>,
 }
@@ -129,7 +133,7 @@ pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
     let state = RigState::load(&rig.id)?;
     let mut services = Vec::with_capacity(rig.services.len());
 
-    for id in rig.services.keys() {
+    for (id, spec) in &rig.services {
         let live = service::status(&rig.id, id)?;
         let (status_str, pid) = match live {
             ServiceStatus::Running(pid) => ("running", Some(pid)),
@@ -137,10 +141,16 @@ pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
             ServiceStatus::Stale(pid) => ("stale", Some(pid)),
         };
         let started_at = state.services.get(id).and_then(|s| s.started_at.clone());
+        let log_path = service::log_path(&rig.id, id)?
+            .to_string_lossy()
+            .into_owned();
         services.push(ServiceStatusReport {
             id: id.clone(),
+            kind: service_kind_label(spec.kind).to_string(),
             status: status_str.to_string(),
             pid,
+            port: spec.port,
+            log_path,
             started_at,
         });
     }
@@ -154,6 +164,14 @@ pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
         last_check: state.last_check,
         last_check_result: state.last_check_result,
     })
+}
+
+fn service_kind_label(kind: ServiceKind) -> &'static str {
+    match kind {
+        ServiceKind::HttpStatic => "http-static",
+        ServiceKind::Command => "command",
+        ServiceKind::External => "external",
+    }
 }
 
 /// Captured component state for one entry in a rig's components map.

--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -53,6 +53,11 @@ pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
     platform::status(rig_id, service_id)
 }
 
+/// Log file path for a supervised service.
+pub fn log_path(rig_id: &str, service_id: &str) -> Result<std::path::PathBuf> {
+    platform::log_file_path(rig_id, service_id)
+}
+
 /// Find the newest process whose command line contains `pattern`.
 ///
 /// Used by `external` services (`stop` discovery) and the `newer_than`
@@ -223,23 +228,20 @@ mod platform {
             return Ok(());
         }
 
-        unsafe {
-            libc::kill(pid as libc::pid_t, libc::SIGTERM);
-        }
+        let managed_process_group = spec.kind != ServiceKind::External;
+        signal(pid, managed_process_group, libc::SIGTERM);
 
         // Grace period up to 5s.
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline {
-            if !pid_alive(pid) {
+            if !target_alive(pid, managed_process_group) {
                 break;
             }
             thread::sleep(Duration::from_millis(100));
         }
 
-        if pid_alive(pid) {
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGKILL);
-            }
+        if target_alive(pid, managed_process_group) {
+            signal(pid, managed_process_group, libc::SIGKILL);
             thread::sleep(Duration::from_millis(200));
         }
 
@@ -318,6 +320,10 @@ mod platform {
         }
     }
 
+    pub(super) fn log_file_path(rig_id: &str, service_id: &str) -> Result<PathBuf> {
+        Ok(paths::rig_logs_dir(rig_id)?.join(format!("{}.log", service_id)))
+    }
+
     fn log_file_for(rig_id: &str, service_id: &str) -> Result<PathBuf> {
         let dir = paths::rig_logs_dir(rig_id)?;
         std::fs::create_dir_all(&dir).map_err(|e| {
@@ -327,7 +333,7 @@ mod platform {
                 e
             ))
         })?;
-        Ok(dir.join(format!("{}.log", service_id)))
+        log_file_path(rig_id, service_id)
     }
 
     fn open_log(path: &PathBuf) -> Result<File> {
@@ -347,6 +353,32 @@ mod platform {
             return false;
         }
         unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+
+    fn process_group_alive(pgid: u32) -> bool {
+        if pgid == 0 {
+            return false;
+        }
+        unsafe { libc::kill(-(pgid as libc::pid_t), 0) == 0 }
+    }
+
+    fn target_alive(pid: u32, process_group: bool) -> bool {
+        if process_group {
+            process_group_alive(pid)
+        } else {
+            pid_alive(pid)
+        }
+    }
+
+    fn signal(pid: u32, process_group: bool, sig: libc::c_int) {
+        let target = if process_group {
+            -(pid as libc::pid_t)
+        } else {
+            pid as libc::pid_t
+        };
+        unsafe {
+            libc::kill(target, sig);
+        }
     }
 
     /// Find processes whose argv contains `pattern`, return the newest by
@@ -471,6 +503,10 @@ mod platform {
     }
 
     pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
+        Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
+    }
+
+    pub fn log_file_path(rig_id: &str, service_id: &str) -> Result<std::path::PathBuf> {
         Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
     }
 

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -23,7 +23,9 @@ use crate::rig::runner::{
     run_check, run_down, run_status, run_up, snapshot_state, CheckReport, RigStatusReport,
     ServiceStatusReport, UpReport,
 };
-use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
+use crate::rig::spec::{
+    ComponentSpec, PipelineStep, RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec,
+};
 
 fn empty_pipeline(name: &str) -> PipelineOutcome {
     PipelineOutcome {
@@ -121,8 +123,11 @@ fn test_status_report_empty_services_serializes() {
 fn test_service_status_report_omits_optional_fields_when_stopped() {
     let report = ServiceStatusReport {
         id: "svc".to_string(),
+        kind: "command".to_string(),
         status: "stopped".to_string(),
         pid: None,
+        port: None,
+        log_path: "/tmp/svc.log".to_string(),
         started_at: None,
     };
     let json = serde_json::to_string(&report).expect("serialize");
@@ -134,12 +139,18 @@ fn test_service_status_report_omits_optional_fields_when_stopped() {
 fn test_service_status_report_emits_pid_when_running() {
     let report = ServiceStatusReport {
         id: "svc".to_string(),
+        kind: "http-static".to_string(),
         status: "running".to_string(),
         pid: Some(4321),
+        port: Some(9724),
+        log_path: "/tmp/svc.log".to_string(),
         started_at: Some("2026-04-24T13:00:00Z".to_string()),
     };
     let json = serde_json::to_string(&report).expect("serialize");
     assert!(json.contains("\"pid\":4321"));
+    assert!(json.contains("\"kind\":\"http-static\""));
+    assert!(json.contains("\"port\":9724"));
+    assert!(json.contains("\"log_path\":\"/tmp/svc.log\""));
     assert!(json.contains("\"started_at\":\"2026-04-24T13:00:00Z\""));
 }
 
@@ -248,6 +259,46 @@ fn test_run_status() {
         );
         assert!(status.last_check.is_none());
         assert!(status.last_check_result.is_none());
+
+        let mut services = HashMap::new();
+        services.insert(
+            "assets".to_string(),
+            ServiceSpec {
+                kind: ServiceKind::HttpStatic,
+                cwd: Some("/tmp".to_string()),
+                port: Some(9724),
+                command: None,
+                env: HashMap::new(),
+                health: None,
+                discover: None,
+            },
+        );
+        let rig = RigSpec {
+            id: "run-status-service-fixture".to_string(),
+            description: "service status".to_string(),
+            components: HashMap::new(),
+            services,
+            symlinks: Vec::new(),
+            shared_paths: Vec::new(),
+            pipeline: HashMap::new(),
+            bench: None,
+            bench_workloads: HashMap::new(),
+        };
+
+        let status = run_status(&rig).expect("run_status with service");
+        assert_eq!(status.services.len(), 1);
+        let service = &status.services[0];
+        assert_eq!(service.id, "assets");
+        assert_eq!(service.kind, "http-static");
+        assert_eq!(service.status, "stopped");
+        assert_eq!(service.port, Some(9724));
+        assert!(
+            service
+                .log_path
+                .ends_with("run-status-service-fixture.state/logs/assets.log"),
+            "unexpected log path: {}",
+            service.log_path
+        );
     });
 }
 

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -6,6 +6,267 @@
 
 use crate::rig::service::ServiceStatus;
 
+#[cfg(unix)]
+mod lifecycle {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    use tempfile::TempDir;
+
+    use crate::rig::service::{self, ServiceStatus};
+    use crate::rig::spec::{DiscoverSpec, RigSpec, ServiceKind, ServiceSpec};
+    use crate::rig::state::{RigState, ServiceState};
+
+    fn home_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
+        let guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var("HOME").ok();
+        let dir = TempDir::new().expect("home tempdir");
+        std::env::set_var("HOME", dir.path());
+        let result = body(&dir);
+        match prior {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        drop(guard);
+        result
+    }
+
+    fn command_rig(id: &str, command: &str, cwd: Option<String>) -> RigSpec {
+        let mut services = HashMap::new();
+        services.insert(
+            "cmd".to_string(),
+            ServiceSpec {
+                kind: ServiceKind::Command,
+                cwd,
+                port: None,
+                command: Some(command.to_string()),
+                env: HashMap::new(),
+                health: None,
+                discover: None,
+            },
+        );
+        RigSpec {
+            id: id.to_string(),
+            description: String::new(),
+            components: HashMap::new(),
+            services,
+            symlinks: Vec::new(),
+            shared_paths: Vec::new(),
+            pipeline: HashMap::new(),
+            bench: None,
+            bench_workloads: HashMap::new(),
+        }
+    }
+
+    fn single_service_rig(id: &str, service: ServiceSpec) -> RigSpec {
+        let mut services = HashMap::new();
+        services.insert("svc".to_string(), service);
+        RigSpec {
+            id: id.to_string(),
+            description: String::new(),
+            components: HashMap::new(),
+            services,
+            symlinks: Vec::new(),
+            shared_paths: Vec::new(),
+            pipeline: HashMap::new(),
+            bench: None,
+            bench_workloads: HashMap::new(),
+        }
+    }
+
+    fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if predicate() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        predicate()
+    }
+
+    #[test]
+    fn test_http_static_service_still_starts_and_stops() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            std::fs::write(tmp.path().join("index.html"), "ok").expect("index");
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+            let port = listener.local_addr().expect("local_addr").port();
+            drop(listener);
+            let rig = single_service_rig(
+                "service-http-static",
+                ServiceSpec {
+                    kind: ServiceKind::HttpStatic,
+                    cwd: Some(tmp.path().to_string_lossy().into_owned()),
+                    port: Some(port),
+                    command: None,
+                    env: HashMap::new(),
+                    health: None,
+                    discover: None,
+                },
+            );
+
+            let pid = service::start(&rig, "svc").expect("start http-static service");
+            assert!(
+                wait_until(Duration::from_secs(5), || std::net::TcpStream::connect((
+                    "127.0.0.1",
+                    port
+                ))
+                .is_ok()),
+                "http-static listener should accept connections"
+            );
+            assert_eq!(
+                service::status(&rig.id, "svc").expect("status"),
+                ServiceStatus::Running(pid)
+            );
+
+            service::stop(&rig, "svc").expect("stop http-static service");
+            assert_eq!(
+                service::status(&rig.id, "svc").expect("status after stop"),
+                ServiceStatus::Stopped
+            );
+        });
+    }
+
+    #[test]
+    fn test_external_services_remain_adoption_only() {
+        with_isolated_home(|_home| {
+            let rig = single_service_rig(
+                "service-external",
+                ServiceSpec {
+                    kind: ServiceKind::External,
+                    cwd: None,
+                    port: None,
+                    command: None,
+                    env: HashMap::new(),
+                    health: None,
+                    discover: Some(DiscoverSpec {
+                        pattern: "homeboy-test-no-such-external-process-XQZ-1463".to_string(),
+                    }),
+                },
+            );
+
+            let err = service::start(&rig, "svc").expect_err("external start rejected");
+            assert!(
+                err.message.contains("adopted, not spawned"),
+                "unexpected error: {}",
+                err.message
+            );
+            service::stop(&rig, "svc").expect("external stop with no match is idempotent");
+            assert_eq!(
+                service::status(&rig.id, "svc").expect("status"),
+                ServiceStatus::Stopped
+            );
+        });
+    }
+
+    #[test]
+    fn test_command_service_start_status_stop_lifecycle() {
+        with_isolated_home(|_home| {
+            let rig = command_rig("service-lifecycle", "sleep 30", None);
+            let pid = service::start(&rig, "cmd").expect("start command service");
+
+            assert_eq!(
+                service::status(&rig.id, "cmd").expect("status"),
+                ServiceStatus::Running(pid)
+            );
+
+            service::stop(&rig, "cmd").expect("stop command service");
+            assert_eq!(
+                service::status(&rig.id, "cmd").expect("status after stop"),
+                ServiceStatus::Stopped
+            );
+        });
+    }
+
+    #[test]
+    fn test_command_service_stop_kills_process_group_children() {
+        with_isolated_home(|_home| {
+            let rig = command_rig("service-process-group", "sleep 30 & wait", None);
+            let pid = service::start(&rig, "cmd").expect("start command service");
+            assert!(
+                wait_until(Duration::from_secs(2), || unsafe {
+                    libc::kill(-(pid as libc::pid_t), 0) == 0
+                }),
+                "process group should exist after start"
+            );
+
+            service::stop(&rig, "cmd").expect("stop command service");
+            assert!(
+                !wait_until(Duration::from_secs(2), || unsafe {
+                    libc::kill(-(pid as libc::pid_t), 0) == 0
+                }),
+                "stop should terminate the whole managed process group, not just the shell"
+            );
+        });
+    }
+
+    #[test]
+    fn test_start_overwrites_stale_pid_state() {
+        with_isolated_home(|_home| {
+            let rig = command_rig("service-stale", "sleep 30", None);
+            let mut state = RigState::default();
+            state.services.insert(
+                "cmd".to_string(),
+                ServiceState {
+                    pid: Some(999_999),
+                    started_at: Some("2026-04-24T00:00:00Z".to_string()),
+                    status: "running".to_string(),
+                },
+            );
+            state.save(&rig.id).expect("save stale state");
+
+            assert_eq!(
+                service::status(&rig.id, "cmd").expect("stale status"),
+                ServiceStatus::Stale(999_999)
+            );
+            let pid = service::start(&rig, "cmd").expect("start replaces stale pid");
+            assert_ne!(pid, 999_999);
+            assert_eq!(
+                service::status(&rig.id, "cmd").expect("fresh status"),
+                ServiceStatus::Running(pid)
+            );
+
+            service::stop(&rig, "cmd").expect("cleanup");
+        });
+    }
+
+    #[test]
+    fn test_command_service_writes_to_supervisor_log() {
+        with_isolated_home(|_home| {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let rig = command_rig(
+                "service-log",
+                "printf supervisor-log-marker; sleep 30",
+                Some(tmp.path().to_string_lossy().into_owned()),
+            );
+            let pid = service::start(&rig, "cmd").expect("start command service");
+            let log_path = service::log_path(&rig.id, "cmd").expect("log path");
+            assert!(
+                wait_until(Duration::from_secs(2), || std::fs::read_to_string(
+                    &log_path
+                )
+                .map(|s| s.contains("supervisor-log-marker"))
+                .unwrap_or(false)),
+                "expected command output in log {}",
+                log_path.display()
+            );
+
+            assert_eq!(
+                service::status(&rig.id, "cmd").expect("status"),
+                ServiceStatus::Running(pid)
+            );
+            service::stop(&rig, "cmd").expect("cleanup");
+        });
+    }
+}
+
 #[test]
 fn test_service_status_variants_distinguish() {
     let running = ServiceStatus::Running(42);


### PR DESCRIPTION
## Summary
- Harden rig-managed service shutdown by signalling the detached process group for managed services, so `command` service children do not survive `rig down` / service stop.
- Enrich `rig status` service entries with service kind, port, and supervisor log path.
- Add lifecycle coverage for command services, process-group shutdown, stale PID replacement, supervisor logs, `http-static`, `external`, and status metadata.

Closes #1463.

## Validation
- `cargo fmt --check`
- `cargo test service_test --release -- --test-threads=1`
- `cargo test runner_test --release -- --test-threads=1`
- `cargo test --release -- --test-threads=1` — 1547 lib + 96 main + 1 integration passed; 1 ignored lib + 5 ignored doctests
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@rig-service-supervisor --json-summary` — reports 6 baseline-drift findings, all pre-existing/unrelated to this change (`src/core/triage.rs` / `src/core/git/github.rs`); no baseline refresh performed

## Notes
- This does not add the originally-sketchy `rig service ...` debug subcommands. The remaining practical supervisor gap was stop/status hardening around the service model that already shipped (`command`, `http-static`, `external`, state, health, wait-ready).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / `openai/gpt-5.5`)
- **Used for:** Implemented the supervisor hardening, tests, validation, and PR description; Chris remains responsible for review and merge.
