### PR TITLE
fix(extension): bootstrap runner toolchain path

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -5,6 +5,7 @@ use crate::engine::shell;
 use crate::engine::{template, validation};
 use crate::error::{Error, Result};
 use crate::project::{self, Project};
+use crate::rig::toolchain;
 use crate::server::http::ApiClient;
 use crate::server::{
     execute_local_command_in_dir, execute_local_command_interactive,
@@ -863,6 +864,10 @@ pub fn build_exec_env(
         env.extend(helper_pairs);
     }
 
+    if let Some(path) = toolchain::command_step_path() {
+        env.push(("PATH".to_string(), path.to_string_lossy().to_string()));
+    }
+
     if let Some(pbp) = project_base_path {
         env.push((exec_context::PROJECT_PATH.to_string(), pbp.to_string()));
     }
@@ -1075,6 +1080,18 @@ mod tests {
 
         assert!(helper.is_some());
         assert!(helper.unwrap().ends_with("runner-steps.sh"));
+    }
+
+    #[test]
+    fn build_exec_env_includes_toolchain_path() {
+        let env = build_exec_env("nodejs", None, None, "{}", Some("/tmp/ext"), None, None, None);
+
+        let path = env
+            .iter()
+            .find(|(k, _)| k == "PATH")
+            .map(|(_, v)| v.clone());
+
+        assert!(path.is_some(), "expected extension env to include PATH");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add the same portable toolchain PATH bootstrap to extension runner environments that rig command steps now use.
- Ensures extension scripts can find tools installed under NVM/Homebrew/local bins in non-interactive agent shells.
- Keeps caller-provided extra env able to override later in the env list.

## Tests
- `cargo test build_exec_env_includes_toolchain_path -- --test-threads=1`
- `cargo test command_step -- --test-threads=1`

## Context
This is a follow-up to #1768 and #1776. Rig command steps can now find `npm`, but extension bench runners still inherited the sparse non-interactive PATH and could not find `npx` for Node bench workloads.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the extension-runner PATH gap during the Studio A/B bench setup, reused the existing toolchain helper, added focused coverage, and prepared the PR. Chris remains responsible for review and merge.