### PR TITLE
feat(rig): track materialized ownership state

### DIFF
--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -41,8 +41,8 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    run_check, run_down, run_status, run_up, snapshot_state, CheckReport, ComponentSnapshot,
-    DownReport, RigStateSnapshot, RigStatusReport, UpReport,
+    run_check, run_down, run_status, run_up, snapshot_state, CheckReport, DownReport,
+    RigStatusReport, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{
@@ -61,7 +61,9 @@ pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,
     RigStackSyncReport,
 };
-pub use state::{RigState, ServiceState};
+pub use state::{
+    ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
+};
 pub use workloads::{extension_ids_for_workloads, workloads_for_extension, RigWorkloadKind};
 
 use crate::error::{Error, Result};

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -6,14 +6,16 @@
 
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-use super::expand::expand_vars;
+use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
 use super::pipeline::{cleanup_shared_paths, run_pipeline, PipelineOutcome};
 use super::service::{self, ServiceStatus};
 use super::spec::{RigSpec, ServiceKind};
-use super::state::{now_rfc3339, RigState};
+use super::state::{
+    now_rfc3339, ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot,
+};
 use crate::engine::command::run_in_optional;
 use crate::error::Result;
 
@@ -51,6 +53,7 @@ pub struct RigStatusReport {
     pub last_up: Option<String>,
     pub last_check: Option<String>,
     pub last_check_result: Option<String>,
+    pub materialized: Option<MaterializedRigState>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -74,7 +77,15 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
 
     if outcome.is_success() {
         let mut state = RigState::load(&rig.id)?;
-        state.last_up = Some(now_rfc3339());
+        let materialized_at = now_rfc3339();
+        let snapshot = snapshot_state(rig);
+        state.last_up = Some(materialized_at.clone());
+        state.materialized = Some(MaterializedRigState {
+            rig_id: rig.id.clone(),
+            materialized_at,
+            resources: expand_resources(rig),
+            components: snapshot.components,
+        });
         state.save(&rig.id)?;
     }
 
@@ -123,6 +134,10 @@ pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
     stopped.sort();
 
     let success = pipeline.as_ref().is_none_or(|p| p.is_success());
+    let mut state = RigState::load(&rig.id)?;
+    state.materialized = None;
+    state.save(&rig.id)?;
+
     Ok(DownReport {
         rig_id: rig.id.clone(),
         stopped,
@@ -166,6 +181,7 @@ pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
         last_up: state.last_up,
         last_check: state.last_check,
         last_check_result: state.last_check_result,
+        materialized: state.materialized,
     })
 }
 
@@ -175,38 +191,6 @@ fn service_kind_label(kind: ServiceKind) -> &'static str {
         ServiceKind::Command => "command",
         ServiceKind::External => "external",
     }
-}
-
-/// Captured component state for one entry in a rig's components map.
-///
-/// Captured at the start of every `homeboy rig bench` run so bench results
-/// can be tagged with the exact code state they were measured against.
-/// Without this, bench-to-bench comparisons can't distinguish "the code got
-/// slower" from "I'm comparing against a different commit." Surfaced in
-/// the bench command output alongside the bench result; persisting into
-/// the baseline JSON is a follow-up (see Extra-Chill/homeboy#1466 docs).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ComponentSnapshot {
-    /// Resolved filesystem path (after `~` / `${env.X}` / `${components.X}`
-    /// expansion). Useful for humans reviewing a snapshot offline.
-    pub path: String,
-    /// `git rev-parse HEAD` for the path's repo. `None` if the path is not
-    /// a git repo or the command fails.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sha: Option<String>,
-    /// `git rev-parse --abbrev-ref HEAD` — current branch name, or `HEAD`
-    /// for detached. `None` if the path is not a git repo.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub branch: Option<String>,
-}
-
-/// Snapshot of every component in a rig at a moment in time. Sorted by
-/// component ID for stable output (BTreeMap).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct RigStateSnapshot {
-    pub rig_id: String,
-    pub captured_at: String,
-    pub components: BTreeMap<String, ComponentSnapshot>,
 }
 
 /// Capture the current state of every component in a rig.

--- a/src/core/rig/state.rs
+++ b/src/core/rig/state.rs
@@ -4,11 +4,13 @@
 //! next invocation. Never source-of-truth for the rig spec.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 
 use crate::error::{Error, Result};
 use crate::paths;
