### PR TITLE
feat(bench): surface artifact paths in reports

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -430,6 +430,26 @@ The extension's bench script must:
   `label` metadata. Homeboy preserves and indexes these pointers but does
   not upload, retain, or diff artifact contents.
 
+### Artifact kind conventions
+
+`kind` is an open string, not a closed enum. Homeboy preserves unknown kinds
+so extensions can add new evidence types without requiring a core release.
+Use these conventional values when they fit:
+
+- `json` — structured machine-readable data, summaries, or transcripts.
+- `directory` — a directory containing multiple related files.
+- `playwright-trace` — Playwright trace archive, usually a `.zip` file.
+- `screenshot` — browser or UI screenshot evidence.
+- `network-log` — captured request/response metadata such as HAR or JSONL.
+- `console-log` — browser console output or page-level JavaScript logs.
+
+For browser benchmarks, prefer specific labels such as `Playwright trace`,
+`Final screenshot`, `Network log`, or `Console log`. The JSON result keeps
+the full artifact map under each scenario, and Homeboy also promotes artifact
+pointers into the top-level `artifacts` index. Markdown reports render those
+labels and paths so users can find trace and screenshot files without opening
+the raw JSON payload.
+
 ### Environment variables injected
 
 Bench scripts receive the standard runner contract plus bench-specific

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -143,6 +143,9 @@ pub fn render_failure_digest(context: &FailureDigestContext) -> String {
     if command_reported(&context.results, "trace") {
         render_trace_section(&mut out, &context.output_dir, &context.run_url);
     }
+    if command_reported(&context.results, "bench") {
+        render_bench_section(&mut out, &context.output_dir, &context.run_url);
+    }
 
     render_autofix_section(&mut out, context);
     render_tooling_section(&mut out, &context.tooling);
@@ -443,6 +446,38 @@ fn render_trace_section(out: &mut String, output_dir: &Path, run_url: &str) {
     out.push('\n');
 }
 
+fn render_bench_section(out: &mut String, output_dir: &Path, run_url: &str) {
+    let (data, error) = envelope_parts(read_command_json(output_dir, "bench"));
+
+    let component = string_value(&data, "component")
+        .or_else(|| string_value(&object_value(&data, "results"), "component_id"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let status = string_value(&data, "status")
+        .or_else(|| string_value(&error, "code"))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let _ = writeln!(out, "### Bench: {}", component);
+    let _ = writeln!(out, "**Status:** {}\n", status.to_uppercase());
+
+    if let Some(message) = string_value(&error, "message") {
+        out.push_str("**Summary**\n");
+        let _ = writeln!(out, "- {}\n", message);
+    }
+
+    let artifacts = collect_bench_artifacts(&data);
+    if !artifacts.is_empty() {
+        out.push_str("**Artifacts**\n");
+        for artifact in artifacts {
+            let _ = writeln!(out, "- {}", artifact);
+        }
+    } else {
+        out.push_str("**Artifacts**\n- No structured bench artifacts available.\n");
+    }
+
+    render_full_log(out, "bench", run_url);
+    out.push('\n');
+}
+
 fn render_error_details(out: &mut String, error: &Map<String, Value>) {
     if let Some(code) = string_value(error, "code") {
         let _ = writeln!(out, "- Error code: `{}`", code);
@@ -656,6 +691,74 @@ fn collect_trace_artifacts(
         Some((label, path))
     })
     .collect()
+}
+
+fn collect_bench_artifacts(data: &Map<String, Value>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut rendered = Vec::new();
+
+    for artifact in array_value(data, "artifacts") {
+        push_bench_artifact(&mut seen, &mut rendered, None, artifact);
+    }
+
+    for rig in array_value(data, "rigs") {
+        let Some(rig_obj) = rig.as_object() else {
+            continue;
+        };
+        let rig_id = string_value(rig_obj, "rig_id");
+        for artifact in array_value(rig_obj, "artifacts") {
+            push_bench_artifact(&mut seen, &mut rendered, rig_id.as_deref(), artifact);
+        }
+    }
+
+    rendered
+}
+
+fn push_bench_artifact(
+    seen: &mut BTreeSet<(Option<String>, String)>,
+    rendered: &mut Vec<String>,
+    rig_id: Option<&str>,
+    artifact: &Value,
+) {
+    let Some(obj) = artifact.as_object() else {
+        return;
+    };
+    let Some(path) = string_value(obj, "path") else {
+        return;
+    };
+    let key = (rig_id.map(str::to_string), path.clone());
+    if !seen.insert(key) {
+        return;
+    }
+
+    let label = string_value(obj, "label")
+        .or_else(|| string_value(obj, "name"))
+        .unwrap_or_else(|| "artifact".to_string());
+    let scenario = string_value(obj, "scenario_id");
+    let run_index = string_value(obj, "run_index");
+    let kind = string_value(obj, "kind");
+
+    let mut prefix = Vec::new();
+    if let Some(rig) = rig_id {
+        prefix.push(format!("rig `{}`", rig));
+    }
+    if let Some(scenario) = scenario {
+        prefix.push(format!("scenario `{}`", scenario));
+    }
+    if let Some(run_index) = run_index {
+        prefix.push(format!("run {}", run_index));
+    }
+
+    let mut line = if prefix.is_empty() {
+        label
+    } else {
+        format!("{} — {}", prefix.join(" / "), label)
+    };
+    if let Some(kind) = kind {
+        let _ = write!(line, " ({})", kind);
+    }
+    let _ = write!(line, ": {}", path);
+    rendered.push(line);
 }
 
 fn string_array(map: &Map<String, Value>, key: &str) -> Vec<String> {

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -67,6 +67,42 @@ fn trace_json(status: &str, summary: &str) -> String {
     )
 }
 
+fn bench_json() -> &'static str {
+    r#"{
+        "success": true,
+        "data": {
+            "passed": true,
+            "status": "passed",
+            "component": "studio",
+            "exit_code": 0,
+            "iterations": 5,
+            "artifacts": [
+                {
+                    "scenario_id": "wp-admin-load",
+                    "run_index": 0,
+                    "name": "trace",
+                    "path": "bench-artifacts/wp-admin-load/trace.zip",
+                    "kind": "playwright-trace",
+                    "label": "Playwright trace",
+                    "content": "trace bytes should never appear"
+                },
+                {
+                    "scenario_id": "wp-admin-load",
+                    "name": "screenshot",
+                    "path": "bench-artifacts/wp-admin-load/final.png",
+                    "kind": "screenshot",
+                    "label": "Final screenshot"
+                }
+            ],
+            "results": {
+                "component_id": "studio",
+                "iterations": 5,
+                "scenarios": []
+            }
+        }
+    }"#
+}
+
 #[test]
 fn renders_lint_failure_digest_from_fixture() {
     let dir = tmp_dir("lint");
@@ -231,6 +267,27 @@ fn renders_trace_pass_status_and_artifact_paths() {
     assert!(markdown.contains("- main log: artifacts/main.log"));
     assert!(markdown.contains("- process tree: artifacts/process-tree.txt"));
     assert!(!markdown.contains("raw log body that should never appear"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_bench_status_and_artifact_paths() {
+    let dir = tmp_dir("bench-pass");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "bench.json", bench_json());
+
+    let markdown = render(&dir, r#"{"bench":"pass"}"#, false, false);
+
+    assert!(markdown.contains("### Bench: studio"));
+    assert!(markdown.contains("**Status:** PASSED"));
+    assert!(markdown.contains(
+        "- scenario `wp-admin-load` / run 0 — Playwright trace (playwright-trace): bench-artifacts/wp-admin-load/trace.zip"
+    ));
+    assert!(markdown.contains(
+        "- scenario `wp-admin-load` — Final screenshot (screenshot): bench-artifacts/wp-admin-load/final.png"
+    ));
+    assert!(!markdown.contains("trace bytes should never appear"));
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- Surface bench artifact labels, kinds, scenario/run context, and paths in markdown failure digest output.
- Document open artifact `kind` conventions for browser-oriented benchmark evidence.

## Changes
- Adds a bench section to `homeboy report failure-digest` when bench output is present.
- Renders top-level single-run artifacts and cross-rig artifact indexes without inlining artifact contents.
- Documents conventional artifact kinds: `json`, `directory`, `playwright-trace`, `screenshot`, `network-log`, and `console-log`.
- Keeps the existing bench JSON result schema and parser compatibility unchanged.

## Tests
- `cargo test renders_bench_status_and_artifact_paths -- --test-threads=1`
- `cargo test --test report_failure_digest_test -- --test-threads=1`
- `git diff --check`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-bench-artifact-ux`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-bench-artifact-ux --changed-since origin/main`

Note: `homeboy test homeboy --path /Users/chubes/Developer/homeboy@feat-bench-artifact-ux --test report_failure_digest_test` ran the Rust test successfully, then failed in the Homeboy wrapper with the pre-existing macOS `grep -P` harness issue.

Closes #1960

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the report rendering/docs/test changes and ran focused validation. Chris remains responsible for review and merge.
