### PR TITLE
feat(bench): resolve package-relative workloads

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -165,7 +165,7 @@ bench workflows:
     "default_baseline_rig": "studio-trunk"
   },
   "bench_workloads": {
-    "wordpress": ["~/Developer/homeboy-rigs/bench/studio-admin.php"]
+    "wordpress": ["${package.root}/bench/studio-admin.php"]
   }
 }
 ```
@@ -184,7 +184,10 @@ bench workflows:
   passes `--ignore-default-baseline`, or the candidate rig declares a
   multi-component `bench.components` matrix.
 - `bench_workloads` supplies rig-owned workload files keyed by extension ID.
-  Paths support `~`, `${env.NAME}`, and `${components.<id>.path}` expansion.
+  Paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and
+  `${package.root}` expansion. `${package.root}` resolves to the installed
+  rig package root, so portable rig packages can keep sibling `bench/` files
+  without hardcoded machine paths.
 
 ### Output shape (cross-rig)
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
@@ -396,13 +396,30 @@ fn maybe_expand_default_baseline(args: &BenchRunArgs) -> homeboy::Result<Option<
     Ok(Some(vec![baseline_rig_id, candidate.clone()]))
 }
 
-fn bench_workloads_for_extension(rig_spec: &RigSpec, extension_id: &str) -> Vec<PathBuf> {
+fn expand_bench_workload_path(
+    rig_spec: &RigSpec,
+    package_root: Option<&Path>,
+    path: &str,
+) -> PathBuf {
+    let expanded = rig::expand::expand_vars(rig_spec, path);
+    let expanded = match package_root {
+        Some(root) => expanded.replace("${package.root}", &root.to_string_lossy()),
+        None => expanded,
+    };
+    PathBuf::from(expanded)
+}
+
+fn bench_workloads_for_extension(
+    rig_spec: &RigSpec,
+    package_root: Option<&Path>,
+    extension_id: &str,
+) -> Vec<PathBuf> {
     rig_spec
         .bench_workloads
         .get(extension_id)
         .into_iter()
         .flat_map(|paths| paths.iter())
-        .map(|path| PathBuf::from(rig::expand::expand_vars(rig_spec, path)))
+        .map(|path| expand_bench_workload_path(rig_spec, package_root, path))
         .collect()
 }
 
@@ -445,7 +462,7 @@ mod tests {
         )
         .expect("parse rig spec");
 
-        let workloads = bench_workloads_for_extension(&rig_spec, "wordpress");
+        let workloads = bench_workloads_for_extension(&rig_spec, None, "wordpress");
 
         assert_eq!(
             workloads,
@@ -454,7 +471,56 @@ mod tests {
                 PathBuf::from("/tmp/playground/fixtures/wc-loaded.php"),
             ]
         );
-        assert!(bench_workloads_for_extension(&rig_spec, "rust").is_empty());
+        assert!(bench_workloads_for_extension(&rig_spec, None, "rust").is_empty());
+    }
+
+    #[test]
+    fn bench_workloads_for_extension_expands_package_root_when_available() {
+        let rig_spec: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "studio-agent-sdk",
+                "bench_workloads": {
+                    "nodejs": [
+                        "${package.root}/bench/studio-agent-runtime.bench.mjs",
+                        "/tmp/absolute.bench.mjs"
+                    ]
+                }
+            }"#,
+        )
+        .expect("parse rig spec");
+        let package = PathBuf::from("/tmp/homeboy-rigs/Automattic/studio");
+
+        let workloads = bench_workloads_for_extension(&rig_spec, Some(&package), "nodejs");
+
+        assert_eq!(
+            workloads,
+            vec![
+                PathBuf::from(
+                    "/tmp/homeboy-rigs/Automattic/studio/bench/studio-agent-runtime.bench.mjs"
+                ),
+                PathBuf::from("/tmp/absolute.bench.mjs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn bench_workloads_for_extension_leaves_package_root_unexpanded_without_metadata() {
+        let rig_spec: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "manual",
+                "bench_workloads": {
+                    "nodejs": ["${package.root}/bench/manual.bench.mjs"]
+                }
+            }"#,
+        )
+        .expect("parse rig spec");
+
+        let workloads = bench_workloads_for_extension(&rig_spec, None, "nodejs");
+
+        assert_eq!(
+            workloads,
+            vec![PathBuf::from("${package.root}/bench/manual.bench.mjs")]
+        );
     }
 
     #[test]

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -13,6 +13,7 @@ use super::{bench_workloads_for_extension, BenchRunArgs, CmdResult};
 struct RigBenchContext {
     id: String,
     spec: RigSpec,
+    package_root: Option<PathBuf>,
     snapshot: RigStateSnapshot,
 }
 
@@ -27,9 +28,12 @@ fn prepare_rig_bench_context(rig_id: &str) -> homeboy::Result<RigBenchContext> {
         ));
     }
     let snapshot = rig::snapshot_state(&spec);
+    let package_root =
+        rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
     Ok(RigBenchContext {
         id: spec.id.clone(),
         spec,
+        package_root,
         snapshot,
     })
 }
@@ -260,9 +264,13 @@ fn run_component_with_rig_context(
     let extra_workloads = rig_spec
         .as_ref()
         .and_then(|spec| {
-            ctx.extension_id
-                .as_deref()
-                .map(|id| bench_workloads_for_extension(spec, id))
+            ctx.extension_id.as_deref().map(|id| {
+                bench_workloads_for_extension(
+                    spec,
+                    rig_context.and_then(|context| context.package_root.as_deref()),
+                    id,
+                )
+            })
         })
         .unwrap_or_default();
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -1084,7 +1084,16 @@ mod tests {
 
     #[test]
     fn build_exec_env_includes_toolchain_path() {
-        let env = build_exec_env("nodejs", None, None, "{}", Some("/tmp/ext"), None, None, None);
+        let env = build_exec_env(
+            "nodejs",
+            None,
+            None,
+            "{}",
+            Some("/tmp/ext"),
+            None,
+            None,
+            None,
+        );
 
         let path = env
             .iter()

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -62,7 +62,8 @@ pub struct RigSpec {
     /// These are private, rig-owned workloads that should run alongside the
     /// component's in-tree bench discovery when `homeboy bench --rig <id>` is
     /// invoked. Values support the same `~`, `${env.NAME}`, and
-    /// `${components.<id>.path}` expansion as other rig path fields.
+    /// `${components.<id>.path}` expansion as other rig path fields, plus
+    /// `${package.root}` for rigs installed from a package source.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub bench_workloads: HashMap<String, Vec<String>>,
 


### PR DESCRIPTION
## Summary
- Add `${package.root}` expansion for rig-owned `bench_workloads`.
- Thread installed rig package metadata into bench dispatch so portable rig packages can reference sibling workload files.
- Document the package-root workload variable and cover the expansion with focused tests.

## Behavior
- Package-installed rigs can declare workloads like `${package.root}/bench/studio-agent-runtime.bench.mjs`.
- Existing absolute paths, `~`, `${env.NAME}`, and `${components.<id>.path}` expansions continue to work.
- Rigs without source metadata leave `${package.root}` literal, matching the existing unknown-token behavior.

## Tests
- `cargo test bench_workloads_for_extension`
- `cargo test bench_default_baseline_spec_test`
- `cargo test install_test`
- `cargo test source_test`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-bench-package-relative-workloads`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-bench-package-relative-workloads --changed-since origin/main`
- `cargo test -- --test-threads=1`

Closes #1777

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing package-relative bench workload resolution, tests, and PR description. Chris remains responsible for review and merge.