### PR TITLE
fix(test): stabilize release autofix blockers

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -240,6 +240,11 @@ mod tests {
             "pub fn run() {}\npub fn execute() {}\n",
         )
         .unwrap();
+        fs::write(
+            root.join("commands/good_three.rs"),
+            "pub fn run() {}\npub fn execute() {}\n",
+        )
+        .unwrap();
         fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
 
         let args = AuditArgs {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -260,7 +260,11 @@ fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
     )
 }
 
-fn pid_is_running(pid: u32) -> bool {
+pub(crate) fn pid_is_running(pid: u32) -> bool {
+    if pid > i32::MAX as u32 {
+        return false;
+    }
+
     #[cfg(unix)]
     unsafe {
         libc::kill(pid as libc::pid_t, 0) == 0

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -228,7 +228,7 @@ mod tests {
         assert!(run_dir
             .step_file(files::TRACE_RESULTS)
             .to_string_lossy()
-            .ends_with("trace-results.json"));
+            .ends_with("trace.json"));
         run_dir.cleanup();
     }
 

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -165,7 +165,7 @@ fn prune_stale_leases() -> Result<()> {
         let Some(lease) = read_lease(&path)? else {
             continue;
         };
-        if !pid_is_live(lease.pid) {
+        if !crate::core::daemon::pid_is_running(lease.pid) {
             fs::remove_file(&path).map_err(|e| {
                 Error::internal_unexpected(format!(
                     "Failed to remove stale rig lease {}: {}",
@@ -182,7 +182,7 @@ fn live_leases() -> Result<Vec<RigRunLease>> {
     let mut leases = Vec::new();
     for path in lease_files()? {
         if let Some(lease) = read_lease(&path)? {
-            if pid_is_live(lease.pid) {
+            if crate::core::daemon::pid_is_running(lease.pid) {
                 leases.push(lease);
             }
         }
@@ -248,23 +248,6 @@ fn sanitize_id(id: &str) -> String {
             }
         })
         .collect()
-}
-
-fn pid_is_live(pid: u32) -> bool {
-    if pid == std::process::id() {
-        return true;
-    }
-    #[cfg(unix)]
-    {
-        if pid > i32::MAX as u32 {
-            return false;
-        }
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-    }
-    #[cfg(not(unix))]
-    {
-        false
-    }
 }
 
 #[cfg(test)]

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -256,13 +256,10 @@ fn pid_is_live(pid: u32) -> bool {
     }
     #[cfg(unix)]
     {
-        std::process::Command::new("kill")
-            .arg("-0")
-            .arg(pid.to_string())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
+        if pid > i32::MAX as u32 {
+            return false;
+        }
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
     }
     #[cfg(not(unix))]
     {

--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -246,6 +246,10 @@ mod platform {
             thread::sleep(Duration::from_millis(200));
         }
 
+        if managed_process_group {
+            reap_child(pid);
+        }
+
         state.services.remove(service_id);
         state.save(&rig.id)?;
         Ok(())
@@ -393,6 +397,16 @@ mod platform {
         };
         unsafe {
             libc::kill(target, sig);
+        }
+    }
+
+    fn reap_child(pid: u32) {
+        if pid > i32::MAX as u32 {
+            return;
+        }
+        let mut status = 0;
+        unsafe {
+            libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG);
         }
     }
 

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -85,7 +85,7 @@ fn commit_package(package: &Path, message: &str) {
 }
 
 fn create_bare_source(package: &Path) -> tempfile::TempDir {
-    run_git(package, &["init"]);
+    run_git(package, &["init", "-b", "main"]);
     commit_package(package, "initial rigs");
 
     let bare = tempfile::tempdir().expect("bare parent");


### PR DESCRIPTION
## Summary
- Stabilizes the tests that were blocking the Release workflow's auto-refactor path after audit baseline/autofix changes.
- Fixes CI/Linux-sensitive assumptions around trace result filenames, rig source default branches, stale PID probing, and managed process-group cleanup.

## Changes
- Aligns `RunDir`'s trace-file test with the current `trace.json` output filename.
- Uses `libc::kill(pid, 0)` with a signed PID guard for rig lease liveness so invalid `u32::MAX` leases prune reliably on Unix.
- Reaps the managed service session leader after process-group termination to avoid lingering zombies keeping process-group probes alive.
- Forces rig source test repos to initialize on `main`, avoiding runner-dependent default-branch behavior.
- Adds a third conforming audit fixture file so the outlier command test is less threshold-sensitive.

## Tests
- `cargo test audit_detects_outliers_in_convention_group -- --test-threads=1`
- `cargo test test_step_file -- --test-threads=1`
- `cargo test test_acquire_active_run_lease_prunes_stale_pid -- --test-threads=1`
- `cargo test test_command_service_stop_kills_process_group_children -- --test-threads=1`
- `cargo test update_all_reports_broken_sources_and_continues -- --test-threads=1`
- `cargo test update_git_source_fast_forwards_package_and_refreshes_metadata -- --test-threads=1`
- `cargo test update_git_source_refreshes_owned_stack_specs -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-release-autofix-tests`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-release-autofix-tests --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the release auto-refactor test failures, made the targeted fixes, and ran focused/full verification. Chris remains responsible for review and merge.