### PR TITLE
feat(bench): add scenario selector

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -60,11 +60,15 @@ the other capabilities.
   run the same component + workload + iteration count against each rig in
   sequence and emit a cross-rig comparison envelope. See "Cross-rig
   comparison" below.
+- `--scenario <SCENARIO_ID>`: Run or list only the exact scenario id. May
+  be repeated. Homeboy validates selected ids against discovery before
+  execution and forwards the comma-separated selector to runners via
+  `$HOMEBOY_BENCH_SCENARIOS`.
 - `--ignore-default-baseline`: Skip automatic single-rig expansion when
   the rig declares `bench.default_baseline_rig`.
 
 Arguments after `--` are passed verbatim to the extension's bench runner
-script (e.g., `--filter=scenario_id` for selective execution).
+script.
 
 ## Scenario Discovery
 
@@ -95,8 +99,13 @@ homeboy bench my-component --baseline
 # Run with auto-ratchet on improvement
 homeboy bench my-component --ratchet
 
-# Select a single scenario via passthrough args
-homeboy bench my-component -- --filter=hot_path
+# Select a single scenario
+homeboy bench my-component --scenario hot_path
+
+# Select two scenarios in a cross-rig comparison
+homeboy bench studio --rig studio-trunk,studio-branch \
+    --scenario studio-agent-runtime \
+    --scenario wp-admin-load
 
 # Share warm state across invocations and run four instances in parallel
 homeboy bench my-component --shared-state /tmp/homeboy-bench --concurrency 4

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -42,6 +42,10 @@ struct BenchListArgs {
     #[arg(long, value_name = "RIG_ID", value_delimiter = ',')]
     rig: Vec<String>,
 
+    /// Only list matching benchmark scenario ids. Repeat to select multiple.
+    #[arg(long = "scenario", value_name = "SCENARIO_ID")]
+    scenario_ids: Vec<String>,
+
     #[command(flatten)]
     setting_args: SettingArgs,
 
@@ -123,6 +127,10 @@ pub struct BenchRunArgs {
     #[arg(long, value_name = "RIG_ID[,RIG_ID...]", value_delimiter = ',')]
     rig: Vec<String>,
 
+    /// Only run matching benchmark scenario ids. Repeat to select multiple.
+    #[arg(long = "scenario", value_name = "SCENARIO_ID")]
+    scenario_ids: Vec<String>,
+
     /// Skip auto-upgrading single-rig runs into a comparison even when
     /// the rig spec declares `bench.default_baseline_rig`. Use with
     /// `--baseline` / `--ratchet` against a rig that normally
@@ -154,6 +162,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
         "--shared-state",
         "--concurrency",
         "--regression-threshold",
+        "--scenario",
         "--rig",
         "--setting",
         "--path",
@@ -366,6 +375,7 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
                 })
                 .collect(),
             passthrough_args,
+            scenario_ids: args.scenario_ids.clone(),
             extra_workloads,
         },
         &run_dir,
@@ -552,16 +562,34 @@ mod tests {
             &script_path,
             r#"#!/bin/sh
 if [ -n "$HOMEBOY_BENCH_EXTRA_WORKLOADS" ]; then
-  scenario="rig-extra"
+  all_scenarios="rig-extra rig-slow"
 else
-  scenario="in-tree"
+  all_scenarios="in-tree slow"
 fi
+
+if [ "$HOMEBOY_BENCH_LIST_ONLY" = "1" ] || [ -z "$HOMEBOY_BENCH_SCENARIOS" ]; then
+  selected="$all_scenarios"
+else
+  selected=$(printf '%s' "$HOMEBOY_BENCH_SCENARIOS" | tr ',' ' ')
+fi
+
 cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
 {
   "component_id": "$HOMEBOY_COMPONENT_ID",
-  "iterations": 0,
+  "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0},
   "scenarios": [
-    { "id": "$scenario", "iterations": 0, "metrics": { "p95_ms": 1.0 } }
+JSON
+
+comma=""
+for scenario in $selected; do
+  cat >> "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+    $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0 } }
+JSON
+  comma=",
+"
+done
+
+cat >> "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
   ],
   "metric_policies": { "p95_ms": { "direction": "lower_is_better" } }
 }
@@ -628,8 +656,38 @@ JSON
                 path: None,
             },
             rig,
