### PR TITLE
feat(rig): persist observation runs

### DIFF
--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -21,6 +21,7 @@ use super::state::{
 };
 use crate::engine::command::run_in_optional;
 use crate::error::{Error, Result};
+use crate::observation::{NewRunRecord, ObservationStore, RunStatus};
 
 /// Report from `rig up`.
 #[derive(Debug, Clone, Serialize)]
@@ -119,44 +120,69 @@ pub enum SymlinkStatusState {
 /// Materialize a rig: run the `up` pipeline, stash timestamp in state.
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     let _lease = acquire_active_run_lease(rig, "up")?;
-    let outcome = run_pipeline(rig, "up", true)?;
+    let observer = RigRunObserver::start(rig, "up");
 
-    if outcome.is_success() {
-        let mut state = RigState::load(&rig.id)?;
-        let materialized_at = now_rfc3339();
-        let snapshot = snapshot_state(rig);
-        state.last_up = Some(materialized_at.clone());
-        state.materialized = Some(MaterializedRigState {
+    let result = (|| {
+        let outcome = run_pipeline(rig, "up", true)?;
+
+        if outcome.is_success() {
+            let mut state = RigState::load(&rig.id)?;
+            let materialized_at = now_rfc3339();
+            let snapshot = snapshot_state(rig);
+            state.last_up = Some(materialized_at.clone());
+            state.materialized = Some(MaterializedRigState {
+                rig_id: rig.id.clone(),
+                materialized_at,
+                resources: expand_resources(rig),
+                components: snapshot.components,
+            });
+            state.save(&rig.id)?;
+        }
+
+        Ok(UpReport {
             rig_id: rig.id.clone(),
-            materialized_at,
-            resources: expand_resources(rig),
-            components: snapshot.components,
-        });
-        state.save(&rig.id)?;
-    }
+            success: outcome.is_success(),
+            pipeline: outcome,
+        })
+    })();
 
-    Ok(UpReport {
-        rig_id: rig.id.clone(),
-        success: outcome.is_success(),
-        pipeline: outcome,
-    })
+    RigRunObserver::finish(
+        observer.as_ref(),
+        rig,
+        result.as_ref().ok().map(|report| &report.pipeline),
+        &result,
+    );
+    result
 }
 
 /// Run the `check` pipeline. Unlike `up`, does NOT fail-fast — reports every
 /// failing check so the user can fix them all in one pass.
 pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
-    let outcome = run_pipeline(rig, "check", false)?;
+    let observer = RigRunObserver::start(rig, "check");
 
-    let mut state = RigState::load(&rig.id)?;
-    state.last_check = Some(now_rfc3339());
-    state.last_check_result = Some(if outcome.is_success() { "pass" } else { "fail" }.to_string());
-    state.save(&rig.id)?;
+    let result = (|| {
+        let outcome = run_pipeline(rig, "check", false)?;
 
-    Ok(CheckReport {
-        rig_id: rig.id.clone(),
-        success: outcome.is_success(),
-        pipeline: outcome,
-    })
+        let mut state = RigState::load(&rig.id)?;
+        state.last_check = Some(now_rfc3339());
+        state.last_check_result =
+            Some(if outcome.is_success() { "pass" } else { "fail" }.to_string());
+        state.save(&rig.id)?;
+
+        Ok(CheckReport {
+            rig_id: rig.id.clone(),
+            success: outcome.is_success(),
+            pipeline: outcome,
+        })
+    })();
+
+    RigRunObserver::finish(
+        observer.as_ref(),
+        rig,
+        result.as_ref().ok().map(|report| &report.pipeline),
+        &result,
+    );
+    result
 }
 
 /// Run only the grouped check-pipeline steps required by a workload command.
@@ -478,6 +504,86 @@ pub fn snapshot_state(rig: &RigSpec) -> RigStateSnapshot {
     }
 }
 
