### PR TITLE
feat(rig): update installed package sources

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -12,6 +12,7 @@ use homeboy::rig;
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledSummary,
     RigListOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigUpOutput,
+    RigUpdateOutput,
 };
 use super::CmdResult;
 
@@ -58,6 +59,14 @@ enum RigCommand {
         #[arg(long)]
         id: Option<String>,
         /// Install every rig in the package
+        #[arg(long)]
+        all: bool,
+    },
+    /// Update rigs installed from git-backed rig packages
+    Update {
+        /// Rig ID to update. Updates the source package that owns this rig.
+        rig_id: Option<String>,
+        /// Update every installed git-backed rig source package
         #[arg(long)]
         all: bool,
     },
@@ -110,6 +119,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Down { rig_id } => down(&rig_id),
         RigCommand::Status { rig_id } => status(&rig_id),
         RigCommand::Install { source, id, all } => install(&source, id.as_deref(), all),
+        RigCommand::Update { rig_id, all } => update(rig_id.as_deref(), all),
         RigCommand::Sources { command } => sources::run(command),
         RigCommand::App { command } => app(command),
     }
@@ -167,6 +177,37 @@ fn install(source: &str, id: Option<&str>, all: bool) -> CmdResult<RigCommandOut
                     source_revision: rig.source_revision,
                 })
                 .collect(),
