### PR TITLE
feat(stack): add sync diff preview

### DIFF
--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -7,8 +7,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::stack::{
-    self, ApplyOutput, GitRef, InspectOptions, InspectOutput, PushOutput, RebaseOutput,
-    StackPrEntry, StackSpec, StatusOutput, SyncOutput,
+    self, ApplyOutput, DiffOutput, GitRef, InspectOptions, InspectOutput, PushOutput,
+    RebaseOutput, StackPrEntry, StackSpec, StatusOutput, SyncOutput,
 };
 
 use super::CmdResult;
@@ -116,6 +116,11 @@ enum StackCommand {
         /// Stack ID.
         stack_id: String,
     },
+    /// Preview what `stack sync` would change without mutating target or spec.
+    Diff {
+        /// Stack ID.
+        stack_id: String,
+    },
     /// Spec-less inspection of the current branch as a stack of commits.
     /// Replaces the previous `homeboy git stack` command (re-homed into
     /// the stack domain).
@@ -151,6 +156,7 @@ pub enum StackCommandOutput {
     Status(StackStatusOutput),
     Sync(StackSyncOutput),
     Push(StackPushOutput),
+    Diff(StackDiffOutput),
     Inspect(StackInspectOutput),
 }
 
@@ -219,6 +225,13 @@ pub struct StackPushOutput {
 }
 
 #[derive(Serialize)]
