### PR TITLE
fix(audit): detect unwired nested Rust tests

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -222,6 +222,9 @@ pub enum AuditFinding {
     StaleCliInvocation,
     /// Homeboy shell-out consumer uses a known-stale argument shape.
     StaleCliArgumentShape,
+    /// Nested Rust test file is not wired into Cargo via a source-module
+    /// `#[path = "..."] mod ...;` declaration.
+    UnwiredNestedRustTest,
 }
 
 impl AuditFinding {
@@ -277,6 +280,7 @@ impl AuditFinding {
             "global_env_mutation_guard",
             "stale_cli_invocation",
             "stale_cli_argument_shape",
+            "unwired_nested_rust_test",
         ]
     }
 }

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -77,7 +77,8 @@ impl AuditFinding {
             AuditFinding::MissingImport
             | AuditFinding::CompilerWarning
             | AuditFinding::BrokenDocReference
-            | AuditFinding::StaleDocReference => FindingConfidence::Structural,
+            | AuditFinding::StaleDocReference
+            | AuditFinding::UnwiredNestedRustTest => FindingConfidence::Structural,
 
             // Depends on cross-file reference resolution or declared ownership maps.
             AuditFinding::UnusedParameter

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -42,6 +42,7 @@ pub mod report;
 mod requested_detectors;
 mod requirements;
 pub mod run;
+mod rust_test_wiring;
 mod shadow_modules;
 mod shared_scaffolding;
 mod signatures;
@@ -546,6 +547,19 @@ fn audit_internal(
             topology_findings.len()
         );
         all_findings.extend(topology_findings);
+    }
+
+    // Phase 4i2: Rust nested test harness wiring checks. Cargo only
+    // auto-discovers direct `tests/*.rs` integration tests; nested tests need
+    // explicit `#[path = "..."]` wiring from a source module.
+    let rust_test_wiring_findings = rust_test_wiring::run(root);
+    if !rust_test_wiring_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Rust test wiring: {} finding(s) (nested tests not wired into Cargo)",
+            rust_test_wiring_findings.len()
+        );
+        all_findings.extend(rust_test_wiring_findings);
     }
 
     // Phase 4j: Documentation drift detection (broken/stale references in markdown)

--- a/src/core/code_audit/rust_test_wiring.rs
+++ b/src/core/code_audit/rust_test_wiring.rs
@@ -1,0 +1,164 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+
+pub(crate) fn run(root: &Path) -> Vec<Finding> {
+    let tests_dir = root.join("tests");
+    if !tests_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let source_text = collect_source_text(&root.join("src"));
+    let mut findings = Vec::new();
+
+    for path in collect_rs_files(&tests_dir) {
+        let Ok(relative) = path.strip_prefix(root) else {
+            continue;
+        };
+        let relative = normalize_path(relative);
+
+        if !is_nested_rust_test_file(&relative) || is_wired(&relative, &source_text) {
+            continue;
+        }
+
+        findings.push(Finding {
+            convention: "Rust test discovery".to_string(),
+            severity: Severity::Warning,
+            file: relative.clone(),
+            description: format!(
+                "Nested Rust test file `{}` is not wired into Cargo's test harness",
+                relative
+            ),
+            suggestion: format!(
+                "Wire `{}` from the covered source module with `#[cfg(test)] #[path = \"...\"] mod ...;`, or move it to top-level `tests/*.rs` if it should be a Cargo integration test.",
+                relative
+            ),
+            kind: AuditFinding::UnwiredNestedRustTest,
+        });
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file));
+    findings
+}
+
+fn is_nested_rust_test_file(relative: &str) -> bool {
+    if !relative.starts_with("tests/") || !relative.ends_with("_test.rs") {
+        return false;
+    }
+
+    // Cargo auto-discovers only direct children like `tests/foo_test.rs`.
+    // Nested files need an explicit `#[path = "..."] mod ...;` include.
+    relative.trim_start_matches("tests/").contains('/')
+}
+
+fn is_wired(relative: &str, source_text: &str) -> bool {
+    // Existing Homeboy convention wires nested tests by embedding the relative
+    // path in a `#[path = "../../../tests/..._test.rs"]` attribute.
+    source_text.contains(relative)
+}
+
+fn collect_source_text(src_dir: &Path) -> String {
+    let mut text = String::new();
+    for path in collect_rs_files(src_dir) {
+        if let Ok(content) = fs::read_to_string(path) {
+            text.push_str(&content);
+            text.push('\n');
+        }
+    }
+    text
+}
+
+fn collect_rs_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_rs_files_into(dir, &mut files);
+    files.sort();
+    files
+}
+
+fn collect_rs_files_into(dir: &Path, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files_into(&path, files);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            files.push(path);
+        }
+    }
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(path, content).expect("write fixture");
+    }
+
+    #[test]
+    fn flags_nested_test_file_not_referenced_from_src() {
+        let dir = TempDir::new().expect("tempdir");
+        write(&dir.path().join("src/core/foo.rs"), "pub fn foo() {}\n");
+        write(
+            &dir.path().join("tests/core/foo_test.rs"),
+            "#[test] fn works() {}\n",
+        );
+
+        let findings = run(dir.path());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "tests/core/foo_test.rs");
+        assert_eq!(findings[0].kind, AuditFinding::UnwiredNestedRustTest);
+    }
+
+    #[test]
+    fn accepts_nested_test_file_referenced_from_path_attribute() {
+        let dir = TempDir::new().expect("tempdir");
+        write(
+            &dir.path().join("src/core/foo.rs"),
+            "#[cfg(test)]\n#[path = \"../../tests/core/foo_test.rs\"]\nmod foo_test;\n",
+        );
+        write(
+            &dir.path().join("tests/core/foo_test.rs"),
+            "#[test] fn works() {}\n",
+        );
+
+        let findings = run(dir.path());
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn ignores_top_level_cargo_integration_tests_and_support_modules() {
+        let dir = TempDir::new().expect("tempdir");
+        write(&dir.path().join("src/lib.rs"), "pub fn foo() {}\n");
+        write(
+            &dir.path().join("tests/api_jobs_test.rs"),
+            "#[test] fn works() {}\n",
+        );
+        write(
+            &dir.path().join("tests/core/support.rs"),
+            "pub fn helper() {}\n",
+        );
+
+        let findings = run(dir.path());
+
+        assert!(findings.is_empty());
+    }
+}

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -1084,7 +1084,16 @@ mod tests {
 
     #[test]
     fn build_exec_env_includes_toolchain_path() {
-        let env = build_exec_env("nodejs", None, None, "{}", Some("/tmp/ext"), None, None, None);
+        let env = build_exec_env(
+            "nodejs",
+            None,
+            None,
+            "{}",
+            Some("/tmp/ext"),
+            None,
+            None,
+            None,
+        );
 
         let path = env
             .iter()


### PR DESCRIPTION
## Summary
- Adds an audit finding for nested Rust test files under `tests/**` that Cargo will not auto-discover unless they are wired from source with a `#[path = "..."] mod ...;` declaration.
- Ignores top-level Cargo integration tests and helper modules so only inert nested `*_test.rs` files are flagged.
- Includes a small formatting cleanup required by latest `origin/main` for `homeboy lint` to pass after rebase.

## Tests
- `cargo test rust_test_wiring -- --test-threads=1`
- `cargo test -- --test-threads=1` before final rebase: 1872 passed, 0 failed, 1 ignored
- `homeboy lint homeboy --path "/Users/chubes/Developer/homeboy@fix-unwired-nested-rust-tests"`

Closes #1770

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the detector, test coverage, verification, and PR drafting; Chris remains responsible for review and merge.