### PR TITLE
feat(rig): install stack specs from packages

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -10,9 +10,9 @@ use clap::{Args, Subcommand};
 use homeboy::rig;
 
 use self::output::{
-    RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledSummary,
-    RigListOutput, RigShowOutput, RigSourceSummary, RigStatusOutput, RigSummary, RigSyncOutput,
-    RigUpOutput, RigUpdateOutput,
+    RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
+    RigInstalledSummary, RigListOutput, RigShowOutput, RigSourceSummary, RigStatusOutput,
+    RigSummary, RigSyncOutput, RigUpOutput, RigUpdateOutput,
 };
 use super::CmdResult;
 
@@ -186,6 +186,17 @@ fn install(source: &str, id: Option<&str>, all: bool) -> CmdResult<RigCommandOut
                     path: rig.path.to_string_lossy().to_string(),
                     spec_path: rig.spec_path.to_string_lossy().to_string(),
                     source_revision: rig.source_revision,
+                })
+                .collect(),
+            installed_stacks: result
+                .installed_stacks
+                .into_iter()
+                .map(|stack| RigInstalledStackSummary {
+                    id: stack.id,
+                    description: stack.description,
+                    path: stack.path.to_string_lossy().to_string(),
+                    spec_path: stack.spec_path.to_string_lossy().to_string(),
+                    source_revision: stack.source_revision,
                 })
                 .collect(),
         }),

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -105,10 +105,21 @@ pub struct RigInstallOutput {
     pub package_path: String,
     pub linked: bool,
     pub installed: Vec<RigInstalledSummary>,
+    pub installed_stacks: Vec<RigInstalledStackSummary>,
 }
 
 #[derive(Serialize)]
 pub struct RigInstalledSummary {
+    pub id: String,
+    pub description: String,
+    pub path: String,
+    pub spec_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RigInstalledStackSummary {
     pub id: String,
     pub description: String,
     pub path: String,

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -100,6 +100,16 @@ pub fn rig_source_metadata(id: &str) -> Result<PathBuf> {
     Ok(rig_sources()?.join(format!("{}.json", id)))
 }
 
+/// Stack source metadata directory (~/.config/homeboy/stack-sources/)
+pub fn stack_sources() -> Result<PathBuf> {
+    Ok(homeboy()?.join("stack-sources"))
+}
+
+/// Stack source metadata file (~/.config/homeboy/stack-sources/{id}.json)
+pub fn stack_source_metadata(id: &str) -> Result<PathBuf> {
+    Ok(stack_sources()?.join(format!("{}.json", id)))
+}
+
 /// Rig state directory (~/.config/homeboy/rigs/{id}.state/)
 /// Holds service PIDs, logs, and last check results.
 pub fn rig_state_dir(id: &str) -> Result<PathBuf> {

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -6,7 +6,7 @@
 //! linking `~/.config/homeboy/rigs/<id>.json` to the package spec.
 
 use crate::error::{Error, Result};
-use crate::{extension, git, paths};
+use crate::{extension, git, paths, stack};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -20,11 +20,19 @@ pub struct DiscoveredRig {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct DiscoveredStack {
+    pub id: String,
+    pub description: String,
+    pub stack_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct RigInstallResult {
     pub source: String,
     pub package_path: PathBuf,
     pub linked: bool,
     pub installed: Vec<InstalledRig>,
+    pub installed_stacks: Vec<InstalledStack>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,11 +53,33 @@ pub struct InstalledRig {
     pub source_revision: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct InstalledStack {
+    pub id: String,
+    pub description: String,
+    pub path: PathBuf,
+    pub spec_path: PathBuf,
+    pub source_revision: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RigSourceMetadata {
     pub source: String,
     pub package_path: String,
     pub rig_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discovery_path: Option<String>,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StackSourceMetadata {
+    pub source: String,
+    pub package_path: String,
+    pub stack_path: String,
+    pub discovery_path: String,
     pub linked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
@@ -59,11 +89,32 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
     let prepared = prepare_source(source)?;
     let discovered = discover_rigs(&prepared.discovery_path)?;
     let selected = select_rigs(discovered, id, all, source)?;
+    let discovered_stacks = discover_stacks(&prepared.discovery_path)?;
 
     fs::create_dir_all(paths::rigs()?)
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rigs dir".into())))?;
+    fs::create_dir_all(paths::stacks()?)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create stacks dir".into())))?;
     fs::create_dir_all(paths::rig_sources()?)
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rig sources dir".into())))?;
+    fs::create_dir_all(paths::stack_sources()?)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create stack sources dir".into())))?;
+
+    for stack in &discovered_stacks {
+        let target = paths::stack_config(&stack.id)?;
+        if target.exists() || fs::symlink_metadata(&target).is_ok() {
+            return Err(Error::validation_invalid_argument(
+                "stack_id",
+                format!(
+                    "Stack '{}' already exists at {}",
+                    stack.id,
+                    target.display()
+                ),
+                Some(stack.id.clone()),
+                None,
+            ));
+        }
+    }
 
     let mut installed = Vec::new();
     for rig in selected {
@@ -83,6 +134,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
             source: prepared.source.clone(),
             package_path: prepared.package_path.to_string_lossy().to_string(),
             rig_path: rig.rig_path.to_string_lossy().to_string(),
+            discovery_path: Some(prepared.discovery_path.to_string_lossy().to_string()),
             linked: prepared.linked,
             source_revision: prepared.source_revision.clone(),
         };
@@ -97,16 +149,47 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
         });
     }
 
+    let mut installed_stacks = Vec::new();
+    for stack in discovered_stacks {
+        let target = paths::stack_config(&stack.id)?;
+        link_or_copy_file(&stack.stack_path, &target)?;
+
+        let metadata = StackSourceMetadata {
+            source: prepared.source.clone(),
+            package_path: prepared.package_path.to_string_lossy().to_string(),
+            stack_path: stack.stack_path.to_string_lossy().to_string(),
+            discovery_path: prepared.discovery_path.to_string_lossy().to_string(),
+            linked: prepared.linked,
+            source_revision: prepared.source_revision.clone(),
+        };
+        write_stack_source_metadata(&stack.id, &metadata)?;
+
+        installed_stacks.push(InstalledStack {
+            id: stack.id,
+            description: stack.description,
+            path: target,
+            spec_path: stack.stack_path,
+            source_revision: prepared.source_revision.clone(),
+        });
+    }
+
     Ok(RigInstallResult {
         source: prepared.source,
         package_path: prepared.package_path,
         linked: prepared.linked,
         installed,
+        installed_stacks,
     })
 }
 
 pub fn read_source_metadata(id: &str) -> Option<RigSourceMetadata> {
     let path = paths::rig_source_metadata(id).ok()?;
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn read_stack_source_metadata(id: &str) -> Option<StackSourceMetadata> {
+    let path = paths::stack_source_metadata(id).ok()?;
     let content = fs::read_to_string(path).ok()?;
     serde_json::from_str(&content).ok()
 }
@@ -247,6 +330,61 @@ pub fn discover_rigs(package_path: &Path) -> Result<Vec<DiscoveredRig>> {
     Ok(rigs)
 }
 
+pub fn discover_stacks(package_path: &Path) -> Result<Vec<DiscoveredStack>> {
+    let stacks_dir = package_path.join("stacks");
+    if !stacks_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut stacks = Vec::new();
+    for entry in fs::read_dir(&stacks_dir)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("read stacks dir".into())))?
+    {
+        let entry = entry
+            .map_err(|e| Error::internal_io(e.to_string(), Some("read stack entry".into())))?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        stacks.push(discovered_stack_from_path(&path)?);
+    }
+
+    stacks.sort_by(|a, b| a.id.cmp(&b.id));
+    stacks.dedup_by(|a, b| a.id == b.id);
+    Ok(stacks)
+}
+
+fn discovered_stack_from_path(path: &Path) -> Result<DiscoveredStack> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("read stack spec".into())))?;
+    let mut spec: stack::StackSpec = serde_json::from_str(&content).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse stack spec {}", path.display())),
+            Some(content.chars().take(200).collect()),
+        )
+    })?;
+    if spec.id.is_empty() {
+        spec.id = path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "stack_id",
+                    "Stack spec has no id and no filename fallback",
+                    None,
+                    None,
+                )
+            })?
+            .to_string();
+    }
+    Ok(DiscoveredStack {
+        id: spec.id,
+        description: spec.description,
+        stack_path: path.to_path_buf(),
+    })
+}
+
 fn discovered_from_path(
     path: &Path,
     fallback_name: Option<&std::ffi::OsStr>,
@@ -323,6 +461,16 @@ pub(crate) fn write_source_metadata(id: &str, metadata: &RigSourceMetadata) -> R
         .map_err(|e| Error::internal_json(e.to_string(), Some("serialize rig source".into())))?;
     fs::write(&path, format!("{}\n", content))
         .map_err(|e| Error::internal_io(e.to_string(), Some("write rig source".into())))
+}
+
+pub(crate) fn write_stack_source_metadata(id: &str, metadata: &StackSourceMetadata) -> Result<()> {
+    fs::create_dir_all(paths::stack_sources()?)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create stack sources dir".into())))?;
+    let path = paths::stack_source_metadata(id)?;
+    let content = serde_json::to_string_pretty(metadata)
+        .map_err(|e| Error::internal_json(e.to_string(), Some("serialize stack source".into())))?;
+    fs::write(&path, format!("{}\n", content))
+        .map_err(|e| Error::internal_io(e.to_string(), Some("write stack source".into())))
 }
 
 pub(crate) fn link_or_copy_file(source: &Path, target: &Path) -> Result<()> {

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -33,8 +33,9 @@ pub mod toolchain;
 
 pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
 pub use install::{
-    discover_rigs, install, read_source_metadata, DiscoveredRig, RigInstallResult,
-    RigSourceMetadata,
+    discover_rigs, discover_stacks, install, read_source_metadata, read_stack_source_metadata,
+    DiscoveredRig, DiscoveredStack, InstalledStack, RigInstallResult, RigSourceMetadata,
+    StackSourceMetadata,
 };
 pub use lease::{acquire_active_run_lease, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
@@ -45,9 +46,10 @@ pub use runner::{
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{
     list_sources, remove_source, update_all_sources, update_source_for_rig,
-    InvalidRigSourceMetadata, RemovedRigSourceRig, RigSourceGroup, RigSourceListResult,
-    RigSourceRemoveResult, RigSourceRig, RigSourceUpdateResult, RigSourceUpdatedRig,
-    SkippedRigSourceRig, SkippedRigSourceUpdate,
+    InvalidRigSourceMetadata, RemovedRigSourceRig, RemovedRigSourceStack, RigSourceGroup,
+    RigSourceListResult, RigSourceRemoveResult, RigSourceRig, RigSourceStack,
+    RigSourceUpdateResult, RigSourceUpdatedRig, RigSourceUpdatedStack, SkippedRigSourceRig,
+    SkippedRigSourceStack, SkippedRigSourceUpdate,
 };
 pub use spec::{
     AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, BenchSpec, CheckSpec,

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -8,13 +8,17 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use super::install::{link_or_copy_file, write_source_metadata, RigSourceMetadata};
+use super::install::{
+    discover_stacks, link_or_copy_file, write_source_metadata, write_stack_source_metadata,
+    RigSourceMetadata, StackSourceMetadata,
+};
 
 mod types;
 pub use types::{
-    InvalidRigSourceMetadata, RemovedRigSourceRig, RigSourceGroup, RigSourceListResult,
-    RigSourceRemoveResult, RigSourceRig, RigSourceUpdateResult, RigSourceUpdatedRig,
-    SkippedRigSourceRig, SkippedRigSourceUpdate,
+    InvalidRigSourceMetadata, RemovedRigSourceRig, RemovedRigSourceStack, RigSourceGroup,
+    RigSourceListResult, RigSourceRemoveResult, RigSourceRig, RigSourceStack,
+    RigSourceUpdateResult, RigSourceUpdatedRig, RigSourceUpdatedStack, SkippedRigSourceRig,
+    SkippedRigSourceStack, SkippedRigSourceUpdate,
 };
 
 pub fn list_sources() -> Result<RigSourceListResult> {
@@ -55,7 +59,9 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
 
     let source = matches.into_iter().next().expect("checked non-empty");
     let mut removed = Vec::new();
+    let mut removed_stacks = Vec::new();
     let mut skipped = Vec::new();
+    let mut skipped_stacks = Vec::new();
     for rig in &source.rigs {
         let metadata_path = paths::rig_source_metadata(&rig.id)?;
         let config_path = PathBuf::from(&rig.config_path);
@@ -73,6 +79,31 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
                 id: rig.id.clone(),
                 config_path: rig.config_path.clone(),
                 reason: "config file no longer points at the recorded rig source".to_string(),
+            });
+        }
+    }
+    for stack in &source.stacks {
+        let metadata_path = paths::stack_source_metadata(&stack.id)?;
+        let config_path = PathBuf::from(&stack.config_path);
+        let remove_config = stack.config_present && stack.config_owned;
+        if remove_config {
+            fs::remove_file(&config_path).map_err(|e| {
+                Error::internal_io(e.to_string(), Some("remove stack config".into()))
+            })?;
+        }
+
+        remove_source_metadata(&metadata_path)?;
+        if remove_config || !stack.config_present {
+            removed_stacks.push(RemovedRigSourceStack {
+                id: stack.id.clone(),
+                config_path: stack.config_path.clone(),
+                metadata_path: metadata_path.to_string_lossy().to_string(),
+            });
+        } else {
+            skipped_stacks.push(SkippedRigSourceStack {
+                id: stack.id.clone(),
+                config_path: stack.config_path.clone(),
+                reason: "config file no longer points at the recorded stack source".to_string(),
             });
         }
     }
@@ -95,7 +126,9 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
         selector: selector.to_string(),
         source,
         removed,
+        removed_stacks,
         skipped,
+        skipped_stacks,
         removed_package_path,
     })
 }
