### PR TITLE
fix(audit): skip unrelated detector work for filtered runs

### DIFF
--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -111,6 +111,241 @@ pub struct CodeAuditResult {
     pub duplicate_groups: Vec<duplication::DuplicateGroup>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuditExecutionPlan {
+    pub(crate) run_conventions: bool,
+    pub(crate) run_stale_cli_invocations: bool,
+    pub(crate) run_cli_argument_shapes: bool,
+    pub(crate) run_structural: bool,
+    pub(crate) run_duplication: bool,
+    pub(crate) run_dead_code: bool,
+    pub(crate) run_comment_hygiene: bool,
+    pub(crate) run_test_coverage: bool,
+    pub(crate) run_layer_ownership: bool,
+    pub(crate) run_test_topology: bool,
+    pub(crate) run_docs: bool,
+    pub(crate) run_compiler_warnings: bool,
+    pub(crate) run_wrapper_inference: bool,
+    pub(crate) run_shadow_modules: bool,
+    pub(crate) run_field_patterns: bool,
+    pub(crate) run_facade_passthrough: bool,
+    pub(crate) run_literal_shapes: bool,
+    pub(crate) run_deprecation_age: bool,
+    pub(crate) run_dead_guard: bool,
+    pub(crate) run_requested_detectors: bool,
+    pub(crate) run_global_env_guard: bool,
+    pub(crate) run_shared_scaffolding: bool,
+}
+
+impl AuditExecutionPlan {
+    pub(crate) fn full() -> Self {
+        Self {
+            run_conventions: true,
+            run_stale_cli_invocations: true,
+            run_cli_argument_shapes: true,
+            run_structural: true,
+            run_duplication: true,
+            run_dead_code: true,
+            run_comment_hygiene: true,
+            run_test_coverage: true,
+            run_layer_ownership: true,
+            run_test_topology: true,
+            run_docs: true,
+            run_compiler_warnings: true,
+            run_wrapper_inference: true,
+            run_shadow_modules: true,
+            run_field_patterns: true,
+            run_facade_passthrough: true,
+            run_literal_shapes: true,
+            run_deprecation_age: true,
+            run_dead_guard: true,
+            run_requested_detectors: true,
+            run_global_env_guard: true,
+            run_shared_scaffolding: true,
+        }
+    }
+
+    pub(crate) fn from_filters(only: &[AuditFinding], exclude: &[AuditFinding]) -> Self {
+        if only.is_empty() && exclude.is_empty() {
+            return Self::full();
+        }
+
+        Self {
+            run_conventions: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::MissingMethod,
+                    AuditFinding::ExtraMethod,
+                    AuditFinding::MissingRegistration,
+                    AuditFinding::DifferentRegistration,
+                    AuditFinding::MissingInterface,
+                    AuditFinding::NamingMismatch,
+                    AuditFinding::SignatureMismatch,
+                    AuditFinding::NamespaceMismatch,
+                    AuditFinding::MissingImport,
+                ],
+            ),
+            run_stale_cli_invocations: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::StaleCliInvocation],
+            ),
+            run_cli_argument_shapes: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::StaleCliArgumentShape],
+            ),
+            run_structural: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::GodFile,
+                    AuditFinding::HighItemCount,
+                    AuditFinding::DirectorySprawl,
+                ],
+            ),
+            run_duplication: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::DuplicateFunction,
+                    AuditFinding::IntraMethodDuplicate,
+                    AuditFinding::NearDuplicate,
+                    AuditFinding::ParallelImplementation,
+                ],
+            ),
+            run_dead_code: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::UnusedParameter,
+                    AuditFinding::IgnoredParameter,
+                    AuditFinding::DeadCodeMarker,
+                    AuditFinding::UnreferencedExport,
+                    AuditFinding::OrphanedInternal,
+                ],
+            ),
+            run_comment_hygiene: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::TodoMarker, AuditFinding::LegacyComment],
+            ),
+            run_test_coverage: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::MissingTestFile,
+                    AuditFinding::MissingTestMethod,
+                    AuditFinding::OrphanedTest,
+                    AuditFinding::VacuousTest,
+                ],
+            ),
+            run_layer_ownership: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::LayerOwnershipViolation],
+            ),
+            run_test_topology: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::InlineTestModule,
+                    AuditFinding::ScatteredTestFile,
+                ],
+            ),
+            run_docs: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::BrokenDocReference,
+                    AuditFinding::UndocumentedFeature,
+                    AuditFinding::StaleDocReference,
+                ],
+            ),
+            run_compiler_warnings: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::CompilerWarning],
+            ),
+            run_wrapper_inference: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::MissingWrapperDeclaration],
+            ),
+            run_shadow_modules: Self::family_enabled(only, exclude, &[AuditFinding::ShadowModule]),
+            run_field_patterns: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::RepeatedFieldPattern],
+            ),
+            run_facade_passthrough: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::FacadePassthrough],
+            ),
+            run_literal_shapes: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::RepeatedLiteralShape],
+            ),
+            run_deprecation_age: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::DeprecationAge],
+            ),
+            run_dead_guard: Self::family_enabled(only, exclude, &[AuditFinding::DeadGuard]),
+            run_requested_detectors: Self::family_enabled(
+                only,
+                exclude,
+                &[
+                    AuditFinding::JsonLikeExactMatch,
+                    AuditFinding::ConstantBackedSlugLiteral,
+                    AuditFinding::OptionScopeDrift,
+                ],
+            ),
+            run_global_env_guard: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::GlobalEnvMutationGuard],
+            ),
+            run_shared_scaffolding: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::SharedScaffolding],
+            ),
+        }
+    }
+
+    fn family_enabled(
+        only: &[AuditFinding],
+        exclude: &[AuditFinding],
+        emitted: &[AuditFinding],
+    ) -> bool {
+        let requested = only.is_empty() || emitted.iter().any(|kind| only.contains(kind));
+        let fully_excluded = emitted.iter().all(|kind| exclude.contains(kind));
+
+        requested && !fully_excluded
+    }
+
+    fn requires_discovery(&self) -> bool {
+        self.run_conventions
+            || self.run_duplication
+            || self.run_dead_code
+            || self.run_comment_hygiene
+            || self.run_test_coverage
+            || self.run_wrapper_inference
+            || self.run_shadow_modules
+            || self.run_facade_passthrough
+            || self.run_literal_shapes
+            || self.run_deprecation_age
+            || self.run_dead_guard
+            || self.run_requested_detectors
+            || self.run_global_env_guard
+            || self.run_shared_scaffolding
+    }
+}
+
 /// A cross-directory convention: a pattern that sibling subdirectories share.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DirectoryConvention {
