### PR TITLE
feat(issues): render native outputs for reconcile

### DIFF
--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -13,10 +13,11 @@ use std::path::PathBuf;
 
 use homeboy::code_audit::FindingConfidence;
 use homeboy::issues::{
-    apply_plan, reconcile, GithubTracker, IssueGroup, ReconcileConfig, ReconcilePlan,
-    ReconcileResult, Tracker,
+    apply_plan, build_findings_from_native_output, reconcile, GithubTracker, IssueRenderContext,
+    ReconcileConfig, ReconcileFindingsInput, ReconcilePlan, ReconcileResult, Tracker,
 };
 
+use super::parse_key_val;
 use super::CmdResult;
 
 #[derive(Args)]
@@ -63,7 +64,17 @@ enum IssuesCommand {
         /// `body` is rendered as-is into new or updated issues — callers
         /// own the finding-table format.
         #[arg(long, value_name = "PATH")]
-        findings: String,
+        findings: Option<String>,
+
+        /// Native Homeboy command output to normalize before reconcile.
+        /// Repeatable as `--from-output audit=/tmp/audit.json`.
+        #[arg(long = "from-output", value_name = "COMMAND=PATH", value_parser = parse_key_val)]
+        from_output: Vec<(String, String)>,
+
+        /// Optional run URL appended to generated issue bodies when using
+        /// `--from-output`.
+        #[arg(long, value_name = "URL")]
+        run_url: Option<String>,
 
         /// Read suppressions from `homeboy.json`'s `audit.suppressed_categories`
         /// and `issues.suppression_labels`. When false, suppression must be
@@ -108,12 +119,25 @@ enum IssuesCommand {
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
     },
+
+    /// Convert native command output into the canonical reconcile input shape.
+    BuildFindings {
+        /// Native Homeboy command output to normalize. Repeatable as
+        /// `--from-output audit=/tmp/audit.json`.
+        #[arg(long = "from-output", value_name = "COMMAND=PATH", value_parser = parse_key_val)]
+        from_output: Vec<(String, String)>,
+
+        /// Optional run URL appended to generated issue bodies.
+        #[arg(long, value_name = "URL")]
+        run_url: Option<String>,
+    },
 }
 
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum IssuesCommandOutput {
     Reconcile(ReconcileOutput),
+    BuildFindings(ReconcileFindingsInput),
 }
 
 /// What the CLI emits for `homeboy issues reconcile`. Both dry-run and
@@ -150,6 +174,8 @@ pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCom
             component_id,
             tracker: _tracker,
             findings,
+            from_output,
+            run_url,
             suppress_from_config,
             suppress_category,
             suppress_label,
@@ -159,9 +185,9 @@ pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCom
             apply,
             path,
         } => {
-            let findings_input = read_findings(&findings)?;
+            let findings_input = read_reconcile_input(findings.as_deref(), &from_output, run_url)?;
             let command_label = findings_input.command.clone();
-            let groups = findings_input.into_groups(&component_id);
+            let groups = into_issue_groups(findings_input, &component_id);
 
             // Build reconcile config: CLI overrides take priority; otherwise
             // read homeboy.json when the flag is set; otherwise empty.
@@ -210,6 +236,13 @@ pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCom
                 Ok((IssuesCommandOutput::Reconcile(output), 0))
             }
         }
+        IssuesCommand::BuildFindings {
+            from_output,
+            run_url,
+        } => {
+            let findings_input = build_findings_input(&from_output, run_url)?;
+            Ok((IssuesCommandOutput::BuildFindings(findings_input), 0))
+        }
     }
 }
 
@@ -220,43 +253,101 @@ pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCom
 /// Findings input shape. Designed to be a minimal superset of the JSON the
 /// action's bash already produces, so the migration path doesn't require
 /// changing the audit/lint/test output formats.
