### PR TITLE
feat(extension): add package self-check commands

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -3,7 +3,8 @@ use clap::Args;
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::lint::{
-    report, run_main_lint_workflow, LintCommandOutput, LintRunWorkflowArgs,
+    report, run_main_lint_workflow, run_self_check_lint_workflow, LintCommandOutput,
+    LintRunWorkflowArgs,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::refactor::plan::{run_lint_refactor, LintSourceOptions};
@@ -71,6 +72,28 @@ pub struct LintArgs {
 }
 
 pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput> {
+    let source_ctx = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: None,
+        settings_overrides: args.setting_args.setting.clone(),
+        settings_json_overrides: Vec::new(),
+    })?;
+
+    if !args.fix
+        && source_ctx
+            .component
+            .has_self_check(ExtensionCapability::Lint)
+    {
+        let workflow = run_self_check_lint_workflow(
+            &source_ctx.component,
+            &source_ctx.source_path,
+            source_ctx.component_id.clone(),
+        )?;
+
+        return Ok(report::from_main_workflow(workflow));
+    }
+
     let ctx = execution_context::resolve(&ResolveOptions {
         component_id: args.comp.component.clone(),
         path_override: args.comp.path.clone(),

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -3,7 +3,9 @@ use clap::Args;
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::test as extension_test;
-use homeboy::extension::test::{detect_test_drift, report, TestCommandOutput, TestRunWorkflowArgs};
+use homeboy::extension::test::{
+    detect_test_drift, report, run_self_check_test_workflow, TestCommandOutput, TestRunWorkflowArgs,
+};
 use homeboy::extension::ExtensionCapability;
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
@@ -135,6 +137,29 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 }
 
 pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput> {
+    let source_ctx = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: None,
+        settings_overrides: args.setting_args.setting.clone(),
+        settings_json_overrides: args.setting_args.setting_json.clone(),
+    })?;
+
+    if !args.drift
+        && source_ctx
+            .component
+            .has_self_check(ExtensionCapability::Test)
+    {
+        let workflow = run_self_check_test_workflow(
+            &source_ctx.component,
+            &source_ctx.source_path,
+            source_ctx.component_id.clone(),
+            args.json_summary,
+        )?;
+
+        return Ok(report::from_main_workflow(workflow));
+    }
+
     let ctx = execution_context::resolve(&ResolveOptions {
         component_id: args.comp.component.clone(),
         path_override: args.comp.path.clone(),

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -117,6 +117,14 @@ pub struct ScopeConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SelfCheckConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lint: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub test: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(from = "RawComponent", into = "RawComponent")]
 pub struct Component {
     pub id: String,
@@ -149,6 +157,8 @@ pub struct Component {
     pub docs_dir: Option<String>,
     pub docs_dirs: Vec<String>,
     pub scopes: Option<ScopeConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_checks: Option<SelfCheckConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit: Option<AuditConfig>,
     /// Override the CLI path used by extension deploy install steps.
@@ -216,6 +226,8 @@ struct RawComponent {
     #[serde(skip_serializing_if = "Option::is_none")]
     scopes: Option<ScopeConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    self_checks: Option<SelfCheckConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     audit: Option<AuditConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cli_path: Option<String>,
@@ -266,6 +278,7 @@ impl From<RawComponent> for Component {
             docs_dir: raw.docs_dir,
             docs_dirs: raw.docs_dirs,
             scopes: raw.scopes,
+            self_checks: raw.self_checks,
             audit: raw.audit,
             cli_path: raw.cli_path,
         }
@@ -300,6 +313,7 @@ impl From<Component> for RawComponent {
             docs_dir: c.docs_dir,
             docs_dirs: c.docs_dirs,
             scopes: c.scopes,
+            self_checks: c.self_checks,
             audit: c.audit,
             cli_path: c.cli_path,
         }
@@ -371,6 +385,7 @@ impl Component {
             docs_dir: None,
             docs_dirs: Vec::new(),
             scopes: None,
+            self_checks: None,
             audit: None,
             cli_path: None,
         }
@@ -454,6 +469,25 @@ impl Component {
     pub fn is_file_component(&self) -> bool {
         self.deploy_strategy.as_deref() == Some("file")
             || (std::path::Path::new(&self.local_path).is_file() && self.deploy_strategy.is_none())
+    }
+
+    pub fn self_check_commands(
+        &self,
+        capability: crate::extension::ExtensionCapability,
+    ) -> &[String] {
+        let Some(checks) = self.self_checks.as_ref() else {
+            return &[];
+        };
+
+        match capability {
+            crate::extension::ExtensionCapability::Lint => &checks.lint,
+            crate::extension::ExtensionCapability::Test => &checks.test,
+            _ => &[],
+        }
+    }
+
+    pub fn has_self_check(&self, capability: crate::extension::ExtensionCapability) -> bool {
+        !self.self_check_commands(capability).is_empty()
     }
 
     /// Ensure `remote_path` is populated. If empty, attempt auto-resolution.

--- a/src/core/extension/lint/mod.rs
+++ b/src/core/extension/lint/mod.rs
@@ -7,7 +7,10 @@ use crate::extension::{ExtensionCapability, ExtensionExecutionContext, Extension
 
 pub use baseline::{BaselineComparison, LintBaseline, LintBaselineMetadata, LintFinding};
 pub use report::LintCommandOutput;
-pub use run::{run_main_lint_workflow, LintRunWorkflowArgs, LintRunWorkflowResult};
+pub use run::{
+    run_main_lint_workflow, run_self_check_lint_workflow, LintRunWorkflowArgs,
+    LintRunWorkflowResult,
+};
 
 use crate::engine::run_dir::RunDir;
 

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -247,6 +247,37 @@ fn resolve_effective_glob(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::SelfCheckConfig;
+
+    #[test]
+    fn test_run_self_check_lint_workflow() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join("lint.sh"), "printf lint-ok\n")
+            .expect("script should be written");
+
+        let mut component = Component::new(
+            "fixture".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            "".to_string(),
+            None,
+        );
+        component.self_checks = Some(SelfCheckConfig {
+            lint: vec!["sh lint.sh".to_string()],
+            test: Vec::new(),
+        });
+
+        let result = run_self_check_lint_workflow(&component, dir.path(), "fixture".to_string())
+            .expect("lint self-check should run");
+
+        assert_eq!(result.status, "passed");
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.component, "fixture");
+    }
+}
+
 /// Process baseline lifecycle — save, load, compare.
 fn process_baseline(
     source_path: &PathBuf,

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -9,10 +9,11 @@ use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
 use crate::extension::lint::baseline::{self as lint_baseline, LintFinding};
 use crate::extension::lint::build_lint_runner;
+use crate::extension::{self, ExtensionCapability};
 use crate::git;
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Arguments for the main lint workflow — populated by the command layer from CLI flags.
 #[derive(Debug, Clone)]
@@ -163,6 +164,32 @@ pub fn run_main_lint_workflow(
         hints,
         baseline_comparison,
         lint_findings: Some(lint_findings),
+    })
+}
+
+pub fn run_self_check_lint_workflow(
+    component: &Component,
+    source_path: &Path,
+    component_label: String,
+) -> crate::Result<LintRunWorkflowResult> {
+    let output =
+        extension::self_check::run_self_checks(component, ExtensionCapability::Lint, source_path)?;
+    let status = if output.success { "passed" } else { "failed" }.to_string();
+    let hints = (!output.success).then(|| {
+        vec![format!(
+            "Fix the failing self-check command declared in {}'s homeboy.json self_checks.lint",
+            component.id
+        )]
+    });
+
+    Ok(LintRunWorkflowResult {
+        status,
+        component: component_label,
+        exit_code: output.exit_code,
+        autofix: None,
+        hints,
+        baseline_comparison: None,
+        lint_findings: Some(Vec::new()),
     })
 }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -10,6 +10,7 @@ mod runner;
 mod runner_contract;
 mod runtime_helper;
 mod scope;
+pub mod self_check;
 pub mod test;
 pub mod update_check;
 pub mod version;

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -1,0 +1,70 @@
+use crate::component::Component;
+use crate::error::{Error, Result};
+use crate::extension::ExtensionCapability;
+use crate::server::{execute_local_command_passthrough, CommandOutput};
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct SelfCheckOutput {
+    pub exit_code: i32,
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub fn run_self_checks(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+) -> Result<SelfCheckOutput> {
+    let commands = component.self_check_commands(capability);
+    if commands.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "self_checks",
+            format!(
+                "Component '{}' has no {} self-check commands configured",
+                component.id,
+                capability.label()
+            ),
+            None,
+            None,
+        ));
+    }
+
+    let working_dir = source_path.to_string_lossy();
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+
+    for command in commands {
+        crate::log_status!(
+            "self-check",
+            "running {} self-check for {}: {}",
+            capability.label(),
+            component.id,
+            command
+        );
+        let output = execute_self_check_command(command, &working_dir);
+        stdout.push_str(&output.stdout);
+        stderr.push_str(&output.stderr);
+
+        if !output.success {
+            return Ok(SelfCheckOutput {
+                exit_code: output.exit_code,
+                success: false,
+                stdout,
+                stderr,
+            });
+        }
+    }
+
+    Ok(SelfCheckOutput {
+        exit_code: 0,
+        success: true,
+        stdout,
+        stderr,
+    })
+}
+
+fn execute_self_check_command(command: &str, working_dir: &str) -> CommandOutput {
+    execute_local_command_passthrough(command, Some(working_dir), None)
+}

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -68,3 +68,53 @@ pub fn run_self_checks(
 fn execute_self_check_command(command: &str, working_dir: &str) -> CommandOutput {
     execute_local_command_passthrough(command, Some(working_dir), None)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::{Component, SelfCheckConfig};
+
+    #[test]
+    fn test_run_self_checks_requires_configured_commands() {
+        let component = Component::new(
+            "fixture".to_string(),
+            "/tmp/fixture".to_string(),
+            "".to_string(),
+            None,
+        );
+
+        let err = run_self_checks(&component, ExtensionCapability::Test, Path::new("/tmp"))
+            .expect_err("missing self-checks should fail");
+
+        assert!(err.to_string().contains("no test self-check commands"));
+    }
+
+    #[test]
+    fn test_run_self_checks_runs_commands_in_order() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join("one.sh"), "printf one >> order.txt\n")
+            .expect("first script should be written");
+        std::fs::write(dir.path().join("two.sh"), "printf two >> order.txt\n")
+            .expect("second script should be written");
+
+        let mut component = Component::new(
+            "fixture".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            "".to_string(),
+            None,
+        );
+        component.self_checks = Some(SelfCheckConfig {
+            lint: vec!["sh one.sh".to_string(), "sh two.sh".to_string()],
+            test: Vec::new(),
+        });
+
+        let output = run_self_checks(&component, ExtensionCapability::Lint, dir.path())
+            .expect("self-checks should run");
+
+        assert!(output.success);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("order.txt")).unwrap(),
+            "onetwo"
+        );
+    }
+}

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -35,7 +35,10 @@ pub use parsing::{
     parse_test_results_text, parse_test_results_text_with_spec, CoverageOutput, TestSummaryOutput,
 };
 pub use report::{FailedTest, TestCommandOutput};
