### PR TITLE
fix(bench): compact cross-rig summary output

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -6,8 +6,9 @@ use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::bench as extension_bench;
 use homeboy::extension::bench::{
-    aggregate_comparison, BenchCommandOutput, BenchComparisonOutput, BenchListWorkflowArgs,
-    BenchListWorkflowResult, RigBenchEntry, DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+    aggregate_comparison, BenchCommandOutput, BenchComparisonOutput, BenchComparisonSummaryOutput,
+    BenchListWorkflowArgs, BenchListWorkflowResult, RigBenchEntry,
+    DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::rig::{self, RigSpec};
@@ -248,6 +249,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 pub enum BenchOutput {
     Single(BenchCommandOutput),
     Comparison(BenchComparisonOutput),
+    ComparisonSummary(BenchComparisonSummaryOutput),
     List(BenchListWorkflowResult),
 }
 
@@ -346,6 +348,9 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
         .unwrap_or_else(|| "<unknown>".to_string());
 
     let (output, exit) = aggregate_comparison(component, run_args.iterations, entries);
+    if run_args.json_summary {
+        return Ok((BenchOutput::ComparisonSummary(output.into()), exit));
+    }
     Ok((BenchOutput::Comparison(output), exit))
 }
 

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -522,6 +522,44 @@ fn cross_rig_run_passes_selector_to_each_rig() {
 }
 
 #[test]
+fn cross_rig_json_summary_omits_full_results_payload() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_a = tempfile::TempDir::new().expect("component a");
+        let component_b = tempfile::TempDir::new().expect("component b");
+        write_rig(home, "rig-a", "studio", component_a.path());
+        write_rig(home, "rig-b", "studio", component_b.path());
+
+        let mut args = run_args(
+            None,
+            vec!["rig-a".to_string(), "rig-b".to_string()],
+            vec!["rig-slow".to_string()],
+        );
+        args.run.json_summary = true;
+
+        let (output, exit_code) =
+            run(args, &GlobalArgs {}).expect("cross-rig selected bench summary should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::ComparisonSummary(result) => {
+                assert!(result.summary_only);
+                assert_eq!(result.rigs.len(), 2);
+                assert_eq!(result.rigs[0].rig_id, "rig-a");
+                assert_eq!(result.rigs[1].rig_id, "rig-b");
+
+                let value = serde_json::to_value(result).expect("serialize summary");
+                assert!(value.get("diff").is_none());
+                assert!(value["rigs"][0].get("results").is_none());
+                assert!(value["rigs"][0].get("artifacts").is_none());
+                assert!(value["rigs"][0].get("rig_state").is_none());
+            }
+            _ => panic!("expected comparison summary output"),
+        }
+    });
+}
+
+#[test]
 fn cross_rig_reverse_order_flips_reference_and_execution_order() {
     with_isolated_home(|home| {
         write_bench_extension(home);

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -48,8 +48,8 @@ pub use parsing::{
 };
 pub use report::{
     aggregate_comparison, from_main_workflow, from_main_workflow_with_rig, BenchArtifactRef,
-    BenchCommandOutput, BenchComparisonDiff, BenchComparisonOutput,
-    MetricDelta as ReportMetricDelta, RigBenchEntry,
+    BenchCommandOutput, BenchComparisonDiff, BenchComparisonOutput, BenchComparisonRigSummary,
+    BenchComparisonSummaryOutput, MetricDelta as ReportMetricDelta, RigBenchEntry,
 };
 pub use run::{
     run_bench_list_workflow, run_main_bench_workflow, BenchListWorkflowArgs,

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -120,6 +120,36 @@ pub struct BenchComparisonOutput {
     pub hints: Option<Vec<String>>,
 }
 
+/// Compact cross-rig comparison envelope for operator-facing summary reads.
+///
+/// This intentionally omits the heavy per-rig `results`, `artifacts`, and
+/// `diff` payloads. The full `BenchComparisonOutput` remains the default
+/// machine-readable shape for artifact consumers.
+#[derive(Serialize)]
+pub struct BenchComparisonSummaryOutput {
+    pub comparison: &'static str,
+    pub summary_only: bool,
+    pub passed: bool,
+    pub component: String,
+    pub exit_code: i32,
+    pub iterations: u64,
+    pub rigs: Vec<BenchComparisonRigSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub summary: Vec<BenchScenarioComparisonSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub failures: Vec<BenchComparisonFailure>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct BenchComparisonRigSummary {
+    pub rig_id: String,
+    pub passed: bool,
+    pub status: String,
+    pub exit_code: i32,
+}
+
 #[derive(Serialize, Clone, Debug, PartialEq)]
 pub struct BenchComparisonFailure {
     pub rig_id: String,
@@ -146,6 +176,32 @@ pub struct RigBenchEntry {
     pub rig_state: Option<RigStateSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<BenchRunFailure>,
+}
+
+impl From<BenchComparisonOutput> for BenchComparisonSummaryOutput {
+    fn from(output: BenchComparisonOutput) -> Self {
+        BenchComparisonSummaryOutput {
+            comparison: output.comparison,
+            summary_only: true,
+            passed: output.passed,
+            component: output.component,
+            exit_code: output.exit_code,
+            iterations: output.iterations,
+            rigs: output
+                .rigs
+                .into_iter()
+                .map(|rig| BenchComparisonRigSummary {
+                    rig_id: rig.rig_id,
+                    passed: rig.passed,
+                    status: rig.status,
+                    exit_code: rig.exit_code,
+                })
+                .collect(),
+            summary: output.summary,
+            failures: output.failures,
+            hints: output.hints,
+        }
+    }
 }
 
 /// A compact, grep-friendly pointer to an artifact emitted by a bench


### PR DESCRIPTION
## Summary
- Make `homeboy bench --rig <a>,<b> --json-summary` emit a compact cross-rig comparison summary instead of the full per-rig results envelope.
- Keep the default cross-rig output unchanged so CI/artifact consumers still receive `rigs`, full `results`, `artifacts`, and `diff` unless they opt into summary mode.

## Behaviour
- `--json-summary` now returns `summary_only: true`, lightweight per-rig status rows, promoted scenario summaries, failures, and hints.
- The compact summary intentionally omits heavy per-rig `results`, `artifacts`, `rig_state`, and `diff` payloads.
- Existing default output and `--output` consumers that do not pass `--json-summary` keep the full machine-readable payload.

## Tests
- `cargo test commands::bench::tests -- --test-threads=1`
- `cargo test extension::bench::report::tests -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-bench-summary-output`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-bench-summary-output --changed-since origin/main`

Closes #1871

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the compact bench summary output path, added focused tests, ran validation, and prepared this PR. Chris remains responsible for review and merge.
