### PR TITLE
feat(rig): add argv selectors for external services

### DIFF
--- a/src/core/rig/check.rs
+++ b/src/core/rig/check.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use super::expand::expand_vars;
-use super::service::discover_newest;
+use super::service::discover_newest_for_spec;
 use super::spec::{CheckSpec, NewerThanSpec, RigSpec, TimeSource};
 use crate::error::{Error, Result};
 
@@ -308,8 +308,15 @@ fn resolve_time_source(rig: &RigSpec, src: &TimeSource, side: &str) -> Result<Op
     }
 
     if let Some(disc) = &src.process_start {
-        let pattern = expand_vars(rig, &disc.pattern);
-        let proc = discover_newest(&pattern)?;
+        let expanded = super::spec::DiscoverSpec {
+            pattern: expand_vars(rig, &disc.pattern),
+            argv_contains: disc
+                .argv_contains
+                .iter()
+                .map(|selector| expand_vars(rig, selector))
+                .collect(),
+        };
+        let proc = discover_newest_for_spec(&expanded)?;
         return Ok(proc.map(|p| p.started_at_epoch));
     }
 

--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -17,7 +17,7 @@
 //! inside a `#[cfg(unix)]` module; on Windows the public API compiles but
 //! returns `RigServiceFailed` so the crate still builds everywhere.
 
-use super::spec::RigSpec;
+use super::spec::{DiscoverSpec, RigSpec};
 use crate::error::Result;
 
 /// Live status of a service as seen at probe time.
