### PR TITLE
fix(rig): use installed id for rig lookup

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -132,7 +132,8 @@ fn list() -> CmdResult<RigCommandOutput> {
         .map(|r| {
             let mut pipelines: Vec<String> = r.pipeline.keys().cloned().collect();
             pipelines.sort();
-            RigSummary {
+            let declared_id = rig::declared_id(&r.id)?;
+            Ok(RigSummary {
                 source: rig::read_source_metadata(&r.id).map(|source| RigSourceSummary {
                     source: source.source,
                     package_path: source.package_path,
@@ -141,13 +142,14 @@ fn list() -> CmdResult<RigCommandOutput> {
                     source_revision: source.source_revision,
                 }),
                 id: r.id,
+                declared_id,
                 description: r.description,
                 component_count: r.components.len(),
                 service_count: r.services.len(),
                 pipelines,
-            }
+            })
         })
-        .collect();
+        .collect::<homeboy::Result<Vec<_>>>()?;
 
     Ok((
         RigCommandOutput::List(RigListOutput {

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -34,6 +34,8 @@ pub struct RigListOutput {
 #[derive(Serialize)]
 pub struct RigSummary {
     pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub declared_id: Option<String>,
     pub description: String,
     pub component_count: usize,
     pub service_count: usize,

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -57,8 +57,7 @@ use crate::error::{Error, Result};
 use crate::paths;
 use std::fs;
 
-/// Load a rig spec by ID from `~/.config/homeboy/rigs/{id}.json`.
-pub fn load(id: &str) -> Result<RigSpec> {
+fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
     let path = paths::rig_config(id)?;
     if !path.exists() {
         let suggestions = list_ids().unwrap_or_default();
@@ -74,10 +73,19 @@ pub fn load(id: &str) -> Result<RigSpec> {
             Some(content.chars().take(200).collect()),
         )
     })?;
-    if spec.id.is_empty() {
-        spec.id = id.to_string();
-    }
-    Ok(spec)
+    let declared_id = (!spec.id.is_empty() && spec.id != id).then(|| spec.id.clone());
+    spec.id = id.to_string();
+    Ok((spec, declared_id))
+}
+
+/// Load a rig spec by ID from `~/.config/homeboy/rigs/{id}.json`.
+pub fn load(id: &str) -> Result<RigSpec> {
+    read_config(id).map(|(spec, _)| spec)
+}
+
+/// Return the JSON-declared rig ID when it differs from the installed ID.
+pub fn declared_id(id: &str) -> Result<Option<String>> {
+    read_config(id).map(|(_, declared_id)| declared_id)
 }
 
 /// List all rig specs in `~/.config/homeboy/rigs/`.

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -1,6 +1,6 @@
 //! Rig install lifecycle tests. Covers `src/core/rig/install.rs`.
 
-use crate::rig::{discover_rigs, install, read_source_metadata};
+use crate::rig::{declared_id, discover_rigs, install, list, list_ids, load, read_source_metadata};
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
@@ -186,6 +186,45 @@ fn install_rejects_existing_rig_collision() {
     install(package.path().to_str().unwrap(), None, false).expect("first install");
     let err = install(package.path().to_str().unwrap(), None, false).expect_err("collision");
     assert!(err.message.contains("already exists"));
+}
+
+#[test]
+fn installed_filename_is_runtime_identity_when_declared_id_differs() {
+    let _home = HomeGuard::new();
+    fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
+    fs::write(
+        crate::paths::rig_config("replacement").expect("replacement rig path"),
+        minimal_rig("alpha"),
+    )
+    .expect("replacement rig");
+
+    let ids = list_ids().expect("list ids");
+    assert_eq!(ids, vec!["replacement"]);
+
+    let rigs = list().expect("list rigs");
+    assert_eq!(rigs.len(), 1);
+    assert_eq!(rigs[0].id, "replacement");
+    assert_eq!(
+        declared_id("replacement").expect("declared id"),
+        Some("alpha".to_string())
+    );
+
+    assert_eq!(
+        load("replacement").expect("load replacement").id,
+        "replacement"
+    );
+
+    let err = load("alpha").expect_err("alpha should not resolve");
+    assert_eq!(err.message, "Rig not found");
+    assert_eq!(err.details["id"], "alpha");
+    let hints = err
+        .hints
+        .iter()
+        .map(|hint| hint.message.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(hints.contains("Did you mean: replacement?"));
+    assert!(!hints.contains("Did you mean: alpha?"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Treat the installed rig config filename as the runtime rig identity so IDs printed by `homeboy rig list` are accepted by `homeboy triage rig`.
- Surface a `declared_id` field in rig list output when the JSON-declared ID differs from the installed ID.
- Add a regression test for `replacement.json` declaring `id = alpha` to pin lookup suggestions and list/load behaviour.

## Tests
- `cargo test installed_filename_is_runtime_identity_when_declared_id_differs`
- `cargo test install_test`
- `cargo fmt --check`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-triage-rig-id-lookup`

Closes #1698

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the small rig identity fix, added the regression test, and ran focused validation. Chris remains responsible for review and merge.