### PR TITLE
fix(audit): classify changed-since context findings

### DIFF
--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -27,7 +27,20 @@ pub struct AuditSummaryOutput {
     pub top_findings: Vec<AuditSummaryFinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fixability: Option<AuditFixability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed_since: Option<AuditChangedSinceSummary>,
     pub exit_code: i32,
+}
+
+/// Changed-since audit classification.
+///
+/// `introduced_findings` are findings not present in the selected baseline and
+/// therefore block the PR. `contextual_findings` are existing findings in the
+/// touched/impact scope that are shown for context only.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct AuditChangedSinceSummary {
+    pub introduced_findings: usize,
+    pub contextual_findings: usize,
 }
 
 /// Individual finding in the summary.
@@ -81,6 +94,8 @@ pub enum AuditCommandOutput {
         #[serde(flatten)]
         result: CodeAuditResult,
         baseline_comparison: baseline::BaselineComparison,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        changed_since: Option<AuditChangedSinceSummary>,
         #[serde(skip_serializing_if = "Option::is_none")]
         summary: Option<AuditSummaryOutput>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -152,7 +167,19 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
         info,
         top_findings,
         fixability: None,
+        changed_since: None,
         exit_code,
+    }
+}
+
+pub fn build_changed_since_summary(
+    result: &CodeAuditResult,
+    comparison: &baseline::BaselineComparison,
+) -> AuditChangedSinceSummary {
+    let introduced_findings = comparison.new_items.len();
+    AuditChangedSinceSummary {
+        introduced_findings,
+        contextual_findings: result.findings.len().saturating_sub(introduced_findings),
     }
 }
 

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -279,7 +279,7 @@ fn run_comparison_workflow(
     let exit_code = if args.changed_since.is_some() {
         if !result.findings.is_empty() {
             eprintln!(
-                "[audit] {} finding(s) in changed files — no baseline to compare against, treating as pre-existing",
+                "[audit] No baseline found for changed-since audit; showing {} contextual finding(s) in touched scope without blocking",
                 result.findings.len()
             );
         }
@@ -316,8 +316,33 @@ fn build_comparison_output(
 ) -> crate::Result<AuditRunWorkflowResult> {
     let comparison = baseline::compare(&result, &existing_baseline);
     let exit_code = if comparison.drift_increased { 1 } else { 0 };
+    let changed_since_summary = args
+        .changed_since
+        .as_ref()
+        .map(|_| report::build_changed_since_summary(&result, &comparison));
 
-    if comparison.drift_increased {
+    if let Some(summary) = changed_since_summary {
+        if summary.introduced_findings > 0 {
+            eprintln!(
+                "[audit] DRIFT INCREASED: {} introduced finding(s) since baseline ({} contextual finding(s) already known in touched scope)",
+                summary.introduced_findings,
+                summary.contextual_findings
+            );
+        } else if !comparison.resolved_fingerprints.is_empty() {
+            eprintln!(
+                "[audit] No introduced findings; {} contextual finding(s) remain in touched scope and {} finding(s) resolved since baseline",
+                summary.contextual_findings,
+                comparison.resolved_fingerprints.len()
+            );
+        } else if summary.contextual_findings > 0 {
+            eprintln!(
+                "[audit] No introduced findings; {} contextual finding(s) already known in touched scope",
+                summary.contextual_findings
+            );
+        } else {
+            eprintln!("[audit] No introduced findings in touched scope");
+        }
+    } else if comparison.drift_increased {
         eprintln!(
             "[audit] DRIFT INCREASED: {} new finding(s) since baseline",
             comparison.new_items.len()
@@ -334,6 +359,7 @@ fn build_comparison_output(
     if args.json_summary {
         let mut summary = report::build_audit_summary(&result, exit_code);
         summary.fixability = compute_fixability_if_requested(&result, args);
+        summary.changed_since = changed_since_summary;
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
             exit_code,
@@ -346,6 +372,7 @@ fn build_comparison_output(
                 passed: exit_code == 0,
                 result,
                 baseline_comparison: comparison,
+                changed_since: changed_since_summary,
                 summary: None,
                 fixability,
             },

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -328,12 +328,6 @@ fn build_comparison_output(
                 summary.introduced_findings,
                 summary.contextual_findings
             );
-        } else if !comparison.resolved_fingerprints.is_empty() {
-            eprintln!(
-                "[audit] No introduced findings; {} contextual finding(s) remain in touched scope and {} finding(s) resolved since baseline",
-                summary.contextual_findings,
-                comparison.resolved_fingerprints.len()
-            );
         } else if summary.contextual_findings > 0 {
             eprintln!(
                 "[audit] No introduced findings; {} contextual finding(s) already known in touched scope",

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -1,6 +1,6 @@
 use crate::code_audit::report::{
-    build_audit_summary, compute_fixability, finding_kind_key, from_main_workflow,
-    AuditCommandOutput,
+    build_audit_summary, build_changed_since_summary, compute_fixability, finding_kind_key,
+    from_main_workflow, AuditChangedSinceSummary, AuditCommandOutput,
 };
 use crate::code_audit::test_helpers::{empty_result, make_finding};
 use crate::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
@@ -78,6 +78,68 @@ fn test_build_audit_summary_preserves_alignment_score() {
     let summary = build_audit_summary(&result, 0);
 
     assert_eq!(summary.alignment_score, Some(0.85));
+}
+
+#[test]
+fn test_build_audit_summary_omits_changed_since_by_default() {
+    let result = empty_result();
+    let summary = build_audit_summary(&result, 0);
+
+    assert!(summary.changed_since.is_none());
+}
+
+#[test]
+fn test_build_changed_since_summary_splits_introduced_from_context() {
+    let mut result = empty_result();
+    result.findings.push(Finding {
+        convention: "structural".to_string(),
+        severity: Severity::Warning,
+        file: "src/large.rs".to_string(),
+        description: "Existing large file debt".to_string(),
+        suggestion: "Consider decomposing into focused modules".to_string(),
+        kind: AuditFinding::GodFile,
+    });
+    result.findings.push(Finding {
+        convention: "dead_code".to_string(),
+        severity: Severity::Warning,
+        file: "src/large.rs".to_string(),
+        description: "New unused export".to_string(),
+        suggestion: "Remove or reference the export".to_string(),
+        kind: AuditFinding::UnreferencedExport,
+    });
+
+    let comparison = crate::engine::baseline::Comparison {
+        new_items: vec![crate::engine::baseline::NewItem {
+            fingerprint: "dead_code::src/large.rs::UnreferencedExport".to_string(),
+            description: "New unused export".to_string(),
+            context_label: "dead_code".to_string(),
+        }],
+        resolved_fingerprints: vec![],
+        delta: 1,
+        drift_increased: true,
+    };
+
+    assert_eq!(
+        build_changed_since_summary(&result, &comparison),
+        AuditChangedSinceSummary {
+            introduced_findings: 1,
+            contextual_findings: 1,
+        }
+    );
+}
+
+#[test]
+fn test_changed_since_summary_serializes_as_additive_summary_field() {
+    let mut summary = build_audit_summary(&empty_result(), 0);
+    summary.changed_since = Some(AuditChangedSinceSummary {
+        introduced_findings: 0,
+        contextual_findings: 3,
+    });
+
+    let value = serde_json::to_value(summary).expect("summary serializes");
+
+    assert_eq!(value["changed_since"]["introduced_findings"], 0);
+    assert_eq!(value["changed_since"]["contextual_findings"], 3);
 }
 
 #[test]

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -3,8 +3,8 @@
 //! Wired into `src/core/code_audit/run.rs` via `#[cfg(test)] #[path = ...] mod run_test`.
 
 use super::{
-    apply_finding_filters, compute_fixability_if_requested, scope_convention_outliers_to_findings,
-    AuditRunWorkflowArgs,
+    apply_finding_filters, build_comparison_output, compute_fixability_if_requested,
+    scope_convention_outliers_to_findings, AuditRunWorkflowArgs,
 };
 use crate::code_audit::checks::CheckStatus;
 use crate::code_audit::conventions::{Deviation, Outlier};
@@ -94,6 +94,12 @@ fn make_args(include_fixability: bool) -> AuditRunWorkflowArgs {
         json_summary: false,
         include_fixability,
     }
+}
+
+fn make_changed_since_args() -> AuditRunWorkflowArgs {
+    let mut args = make_args(false);
+    args.changed_since = Some("origin/main".to_string());
+    args
 }
 
 #[test]
@@ -214,6 +220,94 @@ fn scoped_convention_outliers_follow_scoped_findings() {
         AuditFinding::MissingMethod
     );
     assert_eq!(result.summary.outliers_found, 1);
+}
+
+#[test]
+fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
+    let existing_finding = make_finding(AuditFinding::GodFile, "src/large.rs");
+    let mut result = make_result(vec![existing_finding]);
+    result.findings[0].convention = "structural".to_string();
+
+    let baseline = crate::code_audit::baseline::AuditBaseline {
+        created_at: "2026-04-28T00:00:00Z".to_string(),
+        context_id: "test".to_string(),
+        item_count: 1,
+        known_fingerprints: vec!["structural::src/large.rs::GodFile".to_string()],
+        metadata: crate::code_audit::baseline::AuditBaselineMetadata {
+            outliers_count: 1,
+            alignment_score: None,
+            known_outliers: vec!["src/large.rs".to_string()],
+        },
+    };
+
+    let workflow = build_comparison_output(result, baseline, &make_changed_since_args())
+        .expect("comparison output builds");
+
+    assert_eq!(workflow.exit_code, 0);
+    match workflow.output {
+        crate::code_audit::report::AuditCommandOutput::Compared {
+            passed,
+            changed_since,
+            baseline_comparison,
+            ..
+        } => {
+            assert!(passed);
+            assert!(baseline_comparison.new_items.is_empty());
+            assert_eq!(
+                changed_since,
+                Some(crate::code_audit::report::AuditChangedSinceSummary {
+                    introduced_findings: 0,
+                    contextual_findings: 1,
+                })
+            );
+        }
+        _ => panic!("expected compared output"),
+    }
+}
+
+#[test]
+fn changed_since_comparison_counts_new_findings_as_introduced() {
+    let mut existing_finding = make_finding(AuditFinding::GodFile, "src/large.rs");
+    existing_finding.convention = "structural".to_string();
+    let mut introduced_finding = make_finding(AuditFinding::UnreferencedExport, "src/large.rs");
+    introduced_finding.convention = "dead_code".to_string();
+    let result = make_result(vec![existing_finding, introduced_finding]);
+
+    let baseline = crate::code_audit::baseline::AuditBaseline {
+        created_at: "2026-04-28T00:00:00Z".to_string(),
+        context_id: "test".to_string(),
+        item_count: 1,
+        known_fingerprints: vec!["structural::src/large.rs::GodFile".to_string()],
+        metadata: crate::code_audit::baseline::AuditBaselineMetadata {
+            outliers_count: 1,
+            alignment_score: None,
+            known_outliers: vec!["src/large.rs".to_string()],
+        },
+    };
+
+    let workflow = build_comparison_output(result, baseline, &make_changed_since_args())
+        .expect("comparison output builds");
+
+    assert_eq!(workflow.exit_code, 1);
+    match workflow.output {
+        crate::code_audit::report::AuditCommandOutput::Compared {
+            passed,
+            changed_since,
+            baseline_comparison,
+            ..
+        } => {
+            assert!(!passed);
+            assert_eq!(baseline_comparison.new_items.len(), 1);
+            assert_eq!(
+                changed_since,
+                Some(crate::code_audit::report::AuditChangedSinceSummary {
+                    introduced_findings: 1,
+                    contextual_findings: 1,
+                })
+            );
+        }
+        _ => panic!("expected compared output"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Separates `audit --changed-since` findings into introduced blockers and contextual touched-scope debt.
- Keeps scoped audit output backward-compatible by adding optional summary fields instead of removing existing findings.

## Changes
- Adds `changed_since.introduced_findings` and `changed_since.contextual_findings` to changed-since compared/summary output.
- Updates changed-since stderr wording so known touched-file debt is labelled as context, not introduced drift.
- Avoids reporting generic baseline `resolved_fingerprints` as changed-since resolution, because scoped runs only compare the touched/impact scope.
- Adds tests for contextual-only and introduced-plus-context changed-since comparisons plus JSON summary serialization.

## Tests
- `cargo fmt --check`
- `cargo test changed_since -- --test-threads=1`
- `cargo test --lib -- --test-threads=1` (2067 passed, 1 ignored)
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-audit-changed-since-introduced-vs-context --changed-since origin/main`
- `cargo run --quiet --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@fix-audit-changed-since-introduced-vs-context --changed-since origin/main --json-summary`

Closes #1879

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the changed-since output classification, added focused tests, and ran verification commands. Chris remains responsible for review and merge.
