### PR TITLE
feat(rig): repair safe symlink drift

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -11,8 +11,8 @@ use homeboy::rig;
 
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
-    RigInstalledSummary, RigListOutput, RigShowOutput, RigSourceSummary, RigStatusOutput,
-    RigSummary, RigSyncOutput, RigUpOutput, RigUpdateOutput,
+    RigInstalledSummary, RigListOutput, RigRepairOutput, RigShowOutput, RigSourceSummary,
+    RigStatusOutput, RigSummary, RigSyncOutput, RigUpOutput, RigUpdateOutput,
 };
 use super::CmdResult;
 
@@ -43,6 +43,11 @@ enum RigCommand {
     },
     /// Tear down a rig: stop services and run its `down` pipeline
     Down {
+        /// Rig ID
+        rig_id: String,
+    },
+    /// Repair safe declared drift without running the full `up` pipeline
+    Repair {
         /// Rig ID
         rig_id: String,
     },
@@ -125,6 +130,7 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Up { rig_id } => up(&rig_id),
         RigCommand::Check { rig_id } => check(&rig_id),
         RigCommand::Down { rig_id } => down(&rig_id),
+        RigCommand::Repair { rig_id } => repair(&rig_id),
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
         RigCommand::Status { rig_id } => status(&rig_id),
         RigCommand::Install { source, id, all } => install(&source, id.as_deref(), all),
@@ -281,6 +287,19 @@ fn down(rig_id: &str) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::Down(RigDownOutput {
             command: "rig.down",
+            report,
+        }),
+        exit_code,
+    ))
+}
+
+fn repair(rig_id: &str) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(rig_id)?;
+    let report = rig::run_repair(&rig)?;
+    let exit_code = if report.success { 0 } else { 1 };
+    Ok((
+        RigCommandOutput::Repair(RigRepairOutput {
+            command: "rig.repair",
             report,
         }),
         exit_code,

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -18,6 +18,7 @@ pub enum RigCommandOutput {
     Up(RigUpOutput),
     Check(RigCheckOutput),
     Down(RigDownOutput),
+    Repair(RigRepairOutput),
     Sync(RigSyncOutput),
     Status(RigStatusOutput),
     Install(RigInstallOutput),
@@ -82,6 +83,13 @@ pub struct RigDownOutput {
     pub command: &'static str,
     #[serde(flatten)]
     pub report: rig::DownReport,
+}
+
+#[derive(Serialize)]
+pub struct RigRepairOutput {
+    pub command: &'static str,
+    #[serde(flatten)]
+    pub report: rig::RepairReport,
 }
 
 #[derive(Serialize)]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -41,8 +41,9 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    run_check, run_down, run_status, run_up, snapshot_state, CheckReport, DownReport,
-    RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
+    run_check, run_down, run_repair, run_status, run_up, snapshot_state, CheckReport,
+    DownReport, RepairReport, RepairResourceReport, RigStatusReport, SymlinkStatusReport,
+    SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -41,9 +41,9 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    run_check, run_down, run_repair, run_status, run_up, snapshot_state, CheckReport,
-    DownReport, RepairReport, RepairResourceReport, RigStatusReport, SymlinkStatusReport,
-    SymlinkStatusState, UpReport,
+    run_check, run_down, run_repair, run_status, run_up, snapshot_state, CheckReport, DownReport,
+    RepairReport, RepairResourceReport, RigStatusReport, SymlinkStatusReport, SymlinkStatusState,
+    UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -251,12 +251,8 @@ fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceRep
             let previous_target = current.to_string_lossy().into_owned();
             if current == target_path {
                 return Ok(RepairResourceReport {
-                    kind: "symlink".to_string(),
-                    path,
-                    expected_target: Some(expected_target),
-                    previous_target: Some(previous_target),
                     status: "unchanged".to_string(),
-                    error: None,
+                    ..symlink_resource(path, expected_target, Some(previous_target), None)
                 });
             }
 
@@ -267,55 +263,26 @@ fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceRep
                     format!("remove drifted symlink {}: {}", link_path.display(), e),
                 )
             })?;
