### PR TITLE
feat(bench): add warmup control

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -64,6 +64,13 @@ pub struct BenchRunArgs {
     #[arg(long, default_value_t = 10)]
     iterations: u64,
 
+    /// Warmup iterations to run before measured iterations. Forwarded to
+    /// the runner via HOMEBOY_BENCH_WARMUP_ITERATIONS. When omitted,
+    /// rig bench.warmup_iterations may provide the value; otherwise the
+    /// runner keeps its own default.
+    #[arg(long, value_name = "N", allow_hyphen_values = true)]
+    warmup: Option<u64>,
+
     /// Number of independent substrate spawns. Default 1 preserves today's
     /// exact behaviour. When > 1, the bench dispatcher is invoked N times in
     /// sequence and per-scenario metrics carry both the cross-run p50
@@ -158,6 +165,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 
     const HOMEBOY_VALUE_FLAGS: &[&str] = &[
         "--iterations",
+        "--warmup",
         "--runs",
         "--shared-state",
         "--concurrency",
@@ -584,7 +592,7 @@ JSON
 comma=""
 for scenario in $selected; do
   cat >> "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
-    $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0 } }
+    $comma{ "id": "$scenario", "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0}, "metrics": { "p95_ms": 1.0, "warmup_iterations": ${HOMEBOY_BENCH_WARMUP_ITERATIONS:--1} } }
 JSON
   comma=",
 "
@@ -650,6 +658,34 @@ JSON
         .expect("write rig");
     }
 