@@ -138,6 +171,7 @@ pub fn update_source_for_rig(id: &str) -> Result<RigSourceUpdateResult> {
 pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
     let mut aggregate = RigSourceUpdateResult {
         updated: Vec::new(),
+        updated_stacks: Vec::new(),
         skipped: Vec::new(),
     };
     for source in list_sources()?.sources {
@@ -149,10 +183,18 @@ pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
                     reason: "linked local sources are updated in place outside homeboy".to_string(),
                 });
             }
+            for stack in source.stacks {
+                aggregate.skipped.push(SkippedRigSourceUpdate {
+                    id: stack.id,
+                    source: source.source.clone(),
+                    reason: "linked local sources are updated in place outside homeboy".to_string(),
+                });
+            }
             continue;
         }
         let result = update_group(source)?;
         aggregate.updated.extend(result.updated);
+        aggregate.updated_stacks.extend(result.updated_stacks);
         aggregate.skipped.extend(result.skipped);
     }
     Ok(aggregate)
@@ -174,6 +216,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
     let source_revision = short_head_revision(&package_path);
 
     let mut updated = Vec::new();
+    let mut updated_stacks = Vec::new();
     let mut skipped = Vec::new();
     for rig in source.rigs {
         let rig_path = PathBuf::from(&rig.rig_path);
@@ -206,6 +249,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
             source: source.source.clone(),
             package_path: source.package_path.clone(),
             rig_path: rig.rig_path.clone(),
+            discovery_path: Some(source.discovery_path.clone()),
             linked: false,
             source_revision: source_revision.clone(),
         };
