### PR TITLE
feat(daemon): add local HTTP daemon MVP

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1,9 +1,9 @@
 use clap::{Command, CommandFactory, Parser, Subcommand};
 
 use crate::commands::{
-    api, audit, auth, bench, build, changelog, changes, component, config, db, deploy, extension,
-    file, fleet, git, init, issues, lint, logs, project, refactor, release, review, rig, server,
-    ssh, stack, status, test, transfer, triage, undo, upgrade, validate, version,
+    api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
+    extension, file, fleet, git, init, issues, lint, logs, project, refactor, release, review, rig,
+    server, ssh, stack, status, test, transfer, triage, undo, upgrade, validate, version,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -58,6 +58,8 @@ pub enum Commands {
     Component(component::ComponentArgs),
     /// Manage global Homeboy configuration
     Config(config::ConfigArgs),
+    /// Run the local-only HTTP API daemon
+    Daemon(daemon::DaemonArgs),
     /// Execute CLI-compatible extensions
     #[command(visible_alias = "extensions")]
     Extension(extension::ExtensionArgs),

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -1,0 +1,113 @@
+use clap::{Args, Subcommand};
+use serde::Serialize;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use homeboy::daemon::{self, DaemonStartResult, DaemonStatus, DaemonStopResult};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct DaemonArgs {
+    #[command(subcommand)]
+    command: DaemonCommand,
+}
+
+#[derive(Subcommand)]
+enum DaemonCommand {
+    /// Start the local daemon in the background
+    Start {
+        /// Local bind address. Defaults to an OS-selected loopback port.
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
+    /// Run the local daemon in the foreground
+    Serve {
+        /// Local bind address. Defaults to an OS-selected loopback port.
+        #[arg(long, default_value = daemon::DEFAULT_ADDR)]
+        addr: String,
+    },
+    /// Stop the background daemon recorded in the state file
+    Stop,
+    /// Show daemon state and selected local address
+    Status,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum DaemonOutput {
+    Start(DaemonStartResult),
+    Serve(DaemonStartResult),
+    Stop(DaemonStopResult),
+    Status(DaemonStatus),
+}
+
+pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<DaemonOutput> {
+    match args.command {
+        DaemonCommand::Start { addr } => start(&addr),
+        DaemonCommand::Serve { addr } => serve(&addr),
+        DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),
+        DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),
+    }
+}
+
+fn serve(addr: &str) -> CmdResult<DaemonOutput> {
+    let parsed = daemon::parse_bind_addr(addr)?;
+    let state = daemon::serve(parsed)?;
+    Ok((
+        DaemonOutput::Serve(DaemonStartResult {
+            pid: state.pid,
+            address: state.address,
+            state_path: state.state_path,
+        }),
+        0,
+    ))
+}
+
+fn start(addr: &str) -> CmdResult<DaemonOutput> {
+    daemon::parse_bind_addr(addr)?;
+
+    let exe = std::env::current_exe().map_err(|e| {
+        homeboy::Error::internal_io(
+            e.to_string(),
+            Some("resolve current executable".to_string()),
+        )
+    })?;
+    let child = Command::new(exe)
+        .args(["daemon", "serve", "--addr", addr])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| {
+            homeboy::Error::internal_io(e.to_string(), Some("spawn daemon".to_string()))
+        })?;
+    let pid = child.id();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let status = daemon::read_status()?;
+        if let Some(state) = status.state {
+            if state.pid == pid {
+                return Ok((
+                    DaemonOutput::Start(DaemonStartResult {
+                        pid,
+                        address: state.address,
+                        state_path: state.state_path,
+                    }),
+                    0,
+                ));
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return Err(homeboy::Error::internal_unexpected(format!(
+                "daemon process {} did not publish state before timeout",
+                pid
+            )));
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -284,6 +284,7 @@ pub mod changes;
 pub mod cli;
 pub mod component;
 pub mod config;
+pub mod daemon;
 pub mod db;
 pub mod deploy;
 pub mod docs;
@@ -362,6 +363,7 @@ pub fn run_json(
         crate::cli_surface::Commands::Deploy(args) => dispatch!(args, global, deploy),
         crate::cli_surface::Commands::Component(args) => dispatch!(args, global, component),
         crate::cli_surface::Commands::Config(args) => dispatch!(args, global, config),
+        crate::cli_surface::Commands::Daemon(args) => dispatch!(args, global, daemon),
         crate::cli_surface::Commands::Extension(args) => dispatch!(args, global, extension),
         crate::cli_surface::Commands::Docs(args) => dispatch!(args, global, docs),
         crate::cli_surface::Commands::Changelog(args) => dispatch!(args, global, changelog),

--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -7,8 +7,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::stack::{
-    self, ApplyOutput, DiffOutput, GitRef, InspectOptions, InspectOutput, PushOutput,
-    RebaseOutput, StackPrEntry, StackSpec, StatusOutput, SyncOutput,
+    self, ApplyOutput, DiffOutput, GitRef, InspectOptions, InspectOutput, PushOutput, RebaseOutput,
+    StackPrEntry, StackSpec, StatusOutput, SyncOutput,
 };
 
 use super::CmdResult;

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,0 +1,298 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::paths;
+
+pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DaemonState {
+    pub address: String,
+    pub pid: u32,
+    pub state_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonStatus {
+    pub running: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<DaemonState>,
+    pub state_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonStartResult {
+    pub pid: u32,
+    pub address: String,
+    pub state_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DaemonStopResult {
+    pub stopped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    pub state_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    pub status_code: u16,
+    pub body: serde_json::Value,
+}
+
+pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
+    let parsed: SocketAddr = addr.parse().map_err(|e| {
+        Error::validation_invalid_argument(
+            "addr",
+            format!("Invalid daemon bind address `{}`: {}", addr, e),
+            Some(addr.to_string()),
+            Some(vec!["Use a host:port value like 127.0.0.1:0".to_string()]),
+        )
+    })?;
+
+    if !parsed.ip().is_loopback() {
+        return Err(Error::validation_invalid_argument(
+            "addr",
+            "Daemon MVP only accepts loopback bind addresses",
+            Some(addr.to_string()),
+            Some(vec!["Use 127.0.0.1:<port> or [::1]:<port>".to_string()]),
+        ));
+    }
+
+    Ok(parsed)
+}
+
+pub fn state_path() -> Result<PathBuf> {
+    paths::daemon_state_file()
+}
+
+pub fn read_status() -> Result<DaemonStatus> {
+    let path = state_path()?;
+    let state_path = path.display().to_string();
+
+    if !path.exists() {
+        return Ok(DaemonStatus {
+            running: false,
+            state: None,
+            state_path,
+        });
+    }
+
+    let content = fs::read_to_string(&path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
+    let state: DaemonState = serde_json::from_str(&content)
+        .map_err(|e| Error::config_invalid_json(path.display().to_string(), e))?;
+
+    Ok(DaemonStatus {
+        running: pid_is_running(state.pid),
+        state: Some(state),
+        state_path,
+    })
+}
+
+pub fn stop() -> Result<DaemonStopResult> {
+    let status = read_status()?;
+    let Some(state) = status.state else {
+        return Ok(DaemonStopResult {
+            stopped: false,
+            pid: None,
+            state_path: status.state_path,
+        });
+    };
+
+    let stopped = if pid_is_running(state.pid) {
+        terminate_pid(state.pid)?;
+        true
+    } else {
+        false
+    };
+
+    let path = state_path()?;
+    if path.exists() {
+        fs::remove_file(&path).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("delete {}", path.display())))
+        })?;
+    }
+
+    Ok(DaemonStopResult {
+        stopped,
+        pid: Some(state.pid),
+        state_path: status.state_path,
+    })
+}
+
+pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
+    let listener = TcpListener::bind(addr)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("bind daemon to {}", addr))))?;
+    let local_addr = listener.local_addr().map_err(|e| {
+        Error::internal_io(e.to_string(), Some("read daemon local address".to_string()))
+    })?;
+    let state = write_state(local_addr)?;
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let _ = handle_connection(stream);
+            }
+            Err(err) => {
+                return Err(Error::internal_io(
+                    err.to_string(),
+                    Some("accept daemon connection".to_string()),
+                ));
+            }
+        }
+    }
+
+    Ok(state)
+}
+
+pub fn route(method: &str, path: &str) -> HttpResponse {
+    if method != "GET" {
+        return HttpResponse {
+            status_code: 405,
+            body: json!({ "error": "method_not_allowed" }),
+        };
+    }
+
+    match path {
+        "/health" => HttpResponse {
+            status_code: 200,
+            body: json!({
+                "status": "ok",
+                "version": env!("CARGO_PKG_VERSION"),
+            }),
+        },
+        "/version" => HttpResponse {
+            status_code: 200,
+            body: json!({
+                "version": env!("CARGO_PKG_VERSION"),
+            }),
+        },
+        "/config/paths" => match config_paths_body() {
+            Ok(body) => HttpResponse {
+                status_code: 200,
+                body,
+            },
+            Err(err) => HttpResponse {
+                status_code: 500,
+                body: json!({ "error": err.message }),
+            },
+        },
+        _ => HttpResponse {
+            status_code: 404,
+            body: json!({ "error": "not_found" }),
+        },
+    }
+}
+
+fn config_paths_body() -> Result<serde_json::Value> {
+    Ok(json!({
+        "homeboy": paths::homeboy()?.display().to_string(),
+        "homeboy_json": paths::homeboy_json()?.display().to_string(),
+        "projects": paths::projects()?.display().to_string(),
+        "servers": paths::servers()?.display().to_string(),
+        "components": paths::components()?.display().to_string(),
+        "extensions": paths::extensions()?.display().to_string(),
+        "rigs": paths::rigs()?.display().to_string(),
+        "stacks": paths::stacks()?.display().to_string(),
+        "daemon_state": paths::daemon_state_file()?.display().to_string(),
+    }))
+}
+
+fn write_state(addr: SocketAddr) -> Result<DaemonState> {
+    let path = state_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("create {}", parent.display())))
+        })?;
+    }
+
+    let state = DaemonState {
+        address: addr.to_string(),
+        pid: std::process::id(),
+        state_path: path.display().to_string(),
+    };
+    let body = serde_json::to_string_pretty(&state).map_err(|e| {
+        Error::internal_json(e.to_string(), Some("serialize daemon state".to_string()))
+    })?;
+    fs::write(&path, body).map_err(|e| {
+        Error::internal_io(e.to_string(), Some(format!("write {}", path.display())))
+    })?;
+    Ok(state)
+}
+
+fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
+    let mut buffer = [0; 2048];
+    let bytes = stream.read(&mut buffer)?;
+    let request = String::from_utf8_lossy(&buffer[..bytes]);
+    let mut parts = request
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let path = parts.next().unwrap_or_default();
+    let response = route(method, path);
+    let body = serde_json::to_string_pretty(&json!({
+        "success": (200..300).contains(&response.status_code),
+        "data": response.body,
+    }))
+    .unwrap_or_else(|_| "{\"success\":false}".to_string());
+    let status_text = match response.status_code {
+        200 => "OK",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        _ => "Internal Server Error",
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response.status_code,
+        status_text,
+        body.len(),
+        body
+    )
+}
+
+fn pid_is_running(pid: u32) -> bool {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as libc::pid_t, 0) == 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        pid == std::process::id()
+    }
+}
+
+fn terminate_pid(pid: u32) -> Result<()> {
+    #[cfg(unix)]
+    unsafe {
+        if libc::kill(pid as libc::pid_t, libc::SIGTERM) != 0 {
+            return Err(Error::internal_io(
+                std::io::Error::last_os_error().to_string(),
+                Some(format!("stop daemon pid {}", pid)),
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        Err(Error::internal_unexpected(
+            "daemon stop is not implemented on this platform",
+        ))
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/core/daemon_test.rs"]
+mod daemon_test;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod code_audit;
 pub mod component;
 pub mod context;
+pub mod daemon;
 pub mod db;
 pub mod deploy;
 pub mod engine;

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -121,6 +121,16 @@ pub fn stacks() -> Result<PathBuf> {
     Ok(homeboy()?.join("stacks"))
 }
 
+/// Daemon runtime state directory (~/.config/homeboy/daemon/).
+pub fn daemon_state_dir() -> Result<PathBuf> {
+    Ok(homeboy()?.join("daemon"))
+}
+
+/// Daemon runtime state file (~/.config/homeboy/daemon/state.json).
+pub fn daemon_state_file() -> Result<PathBuf> {
+    Ok(daemon_state_dir()?.join("state.json"))
+}
+
 /// Stack config file path (~/.config/homeboy/stacks/{id}.json)
 pub fn stack_config(id: &str) -> Result<PathBuf> {
     Ok(stacks()?.join(format!("{}.json", id)))

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,10 @@ fn main() -> std::process::ExitCode {
     };
 
     // Startup update checks — skip for upgrade/update commands (they handle this themselves)
-    if !matches!(&cli.command, Commands::Upgrade(_) | Commands::Update(_)) {
+    if !matches!(
+        &cli.command,
+        Commands::Upgrade(_) | Commands::Update(_) | Commands::Daemon(_)
+    ) {
         homeboy::upgrade::update_check::run_startup_check();
         homeboy::extension::update_check::run_startup_check();
     }

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -5,6 +5,7 @@ fn includes_current_top_level_commands() {
     let surface = current_command_surface();
 
     assert!(surface.contains_path(&["audit"]));
+    assert!(surface.contains_path(&["daemon"]));
     assert!(surface.contains_path(&["git"]));
     assert!(surface.contains_path(&["stack"]));
 }
@@ -14,6 +15,7 @@ fn includes_first_level_subcommands() {
     let surface = current_command_surface();
 
     assert!(surface.contains_path(&["git", "status"]));
+    assert!(surface.contains_path(&["daemon", "serve"]));
     assert!(surface.contains_path(&["stack", "inspect"]));
 }
 

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,0 +1,57 @@
+use super::*;
+use crate::test_support::HomeGuard;
+
+#[test]
+fn parse_bind_addr_defaults_to_loopback_shape() {
+    let addr = parse_bind_addr(DEFAULT_ADDR).expect("parse default");
+
+    assert!(addr.ip().is_loopback());
+    assert_eq!(addr.port(), 0);
+}
+
+#[test]
+fn parse_bind_addr_rejects_public_bind() {
+    let err = parse_bind_addr("0.0.0.0:8080").expect_err("reject public bind");
+
+    assert!(err.message.contains("loopback"));
+}
+
+#[test]
+fn routes_health_version_and_config_paths() {
+    let _home = HomeGuard::new();
+
+    let health = route("GET", "/health");
+    assert_eq!(health.status_code, 200);
+    assert_eq!(health.body["status"], "ok");
+
+    let version = route("GET", "/version");
+    assert_eq!(version.status_code, 200);
+    assert_eq!(version.body["version"], env!("CARGO_PKG_VERSION"));
+
+    let paths = route("GET", "/config/paths");
+    assert_eq!(paths.status_code, 200);
+    assert!(paths.body["homeboy"]
+        .as_str()
+        .unwrap()
+        .ends_with(".config/homeboy"));
+    assert!(paths.body["daemon_state"]
+        .as_str()
+        .unwrap()
+        .ends_with("daemon/state.json"));
+}
+
+#[test]
+fn route_rejects_unknown_paths_and_methods() {
+    assert_eq!(route("GET", "/missing").status_code, 404);
+    assert_eq!(route("POST", "/health").status_code, 405);
+}
+
+#[test]
+fn status_is_not_running_without_state_file() {
+    let _home = HomeGuard::new();
+
+    let status = read_status().expect("status");
+    assert!(!status.running);
+    assert!(status.state.is_none());
+    assert!(status.state_path.ends_with("daemon/state.json"));
+}

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -166,42 +166,42 @@ fn test_sync_entry_serializes_counts_and_refs() {
     components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
     let rig = rig_with_components(components);
 
-	let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
-		Ok(SyncOutput {
-			preview: SyncPreview {
-				stack_id: stack_id.to_string(),
-				component_path: "/tmp/component".to_string(),
-				branch: "dev/combined-fixes".to_string(),
-				base: GitRef {
-					remote: "origin".to_string(),
-					branch: "main".to_string(),
-				}
-				.display(),
-				target: GitRef {
-					remote: "fork".to_string(),
-					branch: "dev/combined-fixes".to_string(),
-				}
-				.display(),
-				dropped: Vec::new(),
-				replayed: Vec::new(),
-				uncertain: Vec::new(),
-				target_exists: true,
-				target_ahead: Some(0),
-				target_behind: Some(0),
-				dropped_count: 1,
-				replayed_count: 3,
-				uncertain_count: 0,
-				would_mutate: true,
-				blocked: false,
-				success: true,
-			},
-			applied: Vec::new(),
-			dry_run: false,
-			picked_count: 2,
-			skipped_count: 1,
-			success: true,
-		})
-	});
+    let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
+        Ok(SyncOutput {
+            preview: SyncPreview {
+                stack_id: stack_id.to_string(),
+                component_path: "/tmp/component".to_string(),
+                branch: "dev/combined-fixes".to_string(),
+                base: GitRef {
+                    remote: "origin".to_string(),
+                    branch: "main".to_string(),
+                }
+                .display(),
+                target: GitRef {
+                    remote: "fork".to_string(),
+                    branch: "dev/combined-fixes".to_string(),
+                }
+                .display(),
+                dropped: Vec::new(),
+                replayed: Vec::new(),
+                uncertain: Vec::new(),
+                target_exists: true,
+                target_ahead: Some(0),
+                target_behind: Some(0),
+                dropped_count: 1,
+                replayed_count: 3,
+                uncertain_count: 0,
+                would_mutate: true,
+                blocked: false,
+                success: true,
+            },
+            applied: Vec::new(),
+            dry_run: false,
+            picked_count: 2,
+            skipped_count: 1,
+            success: true,
+        })
+    });
 
     let json = serde_json::to_string(&report).expect("serialize");
     assert!(json.contains("\"component_id\":\"a\""));


### PR DESCRIPTION
## Summary
- Adds a local-only `homeboy daemon` command surface with `start`, `serve`, `status`, and `stop`.
- Exposes read-only MVP endpoints: `GET /health`, `GET /version`, and `GET /config/paths`.
- Persists the selected daemon address and PID to `~/.config/homeboy/daemon/state.json` so local clients can discover dynamic ports.

## Behaviour
- `homeboy daemon serve --addr 127.0.0.1:0` runs the HTTP loop in the foreground.
- `homeboy daemon start` spawns the same local daemon in the background and returns the selected address.
- `homeboy daemon status` reads the state file and reports whether the recorded PID is still running.
- `homeboy daemon stop` sends SIGTERM to the recorded daemon PID and removes the state file.
- No new HTTP dependency was added. The MVP uses `std::net::TcpListener` because the first slice only needs simple read-only JSON responses; a richer async dependency can be introduced when the job/event API exists.
- Two unrelated stack files are rustfmt-only changes. Reverting them makes `cargo fmt --check` fail on this branch, so they are included only to keep the existing lint gate green.

## Safety
- The daemon defaults to `127.0.0.1:0` and rejects non-loopback bind addresses.
- The HTTP surface is read-only: no deploy, release, git-write, SSH, shell passthrough, or mutating endpoints.
- Existing CLI behaviour is unchanged unless a `homeboy daemon ...` command is invoked.
- Startup update checks are skipped for daemon commands so the background service does not perform unrelated network/update work.

## Tests
- `cargo test daemon`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-http-daemon-mvp`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-http-daemon-mvp --changed-since origin/main`
- Live smoke with isolated `HOME`: `daemon start`, `daemon status`, `GET /health`, `GET /version`, `GET /config/paths`, `daemon stop`

Closes #1760
Refs #1759

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the daemon MVP, tests, verification commands, and PR description. Chris remains responsible for review and merge decisions.