-            create_symlink(&target_path, &link_path).map_err(|e| {
-                Error::rig_pipeline_failed(
-                    &rig.id,
-                    "repair",
-                    format!(
-                        "create {} → {}: {}",
-                        link_path.display(),
-                        target_path.display(),
-                        e
-                    ),
-                )
-            })?;
+            create_repair_symlink(rig, &target_path, &link_path)?;
             Ok(RepairResourceReport {
-                kind: "symlink".to_string(),
-                path,
-                expected_target: Some(expected_target),
-                previous_target: Some(previous_target),
                 status: "repaired".to_string(),
-                error: None,
+                ..symlink_resource(path, expected_target, Some(previous_target), None)
             })
         }
         Ok(_) => Ok(RepairResourceReport {
-            kind: "symlink".to_string(),
-            path,
-            expected_target: Some(expected_target),
-            previous_target: None,
             status: "blocked".to_string(),
-            error: Some("path exists and is not a symlink; repair will not remove it".to_string()),
+            ..symlink_resource(
+                path,
+                expected_target,
+                None,
+                Some("path exists and is not a symlink; repair will not remove it".to_string()),
+            )
         }),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            create_symlink(&target_path, &link_path).map_err(|e| {
-                Error::rig_pipeline_failed(
-                    &rig.id,
-                    "repair",
-                    format!(
-                        "create {} → {}: {}",
-                        link_path.display(),
-                        target_path.display(),
-                        e
-                    ),
-                )
-            })?;
+            create_repair_symlink(rig, &target_path, &link_path)?;
             Ok(RepairResourceReport {
-                kind: "symlink".to_string(),
-                path,
-                expected_target: Some(expected_target),
-                previous_target: None,
                 status: "repaired".to_string(),
-                error: None,
+                ..symlink_resource(path, expected_target, None, None)
             })
         }
         Err(e) => Err(Error::rig_pipeline_failed(
@@ -324,6 +291,37 @@ fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceRep
             format!("inspect {}: {}", link_path.display(), e),
         )),
     }
+}
+
+fn symlink_resource(
+    path: String,
+    expected_target: String,
+    previous_target: Option<String>,
+    error: Option<String>,
+) -> RepairResourceReport {
+    RepairResourceReport {
+        kind: "symlink".to_string(),
+        path,
+        expected_target: Some(expected_target),
+        previous_target,
+        status: String::new(),
+        error,
+    }
+}
+
+fn create_repair_symlink(rig: &RigSpec, target_path: &Path, link_path: &Path) -> Result<()> {
+    create_symlink(target_path, link_path).map_err(|e| {
+        Error::rig_pipeline_failed(
+            &rig.id,
+            "repair",
+            format!(
+                "create {} → {}: {}",
+                link_path.display(),
+                target_path.display(),
+                e
+            ),
+        )
+    })
 }
 
 #[cfg(unix)]

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -1,11 +1,11 @@
-//! Top-level rig operations: `up`, `check`, `down`, `status`, `snapshot`.
+//! Top-level rig operations: `up`, `check`, `down`, `repair`, `status`, `snapshot`.
 //!
 //! Each function returns a report struct that the CLI layer serializes to
 //! JSON. Reports are the contract — they should be stable across minor
 //! homeboy versions.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
@@ -13,12 +13,12 @@ use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
 use super::pipeline::{cleanup_shared_paths, run_pipeline, PipelineOutcome};
 use super::service::{self, ServiceStatus};
-use super::spec::{RigSpec, ServiceKind};
+use super::spec::{RigSpec, ServiceKind, SymlinkSpec};
 use super::state::{
     now_rfc3339, ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot,
 };
 use crate::engine::command::run_in_optional;
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 /// Report from `rig up`.
 #[derive(Debug, Clone, Serialize)]
