### PR TITLE
docs: refresh rig lifecycle documentation

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -1,98 +1,199 @@
-# Rig spec reference
+# Rig Spec Reference
 
-JSON schema for `~/.config/homeboy/rigs/<id>.json`.
+JSON reference for rig specs loaded from `~/.config/homeboy/rigs/<id>.json` or installed from a rig package.
 
-## Top-level fields
+## Package Layout
+
+A rig package can be a local directory or a git repository. Discovery accepts either shape:
+
+```text
+single-rig-package/
+  rig.json
+
+multi-rig-package/
+  rigs/<rig-id>/rig.json
+  stacks/<stack-id>.json
+```
+
+Install with:
+
+```sh
+homeboy rig install https://github.com/chubes4/homeboy-rigs.git//packages/studio --id studio
+homeboy rig install ./packages/studio
+homeboy rig install ./packages --all
+```
+
+For git sources, `repo.git//subpath` clones the repository root but discovers specs from the selected subpath. Installed source metadata records the package root, discovery path, linked/cloned ownership, and git revision so `rig update` and `rig sources` can refresh or remove the right files later.
+
+## Top-Level Fields
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `id` | string | No | Rig ID. If absent, the filename stem (`<id>.json` → `<id>`) is used. |
+| `id` | string | No | Rig ID. If absent, the filename stem is used. |
 | `description` | string | No | Human-readable description shown in `rig list` / `rig show`. |
-| `components` | object | No | Map of component ID → `ComponentSpec`. |
-| `services` | object | No | Map of service ID → `ServiceSpec`. |
+| `components` | object | No | Map of component ID to `ComponentSpec`. |
+| `services` | object | No | Map of service ID to `ServiceSpec`. |
 | `symlinks` | array | No | List of `SymlinkSpec` entries. |
-| `shared_paths` | array | No | List of ephemeral dependency paths to borrow from another checkout. |
-| `pipeline` | object | No | Map of pipeline name → array of `PipelineStep`. |
+| `shared_paths` | array | No | List of dependency paths the rig may borrow from another checkout. |
+| `resources` | object | No | Resource declarations used by active-run leases. |
+| `pipeline` | object | No | Map of pipeline name to `PipelineStep[]`. |
+| `bench` | object | No | Rig-pinned benchmark component/default-baseline settings. |
+| `bench_workloads` | object | No | Rig-owned out-of-tree benchmark workload paths keyed by extension ID. |
+| `bench_profiles` | object | No | Named benchmark scenario profiles keyed by profile name. |
+| `app_launcher` | object | No | Optional desktop launcher wrapper config. |
 
 ## `ComponentSpec`
 
-Reference to a local checkout of a component. Decoupled from homeboy's global component registry so rigs work without prior `homeboy component create`.
+Components are local checkouts used by pipeline steps. They are intentionally decoupled from the global component registry so package rigs can work on machines where the component has not been registered globally.
 
 | Field | Type | Description |
 |---|---|---|
-| `path` | string | Filesystem path to the checkout. Supports `~` and `${env.VAR}` expansion. |
-| `stack` | string | Stack ID associated with the component. Used by `homeboy stack`; rig pipeline integration is still explicit. |
-| `branch` | string | Expected branch hint for humans reading specs and status output. |
+| `path` | string | Filesystem path to the checkout. Supports `~`, `${env.NAME}`, and use through `${components.<id>.path}`. |
+| `remote_url` | string | Optional source repository URL for triage/reporting fallback. |
+| `triage_remote_url` | string | Optional reporting-only GitHub remote override. |
+| `stack` | string | Stack ID synced by `homeboy rig sync` and by explicit `stack` pipeline steps. |
+| `branch` | string | Expected branch hint surfaced to humans in status/spec output. |
+| `extensions` | object | Optional rig-owned scoped extension config, mainly for rig-pinned bench dispatch. |
+
+Example:
+
+```jsonc
+{
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio",
+      "stack": "studio-combined",
+      "branch": "dev/combined-fixes"
+    }
+  }
+}
+```
 
 ## `ServiceSpec`
 
-A background process the rig manages.
+Services are background processes the rig can start, stop, adopt, or health-check.
 
 | Field | Type | Description |
 |---|---|---|
-| `kind` | enum | `"http-static"`, `"command"`, or `"external"`. |
+| `kind` | enum | `http-static`, `command`, or `external`. |
 | `cwd` | string | Working directory. Supports variable expansion. |
-| `port` | integer | TCP port. Required for `http-static`; surfaced in status for `command`. |
+| `port` | integer | TCP port. Required for `http-static`; shown in status for `command`. |
 | `command` | string | Shell command for `kind: "command"`. |
