### PR TITLE
feat(bench): support agentic result artifacts and run summaries

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -59,7 +59,7 @@ pub struct BenchRunArgs {
     /// exact behaviour. When > 1, the bench dispatcher is invoked N times in
     /// sequence and per-scenario metrics carry both the cross-run p50
     /// (top-level, unchanged shape) and a runs array with each run's raw
-    /// metrics, plus a runs_summary object with stdev/cv_pct/n.
+    /// metrics, plus a runs_summary object with n/min/max/mean/stdev/cv_pct/p50/p95.
     #[arg(long, default_value_t = 1)]
     runs: u64,
 

--- a/src/core/extension/bench/aggregation.rs
+++ b/src/core/extension/bench/aggregation.rs
@@ -1,0 +1,103 @@
+use std::collections::BTreeMap;
+
+use crate::error::{Error, Result};
+use crate::extension::bench::distribution::{distribution, percentile};
+use crate::extension::bench::parsing::{
+    BenchMetrics, BenchResults, BenchRunSnapshot, BenchScenario,
+};
+
+pub fn aggregate_runs(runs: &[BenchResults]) -> Result<BenchResults> {
+    let first = runs
+        .first()
+        .ok_or_else(|| Error::internal_unexpected("cannot aggregate zero bench runs"))?;
+    let mut metric_policies = BTreeMap::new();
+    let mut grouped: BTreeMap<String, (BenchScenario, Vec<BenchScenario>)> = BTreeMap::new();
+
+    for result in runs {
+        if result.component_id != first.component_id {
+            return Err(Error::validation_invalid_argument(
+                "bench_results.component_id",
+                format!(
+                    "bench run component_id mismatch: expected `{}`, got `{}`",
+                    first.component_id, result.component_id
+                ),
+                None,
+                None,
+            ));
+        }
+        if result.iterations != first.iterations {
+            return Err(Error::validation_invalid_argument(
+                "bench_results.iterations",
+                format!(
+                    "bench run iterations mismatch: expected `{}`, got `{}`",
+                    first.iterations, result.iterations
+                ),
+                None,
+                None,
+            ));
+        }
+        for (key, policy) in &result.metric_policies {
+            metric_policies
+                .entry(key.clone())
+                .or_insert_with(|| policy.clone());
+        }
+        for scenario in &result.scenarios {
+            grouped
+                .entry(scenario.id.clone())
+                .and_modify(|(_, scenarios)| scenarios.push(scenario.clone()))
+                .or_insert_with(|| (scenario.clone(), vec![scenario.clone()]));
+        }
+    }
+
+    let scenarios = grouped
+        .into_values()
+        .map(|(template, scenarios)| aggregate_scenario(template, scenarios))
+        .collect();
+
+    Ok(BenchResults {
+        component_id: first.component_id.clone(),
+        iterations: first.iterations,
+        scenarios,
+        metric_policies,
+    })
+}
+
+fn aggregate_scenario(mut template: BenchScenario, scenarios: Vec<BenchScenario>) -> BenchScenario {
+    let mut metric_values: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    for scenario in &scenarios {
+        for (name, value) in &scenario.metrics.values {
+            metric_values.entry(name.clone()).or_default().push(*value);
+        }
+    }
+
+    let mut values = BTreeMap::new();
+    let mut distributions = BTreeMap::new();
+    let mut summary = BTreeMap::new();
+    for (name, samples) in metric_values {
+        values.insert(name.clone(), percentile(&samples, 50.0));
+        distributions.insert(name.clone(), samples.clone());
+        summary.insert(name, distribution(&samples));
+    }
+
+    template.metrics = BenchMetrics {
+        values,
+        distributions,
+    };
+    template.memory = None;
+    template.runs = Some(
+        scenarios
+            .iter()
+            .map(|scenario| BenchRunSnapshot {
+                metrics: scenario.metrics.clone(),
+                memory: scenario.memory.clone(),
+                artifacts: scenario.artifacts.clone(),
+            })
+            .collect(),
+    );
+    template.runs_summary = Some(summary);
+    template
+}
+
+#[cfg(test)]
+#[path = "../../../../tests/core/extension/bench/runs_flag_test.rs"]
+mod runs_flag_test;

--- a/src/core/extension/bench/aggregation.rs
+++ b/src/core/extension/bench/aggregation.rs
@@ -99,5 +99,9 @@ fn aggregate_scenario(mut template: BenchScenario, scenarios: Vec<BenchScenario>
 }
 
 #[cfg(test)]
+#[path = "../../../../tests/core/extension/bench/aggregation_test.rs"]
+mod aggregation_test;
+
+#[cfg(test)]
 #[path = "../../../../tests/core/extension/bench/runs_flag_test.rs"]
 mod runs_flag_test;

--- a/src/core/extension/bench/artifact.rs
+++ b/src/core/extension/bench/artifact.rs
@@ -1,0 +1,13 @@
+//! Bench scenario artifact pointers.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchArtifact {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}

--- a/src/core/extension/bench/artifact.rs
+++ b/src/core/extension/bench/artifact.rs
@@ -11,3 +11,7 @@ pub struct BenchArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
+
+#[cfg(test)]
+#[path = "../../../../tests/core/extension/bench/artifact_test.rs"]
+mod artifact_test;

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -331,6 +331,7 @@ mod tests {
                 distributions: BTreeMap::new(),
             },
             memory: None,
+            artifacts: BTreeMap::new(),
             runs: None,
             runs_summary: None,
         }
