### PR TITLE
fix(bench): propagate scenario and run options to rig workloads

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -563,12 +563,29 @@ mod tests {
             &script_path,
             r#"#!/bin/sh
 if [ -n "$HOMEBOY_BENCH_EXTRA_WORKLOADS" ]; then
-  all_scenarios="rig-extra rig-slow"
+  all_scenarios=""
+  old_ifs="$IFS"
+  IFS=":"
+  for workload in $HOMEBOY_BENCH_EXTRA_WORKLOADS; do
+    name="$(basename "$workload")"
+    name="${name%%.bench.*}"
+    name="${name%.*}"
+    if [ -n "$all_scenarios" ]; then
+      all_scenarios="$all_scenarios $name"
+    else
+      all_scenarios="$name"
+    fi
+  done
+  IFS="$old_ifs"
 else
   all_scenarios="in-tree slow"
 fi
 
-if [ "$HOMEBOY_BENCH_LIST_ONLY" = "1" ] || [ -z "$HOMEBOY_BENCH_SCENARIOS" ]; then
+# Rig-declared workload selection is owned by Homeboy core because the core
+# process builds HOMEBOY_BENCH_EXTRA_WORKLOADS. This intentionally ignores
+# HOMEBOY_BENCH_SCENARIOS when extra workloads are present, matching the real
+# Node runner class that caused #1843.
+if [ -n "$HOMEBOY_BENCH_EXTRA_WORKLOADS" ] || [ "$HOMEBOY_BENCH_LIST_ONLY" = "1" ] || [ -z "$HOMEBOY_BENCH_SCENARIOS" ]; then
   selected="$all_scenarios"
 else
   selected=$(printf '%s' "$HOMEBOY_BENCH_SCENARIOS" | tr ',' ' ')
@@ -642,7 +659,10 @@ JSON
                         }}
                     }},
                     "bench": {{ "default_component": "{component_id}" }},
-                    "bench_workloads": {{ "nodejs": ["${{components.{component_id}.path}}/private.bench.js"] }}
+                    "bench_workloads": {{ "nodejs": [
+                        "${{components.{component_id}.path}}/rig-extra.bench.js",
+                        "${{components.{component_id}.path}}/rig-slow.bench.mjs"
+                    ] }}
                 }}"#,
                 path.display()
             ),
@@ -824,6 +844,31 @@ JSON
     }
 
     #[test]
