### PR TITLE
feat(rig): sync component stacks

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -11,8 +11,8 @@ use homeboy::rig;
 
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledSummary,
-    RigListOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigUpOutput,
-    RigUpdateOutput,
+    RigListOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigSyncOutput,
+    RigUpOutput, RigUpdateOutput,
 };
 use super::CmdResult;
 
@@ -45,6 +45,14 @@ enum RigCommand {
     Down {
         /// Rig ID
         rig_id: String,
+    },
+    /// Sync every stack declared by this rig's components
+    Sync {
+        /// Rig ID
+        rig_id: String,
+        /// Print what WOULD happen without mutating stack specs or target branches.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Show current state of a rig: running services, last up/check
     Status {
@@ -117,6 +125,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Up { rig_id } => up(&rig_id),
         RigCommand::Check { rig_id } => check(&rig_id),
         RigCommand::Down { rig_id } => down(&rig_id),
+        RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
         RigCommand::Status { rig_id } => status(&rig_id),
         RigCommand::Install { source, id, all } => install(&source, id.as_deref(), all),
         RigCommand::Update { rig_id, all } => update(rig_id.as_deref(), all),
@@ -259,6 +268,19 @@ fn down(rig_id: &str) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::Down(RigDownOutput {
             command: "rig.down",
+            report,
+        }),
+        exit_code,
+    ))
+}
+
+fn sync(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(rig_id)?;
+    let report = rig::run_sync(&rig, dry_run)?;
+    let exit_code = if report.success { 0 } else { 1 };
+    Ok((
+        RigCommandOutput::Sync(RigSyncOutput {
+            command: "rig.sync",
             report,
         }),
         exit_code,

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -18,6 +18,7 @@ pub enum RigCommandOutput {
     Up(RigUpOutput),
     Check(RigCheckOutput),
     Down(RigDownOutput),
+    Sync(RigSyncOutput),
     Status(RigStatusOutput),
     Install(RigInstallOutput),
     Update(RigUpdateOutput),
@@ -79,6 +80,13 @@ pub struct RigDownOutput {
     pub command: &'static str,
     #[serde(flatten)]
     pub report: rig::DownReport,
+}
+
+#[derive(Serialize)]
+pub struct RigSyncOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: rig::RigStackSyncReport,
 }
 
 #[derive(Serialize)]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -7,16 +7,15 @@
 //! Phase 1 scope:
 //! - Spec schema with components, services, symlinks, shared paths, and linear pipelines
 //! - Service kinds: `http-static`, `command`, `external` (adopted)
-//! - Pipeline step kinds: `service`, `build`, `git`, `command`, `symlink`,
-//!   `shared-path`, `patch`, `check`
+//! - Pipeline step kinds: `service`, `build`, `git`, `stack`, `command`,
+//!   `symlink`, `shared-path`, `patch`, `check`
 //! - Check probes: `http`, `file` (+ `contains`), `command`, `newer_than`
 //!   (mtime / process-start staleness)
 //! - State file at `~/.config/homeboy/rigs/{id}.state/state.json`
 //! - CLI verbs: `list`, `show`, `up`, `check`, `down`, `status`
 //!
-//! Deferred to later phases (see Automattic/homeboy#1462+): stack integration,
-//! DAG pipelines, extension-registered service kinds, `.app` wrappers,
-//! bench composition, spec sharing.
+//! Deferred to later phases (see Automattic/homeboy#1462+): deeper stack
+//! lifecycle automation, extension-registered service kinds, spec sharing.
 
 pub mod app;
 pub mod check;
@@ -27,6 +26,7 @@ pub mod runner;
 pub mod service;
 pub mod source;
 pub mod spec;
+pub mod stack;
 pub mod state;
 
 pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
@@ -49,7 +49,11 @@ pub use source::{
 pub use spec::{
     AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, BenchSpec, CheckSpec,
     ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep, RigSpec, ServiceKind,
-    ServiceSpec, SharedPathOp, SharedPathSpec, SymlinkSpec, TimeSource,
+    ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource,
+};
+pub use stack::{
+    plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,
+    RigStackSyncReport,
 };
 pub use state::{RigState, ServiceState};
 

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -17,8 +17,9 @@ use super::expand::expand_vars;
 use super::service;
 use super::spec::{
     ComponentSpec, GitOp, PatchOp, PipelineStep, RigSpec, ServiceOp, SharedPathOp, SharedPathSpec,
-    SymlinkOp, SymlinkSpec,
+    StackOp, SymlinkOp, SymlinkSpec,
 };
+use super::stack as rig_stack;
 use super::state::{now_rfc3339, RigState, SharedPathState};
 use crate::error::{Error, Result};
 
@@ -121,6 +122,12 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
             args,
             ..
         } => run_git_step(rig, component, *op, args),
+        PipelineStep::Stack {
+            component,
+            op,
+            dry_run,
+            ..
+        } => run_stack_step(rig, component, *op, *dry_run),
         PipelineStep::Command {
             cmd,
             cwd,
@@ -237,6 +244,7 @@ fn step_id(step: &PipelineStep) -> Option<&str> {
         PipelineStep::Service { step_id, .. }
         | PipelineStep::Build { step_id, .. }
         | PipelineStep::Git { step_id, .. }
+        | PipelineStep::Stack { step_id, .. }
         | PipelineStep::Command { step_id, .. }
         | PipelineStep::Symlink { step_id, .. }
         | PipelineStep::SharedPath { step_id, .. }
@@ -250,6 +258,7 @@ fn step_dependencies(step: &PipelineStep) -> &[String] {
         PipelineStep::Service { depends_on, .. }
         | PipelineStep::Build { depends_on, .. }
         | PipelineStep::Git { depends_on, .. }
+        | PipelineStep::Stack { depends_on, .. }
         | PipelineStep::Command { depends_on, .. }
         | PipelineStep::Symlink { depends_on, .. }
         | PipelineStep::SharedPath { depends_on, .. }
@@ -365,6 +374,15 @@ fn run_git_step(rig: &RigSpec, component_id: &str, op: GitOp, extra_args: &[Stri
         ));
     }
     Ok(())
+}
+
+fn run_stack_step(rig: &RigSpec, component_id: &str, op: StackOp, dry_run: bool) -> Result<()> {
+    match op {
+        StackOp::Sync => {
+            rig_stack::run_component_sync(rig, component_id, dry_run)?;
+            Ok(())
+        }
+    }
 }
 
 fn run_service_step(rig: &RigSpec, service_id: &str, op: ServiceOp) -> Result<()> {
@@ -885,6 +903,7 @@ fn step_kind(step: &PipelineStep) -> &'static str {
         PipelineStep::Service { .. } => "service",
         PipelineStep::Build { .. } => "build",
         PipelineStep::Git { .. } => "git",
+        PipelineStep::Stack { .. } => "stack",
         PipelineStep::Command { .. } => "command",
         PipelineStep::Symlink { .. } => "symlink",
         PipelineStep::SharedPath { .. } => "shared-path",
@@ -914,6 +933,20 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
                 format!(" {}", args.join(" "))
             };
             format!("git {} {}{}", serialize_git_op(*op), component, joined)
+        }),
+        PipelineStep::Stack {
+            component,
+            op,
+            dry_run,
+            label,
+            ..
+        } => label.clone().unwrap_or_else(|| {
+            format!(
+                "stack {} {}{}",
+                serialize_stack_op(*op),
+                component,
+                if *dry_run { " --dry-run" } else { "" }
+            )
         }),
         PipelineStep::Command { cmd, label, .. } => label
             .clone()
@@ -952,6 +985,12 @@ fn serialize_git_op(op: GitOp) -> &'static str {
         GitOp::CurrentBranch => "current-branch",
         GitOp::Rebase => "rebase",
         GitOp::CherryPick => "cherry-pick",
+    }
+}
+
+fn serialize_stack_op(op: StackOp) -> &'static str {
+    match op {
+        StackOp::Sync => "sync",
     }
 }
 

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -352,6 +352,32 @@ pub enum PipelineStep {
         label: Option<String>,
     },
 