-#[derive(Debug)]
-struct FindingsInput {
-    command: String,
-    groups: BTreeMap<String, GroupRow>,
+fn into_issue_groups(
+    input: ReconcileFindingsInput,
+    component_id: &str,
+) -> Vec<homeboy::issues::IssueGroup> {
+    input
+        .groups
+        .into_iter()
+        .map(|(category, row)| homeboy::issues::IssueGroup {
+            command: input.command.clone(),
+            component_id: component_id.to_string(),
+            category,
+            count: row.count,
+            label: row.label,
+            body: row.body,
+            confidence: row.confidence,
+        })
+        .collect()
 }
 
-#[derive(Debug, Default)]
-struct GroupRow {
-    count: usize,
-    label: String,
-    body: String,
-    confidence: Option<FindingConfidence>,
-}
-
-impl FindingsInput {
-    fn into_groups(self, component_id: &str) -> Vec<IssueGroup> {
-        self.groups
-            .into_iter()
-            .map(|(category, row)| IssueGroup {
-                command: self.command.clone(),
-                component_id: component_id.to_string(),
-                category,
-                count: row.count,
-                label: row.label,
-                body: row.body,
-                confidence: row.confidence,
-            })
-            .collect()
+fn read_reconcile_input(
+    findings: Option<&str>,
+    from_output: &[(String, String)],
+    run_url: Option<String>,
+) -> homeboy::Result<ReconcileFindingsInput> {
+    match (findings, from_output.is_empty()) {
+        (Some(path), true) => read_findings(path),
+        (None, false) => build_findings_input(from_output, run_url),
+        (Some(_), false) => Err(homeboy::Error::validation_invalid_argument(
+            "findings",
+            "Use either --findings or --from-output, not both",
+            None,
+            None,
+        )),
+        (None, true) => Err(homeboy::Error::validation_invalid_argument(
+            "findings",
+            "Missing --findings or --from-output",
+            None,
+            Some(vec![
+                "Pass --findings <path> for pre-rendered input".to_string(),
+                "Pass --from-output audit=<path> to normalize native command output".to_string(),
+            ]),
+        )),
     }
 }
 
-fn read_findings(path: &str) -> homeboy::Result<FindingsInput> {
+fn build_findings_input(
+    from_output: &[(String, String)],
+    run_url: Option<String>,
+) -> homeboy::Result<ReconcileFindingsInput> {
+    if from_output.is_empty() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "from-output",
+            "At least one --from-output COMMAND=PATH pair is required",
+            None,
+            None,
+        ));
+    }
+
+    let context = IssueRenderContext { run_url };
+    let mut merged = ReconcileFindingsInput::default();
+    let mut command_label: Option<&str> = None;
+    for (command, path) in from_output {
+        if let Some(existing) = command_label {
+            if existing != command {
+                return Err(homeboy::Error::validation_invalid_argument(
+                    "from-output",
+                    "Multiple command labels in one issue reconcile input are not supported yet",
+                    None,
+                    Some(vec![
+                        "Run one reconcile per command label for now".to_string(),
+                        "Use repeated --from-output only to merge split output files from the same command".to_string(),
+                    ]),
+                ));
+            }
+        } else {
+            command_label = Some(command);
+        }
+        let value = read_json_value(path, "native command output")?;
+        let rendered = build_findings_from_native_output(command, value, &context)?;
+        merged.merge(rendered);
+    }
+    Ok(merged)
+}
+
+fn read_findings(path: &str) -> homeboy::Result<ReconcileFindingsInput> {
+    let value = read_json_value(path, "findings")?;
+    parse_findings_value(value)
+}
+
+fn read_json_value(path: &str, label: &str) -> homeboy::Result<Value> {
     let raw = if path == "-" {
         let mut buf = String::new();
         std::io::stdin().read_to_string(&mut buf).map_err(|e| {
             homeboy::Error::internal_io(
-                format!("read findings from stdin: {}", e),
+                format!("read {} from stdin: {}", label, e),
                 Some("stdin".into()),
             )
         })?;
@@ -264,7 +355,7 @@ fn read_findings(path: &str) -> homeboy::Result<FindingsInput> {
     } else {
         std::fs::read_to_string(path).map_err(|e| {
             homeboy::Error::internal_io(
-                format!("read findings file: {}", e),
+                format!("read {} file: {}", label, e),
                 Some(path.to_string()),
             )
         })?
@@ -278,10 +369,10 @@ fn read_findings(path: &str) -> homeboy::Result<FindingsInput> {
         )
     })?;
 
-    parse_findings_value(value)
+    Ok(value)
 }
 
-fn parse_findings_value(value: Value) -> homeboy::Result<FindingsInput> {
+fn parse_findings_value(value: Value) -> homeboy::Result<ReconcileFindingsInput> {
     let obj = value.as_object().ok_or_else(|| {
         homeboy::Error::validation_invalid_argument(
             "findings",
@@ -304,7 +395,7 @@ fn parse_findings_value(value: Value) -> homeboy::Result<FindingsInput> {
         })?
         .to_string();
 
-    let mut groups: BTreeMap<String, GroupRow> = BTreeMap::new();
+    let mut groups: BTreeMap<String, homeboy::issues::RenderedIssueGroup> = BTreeMap::new();
     if let Some(groups_value) = obj.get("groups") {
         let groups_obj = groups_value.as_object().ok_or_else(|| {
             homeboy::Error::validation_invalid_argument(
@@ -317,7 +408,7 @@ fn parse_findings_value(value: Value) -> homeboy::Result<FindingsInput> {
         for (category, row_value) in groups_obj {
             let row_obj = row_value.as_object().ok_or_else(|| {
                 homeboy::Error::validation_invalid_argument(
-                    &format!("findings.groups.{}", category),
+                    format!("findings.groups.{}", category),
                     "Each group must be a JSON object with `count`, optional `label`, optional `body`, optional `confidence`",
                     None,
                     None,
@@ -344,7 +435,7 @@ fn parse_findings_value(value: Value) -> homeboy::Result<FindingsInput> {
                 .and_then(parse_confidence);
             groups.insert(
                 category.clone(),
-                GroupRow {
+                homeboy::issues::RenderedIssueGroup {
                     count,
                     label,
                     body,
@@ -354,7 +445,7 @@ fn parse_findings_value(value: Value) -> homeboy::Result<FindingsInput> {
         }
     }
 
-    Ok(FindingsInput { command, groups })
+    Ok(ReconcileFindingsInput { command, groups })
 }
 
 fn parse_confidence(raw: &str) -> Option<FindingConfidence> {
@@ -556,7 +647,7 @@ mod tests {
         });
 
         let parsed = parse_findings_value(input).unwrap();
-        let groups = parsed.into_groups("homeboy");
+        let groups = into_issue_groups(parsed, "homeboy");
 
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].confidence, Some(FindingConfidence::Heuristic));

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -20,6 +20,7 @@ use homeboy::extension::lint::LintCommandOutput;
 use homeboy::extension::test::TestCommandOutput;
 use homeboy::git;
 
+use super::parse_key_val;
 use super::utils::args::{BaselineArgs, PositionalComponentArgs};
 use super::{audit, lint, test, CmdResult, GlobalArgs};
 
@@ -57,6 +58,11 @@ pub struct ReviewArgs {
     /// `homeboy git pr comment --body-file`.
     #[arg(long, value_name = "FORMAT", value_parser = ["pr-comment"])]
     pub report: Option<String>,
+
+    /// Action-level banner rendered above the PR-comment scope line.
+    /// Repeatable as `--banner key=value`.
+    #[arg(long, value_name = "KEY=VALUE", value_parser = parse_key_val)]
+    pub banner: Vec<(String, String)>,
 
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
@@ -332,8 +338,13 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
 /// the consumer (`homeboy git pr comment --header`) owns the wrapping
 /// section header.
 pub fn run_markdown(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<String> {
+    let banners = args.banner.clone();
     let (output, exit_code) = run(args, global)?;
-    let md = render::render_pr_comment(&output);
+    let md = if banners.is_empty() {
+        render::render_pr_comment(&output)
+    } else {
+        render::render_pr_comment_with_banners(&output, &banners)
+    };
     Ok((md, exit_code))
 }
 
@@ -533,6 +544,7 @@ mod tests {
             summary: false,
             json: false,
             report: None,
+            banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
         };
         assert_eq!(scope_flag_suffix(&args, true), " --changed-since=trunk");
@@ -551,6 +563,7 @@ mod tests {
             summary: false,
             json: false,
             report: None,
+            banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
         };
         assert_eq!(scope_flag_suffix(&args, true), " --changed-only");
@@ -571,6 +584,7 @@ mod tests {
             summary: false,
             json: false,
             report: None,
+            banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
         };
         assert_eq!(scope_flag_suffix(&args, true), "");

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -6,16 +6,14 @@
 //!
 //! Shape (top-down):
 //!
-//! 1. Scope banner: `:zap:` for changed-since/changed-only, `:information_source:` for full.
-//! 2. Total findings line.
-//! 3. Three stage blocks in fixed order — audit, lint, test. Each stage:
+//! 1. Optional caller-supplied banners for action-level signals.
+//! 2. Scope banner: `:zap:` for changed-since/changed-only, `:information_source:` for full.
+//! 3. Total findings line.
+//! 4. Three stage blocks in fixed order — audit, lint, test. Each stage:
 //!    - icon + name header (`:white_check_mark:`, `:x:`, `:fast_forward:`)
 //!    - up to 10 finding bullets (top categories / sniff codes / failure summary)
 //!    - blockquote with the deep-dive hint
 //!
-//! Action-level signals (autofix banners, binary-source warnings, tooling
-//! versions) are out of scope — those are not present in `ReviewCommandOutput`.
-//! See follow-up: `feat(review): --banner key=value for action-level signals`.
 
 use std::fmt::Write as _;
 
@@ -32,8 +30,17 @@ const TOP_N: usize = 10;
 
 /// Render a `ReviewCommandOutput` into a PR-comment-ready markdown body.
 pub fn render_pr_comment(output: &ReviewCommandOutput) -> String {
+    render_pr_comment_with_banners(output, &[])
+}
+
+/// Render a `ReviewCommandOutput` with optional action-level banner lines.
+pub fn render_pr_comment_with_banners(
+    output: &ReviewCommandOutput,
+    banners: &[(String, String)],
+) -> String {
     let mut out = String::new();
 
+    render_banners(&mut out, banners);
     render_scope_banner(&mut out, output);
     render_total_findings(&mut out, output);
     render_top_hints(&mut out, output);
@@ -48,6 +55,26 @@ pub fn render_pr_comment(output: &ReviewCommandOutput) -> String {
 }
 
 // ── Top-level banners ───────────────────────────────────────────────────
+
+fn render_banners(out: &mut String, banners: &[(String, String)]) {
+    if banners.is_empty() {
+        return;
+    }
+
+    for (key, value) in banners {
+        let _ = writeln!(out, "> {} **{}:** {}", banner_icon(key), key, value);
+    }
+    out.push('\n');
+}
+
+fn banner_icon(key: &str) -> &'static str {
+    match key {
+        "autofix" => ":wrench:",
+        "binary-source" => ":warning:",
+        "scope-mode" => ":information_source:",
+        _ => ":information_source:",
+    }
+}
 
 fn render_scope_banner(out: &mut String, output: &ReviewCommandOutput) {
     match output.summary.scope.as_str() {
@@ -605,6 +632,26 @@ mod tests {
         assert!(
             md.contains(":information_source: Scope: **full**"),
             "missing full-scope banner:\n{}",
+            md
+        );
+    }
+
+    #[test]
+    fn renders_action_banners_before_scope_banner() {
+        let env = passing_envelope();
+        let banners = vec![
+            ("autofix".to_string(), "applied 3 file(s)".to_string()),
+            ("binary-source".to_string(), "fallback".to_string()),
+            ("custom".to_string(), "value".to_string()),
+        ];
+        let md = render_pr_comment_with_banners(&env, &banners);
+
+        assert!(md.starts_with("> :wrench: **autofix:** applied 3 file(s)"));
+        assert!(md.contains("> :warning: **binary-source:** fallback"));
+        assert!(md.contains("> :information_source: **custom:** value"));
+        assert!(
+            md.find("**custom:** value").unwrap() < md.find("Scope: **full**").unwrap(),
+            "banners should render before scope banner:\n{}",
             md
         );
     }

--- a/src/core/issues/mod.rs
+++ b/src/core/issues/mod.rs
@@ -37,6 +37,7 @@
 pub mod apply;
 pub mod plan;
 pub mod reconcile;
+pub mod render;
 pub mod tracker;
 
 pub use apply::{apply_plan, ReconcileExecution, ReconcileResult};
@@ -45,4 +46,8 @@ pub use plan::{
     ReconcileSkipReason, TrackedIssue, TrackedIssueState,
 };
 pub use reconcile::reconcile;
+pub use render::{
+    build_findings_from_native_output, IssueRenderContext, ReconcileFindingsInput,
+    RenderedIssueGroup,
+};
 pub use tracker::{GithubTracker, Tracker};

--- a/src/core/issues/render.rs
+++ b/src/core/issues/render.rs
@@ -1,0 +1,378 @@
+//! Render native Homeboy command output into issue-reconcile groups.
+//!
+//! This is the pre-reconcile contract: command outputs (`audit`, `lint`,
+//! `test`) become grouped issue bodies once, then the reconciler decides how
+//! to apply them against a tracker.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::code_audit::FindingConfidence;
+
+/// Canonical input shape consumed by `homeboy issues reconcile`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReconcileFindingsInput {
+    pub command: String,
+    #[serde(default)]
+    pub groups: BTreeMap<String, RenderedIssueGroup>,
+}
+
+/// One rendered category row in the reconcile input.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RenderedIssueGroup {
+    pub count: usize,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<FindingConfidence>,
+}
+
+/// Optional context appended to generated issue bodies.
+#[derive(Debug, Clone, Default)]
+pub struct IssueRenderContext {
+    pub run_url: Option<String>,
+}
+
+impl ReconcileFindingsInput {
+    pub fn merge(&mut self, other: ReconcileFindingsInput) {
+        if self.command.is_empty() {
+            self.command = other.command;
+        }
+        for (category, group) in other.groups {
+            self.groups.insert(category, group);
+        }
+    }
+}
+
+/// Build reconcile input from one native command output envelope.
+pub fn build_findings_from_native_output(
+    command: &str,
+    output: Value,
+    context: &IssueRenderContext,
+) -> crate::Result<ReconcileFindingsInput> {
+    let data = output.get("data").unwrap_or(&output);
+    match command {
+        "audit" => Ok(render_audit(data, context)),
+        "lint" => Ok(render_lint(data, context)),
+        "test" => Ok(render_test(data, context)),
+        other => Err(crate::Error::validation_invalid_argument(
+            "command",
+            format!("Unsupported native issue output command `{}`", other),
+            None,
+            Some(vec!["Supported commands: audit, lint, test".to_string()]),
+        )),
+    }
+}
+
+fn render_audit(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
+    let mut by_kind: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
+    let findings = data
+        .get("findings")
+        .and_then(Value::as_array)
+        .or_else(|| data.pointer("/top_findings").and_then(Value::as_array));
+    if let Some(findings) = findings {
+        for finding in findings {
+            let kind = finding
+                .get("kind")
+                .and_then(Value::as_str)
+                .or_else(|| finding.get("convention").and_then(Value::as_str))
+                .unwrap_or("audit_finding");
+            by_kind.entry(kind.to_string()).or_default().push(finding);
+        }
+    }
+
+    let mut groups = BTreeMap::new();
+    for (kind, findings) in by_kind {
+        let fixability = data.pointer(&format!("/fixability/by_kind/{}", kind));
+        let confidence = findings
+            .iter()
+            .find_map(|f| f.get("confidence").and_then(Value::as_str))
+            .and_then(|raw| serde_json::from_value(Value::String(raw.to_string())).ok());
+        groups.insert(
+            kind.clone(),
+            RenderedIssueGroup {
+                count: findings.len(),
+                label: labelize(&kind),
+                body: render_audit_body(&kind, &findings, fixability, context),
+                confidence,
+            },
+        );
+    }
+
+    ReconcileFindingsInput {
+        command: "audit".to_string(),
+        groups,
+    }
+}
+
+fn render_audit_body(
+    kind: &str,
+    findings: &[&Value],
+    fixability: Option<&Value>,
+    context: &IssueRenderContext,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "## {}", labelize(kind));
+    let _ = writeln!(out);
+    let _ = writeln!(out, "{} audit finding(s) in this category.", findings.len());
+    if let Some(url) = context.run_url.as_deref() {
+        let _ = writeln!(out, "\nRun: {}", url);
+    }
+    render_fixability(&mut out, fixability);
+    let _ = writeln!(out, "\n### Findings");
+
+    for finding in findings.iter().take(20) {
+        let file = finding
+            .get("file")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let description = finding
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or("audit finding");
+        let suggestion = finding.get("suggestion").and_then(Value::as_str);
+        let _ = writeln!(out, "- `{}` — {}", file, description);
+        if let Some(suggestion) = suggestion {
+            let _ = writeln!(out, "  - Suggested fix: {}", suggestion);
+        }
+    }
+    if findings.len() > 20 {
+        let _ = writeln!(out, "- _... {} more finding(s)_", findings.len() - 20);
+    }
+    out
+}
+
+fn render_lint(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
+    let mut by_category: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
+    if let Some(findings) = data.get("lint_findings").and_then(Value::as_array) {
+        for finding in findings {
+            let category = finding
+                .get("category")
+                .and_then(Value::as_str)
+                .unwrap_or("lint_finding");
+            by_category
+                .entry(category.to_string())
+                .or_default()
+                .push(finding);
+        }
+    }
+
+    if by_category.is_empty() && !data.get("passed").and_then(Value::as_bool).unwrap_or(true) {
+        by_category.insert("lint_failure".to_string(), Vec::new());
+    }
+
+    let mut groups = BTreeMap::new();
+    for (category, findings) in by_category {
+        let count = findings.len().max(1);
+        groups.insert(
+            category.clone(),
+            RenderedIssueGroup {
+                count,
+                label: labelize(&category),
+                body: render_lint_body(&category, &findings, data, context),
+                confidence: None,
+            },
+        );
+    }
+
+    ReconcileFindingsInput {
+        command: "lint".to_string(),
+        groups,
+    }
+}
+
+fn render_lint_body(
+    category: &str,
+    findings: &[&Value],
+    data: &Value,
+    context: &IssueRenderContext,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "## {}", labelize(category));
+    let _ = writeln!(out);
+    if findings.is_empty() {
+        let status = data
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("failed");
+        let exit = data.get("exit_code").and_then(Value::as_i64).unwrap_or(1);
+        let _ = writeln!(
+            out,
+            "Lint {} without structured findings (exit {}).",
+            status, exit
+        );
+        if let Some(url) = context.run_url.as_deref() {
+            let _ = writeln!(out, "\nRun: {}", url);
+        }
+        return out;
+    }
+
+    let _ = writeln!(out, "{} lint finding(s) in this category.", findings.len());
+    if let Some(url) = context.run_url.as_deref() {
+        let _ = writeln!(out, "\nRun: {}", url);
+    }
+    let _ = writeln!(out, "\n### Findings");
+    for finding in findings.iter().take(20) {
+        let id = finding.get("id").and_then(Value::as_str).unwrap_or("lint");
+        let message = finding
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("lint finding");
+        let _ = writeln!(out, "- `{}` — {}", id, message);
+    }
+    if findings.len() > 20 {
+        let _ = writeln!(out, "- _... {} more finding(s)_", findings.len() - 20);
+    }
+    out
+}
+
+fn render_test(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
+    let mut groups = BTreeMap::new();
+
+    if let Some(clusters) = data.pointer("/analysis/clusters").and_then(Value::as_array) {
+        for cluster in clusters {
+            let category = cluster
+                .get("category")
+                .and_then(Value::as_str)
+                .unwrap_or("test_failure");
+            let count = cluster.get("count").and_then(Value::as_u64).unwrap_or(1) as usize;
+            insert_test_group(
+                &mut groups,
+                category,
+                count,
+                render_test_cluster_body(category, cluster, context),
+            );
+        }
+    }
+
+    if groups.is_empty() {
+        let failed = data
+            .pointer("/test_counts/failed")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        if failed > 0 || !data.get("passed").and_then(Value::as_bool).unwrap_or(true) {
+            insert_test_group(
+                &mut groups,
+                "test_failure",
+                failed.max(1),
+                render_test_fallback_body(data, context),
+            );
+        }
+    }
+
+    ReconcileFindingsInput {
+        command: "test".to_string(),
+        groups,
+    }
+}
+
+fn render_test_cluster_body(
+    category: &str,
+    cluster: &Value,
+    context: &IssueRenderContext,
+) -> String {
+    let mut out = String::new();
+    let count = cluster.get("count").and_then(Value::as_u64).unwrap_or(1);
+    let _ = writeln!(out, "## {}", labelize(category));
+    let _ = writeln!(out);
+    let _ = writeln!(out, "{} test failure(s) in this cluster.", count);
+    if let Some(url) = context.run_url.as_deref() {
+        let _ = writeln!(out, "\nRun: {}", url);
+    }
+    if let Some(pattern) = cluster.get("pattern").and_then(Value::as_str) {
+        let _ = writeln!(out, "\n**Pattern:** {}", pattern);
+    }
+    if let Some(fix) = cluster.get("suggested_fix").and_then(Value::as_str) {
+        let _ = writeln!(out, "\n**Suggested fix:** {}", fix);
+    }
+    if let Some(files) = cluster.get("affected_files").and_then(Value::as_array) {
+        let _ = writeln!(out, "\n### Affected files");
+        for file in files.iter().filter_map(Value::as_str).take(20) {
+            let _ = writeln!(out, "- `{}`", file);
+        }
+    }
+    if let Some(tests) = cluster.get("example_tests").and_then(Value::as_array) {
+        let _ = writeln!(out, "\n### Example tests");
+        for test in tests.iter().filter_map(Value::as_str).take(10) {
+            let _ = writeln!(out, "- `{}`", test);
+        }
+    }
+    out
+}
+
+fn render_test_fallback_body(data: &Value, context: &IssueRenderContext) -> String {
+    let mut out = String::new();
+    let failed = data
+        .pointer("/test_counts/failed")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total = data
+        .pointer("/test_counts/total")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let exit = data.get("exit_code").and_then(Value::as_i64).unwrap_or(1);
+    let _ = writeln!(out, "## Test failure");
+    let _ = writeln!(out);
+    if failed > 0 || total > 0 {
+        let _ = writeln!(out, "{} failed test(s) out of {} total.", failed, total);
+    } else {
+        let _ = writeln!(
+            out,
+            "Test phase failed without structured counts (exit {}).",
+            exit
+        );
+    }
+    if let Some(url) = context.run_url.as_deref() {
+        let _ = writeln!(out, "\nRun: {}", url);
+    }
+    out
+}
+
+fn render_fixability(out: &mut String, fixability: Option<&Value>) {
+    let Some(fixability) = fixability else {
+        return;
+    };
+    let automated = fixability
+        .get("automated")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let manual = fixability
+        .get("manual_only")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total = fixability.get("total").and_then(Value::as_u64).unwrap_or(0);
+    let _ = writeln!(out, "\n### Autofix status");
+    let _ = writeln!(out, "- Total fixable: {}", total);
+    let _ = writeln!(out, "- Automated: {}", automated);
+    let _ = writeln!(out, "- Manual-only: {}", manual);
+}
+
+fn insert_test_group(
+    groups: &mut BTreeMap<String, RenderedIssueGroup>,
+    category: &str,
+    count: usize,
+    body: String,
+) {
+    groups.insert(
+        category.to_string(),
+        RenderedIssueGroup {
+            count,
+            label: labelize(category),
+            body,
+            confidence: None,
+        },
+    );
+}
+
+fn labelize(raw: &str) -> String {
+    raw.replace(['_', '-'], " ")
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/issues/render_test.rs"]
+mod render_test;

--- a/tests/core/issues/render_test.rs
+++ b/tests/core/issues/render_test.rs
@@ -1,0 +1,232 @@
+use serde_json::json;
+
+use super::{build_findings_from_native_output, IssueRenderContext};
+use crate::code_audit::FindingConfidence;
+
+#[test]
+fn test_build_findings_from_native_output() {
+    let output = json!({"data": {"passed": true, "lint_findings": []}});
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    assert_eq!(rendered.command, "lint");
+    assert!(rendered.groups.is_empty());
+}
+
+#[test]
+fn test_merge() {
+    let mut first = build_findings_from_native_output(
+        "lint",
+        json!({"data": {"passed": false, "lint_findings": [
+            {"id": "lint-1", "category": "A", "message": "one"}
+        ]}}),
+        &IssueRenderContext::default(),
+    )
+    .unwrap();
+    let second = build_findings_from_native_output(
+        "lint",
+        json!({"data": {"passed": false, "lint_findings": [
+            {"id": "lint-2", "category": "B", "message": "two"}
+        ]}}),
+        &IssueRenderContext::default(),
+    )
+    .unwrap();
+
+    first.merge(second);
+
+    assert_eq!(first.command, "lint");
+    assert!(first.groups.contains_key("A"));
+    assert!(first.groups.contains_key("B"));
+}
+
+#[test]
+fn renders_audit_output_grouped_by_kind_with_fixability() {
+    let output = json!({
+        "success": false,
+        "data": {
+            "command": "audit",
+            "passed": false,
+            "component_id": "homeboy",
+            "source_path": "/tmp/homeboy",
+            "findings": [
+                {
+                    "file": "src/a.rs",
+                    "kind": "unreferenced_export",
+                    "confidence": "structural",
+                    "description": "export is unused",
+                    "suggestion": "remove it"
+                },
+                {
+                    "file": "src/b.rs",
+                    "kind": "unreferenced_export",
+                    "confidence": "structural",
+                    "description": "export is unused",
+                    "suggestion": "remove it"
+                },
+                {
+                    "file": "src/large.rs",
+                    "kind": "god_file",
+                    "confidence": "heuristic",
+                    "description": "file is large",
+                    "suggestion": "split it"
+                }
+            ],
+            "fixability": {
+                "by_kind": {
+                    "unreferenced_export": {
+                        "total": 2,
+                        "automated": 1,
+                        "manual_only": 1
+                    }
+                }
+            }
+        }
+    });
+    let context = IssueRenderContext {
+        run_url: Some("https://github.com/Extra-Chill/homeboy/actions/runs/1".to_string()),
+    };
+
+    let rendered = build_findings_from_native_output("audit", output, &context).unwrap();
+
+    assert_eq!(rendered.command, "audit");
+    assert_eq!(rendered.groups.len(), 2);
+    let group = rendered.groups.get("unreferenced_export").unwrap();
+    assert_eq!(group.count, 2);
+    assert_eq!(group.label, "unreferenced export");
+    assert_eq!(group.confidence, Some(FindingConfidence::Structural));
+    assert!(group.body.contains("## unreferenced export"));
+    assert!(group
+        .body
+        .contains("Run: https://github.com/Extra-Chill/homeboy/actions/runs/1"));
+    assert!(group.body.contains("### Autofix status"));
+    assert!(group.body.contains("- Automated: 1"));
+    assert!(group.body.contains("- `src/a.rs` — export is unused"));
+}
+
+#[test]
+fn renders_lint_output_grouped_by_category() {
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "exit_code": 1,
+            "lint_findings": [
+                {"id": "lint-1", "category": "Squiz.Commenting.FunctionComment.Missing", "message": "missing docblock"},
+                {"id": "lint-2", "category": "Squiz.Commenting.FunctionComment.Missing", "message": "missing docblock"},
+                {"id": "lint-3", "category": "Generic.Files.LineLength.TooLong", "message": "line too long"}
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    assert_eq!(rendered.command, "lint");
+    assert_eq!(rendered.groups.len(), 2);
+    let group = rendered
+        .groups
+        .get("Squiz.Commenting.FunctionComment.Missing")
+        .unwrap();
+    assert_eq!(group.count, 2);
+    assert!(group.body.contains("2 lint finding(s) in this category."));
+    assert!(group.body.contains("- `lint-1` — missing docblock"));
+}
+
+#[test]
+fn renders_lint_aggregate_fallback_when_findings_are_missing() {
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "exit_code": 2
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("lint_failure").unwrap();
+    assert_eq!(group.count, 1);
+    assert!(group
+        .body
+        .contains("Lint failed without structured findings (exit 2)."));
+}
+
+#[test]
+fn renders_test_analysis_clusters_by_category() {
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "exit_code": 1,
+            "analysis": {
+                "clusters": [
+                    {
+                        "category": "missing_method",
+                        "count": 3,
+                        "pattern": "undefined method Widget::render",
+                        "affected_files": ["tests/widget.rs"],
+                        "example_tests": ["widget_renders", "widget_renders_nested"],
+                        "suggested_fix": "Add the missing method"
+                    }
+                ]
+            }
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("test", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("missing_method").unwrap();
+    assert_eq!(group.count, 3);
+    assert_eq!(group.label, "missing method");
+    assert!(group.body.contains("3 test failure(s) in this cluster."));
+    assert!(group
+        .body
+        .contains("**Pattern:** undefined method Widget::render"));
+    assert!(group.body.contains("- `tests/widget.rs`"));
+    assert!(group.body.contains("- `widget_renders`"));
+}
+
+#[test]
+fn renders_test_aggregate_fallback_from_counts() {
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "exit_code": 1,
+            "test_counts": {
+                "total": 12,
+                "passed": 10,
+                "failed": 2,
+                "skipped": 0
+            }
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("test", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("test_failure").unwrap();
+    assert_eq!(group.count, 2);
+    assert!(group.body.contains("2 failed test(s) out of 12 total."));
+}
+
+#[test]
+fn passing_outputs_produce_no_groups() {
+    let lint = json!({"data": {"passed": true, "lint_findings": []}});
+    let test = json!({"data": {"passed": true, "test_counts": {"total": 1, "passed": 1, "failed": 0, "skipped": 0}}});
+
+    assert!(
+        build_findings_from_native_output("lint", lint, &IssueRenderContext::default())
+            .unwrap()
+            .groups
+            .is_empty()
+    );
+    assert!(
+        build_findings_from_native_output("test", test, &IssueRenderContext::default())
+            .unwrap()
+            .groups
+            .is_empty()
+    );
+}


### PR DESCRIPTION
## Summary
- Move native `audit` / `lint` / `test` output normalization and issue-body rendering into Homeboy core.
- Add `homeboy issues build-findings` plus `issues reconcile --from-output <command>=<path>` so callers can pass native command JSON without shell-side renderers.
- Add `homeboy review --report=pr-comment --banner key=value` for action-level PR comment signals.

## Changes
- Adds `core::issues::render` with the canonical `ReconcileFindingsInput` / `RenderedIssueGroup` shape and native-output renderers.
- Keeps `--findings` for callers that already provide fully rendered reconcile input.
- Supports repeated `--from-output` for split files from the same command label; mixed command-label reconciliation is intentionally rejected until the tracker query can reconcile multiple label scopes in one run.

## Tests
- `cargo test`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-issue-report-rendering-core`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-issue-report-rendering-core` *(reports one pre-existing baseline drift item: orphaned `tests/core/lint_baseline_test.rs`; no new findings from this PR after tightening the new renderer)*

Closes #1646
Closes #1510
Refs #1647

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the core native-output issue renderer, wiring the CLI surfaces, adding render fixtures, and validating the change locally. Chris remains responsible for review and merge.