### PR TITLE
fix(audit): source false-positive rules from config

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -225,12 +225,12 @@ mod tests {
 
         fs::write(
             root.join("commands/good_one.rs"),
-            "pub fn run() {}\npub fn helper() {}\n",
+            "pub fn run() {}\npub fn execute() {}\n",
         )
         .unwrap();
         fs::write(
             root.join("commands/good_two.rs"),
-            "pub fn run() {}\npub fn helper() {}\n",
+            "pub fn run() {}\npub fn execute() {}\n",
         )
         .unwrap();
         fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -351,9 +351,15 @@ pub fn discover_conventions(
         }
     }
 
+    let declared_traits: Vec<String> = fingerprints
+        .iter()
+        .filter_map(declared_trait_name)
+        .collect();
+
     let expected_interfaces: Vec<String> = interface_counts
         .iter()
         .filter(|(_, count)| **count >= threshold)
+        .filter(|(name, _)| !declared_traits.contains(name))
         .map(|(name, _)| name.clone())
         .collect();
 
@@ -412,10 +418,11 @@ pub fn discover_conventions(
                     .iter()
                     .all(|name| !suffix_matches(name, suffix))
         });
+        let utility_like = helper_like && is_utility_like_file(fp);
 
         let mut deviations = Vec::new();
 
