### PR TITLE
refactor(version): remove release alias

### DIFF
--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -109,7 +109,7 @@ The `next_steps` array contains context-aware actionable guidance based on the c
 {
   "next_steps": [
     "8 components have uncommitted changes. Review with `homeboy changes <id>`.",
-    "11 components have unreleased commits. Bump with `homeboy version bump <id>`."
+    "11 components have unreleased commits. Release with `homeboy release <id>`."
   ]
 }
 ```

--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -41,7 +41,7 @@ Configure the changelog path:
 homeboy component set <id> --changelog-target "CHANGELOG.md"
 ```
 
-This is required for `version bump` and `release`.
+This is required for `release`.
 
 Release can bootstrap a missing configured changelog target on the first release. Changelog setup is owned by component configuration; there is no manual changelog initialization command.
 

--- a/docs/commands/changes.md
+++ b/docs/commands/changes.md
@@ -48,7 +48,7 @@ Release workflow note:
 
 - `commits[]` is intended as input to help you author complete release notes.
 - `uncommitted`/`uncommitted_diff` is a reminder that you have local edits; if they are intended for the release, commit them as scoped changes before version bumping. If they are not intended for the release, resolve them before version bumping.
-- Commit your changes with conventional prefixes (`feat:`, `fix:`, etc.) before running `homeboy version bump` or `homeboy release`. Changelog entries are generated automatically from commits at release time.
+- Commit your changes with conventional prefixes (`feat:`, `fix:`, etc.) before running `homeboy release`. Changelog entries are generated automatically from commits at release time.
 
 ## Options
 

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -3,189 +3,45 @@
 ## Synopsis
 
 ```sh
-homeboy version <COMMAND>
+homeboy version show [<component_id>] [--path <path>]
 ```
-
-## Subcommands
-
-### `show`
-
-```sh
-homeboy version show [<component_id>]
-```
-
-Shows the current version for the specified component, or the Homeboy binary version if omitted.
-
-### `bump`
-
-```sh
-homeboy version bump <component_id> <patch|minor|major>
-```
-
-Alias for [`homeboy release`](release.md). Bumps version, finalizes changelog, commits, tags, and optionally pushes.
-
-Flags (same as `release`):
-
-- `--dry-run`: Preview without making changes
-- `--no-tag`: Skip git tag creation
-- `--no-push`: Skip pushing to remote
-- `--no-commit`: Fail if uncommitted changes exist (strict mode)
-- `--commit-message <MESSAGE>`: Custom pre-release commit message
-
-### `set`
-
-```sh
-homeboy version set [<component_id>] <new_version>
-```
-
-`set` writes the version targets directly without incrementing and does not finalize the changelog.
 
 ## Description
 
-`homeboy version bump`:
+`homeboy version show` is read-only version inspection. It reports the current version for a component discovered from the current directory, an explicit component ID, or an explicit `--path`. If no component can be discovered, it reports the Homeboy binary version.
 
-Alias for `homeboy release`. Delegates to the release command for full release pipeline execution. See [release](release.md) for details.
+Changing versions and cutting releases belongs to [`homeboy release`](release.md):
 
-`homeboy version set`:
+```sh
+homeboy release <component_id> --bump patch|minor|major|x.y.z
+```
 
-- Writes the new version directly to targets without touching the changelog.
+## Arguments
 
-Changelog entries are generated automatically from conventional-prefixed commits (`feat:` / `fix:` / etc.) at release time — no hand-curation needed.
+- `[<component_id>]`: component ID to inspect.
 
-Recommended release workflow:
+## Options
 
-- Land work as scoped conventional-prefixed commits (`feat:`, `fix:`, etc.) first.
-- Use `homeboy changes <component_id>` to review everything since the last tag.
-- Run `homeboy version bump <component_id> <patch|minor|major>` when the only remaining local changes are release metadata.
-- Homeboy generates the changelog section from the commit trail and finalizes it as `## [X.Y.Z] - YYYY-MM-DD` in one shot.
+- `--path <path>`: override the source root for component version lookup.
 
-Arguments:
+## JSON Output
 