+pub struct StackDiffOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: DiffOutput,
+}
+
+#[derive(Serialize)]
 pub struct StackInspectOutput {
     pub command: &'static str,
     #[serde(flatten)]
@@ -260,6 +273,7 @@ pub fn run(args: StackArgs, _global: &super::GlobalArgs) -> CmdResult<StackComma
         StackCommand::Status { stack_id } => status(&stack_id),
         StackCommand::Sync { stack_id, dry_run } => sync(&stack_id, dry_run),
         StackCommand::Push { stack_id } => push(&stack_id),
+        StackCommand::Diff { stack_id } => diff(&stack_id),
         StackCommand::Inspect {
             component_id,
             base,
@@ -496,6 +510,18 @@ fn push(stack_id: &str) -> CmdResult<StackCommandOutput> {
     Ok((
         StackCommandOutput::Push(StackPushOutput {
             command: "stack.push",
+            report,
+        }),
+        0,
+    ))
+}
+
+fn diff(stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(stack_id)?;
+    let report = stack::diff(&spec)?;
+    Ok((
+        StackCommandOutput::Diff(StackDiffOutput {
+            command: "stack.diff",
             report,
         }),
         0,

--- a/src/core/rig/stack.rs
+++ b/src/core/rig/stack.rs
@@ -186,17 +186,17 @@ where
 }
 
 fn entry_from_output(component_id: &str, output: SyncOutput) -> RigStackSyncEntry {
-    let changed = output.picked_count > 0 || output.dropped_count > 0;
+    let changed = output.picked_count > 0 || output.preview.dropped_count > 0;
     RigStackSyncEntry {
         component_id: component_id.to_string(),
-        stack_id: output.stack_id,
+        stack_id: output.preview.stack_id,
         status: if changed { "changed" } else { "no-op" }.to_string(),
-        branch: Some(output.branch),
-        base: Some(output.base),
-        target: Some(output.target),
+        branch: Some(output.preview.branch),
+        base: Some(output.preview.base),
+        target: Some(output.preview.target),
         picked_count: output.picked_count,
         skipped_count: output.skipped_count,
-        dropped_count: output.dropped_count,
+        dropped_count: output.preview.dropped_count,
         error: None,
     }
 }

--- a/src/core/stack/mod.rs
+++ b/src/core/stack/mod.rs
@@ -41,4 +41,4 @@ pub use spec::{
     exists, expand_path, list, list_ids, load, parse_git_ref, save, GitRef, StackPrEntry, StackSpec,
 };
 pub use status::{status, LocalState, StatusOutput, StatusPr};
-pub use sync::{sync, DroppedPr, SyncOutput};
+pub use sync::{diff, sync, DiffOutput, DroppedPr, ReplayedPr, SyncOutput, UncertainPr};

--- a/src/core/stack/mod.rs
+++ b/src/core/stack/mod.rs
@@ -41,4 +41,6 @@ pub use spec::{
     exists, expand_path, list, list_ids, load, parse_git_ref, save, GitRef, StackPrEntry, StackSpec,
 };
 pub use status::{status, LocalState, StatusOutput, StatusPr};
-pub use sync::{diff, sync, DiffOutput, DroppedPr, ReplayedPr, SyncOutput, UncertainPr};
+pub use sync::{
+    diff, sync, DiffOutput, DroppedPr, ReplayedPr, SyncOutput, SyncPreview, UncertainPr,
+};

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -41,11 +41,27 @@ use super::git::run_git;
 use super::pr_meta::fetch_pr_meta;
 pub(crate) use super::pr_meta::StackPrMeta as PrMeta;
 use super::spec::{resolve_existing_component_path, save, StackPrEntry, StackSpec};
-use super::status::{commit_reachable, patch_in_base};
+use super::status::{commit_reachable, count_revs, git_ref_exists, patch_in_base};
 
 /// Output envelope for `homeboy stack sync`.
 #[derive(Debug, Clone, Serialize)]
 pub struct SyncOutput {
+    #[serde(flatten)]
+    pub preview: SyncPreview,
+    /// PRs cherry-picked onto the rebuilt target branch.
+    pub applied: Vec<AppliedPr>,
+    /// `true` when called with `--dry-run`: the spec on disk was NOT
+    /// mutated and no cherry-picks ran.
+    pub dry_run: bool,
+    pub picked_count: usize,
+    pub skipped_count: usize,
+    pub success: bool,
+}
+
+/// Shared read-only sync preview. Used directly by `stack diff` and flattened
+/// into `stack sync` output.
+#[derive(Debug, Clone, Serialize)]
+pub struct SyncPreview {
     pub stack_id: String,
     pub component_path: String,
     pub branch: String,
@@ -54,16 +70,28 @@ pub struct SyncOutput {
     /// PRs auto-removed from the spec because they were upstream-merged
     /// AND their content was already in base.
     pub dropped: Vec<DroppedPr>,
-    /// PRs cherry-picked onto the rebuilt target branch.
-    pub applied: Vec<AppliedPr>,
-    /// `true` when called with `--dry-run`: the spec on disk was NOT
-    /// mutated and no cherry-picks ran.
-    pub dry_run: bool,
-    pub picked_count: usize,
-    pub skipped_count: usize,
+    /// PRs that `sync` would replay (or did replay) after rebuilding target.
+    pub replayed: Vec<ReplayedPr>,
+    /// PRs that could not be classified because metadata or head-fetching
+    /// failed. `sync` refuses to mutate while this list is non-empty.
+    pub uncertain: Vec<UncertainPr>,
+    /// Whether the local target branch currently exists.
+    pub target_exists: bool,
+    /// `git rev-list --count <base>..<target>` before sync mutates anything.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_ahead: Option<usize>,
+    /// `git rev-list --count <target>..<base>` before sync mutates anything.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_behind: Option<usize>,
     pub dropped_count: usize,
+    pub replayed_count: usize,
+    pub uncertain_count: usize,
+    pub would_mutate: bool,
+    pub blocked: bool,
     pub success: bool,
 }
+
+pub type DiffOutput = SyncPreview;
 
 /// One PR auto-removed from the spec.
 #[derive(Debug, Clone, Serialize)]
@@ -76,6 +104,42 @@ pub struct DroppedPr {
     pub merged_at: Option<String>,
     /// Human-readable reason — e.g. "merged upstream and content in base".
     pub reason: String,
+}
+
+/// One PR that would be replayed during `sync`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReplayedPr {
+    pub repo: String,
+    pub number: u64,
+    pub sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    pub reason: String,
+}
+
+/// One PR whose sync outcome could not be decided safely.
+#[derive(Debug, Clone, Serialize)]
+pub struct UncertainPr {
+    pub repo: String,
+    pub number: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SyncPlan {
+    pub preview: SyncPreview,
+    #[serde(skip)]
+    kept_entries: Vec<StackPrEntry>,
+    #[serde(skip)]
+    kept_metas: Vec<PrMeta>,
 }
 
 /// Decide whether a PR should be dropped from the spec.
@@ -97,46 +161,67 @@ pub(crate) fn is_droppable(meta: &PrMeta, path: &str, base_ref: &str) -> bool {
     patch_in_base(path, &meta.head_sha, base_ref).unwrap_or(false)
 }
 
-/// Sync a stack: rebuild target from base, auto-drop merged PRs, replay
-/// the rest.
-pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
+/// Build the shared read-only plan consumed by `stack diff`, `sync --dry-run`,
+/// and the mutating `sync` path.
+pub(crate) fn plan_sync(spec: &StackSpec) -> Result<SyncPlan> {
     let path = resolve_existing_component_path(spec)?;
 
-    // 1. Fetch base — must succeed so droppability checks are honest.
+    // Fetch base so ahead/behind and droppability checks are honest. This
+    // updates remote-tracking refs only; it does not touch target or the spec.
     fetch_remote_branch(&path, &spec.base.remote, &spec.base.branch)?;
-    // Best-effort fetch target; failure is fine on a fresh stack.
+    // Best-effort fetch target; a fresh stack may not have pushed it yet.
     let _ = fetch_remote_branch(&path, &spec.target.remote, &spec.target.branch);
 
     let base_ref = format!("{}/{}", spec.base.remote, spec.base.branch);
+    let target_branch = &spec.target.branch;
+    let target_exists = git_ref_exists(&path, target_branch);
+    let (target_ahead, target_behind) = if target_exists {
+        (
+            count_revs(&path, &base_ref, target_branch),
+            count_revs(&path, target_branch, &base_ref),
+        )
+    } else {
+        (None, None)
+    };
 
-    // 2. Resolve metadata for every PR up front. We need head SHAs locally
-    //    BEFORE deciding droppability — `commit_reachable` and
-    //    `patch_in_base` both require the SHA to be in the object store.
-    //    Use a temp remote per fork (same machinery as `apply`).
     let mut ensured_remotes: HashSet<String> = HashSet::new();
-    let mut metas: Vec<PrMeta> = Vec::with_capacity(spec.prs.len());
+    let mut dropped = Vec::new();
+    let mut replayed = Vec::new();
+    let mut uncertain = Vec::new();
+    let mut kept_entries = Vec::new();
+    let mut kept_metas = Vec::new();
 
     for pr in &spec.prs {
-        let meta = fetch_pr_meta(pr)?;
-        let head = meta.require_head(pr)?;
-        // Fetch the head SHA into the local object store before asking
-        // git about reachability/patch-id.
-        let head_remote = ensure_head_remote(&path, pr, &head, &mut ensured_remotes)?;
-        if !meta.head_sha.is_empty() {
-            // Best-effort fetch — a 404 here means the SHA is gone from
-            // the head repo (force-pushed away). is_droppable() will then
-            // return false and the cherry-pick path will surface the real
-            // error.
-            let _ = fetch_sha(&path, &head_remote, &meta.head_sha);
-        }
-        metas.push(meta);
-    }
+        let meta = match fetch_pr_meta(pr) {
+            Ok(meta) => meta,
+            Err(e) => {
+                uncertain.push(uncertain_pr(pr, e.to_string()));
+                continue;
+            }
+        };
 
-    // 3. Partition into drop list + pick list, preserving spec order.
-    let mut dropped: Vec<DroppedPr> = Vec::new();
-    let mut keep_indices: Vec<usize> = Vec::new();
-    for (idx, (pr, meta)) in spec.prs.iter().zip(metas.iter()).enumerate() {
-        if is_droppable(meta, &path, &base_ref) {
+        let head = match meta.require_head(pr) {
+            Ok(head) => head,
+            Err(e) => {
+                uncertain.push(uncertain_pr(pr, e.to_string()));
+                continue;
+            }
+        };
+
+        let head_remote = match ensure_head_remote(&path, pr, &head, &mut ensured_remotes) {
+            Ok(remote) => remote,
+            Err(e) => {
+                uncertain.push(uncertain_pr(pr, e.to_string()));
+                continue;
+            }
+        };
+
+        if let Err(e) = fetch_sha(&path, &head_remote, &meta.head_sha) {
+            uncertain.push(uncertain_pr(pr, e.to_string()));
+            continue;
+        }
+
+        if is_droppable(&meta, &path, &base_ref) {
             dropped.push(DroppedPr {
                 repo: pr.repo.clone(),
                 number: pr.number,
@@ -145,50 +230,111 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
                 reason: "merged upstream and content in base".to_string(),
             });
         } else {
-            keep_indices.push(idx);
+            replayed.push(ReplayedPr {
+                repo: pr.repo.clone(),
+                number: pr.number,
+                sha: meta.head_sha.clone(),
+                title: meta.title.clone(),
+                url: meta.url.clone(),
+                upstream_state: Some(meta.state.clone()),
+                note: pr.note.clone(),
+                reason: replay_reason(&meta).to_string(),
+            });
+            kept_entries.push(pr.clone());
+            kept_metas.push(meta);
         }
     }
 
     let dropped_count = dropped.len();
+    let replayed_count = replayed.len();
+    let uncertain_count = uncertain.len();
+    let blocked = uncertain_count > 0;
+    let would_mutate = sync_would_mutate(
+        target_exists,
+        target_ahead,
+        target_behind,
+        dropped_count,
+        replayed_count,
+    );
+
+    Ok(SyncPlan {
+        preview: SyncPreview {
+            stack_id: spec.id.clone(),
+            component_path: path,
+            branch: spec.target.branch.clone(),
+            base: spec.base.display(),
+            target: spec.target.display(),
+            target_exists,
+            target_ahead,
+            target_behind,
+            dropped,
+            replayed,
+            uncertain,
+            dropped_count,
+            replayed_count,
+            uncertain_count,
+            would_mutate,
+            blocked,
+            success: true,
+        },
+        kept_entries,
+        kept_metas,
+    })
+}
+
+/// Read-only preview for `homeboy stack diff`.
+pub fn diff(spec: &StackSpec) -> Result<DiffOutput> {
+    let plan = plan_sync(spec)?;
+    Ok(plan.preview)
+}
+
+/// Sync a stack: rebuild target from base, auto-drop merged PRs, replay
+/// the rest.
+pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
+    let plan = plan_sync(spec)?;
 
     if dry_run {
         // Report what WOULD happen; mutate nothing.
-        return Ok(sync_output(
-            spec,
-            path,
-            dropped,
-            Vec::new(),
-            true,
-            0,
-            0,
-            dropped_count,
-        ));
+        return Ok(sync_output(plan, Vec::new(), true, 0, 0));
+    }
+
+    if plan.preview.blocked {
+        let summary = plan
+            .preview
+            .uncertain
+            .iter()
+            .map(|p| format!("{}#{}: {}", p.repo, p.number, p.error))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(Error::git_command_failed(format!(
+            "stack sync {} is blocked by uncertain PR metadata: {}",
+            spec.id, summary
+        )));
     }
 
     // 4. Persist the pruned spec BEFORE any cherry-picks. A partial pick
     //    failure leaves a half-applied target but a correct spec — re-run
     //    cleanly rebuilds.
-    let kept: Vec<StackPrEntry> = keep_indices.iter().map(|i| spec.prs[*i].clone()).collect();
-    let kept_metas: Vec<PrMeta> = keep_indices.iter().map(|i| metas[*i].clone()).collect();
-    if dropped_count > 0 {
-        spec.prs = kept.clone();
+    if plan.preview.dropped_count > 0 {
+        spec.prs = plan.kept_entries.clone();
         save(spec)?;
     } else {
-        // No spec mutation needed — but keep `kept`/`kept_metas` so the
-        // pick loop has consistent indexing.
-        spec.prs = kept.clone();
+        // No spec mutation needed — but keep `spec.prs` aligned with the
+        // plan so the pick loop has consistent indexing.
+        spec.prs = plan.kept_entries.clone();
     }
 
     // 5. Force-recreate target locally from base.
-    checkout_force(&path, &spec.target.branch, &base_ref)?;
+    let base_ref = format!("{}/{}", spec.base.remote, spec.base.branch);
+    checkout_force(&plan.preview.component_path, &spec.target.branch, &base_ref)?;
 
     // 6. Cherry-pick the kept PRs.
-    let mut applied: Vec<AppliedPr> = Vec::with_capacity(kept.len());
+    let mut applied: Vec<AppliedPr> = Vec::with_capacity(plan.kept_entries.len());
     let mut picked = 0usize;
     let mut skipped = 0usize;
 
-    for (pr, meta) in kept.iter().zip(kept_metas.iter()) {
-        match cherry_pick(&path, &meta.head_sha)? {
+    for (pr, meta) in plan.kept_entries.iter().zip(plan.kept_metas.iter()) {
+        match cherry_pick(&plan.preview.component_path, &meta.head_sha)? {
             CherryPickResult::Picked => {
                 picked += 1;
                 applied.push(AppliedPr {
@@ -210,7 +356,7 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
                 });
             }
             CherryPickResult::Conflict(message) => {
-                let _ = run_git(&path, &["cherry-pick", "--abort"]);
+                let _ = run_git(&plan.preview.component_path, &["cherry-pick", "--abort"]);
 
                 applied.push(AppliedPr {
                     repo: pr.repo.clone(),
@@ -234,42 +380,55 @@ pub fn sync(spec: &mut StackSpec, dry_run: bool) -> Result<SyncOutput> {
         }
     }
 
-    Ok(sync_output(
-        spec,
-        path,
-        dropped,
-        applied,
-        false,
-        picked,
-        skipped,
-        dropped_count,
-    ))
+    Ok(sync_output(plan, applied, false, picked, skipped))
 }
 
 fn sync_output(
-    spec: &StackSpec,
-    path: String,
-    dropped: Vec<DroppedPr>,
+    plan: SyncPlan,
     applied: Vec<AppliedPr>,
     dry_run: bool,
     picked_count: usize,
     skipped_count: usize,
-    dropped_count: usize,
 ) -> SyncOutput {
     SyncOutput {
-        stack_id: spec.id.clone(),
-        component_path: path,
-        branch: spec.target.branch.clone(),
-        base: spec.base.display(),
-        target: spec.target.display(),
-        dropped,
+        preview: plan.preview,
         applied,
         dry_run,
         picked_count,
         skipped_count,
-        dropped_count,
         success: true,
     }
+}
+
+fn uncertain_pr(pr: &StackPrEntry, error: String) -> UncertainPr {
+    UncertainPr {
+        repo: pr.repo.clone(),
+        number: pr.number,
+        note: pr.note.clone(),
+        error,
+    }
+}
+
+fn replay_reason(meta: &PrMeta) -> &'static str {
+    if meta.state == "MERGED" {
+        "merged upstream but content is not in base"
+    } else {
+        "not merged upstream"
+    }
+}
+
+pub(crate) fn sync_would_mutate(
+    target_exists: bool,
+    target_ahead: Option<usize>,
+    target_behind: Option<usize>,
+    dropped_count: usize,
+    replayed_count: usize,
+) -> bool {
+    !target_exists
+        || target_ahead.unwrap_or(0) > 0
+        || target_behind.unwrap_or(0) > 0
+        || dropped_count > 0
+        || replayed_count > 0
 }
 
 #[cfg(test)]

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::error::Error;
 use crate::rig::spec::{ComponentSpec, RigSpec};
-use crate::stack::{GitRef, SyncOutput};
+use crate::stack::{GitRef, SyncOutput, SyncPreview};
 
 use super::{plan_stack_sync, run_sync_with};
 
@@ -36,17 +36,29 @@ fn rig_with_components(components: HashMap<String, ComponentSpec>) -> RigSpec {
 
 fn sync_output(stack_id: &str, picked: usize, skipped: usize, dropped: usize) -> SyncOutput {
     SyncOutput {
-        stack_id: stack_id.to_string(),
-        component_path: "/tmp/component".to_string(),
-        branch: "dev/combined-fixes".to_string(),
-        base: "origin/main".to_string(),
-        target: "fork/dev/combined-fixes".to_string(),
-        dropped: Vec::new(),
+        preview: SyncPreview {
+            stack_id: stack_id.to_string(),
+            component_path: "/tmp/component".to_string(),
+            branch: "dev/combined-fixes".to_string(),
+            base: "origin/main".to_string(),
+            target: "fork/dev/combined-fixes".to_string(),
+            dropped: Vec::new(),
+            replayed: Vec::new(),
+            uncertain: Vec::new(),
+            target_exists: true,
+            target_ahead: Some(0),
+            target_behind: Some(0),
+            dropped_count: dropped,
+            replayed_count: picked + skipped,
+            uncertain_count: 0,
+            would_mutate: picked > 0 || dropped > 0,
+            blocked: false,
+            success: true,
+        },
         applied: Vec::new(),
         dry_run: false,
         picked_count: picked,
         skipped_count: skipped,
-        dropped_count: dropped,
         success: true,
     }
 }
@@ -153,30 +165,42 @@ fn test_sync_entry_serializes_counts_and_refs() {
     components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
     let rig = rig_with_components(components);
 
-    let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
-        Ok(SyncOutput {
-            stack_id: stack_id.to_string(),
-            component_path: "/tmp/component".to_string(),
-            branch: "dev/combined-fixes".to_string(),
-            base: GitRef {
-                remote: "origin".to_string(),
-                branch: "main".to_string(),
-            }
-            .display(),
-            target: GitRef {
-                remote: "fork".to_string(),
-                branch: "dev/combined-fixes".to_string(),
-            }
-            .display(),
-            dropped: Vec::new(),
-            applied: Vec::new(),
-            dry_run: false,
-            picked_count: 2,
-            skipped_count: 1,
-            dropped_count: 1,
-            success: true,
-        })
-    });
+	let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
+		Ok(SyncOutput {
+			preview: SyncPreview {
+				stack_id: stack_id.to_string(),
+				component_path: "/tmp/component".to_string(),
+				branch: "dev/combined-fixes".to_string(),
+				base: GitRef {
+					remote: "origin".to_string(),
+					branch: "main".to_string(),
+				}
+				.display(),
+				target: GitRef {
+					remote: "fork".to_string(),
+					branch: "dev/combined-fixes".to_string(),
+				}
+				.display(),
+				dropped: Vec::new(),
+				replayed: Vec::new(),
+				uncertain: Vec::new(),
+				target_exists: true,
+				target_ahead: Some(0),
+				target_behind: Some(0),
+				dropped_count: 1,
+				replayed_count: 3,
+				uncertain_count: 0,
+				would_mutate: true,
+				blocked: false,
+				success: true,
+			},
+			applied: Vec::new(),
+			dry_run: false,
+			picked_count: 2,
+			skipped_count: 1,
+			success: true,
+		})
+	});
 
     let json = serde_json::to_string(&report).expect("serialize");
     assert!(json.contains("\"component_id\":\"a\""));

--- a/tests/core/stack/sync_test.rs
+++ b/tests/core/stack/sync_test.rs
@@ -11,7 +11,7 @@
 //! from the spec. The cherry-pick orchestration after that decision is
 //! the same machinery `apply` uses (already tested in `apply_test.rs`).
 
-use crate::stack::sync::{is_droppable, PrMeta};
+use crate::stack::sync::{is_droppable, sync_would_mutate, PrMeta};
 use std::fs;
 
 mod support;
@@ -163,5 +163,49 @@ fn is_droppable_state_check_is_case_sensitive() {
     assert!(
         !is_droppable(&lower_case, &path, "main"),
         "is_droppable must match gh's canonical 'MERGED' exactly"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// sync_would_mutate — diff/sync preview state summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sync_would_mutate_false_for_clean_materialized_target() {
+    assert!(
+        !sync_would_mutate(true, Some(0), Some(0), 0, 0),
+        "existing target at base with no drops or replays is a no-op"
+    );
+}
+
+#[test]
+fn sync_would_mutate_true_when_target_missing() {
+    assert!(
+        sync_would_mutate(false, None, None, 0, 0),
+        "sync would create the target branch"
+    );
+}
+
+#[test]
+fn sync_would_mutate_true_when_target_diverged_from_base() {
+    assert!(
+        sync_would_mutate(true, Some(1), Some(0), 0, 0),
+        "sync would drop target-only commits by recreating target from base"
+    );
+    assert!(
+        sync_would_mutate(true, Some(0), Some(1), 0, 0),
+        "sync would move target forward to the newer base"
+    );
+}
+
+#[test]
+fn sync_would_mutate_true_for_drop_or_replay_plan() {
+    assert!(
+        sync_would_mutate(true, Some(0), Some(0), 1, 0),
+        "sync would mutate the stack spec by dropping merged PRs"
+    );
+    assert!(
+        sync_would_mutate(true, Some(0), Some(0), 0, 1),
+        "sync would replay PRs onto the rebuilt target"
     );
 }


### PR DESCRIPTION
## Summary

- Adds `homeboy stack diff <stack-id>` as a read-only preview of what `stack sync` would change.
- Extracts sync planning into a shared preview path used by `diff`, `sync --dry-run`, and mutating `sync`.
- Reports drop, replay, and uncertain PR buckets plus target existence and ahead/behind state.

## Behaviour

- `stack diff` fetches base/target refs for an honest preview, but does not recreate the target branch and does not write the stack spec.
- `stack sync --dry-run` now exposes the same preview shape, including replayed and uncertain entries.
- Mutating `stack sync` refuses to proceed when any PR is uncertain, so it does not partially mutate based on incomplete metadata.

## Tests

- `cargo test stack::sync -- --test-threads=1`
- `cargo test stack::status -- --test-threads=1`
- `cargo test -- --test-threads=1` — 1841 passed; 0 failed; 1 ignored
- `homeboy lint homeboy --path .`
- `homeboy audit homeboy --path . --changed-since origin/main`
- `cargo run --bin homeboy -- stack --help`

Closes #1719

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the `stack diff` command, shared sync preview planning, and focused tests from Chris's issue brief. Chris remains responsible for review and merge.
