### PR TITLE
feat(extension): centralize runner support contracts

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -426,7 +426,11 @@ struct ComponentEnvOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     php: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    php_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     node: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    node_source: Option<String>,
 }
 
 fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
@@ -469,6 +473,8 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
 
     let mut php_version: Option<String> = None;
     let mut node_version: Option<String> = None;
+    let mut php_source: Option<String> = None;
+    let mut node_source: Option<String> = None;
 
     // Read node version from raw homeboy.json (the Rust struct drops unknown
     // fields like "php" and "node" from the extension config during deserialization).
@@ -479,10 +485,12 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
                 if let Some(ext_obj) = json.get("extensions").and_then(|e| e.get(ext_id.as_str())) {
                     if let Some(v) = ext_obj.get("node").and_then(|v| v.as_str()) {
                         node_version = Some(v.to_string());
+                        node_source = Some("component".to_string());
                     }
                     // Read php from homeboy.json as fallback (overridden below by header detection)
                     if let Some(v) = ext_obj.get("php").and_then(|v| v.as_str()) {
                         php_version = Some(v.to_string());
+                        php_source = Some("component".to_string());
                     }
                 }
             }
@@ -494,6 +502,22 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
     if extension_id.as_deref() == Some("wordpress") {
         if let Some(detected_php) = detect_wordpress_requires_php(local_path) {
             php_version = Some(detected_php);
+            php_source = Some("component".to_string());
+        }
+    }
+
+    if let Some(ref ext_id) = extension_id {
+        if let Ok(extension) = homeboy::extension::load_extension(ext_id) {
+            if let Some(runtime) = extension.runtime.as_ref() {
+                apply_extension_runtime_requirements(
+                    ext_id,
+                    runtime,
+                    &mut node_version,
+                    &mut node_source,
+                    &mut php_version,
+                    &mut php_source,
+                );
+            }
         }
     }
 
@@ -502,7 +526,9 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         id: comp_id.clone(),
         extension: extension_id,
         php: php_version,
+        php_source,
         node: node_version,
+        node_source,
     };
 
     let entity = serde_json::to_value(&env_output).map_err(|error| {
@@ -523,6 +549,28 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         },
         0,
     ))
+}
+
+fn apply_extension_runtime_requirements(
+    extension_id: &str,
+    runtime: &homeboy::extension::RuntimeRequirementsConfig,
+    node_version: &mut Option<String>,
+    node_source: &mut Option<String>,
+    php_version: &mut Option<String>,
+    php_source: &mut Option<String>,
+) {
+    if node_version.is_none() {
+        if let Some(node) = runtime.node.as_ref() {
+            *node_version = Some(node.clone());
+            *node_source = Some(format!("extension:{}", extension_id));
+        }
+    }
+    if php_version.is_none() {
+        if let Some(php) = runtime.php.as_ref() {
+            *php_version = Some(php.clone());
+            *php_source = Some(format!("extension:{}", extension_id));
+        }
+    }
 }
 
 /// Parse "Requires PHP: X.Y" from a WordPress plugin or theme header.
