### PR TITLE
feat(bench): add --runs N for cross-spawn distribution math

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -55,6 +55,14 @@ pub struct BenchRunArgs {
     #[arg(long, default_value_t = 10)]
     iterations: u64,
 
+    /// Number of independent substrate spawns. Default 1 preserves today's
+    /// exact behaviour. When > 1, the bench dispatcher is invoked N times in
+    /// sequence and per-scenario metrics carry both the cross-run p50
+    /// (top-level, unchanged shape) and a runs array with each run's raw
+    /// metrics, plus a runs_summary object with stdev/cv_pct/n.
+    #[arg(long, default_value_t = 1)]
+    runs: u64,
+
     /// Directory shared across bench runner instances.
     #[arg(long, value_name = "DIR")]
     shared_state: Option<PathBuf>,
@@ -137,6 +145,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 
     const HOMEBOY_VALUE_FLAGS: &[&str] = &[
         "--iterations",
+        "--runs",
         "--shared-state",
         "--concurrency",
         "--regression-threshold",

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -268,6 +268,7 @@ fn run_component_with_rig_context(
                 })
                 .collect(),
             iterations: args.iterations,
+            runs: args.runs,
             baseline_flags: homeboy::engine::baseline::BaselineFlags {
                 baseline: args.baseline_args.baseline,
                 ignore_baseline: args.baseline_args.ignore_baseline,
@@ -337,6 +338,7 @@ mod tests {
                 path: None,
             },
             iterations: 1,
+            runs: 1,
             shared_state: Some(PathBuf::from("/tmp/shared")),
             concurrency: 1,
             baseline_args: BaselineArgs::default(),

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -143,6 +143,7 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
             "",
             &[
                 "--iterations",
+                "--runs",
                 "--baseline",
                 "--ignore-baseline",
                 "--ignore-default-baseline",
@@ -454,6 +455,23 @@ mod normalize_tests {
             "--shared-state",
             "/tmp/homeboy-bench",
             "--concurrency=4",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// `bench` owns run-level repetition. It must remain a named CLI flag
+    /// even when placed after the positional component.
+    #[test]
+    fn bench_runs_flag_after_component_is_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--runs",
+            "5",
+            "--iterations",
+            "1",
         ]);
         let expected = input.clone();
         assert_eq!(normalize_trailing_flags(input), expected);

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -331,6 +331,8 @@ mod tests {
                 distributions: BTreeMap::new(),
             },
             memory: None,
+            runs: None,
+            runs_summary: None,
         }
     }
 
@@ -352,6 +354,8 @@ mod tests {
                 distributions,
             },
             memory: None,
+            runs: None,
+            runs_summary: None,
         }
     }
 

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -351,6 +351,8 @@ mod tests {
                     distributions: BTreeMap::new(),
                 },
                 memory: None,
+                runs: None,
+                runs_summary: None,
             }],
             metric_policies: BTreeMap::new(),
         }

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -76,6 +76,29 @@ pub struct BenchScenario {
     pub metrics: BenchMetrics,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<BenchMemory>,
+    /// Per-run raw metric snapshots when `homeboy bench --runs N` is used.
+    /// Omitted for the default `--runs 1` path so existing envelopes keep
+    /// their exact shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runs: Option<Vec<BenchRunSnapshot>>,
+    /// Cross-run distribution stats keyed by metric name. Omitted for the
+    /// default `--runs 1` path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runs_summary: Option<BTreeMap<String, BenchRunDistribution>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BenchRunSnapshot {
+    pub metrics: BenchMetrics,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<BenchMemory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BenchRunDistribution {
+    pub stdev: f64,
+    pub cv_pct: f64,
+    pub n: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -378,6 +378,8 @@ mod tests {
                 distributions: BTreeMap::new(),
             },
             memory: None,
+            runs: None,
+            runs_summary: None,
         }
     }
 

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1,5 +1,6 @@
 //! Bench main workflow: invoke extension runner, load JSON, apply baseline.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
@@ -11,7 +12,9 @@ use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
 use crate::extension::bench::baseline::{self, BenchBaselineComparison};
