### PR TITLE
fix(lint): expose json summary output

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -75,6 +75,10 @@ pub struct LintArgs {
 
     #[command(flatten)]
     pub _json: HiddenJsonArgs,
+
+    /// Print compact machine-readable summary (for CI wrappers)
+    #[arg(long)]
+    pub json_summary: bool,
 }
 
 pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput> {
@@ -97,6 +101,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             &source_ctx.component,
             &source_ctx.source_path,
             source_ctx.component_id.clone(),
+            args.json_summary,
         )?;
 
         return Ok(report::from_main_workflow(workflow));
@@ -158,6 +163,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
                 ignore_baseline: args.baseline_args.ignore_baseline,
                 ratchet: args.baseline_args.ratchet,
             },
+            json_summary: args.json_summary,
         },
         &run_dir,
     )?;
@@ -250,6 +256,14 @@ mod tests {
 
         assert_eq!(cli.lint.extension_override.extensions, vec!["nodejs"]);
         assert_eq!(cli.lint.changed_since.as_deref(), Some("origin/main"));
+    }
+
+    #[test]
+    fn parses_json_summary_flag() {
+        let cli = TestCli::try_parse_from(["lint", "homeboy", "--json-summary"])
+            .expect("lint should parse --json-summary");
+
+        assert!(cli.lint.json_summary);
     }
 
     #[test]

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -275,6 +275,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         setting_args: Default::default(),
         baseline_args: args.baseline_args.clone(),
         _json: Default::default(),
+        json_summary: args.summary,
     };
     let (lint_output, lint_exit) = lint::run(lint_args, global)?;
     let lint_passed = lint_exit == 0;

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -440,6 +440,7 @@ mod tests {
             hints: None,
             baseline_comparison: None,
             lint_findings: Some(findings),
+            summary: None,
         }
     }
 

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -202,6 +202,7 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
                 "--setting",
                 "--path",
                 "--extension",
+                "--json-summary",
                 "--json",
                 "--help",
                 "-h",
