### PR TITLE
feat(bench): publish shared runtime helpers

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -1084,7 +1084,16 @@ mod tests {
 
     #[test]
     fn build_exec_env_includes_toolchain_path() {
-        let env = build_exec_env("nodejs", None, None, "{}", Some("/tmp/ext"), None, None, None);
+        let env = build_exec_env(
+            "nodejs",
+            None,
+            None,
+            "{}",
+            Some("/tmp/ext"),
+            None,
+            None,
+            None,
+        );
 
         let path = env
             .iter()

--- a/src/core/extension/runtime/bench-helper.mjs
+++ b/src/core/extension/runtime/bench-helper.mjs
@@ -1,0 +1,45 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, dirname } from 'node:path';
+
+// R-7 percentile, the runner contract used by Homeboy BenchResults producers.
+export function homeboyBenchPercentile(sortedValues, p) {
+    const n = sortedValues.length;
+    if (n === 0) return 0;
+    if (n === 1) return sortedValues[0];
+    const rank = p * (n - 1);
+    const lo = Math.floor(rank);
+    const hi = Math.ceil(rank);
+    if (lo === hi) return sortedValues[lo];
+    const frac = rank - lo;
+    return sortedValues[lo] * (1 - frac) + sortedValues[hi] * frac;
+}
+
+// scenario slug helper: turn a workload basename into a stable BenchScenario id.
+export function homeboyBenchScenarioId(file, extensionPattern = /\.[^.]+$/) {
+    return basename(file)
+        .replace(extensionPattern, '')
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+export function homeboyBenchResultsEnvelope(componentId, iterations, scenarios) {
+    return {
+        component_id: componentId,
+        iterations,
+        scenarios,
+    };
+}
+
+export async function homeboyWriteBenchResults(resultsFile, componentId, iterations, scenarios) {
+    await mkdir(dirname(resultsFile), { recursive: true });
+    await writeFile(
+        resultsFile,
+        JSON.stringify(homeboyBenchResultsEnvelope(componentId, iterations, scenarios), null, 2)
+    );
+}
+
+export async function homeboyWriteEmptyBenchResults(resultsFile, componentId, iterations = 0) {
+    await homeboyWriteBenchResults(resultsFile, componentId, iterations, []);
+}

--- a/src/core/extension/runtime/bench-helper.php
+++ b/src/core/extension/runtime/bench-helper.php
@@ -1,0 +1,54 @@
+<?php
+/** Shared BenchResults helpers for PHP extension runners. */
+
+/** R-7 percentile, the runner contract used by Homeboy BenchResults producers. */
+function homeboy_bench_percentile(array $sorted_values, float $p): float {
+    $n = count($sorted_values);
+    if ($n === 0) {
+        return 0.0;
+    }
+    if ($n === 1) {
+        return (float) $sorted_values[0];
+    }
+
+    $rank = $p * ($n - 1);
+    $lo = (int) floor($rank);
+    $hi = (int) ceil($rank);
+    if ($lo === $hi) {
+        return (float) $sorted_values[$lo];
+    }
+
+    $frac = $rank - $lo;
+    return (float) ($sorted_values[$lo] * (1 - $frac) + $sorted_values[$hi] * $frac);
+}
+
+/** scenario slug helper: turn a workload basename into a stable BenchScenario id. */
+function homeboy_bench_scenario_id(string $basename): string {
+    $name = preg_replace('/\.[^.]+$/', '', $basename);
+    $name = preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $name);
+    $name = strtolower($name);
+    $name = preg_replace('/[^a-z0-9]+/', '-', $name);
+    return trim($name, '-');
+}
+
+function homeboy_bench_results_envelope(string $component_id, int $iterations, array $scenarios): array {
+    return [
+        'component_id' => $component_id,
+        'iterations' => $iterations,
+        'scenarios' => $scenarios,
+    ];
+}
+
+function homeboy_write_bench_results(string $results_path, string $component_id, int $iterations, array $scenarios): void {
+    $json = json_encode(homeboy_bench_results_envelope($component_id, $iterations, $scenarios), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        throw new RuntimeException('json_encode failed: ' . json_last_error_msg());
+    }
+    if (file_put_contents($results_path, $json) === false) {
+        throw new RuntimeException("failed to write $results_path");
+    }
+}
+
+function homeboy_write_empty_bench_results(string $results_path, string $component_id, int $iterations = 0): void {
+    homeboy_write_bench_results($results_path, $component_id, $iterations, []);
+}

--- a/src/core/extension/runtime/bench-helper.sh
+++ b/src/core/extension/runtime/bench-helper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Shared BenchResults helpers for shell extension runners.
+
+homeboy_write_empty_bench_results() {
+    local component_id="${1:-${HOMEBOY_COMPONENT_ID:-}}"
+    local iterations="${2:-0}"
+    local results_file="${3:-${HOMEBOY_BENCH_RESULTS_FILE:-}}"
+
+    if [ -z "$component_id" ]; then
+        echo "homeboy_write_empty_bench_results: component id is required" >&2
+        return 2
+    fi
+    if [ -z "$results_file" ]; then
+        echo "homeboy_write_empty_bench_results: HOMEBOY_BENCH_RESULTS_FILE is required" >&2
+        return 2
+    fi
+
+    mkdir -p "$(dirname "$results_file")"
+    printf '{"component_id":"%s","iterations":%s,"scenarios":[]}\n' "$component_id" "$iterations" > "$results_file"
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -8,11 +8,17 @@ const RUNNER_STEPS_SH: &str = include_str!("runtime/runner-steps.sh");
 const FAILURE_TRAP_SH: &str = include_str!("runtime/failure-trap.sh");
 const WRITE_TEST_RESULTS_SH: &str = include_str!("runtime/write-test-results.sh");
 const RESOLVE_CONTEXT_SH: &str = include_str!("runtime/resolve-context.sh");
+const BENCH_HELPER_SH: &str = include_str!("runtime/bench-helper.sh");
+const BENCH_HELPER_JS: &str = include_str!("runtime/bench-helper.mjs");
+const BENCH_HELPER_PHP: &str = include_str!("runtime/bench-helper.php");
 
 pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
 pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
 pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
 pub const RESOLVE_CONTEXT_ENV: &str = "HOMEBOY_RUNTIME_RESOLVE_CONTEXT";
+pub const BENCH_HELPER_SH_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_SH";
+pub const BENCH_HELPER_JS_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_JS";
+pub const BENCH_HELPER_PHP_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_PHP";
 
 struct RuntimeHelper {
     filename: &'static str,
@@ -40,6 +46,21 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "resolve-context.sh",
         content: RESOLVE_CONTEXT_SH,
         env_var: RESOLVE_CONTEXT_ENV,
+    },
+    RuntimeHelper {
+        filename: "bench-helper.sh",
+        content: BENCH_HELPER_SH,
+        env_var: BENCH_HELPER_SH_ENV,
+    },
+    RuntimeHelper {
+        filename: "bench-helper.mjs",
+        content: BENCH_HELPER_JS,
+        env_var: BENCH_HELPER_JS_ENV,
+    },
+    RuntimeHelper {
+        filename: "bench-helper.php",
+        content: BENCH_HELPER_PHP,
+        env_var: BENCH_HELPER_PHP_ENV,
     },
 ];
 
@@ -109,6 +130,14 @@ mod tests {
             pairs.iter().any(|(k, _)| k == RESOLVE_CONTEXT_ENV),
             "resolve context helper should be in pairs"
         );
+        assert!(
+            pairs.iter().any(|(k, _)| k == BENCH_HELPER_JS_ENV),
+            "bench JS helper should be in pairs"
+        );
+        assert!(
+            pairs.iter().any(|(k, _)| k == BENCH_HELPER_PHP_ENV),
+            "bench PHP helper should be in pairs"
+        );
     }
 
     #[test]
