### PR TITLE
feat(rig): validate stack-backed component paths

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -52,7 +52,7 @@ Components are local checkouts used by pipeline steps. They are intentionally de
 | `path` | string | Filesystem path to the checkout. Supports `~`, `${env.NAME}`, and use through `${components.<id>.path}`. |
 | `remote_url` | string | Optional source repository URL for triage/reporting fallback. |
 | `triage_remote_url` | string | Optional reporting-only GitHub remote override. |
-| `stack` | string | Stack ID synced by `homeboy rig sync` and by explicit `stack` pipeline steps. |
+| `stack` | string | Stack ID synced by `homeboy rig sync` and by explicit `stack` pipeline steps. The component `path` must resolve to the same checkout as the stack's `component_path`. |
 | `branch` | string | Expected branch hint surfaced to humans in status/spec output. |
 | `extensions` | object | Optional rig-owned scoped extension config, mainly for rig-pinned bench dispatch. |
 
@@ -216,7 +216,7 @@ Runs git in the component checkout. Supported operations are `status`, `pull`, `
 { "kind": "stack", "component": "studio", "op": "sync", "dry_run": true }
 ```
 
-Delegates to `homeboy stack sync <stack-id>` for the named component. The component must declare `stack`. `homeboy rig sync <id>` runs this for every stacked component without needing a pipeline step.
+Delegates to `homeboy stack sync <stack-id>` for the named component. The component must declare `stack`, and the rig component `path` must match the stack spec's `component_path`. `homeboy rig sync <id>` runs this for every stacked component without needing a pipeline step.
 
 ### `patch`
 

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -138,7 +138,7 @@ homeboy rig sync studio
 homeboy rig sync studio --dry-run
 ```
 
-`rig sync` finds every component with a `stack` field and delegates to `homeboy stack sync <stack-id>`. This is the rig-level entry point for keeping combined-fixes branches current before a local environment is brought up.
+`rig sync` finds every component with a `stack` field and delegates to `homeboy stack sync <stack-id>`. This is the rig-level entry point for keeping combined-fixes branches current before a local environment is brought up. The rig component `path` must resolve to the same checkout as the referenced stack's `component_path`; mismatches fail before branch rewriting starts.
 
 ```jsonc
 {
@@ -156,6 +156,17 @@ homeboy rig sync studio --dry-run
 ```
 
 `rig up` does not sync stacks implicitly. If stack sync should be part of an `up` pipeline, add an explicit `stack` pipeline step.
+
+```jsonc
+{
+  "pipeline": {
+    "up": [
+      { "kind": "stack", "component": "studio", "op": "sync" },
+      { "kind": "stack", "component": "playground", "op": "sync" }
+    ]
+  }
+}
+```
 
 ## App Launchers
 

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -280,8 +280,9 @@ pub struct ComponentSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triage_remote_url: Option<String>,
 
-    /// Stack ID this component should track (Phase 2 — not enforced in MVP,
-    /// but the field is reserved so existing specs don't break on upgrade).
+    /// Stack ID this component should track. `homeboy rig sync` and explicit
+    /// `stack` pipeline steps use this to delegate combined-fixes upkeep to
+    /// the stack primitive.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stack: Option<String>,
 

--- a/src/core/rig/stack.rs
+++ b/src/core/rig/stack.rs
@@ -5,10 +5,12 @@
 //! rig components, then delegate to the existing stack primitive explicitly.
 
 use serde::Serialize;
+use std::path::{Path, PathBuf};
 
+use super::expand::expand_vars;
 use super::spec::RigSpec;
 use crate::error::{ErrorCode, Result};
-use crate::stack::{self, SyncOutput};
+use crate::stack::{self, StackSpec, SyncOutput};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RigStackPlanEntry {
@@ -64,10 +66,11 @@ pub fn plan_stack_sync(rig: &RigSpec) -> Vec<RigStackPlanEntry> {
 }
 
 pub fn run_sync(rig: &RigSpec, dry_run: bool) -> Result<RigStackSyncReport> {
-    Ok(run_sync_with(rig, dry_run, |stack_id, dry_run| {
-        let mut spec = stack::load(stack_id)?;
-        stack::sync(&mut spec, dry_run)
-    }))
+    Ok(run_sync_with(
+        rig,
+        dry_run,
+        |component_id, stack_id, dry_run| sync_checked(rig, component_id, stack_id, dry_run),
+    ))
 }
 
 pub fn run_component_sync(
@@ -93,10 +96,12 @@ pub fn run_component_sync(
         )
     })?;
 
-    let entry = run_one(component_id, stack_id, dry_run, |stack_id, dry_run| {
-        let mut spec = stack::load(stack_id)?;
-        stack::sync(&mut spec, dry_run)
-    });
+    let entry = run_one(
+        component_id,
+        stack_id,
+        dry_run,
+        |component_id, stack_id, dry_run| sync_checked(rig, component_id, stack_id, dry_run),
+    );
 
     if entry.status == "changed" || entry.status == "no-op" {
         return Ok(entry);
@@ -125,7 +130,7 @@ pub(crate) fn run_sync_with<F>(
     mut sync_stack: F,
 ) -> RigStackSyncReport
 where
-    F: FnMut(&str, bool) -> Result<SyncOutput>,
+    F: FnMut(&str, &str, bool) -> Result<SyncOutput>,
 {
     let mut stacks = Vec::new();
     let mut success = true;
@@ -159,9 +164,9 @@ fn run_one<F>(
     mut sync_stack: F,
 ) -> RigStackSyncEntry
 where
-    F: FnMut(&str, bool) -> Result<SyncOutput>,
+    F: FnMut(&str, &str, bool) -> Result<SyncOutput>,
 {
-    match sync_stack(stack_id, dry_run) {
+    match sync_stack(component_id, stack_id, dry_run) {
         Ok(output) => entry_from_output(component_id, output),
         Err(error) => {
             let status = if error.code == ErrorCode::StackApplyConflict {
@@ -183,6 +188,64 @@ where
             }
         }
     }
+}
+
+fn sync_checked(
+    rig: &RigSpec,
+    component_id: &str,
+    stack_id: &str,
+    dry_run: bool,
+) -> Result<SyncOutput> {
+    let mut spec = stack::load(stack_id)?;
+    validate_component_stack_path(rig, component_id, &spec)?;
+    stack::sync(&mut spec, dry_run)
+}
+
+pub(crate) fn validate_component_stack_path(
+    rig: &RigSpec,
+    component_id: &str,
+    stack_spec: &StackSpec,
+) -> Result<()> {
+    let component = rig.components.get(component_id).ok_or_else(|| {
+        crate::Error::rig_pipeline_failed(
+            &rig.id,
+            "stack",
+            format!(
+                "component '{}' not declared in rig `components` map",
+                component_id
+            ),
+        )
+    })?;
+
+    let rig_path = expand_vars(rig, &component.path);
+    let stack_path = stack::expand_path(&stack_spec.component_path);
+    if comparable_path(&rig_path) == comparable_path(&stack_path) {
+        return Ok(());
+    }
+
+    Err(crate::Error::rig_pipeline_failed(
+        &rig.id,
+        "stack",
+        format!(
+            "component '{}' declares stack '{}' but paths differ: rig component path '{}' vs stack component_path '{}'. Align one spec before running stack sync.",
+            component_id, stack_spec.id, rig_path, stack_path
+        ),
+    ))
+}
+
+fn comparable_path(path: &str) -> PathBuf {
+    let candidate = PathBuf::from(path);
+    if let Ok(canonical) = std::fs::canonicalize(&candidate) {
+        return canonical;
+    }
+
+    if candidate.is_absolute() {
+        return candidate;
+    }
+
+    std::env::current_dir()
+        .unwrap_or_else(|_| Path::new(".").to_path_buf())
+        .join(candidate)
 }
 
 fn entry_from_output(component_id: &str, output: SyncOutput) -> RigStackSyncEntry {

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use crate::error::Error;
 use crate::rig::spec::{ComponentSpec, RigSpec};
-use crate::stack::{GitRef, SyncOutput, SyncPreview};
+use crate::stack::{GitRef, StackPrEntry, StackSpec, SyncOutput, SyncPreview};
 
-use super::{plan_stack_sync, run_sync_with};
+use super::{plan_stack_sync, run_component_sync, run_sync_with, validate_component_stack_path};
 
 fn component(path: &str, stack: Option<&str>) -> ComponentSpec {
     ComponentSpec {
@@ -66,6 +66,24 @@ fn sync_output(stack_id: &str, picked: usize, skipped: usize, dropped: usize) ->
     }
 }
 
+fn stack_spec(id: &str, component_path: &str) -> StackSpec {
+    StackSpec {
+        id: id.to_string(),
+        description: String::new(),
+        component: "studio".to_string(),
+        component_path: component_path.to_string(),
+        base: GitRef {
+            remote: "origin".to_string(),
+            branch: "main".to_string(),
+        },
+        target: GitRef {
+            remote: "fork".to_string(),
+            branch: "dev/combined-fixes".to_string(),
+        },
+        prs: Vec::<StackPrEntry>::new(),
+    }
+}
+
 #[test]
 fn test_plan_stack_sync_uses_components_with_stack_ids_in_sorted_order() {
     let mut components = HashMap::new();
@@ -90,8 +108,9 @@ fn test_run_sync_reports_changed_and_noop_statuses() {
     components.insert("b".to_string(), component("/tmp/b", Some("b-stack")));
     let rig = rig_with_components(components);
 
-    let report = run_sync_with(&rig, false, |stack_id, dry_run| {
+    let report = run_sync_with(&rig, false, |component_id, stack_id, dry_run| {
         assert!(!dry_run);
+        assert!(component_id == "a" || component_id == "b");
         Ok(match stack_id {
             "a-stack" => sync_output(stack_id, 1, 0, 0),
             "b-stack" => sync_output(stack_id, 0, 0, 0),
@@ -115,7 +134,7 @@ fn test_run_sync_stops_on_conflict_before_later_stacks() {
     let rig = rig_with_components(components);
     let mut seen = Vec::new();
 
-    let report = run_sync_with(&rig, true, |stack_id, dry_run| {
+    let report = run_sync_with(&rig, true, |_component_id, stack_id, dry_run| {
         assert!(dry_run);
         seen.push(stack_id.to_string());
         match stack_id {
@@ -148,7 +167,7 @@ fn test_run_sync_reports_general_failure_status() {
     components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
     let rig = rig_with_components(components);
 
-    let report = run_sync_with(&rig, false, |_stack_id, _dry_run| {
+    let report = run_sync_with(&rig, false, |_component_id, _stack_id, _dry_run| {
         Err(Error::stack_not_found("a-stack", Vec::new()))
     });
 
@@ -168,7 +187,7 @@ fn test_sync_entry_serializes_counts_and_refs() {
     components.insert("a".to_string(), component("/tmp/a", Some("a-stack")));
     let rig = rig_with_components(components);
 
-    let report = run_sync_with(&rig, false, |stack_id, _dry_run| {
+    let report = run_sync_with(&rig, false, |_component_id, stack_id, _dry_run| {
         Ok(SyncOutput {
             preview: SyncPreview {
                 stack_id: stack_id.to_string(),
@@ -214,4 +233,71 @@ fn test_sync_entry_serializes_counts_and_refs() {
     assert!(json.contains("\"dropped_count\":1"));
     assert!(json.contains("\"base\":\"origin/main\""));
     assert!(json.contains("\"target\":\"fork/dev/combined-fixes\""));
+}
+
+#[test]
+fn test_validate_component_stack_path_accepts_matching_paths() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let component_path = dir.path().to_string_lossy().to_string();
+    let mut components = HashMap::new();
+    components.insert(
+        "studio".to_string(),
+        component(&component_path, Some("studio-combined")),
+    );
+    let rig = rig_with_components(components);
+    let stack = stack_spec("studio-combined", &component_path);
+
+    validate_component_stack_path(&rig, "studio", &stack).expect("path should match");
+}
+
+#[test]
+fn test_validate_component_stack_path_accepts_canonical_equivalent_paths() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let nested = dir.path().join("checkout");
+    std::fs::create_dir_all(&nested).expect("create checkout");
+    let rig_path = nested
+        .join("..")
+        .join("checkout")
+        .to_string_lossy()
+        .to_string();
+    let stack_path = nested.to_string_lossy().to_string();
+    let mut components = HashMap::new();
+    components.insert(
+        "studio".to_string(),
+        component(&rig_path, Some("studio-combined")),
+    );
+    let rig = rig_with_components(components);
+    let stack = stack_spec("studio-combined", &stack_path);
+
+    validate_component_stack_path(&rig, "studio", &stack).expect("canonical path should match");
+}
+
+#[test]
+fn test_validate_component_stack_path_errors_on_mismatch() {
+    let mut components = HashMap::new();
+    components.insert(
+        "studio".to_string(),
+        component("/tmp/studio", Some("studio-combined")),
+    );
+    let rig = rig_with_components(components);
+    let stack = stack_spec("studio-combined", "/tmp/other-studio");
+
+    let err = validate_component_stack_path(&rig, "studio", &stack).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("paths differ"));
+    assert!(msg.contains("/tmp/studio"));
+    assert!(msg.contains("/tmp/other-studio"));
+}
+
+#[test]
+fn test_run_component_sync_errors_when_component_has_no_stack() {
+    let mut components = HashMap::new();
+    components.insert("plain".to_string(), component("/tmp/plain", None));
+    let rig = rig_with_components(components);
+
+    let err = run_component_sync(&rig, "plain", true).unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("component 'plain' does not declare a stack"));
 }


### PR DESCRIPTION
## Summary
- Validate that rig component paths match referenced stack `component_path` values before stack sync mutates branches.
- Document stack-backed rig components as the explicit combined-fixes path through `rig sync` or `kind: \"stack\"` pipeline steps.
- Add focused rig stack tests for path validation and missing-stack diagnostics.

## Tests
- `cargo fmt --check`
- `cargo test rig::stack::stack_test`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@rig-stack-backed-components --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@rig-stack-backed-components --changed-since origin/main` (passed; no impacted tests selected)

Closes #2029

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the stack-backed rig validation, docs updates, focused tests, and local verification. Chris remains responsible for review and merge.