### PR TITLE
feat(rig): add dev app launcher

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -9,8 +9,8 @@ use clap::{Args, Subcommand};
 use homeboy::rig;
 
 use self::output::{
-    RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledSummary, RigListOutput,
-    RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigUpOutput,
+    RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledSummary,
+    RigListOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigUpOutput,
 };
 use super::CmdResult;
 
@@ -60,6 +60,39 @@ enum RigCommand {
         #[arg(long)]
         all: bool,
     },
+    /// Install, update, or remove this rig's desktop app launcher.
+    App {
+        #[command(subcommand)]
+        command: RigAppCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum RigAppCommand {
+    /// Generate and install this rig's configured launcher.
+    Install {
+        /// Rig ID
+        rig_id: String,
+        /// Print generated paths without writing files.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Regenerate this rig's configured launcher.
+    Update {
+        /// Rig ID
+        rig_id: String,
+        /// Print generated paths without writing files.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Remove this rig's configured launcher.
+    Uninstall {
+        /// Rig ID
+        rig_id: String,
+        /// Print generated paths without deleting files.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOutput> {
@@ -71,6 +104,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Status { rig_id } => status(&rig_id),
         RigCommand::Install { source, id, all } => install(&source, id.as_deref(), all),
+        RigCommand::App { command } => app(command),
     }
 }
 
@@ -187,6 +221,50 @@ fn status(rig_id: &str) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::Status(RigStatusOutput {
             command: "rig.status",
+            report,
+        }),
+        0,
+    ))
+}
+
+fn app(command: RigAppCommand) -> CmdResult<RigCommandOutput> {
+    match command {
+        RigAppCommand::Install { rig_id, dry_run } => app_install(&rig_id, dry_run),
+        RigAppCommand::Update { rig_id, dry_run } => app_update(&rig_id, dry_run),
+        RigAppCommand::Uninstall { rig_id, dry_run } => app_uninstall(&rig_id, dry_run),
+    }
+}
+
+fn app_install(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(rig_id)?;
+    let report = rig::app::install(&rig, rig::AppLauncherOptions { dry_run })?;
+    Ok((
+        RigCommandOutput::App(RigAppOutput {
+            command: "rig.app.install",
+            report,
+        }),
+        0,
+    ))
+}
+
+fn app_update(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(rig_id)?;
+    let report = rig::app::update(&rig, rig::AppLauncherOptions { dry_run })?;
+    Ok((
+        RigCommandOutput::App(RigAppOutput {
+            command: "rig.app.update",
+            report,
+        }),
+        0,
+    ))
+}
+
+fn app_uninstall(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(rig_id)?;
+    let report = rig::app::uninstall(&rig, rig::AppLauncherOptions { dry_run })?;
+    Ok((
+        RigCommandOutput::App(RigAppOutput {
+            command: "rig.app.uninstall",
             report,
         }),
         0,

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -20,6 +20,7 @@ pub enum RigCommandOutput {
     Down(RigDownOutput),
     Status(RigStatusOutput),
     Install(RigInstallOutput),
+    App(RigAppOutput),
 }
 
 #[derive(Serialize)]
@@ -100,4 +101,11 @@ pub struct RigInstalledSummary {
     pub spec_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RigAppOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: rig::AppLauncherReport,
 }

--- a/src/core/rig/app.rs
+++ b/src/core/rig/app.rs
@@ -1,0 +1,209 @@
+//! Desktop launcher wrappers for rigs.
+//!
+//! v1 intentionally ships the smallest useful surface: a macOS `.app` bundle
+//! whose executable is a shell script. Native Swift/Platypus launchers and
+//! cross-platform `.desktop` / `.lnk` generators can layer on this contract.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use super::expand::expand_vars;
+use super::spec::{AppLauncherPlatform, AppLauncherPreflight, RigSpec};
+use crate::error::{Error, Result};
+
+mod bundle;
+
+const DEFAULT_MACOS_INSTALL_DIR: &str = "/Applications";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AppLauncherAction {
+    Install,
+    Uninstall,
+    Update,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AppLauncherReport {
+    pub rig_id: String,
+    pub action: AppLauncherAction,
+    pub platform: AppLauncherPlatform,
+    pub launcher_path: String,
+    pub target_app: String,
+    pub dry_run: bool,
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AppLauncherOptions {
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedLauncher {
+    platform: AppLauncherPlatform,
+    display_name: String,
+    bundle_id: String,
+    target_path: String,
+    launcher_path: PathBuf,
+    preflight: Vec<AppLauncherPreflight>,
+}
+
+pub fn install(rig: &RigSpec, options: AppLauncherOptions) -> Result<AppLauncherReport> {
+    install_inner(rig, options, true)
+}
+
+pub fn update(rig: &RigSpec, options: AppLauncherOptions) -> Result<AppLauncherReport> {
+    let mut report = install_inner(rig, options, true)?;
+    report.action = AppLauncherAction::Update;
+    Ok(report)
+}
+
+pub fn uninstall(rig: &RigSpec, options: AppLauncherOptions) -> Result<AppLauncherReport> {
+    uninstall_inner(rig, options, true)
+}
+
+fn uninstall_inner(
+    rig: &RigSpec,
+    options: AppLauncherOptions,
+    enforce_platform: bool,
+) -> Result<AppLauncherReport> {
+    let launcher = resolve_launcher(rig)?;
+    if enforce_platform && !options.dry_run {
+        validate_platform(launcher.platform)?;
+    }
+    let files = bundle::planned_files(&launcher);
+
+    if !options.dry_run && launcher.launcher_path.exists() {
+        fs::remove_dir_all(&launcher.launcher_path).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to remove launcher {}: {}",
+                launcher.launcher_path.display(),
+                e
+            ))
+        })?;
+    }
+
+    Ok(report(
+        rig,
+        AppLauncherAction::Uninstall,
+        &launcher,
+        options.dry_run,
+        files,
+    ))
+}
+
+fn install_inner(
+    rig: &RigSpec,
+    options: AppLauncherOptions,
+    enforce_platform: bool,
+) -> Result<AppLauncherReport> {
+    let launcher = resolve_launcher(rig)?;
+    if enforce_platform && !options.dry_run {
+        validate_platform(launcher.platform)?;
+    }
+    let files = bundle::planned_files(&launcher);
+
+    if !options.dry_run {
+        bundle::write_macos_bundle(rig, &launcher)?;
+    }
+
+    Ok(report(
+        rig,
+        AppLauncherAction::Install,
+        &launcher,
+        options.dry_run,
+        files,
+    ))
+}
+
+fn resolve_launcher(rig: &RigSpec) -> Result<ResolvedLauncher> {
+    let spec = rig.app_launcher.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "app_launcher",
+            format!("Rig '{}' does not declare an app_launcher block", rig.id),
+            Some(rig.id.clone()),
+            Some(vec![
+                "Add app_launcher to the rig spec before running `homeboy rig app install`"
+                    .to_string(),
+            ]),
+        )
+    })?;
+
+    if spec.wrapper_display_name.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "app_launcher.wrapper_display_name",
+            "Wrapper display name cannot be empty",
+            Some(rig.id.clone()),
+            None,
+        ));
+    }
+    if spec.wrapper_bundle_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "app_launcher.wrapper_bundle_id",
+            "Wrapper bundle id cannot be empty",
+            Some(rig.id.clone()),
+            None,
+        ));
+    }
+
+    let install_dir = spec
+        .install_dir
+        .as_deref()
+        .map(|p| expand_vars(rig, p))
+        .unwrap_or_else(|| DEFAULT_MACOS_INSTALL_DIR.to_string());
+    let install_dir = PathBuf::from(install_dir);
+    let display_name = spec.wrapper_display_name.trim().to_string();
+    let launcher_path = install_dir.join(format!("{}.app", display_name));
+
+    Ok(ResolvedLauncher {
+        platform: spec.platform,
+        display_name,
+        bundle_id: spec.wrapper_bundle_id.trim().to_string(),
+        target_path: expand_vars(rig, &spec.target_app),
+        launcher_path,
+        preflight: if spec.preflight.is_empty() {
+            vec![AppLauncherPreflight::RigCheck]
+        } else {
+            spec.preflight.clone()
+        },
+    })
+}
+
+fn validate_platform(platform: AppLauncherPlatform) -> Result<()> {
+    match platform {
+        AppLauncherPlatform::Macos if cfg!(target_os = "macos") => Ok(()),
+        AppLauncherPlatform::Macos => Err(Error::validation_invalid_argument(
+            "app_launcher.platform",
+            "macOS app launchers can only be installed on macOS; use --dry-run to preview generated paths",
+            None,
+            Some(vec![
+                "Linux .desktop and Windows .lnk launchers are deferred from v1".to_string(),
+            ]),
+        )),
+    }
+}
+
+fn report(
+    rig: &RigSpec,
+    action: AppLauncherAction,
+    launcher: &ResolvedLauncher,
+    dry_run: bool,
+    files: Vec<String>,
+) -> AppLauncherReport {
+    AppLauncherReport {
+        rig_id: rig.id.clone(),
+        action,
+        platform: launcher.platform,
+        launcher_path: launcher.launcher_path.display().to_string(),
+        target_app: launcher.target_path.clone(),
+        dry_run,
+        files,
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/rig/app_test.rs"]
+mod app_test;

--- a/src/core/rig/app/bundle.rs
+++ b/src/core/rig/app/bundle.rs
@@ -1,0 +1,173 @@
+//! macOS script-backed launcher bundle generation.
+
+use std::fs;
+use std::path::Path;
+
+use super::ResolvedLauncher;
+use crate::error::{Error, Result};
+use crate::rig::spec::AppLauncherPreflight;
+use crate::rig::RigSpec;
+
+pub(super) fn write_macos_bundle(rig: &RigSpec, launcher: &ResolvedLauncher) -> Result<()> {
+    let contents = launcher.launcher_path.join("Contents");
+    let macos = contents.join("MacOS");
+    fs::create_dir_all(&macos).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to create launcher bundle {}: {}",
+            macos.display(),
+            e
+        ))
+    })?;
+
+    let plist_path = contents.join("Info.plist");
+    fs::write(&plist_path, render_info_plist(launcher)).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to write launcher plist {}: {}",
+            plist_path.display(),
+            e
+        ))
+    })?;
+
+    let script_path = macos.join("launch");
+    fs::write(&script_path, render_launcher_script(rig, launcher)).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to write launcher script {}: {}",
+            script_path.display(),
+            e
+        ))
+    })?;
+    make_executable(&script_path)?;
+    Ok(())
+}
+
+pub(super) fn planned_files(launcher: &ResolvedLauncher) -> Vec<String> {
+    vec![
+        launcher.launcher_path.display().to_string(),
+        launcher
+            .launcher_path
+            .join("Contents/Info.plist")
+            .display()
+            .to_string(),
+        launcher
+            .launcher_path
+            .join("Contents/MacOS/launch")
+            .display()
+            .to_string(),
+    ]
+}
+
+pub(super) fn render_info_plist(launcher: &ResolvedLauncher) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>launch</string>
+  <key>CFBundleIdentifier</key>
+  <string>{}</string>
+  <key>CFBundleName</key>
+  <string>{}</string>
+  <key>CFBundleDisplayName</key>
+  <string>{}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+</dict>
+</plist>
+"#,
+        xml_escape(&launcher.bundle_id),
+        xml_escape(&launcher.display_name),
+        xml_escape(&launcher.display_name)
+    )
+}
+
+pub(super) fn render_launcher_script(rig: &RigSpec, launcher: &ResolvedLauncher) -> String {
+    let mut preflight = String::new();
+    for step in &launcher.preflight {
+        match step {
+            AppLauncherPreflight::RigCheck => push_rig_check_preflight(rig, &mut preflight),
+        }
+    }
+
+    format!(
+        r#"#!/bin/sh
+set -eu
+
+HOMEBOY_BIN="${{HOMEBOY_BIN:-homeboy}}"
+TARGET_APP={}
+
+{}
+"$HOMEBOY_BIN" rig up {}
+
+if [ -d "$TARGET_APP" ]; then
+  exec open -n "$TARGET_APP" --args "$@"
+fi
+
+exec "$TARGET_APP" "$@"
+"#,
+        sh_single_quote(&launcher.target_path),
+        preflight,
+        sh_single_quote(&rig.id)
+    )
+}
+
+fn push_rig_check_preflight(rig: &RigSpec, preflight: &mut String) {
+    let rig_id = sh_single_quote(&rig.id);
+    let terminal_command =
+        applescript_string_literal(&format!("homeboy rig status {}", sh_single_quote(&rig.id)));
+    preflight.push_str(&format!(
+        r#"if ! "$HOMEBOY_BIN" rig check {}; then
+  osascript -e 'display alert "Homeboy rig check failed" message "Run homeboy rig status {} for details."' >/dev/null 2>&1 || true
+  osascript -e 'tell application "Terminal" to do script {}' >/dev/null 2>&1 || true
+  exit 1
+fi
+"#,
+        rig_id, rig.id, terminal_command
+    ));
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)
+        .map_err(|e| {
+            Error::internal_unexpected(format!("Failed to stat {}: {}", path.display(), e))
+        })?
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to chmod launcher script {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn sh_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn applescript_string_literal(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -18,6 +18,7 @@
 //! DAG pipelines, extension-registered service kinds, `.app` wrappers,
 //! bench composition, spec sharing.
 
+pub mod app;
 pub mod check;
 pub mod expand;
 pub mod install;
@@ -27,6 +28,7 @@ pub mod service;
 pub mod spec;
 pub mod state;
 
+pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
 pub use install::{
     discover_rigs, install, read_source_metadata, DiscoveredRig, RigInstallResult,
     RigSourceMetadata,
@@ -38,8 +40,9 @@ pub use runner::{
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use spec::{
-    BenchSpec, CheckSpec, ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep,
-    RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, SymlinkSpec, TimeSource,
+    AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, BenchSpec, CheckSpec,
+    ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep, RigSpec, ServiceKind,
+    ServiceSpec, SharedPathOp, SharedPathSpec, SymlinkSpec, TimeSource,
 };
 pub use state::{RigState, ServiceState};
 

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -56,6 +56,67 @@ pub struct RigSpec {
     /// `${components.<id>.path}` expansion as other rig path fields.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub bench_workloads: HashMap<String, Vec<String>>,
+
+    /// Optional desktop launcher wrapper for this rig.
+    ///
+    /// v1 is macOS-only and generates a script-backed `.app` bundle that runs
+    /// `homeboy rig check` and `homeboy rig up` before opening the target app.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_launcher: Option<AppLauncherSpec>,
+}
+
+/// Desktop launcher settings for a rig.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppLauncherSpec {
+    /// Launcher platform. v1 supports `macos` only.
+    pub platform: AppLauncherPlatform,
+
+    /// Display name for the generated launcher bundle.
+    pub wrapper_display_name: String,
+
+    /// Bundle identifier written to Info.plist.
+    pub wrapper_bundle_id: String,
+
+    /// Target app or executable to launch after rig prep succeeds.
+    /// Supports `~`, `${env.NAME}`, and `${components.<id>.path}` expansion.
+    pub target_app: String,
+
+    /// Directory that receives the generated wrapper. Defaults to
+    /// `/Applications`; tests and non-global installs can point this at a
+    /// writable directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_dir: Option<String>,
+
+    /// Preflight commands to run before `rig up`. Defaults to `rig:check`.
+    #[serde(
+        default = "default_app_preflight",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub preflight: Vec<AppLauncherPreflight>,
+
+    /// Failure behaviour for preflight. v1 implements the dialog + terminal
+    /// script path on macOS.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_preflight_fail: Option<String>,
+}
+
+/// Platform strategy for a generated desktop launcher.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AppLauncherPlatform {
+    Macos,
+}
+
+/// Preflight command run by a generated launcher before `rig up`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AppLauncherPreflight {
+    #[serde(rename = "rig:check")]
+    RigCheck,
+}
+
+fn default_app_preflight() -> Vec<AppLauncherPreflight> {
+    vec![AppLauncherPreflight::RigCheck]
 }
 
 /// Bench composition for a rig. Pins which component(s) `homeboy bench

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -1,0 +1,171 @@
+//! App launcher tests for `src/core/rig/app.rs`.
+
+use std::collections::HashMap;
+use std::fs;
+
+use crate::rig::app::{install_inner, uninstall_inner, AppLauncherAction, AppLauncherOptions};
+use crate::rig::spec::{
+    AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, ComponentSpec, RigSpec,
+};
+
+fn rig_with_launcher(install_dir: &str) -> RigSpec {
+    let mut components = HashMap::new();
+    components.insert(
+        "studio".to_string(),
+        ComponentSpec {
+            path: "/tmp/studio-dev".to_string(),
+            remote_url: None,
+            stack: None,
+            branch: None,
+        },
+    );
+
+    RigSpec {
+        id: "studio-dev".to_string(),
+        description: String::new(),
+        components,
+        services: Default::default(),
+        symlinks: Vec::new(),
+        shared_paths: Vec::new(),
+        pipeline: Default::default(),
+        bench: None,
+        bench_workloads: Default::default(),
+        app_launcher: Some(AppLauncherSpec {
+            platform: AppLauncherPlatform::Macos,
+            wrapper_display_name: "Studio (Dev)".to_string(),
+            wrapper_bundle_id: "com.chubes.studio-dev".to_string(),
+            target_app: "${components.studio.path}/out/Studio.app".to_string(),
+            install_dir: Some(install_dir.to_string()),
+            preflight: vec![AppLauncherPreflight::RigCheck],
+            on_preflight_fail: Some("dialog-and-open-terminal".to_string()),
+        }),
+    }
+}
+
+#[test]
+fn test_app_launcher_spec_parses() {
+    let json = r#"{
+        "id": "studio-dev",
+        "components": { "studio": { "path": "/tmp/studio" } },
+        "app_launcher": {
+            "platform": "macos",
+            "wrapper_display_name": "Studio (Dev)",
+            "wrapper_bundle_id": "com.chubes.studio-dev",
+            "target_app": "${components.studio.path}/out/Studio.app",
+            "install_dir": "/tmp/apps",
+            "preflight": ["rig:check"],
+            "on_preflight_fail": "dialog-and-open-terminal"
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+    let launcher = spec.app_launcher.expect("launcher");
+    assert_eq!(launcher.platform, AppLauncherPlatform::Macos);
+    assert_eq!(launcher.wrapper_display_name, "Studio (Dev)");
+    assert_eq!(launcher.wrapper_bundle_id, "com.chubes.studio-dev");
+    assert_eq!(launcher.preflight, vec![AppLauncherPreflight::RigCheck]);
+}
+
+#[test]
+fn test_resolve_launcher_expands_paths() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    let launcher = super::resolve_launcher(&rig).expect("resolve");
+    assert_eq!(launcher.target_path, "/tmp/studio-dev/out/Studio.app");
+    assert!(launcher.launcher_path.ends_with("Studio (Dev).app"));
+    assert_eq!(launcher.launcher_path.parent().unwrap(), tmp.path());
+}
+
+#[test]
+fn test_generated_wrapper_content_runs_check_up_then_target() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    let launcher = super::resolve_launcher(&rig).expect("resolve");
+    let script = super::bundle::render_launcher_script(&rig, &launcher);
+    assert!(script.starts_with("#!/bin/sh"));
+    assert!(script.contains("HOMEBOY_BIN=\"${HOMEBOY_BIN:-homeboy}\""));
+    assert!(script.contains("rig check 'studio-dev'"));
+    assert!(script.contains("rig up 'studio-dev'"));
+    assert!(script.contains("tell application \"Terminal\" to do script"));
+    assert!(script.contains("TARGET_APP='/tmp/studio-dev/out/Studio.app'"));
+    assert!(script.contains("exec open -n \"$TARGET_APP\" --args \"$@\""));
+}
+
+#[test]
+fn test_install_dry_run_reports_paths_without_writing() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    let report = install_inner(&rig, AppLauncherOptions { dry_run: true }, false).expect("plan");
+    assert!(report.dry_run);
+    assert_eq!(report.action, AppLauncherAction::Install);
+    assert!(report.launcher_path.ends_with("Studio (Dev).app"));
+    assert_eq!(report.files.len(), 3);
+    assert!(!tmp.path().join("Studio (Dev).app").exists());
+}
+
+#[test]
+fn test_install_writes_script_backed_bundle_to_temp_dir() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    let report =
+        install_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("install");
+    let app = tmp.path().join("Studio (Dev).app");
+    let plist = app.join("Contents/Info.plist");
+    let script = app.join("Contents/MacOS/launch");
+
+    assert!(!report.dry_run);
+    assert!(plist.exists(), "Info.plist written");
+    assert!(script.exists(), "launch script written");
+    assert!(fs::read_to_string(plist)
+        .expect("read plist")
+        .contains("com.chubes.studio-dev"));
+    assert!(fs::read_to_string(script)
+        .expect("read script")
+        .contains("homeboy"));
+}
+
+#[test]
+fn test_uninstall_removes_generated_bundle_from_temp_dir() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    install_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("install");
+    let app = tmp.path().join("Studio (Dev).app");
+    assert!(app.exists());
+
+    let report =
+        uninstall_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("uninstall");
+    assert_eq!(report.action, AppLauncherAction::Uninstall);
+    assert!(!app.exists(), "bundle removed");
+}
+
+#[test]
+fn test_update_reports_update_action() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    let report = crate::rig::app::update(&rig, AppLauncherOptions { dry_run: true })
+        .expect("update dry-run");
+    assert_eq!(report.action, AppLauncherAction::Update);
+    assert!(report.dry_run);
+}
+
+#[test]
+fn test_public_install_refuses_unsupported_platforms() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    let result = crate::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
+    if cfg!(target_os = "macos") {
+        assert!(result.is_ok(), "macOS should allow install");
+    } else {
+        let err = result.expect_err("non-macOS refuses install");
+        assert!(err.to_string().contains("macOS app launchers"));
+    }
+}
+
+#[test]
+fn test_public_install_dry_run_is_cross_platform_preview() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_launcher(&tmp.path().to_string_lossy());
+    let report = crate::rig::app::install(&rig, AppLauncherOptions { dry_run: true })
+        .expect("dry-run preview");
+    assert!(report.dry_run);
+    assert!(!tmp.path().join("Studio (Dev).app").exists());
+}

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -18,6 +18,7 @@ fn minimal_rig() -> RigSpec {
         pipeline: Default::default(),
         bench: None,
         bench_workloads: Default::default(),
+        app_launcher: None,
     }
 }
 

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -18,6 +18,7 @@ fn rig_with(id: &str, components: HashMap<String, ComponentSpec>) -> RigSpec {
         pipeline: Default::default(),
         bench: None,
         bench_workloads: Default::default(),
+        app_launcher: None,
     }
 }
 

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -91,6 +91,7 @@ mod dag {
             shared_paths: Vec::new(),
             pipeline,
             bench: None,
+            app_launcher: None,
             bench_workloads: Default::default(),
         }
     }

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -296,6 +296,7 @@ mod patch {
             pipeline,
             bench: None,
             bench_workloads: Default::default(),
+            app_launcher: None,
         }
     }
 
