### PR TITLE
fix(audit): derive Rust namespaces from file paths

### DIFF
--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -992,24 +992,9 @@ fn extract_namespace(symbols: &[Symbol], relative_path: &str, lang_id: &str) -> 
         }
     }
 
-    // Rust: derive from crate:: imports or file path
+    // Rust module namespace is determined by file location. `crate::...`
+    // imports are cross-module references, not declarations of this file's module.
     if lang_id == "rust" {
-        // Count crate:: use paths
-        let mut module_counts: HashMap<&str, usize> = HashMap::new();
-        for s in symbols.iter().filter(|s| s.concept == "import") {
-            if let Some(path) = s.get("path") {
-                if let Some(rest) = path.strip_prefix("crate::") {
-                    if let Some(module) = rest.split("::").next() {
-                        *module_counts.entry(module).or_insert(0) += 1;
-                    }
-                }
-            }
-        }
-        if let Some((most_common, _)) = module_counts.iter().max_by_key(|(_, count)| *count) {
-            return Some(format!("crate::{}", most_common));
-        }
-
-        // Fall back to file path
         let parts: Vec<&str> = relative_path.trim_end_matches(".rs").split('/').collect();
         if parts.len() > 2 {
             let ns = parts[1..parts.len() - 1].join("::");
@@ -1565,6 +1550,37 @@ mod tests {
             )
             .expect("Failed to parse minimal grammar")
         }
+    }
+
+    #[test]
+    fn rust_namespace_comes_from_file_path_not_crate_imports() {
+        let grammar = rust_grammar();
+
+        let command_content = r#"
+use crate::help_topics;
+
+pub fn run() {
+    help_topics::print_all();
+}
+"#;
+        let command_fp =
+            fingerprint_from_grammar(command_content, &grammar, "src/commands/docs.rs")
+                .expect("fingerprint should succeed");
+
+        assert_eq!(command_fp.namespace.as_deref(), Some("crate::commands"));
+
+        let nested_content = r#"
+use crate::Result;
+
+pub fn undo() -> Result<()> {
+    Ok(())
+}
+"#;
+        let nested_fp =
+            fingerprint_from_grammar(nested_content, &grammar, "src/core/engine/undo.rs")
+                .expect("fingerprint should succeed");
+
+        assert_eq!(nested_fp.namespace.as_deref(), Some("crate::core::engine"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Derive Rust fingerprint namespaces from source file location instead of `crate::...` imports.
- Stop treating cross-module imports like `use crate::help_topics;` as declarations of the current file's module.
- Add a focused regression test for `src/commands/docs.rs`-style and nested module imports.

## Tests
- `cargo fmt --check`
- `cargo test rust_namespace_comes_from_file_path_not_crate_imports`
- `cargo test core::code_audit::core_fingerprint`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-rust-namespace-import-detection --only namespace_mismatch --changed-since origin/main --output /tmp/homeboy-namespace-mismatch-changed.json`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-rust-namespace-import-detection --changed-since origin/main --output /tmp/homeboy-audit-changed.json`
- `cargo run --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@fix-rust-namespace-import-detection --only namespace_mismatch --changed-since origin/main`
- `cargo run --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@fix-rust-namespace-import-detection --changed-since origin/main`

Closes #1724.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Detector fix, focused tests, and validation; reviewed through local test/audit commands.