-| `env` | object | Env vars passed to the service. |
-| `health` | `CheckSpec` | Health probe evaluated by `rig check`. Optional — missing means "alive PID = healthy". |
+| `env` | object | Environment variables passed to the service. |
+| `health` | `CheckSpec` | Optional health probe. Missing means a live PID is healthy. |
+| `discover` | object | Required for `external`; contains `pattern` for process discovery. |
 
-### Service kinds
+### Service Kinds
 
-- **`http-static`** — runs `python3 -m http.server <port>` in `cwd`. The common case for dev envs that need to serve tarballs or static assets locally.
-- **`command`** — runs `sh -c <command>`. Use for anything else (docker, redis, custom dev servers, SSH tunnels).
-- **`external`** — adopts a process the rig did not spawn. Only `service.stop` is meaningful; it discovers the newest process whose command line contains `discover.pattern` and signals it. Use for stale daemons that need recycling after a build.
+- **`http-static`** runs `python3 -m http.server <port>` in `cwd`.
+- **`command`** runs `sh -c <command>` and tracks the spawned PID.
+- **`external`** adopts a process Homeboy did not spawn. It discovers the newest process whose command line contains `discover.pattern`; `service.stop` signals it, while `service.start` intentionally errors.
 
-Services are started detached (new session via `setsid`), tracked by PID in state, and logged to `~/.config/homeboy/rigs/<id>.state/logs/<service-id>.log`.
+```jsonc
+{
+  "services": {
+    "tarballs": {
+      "kind": "http-static",
+      "cwd": "${components.playground.path}/dist/packages-for-self-hosting",
+      "port": 9724,
+      "health": { "http": "http://127.0.0.1:9724/", "expect_status": 200 }
+    },
+    "studio-daemon": {
+      "kind": "external",
+      "discover": { "pattern": "wordpress-server-child.mjs" }
+    }
+  }
+}
+```
+
+Managed services are detached, tracked by PID in rig state, and logged under `~/.config/homeboy/rigs/<id>.state/logs/`.
+
+## `resources` And Active-Run Leases
+
+`resources` declares what a mutating rig command may exclusively touch while it is active. `rig up` and `rig down` acquire a local lease before running, prune stale leases, and fail with a resource-conflict error if another active rig command overlaps.
+
+| Field | Type | Description |
+|---|---|---|
+| `exclusive` | array | Logical tokens that must not overlap with another active rig. |
+| `paths` | array | Filesystem paths the rig mutates or requires exclusively. |
+| `ports` | array | TCP ports the rig binds or assumes ownership of. |
+| `process_patterns` | array | Process command-line substrings the rig may stop or inspect. |
+
+```jsonc
+{
+  "resources": {
+    "exclusive": ["studio-dev"],
+    "paths": ["~/Studio/intelligence-chubes4/wp-content/plugins"],
+    "ports": [9724],
+    "process_patterns": ["wordpress-server-child.mjs"]
+  }
+}
+```
+
+Leases guard concurrent active commands; they are not long-lived ownership records after the command exits.
 
 ## `SymlinkSpec`
 
-A symlink the rig maintains.
-
 | Field | Type | Description |
 |---|---|---|
-| `link` | string | Path where the symlink lives. Supports `~` expansion. |
-| `target` | string | What the symlink points to. Supports `~` expansion. |
+| `link` | string | Path where the symlink lives. Supports `~`. |
+| `target` | string | Expected symlink target. Supports `~`. |
 
-`symlink ensure` creates or re-points the link; `symlink verify` checks it exists with the expected target.
+`symlink ensure` creates or repoints the link. `symlink verify` checks that the link exists and points at the expected target.
 
 ## `SharedPathSpec`
 
-An ephemeral dependency path the rig may borrow from another checkout. Common use: feature worktrees that do not have `node_modules`, while the primary checkout does.
+Shared paths let worktrees borrow heavy dependency directories from another checkout.
 
 | Field | Type | Description |
 |---|---|---|
-| `link` | string | Path inside the active checkout. If missing, `shared-path ensure` creates a symlink here. Supports variable expansion. |
-| `target` | string | Existing path to borrow. Supports variable expansion. |
+| `link` | string | Path inside the active checkout. |
+| `target` | string | Existing path to borrow. |
 
 Safety contract:
 
 - `ensure` creates a symlink only when `link` is missing.
-- If `link` already exists as a real file or directory, it is treated as local dependencies and left alone.
-- If `link` is a symlink to any other target, `ensure` fails instead of replacing it.
-- Cleanup removes only symlinks this rig created and recorded in rig state.
+- Real files or directories at `link` are treated as local dependencies and left alone.
+- A symlink at `link` pointing anywhere else is an error.
+- `cleanup` removes only symlinks this rig created and recorded in rig state.
 
-## `PipelineStep`
+## Pipeline Steps
 