@@ -221,7 +265,50 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
         });
     }
 
-    Ok(RigSourceUpdateResult { updated, skipped })
+    let current_stacks = discover_stacks(Path::new(&source.discovery_path))?;
+    for stack in current_stacks {
+        let existing = source.stacks.iter().find(|entry| entry.id == stack.id);
+        let config_path = paths::stack_config(&stack.id)?;
+        if config_path.exists() || fs::symlink_metadata(&config_path).is_ok() {
+            if existing.is_none_or(|entry| !entry.config_owned) {
+                skipped.push(SkippedRigSourceUpdate {
+                    id: stack.id,
+                    source: source.source.clone(),
+                    reason: "config file no longer points at the recorded stack source".to_string(),
+                });
+                continue;
+            }
+            fs::remove_file(&config_path).map_err(|e| {
+                Error::internal_io(e.to_string(), Some("replace stack config link".into()))
+            })?;
+        }
+        link_or_copy_file(&stack.stack_path, &config_path)?;
+
+        let metadata = StackSourceMetadata {
+            source: source.source.clone(),
+            package_path: source.package_path.clone(),
+            stack_path: stack.stack_path.to_string_lossy().to_string(),
+            discovery_path: source.discovery_path.clone(),
+            linked: false,
+            source_revision: source_revision.clone(),
+        };
+        write_stack_source_metadata(&stack.id, &metadata)?;
+
+        updated_stacks.push(RigSourceUpdatedStack {
+            id: stack.id,
+            source: source.source.clone(),
+            path: config_path.to_string_lossy().to_string(),
+            spec_path: stack.stack_path.to_string_lossy().to_string(),
+            previous_revision: previous_revision.clone(),
+            source_revision: source_revision.clone(),
+        });
+    }
+
+    Ok(RigSourceUpdateResult {
+        updated,
+        updated_stacks,
+        skipped,
+    })
 }
 
 fn short_head_revision(path: &Path) -> Option<String> {
@@ -261,20 +348,29 @@ struct RigSourceEntry {
 #[derive(Debug)]
 struct SourceEntries {
     valid: Vec<RigSourceEntry>,
+    valid_stacks: Vec<StackSourceEntry>,
     invalid: Vec<InvalidRigSourceMetadata>,
+}
+
+#[derive(Debug)]
+struct StackSourceEntry {
+    id: String,
+    metadata: StackSourceMetadata,
 }
 
 fn read_source_entries() -> Result<SourceEntries> {
     let dir = paths::rig_sources()?;
+    let mut invalid = Vec::new();
     if !dir.exists() {
+        let valid_stacks = read_stack_source_entries(&mut invalid)?;
         return Ok(SourceEntries {
             valid: Vec::new(),
-            invalid: Vec::new(),
+            valid_stacks,
+            invalid,
         });
     }
 
     let mut valid = Vec::new();
-    let mut invalid = Vec::new();
     for entry in fs::read_dir(&dir)
         .map_err(|e| Error::internal_io(e.to_string(), Some("read rig sources dir".into())))?
     {
@@ -309,9 +405,61 @@ fn read_source_entries() -> Result<SourceEntries> {
         }
     }
 
+    let valid_stacks = read_stack_source_entries(&mut invalid)?;
     valid.sort_by(|a, b| a.id.cmp(&b.id));
     invalid.sort_by(|a, b| a.id.cmp(&b.id));
-    Ok(SourceEntries { valid, invalid })
+    Ok(SourceEntries {
+        valid,
+        valid_stacks,
+        invalid,
+    })
+}
+
+fn read_stack_source_entries(
+    invalid: &mut Vec<InvalidRigSourceMetadata>,
+) -> Result<Vec<StackSourceEntry>> {
+    let dir = paths::stack_sources()?;
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut valid = Vec::new();
+    for entry in fs::read_dir(&dir)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("read stack sources dir".into())))?
+    {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(e.to_string(), Some("read stack source entry".into()))
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let id = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(err) => {
+                invalid.push(InvalidRigSourceMetadata {
+                    id,
+                    metadata_path: path.to_string_lossy().to_string(),
+                    error: err.to_string(),
+                });
+                continue;
+            }
+        };
+        match serde_json::from_str::<StackSourceMetadata>(&content) {
+            Ok(metadata) => valid.push(StackSourceEntry { id, metadata }),
+            Err(err) => invalid.push(InvalidRigSourceMetadata {
+                id,
+                metadata_path: path.to_string_lossy().to_string(),
+                error: err.to_string(),
+            }),
+        }
+    }
+    valid.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(valid)
 }
 
 fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
