### PR TITLE
docs: align build output examples

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -6,11 +6,14 @@
 homeboy build <component_id>
 homeboy build <component_id> --path /path/to/workspace/clone
 homeboy build --json '<spec>'
+homeboy build <project_id> --all
 ```
 
 ## Description
 
 Resolves a build command from the component's linked extension and runs it in the component's `local_path`.
+
+Builds are extension-owned. A component links to one build-capable extension, and Homeboy asks that extension for the command to run. One-off shell commands that do not belong in a reusable extension should live in a rig `command` step instead.
 
 ## Path Override
 
@@ -27,7 +30,7 @@ This is useful for:
 
 The override is transient — it does not modify the stored component config.
 
-Requires exactly one linked extension with build support. Component-level `build_command` is not supported; for one-off shell builds, define a rig `command` step instead.
+Requires exactly one linked extension with build support. Component-level `build_command` is not supported as configuration; the `build_command` field in command output is the command Homeboy resolved from the linked extension for this run.
 
 Useful remediation paths when a component is not buildable:
 
@@ -62,12 +65,14 @@ Example extension configuration:
 {
   "command": "build.run",
   "component_id": "<component_id>",
-  "build_command": "<command string>",
+  "build_command": "<extension-resolved command string>",
   "stdout": "<stdout>",
   "stderr": "<stderr>",
   "success": true
 }
 ```
+
+`stdout` and `stderr` are omitted when empty. `build_command` is diagnostic output from extension resolution, not a component-level config field.
 
 ### Bulk (`--json`)
 
@@ -77,22 +82,19 @@ Example extension configuration:
   "results": [
     {
       "id": "<component_id>",
-      "result": {
-        "command": "build.run",
-        "component_id": "<component_id>",
-        "build_command": "<command string>",
-        "stdout": "<stdout>",
-        "stderr": "<stderr>",
-        "success": true
-      },
-      "error": null
+      "command": "build.run",
+      "component_id": "<component_id>",
+      "build_command": "<extension-resolved command string>",
+      "stdout": "<stdout>",
+      "stderr": "<stderr>",
+      "success": true
     }
   ],
   "summary": { "total": 1, "succeeded": 1, "failed": 0 }
 }
 ```
 
-Bulk JSON input uses `component_ids`:
+Bulk JSON input accepts either a JSON array or an object with `component_ids`:
 
 ```json
 { "component_ids": ["component-a", "component-b"] }

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -56,31 +56,34 @@ If no component IDs are provided and neither `--all` nor `--outdated` is set, Ho
   "project_id": "<project_id>",
   "all": false,
   "outdated": false,
+  "behind_upstream": false,
   "check": false,
   "dry_run": false,
+  "force": false,
   "results": [
     {
       "id": "<component_id>",
-      "name": "<name>",
       "status": "deployed|failed|skipped|planned|checked",
       "deploy_reason": "explicitly_selected|all_selected|version_mismatch|unknown_local_version|unknown_remote_version",
-      "component_status": "up_to_date|needs_update|behind_remote|unknown",
+      "component_status": "up_to_date|needs_update|behind_remote|behind_upstream|unknown",
       "local_version": "<v>|null",
       "remote_version": "<v>|null",
       "error": "<string>|null",
       "artifact_path": "<path>|null",
       "remote_path": "<path>|null",
-      "build_command": "<cmd>|null",
       "build_exit_code": "<int>|null",
       "deploy_exit_code": "<int>|null",
       "release_state": {
         "commits_since_version": 5,
+        "code_commits": 4,
+        "docs_only_commits": 1,
         "has_uncommitted_changes": false,
         "baseline_ref": "v0.9.15"
-      }
+      },
+      "deployed_ref": "<tag-or-branch>|null"
     }
   ],
-  "summary": { "succeeded": 0, "failed": 0, "skipped": 0 }
+  "summary": { "total": 1, "succeeded": 0, "failed": 0, "skipped": 0 }
 }
 ```
 
@@ -89,6 +92,8 @@ Notes:
 - `deploy_reason` is omitted when not applicable.
 - `component_status` is only present when using `--check` or `--check --dry-run`.
 - `artifact_path` is the component build artifact path as configured; it may be relative but must include a filename.
+- Deploy output does not include `build_command`. Builds are resolved from the linked extension, and deploy records only build/deploy exit codes plus the artifact path used.
+- `deployed_ref` is omitted when no tag or branch ref was deployed.
 
 Note: `build_exit_code`/`deploy_exit_code` are numbers when present (not strings).
 
@@ -99,6 +104,7 @@ When using `--check`, each component result includes a `component_status` field:
 - `up_to_date`: local and remote versions match
 - `needs_update`: local version ahead of remote (needs deployment)
 - `behind_remote`: remote version ahead of local (local is behind)
+- `behind_upstream`: local checkout is behind its upstream branch
 - `unknown`: cannot determine status (missing version information)
 
 ### Release state
@@ -106,8 +112,12 @@ When using `--check`, each component result includes a `component_status` field:
 When using `--check`, each component result includes a `release_state` field that tracks unreleased changes:
 
 - `commits_since_version`: number of commits since the last version tag
+- `code_commits`: number of non-doc commits since the last version tag; omitted when zero
+- `docs_only_commits`: number of docs-only commits since the last version tag; omitted when zero
 - `has_uncommitted_changes`: whether there are uncommitted changes in the working directory
 - `baseline_ref`: the tag or commit hash used as baseline for comparison
+
+`baseline_ref`, `baseline_warning`, `code_commits`, and `docs_only_commits` are omitted when empty.
 
 This helps identify components where `component_status` is `up_to_date` but work has been done since the last version bump (commits_since_version > 0), indicating a version bump may be needed before deployment.
 
@@ -149,20 +159,20 @@ When using `--projects`, the output structure differs:
   "projects": [
     {
       "project_id": "extra-chill",
-      "status": "deployed|failed",
+      "status": "deployed|failed|planned|checked",
       "error": "<string>|null",
       "results": [...],
       "summary": { "total": 1, "succeeded": 1, "skipped": 0, "failed": 0 }
     },
     {
       "project_id": "sarai-chinwag",
-      "status": "deployed|failed",
+      "status": "deployed|failed|planned|checked",
       "error": "<string>|null",
       "results": [...],
       "summary": { "total": 1, "succeeded": 1, "skipped": 0, "failed": 0 }
     }
   ],
-  "summary": { "total_projects": 2, "succeeded": 2, "failed": 0 }
+  "summary": { "total_projects": 2, "succeeded": 2, "failed": 0, "skipped": 0, "planned": 0 }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Refresh build JSON output examples to match the current flattened bulk result shape.
- Align deploy JSON examples with current status fields and remove stale build_command output from deploy docs.
- Clarify that builds are resolved through linked extensions, while one-off shell commands belong in rig command steps.

## Tests
- homeboy build --help
- homeboy deploy --help
- homeboy deploy intelligence-chubes4 --check
- Searched edited docs for build_command and verified remaining mentions are intentional.

Closes #1898

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated documentation examples and wording from the current CLI/source contract; Chris remains responsible for review and merge.