### PR TITLE
fix(test): stabilize audit HOME isolation

### DIFF
--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -10,12 +10,17 @@ pub(crate) struct HomeGuard {
 
 pub(crate) struct AuditGuard {
     _guard: MutexGuard<'static, ()>,
+    _home_guard: MutexGuard<'static, ()>,
 }
 
 impl AuditGuard {
     pub(crate) fn new() -> Self {
+        let home_guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
         let guard = audit_lock().lock().unwrap_or_else(|e| e.into_inner());
-        Self { _guard: guard }
+        Self {
+            _guard: guard,
+            _home_guard: home_guard,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Make `AuditGuard` also hold the shared HOME mutex so audit tests cannot observe another test's temporary HOME while running.
- Stabilizes the release-blocking `audit_detects_outliers_in_convention_group` failure seen in the release workflow.

## Tests
- `cargo test audit_detects_outliers_in_convention_group -- --nocapture`
- `cargo test --lib -- --test-threads=1`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-audit-outlier-test --changed-since origin/main`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-audit-outlier-test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release test failure, made the small test isolation patch, and ran verification. Chris remains responsible for review and merge.