@@ -330,9 +478,15 @@ fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
                 source: entry.metadata.source.clone(),
                 package_id: package_id_from_path(&entry.metadata.package_path),
                 package_path: entry.metadata.package_path.clone(),
+                discovery_path: entry
+                    .metadata
+                    .discovery_path
+                    .clone()
+                    .unwrap_or_else(|| infer_discovery_path(&entry.metadata.rig_path)),
                 linked: entry.metadata.linked,
                 source_revision: entry.metadata.source_revision.clone(),
                 rigs: Vec::new(),
+                stacks: Vec::new(),
             })
             .rigs
             .push(RigSourceRig {
@@ -346,14 +500,65 @@ fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
             });
     }
 
+    for entry in entries.valid_stacks {
+        let key = format!("{}\0{}", entry.metadata.source, entry.metadata.package_path);
+        let config_path = paths::stack_config(&entry.id).ok();
+        let config_present = config_path.as_ref().is_some_and(|path| path.exists());
+        let config_owned = config_path
+            .as_ref()
+            .is_some_and(|path| rig_config_matches_source(path, &entry.metadata.stack_path));
+
+        groups
+            .entry(key)
+            .or_insert_with(|| RigSourceGroup {
+                source: entry.metadata.source.clone(),
+                package_id: package_id_from_path(&entry.metadata.package_path),
+                package_path: entry.metadata.package_path.clone(),
+                discovery_path: entry.metadata.discovery_path.clone(),
+                linked: entry.metadata.linked,
+                source_revision: entry.metadata.source_revision.clone(),
+                rigs: Vec::new(),
+                stacks: Vec::new(),
+            })
+            .stacks
+            .push(RigSourceStack {
+                id: entry.id,
+                stack_path: entry.metadata.stack_path,
+                config_path: config_path
+                    .map(|path| path.to_string_lossy().to_string())
+                    .unwrap_or_default(),
+                config_present,
+                config_owned,
+            });
+    }
+
     let mut sources = groups.into_values().collect::<Vec<_>>();
     for source in &mut sources {
         source.rigs.sort_by(|a, b| a.id.cmp(&b.id));
+        source.stacks.sort_by(|a, b| a.id.cmp(&b.id));
     }
 
     RigSourceListResult {
         sources,
         invalid: entries.invalid,
+    }
+}
+
+fn infer_discovery_path(rig_path: &str) -> String {
+    let path = Path::new(rig_path);
+    match path
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+    {
+        Some("rigs") => path
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string(),
+        _ => path.parent().unwrap_or(path).to_string_lossy().to_string(),
     }
 }
 

