### PR TITLE
refactor(changelog): remove manual init command

### DIFF
--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -33,26 +33,6 @@ Options:
 
 This prints raw markdown to stdout.
 
-### `init`
-
-```sh
-homeboy changelog init <component_id>
-homeboy changelog init <component_id> --path "docs/CHANGELOG.md"
-homeboy changelog init <component_id> --configure
-```
-
-Creates a new changelog file with the Keep a Changelog format (`## [X.Y.Z] - YYYY-MM-DD`).
-
-Options:
-
-- `--path <path>`: Custom path for changelog file (relative to component). Default: `CHANGELOG.md`
-- `--configure`: Also update component config to add `changelog_target`
-
-Requirements:
-
-- Component must have `version_targets` configured (to determine initial version)
-- Errors if changelog file already exists at target path
-
 ## Prerequisites
 
 Configure the changelog path:
@@ -62,6 +42,8 @@ homeboy component set <id> --changelog-target "CHANGELOG.md"
 ```
 
 This is required for `version bump` and `release`.
+
+Release can bootstrap a missing configured changelog target on the first release. Changelog setup is owned by component configuration; there is no manual changelog initialization command.
 
 ## Changelog Resolution
 
@@ -89,7 +71,7 @@ Notes:
 
 `homeboy changelog` returns a tagged union:
 
-- `command`: `show` (default) | `init`
+- `command`: `show` (default)
 
 ### JSON output (default / show)
 
@@ -103,24 +85,9 @@ This section applies only when JSON output is used.
 }
 ```
 
-### JSON output (init)
-
-```json
-{
-  "command": "init",
-  "component_id": "<component_id>",
-  "changelog_path": "<absolute/path/to/CHANGELOG.md>",
-  "initial_version": "0.3.2",
-  "next_section_label": "Unreleased",
-  "created": true,
-  "configured": false
-}
-```
-
 ## Errors
 
 - `show`: errors if embedded docs do not contain `changelog`, or if the component's changelog path cannot be resolved (when a component ID is provided)
-- `init`: errors if changelog already exists, if component not found, or if no version targets configured
 
 ## Related
 

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use super::CmdResult;
-use homeboy::changelog::{self, InitOutput, ShowOutput};
+use homeboy::changelog::{self, ShowOutput};
 
 #[derive(Args)]
 pub struct ChangelogArgs {
@@ -21,20 +21,6 @@ pub enum ChangelogCommand {
         /// Component ID to show changelog for
         component_id: Option<String>,
     },
-
-    /// Initialize a new changelog file
-    Init {
-        /// Path for the changelog file (relative to component)
-        #[arg(long)]
-        path: Option<String>,
-
-        /// Also update component config to add changelogTargets
-        #[arg(long)]
-        configure: bool,
-
-        /// Component ID
-        component_id: Option<String>,
-    },
 }
 
 #[derive(Serialize)]
@@ -50,36 +36,30 @@ pub enum ChangelogOutput {
     Show(ChangelogShowOutput),
 
     ShowComponent(ShowOutput),
-
-    Init(InitOutput),
 }
 
 pub fn run_markdown(args: ChangelogArgs) -> CmdResult<String> {
     match (&args.command, args.show_self) {
         (None, true) => show_homeboy_markdown(),
         (Some(ChangelogCommand::Show { component_id: None }), _) => show_homeboy_markdown(),
-        (Some(ChangelogCommand::Show { component_id: Some(id) }), _) => {
+        (
+            Some(ChangelogCommand::Show {
+                component_id: Some(id),
+            }),
+            _,
+        ) => {
             let output = changelog::show(id)?;
             Ok((output.content, 0))
         }
         (None, false) => Err(homeboy::Error::validation_invalid_argument(
             "command",
-            "No subcommand provided. Use a subcommand (init, show) or --self to view Homeboy's changelog",
+            "No subcommand provided. Use 'show' or --self to view Homeboy's changelog",
             None,
             Some(vec![
-                "homeboy changelog init <component_id>".to_string(),
                 "homeboy changelog show".to_string(),
                 "homeboy changelog show <component_id>".to_string(),
             ]),
         )),
-        (Some(ChangelogCommand::Init { .. }), _) => {
-            Err(homeboy::Error::validation_invalid_argument(
-                "command",
-                "Markdown output is only supported for 'changelog show'",
-                None,
-                None,
-            ))
-        }
     }
 }
 
@@ -101,40 +81,24 @@ pub fn run(
             let (out, code) = show_homeboy_json()?;
             Ok((ChangelogOutput::Show(out), code))
         }
-        (Some(ChangelogCommand::Show { component_id: Some(id) }), _) => {
+        (
+            Some(ChangelogCommand::Show {
+                component_id: Some(id),
+            }),
+            _,
+        ) => {
             let output = changelog::show(id)?;
             Ok((ChangelogOutput::ShowComponent(output), 0))
         }
         (None, false) => Err(homeboy::Error::validation_invalid_argument(
             "command",
-            "No subcommand provided. Use a subcommand (init, show) or --self to view Homeboy's changelog",
+            "No subcommand provided. Use 'show' or --self to view Homeboy's changelog",
             None,
             Some(vec![
-                "homeboy changelog init <component_id>".to_string(),
                 "homeboy changelog show".to_string(),
                 "homeboy changelog show <component_id>".to_string(),
             ]),
         )),
-        (Some(ChangelogCommand::Init {
-            path,
-            configure,
-            component_id,
-        }), _) => {
-            let id = component_id.as_ref().ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
-                    "componentId",
-                    "Missing componentId",
-                    None,
-                    Some(vec![
-                        "Provide a component ID: homeboy changelog init <component-id>".to_string(),
-                        "List available components: homeboy component list".to_string(),
-                    ]),
-                )
-            })?;
-
-            let output = changelog::init(id, path.as_deref(), *configure)?;
-            Ok((ChangelogOutput::Init(output), 0))
-        }
     }
 }
 

