### PR TITLE
feat(rig): report symlink drift in status

### DIFF
--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -42,7 +42,8 @@ pub use lease::{acquire_active_run_lease, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
     run_check, run_down, run_status, run_up, snapshot_state, CheckReport, ComponentSnapshot,
-    DownReport, RigStateSnapshot, RigStatusReport, UpReport,
+    DownReport, RigStateSnapshot, RigStatusReport, SymlinkStatusReport, SymlinkStatusState,
+    UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -5,6 +5,7 @@
 //! homeboy versions.
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +49,7 @@ pub struct RigStatusReport {
     pub rig_id: String,
     pub description: String,
     pub services: Vec<ServiceStatusReport>,
+    pub symlinks: Vec<SymlinkStatusReport>,
     pub last_up: Option<String>,
     pub last_check: Option<String>,
     pub last_check_result: Option<String>,
@@ -65,6 +67,24 @@ pub struct ServiceStatusReport {
     pub log_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub started_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SymlinkStatusReport {
+    pub link: String,
+    pub expected_target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual_target: Option<String>,
+    pub state: SymlinkStatusState,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SymlinkStatusState {
+    Ok,
+    Missing,
+    Drifted,
+    BlockedByNonSymlink,
 }
 
 /// Materialize a rig: run the `up` pipeline, stash timestamp in state.
@@ -159,14 +179,64 @@ pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
     }
     services.sort_by(|a, b| a.id.cmp(&b.id));
 
+    let mut symlinks = rig
+        .symlinks
+        .iter()
+        .map(|link| symlink_status(rig, link))
+        .collect::<Vec<_>>();
+    symlinks.sort_by(|a, b| a.link.cmp(&b.link));
+
     Ok(RigStatusReport {
         rig_id: rig.id.clone(),
         description: rig.description.clone(),
         services,
+        symlinks,
         last_up: state.last_up,
         last_check: state.last_check,
         last_check_result: state.last_check_result,
     })
+}
+
+fn symlink_status(rig: &RigSpec, link: &super::spec::SymlinkSpec) -> SymlinkStatusReport {
+    let link_path = PathBuf::from(expand_vars(rig, &link.link));
+    let target_path = PathBuf::from(expand_vars(rig, &link.target));
+    let link_display = link_path.to_string_lossy().into_owned();
+    let expected_target = target_path.to_string_lossy().into_owned();
+
+    match std::fs::symlink_metadata(&link_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let actual = std::fs::read_link(&link_path).ok();
+            let state = if actual.as_ref() == Some(&target_path) {
+                SymlinkStatusState::Ok
+            } else {
+                SymlinkStatusState::Drifted
+            };
+            SymlinkStatusReport {
+                link: link_display,
+                expected_target,
+                actual_target: actual.map(|path| path.to_string_lossy().into_owned()),
+                state,
+            }
+        }
+        Ok(_) => SymlinkStatusReport {
+            link: link_display,
+            expected_target,
+            actual_target: None,
+            state: SymlinkStatusState::BlockedByNonSymlink,
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => SymlinkStatusReport {
+            link: link_display,
+            expected_target,
+            actual_target: None,
+            state: SymlinkStatusState::Missing,
+        },
+        Err(_) => SymlinkStatusReport {
+            link: link_display,
+            expected_target,
+            actual_target: None,
+            state: SymlinkStatusState::Missing,
+        },
+    }
 }
 
 fn service_kind_label(kind: ServiceKind) -> &'static str {

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -224,12 +224,6 @@ fn symlink_status(rig: &RigSpec, link: &super::spec::SymlinkSpec) -> SymlinkStat
             actual_target: None,
             state: SymlinkStatusState::BlockedByNonSymlink,
         },
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => SymlinkStatusReport {
-            link: link_display,
-            expected_target,
-            actual_target: None,
-            state: SymlinkStatusState::Missing,
-        },
         Err(_) => SymlinkStatusReport {
             link: link_display,
             expected_target,

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -18,10 +18,11 @@ use std::collections::HashMap;
 use crate::rig::pipeline::PipelineOutcome;
 use crate::rig::runner::{
     run_check, run_down, run_status, run_up, snapshot_state, CheckReport, RigStatusReport,
-    ServiceStatusReport, UpReport,
+    ServiceStatusReport, SymlinkStatusState, UpReport,
 };
 use crate::rig::spec::{
     ComponentSpec, PipelineStep, RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec,
+    SymlinkSpec,
 };
 use crate::test_support::with_isolated_home;
 
@@ -85,6 +86,7 @@ fn test_status_report_empty_services_serializes() {
         rig_id: "test".to_string(),
         description: "empty rig".to_string(),
         services: Vec::new(),
+        symlinks: Vec::new(),
         last_up: None,
         last_check: None,
         last_check_result: None,
@@ -285,6 +287,99 @@ fn test_run_status() {
             "unexpected log path: {}",
             service.log_path
         );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_status_reports_declared_symlink_states() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let expected = tmp.path().join("expected-target");
+        let other = tmp.path().join("other-target");
+        let ok = tmp.path().join("ok-link");
+        let missing = tmp.path().join("missing-link");
+        let drifted = tmp.path().join("drifted-link");
+        let blocked = tmp.path().join("blocked-link");
+
+        std::fs::create_dir(&expected).expect("expected target");
+        std::fs::create_dir(&other).expect("other target");
+        std::os::unix::fs::symlink(&expected, &ok).expect("ok symlink");
+        std::os::unix::fs::symlink(&other, &drifted).expect("drifted symlink");
+        std::fs::write(&blocked, "not a symlink").expect("blocked file");
+
+        let mut rig = minimal_spec("run-status-symlink-fixture");
+        rig.symlinks = vec![
+            SymlinkSpec {
+                link: ok.to_string_lossy().into_owned(),
+                target: expected.to_string_lossy().into_owned(),
+            },
+            SymlinkSpec {
+                link: missing.to_string_lossy().into_owned(),
+                target: expected.to_string_lossy().into_owned(),
+            },
+            SymlinkSpec {
+                link: drifted.to_string_lossy().into_owned(),
+                target: expected.to_string_lossy().into_owned(),
+            },
+            SymlinkSpec {
+                link: blocked.to_string_lossy().into_owned(),
+                target: expected.to_string_lossy().into_owned(),
+            },
+        ];
+
+        let status = run_status(&rig).expect("run_status with symlinks");
+        assert_eq!(status.symlinks.len(), 4);
+
+        let by_link = status
+            .symlinks
+            .iter()
+            .map(|entry| (entry.link.as_str(), entry))
+            .collect::<HashMap<_, _>>();
+
+        let ok_report = by_link
+            .get(ok.to_string_lossy().as_ref())
+            .expect("ok report");
+        assert_eq!(ok_report.state, SymlinkStatusState::Ok);
+        assert_eq!(
+            ok_report.actual_target.as_deref(),
+            Some(expected.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            ok_report.expected_target,
+            expected.to_string_lossy().as_ref()
+        );
+
+        let missing_report = by_link
+            .get(missing.to_string_lossy().as_ref())
+            .expect("missing report");
+        assert_eq!(missing_report.state, SymlinkStatusState::Missing);
+        assert!(missing_report.actual_target.is_none());
+
+        let drifted_report = by_link
+            .get(drifted.to_string_lossy().as_ref())
+            .expect("drifted report");
+        assert_eq!(drifted_report.state, SymlinkStatusState::Drifted);
+        assert_eq!(
+            drifted_report.actual_target.as_deref(),
+            Some(other.to_string_lossy().as_ref())
+        );
+
+        let blocked_report = by_link
+            .get(blocked.to_string_lossy().as_ref())
+            .expect("blocked report");
+        assert_eq!(
+            blocked_report.state,
+            SymlinkStatusState::BlockedByNonSymlink
+        );
+        assert!(blocked_report.actual_target.is_none());
+
+        let json = serde_json::to_string(&status).expect("serialize status");
+        assert!(json.contains("\"symlinks\""));
+        assert!(json.contains("\"state\":\"ok\""));
+        assert!(json.contains("\"state\":\"missing\""));
+        assert!(json.contains("\"state\":\"drifted\""));
+        assert!(json.contains("\"state\":\"blocked_by_non_symlink\""));
     });
 }
 


### PR DESCRIPTION
## Summary

- Adds current symlink drift reporting to `homeboy rig status` so stale historical check results do not hide broken declared links.
- Keeps default status lightweight: it reads declared symlink paths and service state only, without running check probes or commands.

## Changes

- Extends `RigStatusReport` JSON with a `symlinks` array.
- Reports each declared symlink's expanded `link`, `expected_target`, optional `actual_target`, and `state` (`ok`, `missing`, `drifted`, `blocked_by_non_symlink`).
- Leaves service status behavior and `last_check_result` storage unchanged; the broader human-output labeling of historical check state remains follow-up work because `rig status` currently serializes the report directly.

## Tests

- `cargo test runner_test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-status-resource-drift`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-status-resource-drift --changed-since origin/main`

Closes #1984

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the symlink status report slice, adding focused tests, and running verification. Chris remains responsible for review and merge.