@@ -354,6 +355,7 @@ mod tests {
                 distributions,
             },
             memory: None,
+            artifacts: BTreeMap::new(),
             runs: None,
             runs_summary: None,
         }

--- a/src/core/extension/bench/distribution.rs
+++ b/src/core/extension/bench/distribution.rs
@@ -1,0 +1,62 @@
+//! Cross-run bench distribution summaries.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BenchRunDistribution {
+    pub n: u64,
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    pub stdev: f64,
+    pub cv_pct: f64,
+    pub p50: f64,
+    pub p95: f64,
+}
+
+pub(crate) fn distribution(samples: &[f64]) -> BenchRunDistribution {
+    let n = samples.len() as f64;
+    let mean = samples.iter().sum::<f64>() / n;
+    let variance = samples
+        .iter()
+        .map(|value| {
+            let delta = value - mean;
+            delta * delta
+        })
+        .sum::<f64>()
+        / n;
+    let stdev = variance.sqrt();
+    let cv_pct = if mean == 0.0 {
+        0.0
+    } else {
+        stdev / mean * 100.0
+    };
+
+    BenchRunDistribution {
+        n: samples.len() as u64,
+        min: samples.iter().copied().fold(f64::INFINITY, f64::min),
+        max: samples.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        mean,
+        stdev,
+        cv_pct,
+        p50: percentile(samples, 50.0),
+        p95: percentile(samples, 95.0),
+    }
+}
+
+pub(crate) fn percentile(samples: &[f64], pct: f64) -> f64 {
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let rank = pct / 100.0 * (sorted.len() as f64 - 1.0);
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+    if lower == upper {
+        sorted[lower]
+    } else {
+        let weight = rank - lower as f64;
+        sorted[lower] * (1.0 - weight) + sorted[upper] * weight
+    }
+}

--- a/src/core/extension/bench/distribution.rs
+++ b/src/core/extension/bench/distribution.rs
@@ -60,3 +60,7 @@ pub(crate) fn percentile(samples: &[f64], pct: f64) -> f64 {
         sorted[lower] * (1.0 - weight) + sorted[upper] * weight
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../tests/core/extension/bench/distribution_test.rs"]
+mod distribution_test;

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -351,6 +351,7 @@ mod tests {
                     distributions: BTreeMap::new(),
                 },
                 memory: None,
+                artifacts: BTreeMap::new(),
                 runs: None,
                 runs_summary: None,
             }],

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -18,20 +18,28 @@
 //!
 //! See `docs/commands/bench.md` for the end-user view.
 
+pub mod aggregation;
+pub mod artifact;
 pub mod baseline;
+pub mod distribution;
 pub mod metrics;
 pub mod parsing;
 pub mod report;
 pub mod run;
+#[cfg(test)]
+pub(crate) mod test_support;
 
 use crate::component::Component;
 use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
 