+struct RigRunObserver {
+    store: ObservationStore,
+    run_id: String,
+    command: String,
+}
+
+impl RigRunObserver {
+    fn start(rig: &RigSpec, command: &str) -> Option<Self> {
+        let store = ObservationStore::open_initialized().ok()?;
+        let run = store
+            .start_run(NewRunRecord {
+                kind: "rig".to_string(),
+                component_id: None,
+                command: Some(format!("rig.{command}")),
+                cwd: std::env::current_dir()
+                    .ok()
+                    .map(|path| path.to_string_lossy().to_string()),
+                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                git_sha: None,
+                rig_id: Some(rig.id.clone()),
+                metadata_json: rig_observation_metadata(rig, command, None, None, None),
+            })
+            .ok()?;
+
+        Some(Self {
+            store,
+            run_id: run.id,
+            command: command.to_string(),
+        })
+    }
+
+    fn finish<T>(
+        observer: Option<&Self>,
+        rig: &RigSpec,
+        pipeline: Option<&PipelineOutcome>,
+        result: &Result<T>,
+    ) {
+        let Some(observer) = observer else {
+            return;
+        };
+        let status = match result {
+            Ok(_) if pipeline.is_some_and(PipelineOutcome::is_success) => RunStatus::Pass,
+            Ok(_) => RunStatus::Fail,
+            Err(_) => RunStatus::Error,
+        };
+        let error = result.as_ref().err().map(ToString::to_string);
+        let state = RigState::load(&rig.id).ok();
+        let metadata =
+            rig_observation_metadata(rig, &observer.command, state, pipeline, error.as_deref());
+        let _ = observer
+            .store
+            .finish_run(&observer.run_id, status, Some(metadata));
+    }
+}
+
+fn rig_observation_metadata(
+    rig: &RigSpec,
+    command: &str,
+    state: Option<RigState>,
+    pipeline: Option<&PipelineOutcome>,
+    error: Option<&str>,
+) -> serde_json::Value {
+    let source = super::install::read_source_metadata(&rig.id);
+    serde_json::json!({
+        "rig_id": rig.id,
+        "command": command,
+        "rig_source": source.as_ref().map(|source| &source.source),
+        "rig_revision": source.as_ref().and_then(|source| source.source_revision.as_deref()),
+        "source": source,
+        "state": state,
+        "component_snapshot": snapshot_state(rig),
+        "pipeline": pipeline,
+        "error": error,
+    })
+}
+
 #[cfg(test)]
 #[path = "../../../tests/core/rig/runner_test.rs"]
 mod runner_test;
