### PR TITLE
feat(bench): include run metadata in results

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -126,6 +126,9 @@ fn merge_matrix_results(
         Some(BenchResults {
             component_id: component_ids.join(","),
             iterations: iterations_seen.unwrap_or(0),
+            run_metadata: outputs
+                .iter()
+                .find_map(|output| output.results.as_ref()?.run_metadata.clone()),
             scenarios: merged_scenarios,
             metric_policies: metric_policies_seen,
         })

--- a/src/core/extension/bench/aggregation.rs
+++ b/src/core/extension/bench/aggregation.rs
@@ -57,6 +57,7 @@ pub fn aggregate_runs(runs: &[BenchResults]) -> Result<BenchResults> {
     Ok(BenchResults {
         component_id: first.component_id.clone(),
         iterations: first.iterations,
+        run_metadata: first.run_metadata.clone(),
         scenarios,
         metric_policies,
     })

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -383,6 +383,7 @@ mod tests {
         BenchResults {
             component_id: "demo".to_string(),
             iterations: 10,
+            run_metadata: None,
             scenarios,
             metric_policies: BTreeMap::new(),
         }
@@ -395,6 +396,7 @@ mod tests {
         BenchResults {
             component_id: "demo".to_string(),
             iterations: 10,
+            run_metadata: None,
             scenarios,
             metric_policies,
         }

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -339,6 +339,7 @@ mod tests {
         BenchResults {
             component_id: "demo".to_string(),
             iterations: 10,
+            run_metadata: None,
             scenarios: vec![BenchScenario {
                 id: "scenario".to_string(),
                 file: None,

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -64,9 +64,60 @@ fn is_true(value: &bool) -> bool {
 pub struct BenchResults {
     pub component_id: String,
     pub iterations: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_metadata: Option<BenchRunMetadata>,
     pub scenarios: Vec<BenchScenario>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metric_policies: BTreeMap<String, BenchMetricPolicy>,
+}
+
+/// Homeboy-owned reproducibility metadata for a bench invocation.
+///
+/// Extension runners are not required to emit this block. Homeboy stamps it
+/// after parsing so stored bench artifacts explain what ran without requiring
+/// each language runner to duplicate CLI/runtime bookkeeping.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BenchRunMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homeboy_version: Option<String>,
+    pub started_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shared_state: Option<String>,
+    pub iterations: u64,
+    pub runs: u64,
+    pub concurrency: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warmup_iterations: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected_scenarios: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env_overrides: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workloads: Vec<BenchWorkloadMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner: Option<BenchRunnerMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchWorkloadMetadata {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchRunnerMetadata {
+    pub extension: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
 }
 
 /// One scenario's measurements.

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -733,6 +733,7 @@ mod tests {
         BenchResults {
             component_id: "studio".to_string(),
             iterations: 10,
+            run_metadata: None,
             scenarios,
             metric_policies: BTreeMap::new(),
         }

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1,10 +1,13 @@
 //! Bench main workflow: invoke extension runner, load JSON, apply baseline.
 
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 use std::thread;
 
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::component::Component;
 use crate::engine::baseline::BaselineFlags;
@@ -12,7 +15,9 @@ use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
 use crate::extension::bench::aggregate_runs;
 use crate::extension::bench::baseline::{self, BenchBaselineComparison};
-use crate::extension::bench::parsing::{self, BenchResults, BenchScenario};
+use crate::extension::bench::parsing::{
+    self, BenchResults, BenchRunMetadata, BenchRunnerMetadata, BenchScenario, BenchWorkloadMetadata,
+};
 use crate::extension::{
     resolve_execution_context, ExtensionCapability, ExtensionExecutionContext, ExtensionRunner,
 };
@@ -317,6 +322,7 @@ pub fn run_main_bench_workflow(
     run_dir: &RunDir,
 ) -> Result<BenchRunWorkflowResult> {
     validate_bench_run_args(&args)?;
+    let started_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
     if let Some(ref shared) = args.shared_state {
         std::fs::create_dir_all(shared).map_err(|e| {
@@ -366,6 +372,10 @@ pub fn run_main_bench_workflow(
     } else {
         run_concurrent_instances(&execution_context, component, &args, run_dir)?
     };
+
+    if let Some(results) = parsed.as_mut() {
+        stamp_run_metadata(results, &execution_context, component, &args, &started_at);
+    }
 
     let gate_failures = parsed
         .as_mut()
@@ -479,6 +489,169 @@ fn stderr_tail(stderr: &str) -> String {
     let lines: Vec<&str> = stderr.lines().collect();
     let start = lines.len().saturating_sub(MAX_LINES);
     lines[start..].join("\n")
+}
+
+fn stamp_run_metadata(
+    results: &mut BenchResults,
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: &BenchRunWorkflowArgs,
+    started_at: &str,
+) {
+    let mut workloads = workload_metadata(&results.scenarios, component, &args.extra_workloads);
+    workloads.sort_by(|a, b| a.id.cmp(&b.id).then_with(|| a.path.cmp(&b.path)));
+
+    results.run_metadata = Some(BenchRunMetadata {
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        started_at: started_at.to_string(),
+        shared_state: args
+            .shared_state
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string()),
+        iterations: args.iterations,
+        runs: args.runs,
+        concurrency: args.concurrency,
+        warmup_iterations: bench_warmup_iterations(),
+        selected_scenarios: args.scenario_ids.clone(),
+        env_overrides: bench_env_overrides(),
+        workloads,
+        runner: Some(BenchRunnerMetadata {
+            extension: execution_context.extension_id.clone(),
+            path: execution_context
+                .extension_path
+                .to_string_lossy()
+                .to_string(),
+            source_revision: source_revision_at(&execution_context.extension_path),
+        }),
+    });
+}
+
+fn workload_metadata(
+    scenarios: &[BenchScenario],
+    component: &Component,
+    extra_workloads: &[PathBuf],
+) -> Vec<BenchWorkloadMetadata> {
+    let mut workloads = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+
+    for scenario in scenarios {
+        let resolved = scenario
+            .file
+            .as_deref()
+            .map(|path| resolve_workload_path(path, component));
+        if let Some(path) = &resolved {
+            seen_paths.insert(path.to_string_lossy().to_string());
+        }
+        workloads.push(BenchWorkloadMetadata {
+            id: scenario.id.clone(),
+            source: scenario.source.clone(),
+            path: resolved
+                .as_ref()
+                .map(|path| path.to_string_lossy().to_string()),
+            sha256: resolved.as_deref().and_then(sha256_file),
+        });
+    }
+
+    for path in extra_workloads {
+        let path_string = path.to_string_lossy().to_string();
+        if !seen_paths.insert(path_string.clone()) {
+            continue;
+        }
+        workloads.push(BenchWorkloadMetadata {
+            id: path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("extra-workload")
+                .to_string(),
+            source: Some("rig".to_string()),
+            path: Some(path_string),
+            sha256: sha256_file(path),
+        });
+    }
+
+    workloads
+}
+
+fn resolve_workload_path(path: &str, component: &Component) -> PathBuf {
+    let workload_path = PathBuf::from(path);
+    if workload_path.is_absolute() {
+        workload_path
+    } else {
+        PathBuf::from(&component.local_path).join(workload_path)
+    }
+}
+
+fn sha256_file(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    let hash = Sha256::digest(&bytes);
+    Some(hash.iter().map(|byte| format!("{:02x}", byte)).collect())
+}
+
+fn bench_warmup_iterations() -> Option<u64> {
+    std::env::var("HOMEBOY_BENCH_WARMUP_ITERATIONS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+}
+
+fn bench_env_overrides() -> BTreeMap<String, String> {
+    bench_env_overrides_from_iter(std::env::vars())
+}
+
+fn bench_env_overrides_from_iter<I, K, V>(vars: I) -> BTreeMap<String, String>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    vars.into_iter()
+        .filter_map(|(key, value)| {
+            let key = key.into();
+            if key.starts_with("HOMEBOY_BENCH_") && !is_secret_like_env_key(&key) {
+                Some((key, value.into()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn is_secret_like_env_key(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    [
+        "TOKEN",
+        "SECRET",
+        "PASSWORD",
+        "CREDENTIAL",
+        "AUTH",
+        "API_KEY",
+        "PRIVATE_KEY",
+    ]
+    .iter()
+    .any(|needle| upper.contains(needle))
+}
+
+fn source_revision_at(path: &Path) -> Option<String> {
+    git_short_revision_at(path).or_else(|| {
+        std::fs::read_to_string(path.join(".source-revision"))
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn git_short_revision_at(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!revision.is_empty()).then_some(revision)
 }
 
 fn run_sequential_runs(
@@ -747,6 +920,7 @@ fn run_concurrent_instances(
         Some(BenchResults {
             component_id: component_id_seen.unwrap_or_else(|| args.component_id.clone()),
             iterations: iterations_seen.unwrap_or(args.iterations),
+            run_metadata: None,
             scenarios: merged_scenarios,
             metric_policies: metric_policies_seen,
         })
@@ -846,5 +1020,129 @@ mod tests {
         .expect_err("zero concurrency must fail before runner resolution");
 
         assert!(format!("{}", err).contains("concurrency"));
+    }
+
+    #[test]
+    fn run_metadata_captures_reproducible_bench_context() {
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        let workload_dir = component_dir.path().join("tests/bench");
+        std::fs::create_dir_all(&workload_dir).expect("workload dir");
+        let workload = workload_dir.join("boot.rs");
+        std::fs::write(&workload, "fn main() {}\n").expect("workload file");
+        let extension_dir = tempfile::TempDir::new().expect("extension dir");
+
+        let component = Component {
+            id: "homeboy".to_string(),
+            local_path: component_dir.path().to_string_lossy().to_string(),
+            ..Component::default()
+        };
+        let execution_context = ExtensionExecutionContext {
+            component: component.clone(),
+            capability: ExtensionCapability::Bench,
+            extension_id: "rust".to_string(),
+            extension_path: extension_dir.path().to_path_buf(),
+            script_path: "bench-runner.sh".to_string(),
+            settings: Vec::new(),
+        };
+        let args = BenchRunWorkflowArgs {
+            component_label: "homeboy".to_string(),
+            component_id: "homeboy".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            iterations: 7,
+            runs: 3,
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent: 5.0,
+            json_summary: false,
+            passthrough_args: Vec::new(),
+            scenario_ids: vec!["boot".to_string()],
+            rig_id: Some("studio".to_string()),
+            shared_state: Some(component_dir.path().join("shared")),
+            concurrency: 2,
+            extra_workloads: Vec::new(),
+        };
+        let mut results = BenchResults {
+            component_id: "homeboy".to_string(),
+            iterations: 7,
+            run_metadata: None,
+            scenarios: vec![BenchScenario {
+                id: "boot".to_string(),
+                file: Some("tests/bench/boot.rs".to_string()),
+                source: Some("in_tree".to_string()),
+                default_iterations: None,
+                tags: Vec::new(),
+                iterations: 7,
+                metrics: parsing::BenchMetrics {
+                    values: BTreeMap::new(),
+                    distributions: BTreeMap::new(),
+                },
+                gates: Vec::new(),
+                gate_results: Vec::new(),
+                passed: true,
+                memory: None,
+                artifacts: BTreeMap::new(),
+                runs: None,
+                runs_summary: None,
+            }],
+            metric_policies: BTreeMap::new(),
+        };
+
+        stamp_run_metadata(
+            &mut results,
+            &execution_context,
+            &component,
+            &args,
+            "2026-04-28T00:00:00Z",
+        );
+
+        let metadata = results.run_metadata.expect("metadata stamped");
+        assert_eq!(
+            metadata.homeboy_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(metadata.started_at, "2026-04-28T00:00:00Z");
+        assert_eq!(metadata.iterations, 7);
+        assert_eq!(metadata.runs, 3);
+        assert_eq!(metadata.concurrency, 2);
+        assert_eq!(metadata.selected_scenarios, vec!["boot".to_string()]);
+        assert_eq!(metadata.runner.as_ref().unwrap().extension, "rust");
+        assert_eq!(metadata.workloads.len(), 1);
+        assert_eq!(metadata.workloads[0].id, "boot");
+        assert_eq!(metadata.workloads[0].source.as_deref(), Some("in_tree"));
+        assert_eq!(
+            metadata.workloads[0].path.as_deref(),
+            Some(workload.to_string_lossy().as_ref())
+        );
+        assert_eq!(metadata.workloads[0].sha256.as_ref().unwrap().len(), 64);
+    }
+
+    #[test]
+    fn bench_env_overrides_are_allow_listed_and_secret_safe() {
+        let vars = vec![
+            ("HOMEBOY_BENCH_WARMUP_ITERATIONS", "0"),
+            ("HOMEBOY_BENCH_PROFILE", "cold"),
+            ("HOMEBOY_BENCH_TOKEN", "secret"),
+            ("HOMEBOY_BENCH_API_KEY", "secret"),
+            ("DATABASE_URL", "postgres://user:pass@example/db"),
+        ];
+
+        let captured = bench_env_overrides_from_iter(vars);
+
+        assert_eq!(
+            captured.get("HOMEBOY_BENCH_WARMUP_ITERATIONS"),
+            Some(&"0".to_string())
+        );
+        assert_eq!(
+            captured.get("HOMEBOY_BENCH_PROFILE"),
+            Some(&"cold".to_string())
+        );
+        assert!(!captured.contains_key("HOMEBOY_BENCH_TOKEN"));
+        assert!(!captured.contains_key("HOMEBOY_BENCH_API_KEY"));
+        assert!(!captured.contains_key("DATABASE_URL"));
     }
 }

--- a/src/core/extension/bench/test_support.rs
+++ b/src/core/extension/bench/test_support.rs
@@ -41,6 +41,7 @@ pub(crate) fn results_with_scenarios(
     BenchResults {
         component_id: component_id.to_string(),
         iterations,
+        run_metadata: None,
         scenarios,
         metric_policies: BTreeMap::new(),
     }

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -55,6 +55,7 @@ fn results_with(
     BenchResults {
         component_id: "demo".to_string(),
         iterations: 10,
+        run_metadata: None,
         scenarios,
         metric_policies: policies,
     }


### PR DESCRIPTION
## Summary

- Add Homeboy-owned `run_metadata` to parsed bench results so artifacts explain what ran without requiring every extension runner to duplicate CLI/runtime bookkeeping.
- Stamp metadata after parsing with Homeboy version, timestamp, iterations/runs/concurrency, shared-state path, selected scenarios, workload paths and SHA-256 hashes, runner identity/revision, and secret-safe `HOMEBOY_BENCH_*` env overrides.
- Preserve legacy runner output compatibility by making `run_metadata` optional/defaulted and omitting it when absent in test fixtures.

## Behavior / Metadata Shape

`results.run_metadata` now includes:

- `homeboy_version`, `started_at`, `iterations`, `runs`, `concurrency`, `shared_state`, and `warmup_iterations` when available.
- `selected_scenarios` from the CLI selector.
- `workloads` from scenario files and rig-provided extra workloads, including path and SHA-256 when the file is readable.
- `runner` with extension id, extension path, and source revision from git or `.source-revision` when available.
- `env_overrides` limited to `HOMEBOY_BENCH_*` names, with secret-looking keys such as token, secret, password, auth, credential, API key, and private key filtered out.

## Tests

- `cargo test bench -- --test-threads=1` — passed, 171 tests.
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-bench-run-metadata --changed-since origin/main` — passed.
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-bench-run-metadata --changed-since origin/main` — ran and reported existing/noisy audit findings in touched bench files plus the intentional repeated `runs`/`concurrency` metadata shape. I kept the explicit output fields because this PR is defining a JSON contract, not extracting an internal abstraction.

Closes #1839

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the metadata stamping, tests, and verification commands; Chris remains responsible for review and merge.
