### PR TITLE
feat(extension): resolve test drift from metadata

### DIFF
--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -90,6 +90,33 @@ pub struct TestMappingConfig {
     pub skip_test_patterns: Vec<String>,
 }
 
+/// Test drift convention: how source and test files are selected for drift scans.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TestDriftConfig {
+    /// Source directories to scan (relative to component root).
+    pub source_dirs: Vec<String>,
+    /// Test directories to scan (relative to component root).
+    pub test_dirs: Vec<String>,
+    /// File extensions to include when building source/test glob patterns.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_extensions: Vec<String>,
+    /// Whether the language supports inline tests. Stored for consumers that
+    /// need it; drift scanning still uses source/test glob patterns.
+    #[serde(default)]
+    pub inline_tests: bool,
+}
+
+impl From<&TestMappingConfig> for TestDriftConfig {
+    fn from(config: &TestMappingConfig) -> Self {
+        Self {
+            source_dirs: config.source_dirs.clone(),
+            test_dirs: config.test_dirs.clone(),
+            file_extensions: Vec::new(),
+            inline_tests: config.inline_tests,
+        }
+    }
+}
+
 fn default_test_prefix() -> String {
     "test_".to_string()
 }
@@ -404,6 +431,18 @@ impl ExtensionManifest {
     /// declared under the audit capability.
     pub fn test_mapping(&self) -> Option<&TestMappingConfig> {
         self.audit.as_ref().and_then(|a| a.test_mapping.as_ref())
+    }
+
+    /// Convenience accessor for the test drift selection contract.
+    ///
+    /// `test.drift` is the primary home. `audit.test_mapping` remains a
+    /// fallback so installed extensions keep their existing drift behavior until
+    /// their manifests are refreshed.
+    pub fn test_drift(&self) -> Option<TestDriftConfig> {
+        self.test
+            .as_ref()
+            .and_then(|t| t.drift.clone())
+            .or_else(|| self.test_mapping().map(TestDriftConfig::from))
     }
 
     /// Convenience accessor for extension-supplied generic audit detector rules.
@@ -764,6 +803,9 @@ pub struct TestConfig {
     pub extension_script: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_parse: Option<ParseSpec>,
+    /// Source/test selection contract used by changed-test and drift workflows.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drift: Option<TestDriftConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -33,7 +33,7 @@ pub use manifest::{
     FileContainsCondition, HttpMethod, InputConfig, LintConfig, OutputConfig, OutputSchema,
     PlatformCapability, ProvidesConfig, RemotePathInferenceRule, RequirementsConfig, RuntimeConfig,
     RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
-    TestConfig, TestMappingConfig, VersionPatternConfig,
+    TestConfig, TestDriftConfig, TestMappingConfig, VersionPatternConfig,
 };
 
 // Re-export version types

--- a/src/core/extension/test/drift.rs
+++ b/src/core/extension/test/drift.rs
@@ -208,7 +208,11 @@ pub fn detect_drift(component: &str, opts: &DriftOptions) -> Result<DriftReport>
     // Also detect file renames
     let renames = get_renamed_files(&opts.root, &opts.since)?;
     for (old, new) in &renames {
-        if !is_test_path(old) {
+        if !is_test_path(old)
+            && !is_test_path(new)
+            && (matches_any_pattern(old, &opts.source_patterns)
+                || matches_any_pattern(new, &opts.source_patterns))
+        {
             changes.push(ProductionChange {
                 change_type: ChangeType::FileMove,
                 file: new.clone(),
@@ -734,6 +738,21 @@ fn looks_like_path(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn extract_method_rename() {
@@ -779,6 +798,31 @@ mod tests {
         assert_eq!(changes[0].change_type, ChangeType::MethodRename);
         assert_eq!(changes[0].old_symbol, "load_config");
         assert_eq!(changes[0].new_symbol.as_deref(), Some("read_config"));
+    }
+
+    #[test]
+    fn detect_drift_ignores_renames_outside_source_patterns() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        run_git(root, &["init", "-q", "-b", "main"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        std::fs::write(root.join("README.md"), "before\n").unwrap();
+        run_git(root, &["add", "README.md"]);
+        run_git(root, &["commit", "-q", "-m", "initial"]);
+        run_git(root, &["mv", "README.md", "docs/README.md"]);
+
+        let opts = DriftOptions {
+            root: root.to_path_buf(),
+            since: "HEAD".to_string(),
+            source_patterns: vec!["src/**/*.rs".to_string()],
+            test_patterns: vec!["tests/**/*.rs".to_string()],
+        };
+
+        let report = detect_drift("fixture", &opts).expect("drift report");
+        assert!(report.production_changes.is_empty());
     }
 
     #[test]

--- a/src/core/extension/test/drift.rs
+++ b/src/core/extension/test/drift.rs
@@ -9,11 +9,13 @@
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::code_audit::walker::is_test_path;
 use crate::error::{Error, Result};
+use crate::extension::TestDriftConfig;
 use crate::git;
 
 // ============================================================================
@@ -98,23 +100,23 @@ pub struct DriftReport {
 // ============================================================================
 
 /// Options for drift detection.
-pub struct DriftOptions<'a> {
+pub struct DriftOptions {
     /// Component root directory.
-    pub root: &'a Path,
+    pub root: PathBuf,
     /// Git ref to compare against (tag, commit, branch).
-    pub since: &'a str,
+    pub since: String,
     /// Glob patterns for production files (non-test).
     pub source_patterns: Vec<String>,
     /// Glob patterns for test files.
     pub test_patterns: Vec<String>,
 }
 
-impl<'a> DriftOptions<'a> {
+impl DriftOptions {
     /// Create options with common defaults for a PHP project.
-    pub fn php(root: &'a Path, since: &'a str) -> Self {
+    pub fn php(root: &Path, since: &str) -> Self {
         Self {
-            root,
-            since,
+            root: root.to_path_buf(),
+            since: since.to_string(),
             source_patterns: vec![
                 "src/**/*.php".into(),
                 "inc/**/*.php".into(),
@@ -125,25 +127,61 @@ impl<'a> DriftOptions<'a> {
     }
 
     /// Create options with common defaults for a Rust project.
-    pub fn rust(root: &'a Path, since: &'a str) -> Self {
+    pub fn rust(root: &Path, since: &str) -> Self {
         Self {
-            root,
-            since,
+            root: root.to_path_buf(),
+            since: since.to_string(),
             source_patterns: vec!["src/**/*.rs".into()],
             test_patterns: vec!["tests/**/*.rs".into()],
         }
     }
+
+    /// Create options from an extension-declared drift selection contract.
+    pub fn from_config(
+        root: &Path,
+        since: &str,
+        config: &TestDriftConfig,
+        fallback_extensions: &[String],
+    ) -> Self {
+        let extensions = if config.file_extensions.is_empty() {
+            fallback_extensions
+        } else {
+            &config.file_extensions
+        };
+
+        Self {
+            root: root.to_path_buf(),
+            since: since.to_string(),
+            source_patterns: glob_patterns(&config.source_dirs, extensions),
+            test_patterns: glob_patterns(&config.test_dirs, extensions),
+        }
+    }
+}
+
+fn glob_patterns(dirs: &[String], extensions: &[String]) -> Vec<String> {
+    dirs.iter()
+        .flat_map(|dir| {
+            extensions.iter().map(move |extension| {
+                let extension = extension.trim_start_matches('.');
+                if dir.is_empty() || dir == "." {
+                    format!("**/*.{}", extension)
+                } else {
+                    format!("{}/**/*.{}", dir.trim_end_matches('/'), extension)
+                }
+            })
+        })
+        .collect()
 }
 
 /// Detect test drift by cross-referencing git changes with test files.
 pub fn detect_drift(component: &str, opts: &DriftOptions) -> Result<DriftReport> {
     // Step 1: Get changed production files from git diff
-    let changed_files = get_changed_files(opts.root, opts.since)?;
+    let changed_files = get_changed_files(&opts.root, &opts.since)?;
 
     // Filter to production files only (exclude tests)
     let prod_files: Vec<&str> = changed_files
         .iter()
-        .filter(|f| !is_test_path(f))
+        .filter(|f| !is_test_path(f) && matches_any_pattern(f, &opts.source_patterns))
         .map(|s| s.as_str())
         .collect();
 
@@ -162,13 +200,13 @@ pub fn detect_drift(component: &str, opts: &DriftOptions) -> Result<DriftReport>
     // Step 2: Parse diffs to extract structural changes
     let mut changes = Vec::new();
     for file in &prod_files {
-        let diff = get_file_diff(opts.root, opts.since, file)?;
+        let diff = get_file_diff(&opts.root, &opts.since, file)?;
         let file_changes = extract_changes_from_diff(file, &diff);
         changes.extend(file_changes);
     }
 
     // Also detect file renames
-    let renames = get_renamed_files(opts.root, opts.since)?;
+    let renames = get_renamed_files(&opts.root, &opts.since)?;
     for (old, new) in &renames {
         if !is_test_path(old) {
             changes.push(ProductionChange {
@@ -182,8 +220,8 @@ pub fn detect_drift(component: &str, opts: &DriftOptions) -> Result<DriftReport>
     }
 
     // Step 3: Scan test files for references to changed symbols
-    let test_files = collect_test_files(opts.root);
-    let drifted = find_drift_references(&changes, &test_files, opts.root);
+    let test_files = collect_test_files(&opts.root, &opts.test_patterns);
+    let drifted = find_drift_references(&changes, &test_files, &opts.root);
 
     // Step 4: Build report
     let total_drifted_files = {
@@ -458,24 +496,36 @@ fn extract_changes_from_diff(file: &str, diff: &str) -> Vec<ProductionChange> {
 // Test file scanning
 // ============================================================================
 
-/// Collect all test files in the repo.
-fn collect_test_files(root: &Path) -> Vec<PathBuf> {
-    let tests_dir = root.join("tests");
-    if !tests_dir.exists() {
-        return Vec::new();
-    }
-
-    collect_files_recursive(&tests_dir)
+fn matches_any_pattern(path: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
+        glob::Pattern::new(pattern)
+            .map(|compiled| compiled.matches_path(Path::new(path)))
+            .unwrap_or(false)
+    })
 }
 
-fn collect_files_recursive(dir: &Path) -> Vec<PathBuf> {
+/// Collect test files in the repo using extension-declared glob patterns.
+fn collect_test_files(root: &Path, test_patterns: &[String]) -> Vec<PathBuf> {
     use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
     let config = ScanConfig {
         extensions: ExtensionFilter::All,
         ..Default::default()
     };
-    codebase_scan::walk_files(dir, &config)
+    let mut files = BTreeSet::new();
+
+    for file in codebase_scan::walk_files(root, &config) {
+        let relative = file
+            .strip_prefix(root)
+            .unwrap_or(&file)
+            .to_string_lossy()
+            .to_string();
+        if matches_any_pattern(&relative, test_patterns) {
+            files.insert(file);
+        }
+    }
+
+    files.into_iter().collect()
 }
 
 /// Scan test files for references to changed production symbols.

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -79,6 +79,39 @@ pub fn build_test_runner(
     Ok(runner)
 }
 
+fn component_source_path(component: &Component) -> PathBuf {
+    let expanded = shellexpand::tilde(&component.local_path);
+    PathBuf::from(expanded.as_ref())
+}
+
+/// Resolve drift detection options from the component's linked test extension.
+///
+/// `test.drift` is the primary contract. Installed extensions that only have
+/// the older `audit.test_mapping` shape still work through the manifest
+/// accessor fallback.
+pub fn resolve_drift_options(
+    component: &Component,
+    since: &str,
+) -> crate::error::Result<DriftOptions> {
+    let source_path = component_source_path(component);
+
+    if let Some(extensions) = &component.extensions {
+        for extension_id in extensions.keys() {
+            let manifest = crate::extension::load_extension(extension_id)?;
+            if let Some(config) = manifest.test_drift() {
+                return Ok(DriftOptions::from_config(
+                    &source_path,
+                    since,
+                    &config,
+                    manifest.provided_file_extensions(),
+                ));
+            }
+        }
+    }
+
+    Ok(DriftOptions::php(&source_path, since))
+}
+
 /// Compute which test files are impacted by changes since a git ref.
 ///
 /// Combines two sources: (1) changed files that are test paths, and
@@ -89,18 +122,11 @@ pub fn compute_changed_test_files(
     component: &Component,
     git_ref: &str,
 ) -> crate::error::Result<Vec<String>> {
-    let source_path = {
-        let expanded = shellexpand::tilde(&component.local_path);
-        PathBuf::from(expanded.as_ref())
-    };
+    let source_path = component_source_path(component);
 
     let changed_files = git::get_files_changed_since(&source_path.to_string_lossy(), git_ref)?;
 
-    let opts = if source_path.join("Cargo.toml").exists() {
-        DriftOptions::rust(&source_path, git_ref)
-    } else {
-        DriftOptions::php(&source_path, git_ref)
-    };
+    let opts = resolve_drift_options(component, git_ref)?;
 
     let report = drift::detect_drift(&component.id, &opts)?;
     let mut selected: BTreeSet<String> = BTreeSet::new();
@@ -139,9 +165,42 @@ pub fn compute_changed_test_scope(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::TestDriftConfig;
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;
+
+    #[test]
+    fn drift_options_use_extension_drift_config() {
+        let dir = TempDir::new().expect("temp dir should be created");
+        let config = TestDriftConfig {
+            source_dirs: vec!["src".to_string(), "inc".to_string()],
+            test_dirs: vec!["tests".to_string()],
+            file_extensions: vec!["php".to_string()],
+            inline_tests: false,
+        };
+
+        let opts = DriftOptions::from_config(dir.path(), "HEAD~1", &config, &["rs".to_string()]);
+
+        assert_eq!(opts.source_patterns, vec!["src/**/*.php", "inc/**/*.php"]);
+        assert_eq!(opts.test_patterns, vec!["tests/**/*.php"]);
+    }
+
+    #[test]
+    fn drift_options_fall_back_to_extension_file_extensions() {
+        let dir = TempDir::new().expect("temp dir should be created");
+        let config = TestDriftConfig {
+            source_dirs: vec!["src".to_string()],
+            test_dirs: vec!["tests".to_string()],
+            file_extensions: Vec::new(),
+            inline_tests: true,
+        };
+
+        let opts = DriftOptions::from_config(dir.path(), "HEAD~1", &config, &["rs".to_string()]);
+
+        assert_eq!(opts.source_patterns, vec!["src/**/*.rs"]);
+        assert_eq!(opts.test_patterns, vec!["tests/**/*.rs"]);
+    }
 
     #[test]
     fn compute_changed_test_scope_detects_new_test_file() {

--- a/src/core/extension/test/workflow.rs
+++ b/src/core/extension/test/workflow.rs
@@ -1,7 +1,6 @@
 use crate::component::Component;
-use crate::extension::test::drift::{
-    detect_drift, generate_transform_rules, DriftOptions, DriftReport,
-};
+use crate::extension::test::drift::{detect_drift, generate_transform_rules, DriftReport};
+use crate::extension::test::resolve_drift_options;
 use crate::extension::test::TestScopeOutput;
 use crate::extension::test::{ChangeType, TestAnalysis};
 use crate::extension::test::{TestBaselineComparison, TestCounts};
@@ -59,11 +58,6 @@ pub fn detect_test_drift(
     component: &Component,
     since: &str,
 ) -> Result<DriftWorkflowResult, crate::Error> {
-    let source_path = {
-        let expanded = shellexpand::tilde(&component.local_path);
-        std::path::PathBuf::from(expanded.as_ref())
-    };
-
     crate::log_status!(
         "drift",
         "Detecting test drift since {} in {}",
@@ -71,11 +65,7 @@ pub fn detect_test_drift(
         component_id
     );
 
-    let opts = if source_path.join("Cargo.toml").exists() {
-        DriftOptions::rust(&source_path, since)
-    } else {
-        DriftOptions::php(&source_path, since)
-    };
+    let opts = resolve_drift_options(component, since)?;
 
     let report = detect_drift(component_id, &opts)?;
 
@@ -200,11 +190,7 @@ pub fn auto_fix_test_drift(
         std::path::PathBuf::from(expanded.as_ref())
     };
 
-    let opts = if source_path.join("Cargo.toml").exists() {
-        DriftOptions::rust(&source_path, since)
-    } else {
-        DriftOptions::php(&source_path, since)
-    };
+    let opts = resolve_drift_options(component, since)?;
 
     crate::log_status!(
         "test",


### PR DESCRIPTION
## Summary
- Move test drift source/test selection behind extension metadata instead of probing `Cargo.toml` in core.
- Add `test.drift` as the primary contract with an `audit.test_mapping` fallback for existing installed extensions.
- Consolidate changed-test, drift detection, and auto-fix drift workflows through the same resolver.

## Changes
- Adds `TestDriftConfig` to extension manifests and exposes `ExtensionManifest::test_drift()`.
- Builds drift source/test glob patterns from extension metadata and filters drift scans through those patterns.
- Keeps the existing PHP fallback for components without an extension drift contract.
- Includes one rustfmt-only cleanup in `src/core/extension/execution.rs` required by the lint runner's `cargo fmt --check` on current main.

## Tests
- `cargo test extension::test::tests -- --test-threads=1`
- `cargo test --lib -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@extension-test-drift-contract`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@extension-test-drift-contract --changed-since origin/main --exclude god_file --exclude high_item_count --exclude intra_method_duplicate --exclude unreferenced_export --exclude missing_test_method --exclude missing_test_file --exclude orphaned_test --exclude repeated_field_pattern`

Closes #1782

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the extension-backed drift contract, updated tests, ran verification, and drafted this PR. Chris remains responsible for review and merge decisions.