### PR TITLE
feat(stack): add no-spec-edit rebase verb

### DIFF
--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -7,8 +7,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::stack::{
-    self, ApplyOutput, GitRef, InspectOptions, InspectOutput, PushOutput, StackPrEntry, StackSpec,
-    StatusOutput, SyncOutput,
+    self, ApplyOutput, GitRef, InspectOptions, InspectOutput, PushOutput, RebaseOutput,
+    StackPrEntry, StackSpec, StatusOutput, SyncOutput,
 };
 
 use super::CmdResult;
@@ -82,6 +82,14 @@ enum StackCommand {
         /// Stack ID.
         stack_id: String,
     },
+    /// Rebuild the target branch from fresh base + current spec PRs.
+    ///
+    /// Unlike `sync`, `rebase` never edits the stack spec: merged PRs stay
+    /// listed until an explicit `sync` or `remove-pr`.
+    Rebase {
+        /// Stack ID.
+        stack_id: String,
+    },
     /// Read-only status report — upstream PR state + local target state.
     Status {
         /// Stack ID.
@@ -139,6 +147,7 @@ pub enum StackCommandOutput {
     AddPr(StackMutationOutput),
     RemovePr(StackMutationOutput),
     Apply(StackApplyOutput),
+    Rebase(StackRebaseOutput),
     Status(StackStatusOutput),
     Sync(StackSyncOutput),
     Push(StackPushOutput),
@@ -179,6 +188,13 @@ pub struct StackApplyOutput {
     pub command: &'static str,
     #[serde(flatten)]
     pub report: ApplyOutput,
+}
+
+#[derive(Serialize)]
+pub struct StackRebaseOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: RebaseOutput,
 }
 
 #[derive(Serialize)]
@@ -240,6 +256,7 @@ pub fn run(args: StackArgs, _global: &super::GlobalArgs) -> CmdResult<StackComma
             repo,
         } => remove_pr(&stack_id, number, repo.as_deref()),
         StackCommand::Apply { stack_id } => apply(&stack_id),
+        StackCommand::Rebase { stack_id } => rebase(&stack_id),
         StackCommand::Status { stack_id } => status(&stack_id),
         StackCommand::Sync { stack_id, dry_run } => sync(&stack_id, dry_run),
         StackCommand::Push { stack_id } => push(&stack_id),
