### PR TITLE
fix(ci): persist release checkout credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       # Rust toolchain needed so run-release.sh can regenerate Cargo.lock
@@ -642,5 +642,4 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-
 


### PR DESCRIPTION
## Summary
- Persist checkout credentials in the release job so Homeboy's internal `git push` can use the GitHub App token.
- This keeps release creation gated on a successful push instead of failing with `could not read Username`.

## Tests
- Verified from release run `25151687306` that quality gates pass and `Prepare Release` now fails only at unauthenticated `git.push`.
- Workflow-only change; no local Rust tests required.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release workflow authentication failure and drafted the one-line workflow fix. Chris remains responsible for review and merge.