+        }),
+        0,
+    ))
+}
+
+fn update(rig_id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
+    let report = match (rig_id, all) {
+        (Some(_), true) => {
+            return Err(homeboy::Error::validation_invalid_argument(
+                "rig_id",
+                "Pass either a rig ID or --all, not both",
+                rig_id.map(str::to_string),
+                None,
+            ))
+        }
+        (Some(id), false) => rig::update_source_for_rig(id)?,
+        (None, true) => rig::update_all_sources()?,
+        (None, false) => {
+            return Err(homeboy::Error::validation_invalid_argument(
+                "rig_id",
+                "Pass a rig ID or --all",
+                None,
+                None,
+            ))
+        }
+    };
+
+    Ok((
+        RigCommandOutput::Update(RigUpdateOutput {
+            command: "rig.update",
+            report,
         }),
         0,
     ))

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -20,6 +20,7 @@ pub enum RigCommandOutput {
     Down(RigDownOutput),
     Status(RigStatusOutput),
     Install(RigInstallOutput),
+    Update(RigUpdateOutput),
     Sources(RigSourcesOutput),
     App(RigAppOutput),
 }
@@ -102,6 +103,13 @@ pub struct RigInstalledSummary {
     pub spec_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RigUpdateOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: rig::RigSourceUpdateResult,
 }
 
 #[derive(Serialize)]

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -10,6 +10,7 @@ use crate::{extension, git, paths};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DiscoveredRig {
@@ -24,6 +25,15 @@ pub struct RigInstallResult {
     pub package_path: PathBuf,
     pub linked: bool,
     pub installed: Vec<InstalledRig>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedSource {
+    pub source: String,
+    pub package_path: PathBuf,
+    pub discovery_path: PathBuf,
+    pub linked: bool,
+    pub source_revision: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -47,7 +57,7 @@ pub struct RigSourceMetadata {
 
 pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallResult> {
     let prepared = prepare_source(source)?;
-    let discovered = discover_rigs(&prepared.package_path)?;
+    let discovered = discover_rigs(&prepared.discovery_path)?;
     let selected = select_rigs(discovered, id, all, source)?;
 
     fs::create_dir_all(paths::rigs()?)
@@ -101,15 +111,8 @@ pub fn read_source_metadata(id: &str) -> Option<RigSourceMetadata> {
     serde_json::from_str(&content).ok()
 }
 
-struct PreparedSource {
-    source: String,
-    package_path: PathBuf,
-    linked: bool,
-    source_revision: Option<String>,
-}
-
-fn prepare_source(source: &str) -> Result<PreparedSource> {
-    if extension::is_git_url(source) {
+pub(crate) fn prepare_source(source: &str) -> Result<PreparedSource> {
+    if extension::is_git_url(source) || source.contains(".git//") {
         prepare_git_source(source)
     } else {
         prepare_local_source(source)
@@ -117,7 +120,8 @@ fn prepare_source(source: &str) -> Result<PreparedSource> {
 }
 
 fn prepare_git_source(source: &str) -> Result<PreparedSource> {
-    let trimmed = source.trim_end_matches('/').trim_end_matches(".git");
+    let (root_source, subpath) = split_git_source_subpath(source)?;
+    let trimmed = root_source.trim_end_matches('/').trim_end_matches(".git");
     let parts = trimmed.rsplit(['/', ':']).take(2).collect::<Vec<_>>();
     let package_id = if parts.len() == 2 {
         extension::slugify_id(&format!("{}-{}", parts[1], parts[0]))?
@@ -133,19 +137,43 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
                 package_id,
                 package_path.display()
             ),
-            Some(source.to_string()),
+            Some(root_source.to_string()),
             None,
         ));
     }
     fs::create_dir_all(paths::rig_packages()?)
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rig packages dir".into())))?;
-    git::clone_repo(source, &package_path)?;
+    git::clone_repo(root_source, &package_path)?;
+    let source_revision = short_head_revision(&package_path);
+    let discovery_path = match subpath {
+        Some(subpath) => package_path.join(subpath),
+        None => package_path.clone(),
+    };
     Ok(PreparedSource {
-        source: source.to_string(),
+        source: root_source.to_string(),
         package_path,
+        discovery_path,
         linked: false,
-        source_revision: None,
+        source_revision,
     })
+}
+
+fn split_git_source_subpath(source: &str) -> Result<(&str, Option<&str>)> {
+    let Some(marker) = source.find(".git//") else {
+        return Ok((source, None));
+    };
+    let root_end = marker + ".git".len();
+    let root = &source[..root_end];
+    let subpath = source[root_end + 2..].trim_matches('/');
+    if subpath.is_empty() || subpath.starts_with("..") || subpath.contains("/../") {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            "Rig package subpath must be a non-empty relative path",
+            Some(source.to_string()),
+            None,
+        ));
+    }
+    Ok((root, Some(subpath)))
 }
 
 fn prepare_local_source(source: &str) -> Result<PreparedSource> {
@@ -167,6 +195,7 @@ fn prepare_local_source(source: &str) -> Result<PreparedSource> {
     }
     Ok(PreparedSource {
         source: package_path.to_string_lossy().to_string(),
+        discovery_path: package_path.clone(),
         package_path,
         linked: true,
         source_revision: None,
@@ -288,7 +317,7 @@ fn select_rigs(
     ))
 }
 
-fn write_source_metadata(id: &str, metadata: &RigSourceMetadata) -> Result<()> {
+pub(crate) fn write_source_metadata(id: &str, metadata: &RigSourceMetadata) -> Result<()> {
     let path = paths::rig_source_metadata(id)?;
     let content = serde_json::to_string_pretty(metadata)
         .map_err(|e| Error::internal_json(e.to_string(), Some("serialize rig source".into())))?;
@@ -296,7 +325,7 @@ fn write_source_metadata(id: &str, metadata: &RigSourceMetadata) -> Result<()> {
         .map_err(|e| Error::internal_io(e.to_string(), Some("write rig source".into())))
 }
 
-fn link_or_copy_file(source: &Path, target: &Path) -> Result<()> {
+pub(crate) fn link_or_copy_file(source: &Path, target: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         std::os::unix::fs::symlink(source, target)
@@ -309,6 +338,21 @@ fn link_or_copy_file(source: &Path, target: &Path) -> Result<()> {
             .map(|_| ())
             .map_err(|e| Error::internal_io(e.to_string(), Some("copy rig spec".into())))
     }
+}
+
+fn short_head_revision(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!revision.is_empty()).then_some(revision)
 }
 
 #[cfg(test)]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -41,8 +41,10 @@ pub use runner::{
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{
-    list_sources, remove_source, InvalidRigSourceMetadata, RemovedRigSourceRig, RigSourceGroup,
-    RigSourceListResult, RigSourceRemoveResult, RigSourceRig, SkippedRigSourceRig,
+    list_sources, remove_source, update_all_sources, update_source_for_rig,
+    InvalidRigSourceMetadata, RemovedRigSourceRig, RigSourceGroup, RigSourceListResult,
+    RigSourceRemoveResult, RigSourceRig, RigSourceUpdateResult, RigSourceUpdatedRig,
+    SkippedRigSourceRig, SkippedRigSourceUpdate,
 };
 pub use spec::{
     AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, BenchSpec, CheckSpec,

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -1,17 +1,20 @@
 //! Installed rig source lifecycle.
 
 use crate::error::{Error, Result};
+use crate::git;
 use crate::paths;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use super::install::RigSourceMetadata;
+use super::install::{link_or_copy_file, write_source_metadata, RigSourceMetadata};
 
 mod types;
 pub use types::{
     InvalidRigSourceMetadata, RemovedRigSourceRig, RigSourceGroup, RigSourceListResult,
-    RigSourceRemoveResult, RigSourceRig, SkippedRigSourceRig,
+    RigSourceRemoveResult, RigSourceRig, RigSourceUpdateResult, RigSourceUpdatedRig,
+    SkippedRigSourceRig, SkippedRigSourceUpdate,
 };
 
 pub fn list_sources() -> Result<RigSourceListResult> {
@@ -95,6 +98,145 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
         skipped,
         removed_package_path,
     })
+}
+
+pub fn update_source_for_rig(id: &str) -> Result<RigSourceUpdateResult> {
+    let metadata = super::install::read_source_metadata(id).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "rig_id",
+            format!("Rig '{}' has no installed source metadata", id),
+            Some(id.to_string()),
+            None,
+        )
+    })?;
+    if metadata.linked {
+        return Err(Error::validation_invalid_argument(
+            "rig_id",
+            format!("Rig '{}' was installed from a linked local source; reinstall or edit the source directly", id),
+            Some(id.to_string()),
+            None,
+        ));
+    }
+
+    let list = list_sources()?;
+    let source = list
+        .sources
+        .into_iter()
+        .find(|source| source.rigs.iter().any(|rig| rig.id == id))
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "rig_id",
+                format!("No installed rig source contains '{}'", id),
+                Some(id.to_string()),
+                None,
+            )
+        })?;
+
+    update_group(source)
+}
+
+pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
+    let mut aggregate = RigSourceUpdateResult {
+        updated: Vec::new(),
+        skipped: Vec::new(),
+    };
+    for source in list_sources()?.sources {
+        if source.linked {
+            for rig in source.rigs {
+                aggregate.skipped.push(SkippedRigSourceUpdate {
+                    id: rig.id,
+                    source: source.source.clone(),
+                    reason: "linked local sources are updated in place outside homeboy".to_string(),
+                });
+            }
+            continue;
+        }
+        let result = update_group(source)?;
+        aggregate.updated.extend(result.updated);
+        aggregate.skipped.extend(result.skipped);
+    }
+    Ok(aggregate)
+}
+
+fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
+    let package_path = PathBuf::from(&source.package_path);
+    if !package_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("Installed rig package is missing: {}", source.package_path),
+            Some(source.source),
+            None,
+        ));
+    }
+
+    let previous_revision = short_head_revision(&package_path);
+    git::pull_repo(&package_path)?;
+    let source_revision = short_head_revision(&package_path);
+
+    let mut updated = Vec::new();
+    let mut skipped = Vec::new();
+    for rig in source.rigs {
+        let rig_path = PathBuf::from(&rig.rig_path);
+        if !rig_path.is_file() {
+            skipped.push(SkippedRigSourceUpdate {
+                id: rig.id,
+                source: source.source.clone(),
+                reason: format!("rig spec missing after update: {}", rig_path.display()),
+            });
+            continue;
+        }
+        if !rig.config_owned {
+            skipped.push(SkippedRigSourceUpdate {
+                id: rig.id,
+                source: source.source.clone(),
+                reason: "config file no longer points at the recorded rig source".to_string(),
+            });
+            continue;
+        }
+
+        let config_path = PathBuf::from(&rig.config_path);
+        if config_path.exists() || fs::symlink_metadata(&config_path).is_ok() {
+            fs::remove_file(&config_path).map_err(|e| {
+                Error::internal_io(e.to_string(), Some("replace rig config link".into()))
+            })?;
+        }
+        link_or_copy_file(&rig_path, &config_path)?;
+
+        let metadata = RigSourceMetadata {
+            source: source.source.clone(),
+            package_path: source.package_path.clone(),
+            rig_path: rig.rig_path.clone(),
+            linked: false,
+            source_revision: source_revision.clone(),
+        };
+        write_source_metadata(&rig.id, &metadata)?;
+
+        updated.push(RigSourceUpdatedRig {
+            id: rig.id,
+            source: source.source.clone(),
+            path: rig.config_path,
+            spec_path: rig.rig_path,
+            previous_revision: previous_revision.clone(),
+            source_revision: source_revision.clone(),
+        });
+    }
+
+    Ok(RigSourceUpdateResult { updated, skipped })
+}
+
+fn short_head_revision(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!revision.is_empty()).then_some(revision)
 }
 
 fn removed_rig_source_rig(rig: &RigSourceRig, metadata_path: &Path) -> RemovedRigSourceRig {

--- a/src/core/rig/source/types.rs
+++ b/src/core/rig/source/types.rs
@@ -56,3 +56,28 @@ pub struct SkippedRigSourceRig {
     pub config_path: String,
     pub reason: String,
 }
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigSourceUpdateResult {
+    pub updated: Vec<RigSourceUpdatedRig>,
+    pub skipped: Vec<SkippedRigSourceUpdate>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigSourceUpdatedRig {
+    pub id: String,
+    pub source: String,
+    pub path: String,
+    pub spec_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SkippedRigSourceUpdate {
+    pub id: String,
+    pub source: String,
+    pub reason: String,
+}

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -4,6 +4,7 @@ use crate::rig::{discover_rigs, install, read_source_metadata};
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 fn write_rig(package: &Path, id: &str, body: &str) -> std::path::PathBuf {
     let rig_dir = package.join("rigs").join(id);
@@ -27,6 +28,64 @@ fn minimal_rig(id: &str) -> String {
         }}"#,
         id, id, id
     )
+}
+
+fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
+    fs::create_dir_all(dir).expect("single rig dir");
+    let rig_path = dir.join("rig.json");
+    fs::write(&rig_path, body).expect("rig json");
+    assert!(body.contains(id));
+    rig_path
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git command");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_package(package: &Path) {
+    run_git(package, &["add", "."]);
+    run_git(
+        package,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "update rigs",
+        ],
+    );
+}
+
+fn bare_package(package: &Path) -> tempfile::TempDir {
+    run_git(package, &["init"]);
+    commit_package(package);
+
+    let bare = tempfile::tempdir().expect("bare parent");
+    let source_path = bare.path().join("rig-package.git");
+    let output = Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            package.to_str().unwrap(),
+            source_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("git clone --bare");
+    assert!(output.status.success());
+    bare
 }
 
 #[test]