--- a/src/core/rig/source/types.rs
+++ b/src/core/rig/source/types.rs
@@ -10,17 +10,28 @@ pub struct RigSourceListResult {
 pub struct RigSourceGroup {
     pub source: String,
     pub package_path: String,
+    pub discovery_path: String,
     pub package_id: String,
     pub linked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
     pub rigs: Vec<RigSourceRig>,
+    pub stacks: Vec<RigSourceStack>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RigSourceRig {
     pub id: String,
     pub rig_path: String,
+    pub config_path: String,
+    pub config_present: bool,
+    pub config_owned: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigSourceStack {
+    pub id: String,
+    pub stack_path: String,
     pub config_path: String,
     pub config_present: bool,
     pub config_owned: bool,
@@ -38,13 +49,22 @@ pub struct RigSourceRemoveResult {
     pub selector: String,
     pub source: RigSourceGroup,
     pub removed: Vec<RemovedRigSourceRig>,
+    pub removed_stacks: Vec<RemovedRigSourceStack>,
     pub skipped: Vec<SkippedRigSourceRig>,
+    pub skipped_stacks: Vec<SkippedRigSourceStack>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub removed_package_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RemovedRigSourceRig {
+    pub id: String,
+    pub config_path: String,
+    pub metadata_path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RemovedRigSourceStack {
     pub id: String,
     pub config_path: String,
     pub metadata_path: String,
@@ -58,13 +78,33 @@ pub struct SkippedRigSourceRig {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct SkippedRigSourceStack {
+    pub id: String,
+    pub config_path: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct RigSourceUpdateResult {
     pub updated: Vec<RigSourceUpdatedRig>,
+    pub updated_stacks: Vec<RigSourceUpdatedStack>,
     pub skipped: Vec<SkippedRigSourceUpdate>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RigSourceUpdatedRig {
+    pub id: String,
+    pub source: String,
+    pub path: String,
+    pub spec_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RigSourceUpdatedStack {
     pub id: String,
     pub source: String,
     pub path: String,

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -1,6 +1,9 @@
 //! Rig install lifecycle tests. Covers `src/core/rig/install.rs`.
 
-use crate::rig::{declared_id, discover_rigs, install, list, list_ids, load, read_source_metadata};
+use crate::rig::{
+    declared_id, discover_rigs, install, list, list_ids, load, read_source_metadata,
+    read_stack_source_metadata,
+};
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
@@ -27,6 +30,29 @@ fn minimal_rig(id: &str) -> String {
             }}
         }}"#,
         id, id, id
+    )
+}
+
+fn write_stack(package: &Path, id: &str, component: &str) -> std::path::PathBuf {
+    let stacks_dir = package.join("stacks");
+    fs::create_dir_all(&stacks_dir).expect("stacks dir");
+    let stack_path = stacks_dir.join(format!("{}.json", id));
+    fs::write(&stack_path, minimal_stack(id, component)).expect("stack json");
+    stack_path
+}
+
+fn minimal_stack(id: &str, component: &str) -> String {
+    format!(
+        r#"{{
+            "id": "{}",
+            "description": "{} stack",
+            "component": "{}",
+            "component_path": "${{env.DEV_ROOT}}/{}",
+            "base": {{ "remote": "origin", "branch": "main" }},
+            "target": {{ "remote": "origin", "branch": "dev/combined-fixes" }},
+            "prs": []
+        }}"#,
+        id, id, component, component
     )
 }
 
@@ -135,6 +161,34 @@ fn test_read_source_metadata_after_local_install() {
     let metadata = read_source_metadata("alpha").expect("metadata");
     assert!(metadata.linked);
     assert_eq!(metadata.rig_path, source.to_string_lossy());
+}
+
+#[test]
+fn install_package_with_sibling_stacks_installs_stack_specs() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "studio", &minimal_rig("studio"));
+    let stack_path = write_stack(package.path(), "studio-combined", "studio");
+
+    let result = install(package.path().to_str().unwrap(), None, false).expect("install");
+
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(result.installed_stacks.len(), 1);
+    assert_eq!(result.installed_stacks[0].id, "studio-combined");
+    let installed = crate::paths::stack_config("studio-combined").expect("stack path");
+    assert!(installed.exists());
+    #[cfg(unix)]
+    assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
+    assert_eq!(crate::stack::list().expect("stack list").len(), 1);
+    assert_eq!(
+        crate::stack::load("studio-combined")
+            .expect("load stack")
+            .component,
+        "studio"
+    );
+    let metadata = read_stack_source_metadata("studio-combined").expect("stack metadata");
+    assert!(metadata.linked);
+    assert_eq!(metadata.stack_path, stack_path.to_string_lossy());
 }
 
 #[test]
@@ -313,6 +367,35 @@ fn git_url_subpath_installs_single_rig_directory() {
     let metadata = read_source_metadata("studio").expect("metadata");
     assert_eq!(metadata.source, root_source.to_string_lossy());
     assert!(metadata.rig_path.ends_with("packages/studio/rig.json"));
+}
+
+#[test]
+fn git_url_subpath_installs_only_stacks_under_selected_subpath() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let selected = package.path().join("packages").join("studio");
+    write_single_rig(&selected, "studio", &minimal_rig("studio"));
+    write_stack(&selected, "studio-combined", "studio");
+    write_stack(package.path(), "root-combined", "root");
+    let bare = bare_package(package.path());
+    let source = format!(
+        "{}//packages/studio",
+        bare.path().join("rig-package.git").to_string_lossy()
+    );
+
+    let result = install(&source, None, false).expect("install subpath");
+
+    assert_eq!(result.installed_stacks.len(), 1);
+    assert_eq!(result.installed_stacks[0].id, "studio-combined");
+    assert!(crate::paths::stack_config("studio-combined")
+        .unwrap()
+        .exists());
+    assert!(!crate::paths::stack_config("root-combined")
+        .unwrap()
+        .exists());
+    let stacks = crate::stack::list().expect("stack list");
+    assert_eq!(stacks.len(), 1);
+    assert_eq!(stacks[0].id, "studio-combined");
 }
 
 #[test]

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -30,6 +30,29 @@ fn minimal_rig(id: &str) -> String {
     )
 }
 
+fn write_stack(package: &Path, id: &str, component: &str) -> std::path::PathBuf {
+    let stacks_dir = package.join("stacks");
+    fs::create_dir_all(&stacks_dir).expect("stacks dir");
+    let stack_path = stacks_dir.join(format!("{}.json", id));
+    fs::write(&stack_path, minimal_stack(id, component)).expect("stack json");
+    stack_path
+}
+
+fn minimal_stack(id: &str, component: &str) -> String {
+    format!(
+        r#"{{
+            "id": "{}",
+            "description": "{} stack",
+            "component": "{}",
+            "component_path": "${{env.DEV_ROOT}}/{}",
+            "base": {{ "remote": "origin", "branch": "main" }},
+            "target": {{ "remote": "origin", "branch": "dev/combined-fixes" }},
+            "prs": []
+        }}"#,
+        id, id, component, component
+    )
+}
+
 fn run_git(dir: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
@@ -99,6 +122,23 @@ fn test_list_sources() {
     assert!(result.sources[0].rigs[0].config_present);
     assert!(result.sources[0].rigs[0].config_owned);
     assert_eq!(result.sources[0].rigs[1].id, "beta");
+}
+
+#[test]
+fn list_sources_reports_stack_specs_from_package() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_stack(package.path(), "alpha-combined", "alpha");
+
+    install(package.path().to_str().unwrap(), None, false).expect("install");
+
+    let result = list_sources().expect("sources");
+    assert_eq!(result.sources.len(), 1);
+    assert_eq!(result.sources[0].stacks.len(), 1);
+    assert_eq!(result.sources[0].stacks[0].id, "alpha-combined");
+    assert!(result.sources[0].stacks[0].config_present);
+    assert!(result.sources[0].stacks[0].config_owned);
 }
 
 #[test]