@@ -43,6 +43,30 @@ pub struct DownReport {
     pub stopped: Vec<String>,
     pub pipeline: Option<PipelineOutcome>,
     pub success: bool,
+}
+
+/// Report from `rig repair`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepairReport {
+    pub rig_id: String,
+    pub resources: Vec<RepairResourceReport>,
+    pub repaired: usize,
+    pub unchanged: usize,
+    pub blocked: usize,
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepairResourceReport {
+    pub kind: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_target: Option<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Report from `rig status`.
@@ -164,6 +188,155 @@ pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
         pipeline,
         success,
     })
+}
+
+/// Repair safe declared drift without running the heavy `up` pipeline.
+///
+/// v1 intentionally repairs only declared symlinks. It will create missing
+/// symlinks and replace drifted symlinks, but refuses to remove real
+/// files/directories at the link path.
+pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
+    let _lease = acquire_active_run_lease(rig, "repair")?;
+    let mut resources = Vec::new();
+    let mut repaired = 0;
+    let mut unchanged = 0;
+    let mut blocked = 0;
+
+    for link in &rig.symlinks {
+        let resource = repair_symlink(rig, link)?;
+        match resource.status.as_str() {
+            "repaired" => repaired += 1,
+            "unchanged" => unchanged += 1,
+            "blocked" => blocked += 1,
+            _ => {}
+        }
+        resources.push(resource);
+    }
+
+    Ok(RepairReport {
+        rig_id: rig.id.clone(),
+        success: blocked == 0,
+        resources,
+        repaired,
+        unchanged,
+        blocked,
+    })
+}
+
+fn repair_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<RepairResourceReport> {
+    let link_path = PathBuf::from(expand_vars(rig, &link.link));
+    let target_path = PathBuf::from(expand_vars(rig, &link.target));
+    let path = link_path.to_string_lossy().into_owned();
+    let expected_target = target_path.to_string_lossy().into_owned();
+
+    if let Some(parent) = link_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            Error::rig_pipeline_failed(
+                &rig.id,
+                "repair",
+                format!("create parent of {}: {}", link_path.display(), e),
+            )
+        })?;
+    }
+
+    match std::fs::symlink_metadata(&link_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let current = std::fs::read_link(&link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "repair",
+                    format!("read {}: {}", link_path.display(), e),
+                )
+            })?;
+            let previous_target = current.to_string_lossy().into_owned();
+            if current == target_path {
+                return Ok(RepairResourceReport {
+                    kind: "symlink".to_string(),
+                    path,
+                    expected_target: Some(expected_target),
+                    previous_target: Some(previous_target),
+                    status: "unchanged".to_string(),
+                    error: None,
+                });
+            }
+
+            std::fs::remove_file(&link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "repair",
+                    format!("remove drifted symlink {}: {}", link_path.display(), e),
+                )
+            })?;
+            create_symlink(&target_path, &link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "repair",
+                    format!(
+                        "create {} → {}: {}",
+                        link_path.display(),
+                        target_path.display(),
+                        e
+                    ),
+                )
+            })?;
+            Ok(RepairResourceReport {
+                kind: "symlink".to_string(),
+                path,
+                expected_target: Some(expected_target),
+                previous_target: Some(previous_target),
+                status: "repaired".to_string(),
+                error: None,
+            })
+        }
+        Ok(_) => Ok(RepairResourceReport {
+            kind: "symlink".to_string(),
+            path,
+            expected_target: Some(expected_target),
+            previous_target: None,
+            status: "blocked".to_string(),
+            error: Some("path exists and is not a symlink; repair will not remove it".to_string()),
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            create_symlink(&target_path, &link_path).map_err(|e| {
+                Error::rig_pipeline_failed(
+                    &rig.id,
+                    "repair",
+                    format!(
+                        "create {} → {}: {}",
+                        link_path.display(),
+                        target_path.display(),
+                        e
+                    ),
+                )
+            })?;
+            Ok(RepairResourceReport {
+                kind: "symlink".to_string(),
+                path,
+                expected_target: Some(expected_target),
+                previous_target: None,
+                status: "repaired".to_string(),
+                error: None,
+            })
+        }
+        Err(e) => Err(Error::rig_pipeline_failed(
+            &rig.id,
+            "repair",
+            format!("inspect {}: {}", link_path.display(), e),
+        )),
+    }
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(not(unix))]
+fn create_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "rig symlink repair is not supported on this platform (Unix only)",
+    ))
 }
 
 /// Summarize current rig state (no mutations).

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 
 use crate::rig::pipeline::PipelineOutcome;
 use crate::rig::runner::{
-    run_check, run_down, run_status, run_up, snapshot_state, CheckReport, RigStatusReport,
-    ServiceStatusReport, SymlinkStatusState, UpReport,
+    run_check, run_down, run_repair, run_status, run_up, snapshot_state, CheckReport,
+    RigStatusReport, ServiceStatusReport, SymlinkStatusState, UpReport,
 };
 use crate::rig::spec::{
     ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp,
@@ -52,6 +52,18 @@ fn minimal_spec(id: &str) -> RigSpec {
         bench_profiles: HashMap::new(),
         app_launcher: None,
     }
+}
+
+fn symlink_spec(id: &str, link: String, target: String) -> RigSpec {
+    RigSpec {
+        symlinks: vec![SymlinkSpec { link, target }],
+        ..minimal_spec(id)
+    }
+}
+
+#[cfg(unix)]
+fn unix_symlink(target: &std::path::Path, link: &std::path::Path) {
+    std::os::unix::fs::symlink(target, link).expect("create symlink");
 }
 
 // ------------------------------------------------------------------
