### PR TITLE
feat(trace): persist observation runs

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use homeboy::component::{Component, ScopedExtensionConfig};
 use homeboy::engine::baseline::BaselineFlags;
@@ -10,6 +10,9 @@ use homeboy::extension::trace::{
     TraceCommandOutput, TraceListWorkflowArgs, TraceRunWorkflowArgs, TraceSpanDefinition,
 };
 use homeboy::extension::ExtensionCapability;
+use homeboy::observation::{
+    NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, ObservationStore, RunStatus,
+};
 use homeboy::rig::{self, RigSpec};
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
@@ -133,6 +136,48 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
         .as_ref()
         .map(|context| rig::snapshot_state(&context.spec));
     let run_dir = RunDir::create()?;
+    let scenario_id = args.scenario.clone();
+    let rig_id = args.rig.clone();
+    let requested_overlays = args.overlays.clone();
+    let component_path_for_observation = path_override
+        .clone()
+        .unwrap_or_else(|| ctx.component.local_path.clone());
+    let observation = ObservationStore::open_initialized().ok().and_then(|store| {
+        store
+            .start_run(NewRunRecord {
+                kind: "trace".to_string(),
+                component_id: Some(ctx.component_id.clone()),
+                command: Some(std::env::args().collect::<Vec<_>>().join(" ")),
+                cwd: std::env::current_dir()
+                    .ok()
+                    .map(|path| path.to_string_lossy().to_string()),
+                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                git_sha: homeboy::git::short_head_revision_at(Path::new(
+                    &component_path_for_observation,
+                )),
+                rig_id: rig_id.clone(),
+                metadata_json: serde_json::json!({
+                    "scenario_id": scenario_id,
+                    "component_path": component_path_for_observation,
+                    "requested_overlays": requested_overlays,
+                    "span_definitions": args.spans.clone(),
+                    "baseline": {
+                        "baseline": args.baseline_args.baseline,
+                        "ignore_baseline": args.baseline_args.ignore_baseline,
+                        "ratchet": args.baseline_args.ratchet,
+                        "regression_threshold_percent": args.regression_threshold
+                    }
+                }),
+            })
+            .ok()
+            .map(|run| ActiveTraceObservation {
+                store,
+                run_id: run.id,
+                component_id: ctx.component_id.clone(),
+                rig_id: rig_id.clone(),
+                scenario_id: scenario_id.clone(),
+            })
+    });
     let extra_workloads = rig_context
         .as_ref()
         .and_then(|context| {
@@ -146,10 +191,10 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
             })
         })
         .unwrap_or_default();
