### PR TITLE
fix(rig): include nvm node bins in command path

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -141,7 +141,7 @@ Applies or verifies an idempotent local-only file patch. `marker` must appear in
 
 Runs via `sh -c`. `cwd`, `command`, and `env` values all support variable expansion. `label` is optional; without it, the command string itself is used in status output.
 
-Command steps bootstrap a portable developer-tool PATH unless the step explicitly sets `env.PATH`. Homeboy prepends existing common bin directories (`$HOME/.local/bin`, `$HOME/.cargo/bin`, `$HOME/.kimaki/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) before the inherited `PATH`. Missing directories are ignored. If a tool lives somewhere else, set `env.PATH` on the step or prefer a typed primitive such as `build`, `git`, or `check` when one fits.
+Command steps bootstrap a portable developer-tool PATH unless the step explicitly sets `env.PATH`. Homeboy prepends existing common bin directories (`$HOME/.local/bin`, `$HOME/.cargo/bin`, `$HOME/.kimaki/bin`, `$HOME/.nvm/versions/node/*/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) before the inherited `PATH`. Missing directories are ignored. If a tool lives somewhere else, set `env.PATH` on the step or prefer a typed primitive such as `build`, `git`, or `check` when one fits.
 
 **Escape hatch — use sparingly.** If a step maps to `build`, `git`, or `check`, use those instead. Generic commands lose homeboy's error formatting, extension integration, and structured output.
 

--- a/src/core/rig/toolchain.rs
+++ b/src/core/rig/toolchain.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 const HOME_BIN_DIRS: &[&str] = &[".local/bin", ".cargo/bin", ".kimaki/bin"];
@@ -36,6 +37,7 @@ fn build_command_step_path_with_absolute_dirs(
         for rel in HOME_BIN_DIRS {
             push_existing_path(&mut paths, &mut seen, home.join(rel));
         }
+        push_nvm_node_bins(&mut paths, &mut seen, home);
     }
 
     for path in absolute_dirs {
@@ -58,6 +60,24 @@ fn build_command_step_path_with_absolute_dirs(
 fn push_existing_path(paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
     if path.exists() {
         push_path(paths, seen, path);
+    }
+}
+
+fn push_nvm_node_bins(paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, home: &Path) {
+    let versions_dir = home.join(".nvm/versions/node");
+    let Ok(entries) = fs::read_dir(versions_dir) else {
+        return;
+    };
+
+    let mut bins = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path().join("bin")))
+        .filter(|path| path.exists())
+        .collect::<Vec<_>>();
+    bins.sort();
+    bins.reverse();
+
+    for bin in bins {
+        push_path(paths, seen, bin);
     }
 }
 
@@ -94,6 +114,25 @@ mod tests {
         assert!(parts.contains(&PathBuf::from("/usr/bin")));
         assert!(parts.contains(&PathBuf::from("/bin")));
         assert!(!parts.contains(&home.join(".kimaki/bin")));
+    }
+
+    #[test]
+    fn test_command_step_path_prepends_nvm_node_bins() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let home = tmp.path().join("home");
+        let node_20 = home.join(".nvm/versions/node/v20.0.0/bin");
+        let node_24 = home.join(".nvm/versions/node/v24.13.1/bin");
+        fs::create_dir_all(&node_20).expect("node 20 bin");
+        fs::create_dir_all(&node_24).expect("node 24 bin");
+
+        let inherited = OsString::from("/usr/bin:/bin");
+        let path = build_command_step_path_with_absolute_dirs(Some(&home), Some(&inherited), &[])
+            .expect("path");
+        let parts = std::env::split_paths(&path).collect::<Vec<_>>();
+
+        assert_eq!(parts[0], node_24);
+        assert_eq!(parts[1], node_20);
+        assert!(parts.contains(&PathBuf::from("/usr/bin")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Include existing `~/.nvm/versions/node/*/bin` directories in rig command-step PATH bootstrapping.
- Keep explicit `env.PATH` override behavior unchanged.
- Document the NVM path discovery alongside other common developer-tool bins.

## Tests
- `cargo test toolchain -- --test-threads=1`
- `cargo test command_step -- --test-threads=1`

## Context
This is a follow-up to #1768. The initial portable PATH list handled Homebrew/local/cargo/kimaki bins, but this host's `npm` lives under NVM, so `homeboy rig up studio-agent-sdk` still failed with `npm: command not found`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining NVM PATH gap after #1768, implemented the generic discovery helper, added focused coverage, and prepared the PR. Chris remains responsible for review and merge.