### PR TITLE
fix(trace): avoid HOME-dependent test path

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -280,6 +280,7 @@ mod tests {
 
     #[test]
     fn rig_component_path_and_trace_env_are_threaded() {
+        let component_dir = tempfile::TempDir::new().expect("component dir");
         let mut components = HashMap::new();
         let mut extensions = HashMap::new();
         extensions.insert(
@@ -289,7 +290,7 @@ mod tests {
         components.insert(
             "studio".to_string(),
             ComponentSpec {
-                path: "~/Developer/studio".to_string(),
+                path: component_dir.path().to_string_lossy().to_string(),
                 remote_url: Some("https://github.com/Automattic/studio".to_string()),
                 triage_remote_url: None,
                 stack: None,
@@ -304,7 +305,7 @@ mod tests {
         };
 
         let path = rig_component_path(&spec, "studio").expect("path resolves");
-        assert!(path.contains("/Developer/studio"));
+        assert_eq!(path, component_dir.path().to_string_lossy());
         let component = rig_component_for_trace(&spec, "studio").expect("component resolves");
         assert_eq!(component.id, "studio");
         assert_eq!(component.local_path, path);


### PR DESCRIPTION
## Summary
- Fix the `commands::trace::tests::rig_component_path_and_trace_env_are_threaded` failure seen on the main release workflow.
- Avoid `~` expansion in the test so parallel tests that mutate `HOME` cannot race the assertion.

## Tests
- `cargo test commands::trace::tests::rig_component_path_and_trace_env_are_threaded -- --test-threads=1`
- `cargo test trace -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy --changed-since origin/main`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release test failure from CI logs, patched the race-prone test fixture, and ran focused verification.