-    let workflow = extension_trace::run_trace_workflow(
+    let workflow = match extension_trace::run_trace_workflow(
         &ctx.component,
         TraceRunWorkflowArgs {
-            component_label: effective_id,
+            component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override,
             settings: settings_as_strings(&ctx.settings),
@@ -170,7 +215,18 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
         },
         &run_dir,
         rig_state.clone(),
-    )?;
+    ) {
+        Ok(workflow) => workflow,
+        Err(error) => {
+            if let Some(observation) = observation.as_ref() {
+                persist_trace_workflow_error(observation, &run_dir, &error);
+            }
+            return Err(error);
+        }
+    };
+    if let Some(observation) = observation.as_ref() {
+        persist_trace_workflow_result(observation, &run_dir, &workflow, rig_state.as_ref());
+    }
 
     Ok(extension_trace::from_main_workflow(
         workflow,
@@ -350,6 +406,167 @@ fn settings_as_json(settings: &[(String, serde_json::Value)]) -> Vec<(String, se
             other => Some((key.clone(), other.clone())),
         })
         .collect()
+}
+
+struct ActiveTraceObservation {
+    store: ObservationStore,
+    run_id: String,
+    component_id: String,
+    rig_id: Option<String>,
+    scenario_id: String,
+}
+
+fn persist_trace_workflow_result(
+    observation: &ActiveTraceObservation,
+    run_dir: &RunDir,
+    workflow: &extension_trace::TraceRunWorkflowResult,
+    rig_state: Option<&rig::RigStateSnapshot>,
+) {
+    let run_status = trace_run_status(workflow);
+    let baseline_status = baseline_status(workflow);
+    let results = workflow.results.as_ref();
+    let _ = observation.store.record_trace_run(NewTraceRunRecord {
+        run_id: observation.run_id.clone(),
+        component_id: observation.component_id.clone(),
+        rig_id: observation.rig_id.clone(),
+        scenario_id: results
+            .map(|results| results.scenario_id.clone())
+            .unwrap_or_else(|| observation.scenario_id.clone()),
+        status: run_status.as_str().to_string(),
+        baseline_status: baseline_status.clone(),
+        metadata_json: serde_json::json!({
+            "status": &workflow.status,
+            "exit_code": workflow.exit_code,
+            "summary": results.and_then(|results| results.summary.clone()),
+            "failure": &workflow.failure,
+            "overlays": &workflow.overlays,
+            "baseline_comparison": &workflow.baseline_comparison,
+            "baseline_status": baseline_status,
+            "hints": &workflow.hints,
+            "rig_state": rig_state,
+            "assertion_count": results.map(|results| results.assertions.len()).unwrap_or(0),
+            "artifact_count": results.map(|results| results.artifacts.len()).unwrap_or(0),
+            "span_count": results.map(|results| results.span_results.len()).unwrap_or(0),
+        }),
+    });
+
+    if let Some(results) = results {
+        for span in &results.span_results {
+            let _ = observation.store.record_trace_span(NewTraceSpanRecord {
+                run_id: observation.run_id.clone(),
+                span_id: span.id.clone(),
+                status: format!("{:?}", span.status).to_ascii_lowercase(),
+                duration_ms: span.duration_ms.map(|value| value as f64),
+                from_event: Some(span.from.clone()),
+                to_event: Some(span.to.clone()),
+                metadata_json: serde_json::json!({
+                    "from_t_ms": span.from_t_ms,
+                    "to_t_ms": span.to_t_ms,
+                    "missing": span.missing,
+                    "message": &span.message,
+                }),
+            });
+        }
+    }
+
+    record_trace_artifacts(&observation.store, &observation.run_id, run_dir, results);
+    let _ = observation.store.finish_run(
+        &observation.run_id,
+        run_status,
+        Some(trace_run_finish_metadata(workflow)),
+    );
+}
+
+fn persist_trace_workflow_error(
+    observation: &ActiveTraceObservation,
+    run_dir: &RunDir,
+    error: &homeboy::Error,
+) {
+    let error_metadata = serde_json::json!({
+        "error": {
+            "code": error.code.as_str(),
+            "message": &error.message,
+            "details": &error.details,
+        }
+    });
+    let _ = observation.store.record_trace_run(NewTraceRunRecord {
+        run_id: observation.run_id.clone(),
+        component_id: observation.component_id.clone(),
+        rig_id: observation.rig_id.clone(),
+        scenario_id: observation.scenario_id.clone(),
+        status: RunStatus::Error.as_str().to_string(),
+        baseline_status: None,
+        metadata_json: error_metadata.clone(),
+    });
+    record_trace_artifacts(&observation.store, &observation.run_id, run_dir, None);
+    let _ =
+        observation
+            .store
+            .finish_run(&observation.run_id, RunStatus::Error, Some(error_metadata));
+}
+
+fn trace_run_status(workflow: &extension_trace::TraceRunWorkflowResult) -> RunStatus {
+    if workflow.failure.is_some() || workflow.status == "error" {
+        RunStatus::Error
+    } else if workflow.exit_code == 0 && workflow.status == "pass" {
+        RunStatus::Pass
+    } else {
+        RunStatus::Fail
+    }
+}
+
+fn baseline_status(workflow: &extension_trace::TraceRunWorkflowResult) -> Option<String> {
+    workflow.baseline_comparison.as_ref().map(|comparison| {
+        if comparison.regression {
+            "regression"
+        } else if comparison.has_improvements {
+            "improvement"
+        } else {
+            "pass"
+        }
+        .to_string()
+    })
+}
+
+fn trace_run_finish_metadata(
+    workflow: &extension_trace::TraceRunWorkflowResult,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": &workflow.status,
+        "exit_code": workflow.exit_code,
+        "failure": &workflow.failure,
+        "overlays": &workflow.overlays,
+        "baseline_comparison": &workflow.baseline_comparison,
+        "hints": &workflow.hints,
+        "results": &workflow.results,
+    })
+}
+
+fn record_trace_artifacts(
+    store: &ObservationStore,
+    run_id: &str,
+    run_dir: &RunDir,
+    results: Option<&extension_trace::TraceResults>,
+) {
+    let trace_results_path = run_dir.step_file(homeboy::engine::run_dir::files::TRACE_RESULTS);
+    record_artifact_if_file(store, run_id, "trace-results", &trace_results_path);
+    if let Some(results) = results {
+        for artifact in &results.artifacts {
+            let path = PathBuf::from(&artifact.path);
+            let resolved = if path.is_absolute() {
+                path
+            } else {
+                run_dir.path().join(path)
+            };
+            record_artifact_if_file(store, run_id, "trace-artifact", &resolved);
+        }
+    }
+}
+
+fn record_artifact_if_file(store: &ObservationStore, run_id: &str, kind: &str, path: &Path) {
+    if path.is_file() {
+        let _ = store.record_artifact(run_id, kind, path);
+    }
 }
 
 #[cfg(test)]