+
+#[cfg(test)]
+#[path = "../../../tests/core/rig/runner_observation_test.rs"]
+mod runner_observation_test;

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -1,0 +1,266 @@
+//! Observation-store persistence tests for `src/core/rig/runner.rs`.
+
+use std::collections::HashMap;
+use std::process::Command;
+
+use crate::observation::{ObservationStore, RunListFilter};
+use crate::paths;
+use crate::rig::runner::{run_check, run_up};
+use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+use crate::rig::{RigSourceMetadata, RigState};
+use crate::test_support::with_isolated_home;
+
+fn observation_spec(id: &str) -> RigSpec {
+    RigSpec {
+        id: id.to_string(),
+        description: "observation persistence fixture".to_string(),
+        components: HashMap::new(),
+        services: HashMap::new(),
+        symlinks: Vec::new(),
+        shared_paths: Vec::new(),
+        resources: Default::default(),
+        pipeline: HashMap::new(),
+        bench: None,
+        bench_workloads: HashMap::new(),
+        trace_workloads: HashMap::new(),
+        bench_profiles: HashMap::new(),
+        app_launcher: None,
+    }
+}
+
+struct XdgDataHomeGuard(Option<String>);
+
+impl XdgDataHomeGuard {
+    fn unset() -> Self {
+        let prior = std::env::var("XDG_DATA_HOME").ok();
+        std::env::remove_var("XDG_DATA_HOME");
+        Self(prior)
+    }
+
+    fn set(value: String) -> Self {
+        let prior = std::env::var("XDG_DATA_HOME").ok();
+        std::env::set_var("XDG_DATA_HOME", value);
+        Self(prior)
+    }
+}
+
+impl Drop for XdgDataHomeGuard {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+    }
+}
+
+fn list_rig_runs(rig_id: &str) -> Vec<crate::observation::RunRecord> {
+    ObservationStore::open_initialized()
+        .expect("observation store")
+        .list_runs(RunListFilter {
+            kind: Some("rig".to_string()),
+            rig_id: Some(rig_id.to_string()),
+            ..RunListFilter::default()
+        })
+        .expect("list rig runs")
+}
+
+#[test]
+fn test_run_check_persists_passing_observation() {
+    with_isolated_home(|_dir| {
+        let _xdg = XdgDataHomeGuard::unset();
+        let rig = observation_spec("observed-check-pass");
+
+        let report = run_check(&rig).expect("check succeeds");
+        assert!(report.success);
+
+        let runs = list_rig_runs(&rig.id);
+        assert_eq!(runs.len(), 1);
+        let run = &runs[0];
+        assert_eq!(run.status, "pass");
+        assert_eq!(run.command.as_deref(), Some("rig.check"));
+        assert_eq!(run.rig_id.as_deref(), Some("observed-check-pass"));
+        assert_eq!(run.metadata_json["command"], "check");
+        assert_eq!(run.metadata_json["pipeline"]["name"], "check");
+        assert_eq!(
+            run.metadata_json["pipeline"]["steps"]
+                .as_array()
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            run.metadata_json["state"]["last_check_result"],
+            serde_json::Value::String("pass".to_string())
+        );
+    });
+}
+
+#[test]
+fn test_run_check_persists_failing_observation() {
+    with_isolated_home(|_dir| {
+        let _xdg = XdgDataHomeGuard::unset();
+        let mut rig = observation_spec("observed-check-fail");
+        rig.pipeline.insert(
+            "check".to_string(),
+            vec![PipelineStep::Command {
+                step_id: None,
+                depends_on: Vec::new(),
+                cmd: "false".to_string(),
+                cwd: None,
+                env: HashMap::new(),
+                label: Some("intentional check failure".to_string()),
+            }],
+        );
+
+        let report = run_check(&rig).expect("check returns failed report");
+        assert!(!report.success);
+
+        let runs = list_rig_runs(&rig.id);
+        assert_eq!(runs.len(), 1);
+        let run = &runs[0];
+        assert_eq!(run.status, "fail");
+        assert_eq!(run.metadata_json["pipeline"]["failed"], 1);
+        assert_eq!(
+            run.metadata_json["pipeline"]["steps"][0]["label"],
+            "intentional check failure"
+        );
+        assert_eq!(run.metadata_json["pipeline"]["steps"][0]["status"], "fail");
+        assert!(run.metadata_json["pipeline"]["steps"][0]["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("exited 1"));
+    });
+}
+
+#[test]
+fn test_run_up_persists_step_order_source_and_component_snapshot() {
+    with_isolated_home(|home| {
+        let _xdg = XdgDataHomeGuard::unset();
+        let repo = home.path().join("component-repo");
+        std::fs::create_dir(&repo).expect("repo dir");
+        git(&repo, &["init"]);
+        git(&repo, &["config", "user.email", "tests@example.com"]);
+        git(&repo, &["config", "user.name", "Tests"]);
+        std::fs::write(repo.join("README.md"), "fixture").expect("write fixture");
+        git(&repo, &["add", "README.md"]);
+        git(&repo, &["commit", "-m", "initial"]);
+        let sha = git_output(&repo, &["rev-parse", "HEAD"]);
+
+        let mut rig = observation_spec("observed-up");
+        rig.components.insert(
+            "component".to_string(),
+            ComponentSpec {
+                path: repo.to_string_lossy().to_string(),
+                remote_url: None,
+                triage_remote_url: None,
+                stack: None,
+                branch: None,
+                extensions: None,
+            },
+        );
+        rig.pipeline.insert(
+            "up".to_string(),
+            vec![
+                PipelineStep::Command {
+                    step_id: None,
+                    depends_on: Vec::new(),
+                    cmd: "true".to_string(),
+                    cwd: None,
+                    env: HashMap::new(),
+                    label: Some("first".to_string()),
+                },
+                PipelineStep::Command {
+                    step_id: None,
+                    depends_on: Vec::new(),
+                    cmd: "true".to_string(),
+                    cwd: None,
+                    env: HashMap::new(),
+                    label: Some("second".to_string()),
+                },
+            ],
+        );
+        write_rig_source_metadata(&rig.id);
+
+        let report = run_up(&rig).expect("up succeeds");
+        assert!(report.success);
+
+        let runs = list_rig_runs(&rig.id);
+        assert_eq!(runs.len(), 1);
+        let metadata = &runs[0].metadata_json;
+        assert_eq!(runs[0].status, "pass");
+        assert_eq!(metadata["command"], "up");
+        assert_eq!(metadata["rig_source"], "https://example.com/rigs.git");
+        assert_eq!(metadata["rig_revision"], "abc123");
+        assert_eq!(metadata["pipeline"]["steps"][0]["label"], "first");
+        assert_eq!(metadata["pipeline"]["steps"][1]["label"], "second");
+        assert_eq!(
+            metadata["component_snapshot"]["components"]["component"]["sha"],
+            sha
+        );
+        assert_eq!(
+            metadata["state"]["materialized"]["components"]["component"]["sha"],
+            sha
+        );
+    });
+}
+
+#[test]
+fn test_observation_store_failure_does_not_fail_rig_check() {
+    with_isolated_home(|home| {
+        let data_home_file = home.path().join("not-a-directory");
+        std::fs::write(&data_home_file, "file").expect("write blocking data home file");
+        let _xdg = XdgDataHomeGuard::set(data_home_file.to_string_lossy().to_string());
+        let rig = observation_spec("observed-check-db-unavailable");
+
+        let report = run_check(&rig).expect("observation failure must not fail check");
+
+        assert!(report.success);
+        assert_eq!(
+            RigState::load(&rig.id)
+                .expect("state still writes")
+                .last_check_result
+                .as_deref(),
+            Some("pass")
+        );
+    });
+}
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+fn git_output(repo: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(output.status.success(), "git {:?} failed", args);
+    String::from_utf8(output.stdout)
+        .expect("utf8")
+        .trim()
+        .to_string()
+}
+
+fn write_rig_source_metadata(rig_id: &str) {
+    let path = paths::rig_source_metadata(rig_id).expect("metadata path");
+    std::fs::create_dir_all(path.parent().expect("metadata parent")).expect("metadata dir");
+    std::fs::write(
+        path,
+        serde_json::to_string(&RigSourceMetadata {
+            source: "https://example.com/rigs.git".to_string(),
+            package_path: "/tmp/rigs".to_string(),
+            rig_path: "/tmp/rigs/rig.json".to_string(),
+            discovery_path: Some("/tmp/rigs".to_string()),
+            linked: false,
+            source_revision: Some("abc123".to_string()),
+        })
+        .expect("serialize source metadata"),
+    )
+    .expect("write source metadata");
+}


### PR DESCRIPTION
## Summary
- Persist `rig up` and `rig check` executions as generic observation-store runs with `kind=rig`.
- Store command, rig source/revision, active state snapshot, component SHAs, ordered pipeline outcomes, and errors in run metadata JSON.
- Keep rig specs and active `.state/state.json` lifecycle state file-backed.

## Tests
- `cargo test runner_test`
- `cargo test rig`
- `cargo test observation`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@obs-store-rig-history`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@obs-store-rig-history --changed-since origin/main`

Closes #2019
Refs #2015

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the rig observation persistence implementation and PR description; Chris remains responsible for review and merge.
