### PR TITLE
docs: remove stale docs audit workflow references

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -182,6 +182,6 @@ With `--baseline` comparison:
 
 ## Related
 
-- [docs audit](docs.md) — documentation-level auditing (broken links, stale references)
+- [docs](docs.md) — embedded documentation topics and codebase maps
 - [lint](lint.md) — extension-driven code style validation
 - [JSON output contract](../architecture/output-system.md)

--- a/docs/commands/docs.md
+++ b/docs/commands/docs.md
@@ -3,105 +3,32 @@
 ## Synopsis
 
 ```sh
-homeboy docs [TOPIC]
+homeboy docs [OPTIONS] [TOPIC] [COMMAND]
 homeboy docs list
-homeboy docs audit <component-id> [--features] [--docs-dir <DIR>]
-homeboy docs map <component-id> [--write] [--include-private]
+homeboy docs map [OPTIONS] <component-id>
 ```
 
 ## Description
 
-This command renders documentation topics and provides tooling for documentation management.
+This command renders embedded documentation topics and provides a codebase-map helper for AI-assisted documentation work.
 
 **Topic display** renders documentation from:
 1. Embedded core docs in the CLI binary
 2. Installed extension docs under `<config dir>/homeboy/extensions/<extension_id>/docs/`
 
-**Audit** validates documentation links, detects stale references, identifies undocumented features, and flags priority docs that need review.
-
 **Map** generates machine-optimized codebase maps for AI documentation.
 
 ## Subcommands
 
-### `audit`
+The command has one documentation-management subcommand:
 
-Validates documentation against the codebase. Extracts claims (file paths, directory paths) from docs and verifies them against the filesystem. Also detects features in source code and checks whether they're documented.
+- `map` — generate a machine-optimized codebase map for AI documentation
 
-```sh
-homeboy docs audit homeboy
-homeboy docs audit data-machine --features
-homeboy docs audit /path/to/project --docs-dir documentation
-```
+`help` is also available as the standard CLI help subcommand.
 
-**Arguments:**
-- `<component-id>`: Component ID or filesystem path to audit (required)
+## Options
 
-**Options:**
-- `--features`: Include full list of all detected features in output
-- `--docs-dir <DIR>`: Docs directory relative to component root (overrides config, default: `docs`)
-
-**Output fields:**
-
-| Field | Description |
-|-------|-------------|
-| `broken_references` | File/directory paths in docs that don't exist on disk |
-| `undocumented_features` | Source features (structs, enums) with no documentation reference |
-| `priority_docs` | Docs whose referenced source files changed since the baseline tag |
-| `detected_features` | All features found in source (only with `--features`) |
-| `summary` | Counts: `docs_scanned`, `broken_references`, `priority_docs`, `documented_features`, `total_features` |
-
-**Output:**
-```json
-{
-  "success": true,
-  "data": {
-    "command": "docs.audit",
-    "component_id": "homeboy",
-    "baseline_ref": "v0.52.1",
-    "summary": {
-      "docs_scanned": 53,
-      "broken_references": 3,
-      "priority_docs": 8,
-      "documented_features": 90,
-      "total_features": 91,
-      "unchanged_docs": 45,
-      "undocumented_features": 1
-    },
-    "broken_references": [
-      {
-        "doc": "commands/refactor.md",
-        "line": 95,
-        "claim": "directory path `scripts/build/`",
-        "confidence": "unclear",
-        "action": "Directory 'scripts/build/' no longer exists. Update or remove this reference."
-      }
-    ],
-    "priority_docs": [
-      {
-        "doc": "commands/docs.md",
-        "reason": "6 referenced source file(s) changed since baseline",
-        "changed_files_referenced": ["src/commands/docs.rs", "..."],
-        "code_examples": 0,
-        "action": "Review documentation for accuracy against current implementation."
-      }
-    ],
-    "undocumented_features": [
-      {
-        "name": "TestMappingConfig",
-        "source_file": "src/core/extension/manifest.rs",
-        "line": 59
-      }
-    ]
-  }
-}
-```
-
-**Agent workflow:**
-1. Run `homeboy docs audit <component>`
-2. Fix `broken_references` — update or remove stale paths
-3. Review `priority_docs` — source changed, verify doc accuracy
-4. Document `undocumented_features` if they're part of the public API
-5. Re-run audit to confirm findings resolved
+- `--output <PATH>`: Write structured JSON output to a file in addition to stdout
 
 ### `map`
 
@@ -111,7 +38,7 @@ Generates a machine-optimized codebase map by fingerprinting source files and ex
 # JSON output to stdout
 homeboy docs map my-plugin
 