@@ -506,6 +507,7 @@ mod shared_path {
             pipeline,
             bench: None,
             bench_workloads: Default::default(),
+            app_launcher: None,
         }
     }
 

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -286,6 +286,7 @@ fn test_run_status() {
             shared_paths: Vec::new(),
             pipeline: HashMap::new(),
             bench: None,
+            app_launcher: None,
             bench_workloads: HashMap::new(),
         };
 

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -47,6 +47,7 @@ fn minimal_spec(id: &str) -> RigSpec {
         pipeline: HashMap::new(),
         bench: None,
         bench_workloads: HashMap::new(),
+        app_launcher: None,
     }
 }
 
@@ -235,6 +236,7 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             pipeline,
             bench: None,
             bench_workloads: HashMap::new(),
+            app_launcher: None,
         };
 
         let up = crate::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");
@@ -341,6 +343,7 @@ fn test_snapshot_state() {
         pipeline: HashMap::new(),
         bench: None,
         bench_workloads: HashMap::new(),
+        app_launcher: None,
     };
 
     let snapshot = snapshot_state(&rig);

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -60,6 +60,7 @@ mod lifecycle {
             shared_paths: Vec::new(),
             pipeline: HashMap::new(),
             bench: None,
+            app_launcher: None,
             bench_workloads: HashMap::new(),
         }
     }
@@ -76,6 +77,7 @@ mod lifecycle {
             shared_paths: Vec::new(),
             pipeline: HashMap::new(),
             bench: None,
+            app_launcher: None,
             bench_workloads: HashMap::new(),
         }
     }


### PR DESCRIPTION
## Summary
- Adds `homeboy rig app install|update|uninstall <rig-id>` for rig-owned desktop launchers.
- Introduces an optional `app_launcher` rig spec block and a pragmatic macOS `.app` wrapper that runs `rig check`, then `rig up`, then launches the target app.
- Covers parsing, dry-run previews, bundle rendering, install/update/uninstall behaviour, and unsupported-platform refusal with rig app tests.

## Tests
- `cargo fmt --check`
- `cargo test --release core::rig::app -- --test-threads=1`
- `cargo test --release -- --test-threads=1`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@rig-dev-app-launcher --output /tmp/homeboy-audit-full.json --json-summary` — no change from baseline

## Follow-up
- Native/cross-platform launcher polish is tracked in Extra-Chill/homeboy#1635.

Closes #1465.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the launcher code, tests, validation, and PR drafting; Chris remains responsible for review and merge.