### PR TITLE
fix(audit): tighten detector precision

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -327,25 +327,18 @@ pub fn discover_conventions_with_config(
     }
 
     // Methods appearing in ≥ threshold files are "expected".
-    // Test lifecycle methods are excluded — they're optional overrides inherited
-    // from test base classes (PHPUnit, WP_UnitTestCase), not convention-specific.
-    let test_lifecycle: &[&str] = &[
-        "set_up",
-        "tear_down",
-        "set_up_before_class",
-        "tear_down_after_class",
-        "setUp",
-        "tearDown",
-        "setUpBeforeClass",
-        "tearDownAfterClass",
-    ];
     let is_test_group = super::walker::is_test_path(glob_pattern);
-    let expected_methods: Vec<String> = method_counts
-        .iter()
-        .filter(|(_, count)| **count >= threshold)
-        .filter(|(name, _)| !is_test_group || !test_lifecycle.contains(&name.as_str()))
-        .map(|(name, _)| name.clone())
-        .collect();
+    let expected_methods: Vec<String> = if is_test_group {
+        // Test-file helpers (`run`, `init_repo`, fixture builders, etc.) are local
+        // scaffolding, not production API conventions every sibling test must carry.
+        Vec::new()
+    } else {
+        method_counts
+            .iter()
+            .filter(|(_, count)| **count >= threshold)
+            .map(|(name, _)| name.clone())
+            .collect()
+    };
 
     if expected_methods.is_empty() {
         return None; // No convention found
@@ -1162,6 +1155,53 @@ mod tests {
                 .flat_map(|o| &o.deviations)
                 .all(|d| d.kind != AuditFinding::MissingMethod),
             "factories produce stores; they should not implement store methods"
+        );
+    }
+
+    #[test]
+    fn test_file_helper_functions_do_not_create_missing_method_conventions() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "tests/core/stack/apply_test.rs".to_string(),
+                language: Language::Rust,
+                methods: vec![
+                    "run".to_string(),
+                    "init_repo".to_string(),
+                    "write_and_commit".to_string(),
+                ],
+                type_name: None,
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "tests/core/stack/status_test.rs".to_string(),
+                language: Language::Rust,
+                methods: vec![
+                    "run".to_string(),
+                    "init_repo".to_string(),
+                    "write_and_commit".to_string(),
+                ],
+                type_name: None,
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "tests/core/stack/spec_test.rs".to_string(),
+                language: Language::Rust,
+                methods: vec!["spec_round_trips".to_string()],
+                type_name: None,
+                ..Default::default()
+            },
+        ];
+
+        let convention = discover_conventions_with_config(
+            "Stack (Tests)",
+            "tests/core/stack/*_test.rs",
+            &fingerprints,
+            &AuditConfig::default(),
+        );
+
+        assert!(
+            convention.is_none(),
+            "test helper functions are local scaffolding, not methods every sibling test file must define"
         );
     }
 

