### PR TITLE
chore(stack): centralize shared stack helpers

### DIFF
--- a/src/core/expand.rs
+++ b/src/core/expand.rs
@@ -1,0 +1,54 @@
+//! Shared `${...}` token expansion helpers.
+
+/// Expand `${...}` tokens with a caller-provided vocabulary.
+///
+/// Unknown and unterminated tokens stay literal so the eventual path or
+/// command failure still shows the user what token was unresolved.
+pub(crate) fn expand_tokens(input: &str, resolve: impl Fn(&str) -> Option<String>) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '$' && chars.peek() == Some(&'{') {
+            chars.next();
+            let mut token = String::new();
+            let mut closed = false;
+            for inner in chars.by_ref() {
+                if inner == '}' {
+                    closed = true;
+                    break;
+                }
+                token.push(inner);
+            }
+
+            if !closed {
+                out.push_str("${");
+                out.push_str(&token);
+                continue;
+            }
+
+            match resolve(&token) {
+                Some(value) => out.push_str(&value),
+                None => {
+                    out.push_str("${");
+                    out.push_str(&token);
+                    out.push('}');
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+
+    out
+}
+
+/// Expand `${...}` tokens, then apply shell-style `~` expansion.
+pub(crate) fn expand_with_tilde(input: &str, resolve: impl Fn(&str) -> Option<String>) -> String {
+    let substituted = expand_tokens(input, resolve);
+    shellexpand::tilde(&substituted).into_owned()
+}
+
+#[cfg(test)]
+#[path = "../../tests/core/expand_test.rs"]
+mod expand_test;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ pub mod db;
 pub mod deploy;
 pub mod engine;
 pub mod error;
+pub(crate) mod expand;
 pub mod extension;
 pub mod fleet;
 pub mod git;

--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -11,49 +11,11 @@
 //! command-run failure instead of a silent empty string.
 
 use super::spec::RigSpec;
+use crate::expand;
 
 /// Expand variables + tilde in a string.
 pub fn expand_vars(rig: &RigSpec, input: &str) -> String {
-    let substituted = substitute(rig, input);
-    shellexpand::tilde(&substituted).into_owned()
-}
-
-fn substitute(rig: &RigSpec, input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if c == '$' && chars.peek() == Some(&'{') {
-            chars.next(); // consume '{'
-            let mut token = String::new();
-            let mut closed = false;
-            for inner in chars.by_ref() {
-                if inner == '}' {
-                    closed = true;
-                    break;
-                }
-                token.push(inner);
-            }
-            if !closed {
-                // Unterminated — emit literal to avoid data loss.
-                out.push_str("${");
-                out.push_str(&token);
-                continue;
-            }
-            match resolve_token(rig, &token) {
-                Some(value) => out.push_str(&value),
-                None => {
-                    // Unknown token: leave literal for diagnostics.
-                    out.push_str("${");
-                    out.push_str(&token);
-                    out.push('}');
-                }
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
+    expand::expand_with_tilde(input, |token| resolve_token(rig, token))
 }
 
 fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {

--- a/src/core/stack/apply.rs
+++ b/src/core/stack/apply.rs
@@ -24,11 +24,12 @@
 
 use serde::Serialize;
 use std::collections::HashSet;
-use std::process::Command;
 
 use crate::error::{Error, Result};
 
-use super::spec::{expand_path, StackPrEntry, StackSpec};
+use super::git::run_git;
+use super::pr_meta::{fetch_pr_meta, PrHead};
+use super::spec::{resolve_existing_component_path, StackPrEntry, StackSpec};
 
 /// Per-PR outcome from a single `apply` run.
 #[derive(Debug, Clone, Serialize)]
@@ -74,23 +75,7 @@ pub struct ApplyOutput {
 
 /// Apply a stack spec: build `target` from `base + prs`.
 pub fn apply(spec: &StackSpec) -> Result<ApplyOutput> {
-    let path = expand_path(&spec.component_path);
-
-    // 1. Verify the checkout exists.
-    if !std::path::Path::new(&path).exists() {
-        return Err(Error::validation_invalid_argument(
-            "component_path",
-            format!(
-                "Component path '{}' does not exist (stack '{}')",
-                path, spec.id
-            ),
-            None,
-            Some(vec![format!(
-                "Edit ~/.config/homeboy/stacks/{}.json or clone the checkout",
-                spec.id
-            )]),
-        ));
-    }
+    let path = resolve_existing_component_path(spec)?;
 
     // 2. Fetch base — must succeed.
     fetch_remote_branch(&path, &spec.base.remote, &spec.base.branch)?;
@@ -111,7 +96,7 @@ pub fn apply(spec: &StackSpec) -> Result<ApplyOutput> {
     let mut skipped = 0usize;
 
     for pr in &spec.prs {
-        let head = resolve_pr_head(pr)?;
+        let head = fetch_pr_meta(pr)?.require_head(pr)?;
 
         // Ensure we can fetch the head SHA. If it lives in a different
         // repo than the base remote, add a temp remote keyed by the head
@@ -186,18 +171,6 @@ pub fn apply(spec: &StackSpec) -> Result<ApplyOutput> {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// PR head info extracted from `gh pr view`.
-#[derive(Debug, Clone)]
-pub(super) struct PrHead {
-    pub(super) sha: String,
-    /// `<owner>/<name>` of the head repo (may differ from the PR's base repo
-    /// if the PR was opened from a fork).
-    pub(super) head_repo: String,
-    /// `https://github.com/<owner>/<name>.git` — used as fetch URL for any
-    /// temp remote we add.
-    pub(super) clone_url: String,
-}
-
 /// One of three outcomes from a single `git cherry-pick` invocation.
 #[derive(Debug)]
 pub(crate) enum CherryPickResult {
@@ -232,88 +205,6 @@ pub(crate) fn checkout_force(path: &str, branch: &str, start_point: &str) -> Res
         )));
     }
     Ok(())
-}
-
-/// Resolve the head SHA + head-repo coordinates for a PR via `gh pr view`.
-fn resolve_pr_head(pr: &StackPrEntry) -> Result<PrHead> {
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr.number.to_string(),
-            "--repo",
-            &pr.repo,
-            "--json",
-            "headRefOid,headRepository,headRepositoryOwner",
-        ])
-        .output()
-        .map_err(|e| {
-            Error::git_command_failed(format!(
-                "gh pr view {}#{}: {} (is `gh` installed and authenticated?)",
-                pr.repo, pr.number, e
-            ))
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::git_command_failed(format!(
-            "gh pr view {}#{} failed: {}",
-            pr.repo,
-            pr.number,
-            stderr.trim()
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(&stdout).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse `gh pr view {}#{}`", pr.repo, pr.number)),
-            Some(stdout.chars().take(200).collect()),
-        )
-    })?;
-
-    let sha = parsed
-        .get("headRefOid")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            Error::git_command_failed(format!(
-                "gh pr view {}#{} returned no headRefOid",
-                pr.repo, pr.number
-            ))
-        })?
-        .to_string();
-    let head_owner = parsed
-        .get("headRepositoryOwner")
-        .and_then(|v| v.get("login"))
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            Error::git_command_failed(format!(
-                "gh pr view {}#{} returned no headRepositoryOwner.login",
-                pr.repo, pr.number
-            ))
-        })?
-        .to_string();
-    let head_name = parsed
-        .get("headRepository")
-        .and_then(|v| v.get("name"))
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            Error::git_command_failed(format!(
-                "gh pr view {}#{} returned no headRepository.name",
-                pr.repo, pr.number
-            ))
-        })?
-        .to_string();
-
-    let head_repo = format!("{}/{}", head_owner, head_name);
-    let clone_url = format!("https://github.com/{}.git", head_repo);
-
-    Ok(PrHead {
-        sha,
-        head_repo,
-        clone_url,
-    })
 }
 
 /// Make sure a git remote exists pointing at the PR's head repo, and return