-- `[<component_id>]`: component ID (optional, shows Homeboy binary version when omitted)
-- `<patch|minor|major>`: version bump type
+> Note: all command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). `homeboy version show` returns a `VersionOutput` object as the `data` payload.
 
-## JSON output
-
-> Note: all command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). `homeboy version` returns a `VersionOutput` object as the `data` payload.
-
-`homeboy version show` data payload:
+Payload fields:
 
 - `command`: `version.show`
-- `component_id`
-- `version` (detected current version)
+- `component_id`: discovered or explicit component ID, omitted for the Homeboy binary version
+- `version`: detected current version
 - `targets`: array of `{ file, pattern, full_path, match_count }`
 
-`homeboy version bump` data payload:
+## Exit Code
 
-- `command`: `version.bump`
-- `component_id`
-- `bump_type`: patch, minor, or major
-- `dry_run`: boolean
-- `no_tag`: boolean
-- `no_push`: boolean
-- `no_commit`: boolean
-- `commit_message` (omitted if not specified)
-- `plan` (present when `--dry-run`): release plan object
-- `run` (present when not `--dry-run`): release run result object
-
-See [release](release.md) for full plan and run object schemas.
-
-`homeboy version set` data payload:
-
-- `command`: `version.set`
-- `component_id`
-- `old_version`
-- `new_version`
-- `targets`: array of `{ file, pattern, full_path, match_count }`
-
-Errors:
-
-- `bump` errors follow the same validation as `release`. See [release](release.md) for error conditions.
-
-## Exit code
-
-- `show`: `0` on success; errors if the version cannot be parsed.
-- `bump`: `0` on success.
-- `set`: `0` on success.
-
-## Notes
-
-- Components must have `version_targets` configured (non-empty). Homeboy uses the first target as the primary version source.
-- Each `version_targets[]` entry has `file` and optional `pattern`. When `pattern` is omitted, Homeboy checks extension-provided version patterns for that file type; if none are provided, the command errors.
-
-### Changelog Requirements
-
-`version bump` requires:
-1. A changelog file to exist
-2. The `changelog_target` to be configured on the component
-
-**Setup:**
-```sh
-homeboy component set <id> --changelog-target "CHANGELOG.md"
-```
-
-To bypass changelog finalization entirely, use `version set` instead of `version bump`.
-
-### Auto-Generation from Commits
-
-`version bump` generates changelog entries from commits since the last tag. There is no manual entry path — all entries come from commits.
-
-Requirements:
-
-1. All changes are **committed** (uncommitted changes don't contribute entries).
-2. At least one commit has an entry-producing prefix (see table below).
-
-| Commit prefix | Changelog section |
-|---------------|------------------|
-| `feat:`       | Added            |
-| `fix:`        | Fixed            |
-| `BREAKING` / `!:` | Changed      |
-| Other (non-conventional) | Changed |
-| `docs:`, `chore:` | **Skipped**  |
-
-**Important:** If all commits are `docs:` or `chore:`, no entries get generated and the release errors out. Commit at least one user-facing change with a `feat:`/`fix:`/conventional prefix before releasing.
-
-## Related Workflows
-
-After bumping, push and optionally tag:
-
-```sh
-homeboy git push <component_id>
-homeboy git tag <component_id>
-```
-
-## Rollback Procedure
-
-If you accidentally bump a version:
-
-### 1. Revert local changes
-```sh
-git checkout -- CHANGELOG.md Cargo.toml package.json  # your version files
-```
-
-### 2. Delete local tag (if created)
-```sh
-git tag -d v0.X.Y
-```
-
-### 3. Delete remote tag (if pushed)
-```sh
-git push origin --delete v0.X.Y
-```
-
-### 4. Force push (if committed and pushed)
-```sh
-git reset --hard HEAD~1
-git push --force-with-lease
-```
-
-**Prevention:** Always use `--dry-run` first:
-```sh
-homeboy version bump <component_id> patch --dry-run
-```
+- `0` on success.
+- Non-zero if the component version cannot be parsed.
 
 ## Related
 
-- [build](build.md)
+- [release](release.md)
+- [changes](changes.md)
 - [component](component.md)
-- [git](git.md)

--- a/docs/cross-compilation.md
+++ b/docs/cross-compilation.md
@@ -32,7 +32,7 @@ Native binaries require platform-specific system libraries. For example, Rust cr
 Use homeboy for orchestration, GitHub Actions for cross-platform builds:
 
 ```
-homeboy version bump → triggers GitHub Actions → builds all platforms → uploads release
+homeboy release → triggers GitHub Actions → builds all platforms → uploads release
 homeboy extension run homebrew → publishes formula to tap
 ```
 

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -49,10 +49,6 @@ pub struct ReleaseArgs {
     #[arg(long)]
     bump: Option<String>,
 
-    /// Deprecated: use --bump major instead. Kept for backwards compatibility.
-    #[arg(long, hide = true)]
-    major: bool,
-
     /// Skip publish/package steps (version bump + tag + push only).
     /// Use when CI handles publishing after the tag is pushed.
     #[arg(long)]
@@ -90,7 +86,7 @@ pub enum ReleaseCommandOutput {
 }
 
 impl ReleaseArgs {
-    /// Construct ReleaseArgs programmatically (used by `version bump` delegation).
+    /// Construct ReleaseArgs programmatically for tests and internal callers.
     pub fn from_parts(
         components: Vec<String>,
         project: Option<String>,
@@ -100,7 +96,6 @@ impl ReleaseArgs {
         deploy: bool,
         recover: bool,
         skip_checks: bool,
-        major: bool,
         skip_publish: bool,
         bump: Option<String>,
     ) -> Self {
@@ -115,7 +110,6 @@ impl ReleaseArgs {
             recover,
             skip_checks,
             bump,
-            major,
             skip_publish,
             no_github_release: false,
             git_identity: None,
@@ -130,8 +124,6 @@ pub fn run(
     let positional = resolve_positional_args(&args)?;
     let component_ids = resolve_component_ids(&args, &positional.components)?;
 
-    // Resolve --bump and --major into a single bump_override.
-    // --major is a deprecated alias for --bump major.
     let bump_override = resolve_bump_override(&args, positional.bump);
 
     // Single component: use the original single-release flow
@@ -312,10 +304,10 @@ fn resolve_positional_args(args: &ReleaseArgs) -> homeboy::Result<PositionalRele
         });
     };
 
-    if args.bump.is_some() || args.major {
+    if args.bump.is_some() {
         return Err(homeboy::Error::validation_invalid_argument(
             "bump",
-            "Use either a positional bump type or --bump/--major, not both",
+            "Use either a positional bump type or --bump, not both",
             Some(bump),
             Some(vec![
                 "Example: homeboy release my-component patch".to_string()
@@ -334,14 +326,9 @@ fn is_bump_keyword(value: &str) -> bool {
     matches!(value, "major" | "minor" | "patch")
 }
 
-/// Resolve --bump and --major into a single bump override string.
-/// --major is a deprecated alias for --bump major.
 fn resolve_bump_override(args: &ReleaseArgs, positional_bump: Option<String>) -> Option<String> {
     if let Some(ref bump) = args.bump {
         Some(bump.clone())
-    } else if args.major {
-        eprintln!("Warning: --major is deprecated. Use --bump major instead.");
-        Some("major".to_string())
     } else {
         positional_bump
     }
@@ -358,7 +345,6 @@ mod tests {
             false,
             None,
             true,
-            false,
             false,
             false,
             false,

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -85,9 +85,10 @@ pub enum ReleaseCommandOutput {
     Batch(BatchReleaseOutput),
 }
 
+#[cfg(test)]
 impl ReleaseArgs {
     /// Construct ReleaseArgs programmatically for tests and internal callers.
-    pub fn from_parts(
+    fn from_parts(
         components: Vec<String>,
         project: Option<String>,
         outdated: bool,

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -2,18 +2,14 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use homeboy::component;
-use homeboy::release::{BatchReleaseResult, ReleaseCommandResult};
 use homeboy::version::{read_component_version, read_version, VersionTargetInfo};
 
-use super::utils::args::{DryRunArgs, HiddenJsonArgs};
 use super::CmdResult;
 
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum VersionOutput {
     Show(VersionShowOutput),
-    Bump(VersionBumpOutput),
-    BatchBump(VersionBatchBumpOutput),
 }
 
 #[derive(Args)]
@@ -24,65 +20,23 @@ pub struct VersionArgs {
 
 #[derive(Subcommand)]
 enum VersionCommand {
-    /// Show current version (default: homeboy binary)
+    /// Show current version (default: discovered component, fallback: homeboy binary)
     Show {
-        /// Component ID (optional - shows homeboy binary version when omitted)
+        /// Component ID (optional - shows discovered component version, or homeboy binary version)
         component_id: Option<String>,
 
         /// Override local_path for version file lookup
         #[arg(long)]
         path: Option<String>,
     },
+}
 
-    /// Bump version and release (alias for `homeboy release`)
-    Bump {
-        /// Component ID(s) to release
-        components: Vec<String>,
+struct VersionShowArgs {
+    /// Component ID (optional - shows discovered component version, or homeboy binary version)
+    component_id: Option<String>,
 
-        /// Release all components in a project that need a version bump
-        #[arg(long, short = 'p')]
-        project: Option<String>,
-
-        /// Only release components with unreleased code commits (use with --project)
-        #[arg(long)]
-        outdated: bool,
-
-        /// Override local_path for version file lookup (single component only)
-        #[arg(long)]
-        path: Option<String>,
-
-        #[command(flatten)]
-        dry_run_args: DryRunArgs,
-
-        #[command(flatten)]
-        _json: HiddenJsonArgs,
-
-        /// Deploy to all projects using this component after release
-        #[arg(long)]
-        deploy: bool,
-
-        /// Recover from an interrupted release (tag + push current version)
-        #[arg(long)]
-        recover: bool,
-
-        /// Skip pre-release lint and test checks
-        #[arg(long)]
-        skip_checks: bool,
-
-        /// Force a specific version bump: major, minor, patch, or an explicit version (e.g. 2.0.0).
-        /// Overrides auto-detection from commit history.
-        #[arg(long)]
-        bump: Option<String>,
-
-        /// Deprecated: use --bump major instead.
-        #[arg(long, hide = true)]
-        major: bool,
-
-        /// Skip publish/package steps (version bump + tag + push only).
-        /// Use when CI handles publishing after the tag is pushed.
-        #[arg(long)]
-        skip_publish: bool,
-    },
+    /// Override local_path for version file lookup
+    path: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -94,103 +48,51 @@ pub struct VersionShowOutput {
     targets: Vec<VersionTargetInfo>,
 }
 
-#[derive(Serialize)]
-#[serde(tag = "command", rename = "release")]
-pub struct VersionBumpOutput {
-    pub result: ReleaseCommandResult,
-}
-
-#[derive(Serialize)]
-#[serde(tag = "command", rename = "release.batch")]
-pub struct VersionBatchBumpOutput {
-    pub result: BatchReleaseResult,
-}
-
 pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<VersionOutput> {
-    match args.command {
-        VersionCommand::Show { component_id, path } => {
-            let info = if let Some(ref p) = path {
-                let comp = component::resolve_effective(component_id.as_deref(), Some(p), None)?;
-                read_component_version(&comp)?
-            } else if component_id.is_some() {
-                // Explicit component ID or CWD discovery
-                let comp = component::resolve_effective(component_id.as_deref(), None, None)?;
-                read_component_version(&comp)?
-            } else {
-                // No component ID and no --path: try CWD discovery first,
-                // fall back to showing homeboy binary version
-                match component::resolve_effective(None, None, None) {
-                    Ok(comp) => read_component_version(&comp)?,
-                    Err(_) => read_version(None)?,
-                }
-            };
+    let VersionCommand::Show { component_id, path } = args.command;
+    show(VersionShowArgs { component_id, path })
+}
 
-            let display_id = component_id.or_else(|| {
-                // Include discovered component ID in output
-                if info.targets.is_empty() {
-                    None
-                } else {
-                    component::resolve_effective(None, None, None)
-                        .ok()
-                        .map(|c| c.id)
-                }
-            });
+fn show(args: VersionShowArgs) -> CmdResult<VersionOutput> {
+    let component_id = args.component_id;
+    let path = args.path;
 
-            Ok((
-                VersionOutput::Show(VersionShowOutput {
-                    command: "version.show".to_string(),
-                    component_id: display_id,
-                    version: info.version,
-                    targets: info.targets,
-                }),
-                0,
-            ))
+    let info = if let Some(ref p) = path {
+        let comp = component::resolve_effective(component_id.as_deref(), Some(p), None)?;
+        read_component_version(&comp)?
+    } else if component_id.is_some() {
+        // Explicit component ID or CWD discovery
+        let comp = component::resolve_effective(component_id.as_deref(), None, None)?;
+        read_component_version(&comp)?
+    } else {
+        // No component ID and no --path: try CWD discovery first,
+        // fall back to showing homeboy binary version
+        match component::resolve_effective(None, None, None) {
+            Ok(comp) => read_component_version(&comp)?,
+            Err(_) => read_version(None)?,
         }
-        VersionCommand::Bump {
-            components,
-            project,
-            outdated,
-            path,
-            dry_run_args,
-            _json: _,
-            deploy,
-            recover,
-            skip_checks,
-            bump,
-            major,
-            skip_publish,
-        } => {
-            // Delegate to the release command's batch infrastructure
-            let release_args = super::release::ReleaseArgs::from_parts(
-                components,
-                project,
-                outdated,
-                path,
-                dry_run_args.dry_run,
-                deploy,
-                recover,
-                skip_checks,
-                major,
-                skip_publish,
-                bump,
-            );
+    };
 
-            match super::release::run(release_args, _global)? {
-                (super::release::ReleaseCommandOutput::Single(output), exit_code) => Ok((
-                    VersionOutput::Bump(VersionBumpOutput {
-                        result: output.result,
-                    }),
-                    exit_code,
-                )),
-                (super::release::ReleaseCommandOutput::Batch(output), exit_code) => Ok((
-                    VersionOutput::BatchBump(VersionBatchBumpOutput {
-                        result: output.result,
-                    }),
-                    exit_code,
-                )),
-            }
+    let display_id = component_id.or_else(|| {
+        // Include discovered component ID in output
+        if info.targets.is_empty() {
+            None
+        } else {
+            component::resolve_effective(None, None, None)
+                .ok()
+                .map(|c| c.id)
         }
-    }
+    });
+
+    Ok((
+        VersionOutput::Show(VersionShowOutput {
+            command: "version.show".to_string(),
+            component_id: display_id,
+            version: info.version,
+            targets: info.targets,
+        }),
+        0,
+    ))
 }
 
 pub fn show_version_output(component_id: &str) -> CmdResult<VersionShowOutput> {

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -206,8 +206,8 @@ fn pre_validate_version_targets(
 /// entries are generated and finalized into a versioned section in a single disk write —
 /// no intermediate `## Unreleased` section is ever persisted.
 ///
-/// When `generated_entries` is None (standalone `homeboy version bump`), falls back to
-/// finalizing an existing `## Unreleased` section.
+/// When `generated_entries` is None, falls back to finalizing an existing
+/// `## Unreleased` section for internal recovery paths.
 pub(crate) fn validate_and_finalize_changelog(
     component: &Component,
     current_version: &str,

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -30,6 +30,8 @@ fn includes_first_level_subcommands() {
     assert!(surface.contains_path(&["file", "upload"]));
     assert!(surface.contains_path(&["file", "copy"]));
     assert!(surface.contains_path(&["file", "sync"]));
+    assert!(surface.contains_path(&["version", "show"]));
+    assert!(!surface.contains_path(&["version", "bump"]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Remove `homeboy version bump` so `homeboy version` stays read-only via `version show`.
- Remove the hidden `--major` compatibility flag from `homeboy release`.
- Refresh docs and command-surface coverage so release remains the only version-changing workflow.

## Tests
- `cargo test version -- --test-threads=1`
- `cargo test release -- --test-threads=1`
- `cargo test --test command_surface_test`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@remove-version-bump-alias --changed-since origin/main`

Closes #1890

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the command-surface cleanup, updated docs/tests, and ran focused verification. Chris remains responsible for review and merge.
