### PR TITLE
fix(rig): isolate update-all package failures

### DIFF
--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -15,8 +15,8 @@ use super::install::{
 
 mod types;
 pub use types::{
-    InvalidRigSourceMetadata, RemovedRigSourceRig, RemovedRigSourceStack, RigSourceGroup,
-    RigSourceListResult, RigSourceRemoveResult, RigSourceRig, RigSourceStack,
+    FailedRigSourceUpdate, InvalidRigSourceMetadata, RemovedRigSourceRig, RemovedRigSourceStack,
+    RigSourceGroup, RigSourceListResult, RigSourceRemoveResult, RigSourceRig, RigSourceStack,
     RigSourceUpdateResult, RigSourceUpdatedRig, RigSourceUpdatedStack, SkippedRigSourceRig,
     SkippedRigSourceStack, SkippedRigSourceUpdate,
 };
@@ -173,6 +173,7 @@ pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
         updated: Vec::new(),
         updated_stacks: Vec::new(),
         skipped: Vec::new(),
+        failed: Vec::new(),
     };
     for source in list_sources()?.sources {
         if source.linked {
@@ -192,10 +193,22 @@ pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
             }
             continue;
         }
-        let result = update_group(source)?;
-        aggregate.updated.extend(result.updated);
-        aggregate.updated_stacks.extend(result.updated_stacks);
-        aggregate.skipped.extend(result.skipped);
+        match update_group(source.clone()) {
+            Ok(result) => {
+                aggregate.updated.extend(result.updated);
+                aggregate.updated_stacks.extend(result.updated_stacks);
+                aggregate.skipped.extend(result.skipped);
+                aggregate.failed.extend(result.failed);
+            }
+            Err(error) => {
+                aggregate.failed.push(FailedRigSourceUpdate {
+                    package_id: source.package_id,
+                    source: source.source,
+                    package_path: source.package_path,
+                    reason: error.message,
+                });
+            }
+        }
     }
     Ok(aggregate)
 }
@@ -308,6 +321,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
         updated,
         updated_stacks,
         skipped,
+        failed: Vec::new(),
     })
 }
 

--- a/src/core/rig/source/types.rs
+++ b/src/core/rig/source/types.rs
@@ -89,6 +89,8 @@ pub struct RigSourceUpdateResult {
     pub updated: Vec<RigSourceUpdatedRig>,
     pub updated_stacks: Vec<RigSourceUpdatedStack>,
     pub skipped: Vec<SkippedRigSourceUpdate>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed: Vec<FailedRigSourceUpdate>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -119,5 +121,13 @@ pub struct RigSourceUpdatedStack {
 pub struct SkippedRigSourceUpdate {
     pub id: String,
     pub source: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FailedRigSourceUpdate {
+    pub package_id: String,
+    pub source: String,
+    pub package_path: String,
     pub reason: String,
 }

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -312,6 +312,51 @@ fn update_git_source_refreshes_owned_stack_specs() {
 }
 
 #[test]
+fn update_all_reports_broken_sources_and_continues() {
+    let _home = HomeGuard::new();
+
+    let broken_package = tempfile::tempdir().expect("broken package");
+    write_rig(broken_package.path(), "broken", &minimal_rig("broken"));
+    let broken_bare = create_bare_source(broken_package.path());
+    let broken_source = broken_bare
+        .path()
+        .join("rig-package.git")
+        .to_string_lossy()
+        .to_string();
+    install(&broken_source, None, false).expect("install broken source");
+    let broken_metadata = crate::rig::read_source_metadata("broken").expect("broken metadata");
+    fs::remove_dir_all(&broken_metadata.package_path).expect("remove installed package clone");
+
+    let good_package = tempfile::tempdir().expect("good package");
+    let good_rig = write_rig(good_package.path(), "good", &minimal_rig("good"));
+    let good_bare = create_bare_source(good_package.path());
+    let good_source = good_bare
+        .path()
+        .join("rig-package.git")
+        .to_string_lossy()
+        .to_string();
+    install(&good_source, None, false).expect("install good source");
+    fs::write(
+        &good_rig,
+        minimal_rig("good").replace("good rig", "good rig updated"),
+    )
+    .expect("update good rig");
+    commit_package(good_package.path(), "update good rig");
+    run_git(good_package.path(), &["push", &good_source, "HEAD:main"]);
+
+    let result = update_all_sources().expect("update all continues after broken source");
+
+    assert_eq!(result.failed.len(), 1);
+    assert_eq!(result.failed[0].source, broken_source);
+    assert!(result.failed[0].reason.contains("missing"));
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].id, "good");
+    let installed =
+        fs::read_to_string(crate::paths::rig_config("good").unwrap()).expect("installed good rig");
+    assert!(installed.contains("good rig updated"));
+}
+
+#[test]
 fn update_git_source_skips_user_replaced_stack_specs() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- Keep `rig update --all` sweeping installed sources when one git-backed package is broken.
- Add a structured `failed` bucket to update-all results with package source metadata and the failure reason.
- Cover the regression with a source lifecycle test that updates a valid package after a broken package fails.

## Behavior
- `homeboy rig update --all` now reports per-source failures without losing successful updates or linked-source skips.
- `homeboy rig update <id>` remains fail-fast through the existing `update_source_for_rig` path.
- Empty `failed` results are omitted from JSON output to preserve the existing clean success shape.

## Tests
- `cargo test source_test`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-rig-update-all-isolation`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-rig-update-all-isolation --changed-since origin/main`
- `cargo test -- --test-threads=1`

Closes #1815

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing failure isolation for `rig update --all`, tests, and PR description. Chris remains responsible for review and merge.
