### PR TITLE
feat(obs-store): add SQLite foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +482,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +719,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -707,6 +740,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -737,6 +779,7 @@ dependencies = [
  "libc",
  "regex",
  "reqwest",
+ "rusqlite",
  "semver",
  "serde",
  "serde_json",
@@ -1102,6 +1145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1697,6 +1751,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ arboard = "3"
 chrono = "0.4"
 semver = "1.0"
 libc = "0.2"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 # CLI dependencies
 clap = { version = "4.5", features = ["derive", "string"] }

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 
 use homeboy::db::{self, DbResult, DbTunnelResult};
 use homeboy::engine::text;
+use homeboy::observation::store::{self, ObservationDbStatus};
 use homeboy::project;
 
 use super::CmdResult;
@@ -15,6 +16,8 @@ pub struct DbArgs {
 
 #[derive(Subcommand)]
 enum DbCommand {
+    /// Show local Homeboy observation-store status
+    Status,
     /// List database tables
     Tables {
         /// Project ID
@@ -98,12 +101,14 @@ pub struct DbOutput {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum DbResultVariant {
+    Status(ObservationDbStatus),
     Query(DbResult),
     Tunnel(DbTunnelResult),
 }
 
 pub fn run(args: DbArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<DbOutput> {
     match args.command {
+        DbCommand::Status => status(),
         DbCommand::Tables { project_id, args } => tables(&project_id, &args),
         DbCommand::Describe { project_id, args } => describe(&project_id, &args),
         DbCommand::Query { project_id, args } => query(&project_id, &args),
@@ -131,6 +136,16 @@ pub fn run(args: DbArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<DbO
             local_port,
         } => tunnel(&project_id, local_port),
     }
+}
+
+fn status() -> CmdResult<DbOutput> {
+    Ok((
+        DbOutput {
+            command: "db.status".to_string(),
+            result: DbResultVariant::Status(store::status()?),
+        },
+        0,
+    ))
 }
 
 fn parse_subtarget(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,6 +17,7 @@ pub mod fleet;
 pub mod git;
 pub mod http_api;
 pub mod issues;
+pub mod observation;
 pub mod output;
 pub mod project;
 pub mod refactor;

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -1,0 +1,7 @@
+//! Local observation store.
+//!
+//! Boundary: JSON/files describe desired state (`homeboy.json`, rig specs,
+//! stack specs, baselines). SQLite stores observed state from command runs and
+//! generated artifacts. This module only provides the storage substrate.
+
+pub mod store;

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1,0 +1,243 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::{paths, Error, Result};
+
+pub const CURRENT_SCHEMA_VERSION: i64 = 1;
+
+struct Migration {
+    version: i64,
+    sql: &'static str,
+}
+
+const MIGRATIONS: &[Migration] = &[Migration {
+    version: 1,
+    sql: r#"
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS runs (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            component_id TEXT,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            status TEXT NOT NULL,
+            command TEXT,
+            cwd TEXT,
+            homeboy_version TEXT,
+            git_sha TEXT,
+            rig_id TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+
+        CREATE TABLE IF NOT EXISTS artifacts (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            path TEXT NOT NULL,
+            sha256 TEXT,
+            size_bytes INTEGER,
+            mime TEXT,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        );
+    "#,
+}];
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ObservationDbStatus {
+    pub path: String,
+    pub exists: bool,
+    pub schema_version: i64,
+    pub migration_count: i64,
+    pub table_count: i64,
+}
+
+pub struct ObservationStore {
+    connection: Connection,
+    path: PathBuf,
+}
+
+impl ObservationStore {
+    /// Open and lazily initialize the local observed-state database.
+    pub fn open_initialized() -> Result<Self> {
+        let path = database_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("create observation store dir {}", parent.display())),
+                )
+            })?;
+        }
+
+        let connection = open_connection(&path)?;
+        apply_migrations(&connection)?;
+        Ok(Self { connection, path })
+    }
+
+    pub fn status(&self) -> Result<ObservationDbStatus> {
+        status_for_open_connection(&self.connection, self.path.clone(), true)
+    }
+}
+
+pub fn database_path() -> Result<PathBuf> {
+    paths::observation_db()
+}
+
+/// Read local observation-store status without creating the database.
+pub fn status() -> Result<ObservationDbStatus> {
+    let path = database_path()?;
+    if !path.exists() {
+        return Ok(ObservationDbStatus {
+            path: path.to_string_lossy().to_string(),
+            exists: false,
+            schema_version: 0,
+            migration_count: 0,
+            table_count: 0,
+        });
+    }
+
+    let connection = open_connection(&path)?;
+    status_for_open_connection(&connection, path, true)
+}
+
+fn apply_migrations(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            );
+        "#,
+        )
+        .map_err(sqlite_error("create schema_migrations"))?;
+
+    for migration in MIGRATIONS {
+        if migration_applied(connection, migration.version)? {
+            continue;
+        }
+
+        let tx = connection
+            .unchecked_transaction()
+            .map_err(sqlite_error("begin observation migration"))?;
+        tx.execute_batch(migration.sql)
+            .map_err(sqlite_error(format!(
+                "apply migration {}",
+                migration.version
+            )))?;
+        tx.execute(
+            "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (?1, ?2)",
+            rusqlite::params![migration.version, chrono::Utc::now().to_rfc3339()],
+        )
+        .map_err(sqlite_error(format!(
+            "record migration {}",
+            migration.version
+        )))?;
+        tx.commit().map_err(sqlite_error(format!(
+            "commit migration {}",
+            migration.version
+        )))?;
+    }
+
+    Ok(())
+}
+
+fn migration_applied(connection: &Connection, version: i64) -> Result<bool> {
+    let count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = ?1",
+            [version],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error(format!("check migration {}", version)))?;
+    Ok(count > 0)
+}
+
+fn status_for_open_connection(
+    connection: &Connection,
+    path: PathBuf,
+    exists: bool,
+) -> Result<ObservationDbStatus> {
+    Ok(ObservationDbStatus {
+        path: path.to_string_lossy().to_string(),
+        exists,
+        schema_version: current_schema_version(connection)?,
+        migration_count: migration_count(connection)?,
+        table_count: table_count(connection)?,
+    })
+}
+
+fn current_schema_version(connection: &Connection) -> Result<i64> {
+    if !table_exists(connection, "schema_migrations")? {
+        return Ok(0);
+    }
+
+    connection
+        .query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error("read current schema version"))
+}
+
+fn migration_count(connection: &Connection) -> Result<i64> {
+    if !table_exists(connection, "schema_migrations")? {
+        return Ok(0);
+    }
+
+    connection
+        .query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| {
+            row.get(0)
+        })
+        .map_err(sqlite_error("count schema migrations"))
+}
+
+fn table_count(connection: &Connection) -> Result<i64> {
+    connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error("count observation tables"))
+}
+
+fn table_exists(connection: &Connection, table: &str) -> Result<bool> {
+    let count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [table],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error(format!("check table {}", table)))?;
+    Ok(count > 0)
+}
+
+fn open_connection(path: &Path) -> Result<Connection> {
+    Connection::open(path).map_err(sqlite_error(format!(
+        "open observation store {}",
+        path.display()
+    )))
+}
+
+fn sqlite_error(context: impl Into<String>) -> impl FnOnce(rusqlite::Error) -> Error {
+    let context = context.into();
+    move |error| {
+        Error::internal_unexpected(format!(
+            "SQLite observation store error: {context}: {error}"
+        ))
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/observation/store_test.rs"]
+mod store_test;

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -30,6 +30,48 @@ pub fn homeboy_json() -> Result<PathBuf> {
     Ok(homeboy()?.join("homeboy.json"))
 }
 
+/// Base Homeboy data directory for local observed state.
+///
+/// Config/spec files remain under `homeboy()` (`~/.config/homeboy`). This
+/// directory is for machine-local observations such as the SQLite store.
+pub fn homeboy_data() -> Result<PathBuf> {
+    #[cfg(windows)]
+    {
+        let base = env::var("LOCALAPPDATA")
+            .or_else(|_| env::var("APPDATA"))
+            .map_err(|_| {
+                Error::internal_unexpected(
+                    "LOCALAPPDATA or APPDATA environment variable not set on Windows".to_string(),
+                )
+            })?;
+        Ok(PathBuf::from(base).join("homeboy"))
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
+            if !xdg_data_home.trim().is_empty() {
+                return Ok(PathBuf::from(xdg_data_home).join("homeboy"));
+            }
+        }
+
+        let home = env::var("HOME").map_err(|_| {
+            Error::internal_unexpected(
+                "HOME environment variable not set on Unix-like system".to_string(),
+            )
+        })?;
+        Ok(PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("homeboy"))
+    }
+}
+
+/// Local SQLite observation-store path.
+pub fn observation_db() -> Result<PathBuf> {
+    Ok(homeboy_data()?.join("homeboy.sqlite"))
+}
+
 /// Projects directory
 pub fn projects() -> Result<PathBuf> {
     Ok(homeboy()?.join("projects"))

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -1,0 +1,100 @@
+//! Observation-store foundation tests.
+//!
+//! These isolate `HOME` / `XDG_DATA_HOME` so the developer's real local DB is
+//! never read or written.
+
+use crate::observation::store::{self, ObservationStore, CURRENT_SCHEMA_VERSION};
+use crate::test_support::with_isolated_home;
+
+struct XdgGuard {
+    prior: Option<String>,
+}
+
+impl XdgGuard {
+    fn unset() -> Self {
+        let prior = std::env::var("XDG_DATA_HOME").ok();
+        std::env::remove_var("XDG_DATA_HOME");
+        Self { prior }
+    }
+
+    fn set(value: &std::path::Path) -> Self {
+        let prior = std::env::var("XDG_DATA_HOME").ok();
+        std::env::set_var("XDG_DATA_HOME", value);
+        Self { prior }
+    }
+}
+
+impl Drop for XdgGuard {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+    }
+}
+
+#[test]
+fn status_reports_missing_database_without_initializing() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+
+        let status = store::status().expect("status");
+
+        assert!(!status.exists);
+        assert_eq!(status.schema_version, 0);
+        assert_eq!(status.migration_count, 0);
+        assert_eq!(status.table_count, 0);
+        assert_eq!(
+            status.path,
+            home.path()
+                .join(".local/share/homeboy/homeboy.sqlite")
+                .to_string_lossy()
+        );
+        assert!(
+            !std::path::Path::new(&status.path).exists(),
+            "read-only status must not create the DB"
+        );
+    });
+}
+
+#[test]
+fn xdg_data_home_overrides_default_database_path() {
+    with_isolated_home(|home| {
+        let data_home = home.path().join("xdg-data");
+        let _xdg = XdgGuard::set(&data_home);
+
+        let path = store::database_path().expect("db path");
+
+        assert_eq!(path, data_home.join("homeboy/homeboy.sqlite"));
+    });
+}
+
+#[test]
+fn initialization_creates_schema_and_status_reports_version() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+
+        let store = ObservationStore::open_initialized().expect("init store");
+        let status = store.status().expect("status");
+
+        assert!(status.exists);
+        assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(status.migration_count, 1);
+        assert_eq!(status.table_count, 3);
+    });
+}
+
+#[test]
+fn initialization_is_idempotent() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+
+        ObservationStore::open_initialized().expect("first init");
+        let second = ObservationStore::open_initialized().expect("second init");
+        let status = second.status().expect("status");
+
+        assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(status.migration_count, 1);
+        assert_eq!(status.table_count, 3);
+    });
+}


### PR DESCRIPTION
## Summary

- Adds a local SQLite observation-store foundation under `core::observation`, with XDG data-path resolution, lazy initialization, and idempotent schema migrations.
- Creates the initial observed-state tables (`schema_migrations`, `runs`, `artifacts`) while keeping config/spec files file-backed.
- Adds `homeboy db status` to report DB path, existence, schema version, migration count, and table count without creating the DB.

## Tests

- `cargo test observation`
- `cargo test db`
- `HOME=$(mktemp -d) XDG_DATA_HOME= target/debug/homeboy db status`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@obs-store-sqlite-foundation`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@obs-store-sqlite-foundation --changed-since origin/main`

Closes #2021
Refs #2015

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the SQLite observation-store foundation, CLI status surface, and focused tests; Chris remains responsible for review and validation.