@@ -183,4 +242,65 @@ fn git_url_installs_clone_package_and_config_link() {
         .ends_with("rig-packages"));
     assert!(crate::paths::rig_config("alpha").unwrap().exists());
     assert_eq!(read_source_metadata("alpha").unwrap().source, source);
+}
+
+#[test]
+fn git_url_subpath_installs_single_rig_directory() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let subdir = package.path().join("packages").join("studio");
+    write_single_rig(
+        &subdir,
+        "studio",
+        include_str!("../../fixtures/rig-package-subpath/packages/studio/rig.json"),
+    );
+    write_rig(package.path(), "other", &minimal_rig("other"));
+    let bare = bare_package(package.path());
+
+    let root_source = bare.path().join("rig-package.git");
+    let source = format!("{}//packages/studio", root_source.to_string_lossy());
+    let result = install(&source, None, false).expect("install subpath");
+
+    assert!(!result.linked);
+    assert_eq!(result.source, root_source.to_string_lossy());
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(result.installed[0].id, "studio");
+    assert!(result.installed[0]
+        .spec_path
+        .ends_with("packages/studio/rig.json"));
+    assert!(crate::paths::rig_config("studio").unwrap().exists());
+    assert!(!crate::paths::rig_config("other").unwrap().exists());
+
+    let metadata = read_source_metadata("studio").expect("metadata");
+    assert_eq!(metadata.source, root_source.to_string_lossy());
+    assert!(metadata.rig_path.ends_with("packages/studio/rig.json"));
+}
+
+#[test]
+fn git_url_subpath_preserves_multi_rig_ambiguity() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let nested = package.path().join("nested");
+    write_rig(&nested, "alpha", &minimal_rig("alpha"));
+    write_rig(&nested, "beta", &minimal_rig("beta"));
+    let bare = bare_package(package.path());
+
+    let source = format!(
+        "{}//nested",
+        bare.path().join("rig-package.git").to_string_lossy()
+    );
+    let err = install(&source, None, false).expect_err("ambiguous subpath");
+
+    assert!(err.message.contains("multiple rigs"));
+    assert!(err.message.contains("alpha"));
+    assert!(err.message.contains("beta"));
+}
+
+#[test]
+fn git_url_subpath_rejects_invalid_relative_path() {
+    let _home = HomeGuard::new();
+    let err = install("https://example.com/rigs.git//../secrets", None, false)
+        .expect_err("invalid subpath");
+
+    assert!(err.message.contains("non-empty relative path"));
 }

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -1,9 +1,10 @@
 //! Rig source lifecycle tests. Covers `src/core/rig/source.rs`.
 
