### PR TITLE
fix(audit): scope convention outliers in changed audits

### DIFF
--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -5,6 +5,7 @@
 
 use crate::code_audit::{self, baseline, CodeAuditResult};
 use crate::git;
+use std::collections::HashSet;
 use std::path::Path;
 
 use super::report::{self, AuditCommandOutput};
@@ -97,6 +98,10 @@ pub fn run_main_audit_workflow(
     // `default_audit_exit_code` reflects the filtered view.
     apply_finding_filters(&mut result, &args.only_kinds, &args.exclude_kinds);
 
+    if args.changed_since.is_some() {
+        scope_convention_outliers_to_findings(&mut result);
+    }
+
     // Default: compare against baseline or return full result
     run_comparison_workflow(result, &args)
 }
@@ -125,6 +130,43 @@ fn apply_finding_filters(
     // closest proxy available without re-running the per-convention check —
     // this keeps `default_audit_exit_code(...) -> outliers_found > 0`
     // honest under filtering.
+    result.summary.outliers_found = result.findings.len();
+}
+
+/// Keep the diagnostic convention report aligned with scoped actionable findings.
+///
+/// Scoped audits already filter `result.findings` to changed files plus impact
+/// call sites. The full convention report is still useful for `audit
+/// --conventions`, but PR-facing machine output treats `conventions[].outliers`
+/// as actionable too. For changed-since audit output, only retain convention
+/// outlier deviations that correspond to the scoped finding set.
+fn scope_convention_outliers_to_findings(result: &mut CodeAuditResult) {
+    let scoped_findings: HashSet<(String, String, code_audit::AuditFinding)> = result
+        .findings
+        .iter()
+        .map(|finding| {
+            (
+                finding.convention.clone(),
+                finding.file.clone(),
+                finding.kind.clone(),
+            )
+        })
+        .collect();
+
+    for convention in &mut result.conventions {
+        convention.outliers.retain_mut(|outlier| {
+            outlier.deviations.retain(|deviation| {
+                scoped_findings.contains(&(
+                    convention.name.clone(),
+                    outlier.file.clone(),
+                    deviation.kind.clone(),
+                ))
+            });
+
+            !outlier.deviations.is_empty()
+        });
+    }
+
     result.summary.outliers_found = result.findings.len();
 }
 

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -2,9 +2,16 @@
 //!
 //! Wired into `src/core/code_audit/run.rs` via `#[cfg(test)] #[path = ...] mod run_test`.
 
-use super::{apply_finding_filters, compute_fixability_if_requested, AuditRunWorkflowArgs};
+use super::{
+    apply_finding_filters, compute_fixability_if_requested, scope_convention_outliers_to_findings,
+    AuditRunWorkflowArgs,
+};
+use crate::code_audit::checks::CheckStatus;
+use crate::code_audit::conventions::{Deviation, Outlier};
 use crate::code_audit::findings::{Finding, Severity};
-use crate::code_audit::{AuditExecutionPlan, AuditFinding, AuditSummary, CodeAuditResult};
+use crate::code_audit::{
+    AuditExecutionPlan, AuditFinding, AuditSummary, CodeAuditResult, ConventionReport,
+};
 
 fn make_finding(kind: AuditFinding, file: &str) -> Finding {
     Finding {
@@ -34,6 +41,38 @@ fn make_result(findings: Vec<Finding>) -> CodeAuditResult {
         directory_conventions: vec![],
         findings,
         duplicate_groups: vec![],
+    }
+}
+
+fn make_convention_report(name: &str, outliers: Vec<Outlier>) -> ConventionReport {
+    ConventionReport {
+        name: name.to_string(),
+        glob: "src/**/*.rs".to_string(),
+        status: CheckStatus::Drift,
+        expected_methods: vec!["run".to_string()],
+        expected_registrations: vec![],
+        expected_interfaces: vec![],
+        expected_namespace: None,
+        expected_imports: vec![],
+        conforming: vec!["src/changed.rs".to_string()],
+        outliers,
+        total_files: 3,
+        confidence: 0.75,
+    }
+}
+
+fn make_outlier(file: &str, kinds: Vec<AuditFinding>) -> Outlier {
+    Outlier {
+        file: file.to_string(),
+        noisy: false,
+        deviations: kinds
+            .into_iter()
+            .map(|kind| Deviation {
+                kind,
+                description: "deviates".to_string(),
+                suggestion: "fix it".to_string(),
+            })
+            .collect(),
     }
 }
 
@@ -140,6 +179,41 @@ fn only_with_no_matches_leaves_zero_findings_and_clean_exit() {
 
     assert!(result.findings.is_empty());
     assert_eq!(result.summary.outliers_found, 0);
+}
+
+#[test]
+fn scoped_convention_outliers_follow_scoped_findings() {
+    let mut result = make_result(vec![make_finding(
+        AuditFinding::MissingMethod,
+        "src/changed.rs",
+    )]);
+    result.findings[0].convention = "ability convention".to_string();
+    result.summary.outliers_found = 3;
+    result.conventions = vec![make_convention_report(
+        "ability convention",
+        vec![
+            make_outlier(
+                "src/changed.rs",
+                vec![
+                    AuditFinding::MissingMethod,
+                    AuditFinding::MissingRegistration,
+                ],
+            ),
+            make_outlier("src/unrelated.rs", vec![AuditFinding::MissingMethod]),
+        ],
+    )];
+
+    scope_convention_outliers_to_findings(&mut result);
+
+    assert_eq!(result.conventions.len(), 1);
+    assert_eq!(result.conventions[0].outliers.len(), 1);
+    assert_eq!(result.conventions[0].outliers[0].file, "src/changed.rs");
+    assert_eq!(result.conventions[0].outliers[0].deviations.len(), 1);
+    assert_eq!(
+        result.conventions[0].outliers[0].deviations[0].kind,
+        AuditFinding::MissingMethod
+    );
+    assert_eq!(result.summary.outliers_found, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Filters `conventions[].outliers[]` in changed-since audit output so PR-scoped machine-readable results only expose deviations that correspond to scoped actionable findings.
- Keeps full convention reports available for full audits and explicit `audit --conventions` views.
- Refreshes scoped `summary.outliers_found` to match the filtered finding set.

## Tests

- `cargo test code_audit::run::run_test`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-audit-scoped-convention-outliers`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-audit-scoped-convention-outliers --changed-since origin/main`

Closes #1858

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scoped audit output fix, added the regression test, and ran local verification. Chris remains responsible for review and merge.