@@ -218,7 +453,23 @@ pub fn audit_path(path: &str) -> Result<CodeAuditResult> {
 /// Also available for callers that have a component ID and an overridden path.
 pub fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeAuditResult> {
     let ref_paths = read_reference_paths_from_env();
-    audit_internal(component_id, source_path, None, None, &ref_paths)
+    audit_internal(
+        component_id,
+        source_path,
+        None,
+        None,
+        &ref_paths,
+        &AuditExecutionPlan::full(),
+    )
+}
+
+pub(crate) fn audit_path_with_id_with_plan(
+    component_id: &str,
+    source_path: &str,
+    plan: &AuditExecutionPlan,
+) -> Result<CodeAuditResult> {
+    let ref_paths = read_reference_paths_from_env();
+    audit_internal(component_id, source_path, None, None, &ref_paths, plan)
 }
 
 /// Audit only specific files within a component path.
@@ -244,6 +495,25 @@ pub fn audit_path_scoped(
         Some(file_filter),
         git_ref,
         &ref_paths,
+        &AuditExecutionPlan::full(),
+    )
+}
+
+pub(crate) fn audit_path_scoped_with_plan(
+    component_id: &str,
+    source_path: &str,
+    file_filter: &[String],
+    git_ref: Option<&str>,
+    plan: &AuditExecutionPlan,
+) -> Result<CodeAuditResult> {
+    let ref_paths = read_reference_paths_from_env();
+    audit_internal(
+        component_id,
+        source_path,
+        Some(file_filter),
+        git_ref,
+        &ref_paths,
+        plan,
     )
 }
 