@@ -436,14 +327,6 @@ pub(crate) fn cherry_pick(path: &str, sha: &str) -> Result<CherryPickResult> {
     }
 
     Ok(CherryPickResult::Conflict(combined.trim().to_string()))
-}
-
-pub(super) fn run_git(path: &str, args: &[&str]) -> Result<std::process::Output> {
-    Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .map_err(|e| Error::git_command_failed(format!("git {}: {}", args.join(" "), e)))
 }
 
 #[cfg(test)]

--- a/src/core/stack/git.rs
+++ b/src/core/stack/git.rs
@@ -1,0 +1,34 @@
+//! Shared git command helpers for stack verbs.
+
+use std::process::Command;
+
+use crate::error::{Error, Result};
+
+pub(crate) fn run_git(path: &str, args: &[&str]) -> Result<std::process::Output> {
+    Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .map_err(|e| Error::git_command_failed(format!("git {}: {}", args.join(" "), e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn test_run_git() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git init");
+
+        let out = run_git(dir.path().to_str().unwrap(), &["status", "--porcelain=v1"])
+            .expect("run git status");
+        assert!(out.status.success());
+        assert!(out.stdout.is_empty());
+    }
+}

--- a/src/core/stack/mod.rs
+++ b/src/core/stack/mod.rs
@@ -27,7 +27,9 @@
 //! - Conflict resolution cache
 
 pub mod apply;
+pub(crate) mod git;
 pub mod inspect;
+pub(crate) mod pr_meta;
 pub mod spec;
 pub mod status;
 pub mod sync;

--- a/src/core/stack/pr_meta.rs
+++ b/src/core/stack/pr_meta.rs
@@ -1,0 +1,276 @@
+//! Shared GitHub PR metadata lookup for stack verbs.
+
+use std::process::Command;
+
+use crate::error::{Error, Result};
+
+use super::spec::StackPrEntry;
+
+/// PR head info extracted from `gh pr view`.
+#[derive(Debug, Clone)]
+pub(crate) struct PrHead {
+    pub(crate) sha: String,
+    /// `<owner>/<name>` of the head repo (may differ from the PR's base repo
+    /// if the PR was opened from a fork).
+    pub(crate) head_repo: String,
+    /// `https://github.com/<owner>/<name>.git` — used as fetch URL for any
+    /// temp remote we add.
+    pub(crate) clone_url: String,
+}
+
+/// Superset of `gh pr view` fields used by stack apply/status/sync.
+#[derive(Debug, Clone)]
+pub(crate) struct StackPrMeta {
+    pub(crate) head_sha: String,
+    pub(crate) head_owner: Option<String>,
+    pub(crate) head_name: Option<String>,
+    pub(crate) state: String,
+    pub(crate) title: Option<String>,
+    pub(crate) url: Option<String>,
+    pub(crate) review_decision: Option<String>,
+    pub(crate) merged_at: Option<String>,
+}
+
+impl StackPrMeta {
+    /// Convert to the fetchable PR-head contract used by apply/sync.
+    pub(crate) fn require_head(&self, pr: &StackPrEntry) -> Result<PrHead> {
+        if self.head_sha.is_empty() {
+            return Err(Error::git_command_failed(format!(
+                "gh pr view {}#{} returned no headRefOid",
+                pr.repo, pr.number
+            )));
+        }
+        let head_owner = self.head_owner.as_deref().ok_or_else(|| {
+            Error::git_command_failed(format!(
+                "gh pr view {}#{} returned no headRepositoryOwner.login",
+                pr.repo, pr.number
+            ))
+        })?;
+        let head_name = self.head_name.as_deref().ok_or_else(|| {
+            Error::git_command_failed(format!(
+                "gh pr view {}#{} returned no headRepository.name",
+                pr.repo, pr.number
+            ))
+        })?;
+        let head_repo = format!("{}/{}", head_owner, head_name);
+        Ok(PrHead {
+            sha: self.head_sha.clone(),
+            clone_url: format!("https://github.com/{}.git", head_repo),
+            head_repo,
+        })
+    }
+
+    pub(crate) fn title_for_status(&self) -> String {
+        self.title.clone().unwrap_or_default()
+    }
+
+    pub(crate) fn url_for_status(&self) -> String {
+        self.url.clone().unwrap_or_default()
+    }
+}
+
+/// Resolve PR metadata via `gh pr view`.
+pub(crate) fn fetch_pr_meta(pr: &StackPrEntry) -> Result<StackPrMeta> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr.number.to_string(),
+            "--repo",
+            &pr.repo,
+            "--json",
+            "headRefOid,headRepository,headRepositoryOwner,state,title,url,reviewDecision,mergedAt",
+        ])
+        .output()
+        .map_err(|e| {
+            Error::git_command_failed(format!(
+                "gh pr view {}#{}: {} (is `gh` installed and authenticated?)",
+                pr.repo, pr.number, e
+            ))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "gh pr view {}#{} failed: {}",
+            pr.repo,
+            pr.number,
+            stderr.trim()
+        )));
+    }
+
+    parse_pr_meta(pr, &String::from_utf8_lossy(&output.stdout))
+}
+
+pub(crate) fn parse_pr_meta(pr: &StackPrEntry, stdout: &str) -> Result<StackPrMeta> {
+    let parsed: serde_json::Value = serde_json::from_str(stdout).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse `gh pr view {}#{}`", pr.repo, pr.number)),
+            Some(stdout.chars().take(200).collect()),
+        )
+    })?;
+
+    Ok(StackPrMeta {
+        head_sha: string_field(&parsed, "headRefOid").unwrap_or_default(),
+        head_owner: nested_string_field(&parsed, "headRepositoryOwner", "login"),
+        head_name: nested_string_field(&parsed, "headRepository", "name"),
+        state: string_field(&parsed, "state").unwrap_or_default(),
+        title: string_field(&parsed, "title"),
+        url: string_field(&parsed, "url"),
+        review_decision: non_empty_string_field(&parsed, "reviewDecision"),
+        merged_at: non_empty_string_field(&parsed, "mergedAt"),
+    })
+}
+
+fn string_field(parsed: &serde_json::Value, key: &str) -> Option<String> {
+    parsed.get(key).and_then(|v| v.as_str()).map(str::to_string)
+}
+
+fn non_empty_string_field(parsed: &serde_json::Value, key: &str) -> Option<String> {
+    string_field(parsed, key).filter(|s| !s.is_empty())
+}
+
+fn nested_string_field(parsed: &serde_json::Value, key: &str, child: &str) -> Option<String> {
+    parsed
+        .get(key)
+        .and_then(|v| v.get(child))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ErrorCode;
+    use std::fs;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn pr() -> StackPrEntry {
+        StackPrEntry {
+            repo: "Extra-Chill/homeboy".to_string(),
+            number: 1653,
+            note: None,
+        }
+    }
+
+    fn full_json() -> &'static str {
+        r#"{
+            "headRefOid": "abc123",
+            "headRepositoryOwner": { "login": "Extra-Chill" },
+            "headRepository": { "name": "homeboy" },
+            "state": "MERGED",
+            "title": "Clean stack internals",
+            "url": "https://github.com/Extra-Chill/homeboy/pull/1",
+            "reviewDecision": "APPROVED",
+            "mergedAt": "2026-04-26T00:00:00Z"
+        }"#
+    }
+
+    #[test]
+    fn test_fetch_pr_meta() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let gh = dir.path().join("gh");
+        fs::write(
+            &gh,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", full_json()),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&gh, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.path().display(), old_path));
+
+        let meta = fetch_pr_meta(&pr()).expect("fetch fake gh metadata");
+
+        std::env::set_var("PATH", old_path);
+
+        assert_eq!(meta.head_sha, "abc123");
+        assert_eq!(meta.title.as_deref(), Some("Clean stack internals"));
+    }
+
+    #[test]
+    fn test_parse_pr_meta() {
+        let meta = parse_pr_meta(&pr(), full_json()).expect("parse metadata");
+
+        assert_eq!(meta.head_sha, "abc123");
+        assert_eq!(meta.state, "MERGED");
+        assert_eq!(meta.review_decision.as_deref(), Some("APPROVED"));
+        assert_eq!(meta.merged_at.as_deref(), Some("2026-04-26T00:00:00Z"));
+    }
+
+    #[test]
+    fn malformed_pr_metadata_surfaces_json_error() {
+        let err = parse_pr_meta(&pr(), "not json").unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationInvalidJson);
+        assert_eq!(
+            err.details.get("context").and_then(|v| v.as_str()),
+            Some("parse `gh pr view Extra-Chill/homeboy#1653`")
+        );
+    }
+
+    #[test]
+    fn test_require_head() {
+        let meta = parse_pr_meta(&pr(), full_json()).expect("parse metadata");
+        let head = meta.require_head(&pr()).expect("required head");
+        assert_eq!(head.sha, "abc123");
+        assert_eq!(head.head_repo, "Extra-Chill/homeboy");
+        assert_eq!(head.clone_url, "https://github.com/Extra-Chill/homeboy.git");
+
+        let missing = parse_pr_meta(&pr(), r#"{ "state": "OPEN" }"#).expect("parse missing head");
+        assert!(missing
+            .require_head(&pr())
+            .unwrap_err()
+            .to_string()
+            .contains("returned no headRefOid"));
+    }
+
+    #[test]
+    fn test_title_for_status() {
+        let meta = parse_pr_meta(&pr(), full_json()).expect("parse metadata");
+        assert_eq!(meta.title_for_status(), "Clean stack internals");
+
+        let missing = parse_pr_meta(&pr(), r#"{ "state": "OPEN" }"#).expect("parse missing title");
+        assert_eq!(missing.title_for_status(), "");
+    }
+
+    #[test]
+    fn test_url_for_status() {
+        let meta = parse_pr_meta(&pr(), full_json()).expect("parse metadata");
+        assert_eq!(
+            meta.url_for_status(),
+            "https://github.com/Extra-Chill/homeboy/pull/1"
+        );
+
+        let missing = parse_pr_meta(&pr(), r#"{ "state": "OPEN" }"#).expect("parse missing url");
+        assert_eq!(missing.url_for_status(), "");
+    }
+
+    #[test]
+    fn missing_head_repo_coordinates_have_specific_errors() {
+        let missing_owner = parse_pr_meta(
+            &pr(),
+            r#"{ "headRefOid": "abc123", "headRepository": { "name": "homeboy" } }"#,
+        )
+        .expect("parse missing owner");
+        assert!(missing_owner
+            .require_head(&pr())
+            .unwrap_err()
+            .to_string()
+            .contains("headRepositoryOwner.login"));
+
+        let missing_name = parse_pr_meta(
+            &pr(),
+            r#"{ "headRefOid": "abc123", "headRepositoryOwner": { "login": "Extra-Chill" } }"#,
+        )
+        .expect("parse missing name");
+        assert!(missing_name
+            .require_head(&pr())
+            .unwrap_err()
+            .to_string()
+            .contains("headRepository.name"));
+    }
+}

--- a/src/core/stack/spec.rs
+++ b/src/core/stack/spec.rs
@@ -6,15 +6,15 @@
 //!
 //! Mirrors the rig spec layout (one JSON file per stack, ID derived from
 //! filename if absent in JSON). Supports `~` and `${env.VAR}` expansion in
-//! the `component_path` field via `shellexpand::tilde` + a small env-var
-//! substitution pass — same shape the rig `expand` module uses, kept
-//! intentionally narrow here so the two modules don't need a hard
-//! dependency.
+//! the `component_path` field via the same token-expansion helper used by
+//! rig specs, with a narrower token vocabulary.
 
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::path::Path;
 
 use crate::error::{Error, Result};
+use crate::expand;
 use crate::paths;
 
 /// A stack: the spec for one combined-fixes branch.
@@ -83,43 +83,32 @@ pub struct StackPrEntry {
 /// Expand `~` and `${env.VAR}` in a stack spec field. Kept tiny on purpose:
 /// stack specs only have one field that needs expansion (`component_path`).
 pub fn expand_path(input: &str) -> String {
-    let substituted = substitute_env(input);
-    shellexpand::tilde(&substituted).into_owned()
+    expand::expand_with_tilde(input, |token| {
+        token
+            .strip_prefix("env.")
+            .map(|name| std::env::var(name).unwrap_or_default())
+    })
 }
 
-fn substitute_env(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '$' && chars.peek() == Some(&'{') {
-            chars.next(); // consume '{'
-            let mut token = String::new();
-            let mut closed = false;
-            for inner in chars.by_ref() {
-                if inner == '}' {
-                    closed = true;
-                    break;
-                }
-                token.push(inner);
-            }
-            if !closed {
-                out.push_str("${");
-                out.push_str(&token);
-                continue;
-            }
-            if let Some(name) = token.strip_prefix("env.") {
-                out.push_str(&std::env::var(name).unwrap_or_default());
-            } else {
-                // Unknown token: leave literal so users get a clear failure.
-                out.push_str("${");
-                out.push_str(&token);
-                out.push('}');
-            }
-        } else {
-            out.push(c);
-        }
+/// Resolve a stack's component checkout path and ensure it exists.
+pub(crate) fn resolve_existing_component_path(spec: &StackSpec) -> Result<String> {
+    let path = expand_path(&spec.component_path);
+    if Path::new(&path).exists() {
+        return Ok(path);
     }
-    out
+
+    Err(Error::validation_invalid_argument(
+        "component_path",
+        format!(
+            "Component path '{}' does not exist (stack '{}')",
+            path, spec.id
+        ),
+        None,
+        Some(vec![format!(
+            "Edit ~/.config/homeboy/stacks/{}.json or clone the checkout",
+            spec.id
+        )]),
+    ))
 }
 
 /// Load a stack spec by ID from `~/.config/homeboy/stacks/{id}.json`.
@@ -250,6 +239,69 @@ pub fn parse_git_ref(value: &str, field: &'static str) -> Result<GitRef> {
                 field
             )]),
         )),