--- a/src/core/release/changelog/bulk.rs
+++ b/src/core/release/changelog/bulk.rs
@@ -1,16 +1,10 @@
-use chrono::Local;
 use serde::Serialize;
-use std::path::Path;
 
 use crate::component;
-use crate::core::release::version;
-use crate::engine::local_files::{self, FileSystem};
-use crate::error::{Error, Result};
-use crate::paths::resolve_path;
+use crate::engine::local_files;
+use crate::error::Result;
 
 use super::io::*;
-use super::sections::*;
-use super::settings::*;
 
 // === Changelog Show Operations ===
 
@@ -34,143 +28,5 @@ pub fn show(component_id: &str) -> Result<ShowOutput> {
         component_id: component_id.to_string(),
         changelog_path: changelog_path.to_string_lossy().to_string(),
         content,
-    })
-}
-
-// === Changelog Init Operations ===
-
-#[derive(Debug, Clone, Serialize)]
-pub struct InitOutput {
-    pub component_id: String,
-    pub changelog_path: String,
-    pub initial_version: String,
-    pub next_section_label: String,
-    pub created: bool,
-    pub changed: bool,
-    pub configured: bool,
-}
-
-fn generate_template(initial_version: &str, next_label: &str) -> String {
-    let today = Local::now().format("%Y-%m-%d");
-    format!(
-        "# Changelog\n\n## {}\n\n## [{}] - {}\n- Initial release\n",
-        next_label, initial_version, today
-    )
-}
-
-/// Initialize a changelog for a component.
-/// If the changelog file doesn't exist, creates a new one with Keep a Changelog template.
-/// If the changelog file exists, ensures it has an Unreleased section.
-pub fn init(component_id: &str, path: Option<&str>, configure: bool) -> Result<InitOutput> {
-    let component = component::resolve_effective(Some(component_id), None, None)?;
-
-    // Validate local_path is absolute and exists before any file operations
-    component::validate_local_path(&component)?;
-
-    let settings = resolve_effective_settings(Some(&component));
-
-    // Determine changelog path (relative to component)
-    let mut relative_path = path.unwrap_or("CHANGELOG.md").to_string();
-    let mut changelog_path = resolve_path(&component.local_path, &relative_path);
-
-    // Check for existing changelog_target configuration
-    if let Some(ref configured_target) = component.changelog_target {
-        let configured_path = resolve_path(&component.local_path, configured_target);
-
-        // If user didn't specify a custom path, or specified the same path, check for existing changelog
-        if (path.is_none() || path == Some(configured_target)) && configured_path.exists() {
-            return Err(Error::validation_invalid_argument(
-                "changelog",
-                "Changelog already exists for this component",
-                None,
-                Some(vec![
-                    format!("Existing changelog at: {}", configured_path.display()),
-                    format!("View with: homeboy changelog show {}", component_id),
-                    format!("Or use --path to specify a different location"),
-                ]),
-            ));
-        }
-    } else {
-        // No changelog_target configured - scan for common changelog filenames
-        let changelog_candidates = [
-            "CHANGELOG.md",
-            "changelog.md",
-            "docs/CHANGELOG.md",
-            "docs/changelog.md",
-            "HISTORY.md",
-        ];
-
-        let local_path = Path::new(&component.local_path);
-        for candidate in &changelog_candidates {
-            let candidate_path = local_path.join(candidate);
-            if candidate_path.exists() {
-                if configure {
-                    // User wants to configure existing changelog - update the path and continue
-                    relative_path = candidate.to_string();
-                    changelog_path = candidate_path;
-                    break;
-                }
-                return Err(Error::validation_invalid_argument(
-                    "changelog",
-                    "Found existing changelog file",
-                    None,
-                    Some(vec![
-                        format!("Existing changelog at: {}", candidate_path.display()),
-                        format!("Configure and use it: homeboy changelog init {} --path \"{}\" --configure", component_id, candidate),
-                        format!("View with: homeboy changelog show {}", component_id),
-                    ]),
-                ));
-            }
-        }
-    }
-
-    // Configure component if requested (do this regardless of file state)
-    let configured = if configure {
-        component::set_changelog_target(component_id, &relative_path)?;
-        true
-    } else {
-        false
-    };
-
-    // Handle existing file: ensure Unreleased section exists
-    if changelog_path.exists() {
-        let content = local_files::read_file(&changelog_path, "read changelog")?;
-
-        let (new_content, changed) = ensure_next_section(&content, &settings.next_section_aliases)?;
-
-        if changed {
-            local_files::local().write(&changelog_path, &new_content)?;
-        }
-
-        return Ok(InitOutput {
-            component_id: component_id.to_string(),
-            changelog_path: changelog_path.to_string_lossy().to_string(),
-            initial_version: String::new(),
-            next_section_label: settings.next_section_label,
-            created: false,
-            changed,
-            configured,
-        });
-    }
-
-    // File doesn't exist: create new changelog with template
-    let version_info = version::read_version(Some(component_id))?;
-    let initial_version = version_info.version;
-
-    if let Some(parent) = changelog_path.parent() {
-        local_files::local().ensure_dir(parent)?;
-    }
-
-    let content = generate_template(&initial_version, &settings.next_section_label);
-    local_files::local().write(&changelog_path, &content)?;
-
-    Ok(InitOutput {
-        component_id: component_id.to_string(),
-        changelog_path: changelog_path.to_string_lossy().to_string(),
-        initial_version,
-        next_section_label: settings.next_section_label,
-        created: true,
-        changed: true,
-        configured,
     })
 }