--- a/src/core/code_audit/field_patterns.rs
+++ b/src/core/code_audit/field_patterns.rs
@@ -49,6 +49,12 @@ struct StructDef {
     fields: Vec<FieldSignature>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldSyntax {
+    RustLike,
+    Php,
+}
+
 fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
     let config = ScanConfig {
         extensions: ExtensionFilter::Only(vec![
@@ -85,7 +91,8 @@ fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
             content
         };
 
-        let structs = extract_structs(&scan_content, &relative);
+        let syntax = field_syntax_for_path(&relative);
+        let structs = extract_structs(&scan_content, &relative, syntax);
         all_structs.extend(structs);
     }
 
@@ -186,7 +193,7 @@ fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
 /// - Rust: `struct Name {` ... `field: Type,` ... `}`
 /// - PHP: `class Name {` ... `type $field;` or `public type $field;`
 /// - TS/JS: `interface Name {` or `type Name = {`
-fn extract_structs(content: &str, file: &str) -> Vec<StructDef> {
+fn extract_structs(content: &str, file: &str, syntax: FieldSyntax) -> Vec<StructDef> {
     let mut result = Vec::new();
     let lines: Vec<&str> = content.lines().collect();
     let mut i = 0;
@@ -224,7 +231,7 @@ fn extract_structs(content: &str, file: &str) -> Vec<StructDef> {
                     // Parse only direct members of the type body. Nested executable bodies
                     // can contain field-shaped syntax that is not extractable type structure.
                     if j > start && depth == 1 {
-                        if let Some(field) = parse_field_line(lines[j]) {
+                        if let Some(field) = parse_field_line(lines[j], syntax) {
                             fields.push(field);
                         }
                     }
@@ -252,6 +259,14 @@ fn extract_structs(content: &str, file: &str) -> Vec<StructDef> {
     }
 
     result
+}
+
+fn field_syntax_for_path(path: &str) -> FieldSyntax {
+    if path.ends_with(".php") {
+        FieldSyntax::Php
+    } else {
+        FieldSyntax::RustLike
+    }
 }
 
 /// Try to extract a type name from a line that starts a struct/class/interface.
@@ -309,7 +324,7 @@ fn extract_type_name(line: &str) -> Option<String> {
 /// - Rust: `field_name: Type,` or `pub field_name: Type,`
 /// - PHP: `public Type $field_name;` or `$field_name;`
 /// - TS: `field_name: type;` or `readonly field_name: type;`
-fn parse_field_line(line: &str) -> Option<FieldSignature> {
+fn parse_field_line(line: &str, syntax: FieldSyntax) -> Option<FieldSignature> {
     let trimmed = line.trim();
 
     // Skip comments, attributes, blank lines, braces.
@@ -328,6 +343,10 @@ fn parse_field_line(line: &str) -> Option<FieldSignature> {
     // Skip function/method declarations.
     if trimmed.contains("fn ") || trimmed.contains("function ") || trimmed.contains("=>") {
         return None;
+    }
+
+    if syntax == FieldSyntax::Php {
+        return parse_php_property_line(trimmed);
     }
 
     // Rust-style: `[pub] name: Type[,]`
@@ -357,6 +376,49 @@ fn parse_field_line(line: &str) -> Option<FieldSignature> {
     }
 
     None
+}
+
+fn parse_php_property_line(line: &str) -> Option<FieldSignature> {
+    let mut content = line.trim().trim_end_matches(';').trim();
+
+    loop {
+        let Some(stripped) = content
+            .strip_prefix("public ")
+            .or_else(|| content.strip_prefix("protected "))
+            .or_else(|| content.strip_prefix("private "))
+            .or_else(|| content.strip_prefix("static "))
+            .or_else(|| content.strip_prefix("readonly "))
+        else {
+            break;
+        };
+        content = stripped.trim_start();
+    }
+
+    let Some(dollar_pos) = content.find('$') else {
+        return None;
+    };
+
+    let field_type = content[..dollar_pos].trim();
+    let after_dollar = &content[dollar_pos + 1..];
+    let name: String = after_dollar
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+
+    if name.is_empty() {
+        return None;
+    }
+
+    let field_type = if field_type.is_empty() {
+        "mixed"
+    } else {
+        field_type
+    };
+
+    Some(FieldSignature {
+        name,
+        field_type: field_type.to_string(),
+    })
 }
 
 fn is_test_path(path: &str) -> bool {
@@ -497,7 +559,7 @@ pub struct Config {
     pub output: Option<String>,
 }
 "#;
-        let structs = extract_structs(content, "test.rs");
+        let structs = extract_structs(content, "test.rs", FieldSyntax::RustLike);
         assert_eq!(structs.len(), 1);
         assert_eq!(structs[0].name, "Config");
         assert_eq!(structs[0].fields.len(), 3);
@@ -521,7 +583,7 @@ struct Beta {
     z: i32,
 }
 "#;
-        let structs = extract_structs(content, "test.rs");
+        let structs = extract_structs(content, "test.rs", FieldSyntax::RustLike);
         assert_eq!(structs.len(), 2);
         assert_eq!(structs[0].name, "Alpha");
         assert_eq!(structs[1].name, "Beta");
@@ -540,7 +602,7 @@ impl Foo {
     }
 }
 "#;
-        let structs = extract_structs(content, "test.rs");
+        let structs = extract_structs(content, "test.rs", FieldSyntax::RustLike);
         assert_eq!(structs.len(), 1);
         assert_eq!(structs[0].fields.len(), 1);
         assert_eq!(structs[0].fields[0].name, "name");
@@ -560,10 +622,70 @@ class AIStep {
 }
 "#;
 
-        let structs = extract_structs(content, "test.php");
+        let structs = extract_structs(content, "test.php", FieldSyntax::Php);
         assert!(
             structs.is_empty(),
             "call-site named arguments inside methods should not create field-bearing structs"
+        );
+    }
+
+    #[test]
+    fn extracts_php_class_properties_without_named_arguments() {
+        let content = r#"
+class Config {
+    public string $label;
+    protected ?array $settings;
+
+    public static function register(): void {
+        self::registerStepType(
+            label: 'Config',
+            stepSettings: array(),
+        );
+    }
+}
+"#;
+
+        let structs = extract_structs(content, "test.php", FieldSyntax::Php);
+        assert_eq!(structs.len(), 1);
+        assert_eq!(structs[0].fields.len(), 2);
+        assert_eq!(structs[0].fields[0].name, "label");
+        assert_eq!(structs[0].fields[0].field_type, "string");
+        assert_eq!(structs[0].fields[1].name, "settings");
+        assert_eq!(structs[0].fields[1].field_type, "?array");
+    }
+
+    #[test]
+    fn does_not_report_repeated_php_presentation_or_command_call_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        for name in &["callback.php", "authorize.php", "webhook.php"] {
+            std::fs::write(
+                src.join(name),
+                format!(
+                    r#"
+class {} {{
+    public function render(): void {{
+        $styles = array(
+            'display' => 'flex',
+            'background' => '#fff',
+        );
+        WP_CLI::log( 'Rendered' );
+    }}
+}}
+"#,
+                    name.replace(".php", "").to_uppercase()
+                ),
+            )
+            .unwrap();
+        }
+
+        let findings = detect_repeated_field_patterns(dir.path());
+        assert!(
+            findings.is_empty(),
+            "presentation arrays and WP_CLI call sites are not extractable field groups: {:?}",
+            findings
         );
     }
 
@@ -584,7 +706,7 @@ impl Foo {
 }
 "#;
 
-        let structs = extract_structs(content, "test.rs");
+        let structs = extract_structs(content, "test.rs", FieldSyntax::RustLike);
         assert_eq!(structs.len(), 1);
         assert_eq!(structs[0].fields.len(), 1);
         assert_eq!(structs[0].fields[0].name, "name");
@@ -606,7 +728,7 @@ class Widget {
 }
 "#;
 
-        let structs = extract_structs(content, "test.ts");
+        let structs = extract_structs(content, "test.ts", FieldSyntax::RustLike);
         assert_eq!(structs.len(), 1);
         assert_eq!(structs[0].fields.len(), 1);
         assert_eq!(structs[0].fields[0].name, "name");
@@ -704,7 +826,7 @@ struct Foo {
 
     #[test]
     fn parse_field_line_rust() {
-        let field = parse_field_line("    pub verbose: bool,");
+        let field = parse_field_line("    pub verbose: bool,", FieldSyntax::RustLike);
         assert!(field.is_some());
         let f = field.unwrap();
         assert_eq!(f.name, "verbose");
@@ -713,7 +835,7 @@ struct Foo {
 
     #[test]
     fn parse_field_line_with_option() {
-        let field = parse_field_line("    output: Option<PathBuf>,");
+        let field = parse_field_line("    output: Option<PathBuf>,", FieldSyntax::RustLike);
         assert!(field.is_some());
         let f = field.unwrap();
         assert_eq!(f.name, "output");
@@ -722,15 +844,15 @@ struct Foo {
 
     #[test]
     fn parse_field_line_skips_comments() {
-        assert!(parse_field_line("    // a comment").is_none());
-        assert!(parse_field_line("    #[derive(Debug)]").is_none());
-        assert!(parse_field_line("").is_none());
+        assert!(parse_field_line("    // a comment", FieldSyntax::RustLike).is_none());
+        assert!(parse_field_line("    #[derive(Debug)]", FieldSyntax::RustLike).is_none());
+        assert!(parse_field_line("", FieldSyntax::RustLike).is_none());
     }
 
     #[test]
     fn parse_field_line_skips_functions() {
-        assert!(parse_field_line("    fn new() -> Self {").is_none());
-        assert!(parse_field_line("    pub function run() {").is_none());
+        assert!(parse_field_line("    fn new() -> Self {", FieldSyntax::RustLike).is_none());
+        assert!(parse_field_line("    pub function run() {", FieldSyntax::RustLike).is_none());
     }
 
     #[test]

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -300,6 +300,7 @@ pub(crate) fn analyze_test_coverage(
         .collect();
 
     let source_name_index = build_source_name_index(&source_fps);
+    let source_symbol_names = collect_source_symbol_names(&source_fps);
 
     for test_fp in &test_fps {
         let expected_source_path = test_to_source_path(&test_fp.relative_path, config);
@@ -336,7 +337,7 @@ pub(crate) fn analyze_test_coverage(
                         ),
                         kind: AuditFinding::OrphanedTest,
                     });
-                } else {
+                } else if !references_multiple_source_symbols(test_fp, &source_symbol_names) {
                     // Truly orphaned — no source found anywhere
                     findings.push(Finding {
                         convention: "test_coverage".to_string(),
@@ -358,6 +359,73 @@ pub(crate) fn analyze_test_coverage(
     // Sort by file path for deterministic output
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
     findings
+}
+
+fn collect_source_symbol_names(source_fps: &[&FileFingerprint]) -> HashSet<String> {
+    let mut names = HashSet::new();
+
+    for fp in source_fps {
+        if let Some(type_name) = &fp.type_name {
+            if is_meaningful_symbol_name(type_name) {
+                names.insert(type_name.clone());
+            }
+        }
+        for type_name in &fp.type_names {
+            if is_meaningful_symbol_name(type_name) {
+                names.insert(type_name.clone());
+            }
+        }
+        if let Some(stem) = Path::new(&fp.relative_path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+        {
+            if is_meaningful_symbol_name(stem) {
+                names.insert(stem.to_string());
+            }
+        }
+    }
+
+    names
+}
+
+fn references_multiple_source_symbols(
+    test_fp: &FileFingerprint,
+    source_symbol_names: &HashSet<String>,
+) -> bool {
+    let mut referenced = HashSet::new();
+    let mut haystacks = Vec::new();
+    haystacks.push(test_fp.content.as_str());
+    haystacks.extend(test_fp.imports.iter().map(|s| s.as_str()));
+
+    for symbol in source_symbol_names {
+        if haystacks
+            .iter()
+            .any(|haystack| contains_symbol(haystack, symbol))
+        {
+            referenced.insert(symbol.as_str());
+            if referenced.len() >= 2 {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn is_meaningful_symbol_name(name: &str) -> bool {
+    name.len() >= 3 && name.chars().any(|c| c.is_alphabetic())
+}
+
+fn contains_symbol(haystack: &str, symbol: &str) -> bool {
+    haystack.match_indices(symbol).any(|(start, _)| {
+        let before = haystack[..start].chars().next_back();
+        let after = haystack[start + symbol.len()..].chars().next();
+        !before.is_some_and(is_identifier_char) && !after.is_some_and(is_identifier_char)
+    })
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
 }
 
 /// Load test methods from disk for a known test file path.
@@ -732,6 +800,48 @@ mod tests {
             .collect();
         assert_eq!(orphaned.len(), 1);
         assert!(orphaned[0].description.contains("old_module"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn behavior_named_test_referencing_multiple_source_symbols_is_not_orphaned() {
+        let config = make_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_behavior_file");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/core")).unwrap();
+        std::fs::create_dir_all(dir.join("tests/core")).unwrap();
+
+        let mut resolver = make_fp("src/core/tool_policy_resolver.rs", vec!["resolve"]);
+        resolver.type_name = Some("ToolPolicyResolver".to_string());
+        let mut registry = make_fp("src/core/tool_registry.rs", vec!["register"]);
+        registry.type_name = Some("ToolRegistry".to_string());
+        let mut test = make_fp(
+            "tests/core/chat_tools_availability_test.rs",
+            vec!["test_chat_tools"],
+        );
+        test.content = r#"
+use crate::core::tool_policy_resolver::ToolPolicyResolver;
+use crate::core::tool_registry::ToolRegistry;
+
+#[test]
+fn test_chat_tools() {
+    let _ = ToolPolicyResolver::new(ToolRegistry::default());
+}
+"#
+        .to_string();
+
+        let findings = analyze_test_coverage(&dir, &[&resolver, &registry, &test], &config);
+        let orphaned: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::OrphanedTest)
+            .collect();
+
+        assert!(
+            orphaned.is_empty(),
+            "behavior/integration test files that reference multiple source symbols should not be marked orphaned: {:?}",
+            orphaned
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary
- Tighten repeated field pattern detection so PHP scans extract real class properties, not named arguments, presentation arrays, or static call sites.
- Treat behavior/integration-style orphan test files as valid when they reference multiple existing production symbols.
- Stop deriving missing-method conventions from test helper functions in sibling test files.

## Root cause
- The repeated-field detector used Rust/TS-style `name: Type` parsing for PHP, where that shape usually means named arguments or call syntax rather than fields.
- File-level orphaned-test detection only checked path/name correspondence, so behavior-named tests with no one-to-one source class were reported as stale.
- Convention discovery treated helper functions in test files as required sibling methods, producing missing-method findings like `run`, `init_repo`, and `write_and_commit`.

## Changes
- Add PHP-specific field parsing for actual `$property` declarations while keeping Rust/TS colon-field parsing unchanged.
- Suppress file-level orphaned-test findings only when the unmatched test references two or more existing production symbols.
- Return no method convention for test-file groups, because shared test helpers are local scaffolding rather than required production API.
- Add focused regression coverage for all three precision gaps.

## Tests
- `cargo test core::code_audit::field_patterns --lib`
- `cargo test core::code_audit::test_coverage --lib`
- `cargo test core::code_audit::conventions --lib`
- `cargo test --lib`

## Closes or Refs
- Closes #1642
- Closes #1622
- Closes #1569

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected representative audit findings, implemented detector precision changes, added regression tests, and ran verification. Chris remains responsible for review and merge.