### PR TITLE
fix(audit): gate fixability computation

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -36,6 +36,11 @@ pub struct AuditArgs {
     /// Include compact machine-readable summary for CI wrappers
     #[arg(long)]
     pub json_summary: bool,
+
+    /// Include automated-fixability metadata. This can be expensive because it
+    /// runs the refactor planner after audit completes.
+    #[arg(long)]
+    pub fixability: bool,
 }
 
 fn parse_finding_kinds(
@@ -107,6 +112,7 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         },
         changed_since: args.changed_since,
         json_summary: args.json_summary,
+        include_fixability: args.fixability,
     })?;
 
     Ok(report::from_main_workflow(workflow))
@@ -251,6 +257,7 @@ mod tests {
             },
             changed_since: None,
             json_summary: false,
+            fixability: false,
         };
 
         let (output, code) = run(args, &crate::commands::GlobalArgs {}).expect("audit should run");

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -201,6 +201,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         baseline_args: args.baseline_args.clone(),
         changed_since: args.changed_since.clone(),
         json_summary: args.summary,
+        fixability: false,
     };
     let (audit_output, audit_exit) = audit::run(audit_args, global)?;
     let audit_passed = audit_exit == 0;

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -25,6 +25,7 @@ pub struct AuditRunWorkflowArgs {
     pub baseline_flags: crate::engine::baseline::BaselineFlags,
     pub changed_since: Option<String>,
     pub json_summary: bool,
+    pub include_fixability: bool,
 }
 
 /// Result of the main audit workflow — ready for report assembly.
@@ -247,13 +248,13 @@ fn run_comparison_workflow(
 
     if args.json_summary {
         let mut summary = report::build_audit_summary(&result, exit_code);
-        summary.fixability = report::compute_fixability(&result);
+        summary.fixability = compute_fixability_if_requested(&result, args);
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
             exit_code,
         })
     } else {
-        let fixability = report::compute_fixability(&result);
+        let fixability = compute_fixability_if_requested(&result, args);
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Full {
                 passed: exit_code == 0,
@@ -290,13 +291,13 @@ fn build_comparison_output(
 
     if args.json_summary {
         let mut summary = report::build_audit_summary(&result, exit_code);
-        summary.fixability = report::compute_fixability(&result);
+        summary.fixability = compute_fixability_if_requested(&result, args);
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
             exit_code,
         })
     } else {
-        let fixability = report::compute_fixability(&result);
+        let fixability = compute_fixability_if_requested(&result, args);
 
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Compared {
@@ -309,6 +310,15 @@ fn build_comparison_output(
             exit_code,
         })
     }
+}
+
+fn compute_fixability_if_requested(
+    result: &CodeAuditResult,
+    args: &AuditRunWorkflowArgs,
+) -> Option<report::AuditFixability> {
+    args.include_fixability
+        .then(|| report::compute_fixability(result))
+        .flatten()
 }
 
 /// Determine exit code for audit results.

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -1534,6 +1534,7 @@ mod tests {
                 open: items.len(),
                 items,
             }),
+            &[],
         );
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].kind, "needs_rebase");

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Wired into `src/core/code_audit/run.rs` via `#[cfg(test)] #[path = ...] mod run_test`.
 
-use super::apply_finding_filters;
+use super::{apply_finding_filters, compute_fixability_if_requested, AuditRunWorkflowArgs};
 use crate::code_audit::findings::{Finding, Severity};
 use crate::code_audit::{AuditExecutionPlan, AuditFinding, AuditSummary, CodeAuditResult};
 
@@ -34,6 +34,26 @@ fn make_result(findings: Vec<Finding>) -> CodeAuditResult {
         directory_conventions: vec![],
         findings,
         duplicate_groups: vec![],
+    }
+}
+
+fn make_args(include_fixability: bool) -> AuditRunWorkflowArgs {
+    AuditRunWorkflowArgs {
+        component_id: "test".to_string(),
+        source_path: "/tmp/test".to_string(),
+        conventions: false,
+        only_kinds: vec![],
+        exclude_kinds: vec![],
+        only_labels: vec![],
+        exclude_labels: vec![],
+        baseline_flags: crate::engine::baseline::BaselineFlags {
+            baseline: false,
+            ignore_baseline: false,
+            ratchet: false,
+        },
+        changed_since: None,
+        json_summary: false,
+        include_fixability,
     }
 }
 
@@ -157,4 +177,27 @@ fn execution_plan_is_full_without_filters() {
         AuditExecutionPlan::from_filters(&[], &[]),
         AuditExecutionPlan::full()
     );
+}
+
+#[test]
+fn fixability_is_skipped_unless_requested() {
+    let result = make_result(vec![make_finding(AuditFinding::TodoMarker, "a.rs")]);
+    let args = make_args(false);
+
+    let fixability = compute_fixability_if_requested(&result, &args);
+
+    assert!(fixability.is_none());
+}
+
+#[test]
+fn fixability_flag_allows_planning_path() {
+    let result = make_result(vec![make_finding(AuditFinding::TodoMarker, "a.rs")]);
+    let args = make_args(true);
+
+    let fixability = compute_fixability_if_requested(&result, &args);
+
+    // The fixture path does not exist, so the planner returns None. The test
+    // still pins the flag contract: true is the only path that reaches the
+    // existing compute_fixability() guard.
+    assert!(fixability.is_none());
 }


### PR DESCRIPTION
## Summary
- Adds an explicit `--fixability` flag for `homeboy audit` so expensive fixability planning only runs when requested.
- Keeps `homeboy review` on the faster default path by passing `fixability: false` into its internal audit call.
- Updates focused audit workflow tests and repairs one stale triage test callsite that prevented current-main Rust tests from compiling.

## Tests
- `cargo check`
- `cargo test fixability -- --test-threads=1`
- `cargo test parse_prs_marks_behind_and_dirty_as_needs_rebase -- --test-threads=1`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Porting the existing uncommitted fixability change onto current main, validating it, and drafting this PR description. Chris remains responsible for review and merge.