-use crate::extension::bench::parsing::{self, BenchResults, BenchScenario};
+use crate::extension::bench::parsing::{
+    self, BenchMetrics, BenchResults, BenchRunDistribution, BenchRunSnapshot, BenchScenario,
+};
 use crate::extension::{
     resolve_execution_context, ExtensionCapability, ExtensionExecutionContext, ExtensionRunner,
 };
@@ -29,6 +32,7 @@ pub struct BenchRunWorkflowArgs {
     /// object, not a JSON-string-of-an-object.
     pub settings_json: Vec<(String, serde_json::Value)>,
     pub iterations: u64,
+    pub runs: u64,
     pub baseline_flags: BaselineFlags,
     pub regression_threshold_percent: f64,
     pub json_summary: bool,
@@ -103,6 +107,7 @@ pub fn run_bench_list_workflow(
             settings: args.settings,
             settings_json: args.settings_json,
             iterations: 0,
+            runs: 1,
             baseline_flags: BaselineFlags {
                 baseline: false,
                 ignore_baseline: true,
@@ -185,6 +190,14 @@ pub fn run_main_bench_workflow(
             None,
         ));
     }
+    if args.runs == 0 {
+        return Err(Error::validation_invalid_argument(
+            "runs",
+            "must be >= 1",
+            None,
+            None,
+        ));
+    }
     if args.concurrency > 1 && args.shared_state.is_none() {
         return Err(Error::validation_invalid_argument(
             "concurrency",
@@ -211,7 +224,9 @@ pub fn run_main_bench_workflow(
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
 
-    let (parsed, runner_success, runner_exit_code) = if args.concurrency <= 1 {
+    let (parsed, runner_success, runner_exit_code) = if args.runs > 1 {
+        run_sequential_runs(&execution_context, component, &args, run_dir)?
+    } else if args.concurrency <= 1 {
         let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
         let runner_output =
             build_runner(&execution_context, component, &args, run_dir, None)?.run()?;
@@ -295,6 +310,207 @@ pub fn run_main_bench_workflow(
         baseline_comparison,
         hints,
     })
+}
+
+fn run_sequential_runs(
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: &BenchRunWorkflowArgs,
+    run_dir: &RunDir,
+) -> Result<(Option<BenchResults>, bool, i32)> {
+    let mut parsed_runs = Vec::new();
+    let mut all_success = true;
+    let mut first_failure_exit: Option<i32> = None;
+
+    for _ in 0..args.runs {
+        let (parsed, success, exit_code) = if args.concurrency <= 1 {
+            run_single_dispatcher(execution_context, component, args, run_dir)?
+        } else {
+            run_concurrent_instances(execution_context, component, args, run_dir)?
+        };
+        if !success {
+            all_success = false;
+            if first_failure_exit.is_none() {
+                first_failure_exit = Some(exit_code);
+            }
+        }
+        if let Some(result) = parsed {
+            parsed_runs.push(result);
+        }
+    }
+
+    let merged = if parsed_runs.is_empty() {
+        None
+    } else {
+        Some(aggregate_runs(&parsed_runs)?)
+    };
+    let exit_code = if all_success {
+        0
+    } else {
+        first_failure_exit.unwrap_or(1)
+    };
+
+    Ok((merged, all_success, exit_code))
+}
+
+fn run_single_dispatcher(
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: &BenchRunWorkflowArgs,
+    run_dir: &RunDir,
+) -> Result<(Option<BenchResults>, bool, i32)> {
+    let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+    if results_file.exists() {
+        std::fs::remove_file(&results_file).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to clear previous bench results file {}: {}",
+                    results_file.display(),
+                    e
+                ),
+                Some("bench.run.results_file".to_string()),
+            )
+        })?;
+    }
+
+    let runner_output = build_runner(execution_context, component, args, run_dir, None)?.run()?;
+    let parsed = if results_file.exists() {
+        Some(parsing::parse_bench_results_file(&results_file)?)
+    } else {
+        None
+    };
+    Ok((parsed, runner_output.success, runner_output.exit_code))
+}
+
+pub fn aggregate_runs(runs: &[BenchResults]) -> Result<BenchResults> {
+    let first = runs
+        .first()
+        .ok_or_else(|| Error::internal_unexpected("cannot aggregate zero bench runs"))?;
+    let mut metric_policies = BTreeMap::new();
+    let mut grouped: BTreeMap<String, (BenchScenario, Vec<BenchScenario>)> = BTreeMap::new();
+
+    for result in runs {
+        if result.component_id != first.component_id {
+            return Err(Error::validation_invalid_argument(
+                "bench_results.component_id",
+                format!(
+                    "bench run component_id mismatch: expected `{}`, got `{}`",
+                    first.component_id, result.component_id
+                ),
+                None,
+                None,
+            ));
+        }
+        if result.iterations != first.iterations {
+            return Err(Error::validation_invalid_argument(
+                "bench_results.iterations",
+                format!(
+                    "bench run iterations mismatch: expected `{}`, got `{}`",
+                    first.iterations, result.iterations
+                ),
+                None,
+                None,
+            ));
+        }
+        for (key, policy) in &result.metric_policies {
+            metric_policies
+                .entry(key.clone())
+                .or_insert_with(|| policy.clone());
+        }
+        for scenario in &result.scenarios {
+            grouped
+                .entry(scenario.id.clone())
+                .and_modify(|(_, scenarios)| scenarios.push(scenario.clone()))
+                .or_insert_with(|| (scenario.clone(), vec![scenario.clone()]));
+        }
+    }
+
+    let scenarios = grouped
+        .into_values()
+        .map(|(template, scenarios)| aggregate_scenario(template, scenarios))
+        .collect();
+
+    Ok(BenchResults {
+        component_id: first.component_id.clone(),
+        iterations: first.iterations,
+        scenarios,
+        metric_policies,
+    })
+}
+
+fn aggregate_scenario(mut template: BenchScenario, scenarios: Vec<BenchScenario>) -> BenchScenario {
+    let mut metric_values: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    for scenario in &scenarios {
+        for (name, value) in &scenario.metrics.values {
+            metric_values.entry(name.clone()).or_default().push(*value);
+        }
+    }
+
+    let mut values = BTreeMap::new();
+    let mut summary = BTreeMap::new();
+    for (name, samples) in metric_values {
+        values.insert(name.clone(), percentile(&samples, 50.0));
+        summary.insert(name, distribution(&samples));
+    }
+
+    template.metrics = BenchMetrics {
+        values,
+        distributions: BTreeMap::new(),
+    };
+    template.memory = None;
+    template.runs = Some(
+        scenarios
+            .iter()
+            .map(|scenario| BenchRunSnapshot {
+                metrics: scenario.metrics.clone(),
+                memory: scenario.memory.clone(),
+            })
+            .collect(),
+    );
+    template.runs_summary = Some(summary);
+    template
+}
+
+fn distribution(samples: &[f64]) -> BenchRunDistribution {
+    let n = samples.len() as f64;
+    let mean = samples.iter().sum::<f64>() / n;
+    let variance = samples
+        .iter()
+        .map(|value| {
+            let delta = value - mean;
+            delta * delta
+        })
+        .sum::<f64>()
+        / n;
+    let stdev = variance.sqrt();
+    let cv_pct = if mean == 0.0 {
+        0.0
+    } else {
+        stdev / mean * 100.0
+    };
+
+    BenchRunDistribution {
+        stdev,
+        cv_pct,
+        n: samples.len() as u64,
+    }
+}
+
+fn percentile(samples: &[f64], pct: f64) -> f64 {
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let rank = pct / 100.0 * (sorted.len() as f64 - 1.0);
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+    if lower == upper {
+        sorted[lower]
+    } else {
+        let weight = rank - lower as f64;
+        sorted[lower] * (1.0 - weight) + sorted[upper] * weight
+    }
 }
 
 /// Per-instance results filename within the run dir.
@@ -517,6 +733,8 @@ mod tests {
                     distributions: BTreeMap::new(),
                 },
                 memory: None,
+                runs: None,
+                runs_summary: None,
             }],
         };
 
