### PR TITLE
feat(bench): persist observation runs

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -20,6 +20,7 @@ use super::utils::args::{
 use super::{CmdResult, GlobalArgs};
 
 mod matrix;
+mod observation;
 
 #[derive(Args)]
 pub struct BenchArgs {

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -11,6 +11,7 @@ use homeboy::extension::bench::{
 use homeboy::extension::ExtensionCapability;
 use homeboy::rig::{self, BenchSpec, RigSpec, RigStateSnapshot};
 
+use super::observation::{self, BenchObservationStart};
 use super::{BenchRunArgs, CmdResult};
 
 struct RigBenchContext {
@@ -388,6 +389,18 @@ fn run_component_with_rig_context(
         })
         .unwrap_or_default();
 
+    let selected_scenarios = selected_scenario_ids(args, rig_spec)?;
+    let observation = observation::start(BenchObservationStart {
+        component_id: &ctx.component_id,
+        component_label: &effective_id,
+        source_path: &ctx.source_path,
+        args,
+        selected_scenarios: &selected_scenarios,
+        rig_id: rig_id.as_deref(),
+        rig_snapshot: rig_snapshot.as_ref(),
+        run_dir: &run_dir,
+    });
+
     let workflow = extension_bench::run_main_bench_workflow(
         &ctx.component,
         &ctx.source_path,
@@ -425,15 +438,27 @@ fn run_component_with_rig_context(
             regression_threshold_percent: args.regression_threshold,
             json_summary: args.json_summary,
             passthrough_args: passthrough_args.to_vec(),
-            scenario_ids: selected_scenario_ids(args, rig_spec)?,
+            scenario_ids: selected_scenarios,
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
             extra_workloads,
         },
         &run_dir,
     );
-    resource_run.write_to_run_dir(&run_dir)?;
-    let workflow = workflow?;
+    if let Err(error) = resource_run.write_to_run_dir(&run_dir) {
+        observation::finish_error(observation, &error, &run_dir);
+        return Err(error);
+    }
+    let workflow = match workflow {
+        Ok(workflow) => {
+            observation::finish_success(observation, &workflow, &run_dir);
+            workflow
+        }
+        Err(error) => {
+            observation::finish_error(observation, &error, &run_dir);
+            return Err(error);
+        }
+    };
 
     Ok(extension_bench::from_main_workflow_with_rig(
         workflow,

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -1,0 +1,467 @@
+use std::path::{Path, PathBuf};
+
+use homeboy::engine::run_dir::{self, RunDir};
+use homeboy::extension::bench::report::collect_artifacts;
+use homeboy::extension::bench::{BenchResults, BenchRunWorkflowResult};
+use homeboy::git::short_head_revision_at;
+use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
+use homeboy::rig::RigStateSnapshot;
+
+use super::BenchRunArgs;
+
+pub(super) struct BenchObservation {
+    store: ObservationStore,
+    run: RunRecord,
+    initial_metadata: serde_json::Value,
+}
+
+pub(super) struct BenchObservationStart<'a> {
+    pub component_id: &'a str,
+    pub component_label: &'a str,
+    pub source_path: &'a Path,
+    pub args: &'a BenchRunArgs,
+    pub selected_scenarios: &'a [String],
+    pub rig_id: Option<&'a str>,
+    pub rig_snapshot: Option<&'a RigStateSnapshot>,
+    pub run_dir: &'a RunDir,
+}
+
+pub(super) fn start(start: BenchObservationStart<'_>) -> Option<BenchObservation> {
+    let store = ObservationStore::open_initialized().ok()?;
+    let metadata = bench_observation_initial_metadata(
+        start.component_label,
+        start.args,
+        start.selected_scenarios,
+        start.rig_snapshot,
+        start.run_dir,
+    );
+    let run = store
+        .start_run(NewRunRecord {
+            kind: "bench".to_string(),
+            component_id: Some(start.component_id.to_string()),
+            command: Some(bench_observation_command(
+                start.component_id,
+                start.args,
+                start.rig_id,
+            )),
+            cwd: Some(start.source_path.to_string_lossy().to_string()),
+            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            git_sha: short_head_revision_at(start.source_path),
+            rig_id: start.rig_id.map(str::to_string),
+            metadata_json: metadata.clone(),
+        })
+        .ok()?;
+
+    Some(BenchObservation {
+        store,
+        run,
+        initial_metadata: metadata,
+    })
+}
+
+pub(super) fn finish_success(
+    observation: Option<BenchObservation>,
+    workflow: &BenchRunWorkflowResult,
+    run_dir: &RunDir,
+) {
+    let Some(observation) = observation else {
+        return;
+    };
+
+    record_bench_observation_artifacts(&observation, workflow, run_dir);
+    let metadata = bench_observation_finish_metadata(observation.initial_metadata, workflow);
+    let status = if workflow.exit_code == 0 {
+        RunStatus::Pass
+    } else {
+        RunStatus::Fail
+    };
+    let _ = observation
+        .store
+        .finish_run(&observation.run.id, status, Some(metadata));
+}
+
+pub(super) fn finish_error(
+    observation: Option<BenchObservation>,
+    error: &homeboy::Error,
+    run_dir: &RunDir,
+) {
+    let Some(observation) = observation else {
+        return;
+    };
+
+    record_if_exists(
+        &observation,
+        "bench_results",
+        run_dir.step_file(run_dir::files::BENCH_RESULTS),
+    );
+    record_if_exists(
+        &observation,
+        "resource_summary",
+        run_dir.step_file(run_dir::files::RESOURCE_SUMMARY),
+    );
+    let metadata = merge_observation_metadata(
+        observation.initial_metadata,
+        serde_json::json!({
+            "observation_status": "error",
+            "error": error.to_string(),
+        }),
+    );
+    let _ = observation
+        .store
+        .finish_run(&observation.run.id, RunStatus::Error, Some(metadata));
+}
+
+fn bench_observation_command(
+    component_id: &str,
+    args: &BenchRunArgs,
+    rig_id: Option<&str>,
+) -> String {
+    let mut parts = vec![
+        "homeboy".to_string(),
+        "bench".to_string(),
+        component_id.to_string(),
+    ];
+    if let Some(rig_id) = rig_id {
+        parts.push(format!("--rig={rig_id}"));
+    }
+    if args.iterations != 10 {
+        parts.push(format!("--iterations={}", args.iterations));
+    }
+    if args.runs != 1 {
+        parts.push(format!("--runs={}", args.runs));
+    }
+    if args.concurrency != 1 {
+        parts.push(format!("--concurrency={}", args.concurrency));
+    }
+    parts.join(" ")
+}
+
+fn bench_observation_initial_metadata(
+    component_label: &str,
+    args: &BenchRunArgs,
+    selected_scenarios: &[String],
+    rig_snapshot: Option<&RigStateSnapshot>,
+    run_dir: &RunDir,
+) -> serde_json::Value {
+    serde_json::json!({
+        "component_label": component_label,
+        "iterations": args.iterations,
+        "warmup_iterations": args.warmup,
+        "runs": args.runs,
+        "concurrency": args.concurrency,
+        "regression_threshold_percent": args.regression_threshold,
+        "baseline": {
+            "baseline": args.baseline_args.baseline,
+            "ignore_baseline": args.baseline_args.ignore_baseline,
+            "ratchet": args.baseline_args.ratchet,
+        },
+        "profile": args.profile,
+        "selected_scenarios": selected_scenarios,
+        "shared_state": args.shared_state.as_ref().map(|path| path.to_string_lossy().to_string()),
+        "run_dir": run_dir.path().to_string_lossy().to_string(),
+        "rig_state": rig_snapshot,
+    })
+}
+
+fn bench_observation_finish_metadata(
+    initial_metadata: serde_json::Value,
+    workflow: &BenchRunWorkflowResult,
+) -> serde_json::Value {
+    merge_observation_metadata(
+        initial_metadata,
+        serde_json::json!({
+            "observation_status": workflow.status,
+            "exit_code": workflow.exit_code,
+            "gate_failures": workflow.gate_failures,
+            "baseline_status": baseline_status(workflow),
+            "failure": workflow.failure,
+            "results": workflow.results,
+            "scenario_metrics": workflow.results.as_ref().map(scenario_metric_summaries).unwrap_or_default(),
+        }),
+    )
+}
+
+fn merge_observation_metadata(
+    mut initial: serde_json::Value,
+    finish: serde_json::Value,
+) -> serde_json::Value {
+    if let (Some(initial), Some(finish)) = (initial.as_object_mut(), finish.as_object()) {
+        for (key, value) in finish {
+            initial.insert(key.clone(), value.clone());
+        }
+    }
+    initial
+}
+
+fn baseline_status(workflow: &BenchRunWorkflowResult) -> Option<&'static str> {
+    workflow.baseline_comparison.as_ref().map(|comparison| {
+        if comparison.regression {
+            "regression"
+        } else if comparison.has_improvements {
+            "improved"
+        } else {
+            "unchanged"
+        }
+    })
+}
+
+fn scenario_metric_summaries(results: &BenchResults) -> Vec<serde_json::Value> {
+    results
+        .scenarios
+        .iter()
+        .map(|scenario| {
+            serde_json::json!({
+                "scenario_id": scenario.id,
+                "iterations": scenario.iterations,
+                "passed": scenario.passed,
+                "metrics": scenario.metrics,
+                "metric_groups": scenario.metric_groups,
+                "memory": scenario.memory,
+                "artifact_count": scenario.artifacts.len(),
+                "run_count": scenario.runs.as_ref().map(Vec::len),
+                "runs_summary": scenario.runs_summary,
+            })
+        })
+        .collect()
+}
+
+fn record_bench_observation_artifacts(
+    observation: &BenchObservation,
+    workflow: &BenchRunWorkflowResult,
+    run_dir: &RunDir,
+) {
+    record_if_exists(
+        observation,
+        "bench_results",
+        run_dir.step_file(run_dir::files::BENCH_RESULTS),
+    );
+    record_if_exists(
+        observation,
+        "resource_summary",
+        run_dir.step_file(run_dir::files::RESOURCE_SUMMARY),
+    );
+
+    let Some(results) = workflow.results.as_ref() else {
+        return;
+    };
+    for artifact in collect_artifacts(results) {
+        let path = resolve_bench_artifact_path(&artifact.path, run_dir);
+        record_if_exists(observation, "bench_artifact", path);
+    }
+}
+
+fn record_if_exists(observation: &BenchObservation, kind: &str, path: PathBuf) {
+    if path.is_file() {
+        let _ = observation
+            .store
+            .record_artifact(&observation.run.id, kind, path);
+    }
+}
+
+fn resolve_bench_artifact_path(path: &str, run_dir: &RunDir) -> PathBuf {
+    let artifact_path = PathBuf::from(path);
+    if artifact_path.is_absolute() || artifact_path.exists() {
+        return artifact_path;
+    }
+    let run_dir_path = run_dir.path().join(path);
+    if run_dir_path.exists() {
+        return run_dir_path;
+    }
+    artifact_path
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use homeboy::engine::run_dir::{self, RunDir};
+    use homeboy::extension::bench::artifact::BenchArtifact;
+    use homeboy::extension::bench::{BenchResults, BenchRunWorkflowResult};
+    use homeboy::observation::ObservationStore;
+
+    use super::*;
+    use crate::commands::bench::BenchRigOrder;
+    use crate::commands::utils::args::{
+        BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
+    };
+    use crate::test_support::with_isolated_home;
+
+    struct XdgGuard(Option<String>);
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    fn bench_results(component_id: &str, scenario_id: &str, p95: f64) -> BenchResults {
+        serde_json::from_value(serde_json::json!({
+            "component_id": component_id,
+            "iterations": 10,
+            "scenarios": [
+                {
+                    "id": scenario_id,
+                    "iterations": 10,
+                    "metrics": { "p95_ms": p95 }
+                }
+            ],
+            "metric_policies": {
+                "p95_ms": { "direction": "lower_is_better" }
+            }
+        }))
+        .expect("bench results")
+    }
+
+    fn bench_args() -> BenchRunArgs {
+        BenchRunArgs {
+            comp: PositionalComponentArgs {
+                component: Some("homeboy".to_string()),
+                path: None,
+            },
+            extension_override: ExtensionOverrideArgs::default(),
+            iterations: 10,
+            warmup: None,
+            runs: 1,
+            shared_state: None,
+            concurrency: 1,
+            baseline_args: BaselineArgs::default(),
+            regression_threshold: 5.0,
+            setting_args: SettingArgs::default(),
+            args: Vec::new(),
+            _json: HiddenJsonArgs::default(),
+            json_summary: false,
+            rig: Vec::new(),
+            rig_order: BenchRigOrder::Input,
+            scenario_ids: Vec::new(),
+            profile: None,
+            ignore_default_baseline: false,
+        }
+    }
+
+    #[test]
+    fn bench_observation_persists_success_with_metrics_and_artifacts() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let run_dir = RunDir::create().expect("run dir");
+            fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+            fs::write(run_dir.step_file(run_dir::files::RESOURCE_SUMMARY), b"{}")
+                .expect("resources");
+            let artifact_path = run_dir.path().join("bench-artifacts/cold/transcript.json");
+            fs::create_dir_all(artifact_path.parent().expect("artifact parent")).expect("mkdir");
+            fs::write(&artifact_path, b"{\"ok\":true}").expect("artifact");
+
+            let mut results = bench_results("homeboy", "cold", 42.0);
+            results.scenarios[0].artifacts.insert(
+                "transcript".to_string(),
+                BenchArtifact {
+                    path: "bench-artifacts/cold/transcript.json".to_string(),
+                    kind: Some("json".to_string()),
+                    label: Some("Transcript".to_string()),
+                },
+            );
+            let workflow = BenchRunWorkflowResult {
+                status: "passed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 0,
+                iterations: 10,
+                results: Some(results),
+                gate_failures: Vec::new(),
+                baseline_comparison: None,
+                hints: None,
+                failure: None,
+            };
+
+            let args = bench_args();
+            let selected_scenarios = vec!["cold".to_string()];
+            let observation = start(BenchObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: home.path(),
+                args: &args,
+                selected_scenarios: &selected_scenarios,
+                rig_id: None,
+                rig_snapshot: None,
+                run_dir: &run_dir,
+            })
+            .expect("start observation");
+            let run_id = observation.run.id.clone();
+            finish_success(Some(observation), &workflow, &run_dir);
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.get_run(&run_id).expect("read run").expect("run");
+            assert_eq!(run.kind, "bench");
+            assert_eq!(run.status, "pass");
+            assert_eq!(run.component_id.as_deref(), Some("homeboy"));
+            assert_eq!(run.metadata_json["selected_scenarios"][0], "cold");
+            assert_eq!(
+                run.metadata_json["scenario_metrics"][0]["scenario_id"],
+                "cold"
+            );
+            assert_eq!(
+                run.metadata_json["scenario_metrics"][0]["metrics"]["p95_ms"],
+                42.0
+            );
+
+            let artifacts = store.list_artifacts(&run_id).expect("artifacts");
+            let kinds: Vec<_> = artifacts
+                .iter()
+                .map(|artifact| artifact.kind.as_str())
+                .collect();
+            assert!(kinds.contains(&"bench_results"));
+            assert!(kinds.contains(&"resource_summary"));
+            assert!(kinds.contains(&"bench_artifact"));
+        });
+    }
+
+    #[test]
+    fn bench_observation_persists_workflow_error() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let run_dir = RunDir::create().expect("run dir");
+            fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+            let mut args = bench_args();
+            args.rig = vec!["studio".to_string()];
+
+            let observation = start(BenchObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: home.path(),
+                args: &args,
+                selected_scenarios: &[],
+                rig_id: Some("studio"),
+                rig_snapshot: None,
+                run_dir: &run_dir,
+            })
+            .expect("start observation");
+            let run_id = observation.run.id.clone();
+            let error = homeboy::Error::validation_invalid_argument(
+                "bench",
+                "synthetic bench error",
+                None,
+                None,
+            );
+            finish_error(Some(observation), &error, &run_dir);
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.get_run(&run_id).expect("read run").expect("run");
+            assert_eq!(run.status, "error");
+            assert_eq!(run.rig_id.as_deref(), Some("studio"));
+            assert!(run.metadata_json["error"]
+                .as_str()
+                .expect("error string")
+                .contains("synthetic bench error"));
+            assert_eq!(store.list_artifacts(&run_id).expect("artifacts").len(), 1);
+        });
+    }
+}

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
 use std::thread;
 
