### PR TITLE
feat(trace): add span reports and baselines

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -9,6 +9,10 @@ homeboy trace <component> <scenario>
 homeboy trace <component> list
 homeboy trace <component> <scenario> --rig <rig-id>
 homeboy trace <component> <scenario> --json-summary
+homeboy trace <component> <scenario> --span submit_to_cli:ui.submit:cli.start
+homeboy trace <component> <scenario> --report=markdown
+homeboy trace <component> <scenario> --baseline
+homeboy trace <component> <scenario> --ratchet
 ```
 
 ## Extension Manifest
@@ -42,6 +46,9 @@ homeboy trace <component> <scenario> --json-summary
   "timeline": [
     { "t_ms": 0, "source": "desktop", "event": "window.closed", "data": { "id": 1 } }
   ],
+  "span_definitions": [
+    { "id": "close_to_assertion", "from": "desktop.window.closed", "to": "assertion.checked" }
+  ],
   "assertions": [
     { "id": "no-window-reopen", "status": "fail", "message": "Window reopened" }
   ],
@@ -52,3 +59,42 @@ homeboy trace <component> <scenario> --json-summary
 ```
 
 V1 statuses are `pass`, `fail`, and `error`.
+
+## Spans
+
+Spans are generic intervals over timeline keys. A timeline key is `source.event`, using the event's `source` and `event` fields.
+
+Runners can emit `span_definitions`, or callers can pass repeatable `--span id:from:to` flags. Homeboy writes computed results back into the command output as `span_results`:
+
+```json
+{
+  "span_results": [
+    {
+      "id": "submit_to_cli",
+      "from": "ui.create_site.submit_clicked",
+      "to": "cli.validating_site_configuration",
+      "status": "ok",
+      "duration_ms": 1065,
+      "from_t_ms": 120,
+      "to_t_ms": 1185
+    }
+  ]
+}
+```
+
+If an endpoint is missing, Homeboy emits a skipped result with `missing` keys instead of panicking.
+
+## Markdown Reports
+
+Use `--report=markdown` to render a skim-friendly report from the same trace run. The report includes status, span table, assertions, artifacts, and timeline events.
+
+## Span Baselines
+
+Trace spans can use the same lifecycle flags as other baseline-aware commands:
+
+- `--baseline` stores the current span durations in `homeboy.json` under `baselines.trace`.
+- `--ratchet` updates the stored baseline when spans improve.
+- `--ignore-baseline` skips comparison.
+- `--regression-threshold=<PCT>` controls the allowed duration slowdown. Default is `5`.
+
+Rig-pinned traces store separate baselines under `trace.rig.<rig-id>` so bare and rig-owned traces do not collide.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -323,6 +323,7 @@ pub fn run_markdown(
         crate::cli_surface::Commands::Docs(args) => docs::run_markdown(args),
         crate::cli_surface::Commands::Changelog(args) => changelog::run_markdown(args),
         crate::cli_surface::Commands::Review(args) => review::run_markdown(args, global),
+        crate::cli_surface::Commands::Trace(args) => trace::run_markdown(args, global),
         crate::cli_surface::Commands::Report(args) => report::run_markdown(args),
         _ => Err(homeboy::Error::validation_invalid_argument(
             "output_mode",

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -2,14 +2,17 @@ use clap::Args;
 use std::path::PathBuf;
 
 use homeboy::component::{Component, ScopedExtensionConfig};
+use homeboy::engine::baseline::BaselineFlags;
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::trace as extension_trace;
-use homeboy::extension::trace::{TraceCommandOutput, TraceListWorkflowArgs, TraceRunWorkflowArgs};
+use homeboy::extension::trace::{
+    TraceCommandOutput, TraceListWorkflowArgs, TraceRunWorkflowArgs, TraceSpanDefinition,
+};
 use homeboy::extension::ExtensionCapability;
 use homeboy::rig::{self, RigSpec};
 
-use super::utils::args::{HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
+use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
 
 #[derive(Args)]
@@ -34,6 +37,21 @@ pub struct TraceArgs {
     #[arg(long)]
     pub json_summary: bool,
 
+    /// Render a Markdown trace report instead of the JSON envelope.
+    #[arg(long, value_parser = ["markdown"])]
+    pub report: Option<String>,
+
+    /// Add a span definition as `id:source.event:source.event`.
+    #[arg(long = "span", value_name = "ID:FROM:TO", value_parser = extension_trace::spans::parse_span_definition)]
+    pub spans: Vec<TraceSpanDefinition>,
+
+    #[command(flatten)]
+    pub baseline_args: BaselineArgs,
+
+    /// Span regression tolerance as a percentage.
+    #[arg(long, value_name = "PERCENT", default_value_t = extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT)]
+    pub regression_threshold: f64,
+
     /// Apply a patch file for this trace run, then reverse it afterward.
     #[arg(long = "overlay", value_name = "PATCH_FILE")]
     pub overlays: Vec<String>,
@@ -41,6 +59,40 @@ pub struct TraceArgs {
     /// Leave overlay changes in place after the trace run.
     #[arg(long)]
     pub keep_overlay: bool,
+}
+
+pub fn is_markdown_mode(args: &TraceArgs) -> bool {
+    args.report.as_deref() == Some("markdown")
+}
+
+pub fn run_markdown(args: TraceArgs, global: &GlobalArgs) -> CmdResult<String> {
+    let (output, exit_code) = run(args, global)?;
+    match output {
+        TraceCommandOutput::Run(run_output) => {
+            let Some(results) = run_output.results else {
+                return Ok(("# Trace\n\nNo trace results were produced.\n".to_string(), exit_code));
+            };
+            Ok((extension_trace::render_markdown(&results), exit_code))
+        }
+        TraceCommandOutput::Summary(summary) => Ok((
+            format!(
+                "# Trace Summary\n\n- **Component:** `{}`\n- **Status:** `{}`\n- **Exit code:** `{}`\n",
+                summary.component, summary.status, summary.exit_code
+            ),
+            exit_code,
+        )),
+        TraceCommandOutput::List(list) => {
+            let mut markdown = format!("# Trace Scenarios: `{}`\n\n", list.component_id);
+            for scenario in list.scenarios {
+                markdown.push_str(&format!("- `{}`", scenario.id));
+                if let Some(summary) = scenario.summary {
+                    markdown.push_str(&format!(": {}", summary));
+                }
+                markdown.push('\n');
+            }
+            Ok((markdown, exit_code))
+        }
+    }
 }
 
 pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutput> {
@@ -108,6 +160,13 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
             overlays: args.overlays,
             keep_overlay: args.keep_overlay,
             extra_workloads,
+            span_definitions: args.spans,
+            baseline_flags: BaselineFlags {
+                baseline: args.baseline_args.baseline,
+                ignore_baseline: args.baseline_args.ignore_baseline,
+                ratchet: args.baseline_args.ratchet,
+            },
+            regression_threshold_percent: args.regression_threshold,
         },
         &run_dir,
         rig_state.clone(),
@@ -380,6 +439,11 @@ mod tests {
                 setting_args: SettingArgs::default(),
                 _json: HiddenJsonArgs::default(),
                 json_summary: false,
+                report: None,
+                spans: Vec::new(),
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 overlays: Vec::new(),
                 keep_overlay: false,
             })
@@ -458,6 +522,11 @@ mod tests {
                 setting_args: SettingArgs::default(),
                 _json: HiddenJsonArgs::default(),
                 json_summary: false,
+                report: None,
+                spans: Vec::new(),
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 overlays: Vec::new(),
                 keep_overlay: false,
             })
@@ -492,6 +561,11 @@ mod tests {
                     setting_args: SettingArgs::default(),
                     _json: HiddenJsonArgs::default(),
                     json_summary: false,
+                    report: None,
+                    spans: Vec::new(),
+                    baseline_args: BaselineArgs::default(),
+                    regression_threshold:
+                        extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                     overlays: Vec::new(),
                     keep_overlay: false,
                 },

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -14,10 +14,7 @@ const BASELINE_KEY: &str = "trace";
 pub const DEFAULT_REGRESSION_THRESHOLD_PERCENT: f64 = 5.0;
 
 fn baseline_key_for(rig_id: Option<&str>) -> String {
-    match rig_id {
-        None => BASELINE_KEY.to_string(),
-        Some(id) => format!("{}.rig.{}", BASELINE_KEY, id),
-    }
+    rig_id.map_or_else(|| BASELINE_KEY.to_string(), |id| format!("trace.rig.{id}"))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -28,7 +25,7 @@ pub struct TraceSpanSnapshot {
 
 impl generic::Fingerprintable for TraceSpanSnapshot {
     fn fingerprint(&self) -> String {
-        self.id.clone()
+        format!("trace-span:{}", self.id)
     }
 
     fn description(&self) -> String {
@@ -36,7 +33,7 @@ impl generic::Fingerprintable for TraceSpanSnapshot {
     }
 
     fn context_label(&self) -> String {
-        self.id.clone()
+        format!("trace span {}", self.id)
     }
 }
 
@@ -89,9 +86,7 @@ pub fn save_baseline(
 pub fn load_baseline(source_path: &Path, rig_id: Option<&str>) -> Option<TraceBaseline> {
     let key = baseline_key_for(rig_id);
     let config = BaselineConfig::new(source_path, key);
-    generic::load::<TraceBaselineMetadata>(&config)
-        .ok()
-        .flatten()
+    generic::load::<TraceBaselineMetadata>(&config).unwrap_or_default()
 }
 
 pub fn compare(
@@ -217,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn compares_span_duration_regressions() {
+    fn test_compare() {
         let baseline = TraceBaseline {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             context_id: "studio".to_string(),
@@ -236,5 +231,22 @@ mod tests {
         assert!(comparison.regression);
         assert_eq!(comparison.spans[0].delta_ms, 30);
         assert_eq!(comparison.spans[0].delta_pct, Some(30.0));
+    }
+
+    #[test]
+    fn test_save_baseline() {
+        let temp = tempfile::tempdir().unwrap();
+        save_baseline(temp.path(), "studio", &results(100), None).unwrap();
+
+        let loaded = load_baseline(temp.path(), None).expect("baseline loads");
+        assert_eq!(loaded.metadata.spans[0].id, "submit_to_cli");
+        assert_eq!(loaded.known_fingerprints[0], "trace-span:submit_to_cli");
+    }
+
+    #[test]
+    fn test_load_baseline() {
+        let temp = tempfile::tempdir().unwrap();
+
+        assert!(load_baseline(temp.path(), Some("studio-rig")).is_none());
     }
 }

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -1,0 +1,240 @@
+//! Trace span baseline and ratchet support.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::baseline::{self as generic, BaselineConfig};
+use crate::error::Result;
+
+use super::parsing::TraceResults;
+
+const BASELINE_KEY: &str = "trace";
+pub const DEFAULT_REGRESSION_THRESHOLD_PERCENT: f64 = 5.0;
+
+fn baseline_key_for(rig_id: Option<&str>) -> String {
+    match rig_id {
+        None => BASELINE_KEY.to_string(),
+        Some(id) => format!("{}.rig.{}", BASELINE_KEY, id),
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TraceSpanSnapshot {
+    pub id: String,
+    pub duration_ms: u64,
+}
+
+impl generic::Fingerprintable for TraceSpanSnapshot {
+    fn fingerprint(&self) -> String {
+        self.id.clone()
+    }
+
+    fn description(&self) -> String {
+        format!("{}ms", self.duration_ms)
+    }
+
+    fn context_label(&self) -> String {
+        self.id.clone()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TraceBaselineMetadata {
+    pub spans: Vec<TraceSpanSnapshot>,
+}
+
+pub type TraceBaseline = generic::Baseline<TraceBaselineMetadata>;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TraceSpanDelta {
+    pub id: String,
+    pub baseline_duration_ms: u64,
+    pub current_duration_ms: u64,
+    pub delta_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta_pct: Option<f64>,
+    pub regression: bool,
+    pub improvement: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TraceBaselineComparison {
+    pub threshold_percent: f64,
+    pub spans: Vec<TraceSpanDelta>,
+    pub new_span_ids: Vec<String>,
+    pub removed_span_ids: Vec<String>,
+    pub regression: bool,
+    pub has_improvements: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}
+
+pub fn save_baseline(
+    source_path: &Path,
+    component_id: &str,
+    results: &TraceResults,
+    rig_id: Option<&str>,
+) -> Result<std::path::PathBuf> {
+    let snapshots = snapshots_from_results(results);
+    let metadata = TraceBaselineMetadata {
+        spans: snapshots.clone(),
+    };
+    let key = baseline_key_for(rig_id);
+    let config = BaselineConfig::new(source_path, key);
+    generic::save(&config, component_id, &snapshots, metadata)
+}
+
+pub fn load_baseline(source_path: &Path, rig_id: Option<&str>) -> Option<TraceBaseline> {
+    let key = baseline_key_for(rig_id);
+    let config = BaselineConfig::new(source_path, key);
+    generic::load::<TraceBaselineMetadata>(&config)
+        .ok()
+        .flatten()
+}
+
+pub fn compare(
+    current: &TraceResults,
+    baseline: &TraceBaseline,
+    threshold_percent: f64,
+) -> TraceBaselineComparison {
+    let current_snapshots = snapshots_from_results(current);
+    let baseline_by_id: HashMap<&str, &TraceSpanSnapshot> = baseline
+        .metadata
+        .spans
+        .iter()
+        .map(|span| (span.id.as_str(), span))
+        .collect();
+    let current_by_id: HashMap<&str, &TraceSpanSnapshot> = current_snapshots
+        .iter()
+        .map(|span| (span.id.as_str(), span))
+        .collect();
+
+    let mut spans = Vec::new();
+    let mut new_span_ids = Vec::new();
+    let mut reasons = Vec::new();
+    let mut regression = false;
+    let mut has_improvements = false;
+
+    for current_span in &current_snapshots {
+        let Some(prior) = baseline_by_id.get(current_span.id.as_str()) else {
+            new_span_ids.push(current_span.id.clone());
+            continue;
+        };
+        let delta_ms = current_span.duration_ms as i64 - prior.duration_ms as i64;
+        let delta_pct = if prior.duration_ms == 0 {
+            None
+        } else {
+            Some((delta_ms as f64 / prior.duration_ms as f64) * 100.0)
+        };
+        let span_regression = delta_pct.is_some_and(|pct| pct > threshold_percent);
+        let span_improvement = delta_ms < 0;
+        if span_regression {
+            regression = true;
+            reasons.push(format!(
+                "{} regressed by {}ms ({:.2}%)",
+                current_span.id,
+                delta_ms,
+                delta_pct.unwrap_or_default()
+            ));
+        }
+        if span_improvement {
+            has_improvements = true;
+        }
+        spans.push(TraceSpanDelta {
+            id: current_span.id.clone(),
+            baseline_duration_ms: prior.duration_ms,
+            current_duration_ms: current_span.duration_ms,
+            delta_ms,
+            delta_pct,
+            regression: span_regression,
+            improvement: span_improvement,
+        });
+    }
+
+    let removed_span_ids = baseline
+        .metadata
+        .spans
+        .iter()
+        .filter(|span| !current_by_id.contains_key(span.id.as_str()))
+        .map(|span| span.id.clone())
+        .collect();
+
+    TraceBaselineComparison {
+        threshold_percent,
+        spans,
+        new_span_ids,
+        removed_span_ids,
+        regression,
+        has_improvements,
+        reasons,
+    }
+}
+
+fn snapshots_from_results(results: &TraceResults) -> Vec<TraceSpanSnapshot> {
+    results
+        .span_results
+        .iter()
+        .filter_map(|span| {
+            span.duration_ms.map(|duration_ms| TraceSpanSnapshot {
+                id: span.id.clone(),
+                duration_ms,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extension::trace::parsing::{TraceSpanResult, TraceSpanStatus, TraceStatus};
+
+    fn results(duration_ms: u64) -> TraceResults {
+        TraceResults {
+            component_id: "studio".to_string(),
+            scenario_id: "create-site".to_string(),
+            status: TraceStatus::Pass,
+            summary: None,
+            failure: None,
+            rig: None,
+            timeline: Vec::new(),
+            span_definitions: Vec::new(),
+            span_results: vec![TraceSpanResult {
+                id: "submit_to_cli".to_string(),
+                from: "ui.submit".to_string(),
+                to: "cli.start".to_string(),
+                status: TraceSpanStatus::Ok,
+                duration_ms: Some(duration_ms),
+                from_t_ms: Some(0),
+                to_t_ms: Some(duration_ms),
+                missing: Vec::new(),
+                message: None,
+            }],
+            assertions: Vec::new(),
+            artifacts: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn compares_span_duration_regressions() {
+        let baseline = TraceBaseline {
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            context_id: "studio".to_string(),
+            item_count: 1,
+            known_fingerprints: vec!["submit_to_cli".to_string()],
+            metadata: TraceBaselineMetadata {
+                spans: vec![TraceSpanSnapshot {
+                    id: "submit_to_cli".to_string(),
+                    duration_ms: 100,
+                }],
+            },
+        };
+
+        let comparison = compare(&results(130), &baseline, 5.0);
+
+        assert!(comparison.regression);
+        assert_eq!(comparison.spans[0].delta_ms, 30);
+        assert_eq!(comparison.spans[0].delta_pct, Some(30.0));
+    }
+}

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -4,11 +4,15 @@
 //! extension script, creates a run directory, passes an env-var contract, and
 //! parses a JSON envelope written by the runner. Unlike bench, trace has no
 //! baselines, ratchets, or metric gates; its job is to preserve causality and
-//! evidence artifacts.
+//! evidence artifacts. Optional span baselines compare generic
+//! `source.event` intervals without teaching core about product-specific
+//! milestones.
 
+pub mod baseline;
 pub mod parsing;
 pub mod report;
 pub mod run;
+pub mod spans;
 
 use crate::component::Component;
 use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
@@ -17,7 +21,8 @@ pub use parsing::{parse_trace_list_str, parse_trace_results_file};
 pub use parsing::{
     TraceArtifact, TraceAssertion, TraceEvent, TraceList, TraceScenario, TraceStatus,
 };
-pub use parsing::{TraceAssertionStatus, TraceResults};
+pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, TraceSpanResult};
+pub use report::render_markdown;
 pub use report::{from_list_workflow, from_main_workflow, TraceCommandOutput};
 pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};
 pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult};

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -48,10 +48,54 @@ pub struct TraceResults {
     pub rig: Option<RigStateSnapshot>,
     #[serde(default)]
     pub timeline: Vec<TraceEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub span_definitions: Vec<TraceSpanDefinition>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub span_results: Vec<TraceSpanResult>,
     #[serde(default)]
     pub assertions: Vec<TraceAssertion>,
     #[serde(default)]
     pub artifacts: Vec<TraceArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceSpanDefinition {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceSpanStatus {
+    Ok,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceSpanResult {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    pub status: TraceSpanStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_t_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_t_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl TraceSpanResult {
+    pub fn is_ok(&self) -> bool {
+        self.status == TraceSpanStatus::Ok
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -153,6 +197,7 @@ mod tests {
                 "status":"fail",
                 "summary":"Window reopened after close",
                 "timeline":[{"t_ms":0,"source":"desktop","event":"window.closed","data":{"id":1}}],
+                "span_definitions":[{"id":"close_to_assertion","from":"desktop.window.closed","to":"assertion.checked"}],
                 "assertions":[{"id":"no-window-reopen","status":"fail","message":"Window reopened"}],
                 "artifacts":[{"label":"main log","path":"artifacts/main.log"}]
             }"#,
@@ -162,6 +207,7 @@ mod tests {
         assert_eq!(parsed.component_id, "studio");
         assert_eq!(parsed.status, TraceStatus::Fail);
         assert_eq!(parsed.timeline[0].t_ms, 0);
+        assert_eq!(parsed.span_definitions[0].id, "close_to_assertion");
         assert_eq!(parsed.assertions[0].id, "no-window-reopen");
         assert_eq!(parsed.artifacts[0].path, "artifacts/main.log");
     }
@@ -172,7 +218,7 @@ mod tests {
         let path = temp.path().join("trace-results.json");
         std::fs::write(
             &path,
-            r#"{"component_id":"studio","scenario_id":"x","status":"pass","timeline":[],"assertions":[],"artifacts":[]}"#,
+            r#"{"component_id":"studio","scenario_id":"x","status":"pass","timeline":[],"span_results":[],"assertions":[],"artifacts":[]}"#,
         )
         .expect("trace results should be written");
 

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -58,8 +58,6 @@ pub struct TraceRunSummaryOutput {
     pub overlays: Vec<TraceOverlay>,
     pub span_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub baseline_comparison: Option<TraceBaselineComparison>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<Vec<String>>,
 }
 
@@ -104,7 +102,6 @@ pub fn from_main_workflow(
                 .as_ref()
                 .map(|r| r.span_results.len())
                 .unwrap_or(0),
-            baseline_comparison: result.baseline_comparison,
             hints: result.hints,
         };
         return (TraceCommandOutput::Summary(output), exit_code);
@@ -299,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_markdown_report_with_spans() {
+    fn test_render_markdown() {
         let results = TraceResults {
             component_id: "studio".to_string(),
             scenario_id: "create-site".to_string(),

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -2,7 +2,10 @@
 
 use serde::Serialize;
 
-use super::parsing::{TraceArtifact, TraceList, TraceResults};
+use super::baseline::TraceBaselineComparison;
+use super::parsing::{
+    TraceArtifact, TraceAssertionStatus, TraceList, TraceResults, TraceSpanStatus,
+};
 use super::run::{TraceOverlay, TraceRunWorkflowResult};
 use crate::rig::RigStateSnapshot;
 
@@ -30,6 +33,10 @@ pub struct TraceRunOutput {
     pub failure: Option<super::run::TraceRunFailure>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub overlays: Vec<TraceOverlay>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<TraceBaselineComparison>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -49,6 +56,11 @@ pub struct TraceRunSummaryOutput {
     pub rig_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub overlays: Vec<TraceOverlay>,
+    pub span_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<TraceBaselineComparison>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -87,6 +99,13 @@ pub fn from_main_workflow(
                 .unwrap_or(0),
             rig_id: rig_state.as_ref().map(|r| r.rig_id.clone()),
             overlays: result.overlays,
+            span_count: result
+                .results
+                .as_ref()
+                .map(|r| r.span_results.len())
+                .unwrap_or(0),
+            baseline_comparison: result.baseline_comparison,
+            hints: result.hints,
         };
         return (TraceCommandOutput::Summary(output), exit_code);
     }
@@ -107,9 +126,84 @@ pub fn from_main_workflow(
             rig_state,
             failure: result.failure,
             overlays: result.overlays,
+            baseline_comparison: result.baseline_comparison,
+            hints: result.hints,
         })),
         exit_code,
     )
+}
+
+pub fn render_markdown(results: &TraceResults) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# Trace: `{}`\n\n", results.scenario_id));
+    out.push_str(&format!("- **Component:** `{}`\n", results.component_id));
+    out.push_str(&format!("- **Status:** `{}`\n", results.status.as_str()));
+    if let Some(summary) = &results.summary {
+        out.push_str(&format!("- **Summary:** {}\n", summary));
+    }
+    if let Some(failure) = &results.failure {
+        out.push_str(&format!("- **Failure:** {}\n", failure));
+    }
+
+    if !results.span_results.is_empty() {
+        out.push_str("\n## Spans\n\n");
+        out.push_str("| Span | From | To | Duration | Status |\n");
+        out.push_str("|---|---|---|---:|---|\n");
+        for span in &results.span_results {
+            let duration = span
+                .duration_ms
+                .map(|ms| format!("{}ms", ms))
+                .unwrap_or_else(|| "-".to_string());
+            let status = match span.status {
+                TraceSpanStatus::Ok => "ok".to_string(),
+                TraceSpanStatus::Skipped => span
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| "skipped".to_string()),
+            };
+            out.push_str(&format!(
+                "| `{}` | `{}` | `{}` | {} | {} |\n",
+                span.id, span.from, span.to, duration, status
+            ));
+        }
+    }
+
+    if !results.assertions.is_empty() {
+        out.push_str("\n## Assertions\n\n");
+        for assertion in &results.assertions {
+            let status = match assertion.status {
+                TraceAssertionStatus::Pass => "pass",
+                TraceAssertionStatus::Fail => "fail",
+                TraceAssertionStatus::Error => "error",
+            };
+            match &assertion.message {
+                Some(message) => out.push_str(&format!(
+                    "- `{}`: **{}** - {}\n",
+                    assertion.id, status, message
+                )),
+                None => out.push_str(&format!("- `{}`: **{}**\n", assertion.id, status)),
+            }
+        }
+    }
+
+    if !results.artifacts.is_empty() {
+        out.push_str("\n## Artifacts\n\n");
+        for artifact in &results.artifacts {
+            out.push_str(&format!("- **{}:** `{}`\n", artifact.label, artifact.path));
+        }
+    }
+
+    if !results.timeline.is_empty() {
+        out.push_str("\n## Timeline\n\n");
+        for event in &results.timeline {
+            out.push_str(&format!(
+                "- `{}ms` `{}.{}`\n",
+                event.t_ms, event.source, event.event
+            ));
+        }
+    }
+
+    out
 }
 
 pub fn from_list_workflow(component: String, list: TraceList) -> (TraceCommandOutput, i32) {
@@ -172,6 +266,8 @@ mod tests {
                 failure: None,
                 rig: None,
                 timeline: Vec::new(),
+                span_definitions: Vec::new(),
+                span_results: Vec::new(),
                 assertions: Vec::new(),
                 artifacts: vec![TraceArtifact {
                     label: "main log".to_string(),
@@ -184,6 +280,8 @@ mod tests {
                 touched_files: vec!["scenario.txt".to_string()],
                 kept: false,
             }],
+            baseline_comparison: None,
+            hints: None,
         };
 
         let (output, exit_code) = from_main_workflow(result, None, true);
@@ -194,8 +292,41 @@ mod tests {
         assert_eq!(value["passed"], true);
         assert_eq!(value["scenario_id"], "close-window-running-site");
         assert_eq!(value["artifact_count"], 1);
+        assert_eq!(value["span_count"], 0);
         assert_eq!(value["overlays"][0]["path"], "/tmp/overlay.patch");
         assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
         assert_eq!(value["overlays"][0]["kept"], false);
+    }
+
+    #[test]
+    fn renders_markdown_report_with_spans() {
+        let results = TraceResults {
+            component_id: "studio".to_string(),
+            scenario_id: "create-site".to_string(),
+            status: TraceStatus::Pass,
+            summary: Some("Created a site".to_string()),
+            failure: None,
+            rig: None,
+            timeline: Vec::new(),
+            span_definitions: Vec::new(),
+            span_results: vec![crate::extension::trace::parsing::TraceSpanResult {
+                id: "submit_to_cli".to_string(),
+                from: "ui.submit".to_string(),
+                to: "cli.start".to_string(),
+                status: crate::extension::trace::parsing::TraceSpanStatus::Ok,
+                duration_ms: Some(42),
+                from_t_ms: Some(10),
+                to_t_ms: Some(52),
+                missing: Vec::new(),
+                message: None,
+            }],
+            assertions: Vec::new(),
+            artifacts: Vec::new(),
+        };
+
+        let markdown = render_markdown(&results);
+
+        assert!(markdown.contains("# Trace: `create-site`"));
+        assert!(markdown.contains("| `submit_to_cli` | `ui.submit` | `cli.start` | 42ms | ok |"));
     }
 }

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -5,15 +5,19 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::component::Component;
+use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
+use crate::extension::trace::baseline::TraceBaselineComparison;
 use crate::extension::{
     resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
 };
 use crate::extension::{ExtensionRunner, RunnerOutput};
 use crate::rig::RigStateSnapshot;
 
-use super::parsing::{parse_trace_list_str, parse_trace_results_file, TraceList, TraceResults};
+use super::parsing::{
+    parse_trace_list_str, parse_trace_results_file, TraceList, TraceResults, TraceSpanDefinition,
+};
 
 #[derive(Debug, Clone)]
 pub struct TraceRunWorkflowArgs {
@@ -28,6 +32,9 @@ pub struct TraceRunWorkflowArgs {
     pub overlays: Vec<String>,
     pub keep_overlay: bool,
     pub extra_workloads: Vec<PathBuf>,
+    pub span_definitions: Vec<TraceSpanDefinition>,
+    pub baseline_flags: BaselineFlags,
+    pub regression_threshold_percent: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -52,6 +59,10 @@ pub struct TraceRunWorkflowResult {
     pub failure: Option<TraceRunFailure>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub overlays: Vec<TraceOverlay>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_comparison: Option<TraceBaselineComparison>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hints: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -100,7 +111,7 @@ fn run_trace_workflow_with_context(
     }
     let runner_output = runner_output?;
     let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
-    let results = if results_path.exists() {
+    let mut results = if results_path.exists() {
         let mut parsed = parse_trace_results_file(&results_path)?;
         if parsed.rig.is_none() {
             parsed.rig = rig_state;
@@ -130,6 +141,74 @@ fn run_trace_workflow_with_context(
         runner_output.exit_code
     };
     let failure = (!runner_output.success).then(|| failure_from_output(&args, &runner_output));
+    if let Some(parsed) = results.as_mut() {
+        super::spans::apply_span_definitions(parsed, &args.span_definitions);
+    }
+
+    let rig_id = args.rig_id.as_deref();
+    let source_path = Path::new(component_path);
+    let mut baseline_comparison = None;
+    let mut baseline_exit_override = None;
+    let mut hints = Vec::new();
+    let has_span_results = results
+        .as_ref()
+        .is_some_and(|parsed| !parsed.span_results.is_empty());
+
+    if args.baseline_flags.baseline && status == "pass" && has_span_results {
+        if let Some(ref parsed) = results {
+            let _ =
+                super::baseline::save_baseline(source_path, &args.component_id, parsed, rig_id)?;
+        }
+    }
+    if has_span_results && !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
+        if let Some(ref parsed) = results {
+            if let Some(existing) = super::baseline::load_baseline(source_path, rig_id) {
+                let comparison =
+                    super::baseline::compare(parsed, &existing, args.regression_threshold_percent);
+                if comparison.regression {
+                    baseline_exit_override = Some(1);
+                } else if comparison.has_improvements && args.baseline_flags.ratchet {
+                    let _ = super::baseline::save_baseline(
+                        source_path,
+                        &args.component_id,
+                        parsed,
+                        rig_id,
+                    );
+                }
+                baseline_comparison = Some(comparison);
+            }
+        }
+    }
+
+    let trace_invocation = match rig_id {
+        Some(id) => format!(
+            "homeboy trace {} {} --rig {}",
+            args.component_id, args.scenario_id, id
+        ),
+        None => format!("homeboy trace {} {}", args.component_id, args.scenario_id),
+    };
+    if has_span_results && !args.baseline_flags.baseline && baseline_comparison.is_none() {
+        hints.push(format!(
+            "Save trace span baseline: {} --baseline",
+            trace_invocation
+        ));
+    }
+    if baseline_comparison.is_some() && !args.baseline_flags.ratchet {
+        hints.push(format!(
+            "Auto-update trace span baseline on improvement: {} --ratchet",
+            trace_invocation
+        ));
+    }
+    if let Some(ref cmp) = baseline_comparison {
+        if cmp.regression {
+            hints.push(format!(
+                "Trace span regression threshold: {}%. Raise it with --regression-threshold=<PCT> if expected.",
+                cmp.threshold_percent
+            ));
+        }
+    }
+
+    let exit_code = baseline_exit_override.unwrap_or(exit_code);
 
     Ok(TraceRunWorkflowResult {
         status,
@@ -145,6 +224,8 @@ fn run_trace_workflow_with_context(
                 kept: overlay.keep,
             })
             .collect(),
+        baseline_comparison,
+        hints: if hints.is_empty() { None } else { Some(hints) },
     })
 }
 
@@ -166,6 +247,13 @@ pub fn run_trace_list_workflow(
         overlays: Vec::new(),
         keep_overlay: false,
         extra_workloads: args.extra_workloads,
+        span_definitions: Vec::new(),
+        baseline_flags: BaselineFlags {
+            baseline: false,
+            ignore_baseline: true,
+            ratchet: false,
+        },
+        regression_threshold_percent: super::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
     };
     let output =
         build_trace_runner(&execution_context, component, &runner_args, run_dir, true)?.run()?;
@@ -520,6 +608,14 @@ JSON
             overlays: Vec::new(),
             keep_overlay: false,
             extra_workloads: vec![component_dir.join("trace-fixture.trace.mjs")],
+            span_definitions: Vec::new(),
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
         };
 
         let output = build_trace_runner(&context, &component, &args, &run_dir, false)
@@ -583,6 +679,14 @@ JSON
             overlays: Vec::new(),
             keep_overlay: false,
             extra_workloads: Vec::new(),
+            span_definitions: Vec::new(),
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
         };
 
         let output = build_trace_runner(&context, &component, &args, &run_dir, true)
@@ -611,6 +715,14 @@ JSON
             overlays: Vec::new(),
             keep_overlay: false,
             extra_workloads: Vec::new(),
+            span_definitions: Vec::new(),
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
         };
         let output = RunnerOutput {
             success: false,
@@ -744,6 +856,14 @@ JSON
             overlays: vec![patch_path.to_string_lossy().to_string()],
             keep_overlay,
             extra_workloads: Vec::new(),
+            span_definitions: Vec::new(),
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
         };
         OverlayFixture {
             _temp: temp,

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -1,0 +1,183 @@
+//! Generic trace span post-processing over `source.event` timeline keys.
+
+use std::collections::HashMap;
+
+use super::parsing::{
+    TraceEvent, TraceResults, TraceSpanDefinition, TraceSpanResult, TraceSpanStatus,
+};
+
+pub fn parse_span_definition(raw: &str) -> Result<TraceSpanDefinition, String> {
+    let parts: Vec<&str> = raw.split(':').collect();
+    if parts.len() != 3 {
+        return Err("expected id:from:to".to_string());
+    }
+    let definition = TraceSpanDefinition {
+        id: parts[0].trim().to_string(),
+        from: parts[1].trim().to_string(),
+        to: parts[2].trim().to_string(),
+    };
+    if definition.id.is_empty() || definition.from.is_empty() || definition.to.is_empty() {
+        return Err("span id, from, and to must be non-empty".to_string());
+    }
+    Ok(definition)
+}
+
+pub fn apply_span_definitions(results: &mut TraceResults, cli_definitions: &[TraceSpanDefinition]) {
+    let definitions = merge_definitions(&results.span_definitions, cli_definitions);
+    if definitions.is_empty() {
+        return;
+    }
+    results.span_definitions = definitions.clone();
+    results.span_results = summarize_spans(&results.timeline, &definitions);
+}
+
+pub fn summarize_spans(
+    timeline: &[TraceEvent],
+    definitions: &[TraceSpanDefinition],
+) -> Vec<TraceSpanResult> {
+    let index = first_event_index(timeline);
+    definitions
+        .iter()
+        .map(|definition| summarize_span(definition, &index))
+        .collect()
+}
+
+fn merge_definitions(
+    runner_definitions: &[TraceSpanDefinition],
+    cli_definitions: &[TraceSpanDefinition],
+) -> Vec<TraceSpanDefinition> {
+    let mut merged = Vec::new();
+    for definition in runner_definitions.iter().chain(cli_definitions.iter()) {
+        if let Some(position) = merged
+            .iter()
+            .position(|existing: &TraceSpanDefinition| existing.id == definition.id)
+        {
+            merged[position] = definition.clone();
+        } else {
+            merged.push(definition.clone());
+        }
+    }
+    merged
+}
+
+fn first_event_index(timeline: &[TraceEvent]) -> HashMap<String, u64> {
+    let mut index = HashMap::new();
+    for event in timeline {
+        index.entry(timeline_key(event)).or_insert(event.t_ms);
+    }
+    index
+}
+
+fn timeline_key(event: &TraceEvent) -> String {
+    format!("{}.{}", event.source, event.event)
+}
+
+fn summarize_span(
+    definition: &TraceSpanDefinition,
+    index: &HashMap<String, u64>,
+) -> TraceSpanResult {
+    let from_t_ms = index.get(&definition.from).copied();
+    let to_t_ms = index.get(&definition.to).copied();
+    let mut missing = Vec::new();
+    if from_t_ms.is_none() {
+        missing.push(definition.from.clone());
+    }
+    if to_t_ms.is_none() {
+        missing.push(definition.to.clone());
+    }
+    if !missing.is_empty() {
+        return TraceSpanResult {
+            id: definition.id.clone(),
+            from: definition.from.clone(),
+            to: definition.to.clone(),
+            status: TraceSpanStatus::Skipped,
+            duration_ms: None,
+            from_t_ms,
+            to_t_ms,
+            missing,
+            message: Some("span endpoint missing from timeline".to_string()),
+        };
+    }
+
+    let from_value = from_t_ms.expect("checked above");
+    let to_value = to_t_ms.expect("checked above");
+    if to_value < from_value {
+        return TraceSpanResult {
+            id: definition.id.clone(),
+            from: definition.from.clone(),
+            to: definition.to.clone(),
+            status: TraceSpanStatus::Skipped,
+            duration_ms: None,
+            from_t_ms,
+            to_t_ms,
+            missing: Vec::new(),
+            message: Some("span end occurred before span start".to_string()),
+        };
+    }
+
+    TraceSpanResult {
+        id: definition.id.clone(),
+        from: definition.from.clone(),
+        to: definition.to.clone(),
+        status: TraceSpanStatus::Ok,
+        duration_ms: Some(to_value - from_value),
+        from_t_ms,
+        to_t_ms,
+        missing: Vec::new(),
+        message: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(t_ms: u64, source: &str, event: &str) -> TraceEvent {
+        TraceEvent {
+            t_ms,
+            source: source.to_string(),
+            event: event.to_string(),
+            data: Default::default(),
+        }
+    }
+
+    #[test]
+    fn parses_span_definition_triplet() {
+        let definition = parse_span_definition("submit:ui.clicked:cli.started").unwrap();
+
+        assert_eq!(definition.id, "submit");
+        assert_eq!(definition.from, "ui.clicked");
+        assert_eq!(definition.to, "cli.started");
+    }
+
+    #[test]
+    fn summarizes_spans_from_source_event_keys() {
+        let results = summarize_spans(
+            &[event(10, "ui", "clicked"), event(75, "cli", "started")],
+            &[TraceSpanDefinition {
+                id: "submit_to_cli".to_string(),
+                from: "ui.clicked".to_string(),
+                to: "cli.started".to_string(),
+            }],
+        );
+
+        assert_eq!(results[0].status, TraceSpanStatus::Ok);
+        assert_eq!(results[0].duration_ms, Some(65));
+    }
+
+    #[test]
+    fn missing_span_endpoint_is_explicitly_skipped() {
+        let results = summarize_spans(
+            &[event(10, "ui", "clicked")],
+            &[TraceSpanDefinition {
+                id: "submit_to_cli".to_string(),
+                from: "ui.clicked".to_string(),
+                to: "cli.started".to_string(),
+            }],
+        );
+
+        assert_eq!(results[0].status, TraceSpanStatus::Skipped);
+        assert_eq!(results[0].duration_ms, None);
+        assert_eq!(results[0].missing, vec!["cli.started"]);
+    }
+}

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -6,7 +6,7 @@ use super::parsing::{
     TraceEvent, TraceResults, TraceSpanDefinition, TraceSpanResult, TraceSpanStatus,
 };
 
-pub fn parse_span_definition(raw: &str) -> Result<TraceSpanDefinition, String> {
+pub(crate) fn parse_span_definition(raw: &str) -> Result<TraceSpanDefinition, String> {
     let parts: Vec<&str> = raw.split(':').collect();
     if parts.len() != 3 {
         return Err("expected id:from:to".to_string());
@@ -22,7 +22,10 @@ pub fn parse_span_definition(raw: &str) -> Result<TraceSpanDefinition, String> {
     Ok(definition)
 }
 
-pub fn apply_span_definitions(results: &mut TraceResults, cli_definitions: &[TraceSpanDefinition]) {
+pub(crate) fn apply_span_definitions(
+    results: &mut TraceResults,
+    cli_definitions: &[TraceSpanDefinition],
+) {
     let definitions = merge_definitions(&results.span_definitions, cli_definitions);
     if definitions.is_empty() {
         return;
@@ -31,7 +34,7 @@ pub fn apply_span_definitions(results: &mut TraceResults, cli_definitions: &[Tra
     results.span_results = summarize_spans(&results.timeline, &definitions);
 }
 
-pub fn summarize_spans(
+pub(crate) fn summarize_spans(
     timeline: &[TraceEvent],
     definitions: &[TraceSpanDefinition],
 ) -> Vec<TraceSpanResult> {
@@ -142,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_span_definition_triplet() {
+    fn test_parse_span_definition() {
         let definition = parse_span_definition("submit:ui.clicked:cli.started").unwrap();
 
         assert_eq!(definition.id, "submit");
@@ -151,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn summarizes_spans_from_source_event_keys() {
+    fn test_summarize_spans() {
         let results = summarize_spans(
             &[event(10, "ui", "clicked"), event(75, "cli", "started")],
             &[TraceSpanDefinition {
@@ -179,5 +182,33 @@ mod tests {
         assert_eq!(results[0].status, TraceSpanStatus::Skipped);
         assert_eq!(results[0].duration_ms, None);
         assert_eq!(results[0].missing, vec!["cli.started"]);
+    }
+
+    #[test]
+    fn test_apply_span_definitions() {
+        let mut results = TraceResults {
+            component_id: "studio".to_string(),
+            scenario_id: "create-site".to_string(),
+            status: crate::extension::trace::parsing::TraceStatus::Pass,
+            summary: None,
+            failure: None,
+            rig: None,
+            timeline: vec![event(10, "ui", "clicked"), event(30, "cli", "started")],
+            span_definitions: Vec::new(),
+            span_results: Vec::new(),
+            assertions: Vec::new(),
+            artifacts: Vec::new(),
+        };
+
+        apply_span_definitions(
+            &mut results,
+            &[TraceSpanDefinition {
+                id: "submit_to_cli".to_string(),
+                from: "ui.clicked".to_string(),
+                to: "cli.started".to_string(),
+            }],
+        );
+
+        assert_eq!(results.span_results[0].duration_ms, Some(20));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ enum RawOutputMode {
 
 use homeboy::commands;
 use homeboy::commands::utils::{args, entity_suggest, response as output, tty};
-use homeboy::commands::{changelog, cli, file, logs, report, review};
+use homeboy::commands::{changelog, cli, file, logs, report, review, trace};
 use homeboy::extension::load_all_extensions;
 
 fn response_mode(command: &Commands) -> ResponseMode {
@@ -38,6 +38,9 @@ fn response_mode(command: &Commands) -> ResponseMode {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
         Commands::Review(args) if review::is_markdown_mode(args) => {
+            ResponseMode::Raw(RawOutputMode::Markdown)
+        }
+        Commands::Trace(args) if trace::is_markdown_mode(args) => {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
         Commands::Report(args) if report::is_markdown_mode(args) => {


### PR DESCRIPTION
## Summary
- Add generic trace span post-processing over `source.event` timeline keys.
- Add Markdown trace reports and span baseline/ratchet support without teaching core about Studio-specific milestones.

## Changes
- Adds optional `span_definitions` / computed `span_results` to trace result parsing and output.
- Adds repeatable `--span id:from:to`, `--report=markdown`, `--baseline`, `--ratchet`, `--ignore-baseline`, and `--regression-threshold` support to `homeboy trace`.
- Stores span baselines under `baselines.trace` or `baselines.trace.rig.<rig-id>`, matching bench's rig-scoped baseline shape.
- Documents spans, reports, and trace baseline behavior in `docs/commands/trace.md`.
- Adds focused Rust coverage for parsing, span summaries, missing endpoints, Markdown rendering, and baseline comparison/save/load.

## Tests
- `cargo test trace -- --test-threads=1`
- `cargo test -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@feat-trace-span-report-baselines --changed-since origin/main`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-trace-span-report-baselines --changed-since origin/main`

Closes #2006
Closes #2007
Closes #2008

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented trace span/report/baseline support, tests, and PR drafting. Chris remains responsible for review and merge.