@@ -282,6 +552,7 @@ fn audit_internal(
     file_filter: Option<&[String]>,
     git_ref: Option<&str>,
     reference_paths: &[String],
+    plan: &AuditExecutionPlan,
 ) -> Result<CodeAuditResult> {
     let root = Path::new(source_path);
     let audit_config = audit_config_for(component_id, root);
@@ -297,13 +568,25 @@ fn audit_internal(
         log_status!("audit", "Scanning {} for conventions...", source_path);
     }
 
+    if !plan.requires_discovery() {
+        return Ok(audit_root_only(component_id, source_path, root, plan));
+    }
+
     // Phase 1: Auto-discover file groups (always full codebase for convention detection)
     let discovery = discovery::auto_discover_groups(root);
     let files_skipped = discovery
         .files_walked
         .saturating_sub(discovery.files_fingerprinted);
-    let stale_cli_findings = stale_cli_invocation::run(root);
-    let cli_argument_findings = cli_invocation_arguments::run(root);
+    let stale_cli_findings = if plan.run_stale_cli_invocations {
+        stale_cli_invocation::run(root)
+    } else {
+        Vec::new()
+    };
+    let cli_argument_findings = if plan.run_cli_argument_shapes {
+        cli_invocation_arguments::run(root)
+    } else {
+        Vec::new()
+    };
 
     if discovery.groups.is_empty() {
         let mut warnings = Vec::new();
@@ -401,7 +684,11 @@ fn audit_internal(
     }
 
     // Phase 4b: Structural complexity analysis (god files, high item counts)
-    let structural_findings = structural::analyze_structure(root);
+    let structural_findings = if plan.run_structural {
+        structural::analyze_structure(root)
+    } else {
+        Vec::new()
+    };
     if !structural_findings.is_empty() {
         log_status!(
             "audit",
@@ -424,9 +711,16 @@ fn audit_internal(
     let convention_methods =
         build_convention_method_set(&discovered_conventions, &all_fingerprints);
 
-    let duplication_findings =
-        duplication::detect_duplicates(&all_fingerprints, &convention_methods);
-    let duplicate_groups = duplication::detect_duplicate_groups(&all_fingerprints);
+    let duplication_findings = if plan.run_duplication {
+        duplication::detect_duplicates(&all_fingerprints, &convention_methods)
+    } else {
+        Vec::new()
+    };
+    let duplicate_groups = if plan.run_duplication {
+        duplication::detect_duplicate_groups(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !duplication_findings.is_empty() {
         log_status!(
             "audit",
@@ -438,7 +732,11 @@ fn audit_internal(
     }
 
     // Phase 4c2: Intra-method duplication (duplicated blocks within a single method)
-    let intra_dup_findings = duplication::detect_intra_method_duplicates(&all_fingerprints);
+    let intra_dup_findings = if plan.run_duplication {
+        duplication::detect_intra_method_duplicates(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !intra_dup_findings.is_empty() {
         log_status!(
             "audit",
@@ -449,7 +747,11 @@ fn audit_internal(
     }
 
     // Phase 4d: Near-duplicate detection (structural similarity)
-    let near_dup_findings = duplication::detect_near_duplicates(&all_fingerprints);
+    let near_dup_findings = if plan.run_duplication {
+        duplication::detect_near_duplicates(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !near_dup_findings.is_empty() {
         log_status!(
             "audit",
@@ -460,8 +762,11 @@ fn audit_internal(
     }
 
     // Phase 4d2: Parallel implementation detection (similar call patterns across files)
-    let parallel_findings =
-        duplication::detect_parallel_implementations(&all_fingerprints, &convention_methods);
+    let parallel_findings = if plan.run_duplication {
+        duplication::detect_parallel_implementations(&all_fingerprints, &convention_methods)
+    } else {
+        Vec::new()
+    };
     if !parallel_findings.is_empty() {
         log_status!(
             "audit",
@@ -476,10 +781,17 @@ fn audit_internal(
     // Reference dependencies (e.g. WordPress core, plugin dependencies) are fingerprinted
     // and included in the cross-reference set so that functions called via framework hooks,
     // callbacks, or inherited methods are recognized as referenced.
-    let ref_fingerprints = fingerprint_reference_paths(reference_paths);
+    let ref_fingerprints = if plan.run_dead_code {
+        fingerprint_reference_paths(reference_paths)
+    } else {
+        Vec::new()
+    };
     let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = ref_fingerprints.iter().collect();
-    let dead_code_findings =
-        dead_code::analyze_dead_code_with_config(&all_fingerprints, &ref_fp_refs, &audit_config);
+    let dead_code_findings = if plan.run_dead_code {
+        dead_code::analyze_dead_code_with_config(&all_fingerprints, &ref_fp_refs, &audit_config)
+    } else {
+        Vec::new()
+    };
     if !dead_code_findings.is_empty() {
         log_status!(
             "audit",
@@ -490,7 +802,11 @@ fn audit_internal(
     }
 
     // Phase 4f: Comment hygiene detection (TODO/FIXME/HACK + stale phrasing)
-    let comment_findings = comment_hygiene::run(&all_fingerprints);
+    let comment_findings = if plan.run_comment_hygiene {
+        comment_hygiene::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !comment_findings.is_empty() {
         log_status!(
             "audit",
@@ -502,25 +818,27 @@ fn audit_internal(
 
     // Phase 4g: Structural test coverage gap detection
     // Look up the extension's test mapping config for the component.
-    if let Ok(comp) = component::load(component_id) {
-        if let Some(extensions) = &comp.extensions {
-            for ext_id in extensions.keys() {
-                if let Ok(ext_manifest) = crate::extension::load_extension(ext_id) {
-                    if let Some(test_mapping) = ext_manifest.test_mapping() {
-                        let coverage_findings = test_coverage::analyze_test_coverage(
-                            root,
-                            &all_fingerprints,
-                            test_mapping,
-                        );
-                        if !coverage_findings.is_empty() {
-                            log_status!(
-                                "audit",
-                                "Test coverage: {} finding(s) (missing test files, uncovered methods, orphaned tests)",
-                                coverage_findings.len()
+    if plan.run_test_coverage {
+        if let Ok(comp) = component::load(component_id) {
+            if let Some(extensions) = &comp.extensions {
+                for ext_id in extensions.keys() {
+                    if let Ok(ext_manifest) = crate::extension::load_extension(ext_id) {
+                        if let Some(test_mapping) = ext_manifest.test_mapping() {
+                            let coverage_findings = test_coverage::analyze_test_coverage(
+                                root,
+                                &all_fingerprints,
+                                test_mapping,
                             );
-                            all_findings.extend(coverage_findings);
+                            if !coverage_findings.is_empty() {
+                                log_status!(
+                                    "audit",
+                                    "Test coverage: {} finding(s) (missing test files, uncovered methods, orphaned tests)",
+                                    coverage_findings.len()
+                                );
+                                all_findings.extend(coverage_findings);
+                            }
+                            break; // Only use the first extension that has test_mapping
                         }
-                        break; // Only use the first extension that has test_mapping
                     }
                 }
             }
@@ -528,7 +846,11 @@ fn audit_internal(
     }
 
     // Phase 4h: Architecture/layer ownership rule checks (optional config)
-    let layer_findings = run_layer_ownership(root);
+    let layer_findings = if plan.run_layer_ownership {
+        run_layer_ownership(root)
+    } else {
+        Vec::new()
+    };
     if !layer_findings.is_empty() {
         log_status!(
             "audit",
@@ -539,7 +861,11 @@ fn audit_internal(
     }
 
     // Phase 4i: Test topology checks (extension-driven classification + central policy)
-    let topology_findings = test_topology::run(root);
+    let topology_findings = if plan.run_test_topology {
+        test_topology::run(root)
+    } else {
+        Vec::new()
+    };
     if !topology_findings.is_empty() {
         log_status!(
             "audit",
@@ -563,7 +889,11 @@ fn audit_internal(
     }
 
     // Phase 4j: Documentation drift detection (broken/stale references in markdown)
-    let doc_findings = detect_doc_drift(root, component_id);
+    let doc_findings = if plan.run_docs {
+        detect_doc_drift(root, component_id)
+    } else {
+        Vec::new()
+    };
     if !doc_findings.is_empty() {
         log_status!(
             "audit",
@@ -575,7 +905,11 @@ fn audit_internal(
 
     // Phase 4l: Compiler warnings (dead code, unused imports, unused variables)
     // Runs cargo check / tsc / go vet and parses warnings into findings.
-    let compiler_findings = compiler_warnings::run(root);
+    let compiler_findings = if plan.run_compiler_warnings {
+        compiler_warnings::run(root)
+    } else {
+        Vec::new()
+    };
     if !compiler_findings.is_empty() {
         log_status!(
             "audit",
@@ -588,7 +922,11 @@ fn audit_internal(
     // Phase 4m: Wrapper-to-implementation inference
     // Detects wrapper files missing explicit declarations of what they wrap.
     // Uses configurable call pattern tracing to infer the implementation target.
-    let wrapper_findings = wrapper_inference::analyze_wrappers(&all_fingerprints, root);
+    let wrapper_findings = if plan.run_wrapper_inference {
+        wrapper_inference::analyze_wrappers(&all_fingerprints, root)
+    } else {
+        Vec::new()
+    };
     if !wrapper_findings.is_empty() {
         log_status!(
             "audit",
@@ -599,7 +937,11 @@ fn audit_internal(
     }
 
     // Phase 4n: Shadow module detection — directories that are near-copies.
-    let shadow_findings = shadow_modules::run(&all_fingerprints);
+    let shadow_findings = if plan.run_shadow_modules {
+        shadow_modules::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !shadow_findings.is_empty() {
         log_status!(
             "audit",
@@ -610,7 +952,11 @@ fn audit_internal(
     }
 
     // Phase 4o: Repeated struct field pattern detection.
-    let field_pattern_findings = field_patterns::run(root);
+    let field_pattern_findings = if plan.run_field_patterns {
+        field_patterns::run(root)
+    } else {
+        Vec::new()
+    };
     if !field_pattern_findings.is_empty() {
         log_status!(
             "audit",
@@ -622,7 +968,11 @@ fn audit_internal(
 
     // Phase 4t: Facade-passthrough detection — classes whose public methods
     // mostly delegate to an inner member without adding behavior.
-    let facade_findings = facade_passthrough::run(&all_fingerprints);
+    let facade_findings = if plan.run_facade_passthrough {
+        facade_passthrough::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !facade_findings.is_empty() {
         log_status!(
             "audit",
@@ -633,7 +983,11 @@ fn audit_internal(
     }
 
     // Phase 4u: Repeated inline array literal shape detection.
-    let literal_shape_findings = repeated_literal_shape::run(&all_fingerprints);
+    let literal_shape_findings = if plan.run_literal_shapes {
+        repeated_literal_shape::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !literal_shape_findings.is_empty() {
         log_status!(
             "audit",
@@ -644,7 +998,11 @@ fn audit_internal(
     }
 
     // Phase 4r: Deprecation age detection
-    let deprecation_findings = deprecation_age::run(&all_fingerprints, root);
+    let deprecation_findings = if plan.run_deprecation_age {
+        deprecation_age::run(&all_fingerprints, root)
+    } else {
+        Vec::new()
+    };
     if !deprecation_findings.is_empty() {
         log_status!(
             "audit",
@@ -657,7 +1015,11 @@ fn audit_internal(
     // Phase 4q: Dead guard detection — flag function_exists/class_exists/defined
     // guards on symbols guaranteed to exist given plugin requirements, composer
     // dependencies, and bootstrap requires.
-    let dead_guard_findings = dead_guard::run_with_config(&all_fingerprints, root, &audit_config);
+    let dead_guard_findings = if plan.run_dead_guard {
+        dead_guard::run_with_config(&all_fingerprints, root, &audit_config)
+    } else {
+        Vec::new()
+    };
     if !dead_guard_findings.is_empty() {
         log_status!(
             "audit",
@@ -668,7 +1030,11 @@ fn audit_internal(
     }
 
     // Phase 4t: Requested drift detectors for common WordPress/PHP hazards.
-    let requested_findings = requested_detectors::run(&all_fingerprints);
+    let requested_findings = if plan.run_requested_detectors {
+        requested_detectors::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !requested_findings.is_empty() {
         log_status!(
             "audit",
@@ -679,7 +1045,11 @@ fn audit_internal(
     }
 
     // Phase 4v: Process-global environment mutation guard consistency in tests.
-    let env_guard_findings = global_env_guard::run(&all_fingerprints);
+    let env_guard_findings = if plan.run_global_env_guard {
+        global_env_guard::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !env_guard_findings.is_empty() {
         log_status!(
             "audit",
@@ -691,7 +1061,11 @@ fn audit_internal(
 
     // Phase 4s: Shared scaffolding detection — groups of classes sharing the
     // same method-shape AND high body similarity, candidates for a shared base.
-    let scaffolding_findings = shared_scaffolding::run(&all_fingerprints);
+    let scaffolding_findings = if plan.run_shared_scaffolding {
+        shared_scaffolding::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
     if !scaffolding_findings.is_empty() {
         log_status!(
             "audit",
@@ -840,6 +1214,135 @@ fn audit_internal(
         findings: all_findings,
         duplicate_groups,
     })
+}
+
+fn audit_root_only(
+    component_id: &str,
+    source_path: &str,
+    root: &Path,
+    plan: &AuditExecutionPlan,
+) -> CodeAuditResult {
+    let mut findings = Vec::new();
+
+    if plan.run_stale_cli_invocations {
+        let stale_cli_findings = stale_cli_invocation::run(root);
+        if !stale_cli_findings.is_empty() {
+            log_status!(
+                "audit",
+                "CLI invocations: {} finding(s) (stale Homeboy command arrays)",
+                stale_cli_findings.len()
+            );
+            findings.extend(stale_cli_findings);
+        }
+    }
+
+    if plan.run_cli_argument_shapes {
+        let cli_argument_findings = cli_invocation_arguments::run(root);
+        if !cli_argument_findings.is_empty() {
+            log_status!(
+                "audit",
+                "CLI argument shapes: {} finding(s) (stale Homeboy shell-out forms)",
+                cli_argument_findings.len()
+            );
+            findings.extend(cli_argument_findings);
+        }
+    }
+
+    if plan.run_structural {
+        let structural_findings = structural::analyze_structure(root);
+        if !structural_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Structural: {} finding(s) (god files, high item counts)",
+                structural_findings.len()
+            );
+            findings.extend(structural_findings);
+        }
+    }
+
+    if plan.run_layer_ownership {
+        let layer_findings = run_layer_ownership(root);
+        if !layer_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Layer ownership: {} finding(s) (architecture ownership violations)",
+                layer_findings.len()
+            );
+            findings.extend(layer_findings);
+        }
+    }
+
+    if plan.run_test_topology {
+        let topology_findings = test_topology::run(root);
+        if !topology_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Test topology: {} finding(s) (inline/scattered test placement)",
+                topology_findings.len()
+            );
+            findings.extend(topology_findings);
+        }
+    }
+
+    if plan.run_docs {
+        let doc_findings = detect_doc_drift(root, component_id);
+        if !doc_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Docs: {} finding(s) (broken references, stale paths)",
+                doc_findings.len()
+            );
+            findings.extend(doc_findings);
+        }
+    }
+
+    if plan.run_compiler_warnings {
+        let compiler_findings = compiler_warnings::run(root);
+        if !compiler_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Compiler warnings: {} finding(s) (dead code, unused imports, unused variables)",
+                compiler_findings.len()
+            );
+            findings.extend(compiler_findings);
+        }
+    }
+
+    if plan.run_field_patterns {
+        let field_pattern_findings = field_patterns::run(root);
+        if !field_pattern_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Field patterns: {} finding(s) (repeated struct fields)",
+                field_pattern_findings.len()
+            );
+            findings.extend(field_pattern_findings);
+        }
+    }
+
+    let outliers_found = findings.len();
+    log_status!(
+        "audit",
+        "Complete: root-only filtered run, {} finding(s)",
+        outliers_found
+    );
+
+    CodeAuditResult {
+        component_id: component_id.to_string(),
+        source_path: source_path.to_string(),
+        summary: AuditSummary {
+            files_scanned: 0,
+            conventions_detected: 0,
+            outliers_found,
+            alignment_score: None,
+            files_skipped: 0,
+            warnings: vec![],
+        },
+        conventions: vec![],
+        directory_conventions: vec![],
+        findings,
+        duplicate_groups: vec![],
+    }
 }
 
 // ============================================================================

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -123,6 +123,7 @@ pub(crate) struct AuditExecutionPlan {
     pub(crate) run_test_coverage: bool,
     pub(crate) run_layer_ownership: bool,
     pub(crate) run_test_topology: bool,
+    pub(crate) run_rust_test_wiring: bool,
     pub(crate) run_docs: bool,
     pub(crate) run_compiler_warnings: bool,
     pub(crate) run_wrapper_inference: bool,
@@ -150,6 +151,7 @@ impl AuditExecutionPlan {
             run_test_coverage: true,
             run_layer_ownership: true,
             run_test_topology: true,
+            run_rust_test_wiring: true,
             run_docs: true,
             run_compiler_warnings: true,
             run_wrapper_inference: true,
@@ -253,6 +255,11 @@ impl AuditExecutionPlan {
                     AuditFinding::InlineTestModule,
                     AuditFinding::ScatteredTestFile,
                 ],
+            ),
+            run_rust_test_wiring: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::UnwiredNestedRustTest],
             ),
             run_docs: Self::family_enabled(
                 only,
@@ -878,7 +885,11 @@ fn audit_internal(
     // Phase 4i2: Rust nested test harness wiring checks. Cargo only
     // auto-discovers direct `tests/*.rs` integration tests; nested tests need
     // explicit `#[path = "..."]` wiring from a source module.
-    let rust_test_wiring_findings = rust_test_wiring::run(root);
+    let rust_test_wiring_findings = if plan.run_rust_test_wiring {
+        rust_test_wiring::run(root)
+    } else {
+        Vec::new()
+    };
     if !rust_test_wiring_findings.is_empty() {
         log_status!(
             "audit",
@@ -1281,6 +1292,18 @@ fn audit_root_only(
                 topology_findings.len()
             );
             findings.extend(topology_findings);
+        }
+    }
+
+    if plan.run_rust_test_wiring {
+        let rust_test_wiring_findings = rust_test_wiring::run(root);
+        if !rust_test_wiring_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Rust test wiring: {} finding(s) (nested tests not wired into Cargo)",
+                rust_test_wiring_findings.len()
+            );
+            findings.extend(rust_test_wiring_findings);
         }
     }
 

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -180,6 +180,20 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
         return None;
     }
 
+    if !result.findings.is_empty()
+        && result.findings.iter().all(|finding| {
+            matches!(
+                finding.kind,
+                AuditFinding::GodFile | AuditFinding::HighItemCount | AuditFinding::DirectorySprawl
+            )
+        })
+    {
+        // Structural decompose planning can be much more expensive than audit
+        // reporting. Keep filtered read-only audits fast; `homeboy refactor`
+        // remains the explicit path for planning those changes.
+        return None;
+    }
+
     // Generate fix plan (dry-run — never writes)
     let mut fix_result = crate::refactor::plan::generate::generate_audit_fixes(
         result,

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -129,22 +129,30 @@ fn apply_finding_filters(
 
 /// Run the audit scan (scoped or full). Returns None if changed-since found no files.
 fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<CodeAuditResult>> {
+    let plan = if args.baseline_flags.baseline {
+        code_audit::AuditExecutionPlan::full()
+    } else {
+        code_audit::AuditExecutionPlan::from_filters(&args.only_kinds, &args.exclude_kinds)
+    };
+
     if let Some(ref git_ref) = args.changed_since {
         let changed = git::get_files_changed_since(&args.source_path, git_ref)?;
         if changed.is_empty() {
             crate::log_status!("audit", "No files changed since {}", git_ref);
             return Ok(None);
         }
-        Ok(Some(code_audit::audit_path_scoped(
+        Ok(Some(code_audit::audit_path_scoped_with_plan(
             &args.component_id,
             &args.source_path,
             &changed,
             Some(git_ref),
+            &plan,
         )?))
     } else {
-        Ok(Some(code_audit::audit_path_with_id(
+        Ok(Some(code_audit::audit_path_with_id_with_plan(
             &args.component_id,
             &args.source_path,
+            &plan,
         )?))
     }
 }

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -3,7 +3,7 @@ use crate::code_audit::report::{
     AuditCommandOutput,
 };
 use crate::code_audit::test_helpers::{empty_result, make_finding};
-use crate::code_audit::{AuditFinding, FindingConfidence, Severity};
+use crate::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
 
 #[test]
 fn test_build_audit_summary_empty_result() {
@@ -103,6 +103,21 @@ fn test_compute_fixability_returns_none_for_nonexistent_path() {
     result.findings.push(make_finding(Severity::Warning));
     let fixability = compute_fixability(&result);
     assert!(fixability.is_none());
+}
+
+#[test]
+fn test_compute_fixability_skips_structural_only_results() {
+    let mut result = empty_result();
+    result.findings.push(Finding {
+        convention: "structural".to_string(),
+        severity: Severity::Warning,
+        file: "src/big.rs".to_string(),
+        description: "File has 1200 lines".to_string(),
+        suggestion: "Consider decomposing into focused modules".to_string(),
+        kind: AuditFinding::GodFile,
+    });
+
+    assert!(compute_fixability(&result).is_none());
 }
 
 #[test]

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -4,7 +4,7 @@
 
 use super::apply_finding_filters;
 use crate::code_audit::findings::{Finding, Severity};
-use crate::code_audit::{AuditFinding, AuditSummary, CodeAuditResult};
+use crate::code_audit::{AuditExecutionPlan, AuditFinding, AuditSummary, CodeAuditResult};
 
 fn make_finding(kind: AuditFinding, file: &str) -> Finding {
     Finding {
@@ -120,4 +120,32 @@ fn only_with_no_matches_leaves_zero_findings_and_clean_exit() {
 
     assert!(result.findings.is_empty());
     assert_eq!(result.summary.outliers_found, 0);
+}
+
+#[test]
+fn execution_plan_for_structural_only_skips_unrelated_detector_families() {
+    let plan = AuditExecutionPlan::from_filters(&[AuditFinding::GodFile], &[]);
+
+    assert!(plan.run_structural);
+    assert!(!plan.run_conventions);
+    assert!(!plan.run_duplication);
+    assert!(!plan.run_dead_code);
+    assert!(!plan.run_compiler_warnings);
+}
+
+#[test]
+fn execution_plan_for_duplicate_only_skips_structural_detector_family() {
+    let plan = AuditExecutionPlan::from_filters(&[AuditFinding::DuplicateFunction], &[]);
+
+    assert!(plan.run_duplication);
+    assert!(!plan.run_structural);
+    assert!(!plan.run_conventions);
+}
+
+#[test]
+fn execution_plan_is_full_without_filters() {
+    assert_eq!(
+        AuditExecutionPlan::from_filters(&[], &[]),
+        AuditExecutionPlan::full()
+    );
 }

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -143,6 +143,15 @@ fn execution_plan_for_duplicate_only_skips_structural_detector_family() {
 }
 
 #[test]
+fn execution_plan_for_unwired_nested_rust_test_runs_wiring_detector() {
+    let plan = AuditExecutionPlan::from_filters(&[AuditFinding::UnwiredNestedRustTest], &[]);
+
+    assert!(plan.run_rust_test_wiring);
+    assert!(!plan.run_test_topology);
+    assert!(!plan.run_conventions);
+}
+
+#[test]
 fn execution_plan_is_full_without_filters() {
     assert_eq!(
         AuditExecutionPlan::from_filters(&[], &[]),


### PR DESCRIPTION
## Summary
- Adds an audit execution plan so filtered runs skip detector families that cannot emit requested finding kinds.
- Adds a root-only fast path for structural/root scanners so `--only god_file` avoids convention discovery and fingerprint-dependent work.
- Keeps baseline saves on the full execution plan so filtered flags do not persist partial baselines.

## Behavior
- `--only god_file` runs structural detection directly and leaves the final finding filter in place as a safety net.
- `--only duplicate_function` still runs the fingerprint/discovery pipeline it needs, but skips structural detection.
- Structural-only summaries skip expensive decompose fixability planning; `homeboy refactor` remains the explicit path for planning those changes.

## Tests
- `cargo test audit`
- `cargo test structural`
- `cargo test report`
- `cargo run --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@fix-filtered-audit-execution --changed-since origin/main --ignore-baseline --json-summary`
- `/usr/bin/time -p cargo run --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@fix-filtered-audit-execution --only god_file --ignore-baseline --json-summary` (4.86s, 26 god_file findings)
- `cargo test -- --test-threads=1` (1854 passed, 0 failed, 1 ignored)

Closes #1753

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented filtered audit execution planning and validation under Chris's review.