-# Write markdown files to docs directory
+# Write markdown files to a docs directory
 homeboy docs map my-plugin --write
 
 # Include protected methods
@@ -125,10 +52,17 @@ homeboy docs map my-plugin --source-dirs src,lib
 - `<component-id>`: Component to analyze (required)
 
 **Options:**
+- `--output <PATH>`: Write structured JSON output to a file in addition to stdout
 - `--source-dirs <DIRS>`: Source directories to analyze (comma-separated, overrides auto-detection)
 - `--include-private`: Include protected methods and internals (default: public API surface only)
 - `--write`: Write markdown files to disk instead of JSON to stdout
 - `--output-dir <DIR>`: Output directory for markdown files (default: `docs`)
+
+**Agent workflow:**
+1. Run `homeboy docs map <component>` to gather source structure for documentation work.
+2. Read the relevant embedded guidance topic, such as `homeboy docs documentation/alignment` or `homeboy docs documentation/generation`.
+3. Edit documentation manually against the current source.
+4. Use focused source checks, `homeboy audit`, and `homeboy lint` as appropriate for the repository.
 
 **Auto-detection:** Without `--source-dirs`, the map command looks for conventional directories (`src`, `lib`, `inc`, `app`, `components`, `extensions`, `crates`). Falls back to extension-based file detection if none found.
 
@@ -162,19 +96,19 @@ Homeboy includes embedded documentation for AI agents:
 
 Typical documentation workflow using these commands:
 
-1. **Audit**: `homeboy docs audit <component>` — find broken refs, stale docs, undocumented features
-2. **Learn**: `homeboy docs documentation/generation` — read guidelines
-3. **Map**: `homeboy docs map <component>` — generate codebase map for AI context
-4. **Maintain**: `homeboy docs documentation/alignment` — keep docs current
+1. **Learn**: `homeboy docs documentation/generation` — read guidelines
+2. **Map**: `homeboy docs map <component>` — generate codebase map for AI context
+3. **Maintain**: `homeboy docs documentation/alignment` — keep docs current
+4. **Verify**: run focused source checks plus `homeboy audit` or `homeboy lint` when those commands cover the changed files
 
 ## Errors
 
 If a topic does not exist, the command fails with an error indicating the topic was not found.
 
-If a component does not exist (for audit/map), the command fails with a component not found error.
+If a component does not exist for `map`, the command fails with a component not found error.
 
 ## Related
 
-- [audit](audit.md) — code-level convention auditing (different from docs audit)
+- [audit](audit.md) — code-level convention auditing, including documentation-reference findings when enabled by the audit implementation
 - [changelog](changelog.md)
 - [JSON output contract](../architecture/output-system.md)

--- a/docs/commands/refactor.md
+++ b/docs/commands/refactor.md
@@ -181,5 +181,5 @@ In addition to content edits, the engine detects files and directories whose nam
 ## Related
 
 - [component](component.md)
-- [docs audit](docs.md) — documentation-level auditing
+- [docs](docs.md) — embedded documentation topics and codebase maps
 - [JSON output contract](../architecture/output-system.md)

--- a/docs/documentation/alignment.md
+++ b/docs/documentation/alignment.md
@@ -26,20 +26,21 @@ Only update what needs correction. Preserve accurate existing content. Do not re
 
 ## Workflow
 
-### 1. Run Audit
+### 1. Build Source Context
 ```sh
-homeboy docs audit <component>
+homeboy docs map <component>
 ```
 
-This extracts claims from documentation (file paths, directory paths, code examples) and verifies them against the codebase.
+Use the map output plus targeted source reads to understand the current code shape before editing documentation.
 
-### 2. Review Priority Docs
-If the output includes `changes_context.priority_docs`, these docs reference recently changed files and should be reviewed first.
+### 2. Find Current-Workflow References
+Search the relevant documentation for command names, file paths, configuration keys, and workflow steps that may have drifted from the current implementation.
 
-### 3. Execute Broken Tasks
-For each task with `status: "broken"`:
-- The `action` field tells you exactly what to do
-- Usually: file/directory was moved or deleted, update the reference
+### 3. Fix Broken References
+For each stale reference:
+- Read the current source or CLI help that owns the behavior
+- Update or remove the reference without inventing replacement workflows
+- Preserve historical changelog entries unless they are presented as current workflow
 
 ### 4. Verify Code Examples
 For tasks with `status: "needs_verification"`:
@@ -47,11 +48,11 @@ For tasks with `status: "needs_verification"`:
 - Verify the example matches current implementation
 - Update if the API has changed
 
