### PR TITLE
feat(trace): add black-box trace runner contract

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -35,6 +35,7 @@
 - [stack](stack.md) — combined-fixes branches from base refs plus cherry-picked PRs
 - [status](status.md) — actionable component overview
 - [test](test.md)
+- [trace](trace.md) — black-box behavioral trace and evidence capture
 - [triage](triage.md) — read-only attention report across components, projects, fleets, and rigs
 - [undo](undo.md) — restore or manage write-operation snapshots
 - [upgrade](upgrade.md)

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -1,0 +1,54 @@
+# homeboy trace
+
+Capture black-box behavioral traces for a component. Trace runners write a JSON evidence envelope plus optional artifacts under the Homeboy run directory.
+
+## Usage
+
+```sh
+homeboy trace <component> <scenario>
+homeboy trace <component> list
+homeboy trace <component> <scenario> --rig <rig-id>
+homeboy trace <component> <scenario> --json-summary
+```
+
+## Extension Manifest
+
+```json
+{
+  "trace": {
+    "extension_script": "scripts/trace/trace-runner.sh"
+  }
+}
+```
+
+## Runner Environment
+
+- `HOMEBOY_TRACE_RESULTS_FILE`
+- `HOMEBOY_TRACE_SCENARIO`
+- `HOMEBOY_TRACE_LIST_ONLY`
+- `HOMEBOY_TRACE_ARTIFACT_DIR`
+- `HOMEBOY_TRACE_RIG_ID` when `--rig` is used
+- `HOMEBOY_TRACE_COMPONENT_PATH` when Homeboy resolves a path override
+- `HOMEBOY_RUN_DIR`
+
+## Results Envelope
+
+```json
+{
+  "component_id": "studio",
+  "scenario_id": "close-window-running-site",
+  "status": "fail",
+  "summary": "Window reopened after close",
+  "timeline": [
+    { "t_ms": 0, "source": "desktop", "event": "window.closed", "data": { "id": 1 } }
+  ],
+  "assertions": [
+    { "id": "no-window-reopen", "status": "fail", "message": "Window reopened" }
+  ],
+  "artifacts": [
+    { "label": "main log", "path": "artifacts/main.log" }
+  ]
+}
+```
+
+V1 statuses are `pass`, `fail`, and `error`.

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -3,7 +3,7 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 use crate::commands::{
     api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
     deps, extension, file, fleet, git, issues, lint, logs, project, refactor, release, report,
-    review, rig, self_cmd, server, ssh, stack, status, test, triage, undo, upgrade, version,
+    review, rig, self_cmd, server, ssh, stack, status, test, trace, triage, undo, upgrade, version,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -36,6 +36,8 @@ pub enum Commands {
     Test(test::TestArgs),
     /// Run performance benchmarks for a component
     Bench(bench::BenchArgs),
+    /// Capture black-box behavioral traces for a component
+    Trace(trace::TraceArgs),
     /// Lint a component
     Lint(lint::LintArgs),
     /// Database operations

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -308,6 +308,7 @@ pub mod ssh;
 pub mod stack;
 pub mod status;
 pub mod test;
+pub mod trace;
 pub mod triage;
 pub mod undo;
 pub mod upgrade;
@@ -350,6 +351,7 @@ pub fn run_json(
         crate::cli_surface::Commands::Status(args) => dispatch!(args, global, status),
         crate::cli_surface::Commands::Test(args) => dispatch!(args, global, test),
         crate::cli_surface::Commands::Bench(args) => dispatch!(args, global, bench),
+        crate::cli_surface::Commands::Trace(args) => dispatch!(args, global, trace),
         crate::cli_surface::Commands::Lint(args) => dispatch!(args, global, lint),
         crate::cli_surface::Commands::Project(args) => dispatch!(args, global, project),
         crate::cli_surface::Commands::Ssh(args) => dispatch!(args, global, ssh),

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1,0 +1,258 @@
+use clap::Args;
+
+use homeboy::component::Component;
+use homeboy::engine::execution_context::{self, ResolveOptions};
+use homeboy::engine::run_dir::RunDir;
+use homeboy::extension::trace as extension_trace;
+use homeboy::extension::trace::{TraceCommandOutput, TraceListWorkflowArgs, TraceRunWorkflowArgs};
+use homeboy::extension::ExtensionCapability;
+use homeboy::rig::{self, RigSpec};
+
+use super::utils::args::{HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
+use super::{CmdResult, GlobalArgs};
+
+#[derive(Args)]
+pub struct TraceArgs {
+    #[command(flatten)]
+    comp: PositionalComponentArgs,
+
+    /// Scenario ID to run, or `list` to discover available scenarios.
+    pub scenario: String,
+
+    /// Run trace against a rig-pinned component path after `rig check` passes.
+    #[arg(long, value_name = "RIG_ID")]
+    pub rig: Option<String>,
+
+    #[command(flatten)]
+    pub setting_args: SettingArgs,
+
+    #[command(flatten)]
+    pub _json: HiddenJsonArgs,
+
+    /// Print compact machine-readable summary.
+    #[arg(long)]
+    pub json_summary: bool,
+}
+
+pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutput> {
+    if args.scenario == "list" {
+        return run_list(args);
+    }
+
+    let rig_context = load_rig_context(args.rig.as_deref())?;
+    let effective_id = resolve_component_id(&args.comp, rig_context.as_ref().map(|c| &c.spec))?;
+    let path_override = args.comp.path.clone().or_else(|| {
+        rig_context
+            .as_ref()
+            .and_then(|context| rig_component_path(&context.spec, &effective_id))
+    });
+    let component_override = rig_context
+        .as_ref()
+        .and_then(|context| rig_component_for_trace(&context.spec, &effective_id));
+
+    let ctx = execution_context::resolve_with_component(
+        &ResolveOptions::with_capability_and_json(
+            &effective_id,
+            path_override.clone(),
+            ExtensionCapability::Trace,
+            args.setting_args.setting.clone(),
+            args.setting_args.setting_json.clone(),
+        ),
+        component_override,
+    )?;
+
+    let rig_state = rig_context
+        .as_ref()
+        .map(|context| rig::snapshot_state(&context.spec));
+    let run_dir = RunDir::create()?;
+    let workflow = extension_trace::run_trace_workflow(
+        &ctx.component,
+        TraceRunWorkflowArgs {
+            component_label: effective_id,
+            component_id: ctx.component_id.clone(),
+            path_override,
+            settings: settings_as_strings(&ctx.settings),
+            settings_json: settings_as_json(&ctx.settings),
+            scenario_id: args.scenario,
+            json_summary: args.json_summary,
+            rig_id: args.rig,
+        },
+        &run_dir,
+        rig_state.clone(),
+    )?;
+
+    Ok(extension_trace::from_main_workflow(
+        workflow,
+        rig_state,
+        args.json_summary,
+    ))
+}
+
+fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
+    let rig_context = load_rig_context(args.rig.as_deref())?;
+    let effective_id = resolve_component_id(&args.comp, rig_context.as_ref().map(|c| &c.spec))?;
+    let path_override = args.comp.path.clone().or_else(|| {
+        rig_context
+            .as_ref()
+            .and_then(|context| rig_component_path(&context.spec, &effective_id))
+    });
+    let component_override = rig_context
+        .as_ref()
+        .and_then(|context| rig_component_for_trace(&context.spec, &effective_id));
+
+    let ctx = execution_context::resolve_with_component(
+        &ResolveOptions::with_capability_and_json(
+            &effective_id,
+            path_override.clone(),
+            ExtensionCapability::Trace,
+            args.setting_args.setting.clone(),
+            args.setting_args.setting_json.clone(),
+        ),
+        component_override,
+    )?;
+
+    let run_dir = RunDir::create()?;
+    let list = extension_trace::run_trace_list_workflow(
+        &ctx.component,
+        TraceListWorkflowArgs {
+            component_label: effective_id.clone(),
+            component_id: ctx.component_id.clone(),
+            path_override,
+            settings: settings_as_strings(&ctx.settings),
+            settings_json: settings_as_json(&ctx.settings),
+            rig_id: args.rig,
+        },
+        &run_dir,
+    )?;
+
+    Ok(extension_trace::from_list_workflow(effective_id, list))
+}
+
+struct TraceRigContext {
+    spec: RigSpec,
+}
+
+fn load_rig_context(rig_id: Option<&str>) -> homeboy::Result<Option<TraceRigContext>> {
+    let Some(rig_id) = rig_id else {
+        return Ok(None);
+    };
+    let spec = rig::load(rig_id)?;
+    let check = rig::run_check(&spec)?;
+    if !check.success {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "--rig",
+            format!(
+                "rig '{}' check failed; fix the rig before running trace",
+                rig_id
+            ),
+            None,
+            None,
+        ));
+    }
+    Ok(Some(TraceRigContext { spec }))
+}
+
+fn resolve_component_id(
+    comp: &PositionalComponentArgs,
+    rig_spec: Option<&RigSpec>,
+) -> homeboy::Result<String> {
+    if let Some(id) = comp.id() {
+        return Ok(id.to_string());
+    }
+    if let Some(spec) = rig_spec {
+        if spec.components.len() == 1 {
+            return Ok(spec.components.keys().next().unwrap().clone());
+        }
+        return Err(homeboy::Error::validation_invalid_argument(
+            "component",
+            format!(
+                "rig '{}' has multiple components; pass the component id to trace",
+                spec.id
+            ),
+            None,
+            None,
+        ));
+    }
+    comp.resolve_id()
+}
+
+fn rig_component_path(spec: &RigSpec, component_id: &str) -> Option<String> {
+    let component = spec.components.get(component_id)?;
+    Some(homeboy::rig::expand::expand_vars(spec, &component.path))
+}
+
+fn rig_component_for_trace(spec: &RigSpec, component_id: &str) -> Option<Component> {
+    let component = spec.components.get(component_id)?;
+    Some(Component {
+        id: component_id.to_string(),
+        local_path: rig_component_path(spec, component_id)
+            .unwrap_or_else(|| component.path.clone()),
+        remote_url: component.remote_url.clone(),
+        triage_remote_url: component.triage_remote_url.clone(),
+        extensions: component.extensions.clone(),
+        ..Default::default()
+    })
+}
+
+fn settings_as_strings(settings: &[(String, serde_json::Value)]) -> Vec<(String, String)> {
+    settings
+        .iter()
+        .filter_map(|(key, value)| match value {
+            serde_json::Value::String(s) => Some((key.clone(), s.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+fn settings_as_json(settings: &[(String, serde_json::Value)]) -> Vec<(String, serde_json::Value)> {
+    settings
+        .iter()
+        .filter_map(|(key, value)| match value {
+            serde_json::Value::String(_) => None,
+            other => Some((key.clone(), other.clone())),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use homeboy::component::ScopedExtensionConfig;
+    use homeboy::rig::ComponentSpec;
+
+    use super::*;
+
+    #[test]
+    fn rig_component_path_and_trace_env_are_threaded() {
+        let mut components = HashMap::new();
+        let mut extensions = HashMap::new();
+        extensions.insert(
+            "trace-extension".to_string(),
+            ScopedExtensionConfig::default(),
+        );
+        components.insert(
+            "studio".to_string(),
+            ComponentSpec {
+                path: "~/Developer/studio".to_string(),
+                remote_url: Some("https://github.com/Automattic/studio".to_string()),
+                triage_remote_url: None,
+                stack: None,
+                branch: None,
+                extensions: Some(extensions),
+            },
+        );
+        let spec = RigSpec {
+            id: "studio-rig".to_string(),
+            components,
+            ..serde_json::from_str(r#"{"id":"studio-rig"}"#).unwrap()
+        };
+
+        let path = rig_component_path(&spec, "studio").expect("path resolves");
+        assert!(path.contains("/Developer/studio"));
+        let component = rig_component_for_trace(&spec, "studio").expect("component resolves");
+        assert_eq!(component.id, "studio");
+        assert_eq!(component.local_path, path);
+        assert!(component.extensions.is_some());
+    }
+}

--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -382,6 +382,7 @@ JSON
             lint: None,
             test: None,
             bench: None,
+            trace: None,
             actions: vec![],
             hooks: std::collections::HashMap::new(),
             settings: vec![],

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -191,7 +191,6 @@ mod tests {
     fn create_run_dir() {
         let run_dir = RunDir::create().expect("should create run dir");
         assert!(run_dir.path().is_dir());
-        assert!(run_dir.annotations_dir().is_dir());
 
         // Well-known paths
         assert!(run_dir
@@ -203,14 +202,59 @@ mod tests {
             .to_string_lossy()
             .ends_with("test-results.json"));
 
-        // Legacy env vars
+        // Cleanup
+        let path = run_dir.path().to_path_buf();
+        run_dir.cleanup();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_path() {
+        let run_dir = RunDir::create().expect("should create run dir");
+        assert!(run_dir.path().is_dir());
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn test_annotations_dir() {
+        let run_dir = RunDir::create().expect("should create run dir");
+        assert!(run_dir.annotations_dir().is_dir());
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn test_step_file() {
+        let run_dir = RunDir::create().expect("should create run dir");
+        assert!(run_dir
+            .step_file(files::TRACE_RESULTS)
+            .to_string_lossy()
+            .ends_with("trace-results.json"));
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn test_legacy_env_vars() {
+        let run_dir = RunDir::create().expect("should create run dir");
         let env_vars = run_dir.legacy_env_vars();
         assert!(env_vars.iter().any(|(k, _)| k == "HOMEBOY_RUN_DIR"));
         assert!(env_vars
             .iter()
-            .any(|(k, _)| k == "HOMEBOY_LINT_FINDINGS_FILE"));
+            .any(|(k, _)| k == "HOMEBOY_TRACE_RESULTS_FILE"));
+        run_dir.cleanup();
+    }
 
-        // Cleanup
+    #[test]
+    fn test_from_existing() {
+        let run_dir = RunDir::create().expect("should create run dir");
+        let path = run_dir.path().to_path_buf();
+        let existing = RunDir::from_existing(path.clone()).expect("existing run dir should load");
+        assert_eq!(existing.path(), path.as_path());
+        existing.cleanup();
+    }
+
+    #[test]
+    fn test_cleanup() {
+        let run_dir = RunDir::create().expect("should create run dir");
         let path = run_dir.path().to_path_buf();
         run_dir.cleanup();
         assert!(!path.exists());

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -35,6 +35,7 @@ pub mod files {
     pub const COVERAGE: &str = "coverage.json";
     pub const FIX_RESULTS: &str = "fix-results.json";
     pub const BENCH_RESULTS: &str = "bench-results.json";
+    pub const TRACE_RESULTS: &str = "trace.json";
     pub const ANNOTATIONS_DIR: &str = "annotations";
 }
 
@@ -137,6 +138,12 @@ impl RunDir {
             (
                 "HOMEBOY_BENCH_RESULTS_FILE".to_string(),
                 self.step_file(files::BENCH_RESULTS)
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+            (
+                "HOMEBOY_TRACE_RESULTS_FILE".to_string(),
+                self.step_file(files::TRACE_RESULTS)
                     .to_string_lossy()
                     .to_string(),
             ),

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -20,7 +20,8 @@ use crate::extension::bench::parsing::{
     BenchWorkloadMetadata,
 };
 use crate::extension::{
-    resolve_execution_context, ExtensionCapability, ExtensionExecutionContext, ExtensionRunner,
+    resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
+    ExtensionRunner,
 };
 
 #[derive(Debug, Clone)]
@@ -580,13 +581,6 @@ pub fn run_main_bench_workflow(
         hints,
         failure,
     })
-}
-
-fn stderr_tail(stderr: &str) -> String {
-    const MAX_LINES: usize = 20;
-    let lines: Vec<&str> = stderr.lines().collect();
-    let start = lines.len().saturating_sub(MAX_LINES);
-    lines[start..].join("\n")
 }
 
 fn stamp_run_metadata(

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -343,6 +343,8 @@ pub struct ExtensionManifest {
     pub test: Option<TestConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bench: Option<BenchConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace: Option<TraceConfig>,
     /// Post-write verify command used as a safety gate after `refactor --from ...`
     /// autofix writes to disk. If the command exits non-zero, the written files
     /// are reverted and the fixes are reclassified as declined. See #1167.
@@ -403,6 +405,13 @@ impl ExtensionManifest {
             .is_some()
     }
 
+    pub fn has_trace(&self) -> bool {
+        self.trace
+            .as_ref()
+            .and_then(|c| c.extension_script.as_ref())
+            .is_some()
+    }
+
     pub fn lint_script(&self) -> Option<&str> {
         self.lint
             .as_ref()
@@ -423,6 +432,12 @@ impl ExtensionManifest {
 
     pub fn bench_script(&self) -> Option<&str> {
         self.bench
+            .as_ref()
+            .and_then(|c| c.extension_script.as_deref())
+    }
+
+    pub fn trace_script(&self) -> Option<&str> {
+        self.trace
             .as_ref()
             .and_then(|c| c.extension_script.as_deref())
     }
@@ -818,6 +833,12 @@ pub struct RuntimeRequirementsConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension_script: Option<String>,
 }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -12,6 +12,7 @@ mod runtime_helper;
 mod scope;
 pub mod self_check;
 pub mod test;
+pub mod trace;
 pub mod update_check;
 pub mod version;
 
@@ -34,7 +35,7 @@ pub use manifest::{
     FileContainsCondition, HttpMethod, InputConfig, LintConfig, OutputConfig, OutputSchema,
     PlatformCapability, ProvidesConfig, RemotePathInferenceRule, RequirementsConfig, RuntimeConfig,
     RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
-    TestConfig, TestDriftConfig, TestMappingConfig, VersionPatternConfig,
+    TestConfig, TestDriftConfig, TestMappingConfig, TraceConfig, VersionPatternConfig,
 };
 
 // Re-export version types
@@ -126,6 +127,7 @@ pub enum ExtensionCapability {
     Test,
     Build,
     Bench,
+    Trace,
 }
 
 impl ExtensionCapability {
@@ -135,6 +137,7 @@ impl ExtensionCapability {
             ExtensionCapability::Test => "test",
             ExtensionCapability::Build => "build",
             ExtensionCapability::Bench => "bench",
+            ExtensionCapability::Trace => "trace",
         }
     }
 
@@ -144,6 +147,7 @@ impl ExtensionCapability {
             ExtensionCapability::Test => manifest.has_test(),
             ExtensionCapability::Build => manifest.has_build(),
             ExtensionCapability::Bench => manifest.has_bench(),
+            ExtensionCapability::Trace => manifest.has_trace(),
         }
     }
 
@@ -153,6 +157,7 @@ impl ExtensionCapability {
             ExtensionCapability::Test => manifest.test_script(),
             ExtensionCapability::Build => manifest.build_script(),
             ExtensionCapability::Bench => manifest.bench_script(),
+            ExtensionCapability::Trace => manifest.trace_script(),
         }
     }
 
@@ -1117,7 +1122,8 @@ mod tests {
                 }
             },
             "build": { "extension_script": "build.sh" },
-            "bench": { "extension_script": "bench.sh" }
+            "bench": { "extension_script": "bench.sh" },
+            "trace": { "extension_script": "trace.sh" }
         }))
         .unwrap();
 
@@ -1142,6 +1148,7 @@ mod tests {
             (ExtensionCapability::Test, "test", "test.sh", true),
             (ExtensionCapability::Build, "build", "build.sh", false),
             (ExtensionCapability::Bench, "bench", "bench.sh", true),
+            (ExtensionCapability::Trace, "trace", "trace.sh", true),
         ] {
             assert_eq!(capability.label(), label);
             assert!(capability.has_manifest_support(&manifest));

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -59,6 +59,13 @@ pub use lifecycle::{
     UpdateAvailable, UpdateResult,
 };
 
+pub(crate) fn stderr_tail(stderr: &str) -> String {
+    const MAX_LINES: usize = 20;
+    let lines: Vec<&str> = stderr.lines().collect();
+    let start = lines.len().saturating_sub(MAX_LINES);
+    lines[start..].join("\n")
+}
+
 // Re-export aggregate query types
 // (ActionSummary, ExtensionSummary, UpdateAllResult, UpdateEntry defined below in this file)
 

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -1,0 +1,29 @@
+//! Extension trace capability — black-box evidence capture for lifecycle bugs.
+//!
+//! Trace is a sibling of `test` and `bench`: Homeboy resolves a component-owned
+//! extension script, creates a run directory, passes an env-var contract, and
+//! parses a JSON envelope written by the runner. Unlike bench, trace has no
+//! baselines, ratchets, or metric gates; its job is to preserve causality and
+//! evidence artifacts.
+
+pub mod parsing;
+pub mod report;
+pub mod run;
+
+use crate::component::Component;
+use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
+
+pub use parsing::{parse_trace_list_str, parse_trace_results_file, parse_trace_results_str};
+pub use parsing::{
+    TraceArtifact, TraceAssertion, TraceEvent, TraceList, TraceScenario, TraceStatus,
+};
+pub use parsing::{TraceAssertionStatus, TraceResults};
+pub use report::{from_list_workflow, from_main_workflow, TraceCommandOutput};
+pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};
+pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult};
+
+pub fn resolve_trace_command(
+    component: &Component,
+) -> crate::error::Result<ExtensionExecutionContext> {
+    crate::extension::resolve_execution_context(component, ExtensionCapability::Trace)
+}

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -13,7 +13,7 @@ pub mod run;
 use crate::component::Component;
 use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
 
-pub use parsing::{parse_trace_list_str, parse_trace_results_file, parse_trace_results_str};
+pub use parsing::{parse_trace_list_str, parse_trace_results_file};
 pub use parsing::{
     TraceArtifact, TraceAssertion, TraceEvent, TraceList, TraceScenario, TraceStatus,
 };

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -122,7 +122,7 @@ pub fn parse_trace_results_file(path: &Path) -> Result<TraceResults> {
     parse_trace_results_str(&content)
 }
 
-pub fn parse_trace_results_str(raw: &str) -> Result<TraceResults> {
+fn parse_trace_results_str(raw: &str) -> Result<TraceResults> {
     serde_json::from_str(raw).map_err(|e| {
         Error::internal_json(
             format!("Failed to parse trace results JSON: {}", e),
@@ -145,7 +145,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trace_json_parser_accepts_minimal_envelope() {
+    fn test_parse_trace_results_str() {
         let parsed = parse_trace_results_str(
             r#"{
                 "component_id":"studio",
@@ -164,6 +164,21 @@ mod tests {
         assert_eq!(parsed.timeline[0].t_ms, 0);
         assert_eq!(parsed.assertions[0].id, "no-window-reopen");
         assert_eq!(parsed.artifacts[0].path, "artifacts/main.log");
+    }
+
+    #[test]
+    fn test_parse_trace_results_file() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let path = temp.path().join("trace-results.json");
+        std::fs::write(
+            &path,
+            r#"{"component_id":"studio","scenario_id":"x","status":"pass","timeline":[],"assertions":[],"artifacts":[]}"#,
+        )
+        .expect("trace results should be written");
+
+        let parsed = parse_trace_results_file(&path).expect("trace results file should parse");
+        assert_eq!(parsed.component_id, "studio");
+        assert_eq!(parsed.status, TraceStatus::Pass);
     }
 
     #[test]
@@ -187,7 +202,7 @@ mod tests {
     }
 
     #[test]
-    fn trace_list_parser_accepts_compact_scenario_inventory() {
+    fn test_parse_trace_list_str() {
         let parsed = parse_trace_list_str(
             r#"{"component_id":"studio","scenarios":[{"id":"close-window","summary":"Close window lifecycle"}]}"#,
         )

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -1,0 +1,186 @@
+//! Trace runner JSON output parsing.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::rig::RigStateSnapshot;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TraceStatus {
+    Pass,
+    Fail,
+    Error,
+}
+
+impl TraceStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TraceStatus::Pass => "pass",
+            TraceStatus::Fail => "fail",
+            TraceStatus::Error => "error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TraceAssertionStatus {
+    Pass,
+    Fail,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceResults {
+    pub component_id: String,
+    pub scenario_id: String,
+    pub status: TraceStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rig: Option<RigStateSnapshot>,
+    #[serde(default)]
+    pub timeline: Vec<TraceEvent>,
+    #[serde(default)]
+    pub assertions: Vec<TraceAssertion>,
+    #[serde(default)]
+    pub artifacts: Vec<TraceArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceEvent {
+    pub t_ms: u64,
+    pub source: String,
+    pub event: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub data: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceAssertion {
+    pub id: String,
+    pub status: TraceAssertionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceArtifact {
+    pub label: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceList {
+    pub component_id: String,
+    #[serde(default)]
+    pub scenarios: Vec<TraceScenario>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceScenario {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+pub fn parse_trace_results_file(path: &Path) -> Result<TraceResults> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read trace results file {}: {}",
+                path.display(),
+                e
+            ),
+            Some("trace.parsing.read".to_string()),
+        )
+    })?;
+    parse_trace_results_str(&content)
+}
+
+pub fn parse_trace_results_str(raw: &str) -> Result<TraceResults> {
+    serde_json::from_str(raw).map_err(|e| {
+        Error::internal_json(
+            format!("Failed to parse trace results JSON: {}", e),
+            Some("trace.parsing.deserialize".to_string()),
+        )
+    })
+}
+
+pub fn parse_trace_list_str(raw: &str) -> Result<TraceList> {
+    serde_json::from_str(raw).map_err(|e| {
+        Error::internal_json(
+            format!("Failed to parse trace list JSON: {}", e),
+            Some("trace.parsing.list.deserialize".to_string()),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_json_parser_accepts_minimal_envelope() {
+        let parsed = parse_trace_results_str(
+            r#"{
+                "component_id":"studio",
+                "scenario_id":"close-window-running-site",
+                "status":"fail",
+                "summary":"Window reopened after close",
+                "timeline":[{"t_ms":0,"source":"desktop","event":"window.closed","data":{"id":1}}],
+                "assertions":[{"id":"no-window-reopen","status":"fail","message":"Window reopened"}],
+                "artifacts":[{"label":"main log","path":"artifacts/main.log"}]
+            }"#,
+        )
+        .expect("minimal trace envelope should parse");
+
+        assert_eq!(parsed.component_id, "studio");
+        assert_eq!(parsed.status, TraceStatus::Fail);
+        assert_eq!(parsed.timeline[0].t_ms, 0);
+        assert_eq!(parsed.assertions[0].id, "no-window-reopen");
+        assert_eq!(parsed.artifacts[0].path, "artifacts/main.log");
+    }
+
+    #[test]
+    fn trace_json_parser_rejects_invalid_status() {
+        let err = parse_trace_results_str(
+            r#"{"component_id":"studio","scenario_id":"x","status":"unknown","timeline":[],"assertions":[],"artifacts":[]}"#,
+        )
+        .unwrap_err();
+
+        assert!(!err.message.is_empty());
+    }
+
+    #[test]
+    fn trace_json_parser_rejects_malformed_timeline_shape() {
+        let err = parse_trace_results_str(
+            r#"{"component_id":"studio","scenario_id":"x","status":"pass","timeline":[{"source":"desktop","event":"x"}],"assertions":[],"artifacts":[]}"#,
+        )
+        .unwrap_err();
+
+        assert!(!err.message.is_empty());
+    }
+
+    #[test]
+    fn trace_list_parser_accepts_compact_scenario_inventory() {
+        let parsed = parse_trace_list_str(
+            r#"{"component_id":"studio","scenarios":[{"id":"close-window","summary":"Close window lifecycle"}]}"#,
+        )
+        .expect("list envelope should parse");
+
+        assert_eq!(parsed.scenarios[0].id, "close-window");
+    }
+}

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -80,18 +80,30 @@ pub struct TraceArtifact {
     pub path: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TraceList {
     pub component_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<TraceStatus>,
     #[serde(default)]
     pub scenarios: Vec<TraceScenario>,
+    #[serde(default)]
+    pub timeline: Vec<TraceEvent>,
+    #[serde(default)]
+    pub assertions: Vec<TraceAssertion>,
+    #[serde(default)]
+    pub artifacts: Vec<TraceArtifact>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct TraceScenario {
     pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
 }
@@ -182,5 +194,30 @@ mod tests {
         .expect("list envelope should parse");
 
         assert_eq!(parsed.scenarios[0].id, "close-window");
+    }
+
+    #[test]
+    fn trace_list_parser_accepts_trace_shaped_inventory_envelope() {
+        let parsed = parse_trace_list_str(
+            r#"{
+                "component_id":"studio",
+                "scenario_id":"__list__",
+                "status":"pass",
+                "scenarios":[{"id":"close-window-running-site","source":"fixtures/close-window.trace.js"}],
+                "timeline":[],
+                "assertions":[],
+                "artifacts":[]
+            }"#,
+        )
+        .expect("trace-shaped list envelope should parse");
+
+        assert_eq!(parsed.component_id, "studio");
+        assert_eq!(parsed.scenario_id.as_deref(), Some("__list__"));
+        assert_eq!(parsed.status, Some(TraceStatus::Pass));
+        assert_eq!(parsed.scenarios[0].id, "close-window-running-site");
+        assert_eq!(
+            parsed.scenarios[0].source.as_deref(),
+            Some("fixtures/close-window.trace.js")
+        );
     }
 }

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -119,3 +119,69 @@ pub fn from_list_workflow(component: String, list: TraceList) -> (TraceCommandOu
         0,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extension::trace::parsing::{TraceScenario, TraceStatus};
+
+    #[test]
+    fn test_from_list_workflow() {
+        let list = TraceList {
+            component_id: "studio".to_string(),
+            scenario_id: None,
+            status: None,
+            scenarios: vec![TraceScenario {
+                id: "close-window-running-site".to_string(),
+                source: Some("fixtures/close-window.trace.js".to_string()),
+                summary: Some("Close window while a site is running".to_string()),
+            }],
+            timeline: Vec::new(),
+            assertions: Vec::new(),
+            artifacts: Vec::new(),
+        };
+
+        let (output, exit_code) = from_list_workflow("Studio".to_string(), list);
+        let value = serde_json::to_value(output).expect("list output should serialize");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["command"], "trace.list");
+        assert_eq!(value["component"], "Studio");
+        assert_eq!(value["component_id"], "studio");
+        assert_eq!(value["count"], 1);
+        assert_eq!(value["scenarios"][0]["id"], "close-window-running-site");
+    }
+
+    #[test]
+    fn test_from_main_workflow() {
+        let result = TraceRunWorkflowResult {
+            status: "pass".to_string(),
+            component: "Studio".to_string(),
+            exit_code: 0,
+            results: Some(TraceResults {
+                component_id: "studio".to_string(),
+                scenario_id: "close-window-running-site".to_string(),
+                status: TraceStatus::Pass,
+                summary: Some("No window reopened".to_string()),
+                failure: None,
+                rig: None,
+                timeline: Vec::new(),
+                assertions: Vec::new(),
+                artifacts: vec![TraceArtifact {
+                    label: "main log".to_string(),
+                    path: "artifacts/main.log".to_string(),
+                }],
+            }),
+            failure: None,
+        };
+
+        let (output, exit_code) = from_main_workflow(result, None, true);
+        let value = serde_json::to_value(output).expect("summary output should serialize");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["summary_only"], true);
+        assert_eq!(value["passed"], true);
+        assert_eq!(value["scenario_id"], "close-window-running-site");
+        assert_eq!(value["artifact_count"], 1);
+    }
+}

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -1,0 +1,121 @@
+//! Trace command output envelopes.
+
+use serde::Serialize;
+
+use super::parsing::{TraceArtifact, TraceList, TraceResults};
+use super::run::TraceRunWorkflowResult;
+use crate::rig::RigStateSnapshot;
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum TraceCommandOutput {
+    Run(Box<TraceRunOutput>),
+    Summary(TraceRunSummaryOutput),
+    List(TraceListOutput),
+}
+
+#[derive(Serialize)]
+pub struct TraceRunOutput {
+    pub passed: bool,
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<TraceArtifact>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub results: Option<TraceResults>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_state: Option<RigStateSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<super::run::TraceRunFailure>,
+}
+
+#[derive(Serialize)]
+pub struct TraceRunSummaryOutput {
+    pub summary_only: bool,
+    pub passed: bool,
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    pub assertion_count: usize,
+    pub artifact_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_id: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct TraceListOutput {
+    pub command: &'static str,
+    pub component: String,
+    pub component_id: String,
+    pub count: usize,
+    pub scenarios: Vec<super::parsing::TraceScenario>,
+}
+
+pub fn from_main_workflow(
+    result: TraceRunWorkflowResult,
+    rig_state: Option<RigStateSnapshot>,
+    summary_only: bool,
+) -> (TraceCommandOutput, i32) {
+    let exit_code = result.exit_code;
+    if summary_only {
+        let output = TraceRunSummaryOutput {
+            summary_only: true,
+            passed: exit_code == 0 && result.status == "pass",
+            status: result.status,
+            component: result.component,
+            exit_code,
+            scenario_id: result.results.as_ref().map(|r| r.scenario_id.clone()),
+            summary: result.results.as_ref().and_then(|r| r.summary.clone()),
+            assertion_count: result
+                .results
+                .as_ref()
+                .map(|r| r.assertions.len())
+                .unwrap_or(0),
+            artifact_count: result
+                .results
+                .as_ref()
+                .map(|r| r.artifacts.len())
+                .unwrap_or(0),
+            rig_id: rig_state.as_ref().map(|r| r.rig_id.clone()),
+        };
+        return (TraceCommandOutput::Summary(output), exit_code);
+    }
+
+    let artifacts = result
+        .results
+        .as_ref()
+        .map(|r| r.artifacts.clone())
+        .unwrap_or_default();
+    (
+        TraceCommandOutput::Run(Box::new(TraceRunOutput {
+            passed: exit_code == 0 && result.status == "pass",
+            status: result.status,
+            component: result.component,
+            exit_code,
+            artifacts,
+            results: result.results,
+            rig_state,
+            failure: result.failure,
+        })),
+        exit_code,
+    )
+}
+
+pub fn from_list_workflow(component: String, list: TraceList) -> (TraceCommandOutput, i32) {
+    let count = list.scenarios.len();
+    (
+        TraceCommandOutput::List(TraceListOutput {
+            command: "trace.list",
+            component,
+            component_id: list.component_id,
+            count,
+            scenarios: list.scenarios,
+        }),
+        0,
+    )
+}

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -5,7 +5,9 @@ use serde::Serialize;
 use crate::component::Component;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
-use crate::extension::{resolve_execution_context, ExtensionCapability, ExtensionExecutionContext};
+use crate::extension::{
+    resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
+};
 use crate::extension::{ExtensionRunner, RunnerOutput};
 use crate::rig::RigStateSnapshot;
 
@@ -48,10 +50,10 @@ pub struct TraceRunWorkflowResult {
 pub struct TraceRunFailure {
     pub component_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub component_path: Option<String>,
+    pub path_override: Option<String>,
     pub scenario_id: String,
     pub exit_code: i32,
-    pub stderr_tail: String,
+    pub stderr_excerpt: String,
 }
 
 pub fn run_trace_workflow(
@@ -206,18 +208,11 @@ pub(crate) fn build_trace_runner(
 fn failure_from_output(args: &TraceRunWorkflowArgs, output: &RunnerOutput) -> TraceRunFailure {
     TraceRunFailure {
         component_id: args.component_id.clone(),
-        component_path: args.path_override.clone(),
+        path_override: args.path_override.clone(),
         scenario_id: args.scenario_id.clone(),
         exit_code: output.exit_code,
-        stderr_tail: stderr_tail(&output.stderr),
+        stderr_excerpt: stderr_tail(&output.stderr),
     }
-}
-
-fn stderr_tail(stderr: &str) -> String {
-    const MAX_LINES: usize = 20;
-    let lines: Vec<&str> = stderr.lines().collect();
-    let start = lines.len().saturating_sub(MAX_LINES);
-    lines[start..].join("\n")
 }
 
 #[cfg(test)]
@@ -231,7 +226,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trace_runner_invokes_extension_script_with_expected_env_vars() {
+    fn test_build_trace_runner() {
         let temp = tempfile::tempdir().unwrap();
         let extension_dir = temp.path().join("extension");
         let component_dir = temp.path().join("component");
@@ -298,7 +293,7 @@ JSON
     }
 
     #[test]
-    fn trace_list_mode_sets_list_env_var() {
+    fn test_run_trace_list_workflow() {
         let temp = tempfile::tempdir().unwrap();
         let extension_dir = temp.path().join("extension");
         let component_dir = temp.path().join("component");
@@ -349,6 +344,37 @@ JSON
             "1"
         );
         run_dir.cleanup();
+    }
+
+    #[test]
+    fn test_run_trace_workflow() {
+        let args = TraceRunWorkflowArgs {
+            component_label: "example".to_string(),
+            component_id: "example".to_string(),
+            path_override: Some("/tmp/example".to_string()),
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            scenario_id: "close-window".to_string(),
+            json_summary: false,
+            rig_id: None,
+        };
+        let output = RunnerOutput {
+            success: false,
+            exit_code: 2,
+            stdout: String::new(),
+            stderr: (0..25)
+                .map(|i| format!("line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        };
+
+        let failure = failure_from_output(&args, &output);
+
+        assert_eq!(failure.component_id, "example");
+        assert_eq!(failure.scenario_id, "close-window");
+        assert_eq!(failure.exit_code, 2);
+        assert!(failure.stderr_excerpt.contains("line 24"));
+        assert!(!failure.stderr_excerpt.contains("line 0"));
     }
 
     fn component_with_extension(id: &str, path: &std::path::Path) -> Component {

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -1,0 +1,393 @@
+//! Trace workflows: invoke extension runners, parse JSON, preserve artifacts.
+
+use serde::Serialize;
+
+use crate::component::Component;
+use crate::engine::run_dir::{self, RunDir};
+use crate::error::{Error, Result};
+use crate::extension::{resolve_execution_context, ExtensionCapability, ExtensionExecutionContext};
+use crate::extension::{ExtensionRunner, RunnerOutput};
+use crate::rig::RigStateSnapshot;
+
+use super::parsing::{parse_trace_list_str, parse_trace_results_file, TraceList, TraceResults};
+
+#[derive(Debug, Clone)]
+pub struct TraceRunWorkflowArgs {
+    pub component_label: String,
+    pub component_id: String,
+    pub path_override: Option<String>,
+    pub settings: Vec<(String, String)>,
+    pub settings_json: Vec<(String, serde_json::Value)>,
+    pub scenario_id: String,
+    pub json_summary: bool,
+    pub rig_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TraceListWorkflowArgs {
+    pub component_label: String,
+    pub component_id: String,
+    pub path_override: Option<String>,
+    pub settings: Vec<(String, String)>,
+    pub settings_json: Vec<(String, serde_json::Value)>,
+    pub rig_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceRunWorkflowResult {
+    pub status: String,
+    pub component: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub results: Option<TraceResults>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<TraceRunFailure>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceRunFailure {
+    pub component_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_path: Option<String>,
+    pub scenario_id: String,
+    pub exit_code: i32,
+    pub stderr_tail: String,
+}
+
+pub fn run_trace_workflow(
+    component: &Component,
+    args: TraceRunWorkflowArgs,
+    run_dir: &RunDir,
+    rig_state: Option<RigStateSnapshot>,
+) -> Result<TraceRunWorkflowResult> {
+    let execution_context = resolve_execution_context(component, ExtensionCapability::Trace)?;
+    let runner_output =
+        build_trace_runner(&execution_context, component, &args, run_dir, false)?.run()?;
+    let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
+    let results = if results_path.exists() {
+        let mut parsed = parse_trace_results_file(&results_path)?;
+        if parsed.rig.is_none() {
+            parsed.rig = rig_state;
+        }
+        Some(parsed)
+    } else {
+        None
+    };
+    let status = results
+        .as_ref()
+        .map(|r| r.status.as_str().to_string())
+        .unwrap_or_else(|| {
+            if runner_output.success {
+                "pass"
+            } else {
+                "error"
+            }
+            .to_string()
+        });
+    let exit_code = if runner_output.success {
+        if status == "pass" {
+            0
+        } else {
+            1
+        }
+    } else {
+        runner_output.exit_code
+    };
+    let failure = (!runner_output.success).then(|| failure_from_output(&args, &runner_output));
+
+    Ok(TraceRunWorkflowResult {
+        status,
+        component: args.component_label,
+        exit_code,
+        results,
+        failure,
+    })
+}
+
+pub fn run_trace_list_workflow(
+    component: &Component,
+    args: TraceListWorkflowArgs,
+    run_dir: &RunDir,
+) -> Result<TraceList> {
+    let execution_context = resolve_execution_context(component, ExtensionCapability::Trace)?;
+    let runner_args = TraceRunWorkflowArgs {
+        component_label: args.component_label.clone(),
+        component_id: args.component_id,
+        path_override: args.path_override,
+        settings: args.settings,
+        settings_json: args.settings_json,
+        scenario_id: String::new(),
+        json_summary: false,
+        rig_id: args.rig_id,
+    };
+    let output =
+        build_trace_runner(&execution_context, component, &runner_args, run_dir, true)?.run()?;
+    if !output.success {
+        return Err(Error::validation_invalid_argument(
+            "trace_list",
+            format!(
+                "trace scenario discovery failed with exit code {}",
+                output.exit_code
+            ),
+            Some(format!(
+                "stdout:\n{}\n\nstderr:\n{}",
+                output.stdout, output.stderr
+            )),
+            None,
+        ));
+    }
+
+    let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
+    if results_path.exists() {
+        let content = std::fs::read_to_string(&results_path).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to read trace list file {}: {}",
+                    results_path.display(),
+                    e
+                ),
+                Some("trace.list.read".to_string()),
+            )
+        })?;
+        return parse_trace_list_str(&content);
+    }
+
+    parse_trace_list_str(&output.stdout)
+}
+
+pub(crate) fn build_trace_runner(
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: &TraceRunWorkflowArgs,
+    run_dir: &RunDir,
+    list_only: bool,
+) -> Result<ExtensionRunner> {
+    let artifact_dir = run_dir.path().join("artifacts");
+    std::fs::create_dir_all(&artifact_dir).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to create trace artifact dir {}: {}",
+                artifact_dir.display(),
+                e
+            ),
+            Some("trace.artifacts.create".to_string()),
+        )
+    })?;
+
+    let mut runner = ExtensionRunner::for_context(execution_context.clone())
+        .component(component.clone())
+        .path_override(args.path_override.clone())
+        .settings(&args.settings)
+        .settings_json(&args.settings_json)
+        .with_run_dir(run_dir)
+        .env(
+            "HOMEBOY_TRACE_RESULTS_FILE",
+            &run_dir
+                .step_file(run_dir::files::TRACE_RESULTS)
+                .to_string_lossy(),
+        )
+        .env("HOMEBOY_TRACE_SCENARIO", &args.scenario_id)
+        .env(
+            "HOMEBOY_TRACE_ARTIFACT_DIR",
+            &artifact_dir.to_string_lossy(),
+        )
+        .env("HOMEBOY_TRACE_LIST_ONLY", if list_only { "1" } else { "0" });
+
+    if let Some(rig_id) = &args.rig_id {
+        runner = runner.env("HOMEBOY_TRACE_RIG_ID", rig_id);
+    }
+    if let Some(path) = &args.path_override {
+        runner = runner.env("HOMEBOY_TRACE_COMPONENT_PATH", path);
+    }
+
+    Ok(runner)
+}
+
+fn failure_from_output(args: &TraceRunWorkflowArgs, output: &RunnerOutput) -> TraceRunFailure {
+    TraceRunFailure {
+        component_id: args.component_id.clone(),
+        component_path: args.path_override.clone(),
+        scenario_id: args.scenario_id.clone(),
+        exit_code: output.exit_code,
+        stderr_tail: stderr_tail(&output.stderr),
+    }
+}
+
+fn stderr_tail(stderr: &str) -> String {
+    const MAX_LINES: usize = 20;
+    let lines: Vec<&str> = stderr.lines().collect();
+    let start = lines.len().saturating_sub(MAX_LINES);
+    lines[start..].join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs;
+
+    use crate::component::{Component, ScopedExtensionConfig};
+    use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
+
+    use super::*;
+
+    #[test]
+    fn trace_runner_invokes_extension_script_with_expected_env_vars() {
+        let temp = tempfile::tempdir().unwrap();
+        let extension_dir = temp.path().join("extension");
+        let component_dir = temp.path().join("component");
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::create_dir_all(&component_dir).unwrap();
+        write_extension_manifest(&extension_dir);
+        let script = extension_dir.join("trace-runner.sh");
+        fs::write(
+            &script,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'results=%s\n' "$HOMEBOY_TRACE_RESULTS_FILE"
+  printf 'scenario=%s\n' "$HOMEBOY_TRACE_SCENARIO"
+  printf 'list=%s\n' "$HOMEBOY_TRACE_LIST_ONLY"
+  printf 'artifact=%s\n' "$HOMEBOY_TRACE_ARTIFACT_DIR"
+  printf 'run=%s\n' "$HOMEBOY_RUN_DIR"
+  printf 'rig=%s\n' "${HOMEBOY_TRACE_RIG_ID:-}"
+  printf 'component_path=%s\n' "${HOMEBOY_TRACE_COMPONENT_PATH:-}"
+} > "$HOMEBOY_TRACE_ARTIFACT_DIR/env.txt"
+cat > "$HOMEBOY_TRACE_RESULTS_FILE" <<JSON
+{"component_id":"example","scenario_id":"close-window","status":"pass","timeline":[],"assertions":[],"artifacts":[{"label":"env","path":"artifacts/env.txt"}]}
+JSON
+"#,
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script, perms).unwrap();
+        }
+
+        let component = component_with_extension("example", &component_dir);
+        let context = trace_context(&component, &extension_dir);
+        let run_dir = RunDir::create().unwrap();
+        let args = TraceRunWorkflowArgs {
+            component_label: "example".to_string(),
+            component_id: "example".to_string(),
+            path_override: Some(component_dir.to_string_lossy().to_string()),
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            scenario_id: "close-window".to_string(),
+            json_summary: false,
+            rig_id: Some("studio".to_string()),
+        };
+
+        let output = build_trace_runner(&context, &component, &args, &run_dir, false)
+            .unwrap()
+            .run()
+            .unwrap();
+        assert!(output.success);
+
+        let env_dump = fs::read_to_string(run_dir.path().join("artifacts/env.txt")).unwrap();
+        assert!(env_dump.contains("scenario=close-window"));
+        assert!(env_dump.contains("list=0"));
+        assert!(env_dump.contains("rig=studio"));
+        assert!(env_dump.contains(&format!("component_path={}", component_dir.display())));
+        assert!(env_dump.contains("results="));
+        assert!(env_dump.contains("artifact="));
+        assert!(env_dump.contains("run="));
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn trace_list_mode_sets_list_env_var() {
+        let temp = tempfile::tempdir().unwrap();
+        let extension_dir = temp.path().join("extension");
+        let component_dir = temp.path().join("component");
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::create_dir_all(&component_dir).unwrap();
+        write_extension_manifest(&extension_dir);
+        let script = extension_dir.join("trace-runner.sh");
+        fs::write(
+            &script,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "$HOMEBOY_TRACE_LIST_ONLY" > "$HOMEBOY_TRACE_ARTIFACT_DIR/list.txt"
+cat > "$HOMEBOY_TRACE_RESULTS_FILE" <<JSON
+{"component_id":"example","scenarios":[{"id":"close-window"}]}
+JSON
+"#,
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script, perms).unwrap();
+        }
+
+        let component = component_with_extension("example", &component_dir);
+        let context = trace_context(&component, &extension_dir);
+        let run_dir = RunDir::create().unwrap();
+        let args = TraceRunWorkflowArgs {
+            component_label: "example".to_string(),
+            component_id: "example".to_string(),
+            path_override: Some(component_dir.to_string_lossy().to_string()),
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            scenario_id: String::new(),
+            json_summary: false,
+            rig_id: None,
+        };
+
+        let output = build_trace_runner(&context, &component, &args, &run_dir, true)
+            .unwrap()
+            .run()
+            .unwrap();
+        assert!(output.success);
+        assert_eq!(
+            fs::read_to_string(run_dir.path().join("artifacts/list.txt")).unwrap(),
+            "1"
+        );
+        run_dir.cleanup();
+    }
+
+    fn component_with_extension(id: &str, path: &std::path::Path) -> Component {
+        let mut extensions = HashMap::new();
+        extensions.insert(
+            "trace-extension".to_string(),
+            ScopedExtensionConfig::default(),
+        );
+        Component {
+            id: id.to_string(),
+            local_path: path.to_string_lossy().to_string(),
+            extensions: Some(extensions),
+            ..Default::default()
+        }
+    }
+
+    fn trace_context(
+        component: &Component,
+        extension_dir: &std::path::Path,
+    ) -> ExtensionExecutionContext {
+        ExtensionExecutionContext {
+            component: component.clone(),
+            capability: ExtensionCapability::Trace,
+            extension_id: "trace-extension".to_string(),
+            extension_path: extension_dir.to_path_buf(),
+            script_path: "trace-runner.sh".to_string(),
+            settings: Vec::new(),
+        }
+    }
+
+    fn write_extension_manifest(extension_dir: &std::path::Path) {
+        fs::write(
+            extension_dir.join("extension.json"),
+            r#"{
+                "name":"Trace Extension",
+                "version":"0.0.0",
+                "trace":{"extension_script":"trace-runner.sh"}
+            }"#,
+        )
+        .unwrap();
+    }
+}

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::expand::expand_vars;
 use super::lease::acquire_active_run_lease;
@@ -185,7 +185,7 @@ fn service_kind_label(kind: ServiceKind) -> &'static str {
 /// slower" from "I'm comparing against a different commit." Surfaced in
 /// the bench command output alongside the bench result; persisting into
 /// the baseline JSON is a follow-up (see Extra-Chill/homeboy#1466 docs).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ComponentSnapshot {
     /// Resolved filesystem path (after `~` / `${env.X}` / `${components.X}`
     /// expansion). Useful for humans reviewing a snapshot offline.
@@ -202,7 +202,7 @@ pub struct ComponentSnapshot {
 
 /// Snapshot of every component in a rig at a moment in time. Sorted by
 /// component ID for stable output (BTreeMap).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RigStateSnapshot {
     pub rig_id: String,
     pub captured_at: String,


### PR DESCRIPTION
## Summary
- Adds `homeboy trace <component> <scenario>` and `homeboy trace <component> list` as a first-class black-box evidence-capture primitive.
- Adds the `trace` extension capability and manifest contract, plus trace result/list parsing and command output envelopes.
- Includes minimal single-rig support: `--rig <id>` runs `rig check`, resolves the rig component path/config, passes rig env vars, and embeds rig state metadata.

## Contract
- Manifest: `trace.extension_script`.
- Runner env: `HOMEBOY_TRACE_RESULTS_FILE`, `HOMEBOY_TRACE_SCENARIO`, `HOMEBOY_TRACE_LIST_ONLY`, `HOMEBOY_TRACE_ARTIFACT_DIR`, `HOMEBOY_TRACE_RIG_ID`, `HOMEBOY_TRACE_COMPONENT_PATH`, and `HOMEBOY_RUN_DIR`.
- Result statuses: `pass`, `fail`, `error`.
- Artifacts remain local paths under the trace run directory; upload/comment integration is intentionally out of scope.

## Tests
- `cargo test trace`
- `cargo test command_surface --test command_surface_test`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-trace-command`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-trace-command --changed-since origin/main`

Closes #1932
Closes #1933

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5; `openai/gpt-5.5`)
- **Used for:** Implemented the trace command, runner contract, rig threading, tests, and docs. Chris remains responsible for review and merge decisions.
