### PR TITLE
feat(rig): scope workload preflight checks

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -38,7 +38,8 @@ For git sources, `repo.git//subpath` clones the repository root but discovers sp
 | `resources` | object | No | Resource declarations used by active-run leases. |
 | `pipeline` | object | No | Map of pipeline name to `PipelineStep[]`. |
 | `bench` | object | No | Rig-pinned benchmark component/default-baseline settings. |
-| `bench_workloads` | object | No | Rig-owned out-of-tree benchmark workload paths keyed by extension ID. |
+| `bench_workloads` | object | No | Rig-owned out-of-tree benchmark workloads keyed by extension ID. |
+| `trace_workloads` | object | No | Rig-owned out-of-tree trace workloads keyed by extension ID. |
 | `bench_profiles` | object | No | Named benchmark scenario profiles keyed by profile name. |
 | `app_launcher` | object | No | Optional desktop launcher wrapper config. |
 
@@ -275,12 +276,13 @@ Operates on every top-level `shared_paths` entry.
 {
   "kind": "check",
   "label": "docker daemon running",
+  "groups": ["desktop-app"],
   "command": "docker info",
   "expect_exit": 0
 }
 ```
 
-Embeds a `CheckSpec`. `up` pipelines fail fast on step failures; `check` pipelines run all steps and report every failure.
+Embeds a `CheckSpec`. `up` pipelines fail fast on step failures; `check` pipelines run all steps and report every failure. Optional `groups` names let rig-owned workloads run only the check-pipeline steps they require; `homeboy rig check <id>` still runs the full pipeline.
 
 ## `CheckSpec`
 
@@ -334,10 +336,13 @@ Rig specs can pin benchmark dispatch for `homeboy bench --rig <id>`.
 | `bench.components` | array | Components to benchmark as a rig-pinned matrix. |
 | `bench.default_baseline_rig` | string | Implicit baseline rig for branch-vs-main comparisons. |
 | `bench.warmup_iterations` | integer | Warmup iterations forwarded to bench runners. |
-| `bench_workloads` | object | Out-of-tree workload paths keyed by extension ID. |
+| `bench_workloads` | object | Out-of-tree workloads keyed by extension ID. |
+| `trace_workloads` | object | Out-of-tree trace workloads keyed by extension ID. |
 | `bench_profiles` | object | Named scenario lists used by `homeboy bench --profile <name>`. |
 
-`bench_workloads` paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${package.root}` for package-installed rigs.
+`bench_workloads` and `trace_workloads` entries support either string paths or object form. String paths preserve historical behaviour: workload commands run the full rig check. Object entries use `path` plus optional `check_groups`; when every workload for the selected extension declares `check_groups`, workload commands run only those grouped check-pipeline steps.
+
+Workload paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${package.root}` for package-installed rigs.
 
 ```jsonc
 {
@@ -347,7 +352,21 @@ Rig specs can pin benchmark dispatch for `homeboy bench --rig <id>`.
     "warmup_iterations": 2
   },
   "bench_workloads": {
-    "wordpress": ["${package.root}/bench/workloads/studio-cold-start"]
+    "wordpress": ["${package.root}/bench/workloads/studio-cold-start"],
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/workloads/studio-app.bench.mjs",
+        "check_groups": ["desktop-app"]
+      }
+    ]
+  },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/studio-app-create-site.trace.mjs",
+        "check_groups": ["desktop-app", "nodejs-trace"]
+      }
+    ]
   },
   "bench_profiles": {
     "cold-start": ["admin-first-load", "site-editor-first-load"]

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -413,6 +413,9 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
+    if let Some(spec) = rig_spec {
+        run_rig_workload_preflight(spec, ctx.extension_id.as_deref())?;
+    }
 
     let extra_workloads = rig_spec
         .as_ref()
@@ -515,6 +518,24 @@ fn resolve_list_component_id(
     }
 
     args.comp.resolve_id()
+}
+
+fn run_rig_workload_preflight(spec: &RigSpec, extension_id: Option<&str>) -> homeboy::Result<()> {
+    let groups = extension_id.and_then(|id| {
+        rig::check_groups_for_extension_workloads(spec, rig::RigWorkloadKind::Bench, id)
+    });
+    let check = match groups {
+        Some(groups) => rig::run_check_groups(spec, &groups)?,
+        None => rig::run_check(spec)?,
+    };
+    if !check.success {
+        return Err(homeboy::Error::rig_pipeline_failed(
+            &spec.id,
+            "check",
+            "rig check failed; refusing to list bench workloads for an unhealthy rig",
+        ));
+    }
+    Ok(())
 }
 
 /// Resolve the candidate rig's `bench.default_baseline_rig` and, when

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -22,14 +22,6 @@ struct RigBenchContext {
 
 fn prepare_rig_bench_context(rig_id: &str) -> homeboy::Result<RigBenchContext> {
     let spec = rig::load(rig_id)?;
-    let check_report = rig::run_check(&spec)?;
-    if !check_report.success {
-        return Err(homeboy::Error::rig_pipeline_failed(
-            &spec.id,
-            "check",
-            "rig check failed; refusing to run bench against an unhealthy rig",
-        ));
-    }
     let snapshot = rig::snapshot_state(&spec);
     let package_root =
         rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
@@ -372,6 +364,10 @@ fn run_component_with_rig_context(
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
 
+    if let Some(spec) = rig_spec {
+        run_rig_workload_preflight(spec, ctx.extension_id.as_deref())?;
+    }
+
     let run_dir = RunDir::create()?;
 
     let extra_workloads = rig_spec
@@ -437,6 +433,24 @@ fn run_component_with_rig_context(
         workflow,
         rig_snapshot,
     ))
+}
+
+fn run_rig_workload_preflight(spec: &RigSpec, extension_id: Option<&str>) -> homeboy::Result<()> {
+    let groups = extension_id.and_then(|id| {
+        rig::check_groups_for_extension_workloads(spec, rig::RigWorkloadKind::Bench, id)
+    });
+    let check = match groups {
+        Some(groups) => rig::run_check_groups(spec, &groups)?,
+        None => rig::run_check(spec)?,
+    };
+    if !check.success {
+        return Err(homeboy::Error::rig_pipeline_failed(
+            &spec.id,
+            "check",
+            "rig check failed; refusing to run bench against an unhealthy rig",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -69,6 +69,13 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
         ),
         component_override,
     )?;
+    if let Some(context) = rig_context.as_ref() {
+        run_rig_workload_preflight(
+            &context.spec,
+            ctx.extension_id.as_deref(),
+            rig::RigWorkloadKind::Trace,
+        )?;
+    }
 
     let rig_state = rig_context
         .as_ref()
@@ -135,6 +142,13 @@ fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         ),
         component_override,
     )?;
+    if let Some(context) = rig_context.as_ref() {
+        run_rig_workload_preflight(
+            &context.spec,
+            ctx.extension_id.as_deref(),
+            rig::RigWorkloadKind::Trace,
+        )?;
+    }
 
     let run_dir = RunDir::create()?;
     let extra_workloads = rig_context
@@ -177,21 +191,34 @@ fn load_rig_context(rig_id: Option<&str>) -> homeboy::Result<Option<TraceRigCont
         return Ok(None);
     };
     let spec = rig::load(rig_id)?;