@@ -69,13 +69,18 @@ pub fn log_path(rig_id: &str, service_id: &str) -> Result<std::path::PathBuf> {
 /// fresh pair surfaces the fresh one to consumers (the rig wants to know
 /// "is the live daemon stale?").
 pub fn discover_newest(pattern: &str) -> Result<Option<DiscoveredProcess>> {
-    platform::discover_newest(pattern)
+    platform::discover_newest(pattern, &[])
+}
+
+/// Find the newest process matching a full discovery spec.
+pub fn discover_newest_for_spec(discover: &DiscoverSpec) -> Result<Option<DiscoveredProcess>> {
+    platform::discover_newest(&discover.pattern, &discover.argv_contains)
 }
 
 /// `discover_newest`, but returning the PID only. Convenience used by
 /// `service::stop` for the `external` kind.
-pub fn discover_external_pid(pattern: &str) -> Result<Option<u32>> {
-    Ok(discover_newest(pattern)?.map(|p| p.pid))
+pub fn discover_external_pid(discover: &DiscoverSpec) -> Result<Option<u32>> {
+    Ok(discover_newest_for_spec(discover)?.map(|p| p.pid))
 }
 
 /// Parse `ps -o etime` output into total seconds.
@@ -199,18 +204,14 @@ mod platform {
         // via the configured pattern. No discovery hit ⇒ nothing to stop;
         // that's the desired posture (idempotent: "make sure it's gone").
         let pid = if spec.kind == ServiceKind::External {
-            let pattern = spec
-                .discover
-                .as_ref()
-                .map(|d| d.pattern.clone())
-                .ok_or_else(|| {
-                    Error::rig_service_failed(
-                        &rig.id,
-                        service_id,
-                        "external service requires `discover.pattern`",
-                    )
-                })?;
-            let expanded = expand_vars(rig, &pattern);
+            let discover = spec.discover.as_ref().ok_or_else(|| {
+                Error::rig_service_failed(
+                    &rig.id,
+                    service_id,
+                    "external service requires `discover.pattern`",
+                )
+            })?;
+            let expanded = expand_discover(rig, discover);
             match super::discover_external_pid(&expanded)? {
                 Some(pid) => pid,
                 None => return Ok(()),
@@ -320,6 +321,20 @@ mod platform {
         }
     }
 
+    fn expand_discover(
+        rig: &RigSpec,
+        discover: &super::super::spec::DiscoverSpec,
+    ) -> super::super::spec::DiscoverSpec {
+        super::super::spec::DiscoverSpec {
+            pattern: expand_vars(rig, &discover.pattern),
+            argv_contains: discover
+                .argv_contains
+                .iter()
+                .map(|selector| expand_vars(rig, selector))
+                .collect(),
+        }
+    }
+
     pub(super) fn log_file_path(rig_id: &str, service_id: &str) -> Result<PathBuf> {
         Ok(paths::rig_logs_dir(rig_id)?.join(format!("{}.log", service_id)))
     }
@@ -387,7 +402,10 @@ mod platform {
     /// (macOS) and procps `ps` (Linux). `etimes` (integer seconds) is
     /// procps-only, so the text format is the portable choice. Newest
     /// match = smallest elapsed seconds.
-    pub fn discover_newest(pattern: &str) -> Result<Option<super::DiscoveredProcess>> {
+    pub fn discover_newest(
+        pattern: &str,
+        argv_contains: &[String],
+    ) -> Result<Option<super::DiscoveredProcess>> {
         let output = Command::new("ps")
             .args(["-axo", "pid=,etime=,args="])
             .output()
@@ -408,8 +426,24 @@ mod platform {
         let self_pid = std::process::id();
         let stdout = String::from_utf8_lossy(&output.stdout);
 
+        Ok(discover_newest_from_ps(
+            pattern,
+            argv_contains,
+            now,
+            self_pid,
+            &stdout,
+        ))
+    }
+
+    pub(super) fn discover_newest_from_ps(
+        pattern: &str,
+        argv_contains: &[String],
+        now: u64,
+        self_pid: u32,
+        ps_stdout: &str,
+    ) -> Option<super::DiscoveredProcess> {
         let mut newest: Option<super::DiscoveredProcess> = None;
-        for line in stdout.lines() {
+        for line in ps_stdout.lines() {
             // Format: "  <pid>  <etime>  <args...>"
             let trimmed = line.trim_start();
             let pid_end = match trimmed.find(char::is_whitespace) {
@@ -429,6 +463,12 @@ mod platform {
             let args = after_pid[etime_end..].trim_start();
 
             if !args.contains(pattern) {
+                continue;
+            }
+            if argv_contains
+                .iter()
+                .any(|selector| !args.contains(selector))
+            {
                 continue;
             }
             if pid == self_pid {
@@ -452,7 +492,7 @@ mod platform {
                 _ => {}
             }
         }
-        Ok(newest)
+        newest
     }
 
     /// Parse `ps -o etime` output into total seconds.
@@ -461,7 +501,7 @@ mod platform {
     /// - `MM:SS`
     /// - `HH:MM:SS`
     /// - `DD-HH:MM:SS`
-    /// Anything else returns `None`.
+    ///   Anything else returns `None`.
     pub(super) fn parse_etime_seconds(s: &str) -> Option<u64> {
         let (days, rest) = match s.split_once('-') {
             Some((d, r)) => (d.parse::<u64>().ok()?, r),
@@ -510,7 +550,10 @@ mod platform {
         Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
     }
 
-    pub fn discover_newest(_pattern: &str) -> Result<Option<super::DiscoveredProcess>> {
+    pub fn discover_newest(
+        _pattern: &str,
+        _argv_contains: &[String],
+    ) -> Result<Option<super::DiscoveredProcess>> {
         Err(Error::internal_unexpected(UNSUPPORTED))
     }
 }

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -295,17 +295,24 @@ pub struct ServiceSpec {
 }
 
 /// Discovery strategy for an `external` service — how to find a PID the rig
-/// didn't spawn. The single `pattern` field matches against the process
-/// command line (`ps -o args`); `kind = "external"` services pick the
-/// newest matching PID. Multiple matches are not an error — a stale
-/// child + a fresh child is the case we care about, and the fresh one
-/// is what the rig wants to interact with.
+/// didn't spawn. The `pattern` field preserves the original broad substring
+/// match against the process command line (`ps -o args`); optional selectors
+/// narrow that candidate set. `kind = "external"` services pick the newest
+/// matching PID. Multiple matches are not an error — a stale child + a fresh
+/// child is the case we care about, and the fresh one is what the rig wants to
+/// interact with.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiscoverSpec {
     /// Substring that must appear in the target process's command line.
     /// Matched against `ps -o args= -p <pid>` output, so users can pin
     /// against script paths (`wordpress-server-child.mjs`) or argv tokens.
     pub pattern: String,
+
+    /// Additional argv substrings that must all appear in the target process's
+    /// command line. Use this to keep a broad `pattern` fallback while pinning
+    /// an external service to a more specific script path or flag set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub argv_contains: Vec<String>,
 }
 
 /// Supported service kinds. Extensions will register more in a future phase.

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -179,6 +179,7 @@ fn test_evaluate_newer_than_missing_left_process_passes() {
                 process_start: Some(DiscoverSpec {
                     // Pattern that cannot match any process — ensures None.
                     pattern: "homeboy-test-marker-no-process-matches-this-XQZ-9999".to_string(),
+                    argv_contains: Vec::new(),
                 }),
                 ..Default::default()
             },

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -133,6 +133,7 @@ mod lifecycle {
                     health: None,
                     discover: Some(DiscoverSpec {
                         pattern: "homeboy-test-no-such-external-process-XQZ-1463".to_string(),
+                        argv_contains: Vec::new(),
                     }),
                 },
             );
@@ -149,6 +150,66 @@ mod lifecycle {
                 ServiceStatus::Stopped
             );
         });
+    }
+
+    #[test]
+    fn test_discover_newest_from_ps_requires_all_argv_selectors() {
+        let now = 1_000;
+        let ps_output = r#"
+101  00:00:50  node /Applications/Studio.app/wordpress-server-child.mjs
+202  00:00:40  node /Users/chubes/Developer/studio@bfb-mu-plugin/playground-server-child.mjs wordpress-server-child.mjs
+303  00:00:30  node /Users/chubes/Developer/studio@other/playground-server-child.mjs wordpress-server-child.mjs
+"#;
+        let selectors = vec![
+            "studio@bfb-mu-plugin".to_string(),
+            "playground-server-child.mjs".to_string(),
+        ];
+
+        let found = super::super::platform::discover_newest_from_ps(
+            "wordpress-server-child.mjs",
+            &selectors,
+            now,
+            999,
+            ps_output,
+        )
+        .expect("matching process");
+
+        assert_eq!(found.pid, 202);
+        assert_eq!(found.started_at_epoch, 960);
+    }
+
+    #[test]
+    fn test_discover_newest_from_ps_returns_none_when_argv_selector_misses() {
+        let selectors = vec!["studio@bfb-mu-plugin".to_string()];
+        let found = super::super::platform::discover_newest_from_ps(
+            "wordpress-server-child.mjs",
+            &selectors,
+            1_000,
+            999,
+            "101  00:00:50  node /Applications/Studio.app/wordpress-server-child.mjs",
+        );
+
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn test_discover_newest_for_spec_returns_none_when_no_process_matches() {
+        let discover = DiscoverSpec {
+            pattern: "homeboy-test-no-such-process-XQZ-1750".to_string(),
+            argv_contains: vec!["homeboy-test-no-such-selector-XQZ-1750".to_string()],
+        };
+
+        assert_eq!(service::discover_newest_for_spec(&discover).unwrap(), None);
+    }
+
+    #[test]
+    fn test_discover_external_pid_returns_none_when_no_process_matches() {
+        let discover = DiscoverSpec {
+            pattern: "homeboy-test-no-such-external-process-XQZ-1750".to_string(),
+            argv_contains: Vec::new(),
+        };
+
+        assert_eq!(service::discover_external_pid(&discover).unwrap(), None);
     }
 
     #[test]

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -490,7 +490,10 @@ fn test_spec_external_service_kind_with_discover() {
         "services": {
             "studio-daemon": {
                 "kind": "external",
-                "discover": { "pattern": "wordpress-server-child.mjs" }
+                "discover": {
+                    "pattern": "wordpress-server-child.mjs",
+                    "argv_contains": ["studio@bfb-mu-plugin", "playground-server-child.mjs"]
+                }
             }
         }
     }"#;
@@ -500,6 +503,13 @@ fn test_spec_external_service_kind_with_discover() {
     assert_eq!(
         svc.discover.as_ref().unwrap().pattern,
         "wordpress-server-child.mjs"
+    );
+    assert_eq!(
+        svc.discover.as_ref().unwrap().argv_contains,
+        vec![
+            "studio@bfb-mu-plugin".to_string(),
+            "playground-server-child.mjs".to_string()
+        ]
     );
 }
 


### PR DESCRIPTION
## Summary
- Add optional `discover.argv_contains` selectors for rig external services so broad `discover.pattern` matches can be narrowed by required argv substrings.
- Apply the same selector contract to `process_start` checks and keep the existing `pattern`-only shape working by default.
- Add focused service/spec coverage for selector parsing and process-discovery filtering.

## Tests
- `cargo test core::rig::service::service_test -- --test-threads=1`
- `cargo test core::rig::spec::spec_test::test_spec_external_service_kind_with_discover -- --test-threads=1`
- `cargo test core::rig -- --test-threads=1`
- `homeboy lint homeboy --path .`
- `homeboy audit homeboy --path .` (reports existing baseline audit findings unrelated to this change)

Closes #1750

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the external-service selector change, added tests, ran verification, and drafted this PR body. Chris remains responsible for review and merge.