@@ -236,6 +276,78 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
 }
 
 #[test]
+fn update_git_source_refreshes_owned_stack_specs() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    let source_stack = write_stack(package.path(), "alpha-combined", "alpha");
+    let bare = create_bare_source(package.path());
+    let source = bare
+        .path()
+        .join("rig-package.git")
+        .to_string_lossy()
+        .to_string();
+
+    install(&source, None, false).expect("install");
+    let before = crate::rig::read_stack_source_metadata("alpha-combined")
+        .expect("stack metadata")
+        .source_revision;
+
+    fs::write(
+        &source_stack,
+        minimal_stack("alpha-combined", "alpha").replace("alpha-combined stack", "updated stack"),
+    )
+    .expect("update stack");
+    commit_package(package.path(), "update alpha stack");
+    run_git(package.path(), &["push", &source, "HEAD:main"]);
+
+    let result = update_source_for_rig("alpha").expect("update rig source");
+
+    assert_eq!(result.updated_stacks.len(), 1);
+    assert_eq!(result.updated_stacks[0].id, "alpha-combined");
+    assert_ne!(result.updated_stacks[0].source_revision, before);
+    let installed = fs::read_to_string(crate::paths::stack_config("alpha-combined").unwrap())
+        .expect("installed stack");
+    assert!(installed.contains("updated stack"));
+}
+
+#[test]
+fn update_git_source_skips_user_replaced_stack_specs() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    let source_stack = write_stack(package.path(), "alpha-combined", "alpha");
+    let bare = create_bare_source(package.path());
+    let source = bare
+        .path()
+        .join("rig-package.git")
+        .to_string_lossy()
+        .to_string();
+
+    install(&source, None, false).expect("install");
+    let config = crate::paths::stack_config("alpha-combined").expect("stack config");
+    fs::remove_file(&config).expect("remove symlink");
+    fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("manual stack");
+    fs::write(
+        &source_stack,
+        minimal_stack("alpha-combined", "alpha").replace("alpha-combined stack", "updated stack"),
+    )
+    .expect("update source stack");
+    commit_package(package.path(), "update alpha stack");
+    run_git(package.path(), &["push", &source, "HEAD:main"]);
+
+    let result = update_source_for_rig("alpha").expect("update rig source");
+
+    assert!(result.updated_stacks.is_empty());
+    assert_eq!(result.skipped.len(), 1);
+    assert_eq!(result.skipped[0].id, "alpha-combined");
+    assert!(result.skipped[0].reason.contains("stack source"));
+    let installed = fs::read_to_string(config).expect("manual stack");
+    assert!(installed.contains("manual"));
+    assert!(!installed.contains("updated stack"));
+}
+
+#[test]
 fn update_all_skips_linked_local_sources() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");