+
+use super::spec::RigResourcesSpec;
 
 /// Snapshot of a rig's running state.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -33,6 +35,50 @@ pub struct RigState {
     /// cleanup. Keyed by expanded link path.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub shared_paths: HashMap<String, SharedPathState>,
+
+    /// Long-lived ownership materialized by the last successful `rig up`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialized: Option<MaterializedRigState>,
+}
+
+/// Persistent record of what a successful `rig up` materialized.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MaterializedRigState {
+    /// Rig identifier that wrote this ownership record.
+    pub rig_id: String,
+
+    /// Timestamp when ownership was materialized, RFC3339.
+    pub materialized_at: String,
+
+    /// Expanded rig resources captured at materialization time.
+    pub resources: RigResourcesSpec,
+
+    /// Component state captured at materialization time.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub components: BTreeMap<String, ComponentSnapshot>,
+}
+
+/// Captured component state for one entry in a rig's components map.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ComponentSnapshot {
+    /// Resolved filesystem path after variable and tilde expansion.
+    pub path: String,
+
+    /// `git rev-parse HEAD` for the path's repo.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha: Option<String>,
+
+    /// `git rev-parse --abbrev-ref HEAD`, or `HEAD` when detached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+}
+
+/// Snapshot of every component in a rig at a moment in time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RigStateSnapshot {
+    pub rig_id: String,
+    pub captured_at: String,
+    pub components: BTreeMap<String, ComponentSnapshot>,
 }
 
 /// Per-service state: PID, start time, health.

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -21,8 +21,10 @@ use crate::rig::runner::{
     ServiceStatusReport, UpReport,
 };
 use crate::rig::spec::{
-    ComponentSpec, PipelineStep, RigSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec,
+    ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp,
+    SharedPathSpec,
 };
