### PR TITLE
fix(bench): support reversed cross-rig order

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
@@ -134,6 +134,14 @@ pub struct BenchRunArgs {
     #[arg(long, value_name = "RIG_ID[,RIG_ID...]", value_delimiter = ',')]
     rig: Vec<String>,
 
+    /// Order to use when running a multi-rig comparison. `input` preserves
+    /// the --rig list order and keeps the first rig as the comparison
+    /// reference. `reverse` flips the order so users can repeat the same
+    /// comparison with the opposite cold/warm position when rigs share
+    /// external daemon or cache state.
+    #[arg(long, value_enum, default_value_t = BenchRigOrder::Input)]
+    rig_order: BenchRigOrder,
+
     /// Only run matching benchmark scenario ids. Repeat to select multiple.
     #[arg(
         long = "scenario",
@@ -152,6 +160,12 @@ pub struct BenchRunArgs {
     /// auto-pairs, or to bench the candidate alone.
     #[arg(long)]
     ignore_default_baseline: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum BenchRigOrder {
+    Input,
+    Reverse,
 }
 
 /// Filter out homeboy-owned flags from trailing args before passing to
@@ -180,6 +194,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
         "--regression-threshold",
         "--scenario",
         "--profile",
+        "--rig-order",
         "--rig",
         "--setting",
         "--path",
@@ -306,7 +321,9 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
     let mut entries = Vec::with_capacity(run_args.rig.len());
     let mut effective_component_label: Option<String> = None;
 
-    for rig_id in &run_args.rig {
+    let ordered_rigs = ordered_rig_ids(run_args);
+
+    for rig_id in ordered_rigs {
         let (single_output, _exit) =
             matrix::run_single(run_args, &passthrough_args, Some(rig_id.clone()))?;
         if effective_component_label.is_none() {
@@ -330,6 +347,14 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
 
     let (output, exit) = aggregate_comparison(component, run_args.iterations, entries);
     Ok((BenchOutput::Comparison(output), exit))
+}
+
+fn ordered_rig_ids(args: &BenchRunArgs) -> Vec<String> {
+    let mut rig_ids = args.rig.clone();
+    if args.rig_order == BenchRigOrder::Reverse {
+        rig_ids.reverse();
+    }
+    rig_ids
 }
 
 fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -517,6 +517,7 @@ mod tests {
             _json: HiddenJsonArgs::default(),
             json_summary: false,
             rig: vec!["rig".to_string()],
+            rig_order: crate::commands::bench::BenchRigOrder::Input,
             scenario_ids: Vec::new(),
             profile: None,
             ignore_default_baseline: false,

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -218,6 +218,7 @@ fn run_args(component: Option<&str>, rig: Vec<String>, scenario_ids: Vec<String>
             _json: HiddenJsonArgs::default(),
             json_summary: false,
             rig,
+            rig_order: BenchRigOrder::Input,
             scenario_ids,
             profile: None,
             ignore_default_baseline: false,
@@ -414,6 +415,20 @@ fn parses_rig_run_options_without_component() {
 }
 
 #[test]
+fn parses_rig_order_flag() {
+    let cli = TestCli::try_parse_from([
+        "bench",
+        "--rig",
+        "studio-agent-sdk,studio-agent-pi",
+        "--rig-order",
+        "reverse",
+    ])
+    .expect("bench --rig-order should parse");
+
+    assert_eq!(cli.bench.run.rig_order, BenchRigOrder::Reverse);
+}
+
+#[test]
 fn run_selects_multiple_scenarios() {
     with_isolated_home(|home| {
         write_bench_extension(home);
@@ -500,6 +515,37 @@ fn cross_rig_run_passes_selector_to_each_rig() {
                     assert_eq!(scenarios.len(), 1);
                     assert_eq!(scenarios[0].id, "rig-slow");
                 }
+            }
+            _ => panic!("expected comparison output"),
+        }
+    });
+}
+
+#[test]
+fn cross_rig_reverse_order_flips_reference_and_execution_order() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_a = tempfile::TempDir::new().expect("component a");
+        let component_b = tempfile::TempDir::new().expect("component b");
+        write_rig(home, "rig-a", "studio", component_a.path());
+        write_rig(home, "rig-b", "studio", component_b.path());
+
+        let mut args = run_args(
+            None,
+            vec!["rig-a".to_string(), "rig-b".to_string()],
+            vec!["rig-slow".to_string()],
+        );
+        args.run.rig_order = BenchRigOrder::Reverse;
+
+        let (output, exit_code) = run(args, &GlobalArgs {})
+            .expect("cross-rig selected bench should run in reverse order");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Comparison(result) => {
+                assert_eq!(result.rigs.len(), 2);
+                assert_eq!(result.rigs[0].rig_id, "rig-b");
+                assert_eq!(result.rigs[1].rig_id, "rig-a");
             }
             _ => panic!("expected comparison output"),
         }
@@ -1150,6 +1196,19 @@ fn filter_strips_shared_state_and_concurrency_forms() {
         "--concurrency=4".to_string(),
         "--keep".to_string(),
     ];
+    assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+}
+
+#[test]
+fn filter_strips_rig_order_forms() {
+    let args = vec![
+        "--rig-order".to_string(),
+        "reverse".to_string(),
+        "--filter=Scenario".to_string(),
+    ];
+    assert_eq!(filter_homeboy_flags(&args), vec!["--filter=Scenario"]);
+
+    let args = vec!["--rig-order=reverse".to_string(), "--keep".to_string()];
     assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
 }
 

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -55,6 +55,7 @@ fn make_args(
             _json: HiddenJsonArgs::default(),
             json_summary: false,
             rig,
+            rig_order: super::BenchRigOrder::Input,
             scenario_ids: Vec::new(),
             profile: None,
             ignore_default_baseline,


### PR DESCRIPTION
## Summary
- Add a `--rig-order input|reverse` option for multi-rig benchmark comparisons.
- Keep the default fixed input order, while allowing a second reversed run to expose shared warm-state bias between rigs.

## Behaviour
- `--rig-order input` preserves existing behavior and keeps the first `--rig` value as the reference.
- `--rig-order reverse` reverses the multi-rig comparison order, so the opposite rig pays the first-run cold/warm-state position.
- The flag is filtered out of extension passthrough args so runner scripts only see their own flags.

## Tests
- `cargo test commands::bench::tests -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-bench-cross-rig-order`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-bench-cross-rig-order --changed-since origin/main`

Closes #1868

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI order-control option, added tests, ran focused validation, and prepared this PR. Chris remains responsible for review and merge.