+    }
+}
+
+#[cfg(test)]
+mod inline_tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_existing_component_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_string_lossy().to_string();
+        let spec = StackSpec {
+            id: "test-stack".to_string(),
+            description: String::new(),
+            component: "homeboy".to_string(),
+            component_path: path.clone(),
+            base: GitRef {
+                remote: "origin".to_string(),
+                branch: "main".to_string(),
+            },
+            target: GitRef {
+                remote: "origin".to_string(),
+                branch: "stack".to_string(),
+            },
+            prs: Vec::new(),
+        };
+
+        assert_eq!(resolve_existing_component_path(&spec).unwrap(), path);
+    }
+
+    #[test]
+    fn resolve_existing_component_path_preserves_error_contract() {
+        let spec = StackSpec {
+            id: "missing-stack".to_string(),
+            description: String::new(),
+            component: "homeboy".to_string(),
+            component_path: "/definitely/missing/homeboy-stack-checkout".to_string(),
+            base: GitRef {
+                remote: "origin".to_string(),
+                branch: "main".to_string(),
+            },
+            target: GitRef {
+                remote: "origin".to_string(),
+                branch: "stack".to_string(),
+            },
+            prs: Vec::new(),
+        };
+
+        let err = resolve_existing_component_path(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("component_path"));
+        assert!(msg.contains(
+            "Component path '/definitely/missing/homeboy-stack-checkout' does not exist"
+        ));
+        assert_eq!(
+            err.details
+                .get("tried")
+                .and_then(|v| v.as_array())
+                .map(|v| v[0].as_str()),
+            Some(Some(
+                "Edit ~/.config/homeboy/stacks/missing-stack.json or clone the checkout"
+            ))
+        );
     }
 }
 

