### PR TITLE
feat(deps): add composer dependency workflow

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -2,8 +2,9 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 
 use crate::commands::{
     api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
-    extension, file, fleet, git, init, issues, lint, logs, project, refactor, release, review, rig,
-    self_cmd, server, ssh, stack, status, test, transfer, triage, undo, upgrade, validate, version,
+    deps, extension, file, fleet, git, init, issues, lint, logs, project, refactor, release,
+    review, rig, self_cmd, server, ssh, stack, status, test, transfer, triage, undo, upgrade,
+    validate, version,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -40,6 +41,9 @@ pub enum Commands {
     Lint(lint::LintArgs),
     /// Database operations
     Db(db::DbArgs),
+    /// Manage component dependencies
+    #[command(visible_alias = "dependencies")]
+    Deps(deps::DepsArgs),
     /// Remote file operations
     File(file::FileArgs),
     /// Manage fleets (groups of projects)

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -1,0 +1,88 @@
+use clap::{Args, Subcommand};
+
+use homeboy::deps::{self, DependencyStatus, DependencyUpdateResult};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct DepsArgs {
+    #[command(subcommand)]
+    command: DepsCommand,
+}
+
+#[derive(Subcommand)]
+enum DepsCommand {
+    /// Inspect dependency constraints and locked package versions
+    Status {
+        /// Component ID. When omitted, auto-detected from CWD.
+        component: Option<String>,
+
+        /// Limit output to one package.
+        #[arg(long, value_name = "PACKAGE")]
+        package: Option<String>,
+
+        /// Workspace path to operate on directly.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Update one Composer package explicitly
+    Update {
+        /// Composer package name, e.g. chubes4/block-format-bridge.
+        package: String,
+
+        /// Component ID. When omitted, auto-detected from CWD.
+        component: Option<String>,
+
+        /// New manifest constraint, e.g. ^0.4.
+        #[arg(long, value_name = "CONSTRAINT")]
+        to: Option<String>,
+
+        /// Workspace path to operate on directly.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+}
+
+pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<serde_json::Value> {
+    match args.command {
+        DepsCommand::Status {
+            component,
+            package,
+            path,
+        } => {
+            let output: DependencyStatus =
+                deps::status(component.as_deref(), path.as_deref(), package.as_deref())?;
+            Ok((
+                serde_json::to_value(output).map_err(|e| {
+                    homeboy::Error::internal_json(
+                        e.to_string(),
+                        Some("serialize deps status".to_string()),
+                    )
+                })?,
+                0,
+            ))
+        }
+        DepsCommand::Update {
+            package,
+            component,
+            to,
+            path,
+        } => {
+            let output: DependencyUpdateResult = deps::update(
+                component.as_deref(),
+                path.as_deref(),
+                &package,
+                to.as_deref(),
+            )?;
+            Ok((
+                serde_json::to_value(output).map_err(|e| {
+                    homeboy::Error::internal_json(
+                        e.to_string(),
+                        Some("serialize deps update".to_string()),
+                    )
+                })?,
+                0,
+            ))
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -287,6 +287,7 @@ pub mod config;
 pub mod daemon;
 pub mod db;
 pub mod deploy;
+pub mod deps;
 pub mod docs;
 pub mod extension;
 pub mod file;
@@ -356,6 +357,7 @@ pub fn run_json(
         crate::cli_surface::Commands::Ssh(args) => dispatch!(args, global, ssh),
         crate::cli_surface::Commands::Server(args) => dispatch!(args, global, server),
         crate::cli_surface::Commands::Db(args) => dispatch!(args, global, db),
+        crate::cli_surface::Commands::Deps(args) => dispatch!(args, global, deps),
         crate::cli_surface::Commands::File(args) => dispatch!(args, global, file),
         crate::cli_surface::Commands::Fleet(args) => dispatch!(args, global, fleet),
         crate::cli_surface::Commands::Logs(args) => dispatch!(args, global, logs),

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -1,0 +1,317 @@
+use crate::component::{self, Component};
+use crate::{Error, Result};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyPackage {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_section: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub constraint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked_reference: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStatus {
+    pub component_id: String,
+    pub component_path: String,
+    pub package_manager: String,
+    pub packages: Vec<DependencyPackage>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyUpdateResult {
+    pub component_id: String,
+    pub component_path: String,
+    pub package_manager: String,
+    pub package: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_constraint: Option<String>,
+    pub command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<DependencyPackage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<DependencyPackage>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComposerAction {
+    Require { constraint: String },
+    Update,
+}
+
+pub fn composer_command_args(package: &str, action: &ComposerAction) -> Vec<String> {
+    match action {
+        ComposerAction::Require { constraint } => vec![
+            "require".to_string(),
+            format!("{package}:{constraint}"),
+            "--with-dependencies".to_string(),
+            "--no-interaction".to_string(),
+        ],
+        ComposerAction::Update => vec![
+            "update".to_string(),
+            package.to_string(),
+            "--with-dependencies".to_string(),
+            "--no-interaction".to_string(),
+        ],
+    }
+}
+
+pub fn status(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+    package_filter: Option<&str>,
+) -> Result<DependencyStatus> {
+    let (component, path) = resolve_component_path(component_id, path_override)?;
+    composer_status(&component, &path, package_filter)
+}
+
+pub fn update(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+    package: &str,
+    constraint: Option<&str>,
+) -> Result<DependencyUpdateResult> {
+    let (component, path) = resolve_component_path(component_id, path_override)?;
+    ensure_composer_component(&path)?;
+
+    let before = package_snapshot(&path, package)?;
+    let action = match constraint {
+        Some(constraint) => ComposerAction::Require {
+            constraint: constraint.to_string(),
+        },
+        None => ComposerAction::Update,
+    };
+    let args = composer_command_args(package, &action);
+    let output = Command::new("composer")
+        .args(&args)
+        .current_dir(&path)
+        .output()
+        .map_err(|e| Error::internal_io(e.to_string(), Some("run composer".to_string())))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "composer",
+            format!(
+                "Composer command failed with status {}: {}",
+                output.status,
+                first_non_empty_line(&stderr)
+                    .or_else(|| first_non_empty_line(&stdout))
+                    .unwrap_or("no output")
+            ),
+            None,
+            Some(vec![format!(
+                "Run manually in {}: composer {}",
+                path.display(),
+                args.join(" ")
+            )]),
+        ));
+    }
+
+    let after = package_snapshot(&path, package)?;
+
+    Ok(DependencyUpdateResult {
+        component_id: component.id,
+        component_path: path.display().to_string(),
+        package_manager: "composer".to_string(),
+        package: package.to_string(),
+        requested_constraint: constraint.map(str::to_string),
+        command: std::iter::once("composer".to_string())
+            .chain(args)
+            .collect(),
+        before,
+        after,
+        stdout,
+        stderr,
+    })
+}
+
+fn resolve_component_path(
+    component_id: Option<&str>,
+    path_override: Option<&str>,
+) -> Result<(Component, PathBuf)> {
+    let component = component::resolve_effective(component_id, path_override, None)?;
+    let path = PathBuf::from(shellexpand::tilde(&component.local_path).as_ref());
+
+    if !path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "component_path",
+            format!(
+                "Component '{}' path does not exist: {}",
+                component.id,
+                path.display()
+            ),
+            Some(component.id.clone()),
+            None,
+        ));
+    }
+
+    Ok((component, path))
+}
+
+fn ensure_composer_component(path: &Path) -> Result<()> {
+    if path.join("composer.json").is_file() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "package_manager",
+        format!("No supported dependency manifest found in {}", path.display()),
+        None,
+        Some(vec![
+            "Composer MVP requires composer.json at the component root".to_string(),
+            "npm, Cargo, and other package managers are intentionally out of scope for this command".to_string(),
+        ]),
+    ))
+}
+
+fn composer_status(
+    component: &Component,
+    path: &Path,
+    package_filter: Option<&str>,
+) -> Result<DependencyStatus> {
+    ensure_composer_component(path)?;
+    let packages = read_composer_packages(path, package_filter)?;
+
+    Ok(DependencyStatus {
+        component_id: component.id.clone(),
+        component_path: path.display().to_string(),
+        package_manager: "composer".to_string(),
+        packages,
+    })
+}
+
+fn package_snapshot(path: &Path, package: &str) -> Result<Option<DependencyPackage>> {
+    Ok(read_composer_packages(path, Some(package))?
+        .into_iter()
+        .next())
+}
+
+fn read_composer_packages(
+    path: &Path,
+    package_filter: Option<&str>,
+) -> Result<Vec<DependencyPackage>> {
+    let manifest = read_json_file(&path.join("composer.json"))?;
+    let lock = read_optional_json_file(&path.join("composer.lock"))?;
+    let mut direct = BTreeMap::new();
+
+    collect_manifest_section(&manifest, "require", &mut direct);
+    collect_manifest_section(&manifest, "require-dev", &mut direct);
+
+    let locked = lock
+        .as_ref()
+        .map(collect_locked_packages)
+        .unwrap_or_default();
+
+    let mut names: BTreeSet<String> = direct.keys().cloned().collect();
+    names.extend(locked.keys().cloned());
+
+    let packages = names
+        .into_iter()
+        .filter(|name| package_filter.map(|filter| filter == name).unwrap_or(true))
+        .map(|name| {
+            let (manifest_section, constraint) = direct
+                .get(&name)
+                .cloned()
+                .map(|(section, constraint)| (Some(section), Some(constraint)))
+                .unwrap_or((None, None));
+            let locked = locked.get(&name);
+            DependencyPackage {
+                name,
+                manifest_section,
+                constraint,
+                locked_version: locked.and_then(|p| p.version.clone()),
+                locked_reference: locked.and_then(|p| p.reference.clone()),
+            }
+        })
+        .collect();
+
+    Ok(packages)
+}
+
+fn collect_manifest_section(
+    manifest: &Value,
+    section: &str,
+    direct: &mut BTreeMap<String, (String, String)>,
+) {
+    let Some(entries) = manifest.get(section).and_then(Value::as_object) else {
+        return;
+    };
+
+    for (name, constraint) in entries {
+        if name == "php" || name.starts_with("ext-") {
+            continue;
+        }
+        if let Some(constraint) = constraint.as_str() {
+            direct.insert(name.clone(), (section.to_string(), constraint.to_string()));
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct LockedPackage {
+    version: Option<String>,
+    reference: Option<String>,
+}
+
+fn collect_locked_packages(lock: &Value) -> BTreeMap<String, LockedPackage> {
+    let mut packages = BTreeMap::new();
+
+    for section in ["packages", "packages-dev"] {
+        let Some(entries) = lock.get(section).and_then(Value::as_array) else {
+            continue;
+        };
+
+        for entry in entries {
+            let Some(name) = entry.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let version = entry
+                .get("version")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let reference = entry
+                .get("source")
+                .and_then(|source| source.get("reference"))
+                .or_else(|| entry.get("dist").and_then(|dist| dist.get("reference")))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+
+            packages.insert(name.to_string(), LockedPackage { version, reference });
+        }
+    }
+
+    packages
+}
+
+fn read_json_file(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&raw)
+        .map_err(|e| Error::validation_invalid_json(e, Some(path.display().to_string()), Some(raw)))
+}
+
+fn read_optional_json_file(path: &Path) -> Result<Option<Value>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    read_json_file(path).map(Some)
+}
+
+fn first_non_empty_line(output: &str) -> Option<&str> {
+    output.lines().find(|line| !line.trim().is_empty())
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod daemon;
 pub mod db;
 pub mod deploy;
+pub mod deps;
 pub mod engine;
 pub mod error;
 pub(crate) mod expand;

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -6,6 +6,7 @@ fn includes_current_top_level_commands() {
 
     assert!(surface.contains_path(&["audit"]));
     assert!(surface.contains_path(&["daemon"]));
+    assert!(surface.contains_path(&["deps"]));
     assert!(surface.contains_path(&["git"]));
     assert!(surface.contains_path(&["self"]));
     assert!(surface.contains_path(&["stack"]));
@@ -16,6 +17,8 @@ fn includes_first_level_subcommands() {
     let surface = current_command_surface();
 
     assert!(surface.contains_path(&["git", "status"]));
+    assert!(surface.contains_path(&["deps", "status"]));
+    assert!(surface.contains_path(&["deps", "update"]));
     assert!(surface.contains_path(&["daemon", "serve"]));
     assert!(surface.contains_path(&["self", "status"]));
     assert!(surface.contains_path(&["stack", "inspect"]));
@@ -26,6 +29,7 @@ fn includes_visible_aliases() {
     let surface = current_command_surface();
 
     assert!(surface.contains_path(&["components"]));
+    assert!(surface.contains_path(&["dependencies"]));
     assert!(surface.contains_path(&["rigs"]));
     assert!(surface.contains_path(&["stacks", "inspect"]));
 }

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -1,0 +1,241 @@
+use homeboy::deps::{self, ComposerAction};
+use std::fs;
+use tempfile::tempdir;
+
+fn write_file(path: &std::path::Path, contents: &str) {
+    fs::write(path, contents).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+fn fixture_component(path: &std::path::Path) -> (&'static str, String) {
+    ("fixture", path.display().to_string())
+}
+
+#[test]
+fn status_reads_composer_direct_constraints_and_lock_details() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let (_, root_path) = fixture_component(root);
+
+    write_file(
+        &root.join("composer.json"),
+        r#"{
+            "name": "fixture/root",
+            "require": {
+                "php": ">=8.1",
+                "fixture/prod": "^1.0"
+            },
+            "require-dev": {
+                "fixture/dev": "dev-main"
+            }
+        }"#,
+    );
+    write_file(
+        &root.join("composer.lock"),
+        r#"{
+            "packages": [
+                {
+                    "name": "fixture/prod",
+                    "version": "1.2.3",
+                    "source": { "reference": "prod-ref" }
+                },
+                {
+                    "name": "fixture/transitive",
+                    "version": "0.1.0",
+                    "dist": { "reference": "transitive-ref" }
+                }
+            ],
+            "packages-dev": [
+                {
+                    "name": "fixture/dev",
+                    "version": "dev-main",
+                    "source": { "reference": "dev-ref" }
+                }
+            ]
+        }"#,
+    );
+
+    let status = deps::status(Some("fixture"), Some(&root_path), None).unwrap();
+
+    assert_eq!(status.component_id, "fixture");
+    assert_eq!(status.package_manager, "composer");
+    assert_eq!(status.packages.len(), 3);
+
+    let prod = status
+        .packages
+        .iter()
+        .find(|package| package.name == "fixture/prod")
+        .unwrap();
+    assert_eq!(prod.manifest_section.as_deref(), Some("require"));
+    assert_eq!(prod.constraint.as_deref(), Some("^1.0"));
+    assert_eq!(prod.locked_version.as_deref(), Some("1.2.3"));
+    assert_eq!(prod.locked_reference.as_deref(), Some("prod-ref"));
+
+    let dev = status
+        .packages
+        .iter()
+        .find(|package| package.name == "fixture/dev")
+        .unwrap();
+    assert_eq!(dev.manifest_section.as_deref(), Some("require-dev"));
+    assert_eq!(dev.constraint.as_deref(), Some("dev-main"));
+    assert_eq!(dev.locked_reference.as_deref(), Some("dev-ref"));
+
+    let transitive = status
+        .packages
+        .iter()
+        .find(|package| package.name == "fixture/transitive")
+        .unwrap();
+    assert_eq!(transitive.manifest_section, None);
+    assert_eq!(transitive.constraint, None);
+    assert_eq!(transitive.locked_reference.as_deref(), Some("transitive-ref"));
+}
+
+#[test]
+fn status_filters_to_one_package() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let (_, root_path) = fixture_component(root);
+
+    write_file(
+        &root.join("composer.json"),
+        r#"{
+            "name": "fixture/root",
+            "require": {
+                "fixture/one": "^1.0",
+                "fixture/two": "^2.0"
+            }
+        }"#,
+    );
+    write_file(&root.join("composer.lock"), r#"{ "packages": [], "packages-dev": [] }"#);
+
+    let status = deps::status(Some("fixture"), Some(&root_path), Some("fixture/two")).unwrap();
+
+    assert_eq!(status.packages.len(), 1);
+    assert_eq!(status.packages[0].name, "fixture/two");
+    assert_eq!(status.packages[0].constraint.as_deref(), Some("^2.0"));
+}
+
+#[test]
+fn update_command_args_are_composer_first_and_package_scoped() {
+    assert_eq!(
+        deps::composer_command_args(
+            "fixture/package",
+            &ComposerAction::Require {
+                constraint: "^2.0".to_string(),
+            },
+        ),
+        vec![
+            "require",
+            "fixture/package:^2.0",
+            "--with-dependencies",
+            "--no-interaction",
+        ]
+    );
+
+    assert_eq!(
+        deps::composer_command_args("fixture/package", &ComposerAction::Update),
+        vec![
+            "update",
+            "fixture/package",
+            "--with-dependencies",
+            "--no-interaction",
+        ]
+    );
+}
+
+#[test]
+fn non_composer_component_returns_clear_unsupported_error() {
+    let dir = tempdir().unwrap();
+    let root_path = dir.path().display().to_string();
+
+    let err = deps::status(Some("fixture"), Some(&root_path), None).unwrap_err();
+
+    assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    assert!(err.message.contains("package_manager"));
+    assert!(err.message.contains("No supported dependency manifest"));
+}
+
+#[test]
+fn update_with_constraint_changes_manifest_and_lock_for_local_path_package() {
+    if std::process::Command::new("composer")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("composer not found; skipping integration-ish deps update test");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let root = dir.path().join("root");
+    let package = dir.path().join("package");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&package).unwrap();
+
+    write_file(
+        &package.join("composer.json"),
+        r#"{
+            "name": "fixture/package",
+            "version": "1.0.0",
+            "autoload": { "psr-4": { "Fixture\\Package\\": "src/" } }
+        }"#,
+    );
+    fs::create_dir_all(package.join("src")).unwrap();
+    write_file(
+        &root.join("composer.json"),
+        &format!(
+            r#"{{
+                "name": "fixture/root",
+                "repositories": [
+                    {{ "type": "path", "url": "{}", "options": {{ "symlink": false }} }}
+                ],
+                "require": {{ "fixture/package": "1.0.0" }}
+            }}"#,
+            package.display()
+        ),
+    );
+
+    let initial = std::process::Command::new("composer")
+        .args(["update", "--no-interaction"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert!(
+        initial.status.success(),
+        "initial composer update failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&initial.stdout),
+        String::from_utf8_lossy(&initial.stderr)
+    );
+
+    write_file(
+        &package.join("composer.json"),
+        r#"{
+            "name": "fixture/package",
+            "version": "1.1.0",
+            "autoload": { "psr-4": { "Fixture\\Package\\": "src/" } }
+        }"#,
+    );
+
+    let root_path = root.display().to_string();
+    let result = deps::update(
+        Some("fixture"),
+        Some(&root_path),
+        "fixture/package",
+        Some("1.1.0"),
+    )
+    .unwrap();
+
+    assert_eq!(result.before.unwrap().locked_version.as_deref(), Some("1.0.0"));
+    let after = result.after.unwrap();
+    assert_eq!(after.constraint.as_deref(), Some("1.1.0"));
+    assert_eq!(after.locked_version.as_deref(), Some("1.1.0"));
+    assert_eq!(
+        result.command,
+        vec![
+            "composer",
+            "require",
+            "fixture/package:1.1.0",
+            "--with-dependencies",
+            "--no-interaction",
+        ]
+    );
+}

--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -1,0 +1,1 @@
+include!("core/deps_test.rs");


### PR DESCRIPTION
## Summary
- Add a first-class `homeboy deps` command group for explicit dependency workflow operations.
- Ship a Composer-first MVP that inspects `composer.json` / `composer.lock` and updates one package through Composer.
- Add focused coverage for status parsing, package filtering, Composer command construction, unsupported components, and a local path-repository update.

## CLI surface
- `homeboy deps status <component> [--package <package>] [--path <path>]`
- `homeboy deps update <package> <component> [--to <constraint>] [--path <path>]`
- `homeboy dependencies ...` is available as a visible alias for `deps`.

## Behaviour
- `deps status` is read-only and reports direct `require` / `require-dev` constraints plus lock versions and references when available.
- `deps update --to <constraint>` runs `composer require <package>:<constraint> --with-dependencies --no-interaction` in the component root.
- `deps update` without `--to` runs `composer update <package> --with-dependencies --no-interaction` in the component root.
- The command returns before/after package snapshots and does not commit, release, deploy, or open downstream PRs.

## Tests
- `cargo test --test deps_test`
- `cargo test --test command_surface_test`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-deps-primitive`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-deps-primitive --changed-since origin/main`

Closes #1866

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the Composer-first dependency workflow, writing tests, and running validation. Chris remains responsible for review and merge.
