### PR TITLE
fix(rig): derive lease resources from rig spec

### DIFF
--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -12,6 +12,7 @@
 
 use super::spec::{RigResourcesSpec, RigSpec};
 use crate::expand;
+use std::collections::BTreeSet;
 
 /// Expand variables + tilde in a string.
 pub fn expand_vars(rig: &RigSpec, input: &str) -> String {
@@ -21,12 +22,57 @@ pub fn expand_vars(rig: &RigSpec, input: &str) -> String {
 /// Return a copy of the rig resource declarations with path entries expanded.
 pub fn expand_resources(rig: &RigSpec) -> RigResourcesSpec {
     let mut resources = rig.resources.clone();
-    resources.paths = resources
-        .paths
-        .iter()
-        .map(|path| expand_vars(rig, path))
-        .collect();
+    let derived_paths = rig.symlinks.iter().map(|symlink| symlink.link.as_str());
+    resources.paths = merge_expanded_strings(
+        rig,
+        resources.paths.iter().map(String::as_str),
+        derived_paths,
+    );
+
+    let derived_ports = rig.services.values().filter_map(|service| service.port);
+    resources.ports = merge_values(resources.ports.iter().copied(), derived_ports);
+
+    let derived_process_patterns = rig
+        .services
+        .values()
+        .filter_map(|service| service.discover.as_ref())
+        .map(|discover| discover.pattern.as_str());
+    resources.process_patterns = merge_strings(
+        resources.process_patterns.iter().map(String::as_str),
+        derived_process_patterns,
+    );
     resources
+}
+
+fn merge_expanded_strings<'a>(
+    rig: &RigSpec,
+    explicit: impl Iterator<Item = &'a str>,
+    derived: impl Iterator<Item = &'a str>,
+) -> Vec<String> {
+    merge_strings(
+        explicit.map(|value| expand_vars(rig, value)),
+        derived.map(|value| expand_vars(rig, value)),
+    )
+}
+
+fn merge_strings(
+    explicit: impl Iterator<Item = impl Into<String>>,
+    derived: impl Iterator<Item = impl Into<String>>,
+) -> Vec<String> {
+    merge_values(explicit.map(Into::into), derived.map(Into::into))
+}
+
+fn merge_values<T: Clone + Eq + Ord>(
+    explicit: impl Iterator<Item = T>,
+    derived: impl Iterator<Item = T>,
+) -> Vec<T> {
+    let mut values: Vec<T> = explicit.collect();
+    for value in derived.collect::<BTreeSet<_>>() {
+        if !values.contains(&value) {
+            values.push(value);
+        }
+    }
+    values
 }
 
 fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -4,7 +4,9 @@
 //! public function of the module; additional cases cover edge conditions.
 
 use crate::rig::expand::{expand_resources, expand_vars};
-use crate::rig::spec::{ComponentSpec, RigSpec};
+use crate::rig::spec::{
+    ComponentSpec, DiscoverSpec, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec,
+};
 use crate::test_support::with_isolated_home;
 use std::collections::HashMap;
 
@@ -124,5 +126,130 @@ fn test_expand_resources_expands_path_entries_only() {
             vec!["wordpress-server-child.mjs"]
         );
         assert_eq!(resources.paths, expected_paths);
+    });
+}
+
+#[test]
+fn test_expand_resources_derives_paths_ports_and_process_patterns() {
+    with_isolated_home(|home| {
+        let mut rig = rig_with("derived", HashMap::new());
+        rig.symlinks = vec![
+            SymlinkSpec {
+                link: "~/bin/studio".to_string(),
+                target: "/tmp/studio".to_string(),
+            },
+            SymlinkSpec {
+                link: "~/bin/playground".to_string(),
+                target: "/tmp/playground".to_string(),
+            },
+        ];
+        rig.services.insert(
+            "tarballs".to_string(),
+            ServiceSpec {
+                kind: ServiceKind::HttpStatic,
+                cwd: None,
+                port: Some(9724),
+                command: None,
+                env: HashMap::new(),
+                health: None,
+                discover: None,
+            },
+        );
+        rig.services.insert(
+            "daemon".to_string(),
+            ServiceSpec {
+                kind: ServiceKind::External,
+                cwd: None,
+                port: None,
+                command: None,
+                env: HashMap::new(),
+                health: None,
+                discover: Some(DiscoverSpec {
+                    pattern: "wordpress-server-child.mjs".to_string(),
+                    argv_contains: Vec::new(),
+                }),
+            },
+        );
+
+        let resources = expand_resources(&rig);
+
+        assert_eq!(
+            resources.paths,
+            vec![
+                home.path()
+                    .join("bin/playground")
+                    .to_string_lossy()
+                    .to_string(),
+                home.path().join("bin/studio").to_string_lossy().to_string(),
+            ]
+        );
+        assert_eq!(resources.ports, vec![9724]);
+        assert_eq!(
+            resources.process_patterns,
+            vec!["wordpress-server-child.mjs"]
+        );
+    });
+}
+
+#[test]
+fn test_expand_resources_merges_explicit_resources_and_deduplicates() {
+    with_isolated_home(|home| {
+        let mut rig = rig_with("dedupe", HashMap::new());
+        rig.resources.paths = vec!["~/bin/studio".to_string(), "~/Developer/manual".to_string()];
+        rig.resources.ports = vec![9724, 3000];
+        rig.resources.process_patterns = vec![
+            "wordpress-server-child.mjs".to_string(),
+            "manual-process".to_string(),
+        ];
+        rig.symlinks = vec![SymlinkSpec {
+            link: "~/bin/studio".to_string(),
+            target: "/tmp/studio".to_string(),
+        }];
+        rig.services.insert(
+            "tarballs".to_string(),
+            ServiceSpec {
+                kind: ServiceKind::HttpStatic,
+                cwd: None,
+                port: Some(9724),
+                command: None,
+                env: HashMap::new(),
+                health: None,
+                discover: None,
+            },
+        );
+        rig.services.insert(
+            "daemon".to_string(),
+            ServiceSpec {
+                kind: ServiceKind::External,
+                cwd: None,
+                port: None,
+                command: None,
+                env: HashMap::new(),
+                health: None,
+                discover: Some(DiscoverSpec {
+                    pattern: "wordpress-server-child.mjs".to_string(),
+                    argv_contains: Vec::new(),
+                }),
+            },
+        );
+
+        let resources = expand_resources(&rig);
+
+        assert_eq!(resources.exclusive, Vec::<String>::new());
+        assert_eq!(
+            resources.paths,
+            vec![
+                home.path().join("bin/studio").to_string_lossy().to_string(),
+                home.path()
+                    .join("Developer/manual")
+                    .to_string_lossy()
+                    .to_string(),
+            ]
+        );
+        assert_eq!(resources.ports, vec![9724, 3000]);
+        assert_eq!(
+            resources.process_patterns,
+            vec!["wordpress-server-child.mjs", "manual-process"]
+        );
     });
 }


### PR DESCRIPTION
## Summary
- Derives active-run rig lease resources from declared symlinks and services so specs no longer need to duplicate obvious shared resources.
- Keeps explicit `resources` declarations as the primary contract while adding conservative derived paths, ports, and external process patterns.

## Changes
- Merge expanded explicit `resources.paths` with derived `symlinks[].link` paths.
- Merge explicit ports with every declared service `port`.
- Merge explicit process patterns with every external service `discover.pattern`.
- Deduplicate derived values while preserving explicit resource ordering.
- Add focused coverage for derivation, explicit resources, and deduplication.

Component paths are not derived in this slice because the current rig model does not distinguish read-only component checkouts from paths a rig mutates. That can be tracked separately if leases need component-level locking.

## Tests
- `cargo test expand_test`
- `cargo test lease_test`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-rig-derived-lease-resources`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-rig-derived-lease-resources --changed-since origin/main`

Closes #1983

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the focused resource derivation change, added tests, and ran verification; Chris remains responsible for review and merge.