### PR TITLE
feat(rig): guard active resource leases

### DIFF
--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -136,6 +136,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
 
         ErrorCode::RigPipelineFailed
         | ErrorCode::RigServiceFailed
+        | ErrorCode::RigResourceConflict
         | ErrorCode::StackApplyConflict => 20,
 
         ErrorCode::SshServerInvalid

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -32,6 +32,7 @@ pub enum ErrorCode {
     RigNotFound,
     RigPipelineFailed,
     RigServiceFailed,
+    RigResourceConflict,
     StackNotFound,
     StackApplyConflict,
 
@@ -78,6 +79,7 @@ impl ErrorCode {
             ErrorCode::RigNotFound => "rig.not_found",
             ErrorCode::RigPipelineFailed => "rig.pipeline_failed",
             ErrorCode::RigServiceFailed => "rig.service_failed",
+            ErrorCode::RigResourceConflict => "rig.resource_conflict",
             ErrorCode::StackNotFound => "stack.not_found",
             ErrorCode::StackApplyConflict => "stack.apply_conflict",
 
@@ -187,6 +189,18 @@ pub struct InvalidArgumentDetails {
     pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tried: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RigResourceConflictInfo {
+    pub rig_id: String,
+    pub command: String,
+    pub resource_kind: String,
+    pub resource_value: String,
+    pub held_by_rig: String,
+    pub held_by_command: String,
+    pub held_by_pid: u32,
+    pub held_since: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -478,6 +492,35 @@ impl Error {
                 "rig_id": rig_id,
                 "service_id": service_id,
                 "reason": reason,
+            }),
+        )
+    }
+
+    pub fn rig_resource_conflict(info: RigResourceConflictInfo) -> Self {
+        Self::new(
+            ErrorCode::RigResourceConflict,
+            format!(
+                "Rig '{}' cannot run '{}': {} resource '{}' is already held by rig '{}' running '{}' (pid {}, since {})",
+                info.rig_id,
+                info.command,
+                info.resource_kind,
+                info.resource_value,
+                info.held_by_rig,
+                info.held_by_command,
+                info.held_by_pid,
+                info.held_since
+            ),
+            serde_json::json!({
+                "rig_id": info.rig_id,
+                "command": info.command,
+                "resource_kind": info.resource_kind,
+                "resource_value": info.resource_value,
+                "held_by": {
+                    "rig_id": info.held_by_rig,
+                    "command": info.held_by_command,
+                    "pid": info.held_by_pid,
+                    "since": info.held_since,
+                }
             }),
         )
     }

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -116,6 +116,11 @@ pub fn rig_logs_dir(id: &str) -> Result<PathBuf> {
     Ok(rig_state_dir(id)?.join("logs"))
 }
 
+/// Active rig run leases (~/.config/homeboy/rig-leases/).
+pub fn rig_leases_dir() -> Result<PathBuf> {
+    Ok(homeboy()?.join("rig-leases"))
+}
+
 /// Stacks directory (~/.config/homeboy/stacks/)
 pub fn stacks() -> Result<PathBuf> {
     Ok(homeboy()?.join("stacks"))

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -8,19 +8,15 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::thread;
-use std::time::{Duration, SystemTime};
+
+mod lock;
 
 use super::expand::expand_resources;
 use super::spec::{RigResourcesSpec, RigSpec};
 use super::state::now_rfc3339;
 use crate::error::{Error, Result, RigResourceConflictInfo};
 use crate::paths;
-
-const INDEX_LOCK_NAME: &str = ".index.lock";
-const INDEX_LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
-const INDEX_LOCK_ATTEMPTS: usize = 100;
-const INDEX_LOCK_SLEEP: Duration = Duration::from_millis(20);
+use lock::LeaseIndexLock;
 
 /// On-disk lease held by one active mutating rig command.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -252,68 +248,6 @@ fn sanitize_id(id: &str) -> String {
             }
         })
         .collect()