@@ -496,6 +497,13 @@ mod normalize_tests {
             "smoke",
             "--iterations=1",
         ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    #[test]
+    fn lint_json_summary_after_component_is_not_separated() {
+        let input = argv(&["homeboy", "lint", "my-comp", "--json-summary"]);
         let expected = input.clone();
         assert_eq!(normalize_trailing_flags(input), expected);
     }

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -506,6 +506,7 @@ pub(crate) fn execute_capability_script(
     env_vars: &[(String, String)],
     working_dir: Option<&str>,
     command_override: Option<&str>,
+    passthrough: bool,
 ) -> Result<CommandOutput> {
     let command = if let Some(cmd) = command_override {
         cmd.to_string()
@@ -532,8 +533,10 @@ pub(crate) fn execute_capability_script(
 
     if let Some(dir) = working_dir {
         Ok(execute_local_command_in_dir(&command, Some(dir), env_opt))
-    } else {
+    } else if passthrough {
         Ok(execute_local_command_passthrough(&command, None, env_opt))
+    } else {
+        Ok(execute_local_command_in_dir(&command, None, env_opt))
     }
 }
 

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -12,7 +12,7 @@ use crate::refactor::plan::RefactorSourceRun;
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
 
-use super::run::LintRunWorkflowResult;
+use super::run::{LintRunWorkflowResult, LintSummaryOutput};
 
 /// Unified output envelope for the lint command.
 ///
@@ -35,6 +35,8 @@ pub struct LintCommandOutput {
     pub baseline_comparison: Option<BaselineComparison>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lint_findings: Option<Vec<LintFinding>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<LintSummaryOutput>,
 }
 
 /// Build output from a main lint workflow result.
@@ -52,6 +54,7 @@ pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, 
         .as_ref()
         .map(|findings| findings.len())
         .unwrap_or(0);
+    let json_summary = result.summary.is_some();
     let phase = lint_phase_report(exit_code, &result.status, finding_count);
     let failure = if exit_code == 0 {
         None
@@ -70,7 +73,12 @@ pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, 
             autofix: result.autofix,
             hints: result.hints,
             baseline_comparison: result.baseline_comparison,
-            lint_findings: result.lint_findings,
+            lint_findings: if json_summary {
+                None
+            } else {
+                result.lint_findings
+            },
+            summary: result.summary,
         },
         exit_code,
     )
@@ -152,6 +160,7 @@ pub fn from_lint_fix(component_label: String, run: RefactorSourceRun) -> (LintCo
             hints,
             baseline_comparison: None,
             lint_findings: None,
+            summary: None,
         },
         exit_code,
     )

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -14,6 +14,7 @@ use crate::extension::{self, ExtensionCapability, LintChangedFileRoute};
 use crate::git;
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// Arguments for the main lint workflow — populated by the command layer from CLI flags.
@@ -33,6 +34,7 @@ pub struct LintRunWorkflowArgs {
     pub exclude_sniffs: Option<String>,
     pub category: Option<String>,
     pub baseline_flags: BaselineFlags,
+    pub json_summary: bool,
 }
 
 /// Result of the main lint workflow — ready for report assembly.
@@ -45,6 +47,18 @@ pub struct LintRunWorkflowResult {
     pub hints: Option<Vec<String>>,
     pub baseline_comparison: Option<lint_baseline::BaselineComparison>,
     pub lint_findings: Option<Vec<LintFinding>>,
+    pub summary: Option<LintSummaryOutput>,
+}
+
+/// Compact lint summary for automation consumers.
+#[derive(Debug, Clone, Serialize)]
+pub struct LintSummaryOutput {
+    pub total_findings: usize,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub categories: BTreeMap<String, usize>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub top_findings: Vec<LintFinding>,
+    pub exit_code: i32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,6 +90,11 @@ pub fn run_main_lint_workflow(
                 hints: None,
                 baseline_comparison: None,
                 lint_findings: None,
+                summary: if args.json_summary {
+                    Some(build_lint_summary(&[], 0))
+                } else {
+                    None
+                },
             });
         }
     }
@@ -88,7 +107,7 @@ pub fn run_main_lint_workflow(
             component,
             args.path_override.clone(),
             &args.settings,
-            args.summary,
+            args.summary || args.json_summary,
             args.file.as_deref(),
             args.glob.as_deref(),
             args.errors_only,
@@ -98,6 +117,7 @@ pub fn run_main_lint_workflow(
             None,
             run_dir,
         )?
+        .passthrough(!args.json_summary)
         .run()?
     };
 
@@ -171,8 +191,27 @@ pub fn run_main_lint_workflow(
         autofix: None,
         hints,
         baseline_comparison,
+        summary: if args.json_summary {
+            Some(build_lint_summary(&lint_findings, exit_code))
+        } else {
+            None
+        },
         lint_findings: Some(lint_findings),
     })