+    fn set_rig_warmup(home: &TempDir, rig_id: &str, warmup: u64) {
+        let rig_path = home
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("rigs")
+            .join(format!("{}.json", rig_id));
+        let mut rig_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&rig_path).expect("read rig"))
+                .expect("parse rig");
+        rig_json["bench"]["warmup_iterations"] = serde_json::json!(warmup);
+        fs::write(
+            &rig_path,
+            serde_json::to_string(&rig_json).expect("serialize rig"),
+        )
+        .expect("write rig");
+    }
+
+    fn first_warmup_metric(output: BenchOutput) -> f64 {
+        match output {
+            BenchOutput::Single(result) => result.results.expect("results").scenarios[0]
+                .metrics
+                .get("warmup_iterations")
+                .expect("warmup metric"),
+            _ => panic!("expected single output"),
+        }
+    }
+
     fn list_args(component: Option<&str>, rig: Vec<String>) -> BenchListArgs {
         BenchListArgs {
             comp: PositionalComponentArgs {
@@ -672,6 +708,7 @@ JSON
                     path: None,
                 },
                 iterations: 1,
+                warmup: None,
                 runs: 1,
                 shared_state: None,
                 concurrency: 1,
@@ -1043,6 +1080,203 @@ JSON
     fn filter_strips_iterations_equals_form() {
         let args = vec!["--iterations=50".to_string(), "--keep".to_string()];
         assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+    }
+
+    #[test]
+    fn parses_warmup_flag() {
+        let cli = TestCli::try_parse_from(["bench", "homeboy", "--warmup", "3"])
+            .expect("bench --warmup should parse");
+
+        assert_eq!(cli.bench.run.warmup, Some(3));
+    }
+
+    #[test]
+    fn rejects_negative_warmup_flag() {
+        let err = match TestCli::try_parse_from(["bench", "homeboy", "--warmup", "-1"]) {
+            Ok(_) => panic!("negative warmup must fail at parse time"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("invalid value"),
+            "expected invalid value error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn filter_strips_warmup_forms() {
+        let args = vec![
+            "--warmup".to_string(),
+            "3".to_string(),
+            "--filter=Scenario".to_string(),
+        ];
+        assert_eq!(filter_homeboy_flags(&args), vec!["--filter=Scenario"]);
+
+        let args = vec!["--warmup=3".to_string(), "--keep".to_string()];
+        assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+    }
+
+    #[test]
+    fn unrigged_bench_forwards_cli_warmup() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_registered_component(home, "studio", component_dir.path());
+
+            let mut args = run_args(Some("studio"), Vec::new(), Vec::new());
+            args.run.warmup = Some(4);
+
+            let (output, exit_code) = run(args, &GlobalArgs {}).expect("bench should run");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(first_warmup_metric(output), 4.0);
+        });
+    }
+
+    #[test]
+    fn unrigged_bench_omits_warmup_env_by_default() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_registered_component(home, "studio", component_dir.path());
+
+            let (output, exit_code) = run(
+                run_args(Some("studio"), Vec::new(), Vec::new()),
+                &GlobalArgs {},
+            )
+            .expect("bench should run");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(first_warmup_metric(output), -1.0);
+        });
+    }
+
+    #[test]
+    fn single_rig_bench_forwards_rig_warmup() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_rig(home, "rig-a", "studio", component_dir.path());
+            set_rig_warmup(home, "rig-a", 6);
+
+            let (output, exit_code) = run(
+                run_args(None, vec!["rig-a".to_string()], Vec::new()),
+                &GlobalArgs {},
+            )
+            .expect("rig bench should run");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(first_warmup_metric(output), 6.0);
+        });
+    }
+
+    #[test]
+    fn cli_warmup_overrides_rig_warmup() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_rig(home, "rig-a", "studio", component_dir.path());
+            set_rig_warmup(home, "rig-a", 6);
+
+            let mut args = run_args(None, vec!["rig-a".to_string()], Vec::new());
+            args.run.warmup = Some(2);
+
+            let (output, exit_code) = run(args, &GlobalArgs {}).expect("rig bench should run");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(first_warmup_metric(output), 2.0);
+        });
+    }
+
+    #[test]
+    fn cross_rig_bench_uses_each_rig_warmup() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_a = tempfile::TempDir::new().expect("component a");
+            let component_b = tempfile::TempDir::new().expect("component b");
+            write_rig(home, "rig-a", "studio", component_a.path());
+            write_rig(home, "rig-b", "studio", component_b.path());
+            set_rig_warmup(home, "rig-a", 2);
+            set_rig_warmup(home, "rig-b", 5);
+
+            let (output, exit_code) = run(
+                run_args(
+                    None,
+                    vec!["rig-a".to_string(), "rig-b".to_string()],
+                    Vec::new(),
+                ),
+                &GlobalArgs {},
+            )
+            .expect("cross-rig bench should run");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Comparison(result) => {
+                    assert_eq!(result.rigs.len(), 2);
+                    assert_eq!(
+                        result.rigs[0]
+                            .results
+                            .as_ref()
+                            .expect("rig-a results")
+                            .scenarios[0]
+                            .metrics
+                            .get("warmup_iterations"),
+                        Some(2.0)
+                    );
+                    assert_eq!(
+                        result.rigs[1]
+                            .results
+                            .as_ref()
+                            .expect("rig-b results")
+                            .scenarios[0]
+                            .metrics
+                            .get("warmup_iterations"),
+                        Some(5.0)
+                    );
+                }
+                _ => panic!("expected comparison output"),
+            }
+        });
+    }
+
+    #[test]
+    fn cross_rig_cli_warmup_overrides_all_rigs() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_a = tempfile::TempDir::new().expect("component a");
+            let component_b = tempfile::TempDir::new().expect("component b");
+            write_rig(home, "rig-a", "studio", component_a.path());
+            write_rig(home, "rig-b", "studio", component_b.path());
+            set_rig_warmup(home, "rig-a", 2);
+            set_rig_warmup(home, "rig-b", 5);
+
+            let mut args = run_args(
+                None,
+                vec!["rig-a".to_string(), "rig-b".to_string()],
+                Vec::new(),
+            );
+            args.run.warmup = Some(9);
+
+            let (output, exit_code) =
+                run(args, &GlobalArgs {}).expect("cross-rig bench should run");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Comparison(result) => {
+                    assert_eq!(result.rigs.len(), 2);
+                    for rig in result.rigs {
+                        assert_eq!(
+                            rig.results.expect("rig results").scenarios[0]
+                                .metrics
+                                .get("warmup_iterations"),
+                            Some(9.0)
+                        );
+                    }
+                }
+                _ => panic!("expected comparison output"),
+            }
+        });
     }
 
     #[test]

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -87,6 +87,14 @@ fn component_shared_state(
     })
 }
 