-}
-
-struct LeaseIndexLock {
-    path: PathBuf,
-}
-
-impl LeaseIndexLock {
-    fn acquire() -> Result<Self> {
-        let dir = paths::rig_leases_dir()?;
-        fs::create_dir_all(&dir).map_err(|e| {
-            Error::internal_unexpected(format!("Failed to create rig lease directory: {}", e))
-        })?;
-        let path = dir.join(INDEX_LOCK_NAME);
-        for _ in 0..INDEX_LOCK_ATTEMPTS {
-            match fs::create_dir(&path) {
-                Ok(()) => return Ok(Self { path }),
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    remove_stale_index_lock(&path)?;
-                    thread::sleep(INDEX_LOCK_SLEEP);
-                }
-                Err(e) => {
-                    return Err(Error::internal_unexpected(format!(
-                        "Failed to acquire rig lease lock {}: {}",
-                        path.display(),
-                        e
-                    )))
-                }
-            }
-        }
-        Err(Error::internal_unexpected(format!(
-            "Timed out acquiring rig lease lock {}",
-            path.display()
-        )))
-    }
-}
-
-impl Drop for LeaseIndexLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir(&self.path);
-    }
-}
-
-fn remove_stale_index_lock(path: &Path) -> Result<()> {
-    let Ok(metadata) = fs::metadata(path) else {
-        return Ok(());
-    };
-    let Ok(modified) = metadata.modified() else {
-        return Ok(());
-    };
-    if SystemTime::now()
-        .duration_since(modified)
-        .is_ok_and(|age| age > INDEX_LOCK_STALE_AFTER)
-    {
-        fs::remove_dir(path).map_err(|e| {
-            Error::internal_unexpected(format!(
-                "Failed to remove stale rig lease lock {}: {}",
-                path.display(),
-                e
-            ))
-        })?;
-    }
-    Ok(())
 }
 
 fn pid_is_live(pid: u32) -> bool {

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -1,0 +1,341 @@
+//! Active-run leases for mutating rig commands.
+//!
+//! These leases are local-machine guardrails. They prevent two concurrent rig
+//! commands from mutating the same declared resources at the same time; they do
+//! not represent the long-lived state of a materialized rig after `rig up`
+//! exits.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, SystemTime};
+
+use super::expand::expand_resources;
+use super::spec::{RigResourcesSpec, RigSpec};
+use super::state::now_rfc3339;
+use crate::error::{Error, Result, RigResourceConflictInfo};
+use crate::paths;
+
+const INDEX_LOCK_NAME: &str = ".index.lock";
+const INDEX_LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
+const INDEX_LOCK_ATTEMPTS: usize = 100;
+const INDEX_LOCK_SLEEP: Duration = Duration::from_millis(20);
+
+/// On-disk lease held by one active mutating rig command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RigRunLease {
+    pub rig_id: String,
+    pub command: String,
+    pub pid: u32,
+    pub started_at: String,
+    pub resources: RigResourcesSpec,
+}
+
+/// RAII guard that removes the lease when the command exits normally or with an
+/// error. Process crashes are handled by stale-PID cleanup on the next acquire.
+#[derive(Debug)]
+pub struct ActiveRigRunLease {
+    rig_id: String,
+    pid: u32,
+}
+
+impl Drop for ActiveRigRunLease {
+    fn drop(&mut self) {
+        let Ok(_lock) = LeaseIndexLock::acquire() else {
+            return;
+        };
+        let Ok(path) = lease_path(&self.rig_id) else {
+            return;
+        };
+        let Ok(Some(lease)) = read_lease(&path) else {
+            return;
+        };
+        if lease.pid == self.pid {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+/// Acquire an active-run lease for a mutating rig command.
+pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<ActiveRigRunLease>> {
+    let resources = expand_resources(rig);
+    if resources.is_empty() {
+        return Ok(None);
+    }
+
+    let _lock = LeaseIndexLock::acquire()?;
+    fs::create_dir_all(paths::rig_leases_dir()?).map_err(|e| {
+        Error::internal_unexpected(format!("Failed to create rig lease directory: {}", e))
+    })?;
+
+    prune_stale_leases()?;
+    if let Some(conflict) = find_conflict(rig, &resources)? {
+        return Err(Error::rig_resource_conflict(RigResourceConflictInfo {
+            rig_id: rig.id.clone(),
+            command: command.to_string(),
+            resource_kind: conflict.resource_kind,
+            resource_value: conflict.resource_value,
+            held_by_rig: conflict.lease.rig_id,
+            held_by_command: conflict.lease.command,
+            held_by_pid: conflict.lease.pid,
+            held_since: conflict.lease.started_at,
+        }));
+    }
+
+    let pid = std::process::id();
+    let lease = RigRunLease {
+        rig_id: rig.id.clone(),
+        command: command.to_string(),
+        pid,
+        started_at: now_rfc3339(),
+        resources,
+    };
+    let json = serde_json::to_string_pretty(&lease)
+        .map_err(|e| Error::internal_unexpected(format!("Failed to serialize rig lease: {}", e)))?;
+    fs::write(lease_path(&rig.id)?, json).map_err(|e| {
+        Error::internal_unexpected(format!("Failed to write rig lease for '{}': {}", rig.id, e))
+    })?;
+
+    Ok(Some(ActiveRigRunLease {
+        rig_id: rig.id.clone(),
+        pid,
+    }))
+}
+
+struct ResourceConflict {
+    lease: RigRunLease,
+    resource_kind: String,
+    resource_value: String,
+}
+
+fn find_conflict(rig: &RigSpec, resources: &RigResourcesSpec) -> Result<Option<ResourceConflict>> {
+    for lease in live_leases()? {
+        if lease.rig_id == rig.id {
+            return Ok(Some(ResourceConflict {
+                resource_kind: "rig".to_string(),
+                resource_value: rig.id.clone(),
+                lease,
+            }));
+        }
+        if let Some((kind, value)) = overlapping_resource(resources, &lease.resources) {
+            return Ok(Some(ResourceConflict {
+                lease,
+                resource_kind: kind,
+                resource_value: value,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+fn overlapping_resource(
+    wanted: &RigResourcesSpec,
+    held: &RigResourcesSpec,
+) -> Option<(String, String)> {
+    for token in &wanted.exclusive {
+        if held.exclusive.contains(token) {
+            return Some(("exclusive".to_string(), token.clone()));
+        }
+    }
+    for port in &wanted.ports {
+        if held.ports.contains(port) {
+            return Some(("port".to_string(), port.to_string()));
+        }
+    }
+    for pattern in &wanted.process_patterns {
+        if held.process_patterns.contains(pattern) {
+            return Some(("process_pattern".to_string(), pattern.clone()));
+        }
+    }
+    for wanted_path in &wanted.paths {
+        for held_path in &held.paths {
+            if paths_overlap(wanted_path, held_path) {
+                return Some(("path".to_string(), wanted_path.clone()));
+            }
+        }
+    }
+    None
+}
+
+fn paths_overlap(a: &str, b: &str) -> bool {
+    let a = Path::new(a);
+    let b = Path::new(b);
+    a == b || a.starts_with(b) || b.starts_with(a)
+}
+
+fn prune_stale_leases() -> Result<()> {
+    for path in lease_files()? {
+        let Some(lease) = read_lease(&path)? else {
+            continue;
+        };
+        if !pid_is_live(lease.pid) {
+            fs::remove_file(&path).map_err(|e| {
+                Error::internal_unexpected(format!(
+                    "Failed to remove stale rig lease {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn live_leases() -> Result<Vec<RigRunLease>> {
+    let mut leases = Vec::new();
+    for path in lease_files()? {
+        if let Some(lease) = read_lease(&path)? {
+            if pid_is_live(lease.pid) {
+                leases.push(lease);
+            }
+        }
+    }
+    Ok(leases)
+}
+
+fn lease_files() -> Result<Vec<PathBuf>> {
+    let dir = paths::rig_leases_dir()?;
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|e| {
+        Error::internal_unexpected(format!("Failed to read rig lease directory: {}", e))
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_unexpected(format!("Failed to read rig lease entry: {}", e))
+        })?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "json") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn read_lease(path: &Path) -> Result<Option<RigRunLease>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(path).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to read rig lease {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    if content.trim().is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str(&content).map(Some).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse rig lease {}", path.display())),
+            Some(content.chars().take(200).collect()),
+        )
+    })
+}
+
+fn lease_path(rig_id: &str) -> Result<PathBuf> {
+    Ok(paths::rig_leases_dir()?.join(format!("{}.json", sanitize_id(rig_id))))
+}
+
+fn sanitize_id(id: &str) -> String {
+    id.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+struct LeaseIndexLock {
+    path: PathBuf,
+}
+
+impl LeaseIndexLock {
+    fn acquire() -> Result<Self> {
+        let dir = paths::rig_leases_dir()?;
+        fs::create_dir_all(&dir).map_err(|e| {
+            Error::internal_unexpected(format!("Failed to create rig lease directory: {}", e))
+        })?;
+        let path = dir.join(INDEX_LOCK_NAME);
+        for _ in 0..INDEX_LOCK_ATTEMPTS {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    remove_stale_index_lock(&path)?;
+                    thread::sleep(INDEX_LOCK_SLEEP);
+                }
+                Err(e) => {
+                    return Err(Error::internal_unexpected(format!(
+                        "Failed to acquire rig lease lock {}: {}",
+                        path.display(),
+                        e
+                    )))
+                }
+            }
+        }
+        Err(Error::internal_unexpected(format!(
+            "Timed out acquiring rig lease lock {}",
+            path.display()
+        )))
+    }
+}
+
+impl Drop for LeaseIndexLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+fn remove_stale_index_lock(path: &Path) -> Result<()> {
+    let Ok(metadata) = fs::metadata(path) else {
+        return Ok(());
+    };
+    let Ok(modified) = metadata.modified() else {
+        return Ok(());
+    };
+    if SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age > INDEX_LOCK_STALE_AFTER)
+    {
+        fs::remove_dir(path).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to remove stale rig lease lock {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn pid_is_live(pid: u32) -> bool {
+    if pid == std::process::id() {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/rig/lease_test.rs"]
+mod lease_test;

--- a/src/core/rig/lease/lock.rs
+++ b/src/core/rig/lease/lock.rs
@@ -1,0 +1,74 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, SystemTime};
+
+use crate::error::{Error, Result};
+use crate::paths;
+
+const INDEX_LOCK_NAME: &str = ".index.lock";
+const INDEX_LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
+const INDEX_LOCK_ATTEMPTS: usize = 100;
+const INDEX_LOCK_SLEEP: Duration = Duration::from_millis(20);
+
+pub(super) struct LeaseIndexLock {
+    path: PathBuf,
+}
+
+impl LeaseIndexLock {
+    pub(super) fn acquire() -> Result<Self> {
+        let dir = paths::rig_leases_dir()?;
+        fs::create_dir_all(&dir).map_err(|e| {
+            Error::internal_unexpected(format!("Failed to create rig lease directory: {}", e))
+        })?;
+        let path = dir.join(INDEX_LOCK_NAME);
+        for _ in 0..INDEX_LOCK_ATTEMPTS {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    remove_stale_index_lock(&path)?;
+                    thread::sleep(INDEX_LOCK_SLEEP);
+                }
+                Err(e) => {
+                    return Err(Error::internal_unexpected(format!(
+                        "Failed to acquire rig lease lock {}: {}",
+                        path.display(),
+                        e
+                    )))
+                }
+            }
+        }
+        Err(Error::internal_unexpected(format!(
+            "Timed out acquiring rig lease lock {}",
+            path.display()
+        )))
+    }
+}
+
+impl Drop for LeaseIndexLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+fn remove_stale_index_lock(path: &Path) -> Result<()> {
+    let Ok(metadata) = fs::metadata(path) else {
+        return Ok(());
+    };
+    let Ok(modified) = metadata.modified() else {
+        return Ok(());
+    };
+    if SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age > INDEX_LOCK_STALE_AFTER)
+    {
+        fs::remove_dir(path).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to remove stale rig lease lock {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+    }
+    Ok(())
+}

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -21,6 +21,7 @@ pub mod app;
 pub mod check;
 pub mod expand;
 pub mod install;
+pub mod lease;
 pub mod pipeline;
 pub mod runner;
 pub mod service;
@@ -35,6 +36,7 @@ pub use install::{
     discover_rigs, install, read_source_metadata, DiscoveredRig, RigInstallResult,
     RigSourceMetadata,
 };
+pub use lease::{acquire_active_run_lease, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
     run_check, run_down, run_status, run_up, snapshot_state, CheckReport, ComponentSnapshot,

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 use super::expand::expand_vars;
+use super::lease::acquire_active_run_lease;
 use super::pipeline::{cleanup_shared_paths, run_pipeline, PipelineOutcome};
 use super::service::{self, ServiceStatus};
 use super::spec::{RigSpec, ServiceKind};
@@ -68,6 +69,7 @@ pub struct ServiceStatusReport {
 
 /// Materialize a rig: run the `up` pipeline, stash timestamp in state.
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
+    let _lease = acquire_active_run_lease(rig, "up")?;
     let outcome = run_pipeline(rig, "up", true)?;
 
     if outcome.is_success() {
@@ -104,6 +106,7 @@ pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
 /// service the rig knows about (belt + suspenders — spec authors sometimes
 /// forget to add `service stop` steps to `down`).
 pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
+    let _lease = acquire_active_run_lease(rig, "down")?;
     let pipeline = if rig.pipeline.contains_key("down") {
         Some(run_pipeline(rig, "down", false)?)
     } else {

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -1,0 +1,94 @@
+//! Tests for active rig run leases.
+
+use crate::error::ErrorCode;
+use crate::rig::lease::acquire_active_run_lease;
+use crate::rig::spec::{RigResourcesSpec, RigSpec};
+use crate::rig::{run_up, RigRunLease};
+use crate::test_support::with_isolated_home;
+
+fn rig(id: &str, resources: RigResourcesSpec) -> RigSpec {
+    RigSpec {
+        id: id.to_string(),
+        description: String::new(),
+        components: Default::default(),
+        services: Default::default(),
+        symlinks: Vec::new(),
+        shared_paths: Vec::new(),
+        resources,
+        pipeline: Default::default(),
+        bench: None,
+        bench_workloads: Default::default(),
+        app_launcher: None,
+    }
+}
+
+fn resources() -> RigResourcesSpec {
+    RigResourcesSpec {
+        exclusive: vec!["studio-runtime".to_string()],
+        paths: vec!["~/Developer/studio".to_string()],
+        ports: vec![9724],
+        process_patterns: vec!["wordpress-server-child.mjs".to_string()],
+    }
+}
+
+#[test]
+fn test_acquire_active_run_lease_blocks_overlapping_resources_until_drop() {
+    with_isolated_home(|_| {
+        let studio = rig("studio", resources());
+        let studio_bfb = rig("studio-bfb", resources());
+
+        let lease = acquire_active_run_lease(&studio, "up")
+            .expect("first lease")
+            .expect("resourceful rig leases");
+        let conflict =
+            acquire_active_run_lease(&studio_bfb, "up").expect_err("second lease conflicts");
+        assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
+        assert!(conflict.message.contains("studio-runtime"));
+        assert!(conflict.message.contains("studio"));
+
+        drop(lease);
+        assert!(acquire_active_run_lease(&studio_bfb, "up")
+            .expect("lease after drop")
+            .is_some());
+    });
+}
+
+#[test]
+fn test_acquire_active_run_lease_prunes_stale_pid() {
+    with_isolated_home(|_| {
+        let stale = RigRunLease {
+            rig_id: "studio".to_string(),
+            command: "up".to_string(),
+            pid: u32::MAX,
+            started_at: "2026-04-27T00:00:00Z".to_string(),
+            resources: resources(),
+        };
+        let lease_dir = crate::paths::rig_leases_dir().expect("lease dir");
+        std::fs::create_dir_all(&lease_dir).expect("create lease dir");
+        std::fs::write(
+            lease_dir.join("studio.json"),
+            serde_json::to_string_pretty(&stale).expect("serialize stale lease"),
+        )
+        .expect("write stale lease");
+
+        let studio_bfb = rig("studio-bfb", resources());
+        assert!(acquire_active_run_lease(&studio_bfb, "up")
+            .expect("stale pid ignored")
+            .is_some());
+    });
+}
+
+#[test]
+fn test_run_up_acquires_active_run_lease() {
+    with_isolated_home(|_| {
+        let studio = rig("studio", resources());
+        let studio_bfb = rig("studio-bfb", resources());
+        let _lease = acquire_active_run_lease(&studio, "up")
+            .expect("first lease")
+            .expect("resourceful rig leases");
+
+        let conflict =
+            run_up(&studio_bfb).expect_err("run_up should acquire lease before pipeline");
+        assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
+    });
+}


### PR DESCRIPTION
## Summary
- Add active-run lease files for rig `up` / `down` commands so overlapping resource declarations cannot run concurrently.
- Detect conflicts across rig id, exclusive tokens, paths, ports, and process patterns, with stale PID pruning.
- Add a structured `rig.resource_conflict` error mapped to exit code 20.

## Behaviour
- Leases live under `~/.config/homeboy/rig-leases/` and are protected by an index lock.
- Lease acquisition expands the rig's declared resources and blocks another active run with overlapping claims.
- Completed commands release their lease; stale leases are pruned when the recorded PID is no longer alive.

## Tests
- `cargo test lease_test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@rig-active-run-leases --changed-since origin/main`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@rig-active-run-leases --changed-since origin/main`

Closes #1752

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing and verifying the active-run lease changes; Chris remains responsible for review and merge.