### PR TITLE
fix(audit): consume runtime dispatch metadata

### DIFF
--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -431,6 +431,9 @@ pub fn fingerprint_from_grammar(
     // --- Hooks (PHP-specific, from grammar) ---
     let hooks = extract_hooks(&symbols);
 
+    // --- Runtime-dispatched types (extension-owned grammar metadata) ---
+    let runtime_dispatched_types = extract_runtime_dispatched_types(&symbols);
+
     Some(FileFingerprint {
         relative_path: relative_path.to_string(),
         language,
@@ -455,6 +458,7 @@ pub fn fingerprint_from_grammar(
         call_sites: Vec::new(), // Core grammar engine doesn't extract call sites yet
         public_api,
         hook_callbacks: Vec::new(), // Core grammar engine doesn't extract hook callbacks yet
+        runtime_dispatched_types,
         trait_impl_methods,
     })
 }
@@ -1120,6 +1124,26 @@ fn extract_registrations(symbols: &[Symbol]) -> Vec<String> {
     }
 
     registrations
+}
+
+/// Extract types registered with runtime dispatchers from grammar symbols.
+fn extract_runtime_dispatched_types(symbols: &[Symbol]) -> Vec<String> {
+    let mut dispatched_types = Vec::new();
+    let mut seen = HashSet::new();
+
+    for s in symbols
+        .iter()
+        .filter(|s| s.concept == "runtime_dispatched_type")
+    {
+        if let Some(name) = s.name() {
+            let normalized = name.trim_start_matches('\\').to_string();
+            if seen.insert(normalized.clone()) {
+                dispatched_types.push(normalized);
+            }
+        }
+    }
+
+    dispatched_types
 }
 
 /// Extract internal function calls from content.

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -61,17 +61,13 @@ pub(crate) fn analyze_dead_code_with_config(
 ) -> Vec<Finding> {
     let mut findings = Vec::new();
 
-    // Build a global set of all internal calls and imports across ALL files
-    // (owned + reference) for cross-file reference checking.
-    let mut all_calls: HashSet<String> = HashSet::new();
-    let mut all_imports: HashSet<String> = HashSet::new();
+    // Build a global set of types registered with runtime dispatchers across
+    // ALL files (owned + reference) for cross-file reference checking.
+    let mut runtime_dispatched_types: HashSet<String> = HashSet::new();
 
     for fp in owned.iter().chain(reference.iter()) {
-        for call in &fp.internal_calls {
-            all_calls.insert(call.clone());
-        }
-        for import in &fp.imports {
-            all_imports.insert(import.clone());
+        for dispatched_type in &fp.runtime_dispatched_types {
+            runtime_dispatched_types.insert(dispatched_type.clone());
         }
     }
 
@@ -138,6 +134,14 @@ pub(crate) fn analyze_dead_code_with_config(
                 // from other source files.
                 // (homeboy#1149 — runtime bootstrap files)
                 if fp.hook_callbacks.contains(export) {
+                    continue;
+                }
+
+                // Skip public methods on types/classes registered with a
+                // runtime dispatcher. The framework-specific detection lives
+                // in extension fingerprint metadata; core only consumes the
+                // normalized type names.
+                if is_runtime_dispatched_type(fp, &runtime_dispatched_types) {
                     continue;
                 }
 
@@ -338,6 +342,36 @@ fn is_runtime_entrypoint_file(fp: &FileFingerprint, audit_config: &AuditConfig) 
             .runtime_entrypoint_markers
             .iter()
             .any(|marker| fp.content.contains(marker))
+}
+
+fn is_runtime_dispatched_type(
+    fp: &FileFingerprint,
+    runtime_dispatched_types: &HashSet<String>,
+) -> bool {
+    let Some(type_name) = fp.type_name.as_deref() else {
+        return false;
+    };
+
+    let qualified_type = fp
+        .namespace
+        .as_deref()
+        .map(|namespace| format!("{}\\{}", namespace, type_name));
+    let type_matches = runtime_dispatched_types.iter().any(|dispatched| {
+        if dispatched.contains('\\') {
+            qualified_type.as_deref() == Some(dispatched.as_str())
+                || qualified_type
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.ends_with(&format!("\\{}", dispatched)))
+        } else {
+            dispatched == type_name
+        }
+    });
+
+    if !type_matches {
+        return false;
+    }
+
+    !fp.public_api.is_empty()
 }
 
 // ============================================================================
@@ -901,5 +935,74 @@ class EmailCommand extends RuntimeCommand {
             unreferenced.is_empty(),
             "configured runtime-dispatched methods are invoked by the runtime"
         );
+    }
+
+    #[test]
+    fn fingerprint_runtime_dispatched_type_suppresses_public_methods() {
+        let mut bootstrap_fp =
+            make_fingerprint("inc/Cli/Bootstrap.php", vec![], vec![], vec![], vec![]);
+        bootstrap_fp.language = Language::Php;
+        bootstrap_fp.runtime_dispatched_types = vec!["Commands\\EmailCommand".to_string()];
+
+        let mut command_fp = make_fingerprint(
+            "inc/Cli/Commands/EmailCommand.php",
+            vec!["test_connection"],
+            vec!["test_connection"],
+            vec![],
+            vec![],
+        );
+        command_fp.language = Language::Php;
+        command_fp.namespace = Some("DataMachine\\Cli\\Commands".to_string());
+        command_fp.type_name = Some("EmailCommand".to_string());
+
+        let findings = analyze_dead_code(&[&bootstrap_fp, &command_fp], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "runtime-dispatched command methods should not be flagged, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn docblock_only_subcommand_does_not_suppress_public_method() {
+        let mut command_fp = make_fingerprint(
+            "inc/Cli/Commands/EmailCommand.php",
+            vec!["test_connection"],
+            vec!["test_connection"],
+            vec![],
+            vec![],
+        );
+        command_fp.language = Language::Php;
+        command_fp.type_name = Some("EmailCommand".to_string());
+        command_fp.content = r#"<?php
+class EmailCommand {
+    /**
+     * Test the IMAP connection.
+     *
+     * @subcommand test-connection
+     */
+    public function test_connection( array $args, array $assoc_args ): void {}
+}
+"#
+        .to_string();
+
+        let findings = analyze_dead_code(&[&command_fp], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert_eq!(
+            unreferenced.len(),
+            1,
+            "docblock-only @subcommand must not imply runtime registration"
+        );
+        assert!(unreferenced[0].description.contains("test_connection"));
     }
 }

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -80,6 +80,13 @@ pub struct FileFingerprint {
     /// hook-registered in the same file IS live code — invoked by the
     /// framework runtime rather than direct calls from other files.
     pub hook_callbacks: Vec<String>,
+    /// Type/class names registered with a runtime dispatcher from any file.
+    ///
+    /// This covers cross-file dispatch where one bootstrap file registers a
+    /// type and the runtime later invokes that type's public methods by
+    /// convention. Core consumes the generic metadata; extensions own the
+    /// framework-specific registration parsing.
+    pub runtime_dispatched_types: Vec<String>,
     /// Method names that are trait implementations (called via trait dispatch).
     pub trait_impl_methods: Vec<String>,
 }
@@ -165,6 +172,7 @@ fn fingerprint_via_extension(
         call_sites: output.call_sites,
         public_api: output.public_api,
         hook_callbacks: output.hook_callbacks,
+        runtime_dispatched_types: output.runtime_dispatched_types,
         trait_impl_methods: Vec::new(), // Extension scripts don't track this
     })
 }

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -164,6 +164,7 @@ pub(crate) fn fingerprint_from_git_ref(
         call_sites: output.call_sites,
         public_api: output.public_api,
         hook_callbacks: output.hook_callbacks,
+        runtime_dispatched_types: output.runtime_dispatched_types,
         trait_impl_methods: Vec::new(),
     })
 }