+use crate::rig::state::RigState;
 use crate::test_support::with_isolated_home;
 
 fn empty_pipeline(name: &str) -> PipelineOutcome {
@@ -88,6 +90,7 @@ fn test_status_report_empty_services_serializes() {
         last_up: None,
         last_check: None,
         last_check_result: None,
+        materialized: None,
     };
     let json = serde_json::to_string(&report).expect("serialize");
     assert!(json.contains("\"services\":[]"));
@@ -137,12 +140,57 @@ fn test_service_status_report_emits_pid_when_running() {
 #[test]
 fn test_run_up() {
     with_isolated_home(|_dir| {
-        let rig = minimal_spec("run-up-fixture");
+        let mut rig = minimal_spec("run-up-fixture");
+        rig.resources = RigResourcesSpec {
+            exclusive: vec!["run-up-exclusive".to_string()],
+            paths: vec!["/tmp/run-up-path".to_string()],
+            ports: vec![9981],
+            process_patterns: vec!["run-up-process".to_string()],
+        };
         let report = run_up(&rig).expect("run_up succeeds with empty pipeline");
         assert_eq!(report.rig_id, "run-up-fixture");
         assert!(report.success, "empty pipeline should report success");
         assert_eq!(report.pipeline.passed, 0);
         assert_eq!(report.pipeline.failed, 0);
+
+        let state = RigState::load(&rig.id).expect("state loads");
+        let materialized = state.materialized.expect("materialized ownership");
+        assert_eq!(materialized.rig_id, "run-up-fixture");
+        assert_eq!(materialized.resources.exclusive, vec!["run-up-exclusive"]);
+        assert_eq!(materialized.resources.ports, vec![9981]);
+        assert!(
+            materialized.components.is_empty(),
+            "minimal spec has no component snapshot entries"
+        );
+    });
+}
+
+#[test]
+fn test_failed_run_up_does_not_write_materialized_ownership() {
+    with_isolated_home(|_dir| {
+        let mut rig = minimal_spec("run-up-failure-fixture");
+        let mut pipeline = HashMap::new();
+        pipeline.insert(
+            "up".to_string(),
+            vec![PipelineStep::Command {
+                step_id: None,
+                depends_on: Vec::new(),
+                cmd: "false".to_string(),
+                cwd: None,
+                env: HashMap::new(),
+                label: Some("intentional failure".to_string()),
+            }],
+        );
+        rig.pipeline = pipeline;
+
+        let report = run_up(&rig).expect("run_up returns a failed report");
+        assert!(!report.success, "failing step should fail up");
+
+        let state = RigState::load(&rig.id).expect("state loads");
+        assert!(
+            state.materialized.is_none(),
+            "failed up must not persist materialized ownership"
+        );
     });
 }
 
@@ -166,6 +214,15 @@ fn test_run_check() {
 fn test_run_down() {
     with_isolated_home(|_dir| {
         let rig = minimal_spec("run-down-fixture");
+        run_up(&rig).expect("seed materialized ownership");
+        assert!(
+            RigState::load(&rig.id)
+                .expect("state loads")
+                .materialized
+                .is_some(),
+            "precondition: up writes ownership"
+        );
+
         let report = run_down(&rig).expect("run_down succeeds with no services");
         assert_eq!(report.rig_id, "run-down-fixture");
         assert!(
@@ -177,6 +234,13 @@ fn test_run_down() {
             "no `down` pipeline declared, so no outcome reported"
         );
         assert!(report.success, "empty teardown is trivially successful");
+        assert!(
+            RigState::load(&rig.id)
+                .expect("state loads")
+                .materialized
+                .is_none(),
+            "down clears materialized ownership"
+        );
     });
 }
 
@@ -241,6 +305,13 @@ fn test_run_status() {
         );
         assert!(status.last_check.is_none());
         assert!(status.last_check_result.is_none());
+        assert!(status.materialized.is_none());
+
+        run_up(&rig).expect("seed materialized ownership");
+        let status = run_status(&rig).expect("run_status reports materialized state");
+        let materialized = status.materialized.expect("materialized ownership");
+        assert_eq!(materialized.rig_id, "run-status-fixture");
+        assert!(!materialized.materialized_at.is_empty());
 
         let mut services = HashMap::new();
         services.insert(

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -4,7 +4,8 @@
 //! touching real user state), so this module exercises serde round-tripping
 //! which is the meaningful invariant.
 
-use crate::rig::state::{RigState, ServiceState, SharedPathState};
+use crate::rig::spec::RigResourcesSpec;
+use crate::rig::state::{MaterializedRigState, RigState, ServiceState, SharedPathState};
 
 #[test]
 fn test_state_round_trips_empty() {
@@ -24,6 +25,7 @@ fn test_state_round_trips_with_service() {
         last_check_result: None,
         services: Default::default(),
         shared_paths: Default::default(),
+        materialized: None,
     };
     state.services.insert(
         "tarball".to_string(),
@@ -62,6 +64,34 @@ fn test_state_round_trips_with_shared_path() {
     let entry = parsed.shared_paths.get("/worktree/node_modules").unwrap();
     assert_eq!(entry.target, "/primary/node_modules");
     assert_eq!(entry.created_at, "2026-04-26T13:00:00Z");
+}
+
+#[test]
+fn test_state_round_trips_with_materialized_ownership() {
+    let state = RigState {
+        materialized: Some(MaterializedRigState {
+            rig_id: "studio".to_string(),
+            materialized_at: "2026-04-30T13:00:00Z".to_string(),
+            resources: RigResourcesSpec {
+                exclusive: vec!["studio-dev".to_string()],
+                paths: vec!["/tmp/studio".to_string()],
+                ports: vec![9724],
+                process_patterns: vec!["wordpress-server-child".to_string()],
+            },
+            components: Default::default(),
+        }),
+        ..RigState::default()
+    };
+
+    let json = serde_json::to_string(&state).expect("serialize");
+    let parsed: RigState = serde_json::from_str(&json).expect("parse");
+    let materialized = parsed.materialized.expect("materialized ownership");
+    assert_eq!(materialized.rig_id, "studio");
+    assert_eq!(materialized.resources.ports, vec![9724]);
+    assert_eq!(
+        materialized.resources.process_patterns,
+        vec!["wordpress-server-child"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Persist materialized rig ownership after a successful rig up so operators can inspect what a rig currently owns after the command exits.
- Clear the materialized ownership marker on rig down while leaving active-run lease enforcement unchanged.

## Changes
- Adds materialized ownership state to RigState with rig id, materialized timestamp, expanded resources, and component snapshots.
- Writes the ownership record only after successful run_up and exposes it through rig status reports.
- Clears the ownership record during run_down.
- Moves component snapshot report types into rig state so persisted ownership and snapshot_state share the same shape.

## Tests
- cargo test test_state
- cargo test test_run_up
- cargo test test_failed_run_up_does_not_write_materialized_ownership
- cargo test test_run_down
- cargo test test_run_status
- cargo test rig -- --test-threads=1
- homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-materialized-ownership
- homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-materialized-ownership --changed-since main

Closes #1982

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the narrow materialized ownership state slice, added focused tests, and ran verification. Chris remains responsible for review and merge decisions.