@@ -429,6 +446,19 @@ fn apply(stack_id: &str) -> CmdResult<StackCommandOutput> {
     Ok((
         StackCommandOutput::Apply(StackApplyOutput {
             command: "stack.apply",
+            report,
+        }),
+        exit_code,
+    ))
+}
+
+fn rebase(stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(stack_id)?;
+    let report = stack::rebase(&spec)?;
+    let exit_code = if report.success { 0 } else { 1 };
+    Ok((
+        StackCommandOutput::Rebase(StackRebaseOutput {
+            command: "stack.rebase",
             report,
         }),
         exit_code,

--- a/src/core/stack/apply.rs
+++ b/src/core/stack/apply.rs
@@ -73,8 +73,26 @@ pub struct ApplyOutput {
     pub success: bool,
 }
 
+/// Output envelope for `homeboy stack rebase`.
+///
+/// `rebase` intentionally reports the same data as `apply`: both verbs rebuild
+/// the target branch from base plus the PRs currently listed in the spec. The
+/// distinction is vocabulary — `rebase` is the upkeep-safe variant that never
+/// edits the spec, while `sync` adds spec maintenance on top.
+pub type RebaseOutput = ApplyOutput;
+
 /// Apply a stack spec: build `target` from `base + prs`.
 pub fn apply(spec: &StackSpec) -> Result<ApplyOutput> {
+    rebuild(spec, "apply")
+}
+
+/// Rebase a stack spec: rebuild `target` from `base + prs` without editing the
+/// stack spec, even when some listed PRs have merged upstream.
+pub fn rebase(spec: &StackSpec) -> Result<RebaseOutput> {
+    rebuild(spec, "rebase")
+}
+
+fn rebuild(spec: &StackSpec, rerun_verb: &str) -> Result<ApplyOutput> {
     let path = resolve_existing_component_path(spec)?;
 
     // 2. Fetch base — must succeed.
@@ -145,8 +163,8 @@ pub fn apply(spec: &StackSpec) -> Result<ApplyOutput> {
                     &pr.repo,
                     format!(
                         "{}\n  Resolve manually with standard git tools, then re-run \
-                         `homeboy stack apply {}`. (Phase 2 will add `--continue`.)",
-                        message, spec.id
+                         `homeboy stack {} {}`. (Phase 3 will add `--continue`.)",
+                        message, rerun_verb, spec.id
                     ),
                 ));
             }

--- a/src/core/stack/mod.rs
+++ b/src/core/stack/mod.rs
@@ -16,13 +16,12 @@
 //! - Spec schema with `id` / `component` / `component_path` / `base` / `target` / `prs`
 //! - State directory at `~/.config/homeboy/stacks/{id}.json` (mirror of rig layout)
 //! - CLI verbs: `list`, `show`, `create`, `add-pr`, `remove-pr`, `apply`,
-//!   `status`, `inspect`
+//!   `rebase`, `sync`, `status`, `inspect`
 //! - Pause-and-resume on cherry-pick conflicts (apply exits non-zero with a
 //!   clear message; user resolves manually with raw git tools)
 //!
 //! Deferred to Phase 2+ (Extra-Chill/homeboy#1462):
-//! - `sync` (auto-drop merged PRs after rebase) — requires `rebase` first
-//! - `rebase`, `push`, `diff`, `continue` / `--reset` resume primitives
+//! - `push`, `diff`, `continue` / `--reset` resume primitives
 //! - Per-PR `--squash` / `--merge` / `--preserve` flags
 //! - Conflict resolution cache
 
@@ -35,7 +34,7 @@ pub mod spec;
 pub mod status;
 pub mod sync;
 
-pub use apply::{apply, AppliedPr, ApplyOutput, PickOutcome};
+pub use apply::{apply, rebase, AppliedPr, ApplyOutput, PickOutcome, RebaseOutput};
 pub use inspect::{inspect, inspect_at, InspectCommit, InspectOptions, InspectOutput, InspectPr};
 pub use push::{push, PushOutput, PushStatus};
 pub use spec::{

--- a/tests/core/stack/apply_test.rs
+++ b/tests/core/stack/apply_test.rs
@@ -9,7 +9,10 @@
 //! End-to-end correctness is verified out-of-band via the live-verify
 //! fixture spec described in the PR body.
 
-use crate::stack::apply::{checkout_force, cherry_pick, url_matches, CherryPickResult};
+use crate::stack::apply::{checkout_force, cherry_pick, rebase, url_matches, CherryPickResult};
+use crate::stack::{save, GitRef, StackSpec};
+use crate::test_support::with_isolated_home;
+use std::fs;
 use std::process::Command;
 
 mod support;
@@ -128,6 +131,62 @@ fn checkout_force_recreates_branch_from_base() {
         !dir.path().join("stale.txt").exists(),
         "stale file should be removed by force-checkout"
     );
+}
+
+// ---------------------------------------------------------------------------
+// rebase
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rebase_rebuilds_target_without_editing_spec() {
+    with_isolated_home(|home| {
+        let (dir, path) = init_repo();
+        git(&path, &["remote", "add", "origin", &path]);
+        commit_file(&dir, &path, "base.txt", "base\n", "base commit");
+
+        // Target starts stale and must be rebuilt from origin/main.
+        git(&path, &["checkout", "-q", "-b", "stack-target"]);
+        commit_file(&dir, &path, "stale.txt", "stale\n", "stale target commit");
+        git(&path, &["checkout", "-q", "main"]);
+
+        let spec = StackSpec {
+            id: "rebase-no-edit".to_string(),
+            description: "prove rebase does not mutate specs".to_string(),
+            component: "homeboy".to_string(),
+            component_path: path.clone(),
+            base: GitRef {
+                remote: "origin".to_string(),
+                branch: "main".to_string(),
+            },
+            target: GitRef {
+                remote: "origin".to_string(),
+                branch: "stack-target".to_string(),
+            },
+            prs: Vec::new(),
+        };
+        save(&spec).expect("save stack spec");
+        let spec_path = home
+            .path()
+            .join(".config/homeboy/stacks/rebase-no-edit.json");
+        let before = fs::read_to_string(&spec_path).expect("read spec before rebase");
+
+        let output = rebase(&spec).expect("rebase stack");
+        assert!(output.success);
+        assert_eq!(output.picked_count, 0);
+        assert_eq!(output.skipped_count, 0);
+
+        let after = fs::read_to_string(&spec_path).expect("read spec after rebase");
+        assert_eq!(after, before, "stack rebase must not edit the spec file");
+
+        assert_eq!(
+            rev_parse(&path, "stack-target"),
+            rev_parse(&path, "origin/main")
+        );
+        assert!(
+            !dir.path().join("stale.txt").exists(),
+            "rebase should recreate target from base and remove stale files"
+        );
+    });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `homeboy stack rebase <stack-id>` as the lower-level rebuild primitive from #1718.
- Reuse the existing apply/replay mechanics so `rebase` fetches base, recreates target, and replays the PRs currently listed in the spec.
- Keep `sync` as the holistic upkeep verb that can edit the spec; `rebase` never edits the stack spec.

## Behaviour

- `stack rebase` rebuilds the target branch from `base + prs` exactly like the non-dropping half of `sync`.
- The output envelope matches `apply`, with the command set to `stack.rebase`.
- Conflict handling uses the same abort/manual-resolution path as apply/sync, with the rerun hint pointing back to `homeboy stack rebase <stack-id>`.
- The stack spec remains byte-for-byte unchanged after rebase, even though the target branch is force-recreated.

## Tests

- `cargo test stack::apply::apply_test::rebase_rebuilds_target_without_editing_spec`
- `cargo test stack::`
- `cargo test --test command_surface_test`
- `cargo test --release -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@design-stack-rebase-verb`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@design-stack-rebase-verb --changed-since origin/main`
- `cargo run --quiet --bin homeboy -- stack --help`

Closes #1718

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the stack roadmap and existing `apply`/`sync` internals, implemented the small `rebase` wrapper over the shared replay path, added the no-spec-edit regression test, and ran the verification commands. Chris provided the issue, branch scope, and implementation constraints.