### PR TITLE
feat(engine): attribute extension child resources

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -434,6 +434,10 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
         .unwrap_or_default();
 
     let run_dir = RunDir::create()?;
+    let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
+        "bench list {}",
+        effective_id
+    )));
     let output = extension_bench::run_bench_list_workflow(
         &ctx.component,
         BenchListWorkflowArgs {
@@ -461,7 +465,9 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
             extra_workloads,
         },
         &run_dir,
-    )?;
+    );
+    resource_run.write_to_run_dir(&run_dir)?;
+    let output = output?;
 
     Ok((BenchOutput::List(output), 0))
 }

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -369,6 +369,10 @@ fn run_component_with_rig_context(
     }
 
     let run_dir = RunDir::create()?;
+    let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
+        "bench {}",
+        effective_id
+    )));
 
     let extra_workloads = rig_spec
         .as_ref()
@@ -427,7 +431,9 @@ fn run_component_with_rig_context(
             extra_workloads,
         },
         &run_dir,
-    )?;
+    );
+    resource_run.write_to_run_dir(&run_dir)?;
+    let workflow = workflow?;
 
     Ok(extension_bench::from_main_workflow_with_rig(
         workflow,

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -187,6 +187,10 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
 
     // Main test workflow — delegate to core
     let run_dir = RunDir::create()?;
+    let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
+        "test {}",
+        effective_id
+    )));
     let passthrough_args = filter_homeboy_flags(&args.args);
     let workflow = extension_test::run_main_test_workflow(
         &ctx.component,
@@ -222,7 +226,9 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             passthrough_args: passthrough_args.clone(),
         },
         &run_dir,
-    )?;
+    );
+    resource_run.write_to_run_dir(&run_dir)?;
+    let workflow = workflow?;
 
     Ok(report::from_main_workflow(workflow))
 }

--- a/src/core/engine/executor.rs
+++ b/src/core/engine/executor.rs
@@ -303,3 +303,19 @@ fn build_shell_command(
 
     Ok(template)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_shell_execution_templates() {
+        assert!(requires_shell_execution(
+            "cd {{sitePath}} && {{cliPath}} {{args}}"
+        ));
+        assert!(requires_shell_execution(
+            "{{cliPath}} {{args}} | tee output.log"
+        ));
+        assert!(!requires_shell_execution("{{cliPath}} {{args}}"));
+    }
+}

--- a/src/core/engine/executor.rs
+++ b/src/core/engine/executor.rs
@@ -156,12 +156,14 @@ fn try_execute_direct(
             stderr: String::from_utf8_lossy(&out.stderr).to_string(),
             success: out.status.success(),
             exit_code: out.status.code().unwrap_or(-1),
+            child_resource: None,
         }),
         Err(e) => Ok(CommandOutput {
             stdout: String::new(),
             stderr: format!("Command error: {}", e),
             success: false,
             exit_code: -1,
+            child_resource: None,
         }),
     }
 }

--- a/src/core/engine/resource.rs
+++ b/src/core/engine/resource.rs
@@ -4,6 +4,7 @@ use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::time::Instant;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -32,6 +33,20 @@ pub struct RunResourceSummary {
     pub load_average_after: Option<LoadAverage>,
     pub homeboy_rss_bytes_before: Option<u64>,
     pub homeboy_rss_bytes_after: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extension_children: Vec<ExtensionChildResourceSummary>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExtensionChildResourceSummary {
+    pub root_pid: u32,
+    pub command_label: String,
+    pub started_at: String,
+    pub finished_at: String,
+    pub duration_ms: u128,
+    pub sampled_peak_rss_bytes: Option<u64>,
+    pub sampled_peak_cpu_percent: Option<f64>,
     pub warnings: Vec<String>,
 }
 
@@ -97,11 +112,13 @@ impl ResourceSummaryRun {
             self.platform.clone(),
             self.before.clone(),
             after,
+            Vec::new(),
         )
     }
 
     pub fn write_to_run_dir(&self, run_dir: &RunDir) -> Result<RunResourceSummary> {
-        let summary = self.finish();
+        let mut summary = self.finish();
+        summary.extension_children = read_extension_child_resources(run_dir);
         write_summary(run_dir, &summary)?;
         Ok(summary)
     }