--- a/src/core/code_audit/shadow_modules.rs
+++ b/src/core/code_audit/shadow_modules.rs
@@ -274,6 +274,7 @@ mod tests {
             call_sites: vec![],
             public_api: vec![],
             hook_callbacks: vec![],
+            runtime_dispatched_types: vec![],
             trait_impl_methods: vec![],
         }
     }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -555,6 +555,13 @@ pub struct FingerprintOutput {
     /// language/framework they support — not just WordPress hooks.
     #[serde(default)]
     pub hook_callbacks: Vec<String>,
+    /// Type/class names registered with a runtime dispatcher.
+    ///
+    /// Framework-specific extension scripts populate this for patterns where a
+    /// type is registered in one file and its public methods are invoked by the
+    /// runtime in another file.
+    #[serde(default)]
+    pub runtime_dispatched_types: Vec<String>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds generic runtime-dispatched type metadata to extension fingerprint output and file fingerprints.
- Updates unreferenced export analysis to treat public methods on runtime-dispatched types as live without WordPress-specific parsing in core.
- Covers the original WP-CLI subcommand false positive through generic metadata tests.

## Tests
- cargo fmt --check
- cargo test core::code_audit::dead_code -- --test-threads=1
- cargo test core::code_audit::fingerprint -- --test-threads=1

Closes #1945

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic runtime-dispatch metadata consumer and focused tests; Chris remains responsible for review and merge.