### PR TITLE
fix(audit): clear release-blocking duplication drift

### DIFF
--- a/src/core/deploy/transfer.rs
+++ b/src/core/deploy/transfer.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
 use crate::defaults;
 use crate::engine::shell;
@@ -54,11 +54,7 @@ fn rsync_directory(
 
         let output = Command::new("rsync").args(&rsync_args).output();
         return match output {
-            Ok(output) if output.status.success() => Ok(DeployResult::success(0)),
-            Ok(output) => Ok(DeployResult::failure(
-                output.status.code().unwrap_or(1),
-                String::from_utf8_lossy(&output.stderr).to_string(),
-            )),
+            Ok(output) => Ok(process_output_result(output)),
             Err(err) => Ok(DeployResult::failure(1, format!("rsync failed: {}", err))),
         };
     }
@@ -100,11 +96,7 @@ fn rsync_directory(
 
     let output = Command::new("rsync").args(&rsync_args).output();
     match output {
-        Ok(output) if output.status.success() => Ok(DeployResult::success(0)),
-        Ok(output) => Ok(DeployResult::failure(
-            output.status.code().unwrap_or(1),
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        )),
+        Ok(output) => Ok(process_output_result(output)),
         Err(err) => Ok(DeployResult::failure(1, format!("rsync failed: {}", err))),
     }
 }
@@ -149,11 +141,7 @@ fn scp_transfer(
 
         let output = Command::new("cp").args(&cp_args).output();
         return match output {
-            Ok(output) if output.status.success() => Ok(DeployResult::success(0)),
-            Ok(output) => Ok(DeployResult::failure(
-                output.status.code().unwrap_or(1),
-                String::from_utf8_lossy(&output.stderr).to_string(),
-            )),
+            Ok(output) => Ok(process_output_result(output)),
             Err(err) => Ok(DeployResult::failure(1, err.to_string())),
         };
     }
@@ -193,13 +181,20 @@ fn scp_transfer(
 
     let output = Command::new("scp").args(&scp_args).output();
     match output {
-        Ok(output) if output.status.success() => Ok(DeployResult::success(0)),
-        Ok(output) => Ok(DeployResult::failure(
-            output.status.code().unwrap_or(1),
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        )),
+        Ok(output) => Ok(process_output_result(output)),
         Err(err) => Ok(DeployResult::failure(1, err.to_string())),
     }
+}
+
+fn process_output_result(output: Output) -> DeployResult {
+    if output.status.success() {
+        return DeployResult::success(0);
+    }
+
+    DeployResult::failure(
+        output.status.code().unwrap_or(1),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
 }
 
 pub(super) fn scp_file(
@@ -259,4 +254,105 @@ fn scp_file_atomic(
     }
 
     Ok(DeployResult::success(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{process_output_result, scp_file, upload_directory, upload_file};
+    use crate::server::SshClient;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::process::Command;
+
+    fn local_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "test".to_string(),
+            port: 22,
+            identity_file: None,
+            is_local: true,
+            env: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_upload_directory() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let source = temp.path().join("source");
+        let target = temp.path().join("target");
+        fs::create_dir_all(&source).expect("create source dir");
+        fs::create_dir_all(&target).expect("create target dir");
+        fs::write(source.join("file.txt"), "hello").expect("write source file");
+
+        let result = upload_directory(&local_client(), &source, target.to_str().unwrap())
+            .expect("upload directory");
+
+        assert!(result.success);
+        assert_eq!(
+            fs::read_to_string(target.join("file.txt")).expect("read copied file"),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn test_upload_file() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let source = temp.path().join("source.txt");
+        let target = temp.path().join("target.txt");
+        fs::write(&source, "hello").expect("write source file");
+
+        let result =
+            upload_file(&local_client(), &source, target.to_str().unwrap()).expect("upload file");
+
+        assert!(result.success);
+        assert_eq!(
+            fs::read_to_string(&target).expect("read copied file"),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn test_scp_file() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let source = temp.path().join("source.txt");
+        let target = temp.path().join("target.txt");
+        fs::write(&source, "hello").expect("write source file");
+
+        let result =
+            scp_file(&local_client(), &source, target.to_str().unwrap()).expect("scp file");
+
+        assert!(result.success);
+        assert_eq!(
+            fs::read_to_string(&target).expect("read copied file"),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn process_output_result_returns_success_for_zero_exit() {
+        let output = Command::new("sh")
+            .args(["-c", "exit 0"])
+            .output()
+            .expect("run success fixture");
+
+        let result = process_output_result(output);
+
+        assert!(result.success);
+        assert_eq!(result.exit_code, 0);
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn process_output_result_captures_stderr_for_failed_exit() {
+        let output = Command::new("sh")
+            .args(["-c", "printf 'copy failed' >&2; exit 7"])
+            .output()
+            .expect("run failure fixture");
+
+        let result = process_output_result(output);
+
+        assert!(!result.success);
+        assert_eq!(result.exit_code, 7);
+        assert_eq!(result.error.as_deref(), Some("copy failed"));
+    }
 }

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -141,7 +141,7 @@ pub struct TriageRepoRef {
     pub url: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct TriageIssueBucket {
     pub open: usize,
     pub items: Vec<TriageIssueItem>,
@@ -175,7 +175,7 @@ pub struct TriageLinkedPr {
     pub merged_at: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct TriagePrBucket {
     pub open: usize,
     pub items: Vec<TriagePrItem>,
@@ -609,17 +609,22 @@ fn fetch_component_report(
         .map(|days| Utc::now() - Duration::days(days));
 
     let mut error = None;
+    macro_rules! record_fetch_error {
+        ($next_error:expr) => {
+            error = Some(match error.take() {
+                Some(existing) => format!("{existing}; {}", $next_error),
+                None => $next_error,
+            });
+        };
+    }
     let issues = if options.include_issues {
-        match fetch_issues(&repo, options, stale_cutoff) {
-            Ok(items) => Some(issue_bucket(items)),
-            Err(e) => {
-                error = Some(e);
-                Some(TriageIssueBucket {
-                    open: 0,
-                    items: Vec::new(),
-                })
-            }
-        }
+        fetch_issues(&repo, options, stale_cutoff)
+            .map(issue_bucket)
+            .map(Some)
+            .unwrap_or_else(|e| {
+                record_fetch_error!(e);
+                Some(TriageIssueBucket::default())
+            })
     } else {
         None
     };
@@ -631,14 +636,8 @@ fn fetch_component_report(
                 items,
             }),
             Err(e) => {
-                error = Some(match error {
-                    Some(existing) => format!("{existing}; {e}"),
-                    None => e,
-                });
-                Some(TriagePrBucket {
-                    open: 0,
-                    items: Vec::new(),
-                })
+                record_fetch_error!(e);
+                Some(TriagePrBucket::default())
             }
         }
     } else {


### PR DESCRIPTION
## Summary
- Collapse repeated deploy process-output handling behind one helper and add focused local-transfer tests.
- Normalize triage fetch fallback handling so full audit no longer reports the duplicate branch shape.

## Tests
- `cargo fmt --check`
- `cargo test core::deploy::transfer::tests -- --nocapture`
- `cargo test core::triage::tests -- --nocapture`
- `cargo run --bin homeboy -- --output /tmp/homeboy-audit-unblock-clean.json audit homeboy --path /Users/chubes/Developer/homeboy@fix-deploy-transfer-duplication`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the small audit cleanup, added focused tests, and ran local verification. Chris remains responsible for review and merge.