### PR TITLE
fix(bench): honor rig scenario and iteration overrides

### DIFF
--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -153,6 +153,8 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
                 "--shared-state",
                 "--concurrency",
                 "--rig",
+                "--scenario",
+                "--profile",
                 "--setting",
                 "--path",
                 "--json-summary",
@@ -440,6 +442,45 @@ mod normalize_tests {
             "--iterations",
             "1",
             "--ignore-default-baseline",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    /// Rig-pinned bench commonly omits the positional component because the
+    /// rig declares `bench.default_component`. Scenario/profile selectors in
+    /// that shape must still bind to BenchRunArgs rather than being captured
+    /// as extension passthrough args.
+    #[test]
+    fn bench_rig_selector_flags_without_component_are_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "--rig",
+            "studio-agent-sdk",
+            "--scenario",
+            "studio-agent-runtime",
+            "--iterations",
+            "1",
+            "--runs",
+            "1",
+            "--json-summary",
+            "--ignore-default-baseline",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    #[test]
+    fn bench_rig_profile_flag_without_component_is_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "--rig",
+            "studio-agent-sdk",
+            "--profile",
+            "smoke",
+            "--iterations=1",
         ]);
         let expected = input.clone();
         assert_eq!(normalize_trailing_flags(input), expected);

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -442,7 +442,13 @@ pub fn run_main_bench_workflow(
         };
 
     if let Some(results) = parsed.as_mut() {
-        stamp_run_metadata(results, &execution_context, component, &args, &started_at);
+        stamp_run_metadata(
+            results,
+            &execution_context,
+            component,
+            &execution_args,
+            &started_at,
+        );
     }
 
     let gate_failures = parsed


### PR DESCRIPTION
## Summary
- Keep rig bench `--scenario` and `--profile` flags on Homeboy's named-argument path so they are not swallowed as extension passthrough args.
- Stamp bench run metadata from the effective filtered execution args so rig workload metadata matches the workloads actually executed.

## Tests
- `cargo test bench -- --test-threads=1`
- `cargo run --bin homeboy -- bench --rig studio-agent-sdk --scenario studio-agent-runtime --iterations 1 --runs 1 --json-summary --ignore-default-baseline`
- `cargo run --bin homeboy -- bench --rig studio-agent-sdk --scenario missing-scenario --iterations 1 --runs 1 --json-summary --ignore-default-baseline`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-bench-rig-cli-overrides`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-bench-rig-cli-overrides --changed-since origin/main`

Closes #1862

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the bench override fix, adding tests, and drafting the PR. Chris reviewed/tested before merge.