-use crate::rig::{install, list_sources, remove_source};
+use crate::rig::{install, list_sources, remove_source, update_all_sources, update_source_for_rig};
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 fn write_rig(package: &Path, id: &str, body: &str) -> std::path::PathBuf {
     let rig_dir = package.join("rigs").join(id);
@@ -27,6 +28,56 @@ fn minimal_rig(id: &str) -> String {
         }}"#,
         id, id, id
     )
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git command");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_package(package: &Path, message: &str) {
+    run_git(package, &["add", "."]);
+    run_git(
+        package,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            message,
+        ],
+    );
+}
+
+fn create_bare_source(package: &Path) -> tempfile::TempDir {
+    run_git(package, &["init"]);
+    commit_package(package, "initial rigs");
+
+    let bare = tempfile::tempdir().expect("bare parent");
+    let source_path = bare.path().join("rig-package.git");
+    let output = Command::new("git")
+        .args([
+            "clone",
+            "--bare",
+            package.to_str().unwrap(),
+            source_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("git clone --bare");
+    assert!(output.status.success());
+    bare
 }
 
 #[test]
@@ -139,4 +190,74 @@ fn sources_list_reports_corrupt_metadata_and_missing_configs() {
     assert_eq!(result.sources[0].rigs[0].id, "missing");
     assert!(!result.sources[0].rigs[0].config_present);
     assert!(!result.sources[0].rigs[0].config_owned);
+}
+
+#[test]
+fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    let bare = create_bare_source(package.path());
+    let source = bare
+        .path()
+        .join("rig-package.git")
+        .to_string_lossy()
+        .to_string();
+
+    install(&source, None, false).expect("install");
+    let before = crate::rig::read_source_metadata("alpha")
+        .expect("metadata")
+        .source_revision;
+
+    fs::write(
+        &source_rig,
+        minimal_rig("alpha").replace("alpha rig", "alpha rig updated"),
+    )
+    .expect("update rig");
+    commit_package(package.path(), "update alpha");
+    run_git(package.path(), &["push", &source, "HEAD:main"]);
+
+    let result = update_source_for_rig("alpha").expect("update rig source");
+
+    assert_eq!(result.updated.len(), 1);
+    assert!(result.skipped.is_empty());
+    assert_eq!(result.updated[0].id, "alpha");
+    assert_eq!(result.updated[0].previous_revision, before);
+    assert_ne!(result.updated[0].source_revision, before);
+    let installed =
+        fs::read_to_string(crate::paths::rig_config("alpha").unwrap()).expect("installed rig");
+    assert!(installed.contains("alpha rig updated"));
+    assert_eq!(
+        crate::rig::read_source_metadata("alpha")
+            .expect("metadata")
+            .source_revision,
+        result.updated[0].source_revision
+    );
+}
+
+#[test]
+fn update_all_skips_linked_local_sources() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    let result = update_all_sources().expect("update all");
+
+    assert!(result.updated.is_empty());
+    assert_eq!(result.skipped.len(), 1);
+    assert_eq!(result.skipped[0].id, "alpha");
+    assert!(result.skipped[0].reason.contains("linked local sources"));
+}
+
+#[test]
+fn update_single_linked_local_source_errors() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    let err = update_source_for_rig("alpha").expect_err("linked update error");
+
+    assert!(err.message.contains("linked local source"));
 }