@@ -241,6 +253,169 @@ fn test_run_down() {
                 .materialized
                 .is_none(),
             "down clears materialized ownership"
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_repairs_drifted_symlink() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let old_target = tmp.path().join("old-target");
+        let expected_target = tmp.path().join("expected-target");
+        let link = tmp.path().join("tool");
+        std::fs::write(&old_target, "old").expect("old target");
+        std::fs::write(&expected_target, "expected").expect("expected target");
+        unix_symlink(&old_target, &link);
+
+        let rig = symlink_spec(
+            "repair-drifted-symlink-fixture",
+            link.to_string_lossy().into_owned(),
+            expected_target.to_string_lossy().into_owned(),
+        );
+
+        let report = run_repair(&rig).expect("repair succeeds");
+        assert!(report.success);
+        assert_eq!(report.repaired, 1);
+        assert_eq!(report.unchanged, 0);
+        assert_eq!(report.blocked, 0);
+        assert_eq!(report.resources[0].status, "repaired");
+        assert_eq!(
+            report.resources[0].previous_target.as_deref(),
+            Some(old_target.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            std::fs::read_link(&link).expect("read link"),
+            expected_target
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_creates_missing_symlink() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let expected_target = tmp.path().join("expected-target");
+        let link = tmp.path().join("nested").join("tool");
+        std::fs::write(&expected_target, "expected").expect("expected target");
+
+        let rig = symlink_spec(
+            "repair-missing-symlink-fixture",
+            link.to_string_lossy().into_owned(),
+            expected_target.to_string_lossy().into_owned(),
+        );
+
+        let report = run_repair(&rig).expect("repair succeeds");
+        assert!(report.success);
+        assert_eq!(report.repaired, 1);
+        assert_eq!(report.resources[0].status, "repaired");
+        assert_eq!(report.resources[0].previous_target, None);
+        assert_eq!(
+            std::fs::read_link(&link).expect("read link"),
+            expected_target
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_noops_ok_symlink() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let expected_target = tmp.path().join("expected-target");
+        let link = tmp.path().join("tool");
+        std::fs::write(&expected_target, "expected").expect("expected target");
+        unix_symlink(&expected_target, &link);
+
+        let rig = symlink_spec(
+            "repair-ok-symlink-fixture",
+            link.to_string_lossy().into_owned(),
+            expected_target.to_string_lossy().into_owned(),
+        );
+
+        let report = run_repair(&rig).expect("repair succeeds");
+        assert!(report.success);
+        assert_eq!(report.repaired, 0);
+        assert_eq!(report.unchanged, 1);
+        assert_eq!(report.blocked, 0);
+        assert_eq!(report.resources[0].status, "unchanged");
+        assert_eq!(
+            std::fs::read_link(&link).expect("read link"),
+            expected_target
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_blocks_non_symlink() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let expected_target = tmp.path().join("expected-target");
+        let link = tmp.path().join("tool");
+        std::fs::write(&expected_target, "expected").expect("expected target");
+        std::fs::write(&link, "real file").expect("real file at link path");
+
+        let rig = symlink_spec(
+            "repair-blocked-symlink-fixture",
+            link.to_string_lossy().into_owned(),
+            expected_target.to_string_lossy().into_owned(),
+        );
+
+        let report = run_repair(&rig).expect("repair reports blocked resource");
+        assert!(!report.success);
+        assert_eq!(report.repaired, 0);
+        assert_eq!(report.unchanged, 0);
+        assert_eq!(report.blocked, 1);
+        assert_eq!(report.resources[0].status, "blocked");
+        assert!(report.resources[0]
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("not a symlink"));
+        assert_eq!(
+            std::fs::read_to_string(&link).expect("read file"),
+            "real file"
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_repair_does_not_run_pipeline_commands() {
+    with_isolated_home(|_dir| {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let expected_target = tmp.path().join("expected-target");
+        let link = tmp.path().join("tool");
+        let command_marker = tmp.path().join("command-ran");
+        std::fs::write(&expected_target, "expected").expect("expected target");
+
+        let mut rig = symlink_spec(
+            "repair-skip-pipeline-fixture",
+            link.to_string_lossy().into_owned(),
+            expected_target.to_string_lossy().into_owned(),
+        );
+        rig.pipeline.insert(
+            "up".to_string(),
+            vec![PipelineStep::Command {
+                step_id: None,
+                depends_on: Vec::new(),
+                cmd: format!("printf ran > {}", command_marker.to_string_lossy()),
+                cwd: None,
+                env: HashMap::new(),
+                label: Some("must-not-run".to_string()),
+            }],
+        );
+
+        let report = run_repair(&rig).expect("repair succeeds");
+        assert!(report.success);
+        assert_eq!(report.repaired, 1);
+        assert!(link.is_symlink(), "repair still handled declared symlink");
+        assert!(
+            !command_marker.exists(),
+            "repair must not run heavy or arbitrary pipeline commands"
         );
     });
 }


### PR DESCRIPTION
## Summary
- Adds `homeboy rig repair <id>` as a lightweight recovery path for safe declared rig drift.
- Repairs missing or drifted declared symlinks without running `rig up` or any heavy pipeline steps.
- Reports repaired, unchanged, and blocked resources in the structured rig command output.

## Changes
- Adds `run_repair()` and `RepairReport` / `RepairResourceReport` in the rig runner.
- Wires the new `repair` subcommand into the rig CLI and output enum.
- Refuses unsafe non-symlink paths instead of deleting real files/directories.
- Keeps v1 scoped to symlink repair; external-service stop/restart remains a follow-up because it needs a separate stale/conflict policy.

## Tests
- `cargo test runner_test::test_run_repair -- --test-threads=1`
- `cargo run --bin homeboy -- rig repair --help`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-repair-safe-drift`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-repair-safe-drift --changed-since origin/main`

Closes #1981

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the repair command, focused tests, and validation commands from Chris's issue prompt; Chris remains responsible for review and merge.