-    let check = rig::run_check(&spec)?;
+    let package_root =
+        rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
+    Ok(Some(TraceRigContext { spec, package_root }))
+}
+
+fn run_rig_workload_preflight(
+    spec: &RigSpec,
+    extension_id: Option<&str>,
+    kind: rig::RigWorkloadKind,
+) -> homeboy::Result<()> {
+    let groups =
+        extension_id.and_then(|id| rig::check_groups_for_extension_workloads(spec, kind, id));
+    let check = match groups {
+        Some(groups) => rig::run_check_groups(spec, &groups)?,
+        None => rig::run_check(spec)?,
+    };
     if !check.success {
         return Err(homeboy::Error::validation_invalid_argument(
             "--rig",
             format!(
                 "rig '{}' check failed; fix the rig before running trace",
-                rig_id
+                spec.id
             ),
             None,
             None,
         ));
     }
-    let package_root =
-        rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
-    Ok(Some(TraceRigContext { spec, package_root }))
+    Ok(())
 }
 
 fn resolve_component_id(
@@ -373,6 +400,74 @@ mod tests {
                         result.scenarios[0].source.as_deref(),
                         Some(expected_source.as_str())
                     );
+                }
+                _ => panic!("expected list output"),
+            }
+        });
+    }
+
+    #[test]
+    fn rig_trace_list_uses_scoped_workload_preflight() {
+        with_isolated_home(|home| {
+            write_trace_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+            fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+            fs::write(
+                rig_dir.join("studio-rig.json"),
+                format!(
+                    r#"{{
+                        "components": {{
+                            "studio": {{ "path": "{}" }}
+                        }},
+                        "pipeline": {{
+                            "check": [
+                                {{
+                                    "kind": "check",
+                                    "label": "desktop app packaged",
+                                    "groups": ["desktop-app"],
+                                    "command": "true"
+                                }},
+                                {{
+                                    "kind": "check",
+                                    "label": "unrelated cli symlink",
+                                    "groups": ["cli-dev-copy"],
+                                    "command": "false"
+                                }}
+                            ]
+                        }},
+                        "trace_workloads": {{ "nodejs": [
+                            {{
+                                "path": "${{components.studio.path}}/studio-app-create-site.trace.mjs",
+                                "check_groups": ["desktop-app"]
+                            }}
+                        ] }}
+                    }}"#,
+                    component_dir.path().display()
+                ),
+            )
+            .expect("write rig");
+
+            let (output, exit_code) = run_list(TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: None,
+                    path: None,
+                },
+                scenario: "list".to_string(),
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                overlays: Vec::new(),
+                keep_overlay: false,
+            })
+            .expect("scoped rig trace list should bypass unrelated failed check");
+
+            assert_eq!(exit_code, 0);
+            match output {
+                TraceCommandOutput::List(result) => {
+                    assert_eq!(result.count, 1);
+                    assert_eq!(result.scenarios[0].id, "studio-app-create-site");
                 }
                 _ => panic!("expected list output"),
             }

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -41,8 +41,8 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    run_check, run_down, run_status, run_up, snapshot_state, CheckReport, DownReport,
-    RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
+    run_check, run_check_groups, run_down, run_status, run_up, snapshot_state, CheckReport,
+    DownReport, RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{
@@ -56,6 +56,7 @@ pub use spec::{
     AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, BenchSpec, CheckSpec,
     ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep, RigResourcesSpec, RigSpec,
     ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource,
+    WorkloadEntry, WorkloadSpec,
 };
 pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,
@@ -64,7 +65,10 @@ pub use stack::{
 pub use state::{
     ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
 };
-pub use workloads::{extension_ids_for_workloads, workloads_for_extension, RigWorkloadKind};
+pub use workloads::{
+    check_groups_for_extension_workloads, extension_ids_for_workloads, workloads_for_extension,
+    RigWorkloadKind,
+};
 
 use crate::error::{Error, Result};
 use crate::paths;

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -6,7 +6,7 @@
 //! Every step emits a `PipelineStepOutcome`. The runner aggregates them into
 //! a `PipelineOutcome` with overall success/failure.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -56,6 +56,34 @@ impl PipelineOutcome {
 pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<PipelineOutcome> {
     let steps = rig.pipeline.get(name).cloned().unwrap_or_default();
     let ordered_indices = order_pipeline_steps(rig, name, &steps)?;
+    run_ordered_steps(rig, name, &steps, ordered_indices, fail_fast)
+}
+
+pub fn run_pipeline_check_groups(
+    rig: &RigSpec,
+    groups: &[String],
+    fail_fast: bool,
+) -> Result<PipelineOutcome> {
+    let wanted: BTreeSet<&str> = groups.iter().map(String::as_str).collect();
+    let steps = rig
+        .pipeline
+        .get("check")
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|step| step_matches_groups(step, &wanted))
+        .collect::<Vec<_>>();
+    let ordered_indices = order_pipeline_steps(rig, "check", &steps)?;
+    run_ordered_steps(rig, "check", &steps, ordered_indices, fail_fast)
+}
+
+fn run_ordered_steps(
+    rig: &RigSpec,
+    name: &str,
+    steps: &[PipelineStep],
+    ordered_indices: Vec<usize>,
+    fail_fast: bool,
+) -> Result<PipelineOutcome> {
     let mut outcomes = Vec::with_capacity(ordered_indices.len());
     let mut failed = 0;
     let mut passed = 0;
@@ -112,6 +140,15 @@ pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<Pipeli
         passed,
         failed,
     })