+            scenario_ids: Vec::new(),
             setting_args: SettingArgs::default(),
             args: Vec::new(),
+        }
+    }
+
+    fn run_args(component: Option<&str>, rig: Vec<String>, scenario_ids: Vec<String>) -> BenchArgs {
+        BenchArgs {
+            command: None,
+            run: BenchRunArgs {
+                comp: PositionalComponentArgs {
+                    component: component.map(str::to_string),
+                    path: None,
+                },
+                iterations: 1,
+                runs: 1,
+                shared_state: None,
+                concurrency: 1,
+                baseline_args: BaselineArgs {
+                    baseline: false,
+                    ignore_baseline: true,
+                    ratchet: false,
+                },
+                regression_threshold: 5.0,
+                setting_args: SettingArgs::default(),
+                args: Vec::new(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                rig,
+                scenario_ids,
+                ignore_default_baseline: false,
+            },
         }
     }
 
@@ -651,6 +709,27 @@ JSON
     }
 
     #[test]
+    fn parses_repeated_scenario_flags() {
+        let cli = TestCli::try_parse_from([
+            "bench",
+            "homeboy",
+            "--scenario",
+            "studio-agent-runtime",
+            "--scenario",
+            "wp-admin-load",
+        ])
+        .expect("bench --scenario should parse");
+
+        assert_eq!(
+            cli.bench.run.scenario_ids,
+            vec![
+                "studio-agent-runtime".to_string(),
+                "wp-admin-load".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn run_list_uses_rig_default_component_and_workloads() {
         with_isolated_home(|home| {
             write_bench_extension(home);
@@ -665,7 +744,7 @@ JSON
                 BenchOutput::List(result) => {
                     assert_eq!(result.component, "studio");
                     assert_eq!(result.component_id, "studio");
-                    assert_eq!(result.count, 1);
+                    assert_eq!(result.count, 2);
                     assert_eq!(result.scenarios[0].id, "rig-extra");
                 }
                 _ => panic!("expected list output"),
@@ -688,10 +767,150 @@ JSON
                 BenchOutput::List(result) => {
                     assert_eq!(result.component, "studio");
                     assert_eq!(result.component_id, "studio");
-                    assert_eq!(result.count, 1);
+                    assert_eq!(result.count, 2);
                     assert_eq!(result.scenarios[0].id, "in-tree");
                 }
                 _ => panic!("expected list output"),
+            }
+        });
+    }
+
+    #[test]
+    fn run_list_filters_selected_scenario() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_registered_component(home, "studio", component_dir.path());
+
+            let mut args = list_args(Some("studio"), Vec::new());
+            args.scenario_ids = vec!["slow".to_string()];
+            let (output, exit_code) = run_list(&args).expect("plain bench list should run");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::List(result) => {
+                    assert_eq!(result.count, 1);
+                    assert_eq!(result.scenarios[0].id, "slow");
+                }
+                _ => panic!("expected list output"),
+            }
+        });
+    }
+
+    #[test]
+    fn run_selects_single_scenario() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_registered_component(home, "studio", component_dir.path());
+
+            let (output, exit_code) = run(
+                run_args(Some("studio"), Vec::new(), vec!["slow".to_string()]),
+                &GlobalArgs {},
+            )
+            .expect("selected bench should run");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Single(result) => {
+                    let scenarios = result.results.expect("results").scenarios;
+                    assert_eq!(scenarios.len(), 1);
+                    assert_eq!(scenarios[0].id, "slow");
+                }
+                _ => panic!("expected single output"),
+            }
+        });
+    }
+
+    #[test]
+    fn run_selects_multiple_scenarios() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_registered_component(home, "studio", component_dir.path());
+
+            let (output, exit_code) = run(
+                run_args(
+                    Some("studio"),
+                    Vec::new(),
+                    vec!["in-tree".to_string(), "slow".to_string()],
+                ),
+                &GlobalArgs {},
+            )
+            .expect("selected bench should run");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Single(result) => {
+                    let scenario_ids: Vec<String> = result
+                        .results
+                        .expect("results")
+                        .scenarios
+                        .into_iter()
+                        .map(|scenario| scenario.id)
+                        .collect();
+                    assert_eq!(
+                        scenario_ids,
+                        vec!["in-tree".to_string(), "slow".to_string()]
+                    );
+                }
+                _ => panic!("expected single output"),
+            }
+        });
+    }
+
+    #[test]
+    fn unknown_scenario_reports_discovered_ids() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_registered_component(home, "studio", component_dir.path());
+
+            let err = match run(
+                run_args(Some("studio"), Vec::new(), vec!["missing".to_string()]),
+                &GlobalArgs {},
+            ) {
+                Ok(_) => panic!("unknown scenario should fail"),
+                Err(err) => err,
+            };
+            let message = err.to_string();
+
+            assert!(message.contains("missing"), "got: {}", message);
+            assert!(message.contains("in-tree"), "got: {}", message);
+            assert!(message.contains("slow"), "got: {}", message);
+        });
+    }
+
+    #[test]
+    fn cross_rig_run_passes_selector_to_each_rig() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_a = tempfile::TempDir::new().expect("component a");
+            let component_b = tempfile::TempDir::new().expect("component b");
+            write_rig(home, "rig-a", "studio", component_a.path());
+            write_rig(home, "rig-b", "studio", component_b.path());
+
+            let (output, exit_code) = run(
+                run_args(
+                    None,
+                    vec!["rig-a".to_string(), "rig-b".to_string()],
+                    vec!["rig-slow".to_string()],
+                ),
+                &GlobalArgs {},
+            )
+            .expect("cross-rig selected bench should run");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Comparison(result) => {
+                    assert_eq!(result.rigs.len(), 2);
+                    for rig in result.rigs {
+                        let scenarios = rig.results.expect("rig results").scenarios;
+                        assert_eq!(scenarios.len(), 1);
+                        assert_eq!(scenarios[0].id, "rig-slow");
+                    }
+                }
+                _ => panic!("expected comparison output"),
             }
         });
     }

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -308,6 +308,7 @@ fn run_component_with_rig_context(
             regression_threshold_percent: args.regression_threshold,
             json_summary: args.json_summary,
             passthrough_args: passthrough_args.to_vec(),
+            scenario_ids: args.scenario_ids.clone(),
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
             concurrency: args.concurrency,
@@ -400,6 +401,7 @@ mod tests {
             _json: HiddenJsonArgs::default(),
             json_summary: false,
             rig: vec!["rig".to_string()],
+            scenario_ids: Vec::new(),
             ignore_default_baseline: false,
         };
 

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -13,6 +13,7 @@
 //! - `$HOMEBOY_BENCH_RESULTS_FILE` — path to write the JSON envelope to.
 //! - `$HOMEBOY_BENCH_ITERATIONS` — iterations per scenario.
 //! - `$HOMEBOY_BENCH_LIST_ONLY` — when `1`, emit scenario inventory only.
+//! - `$HOMEBOY_BENCH_SCENARIOS` — comma-separated exact scenario ids selected by `--scenario`.
 //! - `$HOMEBOY_RUN_DIR` — the per-run directory (same as test/lint/build).
 //! - Passthrough args after `--` forwarded verbatim to the script.
 //!

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -35,6 +35,9 @@ pub struct BenchRunWorkflowArgs {
     pub regression_threshold_percent: f64,
     pub json_summary: bool,
     pub passthrough_args: Vec<String>,
+    /// Exact scenario ids selected by the CLI. Empty means run every
+    /// discovered scenario.
+    pub scenario_ids: Vec<String>,
     /// Optional rig identifier when bench was invoked via `--rig <id>`.
     /// Threads through to the baseline storage key so rig-pinned and
     /// unpinned baselines stay in separate slots inside `homeboy.json`.
@@ -88,6 +91,7 @@ pub struct BenchListWorkflowArgs {
     pub settings: Vec<(String, String)>,
     pub settings_json: Vec<(String, serde_json::Value)>,
     pub passthrough_args: Vec<String>,
+    pub scenario_ids: Vec<String>,
     pub extra_workloads: Vec<PathBuf>,
 }
 
@@ -127,6 +131,7 @@ pub fn run_bench_list_workflow(
             regression_threshold_percent: 0.0,
             json_summary: false,
             passthrough_args: args.passthrough_args,
+            scenario_ids: Vec::new(),
             rig_id: None,
             shared_state: None,
             concurrency: 1,
@@ -153,7 +158,10 @@ pub fn run_bench_list_workflow(
         ));
     }
 
-    let parsed = parsing::parse_bench_results_file(&results_file)?;
+    let parsed = apply_scenario_filter(
+        parsing::parse_bench_results_file(&results_file)?,
+        &args.scenario_ids,
+    )?;
     let count = parsed.scenarios.len();
 
     Ok(BenchListWorkflowResult {
@@ -162,6 +170,89 @@ pub fn run_bench_list_workflow(
         scenarios: parsed.scenarios,
         count,
     })
+}
+
+fn apply_scenario_filter(
+    mut results: BenchResults,
+    scenario_ids: &[String],
+) -> Result<BenchResults> {
+    if scenario_ids.is_empty() {
+        return Ok(results);
+    }
+
+    let discovered: Vec<String> = results.scenarios.iter().map(|s| s.id.clone()).collect();
+    let missing: Vec<String> = scenario_ids
+        .iter()
+        .filter(|id| !discovered.contains(id))
+        .cloned()
+        .collect();
+
+    if !missing.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "scenario",
+            format!(
+                "unknown bench scenario id(s): {}; discovered ids: {}",
+                missing.join(", "),
+                if discovered.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    discovered.join(", ")
+                }
+            ),
+            Some(missing.join(", ")),
+            Some(discovered),
+        ));
+    }
+
+    results
+        .scenarios
+        .retain(|scenario| scenario_ids.contains(&scenario.id));
+    Ok(results)
+}
+
+fn discover_bench_scenarios(
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: &BenchRunWorkflowArgs,
+    run_dir: &RunDir,
+) -> Result<BenchResults> {
+    let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+    if results_file.exists() {
+        std::fs::remove_file(&results_file).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to clear previous bench discovery results file {}: {}",
+                    results_file.display(),
+                    e
+                ),
+                Some("bench.discovery.results_file".to_string()),
+            )
+        })?;
+    }
+
+    let mut discovery_args = args.clone();
+    discovery_args.scenario_ids.clear();
+
+    let runner_output = build_runner(execution_context, component, &discovery_args, run_dir, None)?
+        .env("HOMEBOY_BENCH_LIST_ONLY", "1")
+        .run()?;
+
+    if !runner_output.success {
+        return Err(Error::validation_invalid_argument(
+            "scenario",
+            format!(
+                "bench scenario discovery failed with exit code {}",
+                runner_output.exit_code
+            ),
+            Some(format!(
+                "stdout:\n{}\n\nstderr:\n{}",
+                runner_output.stdout, runner_output.stderr
+            )),
+            None,
+        ));
+    }
+
+    parsing::parse_bench_results_file(&results_file)
 }
 
 fn validate_bench_run_args(args: &BenchRunWorkflowArgs) -> Result<()> {
@@ -240,6 +331,11 @@ pub fn run_main_bench_workflow(
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
 
+    if !args.scenario_ids.is_empty() {
+        let discovered = discover_bench_scenarios(&execution_context, component, &args, run_dir)?;
+        apply_scenario_filter(discovered, &args.scenario_ids)?;
+    }
+
     let (parsed, runner_success, runner_exit_code, failure_stderr_tail) = if args.runs > 1 {
         run_sequential_runs(&execution_context, component, &args, run_dir)?
     } else if args.concurrency <= 1 {
@@ -247,7 +343,10 @@ pub fn run_main_bench_workflow(
         let runner_output =
             build_runner(&execution_context, component, &args, run_dir, None)?.run()?;
         let parsed = if results_file.exists() {
-            parsing::parse_bench_results_file(&results_file).ok()
+            parsing::parse_bench_results_file(&results_file)
+                .ok()
+                .map(|results| apply_scenario_filter(results, &args.scenario_ids))
+                .transpose()?
         } else {
             None
         };
@@ -427,7 +526,10 @@ fn run_single_dispatcher(
 
     let runner_output = build_runner(execution_context, component, args, run_dir, None)?.run()?;
     let parsed = if results_file.exists() {
-        Some(parsing::parse_bench_results_file(&results_file)?)
+        Some(apply_scenario_filter(
+            parsing::parse_bench_results_file(&results_file)?,
+            &args.scenario_ids,
+        )?)
     } else {
         None
     };
@@ -480,6 +582,10 @@ fn build_runner(
             "HOMEBOY_BENCH_EXTRA_WORKLOADS",
             &extra_workloads_env_value(&args.extra_workloads)?,
         );
+    }
+
+    if !args.scenario_ids.is_empty() {
+        runner = runner.env("HOMEBOY_BENCH_SCENARIOS", &args.scenario_ids.join(","));
     }
 
     if let Some(ref shared) = args.shared_state {
@@ -592,7 +698,9 @@ fn run_concurrent_instances(
         if !path.exists() {
             continue;
         }
-        let parsed = match parsing::parse_bench_results_file(&path) {
+        let parsed = match parsing::parse_bench_results_file(&path)
+            .and_then(|results| apply_scenario_filter(results, &args.scenario_ids))
+        {
             Ok(p) => p,
             Err(_) => continue,
         };
@@ -702,6 +810,7 @@ mod tests {
                 regression_threshold_percent: 5.0,
                 json_summary: false,
                 passthrough_args: Vec::new(),
+                scenario_ids: Vec::new(),
                 rig_id: None,
                 shared_state: None,
                 concurrency: 0,

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -54,6 +54,7 @@ fn make_args(
             _json: HiddenJsonArgs::default(),
             json_summary: false,
             rig,
+            scenario_ids: Vec::new(),
             ignore_default_baseline,
         },
     }


### PR DESCRIPTION
## Summary
- Add repeated `--scenario <id>` filtering for bench runs and `bench list`.
- Validate selected scenario ids against discovery before execution and surface discovered ids on mistakes.
- Thread the selector through normal, single-rig, and cross-rig bench paths via `HOMEBOY_BENCH_SCENARIOS`.

## Changes
- Adds `scenario_ids` to bench CLI/workflow args and strips `--scenario` from runner passthrough args.
- Discovers scenarios without the selector, validates exact ids, then exports a comma-separated selector for execution.
- Post-filters parsed results to keep output aligned with the selected scenario set.
- Documents the CLI flag and runner env contract.

## Tests
- `cargo test bench -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@bench-scenario-selector`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@bench-scenario-selector --changed-since origin/main`

Closes #1817

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scenario selector plumbing, tests, docs, and local verification; Chris remains responsible for review and merge.