### PR TITLE
feat(trace): include trace artifacts in reports

### DIFF
--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -219,20 +219,16 @@ fn envelope_parts(value: Option<Value>) -> (Map<String, Value>, Map<String, Valu
     };
 
     if root.contains_key("success") || root.contains_key("data") || root.contains_key("error") {
-        let data = root
-            .remove("data")
-            .and_then(|v| match v {
-                Value::Object(map) => Some(map),
-                _ => None,
-            })
-            .unwrap_or_default();
-        let error = root
-            .remove("error")
-            .and_then(|v| match v {
-                Value::Object(map) => Some(map),
-                _ => None,
-            })
-            .unwrap_or_default();
+        let take_object = |root: &mut Map<String, Value>, key: &str| {
+            root.remove(key)
+                .and_then(|v| match v {
+                    Value::Object(map) => Some(map),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        };
+        let data = take_object(&mut root, "data");
+        let error = take_object(&mut root, "error");
         return (data, error);
     }
 

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -140,6 +140,9 @@ pub fn render_failure_digest(context: &FailureDigestContext) -> String {
     if command_failed(&context.results, "audit") {
         render_audit_section(&mut out, &context.output_dir, &context.run_url);
     }
+    if command_reported(&context.results, "trace") {
+        render_trace_section(&mut out, &context.output_dir, &context.run_url);
+    }
 
     render_autofix_section(&mut out, context);
     render_tooling_section(&mut out, &context.tooling);
@@ -175,6 +178,10 @@ fn command_failed(results: &Map<String, Value>, command: &str) -> bool {
         .get(command)
         .and_then(Value::as_str)
         .is_some_and(|status| status == "fail")
+}
+
+fn command_reported(results: &Map<String, Value>, command: &str) -> bool {
+    results.contains_key(command)
 }
 
 fn command_names_from_csv(raw: &str) -> BTreeSet<String> {
@@ -378,6 +385,68 @@ fn render_audit_section(out: &mut String, output_dir: &Path, run_url: &str) {
     out.push('\n');
 }
 
+fn render_trace_section(out: &mut String, output_dir: &Path, run_url: &str) {
+    let (data, error) = envelope_parts(read_command_json(output_dir, "trace"));
+    let results = object_value(&data, "results");
+    let failure = object_value(&data, "failure");
+
+    let component = string_value(&data, "component")
+        .or_else(|| string_value(&results, "component_id"))
+        .or_else(|| string_value(&failure, "component_id"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let scenario_id = string_value(&data, "scenario_id")
+        .or_else(|| string_value(&results, "scenario_id"))
+        .or_else(|| string_value(&failure, "scenario_id"));
+    let status = string_value(&data, "status")
+        .or_else(|| string_value(&results, "status"))
+        .or_else(|| string_value(&error, "code"))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let title = scenario_id
+        .as_ref()
+        .map(|scenario| format!("{} / {}", component, scenario))
+        .unwrap_or(component);
+    let _ = writeln!(out, "### Trace: {}", title);
+    let _ = writeln!(out, "**Status:** {}\n", status.to_uppercase());
+
+    let mut summary_lines = Vec::new();
+    if let Some(summary) =
+        string_value(&data, "summary").or_else(|| string_value(&results, "summary"))
+    {
+        summary_lines.push(summary);
+    }
+    if let Some(failure_message) = string_value(&results, "failure") {
+        summary_lines.push(failure_message);
+    }
+    if let Some(stderr_excerpt) = string_value(&failure, "stderr_excerpt") {
+        summary_lines.push(stderr_excerpt);
+    }
+    if let Some(message) = string_value(&error, "message") {
+        summary_lines.push(message);
+    }
+
+    if !summary_lines.is_empty() {
+        out.push_str("**Summary**\n");
+        for line in summary_lines {
+            let _ = writeln!(out, "- {}", line);
+        }
+        out.push('\n');
+    }
+
+    let artifacts = collect_trace_artifacts(&data, &results);
+    if !artifacts.is_empty() {
+        out.push_str("**Artifacts**\n");
+        for (label, path) in artifacts {
+            let _ = writeln!(out, "- {}: {}", label, path);
+        }
+    } else {
+        out.push_str("**Artifacts**\n- No structured trace artifacts available.\n");
+    }
+
+    render_full_log(out, "trace", run_url);
+    out.push('\n');
+}
+
 fn render_error_details(out: &mut String, error: &Map<String, Value>) {
     if let Some(code) = string_value(error, "code") {
         let _ = writeln!(out, "- Error code: `{}`", code);
@@ -568,6 +637,29 @@ fn array_from_object(map: &Map<String, Value>, key: &str) -> Vec<Value> {
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default()
+}
+
+fn collect_trace_artifacts(
+    data: &Map<String, Value>,
+    results: &Map<String, Value>,
+) -> Vec<(String, String)> {
+    let mut seen = BTreeSet::new();
+    [
+        array_value(data, "artifacts"),
+        array_value(results, "artifacts"),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(|artifact| {
+        let obj = artifact.as_object()?;
+        let label = string_value(obj, "label").or_else(|| string_value(obj, "name"))?;
+        let path = string_value(obj, "path")?;
+        if !seen.insert((label.clone(), path.clone())) {
+            return None;
+        }
+        Some((label, path))
+    })
+    .collect()
 }
 
 fn string_array(map: &Map<String, Value>, key: &str) -> Vec<String> {

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -45,7 +45,7 @@ fn trace_json(status: &str, summary: &str) -> String {
                 "component": "studio",
                 "exit_code": {exit_code},
                 "artifacts": [
-                    {{"label":"main log","path":"artifacts/main.log"}},
+                    {{"label":"main log","path":"artifacts/main.log","content":"raw log body that should never appear"}},
                     {{"label":"process tree","path":"artifacts/process-tree.txt"}}
                 ],
                 "results": {{
@@ -56,7 +56,7 @@ fn trace_json(status: &str, summary: &str) -> String {
                     "timeline": [],
                     "assertions": [],
                     "artifacts": [
-                        {{"label":"main log","path":"artifacts/main.log"}},
+                        {{"label":"main log","path":"artifacts/main.log","content":"raw log body that should never appear"}},
                         {{"label":"process tree","path":"artifacts/process-tree.txt"}}
                     ]
                 }}
@@ -243,12 +243,6 @@ fn renders_trace_fail_status_without_inlining_artifact_content() {
         &dir,
         "trace.json",
         &trace_json("fail", "Window reopened after close."),
-    );
-    fs::create_dir_all(dir.join("artifacts")).expect("artifact dir should exist");
-    write_file(
-        &dir,
-        "artifacts/main.log",
-        "raw log body that should never appear",
     );
 
     let markdown = render(&dir, r#"{"trace":"fail"}"#, false, false);

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -35,6 +35,38 @@ fn render(dir: &Path, results: &str, autofix_enabled: bool, autofix_attempted: b
     .expect("failure digest should render")
 }
 
+fn trace_json(status: &str, summary: &str) -> String {
+    format!(
+        r#"{{
+            "success": {success},
+            "data": {{
+                "passed": {success},
+                "status": "{status}",
+                "component": "studio",
+                "exit_code": {exit_code},
+                "artifacts": [
+                    {{"label":"main log","path":"artifacts/main.log"}},
+                    {{"label":"process tree","path":"artifacts/process-tree.txt"}}
+                ],
+                "results": {{
+                    "component_id": "studio",
+                    "scenario_id": "close-window-running-site",
+                    "status": "{status}",
+                    "summary": "{summary}",
+                    "timeline": [],
+                    "assertions": [],
+                    "artifacts": [
+                        {{"label":"main log","path":"artifacts/main.log"}},
+                        {{"label":"process tree","path":"artifacts/process-tree.txt"}}
+                    ]
+                }}
+            }}
+        }}"#,
+        success = status == "pass",
+        exit_code = if status == "pass" { 0 } else { 1 }
+    )
+}
+
 #[test]
 fn renders_lint_failure_digest_from_fixture() {
     let dir = tmp_dir("lint");
@@ -177,6 +209,88 @@ fn renders_tooling_metadata_from_json_file() {
     assert!(markdown.contains("### Tooling metadata"));
     assert!(markdown.contains("- action_repository: `Extra-Chill/homeboy-action`"));
     assert!(markdown.contains("- extension_id: `wordpress`"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_trace_pass_status_and_artifact_paths() {
+    let dir = tmp_dir("trace-pass");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(
+        &dir,
+        "trace.json",
+        &trace_json("pass", "Window stayed closed."),
+    );
+
+    let markdown = render(&dir, r#"{"trace":"pass"}"#, false, false);
+
+    assert!(markdown.contains("### Trace: studio / close-window-running-site"));
+    assert!(markdown.contains("**Status:** PASS"));
+    assert!(markdown.contains("- Window stayed closed."));
+    assert!(markdown.contains("- main log: artifacts/main.log"));
+    assert!(markdown.contains("- process tree: artifacts/process-tree.txt"));
+    assert!(!markdown.contains("raw log body that should never appear"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_trace_fail_status_without_inlining_artifact_content() {
+    let dir = tmp_dir("trace-fail");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(
+        &dir,
+        "trace.json",
+        &trace_json("fail", "Window reopened after close."),
+    );
+    fs::create_dir_all(dir.join("artifacts")).expect("artifact dir should exist");
+    write_file(
+        &dir,
+        "artifacts/main.log",
+        "raw log body that should never appear",
+    );
+
+    let markdown = render(&dir, r#"{"trace":"fail"}"#, false, false);
+
+    assert!(markdown.contains("**Status:** FAIL"));
+    assert!(markdown.contains("- Window reopened after close."));
+    assert!(markdown.contains("- main log: artifacts/main.log"));
+    assert!(!markdown.contains("raw log body that should never appear"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_trace_error_status_from_failure_envelope() {
+    let dir = tmp_dir("trace-error");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(
+        &dir,
+        "trace.json",
+        r#"{
+            "success": false,
+            "data": {
+                "passed": false,
+                "status": "error",
+                "component": "studio",
+                "exit_code": 2,
+                "failure": {
+                    "component_id": "studio",
+                    "scenario_id": "close-window-running-site",
+                    "exit_code": 2,
+                    "stderr_excerpt": "runner failed before assertions"
+                }
+            }
+        }"#,
+    );
+
+    let markdown = render(&dir, r#"{"trace":"error"}"#, false, false);
+
+    assert!(markdown.contains("### Trace: studio / close-window-running-site"));
+    assert!(markdown.contains("**Status:** ERROR"));
+    assert!(markdown.contains("- runner failed before assertions"));
+    assert!(markdown.contains("- No structured trace artifacts available."));
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- Add trace sections to `homeboy report failure-digest` so PR-comment-ready output shows trace status, summary, and artifact labels/paths.
- Preserve trace artifact references as links/paths only; raw artifact contents are not read or inlined.
- Cover pass, fail, and error trace rendering in the failure digest tests.

## Report behavior
- Renders `### Trace: <component> / <scenario>` when `trace` is present in the results map.
- Shows `PASS`, `FAIL`, or `ERROR` status from the trace envelope.
- Lists structured artifact labels and paths from `trace.json`, de-duplicating root/results artifact refs.

## Tests
- `cargo fmt --check`
- `cargo test trace`
- `cargo test --test report_failure_digest_test`
- `cargo test command_surface --test command_surface_test`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-trace-report-artifacts --changed-since origin/main --json-summary`

Closes #1936

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the report renderer change, added focused tests, and ran the verification commands. Chris remains responsible for review and merge.