+}
+
+fn step_matches_groups(step: &PipelineStep, wanted: &BTreeSet<&str>) -> bool {
+    match step {
+        PipelineStep::Check { groups, .. } => {
+            groups.iter().any(|group| wanted.contains(group.as_str()))
+        }
+        _ => false,
+    }
 }
 
 fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -11,7 +11,9 @@ use serde::Serialize;
 
 use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
-use super::pipeline::{cleanup_shared_paths, run_pipeline, PipelineOutcome};
+use super::pipeline::{
+    cleanup_shared_paths, run_pipeline, run_pipeline_check_groups, PipelineOutcome,
+};
 use super::service::{self, ServiceStatus};
 use super::spec::{RigSpec, ServiceKind};
 use super::state::{
@@ -125,6 +127,20 @@ pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
     state.last_check = Some(now_rfc3339());
     state.last_check_result = Some(if outcome.is_success() { "pass" } else { "fail" }.to_string());
     state.save(&rig.id)?;
+
+    Ok(CheckReport {
+        rig_id: rig.id.clone(),
+        success: outcome.is_success(),
+        pipeline: outcome,
+    })
+}
+
+/// Run only the grouped check-pipeline steps required by a workload command.
+///
+/// This intentionally does not update `last_check`: the report is a scoped
+/// command preflight, not proof that the whole rig passed `homeboy rig check`.
+pub fn run_check_groups(rig: &RigSpec, groups: &[String]) -> Result<CheckReport> {
+    let outcome = run_pipeline_check_groups(rig, groups, false)?;
 
     Ok(CheckReport {
         rig_id: rig.id.clone(),

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -65,7 +65,7 @@ pub struct RigSpec {
     /// `${components.<id>.path}` expansion as other rig path fields, plus
     /// `${package.root}` for rigs installed from a package source.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub bench_workloads: HashMap<String, Vec<String>>,
+    pub bench_workloads: HashMap<String, Vec<WorkloadSpec>>,
 
     /// Out-of-tree trace workloads keyed by extension id.
     ///
@@ -75,7 +75,7 @@ pub struct RigSpec {
     /// `${components.<id>.path}` expansion as other rig path fields, plus
     /// `${package.root}` for rigs installed from a package source.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub trace_workloads: HashMap<String, Vec<String>>,
+    pub trace_workloads: HashMap<String, Vec<WorkloadSpec>>,
 
     /// Named bench scenario suites keyed by profile name.
     ///
@@ -225,6 +225,41 @@ pub struct BenchSpec {
     /// can emit supplemental pairwise diffs grouped by the non-varying axes.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub axes: BTreeMap<String, String>,
+}
+
+/// Rig-owned extension workload declaration.
+///
+/// The string shorthand keeps existing rig specs valid. Object form lets a
+/// workload opt into scoped rig preflights by naming the check groups it needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkloadSpec {
+    Path(String),
+    Detailed(WorkloadEntry),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkloadEntry {
+    pub path: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check_groups: Option<Vec<String>>,
+}
+
+impl WorkloadSpec {
+    pub fn path(&self) -> &str {
+        match self {
+            WorkloadSpec::Path(path) => path,
+            WorkloadSpec::Detailed(entry) => &entry.path,
+        }
+    }
+
+    pub fn check_groups(&self) -> Option<&[String]> {
+        match self {
+            WorkloadSpec::Path(_) => None,
+            WorkloadSpec::Detailed(entry) => entry.check_groups.as_deref(),
+        }
+    }
 }
 
 /// Component reference inside a rig spec. Decoupled from the global component
@@ -584,6 +619,11 @@ pub enum PipelineStep {
         /// Step IDs that must run before this step.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         depends_on: Vec<String>,
+        /// Named preflight groups this check belongs to. Workload commands can
+        /// run only the groups required by a rig-owned workload while full
+        /// `rig check` continues to evaluate every check-pipeline step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        groups: Vec<String>,
         /// Human-readable label.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         label: Option<String>,

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -1,5 +1,6 @@
 //! Rig-owned extension workload resolution.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use super::spec::RigSpec;
@@ -34,8 +35,36 @@ pub fn workloads_for_extension(
         .get(extension_id)
         .into_iter()
         .flat_map(|paths| paths.iter())
-        .map(|path| expand_workload_path(rig_spec, package_root, path))
+        .map(|workload| expand_workload_path(rig_spec, package_root, workload.path()))
         .collect()
+}
+
+/// Return the scoped check groups required by all rig-owned workloads for an
+/// extension.
+///
+/// `None` means at least one relevant workload uses the legacy string shorthand
+/// (or the extension declares no rig-owned workloads), so callers should keep
+/// the historical full `rig check` behaviour. `Some(groups)` means every
+/// workload opted into scoped preflights; an empty vector intentionally means no
+/// rig check-pipeline step is required.
+pub fn check_groups_for_extension_workloads(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    extension_id: &str,
+) -> Option<Vec<String>> {
+    let workloads = match kind {
+        RigWorkloadKind::Bench => &rig_spec.bench_workloads,
+        RigWorkloadKind::Trace => &rig_spec.trace_workloads,
+    };
+    let entries = workloads.get(extension_id)?;
+
+    let mut groups = BTreeSet::new();
+    for workload in entries {
+        let required = workload.check_groups()?;
+        groups.extend(required.iter().filter(|group| !group.is_empty()).cloned());
+    }
+
+    Some(groups.into_iter().collect())
 }
 
 fn expand_workload_path(rig_spec: &RigSpec, package_root: Option<&Path>, path: &str) -> PathBuf {

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -88,21 +88,25 @@ fn test_rig_spec_deserializes_bench_workloads_by_extension() {
     )
     .expect("parse RigSpec");
 
+    let wordpress: Vec<&str> = spec
+        .bench_workloads
+        .get("wordpress")
+        .expect("wordpress workloads")
+        .iter()
+        .map(|workload| workload.path())
+        .collect();
     assert_eq!(
-        spec.bench_workloads
-            .get("wordpress")
-            .expect("wordpress workloads"),
-        &vec![
-            "/private/benches/cold-boot.php".to_string(),
-            "~/benches/wc-loaded.php".to_string(),
-        ]
+        wordpress,
+        vec!["/private/benches/cold-boot.php", "~/benches/wc-loaded.php"]
     );
-    assert_eq!(
-        spec.bench_workloads
-            .get("nodejs")
-            .expect("nodejs workloads"),
-        &vec!["/private/benches/electron-startup.bench.ts".to_string()]
-    );
+    let nodejs: Vec<&str> = spec
+        .bench_workloads
+        .get("nodejs")
+        .expect("nodejs workloads")
+        .iter()
+        .map(|workload| workload.path())
+        .collect();
+    assert_eq!(nodejs, vec!["/private/benches/electron-startup.bench.ts"]);
 }
 
 #[test]
@@ -121,21 +125,28 @@ fn test_rig_spec_deserializes_trace_workloads_by_extension() {
     )
     .expect("parse RigSpec");
 
+    let nodejs: Vec<&str> = spec
+        .trace_workloads
+        .get("nodejs")
+        .expect("nodejs workloads")
+        .iter()
+        .map(|workload| workload.path())
+        .collect();
     assert_eq!(
-        spec.trace_workloads
-            .get("nodejs")
-            .expect("nodejs workloads"),
-        &vec![
-            "${package.root}/bench/studio-app-create-site.trace.mjs".to_string(),
-            "~/traces/window-close.trace.mjs".to_string(),
+        nodejs,
+        vec![
+            "${package.root}/bench/studio-app-create-site.trace.mjs",
+            "~/traces/window-close.trace.mjs",
         ]
     );
-    assert_eq!(
-        spec.trace_workloads
-            .get("wordpress")
-            .expect("wordpress workloads"),
-        &vec!["/private/traces/wp-admin-load.trace.php".to_string()]
-    );
+    let wordpress: Vec<&str> = spec
+        .trace_workloads
+        .get("wordpress")
+        .expect("wordpress workloads")
+        .iter()
+        .map(|workload| workload.path())
+        .collect();
+    assert_eq!(wordpress, vec!["/private/traces/wp-admin-load.trace.php"]);
 }
 
 #[test]

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -4,7 +4,8 @@
 //! and are covered by the manual smoke documented in #1468. Scope here is
 //! the public outcome types — shape, serialization, `is_success` contract.
 
-use crate::rig::pipeline::{PipelineOutcome, PipelineStepOutcome};
+use crate::rig::pipeline::{run_pipeline_check_groups, PipelineOutcome, PipelineStepOutcome};
+use crate::rig::spec::RigSpec;
 
 fn step(status: &str) -> PipelineStepOutcome {
     PipelineStepOutcome {
@@ -54,6 +55,39 @@ fn test_pipeline_step_outcome_omits_error_when_absent() {
     let outcome = step("pass");
     let json = serde_json::to_string(&outcome).expect("serialize");
     assert!(!json.contains("\"error\""));
+}
+
+#[test]
+fn test_run_pipeline_check_groups() {
+    let rig: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "scoped-pipeline",
+            "pipeline": {
+                "check": [
+                    {
+                        "kind": "check",
+                        "label": "selected",
+                        "groups": ["desktop-app"],
+                        "command": "true"
+                    },
+                    {
+                        "kind": "check",
+                        "label": "unselected",
+                        "groups": ["cli"],
+                        "command": "false"
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse rig");
+
+    let outcome = run_pipeline_check_groups(&rig, &["desktop-app".to_string()], false)
+        .expect("scoped pipeline runs");
+
+    assert!(outcome.is_success());
+    assert_eq!(outcome.steps.len(), 1);
+    assert_eq!(outcome.steps[0].label, "selected");
 }
 
 // ---- Dependency-aware ordering ---------------------------------------------

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 
 use crate::rig::pipeline::PipelineOutcome;
 use crate::rig::runner::{
-    run_check, run_down, run_status, run_up, snapshot_state, CheckReport, RigStatusReport,
-    ServiceStatusReport, SymlinkStatusState, UpReport,
+    run_check, run_check_groups, run_down, run_status, run_up, snapshot_state, CheckReport,
+    RigStatusReport, ServiceStatusReport, SymlinkStatusState, UpReport,
 };
 use crate::rig::spec::{
     ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp,
@@ -208,6 +208,51 @@ fn test_run_check() {
         let status = run_status(&rig).expect("run_status reads back state");
         assert_eq!(status.last_check_result.as_deref(), Some("pass"));
         assert!(status.last_check.is_some(), "last_check timestamp recorded");
+    });
+}
+
+#[test]
+fn test_run_check_groups_runs_only_matching_check_steps() {
+    with_isolated_home(|_dir| {
+        let rig: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "scoped-check-fixture",
+                "pipeline": {
+                    "check": [
+                        {
+                            "kind": "check",
+                            "label": "desktop app exists",
+                            "groups": ["desktop-app"],
+                            "command": "true"
+                        },
+                        {
+                            "kind": "check",
+                            "label": "unrelated cli symlink",
+                            "groups": ["cli-dev-copy"],
+                            "command": "false"
+                        },
+                        {
+                            "kind": "symlink",
+                            "op": "verify"
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .expect("parse rig");
+
+        let report =
+            run_check_groups(&rig, &["desktop-app".to_string()]).expect("scoped check runs");
+
+        assert!(report.success, "unselected failing checks are skipped");
+        assert_eq!(report.pipeline.steps.len(), 1);
+        assert_eq!(report.pipeline.steps[0].label, "desktop app exists");
+        assert_eq!(report.pipeline.passed, 1);
+        assert_eq!(report.pipeline.failed, 0);
+
+        let full = run_check(&rig).expect("full check returns failed report");
+        assert!(!full.success, "full rig check remains strict");
+        assert!(full.pipeline.failed >= 1);
     });
 }
 

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -3,6 +3,7 @@
 
 use crate::rig::{
     PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec,
+    WorkloadEntry, WorkloadSpec,
 };
 
 /// Canonical fixture matching the studio-playground-dev shape used as the
@@ -210,6 +211,51 @@ fn test_spec_check_step_with_command_probe() {
         }
         other => panic!("expected Check, got {:?}", other),
     }
+}
+
+#[test]
+fn test_spec_check_step_parses_groups() {
+    let json = r#"{
+        "id": "r",
+        "pipeline": {
+            "check": [
+                {
+                    "kind": "check",
+                    "label": "desktop app packaged",
+                    "groups": ["desktop-app", "trace"],
+                    "command": "test -d apps/studio/out"
+                }
+            ]
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+    let steps = spec.pipeline.get("check").unwrap();
+    match &steps[0] {
+        PipelineStep::Check { groups, .. } => {
+            assert_eq!(
+                groups,
+                &vec!["desktop-app".to_string(), "trace".to_string()]
+            );
+        }
+        other => panic!("expected Check, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_check_groups() {
+    let legacy = WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string());
+    assert_eq!(legacy.path(), "/tmp/legacy.trace.mjs");
+    assert!(legacy.check_groups().is_none());
+
+    let detailed = WorkloadSpec::Detailed(WorkloadEntry {
+        path: "/tmp/scoped.trace.mjs".to_string(),
+        check_groups: Some(vec!["desktop-app".to_string()]),
+    });
+    assert_eq!(detailed.path(), "/tmp/scoped.trace.mjs");
+    assert_eq!(
+        detailed.check_groups(),
+        Some(&["desktop-app".to_string()][..])
+    );
 }
 
 #[test]

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use crate::rig::spec::RigSpec;
-use crate::rig::{extension_ids_for_workloads, workloads_for_extension, RigWorkloadKind};
+use crate::rig::{
+    check_groups_for_extension_workloads, extension_ids_for_workloads, workloads_for_extension,
+    RigWorkloadKind,
+};
 
 #[test]
 fn test_bench_workloads_for_extension_filters_and_expands_paths() {
@@ -119,6 +122,83 @@ fn test_extension_workloads_leave_package_root_unexpanded_without_metadata() {
     assert_eq!(
         workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "nodejs"),
         vec![PathBuf::from("${package.root}/bench/manual.trace.mjs")]
+    );
+}
+
+#[test]
+fn test_check_groups_for_extension_workloads() {
+    let rig_spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "studio",
+            "components": {
+                "studio": { "path": "/tmp/studio" }
+            },
+            "trace_workloads": {
+                "nodejs": [
+                    {
+                        "path": "${components.studio.path}/bench/create-site.trace.mjs",
+                        "check_groups": ["desktop-app", "nodejs-trace"]
+                    },
+                    {
+                        "path": "/tmp/other.trace.mjs",
+                        "check_groups": ["desktop-app"]
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse rig spec");
+
+    assert_eq!(
+        workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "nodejs"),
+        vec![
+            PathBuf::from("/tmp/studio/bench/create-site.trace.mjs"),
+            PathBuf::from("/tmp/other.trace.mjs"),
+        ]
+    );
+    assert_eq!(
+        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Trace, "nodejs")
+            .expect("scoped groups"),
+        vec!["desktop-app".to_string(), "nodejs-trace".to_string()]
+    );
+}
+
+#[test]
+fn test_string_workloads_keep_full_check_contract() {
+    let rig_spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "studio",
+            "trace_workloads": {
+                "nodejs": ["/tmp/create-site.trace.mjs"]
+            }
+        }"#,
+    )
+    .expect("parse rig spec");
+
+    assert_eq!(
+        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Trace, "nodejs"),
+        None
+    );
+}
+
+#[test]
+fn test_mixed_workload_declarations_keep_full_check_contract() {
+    let rig_spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "studio",
+            "bench_workloads": {
+                "nodejs": [
+                    { "path": "/tmp/scoped.bench.mjs", "check_groups": ["desktop-app"] },
+                    "/tmp/legacy.bench.mjs"
+                ]
+            }
+        }"#,
+    )
+    .expect("parse rig spec");
+
+    assert_eq!(
+        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Bench, "nodejs"),
+        None
     );
 }
 


### PR DESCRIPTION
## Summary
- Adds object-form rig workload declarations with optional check_groups for bench and trace workloads.
- Lets rig-owned trace/bench workloads run only their required preflight check groups instead of the full rig check.
- Keeps legacy string workloads and full homeboy rig check strict/full for backwards compatibility.

## Changes
- Adds WorkloadSpec / WorkloadEntry parsing for bench_workloads and trace_workloads.
- Adds grouped check metadata on rig check steps plus scoped check execution helpers.
- Defers trace rig preflight until after extension workload resolution so scoped preflight can be selected per workload.
- Documents workload object syntax and check step groups.
- Covers scoped preflight, legacy fallback, mixed workload fallback, check group parsing, and full-check strictness in tests.

## Tests
- cargo test rig -- --test-threads=1
- cargo test trace -- --test-threads=1
- cargo test -- --test-threads=1
- homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-rig-workload-preflights --changed-since origin/main
- homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-rig-workload-preflights --changed-since origin/main

Closes #1991

## AI assistance
- AI assistance: Yes
- Tool(s): OpenCode (GPT-5.5 / openai/gpt-5.5)
- Used for: Implementation, test updates, documentation edits, and local verification; Chris remains responsible for review and merge.