### PR TITLE
feat(changes): add path override

### DIFF
--- a/docs/commands/changes.md
+++ b/docs/commands/changes.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```sh
-homeboy changes [<component_id>] [--since <tag>] [--git-diffs]
+homeboy changes [<component_id>] [--path <path>] [--since <tag>] [--git-diffs]
 homeboy changes --json <spec> [--git-diffs]
 
 # Project mode
@@ -22,6 +22,17 @@ homeboy changes my-component # Explicit (always works)
 ```
 
 When multiple components exist or directory is unmanaged, explicit ID is required.
+
+## Worktree / Headless Usage
+
+Use `--path` to run against a specific checkout from any current directory:
+
+```sh
+homeboy changes --path /path/to/worktree
+homeboy changes my-component --path /path/to/worktree
+```
+
+With `--path` only, Homeboy derives the component ID from the checkout's portable `homeboy.json` when present, then falls back to the path basename. With both `<component_id>` and `--path`, Homeboy trusts both values and runs git operations in the supplied path.
 
 ## Description
 
@@ -47,6 +58,7 @@ Release workflow note:
   - Spec format: `{ "component_ids": ["id1", "id2"] }`
 - `--project <project_id>`: show changes for all components attached to a project
   - If you also pass positional `<component_ids...>`, Homeboy only returns changes for those components
+- `--path <path>`: run single-component changes against a specific checkout path
 - `--since <tag>`: tag name to compare against (single-component mode only)
 - `--git-diffs`: include commit-range diff content in output
 