@@ -546,6 +763,7 @@ mod tests {
     #[test]
     fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
         with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
             write_trace_extension(home);
             let component_dir = tempfile::TempDir::new().expect("component dir");
             write_trace_rig(home, "studio-rig", "studio", component_dir.path());
@@ -586,6 +804,148 @@ mod tests {
                 _ => panic!("expected run output"),
             }
         });
+    }
+
+    #[test]
+    fn trace_run_persists_observation_history() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            write_trace_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_trace_rig(home, "studio-rig", "studio", component_dir.path());
+
+            let (_output, exit_code) = run(
+                TraceArgs {
+                    comp: PositionalComponentArgs {
+                        component: Some("studio".to_string()),
+                        path: None,
+                    },
+                    scenario: "studio-app-create-site".to_string(),
+                    rig: Some("studio-rig".to_string()),
+                    setting_args: SettingArgs::default(),
+                    _json: HiddenJsonArgs::default(),
+                    json_summary: false,
+                    report: None,
+                    spans: Vec::new(),
+                    baseline_args: BaselineArgs::default(),
+                    regression_threshold:
+                        extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    overlays: Vec::new(),
+                    keep_overlay: false,
+                },
+                &GlobalArgs {},
+            )
+            .expect("trace should run");
+
+            assert_eq!(exit_code, 0);
+            let store = ObservationStore::open_initialized().expect("store");
+            let runs = store
+                .list_runs(homeboy::observation::RunListFilter {
+                    kind: Some("trace".to_string()),
+                    ..Default::default()
+                })
+                .expect("runs");
+            assert_eq!(runs.len(), 1);
+            assert_eq!(runs[0].status, "pass");
+            assert_eq!(runs[0].component_id.as_deref(), Some("studio"));
+            assert_eq!(runs[0].rig_id.as_deref(), Some("studio-rig"));
+
+            let trace_run = store
+                .get_trace_run(&runs[0].id)
+                .expect("trace run")
+                .expect("trace run row");
+            assert_eq!(trace_run.component_id, "studio");
+            assert_eq!(trace_run.scenario_id, "studio-app-create-site");
+            assert_eq!(trace_run.status, "pass");
+            assert_eq!(trace_run.metadata_json["span_count"], 1);
+
+            let spans = store.list_trace_spans(&runs[0].id).expect("spans");
+            assert_eq!(spans.len(), 1);
+            assert_eq!(spans[0].span_id, "boot_to_ready");
+            assert_eq!(spans[0].duration_ms, Some(125.0));
+
+            let artifacts = store.list_artifacts(&runs[0].id).expect("artifacts");
+            assert_eq!(artifacts.len(), 2);
+            assert!(artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "trace-results"));
+            assert!(artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "trace-artifact"));
+        });
+    }
+
+    #[test]
+    fn failed_trace_run_persists_observation_history() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            write_trace_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            write_trace_rig(home, "studio-rig", "studio", component_dir.path());
+
+            let (_output, exit_code) = run(
+                TraceArgs {
+                    comp: PositionalComponentArgs {
+                        component: Some("studio".to_string()),
+                        path: None,
+                    },
+                    scenario: "missing-scenario".to_string(),
+                    rig: Some("studio-rig".to_string()),
+                    setting_args: SettingArgs::default(),
+                    _json: HiddenJsonArgs::default(),
+                    json_summary: false,
+                    report: None,
+                    spans: Vec::new(),
+                    baseline_args: BaselineArgs::default(),
+                    regression_threshold:
+                        extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    overlays: Vec::new(),
+                    keep_overlay: false,
+                },
+                &GlobalArgs {},
+            )
+            .expect("trace command should return structured failure output");
+
+            assert_eq!(exit_code, 3);
+            let store = ObservationStore::open_initialized().expect("store");
+            let runs = store
+                .list_runs(homeboy::observation::RunListFilter {
+                    kind: Some("trace".to_string()),
+                    ..Default::default()
+                })
+                .expect("runs");
+            assert_eq!(runs.len(), 1);
+            assert_eq!(runs[0].status, "error");
+
+            let trace_run = store
+                .get_trace_run(&runs[0].id)
+                .expect("trace run")
+                .expect("trace run row");
+            assert_eq!(trace_run.status, "error");
+            assert!(trace_run.metadata_json["failure"]["stderr_excerpt"]
+                .as_str()
+                .expect("stderr excerpt")
+                .contains("unknown scenario missing-scenario"));
+        });
+    }
+
+    struct XdgGuard(Option<String>);
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
     }
 
     fn write_trace_extension(home: &tempfile::TempDir) {
@@ -651,8 +1011,10 @@ case " $scenario_ids " in
 esac
 
 cat > "$HOMEBOY_TRACE_RESULTS_FILE" <<JSON
-{"component_id":"$HOMEBOY_COMPONENT_ID","scenario_id":"$HOMEBOY_TRACE_SCENARIO","status":"pass","timeline":[],"assertions":[],"artifacts":[]}
+{"component_id":"$HOMEBOY_COMPONENT_ID","scenario_id":"$HOMEBOY_TRACE_SCENARIO","status":"pass","timeline":[{"t_ms":0,"source":"runner","event":"boot"},{"t_ms":125,"source":"runner","event":"ready"}],"span_results":[{"id":"boot_to_ready","from":"runner.boot","to":"runner.ready","status":"ok","duration_ms":125,"from_t_ms":0,"to_t_ms":125}],"assertions":[],"artifacts":[{"label":"trace log","path":"artifacts/trace-log.txt"}]}
 JSON
+mkdir -p "$HOMEBOY_TRACE_ARTIFACT_DIR"
+printf 'trace log\n' > "$HOMEBOY_TRACE_ARTIFACT_DIR/trace-log.txt"
 "#,
         )
         .expect("write trace script");

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -553,6 +553,7 @@ mod tests {
 
     use crate::component::{Component, ScopedExtensionConfig};
     use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
+    use crate::test_support::with_isolated_home;
 
     use super::*;
 
@@ -745,28 +746,30 @@ JSON
 
     #[test]
     fn trace_overlay_applies_for_run_and_reverts_afterward() {
-        let fixture = overlay_fixture(false);
-        let run_dir = RunDir::create().unwrap();
-        let context = trace_context(&fixture.component, &fixture.extension_dir);
+        with_isolated_home(|_| {
+            let fixture = overlay_fixture(false);
+            let run_dir = RunDir::create().unwrap();
+            let context = trace_context(&fixture.component, &fixture.extension_dir);
 
-        let result = run_trace_workflow_with_context(
-            &context,
-            &fixture.component,
-            fixture.args,
-            &run_dir,
-            None,
-        )
-        .unwrap();
+            let result = run_trace_workflow_with_context(
+                &context,
+                &fixture.component,
+                fixture.args,
+                &run_dir,
+                None,
+            )
+            .unwrap();
 
-        assert_eq!(result.exit_code, 0);
-        assert_eq!(result.overlays.len(), 1);
-        assert_eq!(result.overlays[0].touched_files, vec!["scenario.txt"]);
-        assert!(!result.overlays[0].kept);
-        assert_eq!(
-            fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
-            "base\n"
-        );
-        run_dir.cleanup();
+            assert_eq!(result.exit_code, 0);
+            assert_eq!(result.overlays.len(), 1);
+            assert_eq!(result.overlays[0].touched_files, vec!["scenario.txt"]);
+            assert!(!result.overlays[0].kept);
+            assert_eq!(
+                fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
+                "base\n"
+            );
+            run_dir.cleanup();
+        });
     }
 
     #[test]
@@ -790,27 +793,29 @@ JSON
 
     #[test]
     fn trace_overlay_keep_overlay_leaves_changes_in_place() {
-        let fixture = overlay_fixture(true);
-        let run_dir = RunDir::create().unwrap();
-        let context = trace_context(&fixture.component, &fixture.extension_dir);
+        with_isolated_home(|_| {
+            let fixture = overlay_fixture(true);
+            let run_dir = RunDir::create().unwrap();
+            let context = trace_context(&fixture.component, &fixture.extension_dir);
 
-        let result = run_trace_workflow_with_context(
-            &context,
-            &fixture.component,
-            fixture.args,
-            &run_dir,
-            None,
-        )
-        .unwrap();
+            let result = run_trace_workflow_with_context(
+                &context,
+                &fixture.component,
+                fixture.args,
+                &run_dir,
+                None,
+            )
+            .unwrap();
 
-        assert_eq!(result.exit_code, 0);
-        assert_eq!(result.overlays.len(), 1);
-        assert!(result.overlays[0].kept);
-        assert_eq!(
-            fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
-            "overlay\n"
-        );
-        run_dir.cleanup();
+            assert_eq!(result.exit_code, 0);
+            assert_eq!(result.overlays.len(), 1);
+            assert!(result.overlays[0].kept);
+            assert_eq!(
+                fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
+                "overlay\n"
+            );
+            run_dir.cleanup();
+        });
     }
 
     struct OverlayFixture {

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -7,5 +7,8 @@
 pub mod records;
 pub mod store;
 
-pub use records::{ArtifactRecord, NewRunRecord, RunListFilter, RunRecord, RunStatus};
+pub use records::{
+    ArtifactRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord,
+    RunStatus, TraceRunRecord, TraceSpanRecord,
+};
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -70,6 +70,51 @@ pub struct ArtifactRecord {
     pub created_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct NewTraceRunRecord {
+    pub run_id: String,
+    pub component_id: String,
+    pub rig_id: Option<String>,
+    pub scenario_id: String,
+    pub status: String,
+    pub baseline_status: Option<String>,
+    pub metadata_json: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TraceRunRecord {
+    pub run_id: String,
+    pub component_id: String,
+    pub rig_id: Option<String>,
+    pub scenario_id: String,
+    pub status: String,
+    pub baseline_status: Option<String>,
+    pub metadata_json: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct NewTraceSpanRecord {
+    pub run_id: String,
+    pub span_id: String,
+    pub status: String,
+    pub duration_ms: Option<f64>,
+    pub from_event: Option<String>,
+    pub to_event: Option<String>,
+    pub metadata_json: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TraceSpanRecord {
+    pub id: String,
+    pub run_id: String,
+    pub span_id: String,
+    pub status: String,
+    pub duration_ms: Option<f64>,
+    pub from_event: Option<String>,
+    pub to_event: Option<String>,
+    pub metadata_json: serde_json::Value,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -6,19 +6,23 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use super::records::{ArtifactRecord, NewRunRecord, RunListFilter, RunRecord, RunStatus};
+use super::records::{
+    ArtifactRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord,
+    RunStatus, TraceRunRecord, TraceSpanRecord,
+};
 use crate::{paths, Error, Result};
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 1;
+pub const CURRENT_SCHEMA_VERSION: i64 = 2;
 
 struct Migration {
     version: i64,
     sql: &'static str,
 }
 
-const MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    sql: r#"
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        sql: r#"
         CREATE TABLE IF NOT EXISTS schema_migrations (
             version INTEGER PRIMARY KEY,
             applied_at TEXT NOT NULL
@@ -51,7 +55,42 @@ const MIGRATIONS: &[Migration] = &[Migration {
             FOREIGN KEY(run_id) REFERENCES runs(id)
         );
     "#,
-}];
+    },
+    Migration {
+        version: 2,
+        sql: r#"
+        CREATE TABLE IF NOT EXISTS trace_runs (
+            run_id TEXT PRIMARY KEY,
+            component_id TEXT NOT NULL,
+            rig_id TEXT,
+            scenario_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            baseline_status TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        );
+
+        CREATE TABLE IF NOT EXISTS trace_spans (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            span_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            duration_ms REAL,
+            from_event TEXT,
+            to_event TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_trace_runs_component_scenario
+            ON trace_runs(component_id, scenario_id);
+        CREATE INDEX IF NOT EXISTS idx_trace_runs_rig
+            ON trace_runs(rig_id);
+        CREATE INDEX IF NOT EXISTS idx_trace_spans_run
+            ON trace_spans(run_id);
+    "#,
+    },
+];
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ObservationDbStatus {
@@ -333,6 +372,146 @@ impl ObservationStore {
 
         collect_rows(rows, "collect artifact records")
     }
+
+    pub fn record_trace_run(&self, record: NewTraceRunRecord) -> Result<TraceRunRecord> {
+        let run_id = record.run_id.clone();
+        validate_required("run_id", &record.run_id)?;
+        validate_required("component_id", &record.component_id)?;
+        validate_required("scenario_id", &record.scenario_id)?;
+        validate_required("status", &record.status)?;
+        if self.get_run(&record.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                format!("run record not found: {}", record.run_id),
+                Some(record.run_id),
+                None,
+            ));
+        }
+        let metadata_json = serialize_metadata(&record.metadata_json)?;
+
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO trace_runs(
+                    run_id,
+                    component_id,
+                    rig_id,
+                    scenario_id,
+                    status,
+                    baseline_status,
+                    metadata_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                "#,
+                params![
+                    record.run_id,
+                    record.component_id,
+                    record.rig_id,
+                    record.scenario_id,
+                    record.status,
+                    record.baseline_status,
+                    metadata_json,
+                ],
+            )
+            .map_err(sqlite_error("insert trace run record"))?;
+
+        self.get_trace_run(&run_id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Inserted trace run record {} but could not read it back",
+                run_id
+            ))
+        })
+    }
+
+    pub fn get_trace_run(&self, run_id: &str) -> Result<Option<TraceRunRecord>> {
+        validate_required("run_id", run_id)?;
+        self.connection
+            .query_row(
+                r#"
+                SELECT run_id, component_id, rig_id, scenario_id, status, baseline_status,
+                       metadata_json
+                FROM trace_runs
+                WHERE run_id = ?1
+                "#,
+                [run_id],
+                row_to_trace_run_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read trace run record"))
+    }
+
+    pub fn record_trace_span(&self, record: NewTraceSpanRecord) -> Result<TraceSpanRecord> {
+        let run_id = record.run_id.clone();
+        validate_required("run_id", &record.run_id)?;
+        validate_required("span_id", &record.span_id)?;
+        validate_required("status", &record.status)?;
+        if self.get_run(&record.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                format!("run record not found: {}", record.run_id),
+                Some(record.run_id),
+                None,
+            ));
+        }
+        let id = Uuid::new_v4().to_string();
+        let metadata_json = serialize_metadata(&record.metadata_json)?;
+
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO trace_spans(
+                    id,
+                    run_id,
+                    span_id,
+                    status,
+                    duration_ms,
+                    from_event,
+                    to_event,
+                    metadata_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                "#,
+                params![
+                    id,
+                    record.run_id,
+                    record.span_id,
+                    record.status,
+                    record.duration_ms,
+                    record.from_event,
+                    record.to_event,
+                    metadata_json,
+                ],
+            )
+            .map_err(sqlite_error("insert trace span record"))?;
+
+        self.list_trace_spans(&run_id)?
+            .into_iter()
+            .find(|span| span.id == id)
+            .ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "Inserted trace span record {id} but could not read it back"
+                ))
+            })
+    }
+
+    pub fn list_trace_spans(&self, run_id: &str) -> Result<Vec<TraceSpanRecord>> {
+        validate_required("run_id", run_id)?;
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, run_id, span_id, status, duration_ms, from_event, to_event,
+                       metadata_json
+                FROM trace_spans
+                WHERE run_id = ?1
+                ORDER BY rowid ASC
+                "#,
+            )
+            .map_err(sqlite_error("prepare list trace span records"))?;
+        let rows = statement
+            .query_map([run_id], row_to_trace_span_record)
+            .map_err(sqlite_error("list trace span records"))?;
+
+        collect_rows(rows, "collect trace span records")
+    }
 }
 
 pub fn database_path() -> Result<PathBuf> {
@@ -535,6 +714,31 @@ fn row_to_artifact_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArtifactR
     })
 }
 