+}
+
+fn build_lint_summary(findings: &[LintFinding], exit_code: i32) -> LintSummaryOutput {
+    let mut categories = BTreeMap::new();
+    for finding in findings {
+        *categories.entry(finding.category.clone()).or_insert(0) += 1;
+    }
+
+    LintSummaryOutput {
+        total_findings: findings.len(),
+        categories,
+        top_findings: findings.iter().take(20).cloned().collect(),
+        exit_code,
+    }
 }
 
 fn build_autofix_hint(args: &LintRunWorkflowArgs) -> String {
@@ -268,7 +307,7 @@ fn run_scoped_lint_runs(
             component,
             args.path_override.clone(),
             &args.settings,
-            args.summary,
+            args.summary || args.json_summary,
             args.file.as_deref(),
             Some(run.glob.as_str()),
             args.errors_only,
@@ -278,6 +317,7 @@ fn run_scoped_lint_runs(
             run.step.as_deref(),
             active_run_dir,
         )?
+        .passthrough(!args.json_summary)
         .run()?;
 
         if !output.success {
@@ -300,9 +340,14 @@ pub fn run_self_check_lint_workflow(
     component: &Component,
     source_path: &Path,
     component_label: String,
+    json_summary: bool,
 ) -> crate::Result<LintRunWorkflowResult> {
-    let output =
-        extension::self_check::run_self_checks(component, ExtensionCapability::Lint, source_path)?;
+    let output = extension::self_check::run_self_checks_with_passthrough(
+        component,
+        ExtensionCapability::Lint,
+        source_path,
+        !json_summary,
+    )?;
     let status = if output.success { "passed" } else { "failed" }.to_string();
     let hints = (!output.success).then(|| {
         vec![format!(
@@ -319,6 +364,11 @@ pub fn run_self_check_lint_workflow(
         hints,
         baseline_comparison: None,
         lint_findings: Some(Vec::new()),
+        summary: if json_summary {
+            Some(build_lint_summary(&[], output.exit_code))
+        } else {
+            None
+        },
     })
 }
 
@@ -532,6 +582,7 @@ mod tests {
             exclude_sniffs: None,
             category: None,
             baseline_flags: BaselineFlags::default(),
+            json_summary: false,
         }
     }
 
@@ -580,12 +631,36 @@ mod tests {
             test: Vec::new(),
         });
 
-        let result = run_self_check_lint_workflow(&component, dir.path(), "fixture".to_string())
-            .expect("lint self-check should run");
+        let result =
+            run_self_check_lint_workflow(&component, dir.path(), "fixture".to_string(), false)
+                .expect("lint self-check should run");
 
         assert_eq!(result.status, "passed");
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.component, "fixture");
+    }
+
+    #[test]
+    fn lint_summary_counts_categories_and_caps_top_findings() {
+        let findings = (0..25)
+            .map(|index| LintFinding {
+                id: format!("src/file-{index}.rs::rule"),
+                message: "message".to_string(),
+                category: if index % 2 == 0 {
+                    "style".to_string()
+                } else {
+                    "correctness".to_string()
+                },
+            })
+            .collect::<Vec<_>>();
+
+        let summary = build_lint_summary(&findings, 1);
+
+        assert_eq!(summary.total_findings, 25);
+        assert_eq!(summary.categories.get("style"), Some(&13));
+        assert_eq!(summary.categories.get("correctness"), Some(&12));
+        assert_eq!(summary.top_findings.len(), 20);
+        assert_eq!(summary.exit_code, 1);
     }
 
     #[test]

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -36,6 +36,8 @@ pub struct ExtensionRunner {
     /// Override the command string instead of constructing from extension_path + script_path.
     /// Used by Build when `command_template` produces a pre-resolved command.
     command_override: Option<String>,
+    /// Tee runner stdout/stderr to the terminal while capturing it.
+    passthrough: bool,
 }
 
 impl ExtensionRunner {
@@ -60,6 +62,7 @@ impl ExtensionRunner {
             pre_loaded_component: None,
             working_dir: None,
             command_override: None,
+            passthrough: true,
         }
     }
 
@@ -140,6 +143,12 @@ impl ExtensionRunner {
         self
     }
 
+    /// Control whether runner output is streamed to the terminal while captured.
+    pub(crate) fn passthrough(mut self, passthrough: bool) -> Self {
+        self.passthrough = passthrough;
+        self
+    }
+
     /// Execute the extension runner script.
     ///
     /// Performs the full orchestration:
@@ -208,6 +217,7 @@ impl ExtensionRunner {
             env_vars,
             self.working_dir.as_deref(),
             self.command_override.as_deref(),
+            self.passthrough,
         )
     }
 }

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -138,4 +138,37 @@ mod tests {
             "onetwo"
         );
     }
