### PR TITLE
test(review): cover repeatable PR comment banners

### DIFF
--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -652,6 +652,30 @@ mod tests {
     }
 
     #[test]
+    fn parses_repeatable_pr_comment_banners_in_order() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "my-comp",
+            "--report=pr-comment",
+            "--banner",
+            "autofix=applied 3 file(s)",
+            "--banner=binary-source=fallback",
+            "--banner",
+            "custom=value=with=equals",
+        ])
+        .expect("should parse repeatable banners");
+
+        assert_eq!(
+            cli.review.banner,
+            vec![
+                ("autofix".to_string(), "applied 3 file(s)".to_string()),
+                ("binary-source".to_string(), "fallback".to_string()),
+                ("custom".to_string(), "value=with=equals".to_string()),
+            ]
+        );
+    }
+
+    #[test]
     fn rejects_unknown_report_format() {
         let result = TestCli::try_parse_from(["test", "my-comp", "--report=slack"]);
         assert!(


### PR DESCRIPTION
## Summary
- Adds explicit regression coverage for `homeboy review --report=pr-comment --banner key=value`.
- Locks the CLI contract that banners are repeatable, order-preserving, and can carry values containing additional `=` characters.

## Changes
- Added a `ReviewArgs` clap parsing test for repeated `--banner` arguments.
- Confirmed the current runtime path already threads `args.banner` into the PR-comment renderer and keeps `ReviewCommandOutput` clean.

## Tests
- `cargo fmt`
- `cargo test commands::review`
- `git diff --check`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-review-pr-comment-banners --file src/commands/review/mod.rs`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-review-pr-comment-banners --changed-since origin/main`

Note: `homeboy audit --file` is not supported. The changed-since audit passed, but scanned zero files because this is a test-only working-tree change before commit.

Closes #1510

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** inspected the existing review implementation, added the regression test, ran focused validation, and drafted this PR description.
