### PR TITLE
chore(audit): consolidate obvious duplicate helpers

### DIFF
--- a/src/core/refactor/add.rs
+++ b/src/core/refactor/add.rs
@@ -6,12 +6,12 @@
 //! - **Explicit**: Add imports/stubs to files matching a glob pattern.
 //!   Example: `refactor add --import "use serde::Serialize" --to "src/commands/*.rs"`
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::code_audit::CodeAuditResult;
 use crate::refactor::auto::{self, ChunkStatus, Fix, FixResult, Insertion, InsertionKind, NewFile};
 use crate::refactor::plan;
-use crate::{component, Result};
+use crate::Result;
 
 /// Result of an explicit import addition (not from audit).
 #[derive(Debug, Clone, serde::Serialize)]
@@ -78,7 +78,7 @@ pub fn add_import(
     path: Option<&str>,
     write: bool,
 ) -> Result<AddResult> {
-    let root = resolve_root(component_id, path)?;
+    let root = super::resolve_root(component_id, path)?;
     let matched_files = resolve_target_files(&root, target)?;
 
     if matched_files.is_empty() {
@@ -147,26 +147,6 @@ pub fn add_import(
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/// Resolve the root directory from component ID or explicit path.
-fn resolve_root(component_id: Option<&str>, path: Option<&str>) -> Result<PathBuf> {
-    if let Some(p) = path {
-        let pb = PathBuf::from(p);
-        if !pb.is_dir() {
-            return Err(crate::Error::validation_invalid_argument(
-                "path",
-                format!("Not a directory: {}", p),
-                None,
-                None,
-            ));
-        }
-        Ok(pb)
-    } else {
-        let comp = component::resolve(component_id)?;
-        let validated = component::validate_local_path(&comp)?;
-        Ok(validated)
-    }
-}
 
 /// Resolve target files from a glob pattern or direct file path.
 ///

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -5,6 +5,7 @@
 
 use crate::refactor::auto::{AppliedAutofixCapture, FixResultsSummary};
 use serde::Serialize;
+use std::path::PathBuf;
 
 pub mod add;
 pub mod auto;
@@ -14,6 +15,25 @@ pub mod plan;
 pub mod propagate;
 mod rename;
 pub mod transform;
+
+/// Resolve the refactor root directory from an explicit path or component id.
+pub fn resolve_root(component_id: Option<&str>, path: Option<&str>) -> crate::Result<PathBuf> {
+    if let Some(p) = path {
+        let pb = PathBuf::from(p);
+        if !pb.is_dir() {
+            return Err(crate::Error::validation_invalid_argument(
+                "path",
+                format!("Not a directory: {}", p),
+                None,
+                None,
+            ));
+        }
+        Ok(pb)
+    } else {
+        let comp = crate::component::resolve(component_id)?;
+        crate::component::validate_local_path(&comp)
+    }
+}
 
 /// Shared output for refactors/fixes.
 ///

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -17,6 +17,7 @@ mod move_options;
 mod types;
 mod whole_file_move;
 
+pub use super::resolve_root;
 pub(crate) use extension_integration::*;
 pub use item_kind::*;
 pub use move_options::*;

--- a/src/core/refactor/move_items/whole_file_move.rs
+++ b/src/core/refactor/move_items/whole_file_move.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::engine::symbol_graph::module_path_from_file;
 use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::{component, Result};
+use crate::Result;
 
 use super::{
     core_parse_items, ext_parse_items, ext_rewrite_caller_imports, find_refactor_extension,
@@ -327,24 +327,4 @@ pub(crate) fn add_mod_declaration(content: &str, module_name: &str) -> String {
         out.push('\n');
     }
     out
-}
-
-/// Resolve the root directory from component ID or explicit path.
-pub fn resolve_root(component_id: Option<&str>, path: Option<&str>) -> Result<PathBuf> {
-    if let Some(p) = path {
-        let pb = PathBuf::from(p);
-        if !pb.is_dir() {
-            return Err(crate::Error::validation_invalid_argument(
-                "path",
-                format!("Not a directory: {}", p),
-                None,
-                None,
-            ));
-        }
-        Ok(pb)
-    } else {
-        let comp = component::resolve(component_id)?;
-        let validated = component::validate_local_path(&comp)?;
-        Ok(validated)
-    }
 }

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -14,6 +14,7 @@ use std::process::Command;
 use crate::component;
 use crate::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
 use crate::error::{Error, Result};
+use crate::git::gh_probe_succeeds;
 use crate::{fleet, project, rig};
 
 #[derive(Debug, Clone)]
@@ -705,16 +706,6 @@ fn ensure_gh_ready() -> std::result::Result<(), String> {
         return Err("gh is not authenticated for github.com".to_string());
     }
     Ok(())
-}
-
-fn gh_probe_succeeds(args: &[&str]) -> bool {
-    Command::new("gh")
-        .args(args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
 }
 
 fn run_gh(args: &[String]) -> std::result::Result<String, String> {


### PR DESCRIPTION
## Summary

- Consolidates two small, obvious duplicate helper clusters surfaced by the audit triage.
- Leaves weak duplication-pattern categories as triage/tuning issues instead of extracting speculative helpers.

## Changes

- Reuses `crate::git::gh_probe_succeeds` from triage instead of keeping a local duplicate.
- Moves refactor root resolution to the refactor module boundary and reuses it from both `refactor add` and `refactor move`.

## Tests

- `cargo test refactor -- --test-threads=1`
- `homeboy lint homeboy --path .`
- `homeboy audit homeboy --path . --changed-since origin/main`
- `homeboy audit homeboy --path . --ignore-baseline --only near_duplicate`

Closes #1453.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audit triage, small helper consolidation, validation, and PR description drafting. Chris remains responsible for review and merge.
