### PR TITLE
docs(commands): add doctor to command index

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -14,6 +14,7 @@
 - [db](db.md)
 - [deploy](deploy.md)
 - [deps](deps.md) — component dependency inspection and updates
+- [doctor](doctor.md) — local diagnostics for runtime and resource health
 - [docs](docs.md) — embedded topic display and codebase map generation
 - [extension](extension.md)
 - [file](file.md) — remote file operations, downloads, uploads, copies, and syncs


### PR DESCRIPTION
## Summary
- Adds `doctor` to `docs/commands/commands-index.md` so the command surface docs match `homeboy --help`.

## Tests
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the release failure, applying the docs fix, and running the focused command-surface test.