+    fn parses_rig_run_options_without_component() {
+        let cli = TestCli::try_parse_from([
+            "bench",
+            "--rig",
+            "studio-agent-sdk,studio-agent-pi",
+            "--scenario",
+            "studio-agent-runtime",
+            "--runs",
+            "3",
+            "--iterations",
+            "1",
+        ])
+        .expect("rig bench options without component should parse");
+
+        assert_eq!(
+            cli.bench.run.rig,
+            vec!["studio-agent-sdk", "studio-agent-pi"]
+        );
+        assert_eq!(cli.bench.run.scenario_ids, vec!["studio-agent-runtime"]);
+        assert_eq!(cli.bench.run.runs, 3);
+        assert_eq!(cli.bench.run.iterations, 1);
+        assert!(cli.bench.run.comp.id().is_none());
+    }
+
+    #[test]
     fn run_selects_multiple_scenarios() {
         with_isolated_home(|home| {
             write_bench_extension(home);
@@ -909,6 +954,107 @@ JSON
                         let scenarios = rig.results.expect("rig results").scenarios;
                         assert_eq!(scenarios.len(), 1);
                         assert_eq!(scenarios[0].id, "rig-slow");
+                    }
+                }
+                _ => panic!("expected comparison output"),
+            }
+        });
+    }
+
+    #[test]
+    fn single_rig_selector_filters_extra_workloads_before_execution() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_rig(home, "rig-a", "studio", component_dir.path());
+
+            let (output, exit_code) = run(
+                run_args(
+                    None,
+                    vec!["rig-a".to_string()],
+                    vec!["rig-slow".to_string()],
+                ),
+                &GlobalArgs {},
+            )
+            .expect("single-rig selected bench should run");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Single(result) => {
+                    assert_eq!(result.iterations, 1);
+                    let scenarios = result.results.expect("results").scenarios;
+                    assert_eq!(scenarios.len(), 1);
+                    assert_eq!(scenarios[0].id, "rig-slow");
+                    assert_eq!(scenarios[0].iterations, 1);
+                }
+                _ => panic!("expected single output"),
+            }
+        });
+    }
+
+    #[test]
+    fn single_rig_runs_preserve_run_level_summaries_after_selection() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_rig(home, "rig-a", "studio", component_dir.path());
+            let mut args = run_args(
+                None,
+                vec!["rig-a".to_string()],
+                vec!["rig-slow".to_string()],
+            );
+            args.run.runs = 3;
+
+            let (output, exit_code) = run(args, &GlobalArgs {})
+                .expect("single-rig selected bench should run multiple runs");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Single(result) => {
+                    let scenarios = result.results.expect("results").scenarios;
+                    assert_eq!(scenarios.len(), 1);
+                    let runs = scenarios[0].runs.as_ref().expect("per-run metrics");
+                    assert_eq!(runs.len(), 3);
+                    assert!(scenarios[0].runs_summary.as_ref().is_some_and(|summary| {
+                        summary.get("p95_ms").is_some_and(|metric| metric.n == 3)
+                    }));
+                }
+                _ => panic!("expected single output"),
+            }
+        });
+    }
+
+    #[test]
+    fn cross_rig_runs_preserve_run_level_summaries_after_selection() {
+        with_isolated_home(|home| {
+            write_bench_extension(home);
+            let component_a = tempfile::TempDir::new().expect("component a");
+            let component_b = tempfile::TempDir::new().expect("component b");
+            write_rig(home, "rig-a", "studio", component_a.path());
+            write_rig(home, "rig-b", "studio", component_b.path());
+            let mut args = run_args(
+                None,
+                vec!["rig-a".to_string(), "rig-b".to_string()],
+                vec!["rig-slow".to_string()],
+            );
+            args.run.runs = 3;
+
+            let (output, exit_code) = run(args, &GlobalArgs {})
+                .expect("cross-rig selected bench should run multiple runs");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                BenchOutput::Comparison(result) => {
+                    assert_eq!(result.rigs.len(), 2);
+                    assert!(result
+                        .summary
+                        .iter()
+                        .all(|summary| summary.rows.iter().all(|row| row.n == Some(3))));
+                    for rig in result.rigs {
+                        let scenarios = rig.results.expect("rig results").scenarios;
+                        assert_eq!(scenarios.len(), 1);
+                        assert_eq!(scenarios[0].id, "rig-slow");
+                        assert_eq!(scenarios[0].runs.as_ref().expect("runs").len(), 3);
                     }
                 }
                 _ => panic!("expected comparison output"),

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -212,6 +212,60 @@ fn apply_scenario_filter(
     Ok(results)
 }
 
+fn scenario_id_for_workload_path(path: &std::path::Path) -> String {
+    let basename = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_default();
+    let name = basename
+        .split_once(".bench.")
+        .map(|(stem, _)| stem)
+        .unwrap_or_else(|| {
+            basename
+                .rsplit_once('.')
+                .map(|(stem, _)| stem)
+                .unwrap_or(&basename)
+        });
+
+    let mut slug = String::new();
+    let mut prev_was_separator = true;
+    let mut prev_was_lower_or_digit = false;
+    for ch in name.chars() {
+        if ch.is_ascii_uppercase() && prev_was_lower_or_digit && !prev_was_separator {
+            slug.push('-');
+        }
+
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            prev_was_separator = false;
+            prev_was_lower_or_digit = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+        } else if !prev_was_separator {
+            slug.push('-');
+            prev_was_separator = true;
+            prev_was_lower_or_digit = false;
+        } else {
+            prev_was_lower_or_digit = false;
+        }
+    }
+
+    slug.trim_matches('-').to_string()
+}
+
+fn filter_extra_workloads_by_scenario_ids(
+    workloads: &[PathBuf],
+    scenario_ids: &[String],
+) -> Vec<PathBuf> {
+    if scenario_ids.is_empty() {
+        return workloads.to_vec();
+    }
+
+    workloads
+        .iter()
+        .filter(|path| scenario_ids.contains(&scenario_id_for_workload_path(path)))
+        .cloned()
+        .collect()
+}
+
 fn discover_bench_scenarios(
     execution_context: &ExtensionExecutionContext,
     component: &Component,
@@ -333,39 +387,49 @@ pub fn run_main_bench_workflow(
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
 
+    let mut execution_args = args.clone();
     if !args.scenario_ids.is_empty() {
         let discovered = discover_bench_scenarios(&execution_context, component, &args, run_dir)?;
         apply_scenario_filter(discovered, &args.scenario_ids)?;
+        execution_args.extra_workloads =
+            filter_extra_workloads_by_scenario_ids(&args.extra_workloads, &args.scenario_ids);
     }
 
-    let (mut parsed, runner_success, runner_exit_code, failure_stderr_tail) = if args.runs > 1 {
-        run_sequential_runs(&execution_context, component, &args, run_dir)?
-    } else if args.concurrency <= 1 {
-        let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
-        let runner_output =
-            build_runner(&execution_context, component, &args, run_dir, None)?.run()?;
-        let parsed = if results_file.exists() {
-            parsing::parse_bench_results_file(&results_file)
-                .ok()
-                .map(|results| apply_scenario_filter(results, &args.scenario_ids))
-                .transpose()?
+    let (mut parsed, runner_success, runner_exit_code, failure_stderr_tail) =
+        if execution_args.runs > 1 {
+            run_sequential_runs(&execution_context, component, &execution_args, run_dir)?
+        } else if execution_args.concurrency <= 1 {
+            let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+            let runner_output = build_runner(
+                &execution_context,
+                component,
+                &execution_args,
+                run_dir,
+                None,
+            )?
+            .run()?;
+            let parsed = if results_file.exists() {
+                parsing::parse_bench_results_file(&results_file)
+                    .ok()
+                    .map(|results| apply_scenario_filter(results, &execution_args.scenario_ids))
+                    .transpose()?
+            } else {
+                None
+            };
+            let failure_stderr_tail = if !runner_output.success {
+                Some(stderr_tail(&runner_output.stderr))
+            } else {
+                None
+            };
+            (
+                parsed,
+                runner_output.success,
+                runner_output.exit_code,
+                failure_stderr_tail,
+            )
         } else {
-            None
+            run_concurrent_instances(&execution_context, component, &execution_args, run_dir)?
         };
-        let failure_stderr_tail = if !runner_output.success {
-            Some(stderr_tail(&runner_output.stderr))
-        } else {
-            None
-        };
-        (
-            parsed,
-            runner_output.success,
-            runner_output.exit_code,
-            failure_stderr_tail,
-        )
-    } else {
-        run_concurrent_instances(&execution_context, component, &args, run_dir)?
-    };
 
     let gate_failures = parsed
         .as_mut()
@@ -777,6 +841,31 @@ mod tests {
         assert_eq!(
             extra_workloads_env_value(&paths).unwrap(),
             "/tmp/bench-one.php:/tmp/bench-two.php"
+        );
+    }
+
+    #[test]
+    fn filter_extra_workloads_by_selected_scenario_ids_matches_runner_slugs() {
+        let workloads = vec![
+            PathBuf::from("/tmp/bench/studio-agent-runtime.bench.mjs"),
+            PathBuf::from("/tmp/bench/studio-bfb-write-path.bench.js"),
+            PathBuf::from("/tmp/bench/WpAdminLoad.php"),
+        ];
+
+        let filtered = filter_extra_workloads_by_scenario_ids(
+            &workloads,
+            &[
+                "studio-agent-runtime".to_string(),
+                "wp-admin-load".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            filtered,
+            vec![
+                PathBuf::from("/tmp/bench/studio-agent-runtime.bench.mjs"),
+                PathBuf::from("/tmp/bench/WpAdminLoad.php"),
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- Fixes rig-pinned bench runs so selected rig workload scenarios are filtered before the runner executes.
- Preserves CLI iteration and run-count options through selected single-rig and cross-rig bench runs.

## Changes
- Filters rig-declared extra workload paths to selected scenario IDs after the discovery/validation pass and before execution.
- Keeps broad no-scenario runs unchanged.
- Adds regression coverage for no-component rig option parsing, single-rig selection, cross-rig selection, CLI iteration override, and per-run summaries.

## Tests
- cargo test bench::tests -- --test-threads=1
- cargo test extension::bench -- --test-threads=1
- cargo test -- --test-threads=1
- homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-bench-scenario-options
- homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-bench-scenario-options --changed-since origin/main

Closes #1843

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bench option propagation fix and tests from Chris's issue/brief; Chris reviewed the resulting PR.