### PR TITLE
fix(triage): flag dirty merge states for rebase

### DIFF
--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -1016,10 +1016,10 @@ const PR_ACTION_PRIORITY: &[&str] = &[
 
 fn pr_action_severity(kind: &str) -> &'static str {
     match kind {
-        "draft_with_failing_checks" | "checks_failed" | "approved_but_dirty" | "needs_rebase" => {
-            "high"
+        "draft_with_failing_checks" | "checks_failed" | "approved_but_dirty" => "high",
+        "needs_rebase" | "review_required" | "approved_but_pending_checks" | "clean_and_ready" => {
+            "medium"
         }
-        "review_required" | "approved_but_pending_checks" | "clean_and_ready" => "medium",
         _ => "low",
     }
 }
@@ -1416,6 +1416,71 @@ mod tests {
                 "approved_but_pending_checks",
             ]
         );
+    }
+
+    #[test]
+    fn parse_prs_marks_behind_and_dirty_as_needs_rebase() {
+        let raw = r#"[
+            {
+              "number": 1,
+              "title": "Behind",
+              "url": "https://github.com/o/r/pull/1",
+              "state": "OPEN",
+              "isDraft": false,
+              "reviewDecision": "",
+              "mergeStateStatus": "BEHIND",
+              "statusCheckRollup": [{"status":"COMPLETED","conclusion":"SUCCESS"}],
+              "labels": [],
+              "assignees": [],
+              "author": {"login":"chubes4"},
+              "updatedAt": "2026-04-26T00:00:00Z"
+            },
+            {
+              "number": 2,
+              "title": "Dirty",
+              "url": "https://github.com/o/r/pull/2",
+              "state": "OPEN",
+              "isDraft": false,
+              "reviewDecision": "",
+              "mergeStateStatus": "DIRTY",
+              "statusCheckRollup": [{"status":"COMPLETED","conclusion":"SUCCESS"}],
+              "labels": [],
+              "assignees": [],
+              "author": {"login":"chubes4"},
+              "updatedAt": "2026-04-26T00:00:00Z"
+            },
+            {
+              "number": 3,
+              "title": "Unstable",
+              "url": "https://github.com/o/r/pull/3",
+              "state": "OPEN",
+              "isDraft": false,
+              "reviewDecision": "",
+              "mergeStateStatus": "UNSTABLE",
+              "statusCheckRollup": [{"status":"COMPLETED","conclusion":"SUCCESS"}],
+              "labels": [],
+              "assignees": [],
+              "author": {"login":"chubes4"},
+              "updatedAt": "2026-04-26T00:00:00Z"
+            }
+        ]"#;
+
+        let items = parse_prs(raw, None, false).unwrap();
+        assert_eq!(items[0].next_action.as_deref(), Some("needs_rebase"));
+        assert_eq!(items[1].next_action.as_deref(), Some("needs_rebase"));
+        assert!(items[2].next_action.is_none());
+
+        let actions = build_actions(
+            None,
+            Some(&TriagePrBucket {
+                open: items.len(),
+                items,
+            }),
+        );
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].kind, "needs_rebase");
+        assert_eq!(actions[0].severity, "medium");
+        assert_eq!(actions[0].label, "2 PRs need rebase");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Surface PRs with `BEHIND` or `DIRTY` merge states as `needs_rebase` triage actions.
- Keep `UNSTABLE` out of the generic rebase action and set `needs_rebase` severity to medium.
- Repair a bench test fixture missing the new `warmup_iterations` field so the test suite compiles.

## Tests
- `cargo test triage`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-triage-merge-state-action`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-triage-merge-state-action --changed-since origin/main`
- `cargo test -- --test-threads=1`

Closes #1847

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the triage action and tests; Chris reviews and owns the final change.