### PR TITLE
feat(audit): load dead-guard symbols from providers

### DIFF
--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -4,7 +4,7 @@
 //! and `defined('CONST')` guards (and their negations) and emits a finding
 //! when the checked symbol is guaranteed to exist given:
 //!
-//! 1. The plugin's declared requirements (`Requires at least:`).
+//! 1. Extension-provided runtime requirement metadata.
 //! 2. Unconditional `require` calls from the plugin main file.
 //! 3. Known vendor packages declared in `composer.json`.
 //!
@@ -50,7 +50,7 @@ pub(super) fn run_with_config(
     root: &Path,
     audit_config: &AuditConfig,
 ) -> Vec<Finding> {
-    let known = known_available_symbols(root);
+    let known = known_available_symbols(root, audit_config);
     if known.functions.is_empty() && known.classes.is_empty() && known.constants.is_empty() {
         return Vec::new();
     }
@@ -149,7 +149,7 @@ fn camel_to_kebab(symbol: &str) -> String {
 ///
 /// Examples matched:
 /// - `function_exists('foo_bar')`
-/// - `! class_exists( "WP_Ability" )`
+/// - `! class_exists( "RuntimeCapability" )`
 /// - `defined('RUNTIME_REQUEST')`
 ///
 /// Group 1: guard name. Group 2 or 3: quoted symbol (without quotes).
@@ -217,19 +217,46 @@ mod tests {
         }
     }
 
+    fn test_config() -> AuditConfig {
+        serde_json::from_value(serde_json::json!({
+            "known_symbols": {
+                "header_versions": [
+                    {
+                        "file_marker": "Runtime Plugin:",
+                        "version_header": "Runtime Requires:",
+                        "symbols": [
+                            {"name": "RuntimeCapability", "kind": "class", "introduced": "2.4"},
+                            {"name": "runtime_json_encode", "kind": "function", "introduced": "1.0"},
+                            {"name": "runtime_unschedule_all", "kind": "function", "introduced": "1.0"}
+                        ]
+                    }
+                ],
+                "bootstrap_paths": [
+                    {
+                        "path_contains": "runtime-queue/runtime-queue.php",
+                        "symbols": [
+                            {"name": "runtime_schedule_once", "kind": "function"}
+                        ]
+                    }
+                ]
+            }
+        }))
+        .unwrap()
+    }
+
     fn write_plugin_main(root: &Path, requires_at_least: Option<&str>, body: &str) {
         let header = requires_at_least
-            .map(|v| format!(" * Requires at least: {}\n", v))
+            .map(|v| format!(" * Runtime Requires: {}\n", v))
             .unwrap_or_default();
         let content = format!(
-            "<?php\n/**\n * Plugin Name: Demo\n{} */\n\n{}",
+            "<?php\n/**\n * Runtime Plugin: Demo\n{} */\n\n{}",
             header, body
         );
         fs::write(root.join("plugin.php"), content).unwrap();
     }
 
     fn run(fingerprints: &[&FileFingerprint], root: &Path) -> Vec<Finding> {
-        run_with_config(fingerprints, root, &AuditConfig::default())
+        run_with_config(fingerprints, root, &test_config())
     }
 
     #[test]
@@ -250,14 +277,14 @@ if ( defined("RUNTIME_REQUEST") ) {}
     }
 
     #[test]