+fn row_to_trace_run_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceRunRecord> {
+    Ok(TraceRunRecord {
+        run_id: row.get(0)?,
+        component_id: row.get(1)?,
+        rig_id: row.get(2)?,
+        scenario_id: row.get(3)?,
+        status: row.get(4)?,
+        baseline_status: row.get(5)?,
+        metadata_json: parse_metadata(row.get(6)?)?,
+    })
+}
+
+fn row_to_trace_span_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceSpanRecord> {
+    Ok(TraceSpanRecord {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        span_id: row.get(2)?,
+        status: row.get(3)?,
+        duration_ms: row.get(4)?,
+        from_event: row.get(5)?,
+        to_event: row.get(6)?,
+        metadata_json: parse_metadata(row.get(7)?)?,
+    })
+}
+
 fn collect_rows<T>(
     rows: rusqlite::MappedRows<'_, impl FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>>,
     context: &'static str,
@@ -731,6 +935,95 @@ mod api_coverage_tests {
                 .record_artifact(&run.id, "log", &path)
                 .expect("artifact");
             assert_eq!(store.list_artifacts(&run.id).expect("list"), vec![artifact]);
+        });
+    }
+
+    #[test]
+    fn test_record_trace_run() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run("trace")).expect("start");
+
+            let trace_run = store
+                .record_trace_run(NewTraceRunRecord {
+                    run_id: run.id.clone(),
+                    component_id: "studio".to_string(),
+                    rig_id: Some("studio-rig".to_string()),
+                    scenario_id: "create-site".to_string(),
+                    status: "pass".to_string(),
+                    baseline_status: Some("pass".to_string()),
+                    metadata_json: serde_json::json!({ "span_count": 1 }),
+                })
+                .expect("trace run");
+
+            assert_eq!(trace_run.run_id, run.id);
+            assert_eq!(trace_run.component_id, "studio");
+            assert_eq!(trace_run.rig_id.as_deref(), Some("studio-rig"));
+            assert_eq!(trace_run.metadata_json["span_count"], 1);
+        });
+    }
+
+    #[test]
+    fn test_record_trace_span() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run("trace")).expect("start");
+
+            let span = store
+                .record_trace_span(NewTraceSpanRecord {
+                    run_id: run.id.clone(),
+                    span_id: "boot_to_ready".to_string(),
+                    status: "ok".to_string(),
+                    duration_ms: Some(125.0),
+                    from_event: Some("runner.boot".to_string()),
+                    to_event: Some("runner.ready".to_string()),
+                    metadata_json: serde_json::json!({ "source": "test" }),
+                })
+                .expect("trace span");
+
+            let spans = store.list_trace_spans(&run.id).expect("spans");
+            assert_eq!(spans, vec![span]);
+            assert_eq!(spans[0].duration_ms, Some(125.0));
+        });
+    }
+
+    #[test]
+    fn test_list_trace_spans() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run("trace")).expect("start");
+
+            store
+                .record_trace_span(NewTraceSpanRecord {
+                    run_id: run.id.clone(),
+                    span_id: "first".to_string(),
+                    status: "ok".to_string(),
+                    duration_ms: Some(10.0),
+                    from_event: Some("runner.first".to_string()),
+                    to_event: Some("runner.second".to_string()),
+                    metadata_json: serde_json::json!({}),
+                })
+                .expect("first span");
+            store
+                .record_trace_span(NewTraceSpanRecord {
+                    run_id: run.id.clone(),
+                    span_id: "second".to_string(),
+                    status: "skipped".to_string(),
+                    duration_ms: None,
+                    from_event: Some("runner.second".to_string()),
+                    to_event: Some("runner.third".to_string()),
+                    metadata_json: serde_json::json!({ "missing": ["runner.third"] }),
+                })
+                .expect("second span");
+
+            let spans = store.list_trace_spans(&run.id).expect("spans");
+            assert_eq!(spans.len(), 2);
+            assert_eq!(spans[0].span_id, "first");
+            assert_eq!(spans[1].span_id, "second");
+            assert_eq!(spans[1].metadata_json["missing"][0], "runner.third");
         });
     }
 }

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -80,8 +80,8 @@ fn test_open_initialized() {
 
         assert!(status.exists);
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 1);
-        assert_eq!(status.table_count, 3);
+        assert_eq!(status.migration_count, 2);
+        assert_eq!(status.table_count, 5);
     });
 }
 
@@ -95,8 +95,8 @@ fn initialization_is_idempotent() {
         let status = second.status().expect("status");
 
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 1);
-        assert_eq!(status.table_count, 3);
+        assert_eq!(status.migration_count, 2);
+        assert_eq!(status.table_count, 5);
     });
 }
 


### PR DESCRIPTION
## Summary
- Persist `homeboy trace` executions as generic observation `runs` with trace-specific `trace_runs` and `trace_spans` rows.
- Record successful and failed trace outcomes, rig/scenario/overlay/baseline metadata, span results, and trace result/artifact file indexes.
- Add focused store and trace command coverage, including failed-run persistence and trace artifact indexing.

## Tests
- `cargo test trace`
- `cargo test observation`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@obs-store-trace-history`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@obs-store-trace-history --changed-since origin/main`

Closes #2018
Refs #2015

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the trace observation-store persistence path and focused tests; Chris remains responsible for review and merge.