--- a/src/core/stack/status.rs
+++ b/src/core/stack/status.rs
@@ -14,11 +14,12 @@
 //! to a per-PR error note; the rest of the report still renders.
 
 use serde::Serialize;
-use std::process::Command;
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 
-use super::spec::{expand_path, StackPrEntry, StackSpec};
+use super::git::run_git;
+use super::pr_meta::fetch_pr_meta;
+use super::spec::{resolve_existing_component_path, StackPrEntry, StackSpec};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct StatusOutput {
@@ -92,21 +93,7 @@ fn is_false(b: &bool) -> bool {
 
 /// Run `homeboy stack status <id>`.
 pub fn status(spec: &StackSpec) -> Result<StatusOutput> {
-    let path = expand_path(&spec.component_path);
-    if !std::path::Path::new(&path).exists() {
-        return Err(Error::validation_invalid_argument(
-            "component_path",
-            format!(
-                "Component path '{}' does not exist (stack '{}')",
-                path, spec.id
-            ),
-            None,
-            Some(vec![format!(
-                "Edit ~/.config/homeboy/stacks/{}.json or clone the checkout",
-                spec.id
-            )]),
-        ));
-    }
+    let path = resolve_existing_component_path(spec)?;
 
     // Single fetch of the base, so ahead-counts are honest. Failure here is
     // non-fatal — we want status to work offline.
@@ -187,8 +174,8 @@ fn build_status_row(
                 repo: pr.repo.clone(),
                 number: pr.number,
                 note: pr.note.clone(),
-                title: Some(meta.title),
-                url: Some(meta.url),
+                title: Some(meta.title_for_status()),
+                url: Some(meta.url_for_status()),
                 upstream_state: Some(meta.state),
                 review_decision: meta.review_decision,
                 merged_at: meta.merged_at,
@@ -211,94 +198,6 @@ fn build_status_row(
             error: Some(e.to_string()),
         },
     }
-}
-
-struct PrMeta {
-    head_sha: String,
-    state: String,
-    title: String,
-    url: String,
-    review_decision: Option<String>,
-    merged_at: Option<String>,
-}
-
-fn fetch_pr_meta(pr: &StackPrEntry) -> Result<PrMeta> {
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr.number.to_string(),
-            "--repo",
-            &pr.repo,
-            "--json",
-            "headRefOid,state,title,url,reviewDecision,mergedAt",
-        ])
-        .output()
-        .map_err(|e| {
-            Error::git_command_failed(format!(
-                "gh pr view {}#{}: {} (is `gh` installed and authenticated?)",
-                pr.repo, pr.number, e
-            ))
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::git_command_failed(format!(
-            "gh pr view {}#{} failed: {}",
-            pr.repo,
-            pr.number,
-            stderr.trim()
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(&stdout).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse `gh pr view {}#{}`", pr.repo, pr.number)),
-            Some(stdout.chars().take(200).collect()),
-        )
-    })?;
-
-    let head_sha = parsed
-        .get("headRefOid")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let state = parsed
-        .get("state")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let title = parsed
-        .get("title")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let url = parsed
-        .get("url")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let review_decision = parsed
-        .get("reviewDecision")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
-    let merged_at = parsed
-        .get("mergedAt")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
-
-    Ok(PrMeta {
-        head_sha,
-        state,
-        title,
-        url,
-        review_decision,
-        merged_at,
-    })
 }
 
 pub(crate) fn count_revs(path: &str, from: &str, to: &str) -> Option<usize> {
@@ -372,14 +271,6 @@ pub(crate) fn patch_in_base(path: &str, head_sha: &str, base_ref: &str) -> Optio
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     Some(stdout.lines().any(|l| l.starts_with("- ")))
-}
-
-fn run_git(path: &str, args: &[&str]) -> Result<std::process::Output> {
-    Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .map_err(|e| Error::git_command_failed(format!("git {}: {}", args.join(" "), e)))
 }
 
 #[cfg(test)]

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -30,15 +30,17 @@
 
 use serde::Serialize;
 use std::collections::HashSet;
-use std::process::Command;
 
 use crate::error::{Error, Result};
 
 use super::apply::{
-    checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, run_git,
-    AppliedPr, CherryPickResult, PickOutcome, PrHead,
+    checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, AppliedPr,
+    CherryPickResult, PickOutcome,
 };
-use super::spec::{expand_path, save, StackPrEntry, StackSpec};
+use super::git::run_git;
+use super::pr_meta::fetch_pr_meta;
+pub(crate) use super::pr_meta::StackPrMeta as PrMeta;
+use super::spec::{resolve_existing_component_path, save, StackPrEntry, StackSpec};
 use super::status::{commit_reachable, patch_in_base};
 
 /// Output envelope for `homeboy stack sync`.
@@ -76,40 +78,6 @@ pub struct DroppedPr {
     pub reason: String,
 }
 
-/// Pre-fetched PR metadata used by [`is_droppable`] and the cherry-pick
-/// path. Public-in-module so tests can build fixtures without invoking
-/// `gh`.
-#[derive(Debug, Clone)]
-pub(crate) struct PrMeta {
-    pub head_sha: String,
-    pub head_owner: String,
-    pub head_name: String,
-    pub state: String,
-    pub title: Option<String>,
-    pub merged_at: Option<String>,
-}
-
-impl PrMeta {
-    fn head_repo(&self) -> String {
-        format!("{}/{}", self.head_owner, self.head_name)
-    }
-
-    fn clone_url(&self) -> String {
-        format!(
-            "https://github.com/{}/{}.git",
-            self.head_owner, self.head_name
-        )
-    }
-
-    fn to_pr_head(&self) -> PrHead {
-        PrHead {
-            sha: self.head_sha.clone(),
-            head_repo: self.head_repo(),
-            clone_url: self.clone_url(),
-        }
-    }
-}
-
 /// Decide whether a PR should be dropped from the spec.
 ///
 /// Pure with respect to the (already-fetched) `PrMeta` — only touches the
@@ -132,22 +100,7 @@ pub(crate) fn is_droppable(meta: &PrMeta, path: &str, base_ref: &str) -> bool {
 /// Sync a stack: rebuild target from base, auto-drop merged PRs, replay
 /// the rest.
 pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
-    let path = expand_path(&spec.component_path);
-
-    if !std::path::Path::new(&path).exists() {
-        return Err(Error::validation_invalid_argument(
-            "component_path",
-            format!(
-                "Component path '{}' does not exist (stack '{}')",
-                path, spec.id
-            ),
-            None,
-            Some(vec![format!(
-                "Edit ~/.config/homeboy/stacks/{}.json or clone the checkout",
-                spec.id
-            )]),
-        ));
-    }
+    let path = resolve_existing_component_path(spec)?;
 
     // 1. Fetch base — must succeed so droppability checks are honest.
     fetch_remote_branch(&path, &spec.base.remote, &spec.base.branch)?;
@@ -165,9 +118,10 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
 
     for pr in &spec.prs {
         let meta = fetch_pr_meta(pr)?;
+        let head = meta.require_head(pr)?;
         // Fetch the head SHA into the local object store before asking
         // git about reachability/patch-id.
-        let head_remote = ensure_head_remote(&path, pr, &meta.to_pr_head(), &mut ensured_remotes)?;
+        let head_remote = ensure_head_remote(&path, pr, &head, &mut ensured_remotes)?;
         if !meta.head_sha.is_empty() {
             // Best-effort fetch — a 404 here means the SHA is gone from
             // the head repo (force-pushed away). is_droppable() will then
@@ -199,20 +153,16 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
 
     if dry_run {
         // Report what WOULD happen; mutate nothing.
-        return Ok(SyncOutput {
-            stack_id: spec.id.clone(),
-            component_path: path,
-            branch: spec.target.branch.clone(),
-            base: spec.base.display(),
-            target: spec.target.display(),
+        return Ok(sync_output(
+            spec,
+            path,
             dropped,
-            applied: Vec::new(),
-            dry_run: true,
-            picked_count: 0,
-            skipped_count: 0,
+            Vec::new(),
+            true,
+            0,
+            0,
             dropped_count,
-            success: true,
-        });
+        ));
     }
 
     // 4. Persist the pruned spec BEFORE any cherry-picks. A partial pick
@@ -284,7 +234,29 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
         }
     }
 
-    Ok(SyncOutput {
+    Ok(sync_output(
+        spec,
+        path,
+        dropped,
+        applied,
+        false,
+        picked,
+        skipped,
+        dropped_count,
+    ))
+}
+
+fn sync_output(
+    spec: &StackSpec,
+    path: String,
+    dropped: Vec<DroppedPr>,
+    applied: Vec<AppliedPr>,
+    dry_run: bool,
+    picked_count: usize,
+    skipped_count: usize,
+    dropped_count: usize,
+) -> SyncOutput {
+    SyncOutput {
         stack_id: spec.id.clone(),
         component_path: path,
         branch: spec.target.branch.clone(),
@@ -292,99 +264,12 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
         target: spec.target.display(),
         dropped,
         applied,
-        dry_run: false,
-        picked_count: picked,
-        skipped_count: skipped,
+        dry_run,
+        picked_count,
+        skipped_count,
         dropped_count,
         success: true,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// gh pr view glue
-// ---------------------------------------------------------------------------
-
-/// Resolve PR metadata via `gh pr view`. Fetches every field both
-/// `is_droppable` and the cherry-pick path need, in one call.
-fn fetch_pr_meta(pr: &StackPrEntry) -> Result<PrMeta> {
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr.number.to_string(),
-            "--repo",
-            &pr.repo,
-            "--json",
-            "headRefOid,headRepository,headRepositoryOwner,state,title,mergedAt",
-        ])
-        .output()
-        .map_err(|e| {
-            Error::git_command_failed(format!(
-                "gh pr view {}#{}: {} (is `gh` installed and authenticated?)",
-                pr.repo, pr.number, e
-            ))
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::git_command_failed(format!(
-            "gh pr view {}#{} failed: {}",
-            pr.repo,
-            pr.number,
-            stderr.trim()
-        )));
     }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(&stdout).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse `gh pr view {}#{}`", pr.repo, pr.number)),
-            Some(stdout.chars().take(200).collect()),
-        )
-    })?;
-
-    let head_sha = parsed
-        .get("headRefOid")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let head_owner = parsed
-        .get("headRepositoryOwner")
-        .and_then(|v| v.get("login"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let head_name = parsed
-        .get("headRepository")
-        .and_then(|v| v.get("name"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let state = parsed
-        .get("state")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let title = parsed
-        .get("title")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
-    let merged_at = parsed
-        .get("mergedAt")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
-
-    Ok(PrMeta {
-        head_sha,
-        head_owner,
-        head_name,
-        state,
-        title,
-        merged_at,
-    })
 }
 
 #[cfg(test)]

--- a/tests/core/expand_test.rs
+++ b/tests/core/expand_test.rs
@@ -1,0 +1,29 @@
+//! Tests for shared token expansion helpers.
+
+use crate::expand::{expand_tokens, expand_with_tilde};
+
+#[test]
+fn test_expand_tokens() {
+    let out = expand_tokens("/a/${known}/b/${unknown}", |token| {
+        (token == "known").then(|| "value".to_string())
+    });
+
+    assert_eq!(out, "/a/value/b/${unknown}");
+}
+
+#[test]
+fn test_expand_with_tilde() {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let out = expand_with_tilde("~/${name}", |token| {
+        (token == "name").then(|| "repo".to_string())
+    });
+
+    assert!(out.starts_with(&home));
+    assert!(out.ends_with("/repo"));
+}
+
+#[test]
+fn unknown_and_unterminated_tokens_stay_literal() {
+    assert_eq!(expand_tokens("${unknown}", |_| None), "${unknown}");
+    assert_eq!(expand_tokens("${unterminated", |_| None), "${unterminated");
+}

--- a/tests/core/stack/sync_test.rs
+++ b/tests/core/stack/sync_test.rs
@@ -65,10 +65,12 @@ fn write_and_commit(dir: &TempDir, path: &str, file: &str, body: &str, msg: &str
 fn meta(state: &str, head_sha: &str) -> PrMeta {
     PrMeta {
         head_sha: head_sha.to_string(),
-        head_owner: "Automattic".to_string(),
-        head_name: "studio".to_string(),
+        head_owner: Some("Automattic".to_string()),
+        head_name: Some("studio".to_string()),
         state: state.to_string(),
         title: Some("test PR".to_string()),
+        url: Some("https://github.com/Automattic/studio/pull/1".to_string()),
+        review_decision: None,
         merged_at: if state == "MERGED" {
             Some("2026-04-26T00:00:00Z".to_string())
         } else {


### PR DESCRIPTION
## Summary
- Centralize stack PR metadata fetching/parsing so `apply`, `status`, and `sync` share one `gh pr view` contract.
- Move stack `component_path` existence validation into the spec layer and reuse the rig-style token scanner from `core::paths`.
- Preserve stack/rig expansion behavior while deleting duplicated local parsers and validation blocks.

## Changes
- Added `core::stack::pr_meta` with a shared metadata superset, parser tests, and explicit `require_head()` conversion for fetch/cherry-pick paths.
- Added `resolve_existing_component_path()` for stack specs and shared `${...}` expansion helpers in `core::paths`.
- Updated rig expansion and stack apply/status/sync to call the shared helpers.

## Tests
- `cargo fmt --check`
- `cargo test core::stack`
- `cargo test core::rig::expand`

Closes #1653
Closes #1654
Closes #1655

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the refactor, added focused tests, and ran local validation. Chris remains responsible for review and merge.