### PR TITLE
feat(rig): allow component bench config

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use homeboy::component::Component;
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::bench as extension_bench;
@@ -51,6 +52,20 @@ fn rig_component_path(spec: &RigSpec, component_id: &str) -> Option<String> {
     spec.components
         .get(component_id)
         .map(|component| rig::expand::expand_vars(spec, &component.path))
+}
+
+fn rig_component_for_bench(spec: &RigSpec, component_id: &str) -> Option<Component> {
+    let rig_component = spec.components.get(component_id)?;
+    let extensions = rig_component.extensions.clone()?;
+    let mut component = Component {
+        id: component_id.to_string(),
+        local_path: rig::expand::expand_vars(spec, &rig_component.path),
+        remote_url: rig_component.remote_url.clone(),
+        extensions: Some(extensions),
+        ..Component::default()
+    };
+    component.resolve_remote_path();
+    Some(component)
 }
 
 fn component_shared_state(
@@ -225,13 +240,20 @@ fn run_component_with_rig_context(
         .clone()
         .or_else(|| rig_spec.and_then(|spec| rig_component_path(spec, &effective_id)));
 
-    let ctx = execution_context::resolve(&ResolveOptions::with_capability_and_json(
-        &effective_id,
-        path_override.clone(),
-        ExtensionCapability::Bench,
-        args.setting_args.setting.clone(),
-        args.setting_args.setting_json.clone(),
-    ))?;
+    let component_override = rig_spec
+        .as_ref()
+        .and_then(|spec| rig_component_for_bench(spec, &effective_id));
+
+    let ctx = execution_context::resolve_with_component(
+        &ResolveOptions::with_capability_and_json(
+            &effective_id,
+            path_override.clone(),
+            ExtensionCapability::Bench,
+            args.setting_args.setting.clone(),
+            args.setting_args.setting_json.clone(),
+        ),
+        component_override,
+    )?;
 
     let run_dir = RunDir::create()?;
 
@@ -297,6 +319,27 @@ mod tests {
     use crate::commands::utils::args::{
         BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
     };
+    use crate::test_support::with_isolated_home;
+    use std::fs;
+
+    fn write_bench_extension(home: &tempfile::TempDir, extension_id: &str) {
+        let extension_dir = home
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("extensions")
+            .join(extension_id);
+        fs::create_dir_all(&extension_dir).expect("mkdir extension");
+        fs::write(
+            extension_dir.join(format!("{}.json", extension_id)),
+            r#"{
+                "name": "Node.js",
+                "version": "0.0.0",
+                "bench": { "extension_script": "bench-runner.sh" }
+            }"#,
+        )
+        .expect("write extension manifest");
+    }
 
     #[test]
     fn rig_bench_components_prefers_matrix_over_default_component() {
@@ -362,6 +405,135 @@ mod tests {
 
         args.shared_state = None;
         assert_eq!(component_shared_state(&args, "mdi-primary", 3), None);
+    }
+
+    #[test]
+    fn rig_component_for_bench_synthesizes_extension_config() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let rig_spec: RigSpec = serde_json::from_str(&format!(
+            r#"{{
+                "id": "studio",
+                "components": {{
+                    "studio": {{
+                        "path": "{}",
+                        "extensions": {{
+                            "nodejs": {{
+                                "settings": {{ "package_manager": "pnpm" }},
+                                "workspace": "apps/studio"
+                            }}
+                        }}
+                    }}
+                }},
+                "bench": {{ "default_component": "studio" }}
+            }}"#,
+            temp.path().display()
+        ))
+        .expect("parse rig spec");
+
+        let component = rig_component_for_bench(&rig_spec, "studio")
+            .expect("rig component with extensions should synthesize component");
+
+        assert_eq!(component.id, "studio");
+        assert_eq!(component.local_path, temp.path().to_string_lossy());
+        let nodejs = component
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.get("nodejs"))
+            .expect("nodejs config preserved");
+        assert_eq!(
+            nodejs.settings.get("package_manager"),
+            Some(&serde_json::json!("pnpm"))
+        );
+        assert_eq!(
+            nodejs.settings.get("workspace"),
+            Some(&serde_json::json!("apps/studio"))
+        );
+    }
+
+    #[test]
+    fn rig_component_for_bench_absent_extension_config_falls_back() {
+        let rig_spec: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "legacy",
+                "components": { "studio": { "path": "/tmp/studio" } },
+                "bench": { "default_component": "studio" }
+            }"#,
+        )
+        .expect("parse rig spec");
+
+        assert!(rig_component_for_bench(&rig_spec, "studio").is_none());
+        assert!(rig_component_for_bench(&rig_spec, "missing").is_none());
+    }
+
+    #[test]
+    fn rig_component_extension_config_resolves_bench_context() {
+        with_isolated_home(|home| {
+            write_bench_extension(home, "nodejs");
+            let temp = tempfile::TempDir::new().expect("component dir");
+            let rig_spec: RigSpec = serde_json::from_str(&format!(
+                r#"{{
+                    "id": "studio",
+                    "components": {{
+                        "studio": {{
+                            "path": "{}",
+                            "extensions": {{
+                                "nodejs": {{ "package_manager": "pnpm" }}
+                            }}
+                        }}
+                    }},
+                    "bench": {{ "default_component": "studio" }}
+                }}"#,
+                temp.path().display()
+            ))
+            .expect("parse rig spec");
+            let component_override = rig_component_for_bench(&rig_spec, "studio");
+
+            let ctx = execution_context::resolve_with_component(
+                &ResolveOptions::with_capability_and_json(
+                    "studio",
+                    Some(temp.path().to_string_lossy().to_string()),
+                    ExtensionCapability::Bench,
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                component_override,
+            )
+            .expect("rig-owned extension config resolves bench context");
+
+            assert_eq!(ctx.component_id, "studio");
+            assert_eq!(ctx.extension_id.as_deref(), Some("nodejs"));
+            assert!(ctx
+                .settings
+                .iter()
+                .any(|(key, value)| key == "package_manager" && value == "pnpm"));
+        });
+    }
+
+    #[test]
+    fn missing_rig_extension_config_keeps_clear_error() {
+        let temp = tempfile::TempDir::new().expect("component dir");
+        let err = execution_context::resolve_with_component(
+            &ResolveOptions::with_capability_and_json(
+                "studio",
+                Some(temp.path().to_string_lossy().to_string()),
+                ExtensionCapability::Bench,
+                Vec::new(),
+                Vec::new(),
+            ),
+            Some(Component {
+                id: "studio".to_string(),
+                local_path: temp.path().to_string_lossy().to_string(),
+                ..Component::default()
+            }),
+        )
+        .expect_err("component without extensions should fail clearly");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("has no extensions configured"),
+            "expected missing-extension error, got: {}",
+            message
+        );
     }
 
     fn bench_results(component_id: &str, scenario_id: &str, p95: f64) -> BenchResults {

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -137,12 +137,32 @@ impl ResolveOptions {
 /// 4. **Extension**: resolved from component's linked extensions for the requested capability
 /// 5. **Settings**: extension manifest defaults → component-level → CLI overrides
 pub fn resolve(options: &ResolveOptions) -> Result<ExecutionContext> {
+    resolve_with_component(options, None)
+}
+
+/// Resolve a unified execution context, optionally starting from an in-memory
+/// component supplied by a higher-level dispatcher.
+///
+/// Rig-pinned bench runs use this to provide private extension config from the
+/// rig spec without requiring global component registration or repo-owned
+/// `homeboy.json`. Other commands should continue using [`resolve()`].
+pub fn resolve_with_component(
+    options: &ResolveOptions,
+    component_override: Option<Component>,
+) -> Result<ExecutionContext> {
     // 1. Resolve component
-    let component = component::resolve_effective(
-        options.component_id.as_deref(),
-        options.path_override.as_deref(),
-        None,
-    )?;
+    let component = if let Some(mut component) = component_override {
+        if let Some(path) = options.path_override.as_deref() {
+            component.local_path = path.to_string();
+        }
+        component
+    } else {
+        component::resolve_effective(
+            options.component_id.as_deref(),
+            options.path_override.as_deref(),
+            None,
+        )?
+    };
 
     // 2. Resolve source path
     let source_path = if let Some(ref path) = options.path_override {

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -370,6 +370,27 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_with_component() {
+        let dir = TempDir::new().expect("temp dir");
+        let root = dir.path();
+        fs::create_dir_all(root).expect("create dir");
+
+        let component = Component {
+            id: "rig-owned".to_string(),
+            local_path: root.to_string_lossy().to_string(),
+            ..Component::default()
+        };
+        let options = ResolveOptions::source_only("registered-id", None);
+
+        let ctx = resolve_with_component(&options, Some(component))
+            .expect("in-memory component should resolve");
+
+        assert_eq!(ctx.component_id, "rig-owned");
+        assert_eq!(ctx.source_path, root);
+        assert!(ctx.extension_id.is_none());
+    }
+
+    #[test]
     fn resolve_capability_raw_path_reports_unsupported_shape() {
         let dir = TempDir::new().expect("temp dir");
         let root = dir.path();

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::component::ScopedExtensionConfig;
+
 /// A rig: components + services + pipelines.
 ///
 /// Lives at `~/.config/homeboy/rigs/{id}.json`.
@@ -179,6 +181,15 @@ pub struct ComponentSpec {
     /// this field documents expected branch for humans reading specs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
+
+    /// Optional extension config for rig-owned bench dispatch.
+    ///
+    /// This is intentionally narrower than the global component registry: rigs
+    /// may provide the extension settings needed by `homeboy bench --rig`, but
+    /// release/deploy/component-management semantics still belong to registered
+    /// components or repo-owned `homeboy.json` files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, ScopedExtensionConfig>>,
 }
 
 /// A background service the rig manages.

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -17,6 +17,7 @@ fn rig_with_launcher(install_dir: &str) -> RigSpec {
             remote_url: None,
             stack: None,
             branch: None,
+            extensions: None,
         },
     );
 

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -85,6 +85,68 @@ fn test_rig_spec_deserializes_bench_workloads_by_extension() {
 }
 
 #[test]
+fn test_rig_component_deserializes_extension_config() {
+    let spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "studio",
+            "components": {
+                "studio": {
+                    "path": "~/Developer/studio",
+                    "extensions": {
+                        "nodejs": {
+                            "settings": { "package_manager": "pnpm" },
+                            "workspace": "apps/studio"
+                        }
+                    }
+                }
+            },
+            "bench": { "default_component": "studio" }
+        }"#,
+    )
+    .expect("parse RigSpec");
+
+    let component = spec.components.get("studio").expect("studio component");
+    let extensions = component.extensions.as_ref().expect("extensions present");
+    let nodejs = extensions.get("nodejs").expect("nodejs extension config");
+
+    assert_eq!(component.path, "~/Developer/studio");
+    assert_eq!(
+        nodejs.settings.get("package_manager"),
+        Some(&serde_json::json!("pnpm"))
+    );
+    assert_eq!(
+        nodejs.settings.get("workspace"),
+        Some(&serde_json::json!("apps/studio"))
+    );
+}
+
+#[test]
+fn test_rig_component_extension_config_round_trips() {
+    let original_json = r#"{
+        "id": "studio",
+        "components": {
+            "studio": {
+                "path": "/tmp/studio",
+                "extensions": {
+                    "nodejs": { "settings": { "package_manager": "pnpm" } }
+                }
+            }
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(original_json).expect("parse");
+    let re_serialized = serde_json::to_string(&spec).expect("serialize");
+    let reparsed: RigSpec = serde_json::from_str(&re_serialized).expect("reparse");
+
+    let extensions = reparsed
+        .components
+        .get("studio")
+        .and_then(|component| component.extensions.as_ref())
+        .expect("extensions preserved");
+    assert!(extensions.contains_key("nodejs"));
+    assert!(re_serialized.contains("extensions"));
+}
+
+#[test]
 fn test_bench_spec_default_component_only_back_compat() {
     // Pre-PR specs declare only `default_component`; the new field
     // must default to None so existing rigs keep parsing.

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -39,6 +39,7 @@ fn test_expand_vars_component_path() {
             remote_url: None,
             stack: None,
             branch: None,
+            extensions: None,
         },
     );
     let rig = rig_with("t", components);

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -217,6 +217,7 @@ mod dag {
                 remote_url: None,
                 stack: None,
                 branch: None,
+                extensions: None,
             },
         );
         components.insert(
@@ -226,6 +227,7 @@ mod dag {
                 remote_url: None,
                 stack: None,
                 branch: None,
+                extensions: None,
             },
         );
 
@@ -283,6 +285,7 @@ mod patch {
                 remote_url: None,
                 stack: None,
                 branch: None,
+                extensions: None,
             },
         );
         let mut pipeline = HashMap::new();

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -295,6 +295,7 @@ fn test_snapshot_state() {
             remote_url: None,
             stack: None,
             branch: None,
+            extensions: None,
         },
     );
     components.insert(
@@ -304,6 +305,7 @@ fn test_snapshot_state() {
             remote_url: None,
             stack: None,
             branch: None,
+            extensions: None,
         },
     );
     let rig = RigSpec {


### PR DESCRIPTION
## Summary

- Lets rig components declare extension config for rig-pinned bench runs, so private rigs can dispatch `homeboy bench --rig <id>` without global component registration or repo-owned `homeboy.json`.
- Keeps the in-memory component synthesis scoped to bench dispatch; existing component resolution is unchanged when rig extension config is absent.

## Changes

- Added optional `components.<id>.extensions` to rig `ComponentSpec`, using the same `ScopedExtensionConfig` shape as component config.
- Added `resolve_with_component()` for callers that need to supply an in-memory component while preserving normal execution-context resolution for everyone else.
- Updated rig bench matrix dispatch to synthesize a component from rig path + extension settings only when the selected rig component declares extensions.
- Added schema and dispatch tests for extension config round-tripping, rig-only bench resolution, fallback behavior, and missing-extension errors.

## Tests

- `cargo test bench_default_baseline_spec_test`
- `cargo test commands::bench::matrix::tests`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-component-bench-config`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-component-bench-config --changed-since origin/main`

## Closes #1709

Closes #1709.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the rig bench dispatch change, added tests, ran validation, and drafted this PR description. Chris remains responsible for review and merge.
