### PR TITLE
fix(bench): surface cross-rig failure stderr

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -290,6 +290,7 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
             exit_code: single_output.exit_code,
             results: single_output.results,
             rig_state: single_output.rig_state,
+            failure: single_output.failure,
         });
     }
 
@@ -923,6 +924,7 @@ JSON
             baseline_comparison: None,
             hints: None,
             rig_state: None,
+            failure: None,
         };
         let value = serde_json::to_value(BenchOutput::Single(single)).unwrap();
         assert!(value.get("comparison").is_none());

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -198,6 +198,7 @@ pub(super) fn run_single_rig(
             baseline_comparison: None,
             hints: if hints.is_empty() { None } else { Some(hints) },
             rig_state: Some(context.snapshot),
+            failure: None,
         },
         exit_code,
     ))
@@ -573,6 +574,7 @@ mod tests {
             baseline_comparison: None,
             hints: None,
             rig_state: None,
+            failure: None,
         }
     }
 

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use super::baseline::BenchBaselineComparison;
 use super::distribution::BenchRunDistribution;
 use super::parsing::{BenchMetricPhase, BenchResults, BenchScenario};
-use super::run::BenchRunWorkflowResult;
+use super::run::{BenchRunFailure, BenchRunWorkflowResult};
 use crate::rig::RigStateSnapshot;
 
 #[derive(Serialize)]
@@ -29,6 +29,8 @@ pub struct BenchCommandOutput {
     /// path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_state: Option<RigStateSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<BenchRunFailure>,
 }
 
 pub fn from_main_workflow(result: BenchRunWorkflowResult) -> (BenchCommandOutput, i32) {
@@ -55,6 +57,7 @@ pub fn from_main_workflow_with_rig(
             baseline_comparison: result.baseline_comparison,
             hints: result.hints,
             rig_state,
+            failure: result.failure,
         },
         exit_code,
     )
@@ -100,8 +103,22 @@ pub struct BenchComparisonOutput {
     /// cross-rig comparison shape.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub summary: Vec<BenchScenarioComparisonSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub failures: Vec<BenchComparisonFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct BenchComparisonFailure {
+    pub rig_id: String,
+    pub component_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    pub exit_code: i32,
+    pub stderr_tail: String,
 }
 
 #[derive(Serialize)]
@@ -114,6 +131,8 @@ pub struct RigBenchEntry {
     pub results: Option<BenchResults>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_state: Option<RigStateSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<BenchRunFailure>,
 }
 
 /// Per-scenario, per-metric percent deltas of each non-reference rig vs
@@ -511,7 +530,28 @@ pub fn aggregate_comparison(
     };
     let summary = BenchScenarioComparisonSummary::build(&entries);
 
+    let failures: Vec<BenchComparisonFailure> = entries
+        .iter()
+        .filter(|entry| entry.results.is_none())
+        .filter_map(|entry| {
+            entry
+                .failure
+                .as_ref()
+                .map(|failure| BenchComparisonFailure {
+                    rig_id: entry.rig_id.clone(),
+                    component_id: failure.component_id.clone(),
+                    component_path: failure.component_path.clone(),
+                    scenario_id: failure.scenario_id.clone(),
+                    exit_code: failure.exit_code,
+                    stderr_tail: failure.stderr_tail.clone(),
+                })
+        })
+        .collect();
+
     let mut hints = Vec::new();
+    for failure in &failures {
+        hints.push(format_failure_hint(failure));
+    }
     if entries.iter().any(|e| e.results.is_none()) {
         hints.push(
             "One or more rigs produced no parseable results; their columns are absent from `diff`."
@@ -533,9 +573,27 @@ pub fn aggregate_comparison(
             rigs: entries,
             diff,
             summary,
+            failures,
             hints: Some(hints),
         },
         exit_code,
+    )
+}
+
+fn format_failure_hint(failure: &BenchComparisonFailure) -> String {
+    let component = match &failure.component_path {
+        Some(path) => format!("{} ({})", failure.component_id, path),
+        None => failure.component_id.clone(),
+    };
+    let scenario = failure
+        .scenario_id
+        .as_deref()
+        .map(|id| format!("\n- scenario: {}", id))
+        .unwrap_or_default();
+
+    format!(
+        "Rig failed before producing parseable bench results:\n- rig: {}\n- component: {}{}\n- exit: {}\n- stderr: {}",
+        failure.rig_id, component, scenario, failure.exit_code, failure.stderr_tail
     )
 }
 
@@ -618,6 +676,25 @@ mod tests {
             exit_code: if passed { 0 } else { 1 },
             results,
             rig_state: None,
+            failure: None,
+        }
+    }
+
+    fn failed_entry_with_stderr(rig_id: &str) -> RigBenchEntry {
+        RigBenchEntry {
+            rig_id: rig_id.to_string(),
+            passed: false,
+            status: "failed".to_string(),
+            exit_code: 2,
+            results: None,
+            rig_state: None,
+            failure: Some(BenchRunFailure {
+                component_id: "studio".to_string(),
+                component_path: Some("/Users/chubes/Developer/studio@candidate".to_string()),
+                scenario_id: None,
+                exit_code: 2,
+                stderr_tail: "ERROR: Homeboy bench helper not found at /Users/chubes/.homeboy/runtime/bench-helper.sh".to_string(),
+            }),
         }
     }
 