@@ -722,27 +721,12 @@ fn is_secret_like_env_key(key: &str) -> bool {
 }
 
 fn source_revision_at(path: &Path) -> Option<String> {
-    git_short_revision_at(path).or_else(|| {
+    crate::git::short_head_revision_at(path).or_else(|| {
         std::fs::read_to_string(path.join(".source-revision"))
             .ok()
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
     })
-}
-
-fn git_short_revision_at(path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .current_dir(path)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!revision.is_empty()).then_some(revision)
 }
 
 fn run_sequential_runs(

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::process::Command;
 
 use crate::config::read_json_spec_to_string;
@@ -1073,6 +1074,22 @@ pub fn get_head_commit(path: &str) -> Result<String> {
     crate::engine::command::run_in(path, "git", &["rev-parse", "HEAD"], "get HEAD commit")
 }
 
+/// Get the current HEAD short commit SHA, returning `None` outside git checkouts.
+pub fn short_head_revision_at(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!revision.is_empty()).then_some(revision)
+}
+
 /// Fetch from remote and return count of commits behind upstream.
 /// Returns Ok(Some(n)) if behind by n commits, Ok(None) if not behind or no upstream.
 pub fn fetch_and_get_behind_count(path: &str) -> Result<Option<u32>> {
@@ -1659,5 +1676,15 @@ mod tests {
             "--force-with-lease should be a known flag, got: {}",
             out.stderr
         );
+    }
+
+    #[test]
+    fn test_short_head_revision_at() {
+        let (_dir, path) = init_repo_with_initial_commit();
+
+        let revision = short_head_revision_at(Path::new(&path)).expect("short revision");
+
+        assert!(!revision.is_empty());
+        assert!(revision.len() <= 12, "unexpected short sha: {revision}");
     }
 }


### PR DESCRIPTION
## Summary
- Persist `homeboy bench` executions as generic observation-store `bench` runs.
- Finish observations as pass/fail/error and store bench envelope, scenario metric summaries, rig context, command context, version, git SHA, and run-dir details in `metadata_json`.
- Attach available bench result/resource files and scenario artifact paths to the run artifact index without changing bench stdout/stderr or baseline behavior.

## Tests
- `cargo test bench_observation`
- `cargo test bench`
- `cargo test observation`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@obs-store-bench-history`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@obs-store-bench-history --changed-since origin/main`

Closes #2017
Refs #2015

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the bench observation-store persistence wiring and focused tests; Chris to review before merge.