### PR TITLE
feat(rig): add extension lifecycle step

### DIFF
--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -7,8 +7,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::stack::{
-    self, ApplyOutput, DiffOutput, GitRef, InspectOptions, InspectOutput, PushOutput,
-    RebaseOutput, StackPrEntry, StackSpec, StatusOutput, SyncOutput,
+    self, ApplyOutput, DiffOutput, GitRef, InspectOptions, InspectOutput, PushOutput, RebaseOutput,
+    StackPrEntry, StackSpec, StatusOutput, SyncOutput,
 };
 
 use super::CmdResult;

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -7,8 +7,8 @@
 //! Phase 1 scope:
 //! - Spec schema with components, services, symlinks, shared paths, and linear pipelines
 //! - Service kinds: `http-static`, `command`, `external` (adopted)
-//! - Pipeline step kinds: `service`, `build`, `git`, `stack`, `command`,
-//!   `symlink`, `shared-path`, `patch`, `check`
+//! - Pipeline step kinds: `service`, `build`, `extension`, `git`, `stack`,
+//!   `command`, `symlink`, `shared-path`, `patch`, `check`
 //! - Check probes: `http`, `file` (+ `contains`), `command`, `newer_than`
 //!   (mtime / process-start staleness)
 //! - State file at `~/.config/homeboy/rigs/{id}.state/state.json`

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -22,6 +22,7 @@ use super::spec::{
 use super::stack as rig_stack;
 use super::state::{now_rfc3339, RigState, SharedPathState};
 use super::toolchain;
+use crate::component::Component;
 use crate::error::{Error, Result};
 
 /// Result of one pipeline step.
@@ -117,6 +118,7 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
     match step {
         PipelineStep::Service { id, op, .. } => run_service_step(rig, id, *op),
         PipelineStep::Build { component, .. } => run_build_step(rig, component),
+        PipelineStep::Extension { component, op, .. } => run_extension_step(rig, component, op),
         PipelineStep::Git {
             component,
             op,
@@ -244,6 +246,7 @@ fn step_id(step: &PipelineStep) -> Option<&str> {
     match step {
         PipelineStep::Service { step_id, .. }
         | PipelineStep::Build { step_id, .. }
+        | PipelineStep::Extension { step_id, .. }
         | PipelineStep::Git { step_id, .. }
         | PipelineStep::Stack { step_id, .. }
         | PipelineStep::Command { step_id, .. }
@@ -258,6 +261,7 @@ fn step_dependencies(step: &PipelineStep) -> &[String] {
     match step {
         PipelineStep::Service { depends_on, .. }
         | PipelineStep::Build { depends_on, .. }
+        | PipelineStep::Extension { depends_on, .. }
         | PipelineStep::Git { depends_on, .. }
         | PipelineStep::Stack { depends_on, .. }
         | PipelineStep::Command { depends_on, .. }
@@ -293,9 +297,23 @@ fn resolve_component_path(rig: &RigSpec, component_id: &str) -> Result<(Componen
     Ok((component.clone(), path))
 }
 
+fn resolve_rig_component(rig: &RigSpec, component_id: &str) -> Result<Component> {
+    let (component, path) = resolve_component_path(rig, component_id)?;
+    let mut resolved = Component {
+        id: component_id.to_string(),
+        local_path: path,
+        remote_url: component.remote_url,
+        triage_remote_url: component.triage_remote_url,
+        extensions: component.extensions,
+        ..Component::default()
+    };
+    resolved.resolve_remote_path();
+    Ok(resolved)
+}
+
 fn run_build_step(rig: &RigSpec, component_id: &str) -> Result<()> {
-    let (_, path) = resolve_component_path(rig, component_id)?;
-    let (result, exit_code) = crate::build::run_with_path(component_id, &path)?;
+    let component = resolve_rig_component(rig, component_id)?;
+    let (result, exit_code) = crate::build::run_component(&component)?;
 
     if exit_code != 0 {
         let detail = match &result {
@@ -326,6 +344,20 @@ fn run_build_step(rig: &RigSpec, component_id: &str) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn run_extension_step(rig: &RigSpec, component_id: &str, op: &str) -> Result<()> {
+    match op {
+        "build" => run_build_step(rig, component_id),
+        other => Err(Error::rig_pipeline_failed(
+            &rig.id,
+            "extension",
+            format!(
+                "extension op '{}' is not supported for component '{}'; supported ops: build",
+                other, component_id
+            ),
+        )),
+    }
 }
 
 fn run_git_step(rig: &RigSpec, component_id: &str, op: GitOp, extra_args: &[String]) -> Result<()> {
@@ -1019,6 +1051,7 @@ fn step_kind(step: &PipelineStep) -> &'static str {
     match step {
         PipelineStep::Service { .. } => "service",
         PipelineStep::Build { .. } => "build",
+        PipelineStep::Extension { .. } => "extension",
         PipelineStep::Git { .. } => "git",
         PipelineStep::Stack { .. } => "stack",
         PipelineStep::Command { .. } => "command",
@@ -1037,6 +1070,14 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
         } => label
             .clone()
             .unwrap_or_else(|| format!("build {}", component)),
+        PipelineStep::Extension {
+            component,
+            op,
+            label,
+            ..
+        } => label
+            .clone()
+            .unwrap_or_else(|| format!("extension {} {}", op, component)),
         PipelineStep::Git {
             component,
             op,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -362,6 +362,28 @@ pub enum PipelineStep {
         label: Option<String>,
     },
 
+    /// Delegate a component lifecycle operation to its configured extension.
+    ///
+    /// V1 intentionally exposes only operations that Homeboy core already knows
+    /// how to dispatch through extension infrastructure. Use `command` for
+    /// one-off shell escape hatches; add new extension ops only when the
+    /// extension layer owns the corresponding lifecycle contract.
+    Extension {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+        /// Component ID — must exist in the rig's `components` map.
+        component: String,
+        /// Extension-owned operation. V1 supports `build`.
+        op: String,
+        /// Human-readable label shown during execution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
+
     /// Delegate to `homeboy git`.
     ///
     /// Wraps homeboy's own git primitive with a path override so rigs can

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -319,6 +319,145 @@ mod dag {
     }
 }
 
+// ---- Extension-backed lifecycle steps ---------------------------------------
+
+mod extension_lifecycle {
+    use std::collections::HashMap;
+    use std::fs;
+
+    use crate::component::ScopedExtensionConfig;
+    use crate::rig::pipeline::run_pipeline;
+    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+    use crate::test_support;
+
+    fn rig_with_step(component_path: String, step: PipelineStep) -> RigSpec {
+        let mut component_settings = HashMap::new();
+        component_settings.insert(
+            "rig_local".to_string(),
+            serde_json::Value::String("yes".to_string()),
+        );
+
+        let mut extensions = HashMap::new();
+        extensions.insert(
+            "nodejs".to_string(),
+            ScopedExtensionConfig {
+                version: None,
+                settings: component_settings,
+            },
+        );
+
+        let mut components = HashMap::new();
+        components.insert(
+            "studio".to_string(),
+            ComponentSpec {
+                path: component_path,
+                remote_url: None,
+                triage_remote_url: None,
+                stack: None,
+                branch: None,
+                extensions: Some(extensions),
+            },
+        );
+
+        let mut pipeline = HashMap::new();
+        pipeline.insert("up".to_string(), vec![step]);
+
+        RigSpec {
+            id: "extension-step-test".to_string(),
+            description: String::new(),
+            components,
+            services: Default::default(),
+            symlinks: Vec::new(),
+            shared_paths: Vec::new(),
+            resources: Default::default(),
+            pipeline,
+            bench: None,
+            app_launcher: None,
+            bench_workloads: Default::default(),
+        }
+    }
+
+    fn write_nodejs_build_extension(home: &std::path::Path) {
+        let extension_dir = home.join(".config/homeboy/extensions/nodejs");
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join("nodejs.json"),
+            r#"{
+                "name": "Node.js",
+                "version": "1.0.0",
+                "build": {
+                    "extension_script": "build.sh",
+                    "command_template": "sh {{script}}",
+                    "script_names": []
+                }
+            }"#,
+        )
+        .expect("extension manifest");
+        fs::write(
+            extension_dir.join("build.sh"),
+            "printf '%s\n' \"$HOMEBOY_COMPONENT_PATH\" > build-path.txt\nprintf '%s\n' \"$HOMEBOY_SETTINGS_JSON\" > build-settings.json\n",
+        )
+        .expect("extension script");
+    }
+
+    #[test]
+    fn test_extension_build_uses_rig_component_path_and_extension_config() {
+        test_support::with_isolated_home(|home| {
+            write_nodejs_build_extension(home.path());
+            let component_dir = tempfile::tempdir().expect("component dir");
+            let component_path = component_dir.path().to_string_lossy().to_string();
+            let rig = rig_with_step(
+                component_path.clone(),
+                PipelineStep::Extension {
+                    step_id: None,
+                    depends_on: Vec::new(),
+                    component: "studio".to_string(),
+                    op: "build".to_string(),
+                    label: None,
+                },
+            );
+
+            let out = run_pipeline(&rig, "up", true).expect("pipeline");
+            assert!(out.is_success(), "outcomes: {:?}", out.steps);
+            assert_eq!(out.steps[0].kind, "extension");
+
+            let build_path = fs::read_to_string(component_dir.path().join("build-path.txt"))
+                .expect("build path marker");
+            assert_eq!(build_path.trim(), component_path);
+
+            let settings = fs::read_to_string(component_dir.path().join("build-settings.json"))
+                .expect("settings marker");
+            assert!(settings.contains("rig_local"), "settings: {settings}");
+            assert!(settings.contains("yes"), "settings: {settings}");
+        });
+    }
+
+    #[test]
+    fn test_extension_step_reports_unsupported_op() {
+        let component_dir = tempfile::tempdir().expect("component dir");
+        let rig = rig_with_step(
+            component_dir.path().to_string_lossy().to_string(),
+            PipelineStep::Extension {
+                step_id: None,
+                depends_on: Vec::new(),
+                component: "studio".to_string(),
+                op: "setup".to_string(),
+                label: None,
+            },
+        );
+
+        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        assert!(!out.is_success());
+        assert_eq!(out.steps[0].kind, "extension");
+        let error = out.steps[0].error.as_deref().expect("error");
+        assert!(
+            error.contains("extension op 'setup' is not supported"),
+            "{error}"
+        );
+        assert!(error.contains("supported ops: build"), "{error}");
+    }
+}
+
 // ---- Patch step end-to-end -------------------------------------------------
 //
 // The patch step is the smallest of the three new pipeline kinds and the

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -237,6 +237,34 @@ fn test_spec_build_step_parses() {
 }
 
 #[test]
+fn test_spec_extension_step_parses() {
+    let json = r#"{
+        "id": "r",
+        "components": { "studio": { "path": "/tmp/studio" } },
+        "pipeline": {
+            "up": [
+                { "kind": "extension", "component": "studio", "op": "build", "label": "extension build" }
+            ]
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+    let steps = spec.pipeline.get("up").unwrap();
+    match &steps[0] {
+        PipelineStep::Extension {
+            component,
+            op,
+            label,
+            ..
+        } => {
+            assert_eq!(component, "studio");
+            assert_eq!(op, "build");
+            assert_eq!(label.as_deref(), Some("extension build"));
+        }
+        other => panic!("expected Extension, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_spec_pipeline_step_id_and_dependencies_parse() {
     let json = r#"{
         "id": "r",

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -166,42 +166,42 @@ fn test_sync_entry_serializes_counts_and_refs() {
     components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
     let rig = rig_with_components(components);
 
-	let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
-		Ok(SyncOutput {
-			preview: SyncPreview {
-				stack_id: stack_id.to_string(),
-				component_path: "/tmp/component".to_string(),
-				branch: "dev/combined-fixes".to_string(),
-				base: GitRef {
-					remote: "origin".to_string(),
-					branch: "main".to_string(),
-				}
-				.display(),
-				target: GitRef {
-					remote: "fork".to_string(),
-					branch: "dev/combined-fixes".to_string(),
-				}
-				.display(),
-				dropped: Vec::new(),
-				replayed: Vec::new(),
-				uncertain: Vec::new(),
-				target_exists: true,
-				target_ahead: Some(0),
-				target_behind: Some(0),
-				dropped_count: 1,
-				replayed_count: 3,
-				uncertain_count: 0,
-				would_mutate: true,
-				blocked: false,
-				success: true,
-			},
-			applied: Vec::new(),
-			dry_run: false,
-			picked_count: 2,
-			skipped_count: 1,
-			success: true,
-		})
-	});
+    let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
+        Ok(SyncOutput {
+            preview: SyncPreview {
+                stack_id: stack_id.to_string(),
+                component_path: "/tmp/component".to_string(),
+                branch: "dev/combined-fixes".to_string(),
+                base: GitRef {
+                    remote: "origin".to_string(),
+                    branch: "main".to_string(),
+                }
+                .display(),
+                target: GitRef {
+                    remote: "fork".to_string(),
+                    branch: "dev/combined-fixes".to_string(),
+                }
+                .display(),
+                dropped: Vec::new(),
+                replayed: Vec::new(),
+                uncertain: Vec::new(),
+                target_exists: true,
+                target_ahead: Some(0),
+                target_behind: Some(0),
+                dropped_count: 1,
+                replayed_count: 3,
+                uncertain_count: 0,
+                would_mutate: true,
+                blocked: false,
+                success: true,
+            },
+            applied: Vec::new(),
+            dry_run: false,
+            picked_count: 2,
+            skipped_count: 1,
+            success: true,
+        })
+    });
 
     let json = serde_json::to_string(&report).expect("serialize");
     assert!(json.contains("\"component_id\":\"a\""));


### PR DESCRIPTION
## Summary
- Add a rig `extension` pipeline step that delegates supported component lifecycle operations through the component's configured extension.
- Route both `kind: "build"` and `kind: "extension", op: "build"` through a rig-resolved `Component`, preserving the rig's component path and rig-local `extensions` config instead of falling back to the global registry.
- Keep v1 intentionally narrow: unsupported extension ops such as `setup` fail with a clear supported-ops message rather than hiding a raw command workaround.

## Changes
- Adds `PipelineStep::Extension` with `component`, `op`, optional `label`, `id`, and `depends_on` fields.
- Introduces rig component resolution for build dispatch so rig-local extension config reaches `ExtensionRunner`.
- Adds focused tests proving successful extension-backed build dispatch and unsupported-op reporting.
- Runs `cargo fmt` after rebasing onto current `origin/main`, which also picks up unrelated format drift from the stack sync files.

## Tests
- `cargo test extension_lifecycle`
- `cargo test test_spec_extension_step_parses`
- `cargo test pipeline_test`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-extension-lifecycle-steps`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-extension-lifecycle-steps --changed-since origin/main` *(reports existing size/test-coverage heuristics on touched rig files; no targeted regression found)*

Closes #1765

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the rig extension lifecycle step, wrote focused tests, ran verification, and prepared the PR. Chris remains responsible for review and merge.