+fn effective_warmup_iterations(args: &BenchRunArgs, rig_spec: Option<&RigSpec>) -> Option<u64> {
+    args.warmup.or_else(|| {
+        rig_spec
+            .and_then(|spec| spec.bench.as_ref())
+            .and_then(|bench| bench.warmup_iterations)
+    })
+}
+
 fn suffix_component_results(mut results: BenchResults, component_id: &str) -> BenchResults {
     for scenario in &mut results.scenarios {
         scenario.id = format!("{}:c{}", scenario.id, component_id);
@@ -311,6 +319,7 @@ fn run_component_with_rig_context(
                 })
                 .collect(),
             iterations: args.iterations,
+            warmup_iterations: effective_warmup_iterations(args, rig_spec),
             runs: args.runs,
             baseline_flags: homeboy::engine::baseline::BaselineFlags {
                 baseline: args.baseline_args.baseline,
@@ -403,6 +412,7 @@ mod tests {
                 path: None,
             },
             iterations: 1,
+            warmup: None,
             runs: 1,
             shared_state: Some(PathBuf::from("/tmp/shared")),
             concurrency: 1,

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -143,6 +143,7 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
             "",
             &[
                 "--iterations",
+                "--warmup",
                 "--runs",
                 "--baseline",
                 "--ignore-baseline",
@@ -470,6 +471,24 @@ mod normalize_tests {
             "my-comp",
             "--runs",
             "5",
+            "--iterations",
+            "1",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// `bench` owns warmup control. It must remain a named CLI flag even
+    /// when placed after the positional component so clap can reject
+    /// negative values instead of passing them through to the runner.
+    #[test]
+    fn bench_warmup_flag_after_component_is_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--warmup",
+            "-1",
             "--iterations",
             "1",
         ]);

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -30,6 +30,7 @@ pub struct BenchRunWorkflowArgs {
     /// object, not a JSON-string-of-an-object.
     pub settings_json: Vec<(String, serde_json::Value)>,
     pub iterations: u64,
+    pub warmup_iterations: Option<u64>,
     pub runs: u64,
     pub baseline_flags: BaselineFlags,
     pub regression_threshold_percent: f64,
@@ -124,6 +125,7 @@ pub fn run_bench_list_workflow(
             settings: args.settings,
             settings_json: args.settings_json,
             iterations: 0,
+            warmup_iterations: None,
             runs: 1,
             baseline_flags: BaselineFlags {
                 baseline: false,
@@ -599,6 +601,13 @@ fn build_runner(
         .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
         .script_args(&args.passthrough_args);
 
+    if let Some(warmup_iterations) = args.warmup_iterations {
+        runner = runner.env(
+            "HOMEBOY_BENCH_WARMUP_ITERATIONS",
+            &warmup_iterations.to_string(),
+        );
+    }
+
     if !args.extra_workloads.is_empty() {
         runner = runner.env(
             "HOMEBOY_BENCH_EXTRA_WORKLOADS",
@@ -826,6 +835,7 @@ mod tests {
                 settings: Vec::new(),
                 settings_json: Vec::new(),
                 iterations: 1,
+                warmup_iterations: None,
                 runs: 1,
                 baseline_flags: BaselineFlags {
                     baseline: false,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -194,6 +194,12 @@ pub struct BenchSpec {
     /// pass `--ignore-default-baseline`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_baseline_rig: Option<String>,
+
+    /// Warmup iterations to forward to bench runners for this rig. CLI
+    /// `homeboy bench --warmup <N>` overrides this value; omitted keeps
+    /// the runner's own default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warmup_iterations: Option<u64>,
 }
 
 /// Component reference inside a rig spec. Decoupled from the global component

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -40,6 +40,7 @@ fn make_args(
                 path: None,
             },
             iterations: 1,
+            warmup: None,
             runs: 1,
             shared_state: None,
             concurrency: 1,

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -20,13 +20,15 @@ fn test_bench_spec_deserializes_both_fields() {
             "id": "candidate",
             "bench": {
                 "default_component": "homeboy",
-                "default_baseline_rig": "homeboy-main"
+                "default_baseline_rig": "homeboy-main",
+                "warmup_iterations": 3
             }
         }"#,
     );
     assert_eq!(spec.default_component.as_deref(), Some("homeboy"));
     assert!(spec.components.is_empty());
     assert_eq!(spec.default_baseline_rig.as_deref(), Some("homeboy-main"));
+    assert_eq!(spec.warmup_iterations, Some(3));
 }
 
 #[test]
@@ -159,6 +161,7 @@ fn test_bench_spec_default_component_only_back_compat() {
     assert_eq!(spec.default_component.as_deref(), Some("homeboy"));
     assert!(spec.components.is_empty());
     assert!(spec.default_baseline_rig.is_none());
+    assert!(spec.warmup_iterations.is_none());
 }
 
 #[test]
@@ -189,11 +192,12 @@ fn test_rig_spec_without_bench_block_back_compat() {
 fn test_bench_spec_round_trip_preserves_both_fields() {
     let original_json = r#"{
         "id": "candidate",
-        "bench": {
-            "default_component": "homeboy",
-            "default_baseline_rig": "homeboy-main"
-        }
-    }"#;
+            "bench": {
+                "default_component": "homeboy",
+                "default_baseline_rig": "homeboy-main",
+                "warmup_iterations": 4
+            }
+        }"#;
     let spec: RigSpec = serde_json::from_str(original_json).expect("parse");
     let re_serialized = serde_json::to_string(&spec).expect("serialize");
     let reparsed: RigSpec = serde_json::from_str(&re_serialized).expect("reparse");
@@ -202,6 +206,7 @@ fn test_bench_spec_round_trip_preserves_both_fields() {
     assert_eq!(bench.default_component.as_deref(), Some("homeboy"));
     assert!(bench.components.is_empty());
     assert_eq!(bench.default_baseline_rig.as_deref(), Some("homeboy-main"));
+    assert_eq!(bench.warmup_iterations, Some(4));
 }
 
 #[test]
@@ -247,6 +252,7 @@ fn test_bench_spec_skips_serializing_none_fields() {
         re_serialized
     );
     assert!(re_serialized.contains("default_baseline_rig"));
+    assert!(!re_serialized.contains("warmup_iterations"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds first-class bench warmup control via --warmup N and rig bench.warmup_iterations.
- Forwards the resolved value to bench runners as HOMEBOY_BENCH_WARMUP_ITERATIONS only when configured, preserving runner defaults otherwise.
- Keeps CLI precedence explicit: CLI flag overrides rig config; each rig supplies its own value in cross-rig comparisons unless the CLI overrides globally.

## Behavior
- Unrigged runs use --warmup when provided and omit the env var when absent.
- Single-rig runs fall back to bench.warmup_iterations when --warmup is absent.
- Cross-rig runs resolve warmup per rig, with --warmup overriding all rig-specific values.
- Negative warmup values fail at parse time with an invalid-value error instead of leaking into runner args.

## Tests
- cargo test bench -- --test-threads=1
- ./target/debug/homeboy bench homeboy --warmup -1 --json-summary (verified invalid-value parse failure)
- homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-bench-warmup-control --changed-since origin/main
- homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-bench-warmup-control --changed-since origin/main (runs, but reports existing audit findings in touched files: intra_method_duplicate in args normalizer, unreferenced_export for run_main_bench_workflow, repeated_field_pattern in bench result structs)

Closes #1837

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the warmup-control implementation and focused tests; Chris remains responsible for review and merge.