### PR TITLE
feat(rig): install shareable rig packages

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -9,8 +9,8 @@ use clap::{Args, Subcommand};
 use homeboy::rig;
 
 use self::output::{
-    RigCheckOutput, RigDownOutput, RigListOutput, RigShowOutput, RigStatusOutput, RigSummary,
-    RigUpOutput,
+    RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledSummary, RigListOutput,
+    RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigUpOutput,
 };
 use super::CmdResult;
 
@@ -49,6 +49,17 @@ enum RigCommand {
         /// Rig ID
         rig_id: String,
     },
+    /// Install rigs from a local package path or git URL
+    Install {
+        /// Git URL or local path containing rig.json or rigs/<id>/rig.json
+        source: String,
+        /// Install a specific rig from a multi-rig package
+        #[arg(long)]
+        id: Option<String>,
+        /// Install every rig in the package
+        #[arg(long)]
+        all: bool,
+    },
 }
 
 pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOutput> {
@@ -59,6 +70,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Check { rig_id } => check(&rig_id),
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Status { rig_id } => status(&rig_id),
+        RigCommand::Install { source, id, all } => install(&source, id.as_deref(), all),
     }
 }
 
@@ -70,6 +82,13 @@ fn list() -> CmdResult<RigCommandOutput> {
             let mut pipelines: Vec<String> = r.pipeline.keys().cloned().collect();
             pipelines.sort();
             RigSummary {
+                source: rig::read_source_metadata(&r.id).map(|source| RigSourceSummary {
+                    source: source.source,
+                    package_path: source.package_path,
+                    rig_path: source.rig_path,
+                    linked: source.linked,
+                    source_revision: source.source_revision,
+                }),
                 id: r.id,
                 description: r.description,
                 component_count: r.components.len(),
@@ -83,6 +102,30 @@ fn list() -> CmdResult<RigCommandOutput> {
         RigCommandOutput::List(RigListOutput {
             command: "rig.list",
             rigs: summaries,
+        }),
+        0,
+    ))
+}
+
+fn install(source: &str, id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
+    let result = rig::install(source, id, all)?;
+    Ok((
+        RigCommandOutput::Install(RigInstallOutput {
+            command: "rig.install",
+            source: result.source,
+            package_path: result.package_path.to_string_lossy().to_string(),
+            linked: result.linked,
+            installed: result
+                .installed
+                .into_iter()
+                .map(|rig| RigInstalledSummary {
+                    id: rig.id,
+                    description: rig.description,
+                    path: rig.path.to_string_lossy().to_string(),
+                    spec_path: rig.spec_path.to_string_lossy().to_string(),
+                    source_revision: rig.source_revision,
+                })
+                .collect(),
         }),
         0,
     ))

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -19,6 +19,7 @@ pub enum RigCommandOutput {
     Check(RigCheckOutput),
     Down(RigDownOutput),
     Status(RigStatusOutput),
+    Install(RigInstallOutput),
 }
 
 #[derive(Serialize)]
@@ -34,6 +35,18 @@ pub struct RigSummary {
     pub component_count: usize,
     pub service_count: usize,
     pub pipelines: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<RigSourceSummary>,
+}
+
+#[derive(Serialize)]
+pub struct RigSourceSummary {
+    pub source: String,
+    pub package_path: String,
+    pub rig_path: String,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -68,4 +81,23 @@ pub struct RigStatusOutput {
     pub command: &'static str,
     #[serde(flatten)]
     pub report: rig::RigStatusReport,
+}
+
+#[derive(Serialize)]
+pub struct RigInstallOutput {
+    pub command: &'static str,
+    pub source: String,
+    pub package_path: String,
+    pub linked: bool,
+    pub installed: Vec<RigInstalledSummary>,
+}
+
+#[derive(Serialize)]
+pub struct RigInstalledSummary {
+    pub id: String,
+    pub description: String,
+    pub path: String,
+    pub spec_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
 }

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -80,6 +80,26 @@ pub fn rig_config(id: &str) -> Result<PathBuf> {
     Ok(rigs()?.join(format!("{}.json", id)))
 }
 
+/// Installed rig package directory (~/.config/homeboy/rig-packages/)
+pub fn rig_packages() -> Result<PathBuf> {
+    Ok(homeboy()?.join("rig-packages"))
+}
+
+/// Cloned rig package path (~/.config/homeboy/rig-packages/{id}/)
+pub fn rig_package(id: &str) -> Result<PathBuf> {
+    Ok(rig_packages()?.join(id))
+}
+
+/// Rig source metadata directory (~/.config/homeboy/rig-sources/)
+pub fn rig_sources() -> Result<PathBuf> {
+    Ok(homeboy()?.join("rig-sources"))
+}
+
+/// Rig source metadata file (~/.config/homeboy/rig-sources/{id}.json)
+pub fn rig_source_metadata(id: &str) -> Result<PathBuf> {
+    Ok(rig_sources()?.join(format!("{}.json", id)))
+}
+
 /// Rig state directory (~/.config/homeboy/rigs/{id}.state/)
 /// Holds service PIDs, logs, and last check results.
 pub fn rig_state_dir(id: &str) -> Result<PathBuf> {

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -1,0 +1,316 @@
+//! Rig package install lifecycle.
+//!
+//! A rig package is a directory or git repository with specs at
+//! `rigs/<id>/rig.json` (or a single rig directory containing `rig.json`).
+//! Installed rigs stay loadable through the existing flat rig config path by
+//! linking `~/.config/homeboy/rigs/<id>.json` to the package spec.
+
+use crate::error::{Error, Result};
+use crate::{extension, git, paths};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoveredRig {
+    pub id: String,
+    pub description: String,
+    pub rig_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigInstallResult {
+    pub source: String,
+    pub package_path: PathBuf,
+    pub linked: bool,
+    pub installed: Vec<InstalledRig>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InstalledRig {
+    pub id: String,
+    pub description: String,
+    pub path: PathBuf,
+    pub spec_path: PathBuf,
+    pub source_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RigSourceMetadata {
+    pub source: String,
+    pub package_path: String,
+    pub rig_path: String,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallResult> {
+    let prepared = prepare_source(source)?;
+    let discovered = discover_rigs(&prepared.package_path)?;
+    let selected = select_rigs(discovered, id, all, source)?;
+
+    fs::create_dir_all(paths::rigs()?)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create rigs dir".into())))?;
+    fs::create_dir_all(paths::rig_sources()?)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create rig sources dir".into())))?;
+
+    let mut installed = Vec::new();
+    for rig in selected {
+        let target = paths::rig_config(&rig.id)?;
+        if target.exists() || fs::symlink_metadata(&target).is_ok() {
+            return Err(Error::validation_invalid_argument(
+                "rig_id",
+                format!("Rig '{}' already exists at {}", rig.id, target.display()),
+                Some(rig.id),
+                None,
+            ));
+        }
+
+        link_or_copy_file(&rig.rig_path, &target)?;
+
+        let metadata = RigSourceMetadata {
+            source: prepared.source.clone(),
+            package_path: prepared.package_path.to_string_lossy().to_string(),
+            rig_path: rig.rig_path.to_string_lossy().to_string(),
+            linked: prepared.linked,
+            source_revision: prepared.source_revision.clone(),
+        };
+        write_source_metadata(&rig.id, &metadata)?;
+
+        installed.push(InstalledRig {
+            id: rig.id,
+            description: rig.description,
+            path: target,
+            spec_path: rig.rig_path,
+            source_revision: prepared.source_revision.clone(),
+        });
+    }
+
+    Ok(RigInstallResult {
+        source: prepared.source,
+        package_path: prepared.package_path,
+        linked: prepared.linked,
+        installed,
+    })
+}
+
+pub fn read_source_metadata(id: &str) -> Option<RigSourceMetadata> {
+    let path = paths::rig_source_metadata(id).ok()?;
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+struct PreparedSource {
+    source: String,
+    package_path: PathBuf,
+    linked: bool,
+    source_revision: Option<String>,
+}
+
+fn prepare_source(source: &str) -> Result<PreparedSource> {
+    if extension::is_git_url(source) {
+        prepare_git_source(source)
+    } else {
+        prepare_local_source(source)
+    }
+}
+
+fn prepare_git_source(source: &str) -> Result<PreparedSource> {
+    let trimmed = source.trim_end_matches('/').trim_end_matches(".git");
+    let parts = trimmed.rsplit(['/', ':']).take(2).collect::<Vec<_>>();
+    let package_id = if parts.len() == 2 {
+        extension::slugify_id(&format!("{}-{}", parts[1], parts[0]))?
+    } else {
+        extension::slugify_id(parts.first().copied().unwrap_or(trimmed))?
+    };
+    let package_path = paths::rig_package(&package_id)?;
+    if package_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!(
+                "Rig package '{}' already exists at {}",
+                package_id,
+                package_path.display()
+            ),
+            Some(source.to_string()),
+            None,
+        ));
+    }
+    fs::create_dir_all(paths::rig_packages()?)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create rig packages dir".into())))?;
+    git::clone_repo(source, &package_path)?;
+    Ok(PreparedSource {
+        source: source.to_string(),
+        package_path,
+        linked: false,
+        source_revision: None,
+    })
+}
+
+fn prepare_local_source(source: &str) -> Result<PreparedSource> {
+    let source_path = Path::new(source);
+    let package_path = if source_path.is_absolute() {
+        source_path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| Error::internal_io(e.to_string(), Some("get current dir".into())))?
+            .join(source_path)
+    };
+    if !package_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("Path does not exist: {}", package_path.display()),
+            Some(source.to_string()),
+            None,
+        ));
+    }
+    Ok(PreparedSource {
+        source: package_path.to_string_lossy().to_string(),
+        package_path,
+        linked: true,
+        source_revision: None,
+    })
+}
+
+pub fn discover_rigs(package_path: &Path) -> Result<Vec<DiscoveredRig>> {
+    let mut rigs = Vec::new();
+
+    let single = package_path.join("rig.json");
+    if single.is_file() {
+        rigs.push(discovered_from_path(&single, package_path.file_name())?);
+    }
+
+    let rigs_dir = package_path.join("rigs");
+    if rigs_dir.is_dir() {
+        for entry in fs::read_dir(&rigs_dir)
+            .map_err(|e| Error::internal_io(e.to_string(), Some("read rigs dir".into())))?
+        {
+            let entry = entry.map_err(|e| {
+                Error::internal_io(e.to_string(), Some("read rig dir entry".into()))
+            })?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let rig_path = path.join("rig.json");
+            if rig_path.is_file() {
+                rigs.push(discovered_from_path(&rig_path, path.file_name())?);
+            }
+        }
+    }
+
+    rigs.sort_by(|a, b| a.id.cmp(&b.id));
+    rigs.dedup_by(|a, b| a.id == b.id);
+
+    if rigs.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!(
+                "No rig specs found at {} (expected rig.json or rigs/<id>/rig.json)",
+                package_path.display()
+            ),
+            Some(package_path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+
+    Ok(rigs)
+}
+
+fn discovered_from_path(
+    path: &Path,
+    fallback_name: Option<&std::ffi::OsStr>,
+) -> Result<DiscoveredRig> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("read rig spec".into())))?;
+    let mut spec: super::RigSpec = serde_json::from_str(&content).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse rig spec {}", path.display())),
+            Some(content.chars().take(200).collect()),
+        )
+    })?;
+    if spec.id.is_empty() {
+        spec.id = fallback_name
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "rig_id",
+                    "Rig spec has no id and no directory name fallback",
+                    None,
+                    None,
+                )
+            })?
+            .to_string();
+    }
+    Ok(DiscoveredRig {
+        id: extension::slugify_id(&spec.id)?,
+        description: spec.description,
+        rig_path: path.to_path_buf(),
+    })
+}
+
+fn select_rigs(
+    rigs: Vec<DiscoveredRig>,
+    id: Option<&str>,
+    all: bool,
+    source: &str,
+) -> Result<Vec<DiscoveredRig>> {
+    if all {
+        return Ok(rigs);
+    }
+    if let Some(id) = id {
+        let id = extension::slugify_id(id)?;
+        let found: Vec<_> = rigs.into_iter().filter(|rig| rig.id == id).collect();
+        if found.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "id",
+                format!("Rig '{}' not found in package", id),
+                Some(id),
+                None,
+            ));
+        }
+        return Ok(found);
+    }
+    if rigs.len() == 1 {
+        return Ok(rigs);
+    }
+    let available = rigs.iter().map(|rig| rig.id.clone()).collect::<Vec<_>>();
+    Err(Error::validation_invalid_argument(
+        "id",
+        format!(
+            "Package contains multiple rigs; pass --id <rig> or --all. Available: {}",
+            available.join(", ")
+        ),
+        Some(source.to_string()),
+        Some(available),
+    ))
+}
+
+fn write_source_metadata(id: &str, metadata: &RigSourceMetadata) -> Result<()> {
+    let path = paths::rig_source_metadata(id)?;
+    let content = serde_json::to_string_pretty(metadata)
+        .map_err(|e| Error::internal_json(e.to_string(), Some("serialize rig source".into())))?;
+    fs::write(&path, format!("{}\n", content))
+        .map_err(|e| Error::internal_io(e.to_string(), Some("write rig source".into())))
+}
+
+fn link_or_copy_file(source: &Path, target: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+            .map_err(|e| Error::internal_io(e.to_string(), Some("create rig symlink".into())))
+    }
+
+    #[cfg(windows)]
+    {
+        fs::copy(source, target)
+            .map(|_| ())
+            .map_err(|e| Error::internal_io(e.to_string(), Some("copy rig spec".into())))
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/rig/install_test.rs"]
+mod install_test;

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -20,12 +20,17 @@
 
 pub mod check;
 pub mod expand;
+pub mod install;
 pub mod pipeline;
 pub mod runner;
 pub mod service;
 pub mod spec;
 pub mod state;
 
+pub use install::{
+    discover_rigs, install, read_source_metadata, DiscoveredRig, RigInstallResult,
+    RigSourceMetadata,
+};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
     run_check, run_down, run_status, run_up, snapshot_state, CheckReport, ComponentSnapshot,

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -1,0 +1,211 @@
+//! Rig install lifecycle tests. Covers `src/core/rig/install.rs`.
+
+use crate::rig::{discover_rigs, install, read_source_metadata};
+use std::fs;
+use std::path::Path;
+
+struct HomeGuard {
+    old_home: Option<String>,
+    _dir: tempfile::TempDir,
+}
+
+impl HomeGuard {
+    fn new() -> Self {
+        let old_home = std::env::var("HOME").ok();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HOME", dir.path());
+        Self {
+            old_home,
+            _dir: dir,
+        }
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        match &self.old_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
+
+fn write_rig(package: &Path, id: &str, body: &str) -> std::path::PathBuf {
+    let rig_dir = package.join("rigs").join(id);
+    fs::create_dir_all(&rig_dir).expect("rig dir");
+    let rig_path = rig_dir.join("rig.json");
+    fs::write(&rig_path, body).expect("rig json");
+    rig_path
+}
+
+fn minimal_rig(id: &str) -> String {
+    format!(
+        r#"{{
+            "id": "{}",
+            "description": "{} rig",
+            "components": {{
+                "app": {{ "path": "${{env.DEV_ROOT}}/{}" }}
+            }},
+            "pipeline": {{
+                "check": [{{ "kind": "check", "label": "app exists", "file": "${{components.app.path}}" }}]
+            }}
+        }}"#,
+        id, id, id
+    )
+}
+
+#[test]
+fn test_discover_rigs_from_convention_paths() {
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_rig(package.path(), "beta", &minimal_rig("beta"));
+
+    let rigs = discover_rigs(package.path()).expect("discover");
+    assert_eq!(rigs.len(), 2);
+    assert_eq!(rigs[0].id, "alpha");
+    assert_eq!(rigs[0].description, "alpha rig");
+    assert_eq!(rigs[1].id, "beta");
+}
+
+#[test]
+fn discover_single_rig_directory_with_rig_json() {
+    let package = tempfile::tempdir().expect("package");
+    fs::write(package.path().join("rig.json"), minimal_rig("solo")).expect("rig json");
+
+    let rigs = discover_rigs(package.path()).expect("discover");
+    assert_eq!(rigs.len(), 1);
+    assert_eq!(rigs[0].id, "solo");
+    assert_eq!(rigs[0].rig_path, package.path().join("rig.json"));
+}
+
+#[test]
+fn test_read_source_metadata_after_local_install() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let source = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    let result = install(package.path().to_str().unwrap(), None, false).expect("install");
+    assert!(result.linked);
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(result.installed[0].id, "alpha");
+
+    let installed = crate::paths::rig_config("alpha").expect("rig path");
+    assert!(installed.exists());
+    #[cfg(unix)]
+    assert_eq!(fs::read_link(&installed).expect("symlink"), source);
+
+    let installed_content = fs::read_to_string(&installed).expect("installed content");
+    assert!(installed_content.contains("${env.DEV_ROOT}/alpha"));
+    assert!(installed_content.contains("${components.app.path}"));
+
+    let metadata = read_source_metadata("alpha").expect("metadata");
+    assert!(metadata.linked);
+    assert_eq!(metadata.rig_path, source.to_string_lossy());
+}
+
+#[test]
+fn install_multi_rig_package_requires_id_or_all() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_rig(package.path(), "beta", &minimal_rig("beta"));
+
+    let err = install(package.path().to_str().unwrap(), None, false).expect_err("error");
+    assert!(err.message.contains("multiple rigs"));
+    assert!(err.message.contains("alpha"));
+    assert!(err.message.contains("beta"));
+}
+
+#[test]
+fn install_multi_rig_package_can_select_id() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_rig(package.path(), "beta", &minimal_rig("beta"));
+
+    let result = install(package.path().to_str().unwrap(), Some("beta"), false).expect("install");
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(result.installed[0].id, "beta");
+    assert!(crate::paths::rig_config("beta").unwrap().exists());
+    assert!(!crate::paths::rig_config("alpha").unwrap().exists());
+}
+
+#[test]
+fn install_multi_rig_package_can_install_all() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_rig(package.path(), "beta", &minimal_rig("beta"));
+
+    let result = install(package.path().to_str().unwrap(), None, true).expect("install");
+    assert_eq!(result.installed.len(), 2);
+    assert!(crate::paths::rig_config("alpha").unwrap().exists());
+    assert!(crate::paths::rig_config("beta").unwrap().exists());
+}
+
+#[test]
+fn install_rejects_existing_rig_collision() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    install(package.path().to_str().unwrap(), None, false).expect("first install");
+    let err = install(package.path().to_str().unwrap(), None, false).expect_err("collision");
+    assert!(err.message.contains("already exists"));
+}
+
+#[test]
+fn git_url_installs_clone_package_and_config_link() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(package.path())
+        .output()
+        .expect("git init");
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(package.path())
+        .output()
+        .expect("git add");
+    std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "init",
+        ])
+        .current_dir(package.path())
+        .output()
+        .expect("git commit");
+
+    let bare = tempfile::tempdir().expect("bare parent");
+    let source_path = bare.path().join("rig-package.git");
+    let clone_bare = std::process::Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            package.path().to_str().unwrap(),
+            source_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("git clone --bare");
+    assert!(clone_bare.status.success());
+
+    let source = source_path.to_string_lossy().to_string();
+    let result = install(&source, None, false).expect("install");
+    assert!(!result.linked);
+    assert_eq!(result.installed.len(), 1);
+    assert!(result
+        .package_path
+        .parent()
+        .unwrap()
+        .ends_with("rig-packages"));
+    assert!(crate::paths::rig_config("alpha").unwrap().exists());
+    assert_eq!(read_source_metadata("alpha").unwrap().source, source);
+}