+pub use aggregation::aggregate_runs;
+pub use artifact::BenchArtifact;
 pub use baseline::{
     compare as compare_baseline, load_baseline, save_baseline, BenchBaseline,
     BenchBaselineComparison, BenchBaselineMetadata, BenchScenarioSnapshot, ScenarioDelta,
     DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
+pub use distribution::BenchRunDistribution;
 pub use metrics::MetricDelta;
 pub use parsing::{
     parse_bench_results_file, parse_bench_results_str, BenchMemory, BenchMetrics, BenchResults,

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -47,6 +47,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
+use super::artifact::BenchArtifact;
+use super::distribution::BenchRunDistribution;
+
 /// Full bench run output from an extension script.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -108,18 +111,6 @@ pub struct BenchRunSnapshot {
     pub memory: Option<BenchMemory>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub artifacts: BTreeMap<String, BenchArtifact>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct BenchRunDistribution {
-    pub n: u64,
-    pub min: f64,
-    pub max: f64,
-    pub mean: f64,
-    pub stdev: f64,
-    pub cv_pct: f64,
-    pub p50: f64,
-    pub p95: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -236,16 +227,6 @@ pub enum BenchMetricPhase {
 #[serde(deny_unknown_fields)]
 pub struct BenchMemory {
     pub peak_bytes: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct BenchArtifact {
-    pub path: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub kind: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
 }
 
 /// Read and parse a `$HOMEBOY_BENCH_RESULTS_FILE` written by an extension.

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -27,7 +27,14 @@
 //!           "agent_loop_ms": [1000.0, 1200.0, 1400.0]
 //!         }
 //!       },
-//!       "memory": { "peak_bytes": 41943040 }
+//!       "memory": { "peak_bytes": 41943040 },
+//!       "artifacts": {
+//!         "transcript": {
+//!           "path": "bench-artifacts/scenario/transcript.json",
+//!           "kind": "json",
+//!           "label": "Agent transcript"
+//!         }
+//!       }
 //!     }
 //!   ]
 //! }
@@ -76,6 +83,13 @@ pub struct BenchScenario {
     pub metrics: BenchMetrics,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<BenchMemory>,
+    /// Optional local artifact pointers produced by the scenario.
+    ///
+    /// Homeboy preserves paths and metadata but does not upload, retain, or
+    /// diff artifact contents. Consumers can correlate artifacts by scenario,
+    /// rig, and run without scraping logs or side-channel files.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub artifacts: BTreeMap<String, BenchArtifact>,
     /// Per-run raw metric snapshots when `homeboy bench --runs N` is used.
     /// Omitted for the default `--runs 1` path so existing envelopes keep
     /// their exact shape.
@@ -92,13 +106,20 @@ pub struct BenchRunSnapshot {
     pub metrics: BenchMetrics,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<BenchMemory>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub artifacts: BTreeMap<String, BenchArtifact>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BenchRunDistribution {
+    pub n: u64,
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
     pub stdev: f64,
     pub cv_pct: f64,
-    pub n: u64,
+    pub p50: f64,
+    pub p95: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -215,6 +236,16 @@ pub enum BenchMetricPhase {
 #[serde(deny_unknown_fields)]
 pub struct BenchMemory {
     pub peak_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchArtifact {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// Read and parse a `$HOMEBOY_BENCH_RESULTS_FILE` written by an extension.
@@ -359,6 +390,63 @@ mod tests {
         assert_eq!(scenario.tags, vec!["cold", "cli"]);
         assert_eq!(scenario.metrics.get("p95_ms"), Some(145.0));
         assert_eq!(scenario.memory.as_ref().unwrap().peak_bytes, 41943040);
+        assert!(scenario.artifacts.is_empty());
+    }
+
+    #[test]
+    fn parses_scenario_artifacts() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 1,
+            "scenarios": [
+                {
+                    "id": "agent_loop",
+                    "iterations": 1,
+                    "metrics": { "success_rate": 1.0 },
+                    "artifacts": {
+                        "transcript": {
+                            "path": "artifacts/agent-loop/transcript.json",
+                            "kind": "json",
+                            "label": "Agent transcript"
+                        },
+                        "final_output": {
+                            "path": "artifacts/agent-loop/final.md"
+                        }
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = parse_bench_results_str(raw).unwrap();
+        let artifacts = &parsed.scenarios[0].artifacts;
+
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(
+            artifacts["transcript"].path,
+            "artifacts/agent-loop/transcript.json"
+        );
+        assert_eq!(artifacts["transcript"].kind.as_deref(), Some("json"));
+        assert_eq!(
+            artifacts["transcript"].label.as_deref(),
+            Some("Agent transcript")
+        );
+        assert_eq!(
+            artifacts["final_output"].path,
+            "artifacts/agent-loop/final.md"
+        );
+        assert_eq!(artifacts["final_output"].kind, None);
+
+        let serialized = serde_json::to_string(&parsed).unwrap();
+        assert!(serialized.contains("\"artifacts\""));
+        assert!(serialized.contains("artifacts/agent-loop/transcript.json"));
+    }
+
+    #[test]
+    fn omits_empty_scenario_artifacts() {
+        let parsed = parse_bench_results_str(VALID_RESULTS).unwrap();
+        let raw = serde_json::to_string(&parsed.scenarios[0]).unwrap();
+
+        assert!(!raw.contains("artifacts"));
     }
 
     #[test]

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -378,6 +378,7 @@ mod tests {
                 distributions: BTreeMap::new(),
             },
             memory: None,
+            artifacts: BTreeMap::new(),
             runs: None,
             runs_summary: None,
         }

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1,6 +1,5 @@
 //! Bench main workflow: invoke extension runner, load JSON, apply baseline.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
@@ -11,10 +10,9 @@ use crate::component::Component;
 use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
+use crate::extension::bench::aggregate_runs;
 use crate::extension::bench::baseline::{self, BenchBaselineComparison};
-use crate::extension::bench::parsing::{
-    self, BenchMetrics, BenchResults, BenchRunDistribution, BenchRunSnapshot, BenchScenario,
-};
+use crate::extension::bench::parsing::{self, BenchResults, BenchScenario};
 use crate::extension::{
     resolve_execution_context, ExtensionCapability, ExtensionExecutionContext, ExtensionRunner,
 };
@@ -153,6 +151,36 @@ pub fn run_bench_list_workflow(
     })
 }
 
+fn validate_bench_run_args(args: &BenchRunWorkflowArgs) -> Result<()> {
+    require_positive("concurrency", args.concurrency as u64)?;
+    require_positive("runs", args.runs)?;
+    if args.concurrency > 1 && args.shared_state.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "concurrency",
+            "--concurrency > 1 requires --shared-state <DIR>; \
+             N parallel cold-boots without shared state are N independent \
+             runs, not a multi-instance contention test",
+            None,
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
+fn require_positive(name: &str, value: u64) -> Result<()> {
+    if value == 0 {
+        return Err(Error::validation_invalid_argument(
+            name,
+            "must be >= 1",
+            None,
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
 /// Runs the extension's bench script and produces a structured result.
 ///
 /// Same runner contract as test/lint/build: the script writes a JSON
@@ -182,32 +210,7 @@ pub fn run_main_bench_workflow(
     args: BenchRunWorkflowArgs,
     run_dir: &RunDir,
 ) -> Result<BenchRunWorkflowResult> {
-    if args.concurrency == 0 {
-        return Err(Error::validation_invalid_argument(
-            "concurrency",
-            "must be >= 1",
-            None,
-            None,
-        ));
-    }
-    if args.runs == 0 {
-        return Err(Error::validation_invalid_argument(
-            "runs",
-            "must be >= 1",
-            None,
-            None,
-        ));
-    }
-    if args.concurrency > 1 && args.shared_state.is_none() {
-        return Err(Error::validation_invalid_argument(
-            "concurrency",
-            "--concurrency > 1 requires --shared-state <DIR>; \
-             N parallel cold-boots without shared state are N independent \
-             runs, not a multi-instance contention test",
-            None,
-            None,
-        ));
-    }
+    validate_bench_run_args(&args)?;
 
     if let Some(ref shared) = args.shared_state {
         std::fs::create_dir_all(shared).map_err(|e| {
@@ -380,145 +383,6 @@ fn run_single_dispatcher(
         None
     };
     Ok((parsed, runner_output.success, runner_output.exit_code))
-}
-
-pub fn aggregate_runs(runs: &[BenchResults]) -> Result<BenchResults> {
-    let first = runs
-        .first()
-        .ok_or_else(|| Error::internal_unexpected("cannot aggregate zero bench runs"))?;
-    let mut metric_policies = BTreeMap::new();
-    let mut grouped: BTreeMap<String, (BenchScenario, Vec<BenchScenario>)> = BTreeMap::new();
-
-    for result in runs {
-        if result.component_id != first.component_id {
-            return Err(Error::validation_invalid_argument(
-                "bench_results.component_id",
-                format!(
-                    "bench run component_id mismatch: expected `{}`, got `{}`",
-                    first.component_id, result.component_id
-                ),
-                None,
-                None,
-            ));
-        }
-        if result.iterations != first.iterations {
-            return Err(Error::validation_invalid_argument(
-                "bench_results.iterations",
-                format!(
-                    "bench run iterations mismatch: expected `{}`, got `{}`",
-                    first.iterations, result.iterations
-                ),
-                None,
-                None,
-            ));
-        }
-        for (key, policy) in &result.metric_policies {
-            metric_policies
-                .entry(key.clone())
-                .or_insert_with(|| policy.clone());
-        }
-        for scenario in &result.scenarios {
-            grouped
-                .entry(scenario.id.clone())
-                .and_modify(|(_, scenarios)| scenarios.push(scenario.clone()))
-                .or_insert_with(|| (scenario.clone(), vec![scenario.clone()]));
-        }
-    }
-
-    let scenarios = grouped
-        .into_values()
-        .map(|(template, scenarios)| aggregate_scenario(template, scenarios))
-        .collect();
-
-    Ok(BenchResults {
-        component_id: first.component_id.clone(),
-        iterations: first.iterations,
-        scenarios,
-        metric_policies,
-    })
-}
-
-fn aggregate_scenario(mut template: BenchScenario, scenarios: Vec<BenchScenario>) -> BenchScenario {
-    let mut metric_values: BTreeMap<String, Vec<f64>> = BTreeMap::new();
-    for scenario in &scenarios {
-        for (name, value) in &scenario.metrics.values {
-            metric_values.entry(name.clone()).or_default().push(*value);
-        }
-    }
-
-    let mut values = BTreeMap::new();
-    let mut distributions = BTreeMap::new();
-    let mut summary = BTreeMap::new();
-    for (name, samples) in metric_values {
-        values.insert(name.clone(), percentile(&samples, 50.0));
-        distributions.insert(name.clone(), samples.clone());
-        summary.insert(name, distribution(&samples));
-    }
-
-    template.metrics = BenchMetrics {
-        values,
-        distributions,
-    };
-    template.memory = None;
-    template.runs = Some(
-        scenarios
-            .iter()
-            .map(|scenario| BenchRunSnapshot {
-                metrics: scenario.metrics.clone(),
-                memory: scenario.memory.clone(),
-                artifacts: scenario.artifacts.clone(),
-            })
-            .collect(),
-    );
-    template.runs_summary = Some(summary);
-    template
-}
-
-fn distribution(samples: &[f64]) -> BenchRunDistribution {
-    let n = samples.len() as f64;
-    let mean = samples.iter().sum::<f64>() / n;
-    let variance = samples
-        .iter()
-        .map(|value| {
-            let delta = value - mean;
-            delta * delta
-        })
-        .sum::<f64>()
-        / n;
-    let stdev = variance.sqrt();
-    let cv_pct = if mean == 0.0 {
-        0.0
-    } else {
-        stdev / mean * 100.0
-    };
-
-    BenchRunDistribution {
-        n: samples.len() as u64,
-        min: samples.iter().copied().fold(f64::INFINITY, f64::min),
-        max: samples.iter().copied().fold(f64::NEG_INFINITY, f64::max),
-        mean,
-        stdev,
-        cv_pct,
-        p50: percentile(samples, 50.0),
-        p95: percentile(samples, 95.0),
-    }
-}
-
-fn percentile(samples: &[f64], pct: f64) -> f64 {
-    let mut sorted = samples.to_vec();
-    sorted.sort_by(|a, b| a.total_cmp(b));
-    if sorted.len() == 1 {
-        return sorted[0];
-    }
-    let rank = pct / 100.0 * (sorted.len() as f64 - 1.0);
-    let lower = rank.floor() as usize;
-    let upper = rank.ceil() as usize;
-    if lower == upper {
-        sorted[lower]
-    } else {
-        let weight = rank - lower as f64;
-        sorted[lower] * (1.0 - weight) + sorted[upper] * weight
-    }
 }
 
 /// Per-instance results filename within the run dir.
@@ -787,7 +651,3 @@ mod tests {
         assert!(format!("{}", err).contains("concurrency"));
     }
 }
-
-#[cfg(test)]
-#[path = "../../../../tests/core/extension/bench/runs_flag_test.rs"]
-mod runs_flag_test;

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -447,15 +447,17 @@ fn aggregate_scenario(mut template: BenchScenario, scenarios: Vec<BenchScenario>
     }
 
     let mut values = BTreeMap::new();
+    let mut distributions = BTreeMap::new();
     let mut summary = BTreeMap::new();
     for (name, samples) in metric_values {
         values.insert(name.clone(), percentile(&samples, 50.0));
+        distributions.insert(name.clone(), samples.clone());
         summary.insert(name, distribution(&samples));
     }
 
     template.metrics = BenchMetrics {
         values,
-        distributions: BTreeMap::new(),
+        distributions,
     };
     template.memory = None;
     template.runs = Some(
@@ -464,6 +466,7 @@ fn aggregate_scenario(mut template: BenchScenario, scenarios: Vec<BenchScenario>
             .map(|scenario| BenchRunSnapshot {
                 metrics: scenario.metrics.clone(),
                 memory: scenario.memory.clone(),
+                artifacts: scenario.artifacts.clone(),
             })
             .collect(),
     );
@@ -490,9 +493,14 @@ fn distribution(samples: &[f64]) -> BenchRunDistribution {
     };
 
     BenchRunDistribution {
+        n: samples.len() as u64,
+        min: samples.iter().copied().fold(f64::INFINITY, f64::min),
+        max: samples.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        mean,
         stdev,
         cv_pct,
-        n: samples.len() as u64,
+        p50: percentile(samples, 50.0),
+        p95: percentile(samples, 95.0),
     }
 }
 
@@ -733,6 +741,7 @@ mod tests {
                     distributions: BTreeMap::new(),
                 },
                 memory: None,
+                artifacts: BTreeMap::new(),
                 runs: None,
                 runs_summary: None,
             }],

--- a/src/core/extension/bench/test_support.rs
+++ b/src/core/extension/bench/test_support.rs
@@ -1,0 +1,44 @@
+use std::collections::BTreeMap;
+
+use crate::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
+
+pub(crate) fn scenario_with_iterations(
+    id: &str,
+    metrics: &[(&str, f64)],
+    iterations: u64,
+) -> BenchScenario {
+    let mut values = BTreeMap::new();
+    for (name, value) in metrics {
+        values.insert((*name).to_string(), *value);
+    }
+
+    BenchScenario {
+        id: id.to_string(),
+        file: None,
+        source: None,
+        default_iterations: None,
+        tags: Vec::new(),
+        iterations,
+        metrics: BenchMetrics {
+            values,
+            distributions: BTreeMap::new(),
+        },
+        memory: None,
+        artifacts: BTreeMap::new(),
+        runs: None,
+        runs_summary: None,
+    }
+}
+
+pub(crate) fn results_with_scenarios(
+    component_id: &str,
+    iterations: u64,
+    scenarios: Vec<BenchScenario>,
+) -> BenchResults {
+    BenchResults {
+        component_id: component_id.to_string(),
+        iterations,
+        scenarios,
+        metric_policies: BTreeMap::new(),
+    }
+}

--- a/src/core/extension/bench/test_support.rs
+++ b/src/core/extension/bench/test_support.rs
@@ -2,13 +2,6 @@ use std::collections::BTreeMap;
 
 use crate::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
 
-pub(crate) fn approx_eq(actual: f64, expected: f64) {
-    assert!(
-        (actual - expected).abs() < 1e-9,
-        "expected {expected}, got {actual}"
-    );
-}
-
 pub(crate) fn scenario_with_iterations(
     id: &str,
     metrics: &[(&str, f64)],

--- a/src/core/extension/bench/test_support.rs
+++ b/src/core/extension/bench/test_support.rs
@@ -2,6 +2,13 @@ use std::collections::BTreeMap;
 
 use crate::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
 
+pub(crate) fn approx_eq(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1e-9,
+        "expected {expected}, got {actual}"
+    );
+}
+
 pub(crate) fn scenario_with_iterations(
     id: &str,
     metrics: &[(&str, f64)],
@@ -42,3 +49,7 @@ pub(crate) fn results_with_scenarios(
         metric_policies: BTreeMap::new(),
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../tests/core/extension/bench/test_support_test.rs"]
+mod test_support_test;

--- a/tests/core/extension/bench/aggregation_test.rs
+++ b/tests/core/extension/bench/aggregation_test.rs
@@ -1,0 +1,48 @@
+use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+
+use super::aggregate_runs;
+
+#[test]
+fn test_aggregate_runs() {
+    let aggregated = aggregate_runs(&[
+        results_with_scenarios(
+            "bench-noop",
+            5,
+            vec![scenario_with_iterations("s", &[("ms", 10.0)], 1)],
+        ),
+        results_with_scenarios(
+            "bench-noop",
+            5,
+            vec![scenario_with_iterations("s", &[("ms", 30.0)], 1)],
+        ),
+    ])
+    .unwrap();
+
+    let scenario = aggregated.scenarios.first().unwrap();
+    assert_eq!(scenario.metrics.get("ms"), Some(20.0));
+    assert_eq!(scenario.metrics.distribution("ms"), Some(&[10.0, 30.0][..]));
+    assert_eq!(scenario.runs.as_ref().unwrap().len(), 2);
+    assert_eq!(scenario.runs_summary.as_ref().unwrap()["ms"].n, 2);
+}
+
+#[test]
+fn aggregate_runs_rejects_mismatched_component_id() {
+    let err = aggregate_runs(&[
+        results_with_scenarios("one", 5, vec![]),
+        results_with_scenarios("two", 5, vec![]),
+    ])
+    .expect_err("component mismatch must fail");
+
+    assert!(format!("{}", err).contains("component_id"));
+}
+
+#[test]
+fn aggregate_runs_rejects_mismatched_iterations() {
+    let err = aggregate_runs(&[
+        results_with_scenarios("bench-noop", 5, vec![]),
+        results_with_scenarios("bench-noop", 7, vec![]),
+    ])
+    .expect_err("iteration mismatch must fail");
+
+    assert!(format!("{}", err).contains("iterations"));
+}

--- a/tests/core/extension/bench/artifact_test.rs
+++ b/tests/core/extension/bench/artifact_test.rs
@@ -1,0 +1,38 @@
+use super::BenchArtifact;
+
+#[test]
+fn bench_artifact_serializes_optional_fields_when_present() {
+    let artifact = BenchArtifact {
+        path: "artifacts/run-1/transcript.json".to_string(),
+        kind: Some("json".to_string()),
+        label: Some("Run 1 transcript".to_string()),
+    };
+
+    let raw = serde_json::to_string(&artifact).unwrap();
+
+    assert_eq!(
+        raw,
+        r#"{"path":"artifacts/run-1/transcript.json","kind":"json","label":"Run 1 transcript"}"#
+    );
+}
+
+#[test]
+fn bench_artifact_omits_absent_optional_fields() {
+    let artifact = BenchArtifact {
+        path: "artifacts/run-1/out.txt".to_string(),
+        kind: None,
+        label: None,
+    };
+
+    let raw = serde_json::to_string(&artifact).unwrap();
+
+    assert_eq!(raw, r#"{"path":"artifacts/run-1/out.txt"}"#);
+}
+
+#[test]
+fn bench_artifact_rejects_unknown_fields() {
+    let err = serde_json::from_str::<BenchArtifact>(r#"{"path":"artifact.txt","unexpected":true}"#)
+        .expect_err("artifact schema is strict");
+
+    assert!(err.to_string().contains("unknown field"));
+}

--- a/tests/core/extension/bench/distribution_test.rs
+++ b/tests/core/extension/bench/distribution_test.rs
@@ -1,5 +1,4 @@
 use super::{distribution, percentile};
-use crate::extension::bench::test_support::approx_eq;
 
 #[test]
 fn distribution_reports_population_summary() {
@@ -9,8 +8,8 @@ fn distribution_reports_population_summary() {
     assert_eq!(summary.min, 1.0);
     assert_eq!(summary.max, 3.0);
     assert_eq!(summary.mean, 2.0);
-    approx_eq(summary.stdev, (2.0_f64 / 3.0).sqrt());
-    approx_eq(summary.cv_pct, summary.stdev / 2.0 * 100.0);
+    assert!((summary.stdev - (2.0_f64 / 3.0).sqrt()).abs() < 1e-9);
+    assert!((summary.cv_pct - summary.stdev / 2.0 * 100.0).abs() < 1e-9);
     assert_eq!(summary.p50, 2.0);
     assert_eq!(summary.p95, 2.9);
 }

--- a/tests/core/extension/bench/distribution_test.rs
+++ b/tests/core/extension/bench/distribution_test.rs
@@ -1,0 +1,31 @@
+use super::{distribution, percentile};
+use crate::extension::bench::test_support::approx_eq;
+
+#[test]
+fn distribution_reports_population_summary() {
+    let summary = distribution(&[1.0, 2.0, 3.0]);
+
+    assert_eq!(summary.n, 3);
+    assert_eq!(summary.min, 1.0);
+    assert_eq!(summary.max, 3.0);
+    assert_eq!(summary.mean, 2.0);
+    approx_eq(summary.stdev, (2.0_f64 / 3.0).sqrt());
+    approx_eq(summary.cv_pct, summary.stdev / 2.0 * 100.0);
+    assert_eq!(summary.p50, 2.0);
+    assert_eq!(summary.p95, 2.9);
+}
+
+#[test]
+fn distribution_handles_zero_mean_cv() {
+    let summary = distribution(&[0.0, 0.0, 0.0]);
+
+    assert_eq!(summary.cv_pct, 0.0);
+    assert!(summary.cv_pct.is_finite());
+}
+
+#[test]
+fn percentile_interpolates_r7_style() {
+    assert_eq!(percentile(&[100.0, 200.0, 300.0], 50.0), 200.0);
+    assert_eq!(percentile(&[100.0, 200.0, 300.0], 95.0), 290.0);
+    assert_eq!(percentile(&[42.0], 95.0), 42.0);
+}

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -27,9 +27,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::extension::bench::parsing::{
     parse_bench_results_str, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy,
-    BenchMetrics, BenchResults, BenchScenario,
+    BenchResults, BenchScenario,
 };
 use crate::extension::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
+use crate::extension::bench::test_support::scenario_with_iterations;
 
 fn policy(direction: BenchMetricDirection, phase: Option<BenchMetricPhase>) -> BenchMetricPolicy {
     BenchMetricPolicy {
@@ -44,26 +45,7 @@ fn policy(direction: BenchMetricDirection, phase: Option<BenchMetricPhase>) -> B
 }
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
-    let mut values = BTreeMap::new();
-    for (k, v) in metrics {
-        values.insert((*k).to_string(), *v);
-    }
-    BenchScenario {
-        id: id.to_string(),
-        file: None,
-        source: None,
-        default_iterations: None,
-        tags: Vec::new(),
-        iterations: 10,
-        metrics: BenchMetrics {
-            values,
-            distributions: BTreeMap::new(),
-        },
-        memory: None,
-        artifacts: BTreeMap::new(),
-        runs: None,
-        runs_summary: None,
-    }
+    scenario_with_iterations(id, metrics, 10)
 }
 
 fn results_with(

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -60,6 +60,7 @@ fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
             distributions: BTreeMap::new(),
         },
         memory: None,
+        artifacts: BTreeMap::new(),
         runs: None,
         runs_summary: None,
     }

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -9,42 +9,17 @@
 //! 4. Scenarios missing from some runs aggregate from the runs that emitted
 //!    them instead of failing the whole bench.
 
-use std::collections::BTreeMap;
-
-use crate::extension::bench::parsing::{BenchArtifact, BenchMetrics, BenchResults, BenchScenario};
-use crate::extension::bench::run::aggregate_runs;
+use crate::extension::bench::aggregation::aggregate_runs;
+use crate::extension::bench::artifact::BenchArtifact;
+use crate::extension::bench::parsing::{BenchResults, BenchScenario};
+use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
-    let mut values = BTreeMap::new();
-    for (name, value) in metrics {
-        values.insert((*name).to_string(), *value);
-    }
-
-    BenchScenario {
-        id: id.to_string(),
-        file: None,
-        source: None,
-        default_iterations: None,
-        tags: Vec::new(),
-        iterations: 1,
-        metrics: BenchMetrics {
-            values,
-            distributions: BTreeMap::new(),
-        },
-        memory: None,
-        artifacts: BTreeMap::new(),
-        runs: None,
-        runs_summary: None,
-    }
+    scenario_with_iterations(id, metrics, 1)
 }
 
 fn results(scenarios: Vec<BenchScenario>) -> BenchResults {
-    BenchResults {
-        component_id: "bench-noop".to_string(),
-        iterations: 5,
-        scenarios,
-        metric_policies: BTreeMap::new(),
-    }
+    results_with_scenarios("bench-noop", 5, scenarios)
 }
 
 fn approx_eq(actual: f64, expected: f64) {
@@ -71,7 +46,7 @@ mod cases {
     }
 
     #[test]
-    fn runs_three_aggregates_correctly() {
+    fn test_aggregate_runs() {
         let aggregated = aggregate_runs(&[
             results(vec![scenario("__bootstrap", &[("install_ms", 100.0)])]),
             results(vec![scenario("__bootstrap", &[("install_ms", 200.0)])]),

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -12,9 +12,7 @@
 use crate::extension::bench::aggregation::aggregate_runs;
 use crate::extension::bench::artifact::BenchArtifact;
 use crate::extension::bench::parsing::{BenchResults, BenchScenario};
-use crate::extension::bench::test_support::{
-    approx_eq, results_with_scenarios, scenario_with_iterations,
-};
+use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
     scenario_with_iterations(id, metrics, 1)
@@ -59,8 +57,8 @@ mod cases {
             .unwrap()
             .get("install_ms")
             .unwrap();
-        approx_eq(summary.stdev, (20000.0_f64 / 3.0).sqrt());
-        approx_eq(summary.cv_pct, summary.stdev / 200.0 * 100.0);
+        assert!((summary.stdev - (20000.0_f64 / 3.0).sqrt()).abs() < 1e-9);
+        assert!((summary.cv_pct - summary.stdev / 200.0 * 100.0).abs() < 1e-9);
         assert_eq!(summary.n, 3);
         assert_eq!(summary.min, 100.0);
         assert_eq!(summary.max, 300.0);
@@ -115,7 +113,7 @@ mod cases {
             .unwrap()
             .get("value")
             .unwrap();
-        approx_eq(summary.stdev, (2.0_f64 / 3.0).sqrt());
+        assert!((summary.stdev - (2.0_f64 / 3.0).sqrt()).abs() < 1e-9);
         assert_eq!(summary.n, 3);
     }
 

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -11,7 +11,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
+use crate::extension::bench::parsing::{BenchArtifact, BenchMetrics, BenchResults, BenchScenario};
 use crate::extension::bench::run::aggregate_runs;
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
@@ -32,6 +32,7 @@ fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
             distributions: BTreeMap::new(),
         },
         memory: None,
+        artifacts: BTreeMap::new(),
         runs: None,
         runs_summary: None,
     }
@@ -91,6 +92,15 @@ mod cases {
         approx_eq(summary.stdev, (20000.0_f64 / 3.0).sqrt());
         approx_eq(summary.cv_pct, summary.stdev / 200.0 * 100.0);
         assert_eq!(summary.n, 3);
+        assert_eq!(summary.min, 100.0);
+        assert_eq!(summary.max, 300.0);
+        assert_eq!(summary.mean, 200.0);
+        assert_eq!(summary.p50, 200.0);
+        assert_eq!(summary.p95, 290.0);
+        assert_eq!(
+            scenario.metrics.distribution("install_ms"),
+            Some(&[100.0, 200.0, 300.0][..])
+        );
     }
 
     #[test]
@@ -164,6 +174,41 @@ mod cases {
                 .unwrap()
                 .n,
             2
+        );
+    }
+
+    #[test]
+    fn runs_preserve_per_run_artifacts() {
+        let mut first = scenario("agent", &[("success_rate", 1.0)]);
+        first.artifacts.insert(
+            "transcript".to_string(),
+            BenchArtifact {
+                path: "artifacts/run-1/transcript.json".to_string(),
+                kind: Some("json".to_string()),
+                label: Some("Run 1 transcript".to_string()),
+            },
+        );
+        let mut second = scenario("agent", &[("success_rate", 1.0)]);
+        second.artifacts.insert(
+            "transcript".to_string(),
+            BenchArtifact {
+                path: "artifacts/run-2/transcript.json".to_string(),
+                kind: Some("json".to_string()),
+                label: Some("Run 2 transcript".to_string()),
+            },
+        );
+
+        let aggregated = aggregate_runs(&[results(vec![first]), results(vec![second])]).unwrap();
+        let runs = aggregated.scenarios[0].runs.as_ref().unwrap();
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(
+            runs[0].artifacts["transcript"].path,
+            "artifacts/run-1/transcript.json"
+        );
+        assert_eq!(
+            runs[1].artifacts["transcript"].path,
+            "artifacts/run-2/transcript.json"
         );
     }
 }

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -12,7 +12,9 @@
 use crate::extension::bench::aggregation::aggregate_runs;
 use crate::extension::bench::artifact::BenchArtifact;
 use crate::extension::bench::parsing::{BenchResults, BenchScenario};
-use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+use crate::extension::bench::test_support::{
+    approx_eq, results_with_scenarios, scenario_with_iterations,
+};
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
     scenario_with_iterations(id, metrics, 1)
@@ -20,13 +22,6 @@ fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
 
 fn results(scenarios: Vec<BenchScenario>) -> BenchResults {
     results_with_scenarios("bench-noop", 5, scenarios)
-}
-
-fn approx_eq(actual: f64, expected: f64) {
-    assert!(
-        (actual - expected).abs() < 1e-9,
-        "expected {expected}, got {actual}"
-    );
 }
 
 mod cases {

--- a/tests/core/extension/bench/test_support_test.rs
+++ b/tests/core/extension/bench/test_support_test.rs
@@ -1,12 +1,4 @@
-use super::{approx_eq, results_with_scenarios, scenario_with_iterations};
-
-#[test]
-fn test_approx_eq() {
-    approx_eq(1.0 + 1e-12, 1.0);
-
-    let mismatch = std::panic::catch_unwind(|| approx_eq(1.1, 1.0));
-    assert!(mismatch.is_err());
-}
+use super::{results_with_scenarios, scenario_with_iterations};
 
 #[test]
 fn scenario_with_iterations_builds_minimal_bench_scenario() {

--- a/tests/core/extension/bench/test_support_test.rs
+++ b/tests/core/extension/bench/test_support_test.rs
@@ -1,0 +1,33 @@
+use super::{approx_eq, results_with_scenarios, scenario_with_iterations};
+
+#[test]
+fn test_approx_eq() {
+    approx_eq(1.0 + 1e-12, 1.0);
+
+    let mismatch = std::panic::catch_unwind(|| approx_eq(1.1, 1.0));
+    assert!(mismatch.is_err());
+}
+
+#[test]
+fn scenario_with_iterations_builds_minimal_bench_scenario() {
+    let scenario = scenario_with_iterations("cold", &[("p95_ms", 12.0)], 7);
+
+    assert_eq!(scenario.id, "cold");
+    assert_eq!(scenario.iterations, 7);
+    assert_eq!(scenario.metrics.get("p95_ms"), Some(12.0));
+    assert!(scenario.metrics.distributions.is_empty());
+    assert!(scenario.artifacts.is_empty());
+    assert!(scenario.runs.is_none());
+    assert!(scenario.runs_summary.is_none());
+}
+
+#[test]
+fn results_with_scenarios_builds_minimal_bench_results() {
+    let scenario = scenario_with_iterations("warm", &[("mean_ms", 3.0)], 2);
+    let results = results_with_scenarios("bench-noop", 5, vec![scenario]);
+
+    assert_eq!(results.component_id, "bench-noop");
+    assert_eq!(results.iterations, 5);
+    assert_eq!(results.scenarios.len(), 1);
+    assert!(results.metric_policies.is_empty());
+}


### PR DESCRIPTION
## Summary
- Adds first-class bench scenario artifacts so agentic runs can preserve transcript/output/tool-timeline paths in the structured result envelope.
- Expands `--runs` aggregation with full cross-run summaries while keeping flat `metrics` values as the representative p50 for compatibility.
- Preserves per-run artifact snapshots and cross-run metric samples so variance-aware reporting/baselines have distribution data to consume.

## Changes
- Adds `BenchArtifact` and `BenchScenario.artifacts`, omitted when empty.
- Adds artifacts to `BenchRunSnapshot` so `--runs N` keeps run-specific paths instead of forcing consumers into log scraping.
- Expands `runs_summary` from `stdev/cv_pct/n` to `n/min/max/mean/stdev/cv_pct/p50/p95`.
- Carries cross-run metric samples into `metrics.distributions` during aggregation.
- Updates `homeboy bench --help` text for the expanded summary shape.

## Tests
- `cargo test runs_flag_test && cargo test parses_scenario_artifacts && cargo test omits_empty_scenario_artifacts`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-bench-agentic-results --changed-since origin/main`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-bench-agentic-results`
- `target/debug/homeboy bench --help`

Closes #1708
Closes #1686
Closes #1567

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bench schema/reporting changes, updated focused tests, ran verification, and drafted this PR description. Chris remains responsible for review and merge decisions.
