### PR TITLE
feat(trace): support temporary overlays

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -32,6 +32,14 @@ pub struct TraceArgs {
     /// Print compact machine-readable summary.
     #[arg(long)]
     pub json_summary: bool,
+
+    /// Apply a patch file for this trace run, then reverse it afterward.
+    #[arg(long = "overlay", value_name = "PATCH_FILE")]
+    pub overlays: Vec<String>,
+
+    /// Leave overlay changes in place after the trace run.
+    #[arg(long)]
+    pub keep_overlay: bool,
 }
 
 pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutput> {
@@ -76,6 +84,8 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
             scenario_id: args.scenario,
             json_summary: args.json_summary,
             rig_id: args.rig,
+            overlays: args.overlays,
+            keep_overlay: args.keep_overlay,
         },
         &run_dir,
         rig_state.clone(),

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -3,7 +3,7 @@
 use serde::Serialize;
 
 use super::parsing::{TraceArtifact, TraceList, TraceResults};
-use super::run::TraceRunWorkflowResult;
+use super::run::{TraceOverlay, TraceRunWorkflowResult};
 use crate::rig::RigStateSnapshot;
 
 #[derive(Serialize)]
@@ -28,6 +28,8 @@ pub struct TraceRunOutput {
     pub rig_state: Option<RigStateSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<super::run::TraceRunFailure>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlays: Vec<TraceOverlay>,
 }
 
 #[derive(Serialize)]
@@ -45,6 +47,8 @@ pub struct TraceRunSummaryOutput {
     pub artifact_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlays: Vec<TraceOverlay>,
 }
 
 #[derive(Serialize)]
@@ -82,6 +86,7 @@ pub fn from_main_workflow(
                 .map(|r| r.artifacts.len())
                 .unwrap_or(0),
             rig_id: rig_state.as_ref().map(|r| r.rig_id.clone()),
+            overlays: result.overlays,
         };
         return (TraceCommandOutput::Summary(output), exit_code);
     }
@@ -101,6 +106,7 @@ pub fn from_main_workflow(
             results: result.results,
             rig_state,
             failure: result.failure,
+            overlays: result.overlays,
         })),
         exit_code,
     )
@@ -173,6 +179,11 @@ mod tests {
                 }],
             }),
             failure: None,
+            overlays: vec![TraceOverlay {
+                path: "/tmp/overlay.patch".to_string(),
+                touched_files: vec!["scenario.txt".to_string()],
+                kept: false,
+            }],
         };
 
         let (output, exit_code) = from_main_workflow(result, None, true);
@@ -183,5 +194,8 @@ mod tests {
         assert_eq!(value["passed"], true);
         assert_eq!(value["scenario_id"], "close-window-running-site");
         assert_eq!(value["artifact_count"], 1);
+        assert_eq!(value["overlays"][0]["path"], "/tmp/overlay.patch");
+        assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
+        assert_eq!(value["overlays"][0]["kept"], false);
     }
 }

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -1,6 +1,8 @@
 //! Trace workflows: invoke extension runners, parse JSON, preserve artifacts.
 
 use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::component::Component;
 use crate::engine::run_dir::{self, RunDir};