@@ -539,6 +757,7 @@ mod tests {
                 settings: Vec::new(),
                 settings_json: Vec::new(),
                 iterations: 1,
+                runs: 1,
                 baseline_flags: BaselineFlags {
                     baseline: false,
                     ignore_baseline: true,
@@ -559,3 +778,7 @@ mod tests {
         assert!(format!("{}", err).contains("concurrency"));
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../tests/core/extension/bench/runs_flag_test.rs"]
+mod runs_flag_test;

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -60,6 +60,8 @@ fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
             distributions: BTreeMap::new(),
         },
         memory: None,
+        runs: None,
+        runs_summary: None,
     }
 }
 

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -1,0 +1,169 @@
+//! Cross-spawn aggregation smokes for `homeboy bench --runs N`.
+//!
+//! The contract under test:
+//! 1. The default `runs=1` envelope shape remains flat: no `runs` or
+//!    `runs_summary` keys appear unless aggregation is requested.
+//! 2. Multi-run aggregation keeps top-level metrics as cross-run p50 values
+//!    while preserving per-run snapshots and stdev/cv_pct/n diagnostics.
+//! 3. Distribution math uses population stdev and protects zero-mean CV.
+//! 4. Scenarios missing from some runs aggregate from the runs that emitted
+//!    them instead of failing the whole bench.
+
+use std::collections::BTreeMap;
+
+use crate::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
+use crate::extension::bench::run::aggregate_runs;
+
+fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
+    let mut values = BTreeMap::new();
+    for (name, value) in metrics {
+        values.insert((*name).to_string(), *value);
+    }
+
+    BenchScenario {
+        id: id.to_string(),
+        file: None,
+        source: None,
+        default_iterations: None,
+        tags: Vec::new(),
+        iterations: 1,
+        metrics: BenchMetrics {
+            values,
+            distributions: BTreeMap::new(),
+        },
+        memory: None,
+        runs: None,
+        runs_summary: None,
+    }
+}
+
+fn results(scenarios: Vec<BenchScenario>) -> BenchResults {
+    BenchResults {
+        component_id: "bench-noop".to_string(),
+        iterations: 5,
+        scenarios,
+        metric_policies: BTreeMap::new(),
+    }
+}
+
+fn approx_eq(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1e-9,
+        "expected {expected}, got {actual}"
+    );
+}
+
+mod cases {
+    use super::*;
+
+    #[test]
+    fn runs_default_one_preserves_envelope_shape() {
+        let single = results(vec![scenario("__bootstrap", &[("install_ms", 3107.66)])]);
+        let raw = serde_json::to_string(&single).unwrap();
+
+        assert_eq!(
+            raw,
+            r#"{"component_id":"bench-noop","iterations":5,"scenarios":[{"id":"__bootstrap","iterations":1,"metrics":{"install_ms":3107.66}}]}"#
+        );
+        assert!(!raw.contains("runs"));
+        assert!(!raw.contains("runs_summary"));
+    }
+
+    #[test]
+    fn runs_three_aggregates_correctly() {
+        let aggregated = aggregate_runs(&[
+            results(vec![scenario("__bootstrap", &[("install_ms", 100.0)])]),
+            results(vec![scenario("__bootstrap", &[("install_ms", 200.0)])]),
+            results(vec![scenario("__bootstrap", &[("install_ms", 300.0)])]),
+        ])
+        .unwrap();
+
+        let scenario = aggregated.scenarios.first().unwrap();
+        assert_eq!(scenario.metrics.get("install_ms"), Some(200.0));
+        assert_eq!(scenario.runs.as_ref().unwrap().len(), 3);
+
+        let summary = scenario
+            .runs_summary
+            .as_ref()
+            .unwrap()
+            .get("install_ms")
+            .unwrap();
+        approx_eq(summary.stdev, (20000.0_f64 / 3.0).sqrt());
+        approx_eq(summary.cv_pct, summary.stdev / 200.0 * 100.0);
+        assert_eq!(summary.n, 3);
+    }
+
+    #[test]
+    fn runs_handles_zero_mean_for_cv() {
+        let aggregated = aggregate_runs(&[
+            results(vec![scenario("zero", &[("count", 0.0)])]),
+            results(vec![scenario("zero", &[("count", 0.0)])]),
+            results(vec![scenario("zero", &[("count", 0.0)])]),
+        ])
+        .unwrap();
+
+        let summary = aggregated.scenarios[0]
+            .runs_summary
+            .as_ref()
+            .unwrap()
+            .get("count")
+            .unwrap();
+        assert_eq!(summary.cv_pct, 0.0);
+        assert!(summary.cv_pct.is_finite());
+    }
+
+    #[test]
+    fn runs_skip_serializes_when_none() {
+        let raw = serde_json::to_string(&scenario("plain", &[("p95_ms", 12.0)])).unwrap();
+
+        assert!(!raw.contains("runs"));
+        assert!(!raw.contains("runs_summary"));
+    }
+
+    #[test]
+    fn runs_distribution_math_population_stdev() {
+        let aggregated = aggregate_runs(&[
+            results(vec![scenario("known", &[("value", 1.0)])]),
+            results(vec![scenario("known", &[("value", 2.0)])]),
+            results(vec![scenario("known", &[("value", 3.0)])]),
+        ])
+        .unwrap();
+
+        let summary = aggregated.scenarios[0]
+            .runs_summary
+            .as_ref()
+            .unwrap()
+            .get("value")
+            .unwrap();
+        approx_eq(summary.stdev, (2.0_f64 / 3.0).sqrt());
+        assert_eq!(summary.n, 3);
+    }
+
+    #[test]
+    fn runs_handles_missing_scenario_in_some_runs() {
+        let aggregated = aggregate_runs(&[
+            results(vec![scenario("x", &[("install_ms", 10.0)])]),
+            results(vec![scenario("other", &[("install_ms", 999.0)])]),
+            results(vec![scenario("x", &[("install_ms", 30.0)])]),
+        ])
+        .unwrap();
+
+        let scenario = aggregated
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.id == "x")
+            .unwrap();
+        assert_eq!(scenario.metrics.get("install_ms"), Some(20.0));
+        assert_eq!(scenario.runs.as_ref().unwrap().len(), 2);
+        assert_eq!(
+            scenario
+                .runs_summary
+                .as_ref()
+                .unwrap()
+                .get("install_ms")
+                .unwrap()
+                .n,
+            2
+        );
+    }
+}

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -40,6 +40,7 @@ fn make_args(
                 path: None,
             },
             iterations: 1,
