### PR TITLE
fix(audit): include Rust facade references for exports

### DIFF
--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -1132,7 +1132,7 @@ fn extract_internal_calls(content: &str, skip_calls: &[&str]) -> Vec<String> {
         std::sync::LazyLock::new(|| regex::Regex::new(r"\b(\w+)\s*\(").unwrap());
     for caps in RE.captures_iter(content) {
         let name = &caps[1];
-        if !skip_set.contains(name) && !name.starts_with("test_") {
+        if !skip_set.contains(name) {
             calls.insert(name.to_string());
         }
     }
@@ -1142,7 +1142,7 @@ fn extract_internal_calls(content: &str, skip_calls: &[&str]) -> Vec<String> {
         std::sync::LazyLock::new(|| regex::Regex::new(r"[.:](\w+)\s*\(").unwrap());
     for caps in METHOD_RE.captures_iter(content) {
         let name = &caps[1];
-        if !skip_set.contains(name) && !name.starts_with("test_") {
+        if !skip_set.contains(name) {
             calls.insert(name.to_string());
         }
     }
@@ -1951,6 +1951,29 @@ fn write(msg: &str) -> bool {
         assert!(
             fp.internal_calls.contains(&"write".to_string()),
             "write should be in internal_calls when the file defines fn write(), got: {:?}",
+            fp.internal_calls
+        );
+    }
+
+    #[test]
+    fn rust_internal_calls_include_test_prefixed_production_helpers() {
+        let grammar = rust_grammar();
+        let content = r#"
+use crate::core::code_audit::test_mapping::test_to_source_path;
+
+pub fn map_source() {
+    let _ = test_to_source_path("tests/core/audit_test.rs", &Default::default());
+}
+"#;
+
+        let fp =
+            fingerprint_from_grammar(content, &grammar, "src/core/code_audit/test_coverage.rs")
+                .unwrap();
+
+        assert!(
+            fp.internal_calls
+                .contains(&"test_to_source_path".to_string()),
+            "test_-prefixed production helpers should be retained as references, got: {:?}",
             fp.internal_calls
         );
     }

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -595,6 +595,101 @@ mod tests {
     }
 
     #[test]
+    fn rust_path_qualified_index_call_suppresses_unreferenced_export() {
+        let exported =
+            make_fingerprint("src/foo.rs", vec!["helper"], vec!["helper"], vec![], vec![]);
+        let main = make_fingerprint(
+            "src/main.rs",
+            vec![],
+            vec![],
+            vec!["helper"], // foo::helper()
+            vec![],
+        );
+
+        let findings = analyze_dead_code(&[&exported], &[&main]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "Path-qualified calls from index files should suppress unreferenced_export, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rust_reexport_facade_call_suppresses_original_export() {
+        let exported = make_fingerprint(
+            "src/foo/bar.rs",
+            vec!["helper"],
+            vec!["helper"],
+            vec![],
+            vec![],
+        );
+        let facade_consumer = make_fingerprint(
+            "src/consumer.rs",
+            vec![],
+            vec![],
+            vec!["helper"], // foo::helper() after `pub use bar::helper` in foo/mod.rs.
+            vec![],
+        );
+        let facade = make_fingerprint("src/foo/mod.rs", vec![], vec![], vec![], vec![]);
+
+        let findings = analyze_dead_code(&[&exported, &facade_consumer], &[&facade]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "Facade calls to re-exported functions should suppress unreferenced_export, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rust_imported_test_prefixed_helper_call_suppresses_unreferenced_export() {
+        let exported = make_fingerprint(
+            "src/core/code_audit/test_mapping.rs",
+            vec!["test_to_source_path"],
+            vec!["test_to_source_path"],
+            vec![],
+            vec![],
+        );
+        let mut caller = make_fingerprint(
+            "src/core/code_audit/test_coverage.rs",
+            vec![],
+            vec![],
+            vec!["test_to_source_path"],
+            vec![],
+        );
+        caller
+            .imports
+            .push("crate::core::code_audit::test_mapping::test_to_source_path".to_string());
+
+        let findings = analyze_dead_code(&[&exported, &caller], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "Imported Rust helpers beginning with test_ are normal production references, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn orphaned_private_function_detected() {
         let fp = make_fingerprint(
             "src/foo.rs",

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -793,7 +793,15 @@ fn audit_internal(
     } else {
         Vec::new()
     };
-    let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = ref_fingerprints.iter().collect();
+    let component_ref_fingerprints = if plan.run_dead_code {
+        fingerprint_component_reference_files(root)
+    } else {
+        Vec::new()
+    };
+    let ref_fp_refs: Vec<&fingerprint::FileFingerprint> = ref_fingerprints
+        .iter()
+        .chain(component_ref_fingerprints.iter())
+        .collect();
     let dead_code_findings = if plan.run_dead_code {
         dead_code::analyze_dead_code_with_config(&all_fingerprints, &ref_fp_refs, &audit_config)
     } else {
@@ -1668,6 +1676,25 @@ fn fingerprint_reference_paths(reference_paths: &[String]) -> Vec<fingerprint::F
     ref_fps
 }
 
+/// Fingerprint this component's source files as dead-code references.
+///
+/// Dead-code findings are still emitted only for the owned convention
+/// fingerprints. This reference-only pass keeps calls from singleton files,
+/// index files, and module facades in the graph so exported functions are not
+/// reported just because their consumers live outside a convention group.
+fn fingerprint_component_reference_files(root: &Path) -> Vec<fingerprint::FileFingerprint> {
+    let snapshot = walker::walk_all_source_files_snapshot(root);
+    let mut fingerprints = Vec::new();
+
+    for (path, content) in snapshot.iter() {
+        if let Some(fp) = fingerprint::fingerprint_content(path, root, content) {
+            fingerprints.push(fp);
+        }
+    }
+
+    fingerprints
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -1729,6 +1756,52 @@ mod tests {
         let findings = layer_ownership::run(&dir);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].convention, "layer_ownership");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dead_code_reference_fingerprints_include_rust_singleton_and_index_files() {
+        let dir =
+            std::env::temp_dir().join(format!("homeboy_audit_index_refs_{}", std::process::id()));
+        let src = dir.join("src");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&src).unwrap();
+
+        fs::write(src.join("foo.rs"), "pub fn helper() -> bool { true }\n").unwrap();
+        fs::write(
+            src.join("main.rs"),
+            "mod foo;\nfn main() { let _ = foo::helper(); }\n",
+        )
+        .unwrap();
+
+        let regular_snapshot = walker::walk_source_files_snapshot(&dir);
+        let owned_fingerprints: Vec<_> = regular_snapshot
+            .iter()
+            .filter_map(|(path, content)| fingerprint::fingerprint_content(path, &dir, content))
+            .collect();
+        let component_ref_fingerprints = fingerprint_component_reference_files(&dir);
+
+        let owned_refs: Vec<_> = owned_fingerprints.iter().collect();
+        let component_refs: Vec<_> = component_ref_fingerprints.iter().collect();
+        let findings = dead_code::analyze_dead_code_with_config(
+            &owned_refs,
+            &component_refs,
+            &AuditConfig::default(),
+        );
+        let unreferenced: Vec<_> = findings
+            .iter()
+            .filter(|finding| finding.kind == AuditFinding::UnreferencedExport)
+            .collect();
+
+        assert!(
+            unreferenced.is_empty(),
+            "singleton and index files should contribute reference-only calls for dead-code analysis, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|finding| &finding.description)
+                .collect::<Vec<_>>()
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/core/code_audit/walker.rs
+++ b/src/core/code_audit/walker.rs
@@ -81,6 +81,16 @@ pub(crate) fn walk_source_files_snapshot(root: &Path) -> CodebaseSnapshot {
     snapshot
 }
 
+/// Build a snapshot containing every extension-provided source file.
+///
+/// Convention detectors use [`walk_source_files_snapshot`] to skip index files
+/// and later keep only directories with enough siblings. Dead-code analysis uses
+/// this broader view as reference-only data so singleton callers, `main.rs`,
+/// `lib.rs`, and module facades can still prove exports are live.
+pub(crate) fn walk_all_source_files_snapshot(root: &Path) -> CodebaseSnapshot {
+    CodebaseSnapshot::build(root, &source_scan_config())
+}
+
 /// Check if a relative path points to a test file using heuristic patterns.
 ///
 /// Used to separate test files from production code during convention discovery,


### PR DESCRIPTION
## Summary
- Includes every component source file as reference-only data for dead-code analysis so singleton callers, `main.rs`, `lib.rs`, and `mod.rs` facades can suppress false `unreferenced_export` findings without becoming owned findings themselves.
- Preserves `test_`-prefixed Rust production helper calls as normal references, fixing helpers such as `test_to_source_path`.
- Adds focused regression coverage for path-qualified calls, re-export facade calls, imported `test_` helpers, and component reference fingerprinting.

## Tests
- `cargo test rust_ -- --nocapture`
- `cargo test core::code_audit -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-audit-rust-path-qualified-refs`
- `cargo run --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@fix-audit-rust-path-qualified-refs --changed-since origin/main --ignore-baseline --json-summary`
- Patched focused audit check: `unreferenced_export` findings dropped from 60 to 32, and all #1725 example findings are absent.

Closes #1725

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the detector fix, adding targeted regression tests, running verification, and drafting this PR summary for human review.
