### PR TITLE
fix(refactor): remove named transform config support

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -176,13 +176,9 @@ enum RefactorCommand {
         write_mode: WriteModeArgs,
     },
 
-    /// Apply pattern-based find/replace transforms across a codebase
+    /// Apply an ad-hoc pattern-based find/replace transform across a codebase
     ///
-    /// Rules are defined in homeboy.json under the "transforms" key,
-    /// or passed ad-hoc via --find/--replace/--files flags.
-    ///
-    /// Named:  `refactor transform wp69_migration --component data-machine`
-    /// Ad-hoc: `refactor transform --find "old" --replace "new" --files "**/*.php" --component C`
+    /// Example: `refactor transform --find "old" --replace "new" --files "**/*.php" --component C`
     ///
     /// Replacement templates support capture group refs ($1, $2, ${name}),
     /// case transforms ($1:lower, $1:upper, $1:kebab, $1:snake, $1:pascal, $1:camel),
@@ -190,27 +186,23 @@ enum RefactorCommand {
     ///
     /// Backslash escapes collapse before regex replacement: `\\` → one literal
     /// backslash, `\n` → newline, `\t` → tab, `\r` → CR, `\"` / `\'` → the quote.
-    /// Write `\\WP_Foo` in JSON to emit `\WP_Foo` on disk (useful for PHP
-    /// fully-qualified class names). Unknown `\X` sequences pass through as-is.
+    /// Write `\\WP_Foo` to emit `\WP_Foo` on disk (useful for PHP fully-qualified
+    /// class names). Unknown `\X` sequences pass through as-is.
     Transform {
-        /// Transform set name (from homeboy.json transforms key)
-        #[arg(value_name = "NAME")]
-        name: Option<String>,
-
-        /// Regex pattern to find (ad-hoc mode)
+        /// Regex pattern to find
         #[arg(long, value_name = "REGEX")]
-        find: Option<String>,
+        find: String,
 
-        /// Replacement template (ad-hoc mode).
+        /// Replacement template.
         /// Supports $1, $2 capture group refs, ${name} named groups,
         /// $1:lower/:upper/:kebab/:snake/:pascal/:camel case transforms,
         /// and $$ for a literal dollar sign.
         /// Backslash escapes are collapsed: \\ → one literal backslash,
         /// \n/\t/\r/\0 → the control character, \" / \' → the quote.
         #[arg(long, value_name = "TEMPLATE")]
-        replace: Option<String>,
+        replace: String,
 
-        /// Glob pattern for files to apply to (ad-hoc mode, default: **/*)
+        /// Glob pattern for files to apply to (default: **/*)
         #[arg(long, value_name = "GLOB", default_value = "**/*")]
         files: String,
 
@@ -218,10 +210,6 @@ enum RefactorCommand {
         /// enables multi-line regex with (?s) dotall flag for patterns spanning newlines)
         #[arg(long, value_name = "CONTEXT", default_value = "line")]
         context: String,
-
-        /// Only apply a specific rule ID within a named transform set
-        #[arg(long, value_name = "RULE_ID")]
-        rule: Option<String>,
 
         #[command(flatten)]
         target: RefactorTargetArgs,
@@ -368,24 +356,13 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
         ),
 
         Some(RefactorCommand::Transform {
-            name,
             find,
             replace,
             files,
             context,
-            rule,
             target,
             write_mode,
-        }) => run_transform(
-            name.as_deref(),
-            find.as_deref(),
-            replace.as_deref(),
-            &files,
-            &context,
-            rule.as_deref(),
-            &target,
-            write_mode.write,
-        ),
+        }) => run_transform(&find, &replace, &files, &context, &target, write_mode.write),
 
         Some(RefactorCommand::Decompose {
             file,
@@ -1319,72 +1296,32 @@ fn run_propagate_single(
 // Transform
 // ============================================================================
 
-#[allow(clippy::too_many_arguments)]
 fn run_transform(
-    name: Option<&str>,
-    find: Option<&str>,
-    replace: Option<&str>,
+    find: &str,
+    replace: &str,
     files: &str,
     context: &str,
-    rule_filter: Option<&str>,
     target: &RefactorTargetArgs,
     write: bool,
 ) -> CmdResult<RefactorOutput> {
     let targets = target.resolve_targets()?;
     run_across_targets("transform", targets, |component_id, path| {
-        run_transform_single(
-            name,
-            find,
-            replace,
-            files,
-            context,
-            rule_filter,
-            component_id,
-            path,
-            write,
-        )
+        run_transform_single(find, replace, files, context, component_id, path, write)
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn run_transform_single(
-    name: Option<&str>,
-    find: Option<&str>,
-    replace: Option<&str>,
+    find: &str,
+    replace: &str,
     files: &str,
     context: &str,
-    rule_filter: Option<&str>,
     component_id: Option<&str>,
     path: Option<&str>,
     write: bool,
 ) -> CmdResult<RefactorOutput> {
     let root = refactor::move_items::resolve_root(component_id, path)?;
-
-    // Resolve transform set: ad-hoc or named
-    let (set_name, set) = if let (Some(f), Some(r)) = (find, replace) {
-        // Ad-hoc mode
-        if name.is_some() {
-            return Err(homeboy::Error::validation_invalid_argument(
-                "name",
-                "Cannot use both a named transform and --find/--replace",
-                None,
-                None,
-            ));
-        }
-        (
-            "ad-hoc".to_string(),
-            refactor::ad_hoc_transform(f, r, files, context),
-        )
-    } else if let Some(n) = name {
-        // Named mode — load from homeboy.json
-        let set = refactor::load_transform_set(&root, n)?;
-        (n.to_string(), set)
-    } else {
-        return Err(homeboy::Error::validation_missing_argument(vec![
-            "name".to_string(),
-            "--find/--replace".to_string(),
-        ]));
-    };
+    let set_name = "ad-hoc";
+    let set = refactor::ad_hoc_transform(find, replace, files, context);
 
     // Report what we're about to do
     homeboy::log_status!(
@@ -1401,8 +1338,7 @@ fn run_transform_single(
 
     if write {
         // Dry-run to discover affected files for the undo snapshot
-        if let Ok(preview) = refactor::apply_transforms(&root, &set_name, &set, false, rule_filter)
-        {
+        if let Ok(preview) = refactor::apply_transforms(&root, set_name, &set, false, None) {
             let affected_files: std::collections::HashSet<String> = preview
                 .rules
                 .iter()
@@ -1417,7 +1353,7 @@ fn run_transform_single(
     }
 
     // Apply transforms
-    let result = refactor::apply_transforms(&root, &set_name, &set, write, rule_filter)?;
+    let result = refactor::apply_transforms(&root, set_name, &set, write, None)?;
 
     // Report results to stderr
     for rule_result in &result.rules {

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -115,8 +115,8 @@ pub fn portable_json(component: &Component) -> Result<Value> {
 ///
 /// Uses a read-modify-write pattern: reads the existing JSON first, merges the
 /// component's known fields on top, and writes the result. This preserves fields
-/// like `baselines`, `transforms`, `audit_rules` that the Component struct doesn't
-/// model but other subsystems (baseline, refactor transform, audit) read/write directly.
+/// like `baselines`, `audit_rules`, and custom local metadata that the Component
+/// struct doesn't model but other subsystems or users read/write directly.
 ///
 /// If no existing file exists, writes from scratch (no fields to preserve).
 pub fn write_portable_config(dir: &Path, component: &Component) -> Result<()> {
@@ -257,7 +257,6 @@ mod tests {
             "id": "test-comp",
             "remote_path": "wp-content/plugins/test",
             "baselines": { "audit": { "item_count": 42 } },
-            "transforms": { "rename-foo": { "rules": [] } },
             "custom_field": "preserve-me"
         });
         fs::write(
@@ -287,13 +286,6 @@ mod tests {
                 .and_then(|v| v.as_i64()),
             Some(42),
             "baselines should be preserved"
-        );
-        assert!(
-            result
-                .get("transforms")
-                .and_then(|v| v.get("rename-foo"))
-                .is_some(),
-            "transforms should be preserved"
         );
         assert_eq!(
             result.get("custom_field").and_then(|v| v.as_str()),

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -87,6 +87,6 @@ pub use rename::{
     RenameResult, RenameScope, RenameSpec, RenameTargeting, RenameWarning,
 };
 pub use transform::{
-    ad_hoc_transform, apply_transforms, load_transform_set, RuleResult, TransformMatch,
-    TransformResult, TransformRule, TransformSet,
+    ad_hoc_transform, apply_transforms, RuleResult, TransformMatch, TransformResult, TransformRule,
+    TransformSet,
 };

--- a/src/core/refactor/transform.rs
+++ b/src/core/refactor/transform.rs
@@ -1,8 +1,7 @@
 //! Pattern-based code transforms — regex find/replace across a codebase.
 //!
-//! Applies named transform sets (collections of find/replace rules) to files
-//! matching glob patterns. Rules are defined in `homeboy.json` under the
-//! `transforms` key, or passed ad-hoc via CLI flags.
+//! Applies find/replace rules to files matching glob patterns. Rules are passed
+//! ad-hoc via CLI flags or constructed by callers that need a `TransformSet`.
 //!
 //! Phase 1: line-context regex transforms (no AST, no extension scripts).
 
@@ -20,7 +19,7 @@ use crate::error::{Error, Result};
 // Rule model
 // ============================================================================
 
-/// A named collection of transform rules.
+/// A collection of transform rules.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransformSet {
     /// Human-readable description of this transform set.
@@ -118,8 +117,8 @@ pub struct TransformMatch {
 
 /// Unescape backslash sequences in a replacement template.
 ///
-/// Users writing regex-replace rules in `homeboy.json` (or on the CLI) think of
-/// the `replace` value the way they think of sed, shell, or `String.replace` —
+/// Users writing regex-replace rules think of the `replace` value the way they
+/// think of sed, shell, or `String.replace` —
 /// `\\` means one literal backslash, `\n` means a newline, `\t` means a tab.
 /// The regex crate's native replacement syntax, on the other hand, passes
 /// backslashes through verbatim and only recognizes `$1`/`${name}`/`$$`. That
@@ -167,61 +166,6 @@ pub(crate) fn unescape_replacement_template(template: &str) -> String {
         }
     }
     out
-}
-
-// ============================================================================
-// Rule loading
-// ============================================================================
-
-const HOMEBOY_JSON: &str = "homeboy.json";
-const TRANSFORMS_KEY: &str = "transforms";
-
-/// Load a named transform set from `homeboy.json` in the given root directory.
-pub fn load_transform_set(root: &Path, name: &str) -> Result<TransformSet> {
-    let json_path = root.join(HOMEBOY_JSON);
-    if !json_path.exists() {
-        return Err(Error::internal_io(
-            format!("No homeboy.json found at {}", json_path.display()),
-            Some("transform.load".to_string()),
-        ));
-    }
-
-    let content = local_files::read_file(&json_path, "read homeboy.json")?;
-    let data: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to parse homeboy.json: {}", e),
-            Some("transform.load".to_string()),
-        )
-    })?;
-
-    let transforms = data.get(TRANSFORMS_KEY).ok_or_else(|| {
-        Error::config_missing_key(
-            TRANSFORMS_KEY.to_string(),
-            Some(json_path.to_string_lossy().to_string()),
-        )
-    })?;
-
-    let set_value = transforms.get(name).ok_or_else(|| {
-        // List available transforms for a helpful error
-        let available: Vec<&str> = transforms
-            .as_object()
-            .map(|o| o.keys().map(|k| k.as_str()).collect::<Vec<_>>())
-            .unwrap_or_default();
-        Error::internal_io(
-            format!(
-                "Transform set '{}' not found. Available: {:?}",
-                name, available
-            ),
-            Some("transform.load".to_string()),
-        )
-    })?;
-
-    serde_json::from_value(set_value.clone()).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to parse transform set '{}': {}", name, e),
-            Some("transform.load".to_string()),
-        )
-    })
 }
 
 /// Create a transform set from ad-hoc CLI arguments.
@@ -856,7 +800,6 @@ fn replace_with_case_transforms(regex: &Regex, replace: &str, text: &str) -> Str
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
 
     // --- Replacement unescape tests (regression for #1277) ---
 
@@ -1183,61 +1126,15 @@ mod tests {
     // --- Integration: apply_transforms with temp dir ---
 
     #[test]
-    fn load_transform_set_from_json() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
+    fn ad_hoc_transform_builds_single_rule_set() {
+        let set = ad_hoc_transform("old", "new", "**/*.php", "file");
 
-        let homeboy_json = serde_json::json!({
-            "transforms": {
-                "my_migration": {
-                    "description": "Test migration",
-                    "rules": [
-                        {
-                            "id": "rule1",
-                            "find": "old",
-                            "replace": "new",
-                            "files": "**/*.php"
-                        }
-                    ]
-                }
-            }
-        });
-
-        fs::write(
-            root.join("homeboy.json"),
-            serde_json::to_string_pretty(&homeboy_json).unwrap(),
-        )
-        .unwrap();
-
-        let set = load_transform_set(root, "my_migration").unwrap();
-        assert_eq!(set.description, "Test migration");
+        assert_eq!(set.description, "Ad-hoc transform");
         assert_eq!(set.rules.len(), 1);
-        assert_eq!(set.rules[0].id, "rule1");
-    }
-
-    #[test]
-    fn load_transform_set_not_found_lists_available() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-
-        let homeboy_json = serde_json::json!({
-            "transforms": {
-                "exists": {
-                    "description": "",
-                    "rules": []
-                }
-            }
-        });
-
-        fs::write(
-            root.join("homeboy.json"),
-            serde_json::to_string_pretty(&homeboy_json).unwrap(),
-        )
-        .unwrap();
-
-        let err = load_transform_set(root, "not_here").unwrap_err();
-        let msg = format!("{:?}", err.details);
-        assert!(msg.contains("not_here"));
-        assert!(msg.contains("exists"));
+        assert_eq!(set.rules[0].id, "ad-hoc");
+        assert_eq!(set.rules[0].find, "old");
+        assert_eq!(set.rules[0].replace, "new");
+        assert_eq!(set.rules[0].files, "**/*.php");
+        assert_eq!(set.rules[0].context, "file");
     }
 }


### PR DESCRIPTION
## Summary
- Removes durable `homeboy.json` named transform loading from `homeboy refactor transform`.
- Keeps the command as an ad-hoc regex find/replace tool requiring `--find` and `--replace`.

## Changes
- Removed the positional transform name and `--rule` CLI path from `refactor transform`.
- Deleted `load_transform_set()` and its `homeboy.json.transforms` loader tests.
- Updated portable-config preservation coverage to use neutral custom metadata instead of blessing `transforms`.

## Tests
- `cargo test transform -- --test-threads=1`
- `cargo test portable -- --test-threads=1`
- `cargo test command_surface -- --test-threads=1`
- `cargo test refactor -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@remove-named-refactor-transforms`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@remove-named-refactor-transforms --changed-since origin/main`
- `cargo run --quiet --bin homeboy -- refactor transform --help`
- `cargo run --quiet --bin homeboy -- refactor transform old_name --path /Users/chubes/Developer/homeboy@remove-named-refactor-transforms` confirms named transform positional args are rejected

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5; model ID `openai/gpt-5.5`)
- **Used for:** Drafted and verified the cleanup implementation under Chris's direction; Chris remains responsible for review and merge.