### PR TITLE
fix(rig): bootstrap command step toolchain path

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -141,6 +141,8 @@ Applies or verifies an idempotent local-only file patch. `marker` must appear in
 
 Runs via `sh -c`. `cwd`, `command`, and `env` values all support variable expansion. `label` is optional; without it, the command string itself is used in status output.
 
+Command steps bootstrap a portable developer-tool PATH unless the step explicitly sets `env.PATH`. Homeboy prepends existing common bin directories (`$HOME/.local/bin`, `$HOME/.cargo/bin`, `$HOME/.kimaki/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) before the inherited `PATH`. Missing directories are ignored. If a tool lives somewhere else, set `env.PATH` on the step or prefer a typed primitive such as `build`, `git`, or `check` when one fits.
+
 **Escape hatch — use sparingly.** If a step maps to `build`, `git`, or `check`, use those instead. Generic commands lose homeboy's error formatting, extension integration, and structured output.
 
 ### `symlink`

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -28,6 +28,7 @@ pub mod source;
 pub mod spec;
 pub mod stack;
 pub mod state;
+pub mod toolchain;
 
 pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
 pub use install::{

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -21,6 +21,7 @@ use super::spec::{
 };
 use super::stack as rig_stack;
 use super::state::{now_rfc3339, RigState, SharedPathState};
+use super::toolchain;
 use crate::error::{Error, Result};
 
 /// Result of one pipeline step.
@@ -423,13 +424,20 @@ fn run_command_step(
     env: &HashMap<String, String>,
 ) -> Result<()> {
     let expanded = expand_vars(rig, cmd);
-    let mut command = Command::new("sh");
+    let mut command = Command::new(command_step_shell());
     command.arg("-c").arg(&expanded);
 
     if let Some(cwd) = cwd {
         let resolved = expand_vars(rig, cwd);
         command.current_dir(PathBuf::from(resolved));
     }
+
+    if !env.contains_key("PATH") {
+        if let Some(path) = toolchain::command_step_path() {
+            command.env("PATH", path);
+        }
+    }
+
     for (k, v) in env {
         command.env(k, expand_vars(rig, v));
     }
@@ -443,13 +451,29 @@ fn run_command_step(
     })?;
 
     if !status.success() {
+        let code = status.code().unwrap_or(-1);
+        let hint = if code == 127 {
+            ": command not found. Rig command steps bootstrap common toolchain PATHs automatically; if the tool lives elsewhere, set env.PATH for this step or prefer a typed build/git/check step"
+        } else {
+            ""
+        };
         return Err(Error::rig_pipeline_failed(
             &rig.id,
             "command",
-            format!("`{}` exited {}", expanded, status.code().unwrap_or(-1)),
+            format!("`{}` exited {}{}", expanded, code, hint),
         ));
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn command_step_shell() -> &'static str {
+    "/bin/sh"
+}
+
+#[cfg(not(unix))]
+fn command_step_shell() -> &'static str {
+    "sh"
 }
 
 fn run_symlink_step(rig: &RigSpec, op: SymlinkOp) -> Result<()> {
@@ -517,6 +541,99 @@ fn create_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
         std::io::ErrorKind::Unsupported,
         "rig symlinks are not supported on this platform (Unix only)",
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs;
+
+    use super::run_pipeline;
+    use crate::rig::spec::{PipelineStep, RigSpec};
+    use crate::rig::toolchain;
+
+    fn rig_with_command(cmd: String, env: HashMap<String, String>) -> RigSpec {
+        let mut pipeline = HashMap::new();
+        pipeline.insert(
+            "up".to_string(),
+            vec![PipelineStep::Command {
+                step_id: None,
+                depends_on: Vec::new(),
+                cmd,
+                cwd: None,
+                env,
+                label: Some("command".to_string()),
+            }],
+        );
+
+        RigSpec {
+            id: "command-env-test".to_string(),
+            description: String::new(),
+            components: Default::default(),
+            services: Default::default(),
+            symlinks: Vec::new(),
+            shared_paths: Vec::new(),
+            resources: Default::default(),
+            pipeline,
+            bench: None,
+            app_launcher: None,
+            bench_workloads: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_command_step_explicit_path_env_wins() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path_file = tmp.path().join("path.txt");
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), "/tmp/explicit-toolchain".to_string());
+
+        let rig = rig_with_command(
+            format!("printf '%s' \"$PATH\" > {}", path_file.to_string_lossy()),
+            env,
+        );
+        let outcome = run_pipeline(&rig, "up", true).expect("pipeline");
+
+        assert!(outcome.is_success(), "outcomes: {:?}", outcome.steps);
+        assert_eq!(
+            fs::read_to_string(path_file).expect("path file"),
+            "/tmp/explicit-toolchain"
+        );
+    }
+
+    #[test]
+    fn test_command_step_uses_bootstrapped_toolchain_path() {
+        let expected = toolchain::command_step_path().expect("toolchain path");
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path_file = tmp.path().join("path.txt");
+
+        let rig = rig_with_command(
+            format!("printf '%s' \"$PATH\" > {}", path_file.to_string_lossy()),
+            HashMap::new(),
+        );
+        let outcome = run_pipeline(&rig, "up", true).expect("pipeline");
+
+        assert!(outcome.is_success(), "outcomes: {:?}", outcome.steps);
+        assert_eq!(
+            fs::read_to_string(path_file).expect("path file"),
+            expected.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_command_step_exit_127_mentions_path_contract() {
+        let rig = rig_with_command(
+            "definitely-not-a-homeboy-test-command-1758 2>/dev/null".to_string(),
+            HashMap::new(),
+        );
+        let outcome = run_pipeline(&rig, "up", true).expect("pipeline report");
+
+        assert!(!outcome.is_success());
+        let error = outcome.steps[0].error.as_deref().expect("error");
+        assert!(error.contains("exited 127"), "{error}");
+        assert!(error.contains("command not found"), "{error}");
+        assert!(error.contains("env.PATH"), "{error}");
+    }
 }
 
 fn verify_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<()> {

--- a/src/core/rig/toolchain.rs
+++ b/src/core/rig/toolchain.rs
@@ -1,0 +1,144 @@
+//! Toolchain environment helpers for rig command steps.
+
+use std::collections::HashSet;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+const HOME_BIN_DIRS: &[&str] = &[".local/bin", ".cargo/bin", ".kimaki/bin"];
+const ABSOLUTE_BIN_DIRS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin"];
+
+/// Builds the default PATH for rig `command` steps.
+///
+/// Existing developer-tool locations are prepended before the inherited PATH.
+/// Missing directories are ignored so the result stays portable across hosts.
+pub fn command_step_path() -> Option<OsString> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let existing_path = std::env::var_os("PATH");
+    build_command_step_path(home.as_deref(), existing_path.as_deref())
+}
+
+pub(crate) fn build_command_step_path(
+    home: Option<&Path>,
+    existing_path: Option<&OsStr>,
+) -> Option<OsString> {
+    build_command_step_path_with_absolute_dirs(home, existing_path, ABSOLUTE_BIN_DIRS)
+}
+
+fn build_command_step_path_with_absolute_dirs(
+    home: Option<&Path>,
+    existing_path: Option<&OsStr>,
+    absolute_dirs: &[&str],
+) -> Option<OsString> {
+    let mut seen = HashSet::new();
+    let mut paths = Vec::new();
+
+    if let Some(home) = home {
+        for rel in HOME_BIN_DIRS {
+            push_existing_path(&mut paths, &mut seen, home.join(rel));
+        }
+    }
+
+    for path in absolute_dirs {
+        push_existing_path(&mut paths, &mut seen, PathBuf::from(path));
+    }
+
+    if let Some(existing_path) = existing_path {
+        for path in std::env::split_paths(existing_path) {
+            push_path(&mut paths, &mut seen, path);
+        }
+    }
+
+    if paths.is_empty() {
+        None
+    } else {
+        std::env::join_paths(paths).ok()
+    }
+}
+
+fn push_existing_path(paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
+    if path.exists() {
+        push_path(paths, seen, path);
+    }
+}
+
+fn push_path(paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
+    if seen.insert(path.clone()) {
+        paths.push(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::build_command_step_path_with_absolute_dirs;
+
+    #[test]
+    fn test_command_step_path_prepends_existing_toolchain_dirs() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let home = tmp.path().join("home");
+        let local = home.join(".local/bin");
+        let cargo = home.join(".cargo/bin");
+        fs::create_dir_all(&local).expect("local bin");
+        fs::create_dir_all(&cargo).expect("cargo bin");
+
+        let inherited = OsString::from("/usr/bin:/bin");
+        let path = build_command_step_path_with_absolute_dirs(Some(&home), Some(&inherited), &[])
+            .expect("path");
+        let parts = std::env::split_paths(&path).collect::<Vec<_>>();
+
+        assert_eq!(parts[0], local);
+        assert_eq!(parts[1], cargo);
+        assert!(parts.contains(&PathBuf::from("/usr/bin")));
+        assert!(parts.contains(&PathBuf::from("/bin")));
+        assert!(!parts.contains(&home.join(".kimaki/bin")));
+    }
+
+    #[test]
+    fn test_command_step_path_keeps_existing_path_without_home() {
+        let inherited = OsString::from("/usr/bin:/bin");
+        let path =
+            build_command_step_path_with_absolute_dirs(None, Some(&inherited), &[]).expect("path");
+        let parts = std::env::split_paths(&path).collect::<Vec<_>>();
+
+        assert_eq!(
+            parts,
+            vec![PathBuf::from("/usr/bin"), PathBuf::from("/bin")]
+        );
+    }
+
+    #[test]
+    fn test_command_step_path_deduplicates_entries() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let home = tmp.path().join("home");
+        let local = home.join(".local/bin");
+        fs::create_dir_all(&local).expect("local bin");
+
+        let inherited = OsString::from(local.to_string_lossy().into_owned());
+        let path = build_command_step_path_with_absolute_dirs(Some(&home), Some(&inherited), &[])
+            .expect("path");
+        let parts = std::env::split_paths(&path).collect::<Vec<_>>();
+
+        assert_eq!(parts, vec![local]);
+    }
+
+    #[test]
+    fn test_command_step_path_prepends_existing_absolute_toolchain_dirs() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let homebrew = tmp.path().join("opt-homebrew-bin");
+        let missing = tmp.path().join("missing-bin");
+        fs::create_dir_all(&homebrew).expect("homebrew bin");
+
+        let inherited = OsString::from("/usr/bin:/bin");
+        let absolute_dirs = [homebrew.to_str().unwrap(), missing.to_str().unwrap()];
+        let path =
+            build_command_step_path_with_absolute_dirs(None, Some(&inherited), &absolute_dirs)
+                .expect("path");
+        let parts = std::env::split_paths(&path).collect::<Vec<_>>();
+
+        assert_eq!(parts[0], homebrew);
+        assert!(!parts.contains(&missing));
+    }
+}


### PR DESCRIPTION
## Summary
- Bootstrap a portable developer-tool PATH for rig `command` steps when the step does not explicitly set `env.PATH`.
- Add a focused toolchain helper and tests so common locations like `~/.local/bin`, `~/.cargo/bin`, `~/.kimaki/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` are available to command steps.
- Improve exit-127 errors with guidance to set `env.PATH` or use typed rig primitives.

## Tests
- `cargo test command_step -- --test-threads=1`
- `cargo test toolchain -- --test-threads=1`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-rig-command-toolchain-path --changed-since origin/main`

## Audit notes
- Changed-since audit reports pre-existing/threshold-style findings on touched rig files, including `src/core/rig/pipeline.rs` `god_file` / `high_item_count` and missing-test-method heuristics. The branch adds focused coverage for the new command-step PATH behavior.

Closes #1758

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Finished the minion-started PATH bootstrap change, added/ran focused tests, and prepared the PR. Chris remains responsible for review and merge.