-pub use run::{run_main_test_workflow, RawTestOutput, TestRunWorkflowArgs, TestRunWorkflowResult};
+pub use run::{
+    run_main_test_workflow, run_self_check_test_workflow, RawTestOutput, TestRunWorkflowArgs,
+    TestRunWorkflowResult,
+};
 pub use workflow::{
     auto_fix_test_drift, detect_test_drift, AutoFixDriftOutput, AutoFixDriftWorkflowResult,
     DriftWorkflowResult, MainTestWorkflowResult,

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -9,9 +9,10 @@ use crate::extension::test::{
     parse_test_results_text_with_spec, CoverageOutput, FailedTest, TestScopeOutput,
     TestSummaryOutput,
 };
+use crate::extension::{self, ExtensionCapability};
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct TestRunWorkflowArgs {
@@ -393,6 +394,51 @@ pub fn run_main_test_workflow(
         hints,
         test_scope: changed_scope,
         summary,
+        raw_output,
+    })
+}
+
+pub fn run_self_check_test_workflow(
+    component: &Component,
+    source_path: &Path,
+    component_label: String,
+    json_summary: bool,
+) -> crate::Result<TestRunWorkflowResult> {
+    let output =
+        extension::self_check::run_self_checks(component, ExtensionCapability::Test, source_path)?;
+    let status = if output.success { "passed" } else { "failed" }.to_string();
+    let raw_output = (!output.success).then(|| {
+        let (stdout_tail, stdout_truncated) = tail_lines(&output.stdout, RAW_OUTPUT_TAIL_LINES);
+        let (stderr_tail, stderr_truncated) = tail_lines(&output.stderr, RAW_OUTPUT_TAIL_LINES);
+        RawTestOutput {
+            stdout_tail,
+            stderr_tail,
+            truncated: stdout_truncated || stderr_truncated,
+        }
+    });
+
+    Ok(TestRunWorkflowResult {
+        status,
+        component: component_label,
+        exit_code: output.exit_code,
+        test_counts: None,
+        failed_tests: None,
+        coverage: None,
+        baseline_comparison: None,
+        analysis: None,
+        autofix: None,
+        hints: (!output.success).then(|| {
+            vec![format!(
+                "Fix the failing self-check command declared in {}'s homeboy.json self_checks.test",
+                component.id
+            )]
+        }),
+        test_scope: None,
+        summary: if json_summary {
+            Some(build_test_summary(None, None, output.exit_code))
+        } else {
+            None
+        },
         raw_output,
     })
 }

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -446,6 +446,7 @@ pub fn run_self_check_test_workflow(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::component::SelfCheckConfig;
     use crate::extension::test::TestFailure;
 
     #[test]
@@ -509,5 +510,32 @@ mod tests {
             Some("AssertionFailed: expected true")
         );
         assert_eq!(failed_tests[0].location.as_deref(), Some("src/lib.rs:42"));
+    }
+
+    #[test]
+    fn test_run_self_check_test_workflow() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join("test.sh"), "printf test-ok\n")
+            .expect("script should be written");
+
+        let mut component = Component::new(
+            "fixture".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            "".to_string(),
+            None,
+        );
+        component.self_checks = Some(SelfCheckConfig {
+            lint: Vec::new(),
+            test: vec!["sh test.sh".to_string()],
+        });
+
+        let result =
+            run_self_check_test_workflow(&component, dir.path(), "fixture".to_string(), true)
+                .expect("test self-check should run");
+
+        assert_eq!(result.status, "passed");
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.component, "fixture");
+        assert!(result.summary.is_some());
     }
 }

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -1,0 +1,141 @@
+use homeboy::commands::lint::{run as run_lint, LintArgs};
+use homeboy::commands::test::{run as run_test, TestArgs};
+use homeboy::commands::utils::args::{
+    BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
+};
+use homeboy::commands::GlobalArgs;
+use std::fs;
+use std::path::Path;
+
+fn write_component(root: &Path, self_checks: &str) {
+    fs::write(
+        root.join("homeboy.json"),
+        format!(
+            r#"{{
+  "id": "fixture",
+  "self_checks": {}
+}}"#,
+            self_checks
+        ),
+    )
+    .expect("homeboy.json should be written");
+}
+
+fn write_script(root: &Path, name: &str, body: &str) {
+    let script_dir = root.join("scripts");
+    fs::create_dir_all(&script_dir).expect("script dir should be created");
+    fs::write(script_dir.join(name), body).expect("script should be written");
+}
+
+fn component_args(root: &Path) -> PositionalComponentArgs {
+    PositionalComponentArgs {
+        component: Some("fixture".to_string()),
+        path: Some(root.to_string_lossy().to_string()),
+    }
+}
+
+fn lint_args(root: &Path) -> LintArgs {
+    LintArgs {
+        comp: component_args(root),
+        summary: false,
+        file: None,
+        glob: None,
+        changed_only: false,
+        changed_since: None,
+        errors_only: false,
+        sniffs: None,
+        exclude_sniffs: None,
+        category: None,
+        fix: false,
+        setting_args: SettingArgs::default(),
+        baseline_args: BaselineArgs::default(),
+        _json: HiddenJsonArgs::default(),
+    }
+}
+
+fn test_args(root: &Path) -> TestArgs {
+    TestArgs {
+        comp: component_args(root),
+        skip_lint: false,
+        coverage: false,
+        coverage_min: None,
+        baseline_args: BaselineArgs::default(),
+        analyze: false,
+        drift: false,
+        write: false,
+        since: "HEAD~10".to_string(),
+        changed_since: None,
+        setting_args: SettingArgs::default(),
+        args: Vec::new(),
+        _json: HiddenJsonArgs::default(),
+        json_summary: false,
+    }
+}
+
+#[test]
+fn lint_runs_declared_self_check_without_extensions() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_component(dir.path(), r#"{ "lint": ["sh scripts/lint.sh"] }"#);
+    write_script(dir.path(), "lint.sh", "printf 'lint self-check ran\\n'\n");
+
+    let (output, exit_code) =
+        run_lint(lint_args(dir.path()), &GlobalArgs {}).expect("lint self-check should run");
+
+    assert_eq!(exit_code, 0);
+    assert!(output.passed);
+    assert_eq!(output.component, "fixture");
+}
+
+#[test]
+fn test_runs_declared_self_check_without_extensions() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_component(dir.path(), r#"{ "test": ["sh scripts/test.sh"] }"#);
+    write_script(dir.path(), "test.sh", "printf 'test self-check ran\\n'\n");
+
+    let (output, exit_code) =
+        run_test(test_args(dir.path()), &GlobalArgs {}).expect("test self-check should run");
+
+    assert_eq!(exit_code, 0);
+    assert!(output.passed);
+    assert_eq!(output.component, "fixture");
+}
+
+#[test]
+fn non_zero_self_check_fails_command_and_surfaces_output() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_component(dir.path(), r#"{ "test": ["sh scripts/fail.sh"] }"#);
+    write_script(
+        dir.path(),
+        "fail.sh",
+        "printf 'visible failure stdout\\n'\nprintf 'visible failure stderr\\n' >&2\nexit 7\n",
+    );
+
+    let (output, exit_code) = run_test(test_args(dir.path()), &GlobalArgs {})
+        .expect("test self-check failure should return structured output");
+
+    assert_eq!(exit_code, 7);
+    assert!(!output.passed);
+    assert_eq!(output.status, "failed");
+    let raw = output
+        .raw_output
+        .expect("failure should include raw output");
+    assert!(raw.stdout_tail.contains("visible failure stdout"));
+    assert!(raw.stderr_tail.contains("visible failure stderr"));
+}
+
+#[test]
+fn missing_extension_and_self_check_keeps_existing_error() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_component(dir.path(), r#"{}"#);
+
+    let err = match run_lint(lint_args(dir.path()), &GlobalArgs {}) {
+        Ok(_) => panic!("lint without extension or self-check should fail"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string()
+            .contains("Component 'fixture' has no extensions configured"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `self_checks.lint` and `self_checks.test` to component config so extension packages can run package-local checks without pretending to be consumers of their own extension.
- Routes `homeboy lint` / `homeboy test` through those self-check commands when configured, while preserving the existing extension-backed path for normal components.
- Adds coverage for successful self-checks, non-zero failures, and the existing missing-extension error path.

## Contract
- `self_checks.lint` and `self_checks.test` are arrays of shell commands run from the component source path.
- Commands execute in order and stop on the first non-zero exit.
- Components with no self-check for the requested capability continue to use the existing `extensions` capability dispatch.

## Tests
- `cargo test --test self_checks_test`
- `cargo test test_run_self_check`
- `cargo test test_run_self_checks`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@extension-self-test-contract --changed-since origin/main`
- Live verify: `/Users/chubes/Developer/homeboy@extension-self-test-contract/target/debug/homeboy test wordpress --path /Users/chubes/Developer/homeboy-extensions@fix-wordpress-runner-host-smokes/wordpress` with a temporary `self_checks.test` entry in `wordpress/homeboy.json`, then reverted

`homeboy audit ... --changed-since origin/main` was also run. It still reports existing audit noise in touched files, plus broad heuristic findings, so it is not clean in this worktree.

Closes #1859

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the component self-check contract, adding tests, and live-verifying the new path against the WordPress extension package; Chris reviewed the direction and verification output.