@@ -23,6 +25,8 @@ pub struct TraceRunWorkflowArgs {
     pub scenario_id: String,
     pub json_summary: bool,
     pub rig_id: Option<String>,
+    pub overlays: Vec<String>,
+    pub keep_overlay: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +48,15 @@ pub struct TraceRunWorkflowResult {
     pub results: Option<TraceResults>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<TraceRunFailure>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlays: Vec<TraceOverlay>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TraceOverlay {
+    pub path: String,
+    pub touched_files: Vec<String>,
+    pub kept: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -63,8 +76,29 @@ pub fn run_trace_workflow(
     rig_state: Option<RigStateSnapshot>,
 ) -> Result<TraceRunWorkflowResult> {
     let execution_context = resolve_execution_context(component, ExtensionCapability::Trace)?;
-    let runner_output =
-        build_trace_runner(&execution_context, component, &args, run_dir, false)?.run()?;
+    run_trace_workflow_with_context(&execution_context, component, args, run_dir, rig_state)
+}
+
+fn run_trace_workflow_with_context(
+    execution_context: &ExtensionExecutionContext,
+    component: &Component,
+    args: TraceRunWorkflowArgs,
+    run_dir: &RunDir,
+    rig_state: Option<RigStateSnapshot>,
+) -> Result<TraceRunWorkflowResult> {
+    let component_path = args
+        .path_override
+        .as_deref()
+        .unwrap_or(component.local_path.as_str());
+    let applied_overlays = apply_trace_overlays(component_path, &args.overlays, args.keep_overlay)?;
+    let runner = build_trace_runner(execution_context, component, &args, run_dir, false)?;
+    let runner_output = runner.run();
+    if !args.keep_overlay {
+        if let Err(cleanup_error) = cleanup_trace_overlays(&applied_overlays) {
+            return Err(cleanup_error);
+        }
+    }
+    let runner_output = runner_output?;
     let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
     let results = if results_path.exists() {
         let mut parsed = parse_trace_results_file(&results_path)?;
@@ -103,6 +137,14 @@ pub fn run_trace_workflow(
         exit_code,
         results,
         failure,
+        overlays: applied_overlays
+            .into_iter()
+            .map(|overlay| TraceOverlay {
+                path: overlay.patch_path.to_string_lossy().to_string(),
+                touched_files: overlay.touched_files,
+                kept: overlay.keep,
+            })
+            .collect(),
     })
 }
 
@@ -121,6 +163,8 @@ pub fn run_trace_list_workflow(
         scenario_id: String::new(),
         json_summary: false,
         rig_id: args.rig_id,
+        overlays: Vec::new(),
+        keep_overlay: false,
     };
     let output =
         build_trace_runner(&execution_context, component, &runner_args, run_dir, true)?.run()?;
@@ -215,10 +259,189 @@ fn failure_from_output(args: &TraceRunWorkflowArgs, output: &RunnerOutput) -> Tr
     }
 }
 
+#[derive(Debug, Clone)]
+struct AppliedTraceOverlay {
+    component_path: PathBuf,
+    patch_path: PathBuf,
+    touched_files: Vec<String>,
+    keep: bool,
+}
+
+fn apply_trace_overlays(
+    component_path: &str,
+    overlay_paths: &[String],
+    keep: bool,
+) -> Result<Vec<AppliedTraceOverlay>> {
+    let component_path = PathBuf::from(component_path);
+    let mut applied = Vec::new();
+    for overlay_path in overlay_paths {
+        let patch_path = PathBuf::from(overlay_path);
+        let touched_files = match overlay_touched_files(&component_path, &patch_path) {
+            Ok(files) => files,
+            Err(error) => {
+                if !keep {
+                    let _ = cleanup_trace_overlays(&applied);
+                }
+                return Err(error);
+            }
+        };
+        if let Err(error) =
+            ensure_overlay_targets_clean(&component_path, &patch_path, &touched_files)
+        {
+            if !keep {
+                let _ = cleanup_trace_overlays(&applied);
+            }
+            return Err(error);
+        }
+        if let Err(error) = run_git_apply(&component_path, &patch_path, false) {
+            if !keep {
+                let _ = cleanup_trace_overlays(&applied);
+            }
+            return Err(error);
+        }
+        applied.push(AppliedTraceOverlay {
+            component_path: component_path.clone(),
+            patch_path,
+            touched_files,
+            keep,
+        });
+    }
+    Ok(applied)
+}
+
+fn cleanup_trace_overlays(applied: &[AppliedTraceOverlay]) -> Result<()> {
+    for overlay in applied.iter().rev() {
+        run_git_apply(&overlay.component_path, &overlay.patch_path, true)?;
+    }
+    Ok(())
+}
+
+fn overlay_touched_files(component_path: &Path, patch_path: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["apply", "--numstat"])
+        .arg(patch_path)
+        .current_dir(component_path)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to inspect trace overlay {}: {}",
+                    patch_path.display(),
+                    e
+                ),
+                Some("trace.overlay.inspect".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "--overlay",
+            format!("trace overlay {} cannot be inspected", patch_path.display()),
+            Some(String::from_utf8_lossy(&output.stderr).to_string()),
+            None,
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split('\t').nth(2))
+        .map(unquote_numstat_path)
+        .filter(|path| !path.is_empty())
+        .collect())
+}
+
+fn ensure_overlay_targets_clean(
+    component_path: &Path,
+    patch_path: &Path,
+    touched_files: &[String],
+) -> Result<()> {
+    if touched_files.is_empty() {
+        return Ok(());
+    }
+    let mut command = Command::new("git");
+    command
+        .args(["status", "--porcelain=v1", "--"])
+        .args(touched_files)
+        .current_dir(component_path);
+    let output = command.output().map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to check trace overlay targets for {}: {}",
+                patch_path.display(),
+                e
+            ),
+            Some("trace.overlay.status".to_string()),
+        )
+    })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "--overlay",
+            format!(
+                "failed to check overlay target status for {}",
+                patch_path.display()
+            ),
+            Some(String::from_utf8_lossy(&output.stderr).to_string()),
+            None,
+        ));
+    }
+    let dirty = String::from_utf8_lossy(&output.stdout);
+    if !dirty.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "--overlay",
+            format!(
+                "trace overlay {} touches files with pre-existing changes",
+                patch_path.display()
+            ),
+            Some(dirty.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn run_git_apply(component_path: &Path, patch_path: &Path, reverse: bool) -> Result<()> {
+    let mut command = Command::new("git");
+    command.arg("apply");
+    if reverse {
+        command.arg("--reverse");
+    }
+    let output = command
+        .arg(patch_path)
+        .current_dir(component_path)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to apply trace overlay {}: {}",
+                    patch_path.display(),
+                    e
+                ),
+                Some("trace.overlay.apply".to_string()),
+            )
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let action = if reverse { "revert" } else { "apply" };
+    Err(Error::validation_invalid_argument(
+        "--overlay",
+        format!(
+            "failed to {} trace overlay {}",
+            action,
+            patch_path.display()
+        ),
+        Some(String::from_utf8_lossy(&output.stderr).to_string()),
+        None,
+    ))
+}
+
+fn unquote_numstat_path(path: &str) -> String {
+    path.trim().trim_matches('"').to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
     use std::fs;
+    use std::process::Command;
 
     use crate::component::{Component, ScopedExtensionConfig};
     use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
@@ -273,6 +496,8 @@ JSON
             scenario_id: "close-window".to_string(),
             json_summary: false,
             rig_id: Some("studio".to_string()),
+            overlays: Vec::new(),
+            keep_overlay: false,
         };
 
         let output = build_trace_runner(&context, &component, &args, &run_dir, false)
