### PR TITLE
feat(stack): push materialized targets

### DIFF
--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -7,7 +7,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::stack::{
-    self, ApplyOutput, GitRef, InspectOptions, InspectOutput, StackPrEntry, StackSpec,
+    self, ApplyOutput, GitRef, InspectOptions, InspectOutput, PushOutput, StackPrEntry, StackSpec,
     StatusOutput, SyncOutput,
 };
 
@@ -103,6 +103,11 @@ enum StackCommand {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Push the materialized target branch to its configured remote.
+    Push {
+        /// Stack ID.
+        stack_id: String,
+    },
     /// Spec-less inspection of the current branch as a stack of commits.
     /// Replaces the previous `homeboy git stack` command (re-homed into
     /// the stack domain).
@@ -136,6 +141,7 @@ pub enum StackCommandOutput {
     Apply(StackApplyOutput),
     Status(StackStatusOutput),
     Sync(StackSyncOutput),
+    Push(StackPushOutput),
     Inspect(StackInspectOutput),
 }
 
@@ -190,6 +196,13 @@ pub struct StackSyncOutput {
 }
 
 #[derive(Serialize)]
+pub struct StackPushOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: PushOutput,
+}
+
+#[derive(Serialize)]
 pub struct StackInspectOutput {
     pub command: &'static str,
     #[serde(flatten)]
@@ -229,6 +242,7 @@ pub fn run(args: StackArgs, _global: &super::GlobalArgs) -> CmdResult<StackComma
         StackCommand::Apply { stack_id } => apply(&stack_id),
         StackCommand::Status { stack_id } => status(&stack_id),
         StackCommand::Sync { stack_id, dry_run } => sync(&stack_id, dry_run),
+        StackCommand::Push { stack_id } => push(&stack_id),
         StackCommand::Inspect {
             component_id,
             base,
@@ -443,6 +457,18 @@ fn sync(stack_id: &str, dry_run: bool) -> CmdResult<StackCommandOutput> {
             report,
         }),
         exit_code,
+    ))
+}
+
+fn push(stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(stack_id)?;
+    let report = stack::push(&spec)?;
+    Ok((
+        StackCommandOutput::Push(StackPushOutput {
+            command: "stack.push",
+            report,
+        }),
+        0,
     ))
 }
 

--- a/src/core/stack/mod.rs
+++ b/src/core/stack/mod.rs
@@ -30,12 +30,14 @@ pub mod apply;
 pub(crate) mod git;
 pub mod inspect;
 pub(crate) mod pr_meta;
+pub mod push;
 pub mod spec;
 pub mod status;
 pub mod sync;
 
 pub use apply::{apply, AppliedPr, ApplyOutput, PickOutcome};
 pub use inspect::{inspect, inspect_at, InspectCommit, InspectOptions, InspectOutput, InspectPr};
+pub use push::{push, PushOutput, PushStatus};
 pub use spec::{
     exists, expand_path, list, list_ids, load, parse_git_ref, save, GitRef, StackPrEntry, StackSpec,
 };