@@ -631,6 +708,7 @@ mod tests {
             results: None,
             baseline_comparison: None,
             hints: None,
+            failure: None,
         });
 
         assert!(out.passed);
@@ -650,6 +728,7 @@ mod tests {
                 results: None,
                 baseline_comparison: None,
                 hints: Some(vec!["check output".to_string()]),
+                failure: None,
             },
             None,
         );
@@ -934,6 +1013,53 @@ mod tests {
         assert_eq!(rows[0]["assistant_message_count"], 2.0);
         assert_eq!(rows[1]["rig_id"], "next");
         assert_eq!(rows[1]["delta_p50_pct"], -20.0);
+    }
+
+    #[test]
+    fn aggregate_surfaces_no_parseable_failure_metadata() {
+        let r = results(vec![scenario("boot", &[("p95_ms", 100.0)])]);
+        let entries = vec![
+            entry("baseline", true, Some(r)),
+            failed_entry_with_stderr("candidate"),
+        ];
+        let (out, exit) = aggregate_comparison("studio".into(), 10, entries);
+
+        assert_eq!(exit, 2);
+        assert_eq!(out.failures.len(), 1);
+        let failure = &out.failures[0];
+        assert_eq!(failure.rig_id, "candidate");
+        assert_eq!(failure.component_id, "studio");
+        assert_eq!(failure.exit_code, 2);
+        assert!(failure
+            .stderr_tail
+            .contains("Homeboy bench helper not found"));
+
+        let value = serde_json::to_value(&out).unwrap();
+        let json_failure = &value["failures"][0];
+        assert_eq!(json_failure["rig_id"], "candidate");
+        assert_eq!(json_failure["component_id"], "studio");
+        assert!(json_failure["stderr_tail"]
+            .as_str()
+            .unwrap()
+            .contains("bench-helper.sh"));
+    }
+
+    #[test]
+    fn aggregate_puts_actionable_failure_block_before_generic_hint() {
+        let r = results(vec![scenario("boot", &[("p95_ms", 100.0)])]);
+        let entries = vec![
+            entry("baseline", true, Some(r)),
+            failed_entry_with_stderr("candidate"),
+        ];
+        let (out, _) = aggregate_comparison("studio".into(), 10, entries);
+        let hints = out.hints.as_ref().unwrap();
+
+        assert!(hints[0].starts_with("Rig failed before producing parseable bench results:"));
+        assert!(hints[0].contains("- rig: candidate"));
+        assert!(hints[0].contains("- component: studio (/Users/chubes/Developer/studio@candidate)"));
+        assert!(hints[0].contains("- exit: 2"));
+        assert!(hints[0].contains("Homeboy bench helper not found"));
+        assert!(hints[1].contains("no parseable results"));
     }
 }
 

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -65,6 +65,19 @@ pub struct BenchRunWorkflowResult {
     pub results: Option<BenchResults>,
     pub baseline_comparison: Option<BenchBaselineComparison>,
     pub hints: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<BenchRunFailure>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BenchRunFailure {
+    pub component_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    pub exit_code: i32,
+    pub stderr_tail: String,
 }
 
 #[derive(Debug, Clone)]
@@ -227,7 +240,7 @@ pub fn run_main_bench_workflow(
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
 
-    let (parsed, runner_success, runner_exit_code) = if args.runs > 1 {
+    let (parsed, runner_success, runner_exit_code, failure_stderr_tail) = if args.runs > 1 {
         run_sequential_runs(&execution_context, component, &args, run_dir)?
     } else if args.concurrency <= 1 {
         let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
@@ -238,7 +251,17 @@ pub fn run_main_bench_workflow(
         } else {
             None
         };
-        (parsed, runner_output.success, runner_output.exit_code)
+        let failure_stderr_tail = if !runner_output.success {
+            Some(stderr_tail(&runner_output.stderr))
+        } else {
+            None
+        };
+        (
+            parsed,
+            runner_output.success,
+            runner_output.exit_code,
+            failure_stderr_tail,
+        )
     } else {
         run_concurrent_instances(&execution_context, component, &args, run_dir)?
     };
@@ -303,6 +326,20 @@ pub fn run_main_bench_workflow(
     let hints = if hints.is_empty() { None } else { Some(hints) };
 
     let exit_code = baseline_exit_override.unwrap_or(runner_exit_code);
+    let failure = if parsed.is_none() && !runner_success {
+        failure_stderr_tail.map(|stderr_tail| BenchRunFailure {
+            component_id: args.component_id.clone(),
+            component_path: args
+                .path_override
+                .clone()
+                .or_else(|| Some(component.local_path.clone())),
+            scenario_id: None,
+            exit_code: runner_exit_code,
+            stderr_tail,
+        })
+    } else {
+        None
+    };
 
     Ok(BenchRunWorkflowResult {
         status: status.to_string(),
@@ -312,7 +349,15 @@ pub fn run_main_bench_workflow(
         results: parsed,
         baseline_comparison,
         hints,
+        failure,
     })
+}
+
+fn stderr_tail(stderr: &str) -> String {
+    const MAX_LINES: usize = 20;
+    let lines: Vec<&str> = stderr.lines().collect();
+    let start = lines.len().saturating_sub(MAX_LINES);
+    lines[start..].join("\n")
 }
 
 fn run_sequential_runs(
@@ -320,13 +365,14 @@ fn run_sequential_runs(
     component: &Component,
     args: &BenchRunWorkflowArgs,
     run_dir: &RunDir,
-) -> Result<(Option<BenchResults>, bool, i32)> {
+) -> Result<(Option<BenchResults>, bool, i32, Option<String>)> {
     let mut parsed_runs = Vec::new();
     let mut all_success = true;
     let mut first_failure_exit: Option<i32> = None;
+    let mut first_failure_stderr_tail: Option<String> = None;
 
     for _ in 0..args.runs {
-        let (parsed, success, exit_code) = if args.concurrency <= 1 {
+        let (parsed, success, exit_code, stderr_tail) = if args.concurrency <= 1 {
             run_single_dispatcher(execution_context, component, args, run_dir)?
         } else {
             run_concurrent_instances(execution_context, component, args, run_dir)?
@@ -335,6 +381,9 @@ fn run_sequential_runs(
             all_success = false;
             if first_failure_exit.is_none() {
                 first_failure_exit = Some(exit_code);
+            }
+            if first_failure_stderr_tail.is_none() {
+                first_failure_stderr_tail = stderr_tail;
             }
         }
         if let Some(result) = parsed {
@@ -353,7 +402,7 @@ fn run_sequential_runs(
         first_failure_exit.unwrap_or(1)
     };
 
-    Ok((merged, all_success, exit_code))
+    Ok((merged, all_success, exit_code, first_failure_stderr_tail))
 }
 
 fn run_single_dispatcher(
@@ -361,7 +410,7 @@ fn run_single_dispatcher(
     component: &Component,
     args: &BenchRunWorkflowArgs,
     run_dir: &RunDir,
-) -> Result<(Option<BenchResults>, bool, i32)> {
+) -> Result<(Option<BenchResults>, bool, i32, Option<String>)> {
     let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
     if results_file.exists() {
         std::fs::remove_file(&results_file).map_err(|e| {
@@ -382,7 +431,17 @@ fn run_single_dispatcher(
     } else {
         None
     };
-    Ok((parsed, runner_output.success, runner_output.exit_code))
+    let failure_stderr_tail = if !runner_output.success {
+        Some(stderr_tail(&runner_output.stderr))
+    } else {
+        None
+    };
+    Ok((
+        parsed,
+        runner_output.success,
+        runner_output.exit_code,
+        failure_stderr_tail,
+    ))
 }
 
 /// Per-instance results filename within the run dir.
@@ -468,7 +527,7 @@ fn run_concurrent_instances(
     component: &Component,
     args: &BenchRunWorkflowArgs,
     run_dir: &RunDir,
-) -> Result<(Option<BenchResults>, bool, i32)> {
+) -> Result<(Option<BenchResults>, bool, i32, Option<String>)> {
     let concurrency = args.concurrency;
     let execution_context = Arc::new(execution_context.clone());
     let component = Arc::new(component.clone());
@@ -503,11 +562,15 @@ fn run_concurrent_instances(
     // First failure wins for the exit code surface; status is "all-or-nothing".
     let mut all_success = true;
     let mut first_failure_exit: Option<i32> = None;
+    let mut first_failure_stderr_tail: Option<String> = None;
     for (_, output) in &per_instance {
         if !output.success {
             all_success = false;
             if first_failure_exit.is_none() {
                 first_failure_exit = Some(output.exit_code);
+            }
+            if first_failure_stderr_tail.is_none() {
+                first_failure_stderr_tail = Some(stderr_tail(&output.stderr));
             }
         }
     }
@@ -559,7 +622,7 @@ fn run_concurrent_instances(
         })
     };
 
-    Ok((merged, all_success, exit_code))
+    Ok((merged, all_success, exit_code, first_failure_stderr_tail))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Surface cross-rig bench failures that happen before a parseable results file exists.
- Preserve the failing runner's stderr tail so setup errors are visible beside the comparison summary.

## Changes
- Adds failure metadata to bench run output and promotes it to a comparison-level `failures` array.
- Includes rig id, component id/path, optional scenario id, exit code, and stderr tail.
- Prepends an actionable failure block to hints before the generic no-parseable-results guidance.
- Covers the no-parseable-results cross-rig path with focused serialization and hint-order tests.

## Tests
- `cargo test bench -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@bench-failure-surfacing`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@bench-failure-surfacing --changed-since origin/main`

Closes #1818

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the bench failure metadata plumbing, focused tests, and PR preparation.
