### PR TITLE
fix(lint): preserve scope in autofix hints

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -7,7 +7,8 @@ use homeboy::extension::lint::{
     LintRunWorkflowArgs,
 };
 use homeboy::extension::ExtensionCapability;
-use homeboy::refactor::plan::{run_lint_refactor, LintSourceOptions};
+use homeboy::git;
+use homeboy::refactor::plan::{collect_refactor_sources, lint_refactor_request, LintSourceOptions};
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
@@ -172,8 +173,19 @@ fn run_fix(
     component_label: String,
     settings: Vec<(String, String)>,
 ) -> CmdResult<LintCommandOutput> {
+    let selected_files = if args.changed_only {
+        let changes = git::get_uncommitted_changes(&ctx.component.local_path)?;
+        let mut files = Vec::new();
+        files.extend(changes.staged);
+        files.extend(changes.unstaged);
+        files.extend(changes.untracked);
+        Some(files)
+    } else {
+        None
+    };
+
     let lint_options = LintSourceOptions {
-        selected_files: None,
+        selected_files,
         file: args.file.clone(),
         glob: args.glob.clone(),
         errors_only: args.errors_only,
@@ -182,13 +194,16 @@ fn run_fix(
         category: args.category.clone(),
     };
 
-    let run = run_lint_refactor(
+    let mut request = lint_refactor_request(
         ctx.component.clone(),
         ctx.source_path.clone(),
         settings,
         lint_options,
         true,
-    )?;
+    );
+    request.changed_since = args.changed_since.clone();
+
+    let run = collect_refactor_sources(request)?;
 
     Ok(report::from_lint_fix(component_label, run))
 }

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -7,6 +7,7 @@
 use crate::component::Component;
 use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
+use crate::engine::shell;
 use crate::extension::lint::baseline::{self as lint_baseline, LintFinding};
 use crate::extension::lint::build_lint_runner;
 use crate::extension::{self, ExtensionCapability};
@@ -134,10 +135,7 @@ pub fn run_main_lint_workflow(
     // listed first; the canonical `homeboy refactor --from lint --write`
     // invocation follows for users who want the longer form.
     if !lint_clean {
-        hints.push(format!(
-            "Auto-fix: homeboy lint {} --fix (or homeboy refactor {} --from lint --write)",
-            args.component_label, args.component_label
-        ));
+        hints.push(build_autofix_hint(&args));
         hints.push("Some issues may require manual fixes".to_string());
     }
 
@@ -175,6 +173,77 @@ pub fn run_main_lint_workflow(
         baseline_comparison,
         lint_findings: Some(lint_findings),
     })
+}
+
+fn build_autofix_hint(args: &LintRunWorkflowArgs) -> String {
+    let lint_command = lint_autofix_command(args);
+
+    if refactor_can_preserve_scope(args) {
+        let refactor_command = refactor_autofix_command(args);
+        format!("Auto-fix: {lint_command} (or {refactor_command})")
+    } else {
+        format!("Auto-fix: {lint_command}")
+    }
+}
+
+fn lint_autofix_command(args: &LintRunWorkflowArgs) -> String {
+    let mut parts = vec![
+        "homeboy".to_string(),
+        "lint".to_string(),
+        args.component_label.clone(),
+    ];
+
+    append_common_scope_args(&mut parts, args);
+    parts.push("--fix".to_string());
+
+    shell::quote_args(&parts)
+}
+
+fn refactor_autofix_command(args: &LintRunWorkflowArgs) -> String {
+    let mut parts = vec![
+        "homeboy".to_string(),
+        "refactor".to_string(),
+        args.component_label.clone(),
+    ];
+
+    append_path_and_changed_since_args(&mut parts, args);
+    parts.extend([
+        "--from".to_string(),
+        "lint".to_string(),
+        "--write".to_string(),
+    ]);
+
+    shell::quote_args(&parts)
+}
+
+fn refactor_can_preserve_scope(args: &LintRunWorkflowArgs) -> bool {
+    args.file.is_none() && args.glob.is_none() && !args.changed_only
+}
+
+fn append_common_scope_args(parts: &mut Vec<String>, args: &LintRunWorkflowArgs) {
+    append_path_and_changed_since_args(parts, args);
+    if let Some(file) = &args.file {
+        parts.push("--file".to_string());
+        parts.push(file.clone());
+    }
+    if let Some(glob) = &args.glob {
+        parts.push("--glob".to_string());
+        parts.push(glob.clone());
+    }
+    if args.changed_only {
+        parts.push("--changed-only".to_string());
+    }
+}
+
+fn append_path_and_changed_since_args(parts: &mut Vec<String>, args: &LintRunWorkflowArgs) {
+    if let Some(path) = &args.path_override {
+        parts.push("--path".to_string());
+        parts.push(path.clone());
+    }
+    if let Some(changed_since) = &args.changed_since {
+        parts.push("--changed-since".to_string());
+        parts.push(changed_since.clone());
+    }
 }
 
 fn run_scoped_lint_runs(
@@ -399,6 +468,7 @@ fn process_baseline(
 mod tests {
     use super::*;
     use crate::component::{ScopedExtensionConfig, SelfCheckConfig};
+    use crate::engine::baseline::BaselineFlags;
     use std::collections::HashMap;
 
     fn wordpress_component(root: &str) -> Component {
@@ -413,6 +483,53 @@ mod tests {
             ScopedExtensionConfig::default(),
         )]));
         component
+    }
+
+    fn lint_args() -> LintRunWorkflowArgs {
+        LintRunWorkflowArgs {
+            component_label: "demo".to_string(),
+            component_id: "demo".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            summary: false,
+            file: None,
+            glob: None,
+            changed_only: false,
+            changed_since: None,
+            errors_only: false,
+            sniffs: None,
+            exclude_sniffs: None,
+            category: None,
+            baseline_flags: BaselineFlags::default(),
+        }
+    }
+
+    #[test]
+    fn autofix_hint_preserves_changed_since_scope() {
+        let mut args = lint_args();
+        args.path_override = Some("/tmp/pr checkout".to_string());
+        args.changed_since = Some("origin/main".to_string());
+
+        let hint = build_autofix_hint(&args);
+
+        assert!(hint.contains(
+            "homeboy lint demo --path '/tmp/pr checkout' --changed-since origin/main --fix"
+        ));
+        assert!(hint.contains(
+            "homeboy refactor demo --path '/tmp/pr checkout' --changed-since origin/main --from lint --write"
+        ));
+    }
+
+    #[test]
+    fn autofix_hint_preserves_changed_only_and_file_scope() {
+        let mut args = lint_args();
+        args.file = Some("src/lib.rs".to_string());
+        args.changed_only = true;
+
+        let hint = build_autofix_hint(&args);
+
+        assert!(hint.contains("homeboy lint demo --file src/lib.rs --changed-only --fix"));
+        assert!(!hint.contains("homeboy refactor"));
     }
 
     #[test]

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -862,19 +862,32 @@ fn run_lint_stage(
     let fix_sidecars = auto::AutofixSidecarFiles::for_run_dir(run_dir);
 
     let selected_files = options.selected_files.as_deref().or(changed_files);
+    if selected_files.is_some_and(|files| files.is_empty()) {
+        return Ok(PlannedStage {
+            source: "lint".to_string(),
+            summary: SourceStageSummary {
+                stage: "lint".to_string(),
+                collected: true,
+                applied: false,
+                edit_count: 0,
+                files_modified: 0,
+                detected_findings: Some(0),
+                changed_files: Vec::new(),
+                fix_summary: None,
+                warnings: Vec::new(),
+            },
+            fix_results: Vec::new(),
+        });
+    }
     let effective_glob = if let Some(changed_files) = selected_files {
-        if changed_files.is_empty() {
-            None
+        let abs_files: Vec<String> = changed_files
+            .iter()
+            .map(|f| format!("{}/{}", root_str, f))
+            .collect();
+        if abs_files.len() == 1 {
+            Some(abs_files[0].clone())
         } else {
-            let abs_files: Vec<String> = changed_files
-                .iter()
-                .map(|f| format!("{}/{}", root_str, f))
-                .collect();
-            if abs_files.len() == 1 {
-                Some(abs_files[0].clone())
-            } else {
-                Some(format!("{{{}}}", abs_files.join(",")))
-            }
+            Some(format!("{{{}}}", abs_files.join(",")))
         }
     } else {
         options.glob.clone()
@@ -1490,6 +1503,35 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.starts_with("audit refactor: ")));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lint_stage_empty_selected_files_does_not_fall_back_to_broad_lint() {
+        let root = tmp_dir("lint-empty-selected-files");
+        fs::create_dir_all(&root).unwrap();
+        let run_dir = RunDir::create().unwrap();
+        let component = test_component(&root);
+
+        let stage = run_lint_stage(
+            &component,
+            &root,
+            &[],
+            &LintSourceOptions {
+                selected_files: Some(Vec::new()),
+                ..Default::default()
+            },
+            None,
+            true,
+            &run_dir,
+        )
+        .expect("empty selected files should be a clean no-op");
+
+        assert_eq!(stage.summary.stage, "lint");
+        assert_eq!(stage.summary.detected_findings, Some(0));
+        assert_eq!(stage.summary.files_modified, 0);
+        assert!(stage.fix_results.is_empty());
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -840,21 +840,7 @@ fn run_lint_stage(
 
     // If clean, nothing to fix — skip entirely.
     if let Some(CachedLintResult::Clean) = cached {
-        return Ok(PlannedStage {
-            source: "lint".to_string(),
-            summary: SourceStageSummary {
-                stage: "lint".to_string(),
-                collected: true,
-                applied: false,
-                edit_count: 0,
-                files_modified: 0,
-                detected_findings: Some(0),
-                changed_files: Vec::new(),
-                fix_summary: None,
-                warnings: Vec::new(),
-            },
-            fix_results: Vec::new(),
-        });
+        return Ok(empty_lint_stage());
     }
 
     let root_str = root.to_string_lossy().to_string();
@@ -863,21 +849,7 @@ fn run_lint_stage(
 
     let selected_files = options.selected_files.as_deref().or(changed_files);
     if selected_files.is_some_and(|files| files.is_empty()) {
-        return Ok(PlannedStage {
-            source: "lint".to_string(),
-            summary: SourceStageSummary {
-                stage: "lint".to_string(),
-                collected: true,
-                applied: false,
-                edit_count: 0,
-                files_modified: 0,
-                detected_findings: Some(0),
-                changed_files: Vec::new(),
-                fix_summary: None,
-                warnings: Vec::new(),
-            },
-            fix_results: Vec::new(),
-        });
+        return Ok(empty_lint_stage());
     }
     let effective_glob = if let Some(changed_files) = selected_files {
         let abs_files: Vec<String> = changed_files
@@ -1000,6 +972,24 @@ fn run_lint_stage(
         },
         fix_results,
     })
+}
+
+fn empty_lint_stage() -> PlannedStage {
+    PlannedStage {
+        source: "lint".to_string(),
+        summary: SourceStageSummary {
+            stage: "lint".to_string(),
+            collected: true,
+            applied: false,
+            edit_count: 0,
+            files_modified: 0,
+            detected_findings: Some(0),
+            changed_files: Vec::new(),
+            fix_summary: None,
+            warnings: Vec::new(),
+        },
+        fix_results: Vec::new(),
+    }
 }
 
 fn run_test_stage(


### PR DESCRIPTION
## Summary

- Preserve lint scope flags in autofix hints so changed-scope failures suggest scoped fix commands instead of broad component-wide fixes.
- Route `homeboy lint --fix --changed-since` and `--changed-only` through the same scoped file selection used by regular lint runs.
- Treat an empty selected-file set as a lint no-op instead of falling back to broad lint/fix execution.

## Behaviour

- A failed lint run such as `homeboy lint homeboy --path /checkout --changed-since origin/main` now suggests `homeboy lint homeboy --path /checkout --changed-since origin/main --fix`.
- The longer `homeboy refactor ... --from lint --write` fallback is only shown when it can preserve the requested scope.
- `--changed-only --fix` fixes only uncommitted changed files, and an empty changed set does not run a broad fixer.

## Tests

- `cargo test autofix_hint_preserves -- --test-threads=1`
- `cargo test lint_stage_empty_selected_files_does_not_fall_back_to_broad_lint -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-scoped-autofix-hints --changed-since origin/main`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-scoped-autofix-hints --changed-since origin/main`

Closes #1963

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the scoped lint autofix hint/fix-path changes and focused regression tests; Chris owns review and final merge decision.