+            runs: 1,
             shared_state: None,
             concurrency: 1,
             baseline_args: BaselineArgs {


### PR DESCRIPTION
## Summary
- Adds `--runs N` flag to `homeboy bench`.
- When `runs > 1`, the dispatcher is invoked N times sequentially; per-scenario metrics carry top-level cross-run p50 (unchanged shape) plus optional `runs` array and `runs_summary` object with stdev/cv_pct/n.
- Closes #1686.

## Why this matters
Cold-start workloads (e.g. the `__bootstrap` synthetic scenario from Extra-Chill/homeboy-extensions#258) report `iterations=1` because a run *is* one boot. Without cross-run distribution math, single measurements have high spread and any optimization claim is noise. `--runs N` is the structural foundation for credible regression detection on cold-start metrics.

## Backwards compatibility
- `--runs 1` (default) is byte-identical to today's behaviour. New `runs` and `runs_summary` fields are `Option`, skipped on serialization when `None`.
- Existing tests pass unchanged.
- Existing JSON consumers see no schema change unless they opt in to `runs > 1`.

## Architecture
Top-level scenario metrics stay flat and carry cross-run p50 values so baseline/ratchet logic can keep comparing one scalar per metric. The raw per-run snapshots and distribution metadata live in optional scenario fields, which keeps the default envelope unchanged and makes multi-run data explicitly opt-in. The aggregation runs after each dispatcher invocation, so extensions do not need a new contract beyond the existing bench results file.

## Tests
- New: `tests/core/extension/bench/runs_flag_test.rs` (6 cases covering default behaviour, aggregation correctness, zero-mean cv, skip_serializing, population stdev math, missing-scenario-across-runs).
- New: trailing-flag normalizer coverage for `bench --runs` after the positional component.
- Pre-existing: full suite passes.

## Live verify
- `homeboy bench --runs 5 --iterations 5` against the Playground `bench-noop` fixture.
- Result: `__bootstrap.install_ms` p50=`1360.862833ms`, `cv_pct=6.304096415501354%`; `runs` contained 5 snapshots and `runs_summary.install_ms.n=5`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented from #1686 spec; Chris reviewed and live-verified.

Closes #1686
