### PR TITLE
test: isolate env-sensitive tests

### DIFF
--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -160,6 +160,10 @@ mod tests {
                 helper_path.display(),
                 script_dir.display()
             ))
+            .env_remove("HOMEBOY_EXTENSION_PATH")
+            .env_remove("HOMEBOY_COMPONENT_PATH")
+            .env_remove("HOMEBOY_COMPONENT_ID")
+            .env_remove("HOMEBOY_PROJECT_PATH")
             .output()
             .expect("run bash");
 

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -1241,7 +1241,13 @@ mod tests {
     use super::*;
     use crate::component::Component;
     use std::fs;
+    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn tmp_dir(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -1517,6 +1523,7 @@ mod tests {
 
     #[test]
     fn try_load_cached_audit_reads_output_dir() {
+        let _guard = env_lock().lock().unwrap();
         std::env::remove_var(OUTPUT_DIR_ENV);
         let dir = tmp_dir("cached-audit");
         fs::create_dir_all(&dir).unwrap();
@@ -1562,6 +1569,7 @@ mod tests {
 
     #[test]
     fn try_load_cached_audit_skips_failed_envelope() {
+        let _guard = env_lock().lock().unwrap();
         std::env::remove_var(OUTPUT_DIR_ENV);
         let dir = tmp_dir("cached-audit-fail");
         fs::create_dir_all(&dir).unwrap();
@@ -1590,6 +1598,7 @@ mod tests {
 
     #[test]
     fn try_load_cached_audit_returns_none_when_unset() {
+        let _guard = env_lock().lock().unwrap();
         std::env::remove_var(OUTPUT_DIR_ENV);
         assert!(try_load_cached_audit().is_none());
     }

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use crate::component;
@@ -1113,11 +1113,6 @@ pub fn parse_stale_days(input: &str) -> Result<i64> {
         ));
     }
     Ok(days)
-}
-
-#[allow(dead_code)]
-fn _pathbuf(path: &str) -> PathBuf {
-    PathBuf::from(path)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Isolate extension runtime helper tests from `HOMEBOY_*` environment injected by the Homeboy test runner.
- Serialize cached audit tests that mutate `HOMEBOY_OUTPUT_DIR`.
- Remove the dead `_pathbuf` helper flagged by audit.

## Tests
- `cargo fmt`
- `cargo test -- --test-threads=1`
- `./target/debug/homeboy audit homeboy --path /Users/chubes/Developer/homeboy@cleanup-auto-reconcile --changed-since origin/main`
- `./target/debug/homeboy test homeboy --path /Users/chubes/Developer/homeboy@cleanup-auto-reconcile` now shows Rust tests pass, but still exits 2 because the installed Rust extension runner uses GNU-only `grep -P` on macOS. Filed Extra-Chill/homeboy-extensions#297 for that runner bug.

Closes #1610.
Refs #1643.
Refs #1712.
Refs Extra-Chill/homeboy-extensions#297.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Issue reconciliation, test-failure diagnosis, small test isolation cleanup, and validation. Chris remains responsible for review and merge.