-    fn flags_dead_class_exists_for_wp_ability() {
+    fn flags_dead_class_exists_for_known_runtime_symbol() {
         let tmp = tempfile::tempdir().unwrap();
-        write_plugin_main(tmp.path(), Some("6.9"), "");
+        write_plugin_main(tmp.path(), Some("2.4"), "");
 
         let fp = make_fp(
             "inc/Abilities/Register.php",
             r#"<?php
-if ( ! class_exists( 'WP_Ability' ) ) {
+if ( ! class_exists( 'RuntimeCapability' ) ) {
     return;
 }
 
@@ -269,7 +296,7 @@ class Register {}
         assert_eq!(findings.len(), 1, "expected one dead-guard finding");
         assert_eq!(findings[0].kind, AuditFinding::DeadGuard);
         assert_eq!(findings[0].severity, Severity::Warning);
-        assert!(findings[0].description.contains("WP_Ability"));
+        assert!(findings[0].description.contains("RuntimeCapability"));
         assert!(findings[0].description.contains("class_exists"));
     }
 
@@ -296,47 +323,44 @@ if ( ! function_exists('my_plugin_helper') ) {
     }
 
     #[test]
-    fn action_scheduler_guard_becomes_dead_when_bootstrap_requires_it() {
+    fn configured_bootstrap_provider_guard_becomes_dead_when_required() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::create_dir_all(tmp.path().join("vendor/woocommerce/action-scheduler")).unwrap();
+        fs::create_dir_all(tmp.path().join("vendor/runtime-queue")).unwrap();
         fs::write(
-            tmp.path()
-                .join("vendor/woocommerce/action-scheduler/action-scheduler.php"),
+            tmp.path().join("vendor/runtime-queue/runtime-queue.php"),
             "<?php\n",
         )
         .unwrap();
 
         write_plugin_main(
             tmp.path(),
-            Some("6.0"),
-            "require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';\n",
+            Some("2.0"),
+            "require_once __DIR__ . '/vendor/runtime-queue/runtime-queue.php';\n",
         );
 
         let fp = make_fp(
             "inc/Scheduler.php",
             r#"<?php
-if ( function_exists('as_schedule_single_action') ) {
-    as_schedule_single_action( time(), 'my_hook' );
+if ( function_exists('runtime_schedule_once') ) {
+    runtime_schedule_once( time(), 'my_hook' );
 }
 "#,
         );
 
         let findings = run(&[&fp], tmp.path());
         assert_eq!(findings.len(), 1);
-        assert!(findings[0]
-            .description
-            .contains("as_schedule_single_action"));
+        assert!(findings[0].description.contains("runtime_schedule_once"));
     }
 
     #[test]
     fn non_php_files_are_ignored() {
         let tmp = tempfile::tempdir().unwrap();
-        write_plugin_main(tmp.path(), Some("6.9"), "");
+        write_plugin_main(tmp.path(), Some("2.4"), "");
 
         let fp = FileFingerprint {
             relative_path: "src/lib.rs".to_string(),
             language: Language::Rust,
-            content: "function_exists('WP_Ability')".to_string(),
+            content: "function_exists('RuntimeCapability')".to_string(),
             ..Default::default()
         };
 
@@ -381,6 +405,7 @@ if ( function_exists('runtime_unschedule_all') ) {
 
         let config = AuditConfig {
             lifecycle_path_globs: vec!["lifecycle/*.php".to_string()],
+            known_symbols: test_config().known_symbols,
             ..Default::default()
         };
         let guard = extract_guards(&fp.content).remove(0);
@@ -401,7 +426,7 @@ if ( function_exists('runtime_unschedule_all') ) {
         // No plugin main, no composer.json → known is empty.
         let fp = make_fp(
             "inc/X.php",
-            r#"<?php if ( class_exists('WP_Ability') ) {} "#,
+            r#"<?php if ( class_exists('RuntimeCapability') ) {} "#,
         );
 
         let findings = run(&[&fp], tmp.path());

--- a/src/core/code_audit/requirements.rs
+++ b/src/core/code_audit/requirements.rs
@@ -1,20 +1,24 @@
-//! Plugin requirement + bootstrap parser — collects symbols that are guaranteed
+//! Runtime requirement + bootstrap parser — collects symbols that are guaranteed
 //! to exist at runtime so downstream detectors (e.g. `dead_guard`) can skip
 //! `function_exists` / `class_exists` / `defined` guards on them.
 //!
 //! Sources of "guaranteed available" symbols:
-//! 1. The WordPress plugin header's `Requires at least: X.Y` value, mapped
-//!    against a hard-coded WP-core symbol-availability table.
-//! 2. `composer.json` `require` and `require-dev` entries — when a known
-//!    vendor package is present, its public symbols are considered available.
-//! 3. Unconditional `require` / `require_once` calls from the plugin main
-//!    file — anything pulled in at bootstrap is guaranteed loaded.
+//! 1. Extension-provided header-version rules mapped against symbols.
+//! 2. `composer.json` `require` and `require-dev` entries mapped against
+//!    extension-provided package rules.
+//! 3. Unconditional `require` / `require_once` calls from entry files mapped
+//!    against extension-provided bootstrap-path rules.
 //!
 //! The parser is lenient: every source is optional and a missing / malformed
 //! file yields an empty contribution rather than an error.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+
+use crate::component::{
+    AuditConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
+    KnownSymbolVersionedEntry,
+};
 
 /// Symbols guaranteed to be defined at runtime given the plugin's declared
 /// requirements and its explicit bootstrap wiring.
@@ -42,32 +46,42 @@ impl KnownSymbols {
 }
 
 /// Entry point: inspect a plugin root and return the set of guaranteed symbols.
-pub fn known_available_symbols(root: &Path) -> KnownSymbols {
+pub fn known_available_symbols(root: &Path, audit_config: &AuditConfig) -> KnownSymbols {
     let mut symbols = KnownSymbols::default();
+    let providers = &audit_config.known_symbols;
 
-    let main_file = find_plugin_main_file(root);
-    let wp_baseline = main_file
-        .as_ref()
-        .and_then(|p| parse_wp_requires_at_least(p))
-        .unwrap_or(0);
-
-    seed_wp_core_symbols(&mut symbols, wp_baseline);
-
-    if let Some(ref main) = main_file {
-        let required_paths = parse_bootstrap_requires(main, root);
-        for path in &required_paths {
-            seed_vendor_symbols_from_path(&mut symbols, path);
+    for provider in &providers.header_versions {
+        if let Some(main_file) = find_file_with_marker(root, &provider.file_marker) {
+            seed_header_version_symbols(&mut symbols, &main_file, provider);
         }
     }
 
-    apply_composer_requires(&mut symbols, root);
+    for main in find_bootstrap_files(root, audit_config) {
+        let required_paths = parse_bootstrap_requires(&main, root);
+        for path in &required_paths {
+            seed_symbols_from_bootstrap_path(&mut symbols, path, audit_config);
+        }
+    }
+
+    apply_composer_requires(&mut symbols, root, audit_config);
 
     symbols
 }
 
-/// Locate the plugin main file: a `*.php` file in `root` whose content contains
-/// `Plugin Name:` in the header comment.
-pub fn find_plugin_main_file(root: &Path) -> Option<PathBuf> {
+fn find_bootstrap_files(root: &Path, audit_config: &AuditConfig) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for provider in &audit_config.known_symbols.header_versions {
+        if let Some(path) = find_file_with_marker(root, &provider.file_marker) {
+            if !files.contains(&path) {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+/// Locate a root-level PHP entry file whose header contains an extension-owned marker.
+pub fn find_file_with_marker(root: &Path, marker: &str) -> Option<PathBuf> {
     let entries = std::fs::read_dir(root).ok()?;
     for entry in entries.flatten() {
         let path = entry.path();
@@ -77,21 +91,17 @@ pub fn find_plugin_main_file(root: &Path) -> Option<PathBuf> {
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        // Check first ~50 lines for "Plugin Name:" marker.
-        if content.lines().take(50).any(|l| l.contains("Plugin Name:")) {
+        if content.lines().take(80).any(|l| l.contains(marker)) {
             return Some(path);
         }
     }
     None
 }
 
-/// Parse `Requires at least: X.Y` from the plugin header. Returns the WP core
-/// version encoded as `major * 100 + minor` (e.g. 5.3 → 503) for easy
-/// comparison, or `None` if absent.
-pub fn parse_wp_requires_at_least(main_file: &Path) -> Option<u32> {
+pub fn parse_header_version(main_file: &Path, header: &str) -> Option<u32> {
     let content = std::fs::read_to_string(main_file).ok()?;
     for line in content.lines().take(80) {
-        if let Some(rest) = line.split_once("Requires at least:") {
+        if let Some(rest) = line.split_once(header) {
             let value = rest.1.trim().trim_end_matches('*').trim();
             return parse_version_encoded(value);
         }
@@ -109,58 +119,35 @@ fn parse_version_encoded(v: &str) -> Option<u32> {
     Some(major * 100 + minor)
 }
 
-/// Seed a minimum set of WP-core symbols known to exist when the plugin
-/// declares a floor of WP version `wp_baseline` (encoded as major*100+minor).
-///
-/// The table is intentionally small and conservative — the intent is to catch
-/// guards that are obviously dead given the plugin's declared floor, not to
-/// enumerate every WP symbol.
-fn seed_wp_core_symbols(symbols: &mut KnownSymbols, wp_baseline: u32) {
-    // (symbol_name, introduced_in_encoded_version, kind)
-    // kind: 'f' = function, 'c' = class, 'k' = constant
-    const WP_SYMBOLS: &[(&str, u32, char)] = &[
-        // Functions
-        ("wp_generate_uuid4", 407, 'f'),
-        ("wp_timezone", 503, 'f'),
-        ("wp_timezone_string", 501, 'f'),
-        ("wp_get_environment_type", 505, 'f'),
-        ("wp_date", 503, 'f'),
-        ("wp_json_encode", 404, 'f'),
-        ("get_post_type_object", 300, 'f'),
-        ("register_rest_route", 404, 'f'),
-        ("register_block_type", 500, 'f'),
-        ("has_blocks", 500, 'f'),
-        ("parse_blocks", 500, 'f'),
-        // Classes
-        ("WP_Ability", 609, 'c'),
-        ("WP_REST_Server", 404, 'c'),
-        ("WP_REST_Request", 404, 'c'),
-        ("WP_REST_Response", 404, 'c'),
-        ("WP_Block_Type_Registry", 500, 'c'),
-        ("WP_Block", 501, 'c'),
-        ("WP_HTML_Tag_Processor", 602, 'c'),
-        // Constants
-        ("REST_REQUEST", 404, 'k'),
-    ];
-
-    if wp_baseline == 0 {
+fn seed_header_version_symbols(
+    symbols: &mut KnownSymbols,
+    main_file: &Path,
+    provider: &KnownSymbolHeaderVersionProvider,
+) {
+    let Some(baseline) = parse_header_version(main_file, &provider.version_header) else {
         return;
+    };
+    for entry in &provider.symbols {
+        if versioned_entry_is_available(entry, baseline) {
+            insert_symbol(symbols, &entry.name, &entry.kind);
+        }
     }
+}
 
-    for (name, introduced, kind) in WP_SYMBOLS {
-        if *introduced <= wp_baseline {
-            match kind {
-                'f' => {
-                    symbols.functions.insert((*name).to_string());
-                }
-                'c' => {
-                    symbols.classes.insert((*name).to_string());
-                }
-                'k' => {
-                    symbols.constants.insert((*name).to_string());
-                }
-                _ => {}
-            }
+fn versioned_entry_is_available(entry: &KnownSymbolVersionedEntry, baseline: u32) -> bool {
+    parse_version_encoded(&entry.introduced).is_some_and(|introduced| introduced <= baseline)
+}
+
+fn insert_symbol(symbols: &mut KnownSymbols, name: &str, kind: &KnownSymbolKind) {
+    match kind {
+        KnownSymbolKind::Function => {
+            symbols.functions.insert(name.to_string());
+        }
+        KnownSymbolKind::Class => {
+            symbols.classes.insert(name.to_string());
+        }
+        KnownSymbolKind::Constant => {
+            symbols.constants.insert(name.to_string());
         }
     }
 }
@@ -260,45 +247,23 @@ fn resolve_require_path(raw: &str, main_dir: &Path) -> Option<PathBuf> {
     Some(main_dir.join(cleaned))
 }
 
-/// Inspect a bootstrap `require`d path and seed vendor-specific symbols when
-/// the path matches a known library bootstrap.
-fn seed_vendor_symbols_from_path(symbols: &mut KnownSymbols, path: &Path) {
+fn seed_symbols_from_bootstrap_path(symbols: &mut KnownSymbols, path: &Path, config: &AuditConfig) {
     let p = path.to_string_lossy().replace('\\', "/");
-
-    // Action Scheduler — loaded by `vendor/woocommerce/action-scheduler/action-scheduler.php`.
-    if p.contains("action-scheduler/action-scheduler.php") || p.ends_with("/action-scheduler.php") {
-        seed_action_scheduler_symbols(symbols);
+    for provider in &config.known_symbols.bootstrap_paths {
+        if p.contains(&provider.path_contains) || p.ends_with(&provider.path_contains) {
+            seed_entries(symbols, &provider.symbols);
+        }
     }
 }
 
-fn seed_action_scheduler_symbols(symbols: &mut KnownSymbols) {
-    const AS_FUNCTIONS: &[&str] = &[
-        "as_schedule_single_action",
-        "as_schedule_recurring_action",
-        "as_schedule_cron_action",
-        "as_enqueue_async_action",
-        "as_unschedule_action",
-        "as_unschedule_all_actions",
-        "as_next_scheduled_action",
-        "as_has_scheduled_action",
-        "as_get_scheduled_actions",
-    ];
-    const AS_CLASSES: &[&str] = &[
-        "ActionScheduler",
-        "ActionScheduler_Action",
-        "ActionScheduler_Store",
-        "ActionScheduler_Versions",
-    ];
-    for f in AS_FUNCTIONS {
-        symbols.functions.insert((*f).to_string());
-    }
-    for c in AS_CLASSES {
-        symbols.classes.insert((*c).to_string());
+fn seed_entries(symbols: &mut KnownSymbols, entries: &[KnownSymbolEntry]) {
+    for entry in entries {
+        insert_symbol(symbols, &entry.name, &entry.kind);
     }
 }
 
-/// Inspect `composer.json` and seed symbols for well-known packages.
-fn apply_composer_requires(symbols: &mut KnownSymbols, root: &Path) {
+/// Inspect `composer.json` and seed symbols for extension-provided packages.
+fn apply_composer_requires(symbols: &mut KnownSymbols, root: &Path, config: &AuditConfig) {
     let composer = root.join("composer.json");
     let Ok(content) = std::fs::read_to_string(&composer) else {
         return;
@@ -316,8 +281,10 @@ fn apply_composer_requires(symbols: &mut KnownSymbols, root: &Path) {
         }
     }
 
-    if packages.contains("woocommerce/action-scheduler") {
-        seed_action_scheduler_symbols(symbols);
+    for provider in &config.known_symbols.composer_packages {
+        if packages.contains(&provider.package) {
+            seed_entries(symbols, &provider.symbols);
+        }
     }
 }
 
@@ -326,12 +293,49 @@ mod tests {
     use super::*;
     use std::fs;
 
-    fn write_plugin_main(dir: &Path, requires_at_least: Option<&str>, body: &str) -> PathBuf {
+    fn test_config() -> AuditConfig {
+        serde_json::from_value(serde_json::json!({
+            "known_symbols": {
+                "header_versions": [
+                    {
+                        "file_marker": "Runtime Plugin:",
+                        "version_header": "Runtime Requires:",
+                        "symbols": [
+                            {"name": "runtime_uuid", "kind": "function", "introduced": "1.2"},
+                            {"name": "RuntimeCapability", "kind": "class", "introduced": "2.4"},
+                            {"name": "RUNTIME_REQUEST", "kind": "constant", "introduced": "1.0"}
+                        ]
+                    }
+                ],
+                "composer_packages": [
+                    {
+                        "package": "vendor/runtime-queue",
+                        "symbols": [
+                            {"name": "runtime_schedule_once", "kind": "function"},
+                            {"name": "RuntimeScheduler", "kind": "class"}
+                        ]
+                    }
+                ],
+                "bootstrap_paths": [
+                    {
+                        "path_contains": "runtime-queue/runtime-queue.php",
+                        "symbols": [
+                            {"name": "runtime_schedule_once", "kind": "function"},
+                            {"name": "RuntimeScheduler", "kind": "class"}
+                        ]
+                    }
+                ]
+            }
+        }))
+        .unwrap()
+    }
+
+    fn write_runtime_main(dir: &Path, requires_at_least: Option<&str>, body: &str) -> PathBuf {
         let header_line = requires_at_least
-            .map(|v| format!(" * Requires at least: {}\n", v))
+            .map(|v| format!(" * Runtime Requires: {}\n", v))
             .unwrap_or_default();
         let content = format!(
-            "<?php\n/**\n * Plugin Name: Test Plugin\n{} */\n\n{}",
+            "<?php\n/**\n * Runtime Plugin: Test Plugin\n{} */\n\n{}",
             header_line, body
         );
         let path = dir.join("plugin.php");
@@ -342,80 +346,81 @@ mod tests {
     #[test]
     fn parses_requires_at_least() {
         let tmp = tempfile::tempdir().unwrap();
-        let main = write_plugin_main(tmp.path(), Some("6.9"), "");
-        let baseline = parse_wp_requires_at_least(&main).unwrap();
-        assert_eq!(baseline, 609);
+        let main = write_runtime_main(tmp.path(), Some("2.4"), "");
+        let baseline = parse_header_version(&main, "Runtime Requires:").unwrap();
+        assert_eq!(baseline, 204);
     }
 
     #[test]
-    fn seeds_wp_core_symbols_up_to_baseline() {
-        let mut syms = KnownSymbols::default();
-        seed_wp_core_symbols(&mut syms, 609);
-        assert!(syms.has_class("WP_Ability"));
-        assert!(syms.has_function("wp_timezone"));
-        assert!(syms.has_function("wp_generate_uuid4"));
+    fn seeds_header_version_symbols_up_to_baseline() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_runtime_main(tmp.path(), Some("2.4"), "");
+        let syms = known_available_symbols(tmp.path(), &test_config());
+        assert!(syms.has_class("RuntimeCapability"));
+        assert!(syms.has_function("runtime_uuid"));
+        assert!(syms.has_constant("RUNTIME_REQUEST"));
     }
 
     #[test]
     fn does_not_seed_symbols_introduced_later_than_baseline() {
-        let mut syms = KnownSymbols::default();
-        seed_wp_core_symbols(&mut syms, 500);
-        assert!(!syms.has_class("WP_Ability"));
-        assert!(syms.has_function("wp_generate_uuid4"));
+        let tmp = tempfile::tempdir().unwrap();
+        write_runtime_main(tmp.path(), Some("1.2"), "");
+        let syms = known_available_symbols(tmp.path(), &test_config());
+        assert!(!syms.has_class("RuntimeCapability"));
+        assert!(syms.has_function("runtime_uuid"));
     }
 
     #[test]
     fn missing_plugin_main_returns_empty() {
         let tmp = tempfile::tempdir().unwrap();
-        let syms = known_available_symbols(tmp.path());
+        let syms = known_available_symbols(tmp.path(), &test_config());
         assert!(syms.functions.is_empty());
         assert!(syms.classes.is_empty());
     }
 
     #[test]
-    fn detects_action_scheduler_bootstrap_require() {
+    fn detects_configured_bootstrap_require() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::create_dir_all(tmp.path().join("vendor/woocommerce/action-scheduler")).unwrap();
+        fs::create_dir_all(tmp.path().join("vendor/runtime-queue")).unwrap();
         fs::write(
-            tmp.path()
-                .join("vendor/woocommerce/action-scheduler/action-scheduler.php"),
+            tmp.path().join("vendor/runtime-queue/runtime-queue.php"),
             "<?php\n",
         )
         .unwrap();
 
-        let main = write_plugin_main(
+        let main = write_runtime_main(
             tmp.path(),
-            Some("6.0"),
-            "require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';\n",
+            Some("2.0"),
+            "require_once __DIR__ . '/vendor/runtime-queue/runtime-queue.php';\n",
         );
         let requires = parse_bootstrap_requires(&main, tmp.path());
         assert_eq!(requires.len(), 1);
 
-        let syms = known_available_symbols(tmp.path());
-        assert!(syms.has_function("as_schedule_single_action"));
-        assert!(syms.has_function("as_unschedule_action"));
+        let syms = known_available_symbols(tmp.path(), &test_config());
+        assert!(syms.has_function("runtime_schedule_once"));
+        assert!(syms.has_class("RuntimeScheduler"));
     }
 
     #[test]
-    fn composer_require_seeds_action_scheduler() {
+    fn composer_require_seeds_configured_package() {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("composer.json"),
-            r#"{"require":{"woocommerce/action-scheduler":"^3.0"}}"#,
+            r#"{"require":{"vendor/runtime-queue":"^3.0"}}"#,
         )
         .unwrap();
         let mut syms = KnownSymbols::default();
-        apply_composer_requires(&mut syms, tmp.path());
-        assert!(syms.has_function("as_schedule_single_action"));
+        apply_composer_requires(&mut syms, tmp.path(), &test_config());
+        assert!(syms.has_function("runtime_schedule_once"));
     }
 
     #[test]
     fn guarded_require_is_skipped() {
         let tmp = tempfile::tempdir().unwrap();
-        let main = write_plugin_main(
+        let main = write_runtime_main(
             tmp.path(),
-            Some("6.0"),
-            "if ( ! class_exists( 'ActionScheduler' ) ) {\n    require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';\n}\n",
+            Some("2.0"),
+            "if ( ! class_exists( 'RuntimeScheduler' ) ) {\n    require_once __DIR__ . '/vendor/runtime-queue/runtime-queue.php';\n}\n",
         );
         let requires = parse_bootstrap_requires(&main, tmp.path());
         assert!(

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -17,6 +17,83 @@ pub struct AuditConfig {
     /// Files exempt from convention outlier checks.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub convention_exception_globs: Vec<String>,
+    /// Symbols that are known to exist when component metadata proves a runtime
+    /// floor, package, or bootstrap file is present.
+    #[serde(default, skip_serializing_if = "KnownSymbolsConfig::is_empty")]
+    pub known_symbols: KnownSymbolsConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct KnownSymbolsConfig {
+    /// Header-version providers keyed by an extension-owned marker and header.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub header_versions: Vec<KnownSymbolHeaderVersionProvider>,
+    /// Composer package providers keyed by package name.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub composer_packages: Vec<KnownSymbolPackageProvider>,
+    /// Bootstrap path providers keyed by a normalized path substring or suffix.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bootstrap_paths: Vec<KnownSymbolBootstrapPathProvider>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KnownSymbolHeaderVersionProvider {
+    /// Marker used to locate the component entry file.
+    pub file_marker: String,
+    /// Header key whose value contains the runtime version floor.
+    pub version_header: String,
+    /// Symbols introduced by runtime version.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub symbols: Vec<KnownSymbolVersionedEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KnownSymbolPackageProvider {
+    pub package: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub symbols: Vec<KnownSymbolEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KnownSymbolBootstrapPathProvider {
+    pub path_contains: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub symbols: Vec<KnownSymbolEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KnownSymbolVersionedEntry {
+    pub name: String,
+    pub kind: KnownSymbolKind,
+    pub introduced: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KnownSymbolEntry {
+    pub name: String,
+    pub kind: KnownSymbolKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum KnownSymbolKind {
+    Function,
+    Class,
+    Constant,
+}
+
+impl KnownSymbolsConfig {
+    pub fn is_empty(&self) -> bool {
+        self.header_versions.is_empty()
+            && self.composer_packages.is_empty()
+            && self.bootstrap_paths.is_empty()
+    }
+
+    fn merge(&mut self, other: &KnownSymbolsConfig) {
+        extend_unique(&mut self.header_versions, &other.header_versions);
+        extend_unique(&mut self.composer_packages, &other.composer_packages);
+        extend_unique(&mut self.bootstrap_paths, &other.bootstrap_paths);
+    }
 }
 
 impl AuditConfig {
@@ -26,6 +103,7 @@ impl AuditConfig {
             && self.lifecycle_path_globs.is_empty()
             && self.utility_suffixes.is_empty()
             && self.convention_exception_globs.is_empty()
+            && self.known_symbols.is_empty()
     }
 
     pub fn merge(&mut self, other: &AuditConfig) {
@@ -43,10 +121,11 @@ impl AuditConfig {
             &mut self.convention_exception_globs,
             &other.convention_exception_globs,
         );
+        self.known_symbols.merge(&other.known_symbols);
     }
 }
 
-fn extend_unique(target: &mut Vec<String>, source: &[String]) {
+fn extend_unique<T: Clone + PartialEq>(target: &mut Vec<T>, source: &[T]) {
     for value in source {
         if !target.contains(value) {
             target.push(value.clone());

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -10,7 +10,10 @@ pub mod resolution;
 pub mod scope;
 pub mod versioning;
 
-pub use audit::AuditConfig;
+pub use audit::{
+    AuditConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
+    KnownSymbolVersionedEntry,
+};
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,
     write_standalone_registration,


### PR DESCRIPTION
## Summary
- Adds a generic `known_symbols` audit metadata contract for header-version, Composer package, and bootstrap-path symbol providers.
- Updates `dead_guard` to aggregate those providers through `AuditConfig` instead of using Homeboy core WordPress or Action Scheduler tables.
- Replaces core dead-guard symbol-table tests with generic runtime/provider fixtures.

## Tests
- `cargo test code_audit::requirements`
- `cargo test code_audit::dead_guard`
- `cargo fmt --check`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@extract-known-symbol-providers --changed-since origin/main`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@extract-known-symbol-providers --changed-since origin/main`

## Related
- Sibling WordPress extension provider PR: https://github.com/Extra-Chill/homeboy-extensions/pull/361

Closes #1949

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the core provider substrate, moved tests off WordPress/Action Scheduler fixtures, and ran focused validation; Chris remains responsible for review and merge.
