### PR TITLE
fix(bench): preserve workload runner failures

### DIFF
--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -99,6 +99,64 @@ JSON
     }
 }
 
+fn write_failing_bench_extension(home: &TempDir) {
+    let extension_dir = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("extensions")
+        .join("nodejs");
+    fs::create_dir_all(&extension_dir).expect("mkdir extension");
+    fs::write(
+        extension_dir.join("nodejs.json"),
+        r#"{
+                "name": "Node.js",
+                "version": "0.0.0",
+                "bench": { "extension_script": "bench-runner.sh" }
+            }"#,
+    )
+    .expect("write extension manifest");
+
+    let script_path = extension_dir.join("bench-runner.sh");
+    fs::write(
+        &script_path,
+        r#"#!/bin/sh
+if [ "$HOMEBOY_BENCH_LIST_ONLY" = "1" ]; then
+  cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+{
+  "component_id": "$HOMEBOY_COMPONENT_ID",
+  "iterations": 0,
+  "scenarios": [
+    { "id": "studio-agent-site-build", "iterations": 0, "metrics": {} }
+  ]
+}
+JSON
+  exit 0
+fi
+
+cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+{
+  "component_id": "$HOMEBOY_COMPONENT_ID",
+  "iterations": ${HOMEBOY_BENCH_ITERATIONS:-0},
+  "scenarios": []
+}
+JSON
+printf 'WORKLOAD_ERROR: studio-agent-site-build - warmup iteration threw: Studio site-build eval failed\n' >&2
+exit 7
+"#,
+    )
+    .expect("write bench script");
+
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&script_path)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod script");
+    }
+}
+
 fn write_registered_component(home: &TempDir, component_id: &str, path: &std::path::Path) {
     let component_dir = home
         .path()
@@ -383,6 +441,42 @@ fn run_selects_single_scenario() {
                 let scenarios = result.results.expect("results").scenarios;
                 assert_eq!(scenarios.len(), 1);
                 assert_eq!(scenarios[0].id, "slow");
+            }
+            _ => panic!("expected single output"),
+        }
+    });
+}
+
+#[test]
+fn selected_scenario_workload_failure_preserves_runner_error() {
+    with_isolated_home(|home| {
+        write_failing_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_registered_component(home, "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            run_args(
+                Some("studio"),
+                Vec::new(),
+                vec!["studio-agent-site-build".to_string()],
+            ),
+            &GlobalArgs {},
+        )
+        .expect("runner failure should return structured bench output");
+
+        assert_eq!(exit_code, 7);
+        match output {
+            BenchOutput::Single(result) => {
+                assert_eq!(result.status, "failed");
+                assert_eq!(result.exit_code, 7);
+                assert_eq!(result.results.expect("partial results").scenarios.len(), 0);
+                let failure = result.failure.expect("runner failure metadata");
+                assert_eq!(
+                    failure.scenario_id.as_deref(),
+                    Some("studio-agent-site-build")
+                );
+                assert!(failure.stderr_tail.contains("WORKLOAD_ERROR"));
+                assert!(failure.stderr_tail.contains("warmup iteration threw"));
             }
             _ => panic!("expected single output"),
         }

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -275,6 +275,33 @@ fn filter_extra_workloads_by_scenario_ids(
         .collect()
 }
 
+fn parse_execution_results_file(
+    results_file: &Path,
+    scenario_ids: &[String],
+    runner_success: bool,
+) -> Result<Option<BenchResults>> {
+    if !results_file.exists() {
+        return Ok(None);
+    }
+
+    if runner_success {
+        return Ok(Some(apply_scenario_filter(
+            parsing::parse_bench_results_file(results_file)?,
+            scenario_ids,
+        )?));
+    }
+
+    Ok(parsing::parse_bench_results_file(results_file).ok())
+}
+
+fn failure_scenario_id(scenario_ids: &[String]) -> Option<String> {
+    if scenario_ids.len() == 1 {
+        Some(scenario_ids[0].clone())
+    } else {
+        None
+    }
+}
+
 fn discover_bench_scenarios(
     execution_context: &ExtensionExecutionContext,
     component: &Component,
@@ -418,14 +445,11 @@ pub fn run_main_bench_workflow(
                 None,
             )?
             .run()?;
-            let parsed = if results_file.exists() {
-                parsing::parse_bench_results_file(&results_file)
-                    .ok()
-                    .map(|results| apply_scenario_filter(results, &execution_args.scenario_ids))
-                    .transpose()?
-            } else {
-                None
-            };
+            let parsed = parse_execution_results_file(
+                &results_file,
+                &execution_args.scenario_ids,
+                runner_output.success,
+            )?;
             let failure_stderr_tail = if !runner_output.success {
                 Some(stderr_tail(&runner_output.stderr))
             } else {
@@ -530,14 +554,14 @@ pub fn run_main_bench_workflow(
     } else {
         baseline_exit_override.unwrap_or(0)
     };
-    let failure = if parsed.is_none() && !runner_success {
+    let failure = if !runner_success {
         failure_stderr_tail.map(|stderr_tail| BenchRunFailure {
             component_id: args.component_id.clone(),
             component_path: args
                 .path_override
                 .clone()
                 .or_else(|| Some(component.local_path.clone())),
-            scenario_id: None,
+            scenario_id: failure_scenario_id(&execution_args.scenario_ids),
             exit_code: runner_exit_code,
             stderr_tail,
         })
@@ -793,14 +817,8 @@ fn run_single_dispatcher(
     }
 
     let runner_output = build_runner(execution_context, component, args, run_dir, None)?.run()?;
-    let parsed = if results_file.exists() {
-        Some(apply_scenario_filter(
-            parsing::parse_bench_results_file(&results_file)?,
-            &args.scenario_ids,
-        )?)
-    } else {
-        None
-    };
+    let parsed =
+        parse_execution_results_file(&results_file, &args.scenario_ids, runner_output.success)?;
     let failure_stderr_tail = if !runner_output.success {
         Some(stderr_tail(&runner_output.stderr))
     } else {


### PR DESCRIPTION
## Summary
- Preserve runner/workload failures when a selected bench scenario was already validated during discovery.
- Keep scenario validation for successful runs, but avoid turning failed execution output into a fake unknown-scenario error.
- Include the selected scenario id in structured bench failure metadata when exactly one scenario was requested.

## Behavior
A selected scenario that fails during warmup/execution now returns the runner exit code and stderr tail instead of `validation.invalid_argument` / unknown scenario with `discovered ids: <none>`.

## Tests
- `cargo fmt --check`
- `cargo test commands::bench::tests::selected_scenario_workload_failure_preserves_runner_error`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-bench-workload-error-reporting`

Closes #1921

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the targeted fix and regression test; Chris remains responsible for review and merge.