-Tagged union via the `kind` discriminator. **Prefer the typed primitives (`build`, `git`, `check`, `shared-path`) over generic `command` wherever they fit — typed steps reuse homeboy's existing build/git plumbing, error mapping, and extension hooks rather than shelling out blindly.**
+Pipeline steps are a tagged union via the `kind` field. Every step can include:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Optional stable step ID. |
+| `depends_on` | array | Step IDs that must run first. |
+| `label` | string | Optional human-readable status label where the step type supports it. |
+
+Steps are ordered topologically by `depends_on`, then executed in order. Cycles and missing dependency IDs fail before running the pipeline. This gives dependency-aware ordering without making `up` / `check` / `down` parallel.
 
 ### `service`
 
 ```jsonc
-{ "kind": "service", "id": "<service-id>", "op": "start" }
-{ "kind": "service", "id": "<service-id>", "op": "stop" }
-{ "kind": "service", "id": "<service-id>", "op": "health" }
+{ "kind": "service", "id": "tarballs", "op": "start" }
+{ "kind": "service", "id": "tarballs", "op": "health" }
+{ "kind": "service", "id": "tarballs", "op": "stop" }
 ```
 
-`start` is idempotent — a running PID is reused. `stop` sends SIGTERM with 5s grace then SIGKILL. `health` evaluates the service's `health` check and verifies the PID is live.
+Starts, checks, or stops a declared service. `start` is idempotent for managed services. `stop` sends SIGTERM with a grace period and then SIGKILL if needed.
 
 ### `build`
 
 ```jsonc
-{ "kind": "build", "component": "wordpress-playground", "label": "playground tarballs" }
+{ "kind": "build", "component": "wordpress-playground", "label": "build tarballs" }
 ```
 
-Delegates to `homeboy build`, using the component's path from the rig's `components` map. The component does NOT need to be registered in homeboy's global component registry — path override wins. Build semantics (extension-registered build scripts, error formatting, structured result) are inherited from `homeboy::build::run_with_path`. Exit code non-zero fails the step with the stderr tail in the pipeline outcome.
+Delegates to `homeboy build` using the component path from the rig spec.
+
+### `extension`
+
+```jsonc
+{ "kind": "extension", "component": "studio", "op": "build" }
+```
+
+Delegates a supported component lifecycle operation through extension infrastructure. Current rig support is `op: "build"`; use `command` for one-off escape hatches.
 
 ### `git`
 
@@ -100,15 +201,21 @@ Delegates to `homeboy build`, using the component's path from the rig's `compone
 {
   "kind": "git",
   "component": "studio",
-  "op": "pull",
-  "args": ["origin", "trunk"],
-  "label": "pull studio trunk"
+  "op": "rebase",
+  "args": ["--autostash", "origin/trunk"],
+  "label": "rebase Studio"
 }
 ```
 
-Delegates to homeboy's git primitive (`git::execute_git_for_release` under the hood). Operation set: `status`, `pull`, `push`, `fetch`, `checkout`, `current-branch`, `rebase`, and `cherry-pick`. `args` are appended after the op-specific base args, so `op: pull` with `args: ["origin", "trunk"]` runs `git pull origin trunk`. Variable expansion applies to `args` entries.
+Runs git in the component checkout. Supported operations are `status`, `pull`, `push`, `fetch`, `checkout`, `current-branch`, `rebase`, and `cherry-pick`. `args` are appended after the operation's base arguments and support variable expansion.
 
-For long-lived combined-fixes branches, prefer a `homeboy stack` spec plus explicit `stack` invocations over hand-maintaining a long sequence of raw cherry-pick steps in the rig.
+### `stack`
+
+```jsonc
+{ "kind": "stack", "component": "studio", "op": "sync", "dry_run": true }
+```
+
+Delegates to `homeboy stack sync <stack-id>` for the named component. The component must declare `stack`. `homeboy rig sync <id>` runs this for every stacked component without needing a pipeline step.
 
 ### `patch`
 
@@ -125,7 +232,7 @@ For long-lived combined-fixes branches, prefer a `homeboy stack` spec plus expli
 }
 ```
 
-Applies or verifies an idempotent local-only file patch. `marker` must appear in `content`; if the marker is already present, `apply` is a no-op. If `after` is set and missing from the file, the step fails instead of guessing where to insert. Use `op: "verify"` in `check` pipelines.
+Applies or verifies an idempotent local-only patch. `marker` must appear in `content`; when the marker is already present, `apply` is a no-op. If `after` is set and not found, the step fails rather than guessing where to insert. Use `op: "verify"` in `check` pipelines.
 
 ### `command`
 
@@ -139,11 +246,9 @@ Applies or verifies an idempotent local-only file patch. `marker` must appear in
 }
 ```
 