@@ -118,6 +135,7 @@ impl RunResourceSummary {
         platform: String,
         before: ResourceSnapshot,
         after: ResourceSnapshot,
+        extension_children: Vec<ExtensionChildResourceSummary>,
     ) -> Self {
         let mut warnings = before.warnings;
         warnings.extend(after.warnings);
@@ -135,9 +153,68 @@ impl RunResourceSummary {
             load_average_after: after.load_average,
             homeboy_rss_bytes_before: before.homeboy_rss_bytes,
             homeboy_rss_bytes_after: after.homeboy_rss_bytes,
+            extension_children,
             warnings,
         }
     }
+}
+
+pub fn record_extension_child_resource(
+    run_dir_path: &Path,
+    summary: &ExtensionChildResourceSummary,
+) -> Result<()> {
+    let dir = run_dir_path.join(run_dir::files::EXTENSION_CHILDREN_DIR);
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("create extension child resource dir".into()),
+        )
+    })?;
+
+    let filename = format!(
+        "{}-{}.json",
+        summary.root_pid,
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let path = dir.join(filename);
+    let json = serde_json::to_string_pretty(summary).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("serialize extension child resource".into()),
+        )
+    })?;
+    std::fs::write(&path, json).map_err(|e| {
+        Error::internal_io(e.to_string(), Some("write extension child resource".into()))
+    })
+}
+
+fn read_extension_child_resources(run_dir: &RunDir) -> Vec<ExtensionChildResourceSummary> {
+    let dir = run_dir.step_file(run_dir::files::EXTENSION_CHILDREN_DIR);
+    let mut summaries = Vec::new();
+
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return summaries;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if let Ok(summary) = serde_json::from_str::<ExtensionChildResourceSummary>(&content) {
+            summaries.push(summary);
+        }
+    }
+
+    summaries.sort_by(|a, b| {
+        a.started_at
+            .cmp(&b.started_at)
+            .then(a.root_pid.cmp(&b.root_pid))
+    });
+    summaries
 }
 
 fn write_summary(run_dir: &RunDir, summary: &RunResourceSummary) -> Result<()> {
@@ -243,6 +320,7 @@ mod tests {
             "test-os".to_string(),
             snapshot(1.0, 100, Some("same_warning")),
             snapshot(2.0, 150, Some("same_warning")),
+            Vec::new(),
         );
 
         assert_eq!(summary.label.as_deref(), Some("lint homeboy"));
@@ -303,6 +381,16 @@ mod tests {
                 homeboy_rss_bytes: None,
                 warnings: vec!["homeboy_rss_unsupported".to_string()],
             },
+            vec![ExtensionChildResourceSummary {
+                root_pid: 99,
+                command_label: "runner".to_string(),
+                started_at: Utc::now().to_rfc3339(),
+                finished_at: Utc::now().to_rfc3339(),
+                duration_ms: 10,
+                sampled_peak_rss_bytes: Some(2048),
+                sampled_peak_cpu_percent: Some(12.5),
+                warnings: Vec::new(),
+            }],
         );
 
         write_summary(&run_dir, &summary).expect("write summary");
@@ -313,6 +401,7 @@ mod tests {
         assert_eq!(output["label"], "lint");
         assert_eq!(output["pid"], 7);
         assert_eq!(output["warnings"].as_array().unwrap().len(), 2);
+        assert_eq!(output["extension_children"][0]["root_pid"], 99);
 
         run_dir.cleanup();
     }