@@ -965,5 +1013,57 @@ mod tests {
 
         assert_eq!(obj["local_path"], serde_json::json!("/override"));
         assert_eq!(obj["remote_path"], serde_json::json!("/keep-this"));
+    }
+
+    #[test]
+    fn extension_runtime_requirements_fill_missing_component_versions() {
+        let runtime = homeboy::extension::RuntimeRequirementsConfig {
+            node: Some("24".to_string()),
+            php: Some("8.3".to_string()),
+        };
+        let mut node = None;
+        let mut node_source = None;
+        let mut php = None;
+        let mut php_source = None;
+
+        apply_extension_runtime_requirements(
+            "nodejs",
+            &runtime,
+            &mut node,
+            &mut node_source,
+            &mut php,
+            &mut php_source,
+        );
+
+        assert_eq!(node.as_deref(), Some("24"));
+        assert_eq!(node_source.as_deref(), Some("extension:nodejs"));
+        assert_eq!(php.as_deref(), Some("8.3"));
+        assert_eq!(php_source.as_deref(), Some("extension:nodejs"));
+    }
+
+    #[test]
+    fn component_versions_win_over_extension_runtime_requirements() {
+        let runtime = homeboy::extension::RuntimeRequirementsConfig {
+            node: Some("24".to_string()),
+            php: Some("8.3".to_string()),
+        };
+        let mut node = Some("22".to_string());
+        let mut node_source = Some("component".to_string());
+        let mut php = Some("8.2".to_string());
+        let mut php_source = Some("component".to_string());
+
+        apply_extension_runtime_requirements(
+            "nodejs",
+            &runtime,
+            &mut node,
+            &mut node_source,
+            &mut php,
+            &mut php_source,
+        );
+
+        assert_eq!(node.as_deref(), Some("22"));
+        assert_eq!(node_source.as_deref(), Some("component"));
+        assert_eq!(php.as_deref(), Some("8.2"));
+        assert_eq!(php_source.as_deref(), Some("component"));
     }
 }

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -269,6 +269,8 @@ pub struct ExtensionDetail {
     pub source_url: Option<String>,
     pub runtime: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_requirements: Option<homeboy::extension::RuntimeRequirementsConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub has_setup: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_ready_check: Option<bool>,
@@ -391,6 +393,7 @@ fn show_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
         } else {
             "platform".to_string()
         },
+        runtime_requirements: extension.runtime.clone(),
         has_setup,
         has_ready_check,
         ready: ready_status.ready,

--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -375,6 +375,7 @@ JSON
             audit: None,
             executable: None,
             platform: None,
+            runtime: None,
             cli: None,
             build: None,
             lint: None,