-        if helper_like {
+        if helper_like && !utility_like {
             let suffix = naming_suffix.as_deref().unwrap_or("member");
             deviations.push(Deviation {
                 kind: AuditFinding::NamingMismatch,
@@ -569,6 +576,41 @@ pub fn discover_conventions(
         total_files: total,
         confidence,
     })
+}
+
+fn declared_trait_name(fp: &FileFingerprint) -> Option<String> {
+    let re = regex::Regex::new(r"(?m)^\s*trait\s+([A-Za-z_][A-Za-z0-9_]*)\b").ok()?;
+    re.captures(&fp.content)
+        .and_then(|cap| cap.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+fn is_utility_like_file(fp: &FileFingerprint) -> bool {
+    let suffixes = [
+        "Helper",
+        "Helpers",
+        "Constants",
+        "Categories",
+        "Sanitizer",
+        "Renderer",
+        "Validator",
+        "Verifier",
+        "Resolver",
+        "Factory",
+        "Builder",
+        "Result",
+        "Scheduling",
+    ];
+    let names_to_check: Vec<&str> = if !fp.type_names.is_empty() {
+        fp.type_names.iter().map(|s| s.as_str()).collect()
+    } else {
+        fp.type_name.as_deref().into_iter().collect()
+    };
+
+    declared_trait_name(fp).is_some()
+        || names_to_check
+            .iter()
+            .any(|name| suffixes.iter().any(|suffix| name.ends_with(suffix)))
 }
 
 // ============================================================================
@@ -854,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn helper_like_outlier_collapses_to_naming_mismatch() {
+    fn utility_like_outlier_is_not_promoted_to_naming_mismatch() {
         let fingerprints = vec![
             FileFingerprint {
                 relative_path: "abilities/CreateAbility.php".to_string(),
@@ -882,13 +924,92 @@ mod tests {
         let convention =
             discover_conventions("Abilities", "abilities/*.php", &fingerprints).unwrap();
 
+        assert!(
+            convention.outliers.is_empty(),
+            "recognized helper files are intentional utilities, got: {:?}",
+            convention.outliers
+        );
+    }
+
+    #[test]
+    fn non_utility_helper_like_outlier_still_reports_naming_mismatch() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "abilities/CreateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("CreateAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/UpdateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("UpdateAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/FlowThing.php".to_string(),
+                language: Language::Php,
+                methods: vec!["formatFlow".to_string()],
+                type_name: Some("FlowThing".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let convention =
+            discover_conventions("Abilities", "abilities/*.php", &fingerprints).unwrap();
+
         assert_eq!(convention.outliers.len(), 1);
-        assert!(convention.outliers[0].noisy);
-        assert_eq!(convention.outliers[0].deviations.len(), 1);
         assert!(matches!(
             convention.outliers[0].deviations[0].kind,
             AuditFinding::NamingMismatch
         ));
+    }
+
+    #[test]
+    fn declared_traits_do_not_become_missing_interfaces() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "chat/ListChatSessionsAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string()],
+                type_name: Some("ListChatSessionsAbility".to_string()),
+                implements: vec!["ChatSessionHelpers".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "chat/DeleteChatSessionAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string()],
+                type_name: Some("DeleteChatSessionAbility".to_string()),
+                implements: vec!["ChatSessionHelpers".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "chat/ChatSessionHelpers.php".to_string(),
+                language: Language::Php,
+                methods: vec!["verifySessionOwnership".to_string()],
+                type_name: Some("ChatSessionHelpers".to_string()),
+                content: "<?php\ntrait ChatSessionHelpers {}".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let convention = discover_conventions("Chat", "chat/*.php", &fingerprints).unwrap();
+        assert!(
+            convention.expected_interfaces.is_empty(),
+            "traits should not be treated as interfaces: {:?}",
+            convention.expected_interfaces
+        );
+        assert!(
+            convention
+                .outliers
+                .iter()
+                .flat_map(|o| &o.deviations)
+                .all(|d| d.kind != AuditFinding::MissingInterface),
+            "declared trait should not produce MissingInterface deviations"
+        );
     }
 
     #[test]

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -285,19 +285,6 @@ impl std::str::FromStr for AuditFinding {
 /// The algorithm:
 /// 1. Find methods that appear in ≥ 60% of files (the "convention")
 /// 2. Find files that are missing any of those methods (the "outliers")
-pub fn discover_conventions(
-    group_name: &str,
-    glob_pattern: &str,
-    fingerprints: &[FileFingerprint],
-) -> Option<Convention> {
-    discover_conventions_with_config(
-        group_name,
-        glob_pattern,
-        fingerprints,
-        &AuditConfig::default(),
-    )
-}
-
 pub fn discover_conventions_with_config(
     group_name: &str,
     glob_pattern: &str,
@@ -853,7 +840,20 @@ pub fn check_signature_consistency(conventions: &mut [Convention], root: &Path) 
 mod tests {
     use super::*;
 
-    fn wordpress_like_audit_config() -> AuditConfig {
+    fn discover_conventions(
+        group_name: &str,
+        glob_pattern: &str,
+        fingerprints: &[FileFingerprint],
+    ) -> Option<Convention> {
+        discover_conventions_with_config(
+            group_name,
+            glob_pattern,
+            fingerprints,
+            &AuditConfig::default(),
+        )
+    }
+
+    fn framework_like_audit_config() -> AuditConfig {
         AuditConfig {
             utility_suffixes: vec![
                 "Helper".to_string(),
@@ -958,7 +958,7 @@ mod tests {
             "Abilities",
             "abilities/*.php",
             &fingerprints,
-            &wordpress_like_audit_config(),
+            &framework_like_audit_config(),
         )
         .unwrap();
 
@@ -1038,7 +1038,7 @@ mod tests {
             "Chat",
             "chat/*.php",
             &fingerprints,
-            &wordpress_like_audit_config(),
+            &framework_like_audit_config(),
         )
         .unwrap();
         assert!(
@@ -1057,38 +1057,38 @@ mod tests {
     }
 
     #[test]
-    fn rest_utility_classes_do_not_need_route_registration() {
+    fn utility_classes_do_not_need_dispatch_registration() {
         let fingerprints = vec![
             FileFingerprint {
-                relative_path: "api/PostsController.php".to_string(),
+                relative_path: "endpoints/PostsEndpoint.php".to_string(),
                 language: Language::Php,
-                methods: vec!["register_routes".to_string()],
-                registrations: vec!["rest_api_init".to_string()],
-                type_name: Some("PostsController".to_string()),
+                methods: vec!["register".to_string()],
+                registrations: vec!["runtime_dispatch".to_string()],
+                type_name: Some("PostsEndpoint".to_string()),
                 ..Default::default()
             },
             FileFingerprint {
-                relative_path: "api/PagesController.php".to_string(),
+                relative_path: "endpoints/PagesEndpoint.php".to_string(),
                 language: Language::Php,
-                methods: vec!["register_routes".to_string()],
-                registrations: vec!["rest_api_init".to_string()],
-                type_name: Some("PagesController".to_string()),
+                methods: vec!["register".to_string()],
+                registrations: vec!["runtime_dispatch".to_string()],
+                type_name: Some("PagesEndpoint".to_string()),
                 ..Default::default()
             },
             FileFingerprint {
-                relative_path: "api/WebhookVerifier.php".to_string(),
+                relative_path: "endpoints/SignatureVerifier.php".to_string(),
                 language: Language::Php,
                 methods: vec!["verify".to_string()],
-                type_name: Some("WebhookVerifier".to_string()),
+                type_name: Some("SignatureVerifier".to_string()),
                 ..Default::default()
             },
         ];
 
         let convention = discover_conventions_with_config(
             "Api",
-            "api/*.php",
+            "endpoints/*.php",
             &fingerprints,
-            &wordpress_like_audit_config(),
+            &framework_like_audit_config(),
         )
         .unwrap();
         assert!(
@@ -1098,7 +1098,7 @@ mod tests {
                 .flat_map(|o| &o.deviations)
                 .all(|d| d.kind != AuditFinding::MissingRegistration
                     && d.kind != AuditFinding::MissingMethod),
-            "REST utility classes should not be treated as endpoint registrants"
+            "utility classes should not be treated as runtime endpoint registrants"
         );
     }
 
@@ -1132,7 +1132,7 @@ mod tests {
             "Chat",
             "chat/*.php",
             &fingerprints,
-            &wordpress_like_audit_config(),
+            &framework_like_audit_config(),
         )
         .unwrap();
         assert!(

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -1013,6 +1013,83 @@ mod tests {
     }
 
     #[test]
+    fn rest_utility_classes_do_not_need_route_registration() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "api/PostsController.php".to_string(),
+                language: Language::Php,
+                methods: vec!["register_routes".to_string()],
+                registrations: vec!["rest_api_init".to_string()],
+                type_name: Some("PostsController".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "api/PagesController.php".to_string(),
+                language: Language::Php,
+                methods: vec!["register_routes".to_string()],
+                registrations: vec!["rest_api_init".to_string()],
+                type_name: Some("PagesController".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "api/WebhookVerifier.php".to_string(),
+                language: Language::Php,
+                methods: vec!["verify".to_string()],
+                type_name: Some("WebhookVerifier".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let convention = discover_conventions("Api", "api/*.php", &fingerprints).unwrap();
+        assert!(
+            convention
+                .outliers
+                .iter()
+                .flat_map(|o| &o.deviations)
+                .all(|d| d.kind != AuditFinding::MissingRegistration
+                    && d.kind != AuditFinding::MissingMethod),
+            "REST utility classes should not be treated as endpoint registrants"
+        );
+    }
+
+    #[test]
+    fn factories_do_not_need_methods_of_created_type() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "chat/DatabaseConversationStore.php".to_string(),
+                language: Language::Php,
+                methods: vec!["update_title".to_string(), "delete_session".to_string()],
+                type_name: Some("DatabaseConversationStore".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "chat/MemoryConversationStore.php".to_string(),
+                language: Language::Php,
+                methods: vec!["update_title".to_string(), "delete_session".to_string()],
+                type_name: Some("MemoryConversationStore".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "chat/ConversationStoreFactory.php".to_string(),
+                language: Language::Php,
+                methods: vec!["get".to_string()],
+                type_name: Some("ConversationStoreFactory".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let convention = discover_conventions("Chat", "chat/*.php", &fingerprints).unwrap();
+        assert!(
+            convention
+                .outliers
+                .iter()
+                .flat_map(|o| &o.deviations)
+                .all(|d| d.kind != AuditFinding::MissingMethod),
+            "factories produce stores; they should not implement store methods"
+        );
+    }
+
+    #[test]
     fn no_interface_convention_when_none_shared() {
         let fingerprints = vec![
             FileFingerprint {

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -11,6 +11,7 @@ use super::fingerprint::FileFingerprint;
 use super::import_matching::has_import_with_context;
 use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
+use crate::component::AuditConfig;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -289,6 +290,20 @@ pub fn discover_conventions(
     glob_pattern: &str,
     fingerprints: &[FileFingerprint],
 ) -> Option<Convention> {
+    discover_conventions_with_config(
+        group_name,
+        glob_pattern,
+        fingerprints,
+        &AuditConfig::default(),
+    )
+}
+
+pub fn discover_conventions_with_config(
+    group_name: &str,
+    glob_pattern: &str,
+    fingerprints: &[FileFingerprint],
+    audit_config: &AuditConfig,
+) -> Option<Convention> {
     if fingerprints.len() < 2 {
         return None; // Need at least 2 files to detect a pattern
     }
@@ -418,11 +433,12 @@ pub fn discover_conventions(
                     .iter()
                     .all(|name| !suffix_matches(name, suffix))
         });
-        let utility_like = helper_like && is_utility_like_file(fp);
+        let utility_like = helper_like && is_utility_like_file(fp, audit_config);
+        let convention_exempt = is_convention_exception(fp, audit_config);
 
         let mut deviations = Vec::new();
 
-        if helper_like && !utility_like {
+        if helper_like && !utility_like && !convention_exempt {
             let suffix = naming_suffix.as_deref().unwrap_or("member");
             deviations.push(Deviation {
                 kind: AuditFinding::NamingMismatch,
@@ -442,7 +458,7 @@ pub fn discover_conventions(
 
         // Check missing methods
         for expected in &expected_methods {
-            if helper_like {
+            if helper_like || convention_exempt {
                 continue;
             }
             if !fp.methods.contains(expected) {
@@ -459,7 +475,7 @@ pub fn discover_conventions(
 
         // Check missing registrations
         for expected in &expected_registrations {
-            if helper_like {
+            if helper_like || convention_exempt {
                 continue;
             }
             if !fp.registrations.contains(expected) {
@@ -476,7 +492,7 @@ pub fn discover_conventions(
 
         // Check missing interfaces/traits
         for expected in &expected_interfaces {
-            if helper_like {
+            if helper_like || convention_exempt {
                 continue;
             }
             if !fp.implements.contains(expected) {
@@ -585,22 +601,7 @@ fn declared_trait_name(fp: &FileFingerprint) -> Option<String> {
         .map(|m| m.as_str().to_string())
 }
 
-fn is_utility_like_file(fp: &FileFingerprint) -> bool {
-    let suffixes = [
-        "Helper",
-        "Helpers",
-        "Constants",
-        "Categories",
-        "Sanitizer",
-        "Renderer",
-        "Validator",
-        "Verifier",
-        "Resolver",
-        "Factory",
-        "Builder",
-        "Result",
-        "Scheduling",
-    ];
+fn is_utility_like_file(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
     let names_to_check: Vec<&str> = if !fp.type_names.is_empty() {
         fp.type_names.iter().map(|s| s.as_str()).collect()
     } else {
@@ -608,9 +609,20 @@ fn is_utility_like_file(fp: &FileFingerprint) -> bool {
     };
 
     declared_trait_name(fp).is_some()
-        || names_to_check
-            .iter()
-            .any(|name| suffixes.iter().any(|suffix| name.ends_with(suffix)))
+        || names_to_check.iter().any(|name| {
+            audit_config
+                .utility_suffixes
+                .iter()
+                .any(|suffix| name.ends_with(suffix))
+        })
+}
+
+fn is_convention_exception(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
+    let normalized = fp.relative_path.replace('\\', "/");
+    audit_config
+        .convention_exception_globs
+        .iter()
+        .any(|pattern| glob_match::glob_match(pattern, &normalized))
 }
 
 // ============================================================================
@@ -841,6 +853,27 @@ pub fn check_signature_consistency(conventions: &mut [Convention], root: &Path) 
 mod tests {
     use super::*;
 
+    fn wordpress_like_audit_config() -> AuditConfig {
+        AuditConfig {
+            utility_suffixes: vec![
+                "Helper".to_string(),
+                "Helpers".to_string(),
+                "Constants".to_string(),
+                "Categories".to_string(),
+                "Sanitizer".to_string(),
+                "Renderer".to_string(),
+                "Validator".to_string(),
+                "Verifier".to_string(),
+                "Resolver".to_string(),
+                "Factory".to_string(),
+                "Builder".to_string(),
+                "Result".to_string(),
+                "Scheduling".to_string(),
+            ],
+            ..Default::default()
+        }
+    }
+
     /// Return `true` only when the Rust grammar is discoverable via the
     /// extension registry.
     ///
@@ -921,8 +954,13 @@ mod tests {
             },
         ];
 
-        let convention =
-            discover_conventions("Abilities", "abilities/*.php", &fingerprints).unwrap();
+        let convention = discover_conventions_with_config(
+            "Abilities",
+            "abilities/*.php",
+            &fingerprints,
+            &wordpress_like_audit_config(),
+        )
+        .unwrap();
 
         assert!(
             convention.outliers.is_empty(),
@@ -996,7 +1034,13 @@ mod tests {
             },
         ];
 
-        let convention = discover_conventions("Chat", "chat/*.php", &fingerprints).unwrap();
+        let convention = discover_conventions_with_config(
+            "Chat",
+            "chat/*.php",
+            &fingerprints,
+            &wordpress_like_audit_config(),
+        )
+        .unwrap();
         assert!(
             convention.expected_interfaces.is_empty(),
             "traits should not be treated as interfaces: {:?}",
@@ -1040,7 +1084,13 @@ mod tests {
             },
         ];
 
-        let convention = discover_conventions("Api", "api/*.php", &fingerprints).unwrap();
+        let convention = discover_conventions_with_config(
+            "Api",
+            "api/*.php",
+            &fingerprints,
+            &wordpress_like_audit_config(),
+        )
+        .unwrap();
         assert!(
             convention
                 .outliers
@@ -1078,7 +1128,13 @@ mod tests {
             },
         ];
 
-        let convention = discover_conventions("Chat", "chat/*.php", &fingerprints).unwrap();
+        let convention = discover_conventions_with_config(
+            "Chat",
+            "chat/*.php",
+            &fingerprints,
+            &wordpress_like_audit_config(),
+        )
+        .unwrap();
         assert!(
             convention
                 .outliers

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -53,14 +53,7 @@ fn build_caller_map(
 ///
 /// `reference` fingerprints contribute calls and imports to the cross-reference
 /// set but are NOT checked for dead code themselves. This prevents false positives
-/// when framework source (e.g. WordPress core) is included as a reference dependency.
-pub(crate) fn analyze_dead_code(
-    owned: &[&FileFingerprint],
-    reference: &[&FileFingerprint],
-) -> Vec<Finding> {
-    analyze_dead_code_with_config(owned, reference, &AuditConfig::default())
-}
-
+/// when framework source is included as a reference dependency.
 pub(crate) fn analyze_dead_code_with_config(
     owned: &[&FileFingerprint],
     reference: &[&FileFingerprint],
@@ -141,19 +134,17 @@ pub(crate) fn analyze_dead_code_with_config(
             for export in &fp.public_api {
                 // Skip if this function is registered as a hook/callback target
                 // from within this same file. Such functions ARE referenced —
-                // just by the framework runtime (WordPress hook system, REST
-                // route callbacks, activation hooks, block render callbacks,
-                // etc.) rather than by direct calls from other source files.
-                // (homeboy#1149 — WP plugin bootstrap files)
+                // just by the framework runtime rather than by direct calls
+                // from other source files.
+                // (homeboy#1149 — runtime bootstrap files)
                 if fp.hook_callbacks.contains(export) {
                     continue;
                 }
 
                 // For languages without finer visibility, same-file direct
-                // calls count as references. This catches WP plugin bootstrap
-                // patterns where a top-level helper is called from the main
-                // plugin file (e.g., the top-level WPINC guard that runs
-                // `datamachine_check_requirements()` before continuing).
+                // calls count as references. This catches bootstrap patterns
+                // where a top-level helper is called from the entry file before
+                // continuing.
                 if language_allows_self_reference && fp.internal_calls.contains(export) {
                     continue;
                 }
@@ -449,6 +440,13 @@ mod tests {
             public_api: public_api.into_iter().map(String::from).collect(),
             ..Default::default()
         }
+    }
+
+    fn analyze_dead_code(
+        owned: &[&FileFingerprint],
+        reference: &[&FileFingerprint],
+    ) -> Vec<Finding> {
+        analyze_dead_code_with_config(owned, reference, &AuditConfig::default())
     }
 
     #[test]
@@ -762,7 +760,7 @@ mod tests {
         // Framework has an export that nobody calls — should NOT be flagged
         // because framework fingerprints are reference-only.
         let framework_fp = make_fingerprint(
-            "wp-includes/internal.php",
+            "vendor/framework/internal.php",
             vec!["internal_helper"],
             vec!["internal_helper"],
             vec![],
@@ -779,18 +777,18 @@ mod tests {
 
     #[test]
     fn php_hook_callback_suppresses_unreferenced_export() {
-        // data-machine.php pattern: function is defined and registered as a
-        // WordPress hook callback in the same file. The hook system invokes
-        // it, but no other file has a direct call. This is NOT dead code.
+        // Runtime-callback pattern: function is defined and registered as a
+        // callback in the same file. The dispatcher invokes it, but no other
+        // file has a direct call. This is NOT dead code.
         let mut fp = make_fingerprint(
-            "data-machine.php",
-            vec!["datamachine_activate_plugin"],
-            vec!["datamachine_activate_plugin"],
+            "plugin.php",
+            vec!["activate_plugin"],
+            vec!["activate_plugin"],
             vec![], // no self-calls
             vec![],
         );
         fp.language = Language::Php;
-        fp.hook_callbacks = vec!["datamachine_activate_plugin".to_string()];
+        fp.hook_callbacks = vec!["activate_plugin".to_string()];
 
         let findings = analyze_dead_code(&[&fp], &[]);
         let unreferenced: Vec<&Finding> = findings
@@ -809,16 +807,16 @@ mod tests {
 
     #[test]
     fn php_same_file_internal_call_suppresses_unreferenced_export() {
-        // data-machine.php pattern: top-level bootstrap file calls its own
-        // helper functions directly. PHP has no finer visibility than
-        // "public" for top-level functions, so "make it private" is not
-        // actionable advice — the reference IS the justification for export.
+        // Top-level bootstrap pattern: the file calls its own helper functions
+        // directly. PHP has no finer visibility than "public" for top-level
+        // functions, so "make it private" is not actionable advice — the
+        // reference IS the justification for export.
         let mut fp = make_fingerprint(
-            "data-machine.php",
-            vec!["datamachine_check_requirements"],
-            vec!["datamachine_check_requirements"],
-            // Same-file call (e.g., line-20 WPINC guard)
-            vec!["datamachine_check_requirements"],
+            "plugin.php",
+            vec!["check_runtime_requirements"],
+            vec!["check_runtime_requirements"],
+            // Same-file call from bootstrap guard.
+            vec!["check_runtime_requirements"],
             vec![],
         );
         fp.language = Language::Php;
@@ -866,26 +864,22 @@ mod tests {
     }
 
     #[test]
-    fn configured_runtime_command_methods_are_entry_points() {
+    fn configured_runtime_dispatched_methods_are_entry_points() {
         let mut fp = make_fingerprint(
-            "inc/Cli/Commands/EmailCommand.php",
+            "src/Commands/EmailCommand.php",
             vec!["test_connection"],
             vec!["test_connection"],
             vec![],
             vec![],
         );
         fp.language = Language::Php;
-        fp.extends = Some("BaseCommand".to_string());
+        fp.extends = Some("RuntimeCommand".to_string());
         fp.content = r#"<?php
-class EmailCommand extends BaseCommand {
+class EmailCommand extends RuntimeCommand {
     /**
      * Test the IMAP connection.
      *
-     * ## EXAMPLES
-     *
-     *     wp datamachine email test-connection
-     *
-     * @subcommand test-connection
+     * @runtime-entrypoint test-connection
      */
     public function test_connection( array $args, array $assoc_args ): void {}
 }
@@ -893,8 +887,8 @@ class EmailCommand extends BaseCommand {
         .to_string();
 
         let config = AuditConfig {
-            runtime_entrypoint_extends: vec!["BaseCommand".to_string()],
-            runtime_entrypoint_markers: vec!["@subcommand".to_string(), "## EXAMPLES".to_string()],
+            runtime_entrypoint_extends: vec!["RuntimeCommand".to_string()],
+            runtime_entrypoint_markers: vec!["@runtime-entrypoint".to_string()],
             ..Default::default()
         };
 
@@ -905,7 +899,7 @@ class EmailCommand extends BaseCommand {
             .collect();
         assert!(
             unreferenced.is_empty(),
-            "WP-CLI public subcommands are invoked by runtime dispatch"
+            "configured runtime-dispatched methods are invoked by the runtime"
         );
     }
 }

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -294,6 +294,10 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint) -> bool {
 
     // PHP/WordPress-specific: hook callbacks, lifecycle methods
     if matches!(fp.language, super::conventions::Language::Php) {
+        if is_wp_cli_command_file(fp) {
+            return true;
+        }
+
         let php_entry_points = [
             "__construct",
             "__destruct",
@@ -322,6 +326,15 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint) -> bool {
     }
 
     false
+}
+
+fn is_wp_cli_command_file(fp: &FileFingerprint) -> bool {
+    let extends = fp.extends.as_deref().unwrap_or("");
+    extends.ends_with("WP_CLI_Command")
+        || extends.ends_with("BaseCommand")
+        || fp.content.contains("@subcommand")
+        || fp.content.contains("## OPTIONS")
+        || fp.content.contains("## EXAMPLES")
 }
 
 // ============================================================================
@@ -837,6 +850,44 @@ mod tests {
             unreferenced.len(),
             1,
             "Rust public functions called only from their own file should still be flagged for visibility narrowing"
+        );
+    }
+
+    #[test]
+    fn wp_cli_command_methods_are_runtime_entry_points() {
+        let mut fp = make_fingerprint(
+            "inc/Cli/Commands/EmailCommand.php",
+            vec!["test_connection"],
+            vec!["test_connection"],
+            vec![],
+            vec![],
+        );
+        fp.language = Language::Php;
+        fp.extends = Some("BaseCommand".to_string());
+        fp.content = r#"<?php
+class EmailCommand extends BaseCommand {
+    /**
+     * Test the IMAP connection.
+     *
+     * ## EXAMPLES
+     *
+     *     wp datamachine email test-connection
+     *
+     * @subcommand test-connection
+     */
+    public function test_connection( array $args, array $assoc_args ): void {}
+}
+"#
+        .to_string();
+
+        let findings = analyze_dead_code(&[&fp], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "WP-CLI public subcommands are invoked by runtime dispatch"
         );
     }
 }

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -11,6 +11,7 @@ use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::walker::is_test_path;
+use crate::component::AuditConfig;
 
 /// A cross-file caller record: which files call a function and with how many args.
 struct CallerRecord {
@@ -56,6 +57,14 @@ fn build_caller_map(
 pub(crate) fn analyze_dead_code(
     owned: &[&FileFingerprint],
     reference: &[&FileFingerprint],
+) -> Vec<Finding> {
+    analyze_dead_code_with_config(owned, reference, &AuditConfig::default())
+}
+
+pub(crate) fn analyze_dead_code_with_config(
+    owned: &[&FileFingerprint],
+    reference: &[&FileFingerprint],
+    audit_config: &AuditConfig,
 ) -> Vec<Finding> {
     let mut findings = Vec::new();
 
@@ -173,7 +182,7 @@ pub(crate) fn analyze_dead_code(
                 if !referenced_elsewhere {
                     // Skip common entry points and framework methods that are called
                     // by the runtime, not by other source files.
-                    if is_framework_entry_point(export, fp) {
+                    if is_framework_entry_point(export, fp, audit_config) {
                         continue;
                     }
 
@@ -251,7 +260,7 @@ pub(crate) fn analyze_dead_code(
 ///
 /// These are common patterns across languages where functions are invoked by
 /// convention/framework rather than explicit calls from other source files.
-fn is_framework_entry_point(name: &str, fp: &FileFingerprint) -> bool {
+fn is_framework_entry_point(name: &str, fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
     // Common entry points across all languages
     let universal_entry_points = [
         "main", "new", "default", "from", "try_from", "into", "drop", "clone", "fmt", "display",
@@ -292,9 +301,9 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint) -> bool {
         }
     }
 
-    // PHP/WordPress-specific: hook callbacks, lifecycle methods
+    // PHP/framework-specific: hook callbacks, lifecycle methods
     if matches!(fp.language, super::conventions::Language::Php) {
-        if is_wp_cli_command_file(fp) {
+        if is_runtime_entrypoint_file(fp, audit_config) {
             return true;
         }
 
@@ -328,13 +337,16 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint) -> bool {
     false
 }
 
-fn is_wp_cli_command_file(fp: &FileFingerprint) -> bool {
+fn is_runtime_entrypoint_file(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
     let extends = fp.extends.as_deref().unwrap_or("");
-    extends.ends_with("WP_CLI_Command")
-        || extends.ends_with("BaseCommand")
-        || fp.content.contains("@subcommand")
-        || fp.content.contains("## OPTIONS")
-        || fp.content.contains("## EXAMPLES")
+    audit_config
+        .runtime_entrypoint_extends
+        .iter()
+        .any(|expected| extends.ends_with(expected))
+        || audit_config
+            .runtime_entrypoint_markers
+            .iter()
+            .any(|marker| fp.content.contains(marker))
 }
 
 // ============================================================================
@@ -854,7 +866,7 @@ mod tests {
     }
 
     #[test]
-    fn wp_cli_command_methods_are_runtime_entry_points() {
+    fn configured_runtime_command_methods_are_entry_points() {
         let mut fp = make_fingerprint(
             "inc/Cli/Commands/EmailCommand.php",
             vec!["test_connection"],
@@ -880,7 +892,13 @@ class EmailCommand extends BaseCommand {
 "#
         .to_string();
 
-        let findings = analyze_dead_code(&[&fp], &[]);
+        let config = AuditConfig {
+            runtime_entrypoint_extends: vec!["BaseCommand".to_string()],
+            runtime_entrypoint_markers: vec!["@subcommand".to_string(), "## EXAMPLES".to_string()],
+            ..Default::default()
+        };
+
+        let findings = analyze_dead_code_with_config(&[&fp], &[], &config);
         let unreferenced: Vec<&Finding> = findings
             .iter()
             .filter(|f| f.kind == AuditFinding::UnreferencedExport)

--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -56,6 +56,9 @@ pub(super) fn run(fingerprints: &[&FileFingerprint], root: &Path) -> Vec<Finding
             continue;
         }
         for guard in extract_guards(&fp.content) {
+            if guard_is_contextual(fp, &guard) {
+                continue;
+            }
             if symbol_is_known(&known, &guard) {
                 findings.push(Finding {
                     convention: "dead_guard".to_string(),
@@ -88,6 +91,57 @@ fn symbol_is_known(known: &KnownSymbols, guard: &Guard) -> bool {
         GuardKind::Class => known.has_class(&guard.symbol),
         GuardKind::Constant => known.has_constant(&guard.symbol),
     }
+}
+
+fn guard_is_contextual(fp: &FileFingerprint, guard: &Guard) -> bool {
+    is_lifecycle_or_test_path(&fp.relative_path)
+        || guard_defines_stub(&fp.content, guard)
+        || guard_loads_symbol_provider(&fp.content, guard)
+}
+
+fn is_lifecycle_or_test_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.starts_with("tests/")
+        || normalized.contains("/tests/")
+        || normalized == "uninstall.php"
+        || normalized.ends_with("/uninstall.php")
+        || normalized == "activate.php"
+        || normalized.ends_with("/activate.php")
+        || normalized.starts_with("inc/migrations/")
+        || normalized.contains("/inc/migrations/")
+}
+
+fn guard_defines_stub(content: &str, guard: &Guard) -> bool {
+    if guard.kind != GuardKind::Function {
+        return false;
+    }
+    let pattern = format!(r"(?m)\bfunction\s+{}\s*\(", regex::escape(&guard.symbol));
+    Regex::new(&pattern)
+        .map(|re| re.is_match(content))
+        .unwrap_or(false)
+}
+
+fn guard_loads_symbol_provider(content: &str, guard: &Guard) -> bool {
+    if guard.kind != GuardKind::Class {
+        return false;
+    }
+    let symbol = guard.symbol.to_ascii_lowercase();
+    let content = content.to_ascii_lowercase();
+    content.contains("require")
+        && (content.contains(&symbol)
+            || content.contains(&symbol.replace('_', "-"))
+            || content.contains(&camel_to_kebab(&guard.symbol)))
+}
+
+fn camel_to_kebab(symbol: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in symbol.chars().enumerate() {
+        if ch.is_ascii_uppercase() && idx > 0 {
+            out.push('-');
+        }
+        out.push(ch.to_ascii_lowercase());
+    }
+    out
 }
 
 /// Regex matching any of the three guard calls plus a quoted symbol argument.
@@ -283,6 +337,43 @@ if ( function_exists('as_schedule_single_action') ) {
 
         let findings = run(&[&fp], tmp.path());
         assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_stub_definition_guard_is_not_dead() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.0"), "");
+        let fp = make_fp(
+            "tests/queueable-trait-smoke.php",
+            r#"<?php
+if ( ! function_exists('wp_json_encode') ) {
+    function wp_json_encode( $value ) { return json_encode( $value ); }
+}
+"#,
+        );
+
+        let findings = run(&[&fp], tmp.path());
+        assert!(findings.is_empty(), "stub guards are test scaffolding");
+    }
+
+    #[test]
+    fn lifecycle_paths_are_not_production_dead_guards() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.0"), "");
+        let fp = make_fp(
+            "uninstall.php",
+            r#"<?php
+if ( function_exists('as_unschedule_all_actions') ) {
+    as_unschedule_all_actions('demo');
+}
+"#,
+        );
+
+        let findings = run(&[&fp], tmp.path());
+        assert!(
+            findings.is_empty(),
+            "uninstall context is not normal runtime"
+        );
     }
 
     #[test]

--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -45,10 +45,6 @@ struct Guard {
     line: usize,
 }
 
-pub(super) fn run(fingerprints: &[&FileFingerprint], root: &Path) -> Vec<Finding> {
-    run_with_config(fingerprints, root, &AuditConfig::default())
-}
-
 pub(super) fn run_with_config(
     fingerprints: &[&FileFingerprint],
     root: &Path,
@@ -154,7 +150,7 @@ fn camel_to_kebab(symbol: &str) -> String {
 /// Examples matched:
 /// - `function_exists('foo_bar')`
 /// - `! class_exists( "WP_Ability" )`
-/// - `defined('REST_REQUEST')`
+/// - `defined('RUNTIME_REQUEST')`
 ///
 /// Group 1: guard name. Group 2 or 3: quoted symbol (without quotes).
 fn guards_regex() -> &'static Regex {
@@ -232,21 +228,25 @@ mod tests {
         fs::write(root.join("plugin.php"), content).unwrap();
     }
 
+    fn run(fingerprints: &[&FileFingerprint], root: &Path) -> Vec<Finding> {
+        run_with_config(fingerprints, root, &AuditConfig::default())
+    }
+
     #[test]
     fn extract_guards_finds_all_three_kinds() {
         let content = r#"<?php
-if ( function_exists('wp_timezone') ) {}
-if ( ! class_exists( 'WP_Ability' ) ) {}
-if ( defined("REST_REQUEST") ) {}
+if ( function_exists('runtime_now') ) {}
+if ( ! class_exists( 'RuntimeCapability' ) ) {}
+if ( defined("RUNTIME_REQUEST") ) {}
 "#;
         let guards = extract_guards(content);
         assert_eq!(guards.len(), 3);
         assert_eq!(guards[0].kind, GuardKind::Function);
-        assert_eq!(guards[0].symbol, "wp_timezone");
+        assert_eq!(guards[0].symbol, "runtime_now");
         assert_eq!(guards[1].kind, GuardKind::Class);
-        assert_eq!(guards[1].symbol, "WP_Ability");
+        assert_eq!(guards[1].symbol, "RuntimeCapability");
         assert_eq!(guards[2].kind, GuardKind::Constant);
-        assert_eq!(guards[2].symbol, "REST_REQUEST");
+        assert_eq!(guards[2].symbol, "RUNTIME_REQUEST");
     }
 
     #[test]
@@ -349,14 +349,19 @@ if ( function_exists('as_schedule_single_action') ) {
         let tmp = tempfile::tempdir().unwrap();
         write_plugin_main(tmp.path(), Some("6.0"), "");
         let fp = make_fp(
-            "tests/queueable-trait-smoke.php",
+            "tests/compat-smoke.php",
             r#"<?php
-if ( ! function_exists('wp_json_encode') ) {
-    function wp_json_encode( $value ) { return json_encode( $value ); }
+if ( ! function_exists('runtime_json_encode') ) {
+    function runtime_json_encode( $value ) { return json_encode( $value ); }
 }
 "#,
         );
 
+        let guard = extract_guards(&fp.content).remove(0);
+        assert!(
+            guard_is_contextual(&fp, &guard, &AuditConfig::default()),
+            "stub definition guards are contextual even when the symbol is otherwise available"
+        );
         let findings = run(&[&fp], tmp.path());
         assert!(findings.is_empty(), "stub guards are test scaffolding");
     }
@@ -366,18 +371,23 @@ if ( ! function_exists('wp_json_encode') ) {
         let tmp = tempfile::tempdir().unwrap();
         write_plugin_main(tmp.path(), Some("6.0"), "");
         let fp = make_fp(
-            "uninstall.php",
+            "lifecycle/teardown.php",
             r#"<?php
-if ( function_exists('as_unschedule_all_actions') ) {
-    as_unschedule_all_actions('demo');
+if ( function_exists('runtime_unschedule_all') ) {
+    runtime_unschedule_all('demo');
 }
 "#,
         );
 
         let config = AuditConfig {
-            lifecycle_path_globs: vec!["uninstall.php".to_string()],
+            lifecycle_path_globs: vec!["lifecycle/*.php".to_string()],
             ..Default::default()
         };
+        let guard = extract_guards(&fp.content).remove(0);
+        assert!(
+            guard_is_contextual(&fp, &guard, &config),
+            "configured lifecycle globs mark guards as contextual"
+        );
         let findings = run_with_config(&[&fp], tmp.path(), &config);
         assert!(
             findings.is_empty(),

--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -19,6 +19,7 @@ use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::requirements::{known_available_symbols, KnownSymbols};
+use crate::component::AuditConfig;
 
 /// Kinds of guards we detect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,6 +46,14 @@ struct Guard {
 }
 
 pub(super) fn run(fingerprints: &[&FileFingerprint], root: &Path) -> Vec<Finding> {
+    run_with_config(fingerprints, root, &AuditConfig::default())
+}
+
+pub(super) fn run_with_config(
+    fingerprints: &[&FileFingerprint],
+    root: &Path,
+    audit_config: &AuditConfig,
+) -> Vec<Finding> {
     let known = known_available_symbols(root);
     if known.functions.is_empty() && known.classes.is_empty() && known.constants.is_empty() {
         return Vec::new();
@@ -56,7 +65,7 @@ pub(super) fn run(fingerprints: &[&FileFingerprint], root: &Path) -> Vec<Finding
             continue;
         }
         for guard in extract_guards(&fp.content) {
-            if guard_is_contextual(fp, &guard) {
+            if guard_is_contextual(fp, &guard, audit_config) {
                 continue;
             }
             if symbol_is_known(&known, &guard) {
@@ -93,22 +102,18 @@ fn symbol_is_known(known: &KnownSymbols, guard: &Guard) -> bool {
     }
 }
 
-fn guard_is_contextual(fp: &FileFingerprint, guard: &Guard) -> bool {
-    is_lifecycle_or_test_path(&fp.relative_path)
+fn guard_is_contextual(fp: &FileFingerprint, guard: &Guard, audit_config: &AuditConfig) -> bool {
+    is_lifecycle_or_test_path(&fp.relative_path, audit_config)
         || guard_defines_stub(&fp.content, guard)
         || guard_loads_symbol_provider(&fp.content, guard)
 }
 
-fn is_lifecycle_or_test_path(path: &str) -> bool {
+fn is_lifecycle_or_test_path(path: &str, audit_config: &AuditConfig) -> bool {
     let normalized = path.replace('\\', "/");
-    normalized.starts_with("tests/")
-        || normalized.contains("/tests/")
-        || normalized == "uninstall.php"
-        || normalized.ends_with("/uninstall.php")
-        || normalized == "activate.php"
-        || normalized.ends_with("/activate.php")
-        || normalized.starts_with("inc/migrations/")
-        || normalized.contains("/inc/migrations/")
+    audit_config
+        .lifecycle_path_globs
+        .iter()
+        .any(|pattern| glob_match::glob_match(pattern, &normalized))
 }
 
 fn guard_defines_stub(content: &str, guard: &Guard) -> bool {
@@ -357,7 +362,7 @@ if ( ! function_exists('wp_json_encode') ) {
     }
 
     #[test]
-    fn lifecycle_paths_are_not_production_dead_guards() {
+    fn configured_lifecycle_paths_are_not_production_dead_guards() {
         let tmp = tempfile::tempdir().unwrap();
         write_plugin_main(tmp.path(), Some("6.0"), "");
         let fp = make_fp(
@@ -369,7 +374,11 @@ if ( function_exists('as_unschedule_all_actions') ) {
 "#,
         );
 
-        let findings = run(&[&fp], tmp.path());
+        let config = AuditConfig {
+            lifecycle_path_globs: vec!["uninstall.php".to_string()],
+            ..Default::default()
+        };
+        let findings = run_with_config(&[&fp], tmp.path(), &config);
         assert!(
             findings.is_empty(),
             "uninstall context is not normal runtime"

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -241,11 +241,27 @@ pub fn audit_path_scoped(
 }
 
 fn audit_config_for(component_id: &str, root: &Path) -> AuditConfig {
-    component::load(component_id)
-        .ok()
-        .and_then(|component| component.audit)
-        .or_else(|| component::discover_from_portable(root).and_then(|component| component.audit))
-        .unwrap_or_default()
+    let component =
+        component::discover_from_portable(root).or_else(|| component::load(component_id).ok());
+    let mut audit_config = AuditConfig::default();
+
+    if let Some(component) = &component {
+        if let Some(extensions) = &component.extensions {
+            for extension_id in extensions.keys() {
+                if let Ok(manifest) = crate::extension::load_extension(extension_id) {
+                    if let Some(rules) = manifest.audit_detector_rules() {
+                        audit_config.merge(rules);
+                    }
+                }
+            }
+        }
+
+        if let Some(component_rules) = &component.audit {
+            audit_config.merge(component_rules);
+        }
+    }
+
+    audit_config
 }
 
 /// Internal audit implementation supporting optional file scoping and impact tracing.

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -68,7 +68,7 @@ pub use report::AuditCommandOutput;
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};
 pub use walker::is_test_path;
 
-use crate::{component, is_zero, Result};
+use crate::{component, component::AuditConfig, is_zero, Result};
 
 /// Summary counts for the audit report.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -240,6 +240,14 @@ pub fn audit_path_scoped(
     )
 }
 
+fn audit_config_for(component_id: &str, root: &Path) -> AuditConfig {
+    component::load(component_id)
+        .ok()
+        .and_then(|component| component.audit)
+        .or_else(|| component::discover_from_portable(root).and_then(|component| component.audit))
+        .unwrap_or_default()
+}
+
 /// Internal audit implementation supporting optional file scoping and impact tracing.
 ///
 /// `reference_paths` are external codebases whose fingerprints are included in
@@ -253,6 +261,7 @@ fn audit_internal(
     reference_paths: &[String],
 ) -> Result<CodeAuditResult> {
     let root = Path::new(source_path);
+    let audit_config = audit_config_for(component_id, root);
 
     if let Some(filter) = file_filter {
         log_status!(
@@ -324,7 +333,9 @@ fn audit_internal(
 
     for (name, glob, fingerprints) in &discovery.groups {
         total_files += fingerprints.len();
-        if let Some(convention) = conventions::discover_conventions(name, glob, fingerprints) {
+        if let Some(convention) =
+            conventions::discover_conventions_with_config(name, glob, fingerprints, &audit_config)
+        {
             discovered_conventions.push(convention);
         }
     }
@@ -416,7 +427,8 @@ fn audit_internal(
     // callbacks, or inherited methods are recognized as referenced.
     let ref_fingerprints = fingerprint_reference_paths(reference_paths);
     let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = ref_fingerprints.iter().collect();
-    let dead_code_findings = dead_code::analyze_dead_code(&all_fingerprints, &ref_fp_refs);
+    let dead_code_findings =
+        dead_code::analyze_dead_code_with_config(&all_fingerprints, &ref_fp_refs, &audit_config);
     if !dead_code_findings.is_empty() {
         log_status!(
             "audit",
@@ -569,7 +581,7 @@ fn audit_internal(
     // Phase 4q: Dead guard detection — flag function_exists/class_exists/defined
     // guards on symbols guaranteed to exist given plugin requirements, composer
     // dependencies, and bootstrap requires.
-    let dead_guard_findings = dead_guard::run(&all_fingerprints, root);
+    let dead_guard_findings = dead_guard::run_with_config(&all_fingerprints, root, &audit_config);
     if !dead_guard_findings.is_empty() {
         log_status!(
             "audit",

--- a/src/core/code_audit/upstream_workaround.rs
+++ b/src/core/code_audit/upstream_workaround.rs
@@ -291,6 +291,21 @@ mod tests {
     }
 
     #[test]
+    fn test_bare_see_design_reference_does_not_trigger() {
+        let fp = make_fp(
+            "src/Api/WebhookAuthResolver.php",
+            Language::Php,
+            "<?php\n/**\n * Webhook auth config resolver.\n *\n * Produces a canonical verifier config for an HMAC flow.\n *\n * @see https://github.com/Extra-Chill/data-machine/issues/1179\n */\nclass WebhookAuthResolver {}\n",
+        );
+
+        let findings = run(&[&fp]);
+        assert!(
+            findings.is_empty(),
+            "bare @see references are design provenance, not workarounds"
+        );
+    }
+
+    #[test]
     fn test_hack_comment_with_trac_ticket() {
         let fp = make_fp(
             "vendor-src/HtmlConverter.php",

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AuditConfig {
+    /// Class/base names whose public methods are invoked by a runtime dispatcher.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_entrypoint_extends: Vec<String>,
+    /// Source markers that indicate public methods are runtime-dispatched.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_entrypoint_markers: Vec<String>,
+    /// Paths whose guards run outside normal production runtime assumptions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lifecycle_path_globs: Vec<String>,
+    /// Type suffixes that mark convention outliers as intentional utilities.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub utility_suffixes: Vec<String>,
+    /// Files exempt from convention outlier checks.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub convention_exception_globs: Vec<String>,
+}
+
+impl AuditConfig {
+    pub fn is_empty(&self) -> bool {
+        self.runtime_entrypoint_extends.is_empty()
+            && self.runtime_entrypoint_markers.is_empty()
+            && self.lifecycle_path_globs.is_empty()
+            && self.utility_suffixes.is_empty()
+            && self.convention_exception_globs.is_empty()
+    }
+
+    pub fn merge(&mut self, other: &AuditConfig) {
+        extend_unique(
+            &mut self.runtime_entrypoint_extends,
+            &other.runtime_entrypoint_extends,
+        );
+        extend_unique(
+            &mut self.runtime_entrypoint_markers,
+            &other.runtime_entrypoint_markers,
+        );
+        extend_unique(&mut self.lifecycle_path_globs, &other.lifecycle_path_globs);
+        extend_unique(&mut self.utility_suffixes, &other.utility_suffixes);
+        extend_unique(
+            &mut self.convention_exception_globs,
+            &other.convention_exception_globs,
+        );
+    }
+}
+
+fn extend_unique(target: &mut Vec<String>, source: &[String]) {
+    for value in source {
+        if !target.contains(value) {
+            target.push(value.clone());
+        }
+    }
+}

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
+pub mod audit;
 pub mod inventory;
 pub mod mutations;
 pub mod portable;
@@ -9,6 +10,7 @@ pub mod resolution;
 pub mod scope;
 pub mod versioning;
 
+pub use audit::AuditConfig;
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,
     write_standalone_registration,
@@ -114,25 +116,6 @@ pub struct ScopeConfig {
     pub release: Option<CommandScopeConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fleet: Option<CommandScopeConfig>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct AuditConfig {
-    /// Class/base names whose public methods are invoked by a runtime dispatcher.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub runtime_entrypoint_extends: Vec<String>,
-    /// Source markers that indicate public methods are runtime-dispatched.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub runtime_entrypoint_markers: Vec<String>,
-    /// Paths whose guards run outside normal production runtime assumptions.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub lifecycle_path_globs: Vec<String>,
-    /// Type suffixes that mark convention outliers as intentional utilities.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub utility_suffixes: Vec<String>,
-    /// Files exempt from convention outlier checks.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub convention_exception_globs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -117,6 +117,25 @@ pub struct ScopeConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AuditConfig {
+    /// Class/base names whose public methods are invoked by a runtime dispatcher.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_entrypoint_extends: Vec<String>,
+    /// Source markers that indicate public methods are runtime-dispatched.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_entrypoint_markers: Vec<String>,
+    /// Paths whose guards run outside normal production runtime assumptions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lifecycle_path_globs: Vec<String>,
+    /// Type suffixes that mark convention outliers as intentional utilities.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub utility_suffixes: Vec<String>,
+    /// Files exempt from convention outlier checks.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub convention_exception_globs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(from = "RawComponent", into = "RawComponent")]
 pub struct Component {
     pub id: String,
@@ -143,6 +162,8 @@ pub struct Component {
     pub docs_dir: Option<String>,
     pub docs_dirs: Vec<String>,
     pub scopes: Option<ScopeConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit: Option<AuditConfig>,
     /// Override the CLI path used by extension deploy install steps.
     /// For example, Studio sites need "studio wp" instead of the default "wp".
     pub cli_path: Option<String>,
@@ -203,6 +224,8 @@ struct RawComponent {
     docs_dirs: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     scopes: Option<ScopeConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    audit: Option<AuditConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cli_path: Option<String>,
 }
@@ -250,6 +273,7 @@ impl From<RawComponent> for Component {
             docs_dir: raw.docs_dir,
             docs_dirs: raw.docs_dirs,
             scopes: raw.scopes,
+            audit: raw.audit,
             cli_path: raw.cli_path,
         }
     }
@@ -281,6 +305,7 @@ impl From<Component> for RawComponent {
             docs_dir: c.docs_dir,
             docs_dirs: c.docs_dirs,
             scopes: c.scopes,
+            audit: c.audit,
             cli_path: c.cli_path,
         }
     }
@@ -349,6 +374,7 @@ impl Component {
             docs_dir: None,
             docs_dirs: Vec::new(),
             scopes: None,
+            audit: None,
             cli_path: None,
         }
     }

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -1,3 +1,4 @@
+use crate::component::AuditConfig;
 use crate::config::ConfigEntity;
 use crate::error::{Error, Result};
 use crate::paths;
@@ -100,6 +101,9 @@ pub struct AuditCapability {
     /// Example: WordPress core + plugin dependencies.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_references: Option<String>,
+    /// Detector rules supplied by this extension for its language/framework.
+    #[serde(default, skip_serializing_if = "AuditConfig::is_empty")]
+    pub detector_rules: AuditConfig,
     /// Glob patterns for paths to ignore during docs audit.
     /// Uses `*` for single segment and `**` for multiple segments (e.g., `/wp-json/**`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -381,6 +385,11 @@ impl ExtensionManifest {
     /// declared under the audit capability.
     pub fn test_mapping(&self) -> Option<&TestMappingConfig> {
         self.audit.as_ref().and_then(|a| a.test_mapping.as_ref())
+    }
+
+    /// Convenience accessor for extension-supplied generic audit detector rules.
+    pub fn audit_detector_rules(&self) -> Option<&AuditConfig> {
+        self.audit.as_ref().map(|a| &a.detector_rules)
     }
 
     /// Convenience: autofix verify config, if this extension declares one.

--- a/tests/core/component/audit_test.rs
+++ b/tests/core/component/audit_test.rs
@@ -1,0 +1,50 @@
+use homeboy::component::AuditConfig;
+
+#[test]
+fn is_empty_reports_only_empty_rule_sets() {
+    assert!(AuditConfig::default().is_empty());
+
+    let config = AuditConfig {
+        utility_suffixes: vec!["Verifier".to_string()],
+        ..Default::default()
+    };
+
+    assert!(!config.is_empty());
+}
+
+#[test]
+fn test_merge() {
+    let mut config = AuditConfig {
+        runtime_entrypoint_extends: vec!["RuntimeCommand".to_string()],
+        runtime_entrypoint_markers: vec!["@runtime-entrypoint".to_string()],
+        lifecycle_path_globs: vec!["lifecycle/*.php".to_string()],
+        utility_suffixes: vec!["Verifier".to_string()],
+        convention_exception_globs: vec!["generated/**".to_string()],
+    };
+
+    config.merge(&AuditConfig {
+        runtime_entrypoint_extends: vec!["RuntimeCommand".to_string(), "Job".to_string()],
+        runtime_entrypoint_markers: vec!["@runtime-entrypoint".to_string(), "@queued".to_string()],
+        lifecycle_path_globs: vec!["lifecycle/*.php".to_string(), "bin/*".to_string()],
+        utility_suffixes: vec!["Verifier".to_string(), "Resolver".to_string()],
+        convention_exception_globs: vec!["generated/**".to_string(), "fixtures/**".to_string()],
+    });
+
+    assert_eq!(
+        config.runtime_entrypoint_extends,
+        vec!["RuntimeCommand", "Job"]
+    );
+    assert_eq!(
+        config.runtime_entrypoint_markers,
+        vec!["@runtime-entrypoint", "@queued"]
+    );
+    assert_eq!(
+        config.lifecycle_path_globs,
+        vec!["lifecycle/*.php", "bin/*"]
+    );
+    assert_eq!(config.utility_suffixes, vec!["Verifier", "Resolver"]);
+    assert_eq!(
+        config.convention_exception_globs,
+        vec!["generated/**", "fixtures/**"]
+    );
+}


### PR DESCRIPTION
## Summary

- Keep Homeboy core framework-agnostic while preserving the false-positive reductions from this branch.
- Add generic audit detector rules that can come from extension manifests and component config.
- Remove the WordPress/WP-CLI-shaped regression fixtures from the new tests; the detector tests now use generic runtime-dispatch/lifecycle/utility examples.

## Changes

- Adds `audit.detector_rules` to extension manifests, plus component-level `audit` rules as an additive override.
- Merges extension-provided rules before component-provided rules when running audit, preferring the worktree's portable `homeboy.json` over the registered primary checkout for path-based audits.
- Moves audit detector config into `src/core/component/audit.rs` to keep `component/mod.rs` below the structural threshold.
- Removes new compatibility wrapper functions that were becoming audit/compiler dead-code findings.
- Keeps runtime entrypoint markers, lifecycle path globs, utility suffixes, and convention exceptions as data, not framework knowledge in core detectors.

## Tests

- `cargo test core::code_audit::conventions --lib`
- `cargo test core::code_audit::dead_code --lib`
- `cargo test core::code_audit::dead_guard --lib`
- `cargo test commands::audit::tests::audit_detects_outliers_in_convention_group --bin homeboy`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@audit-false-positive-rules` — fails on unrelated pre-existing `src/core/triage.rs` drift; the branch-introduced audit-config issues from this rework are cleared.

## Closes

- Closes #1544
- Closes #1545
- Closes #1546
- Closes #1547
- Closes #1548
- Closes #1550
- Closes #1552

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored the audit false-positive rules into generic extension/component-provided detector config and updated tests; Chris remains responsible for review and merge.