### PR DESCRIPTION
## Summary

- Adds `homeboy rig install <source>` for shareable rig packages with specs at `rigs/<id>/rig.json`, plus single-rig directories containing `rig.json`.
- Installs local package specs as config links and clones git package sources under `~/.config/homeboy/rig-packages/`, keeping existing `rig list` / `rig load` paths working through `~/.config/homeboy/rigs/<id>.json`.
- Records source metadata under `~/.config/homeboy/rig-sources/` and surfaces it in `homeboy rig list` output.

## Behaviour

- A one-rig package installs directly.
- A multi-rig package requires `--id <rig>` or `--all`.
- Runtime variables such as `${env.DEV_ROOT}` and `${components.app.path}` are preserved in the installed rig spec.
- Existing rig IDs fail fast instead of overwriting user config.

## Follow-ups

- #1632 — source-management commands (`rig sources list/remove`)
- #1633 — installing a specific rig subpath from a package URL
- #1634 — updating installed rig packages

## Tests

- `cargo fmt --check`
- `cargo test install_test --release -- --test-threads=1`
- `cargo test --release -- --test-threads=1`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@rig-install --json-summary`

Audit result: no change from baseline; no baseline refresh needed.

Closes #1467.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the v1 rig install lifecycle, tests, validation, and follow-up issue drafting. Chris remains responsible for review and merge.