--- a/src/core/engine/output_parse.rs
+++ b/src/core/engine/output_parse.rs
@@ -1,32 +1,44 @@
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Aggregate {
     First,
+    #[default]
     Last,
     Sum,
     Max,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParseRule {
     pub pattern: String,
     pub field: String,
+    #[serde(default = "default_group")]
     pub group: usize,
+    #[serde(default)]
     pub aggregate: Aggregate,
 }
 
-#[derive(Debug, Clone)]
+fn default_group() -> usize {
+    1
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeriveRule {
     pub field: String,
     pub expr: String,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ParseSpec {
+    #[serde(default)]
     pub rules: Vec<ParseRule>,
+    #[serde(default)]
     pub defaults: HashMap<String, f64>,
+    #[serde(default)]
     pub derive: Vec<DeriveRule>,
 }
 

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -1,5 +1,6 @@
 use crate::component::AuditConfig;
 use crate::config::ConfigEntity;
+use crate::engine::output_parse::ParseSpec;
 use crate::error::{Error, Result};
 use crate::paths;
 use serde::{Deserialize, Serialize};
@@ -285,6 +286,12 @@ pub struct ExtensionManifest {
     pub executable: Option<ExecutableCapability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<PlatformCapability>,
+
+    /// Runtime requirements needed to execute this extension's runner scripts.
+    /// Component-declared requirements still win; these are fallbacks for the
+    /// runner substrate itself.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<RuntimeRequirementsConfig>,
 
     // Standalone capabilities (already self-contained structs)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -708,6 +715,16 @@ pub struct LintConfig {
 pub struct TestConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension_script: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_parse: Option<ParseSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct RuntimeRequirementsConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub php: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -30,9 +30,9 @@ pub use manifest::{
     CliConfig, DatabaseCliConfig, DatabaseConfig, DeployCapability, DeployOverride,
     DeployVerification, DiscoveryConfig, DocTarget, ExecutableCapability, ExtensionManifest,
     FeatureContextRule, HttpMethod, InputConfig, LintConfig, OutputConfig, OutputSchema,
-    PlatformCapability, ProvidesConfig, RequirementsConfig, RuntimeConfig, ScriptsConfig,
-    SelectOption, SettingConfig, SinceTagConfig, TestConfig, TestMappingConfig,
-    VersionPatternConfig,
+    PlatformCapability, ProvidesConfig, RequirementsConfig, RuntimeConfig,
+    RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
+    TestConfig, TestMappingConfig, VersionPatternConfig,
 };
 
 // Re-export version types
@@ -1105,12 +1105,34 @@ mod tests {
         let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
             "name": "Example",
             "version": "0.0.0",
+            "runtime": { "node": "24" },
             "lint": { "extension_script": "lint.sh" },
-            "test": { "extension_script": "test.sh" },
+            "test": {
+                "extension_script": "test.sh",
+                "result_parse": {
+                    "rules": [{ "pattern": "Tests: (\\d+)", "field": "total" }]
+                }
+            },
             "build": { "extension_script": "build.sh" },
             "bench": { "extension_script": "bench.sh" }
         }))
         .unwrap();
+
+        assert_eq!(
+            manifest
+                .runtime
+                .as_ref()
+                .and_then(|runtime| runtime.node.as_deref()),
+            Some("24")
+        );
+        assert_eq!(
+            manifest
+                .test
+                .as_ref()
+                .and_then(|test| test.result_parse.as_ref())
+                .map(|spec| spec.rules.len()),
+            Some(1)
+        );
 
         for (capability, label, script, requires_script) in [
             (ExtensionCapability::Lint, "lint", "lint.sh", true),

--- a/src/core/extension/runtime/resolve-context.sh
+++ b/src/core/extension/runtime/resolve-context.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Resolve the Homeboy extension runner execution context for shell scripts.
+# Scripts source this file, then call homeboy_resolve_context before using the
+# exported variables.
+
+homeboy_resolve_context() {
+    local project_alias="PROJECT_PATH"
+    local component_alias=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --project-alias)
+                project_alias="${2:-}"
+                shift 2
+                ;;
+            --component-alias)
+                component_alias="${2:-}"
+                shift 2
+                ;;
+            *)
+                echo "homeboy_resolve_context: unknown argument: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -n "${HOMEBOY_EXTENSION_PATH:-}" ]; then
+        EXTENSION_PATH="$HOMEBOY_EXTENSION_PATH"
+    else
+        if [ -z "${SCRIPT_DIR:-}" ]; then
+            echo "homeboy_resolve_context: SCRIPT_DIR is required when HOMEBOY_EXTENSION_PATH is unset" >&2
+            return 2
+        fi
+
+        local search_dir="$SCRIPT_DIR"
+        while [ "$search_dir" != "/" ] && [ -n "$search_dir" ]; do
+            if compgen -G "$search_dir/*.json" >/dev/null; then
+                EXTENSION_PATH="$search_dir"
+                break
+            fi
+            search_dir="$(dirname "$search_dir")"
+        done
+
+        if [ -z "${EXTENSION_PATH:-}" ]; then
+            echo "homeboy_resolve_context: could not find extension manifest above SCRIPT_DIR=$SCRIPT_DIR" >&2
+            return 2
+        fi
+    fi
+
+    COMPONENT_PATH="${HOMEBOY_COMPONENT_PATH:-$(pwd)}"
+    COMPONENT_ID="${HOMEBOY_COMPONENT_ID:-$(basename "$COMPONENT_PATH")}"
+    PROJECT_PATH="${HOMEBOY_PROJECT_PATH:-$COMPONENT_PATH}"
+
+    export EXTENSION_PATH COMPONENT_PATH COMPONENT_ID PROJECT_PATH
+
+    if [ -n "$project_alias" ] && [ "$project_alias" != "PROJECT_PATH" ]; then
+        export "$project_alias=$PROJECT_PATH"
+    fi
+
+    if [ -n "$component_alias" ]; then
+        export "$component_alias=$COMPONENT_PATH"
+    fi
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -7,10 +7,12 @@ use std::path::PathBuf;
 const RUNNER_STEPS_SH: &str = include_str!("runtime/runner-steps.sh");
 const FAILURE_TRAP_SH: &str = include_str!("runtime/failure-trap.sh");
 const WRITE_TEST_RESULTS_SH: &str = include_str!("runtime/write-test-results.sh");
+const RESOLVE_CONTEXT_SH: &str = include_str!("runtime/resolve-context.sh");
 
 pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
 pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
 pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
+pub const RESOLVE_CONTEXT_ENV: &str = "HOMEBOY_RUNTIME_RESOLVE_CONTEXT";
 
 struct RuntimeHelper {
     filename: &'static str,
@@ -33,6 +35,11 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "write-test-results.sh",
         content: WRITE_TEST_RESULTS_SH,
         env_var: WRITE_TEST_RESULTS_ENV,
+    },
+    RuntimeHelper {
+        filename: "resolve-context.sh",
+        content: RESOLVE_CONTEXT_SH,
+        env_var: RESOLVE_CONTEXT_ENV,
     },
 ];
 