@@ -176,5 +205,56 @@ mod tests {
                 component_dir.display()
             )
         );
+    }
+
+    #[test]
+    fn bench_shell_helper_writes_empty_envelope() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let helper_path = dir.path().join("bench-helper.sh");
+        let results_path = dir.path().join("bench-results.json");
+        std::fs::write(&helper_path, BENCH_HELPER_SH).expect("write helper");
+
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "source {}; HOMEBOY_BENCH_RESULTS_FILE={}; homeboy_write_empty_bench_results demo 7; cat {}",
+                helper_path.display(),
+                results_path.display(),
+                results_path.display()
+            ))
+            .output()
+            .expect("run bash");
+
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "{\"component_id\":\"demo\",\"iterations\":7,\"scenarios\":[]}\n"
+        );
+    }
+
+    #[test]
+    fn bench_runtime_helpers_document_shared_contract() {
+        for content in [BENCH_HELPER_JS, BENCH_HELPER_PHP] {
+            assert!(
+                content.contains("R-7 percentile"),
+                "helper should document percentile method"
+            );
+            assert!(
+                content.contains("p * (n - 1)") || content.contains("$p * ($n - 1)"),
+                "helper should use R-7 rank formula"
+            );
+            assert!(
+                content.contains("scenario") && content.contains("slug"),
+                "helper should own scenario slugging"
+            );
+            assert!(
+                content.contains("component_id") && content.contains("scenarios"),
+                "helper should own BenchResults envelope shape"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds Homeboy-owned runtime helper files for BenchResults producers across shell, Node, and PHP runners.
- Centralizes the R-7 percentile contract, scenario slug helper, and empty/result envelope writing primitives for extensions.

## Changes
- Emits `HOMEBOY_RUNTIME_BENCH_HELPER_SH`, `HOMEBOY_RUNTIME_BENCH_HELPER_JS`, and `HOMEBOY_RUNTIME_BENCH_HELPER_PHP` alongside the existing runtime helpers.
- Adds shell empty-envelope writing plus JS/PHP helpers for percentile math, scenario IDs, and BenchResults envelope serialization.
- Extends runtime helper tests to verify helper emission and the shared bench contract.

## Tests
- `cargo test runtime_helper -- --test-threads=1`
- `git diff --check`
- Companion migration smoke-tested in Extra-Chill/homeboy-extensions#305 with the new helper env vars.

Closes #1780

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper contract implementation, migrated callsites in the companion extension branch, and ran focused verification. Chris remains responsible for review and merge.