-### 5. Re-run Audit
+### 5. Verify Changes
 ```sh
-homeboy docs audit <component>
+homeboy audit <component>
 ```
-Confirm `broken` count is 0. Some `needs_verification` items are acceptable if code examples haven't changed.
+Run focused grep/source checks and repository quality gates that cover the changed docs. If `homeboy audit` reports documentation-reference findings, fix them before completion.
 
 ## Forbidden Content
 

--- a/docs/documentation/generation.md
+++ b/docs/documentation/generation.md
@@ -41,7 +41,7 @@ Find actual usage workflows in existing code, tests, and examples. Document real
 Create subdirectories in `/docs` that directly correspond to actual code extensions and components.
 
 ### 6. Create Documentation Files
-Use `homeboy docs audit <component>` to identify gaps, then create files manually following the structure standards in `homeboy docs documentation/structure`. Use `homeboy docs map <component>` to generate a codebase map for AI-assisted documentation.
+Use `homeboy docs map <component>` to generate a codebase map for AI-assisted documentation, then create files manually following the structure standards in `homeboy docs documentation/structure`.
 
 ### 7. Write Content
 For each file:
@@ -52,11 +52,11 @@ For each file:
 ### 8. Coverage Validation
 Verify ALL discovered components have been documented before completion.
 
-### 9. Run Audit
+### 9. Validate References
 ```sh
-homeboy docs audit <component>
+homeboy audit <component>
 ```
-Verify all generated documentation references valid code paths. Fix any `broken` tasks before marking generation complete.
+Run focused source checks and repository quality gates that cover the changed docs. If `homeboy audit` reports documentation-reference findings, fix them before marking generation complete.
 
 ## Forbidden Content
 

--- a/docs/documentation/structure.md
+++ b/docs/documentation/structure.md
@@ -125,4 +125,4 @@ These belong elsewhere, not in `/docs`:
 
 ## Documentation Commands
 
-Use `homeboy docs audit <component>` to validate existing docs and find gaps. Use `homeboy docs map <component>` to generate a machine-optimized codebase map. Use `homeboy docs generate` to create files in bulk from a JSON spec.
+Use `homeboy docs <topic>` to read embedded guidance and `homeboy docs map <component>` to generate a machine-optimized codebase map. Create or edit documentation manually against the current source, then verify with focused source checks plus `homeboy audit` or `homeboy lint` where those commands apply.

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ Guides for contributing to Homeboy:
 
 Homeboy provides tooling for AI-assisted documentation generation and maintenance:
 
-- `homeboy docs audit <component>` - Validate documentation links, detect stale references and gaps
+- `homeboy docs <topic>` - Display embedded documentation topics
 - `homeboy docs map <component>` - Generate machine-optimized codebase map for AI context
 - `homeboy docs documentation/index` - Documentation philosophy and principles
 - `homeboy docs documentation/alignment` - Instructions for maintaining existing docs

--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -89,7 +89,7 @@ Scripts that implement extension capabilities. Each script path is relative to t
 
 ## Audit Configuration
 
-Configuration for docs audit, feature detection, and test coverage analysis.
+Configuration for documentation-reference analysis, feature detection, and test coverage analysis.
 
 ```json
 {
@@ -126,7 +126,7 @@ Configuration for docs audit, feature detection, and test coverage analysis.
 
 ### Audit Fields
 
-- **`ignore_claim_patterns`** (array): Glob patterns for paths to ignore during docs audit
+- **`ignore_claim_patterns`** (array): Glob patterns for paths to ignore during documentation-reference analysis
 - **`feature_patterns`** (array): Regex patterns to detect features in source code (must have a capture group for the feature name)
 - **`feature_labels`** (object): Maps pattern substrings to human-readable labels for grouping
 - **`doc_targets`** (object): Maps feature labels to documentation file paths and headings


### PR DESCRIPTION
## Summary
- Refresh `homeboy docs` documentation to match the current CLI surface: topic display plus `docs map`.
- Remove current-workflow guidance that told agents to run the removed `homeboy docs audit` or `docs generate` commands.
- Update related command/schema docs to point at supported docs tooling and repository quality gates.

## Tests
- `homeboy docs --help`
- `homeboy docs map --help`
- `git grep -n -E "homeboy docs audit|docs audit|homeboy docs generate|docs generate" -- 'docs/*.md' 'docs/**/*.md' ':!docs/changelog.md'`
- `git diff --check`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@docs-remove-docs-audit-references --glob 'docs/**/*.md'`

Closes #1893

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the documentation updates; Chris remains responsible for review and merge.