### PR TITLE
feat(extension): install configured component extensions

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -6,6 +6,7 @@ use homeboy::extension::{
     UpdateEntry,
 };
 use homeboy::project::{self, Project};
+use std::path::Path;
 
 use crate::commands::CmdResult;
 
@@ -69,6 +70,15 @@ enum ExtensionCommand {
         /// Override extension id
         #[arg(long)]
         id: Option<String>,
+    },
+    /// Install every extension configured by a component
+    InstallForComponent {
+        /// Git URL or local path to extension repository/directory
+        #[arg(long)]
+        source: String,
+        /// Component path containing homeboy.json (defaults to current directory)
+        #[arg(long)]
+        path: Option<String>,
     },
     /// Update an installed extension (git pull)
     Update {
@@ -154,6 +164,9 @@ pub fn run(
         ),
         ExtensionCommand::Setup { extension_id } => setup_extension(&extension_id),
         ExtensionCommand::Install { source, id } => install_extension(&source, id),
+        ExtensionCommand::InstallForComponent { source, path } => {
+            install_for_component(&source, path.as_deref())
+        }
         ExtensionCommand::Update {
             extension_id,
             all,
@@ -209,6 +222,13 @@ pub enum ExtensionOutput {
         linked: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         source_revision: Option<String>,
+    },
+    #[serde(rename = "extension.install_for_component")]
+    InstallForComponent {
+        component_id: String,
+        source: String,
+        installed: Vec<InstallEntry>,
+        skipped: Vec<String>,
     },
     #[serde(rename = "extension.update")]
     Update {
@@ -293,6 +313,15 @@ pub struct ExtensionDetail {
     pub settings: Vec<homeboy::extension::SettingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequiresDetail>,
+}
+
+#[derive(Serialize)]
+pub struct InstallEntry {
+    pub extension_id: String,
+    pub path: String,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -470,6 +499,47 @@ fn install_extension(source: &str, id: Option<String>) -> CmdResult<ExtensionOut
         },
         0,
     ))
+}
+
+fn install_for_component(source: &str, path: Option<&str>) -> CmdResult<ExtensionOutput> {
+    let component = resolve_install_component(path)?;
+    let result = homeboy::extension::install_for_component(&component, source)?;
+
+    let installed = result
+        .installed
+        .into_iter()
+        .map(|entry| InstallEntry {
+            linked: is_extension_linked(&entry.extension_id),
+            extension_id: entry.extension_id,
+            path: entry.path.to_string_lossy().to_string(),
+            source_revision: entry.source_revision,
+        })
+        .collect();
+
+    Ok((
+        ExtensionOutput::InstallForComponent {
+            component_id: result.component_id,
+            source: result.source,
+            installed,
+            skipped: result.skipped,
+        },
+        0,
+    ))
+}
+
+fn resolve_install_component(path: Option<&str>) -> homeboy::Result<homeboy::component::Component> {
+    if let Some(path) = path {
+        return homeboy::component::discover_from_portable(Path::new(path)).ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "path",
+                format!("No homeboy.json found at {}", path),
+                Some(path.to_string()),
+                None,
+            )
+        });
+    }
+
+    homeboy::component::resolve(None)
 }
 
 fn update_extension(

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -20,6 +20,14 @@ pub struct InstallResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct InstallForComponentResult {
+    pub component_id: String,
+    pub source: String,
+    pub installed: Vec<InstallResult>,
+    pub skipped: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct UpdateResult {
     pub extension_id: String,
     pub url: String,
@@ -103,6 +111,72 @@ pub fn install(source: &str, id_override: Option<&str>) -> Result<InstallResult>
     } else {
         install_from_path(source, id_override)
     }
+}
+
+/// Install every extension declared by a component from the same source.
+///
+/// Already-installed extensions are skipped so CI setup can be re-run safely.
+pub fn install_for_component(
+    component: &crate::component::Component,
+    source: &str,
+) -> Result<InstallForComponentResult> {
+    let extensions = component.extensions.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "component",
+            format!("Component '{}' has no extensions configured", component.id),
+            Some(component.id.clone()),
+            None,
+        )
+    })?;
+
+    if extensions.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "component",
+            format!("Component '{}' has no extensions configured", component.id),
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+
+    let mut extension_ids: Vec<String> = extensions.keys().cloned().collect();
+    extension_ids.sort();
+
+    let mut installed = Vec::new();
+    let mut skipped = Vec::new();
+
+    for extension_id in extension_ids {
+        if load_extension(&extension_id).is_ok() {
+            skipped.push(extension_id);
+            continue;
+        }
+
+        installed.push(install_configured_extension(source, &extension_id)?);
+    }
+
+    Ok(InstallForComponentResult {
+        component_id: component.id.clone(),
+        source: source.to_string(),
+        installed,
+        skipped,
+    })
+}
+
+fn install_configured_extension(source: &str, extension_id: &str) -> Result<InstallResult> {
+    if is_git_url(source) {
+        return install(source, Some(extension_id));
+    }
+
+    let source_path = Path::new(source);
+    let candidate = source_path
+        .join(extension_id)
+        .join(format!("{}.json", extension_id));
+
+    if candidate.exists() {
+        let extension_path = source_path.join(extension_id);
+        return install(&extension_path.to_string_lossy(), Some(extension_id));
+    }
+
+    install(source, Some(extension_id))
 }
 
 /// Install a extension by cloning from a git repository URL.

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -51,8 +51,9 @@ pub use scope::ExtensionScope;
 
 // Re-export lifecycle types and functions
 pub use lifecycle::{
-    check_update_available, derive_id_from_url, install, is_git_url, read_source_revision,
-    slugify_id, uninstall, update, InstallResult, UpdateAvailable, UpdateResult,
+    check_update_available, derive_id_from_url, install, install_for_component, is_git_url,
+    read_source_revision, slugify_id, uninstall, update, InstallForComponentResult, InstallResult,
+    UpdateAvailable, UpdateResult,
 };
 
 // Re-export aggregate query types