+    /// Delegate to a declared component's stack spec.
+    ///
+    /// This is intentionally explicit: rigs only rewrite combined-fixes
+    /// branches when a pipeline author opts into a `stack` step (or the user
+    /// runs `homeboy rig sync`). `rig up` never syncs stacks implicitly.
+    Stack {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+        /// Component ID — must exist in the rig's `components` map and declare
+        /// a `stack` field.
+        component: String,
+        /// Stack operation.
+        op: StackOp,
+        /// Print what WOULD happen without mutating the stack spec or target
+        /// branch. Only meaningful for `op = "sync"` today.
+        #[serde(default)]
+        dry_run: bool,
+        /// Human-readable label shown during execution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
+
     /// Run an arbitrary shell command — escape hatch for operations that
     /// don't map to a homeboy primitive (waits, custom tooling, probes).
     ///
@@ -502,6 +528,14 @@ pub enum GitOp {
     /// CLI-only convenience and not modelled at the rig step level —
     /// resolve PR numbers to SHAs in the rig spec.
     CherryPick,
+}
+
+/// Stack operation supported by a rig `stack` step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StackOp {
+    /// Delegate to `homeboy stack sync <stack-id>`.
+    Sync,
 }
 
 /// Service operation in a pipeline step.

--- a/src/core/rig/stack.rs
+++ b/src/core/rig/stack.rs
@@ -1,0 +1,206 @@
+//! Rig-to-stack integration.
+//!
+//! Rigs own local lifecycle orchestration. Stacks own combined-fixes branch
+//! upkeep. This module is the narrow bridge: discover stack IDs declared on
+//! rig components, then delegate to the existing stack primitive explicitly.
+
+use serde::Serialize;
+
+use super::spec::RigSpec;
+use crate::error::{ErrorCode, Result};
+use crate::stack::{self, SyncOutput};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RigStackPlanEntry {
+    pub component_id: String,
+    pub stack_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigStackSyncReport {
+    pub rig_id: String,
+    pub stacks: Vec<RigStackSyncEntry>,
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigStackSyncEntry {
+    pub component_id: String,
+    pub stack_id: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub picked_count: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub skipped_count: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub dropped_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
+
+pub fn plan_stack_sync(rig: &RigSpec) -> Vec<RigStackPlanEntry> {
+    let mut entries = rig
+        .components
+        .iter()
+        .filter_map(|(component_id, component)| {
+            component.stack.as_ref().map(|stack_id| RigStackPlanEntry {
+                component_id: component_id.clone(),
+                stack_id: stack_id.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| a.component_id.cmp(&b.component_id));
+    entries
+}
+
+pub fn run_sync(rig: &RigSpec, dry_run: bool) -> Result<RigStackSyncReport> {
+    Ok(run_sync_with(rig, dry_run, |stack_id, dry_run| {
+        let mut spec = stack::load(stack_id)?;
+        stack::sync(&mut spec, dry_run)
+    }))
+}
+
+pub fn run_component_sync(
+    rig: &RigSpec,
+    component_id: &str,
+    dry_run: bool,
+) -> Result<RigStackSyncEntry> {
+    let component = rig.components.get(component_id).ok_or_else(|| {
+        crate::Error::rig_pipeline_failed(
+            &rig.id,
+            "stack",
+            format!(
+                "component '{}' not declared in rig `components` map",
+                component_id
+            ),
+        )
+    })?;
+    let stack_id = component.stack.as_ref().ok_or_else(|| {
+        crate::Error::rig_pipeline_failed(
+            &rig.id,
+            "stack",
+            format!("component '{}' does not declare a stack", component_id),
+        )
+    })?;
+
+    let entry = run_one(component_id, stack_id, dry_run, |stack_id, dry_run| {
+        let mut spec = stack::load(stack_id)?;
+        stack::sync(&mut spec, dry_run)
+    });
+
+    if entry.status == "changed" || entry.status == "no-op" {
+        return Ok(entry);
+    }
+
+    Err(crate::Error::rig_pipeline_failed(
+        &rig.id,
+        "stack",
+        format!(
+            "stack '{}' for component '{}' {}{}",
+            entry.stack_id,
+            entry.component_id,
+            entry.status,
+            entry
+                .error
+                .as_ref()
+                .map(|e| format!(": {}", e))
+                .unwrap_or_default()
+        ),
+    ))
+}
+
+pub(crate) fn run_sync_with<F>(
+    rig: &RigSpec,
+    dry_run: bool,
+    mut sync_stack: F,
+) -> RigStackSyncReport
+where
+    F: FnMut(&str, bool) -> Result<SyncOutput>,
+{
+    let mut stacks = Vec::new();
+    let mut success = true;
+
+    for entry in plan_stack_sync(rig) {
+        let result = run_one(
+            &entry.component_id,
+            &entry.stack_id,
+            dry_run,
+            &mut sync_stack,
+        );
+        if result.status == "conflict" || result.status == "failed" {
+            success = false;
+            stacks.push(result);
+            break;
+        }
+        stacks.push(result);
+    }
+
+    RigStackSyncReport {
+        rig_id: rig.id.clone(),
+        stacks,
+        success,
+    }
+}
+
+fn run_one<F>(
+    component_id: &str,
+    stack_id: &str,
+    dry_run: bool,
+    mut sync_stack: F,
+) -> RigStackSyncEntry
+where
+    F: FnMut(&str, bool) -> Result<SyncOutput>,
+{
+    match sync_stack(stack_id, dry_run) {
+        Ok(output) => entry_from_output(component_id, output),
+        Err(error) => {
+            let status = if error.code == ErrorCode::StackApplyConflict {
+                "conflict"
+            } else {
+                "failed"
+            };
+            RigStackSyncEntry {
+                component_id: component_id.to_string(),
+                stack_id: stack_id.to_string(),
+                status: status.to_string(),
+                branch: None,
+                base: None,
+                target: None,
+                picked_count: 0,
+                skipped_count: 0,
+                dropped_count: 0,
+                error: Some(error.to_string()),
+            }
+        }
+    }
+}
+
+fn entry_from_output(component_id: &str, output: SyncOutput) -> RigStackSyncEntry {
+    let changed = output.picked_count > 0 || output.dropped_count > 0;
+    RigStackSyncEntry {
+        component_id: component_id.to_string(),
+        stack_id: output.stack_id,
+        status: if changed { "changed" } else { "no-op" }.to_string(),
+        branch: Some(output.branch),
+        base: Some(output.base),
+        target: Some(output.target),
+        picked_count: output.picked_count,
+        skipped_count: output.skipped_count,
+        dropped_count: output.dropped_count,
+        error: None,
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/rig/stack_test.rs"]
+mod stack_test;

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -63,7 +63,7 @@ mod dag {
     use std::fs;
 
     use crate::rig::pipeline::run_pipeline;
-    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec, StackOp};
 
     fn command(id: &str, depends_on: &[&str], cmd: String, cwd: Option<String>) -> PipelineStep {
         PipelineStep::Command {
@@ -74,6 +74,20 @@ mod dag {
             env: HashMap::new(),
             label: Some(id.to_string()),
         }
+    }
+
+    fn stack(id: &str, component: &str, stack_id: &str) -> (String, PipelineStep) {
+        (
+            stack_id.to_string(),
+            PipelineStep::Stack {
+                step_id: Some(id.to_string()),
+                depends_on: Vec::new(),
+                component: component.to_string(),
+                op: StackOp::Sync,
+                dry_run: true,
+                label: Some(id.to_string()),
+            },
+        )
     }
 
     fn rig_with_steps(
@@ -199,6 +213,46 @@ mod dag {
             fs::read_to_string(&log).expect("read log"),
             "one\ntwo\nthree\n"
         );
+    }
+
+    #[test]
+    fn test_stack_failure_skips_later_steps_when_fail_fast() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let marker = tmp.path().join("marker.txt");
+        let marker_arg = marker.to_string_lossy();
+        let (stack_id, stack_step) = stack("sync-stack", "studio", "missing-stack-for-test");
+        let mut components = HashMap::new();
+        components.insert(
+            "studio".to_string(),
+            ComponentSpec {
+                path: tmp.path().to_string_lossy().into_owned(),
+                remote_url: None,
+                triage_remote_url: None,
+                stack: Some(stack_id),
+                branch: None,
+                extensions: None,
+            },
+        );
+        let rig = rig_with_steps(
+            vec![
+                stack_step,
+                command(
+                    "build-after-stack",
+                    &[],
+                    format!("printf 'should-not-run' > {}", marker_arg),
+                    None,
+                ),
+            ],
+            components,
+        );
+
+        let out = run_pipeline(&rig, "up", true).expect("pipeline report");
+        assert!(!out.is_success());
+        assert_eq!(out.failed, 1);
+        assert_eq!(out.steps[0].kind, "stack");
+        assert_eq!(out.steps[0].status, "fail");
+        assert_eq!(out.steps[1].status, "skip");
+        assert!(!marker.exists());
     }
 
     #[test]

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -278,6 +278,55 @@ fn test_spec_git_op_current_branch_kebab_serializes() {
 }
 
 #[test]
+fn test_spec_stack_step_parses_sync_shape() {
+    use crate::rig::spec::StackOp;
+    let json = r#"{
+        "id": "r",
+        "components": {
+            "studio": {
+                "path": "/tmp/studio",
+                "branch": "dev/combined-fixes",
+                "stack": "studio-combined"
+            }
+        },
+        "pipeline": {
+            "sync": [
+                {
+                    "kind": "stack",
+                    "id": "sync-studio-stack",
+                    "component": "studio",
+                    "op": "sync",
+                    "dry_run": true,
+                    "label": "sync Studio combined fixes"
+                }
+            ]
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+    assert_eq!(
+        spec.components.get("studio").unwrap().stack.as_deref(),
+        Some("studio-combined")
+    );
+    match &spec.pipeline.get("sync").unwrap()[0] {
+        PipelineStep::Stack {
+            step_id,
+            component,
+            op,
+            dry_run,
+            label,
+            ..
+        } => {
+            assert_eq!(step_id.as_deref(), Some("sync-studio-stack"));
+            assert_eq!(component, "studio");
+            assert_eq!(*op, StackOp::Sync);
+            assert!(*dry_run);
+            assert_eq!(label.as_deref(), Some("sync Studio combined fixes"));
+        }
+        other => panic!("expected Stack, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_spec_round_trip_preserves_shape() {
     let spec: RigSpec = serde_json::from_str(STUDIO_PLAYGROUND_SPEC).expect("parse");
     let re_serialized = serde_json::to_string(&spec).expect("serialize");

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -1,0 +1,190 @@
+//! Rig stack integration tests for `src/core/rig/stack.rs`.
+
+use std::collections::HashMap;
+
+use crate::error::Error;
+use crate::rig::spec::{ComponentSpec, RigSpec};
+use crate::stack::{GitRef, SyncOutput};
+
+use super::{plan_stack_sync, run_sync_with};
+
+fn component(path: &str, stack: Option<&str>) -> ComponentSpec {
+    ComponentSpec {
+        path: path.to_string(),
+        remote_url: None,
+        triage_remote_url: None,
+        stack: stack.map(str::to_string),
+        branch: None,
+        extensions: None,
+    }
+}
+
+fn rig_with_components(components: HashMap<String, ComponentSpec>) -> RigSpec {
+    RigSpec {
+        id: "stack-rig".to_string(),
+        description: String::new(),
+        components,
+        services: Default::default(),
+        symlinks: Vec::new(),
+        shared_paths: Vec::new(),
+        pipeline: Default::default(),
+        bench: None,
+        bench_workloads: Default::default(),
+        app_launcher: None,
+    }
+}
+
+fn sync_output(stack_id: &str, picked: usize, skipped: usize, dropped: usize) -> SyncOutput {
+    SyncOutput {
+        stack_id: stack_id.to_string(),
+        component_path: "/tmp/component".to_string(),
+        branch: "dev/combined-fixes".to_string(),
+        base: "origin/main".to_string(),
+        target: "fork/dev/combined-fixes".to_string(),
+        dropped: Vec::new(),
+        applied: Vec::new(),
+        dry_run: false,
+        picked_count: picked,
+        skipped_count: skipped,
+        dropped_count: dropped,
+        success: true,
+    }
+}
+
+#[test]
+fn test_plan_stack_sync_uses_components_with_stack_ids_in_sorted_order() {
+    let mut components = HashMap::new();
+    components.insert("z".to_string(), component("/tmp/z", Some("z-stack")));
+    components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
+    components.insert("plain".to_string(), component("/tmp/plain", None));
+    let rig = rig_with_components(components);
+
+    let plan = plan_stack_sync(&rig);
+
+    assert_eq!(plan.len(), 2);
+    assert_eq!(plan[0].component_id, "a");
+    assert_eq!(plan[0].stack_id, "a-stack");
+    assert_eq!(plan[1].component_id, "z");
+    assert_eq!(plan[1].stack_id, "z-stack");
+}
+
+#[test]
+fn test_run_sync_reports_changed_and_noop_statuses() {
+    let mut components = HashMap::new();
+    components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
+    components.insert("b".to_string(), component("/tmp/b", Some("b-stack")));
+    let rig = rig_with_components(components);
+
+    let report = run_sync_with(&rig, false, |stack_id, dry_run| {
+        assert!(!dry_run);
+        Ok(match stack_id {
+            "a-stack" => sync_output(stack_id, 1, 0, 0),
+            "b-stack" => sync_output(stack_id, 0, 0, 0),
+            other => panic!("unexpected stack {other}"),
+        })
+    });
+
+    assert!(report.success);
+    assert_eq!(report.stacks.len(), 2);
+    assert_eq!(report.stacks[0].status, "changed");
+    assert_eq!(report.stacks[0].picked_count, 1);
+    assert_eq!(report.stacks[1].status, "no-op");
+}
+
+#[test]
+fn test_run_sync_stops_on_conflict_before_later_stacks() {
+    let mut components = HashMap::new();
+    components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
+    components.insert("b".to_string(), component("/tmp/b", Some("b-stack")));
+    components.insert("c".to_string(), component("/tmp/c", Some("c-stack")));
+    let rig = rig_with_components(components);
+    let mut seen = Vec::new();
+
+    let report = run_sync_with(&rig, true, |stack_id, dry_run| {
+        assert!(dry_run);
+        seen.push(stack_id.to_string());
+        match stack_id {
+            "a-stack" => Ok(sync_output(stack_id, 0, 0, 0)),
+            "b-stack" => Err(Error::stack_apply_conflict(
+                stack_id,
+                123,
+                "Extra-Chill/homeboy",
+                "conflicting file",
+            )),
+            other => panic!("unexpected stack {other}"),
+        }
+    });
+
+    assert!(!report.success);
+    assert_eq!(seen, vec!["a-stack".to_string(), "b-stack".to_string()]);
+    assert_eq!(report.stacks.len(), 2);
+    assert_eq!(report.stacks[0].status, "no-op");
+    assert_eq!(report.stacks[1].status, "conflict");
+    assert!(report.stacks[1]
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("conflicting file"));
+}
+
+#[test]
+fn test_run_sync_reports_general_failure_status() {
+    let mut components = HashMap::new();
+    components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
+    let rig = rig_with_components(components);
+
+    let report = run_sync_with(&rig, false, |_stack_id, _dry_run| {
+        Err(Error::stack_not_found("a-stack", Vec::new()))
+    });
+
+    assert!(!report.success);
+    assert_eq!(report.stacks.len(), 1);
+    assert_eq!(report.stacks[0].status, "failed");
+    assert!(report.stacks[0]
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("Stack not found"));
+}
+
+#[test]
+fn test_sync_entry_serializes_counts_and_refs() {
+    let mut components = HashMap::new();
+    components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
+    let rig = rig_with_components(components);
+
+    let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
+        Ok(SyncOutput {
+            stack_id: stack_id.to_string(),
+            component_path: "/tmp/component".to_string(),
+            branch: "dev/combined-fixes".to_string(),
+            base: GitRef {
+                remote: "origin".to_string(),
+                branch: "main".to_string(),
+            }
+            .display(),
+            target: GitRef {
+                remote: "fork".to_string(),
+                branch: "dev/combined-fixes".to_string(),
+            }
+            .display(),
+            dropped: Vec::new(),
+            applied: Vec::new(),
+            dry_run: false,
+            picked_count: 2,
+            skipped_count: 1,
+            dropped_count: 1,
+            success: true,
+        })
+    });
+
+    let json = serde_json::to_string(&report).expect("serialize");
+    assert!(json.contains("\"component_id\":\"a\""));
+    assert!(json.contains("\"stack_id\":\"a-stack\""));
+    assert!(json.contains("\"status\":\"changed\""));
+    assert!(json.contains("\"picked_count\":2"));
+    assert!(json.contains("\"skipped_count\":1"));
+    assert!(json.contains("\"dropped_count\":1"));
+    assert!(json.contains("\"base\":\"origin/main\""));
+    assert!(json.contains("\"target\":\"fork/dev/combined-fixes\""));
+}


### PR DESCRIPTION
## Summary

- Adds explicit rig-to-stack lifecycle integration through `homeboy rig sync <rig-id>`.
- Adds a typed rig pipeline step, `{ "kind": "stack", "component": "...", "op": "sync" }`, so rigs can opt into stack upkeep before build/rebuild steps.
- Reports per-stack `changed`, `no-op`, `conflict`, or `failed` status with component and stack IDs plus sync counts.

## Behaviour

- Components can use the existing `stack` field to declare the stack spec they track.
- `rig sync` walks declared component stacks in deterministic component order and delegates to the existing `stack sync` implementation.
- `rig sync --dry-run` forwards dry-run mode to each stack sync.
- Stack conflicts and other sync failures stop the rig sync report at the failing stack and return a non-zero exit code.
- A `kind: "stack"` pipeline step participates in existing pipeline fail-fast behaviour, so a failed stack sync prevents later build/rebuild steps from running.
- `rig up` still does not rewrite branches implicitly; stack work happens only through explicit `rig sync` or explicit pipeline steps.

## Tests

- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-stack-integration`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-stack-integration --changed-since origin/main`

Closes #1716

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the rig-stack integration, tests, and PR description. Chris provided the issue, constraints, and target behaviour.