--- a/src/core/stack/push.rs
+++ b/src/core/stack/push.rs
@@ -1,0 +1,128 @@
+//! `homeboy stack push` — publish a materialized target branch.
+//!
+//! `sync`/`apply` rebuild the local `target.branch`; `push` is the explicit
+//! remote mutation step. Combined-fixes branches are rebuilt history, so this
+//! uses `--force-with-lease` and never plain `--force`.
+
+use serde::Serialize;
+
+use crate::error::{Error, Result};
+
+use super::git::run_git;
+use super::spec::{resolve_existing_component_path, StackSpec};
+
+/// Output envelope for `homeboy stack push`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PushOutput {
+    pub stack_id: String,
+    pub component_path: String,
+    pub remote: String,
+    pub branch: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before_ref: Option<String>,
+    pub after_ref: String,
+    pub status: PushStatus,
+    pub success: bool,
+}
+
+/// Whether the remote branch changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PushStatus {
+    Updated,
+    Unchanged,
+}
+
+/// Push the stack's materialized local target branch to its configured remote.
+pub fn push(spec: &StackSpec) -> Result<PushOutput> {
+    let path = resolve_existing_component_path(spec)?;
+    let remote = spec.target.remote.as_str();
+    let branch = spec.target.branch.as_str();
+
+    // Capture the remote ref first so the lease protects the exact state we
+    // inspected, independent of local remote-tracking refs.
+    let before = remote_branch_ref(&path, remote, branch)?;
+    let local_ref = local_branch_ref(&path, branch)?;
+    push_target_branch(&path, remote, branch, before.as_deref())?;
+    let after = remote_branch_ref(&path, remote, branch)?.unwrap_or(local_ref);
+
+    let status = if before.as_deref() == Some(after.as_str()) {
+        PushStatus::Unchanged
+    } else {
+        PushStatus::Updated
+    };
+
+    Ok(PushOutput {
+        stack_id: spec.id.clone(),
+        component_path: path,
+        remote: remote.to_string(),
+        branch: branch.to_string(),
+        before_ref: before,
+        after_ref: after,
+        status,
+        success: true,
+    })
+}
+
+pub(crate) fn remote_branch_ref(path: &str, remote: &str, branch: &str) -> Result<Option<String>> {
+    let refspec = format!("refs/heads/{}", branch);
+    let output = run_git(path, &["ls-remote", remote, &refspec])?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "git ls-remote {} {}: {}",
+            remote,
+            refspec,
+            stderr.trim()
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .find_map(|line| line.split_whitespace().next().map(str::to_string)))
+}
+
+pub(crate) fn local_branch_ref(path: &str, branch: &str) -> Result<String> {
+    let git_ref = format!("refs/heads/{}", branch);
+    let output = run_git(path, &["rev-parse", &git_ref])?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "git rev-parse {}: {}",
+            git_ref,
+            stderr.trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn push_target_branch(
+    path: &str,
+    remote: &str,
+    branch: &str,
+    expected_remote: Option<&str>,
+) -> Result<()> {
+    let source = format!("refs/heads/{}", branch);
+    let destination = source.clone();
+    let refspec = format!("{}:{}", source, destination);
+    let lease = match expected_remote {
+        Some(expected) => format!("--force-with-lease={}:{}", destination, expected),
+        None => "--force-with-lease".to_string(),
+    };
+    let output = run_git(path, &["push", &lease, remote, &refspec])?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "git push --force-with-lease {} {}: {}",
+            remote,
+            refspec,
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/stack/push_test.rs"]
+mod push_test;

--- a/tests/core/stack/push_test.rs
+++ b/tests/core/stack/push_test.rs
@@ -1,0 +1,157 @@
+//! Tests for `core::stack::push` — publishing the materialized target branch.
+
+use crate::stack::push::{local_branch_ref, push, remote_branch_ref, PushStatus};
+use crate::stack::spec::{GitRef, StackSpec};
+use std::process::Command;
+use tempfile::TempDir;
+
+mod support;
+use support::{commit_file, git, init_repo, rev_parse};
+
+fn init_bare_remote() -> TempDir {
+    let remote = TempDir::new().expect("remote tempdir");
+    let out = Command::new("git")
+        .args(["init", "--bare", "-q"])
+        .current_dir(remote.path())
+        .output()
+        .expect("git init --bare");
+    assert!(
+        out.status.success(),
+        "git init --bare failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    remote
+}
+
+fn stack_spec(path: &str) -> StackSpec {
+    StackSpec {
+        id: "test-stack".to_string(),
+        description: String::new(),
+        component: "homeboy-test".to_string(),
+        component_path: path.to_string(),
+        base: GitRef {
+            remote: "origin".to_string(),
+            branch: "main".to_string(),
+        },
+        target: GitRef {
+            remote: "origin".to_string(),
+            branch: "dev/combined-fixes".to_string(),
+        },
+        prs: Vec::new(),
+    }
+}
+
+fn add_origin(path: &str, remote: &TempDir) {
+    let remote_path = remote.path().to_string_lossy().to_string();
+    git(path, &["remote", "add", "origin", &remote_path]);
+}
+
+#[test]
+fn push_updates_remote_target_branch_with_force_with_lease() {
+    let (dir, path) = init_repo();
+    let remote = init_bare_remote();
+    add_origin(&path, &remote);
+
+    git(&path, &["checkout", "-q", "-b", "dev/combined-fixes"]);
+    let before = commit_file(&dir, &path, "old.txt", "old\n", "old target");
+    git(
+        &path,
+        &[
+            "push",
+            "origin",
+            "refs/heads/dev/combined-fixes:refs/heads/dev/combined-fixes",
+        ],
+    );
+
+    git(&path, &["checkout", "-q", "main"]);
+    git(
+        &path,
+        &["checkout", "-q", "-B", "dev/combined-fixes", "main"],
+    );
+    let after = commit_file(&dir, &path, "new.txt", "new\n", "rebuilt target");
+
+    let report = push(&stack_spec(&path)).expect("stack push");
+
+    assert_eq!(report.stack_id, "test-stack");
+    assert_eq!(report.remote, "origin");
+    assert_eq!(report.branch, "dev/combined-fixes");
+    assert_eq!(report.before_ref.as_deref(), Some(before.as_str()));
+    assert_eq!(report.after_ref, after);
+    assert_eq!(report.status, PushStatus::Updated);
+    assert!(report.success);
+    assert_eq!(
+        remote_branch_ref(&path, "origin", "dev/combined-fixes")
+            .expect("remote ref")
+            .as_deref(),
+        Some(after.as_str())
+    );
+}
+
+#[test]
+fn push_reports_unchanged_when_remote_already_matches_local_target() {
+    let (dir, path) = init_repo();
+    let remote = init_bare_remote();
+    add_origin(&path, &remote);
+
+    git(&path, &["checkout", "-q", "-b", "dev/combined-fixes"]);
+    let head = commit_file(&dir, &path, "same.txt", "same\n", "same target");
+    git(
+        &path,
+        &[
+            "push",
+            "origin",
+            "refs/heads/dev/combined-fixes:refs/heads/dev/combined-fixes",
+        ],
+    );
+
+    let report = push(&stack_spec(&path)).expect("stack push");
+
+    assert_eq!(report.before_ref.as_deref(), Some(head.as_str()));
+    assert_eq!(report.after_ref, head);
+    assert_eq!(report.status, PushStatus::Unchanged);
+    assert!(report.success);
+}
+
+#[test]
+fn push_creates_remote_target_branch_when_missing() {
+    let (dir, path) = init_repo();
+    let remote = init_bare_remote();
+    add_origin(&path, &remote);
+
+    git(&path, &["checkout", "-q", "-b", "dev/combined-fixes"]);
+    let head = commit_file(&dir, &path, "first.txt", "first\n", "first target");
+
+    let report = push(&stack_spec(&path)).expect("stack push");
+
+    assert!(report.before_ref.is_none());
+    assert_eq!(report.after_ref, head);
+    assert_eq!(report.status, PushStatus::Updated);
+    assert_eq!(
+        remote_branch_ref(&path, "origin", "dev/combined-fixes")
+            .expect("remote ref")
+            .as_deref(),
+        Some(head.as_str())
+    );
+}
+
+#[test]
+fn local_branch_ref_errors_when_target_branch_missing() {
+    let (_dir, path) = init_repo();
+    let err = local_branch_ref(&path, "dev/combined-fixes").unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("rev-parse") && msg.contains("dev/combined-fixes"),
+        "expected missing local branch error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn local_branch_ref_reads_multi_segment_branch_name() {
+    let (dir, path) = init_repo();
+    git(&path, &["checkout", "-q", "-b", "dev/combined-fixes"]);
+    let head = commit_file(&dir, &path, "branch.txt", "branch\n", "branch commit");
+
+    assert_eq!(local_branch_ref(&path, "dev/combined-fixes").unwrap(), head);
+    assert_eq!(rev_parse(&path, "refs/heads/dev/combined-fixes"), head);
+}


### PR DESCRIPTION
## Summary
- Add `homeboy stack push <stack-id>` as the explicit publish step for materialized stack target branches.
- Keep `stack sync` local-only while making rebuilt combined-fixes branch publishing a structured Homeboy verb.

## Behaviour
- Resolves the stack spec and pushes the local `target.branch` to `target.remote`.
- Uses `git push --force-with-lease`, with an explicit expected remote ref when the remote branch already exists.
- Reports stack id, component path, remote, branch, before ref, after ref, status (`updated` or `unchanged`), and success.

## Tests
- `cargo test push_test -- --test-threads=1`
- `cargo test stack:: -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-stack-push`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-stack-push --changed-since origin/main`

Closes #1717

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped `stack push` command, added focused git-behaviour tests, and ran verification. Chris remains responsible for review and merge.
