### PR TITLE
feat(report): render failure digests from command outputs

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -3,8 +3,8 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 use crate::commands::{
     api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
     deps, extension, file, fleet, git, init, issues, lint, logs, project, refactor, release,
-    review, rig, self_cmd, server, ssh, stack, status, test, transfer, triage, undo, upgrade,
-    validate, version,
+    report, review, rig, self_cmd, server, ssh, stack, status, test, transfer, triage, undo,
+    upgrade, validate, version,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -90,6 +90,8 @@ pub enum Commands {
     Changes(changes::ChangesArgs),
     /// Plan release workflows
     Release(release::ReleaseArgs),
+    /// Render reports from Homeboy structured output artifacts
+    Report(report::ReportArgs),
     /// Run scoped audit + lint + test umbrella against PR-style changes
     Review(review::ReviewArgs),
     /// Audit code conventions and detect architectural drift

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -300,6 +300,7 @@ pub mod logs;
 pub mod project;
 pub mod refactor;
 pub mod release;
+pub mod report;
 pub mod review;
 pub mod rig;
 pub mod self_cmd;
@@ -324,6 +325,7 @@ pub fn run_markdown(
         crate::cli_surface::Commands::Docs(args) => docs::run_markdown(args),
         crate::cli_surface::Commands::Changelog(args) => changelog::run_markdown(args),
         crate::cli_surface::Commands::Review(args) => review::run_markdown(args, global),
+        crate::cli_surface::Commands::Report(args) => report::run_markdown(args),
         _ => Err(homeboy::Error::validation_invalid_argument(
             "output_mode",
             "Command does not support markdown output",
@@ -377,6 +379,7 @@ pub fn run_json(
         crate::cli_surface::Commands::Validate(args) => dispatch!(args, global, validate),
         crate::cli_surface::Commands::Changes(args) => dispatch!(args, global, changes),
         crate::cli_surface::Commands::Release(args) => dispatch!(args, global, release),
+        crate::cli_surface::Commands::Report(args) => dispatch!(args, global, report),
         crate::cli_surface::Commands::Review(args) => dispatch!(args, global, review),
         crate::cli_surface::Commands::Audit(args) => dispatch!(args, global, audit),
         crate::cli_surface::Commands::Refactor(args) => dispatch!(args, global, refactor),

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -1,0 +1,709 @@
+use clap::{Args, Subcommand};
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use super::CmdResult;
+
+#[derive(Args, Debug, Clone)]
+pub struct ReportArgs {
+    #[command(subcommand)]
+    pub command: ReportCommand,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ReportCommand {
+    /// Render a markdown failure digest from Homeboy command output JSON files
+    FailureDigest(FailureDigestArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FailureDigestArgs {
+    /// Directory containing audit.json, lint.json, test.json, etc.
+    #[arg(long, value_name = "DIR")]
+    pub output_dir: String,
+
+    /// Results JSON, e.g. '{"audit":"fail","lint":"pass"}' (supports @file)
+    #[arg(long, value_name = "JSON")]
+    pub results: String,
+
+    /// Workflow run URL used as the fallback full-log link
+    #[arg(long, value_name = "URL")]
+    pub run_url: Option<String>,
+
+    /// Optional tooling metadata JSON file (supports @file)
+    #[arg(long, value_name = "JSON_OR_FILE")]
+    pub tooling_json: Option<String>,
+
+    /// Commands in this run, used to derive default autofix candidates
+    #[arg(long, value_name = "CSV")]
+    pub commands: Option<String>,
+
+    /// Commands with autofix support. Defaults to failed audit/lint/test commands.
+    #[arg(long, value_name = "CSV")]
+    pub autofix_commands: Option<String>,
+
+    /// Whether automated fixes are enabled for this run
+    #[arg(long)]
+    pub autofix_enabled: bool,
+
+    /// Whether automated fixes were already attempted in this run
+    #[arg(long)]
+    pub autofix_attempted: bool,
+
+    /// Output format. Markdown is the only supported report format for now.
+    #[arg(long, value_parser = ["markdown"], default_value = "markdown")]
+    pub format: String,
+}
+
+#[derive(Serialize)]
+pub struct ReportOutput {
+    pub command: String,
+    pub markdown: String,
+}
+
+pub fn is_markdown_mode(args: &ReportArgs) -> bool {
+    matches!(
+        &args.command,
+        ReportCommand::FailureDigest(failure_args) if failure_args.format == "markdown"
+    )
+}
+
+pub fn run_markdown(args: ReportArgs) -> CmdResult<String> {
+    match args.command {
+        ReportCommand::FailureDigest(failure_args) => {
+            let markdown = render_failure_digest_from_args(&failure_args)?;
+            Ok((markdown, 0))
+        }
+    }
+}
+
+pub fn run(args: ReportArgs, _global: &super::GlobalArgs) -> CmdResult<ReportOutput> {
+    match args.command {
+        ReportCommand::FailureDigest(failure_args) => {
+            let markdown = render_failure_digest_from_args(&failure_args)?;
+            Ok((
+                ReportOutput {
+                    command: "report.failure-digest".to_string(),
+                    markdown,
+                },
+                0,
+            ))
+        }
+    }
+}
+
+pub fn render_failure_digest_from_args(args: &FailureDigestArgs) -> homeboy::Result<String> {
+    let results = read_json_spec_value(&args.results, "results")?;
+    let tooling = match args.tooling_json.as_deref() {
+        Some(spec) => read_json_spec_value(spec, "tooling_json")?,
+        None => Value::Object(Map::new()),
+    };
+
+    let context = FailureDigestContext {
+        output_dir: PathBuf::from(&args.output_dir),
+        results: normalize_object(results),
+        run_url: args.run_url.clone().unwrap_or_default(),
+        tooling: normalize_object(tooling),
+        commands_csv: args.commands.clone().unwrap_or_default(),
+        autofix_enabled: args.autofix_enabled,
+        autofix_attempted: args.autofix_attempted,
+        autofix_commands_csv: args.autofix_commands.clone().unwrap_or_default(),
+    };
+
+    Ok(render_failure_digest(&context))
+}
+
+pub struct FailureDigestContext {
+    pub output_dir: PathBuf,
+    pub results: Map<String, Value>,
+    pub run_url: String,
+    pub tooling: Map<String, Value>,
+    pub commands_csv: String,
+    pub autofix_enabled: bool,
+    pub autofix_attempted: bool,
+    pub autofix_commands_csv: String,
+}
+
+pub fn render_failure_digest(context: &FailureDigestContext) -> String {
+    let mut out = String::new();
+    out.push_str("## Failure Digest\n\n");
+
+    if command_failed(&context.results, "lint") {
+        render_lint_section(&mut out, &context.output_dir, &context.run_url);
+    }
+    if command_failed(&context.results, "test") {
+        render_test_section(&mut out, &context.output_dir, &context.run_url);
+    }
+    if command_failed(&context.results, "audit") {
+        render_audit_section(&mut out, &context.output_dir, &context.run_url);
+    }
+
+    render_autofix_section(&mut out, context);
+    render_tooling_section(&mut out, &context.tooling);
+
+    out.push_str("### Machine-readable artifacts\n");
+    out.push_str("- `{command}.json` — structured output per command (from `homeboy --output`)\n");
+
+    out
+}
+
+fn read_json_spec_value(spec: &str, context: &str) -> homeboy::Result<Value> {
+    let raw = if Path::new(spec).exists() {
+        std::fs::read_to_string(spec).map_err(|e| {
+            homeboy::Error::internal_unexpected(format!("Failed to read {}: {}", spec, e))
+        })?
+    } else {
+        homeboy::config::read_json_spec_to_string(spec)?
+    };
+    serde_json::from_str(&raw).map_err(|e| {
+        homeboy::Error::validation_invalid_json(e, Some(context.to_string()), Some(raw))
+    })
+}
+
+fn normalize_object(value: Value) -> Map<String, Value> {
+    match value {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    }
+}
+
+fn command_failed(results: &Map<String, Value>, command: &str) -> bool {
+    results
+        .get(command)
+        .and_then(Value::as_str)
+        .is_some_and(|status| status == "fail")
+}
+
+fn command_names_from_csv(raw: &str) -> BTreeSet<String> {
+    raw.split(',')
+        .filter_map(|part| part.trim().split(' ').next())
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| part.to_lowercase())
+        .collect()
+}
+
+fn failed_commands(results: &Map<String, Value>) -> Vec<String> {
+    let mut commands = results
+        .iter()
+        .filter_map(|(name, status)| {
+            status
+                .as_str()
+                .filter(|value| *value == "fail")
+                .map(|_| name.clone())
+        })
+        .collect::<Vec<_>>();
+    commands.sort();
+    commands
+}
+
+fn read_command_json(output_dir: &Path, command: &str) -> Option<Value> {
+    let path = output_dir.join(format!("{command}.json"));
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn envelope_parts(value: Option<Value>) -> (Map<String, Value>, Map<String, Value>) {
+    let Some(Value::Object(mut root)) = value else {
+        return (Map::new(), Map::new());
+    };
+
+    if root.contains_key("success") || root.contains_key("data") || root.contains_key("error") {
+        let data = root
+            .remove("data")
+            .and_then(|v| match v {
+                Value::Object(map) => Some(map),
+                _ => None,
+            })
+            .unwrap_or_default();
+        let error = root
+            .remove("error")
+            .and_then(|v| match v {
+                Value::Object(map) => Some(map),
+                _ => None,
+            })
+            .unwrap_or_default();
+        return (data, error);
+    }
+
+    (root, Map::new())
+}
+
+fn render_lint_section(out: &mut String, output_dir: &Path, run_url: &str) {
+    out.push_str("### Lint Failure Digest\n");
+    let (data, error) = envelope_parts(read_command_json(output_dir, "lint"));
+
+    if let Some(summary) = string_value(&data, "summary") {
+        let _ = writeln!(out, "- Lint summary: **{}**", summary);
+    }
+    if let Some(summary) = string_value(&data, "phpcs_summary") {
+        let _ = writeln!(out, "- PHPCS: {}", summary);
+    }
+    if let Some(summary) = string_value(&data, "phpstan_summary") {
+        let _ = writeln!(out, "- PHPStan: {}", summary);
+    }
+    if let Some(build_failed) = string_value(&data, "build_failed") {
+        let _ = writeln!(out, "- Build failed: {}", build_failed);
+    }
+    render_error_details(out, &error);
+
+    let top_violations = string_array(&data, "top_violations");
+    append_details_block(out, "Top lint violations", &top_violations, 10);
+
+    if !has_any_lint_detail(&data, &error) && top_violations.is_empty() {
+        out.push_str("- No structured lint details available.\n");
+    }
+    render_full_log(out, "lint", run_url);
+    out.push('\n');
+}
+
+fn render_test_section(out: &mut String, output_dir: &Path, run_url: &str) {
+    out.push_str("### Test Failure Digest\n");
+    let (data, error) = envelope_parts(read_command_json(output_dir, "test"));
+    render_error_details(out, &error);
+
+    let failed_tests = array_value(&data, "failed_tests");
+    let failed_count = test_failed_count(&data, failed_tests.len());
+    let _ = writeln!(out, "- Failed tests: **{}**", failed_count);
+
+    let details = failed_tests
+        .iter()
+        .take(10)
+        .enumerate()
+        .map(|(idx, item)| summarize_test_failure(item, idx + 1))
+        .collect::<Vec<_>>();
+
+    if details.is_empty() {
+        out.push_str("- No structured test failure details available.\n");
+    } else {
+        append_details_block(
+            out,
+            &format!("Failed test details ({} shown)", details.len()),
+            &details,
+            10,
+        );
+    }
+
+    render_full_log(out, "test", run_url);
+    out.push('\n');
+}
+
+fn render_audit_section(out: &mut String, output_dir: &Path, run_url: &str) {
+    out.push_str("### Audit Failure Digest\n");
+    let (data, error) = envelope_parts(read_command_json(output_dir, "audit"));
+    render_error_details(out, &error);
+
+    let summary = object_value(&data, "summary");
+    let baseline = object_value(&data, "baseline_comparison");
+
+    if let Some(score) = summary.get("alignment_score").and_then(Value::as_f64) {
+        let _ = writeln!(out, "- Alignment score: **{:.3}**", score);
+    }
+    let severity_counts = severity_counts(&data);
+    if !severity_counts.is_empty() {
+        let text = severity_counts
+            .iter()
+            .map(|(severity, count)| format!("{severity}: {count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(out, "- Severity counts: **{}**", text);
+    }
+    if let Some(outliers) = summary.get("outliers_found").and_then(Value::as_i64) {
+        let _ = writeln!(out, "- Outliers in current run: **{}**", outliers);
+    }
+
+    let outlier_items = collect_outlier_items(&data);
+    if !outlier_items.is_empty() {
+        let _ = writeln!(out, "- Parsed outlier entries: **{}**", outlier_items.len());
+    }
+
+    let drift_increased = baseline
+        .get("drift_increased")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let _ = writeln!(
+        out,
+        "- Drift increased: **{}**",
+        if drift_increased { "yes" } else { "no" }
+    );
+
+    let new_items = array_from_object(&baseline, "new_items");
+    if !new_items.is_empty() {
+        let _ = writeln!(
+            out,
+            "- New findings since baseline: **{}**",
+            new_items.len()
+        );
+        for (idx, item) in new_items.iter().take(5).enumerate() {
+            let context = item_string(item, &["context_label", "file"], "unknown");
+            let message = item_string(item, &["description", "message"], "(new finding)");
+            let fingerprint = item_string(item, &["fingerprint"], "");
+            let _ = write!(out, "  {}. **{}**", idx + 1, context);
+            if !message.is_empty() {
+                let _ = write!(out, " — {}", message);
+            }
+            if !fingerprint.is_empty() {
+                let _ = write!(out, " (`{}`)", fingerprint);
+            }
+            out.push('\n');
+        }
+    }
+
+    let top_findings = collect_audit_findings(&data, &outlier_items);
+    if top_findings.is_empty() {
+        out.push_str("- No structured audit findings available.\n");
+    } else {
+        out.push_str("- Top actionable findings:\n");
+        for (idx, finding) in top_findings.iter().take(5).enumerate() {
+            let _ = writeln!(out, "  {}. {}", idx + 1, format_audit_finding(finding));
+        }
+        let detail_lines = top_findings
+            .iter()
+            .take(300)
+            .enumerate()
+            .map(|(idx, finding)| format!("{}. {}", idx + 1, format_audit_finding(finding)))
+            .collect::<Vec<_>>();
+        append_details_block(
+            out,
+            &format!("All parsed audit findings ({})", top_findings.len()),
+            &detail_lines,
+            300,
+        );
+    }
+
+    render_full_log(out, "audit", run_url);
+    out.push('\n');
+}
+
+fn render_error_details(out: &mut String, error: &Map<String, Value>) {
+    if let Some(code) = string_value(error, "code") {
+        let _ = writeln!(out, "- Error code: `{}`", code);
+    }
+    if let Some(message) = string_value(error, "message") {
+        let _ = writeln!(out, "- Error message: {}", message);
+    }
+    if let Some(details) = object_value(error, "details")
+        .get("field")
+        .and_then(Value::as_str)
+    {
+        let _ = writeln!(out, "- Error field: `{}`", details);
+    }
+    if let Some(hints) = error.get("hints").and_then(Value::as_array) {
+        if let Some(first) = hints.first().and_then(Value::as_str) {
+            let _ = writeln!(out, "- Hint: {}", first);
+        }
+    }
+}
+
+fn render_autofix_section(out: &mut String, context: &FailureDigestContext) {
+    let failed = failed_commands(&context.results);
+    let potential = if context.autofix_commands_csv.trim().is_empty() {
+        command_names_from_csv(&context.commands_csv)
+            .into_iter()
+            .filter(|cmd| matches!(cmd.as_str(), "audit" | "lint" | "test"))
+            .collect::<BTreeSet<_>>()
+    } else {
+        command_names_from_csv(&context.autofix_commands_csv)
+    };
+    let fixable = if context.autofix_enabled {
+        potential.clone()
+    } else {
+        BTreeSet::new()
+    };
+
+    let mut auto_fixable_failed = Vec::new();
+    let mut potential_auto_fixable_failed = Vec::new();
+    let mut human_needed_failed = Vec::new();
+
+    for cmd in &failed {
+        let normalized = cmd.to_lowercase();
+        if potential.contains(&normalized) {
+            potential_auto_fixable_failed.push(cmd.clone());
+        }
+        if fixable.contains(&normalized) && !context.autofix_attempted {
+            auto_fixable_failed.push(cmd.clone());
+        } else {
+            human_needed_failed.push(cmd.clone());
+        }
+    }
+
+    let overall = if failed.is_empty() {
+        "none"
+    } else if !auto_fixable_failed.is_empty() && human_needed_failed.is_empty() {
+        "auto_fixable"
+    } else if !auto_fixable_failed.is_empty() {
+        "mixed"
+    } else {
+        "human_needed"
+    };
+
+    out.push_str("### Autofixability classification\n");
+    let _ = writeln!(out, "- Overall: **{}**", overall);
+    let _ = writeln!(
+        out,
+        "- Autofix enabled: **{}**",
+        if context.autofix_enabled { "yes" } else { "no" }
+    );
+    let _ = writeln!(
+        out,
+        "- Autofix attempted this run: **{}**",
+        if context.autofix_attempted {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+
+    if !auto_fixable_failed.is_empty() {
+        out.push_str("- Auto-fixable failed commands:\n");
+        for cmd in &auto_fixable_failed {
+            let _ = writeln!(out, "  - `{}`", cmd);
+        }
+    }
+    if !human_needed_failed.is_empty() {
+        out.push_str("- Human-needed failed commands:\n");
+        for cmd in &human_needed_failed {
+            let _ = writeln!(out, "  - `{}`", cmd);
+        }
+    }
+    if auto_fixable_failed.is_empty() && human_needed_failed.is_empty() {
+        out.push_str("- No failed commands to classify.\n");
+    }
+    if !potential_auto_fixable_failed.is_empty() {
+        out.push_str("- Failed commands with available automated fixes:\n");
+        for cmd in &potential_auto_fixable_failed {
+            let _ = writeln!(out, "  - `{}`", cmd);
+        }
+    }
+    if !context.autofix_enabled {
+        if potential.is_empty() {
+            out.push_str(
+                "- Automated fixes are **disabled for this step** and no fix-capable commands were detected.\n",
+            );
+        } else {
+            let candidates = potential
+                .iter()
+                .map(|cmd| format!("`{cmd}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let _ = writeln!(
+                out,
+                "- Automated fixes are **disabled for this step**. Commands with available fix support in this run: {}",
+                candidates
+            );
+        }
+    }
+    out.push('\n');
+}
+
+fn render_tooling_section(out: &mut String, tooling: &Map<String, Value>) {
+    if tooling.is_empty() {
+        return;
+    }
+
+    out.push_str("### Tooling metadata\n");
+    for (key, value) in BTreeMap::from_iter(tooling.iter()) {
+        let rendered = value
+            .as_str()
+            .map_or_else(|| value.to_string(), str::to_string);
+        let _ = writeln!(out, "- {}: `{}`", key, rendered);
+    }
+    out.push('\n');
+}
+
+fn render_full_log(out: &mut String, command: &str, run_url: &str) {
+    if run_url.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Full {} log: structured job link unavailable",
+            command
+        );
+    } else {
+        let _ = writeln!(out, "- Full {} log: {}", command, run_url);
+    }
+}
+
+fn has_any_lint_detail(data: &Map<String, Value>, error: &Map<String, Value>) -> bool {
+    [
+        "summary",
+        "phpcs_summary",
+        "phpstan_summary",
+        "build_failed",
+    ]
+    .iter()
+    .any(|key| string_value(data, key).is_some())
+        || ["code", "message"]
+            .iter()
+            .any(|key| string_value(error, key).is_some())
+}
+
+fn string_value(map: &Map<String, Value>, key: &str) -> Option<String> {
+    match map.get(key)? {
+        Value::String(s) if !s.is_empty() => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+fn object_value(map: &Map<String, Value>, key: &str) -> Map<String, Value> {
+    map.get(key)
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn array_value<'a>(map: &'a Map<String, Value>, key: &str) -> Vec<&'a Value> {
+    map.get(key)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().collect())
+        .unwrap_or_default()
+}
+
+fn array_from_object(map: &Map<String, Value>, key: &str) -> Vec<Value> {
+    map.get(key)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn string_array(map: &Map<String, Value>, key: &str) -> Vec<String> {
+    map.get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|value| match value {
+                    Value::String(s) => Some(s.clone()),
+                    Value::Object(obj) => Some(Value::Object(obj.clone()).to_string()),
+                    other if !other.is_null() => Some(other.to_string()),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn test_failed_count(data: &Map<String, Value>, fallback: usize) -> usize {
+    let counts = object_value(data, "test_counts");
+    let failed = counts.get("failed").and_then(Value::as_u64).unwrap_or(0);
+    let errors = counts.get("errors").and_then(Value::as_u64).unwrap_or(0);
+    let total = failed + errors;
+    if total > 0 {
+        total as usize
+    } else {
+        fallback
+    }
+}
+
+fn summarize_test_failure(item: &Value, idx: usize) -> String {
+    let Some(obj) = item.as_object() else {
+        return format!("{}. {}", idx, item.as_str().unwrap_or("unknown"));
+    };
+
+    let name = string_value(obj, "name").unwrap_or_else(|| "unknown".to_string());
+    let detail = string_value(obj, "detail").or_else(|| string_value(obj, "message"));
+    let location = string_value(obj, "location").or_else(|| string_value(obj, "file"));
+    let mut parts = vec![format!("{}. {}", idx, name)];
+    if let Some(detail) = detail {
+        parts.push(detail);
+    }
+    if let Some(location) = location {
+        parts.push(location);
+    }
+    parts.join(" — ")
+}
+
+fn severity_counts(data: &Map<String, Value>) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    let outliers = collect_outlier_items(data);
+    for finding in collect_audit_findings(data, &outliers) {
+        let severity = item_string(&finding, &["severity", "level"], "unknown").to_lowercase();
+        *counts.entry(severity).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn collect_outlier_items(data: &Map<String, Value>) -> Vec<Value> {
+    let mut outliers = Vec::new();
+    for convention in array_value(data, "conventions") {
+        let Some(obj) = convention.as_object() else {
+            continue;
+        };
+        let label = item_string(
+            convention,
+            &["context_label", "name", "rule", "pattern"],
+            "unknown",
+        );
+        for outlier in array_value(obj, "outliers") {
+            let mut item = outlier.clone();
+            if let Value::Object(ref mut map) = item {
+                map.entry("context_label".to_string())
+                    .or_insert_with(|| Value::String(label.clone()));
+            }
+            outliers.push(item);
+        }
+    }
+    outliers
+}
+
+fn collect_audit_findings(data: &Map<String, Value>, outliers: &[Value]) -> Vec<Value> {
+    let mut findings = array_value(data, "findings")
+        .into_iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    findings.extend(outliers.iter().cloned());
+    findings
+}
+
+fn item_string(item: &Value, keys: &[&str], fallback: &str) -> String {
+    let Some(obj) = item.as_object() else {
+        return fallback.to_string();
+    };
+
+    for key in keys {
+        if let Some(value) = obj.get(*key) {
+            if let Some(s) = value.as_str() {
+                if !s.is_empty() {
+                    return s.to_string();
+                }
+            } else if !value.is_null() {
+                return value.to_string();
+            }
+        }
+    }
+    fallback.to_string()
+}
+
+fn format_audit_finding(finding: &Value) -> String {
+    let file = item_string(finding, &["file", "path", "context_label"], "unknown");
+    let rule = item_string(finding, &["rule", "kind", "category"], "outlier");
+    let message = item_string(finding, &["description", "message"], "");
+    if message.is_empty() {
+        format!("**{}** — {}", file, rule)
+    } else {
+        format!("**{}** — {} — {}", file, rule, message)
+    }
+}
+
+fn append_details_block(out: &mut String, summary: &str, lines: &[String], limit: usize) {
+    let content = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .take(limit)
+        .collect::<Vec<_>>();
+    if content.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(out, "\n<details><summary>{}</summary>\n", summary);
+    out.push_str("```text\n");
+    for line in content {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str("```\n\n</details>\n");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ enum RawOutputMode {
 
 use homeboy::commands;
 use homeboy::commands::utils::{args, entity_suggest, response as output, tty};
-use homeboy::commands::{changelog, cli, file, logs, review};
+use homeboy::commands::{changelog, cli, file, logs, report, review};
 use homeboy::extension::load_all_extensions;
 
 fn response_mode(command: &Commands) -> ResponseMode {
@@ -38,6 +38,9 @@ fn response_mode(command: &Commands) -> ResponseMode {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
         Commands::Review(args) if review::is_markdown_mode(args) => {
+            ResponseMode::Raw(RawOutputMode::Markdown)
+        }
+        Commands::Report(args) if report::is_markdown_mode(args) => {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
         Commands::List => ResponseMode::Raw(RawOutputMode::Markdown),

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -10,6 +10,7 @@ fn includes_current_top_level_commands() {
     assert!(surface.contains_path(&["git"]));
     assert!(surface.contains_path(&["self"]));
     assert!(surface.contains_path(&["stack"]));
+    assert!(surface.contains_path(&["report"]));
 }
 
 #[test]
@@ -22,6 +23,7 @@ fn includes_first_level_subcommands() {
     assert!(surface.contains_path(&["daemon", "serve"]));
     assert!(surface.contains_path(&["self", "status"]));
     assert!(surface.contains_path(&["stack", "inspect"]));
+    assert!(surface.contains_path(&["report", "failure-digest"]));
 }
 
 #[test]

--- a/tests/fixtures/failure_digest/audit.json
+++ b/tests/fixtures/failure_digest/audit.json
@@ -1,0 +1,47 @@
+{
+  "success": false,
+  "data": {
+    "passed": false,
+    "summary": {
+      "alignment_score": 0.812,
+      "outliers_found": 2
+    },
+    "baseline_comparison": {
+      "drift_increased": true,
+      "new_items": [
+        {
+          "context_label": "src/report.rs",
+          "description": "new report module lacks tests",
+          "fingerprint": "abc123"
+        }
+      ]
+    },
+    "findings": [
+      {
+        "file": "src/report.rs",
+        "kind": "missing_test_file",
+        "severity": "medium",
+        "description": "missing dedicated tests"
+      },
+      {
+        "file": "src/render.rs",
+        "kind": "god_file",
+        "severity": "high",
+        "description": "file is too large"
+      }
+    ],
+    "conventions": [
+      {
+        "context_label": "report modules",
+        "outliers": [
+          {
+            "file": "src/report.rs",
+            "rule": "naming_mismatch",
+            "severity": "low",
+            "message": "module naming drift"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/failure_digest/lint.json
+++ b/tests/fixtures/failure_digest/lint.json
@@ -1,0 +1,13 @@
+{
+  "success": false,
+  "data": {
+    "passed": false,
+    "summary": "3 lint finding(s)",
+    "phpcs_summary": "2 PHPCS error(s)",
+    "phpstan_summary": "1 PHPStan error(s)",
+    "top_violations": [
+      "Squiz.Commenting.FunctionComment.Missing — 2",
+      "PHPStan: Call to undefined method — 1"
+    ]
+  }
+}

--- a/tests/fixtures/failure_digest/test.json
+++ b/tests/fixtures/failure_digest/test.json
@@ -1,0 +1,24 @@
+{
+  "success": false,
+  "data": {
+    "passed": false,
+    "test_counts": {
+      "total": 12,
+      "passed": 10,
+      "failed": 2,
+      "skipped": 0
+    },
+    "failed_tests": [
+      {
+        "name": "test_widget_renders",
+        "detail": "expected widget output",
+        "location": "tests/widget_test.rs:42"
+      },
+      {
+        "name": "test_widget_handles_empty_state",
+        "message": "empty state missing",
+        "file": "tests/widget_test.rs"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/failure_digest/tooling.json
+++ b/tests/fixtures/failure_digest/tooling.json
@@ -1,0 +1,5 @@
+{
+  "homeboy_cli_version": "0.123.0",
+  "extension_id": "wordpress",
+  "action_repository": "Extra-Chill/homeboy-action"
+}

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -1,0 +1,182 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use homeboy::commands::report::{render_failure_digest_from_args, FailureDigestArgs};
+
+const LINT_JSON: &str = include_str!("fixtures/failure_digest/lint.json");
+const TEST_JSON: &str = include_str!("fixtures/failure_digest/test.json");
+const AUDIT_JSON: &str = include_str!("fixtures/failure_digest/audit.json");
+const TOOLING_JSON: &str = include_str!("fixtures/failure_digest/tooling.json");
+
+fn tmp_dir(name: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("homeboy-failure-digest-{name}-{nanos}"))
+}
+
+fn write_file(dir: &Path, name: &str, body: &str) {
+    fs::write(dir.join(name), body).expect("fixture should be written");
+}
+
+fn render(dir: &Path, results: &str, autofix_enabled: bool, autofix_attempted: bool) -> String {
+    render_failure_digest_from_args(&FailureDigestArgs {
+        output_dir: dir.to_string_lossy().to_string(),
+        results: results.to_string(),
+        run_url: Some("https://github.com/Extra-Chill/homeboy/actions/runs/123".to_string()),
+        tooling_json: None,
+        commands: Some("audit,lint,test".to_string()),
+        autofix_commands: None,
+        autofix_enabled,
+        autofix_attempted,
+        format: "markdown".to_string(),
+    })
+    .expect("failure digest should render")
+}
+
+#[test]
+fn renders_lint_failure_digest_from_fixture() {
+    let dir = tmp_dir("lint");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "lint.json", LINT_JSON);
+
+    let markdown = render(&dir, r#"{"lint":"fail"}"#, false, false);
+
+    assert!(markdown.contains("## Failure Digest"));
+    assert!(markdown.contains("### Lint Failure Digest"));
+    assert!(markdown.contains("- Lint summary: **3 lint finding(s)**"));
+    assert!(markdown.contains("<details><summary>Top lint violations</summary>"));
+    assert!(markdown
+        .contains("- Full lint log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
+    assert!(!markdown.contains("### Test Failure Digest"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_test_failure_digest_from_fixture() {
+    let dir = tmp_dir("test");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "test.json", TEST_JSON);
+
+    let markdown = render(&dir, r#"{"test":"fail"}"#, false, false);
+
+    assert!(markdown.contains("### Test Failure Digest"));
+    assert!(markdown.contains("- Failed tests: **2**"));
+    assert!(markdown
+        .contains("1. test_widget_renders — expected widget output — tests/widget_test.rs:42"));
+    assert!(markdown.contains(
+        "2. test_widget_handles_empty_state — empty state missing — tests/widget_test.rs"
+    ));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_audit_failure_digest_from_fixture() {
+    let dir = tmp_dir("audit");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "audit.json", AUDIT_JSON);
+
+    let markdown = render(&dir, r#"{"audit":"fail"}"#, false, false);
+
+    assert!(markdown.contains("### Audit Failure Digest"));
+    assert!(markdown.contains("- Alignment score: **0.812**"));
+    assert!(markdown.contains("- Severity counts: **high: 1, low: 1, medium: 1**"));
+    assert!(markdown.contains("- New findings since baseline: **1**"));
+    assert!(markdown.contains("1. **src/report.rs** — new report module lacks tests (`abc123`)"));
+    assert!(markdown.contains("**src/render.rs** — god_file — file is too large"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_mixed_failures_with_autofix_enabled_not_attempted() {
+    let dir = tmp_dir("mixed-autofix");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "lint.json", LINT_JSON);
+    write_file(&dir, "test.json", TEST_JSON);
+
+    let markdown = render(
+        &dir,
+        r#"{"lint":"fail","test":"fail","audit":"pass"}"#,
+        true,
+        false,
+    );
+
+    assert!(markdown.contains("### Lint Failure Digest"));
+    assert!(markdown.contains("### Test Failure Digest"));
+    assert!(markdown.contains("- Overall: **auto_fixable**"));
+    assert!(markdown.contains("- Autofix enabled: **yes**"));
+    assert!(markdown.contains("- Auto-fixable failed commands:"));
+    assert!(markdown.contains("  - `lint`"));
+    assert!(markdown.contains("  - `test`"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_mixed_failures_after_autofix_attempted_as_human_needed() {
+    let dir = tmp_dir("attempted");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "lint.json", LINT_JSON);
+
+    let markdown = render(&dir, r#"{"lint":"fail"}"#, true, true);
+
+    assert!(markdown.contains("- Overall: **human_needed**"));
+    assert!(markdown.contains("- Autofix attempted this run: **yes**"));
+    assert!(markdown.contains("- Human-needed failed commands:"));
+    assert!(markdown.contains("  - `lint`"));
+    assert!(markdown.contains("- Failed commands with available automated fixes:"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_json_renders_explicit_structured_details_unavailable() {
+    let dir = tmp_dir("missing");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+
+    let markdown = render(
+        &dir,
+        r#"{"lint":"fail","test":"fail","audit":"fail"}"#,
+        false,
+        false,
+    );
+
+    assert!(markdown.contains("- No structured lint details available."));
+    assert!(markdown.contains("- No structured test failure details available."));
+    assert!(markdown.contains("- No structured audit findings available."));
+    assert!(markdown
+        .contains("- Full audit log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_tooling_metadata_from_json_file() {
+    let dir = tmp_dir("tooling");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let tooling_path = dir.join("tooling.json");
+    write_file(&dir, "tooling.json", TOOLING_JSON);
+
+    let markdown = render_failure_digest_from_args(&FailureDigestArgs {
+        output_dir: dir.to_string_lossy().to_string(),
+        results: r#"{"lint":"pass"}"#.to_string(),
+        run_url: None,
+        tooling_json: Some(tooling_path.to_string_lossy().to_string()),
+        commands: Some("lint".to_string()),
+        autofix_commands: None,
+        autofix_enabled: false,
+        autofix_attempted: false,
+        format: "markdown".to_string(),
+    })
+    .expect("failure digest should render");
+
+    assert!(markdown.contains("### Tooling metadata"));
+    assert!(markdown.contains("- action_repository: `Extra-Chill/homeboy-action`"));
+    assert!(markdown.contains("- extension_id: `wordpress`"));
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary

- Adds `homeboy report failure-digest` as a narrow core report primitive for rendering markdown from existing Homeboy command output JSON artifacts.
- Reads `audit.json`, `lint.json`, `test.json`, results JSON, optional run URL, optional tooling metadata, and autofix state without doing GitHub job-link lookup inside the renderer.
- Keeps partial or missing command JSON non-fatal by rendering explicit structured-details-unavailable messages.

## CLI surface

```bash
homeboy report failure-digest \
  --output-dir "$HOMEBOY_OUTPUT_DIR" \
  --results '{"audit":"fail","lint":"pass","test":"fail"}' \
  --run-url "https://github.com/owner/repo/actions/runs/123" \
  --tooling-json "$HOMEBOY_OUTPUT_DIR/tooling.json" \
  --commands audit,lint,test \
  --autofix-enabled \
  --format markdown
```

The action can redirect stdout to `homeboy-failure-digest.md` and keep any GitHub job-link lookup as action-owned context for a later extension.

## Tests

- `cargo fmt --check`
- `cargo test --test report_failure_digest_test --test command_surface_test`
- CLI smoke: `cargo run --quiet --bin homeboy -- report failure-digest --output-dir tests/fixtures/failure_digest --results '{"audit":"fail","lint":"fail","test":"fail"}' --run-url https://github.com/Extra-Chill/homeboy/actions/runs/123 --tooling-json tests/fixtures/failure_digest/tooling.json --commands audit,lint,test --autofix-enabled --format markdown`

Closes #1647.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the core failure-digest report renderer, adding fixtures/tests, and validating the CLI smoke. Chris remains responsible for review and merge.