+
+    #[test]
+    fn test_run_self_checks_with_passthrough() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("lint.sh"),
+            "printf self-check-stdout\nprintf self-check-stderr >&2\n",
+        )
+        .expect("script should be written");
+
+        let mut component = Component::new(
+            "fixture".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            "".to_string(),
+            None,
+        );
+        component.self_checks = Some(SelfCheckConfig {
+            lint: vec!["sh lint.sh".to_string()],
+            test: Vec::new(),
+        });
+
+        let output = run_self_checks_with_passthrough(
+            &component,
+            ExtensionCapability::Lint,
+            dir.path(),
+            false,
+        )
+        .expect("self-checks should run without terminal passthrough");
+
+        assert!(output.success);
+        assert_eq!(output.stdout, "self-check-stdout");
+        assert_eq!(output.stderr, "self-check-stderr");
+    }
 }

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -1,7 +1,9 @@
 use crate::component::Component;
 use crate::error::{Error, Result};
 use crate::extension::ExtensionCapability;
-use crate::server::{execute_local_command_passthrough, CommandOutput};
+use crate::server::{
+    execute_local_command_in_dir, execute_local_command_passthrough, CommandOutput,
+};
 use std::path::Path;
 
 #[derive(Debug, Clone)]
@@ -16,6 +18,15 @@ pub fn run_self_checks(
     component: &Component,
     capability: ExtensionCapability,
     source_path: &Path,
+) -> Result<SelfCheckOutput> {
+    run_self_checks_with_passthrough(component, capability, source_path, true)
+}
+
+pub(crate) fn run_self_checks_with_passthrough(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    passthrough: bool,
 ) -> Result<SelfCheckOutput> {
     let commands = component.self_check_commands(capability);
     if commands.is_empty() {
@@ -36,14 +47,16 @@ pub fn run_self_checks(
     let mut stderr = String::new();
 
     for command in commands {
-        crate::log_status!(
-            "self-check",
-            "running {} self-check for {}: {}",
-            capability.label(),
-            component.id,
-            command
-        );
-        let output = execute_self_check_command(command, &working_dir);
+        if passthrough {
+            crate::log_status!(
+                "self-check",
+                "running {} self-check for {}: {}",
+                capability.label(),
+                component.id,
+                command
+            );
+        }
+        let output = execute_self_check_command(command, &working_dir, passthrough);
         stdout.push_str(&output.stdout);
         stderr.push_str(&output.stderr);
 
@@ -65,8 +78,16 @@ pub fn run_self_checks(
     })
 }
 
-fn execute_self_check_command(command: &str, working_dir: &str) -> CommandOutput {
-    execute_local_command_passthrough(command, Some(working_dir), None)
+fn execute_self_check_command(
+    command: &str,
+    working_dir: &str,
+    passthrough: bool,
+) -> CommandOutput {
+    if passthrough {
+        execute_local_command_passthrough(command, Some(working_dir), None)
+    } else {
+        execute_local_command_in_dir(command, Some(working_dir), None)
+    }
 }
 
 #[cfg(test)]

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -51,6 +51,7 @@ fn lint_args(root: &Path) -> LintArgs {
         setting_args: SettingArgs::default(),
         baseline_args: BaselineArgs::default(),
         _json: HiddenJsonArgs::default(),
+        json_summary: false,
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `--json-summary` to `homeboy lint` so lint matches the quality-command automation surface already available on test/bench/audit.
- Keeps normal lint output unchanged while making summary mode emit a compact, parseable JSON envelope.

## Changes

- Threads `json_summary` through lint args, workflow args, self-check lint, and review summary mode.
- Adds a compact lint `summary` payload with total findings, category counts, top findings, and exit code.
- Suppresses runner/self-check passthrough output in lint JSON summary mode so stdout remains JSON-only.
- Adds parser/normalizer/unit coverage for the new flag and summary shape.

## Tests

- `cargo test lint`
- `cargo build`
- `./target/debug/homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-lint-json-summary --json-summary`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-lint-json-summary`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-lint-json-summary --changed-since origin/main`

Closes #1995

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and validation steps. Chris remains responsible for review and merge decisions.