-Runs via `sh -c`. `cwd`, `command`, and `env` values all support variable expansion. `label` is optional; without it, the command string itself is used in status output.
+Runs via the platform shell. `cwd`, `command`, and `env` values support variable expansion. Command steps bootstrap common developer-tool PATH entries unless `env.PATH` is set explicitly.
 
-Command steps bootstrap a portable developer-tool PATH unless the step explicitly sets `env.PATH`. Homeboy prepends existing common bin directories (`$HOME/.local/bin`, `$HOME/.cargo/bin`, `$HOME/.kimaki/bin`, `$HOME/.nvm/versions/node/*/bin`, `/opt/homebrew/bin`, `/usr/local/bin`) before the inherited `PATH`. Missing directories are ignored. If a tool lives somewhere else, set `env.PATH` on the step or prefer a typed primitive such as `build`, `git`, or `check` when one fits.
-
-**Escape hatch — use sparingly.** If a step maps to `build`, `git`, or `check`, use those instead. Generic commands lose homeboy's error formatting, extension integration, and structured output.
+Prefer typed `build`, `git`, `stack`, `check`, and `service` steps when they fit; generic commands are the escape hatch.
 
 ### `symlink`
 
@@ -152,7 +257,7 @@ Command steps bootstrap a portable developer-tool PATH unless the step explicitl
 { "kind": "symlink", "op": "verify" }
 ```
 
-Operates on every symlink declared at the rig level. No per-step target — rig-wide intent.
+Operates on every top-level `symlinks` entry.
 
 ### `shared-path`
 
@@ -162,7 +267,7 @@ Operates on every symlink declared at the rig level. No per-step target — rig-
 { "kind": "shared-path", "op": "cleanup" }
 ```
 
-Operates on every `shared_paths` entry declared at the rig level. Use `ensure` before dependency-consuming commands, `verify` in `check`, and `cleanup` in `down` when you want explicit teardown. `rig down` also runs shared-path cleanup as a safety net.
+Operates on every top-level `shared_paths` entry.
 
 ### `check`
 
@@ -175,68 +280,134 @@ Operates on every `shared_paths` entry declared at the rig level. Use `ensure` b
 }
 ```
 
-Embeds a `CheckSpec` (see below). Non-fatal in `up` pipelines; fatal in `check` pipelines.
+Embeds a `CheckSpec`. `up` pipelines fail fast on step failures; `check` pipelines run all steps and report every failure.
 
 ## `CheckSpec`
 
-A single declarative probe. Exactly one of the four probe fields must be set.
+Exactly one probe field should be set.
 
-### HTTP probe
+### HTTP Probe
 
 ```jsonc
 { "http": "http://127.0.0.1:9724/", "expect_status": 200 }
 ```
 
-Issues a `GET` with a 5s timeout. Passes if status matches `expect_status` (default `200`).
+Issues a `GET` with a 5s timeout. `expect_status` defaults to `200`.
 
-### File probe
+### File Probe
 
 ```jsonc
 { "file": "~/Studio/mysite/wp-content/db.php" }
 { "file": "~/Studio/mysite/wp-content/db.php", "contains": "Markdown Database Integration" }
 ```
 
-Passes if the file exists. If `contains` is set, also requires the file contents to include that substring.
+Checks that the file exists and optionally contains a substring.
 
-### Command probe
+### Command Probe
 
 ```jsonc
 { "command": "docker info", "expect_exit": 0 }
 ```
 
-Runs via `sh -c`. Passes if exit code matches `expect_exit` (default `0`).
+Runs via the shell. `expect_exit` defaults to `0`.
 
-### Staleness probe
+### Staleness Probe
 
 ```jsonc
 {
   "newer_than": {
-    "left": { "process_start": "wordpress-server-child.mjs" },
+    "left": { "process_start": { "pattern": "wordpress-server-child.mjs" } },
     "right": { "file_mtime": "${components.studio.path}/dist/cli/index.js" }
   }
 }
 ```
 
-Passes when `left` is newer than `right`. Each side chooses one time source: `file_mtime` or `process_start`. If the left side is a `process_start` source and no matching process exists, the check passes because there is no stale process to flag. Other missing sources are errors.
+Passes when `left` is newer than `right`. Each side chooses one time source: `file_mtime` or `process_start`. If the left side is `process_start` and no matching process exists, the check passes because there is no stale process to flag. Other missing sources are errors.
 
-## Variable expansion
+## Bench Fields
 
-Three substitutions apply to `cwd`, `command`, `link`, `target`, shared paths, and `CheckSpec` fields:
+Rig specs can pin benchmark dispatch for `homeboy bench --rig <id>`.
 
-- `${components.<id>.path}` — component path from the rig spec
-- `${env.<NAME>}` — process environment variable (empty if unset)
-- `~` — home directory (standard tilde expansion)
+| Field | Type | Description |
+|---|---|---|
+| `bench.default_component` | string | Component to benchmark when no component is passed. |
+| `bench.components` | array | Components to benchmark as a rig-pinned matrix. |
+| `bench.default_baseline_rig` | string | Implicit baseline rig for branch-vs-main comparisons. |
+| `bench.warmup_iterations` | integer | Warmup iterations forwarded to bench runners. |
+| `bench_workloads` | object | Out-of-tree workload paths keyed by extension ID. |
+| `bench_profiles` | object | Named scenario lists used by `homeboy bench --profile <name>`. |
 
-Unknown `${...}` patterns are left literal so failures are loud and localized.
+`bench_workloads` paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${package.root}` for package-installed rigs.
 