--- a/tests/fixtures/rig-package-subpath/packages/studio/rig.json
+++ b/tests/fixtures/rig-package-subpath/packages/studio/rig.json
@@ -1,0 +1,12 @@
+{
+  "id": "studio",
+  "description": "studio rig",
+  "components": {
+    "app": { "path": "${env.DEV_ROOT}/studio" }
+  },
+  "pipeline": {
+    "check": [
+      { "kind": "check", "label": "app exists", "file": "${components.app.path}" }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `homeboy rig update <rig-id>` and `homeboy rig update --all` for git-backed rig packages.
- Support installing a single rig from a git package subpath with the `repo.git//path/to/rig` syntax.
- Keep local linked rig packages explicit: single-rig update errors, `--all` reports them as skipped.

## Changes
- Rig install now separates package root from discovery path so subpath installs keep the cloned package root as the update source.
- Rig source metadata now records git source revisions and update refreshes owned config links after `git pull`.
- Added update output envelopes and focused fixture-backed tests for subpath install and source update behavior.

## Tests
- `cargo test install_test && cargo test source_test`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-package-lifecycle`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-package-lifecycle --changed-since origin/main`
- `cargo run --quiet --bin homeboy -- rig update --help`

Full `homeboy audit` still reports pre-existing baseline findings outside this change; changed-since audit is clean.

Closes #1633.
Closes #1634.
Refs #1635.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the rig package subpath/update lifecycle changes, added tests/fixtures, and ran verification. Chris remains responsible for review and merge.