--- a/src/core/release/changelog/io.rs
+++ b/src/core/release/changelog/io.rs
@@ -46,14 +46,14 @@ pub fn resolve_changelog_path(component: &Component) -> Result<PathBuf> {
     let target = validation::require_with_hints(
         component.changelog_target.as_ref(),
         "component.changelog_target",
-        "No changelog configured for this component. To add one, run:",
+        "No changelog configured for this component. Configure the component's changelog_target:",
         vec![
             format!(
-                "Create new changelog:\n  homeboy changelog init {} --configure",
+                "Use the conventional root changelog:\n  homeboy component set {} --changelog-target \"CHANGELOG.md\"",
                 component.id
             ),
             format!(
-                "Use existing file:\n  homeboy component set {} --changelog-target \"CHANGELOG.md\"",
+                "Use a docs changelog:\n  homeboy component set {} --changelog-target \"docs/CHANGELOG.md\"",
                 component.id
             ),
         ],

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -424,8 +424,8 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     // If `changelog_target` is configured but the file doesn't exist on disk,
     // synthesize a minimal changelog so downstream stages have something to
     // read and finalize. Without this, three stages below all fail with
-    // "File not found" for the same root cause and none of their hints
-    // mention `homeboy changelog init`. See #1172.
+    // "File not found" for the same root cause instead of teaching the
+    // component-owned `changelog_target` setup path. See #1172.
     //
     // Skipped in dry-run to avoid mutating the working tree during a preview.
     if !options.dry_run {

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -229,7 +229,7 @@ pub(crate) fn validate_and_finalize_changelog(
                     format!("Changelog file not found: {}", changelog_path.display()),
                     None,
                     Some(vec![format!(
-                        "Create a new changelog:\n  homeboy changelog init {} --configure",
+                        "Configure the component's changelog target, then re-run release:\n  homeboy component set {} --changelog-target \"CHANGELOG.md\"",
                         component.id
                     )]),
                 ));


### PR DESCRIPTION
## Summary
- Remove the manual `homeboy changelog init` command now that release/component config owns changelog bootstrap.
- Update changelog resolution and release missing-file hints to teach `changelog_target` configuration instead of the removed command.
- Trim command docs and JSON shape docs to the remaining `show` surface.

## Changes
- Deletes the `ChangelogCommand::Init` CLI branch, `InitOutput`, and the init implementation from changelog bulk operations.
- Keeps `homeboy changelog`, `homeboy changelog --self`, `homeboy changelog show`, and `homeboy changelog show <component>` intact.
- Preserves first-release bootstrap via the release pipeline's configured-target path.

## Tests
- `cargo test changelog -- --test-threads=1`
- `cargo test release -- --test-threads=1`
- `cargo run --bin homeboy -- changelog --help`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@remove-changelog-init`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@remove-changelog-init --changed-since origin/main`

Closes #1887

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the command removal, updated docs/hints, and ran the verification commands. Chris remains responsible for review and merge.