### PR TITLE
fix(deploy): select behind-upstream components

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -35,9 +35,12 @@ pub struct DeployArgs {
     /// Deploy all configured components
     #[arg(long)]
     pub all: bool,
-    /// Deploy only outdated components
+    /// Deploy only components whose local version differs from deployed remote
     #[arg(long)]
     pub outdated: bool,
+    /// Deploy only components whose local checkout is behind upstream
+    #[arg(long, conflicts_with = "outdated")]
+    pub behind_upstream: bool,
     /// Preview what would be deployed without executing
     #[arg(long)]
     pub dry_run: bool,
@@ -79,6 +82,7 @@ pub struct DeployOutput {
     pub project_id: String,
     pub all: bool,
     pub outdated: bool,
+    pub behind_upstream: bool,
     pub dry_run: bool,
     pub check: bool,
     pub force: bool,
@@ -167,6 +171,7 @@ pub fn run(
             project_id,
             all: args.all,
             outdated: args.outdated,
+            behind_upstream: args.behind_upstream,
             dry_run: args.dry_run,
             check: args.check,
             force: args.force,
@@ -205,7 +210,11 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, V
             }
             comps.extend(args.component_ids.clone());
 
-            let has_selector_flag = args.all || args.outdated || args.check || args.json.is_some();
+            let has_selector_flag = args.all
+                || args.outdated
+                || args.behind_upstream
+                || args.check
+                || args.json.is_some();
             if comps.is_empty() && !has_selector_flag {
                 return Err(homeboy::Error::validation_invalid_argument(
                     "input",
@@ -267,6 +276,7 @@ fn build_config(args: &DeployArgs, skip_build: bool) -> DeployConfig {
         component_ids: args.component_ids.clone(),
         all: args.all,
         outdated: args.outdated,
+        behind_upstream: args.behind_upstream,
         dry_run: args.dry_run,
         check: args.check,
         force: args.force,

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -432,6 +432,7 @@ fn log_fleet_dashboard(result: &FleetStatusResult) {
                 FleetComponentDrift::Current => "✅ current",
                 FleetComponentDrift::NeedsUpdate => "⚠️  outdated",
                 FleetComponentDrift::BehindRemote => "🔙 behind",
+                FleetComponentDrift::BehindUpstream => "⬇️  behind upstream",
                 FleetComponentDrift::NeedsBump => "🔶 needs bump",
                 FleetComponentDrift::DocsOnly => "📝 docs only",
                 FleetComponentDrift::Unknown => "❓ unknown",

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -472,6 +472,7 @@ fn fetch_project_remote_versions(project_id: &str) -> std::collections::HashMap<
         component_ids: vec![],
         all: true,
         outdated: false,
+        behind_upstream: false,
         dry_run: false,
         check: true,
         force: false,

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -133,6 +133,7 @@ pub fn run_multi(
             component_ids: component_ids.to_vec(),
             all: config.all,
             outdated: config.outdated,
+            behind_upstream: config.behind_upstream,
             dry_run: config.dry_run,
             check: config.check,
             force: config.force,

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -72,11 +72,12 @@ pub(super) fn deploy_components(
         .iter()
         .filter_map(|c| version::get_component_version(c).map(|v| (c.id.clone(), v)))
         .collect();
-    let remote_versions = if config.outdated || config.dry_run || config.check {
-        fetch_remote_versions(&components, base_path, &ctx.client)
-    } else {
-        HashMap::new()
-    };
+    let remote_versions =
+        if config.outdated || config.behind_upstream || config.dry_run || config.check {
+            fetch_remote_versions(&components, base_path, &ctx.client)
+        } else {
+            HashMap::new()
+        };
 
     // Check and dry-run modes return early without building or deploying
     if config.check {
@@ -662,6 +663,7 @@ fn clone_config(config: &DeployConfig) -> DeployConfig {
         component_ids: config.component_ids.clone(),
         all: config.all,
         outdated: config.outdated,
+        behind_upstream: config.behind_upstream,
         dry_run: config.dry_run,
         check: config.check,
         force: config.force,
@@ -721,6 +723,7 @@ mod tests {
             component_ids: vec![],
             all: false,
             outdated: false,
+            behind_upstream: false,
             dry_run: false,
             check: false,
             force: false,

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -162,9 +162,43 @@ pub(super) fn plan_components(
         return Ok(selected);
     }
 
+    if config.behind_upstream {
+        let selected = select_behind_upstream_components(all_components);
+
+        if selected.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "behind_upstream",
+                "No components behind upstream found",
+                None,
+                None,
+            ));
+        }
+
+        return Ok(selected);
+    }
+
     Err(Error::validation_missing_argument(vec![
-        "component IDs, --all, --outdated, or --check".to_string(),
+        "component IDs, --all, --outdated, --behind-upstream, or --check".to_string(),
     ]))
+}
+
+fn select_behind_upstream_components(all_components: &[Component]) -> Vec<Component> {
+    all_components
+        .iter()
+        .filter(|component| component_is_behind_upstream(component))
+        .cloned()
+        .collect()
+}
+
+fn component_is_behind_upstream(component: &Component) -> bool {
+    if component.is_file_component() {
+        return false;
+    }
+
+    matches!(
+        git::fetch_and_get_behind_count(&component.local_path),
+        Ok(Some(_))
+    )
 }
 
 /// Calculate component status based on local and remote versions.
@@ -172,6 +206,10 @@ pub(super) fn calculate_component_status(
     component: &Component,
     remote_versions: &HashMap<String, String>,
 ) -> ComponentStatus {
+    if component_is_behind_upstream(component) {
+        return ComponentStatus::BehindUpstream;
+    }
+
     let local_version = version::get_component_version(component);
     let remote_version = remote_versions.get(&component.id);
 
@@ -333,4 +371,119 @@ pub(super) fn load_project_components(
         deployable,
         skipped,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn run_git(path: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_source_repo(path: &Path) {
+        run_git(path, &["init", "-q", "-b", "main"]);
+        run_git(path, &["config", "user.email", "test@example.com"]);
+        run_git(path, &["config", "user.name", "Test"]);
+        std::fs::write(path.join("component.txt"), "v1\n").expect("write v1");
+        run_git(path, &["add", "component.txt"]);
+        run_git(path, &["commit", "-q", "-m", "initial"]);
+    }
+
+    fn commit_upstream_change(path: &Path) {
+        std::fs::write(path.join("component.txt"), "v2\n").expect("write v2");
+        run_git(path, &["add", "component.txt"]);
+        run_git(path, &["commit", "-q", "-m", "upstream"]);
+    }
+
+    fn clone_repo(source: &Path, target: &Path) {
+        let output = std::process::Command::new("git")
+            .args([
+                "clone",
+                "-q",
+                source.to_str().expect("source path"),
+                target.to_str().expect("target path"),
+            ])
+            .output()
+            .expect("git clone");
+        assert!(
+            output.status.success(),
+            "git clone failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn component(id: &str, path: &Path) -> Component {
+        Component::new(
+            id.to_string(),
+            path.to_string_lossy().to_string(),
+            String::new(),
+            None,
+        )
+    }
+
+    #[test]
+    fn select_behind_upstream_components_finds_stale_checkout() {
+        let temp = TempDir::new().expect("temp dir");
+        let source = temp.path().join("source");
+        let local = temp.path().join("local");
+        std::fs::create_dir(&source).expect("source dir");
+
+        init_source_repo(&source);
+        clone_repo(&source, &local);
+        commit_upstream_change(&source);
+
+        let stale = component("stale", &local);
+        let selected = select_behind_upstream_components(std::slice::from_ref(&stale));
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].id, "stale");
+    }
+
+    #[test]
+    fn component_status_reports_behind_upstream_before_deployed_version_match() {
+        let temp = TempDir::new().expect("temp dir");
+        let source = temp.path().join("source");
+        let local = temp.path().join("local");
+        std::fs::create_dir(&source).expect("source dir");
+
+        init_source_repo(&source);
+        clone_repo(&source, &local);
+        commit_upstream_change(&source);
+
+        let stale = component("stale", &local);
+        let remote_versions = HashMap::from([("stale".to_string(), "1.0.0".to_string())]);
+
+        assert!(matches!(
+            calculate_component_status(&stale, &remote_versions),
+            ComponentStatus::BehindUpstream
+        ));
+    }
+
+    #[test]
+    fn select_behind_upstream_components_skips_current_checkout() {
+        let temp = TempDir::new().expect("temp dir");
+        let source = temp.path().join("source");
+        let local = temp.path().join("local");
+        std::fs::create_dir(&source).expect("source dir");
+
+        init_source_repo(&source);
+        clone_repo(&source, &local);
+
+        let current = component("current", &local);
+        let selected = select_behind_upstream_components(&[current]);
+
+        assert!(selected.is_empty());
+    }
 }

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -206,14 +206,10 @@ pub(super) fn calculate_component_status(
     component: &Component,
     remote_versions: &HashMap<String, String>,
 ) -> ComponentStatus {
-    if component_is_behind_upstream(component) {
-        return ComponentStatus::BehindUpstream;
-    }
-
     let local_version = version::get_component_version(component);
     let remote_version = remote_versions.get(&component.id);
 
-    match (local_version, remote_version) {
+    let version_status = match (local_version, remote_version) {
         (None, None) => ComponentStatus::Unknown,
         (None, Some(_)) => ComponentStatus::NeedsUpdate,
         (Some(_), None) => ComponentStatus::NeedsUpdate,
@@ -224,6 +220,13 @@ pub(super) fn calculate_component_status(
                 ComponentStatus::NeedsUpdate
             }
         }
+    };
+
+    if matches!(version_status, ComponentStatus::UpToDate) && component_is_behind_upstream(component)
+    {
+        ComponentStatus::BehindUpstream
+    } else {
+        version_status
     }
 }
 
@@ -376,6 +379,7 @@ pub(super) fn load_project_components(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::component::VersionTarget;
     use tempfile::TempDir;
 
     fn run_git(path: &Path, args: &[&str]) {
@@ -433,6 +437,16 @@ mod tests {
         )
     }
 
+    fn versioned_component(id: &str, path: &Path, version: &str) -> Component {
+        std::fs::write(path.join("VERSION"), format!("{}\n", version)).expect("version file");
+        let mut component = component(id, path);
+        component.version_targets = Some(vec![VersionTarget {
+            file: "VERSION".to_string(),
+            pattern: Some(r"^(.+)$".to_string()),
+        }]);
+        component
+    }
+
     #[test]
     fn select_behind_upstream_components_finds_stale_checkout() {
         let temp = TempDir::new().expect("temp dir");
@@ -452,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn component_status_reports_behind_upstream_before_deployed_version_match() {
+    fn component_status_reports_behind_upstream_when_deployed_version_matches() {
         let temp = TempDir::new().expect("temp dir");
         let source = temp.path().join("source");
         let local = temp.path().join("local");
@@ -462,12 +476,32 @@ mod tests {
         clone_repo(&source, &local);
         commit_upstream_change(&source);
 
-        let stale = component("stale", &local);
+        let stale = versioned_component("stale", &local, "1.0.0");
         let remote_versions = HashMap::from([("stale".to_string(), "1.0.0".to_string())]);
 
         assert!(matches!(
             calculate_component_status(&stale, &remote_versions),
             ComponentStatus::BehindUpstream
+        ));
+    }
+
+    #[test]
+    fn component_status_preserves_deployed_version_drift_when_checkout_is_behind_upstream() {
+        let temp = TempDir::new().expect("temp dir");
+        let source = temp.path().join("source");
+        let local = temp.path().join("local");
+        std::fs::create_dir(&source).expect("source dir");
+
+        init_source_repo(&source);
+        clone_repo(&source, &local);
+        commit_upstream_change(&source);
+
+        let stale = versioned_component("stale", &local, "1.0.0");
+        let remote_versions = HashMap::from([("stale".to_string(), "2.0.0".to_string())]);
+
+        assert!(matches!(
+            calculate_component_status(&stale, &remote_versions),
+            ComponentStatus::NeedsUpdate
         ));
     }
 

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -40,6 +40,7 @@ pub struct DeployConfig {
     pub component_ids: Vec<String>,
     pub all: bool,
     pub outdated: bool,
+    pub behind_upstream: bool,
     pub dry_run: bool,
     pub check: bool,
     pub force: bool,
@@ -83,6 +84,8 @@ pub enum ComponentStatus {
     NeedsUpdate,
     /// Remote version ahead of local (local behind)
     BehindRemote,
+    /// Local checkout is behind its upstream branch
+    BehindUpstream,
     /// Cannot determine status
     Unknown,
 }

--- a/src/core/fleet/check.rs
+++ b/src/core/fleet/check.rs
@@ -45,6 +45,7 @@ pub fn collect_check(
             component_ids: vec![],
             all: true,
             outdated: false,
+            behind_upstream: false,
             dry_run: false,
             check: true,
             force: false,
@@ -68,12 +69,15 @@ pub fn collect_check(
                         Some(deploy::ComponentStatus::UpToDate) => "up_to_date",
                         Some(deploy::ComponentStatus::NeedsUpdate) => "needs_update",
                         Some(deploy::ComponentStatus::BehindRemote) => "behind_remote",
+                        Some(deploy::ComponentStatus::BehindUpstream) => "behind_upstream",
                         Some(deploy::ComponentStatus::Unknown) | None => "unknown",
                     };
 
                     match status_str {
                         "up_to_date" => summary.components_up_to_date += 1,
-                        "needs_update" | "behind_remote" => summary.components_needs_update += 1,
+                        "needs_update" | "behind_remote" | "behind_upstream" => {
+                            summary.components_needs_update += 1
+                        }
                         _ => summary.components_unknown += 1,
                     }
 

--- a/src/core/fleet/status.rs
+++ b/src/core/fleet/status.rs
@@ -33,6 +33,8 @@ pub enum FleetComponentDrift {
     NeedsUpdate,
     /// Remote version is ahead of local
     BehindRemote,
+    /// Local checkout is behind its upstream branch
+    BehindUpstream,
     /// Has unreleased code commits (needs version bump)
     NeedsBump,
     /// Only docs changes since last tag
@@ -266,6 +268,7 @@ fn collect_project_component_statuses(
         component_ids: vec![],
         all: true,
         outdated: false,
+        behind_upstream: false,
         dry_run: false,
         check: true,
         force: false,
@@ -288,9 +291,9 @@ fn collect_project_component_statuses(
                 component_summary.total += 1;
                 match &drift {
                     FleetComponentDrift::Current => component_summary.current += 1,
-                    FleetComponentDrift::NeedsUpdate | FleetComponentDrift::BehindRemote => {
-                        component_summary.needs_update += 1
-                    }
+                    FleetComponentDrift::NeedsUpdate
+                    | FleetComponentDrift::BehindRemote
+                    | FleetComponentDrift::BehindUpstream => component_summary.needs_update += 1,
                     FleetComponentDrift::NeedsBump => component_summary.needs_bump += 1,
                     FleetComponentDrift::DocsOnly => component_summary.docs_only += 1,
                     FleetComponentDrift::Unknown => component_summary.unknown += 1,
@@ -369,6 +372,7 @@ fn resolve_component_drift(
         Some(deploy::ComponentStatus::UpToDate) => FleetComponentDrift::Current,
         Some(deploy::ComponentStatus::NeedsUpdate) => FleetComponentDrift::NeedsUpdate,
         Some(deploy::ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
+        Some(deploy::ComponentStatus::BehindUpstream) => FleetComponentDrift::BehindUpstream,
         Some(deploy::ComponentStatus::Unknown) | None => FleetComponentDrift::Unknown,
     };
 

--- a/src/core/project/status.rs
+++ b/src/core/project/status.rs
@@ -43,6 +43,7 @@ fn collect_component_versions(project_id: &str) -> Option<Vec<ProjectComponentSt
         component_ids: vec![],
         all: true,
         outdated: false,
+        behind_upstream: false,
         dry_run: false,
         check: true,
         force: false,

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -466,6 +466,7 @@ fn execute_deployment(
             component_ids: vec![component_id.to_string()],
             all: false,
             outdated: false,
+            behind_upstream: false,
             dry_run: false,
             check: false,
             // Force: the release pipeline just committed and tagged, so the


### PR DESCRIPTION
## Summary
- Add explicit `deploy --behind-upstream` selection for components whose local checkout is stale relative to upstream.
- Surface `behind_upstream` through deploy check and fleet status instead of collapsing it into `up_to_date`.
- Cover stale/current upstream checkout selection with focused deploy planner tests.

## Behaviour
- `homeboy deploy <project> --behind-upstream` now selects deployable components where `git fetch` reports the local checkout behind its upstream branch.
- Actual deploys still use the existing sync path, so selected components are pulled before deployment unless the caller explicitly opts out with `--no-pull`.
- `homeboy deploy <project> --check` reports `component_status: behind_upstream` when local and deployed versions match but the checkout is stale.

## Tests
- `cargo test deploy`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-deploy-behind-upstream`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-deploy-behind-upstream --changed-since origin/main`

Closes #1616.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the deploy/status fix, adding tests, and running validation; Chris remains responsible for review and merge.