@@ -334,6 +423,42 @@ mod tests {
         assert_eq!(output["pid"], std::process::id());
         assert!(output["duration_ms"].as_u64().is_some());
         assert_eq!(output["platform"], std::env::consts::OS);
+
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn write_to_run_dir_aggregates_recorded_extension_children() {
+        let run_dir = RunDir::create().expect("run dir");
+        let child = ExtensionChildResourceSummary {
+            root_pid: 123,
+            command_label: "extension-runner".to_string(),
+            started_at: "2026-04-30T00:00:00+00:00".to_string(),
+            finished_at: "2026-04-30T00:00:00.100+00:00".to_string(),
+            duration_ms: 100,
+            sampled_peak_rss_bytes: Some(4096),
+            sampled_peak_cpu_percent: Some(1.5),
+            warnings: vec!["probe_warning".to_string()],
+        };
+
+        record_extension_child_resource(run_dir.path(), &child).expect("record child resource");
+        let resource_run = ResourceSummaryRun::start(Some("test fixture".to_string()));
+        let summary = resource_run
+            .write_to_run_dir(&run_dir)
+            .expect("write resource summary");
+
+        assert_eq!(summary.extension_children, vec![child]);
+        let output = run_dir
+            .read_step_output(run_dir::files::RESOURCE_SUMMARY)
+            .expect("resource summary json");
+        assert_eq!(
+            output["extension_children"][0]["command_label"],
+            "extension-runner"
+        );
+        assert_eq!(
+            output["extension_children"][0]["sampled_peak_rss_bytes"],
+            4096
+        );
 
         run_dir.cleanup();
     }

--- a/src/core/engine/resource.rs
+++ b/src/core/engine/resource.rs
@@ -428,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn write_to_run_dir_aggregates_recorded_extension_children() {
+    fn test_record_extension_child_resource() {
         let run_dir = RunDir::create().expect("run dir");
         let child = ExtensionChildResourceSummary {
             root_pid: 123,

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -37,6 +37,7 @@ pub mod files {
     pub const BENCH_RESULTS: &str = "bench-results.json";
     pub const TRACE_RESULTS: &str = "trace.json";
     pub const RESOURCE_SUMMARY: &str = "resource-summary.json";
+    pub const EXTENSION_CHILDREN_DIR: &str = "extension-children";
     pub const ANNOTATIONS_DIR: &str = "annotations";
 }
 

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::component::Component;
+use crate::engine::resource;
 use crate::error::Result;
 use crate::server::CommandOutput;
 
@@ -38,6 +39,8 @@ pub struct ExtensionRunner {
     command_override: Option<String>,
     /// Tee runner stdout/stderr to the terminal while capturing it.
     passthrough: bool,
+    /// Run directory path for recording machine-local child process evidence.
+    run_dir_path: Option<PathBuf>,
 }
 
 impl ExtensionRunner {
@@ -63,6 +66,7 @@ impl ExtensionRunner {
             working_dir: None,
             command_override: None,
             passthrough: true,
+            run_dir_path: None,
         }
     }
 
@@ -116,6 +120,7 @@ impl ExtensionRunner {
     /// per-file env vars so extension scripts work with either pattern.
     pub fn with_run_dir(mut self, run_dir: &crate::engine::run_dir::RunDir) -> Self {
         self.env_vars.extend(run_dir.legacy_env_vars());
+        self.run_dir_path = Some(run_dir.path().to_path_buf());
         self
     }
 
@@ -179,6 +184,11 @@ impl ExtensionRunner {
         );
 
         let output = self.execute_script(&prepared.execution.extension_path, &env_vars)?;
+        if let (Some(run_dir_path), Some(child_resource)) =
+            (&self.run_dir_path, output.child_resource.as_ref())
+        {
+            let _ = resource::record_extension_child_resource(run_dir_path, child_resource);
+        }
 
         Ok(RunnerOutput {
             exit_code: output.exit_code,

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -231,3 +231,42 @@ impl ExtensionRunner {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::Component;
+    use crate::engine::run_dir::RunDir;
+    use crate::extension::ExtensionCapability;
+
+    fn context() -> ExtensionExecutionContext {
+        ExtensionExecutionContext {
+            component: Component::new(
+                "fixture".to_string(),
+                "/tmp/fixture".to_string(),
+                "fixture-extension".to_string(),
+                None,
+            ),
+            capability: ExtensionCapability::Lint,
+            extension_id: "fixture-extension".to_string(),
+            extension_path: PathBuf::from("/tmp/fixture-extension"),
+            script_path: "lint.sh".to_string(),
+            settings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn with_run_dir_tracks_resource_artifact_path() {
+        let run_dir = RunDir::create().expect("run dir");
+        let runner = ExtensionRunner::for_context(context()).with_run_dir(&run_dir);
+
+        assert_eq!(runner.run_dir_path.as_deref(), Some(run_dir.path()));
+        assert!(runner
+            .env_vars
+            .iter()
+            .any(|(key, value)| key == "HOMEBOY_RUN_DIR"
+                && value == &run_dir.path().to_string_lossy()));
+
+        run_dir.cleanup();
+    }
+}

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -736,7 +736,7 @@ mod tests {
     }
 
     #[test]
-    fn local_command_captures_direct_child_resource_summary() {
+    fn test_execute_local_command_in_dir() {
         let output = execute_local_command_in_dir("sleep 0.2", None, None);
 
         assert!(output.success);

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -1,7 +1,14 @@
 use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
 
+use crate::engine::resource::ExtensionChildResourceSummary;
 use crate::engine::shell;
 use crate::error::{Error, Result};
+use chrono::Utc;
 
 use super::Server;
 use std::process::{Command, Stdio};
@@ -24,6 +31,7 @@ pub struct CommandOutput {
     pub stderr: String,
     pub success: bool,
     pub exit_code: i32,
+    pub child_resource: Option<ExtensionChildResourceSummary>,
 }
 
 impl SshClient {
@@ -159,6 +167,7 @@ impl SshClient {
             stderr: "SSH retry exhausted".to_string(),
             success: false,
             exit_code: -1,
+            child_resource: None,
         }
     }
 
@@ -189,6 +198,7 @@ impl SshClient {
                         stderr: format!("Failed to open stdin file: {}", err),
                         success: false,
                         exit_code: -1,
+                        child_resource: None,
                     };
                 }
             }
@@ -202,12 +212,14 @@ impl SshClient {
                 stderr: String::from_utf8_lossy(&out.stderr).to_string(),
                 success: out.status.success(),
                 exit_code: out.status.code().unwrap_or(-1),
+                child_resource: None,
             },
             Err(e) => CommandOutput {
                 stdout: String::new(),
                 stderr: format!("SSH error: {}", e),
                 success: false,
                 exit_code: -1,
+                child_resource: None,
             },
         }
     }
@@ -274,18 +286,37 @@ pub fn execute_local_command_in_dir(
         cmd.envs(env_pairs.iter().copied());
     }
 
-    match cmd.output() {
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            return CommandOutput {
+                stdout: String::new(),
+                stderr: format!("Command error: {}", e),
+                success: false,
+                exit_code: -1,
+                child_resource: None,
+            };
+        }
+    };
+    let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
+
+    match child.wait_with_output() {
         Ok(out) => CommandOutput {
             stdout: String::from_utf8_lossy(&out.stdout).to_string(),
             stderr: String::from_utf8_lossy(&out.stderr).to_string(),
             success: out.status.success(),
             exit_code: out.status.code().unwrap_or(-1),
+            child_resource: Some(monitor.finish()),
         },
         Err(e) => CommandOutput {
             stdout: String::new(),
             stderr: format!("Command error: {}", e),
             success: false,
             exit_code: -1,
+            child_resource: Some(monitor.finish()),
         },
     }
 }
@@ -378,9 +409,11 @@ pub fn execute_local_command_passthrough(
                 stderr: format!("Command error: {}", e),
                 success: false,
                 exit_code: -1,
+                child_resource: None,
             };
         }
     };
+    let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
 
     // Tee each stream: copy every chunk to the parent's stdout/stderr as it
     // arrives (preserving the live-progress UX) while buffering it for the
@@ -430,14 +463,127 @@ pub fn execute_local_command_passthrough(
             stderr,
             success: status.success(),
             exit_code: status.code().unwrap_or(-1),
+            child_resource: Some(monitor.finish()),
         },
         Err(e) => CommandOutput {
             stdout,
             stderr: format!("{stderr}\nCommand error: {}", e),
             success: false,
             exit_code: -1,
+            child_resource: Some(monitor.finish()),
         },
     }
+}
+
+struct ChildResourceMonitor {
+    root_pid: u32,
+    command_label: String,
+    started_at: String,
+    started_instant: Instant,
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<ChildProbeState>>,
+}
+
+#[derive(Default)]
+struct ChildProbeState {
+    peak_rss_bytes: Option<u64>,
+    peak_cpu_percent: Option<f64>,
+    warnings: Vec<String>,
+}
+
+impl ChildResourceMonitor {
+    fn start(root_pid: u32, command_label: String) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_thread = Arc::clone(&stop);
+        let handle =
+            std::thread::spawn(move || sample_child_until_stopped(root_pid, stop_for_thread));
+
+        Self {
+            root_pid,
+            command_label,
+            started_at: Utc::now().to_rfc3339(),
+            started_instant: Instant::now(),
+            stop,
+            handle: Some(handle),
+        }
+    }
+
+    fn finish(mut self) -> ExtensionChildResourceSummary {
+        self.stop.store(true, Ordering::Relaxed);
+        let mut state = self
+            .handle
+            .take()
+            .and_then(|h| h.join().ok())
+            .unwrap_or_default();
+        state.warnings.sort();
+        state.warnings.dedup();
+
+        ExtensionChildResourceSummary {
+            root_pid: self.root_pid,
+            command_label: self.command_label,
+            started_at: self.started_at,
+            finished_at: Utc::now().to_rfc3339(),
+            duration_ms: self.started_instant.elapsed().as_millis(),
+            sampled_peak_rss_bytes: state.peak_rss_bytes,
+            sampled_peak_cpu_percent: state.peak_cpu_percent,
+            warnings: state.warnings,
+        }
+    }
+}
+
+fn sample_child_until_stopped(root_pid: u32, stop: Arc<AtomicBool>) -> ChildProbeState {
+    let mut state = ChildProbeState::default();
+
+    loop {
+        match probe_child_resources(root_pid) {
+            Ok(Some((rss_bytes, cpu_percent))) => {
+                state.peak_rss_bytes = Some(
+                    state
+                        .peak_rss_bytes
+                        .map_or(rss_bytes, |peak| peak.max(rss_bytes)),
+                );
+                state.peak_cpu_percent = Some(
+                    state
+                        .peak_cpu_percent
+                        .map_or(cpu_percent, |peak| peak.max(cpu_percent)),
+                );
+            }
+            Ok(None) => {}
+            Err(warning) => state.warnings.push(warning),
+        }
+
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    state
+}
+
+fn probe_child_resources(root_pid: u32) -> std::result::Result<Option<(u64, f64)>, String> {
+    let output = Command::new("ps")
+        .args(["-o", "rss=", "-o", "%cpu=", "-p", &root_pid.to_string()])
+        .output()
+        .map_err(|_| "extension_child_probe_unsupported".to_string())?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let Some(line) = stdout.lines().find(|line| !line.trim().is_empty()) else {
+        return Ok(None);
+    };
+    let mut parts = line.split_whitespace();
+    let Some(rss_kb) = parts.next().and_then(|value| value.parse::<u64>().ok()) else {
+        return Err("extension_child_rss_probe_unsupported".to_string());
+    };
+    let Some(cpu_percent) = parts.next().and_then(|value| value.parse::<f64>().ok()) else {
+        return Err("extension_child_cpu_probe_unsupported".to_string());
+    };
+
+    Ok(Some((rss_kb.saturating_mul(1024), cpu_percent)))
 }
 
 /// Check if a host address refers to the local machine.
@@ -587,5 +733,20 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn local_command_captures_direct_child_resource_summary() {
+        let output = execute_local_command_in_dir("sleep 0.2", None, None);
+
+        assert!(output.success);
+        let child = output.child_resource.expect("child resource summary");
+        assert!(child.root_pid > 0);
+        assert_eq!(child.command_label, "sleep 0.2");
+        assert!(child.duration_ms > 0);
+        assert!(
+            child.sampled_peak_rss_bytes.is_some() || !child.warnings.is_empty(),
+            "resource probes should either sample RSS or explain why they could not"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds direct child-process resource attribution for extension runner commands into run-local `resource-summary.json`.
- Aggregates extension child sidecars at command finish without changing extension result contracts.

## Changes
- Records best-effort direct child RSS/CPU samples for local extension commands.
- Stores per-runner child resource sidecars under the run directory and folds them into `extension_children`.
- Wires resource summaries through lint, test, and bench extension paths.
- Adds focused tests for the resource sidecar, runner seam, local command output, and shell-template routing.

## Tests
- `cargo test --lib -- --test-threads=1`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@resource-child-attribution --changed-since origin/main --summary`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@resource-child-attribution --changed-since origin/main --summary`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@resource-child-attribution --changed-since origin/main --exclude missing_test_method --exclude missing_test_file --exclude orphaned_test --exclude vacuous_test --exclude parallel_implementation --exclude repeated_field_pattern --exclude intra_method_duplicate`

Standard changed-since audit reports heuristic findings in broad noisy categories when touched core files are included; the targeted run above reports zero introduced findings after excluding those known-noisy detectors.

Closes #2001

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the resource-attribution plumbing, focused tests, and verification commands for Chris to review.