@@ -248,6 +360,25 @@ fn update_all_skips_linked_local_sources() {
     assert_eq!(result.skipped.len(), 1);
     assert_eq!(result.skipped[0].id, "alpha");
     assert!(result.skipped[0].reason.contains("linked local sources"));
+}
+
+#[test]
+fn update_all_skips_linked_local_stack_sources() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_stack(package.path(), "alpha-combined", "alpha");
+
+    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    let result = update_all_sources().expect("update all");
+
+    assert!(result.updated.is_empty());
+    assert!(result.updated_stacks.is_empty());
+    assert_eq!(result.skipped.len(), 2);
+    assert!(result
+        .skipped
+        .iter()
+        .any(|skipped| skipped.id == "alpha-combined"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Install `stacks/*.json` specs from rig package roots alongside rig specs.
- Track stack source ownership in package metadata so updates refresh owned stacks and skip user-replaced stack configs.
- Extend rig source listing/removal/update output to include stack specs carried by the same package.

## Behavior
- `homeboy rig install <package>` links/copies sibling stack specs into `~/.config/homeboy/stacks/`.
- Git subpath packages only discover stacks under the selected subpath.
- `homeboy rig update <rig-id>` refreshes owned stack specs from the same package after pull.
- User-replaced stack configs are skipped instead of overwritten; linked local sources remain update-skipped.

## Tests
- `cargo test install_test`
- `cargo test source_test`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-package-stack-specs`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-package-stack-specs --changed-since origin/main`

Closes #1734

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the rig package stack-spec lifecycle, adding focused regression tests, and running validation. Chris remains responsible for review and merge.