-## Pipeline semantics
+```jsonc
+{
+  "bench": {
+    "components": ["studio", "playground"],
+    "default_baseline_rig": "studio-main",
+    "warmup_iterations": 2
+  },
+  "bench_workloads": {
+    "wordpress": ["${package.root}/bench/workloads/studio-cold-start"]
+  },
+  "bench_profiles": {
+    "cold-start": ["admin-first-load", "site-editor-first-load"]
+  }
+}
+```
 
-- `up` — fail-fast; aborts on first failing step, marks downstream steps as `skip`.
-- `check` — runs every step regardless of failures so you see every problem at once.
-- `down` — fail-fast through `down` pipeline, then stops every declared service unconditionally (belt + suspenders).
+## `app_launcher`
 
-Pipelines are linear lists. DAG pipelines with cross-component dependencies + caching are still a future phase (tracked as Extra-Chill/homeboy #1464).
+`app_launcher` config powers `homeboy rig app install|update|uninstall`.
 
-## Example rigs
+| Field | Type | Description |
+|---|---|---|
+| `platform` | enum | Currently `macos`. |
+| `wrapper_display_name` | string | Display name for the generated `.app` bundle. |
+| `wrapper_bundle_id` | string | Bundle identifier written to `Info.plist`. |
+| `target_app` | string | App or executable opened after rig prep succeeds. |
+| `install_dir` | string | Optional install directory; defaults to `/Applications`. |
+| `preflight` | array | Preflight actions; defaults to `rig:check`. |
+| `on_preflight_fail` | string | Optional failure behavior for generated launcher scripts. |
 
-See [rig.md](./rig.md) for the studio-playground-dev example.
+```jsonc
+{
+  "app_launcher": {
+    "platform": "macos",
+    "wrapper_display_name": "Studio Dev",
+    "wrapper_bundle_id": "dev.homeboy.studio",
+    "target_app": "${components.studio.path}/dist/mac/Studio.app",
+    "preflight": ["rig:check"]
+  }
+}
+```
+
+## Variable Expansion
+
+Common path/string fields support:
+
+- `${components.<id>.path}` for component paths from the rig spec.
+- `${env.NAME}` for process environment variables; unset values expand to empty strings.
+- `~` for the current user's home directory.
+
+Rig-owned benchmark workload paths also support `${package.root}` when the rig was installed from a package source.
+
+Unknown `${...}` patterns are left literal so the eventual command or file check fails loudly.
+
+## Pipeline Semantics
+
+- `up` runs the `up` pipeline with fail-fast behavior.
+- `check` runs every step in the `check` pipeline and reports all failures.
+- `down` runs the `down` pipeline, then stops declared services and cleans rig-owned shared paths as a safety net.
+- Dependency edges from `depends_on` are resolved before execution; the executor still runs one ordered list, not parallel jobs.
+- Stack synchronization is explicit through `homeboy rig sync` or `kind: "stack"` steps. `rig up` does not sync stacks unless the spec author adds that step.
+
+## Future Work
+
+The shipped rig lifecycle is local/package/source/stack/app capable. The remaining design work is matrix/axis composition and build DAG caching for derived rig variants, tracked separately from the core rig command reference.
+
+## See Also
+
+- [rig.md](./rig.md) - command lifecycle and examples.
+- [stack.md](./stack.md) - stack specs consumed by `rig sync`.
+- [bench.md](./bench.md) - benchmark command behavior for rig-pinned runs.
+- [rig-matrix-axis-composition.md](../architecture/rig-matrix-axis-composition.md) - future matrix/axis design.

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -1,6 +1,6 @@
 # `homeboy rig`
 
-Manage local dev **rigs** — code-defined, reproducible multi-component development environments.
+Manage local dev **rigs**: reproducible multi-component environments that can start services, prepare checkouts, sync combined-fixes stacks, run health checks, and install desktop launchers.
 
 ## Synopsis
 
@@ -10,15 +10,42 @@ homeboy rig <COMMAND>
 
 ## Overview
 
-A rig is a named bundle of components, local services, shared dependency paths, pre-flight checks, and a linear build pipeline, described as JSON at `~/.config/homeboy/rigs/<id>.json`. `rig up` materializes the env; `rig check` reports health; `rig down` tears it down.
+A rig is a named environment spec. Local rig configs live at `~/.config/homeboy/rigs/<id>.json`; package-installed rigs are linked or copied into that same flat config path so every command uses one lookup model.
 
-Rigs are the missing piece between individual components (one repo, one version) and full deployments (many repos, remote servers) — they capture the setup a dev environment needs: which commits of which components, which background services are running, which pre-flight invariants must hold.
+Use rigs for local environments that otherwise become wiki runbooks: Studio plus Playground, WordPress core plus Gutenberg, a sandbox plus tunnel, or any setup where multiple repositories and services must be moved together.
 
-**Typical consumer:** a cross-repo setup that today lives as a wiki runbook (Studio + Playground with combined-fixes, WordPress core + Gutenberg dev, a sandbox + tunnel, etc).
+```text
+rig package / local spec
+        |
+        v
+~/.config/homeboy/rigs/<id>.json
+        |
+        +-- rig sync   -> declared component stacks
+        +-- rig up     -> services, git/build/patch/check steps, symlinks
+        +-- rig check  -> health/preflight report
+        +-- rig down   -> teardown
+        +-- rig app    -> optional desktop launcher
+```
 
-**Current scope:** linear pipelines, `http-static`, `command`, and `external` service kinds, shared dependency paths, idempotent local patch steps, typed git/build/check primitives, and `up` / `check` / `down` / `status` / `list` / `show` verbs. See Extra-Chill/homeboy #1461 for the broader phased roadmap (DAG pipelines, extension-registered service kinds, `.app` wrappers, bench composition, spec sharing).
+## Command Surface
 
-## Subcommands
+| Command | Purpose |
+|---|---|
+| `list` | List declared rigs. |
+| `show <id>` | Print one rig spec as JSON. |
+| `up <id>` | Run the rig's `up` pipeline and materialize the environment. |
+| `check <id>` | Run the rig's `check` pipeline and report all failures. |
+| `down <id>` | Run the rig's `down` pipeline and stop managed services. |
+| `sync <id>` | Sync every stack declared by the rig's components. |
+| `status <id>` | Show running services and last `up` / `check` state. |
+| `install <source>` | Install rigs from a local package path or git URL. |
+| `update [id]` | Pull and refresh git-backed installed rig packages. |
+| `sources ...` | Inspect or remove installed rig source packages. |
+| `app ...` | Install, update, or remove a rig's desktop launcher. |
+
+All subcommands support `--output <path>` for structured JSON output in addition to stdout.
+
+## Local Lifecycle
 
 ### `list`
 
@@ -26,97 +53,167 @@ Rigs are the missing piece between individual components (one repo, one version)
 homeboy rig list
 ```
 
-List all rigs declared in `~/.config/homeboy/rigs/`.
+Lists every rig config currently visible under the Homeboy config directory.
 
 ### `show`
 
 ```sh
-homeboy rig show <id>
+homeboy rig show studio
 ```
 
-Print the full rig spec as JSON.
+Prints the resolved rig spec. This is the fastest way to inspect a package-installed rig without opening the linked source file manually.
 
 ### `up`
 
 ```sh
-homeboy rig up <id>
+homeboy rig up studio
 ```
 
-Run the rig's `up` pipeline: start services, run commands, ensure symlinks, evaluate checks. Idempotent — already-running services are left alone. Exits non-zero if any pipeline step fails.
+Runs the `up` pipeline. Mutating rig commands acquire a resource lease first when the rig declares `resources`, so two active rig commands cannot mutate the same declared paths, ports, process patterns, or exclusive tokens at once.
+
+The pipeline can start services, run typed `git` / `build` / `extension` / `stack` steps, apply idempotent local patches, create symlinks/shared paths, and run checks.
 
 ### `check`
 
 ```sh
-homeboy rig check <id>
+homeboy rig check studio
 ```
 
-Run the rig's `check` pipeline (health probes, file-existence checks, HTTP probes). Does NOT fail-fast: every failing check is reported so you can fix the env in one pass.
+Runs the `check` pipeline and reports every failing step instead of stopping at the first failure. Use this as the preflight for a local environment.
 
 ### `down`
 
 ```sh
-homeboy rig down <id>
+homeboy rig down studio
 ```
 
-Stop every service the rig manages and run the `down` pipeline if defined.
+Runs the `down` pipeline, cleans rig-owned shared paths, and stops declared services. `external` services are adopted rather than spawned, so `down` can recycle stale daemons that were started by another tool.
 
 ### `status`
 
 ```sh
-homeboy rig status <id>
+homeboy rig status studio
 ```
 
-Report current state: running services with PIDs, timestamps for last `up` / `check`.
+Reports service PIDs, stale service state, and last recorded `up` / `check` timestamps from the rig state directory.
 
-## Rig spec format
+## Package Lifecycle
 
-See [rig-spec.md](./rig-spec.md) for the full schema. Minimal example:
+### `install`
+
+```sh
+homeboy rig install https://github.com/chubes4/homeboy-rigs.git//packages/studio --id studio
+homeboy rig install ./packages/studio
+homeboy rig install https://github.com/chubes4/homeboy-rigs.git//packages --all
+```
+
+Installs rigs from a local directory or git-backed package. Package discovery accepts either a single `rig.json` or a package layout with `rigs/<id>/rig.json`. If the selected package also contains `stacks/*.json`, those stack specs are installed alongside the rig.
+
+Git sources may include a Terraform-style `repo.git//subpath` selector. Homeboy clones the package root, records source metadata, and discovers rigs from the selected subpath. Local package sources are linked in place and are updated outside Homeboy.
+
+### `update`
+
+```sh
+homeboy rig update studio
+homeboy rig update --all
+```
+
+Updates git-backed package sources with `git pull`, then refreshes the installed rig and stack config links. Local linked sources are skipped by `--all` and error for single-rig updates because the source is already the editable checkout.
+
+If the user replaced an installed config file with their own file, update preserves that user-owned config and reports it as skipped instead of overwriting it.
+
+### `sources`
+
+```sh
+homeboy rig sources list
+homeboy rig sources remove chubes4-homeboy-rigs
+```
+
+`sources list` groups installed rigs and stacks by package source, package path, revision, and ownership. `sources remove` removes Homeboy-owned config links and metadata for one source package; it also removes cloned git packages, while linked local package directories are left in place.
+
+## Stack Sync
+
+```sh
+homeboy rig sync studio
+homeboy rig sync studio --dry-run
+```
+
+`rig sync` finds every component with a `stack` field and delegates to `homeboy stack sync <stack-id>`. This is the rig-level entry point for keeping combined-fixes branches current before a local environment is brought up.
 
 ```jsonc
 {
-  "id": "studio-playground-dev",
-  "description": "Dev Studio + Playground with combined-fixes",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio",
+      "stack": "studio-combined"
+    },
+    "playground": {
+      "path": "~/Developer/wordpress-playground",
+      "stack": "playground-combined"
+    }
+  }
+}
+```
 
-  "services": {
-    "tarball-server": {
-      "kind": "http-static",
-      "cwd": "~/Developer/wordpress-playground/dist/packages-for-self-hosting",
-      "port": 9724,
-      "health": { "http": "http://127.0.0.1:9724/", "expect_status": 200 }
+`rig up` does not sync stacks implicitly. If stack sync should be part of an `up` pipeline, add an explicit `stack` pipeline step.
+
+## App Launchers
+
+```sh
+homeboy rig app install studio
+homeboy rig app update studio --dry-run
+homeboy rig app uninstall studio
+```
+
+`rig app` manages an optional desktop launcher declared in `app_launcher`. The current implementation generates a macOS `.app` wrapper that runs rig preflight, runs `rig up`, and opens the target app when the rig is ready. Use `--dry-run` to preview generated paths without writing or deleting files.
+
+## Minimal Example
+
+```jsonc
+{
+  "id": "studio",
+  "description": "Studio + Playground dev environment",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio",
+      "stack": "studio-combined"
     }
   },
-
-  "symlinks": [
-    { "link": "~/.local/bin/studio", "target": "~/.local/bin/studio-dev" }
-  ],
-
-  "shared_paths": [
-    {
-      "link": "${components.studio.path}/node_modules",
-      "target": "~/Developer/studio/node_modules"
+  "resources": {
+    "ports": [9724],
+    "process_patterns": ["wordpress-server-child.mjs"]
+  },
+  "services": {
+    "tarballs": {
+      "kind": "http-static",
+      "cwd": "${components.studio.path}/dist/packages-for-self-hosting",
+      "port": 9724,
+      "health": { "http": "http://127.0.0.1:9724/", "expect_status": 200 }
+    },
+    "studio-daemon": {
+      "kind": "external",
+      "discover": { "pattern": "wordpress-server-child.mjs" }
     }
-  ],
-
+  },
   "pipeline": {
-    "up":    [
-      { "kind": "service", "id": "tarball-server", "op": "start" },
-      { "kind": "symlink", "op": "ensure" },
-      { "kind": "shared-path", "op": "ensure" }
+    "up": [
+      { "kind": "service", "id": "tarballs", "op": "start" },
+      { "kind": "service", "id": "tarballs", "op": "health" }
     ],
     "check": [
-      { "kind": "service", "id": "tarball-server", "op": "health" },
-      { "kind": "symlink", "op": "verify" },
-      { "kind": "shared-path", "op": "verify" },
+      { "kind": "service", "id": "tarballs", "op": "health" },
       {
         "kind": "check",
-        "label": "MDI drop-in intact",
-        "file": "~/Studio/mysite/wp-content/db.php",
-        "contains": "Markdown Database Integration"
+        "label": "daemon newer than CLI bundle",
+        "newer_than": {
+          "left": { "process_start": { "pattern": "wordpress-server-child.mjs" } },
+          "right": { "file_mtime": "${components.studio.path}/dist/cli/index.js" }
+        }
       }
     ],
-    "down":  [
-      { "kind": "shared-path", "op": "cleanup" },
-      { "kind": "service", "id": "tarball-server", "op": "stop" }
+    "down": [
+      { "kind": "service", "id": "studio-daemon", "op": "stop" },
+      { "kind": "service", "id": "tarballs", "op": "stop" }
     ]
   }
 }
@@ -126,24 +223,17 @@ See [rig-spec.md](./rig-spec.md) for the full schema. Minimal example:
 
 Rig runtime state lives at `~/.config/homeboy/rigs/<id>.state/`:
 
-- `state.json` — service PIDs, shared-path ownership markers, last `up`/`check` timestamps
-- `logs/<service-id>.log` — captured stdout/stderr per service
+- `state.json` records service PIDs, shared-path ownership markers, and last `up` / `check` timestamps.
+- `logs/<service-id>.log` captures stdout/stderr for rig-managed services.
 
-State is ephemeral — deleting it means `rig up` will re-probe on next invocation. Never treat it as source of truth.
+Package source metadata lives next to Homeboy's rig and stack config directories so `rig update` and `rig sources` can tell which files are Homeboy-owned.
 
-## Exit codes
+State is ephemeral. Deleting it makes the next command re-probe the environment; it is not the source of truth for the rig spec.
 
-| Code | Meaning |
-|---|---|
-| 0 | Pipeline succeeded |
-| 1 | Pipeline had at least one failing step |
-| 4 | Rig not found (`rig.not_found`) |
-| 20 | Service or pipeline operational failure |
+## See Also
 
-## See also
-
-- [rig-spec.md](./rig-spec.md) — full spec schema reference
-- [rig-matrix-axis-composition.md](../architecture/rig-matrix-axis-composition.md) - design for derived rig variants
-- [stack.md](./stack.md) — combined-fixes branch specs that rigs can reference
-- [fleet.md](./fleet.md) — remote multi-project equivalent (rigs are local, fleets are remote)
-- Extra-Chill/homeboy #1461 — design + phased roadmap
+- [rig-spec.md](./rig-spec.md) - full spec schema reference.
+- [stack.md](./stack.md) - combined-fixes branch specs used by `rig sync`.
+- [bench.md](./bench.md) - rig-pinned benchmark runs.
+- [rig-matrix-axis-composition.md](../architecture/rig-matrix-axis-composition.md) - future design for derived rig variants.
+- [fleet.md](./fleet.md) - remote multi-project equivalent; rigs are local, fleets are remote.


### PR DESCRIPTION
## Summary
- Refresh `homeboy rig` docs around the shipped local, package, source, stack sync, and app launcher lifecycle.
- Expand `rig-spec` coverage for resources/leases, package installs, `repo.git//subpath`, `external`, `newer_than`, `patch`, stack steps, app launchers, and rig-pinned bench fields.
- Remove stale MVP/Phase 1 framing for shipped rig functionality.

## Tests
- `homeboy rig --help`
- `homeboy rig install --help`
- `homeboy rig update --help`
- `homeboy rig sources --help`
- `homeboy rig app --help`
- `homeboy rig sync --help`
- `homeboy rig up --help`
- `homeboy rig check --help`
- `homeboy rig down --help`
- `homeboy rig status --help`
- `homeboy rig sources list --help`
- `homeboy rig sources remove --help`
- `homeboy rig app install --help`
- `homeboy rig app update --help`
- `homeboy rig app uninstall --help`
- `git grep -n -E "MVP|Phase 1|future phase|reserved|deferred" -- docs/commands/rig.md docs/commands/rig-spec.md`
- `homeboy docs commands/rig` and `homeboy docs commands/rig-spec` from the worktree showed the installed Homeboy docs, not the worktree edits.
- `cargo run --bin homeboy -- docs commands/rig`
- `cargo run --bin homeboy -- docs commands/rig-spec`

Closes #1894

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and editing the documentation refresh, grounding it against current CLI help and source types, and running the verification commands. Chris remains responsible for review and merge.
