### PR TITLE
feat(audit): load requested detectors from extensions

### DIFF
--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -1048,16 +1048,16 @@ fn audit_internal(
         all_findings.extend(dead_guard_findings);
     }
 
-    // Phase 4t: Requested drift detectors for common WordPress/PHP hazards.
+    // Phase 4t: Extension-owned requested detector rule packs.
     let requested_findings = if plan.run_requested_detectors {
-        requested_detectors::run(&all_fingerprints)
+        requested_detectors::run(&all_fingerprints, &audit_config)
     } else {
         Vec::new()
     };
     if !requested_findings.is_empty() {
         log_status!(
             "audit",
-            "Requested detectors: {} finding(s) (JSON LIKE, slug literal, option-scope drift)",
+            "Requested detectors: {} finding(s) (extension rule packs)",
             requested_findings.len()
         );
         all_findings.extend(requested_findings);

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -1,14 +1,9 @@
-//! Targeted detector rules requested from real audit misses.
-//!
-//! These are intentionally conservative text-backed rules. They catch common
-//! WordPress/PHP drift shapes without pretending to be a full PHP data-flow
-//! engine: JSON blob exact matching via SQL LIKE, raw slug literals when a
-//! matching class constant exists, and doc/implementation drift around network
-//! option storage.
+//! Extension-owned requested detector rule-pack execution.
 
-use std::sync::LazyLock;
+use regex::{Captures, Regex};
+use std::str::FromStr;
 
-use regex::Regex;
+use crate::component::{AuditConfig, RequestedDetectorRule, RequestedDetectorRuleBody};
 
 use super::comment_blocks;
 use super::conventions::{AuditFinding, Language};
@@ -16,212 +11,338 @@ use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 
 #[derive(Debug, Clone)]
-struct SlugConstant {
-    class_name: Option<String>,
-    const_name: String,
+struct DerivedValue {
     value: String,
+    label: String,
     file: String,
 }
 
-pub(super) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
-    let php_files: Vec<&FileFingerprint> = fingerprints
-        .iter()
-        .copied()
-        .filter(|fp| fp.language == Language::Php && !is_vendored_path(&fp.relative_path))
-        .collect();
-
-    let mut findings = Vec::new();
-    findings.extend(detect_json_like_exact_matches(&php_files));
-    findings.extend(detect_constant_backed_slug_literals(&php_files));
-    findings.extend(detect_option_scope_drift(&php_files));
-    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
-    findings
-}
-
-fn is_vendored_path(path: &str) -> bool {
-    path.contains("/vendor/")
-        || path.starts_with("vendor/")
-        || path.contains("/node_modules/")
-        || path.starts_with("node_modules/")
-}
-
-// ============================================================================
-// #1559 — SQL LIKE exact matches against JSON blob fields
-// ============================================================================
-
-static JSON_LIKE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?is)\b(metadata|engine_data|config|payload)\b\s+LIKE\s+[^;\n]*(?:\\?['\"]|%)(?:\\?\")([A-Za-z_][A-Za-z0-9_\-]*)(?:\\?\")\s*:"#,
-    )
-    .expect("JSON LIKE detector regex compiles")
-});
-
-fn detect_json_like_exact_matches(files: &[&FileFingerprint]) -> Vec<Finding> {
-    let mut findings = Vec::new();
-    for fp in files {
-        for cap in JSON_LIKE_RE.captures_iter(&fp.content) {
-            let full = cap.get(0).unwrap();
-            let column = cap.get(1).map(|m| m.as_str()).unwrap_or("JSON blob");
-            let field = cap.get(2).map(|m| m.as_str()).unwrap_or("field");
-            let line = line_of_offset(&fp.content, full.start());
-            findings.push(Finding {
-                convention: "requested_detectors".to_string(),
-                severity: Severity::Warning,
-                file: fp.relative_path.clone(),
-                description: format!(
-                    "SQL LIKE exact-match against JSON blob `{}` at line {} for key `{}`",
-                    column, line, field
-                ),
-                suggestion: format!(
-                    "Avoid semantic matching inside `{}` with LIKE. Decode candidate rows or promote `{}` to a first-class indexed column before exact matching.",
-                    column, field
-                ),
-                kind: AuditFinding::JsonLikeExactMatch,
-            });
-        }
-    }
-    findings
-}
-
-// ============================================================================
-// #1560 — Literal slug drift when matching constants exist
-// ============================================================================
-
-static CLASS_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"\b(?:final\s+|abstract\s+)?class\s+([A-Za-z_][A-Za-z0-9_]*)"#)
-        .expect("class regex compiles")
-});
-
-static CONST_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r#"(?m)\b(?:(?:public|protected|private)\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*['\"]([^'\"]+)['\"]"#,
-    )
-    .expect("constant regex compiles")
-});
-
-static SLUG_VALUE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"^[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+$"#).expect("slug regex compiles")
-});
-
-fn detect_constant_backed_slug_literals(files: &[&FileFingerprint]) -> Vec<Finding> {
-    let constants = collect_slug_constants(files);
-    if constants.is_empty() {
+pub(super) fn run(fingerprints: &[&FileFingerprint], audit_config: &AuditConfig) -> Vec<Finding> {
+    if audit_config.requested_detectors.is_empty() {
         return Vec::new();
     }
 
     let mut findings = Vec::new();
-    for constant in constants {
-        let literal_re = Regex::new(&format!(r#"['\"]{}['\"]"#, regex::escape(&constant.value)))
-            .expect("escaped literal regex compiles");
-        for fp in files {
-            if fp.relative_path == constant.file {
-                continue;
-            }
-            let Some(m) = literal_re.find(&fp.content) else {
-                continue;
-            };
-            let line = line_of_offset(&fp.content, m.start());
-            findings.push(Finding {
-                convention: "requested_detectors".to_string(),
-                severity: Severity::Info,
-                file: fp.relative_path.clone(),
-                description: format!(
-                    "Raw slug literal `{}` at line {} duplicates constant {}",
-                    constant.value,
-                    line,
-                    constant_label(&constant)
-                ),
-                suggestion: format!(
-                    "Use {} instead of repeating the literal slug so the constant remains the source of truth.",
-                    constant_label(&constant)
-                ),
-                kind: AuditFinding::ConstantBackedSlugLiteral,
-            });
+    for rule in &audit_config.requested_detectors {
+        findings.extend(run_rule(rule, fingerprints));
+    }
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn run_rule(rule: &RequestedDetectorRule, fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    match &rule.rule {
+        RequestedDetectorRuleBody::Regex {
+            pattern,
+            description,
+            suggestion,
+        } => run_regex_rule(rule, fingerprints, pattern, description, suggestion),
+        RequestedDetectorRuleBody::CommentRegex {
+            comment_pattern,
+            comment_exclude_pattern,
+            pattern,
+            description,
+            suggestion,
+        } => run_comment_regex_rule(
+            rule,
+            fingerprints,
+            comment_pattern,
+            comment_exclude_pattern.as_deref(),
+            pattern,
+            description,
+            suggestion,
+        ),
+        RequestedDetectorRuleBody::DerivedLiteral {
+            source_pattern,
+            value_capture,
+            label,
+            literal_pattern,
+            description,
+            suggestion,
+        } => run_derived_literal_rule(
+            rule,
+            fingerprints,
+            source_pattern,
+            value_capture,
+            label,
+            literal_pattern,
+            description,
+            suggestion,
+        ),
+    }
+}
+
+fn run_regex_rule(
+    rule: &RequestedDetectorRule,
+    fingerprints: &[&FileFingerprint],
+    pattern: &str,
+    description: &str,
+    suggestion: &str,
+) -> Vec<Finding> {
+    let Ok(regex) = Regex::new(pattern) else {
+        return Vec::new();
+    };
+    let mut findings = Vec::new();
+    for fp in eligible_files(rule, fingerprints) {
+        for captures in regex.captures_iter(&fp.content) {
+            findings.push(finding_from_captures(
+                rule,
+                fp,
+                &captures,
+                description,
+                suggestion,
+            ));
         }
     }
     findings
 }
 
-fn collect_slug_constants(files: &[&FileFingerprint]) -> Vec<SlugConstant> {
-    let mut constants = Vec::new();
-    for fp in files {
-        let class_name = CLASS_RE
-            .captures(&fp.content)
-            .and_then(|cap| cap.get(1).map(|m| m.as_str().to_string()));
-        for cap in CONST_RE.captures_iter(&fp.content) {
-            let const_name = cap.get(1).map(|m| m.as_str()).unwrap_or("");
-            let value = cap.get(2).map(|m| m.as_str()).unwrap_or("");
-            if !SLUG_VALUE_RE.is_match(value) {
-                continue;
-            }
-            constants.push(SlugConstant {
-                class_name: class_name.clone(),
-                const_name: const_name.to_string(),
-                value: value.to_string(),
-                file: fp.relative_path.clone(),
-            });
-        }
-    }
-    constants
-}
+fn run_comment_regex_rule(
+    rule: &RequestedDetectorRule,
+    fingerprints: &[&FileFingerprint],
+    comment_pattern: &str,
+    comment_exclude_pattern: Option<&str>,
+    pattern: &str,
+    description: &str,
+    suggestion: &str,
+) -> Vec<Finding> {
+    let Ok(comment_regex) = Regex::new(comment_pattern) else {
+        return Vec::new();
+    };
+    let comment_exclude_regex =
+        comment_exclude_pattern.and_then(|pattern| Regex::new(pattern).ok());
+    let Ok(regex) = Regex::new(pattern) else {
+        return Vec::new();
+    };
 
-fn constant_label(constant: &SlugConstant) -> String {
-    match &constant.class_name {
-        Some(class_name) => format!("{}::{}", class_name, constant.const_name),
-        None => constant.const_name.clone(),
-    }
-}
-
-// ============================================================================
-// #1561 — Option scope drift between docs and implementation
-// ============================================================================
-
-static SINGLE_SITE_OPTION_CALL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"\b(get_option|update_option|delete_option)\s*\("#)
-        .expect("single-site option regex compiles")
-});
-
-fn detect_option_scope_drift(files: &[&FileFingerprint]) -> Vec<Finding> {
     let mut findings = Vec::new();
-    for fp in files {
-        if !comments_promise_network_option_storage(fp) {
+    for fp in eligible_files(rule, fingerprints) {
+        let comment_blocks = comment_blocks::extract(fp);
+        if comment_blocks.iter().any(|block| {
+            comment_exclude_regex
+                .as_ref()
+                .is_some_and(|regex| regex.is_match(&block.text))
+        }) {
             continue;
         }
-        for cap in SINGLE_SITE_OPTION_CALL_RE.captures_iter(&fp.content) {
-            let full = cap.get(0).unwrap();
-            let call = cap.get(1).map(|m| m.as_str()).unwrap_or("get_option");
-            let line = line_of_offset(&fp.content, full.start());
-            findings.push(Finding {
-                convention: "requested_detectors".to_string(),
-                severity: Severity::Warning,
-                file: fp.relative_path.clone(),
-                description: format!(
-                    "Option scope drift at line {}: docs mention network/site-option storage but implementation calls `{}`",
-                    line, call
-                ),
-                suggestion: format!(
-                    "Use the matching `{}`site_option call or update the storage contract so multisite behaviour is explicit.",
-                    if call.starts_with("delete") { "delete_" } else if call.starts_with("update") { "update_" } else { "get_" }
-                ),
-                kind: AuditFinding::OptionScopeDrift,
-            });
+        if !comment_blocks
+            .iter()
+            .any(|block| comment_regex.is_match(&block.text))
+        {
+            continue;
+        }
+        for captures in regex.captures_iter(&fp.content) {
+            findings.push(finding_from_captures(
+                rule,
+                fp,
+                &captures,
+                description,
+                suggestion,
+            ));
         }
     }
     findings
 }
 
-fn comments_promise_network_option_storage(fp: &FileFingerprint) -> bool {
-    comment_blocks::extract(fp).into_iter().any(|block| {
-        let text = block.text.to_ascii_lowercase();
-        if text.contains("not a network option") || text.contains("single-site option") {
-            return false;
+#[allow(clippy::too_many_arguments)]
+fn run_derived_literal_rule(
+    rule: &RequestedDetectorRule,
+    fingerprints: &[&FileFingerprint],
+    source_pattern: &str,
+    value_capture: &str,
+    label: &str,
+    literal_pattern: &str,
+    description: &str,
+    suggestion: &str,
+) -> Vec<Finding> {
+    let Ok(source_regex) = Regex::new(source_pattern) else {
+        return Vec::new();
+    };
+
+    let values = collect_derived_values(
+        &source_regex,
+        eligible_files(rule, fingerprints),
+        value_capture,
+        label,
+    );
+    if values.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for value in values {
+        let concrete_pattern = render_template(literal_pattern, None, |name| match name {
+            "value" => value.value.clone(),
+            "label" => value.label.clone(),
+            _ => String::new(),
+        });
+        let Ok(literal_regex) = Regex::new(&concrete_pattern) else {
+            continue;
+        };
+        for fp in eligible_files(rule, fingerprints) {
+            if fp.relative_path == value.file {
+                continue;
+            }
+            for captures in literal_regex.captures_iter(&fp.content) {
+                findings.push(finding_from_captures_with_extra(
+                    rule,
+                    fp,
+                    &captures,
+                    description,
+                    suggestion,
+                    |name| match name {
+                        "value" => value.value.clone(),
+                        "label" => value.label.clone(),
+                        _ => String::new(),
+                    },
+                ));
+            }
         }
-        text.contains("network option")
-            || text.contains("site option")
-            || text.contains("multisite")
-            || text.contains("shared across subsites")
-            || text.contains("shared across sites")
+    }
+    findings
+}
+
+fn collect_derived_values(
+    source_regex: &Regex,
+    files: Vec<&FileFingerprint>,
+    value_capture: &str,
+    label_template: &str,
+) -> Vec<DerivedValue> {
+    let mut values = Vec::new();
+    for fp in files {
+        for captures in source_regex.captures_iter(&fp.content) {
+            let value = capture_value(&captures, value_capture);
+            if value.is_empty() {
+                continue;
+            }
+            values.push(DerivedValue {
+                label: render_template(label_template, Some(&captures), |_| String::new()),
+                value,
+                file: fp.relative_path.clone(),
+            });
+        }
+    }
+    values
+}
+
+fn eligible_files<'a>(
+    rule: &RequestedDetectorRule,
+    fingerprints: &'a [&'a FileFingerprint],
+) -> Vec<&'a FileFingerprint> {
+    fingerprints
+        .iter()
+        .copied()
+        .filter(|fp| language_matches(rule, fp))
+        .filter(|fp| extension_matches(rule, fp))
+        .filter(|fp| {
+            !rule
+                .exclude_path_contains
+                .iter()
+                .any(|needle| fp.relative_path.contains(needle))
+        })
+        .collect()
+}
+
+fn extension_matches(rule: &RequestedDetectorRule, fp: &FileFingerprint) -> bool {
+    if rule.file_extensions.is_empty() {
+        return true;
+    }
+    let extension = std::path::Path::new(&fp.relative_path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default();
+    rule.file_extensions
+        .iter()
+        .any(|expected| expected.trim_start_matches('.') == extension)
+}
+
+fn language_matches(rule: &RequestedDetectorRule, fp: &FileFingerprint) -> bool {
+    let Some(language) = &rule.language else {
+        return true;
+    };
+    match language.trim().to_ascii_lowercase().as_str() {
+        "php" => fp.language == Language::Php,
+        "rust" => fp.language == Language::Rust,
+        "javascript" | "js" => fp.language == Language::JavaScript,
+        "typescript" | "ts" => fp.language == Language::TypeScript,
+        "unknown" => fp.language == Language::Unknown,
+        _ => false,
+    }
+}
+
+fn finding_from_captures(
+    rule: &RequestedDetectorRule,
+    fp: &FileFingerprint,
+    captures: &Captures,
+    description: &str,
+    suggestion: &str,
+) -> Finding {
+    finding_from_captures_with_extra(rule, fp, captures, description, suggestion, |_| {
+        String::new()
     })
+}
+
+fn finding_from_captures_with_extra<F>(
+    rule: &RequestedDetectorRule,
+    fp: &FileFingerprint,
+    captures: &Captures,
+    description: &str,
+    suggestion: &str,
+    extra: F,
+) -> Finding
+where
+    F: Fn(&str) -> String,
+{
+    let offset = captures.get(0).map(|m| m.start()).unwrap_or(0);
+    let line = line_of_offset(&fp.content, offset).to_string();
+    Finding {
+        convention: rule.convention.clone(),
+        severity: severity_from_config(&rule.severity),
+        file: fp.relative_path.clone(),
+        description: render_template(description, Some(captures), |name| match name {
+            "line" => line.clone(),
+            other => extra(other),
+        }),
+        suggestion: render_template(suggestion, Some(captures), extra),
+        kind: AuditFinding::from_str(&rule.kind).unwrap_or(AuditFinding::LegacyComment),
+    }
+}
+
+fn severity_from_config(value: &str) -> Severity {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "info" => Severity::Info,
+        _ => Severity::Warning,
+    }
+}
+
+fn capture_value(captures: &Captures, name: &str) -> String {
+    if let Ok(index) = name.parse::<usize>() {
+        return captures
+            .get(index)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+    }
+    captures
+        .name(name)
+        .map(|m| m.as_str().to_string())
+        .unwrap_or_default()
+}
+
+fn render_template<F>(template: &str, captures: Option<&Captures>, extra: F) -> String
+where
+    F: Fn(&str) -> String,
+{
+    let token =
+        Regex::new(r"\{([A-Za-z_][A-Za-z0-9_]*|[0-9]+)\}").expect("template regex compiles");
+    token
+        .replace_all(template, |caps: &Captures| {
+            let name = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+            captures
+                .map(|c| capture_value(c, name))
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| extra(name))
+        })
+        .to_string()
 }
 
 fn line_of_offset(content: &str, offset: usize) -> usize {
@@ -245,133 +366,128 @@ mod tests {
         }
     }
 
+    fn config(rule: RequestedDetectorRule) -> AuditConfig {
+        AuditConfig {
+            requested_detectors: vec![rule],
+            ..Default::default()
+        }
+    }
+
     #[test]
-    fn flags_json_like_exact_match_against_metadata_key() {
+    fn test_run() {
+        let fp = php_fp("src/storage.php", "<?php noop();");
+
+        assert!(run(&[&fp], &AuditConfig::default()).is_empty());
+    }
+
+    #[test]
+    fn regex_rules_render_capture_templates() {
         let fp = php_fp(
-            "inc/Core/Database/Chat.php",
+            "src/storage.php",
             r#"<?php
-$wpdb->get_results( "SELECT * FROM table WHERE metadata LIKE '%\"status\":\"processing\"%'" );
+query( "SELECT * FROM table WHERE data LIKE '%\"status\":\"processing\"%'" );
 "#,
         );
+        let rule = RequestedDetectorRule {
+            id: "json-like".to_string(),
+            kind: "json_like_exact_match".to_string(),
+            severity: "warning".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec!["/vendor/".to_string(), "vendor/".to_string()],
+            rule: RequestedDetectorRuleBody::Regex {
+                pattern: r#"(?is)\b(?P<column>data)\b\s+LIKE\s+[^;\n]*(?:\\?['\"]|%)(?:\\?\")(?P<field>[A-Za-z_][A-Za-z0-9_\-]*)(?:\\?\")\s*:"#.to_string(),
+                description: "SQL LIKE exact-match against JSON blob `{column}` at line {line} for key `{field}`".to_string(),
+                suggestion: "Promote `{field}` out of `{column}` before exact matching.".to_string(),
+            },
+        };
 
-        let findings = detect_json_like_exact_matches(&[&fp]);
+        let findings = run(&[&fp], &config(rule));
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, AuditFinding::JsonLikeExactMatch);
-        assert!(findings[0].description.contains("metadata"));
+        assert!(findings[0].description.contains("data"));
         assert!(findings[0].description.contains("status"));
     }
 
     #[test]
-    fn ignores_broad_like_search_that_does_not_match_json_key_semantics() {
-        let fp = php_fp(
-            "inc/Search.php",
-            r#"<?php
-$wpdb->get_results( "SELECT * FROM table WHERE metadata LIKE '%processing%'" );
-"#,
-        );
-
-        assert!(detect_json_like_exact_matches(&[&fp]).is_empty());
-    }
-
-    #[test]
-    fn flags_slug_literal_when_matching_constant_exists_elsewhere() {
+    fn derived_literal_rules_collect_values_and_skip_source_file() {
         let constants = php_fp(
-            "inc/Abilities/AbilityCategories.php",
+            "src/categories.php",
             r#"<?php
-final class AbilityCategories {
-    public const CONTENT = 'datamachine-content';
+final class Categories {
+    public const CONTENT = 'content-item';
+    public function value() { return 'content-item'; }
 }
 "#,
         );
         let caller = php_fp(
-            "inc/Abilities/Post/EditPostAbility.php",
+            "src/caller.php",
             r#"<?php
-register_ability( array( 'category' => 'datamachine-content' ) );
+register_item( array( 'category' => 'content-item' ) );
 "#,
         );
+        let rule = RequestedDetectorRule {
+            id: "slug-constant".to_string(),
+            kind: "constant_backed_slug_literal".to_string(),
+            severity: "info".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::DerivedLiteral {
+                source_pattern: r#"(?s)\b(?:final\s+|abstract\s+)?class\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\b.*?\b(?:(?:public|protected|private)\s+)?const\s+(?P<const>[A-Z][A-Z0-9_]*)\s*=\s*['\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\"]"#.to_string(),
+                value_capture: "value".to_string(),
+                label: "{class}::{const}".to_string(),
+                literal_pattern: r#"['\"]{value}['\"]"#.to_string(),
+                description: "Raw slug literal `{value}` at line {line} duplicates constant {label}".to_string(),
+                suggestion: "Use {label} instead.".to_string(),
+            },
+        };
 
-        let findings = detect_constant_backed_slug_literals(&[&constants, &caller]);
+        let findings = run(&[&constants, &caller], &config(rule));
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, AuditFinding::ConstantBackedSlugLiteral);
-        assert!(findings[0]
-            .description
-            .contains("AbilityCategories::CONTENT"));
+        assert_eq!(findings[0].severity, Severity::Info);
+        assert!(findings[0].description.contains("Categories::CONTENT"));
     }
 
     #[test]
-    fn ignores_non_slug_constants_and_declaring_file_literals() {
-        let constants = php_fp(
-            "inc/Status.php",
+    fn comment_regex_rules_require_matching_comment_block() {
+        let matching = php_fp(
+            "src/shared_storage.php",
             r#"<?php
-class Status {
-    public const PROCESSING = 'processing';
-    public const API = 'datamachine-api';
-    public function value() { return 'datamachine-api'; }
-}
+/** Tokens are stored in shared storage across tenants. */
+write_local_option( 'external_tokens', array() );
 "#,
         );
-        let caller = php_fp(
-            "inc/Other.php",
+        let explicit_single_site = php_fp(
+            "src/local_storage.php",
             r#"<?php
-$status = 'processing';
+/** This value is intentionally local-only storage. */
+write_local_option( 'local_setting', true );
 "#,
         );
+        let rule = RequestedDetectorRule {
+            id: "option-scope".to_string(),
+            kind: "option_scope_drift".to_string(),
+            severity: "warning".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::CommentRegex {
+                comment_pattern: r#"(?i)\b(shared storage|shared across tenants|shared across sites)\b"#.to_string(),
+                comment_exclude_pattern: Some(r#"(?i)\b(local-only storage|single-tenant storage)\b"#.to_string()),
+                pattern: r#"\b(?P<call>read_local_option|write_local_option|delete_local_option)\s*\("#.to_string(),
+                description: "Storage scope drift at line {line}: docs mention shared storage but implementation calls `{call}`".to_string(),
+                suggestion: "Use the matching shared-storage call or update the storage contract.".to_string(),
+            },
+        };
 
-        assert!(detect_constant_backed_slug_literals(&[&constants, &caller]).is_empty());
-    }
-
-    #[test]
-    fn flags_single_site_option_call_when_doc_promises_network_storage() {
-        let fp = php_fp(
-            "inc/Core/Auth/Callback.php",
-            r#"<?php
-/**
- * External tokens are stored in a network option shared across subsites.
- */
-class Callback {
-    public function save() {
-        update_option( 'datamachine_external_tokens', array() );
-    }
-}
-"#,
-        );
-
-        let findings = detect_option_scope_drift(&[&fp]);
+        let findings = run(&[&matching, &explicit_single_site], &config(rule));
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, AuditFinding::OptionScopeDrift);
-        assert!(findings[0].description.contains("update_option"));
-    }
-
-    #[test]
-    fn ignores_matching_site_option_calls_and_single_site_docs() {
-        let matching = php_fp(
-            "inc/Core/OAuth/BaseProvider.php",
-            r#"<?php
-/** Auth data is stored in a network option. */
-get_site_option( 'datamachine_auth_data', array() );
-"#,
-        );
-        let single_site = php_fp(
-            "inc/Core/Settings.php",
-            r#"<?php
-/** This value is intentionally a single-site option. */
-get_option( 'datamachine_local_setting' );
-"#,
-        );
-
-        assert!(detect_option_scope_drift(&[&matching, &single_site]).is_empty());
-    }
-
-    #[test]
-    fn run_skips_vendored_php_files() {
-        let fp = php_fp(
-            "vendor/package/File.php",
-            r#"<?php
-/** Tokens use a network option. */
-get_option( 'external_tokens' );
-"#,
-        );
-
-        assert!(run(&[&fp]).is_empty());
+        assert!(findings[0].description.contains("write_local_option"));
     }
 }

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -21,6 +21,9 @@ pub struct AuditConfig {
     /// floor, package, or bootstrap file is present.
     #[serde(default, skip_serializing_if = "KnownSymbolsConfig::is_empty")]
     pub known_symbols: KnownSymbolsConfig,
+    /// Extension-owned text detector rules that emit audit findings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requested_detectors: Vec<RequestedDetectorRule>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -96,6 +99,69 @@ impl KnownSymbolsConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequestedDetectorRule {
+    /// Human-readable detector label used for logging/debugging.
+    pub id: String,
+    /// Audit finding kind in snake_case, e.g. `json_like_exact_match`.
+    pub kind: String,
+    /// `warning` or `info`. Defaults to `warning`.
+    #[serde(default = "default_requested_detector_severity")]
+    pub severity: String,
+    /// Report convention label. Defaults to `requested_detectors`.
+    #[serde(default = "default_requested_detector_convention")]
+    pub convention: String,
+    /// Optional language filter using Homeboy's lowercase language names.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Optional path-extension filter, without leading dots.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_extensions: Vec<String>,
+    /// Path substrings that opt files out of this detector.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_path_contains: Vec<String>,
+    /// Detector body. Core owns the execution primitives; extensions own the rules.
+    #[serde(flatten)]
+    pub rule: RequestedDetectorRuleBody,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RequestedDetectorRuleBody {
+    /// Emit one finding for each regex match in a file.
+    Regex {
+        pattern: String,
+        description: String,
+        suggestion: String,
+    },
+    /// Emit regex findings only when extracted comments match a trigger pattern.
+    CommentRegex {
+        comment_pattern: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        comment_exclude_pattern: Option<String>,
+        pattern: String,
+        description: String,
+        suggestion: String,
+    },
+    /// Collect values with one regex, then flag matching literals in other files.
+    DerivedLiteral {
+        source_pattern: String,
+        value_capture: String,
+        label: String,
+        literal_pattern: String,
+        description: String,
+        suggestion: String,
+    },
+}
+
+fn default_requested_detector_severity() -> String {
+    "warning".to_string()
+}
+
+fn default_requested_detector_convention() -> String {
+    "requested_detectors".to_string()
+}
+
 impl AuditConfig {
     pub fn is_empty(&self) -> bool {
         self.runtime_entrypoint_extends.is_empty()
@@ -104,6 +170,7 @@ impl AuditConfig {
             && self.utility_suffixes.is_empty()
             && self.convention_exception_globs.is_empty()
             && self.known_symbols.is_empty()
+            && self.requested_detectors.is_empty()
     }
 
     pub fn merge(&mut self, other: &AuditConfig) {
@@ -122,6 +189,15 @@ impl AuditConfig {
             &other.convention_exception_globs,
         );
         self.known_symbols.merge(&other.known_symbols);
+        for rule in &other.requested_detectors {
+            if !self
+                .requested_detectors
+                .iter()
+                .any(|existing| existing.id == rule.id)
+            {
+                self.requested_detectors.push(rule.clone());
+            }
+        }
     }
 }
 

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -12,7 +12,7 @@ pub mod versioning;
 
 pub use audit::{
     AuditConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
-    KnownSymbolVersionedEntry,
+    KnownSymbolVersionedEntry, RequestedDetectorRule, RequestedDetectorRuleBody,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,


### PR DESCRIPTION
## Summary
- Replaces the hardcoded WordPress/PHP requested detector bodies in Homeboy core with generic extension-owned rule-pack plumbing.
- Adds configurable regex, comment-triggered regex, and derived-literal detector primitives under audit.detector_rules.
- Leaves Homeboy core responsible for aggregation/reporting while the WordPress extension owns the WordPress/Data Machine rule definitions.

Cross-link: Extra-Chill/homeboy-extensions#367

## Tests
- cargo test requested_detectors -- --test-threads=1
- cargo fmt --check
- homeboy lint homeboy --path /Users/chubes/Developer/homeboy@extension-requested-detectors --summary
- homeboy audit homeboy --path /Users/chubes/Developer/homeboy@extension-requested-detectors --changed-since origin/main --json-summary
- Workspace-local integration: temporary HOME install of homeboy-extensions#367 branch, then audit Data Machine with --only option_scope_drift to confirm moved findings still emit.

## Closes
- Closes #1947

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the generic rule-pack plumbing and tests, moved the WordPress rule ownership into the extension PR, resolved rebase conflicts, and ran validation. Chris remains responsible for review and merge.