--- a/src/commands/changes.rs
+++ b/src/commands/changes.rs
@@ -21,6 +21,11 @@ pub struct ChangesArgs {
     #[arg(long)]
     pub project: Option<String>,
 
+    /// Workspace path to operate on directly. Useful for unregistered
+    /// checkouts (CI runners, ad-hoc clones, worktrees).
+    #[arg(long, value_name = "PATH")]
+    pub path: Option<String>,
+
     /// JSON input spec for bulk operations: {"componentIds": ["id1", "id2"]}
     #[arg(long)]
     pub json: Option<String>,
@@ -47,6 +52,7 @@ pub fn run(
 ) -> CmdResult<ChangesCommandOutput> {
     // Priority: --json > --project flag > positional args
     if let Some(json) = &args.json {
+        reject_path_for_bulk(args.path.as_deref(), "--json")?;
         let output = git::changes_bulk(json, args.git_diffs)?;
         let exit_code = if output.summary.failed > 0 { 1 } else { 0 };
         return Ok((ChangesCommandOutput::Bulk(output), exit_code));
@@ -54,6 +60,7 @@ pub fn run(
 
     // --project flag mode (with optional component filter from positional args)
     if let Some(project_id) = &args.project {
+        reject_path_for_bulk(args.path.as_deref(), "--project")?;
         if args.component_ids.is_empty() {
             let output = git::changes_project(project_id, args.git_diffs)?;
             let exit_code = if output.summary.failed > 0 { 1 } else { 0 };
@@ -70,12 +77,23 @@ pub fn run(
     if let Some(target_id) = &args.target_id {
         // Multiple args: use shared resolver to detect order
         if !args.component_ids.is_empty() {
+            reject_path_for_bulk(args.path.as_deref(), "project positional mode")?;
             let (project_id, component_ids) =
                 resolve_project_components(target_id, &args.component_ids)?;
             let output =
                 git::changes_project_filtered(&project_id, &component_ids, args.git_diffs)?;
             let exit_code = if output.summary.failed > 0 { 1 } else { 0 };
             return Ok((ChangesCommandOutput::Bulk(output), exit_code));
+        }
+
+        if let Some(path) = args.path.as_deref() {
+            let output = git::changes_at(
+                Some(target_id),
+                args.since.as_deref(),
+                args.git_diffs,
+                Some(path),
+            )?;
+            return Ok((ChangesCommandOutput::Single(Box::new(output)), 0));
         }
 
         // Single target_id: try as component first, fall back to project
@@ -90,6 +108,11 @@ pub fn run(
                 return Err(e);
             }
         }
+    }
+
+    if let Some(path) = args.path.as_deref() {
+        let output = git::changes_at(None, args.since.as_deref(), args.git_diffs, Some(path))?;
+        return Ok((ChangesCommandOutput::Single(Box::new(output)), 0));
     }
 
     let (ctx, _) = context::run(None)?;
@@ -123,4 +146,23 @@ pub fn run(
     err = err.with_hint("  homeboy changes <component-id>");
 
     Err(err)
+}
+
+fn reject_path_for_bulk(path: Option<&str>, mode: &str) -> homeboy::Result<()> {
+    if path.is_some() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "path",
+            format!(
+                "--path is only supported for single-component changes, not {}",
+                mode
+            ),
+            None,
+            Some(vec![
+                "Use --path without --json/--project for one checkout".to_string(),
+                "Use component IDs or project mode for bulk changes".to_string(),
+            ]),
+        ));
+    }
+
+    Ok(())
 }

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 
-use crate::component;
 use crate::config::read_json_spec_to_string;
 use crate::error::{Error, Result};
 use crate::output::{BulkResult, BulkSummary, ItemOutcome};
@@ -300,11 +299,6 @@ pub struct CommitOptions {
     pub exclude: Option<Vec<String>>,
     /// Amend the previous commit instead of creating a new one
     pub amend: bool,
-}
-
-fn get_component_path(component_id: &str) -> Result<String> {
-    let comp = component::resolve_effective(Some(component_id), None, None)?;
-    Ok(comp.local_path)
 }
 
 pub fn execute_git_for_release(path: &str, args: &[&str]) -> std::io::Result<std::process::Output> {
@@ -1152,21 +1146,20 @@ pub fn changes(
     since_tag: Option<&str>,
     include_diff: bool,
 ) -> Result<ChangesOutput> {
-    let id = component_id.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "componentId",
-            "Missing componentId",
-            None,
-            Some(vec![
-                "Provide a component ID: homeboy changes <component-id>".to_string(),
-                "List available components: homeboy component list".to_string(),
-            ]),
-        )
-    })?;
-    let path = get_component_path(id)?;
+    changes_at(component_id, since_tag, include_diff, None)
+}
+
+/// Like [`changes`] but with an explicit path override for git operations.
+pub fn changes_at(
+    component_id: Option<&str>,
+    since_tag: Option<&str>,
+    include_diff: bool,
+    path_override: Option<&str>,
+) -> Result<ChangesOutput> {
+    let (id, path) = resolve_target(component_id, path_override)?;
 
     // Load component for version checking and changelog info
-    let component = crate::component::resolve_effective(Some(id), None, None).ok();
+    let component = crate::component::resolve_effective(Some(&id), Some(&path), None).ok();
 
     // Determine baseline with version alignment awareness
     let baseline = match since_tag {
@@ -1215,7 +1208,7 @@ pub fn changes(
     };
 
     Ok(ChangesOutput {
-        component_id: id.to_string(),
+        component_id: id,
         path,
         success: true,
         latest_tag: baseline.latest_tag,
@@ -1464,6 +1457,35 @@ mod tests {
             .unwrap();
 
         (dir, path)
+    }
+
+    #[test]
+    fn changes_at_path_only_discovers_portable_component_id() {
+        use std::fs;
+        let (dir, path) = init_repo_with_initial_commit();
+        fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{"id":"portable-changes"}"#,
+        )
+        .unwrap();
+
+        let out = changes_at(None, None, false, Some(&path)).expect("changes_at with --path");
+
+        assert_eq!(out.component_id, "portable-changes");
+        assert_eq!(out.path, path);
+        assert!(out.success);
+    }
+
+    #[test]
+    fn changes_at_component_and_path_trusts_both_inputs() {
+        let (_dir, path) = init_repo_with_initial_commit();
+
+        let out = changes_at(Some("explicit-changes"), None, false, Some(&path))
+            .expect("changes_at with component and --path");
+
+        assert_eq!(out.component_id, "explicit-changes");
+        assert_eq!(out.path, path);
+        assert!(out.success);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `--path <PATH>` to top-level `homeboy changes` for worktree/headless single-component usage.
- Keep project and JSON bulk modes on their existing component/project resolution path with a clear validation error when mixed with `--path`.
- Document explicit checkout usage and add focused coverage for path-only and component-plus-path resolution.

## Changes
- Adds `ChangesArgs::path` and routes single-component calls through new `git::changes_at()`.
- Reuses the existing git target resolution convention: path-only discovers portable `homeboy.json`/basename; component-plus-path trusts both.
- Updates `docs/commands/changes.md` with worktree/headless examples.

## Tests
- `cargo test changes -- --test-threads=1`
- `target/debug/homeboy changes --path /Users/chubes/Developer/homeboy@feat-changes-path` from outside the checkout
- `target/debug/homeboy changes homeboy --path /Users/chubes/Developer/homeboy@feat-changes-path` from outside the checkout
- `target/debug/homeboy changes --json ... --path ...` validation smoke
- `cargo fmt --check`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-changes-path`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-changes-path --changed-since origin/main`

Closes #1889

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI/core path override, documentation update, focused tests, and local verification; Chris remains responsible for review and merge.