--- a/tests/extension_install_for_component_test.rs
+++ b/tests/extension_install_for_component_test.rs
@@ -1,0 +1,142 @@
+use homeboy::component;
+use homeboy::extension;
+use std::fs;
+use std::path::Path;
+use std::sync::Mutex;
+
+static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+fn with_isolated_home<T>(f: impl FnOnce(&Path) -> T) -> T {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let old_home = std::env::var_os("HOME");
+    let home = tempfile::tempdir().expect("home tempdir");
+
+    std::env::set_var("HOME", home.path());
+    let result = f(home.path());
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+
+    result
+}
+
+fn write_extension_fixture(root: &Path, id: &str) {
+    let dir = root.join(id);
+    fs::create_dir_all(&dir).expect("extension dir");
+    fs::write(
+        dir.join(format!("{}.json", id)),
+        format!(
+            r#"{{
+  "name": "{} extension",
+  "version": "1.0.0"
+}}"#,
+            id
+        ),
+    )
+    .expect("extension manifest");
+}
+
+fn write_component_fixture(root: &Path, extensions: &[&str]) {
+    let extension_json = extensions
+        .iter()
+        .map(|id| format!(r#"    "{}": {{}}"#, id))
+        .collect::<Vec<_>>()
+        .join(",\n");
+
+    fs::write(
+        root.join("homeboy.json"),
+        format!(
+            r#"{{
+  "id": "multi-extension-component",
+  "extensions": {{
+{}
+  }}
+}}"#,
+            extension_json
+        ),
+    )
+    .expect("component config");
+}
+
+#[test]
+fn install_for_component_installs_multiple_extensions() {
+    with_isolated_home(|home| {
+        let source = home.join("source");
+        write_extension_fixture(&source, "alpha");
+        write_extension_fixture(&source, "beta");
+
+        let component_dir = home.join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        write_component_fixture(&component_dir, &["alpha", "beta"]);
+        let component = component::discover_from_portable(&component_dir).expect("component");
+
+        let result = extension::install_for_component(&component, &source.to_string_lossy())
+            .expect("install should succeed");
+
+        let installed_ids = result
+            .installed
+            .iter()
+            .map(|entry| entry.extension_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(installed_ids, vec!["alpha", "beta"]);
+        assert!(result.skipped.is_empty());
+        assert!(home
+            .join(".config/homeboy/extensions/alpha/alpha.json")
+            .exists());
+        assert!(home
+            .join(".config/homeboy/extensions/beta/beta.json")
+            .exists());
+    });
+}
+
+#[test]
+fn install_for_component_skips_already_installed_extensions() {
+    with_isolated_home(|home| {
+        let source = home.join("source");
+        write_extension_fixture(&source, "alpha");
+        write_extension_fixture(&source, "beta");
+
+        let component_dir = home.join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        write_component_fixture(&component_dir, &["alpha", "beta"]);
+        let component = component::discover_from_portable(&component_dir).expect("component");
+
+        extension::install(&source.join("alpha").to_string_lossy(), Some("alpha"))
+            .expect("pre-install alpha");
+
+        let result = extension::install_for_component(&component, &source.to_string_lossy())
+            .expect("install should succeed");
+
+        let installed_ids = result
+            .installed
+            .iter()
+            .map(|entry| entry.extension_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(installed_ids, vec!["beta"]);
+        assert_eq!(result.skipped, vec!["alpha"]);
+    });
+}
+
+#[test]
+fn install_for_component_uses_path_based_portable_component_config() {
+    with_isolated_home(|home| {
+        let source = home.join("source");
+        write_extension_fixture(&source, "alpha");
+        write_extension_fixture(&source, "beta");
+
+        let component_dir = home.join("component");
+        fs::create_dir_all(&component_dir).expect("component dir");
+        write_component_fixture(&component_dir, &["alpha", "beta"]);
+
+        let component = component::discover_from_portable(&component_dir)
+            .expect("component should resolve from portable path");
+        let result = extension::install_for_component(&component, &source.to_string_lossy())
+            .expect("install should succeed");
+
+        assert_eq!(result.component_id, "multi-extension-component");
+        assert_eq!(result.installed.len(), 2);
+    });
+}


### PR DESCRIPTION
## Summary
- Add `homeboy extension install-for-component --source <repo-or-path> [--path <component>]` so CI callers can install every extension declared in a component's `homeboy.json` without parsing the map themselves.
- Reuse the existing single-extension install lifecycle per configured extension and skip entries already installed, making repeated setup calls safe.

## Behaviour
- Resolves `--path` as a portable component config path when provided; otherwise resolves the current component.
- Sorts configured extension IDs for deterministic output.
- For local monorepo-style sources, installs from `<source>/<extension-id>/`; for git sources, uses the existing monorepo clone resolver through `homeboy extension install <source> --id <extension-id>` semantics.
- Returns structured output with `installed` and `skipped` extension lists.

## Tests
- `cargo test install_for_component`
- `cargo test --test extension_install_for_component_test`
- `cargo test --test command_surface_test`
- `cargo run --quiet --bin homeboy -- extension install-for-component --help`
- `git diff --check`
- `homeboy lint homeboy --path . --changed-since origin/main`

Full `homeboy lint homeboy --path .` currently fails on pre-existing `cargo fmt --check` drift in unrelated stack files (`src/commands/stack.rs`, `tests/core/rig/stack_test.rs`); touched files were formatted directly with `rustfmt`.

Refs Extra-Chill/homeboy-action#4

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Researched the action/core boundary, drafted the Homeboy core primitive and focused tests, and ran verification. Chris remains responsible for review and merge.