@@ -97,6 +104,77 @@ mod tests {
         assert!(
             pairs.iter().any(|(k, _)| k == WRITE_TEST_RESULTS_ENV),
             "write test results helper should be in pairs"
+        );
+        assert!(
+            pairs.iter().any(|(k, _)| k == RESOLVE_CONTEXT_ENV),
+            "resolve context helper should be in pairs"
+        );
+    }
+
+    #[test]
+    fn resolve_context_helper_exports_homeboy_env_and_aliases() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let helper_path = dir.path().join("resolve-context.sh");
+        std::fs::write(&helper_path, RESOLVE_CONTEXT_SH).expect("write helper");
+
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "source {}; homeboy_resolve_context --component-alias PLUGIN_PATH; printf '%s|%s|%s|%s' \"$EXTENSION_PATH\" \"$COMPONENT_PATH\" \"$COMPONENT_ID\" \"$PLUGIN_PATH\"",
+                helper_path.display()
+            ))
+            .env("HOMEBOY_EXTENSION_PATH", "/tmp/ext")
+            .env("HOMEBOY_COMPONENT_PATH", "/tmp/project")
+            .env("HOMEBOY_COMPONENT_ID", "demo")
+            .output()
+            .expect("run bash");
+
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "/tmp/ext|/tmp/project|demo|/tmp/project"
+        );
+    }
+
+    #[test]
+    fn resolve_context_helper_supports_direct_invocation_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let extension_dir = dir.path().join("extension");
+        let script_dir = extension_dir.join("scripts/test");
+        let component_dir = dir.path().join("component");
+        std::fs::create_dir_all(&script_dir).expect("script dir");
+        std::fs::create_dir_all(&component_dir).expect("component dir");
+        std::fs::write(extension_dir.join("extension.json"), "{}").expect("manifest marker");
+        let helper_path = dir.path().join("resolve-context.sh");
+        std::fs::write(&helper_path, RESOLVE_CONTEXT_SH).expect("write helper");
+
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "cd {}; source {}; SCRIPT_DIR={}; homeboy_resolve_context; printf '%s|%s|%s' \"$EXTENSION_PATH\" \"$COMPONENT_PATH\" \"$COMPONENT_ID\"",
+                component_dir.display(),
+                helper_path.display(),
+                script_dir.display()
+            ))
+            .output()
+            .expect("run bash");
+
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!(
+                "{}|{}|component",
+                extension_dir.display(),
+                component_dir.display()
+            )
         );
     }
 }

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -32,7 +32,7 @@ pub use baseline::{
 pub use drift::{ChangeType, DriftReport, DriftedTest, ProductionChange};
 pub use parsing::{
     build_test_summary, parse_coverage_file, parse_failures_file, parse_test_results_file,
-    parse_test_results_text, CoverageOutput, TestSummaryOutput,
+    parse_test_results_text, parse_test_results_text_with_spec, CoverageOutput, TestSummaryOutput,
 };
 pub use report::{FailedTest, TestCommandOutput};
 pub use run::{run_main_test_workflow, RawTestOutput, TestRunWorkflowArgs, TestRunWorkflowResult};

--- a/src/core/extension/test/parsing.rs
+++ b/src/core/extension/test/parsing.rs
@@ -130,7 +130,23 @@ pub fn parse_test_results_file(path: &std::path::Path) -> Option<TestCounts> {
 }
 
 pub fn parse_test_results_text(text: &str) -> Option<TestCounts> {
-    let spec = ParseSpec {
+    parse_test_results_text_with_spec(text, &default_test_result_parse_spec())
+}
+
+pub fn parse_test_results_text_with_spec(text: &str, spec: &ParseSpec) -> Option<TestCounts> {
+    let parsed = spec.parse(text);
+    let total = parsed.get("total").copied().unwrap_or(0.0).max(0.0) as u64;
+    if total == 0 {
+        return None;
+    }
+    let passed = parsed.get("passed").copied().unwrap_or(0.0).max(0.0) as u64;
+    let failed = parsed.get("failed").copied().unwrap_or(0.0).max(0.0) as u64;
+    let skipped = parsed.get("skipped").copied().unwrap_or(0.0).max(0.0) as u64;
+    Some(TestCounts::new(total, passed, failed, skipped))
+}
+
+fn default_test_result_parse_spec() -> ParseSpec {
+    ParseSpec {
         rules: vec![
             ParseRule {
                 pattern: r"Tests:\s*(\d+)".to_string(),
@@ -172,17 +188,7 @@ pub fn parse_test_results_text(text: &str) -> Option<TestCounts> {
             field: "passed".to_string(),
             expr: "total - failed - errors - skipped".to_string(),
         }],
-    };
-
-    let parsed = spec.parse(text);
-    let total = parsed.get("total").copied().unwrap_or(0.0).max(0.0) as u64;
-    if total == 0 {
-        return None;
     }
-    let passed = parsed.get("passed").copied().unwrap_or(0.0).max(0.0) as u64;
-    let failed = parsed.get("failed").copied().unwrap_or(0.0).max(0.0) as u64;
-    let skipped = parsed.get("skipped").copied().unwrap_or(0.0).max(0.0) as u64;
-    Some(TestCounts::new(total, passed, failed, skipped))
 }
 
 pub fn parse_coverage_file(path: &std::path::Path) -> std::result::Result<CoverageOutput, ()> {
@@ -242,4 +248,48 @@ pub fn parse_coverage_file(path: &std::path::Path) -> std::result::Result<Covera
         methods_pct,
         uncovered_files,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_parse_spec_can_sum_cargo_result_lines() {
+        let spec: ParseSpec = serde_json::from_value(serde_json::json!({
+            "rules": [
+                { "pattern": "test result:.*?(\\d+) passed", "field": "passed", "aggregate": "sum" },
+                { "pattern": "test result:.*?(\\d+) failed", "field": "failed", "aggregate": "sum" },
+                { "pattern": "test result:.*?(\\d+) ignored", "field": "skipped", "aggregate": "sum" }
+            ],
+            "defaults": { "passed": 0, "failed": 0, "skipped": 0 },
+            "derive": [
+                { "field": "total", "expr": "passed + failed + skipped" }
+            ]
+        }))
+        .expect("parse spec should deserialize from manifest-shaped JSON");
+
+        let counts = parse_test_results_text_with_spec(
+            "test result: ok. 2 passed; 0 failed; 1 ignored\n\
+             test result: FAILED. 3 passed; 1 failed; 0 ignored",
+            &spec,
+        )
+        .expect("cargo-style output should parse");
+
+        assert_eq!(counts.total, 7);
+        assert_eq!(counts.passed, 5);
+        assert_eq!(counts.failed, 1);
+        assert_eq!(counts.skipped, 1);
+    }
+
+    #[test]
+    fn default_parse_spec_preserves_phpunit_summary_fallback() {
+        let counts = parse_test_results_text("Tests: 12, Assertions: 20, Failures: 2, Skipped: 3")
+            .expect("default PHPUnit-ish fallback should still parse");
+
+        assert_eq!(counts.total, 12);
+        assert_eq!(counts.passed, 7);
+        assert_eq!(counts.failed, 2);
+        assert_eq!(counts.skipped, 3);
+    }
 }

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -5,8 +5,9 @@ use crate::extension::test::analyze::{analyze, TestAnalysis, TestAnalysisInput};
 use crate::extension::test::baseline::{self, TestBaselineComparison, TestCounts};
 use crate::extension::test::{
     build_test_runner, build_test_summary, compute_changed_test_scope, parse_coverage_file,
-    parse_failures_file, parse_test_results_file, parse_test_results_text, CoverageOutput,
-    FailedTest, TestScopeOutput, TestSummaryOutput,
+    parse_failures_file, parse_test_results_file, parse_test_results_text,
+    parse_test_results_text_with_spec, CoverageOutput, FailedTest, TestScopeOutput,
+    TestSummaryOutput,
 };
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
@@ -175,6 +176,11 @@ pub fn run_main_test_workflow(
         }
     }
 
+    let result_parse = crate::extension::test::resolve_test_command(component)
+        .ok()
+        .and_then(|context| crate::extension::load_extension(&context.extension_id).ok())
+        .and_then(|extension| extension.test.and_then(|test| test.result_parse));
+
     let output = build_test_runner(
         component,
         args.path_override.clone(),
@@ -188,8 +194,12 @@ pub fn run_main_test_workflow(
     .script_args(&args.passthrough_args)
     .run()?;
 
-    let test_counts =
-        parse_test_results_file(&results_file).or_else(|| parse_test_results_text(&output.stdout));
+    let test_counts = parse_test_results_file(&results_file).or_else(|| {
+        result_parse
+            .as_ref()
+            .and_then(|spec| parse_test_results_text_with_spec(&output.stdout, spec))
+            .or_else(|| parse_test_results_text(&output.stdout))
+    });
 
     // Autofix is owned by `refactor --from test --write`; the test command is read-only.
     let test_autofix: Option<AppliedRefactor> = None;


### PR DESCRIPTION
## Summary
- Adds manifest-declared extension runtime requirements so component env can include the runner substrate fallback when the component itself has no runtime declaration.
- Adds manifest-driven test result parse specs on top of the existing generic output parser, while keeping sidecar JSON as the highest-priority structured contract.
- Ships a shared resolve-context shell helper through Homeboy's runtime helper mechanism for extension runner scripts.

## Changes
- Extension manifests can declare runtime node/php requirements and test.result_parse specs.
- component env now reports component runtime sources and falls back to extension runtime requirements only when component values are absent.
- extension show surfaces runtime_requirements metadata.
- Test output parsing can deserialize aggregate parse specs and apply them before the legacy fallback parser.
- HOMEBOY_RUNTIME_RESOLVE_CONTEXT points scripts at the new resolve-context.sh helper.

## Tests
- cargo test --lib -- --test-threads=1
- cargo test --bin homeboy -- --test-threads=1
- cargo test --tests -- --test-threads=1
- homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-extension-runner-core-support

Closes #1648
Closes #1649
Closes #1650

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the core runner-contract changes, adding focused Rust and shell-helper tests, running verification, and drafting this PR description. Chris reviewed and remains responsible for the change.