@@ -332,6 +557,8 @@ JSON
             scenario_id: String::new(),
             json_summary: false,
             rig_id: None,
+            overlays: Vec::new(),
+            keep_overlay: false,
         };
 
         let output = build_trace_runner(&context, &component, &args, &run_dir, true)
@@ -357,6 +584,8 @@ JSON
             scenario_id: "close-window".to_string(),
             json_summary: false,
             rig_id: None,
+            overlays: Vec::new(),
+            keep_overlay: false,
         };
         let output = RunnerOutput {
             success: false,
@@ -375,6 +604,181 @@ JSON
         assert_eq!(failure.exit_code, 2);
         assert!(failure.stderr_excerpt.contains("line 24"));
         assert!(!failure.stderr_excerpt.contains("line 0"));
+    }
+
+    #[test]
+    fn trace_overlay_applies_for_run_and_reverts_afterward() {
+        let fixture = overlay_fixture(false);
+        let run_dir = RunDir::create().unwrap();
+        let context = trace_context(&fixture.component, &fixture.extension_dir);
+
+        let result = run_trace_workflow_with_context(
+            &context,
+            &fixture.component,
+            fixture.args,
+            &run_dir,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.overlays.len(), 1);
+        assert_eq!(result.overlays[0].touched_files, vec!["scenario.txt"]);
+        assert!(!result.overlays[0].kept);
+        assert_eq!(
+            fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
+            "base\n"
+        );
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn trace_overlay_dirty_target_file_fails_before_patching() {
+        let fixture = overlay_fixture(false);
+        fs::write(fixture.component_dir.join("scenario.txt"), "dirty\n").unwrap();
+
+        let err = apply_trace_overlays(
+            fixture.component_dir.to_str().unwrap(),
+            &[fixture.patch_path.to_string_lossy().to_string()],
+            false,
+        )
+        .unwrap_err();
+
+        assert!(err.message.contains("pre-existing changes"));
+        assert_eq!(
+            fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
+            "dirty\n"
+        );
+    }
+
+    #[test]
+    fn trace_overlay_keep_overlay_leaves_changes_in_place() {
+        let fixture = overlay_fixture(true);
+        let run_dir = RunDir::create().unwrap();
+        let context = trace_context(&fixture.component, &fixture.extension_dir);
+
+        let result = run_trace_workflow_with_context(
+            &context,
+            &fixture.component,
+            fixture.args,
+            &run_dir,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.overlays.len(), 1);
+        assert!(result.overlays[0].kept);
+        assert_eq!(
+            fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
+            "overlay\n"
+        );
+        run_dir.cleanup();
+    }
+
+    struct OverlayFixture {
+        _temp: tempfile::TempDir,
+        component: Component,
+        component_dir: std::path::PathBuf,
+        extension_dir: std::path::PathBuf,
+        patch_path: std::path::PathBuf,
+        args: TraceRunWorkflowArgs,
+    }
+
+    fn overlay_fixture(keep_overlay: bool) -> OverlayFixture {
+        let temp = tempfile::tempdir().unwrap();
+        let extension_dir = temp.path().join("extension");
+        let component_dir = temp.path().join("component");
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::create_dir_all(&component_dir).unwrap();
+        write_extension_manifest(&extension_dir);
+        write_overlay_runner(&extension_dir.join("trace-runner.sh"));
+        fs::write(component_dir.join("scenario.txt"), "base\n").unwrap();
+        init_git_repo(&component_dir);
+        let patch_path = temp.path().join("overlay.patch");
+        fs::write(
+            &patch_path,
+            r#"--- a/scenario.txt
++++ b/scenario.txt
+@@ -1 +1 @@
+-base
++overlay
+"#,
+        )
+        .unwrap();
+        let component = component_with_extension("example", &component_dir);
+        let args = TraceRunWorkflowArgs {
+            component_label: "example".to_string(),
+            component_id: "example".to_string(),
+            path_override: Some(component_dir.to_string_lossy().to_string()),
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            scenario_id: "overlay".to_string(),
+            json_summary: false,
+            rig_id: None,
+            overlays: vec![patch_path.to_string_lossy().to_string()],
+            keep_overlay,
+        };
+        OverlayFixture {
+            _temp: temp,
+            component,
+            component_dir,
+            extension_dir,
+            patch_path,
+            args,
+        }
+    }
+
+    fn write_overlay_runner(script: &std::path::Path) {
+        fs::write(
+            script,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+grep -q '^overlay$' "$HOMEBOY_TRACE_COMPONENT_PATH/scenario.txt"
+cat > "$HOMEBOY_TRACE_RESULTS_FILE" <<JSON
+{"component_id":"example","scenario_id":"overlay","status":"pass","timeline":[],"assertions":[],"artifacts":[]}
+JSON
+"#,
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(script).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(script, perms).unwrap();
+        }
+    }
+
+    fn init_git_repo(path: &std::path::Path) {
+        git(path, &["init"]);
+        git(path, &["add", "scenario.txt"]);
+        git(
+            path,
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "init",
+            ],
+        );
+    }
+
+    fn git(path: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     fn component_with_extension(id: &str, path: &std::path::Path) -> Component {

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -278,26 +278,15 @@ fn apply_trace_overlays(
         let patch_path = PathBuf::from(overlay_path);
         let touched_files = match overlay_touched_files(&component_path, &patch_path) {
             Ok(files) => files,
-            Err(error) => {
-                if !keep {
-                    let _ = cleanup_trace_overlays(&applied);
-                }
-                return Err(error);
-            }
+            Err(error) => return cleanup_after_overlay_error(&applied, keep, error),
         };
         if let Err(error) =
             ensure_overlay_targets_clean(&component_path, &patch_path, &touched_files)
         {
-            if !keep {
-                let _ = cleanup_trace_overlays(&applied);
-            }
-            return Err(error);
+            return cleanup_after_overlay_error(&applied, keep, error);
         }
         if let Err(error) = run_git_apply(&component_path, &patch_path, false) {
-            if !keep {
-                let _ = cleanup_trace_overlays(&applied);
-            }
-            return Err(error);
+            return cleanup_after_overlay_error(&applied, keep, error);
         }
         applied.push(AppliedTraceOverlay {
             component_path: component_path.clone(),
@@ -307,6 +296,17 @@ fn apply_trace_overlays(
         });
     }
     Ok(applied)
+}
+
+fn cleanup_after_overlay_error<T>(
+    applied: &[AppliedTraceOverlay],
+    keep: bool,
+    error: Error,
+) -> Result<T> {
+    if !keep {
+        let _ = cleanup_trace_overlays(applied);
+    }
+    Err(error)
 }
 
 fn cleanup_trace_overlays(applied: &[AppliedTraceOverlay]) -> Result<()> {


### PR DESCRIPTION
## Summary
- Adds repeatable `homeboy trace ... --overlay <patch-file>` support for temporary patch overlays.
- Adds `--keep-overlay` for intentionally leaving applied overlay changes in place after a trace run.
- Records overlay metadata in trace JSON output so runs show which patch paths and target files were involved.

## Behavior
- Inspects each overlay patch with `git apply --numstat` to find target files before applying it.
- Fails before patching if any target file has pre-existing worktree changes.
- Applies overlays for the trace run, then reverse-applies them afterward unless `--keep-overlay` is set.
- Runs overlay cleanup even when the trace runner fails, while preserving unrelated worktree changes.

## Tests
- `cargo fmt --check`
- `cargo test trace`
- `cargo test command_surface --test command_surface_test`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-trace-overlays --changed-since origin/main --json-summary`

Closes #1934

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the trace overlay implementation and PR description; Chris remains responsible for review and merge.