### PR TITLE
chore: collapse tiny cleanup shims

### DIFF
--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 use serde::Serialize;
 
 use crate::component::{self, Component};
-use crate::error::{Error, Result};
-use crate::extension::{self, ExtensionCapability, ExtensionExecutionContext};
+use crate::error::Result;
+use crate::extension::{self, ExtensionCapability};
 
 /// Unified execution context for extension-backed commands.
 ///
@@ -201,78 +201,6 @@ pub fn resolve(options: &ResolveOptions) -> Result<ExecutionContext> {
 }
 
 impl ExecutionContext {
-    /// Convert to the extension-specific `ExtensionExecutionContext` for use with `ExtensionRunner`.
-    ///
-    /// This bridges between the unified context and the existing runner infrastructure.
-    /// Only valid when a capability was resolved (panics otherwise).
-    pub fn to_extension_context(
-        &self,
-        capability: ExtensionCapability,
-    ) -> Result<ExtensionExecutionContext> {
-        let extension_id = self.extension_id.as_ref().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "capability",
-                "No extension was resolved for this execution context",
-                None,
-                Some(vec![
-                    "Use ResolveOptions::with_capability() to resolve an extension".to_string(),
-                ]),
-            )
-        })?;
-
-        let extension_path = self.extension_path.as_ref().ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "extension_path",
-                "Extension path not resolved",
-                None,
-                None,
-            )
-        })?;
-
-        // Resolve the script path for this capability
-        let manifest = extension::load_extension(extension_id)?;
-        let script_path = match capability {
-            ExtensionCapability::Lint => manifest.lint_script(),
-            ExtensionCapability::Test => manifest.test_script(),
-            ExtensionCapability::Build => manifest.build_script(),
-            ExtensionCapability::Bench => manifest.bench_script(),
-        }
-        .map(|s| s.to_string())
-        .or_else(|| {
-            if capability == ExtensionCapability::Build {
-                Some(String::new())
-            } else {
-                None
-            }
-        })
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "extension",
-                format!(
-                    "Extension '{}' does not have {} infrastructure configured",
-                    extension_id,
-                    match capability {
-                        ExtensionCapability::Lint => "lint",
-                        ExtensionCapability::Test => "test",
-                        ExtensionCapability::Build => "build",
-                        ExtensionCapability::Bench => "bench",
-                    }
-                ),
-                None,
-                None,
-            )
-        })?;
-
-        Ok(ExtensionExecutionContext {
-            component: self.component.clone(),
-            capability,
-            extension_id: extension_id.clone(),
-            extension_path: extension_path.clone(),
-            script_path,
-            settings: self.settings.clone(),
-        })
-    }
-
     /// Get the effective working directory for command execution.
     ///
     /// Returns the source path as a string reference.

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -460,19 +460,12 @@ pub(crate) fn validate_capability_script_exists(
 ) -> Result<()> {
     let script_path = extension_path.join(script_path);
     if !script_path.exists() {
-        let label = match capability {
-            super::ExtensionCapability::Lint => "lint",
-            super::ExtensionCapability::Test => "test",
-            super::ExtensionCapability::Build => "build",
-            super::ExtensionCapability::Bench => "bench",
-        };
-
         return Err(Error::validation_invalid_argument(
             "extension",
             format!(
                 "Extension at {} does not have {} infrastructure (missing {})",
                 extension_path.display(),
-                label,
+                capability.label(),
                 script_path.display()
             ),
             None,

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -125,6 +125,39 @@ pub enum ExtensionCapability {
     Bench,
 }
 
+impl ExtensionCapability {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            ExtensionCapability::Lint => "lint",
+            ExtensionCapability::Test => "test",
+            ExtensionCapability::Build => "build",
+            ExtensionCapability::Bench => "bench",
+        }
+    }
+
+    pub(crate) fn has_manifest_support(self, manifest: &ExtensionManifest) -> bool {
+        match self {
+            ExtensionCapability::Lint => manifest.has_lint(),
+            ExtensionCapability::Test => manifest.has_test(),
+            ExtensionCapability::Build => manifest.has_build(),
+            ExtensionCapability::Bench => manifest.has_bench(),
+        }
+    }
+
+    pub(crate) fn script_path<'a>(self, manifest: &'a ExtensionManifest) -> Option<&'a str> {
+        match self {
+            ExtensionCapability::Lint => manifest.lint_script(),
+            ExtensionCapability::Test => manifest.test_script(),
+            ExtensionCapability::Build => manifest.build_script(),
+            ExtensionCapability::Bench => manifest.bench_script(),
+        }
+    }
+
+    pub(crate) fn requires_script(self) -> bool {
+        self != ExtensionCapability::Build
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ExtensionExecutionContext {
     pub component: Component,
@@ -150,26 +183,8 @@ fn no_extensions_error(component: &Component) -> Error {
     err
 }
 
-fn capability_label(capability: ExtensionCapability) -> &'static str {
-    match capability {
-        ExtensionCapability::Lint => "lint",
-        ExtensionCapability::Test => "test",
-        ExtensionCapability::Build => "build",
-        ExtensionCapability::Bench => "bench",
-    }
-}
-
-fn manifest_has_capability(manifest: &ExtensionManifest, capability: ExtensionCapability) -> bool {
-    match capability {
-        ExtensionCapability::Lint => manifest.has_lint(),
-        ExtensionCapability::Test => manifest.has_test(),
-        ExtensionCapability::Build => manifest.has_build(),
-        ExtensionCapability::Bench => manifest.has_bench(),
-    }
-}
-
 fn capability_missing_error(component: &Component, capability: ExtensionCapability) -> Error {
-    let capability_name = capability_label(capability);
+    let capability_name = capability.label();
     let mut err = Error::validation_invalid_argument(
         "extension",
         format!(
@@ -194,7 +209,7 @@ pub(crate) fn extension_guidance_hints(
     let link_hint = match capability {
         Some(capability) => format!(
             "Link an extension with {} support: homeboy component set {} --extension <extension_id>",
-            capability_label(capability),
+            capability.label(),
             component.id
         ),
         None => format!(
@@ -215,7 +230,7 @@ fn capability_ambiguous_error(
     capability: ExtensionCapability,
     matching: &[String],
 ) -> Error {
-    let capability_name = capability_label(capability);
+    let capability_name = capability.label();
     Error::validation_invalid_argument(
         "extension",
         format!(
@@ -273,7 +288,7 @@ pub fn resolve_extension_for_capability(
 
     for extension_id in extensions.keys() {
         let manifest = load_extension(extension_id)?;
-        if manifest_has_capability(&manifest, capability) {
+        if capability.has_manifest_support(&manifest) {
             matching.push(extension_id.clone());
         }
     }
@@ -291,34 +306,30 @@ pub fn resolve_execution_context(
 ) -> Result<ExtensionExecutionContext> {
     let extension_id = resolve_extension_for_capability(component, capability)?;
     let manifest = load_extension(&extension_id)?;
-    let script_path = match capability {
-        ExtensionCapability::Lint => manifest.lint_script(),
-        ExtensionCapability::Test => manifest.test_script(),
-        ExtensionCapability::Build => manifest.build_script(),
-        ExtensionCapability::Bench => manifest.bench_script(),
-    }
-    .map(|s| s.to_string())
-    // Build's extension_script is optional (builds can use local scripts or command templates),
-    // so we allow an empty script_path for Build. Lint/Test/Bench require it.
-    .or_else(|| {
-        if capability == ExtensionCapability::Build {
-            Some(String::new())
-        } else {
-            None
-        }
-    })
-    .ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "extension",
-            format!(
-                "Extension '{}' does not have {} infrastructure configured",
-                extension_id,
-                capability_label(capability)
-            ),
-            None,
-            None,
-        )
-    })?;
+    let script_path = capability
+        .script_path(&manifest)
+        .map(|s| s.to_string())
+        // Build's extension_script is optional (builds can use local scripts or command templates),
+        // so we allow an empty script_path for Build. Lint/Test/Bench require it.
+        .or_else(|| {
+            if capability.requires_script() {
+                None
+            } else {
+                Some(String::new())
+            }
+        })
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "extension",
+                format!(
+                    "Extension '{}' does not have {} infrastructure configured",
+                    extension_id,
+                    capability.label()
+                ),
+                None,
+                None,
+            )
+        })?;
 
     let extension_path = extension_path(&extension_id);
 
@@ -1088,6 +1099,31 @@ mod tests {
     use super::*;
     use crate::component::{Component, ScopedExtensionConfig};
     use std::collections::HashMap;
+
+    #[test]
+    fn extension_capability_owns_labels_and_scripts() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Example",
+            "version": "0.0.0",
+            "lint": { "extension_script": "lint.sh" },
+            "test": { "extension_script": "test.sh" },
+            "build": { "extension_script": "build.sh" },
+            "bench": { "extension_script": "bench.sh" }
+        }))
+        .unwrap();
+
+        for (capability, label, script, requires_script) in [
+            (ExtensionCapability::Lint, "lint", "lint.sh", true),
+            (ExtensionCapability::Test, "test", "test.sh", true),
+            (ExtensionCapability::Build, "build", "build.sh", false),
+            (ExtensionCapability::Bench, "bench", "bench.sh", true),
+        ] {
+            assert_eq!(capability.label(), label);
+            assert!(capability.has_manifest_support(&manifest));
+            assert_eq!(capability.script_path(&manifest), Some(script));
+            assert_eq!(capability.requires_script(), requires_script);
+        }
+    }
 
     #[test]
     fn validate_required_extensions_passes_with_no_modules() {

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -93,16 +93,7 @@ pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::R
 ///    `homeboy.json` at CWD or git root. This is what makes
 ///    `homeboy git status` (and friends) work without arguments when
 ///    run from inside a checkout.
-pub(super) fn resolve_target(
-    component_id: Option<&str>,
-    path_override: Option<&str>,
-) -> crate::error::Result<(String, String)> {
-    resolve_target_pub(component_id, path_override)
-}
-
-/// Public alias of [`resolve_target`] for sibling modules (e.g. `core::stack`)
-/// that need the same git-target resolution but live outside `core::git`.
-pub fn resolve_target_pub(
+pub(crate) fn resolve_target(
     component_id: Option<&str>,
     path_override: Option<&str>,
 ) -> crate::error::Result<(String, String)> {

--- a/src/core/stack/inspect.rs
+++ b/src/core/stack/inspect.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::process::Command;
 
 use crate::error::{Error, Result};
-use crate::git::resolve_target_pub as resolve_target;
+use crate::git::resolve_target;
 
 /// Per-commit detail row for the inspect output.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary

- Remove tiny visibility/dead-code shims now that the canonical resolver paths are clear.
- Keep extension capability labels and script lookup on `ExtensionCapability` so callers stop duplicating enum matches.

## Changes

- Make `git::resolve_target` `pub(crate)` and delete the `resolve_target_pub` alias.
- Delete the unreferenced `ExecutionContext::to_extension_context` bridge.
- Move extension capability label, manifest support, script path, and required-script policy onto `ExtensionCapability`.
- Add a focused capability contract test.

## Tests

- `cargo fmt --check`
- `cargo test resolve_target`
- `cargo test stack::inspect`
- `cargo test extension`
- `cargo test execution_context`
- `cargo test runner_contract`

Closes #1663.
Closes #1665.
Closes #1656.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the cleanup, ran targeted validation, and drafted this PR description. Chris remains responsible for review and merge.
