### PR TITLE
feat(obs-store): add observation bundle export/import

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -8,6 +8,9 @@ Inspect persisted observation-store runs and artifacts.
 homeboy runs list [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20]
 homeboy runs show <run-id>
 homeboy runs artifacts <run-id>
+homeboy runs export --run <run-id> --output <dir>
+homeboy runs export --since <duration> --output <dir>
+homeboy runs import <dir>
 ```
 
 ## Description
@@ -25,3 +28,19 @@ homeboy rig runs <id> [--limit 20]
 ```
 
 These commands are thin read-only wrappers over the same observation-store records.
+
+## Portable Bundles
+
+`homeboy runs export` writes an inspectable directory bundle for moving observation evidence between machines without copying raw SQLite:
+
+```text
+homeboy-observations/
+  manifest.json
+  runs.json
+  artifacts.json
+  trace_spans.json
+```
+
+The v1 bundle is metadata-only: artifact records are exported, but artifact file bytes are not copied. Zip output is intentionally out of scope for v1; pass a directory path to `--output`.
+
+`homeboy runs import` is idempotent. Existing identical records are accepted, while conflicting records with the same primary key fail clearly.

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,22 +1,21 @@
+mod bundle;
+
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use clap::{Args, Subcommand};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{
-    ArtifactRecord, ObservationStore, RunListFilter, RunRecord, TraceSpanRecord,
-};
+use homeboy::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
 use homeboy::Error;
 
 use super::{CmdResult, GlobalArgs};
+use bundle::{
+    export_runs, import_runs, ObservationBundleImportSummary, ObservationBundleManifest,
+    RunsExportArgs, RunsImportArgs,
+};
 
 const DEFAULT_LIMIT: i64 = 20;
-const BUNDLE_FORMAT: &str = "homeboy-observations";
-const BUNDLE_VERSION: u32 = 1;
 
 #[derive(Args)]
 pub struct RunsArgs {
@@ -55,25 +54,6 @@ pub struct RunsListArgs {
     /// Maximum runs to return
     #[arg(long, default_value_t = DEFAULT_LIMIT)]
     pub limit: i64,
-}
-
-#[derive(Args, Clone)]
-pub struct RunsExportArgs {
-    /// Export one run by id
-    #[arg(long, conflicts_with = "since")]
-    pub run: Option<String>,
-    /// Export runs started within a duration, e.g. 24h, 7d, 30m
-    #[arg(long, conflicts_with = "run")]
-    pub since: Option<String>,
-    /// Output bundle directory. Zip output is intentionally out of scope for v1.
-    #[arg(long, value_name = "DIR")]
-    pub output: PathBuf,
-}
-
-#[derive(Args, Clone)]
-pub struct RunsImportArgs {
-    /// Bundle directory produced by `homeboy runs export`
-    pub input: PathBuf,
 }
 
 #[derive(Serialize)]
@@ -142,32 +122,6 @@ pub struct RunsImportOutput {
     pub command: &'static str,
     pub input: String,
     pub imported: ObservationBundleImportSummary,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ObservationBundleManifest {
-    pub format: String,
-    pub version: u32,
-    pub created_at: String,
-    pub homeboy_version: String,
-    pub run_count: usize,
-    pub artifact_count: usize,
-    pub trace_span_count: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ObservationBundle {
-    pub manifest: ObservationBundleManifest,
-    pub runs: Vec<RunRecord>,
-    pub artifacts: Vec<ArtifactRecord>,
-    pub trace_spans: Vec<TraceSpanRecord>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct ObservationBundleImportSummary {
-    pub runs: usize,
-    pub artifacts: usize,
-    pub trace_spans: usize,
 }
 
 #[derive(Serialize)]
@@ -257,76 +211,6 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
             command: "runs.artifacts",
             run_id: run_id.to_string(),
             artifacts: store.list_artifacts(run_id)?,
-        }),
-        0,
-    ))
-}
-
-pub fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
-    if args
-        .output
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
-    {
-        return Err(Error::validation_invalid_argument(
-            "output",
-            "zip output is out of scope for observation bundle v1; pass a directory path",
-            Some(args.output.to_string_lossy().to_string()),
-            None,
-        ));
-    }
-
-    let store = ObservationStore::open_initialized()?;
-    let runs = if let Some(run_id) = args.run.as_deref() {
-        vec![require_run(&store, run_id)?]
-    } else if let Some(since) = args.since.as_deref() {
-        let threshold = since_threshold(since)?;
-        store.list_runs_started_since(&threshold)?
-    } else {
-        return Err(Error::validation_missing_argument(vec![
-            "--run <run-id> or --since <duration>".to_string(),
-        ]));
-    };
-
-    let bundle = build_bundle(&store, runs)?;
-    write_bundle_dir(&args.output, &bundle)?;
-
-    Ok((
-        RunsOutput::Export(RunsExportOutput {
-            command: "runs.export",
-            output: args.output.to_string_lossy().to_string(),
-            run_count: bundle.runs.len(),
-            artifact_count: bundle.artifacts.len(),
-            trace_span_count: bundle.trace_spans.len(),
-            manifest: bundle.manifest,
-        }),
-        0,
-    ))
-}
-
-pub fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
-    let bundle = read_bundle_dir(&args.input)?;
-    let store = ObservationStore::open_initialized()?;
-    for run in &bundle.runs {
-        store.import_run(run)?;
-    }
-    for artifact in &bundle.artifacts {
-        store.import_artifact(artifact)?;
-    }
-    for span in &bundle.trace_spans {
-        store.import_trace_span(span)?;
-    }
-
-    Ok((
-        RunsOutput::Import(RunsImportOutput {
-            command: "runs.import",
-            input: args.input.to_string_lossy().to_string(),
-            imported: ObservationBundleImportSummary {
-                runs: bundle.runs.len(),
-                artifacts: bundle.artifacts.len(),
-                trace_spans: bundle.trace_spans.len(),
-            },
         }),
         0,
     ))
@@ -431,190 +315,6 @@ fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::Result<RunRec
             None,
         )
     })
-}
-
-fn build_bundle(
-    store: &ObservationStore,
-    runs: Vec<RunRecord>,
-) -> homeboy::Result<ObservationBundle> {
-    let mut artifacts = Vec::new();
-    let mut trace_spans = Vec::new();
-    for run in &runs {
-        artifacts.extend(store.list_artifacts(&run.id)?);
-        trace_spans.extend(store.list_trace_spans(&run.id)?);
-    }
-    let manifest = ObservationBundleManifest {
-        format: BUNDLE_FORMAT.to_string(),
-        version: BUNDLE_VERSION,
-        created_at: chrono::Utc::now().to_rfc3339(),
-        homeboy_version: env!("CARGO_PKG_VERSION").to_string(),
-        run_count: runs.len(),
-        artifact_count: artifacts.len(),
-        trace_span_count: trace_spans.len(),
-    };
-    Ok(ObservationBundle {
-        manifest,
-        runs,
-        artifacts,
-        trace_spans,
-    })
-}
-
-fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::Result<()> {
-    if path.exists() && !path.is_dir() {
-        return Err(Error::validation_invalid_argument(
-            "output",
-            "observation bundle output must be a directory",
-            Some(path.to_string_lossy().to_string()),
-            None,
-        ));
-    }
-    fs::create_dir_all(path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("create observation bundle dir {}", path.display())),
-        )
-    })?;
-    write_json(path.join("manifest.json"), &bundle.manifest)?;
-    write_json(path.join("runs.json"), &bundle.runs)?;
-    write_json(path.join("artifacts.json"), &bundle.artifacts)?;
-    write_json(path.join("trace_spans.json"), &bundle.trace_spans)?;
-    Ok(())
-}
-
-fn read_bundle_dir(path: &Path) -> homeboy::Result<ObservationBundle> {
-    if !path.is_dir() {
-        return Err(Error::validation_invalid_argument(
-            "input",
-            "observation bundle input must be a directory",
-            Some(path.to_string_lossy().to_string()),
-            None,
-        ));
-    }
-    let manifest: ObservationBundleManifest = read_json(path.join("manifest.json"))?;
-    if manifest.format != BUNDLE_FORMAT {
-        return Err(Error::validation_invalid_argument(
-            "manifest.format",
-            format!("expected {BUNDLE_FORMAT}, got {}", manifest.format),
-            Some(manifest.format),
-            None,
-        ));
-    }
-    if manifest.version != BUNDLE_VERSION {
-        return Err(Error::validation_invalid_argument(
-            "manifest.version",
-            format!(
-                "expected version {BUNDLE_VERSION}, got {}",
-                manifest.version
-            ),
-            Some(manifest.version.to_string()),
-            None,
-        ));
-    }
-
-    let runs: Vec<RunRecord> = read_json(path.join("runs.json"))?;
-    let artifacts: Vec<ArtifactRecord> = read_json(path.join("artifacts.json"))?;
-    let trace_spans: Vec<TraceSpanRecord> = read_json(path.join("trace_spans.json"))?;
-    if manifest.run_count != runs.len()
-        || manifest.artifact_count != artifacts.len()
-        || manifest.trace_span_count != trace_spans.len()
-    {
-        return Err(Error::validation_invalid_argument(
-            "manifest",
-            "bundle manifest counts do not match record files",
-            Some(path.to_string_lossy().to_string()),
-            None,
-        ));
-    }
-    Ok(ObservationBundle {
-        manifest,
-        runs,
-        artifacts,
-        trace_spans,
-    })
-}
-
-fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::Result<()> {
-    let json = serde_json::to_string_pretty(value).map_err(|e| {
-        Error::internal_json(e.to_string(), Some(format!("serialize {}", path.display())))
-    })?;
-    fs::write(&path, json).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("write observation bundle file {}", path.display())),
-        )
-    })
-}
-
-fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::Result<T> {
-    let raw = fs::read_to_string(&path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("read observation bundle file {}", path.display())),
-        )
-    })?;
-    serde_json::from_str(&raw).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse observation bundle file {}", path.display())),
-            Some(raw),
-        )
-    })
-}
-
-fn since_threshold(raw: &str) -> homeboy::Result<String> {
-    let duration = parse_duration(raw)?;
-    let chrono_duration = chrono::Duration::from_std(duration).map_err(|e| {
-        Error::validation_invalid_argument("since", e.to_string(), Some(raw.to_string()), None)
-    })?;
-    Ok((chrono::Utc::now() - chrono_duration).to_rfc3339())
-}
-
-fn parse_duration(raw: &str) -> homeboy::Result<Duration> {
-    let trimmed = raw.trim();
-    let split = trimmed
-        .find(|ch: char| !ch.is_ascii_digit())
-        .unwrap_or(trimmed.len());
-    let (amount, unit) = trimmed.split_at(split);
-    if amount.is_empty() || unit.is_empty() || !unit.chars().all(|ch| ch.is_ascii_alphabetic()) {
-        return Err(Error::validation_invalid_argument(
-            "since",
-            "expected duration like 30m, 24h, or 7d",
-            Some(raw.to_string()),
-            None,
-        ));
-    }
-    let amount = amount.parse::<u64>().map_err(|_| {
-        Error::validation_invalid_argument(
-            "since",
-            "duration amount must be a positive integer",
-            Some(raw.to_string()),
-            None,
-        )
-    })?;
-    if amount == 0 {
-        return Err(Error::validation_invalid_argument(
-            "since",
-            "duration amount must be greater than zero",
-            Some(raw.to_string()),
-            None,
-        ));
-    }
-    let seconds = match unit {
-        "s" | "sec" | "secs" | "second" | "seconds" => amount,
-        "m" | "min" | "mins" | "minute" | "minutes" => amount * 60,
-        "h" | "hr" | "hrs" | "hour" | "hours" => amount * 60 * 60,
-        "d" | "day" | "days" => amount * 60 * 60 * 24,
-        _ => {
-            return Err(Error::validation_invalid_argument(
-                "since",
-                "duration unit must be one of s, m, h, or d",
-                Some(raw.to_string()),
-                None,
-            ))
-        }
-    };
-    Ok(Duration::from_secs(seconds))
 }
 
 fn require_kind(run: &RunRecord, expected: &str) -> homeboy::Result<()> {
@@ -726,8 +426,11 @@ fn collect_numeric_object(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy::observation::{NewRunRecord, NewTraceSpanRecord, RunStatus};
+    use std::path::Path;
+
+    use homeboy::observation::{NewRunRecord, NewTraceSpanRecord, RunStatus, TraceSpanRecord};
     use homeboy::test_support::with_isolated_home;
+    use serde::Deserialize;
 
     struct XdgGuard(Option<String>);
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,15 +1,22 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use clap::{Args, Subcommand};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use homeboy::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::observation::{
+    ArtifactRecord, ObservationStore, RunListFilter, RunRecord, TraceSpanRecord,
+};
 use homeboy::Error;
 
 use super::{CmdResult, GlobalArgs};
 
 const DEFAULT_LIMIT: i64 = 20;
+const BUNDLE_FORMAT: &str = "homeboy-observations";
+const BUNDLE_VERSION: u32 = 1;
 
 #[derive(Args)]
 pub struct RunsArgs {
@@ -25,6 +32,10 @@ enum RunsCommand {
     Show { run_id: String },
     /// List artifacts recorded for one run
     Artifacts { run_id: String },
+    /// Export observation records as an inspectable directory bundle
+    Export(RunsExportArgs),
+    /// Import an observation bundle into the local observation store
+    Import(RunsImportArgs),
 }
 
 #[derive(Args, Clone, Default)]
@@ -46,6 +57,25 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
+#[derive(Args, Clone)]
+pub struct RunsExportArgs {
+    /// Export one run by id
+    #[arg(long, conflicts_with = "since")]
+    pub run: Option<String>,
+    /// Export runs started within a duration, e.g. 24h, 7d, 30m
+    #[arg(long, conflicts_with = "run")]
+    pub since: Option<String>,
+    /// Output bundle directory. Zip output is intentionally out of scope for v1.
+    #[arg(long, value_name = "DIR")]
+    pub output: PathBuf,
+}
+
+#[derive(Args, Clone)]
+pub struct RunsImportArgs {
+    /// Bundle directory produced by `homeboy runs export`
+    pub input: PathBuf,
+}
+
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
@@ -54,6 +84,8 @@ pub enum RunsOutput {
     Artifacts(RunsArtifactsOutput),
     BenchHistory(BenchHistoryOutput),
     BenchCompare(BenchCompareOutput),
+    Export(RunsExportOutput),
+    Import(RunsImportOutput),
 }
 
 #[derive(Serialize)]
@@ -93,6 +125,49 @@ pub struct BenchCompareOutput {
     pub to_run: RunSummary,
     pub comparisons: Vec<BenchMetricComparison>,
     pub missing: Vec<BenchMissingMetric>,
+}
+
+#[derive(Serialize)]
+pub struct RunsExportOutput {
+    pub command: &'static str,
+    pub output: String,
+    pub manifest: ObservationBundleManifest,
+    pub run_count: usize,
+    pub artifact_count: usize,
+    pub trace_span_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct RunsImportOutput {
+    pub command: &'static str,
+    pub input: String,
+    pub imported: ObservationBundleImportSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObservationBundleManifest {
+    pub format: String,
+    pub version: u32,
+    pub created_at: String,
+    pub homeboy_version: String,
+    pub run_count: usize,
+    pub artifact_count: usize,
+    pub trace_span_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ObservationBundle {
+    pub manifest: ObservationBundleManifest,
+    pub runs: Vec<RunRecord>,
+    pub artifacts: Vec<ArtifactRecord>,
+    pub trace_spans: Vec<TraceSpanRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ObservationBundleImportSummary {
+    pub runs: usize,
+    pub artifacts: usize,
+    pub trace_spans: usize,
 }
 
 #[derive(Serialize)]
@@ -140,6 +215,8 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
         RunsCommand::Show { run_id } => show_run(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
+        RunsCommand::Export(args) => export_runs(args),
+        RunsCommand::Import(args) => import_runs(args),
     }
 }
 
@@ -180,6 +257,76 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
             command: "runs.artifacts",
             run_id: run_id.to_string(),
             artifacts: store.list_artifacts(run_id)?,
+        }),
+        0,
+    ))
+}
+
+pub fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
+    if args
+        .output
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+    {
+        return Err(Error::validation_invalid_argument(
+            "output",
+            "zip output is out of scope for observation bundle v1; pass a directory path",
+            Some(args.output.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+
+    let store = ObservationStore::open_initialized()?;
+    let runs = if let Some(run_id) = args.run.as_deref() {
+        vec![require_run(&store, run_id)?]
+    } else if let Some(since) = args.since.as_deref() {
+        let threshold = since_threshold(since)?;
+        store.list_runs_started_since(&threshold)?
+    } else {
+        return Err(Error::validation_missing_argument(vec![
+            "--run <run-id> or --since <duration>".to_string(),
+        ]));
+    };
+
+    let bundle = build_bundle(&store, runs)?;
+    write_bundle_dir(&args.output, &bundle)?;
+
+    Ok((
+        RunsOutput::Export(RunsExportOutput {
+            command: "runs.export",
+            output: args.output.to_string_lossy().to_string(),
+            run_count: bundle.runs.len(),
+            artifact_count: bundle.artifacts.len(),
+            trace_span_count: bundle.trace_spans.len(),
+            manifest: bundle.manifest,
+        }),
+        0,
+    ))
+}
+
+pub fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
+    let bundle = read_bundle_dir(&args.input)?;
+    let store = ObservationStore::open_initialized()?;
+    for run in &bundle.runs {
+        store.import_run(run)?;
+    }
+    for artifact in &bundle.artifacts {
+        store.import_artifact(artifact)?;
+    }
+    for span in &bundle.trace_spans {
+        store.import_trace_span(span)?;
+    }
+
+    Ok((
+        RunsOutput::Import(RunsImportOutput {
+            command: "runs.import",
+            input: args.input.to_string_lossy().to_string(),
+            imported: ObservationBundleImportSummary {
+                runs: bundle.runs.len(),
+                artifacts: bundle.artifacts.len(),
+                trace_spans: bundle.trace_spans.len(),
+            },
         }),
         0,
     ))
@@ -284,6 +431,190 @@ fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::Result<RunRec
             None,
         )
     })
+}
+
+fn build_bundle(
+    store: &ObservationStore,
+    runs: Vec<RunRecord>,
+) -> homeboy::Result<ObservationBundle> {
+    let mut artifacts = Vec::new();
+    let mut trace_spans = Vec::new();
+    for run in &runs {
+        artifacts.extend(store.list_artifacts(&run.id)?);
+        trace_spans.extend(store.list_trace_spans(&run.id)?);
+    }
+    let manifest = ObservationBundleManifest {
+        format: BUNDLE_FORMAT.to_string(),
+        version: BUNDLE_VERSION,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        homeboy_version: env!("CARGO_PKG_VERSION").to_string(),
+        run_count: runs.len(),
+        artifact_count: artifacts.len(),
+        trace_span_count: trace_spans.len(),
+    };
+    Ok(ObservationBundle {
+        manifest,
+        runs,
+        artifacts,
+        trace_spans,
+    })
+}
+
+fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::Result<()> {
+    if path.exists() && !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "output",
+            "observation bundle output must be a directory",
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    fs::create_dir_all(path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("create observation bundle dir {}", path.display())),
+        )
+    })?;
+    write_json(path.join("manifest.json"), &bundle.manifest)?;
+    write_json(path.join("runs.json"), &bundle.runs)?;
+    write_json(path.join("artifacts.json"), &bundle.artifacts)?;
+    write_json(path.join("trace_spans.json"), &bundle.trace_spans)?;
+    Ok(())
+}
+
+fn read_bundle_dir(path: &Path) -> homeboy::Result<ObservationBundle> {
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "input",
+            "observation bundle input must be a directory",
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    let manifest: ObservationBundleManifest = read_json(path.join("manifest.json"))?;
+    if manifest.format != BUNDLE_FORMAT {
+        return Err(Error::validation_invalid_argument(
+            "manifest.format",
+            format!("expected {BUNDLE_FORMAT}, got {}", manifest.format),
+            Some(manifest.format),
+            None,
+        ));
+    }
+    if manifest.version != BUNDLE_VERSION {
+        return Err(Error::validation_invalid_argument(
+            "manifest.version",
+            format!(
+                "expected version {BUNDLE_VERSION}, got {}",
+                manifest.version
+            ),
+            Some(manifest.version.to_string()),
+            None,
+        ));
+    }
+
+    let runs: Vec<RunRecord> = read_json(path.join("runs.json"))?;
+    let artifacts: Vec<ArtifactRecord> = read_json(path.join("artifacts.json"))?;
+    let trace_spans: Vec<TraceSpanRecord> = read_json(path.join("trace_spans.json"))?;
+    if manifest.run_count != runs.len()
+        || manifest.artifact_count != artifacts.len()
+        || manifest.trace_span_count != trace_spans.len()
+    {
+        return Err(Error::validation_invalid_argument(
+            "manifest",
+            "bundle manifest counts do not match record files",
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    Ok(ObservationBundle {
+        manifest,
+        runs,
+        artifacts,
+        trace_spans,
+    })
+}
+
+fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::Result<()> {
+    let json = serde_json::to_string_pretty(value).map_err(|e| {
+        Error::internal_json(e.to_string(), Some(format!("serialize {}", path.display())))
+    })?;
+    fs::write(&path, json).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("write observation bundle file {}", path.display())),
+        )
+    })
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::Result<T> {
+    let raw = fs::read_to_string(&path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read observation bundle file {}", path.display())),
+        )
+    })?;
+    serde_json::from_str(&raw).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse observation bundle file {}", path.display())),
+            Some(raw),
+        )
+    })
+}
+
+fn since_threshold(raw: &str) -> homeboy::Result<String> {
+    let duration = parse_duration(raw)?;
+    let chrono_duration = chrono::Duration::from_std(duration).map_err(|e| {
+        Error::validation_invalid_argument("since", e.to_string(), Some(raw.to_string()), None)
+    })?;
+    Ok((chrono::Utc::now() - chrono_duration).to_rfc3339())
+}
+
+fn parse_duration(raw: &str) -> homeboy::Result<Duration> {
+    let trimmed = raw.trim();
+    let split = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (amount, unit) = trimmed.split_at(split);
+    if amount.is_empty() || unit.is_empty() || !unit.chars().all(|ch| ch.is_ascii_alphabetic()) {
+        return Err(Error::validation_invalid_argument(
+            "since",
+            "expected duration like 30m, 24h, or 7d",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    let amount = amount.parse::<u64>().map_err(|_| {
+        Error::validation_invalid_argument(
+            "since",
+            "duration amount must be a positive integer",
+            Some(raw.to_string()),
+            None,
+        )
+    })?;
+    if amount == 0 {
+        return Err(Error::validation_invalid_argument(
+            "since",
+            "duration amount must be greater than zero",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    let seconds = match unit {
+        "s" | "sec" | "secs" | "second" | "seconds" => amount,
+        "m" | "min" | "mins" | "minute" | "minutes" => amount * 60,
+        "h" | "hr" | "hrs" | "hour" | "hours" => amount * 60 * 60,
+        "d" | "day" | "days" => amount * 60 * 60 * 24,
+        _ => {
+            return Err(Error::validation_invalid_argument(
+                "since",
+                "duration unit must be one of s, m, h, or d",
+                Some(raw.to_string()),
+                None,
+            ))
+        }
+    };
+    Ok(Duration::from_secs(seconds))
 }
 
 fn require_kind(run: &RunRecord, expected: &str) -> homeboy::Result<()> {
@@ -395,7 +726,7 @@ fn collect_numeric_object(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy::observation::{NewRunRecord, RunStatus};
+    use homeboy::observation::{NewRunRecord, NewTraceSpanRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
     struct XdgGuard(Option<String>);
@@ -652,5 +983,240 @@ mod tests {
             assert_eq!(mismatch.code.as_str(), "validation.invalid_argument");
             assert!(mismatch.message.contains("expected 'bench'"));
         });
+    }
+
+    #[test]
+    fn export_one_run_writes_directory_bundle() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish");
+            let output = home.path().join("bundle");
+
+            let (result, _) = export_runs(RunsExportArgs {
+                run: Some(run.id.clone()),
+                since: None,
+                output: output.clone(),
+            })
+            .expect("export");
+
+            let RunsOutput::Export(result) = result else {
+                panic!("expected export output");
+            };
+            assert_eq!(result.run_count, 1);
+            assert!(output.join("manifest.json").exists());
+            assert!(output.join("runs.json").exists());
+            assert!(output.join("artifacts.json").exists());
+            assert!(output.join("trace_spans.json").exists());
+            let runs: Vec<RunRecord> = read_bundle_test_json(&output.join("runs.json"));
+            assert_eq!(runs.len(), 1);
+            assert_eq!(runs[0].id, run.id);
+        });
+    }
+
+    #[test]
+    fn export_since_writes_multiple_runs() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let first = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("first");
+            let second = store
+                .start_run(sample_run("trace", "homeboy", "studio", Value::Null))
+                .expect("second");
+            let output = home.path().join("recent-bundle");
+
+            export_runs(RunsExportArgs {
+                run: None,
+                since: Some("1d".to_string()),
+                output: output.clone(),
+            })
+            .expect("export recent");
+
+            let runs: Vec<RunRecord> = read_bundle_test_json(&output.join("runs.json"));
+            let ids = runs
+                .iter()
+                .map(|run| run.id.clone())
+                .collect::<BTreeSet<_>>();
+            assert_eq!(ids, BTreeSet::from([first.id, second.id]));
+        });
+    }
+
+    #[test]
+    fn export_artifacts_is_metadata_only() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let artifact_path = home.path().join("bench-results.json");
+            std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact");
+            let artifact = store
+                .record_artifact(&run.id, "bench_results", &artifact_path)
+                .expect("record artifact");
+            let output = home.path().join("artifact-bundle");
+
+            export_runs(RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            })
+            .expect("export");
+
+            let artifacts: Vec<ArtifactRecord> =
+                read_bundle_test_json(&output.join("artifacts.json"));
+            assert_eq!(artifacts, vec![artifact]);
+            assert!(!output.join("files").exists());
+        });
+    }
+
+    #[test]
+    fn export_trace_spans_when_present() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("trace", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let span = store
+                .record_trace_span(NewTraceSpanRecord {
+                    run_id: run.id.clone(),
+                    span_id: "boot".to_string(),
+                    status: "ok".to_string(),
+                    duration_ms: Some(12.5),
+                    from_event: Some("start".to_string()),
+                    to_event: Some("ready".to_string()),
+                    metadata_json: serde_json::json!({ "phase": "cold" }),
+                })
+                .expect("span");
+            let output = home.path().join("trace-bundle");
+
+            export_runs(RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            })
+            .expect("export");
+
+            let spans: Vec<TraceSpanRecord> =
+                read_bundle_test_json(&output.join("trace_spans.json"));
+            assert_eq!(spans, vec![span]);
+        });
+    }
+
+    #[test]
+    fn import_into_empty_db_and_reimport_is_idempotent() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let bundle = home.path().join("portable-bundle");
+            let run_id = {
+                let store = ObservationStore::open_initialized().expect("store");
+                let run = store
+                    .start_run(sample_run("trace", "homeboy", "studio", Value::Null))
+                    .expect("run");
+                let artifact_path = home.path().join("trace.json");
+                std::fs::write(&artifact_path, b"{}").expect("artifact");
+                store
+                    .record_artifact(&run.id, "trace_results", &artifact_path)
+                    .expect("artifact record");
+                store
+                    .record_trace_span(NewTraceSpanRecord {
+                        run_id: run.id.clone(),
+                        span_id: "first".to_string(),
+                        status: "ok".to_string(),
+                        duration_ms: Some(1.0),
+                        from_event: None,
+                        to_event: Some("done".to_string()),
+                        metadata_json: serde_json::json!({}),
+                    })
+                    .expect("span");
+                export_runs(RunsExportArgs {
+                    run: Some(run.id.clone()),
+                    since: None,
+                    output: bundle.clone(),
+                })
+                .expect("export");
+                run.id
+            };
+            std::fs::remove_file(home.path().join(".local/share/homeboy/homeboy.sqlite"))
+                .expect("remove db");
+
+            import_runs(RunsImportArgs {
+                input: bundle.clone(),
+            })
+            .expect("import");
+            import_runs(RunsImportArgs {
+                input: bundle.clone(),
+            })
+            .expect("second import is idempotent");
+
+            let store = ObservationStore::open_initialized().expect("store");
+            assert!(store.get_run(&run_id).expect("get").is_some());
+            assert_eq!(store.list_artifacts(&run_id).expect("artifacts").len(), 1);
+            assert_eq!(store.list_trace_spans(&run_id).expect("spans").len(), 1);
+        });
+    }
+
+    #[test]
+    fn malformed_bundle_validation_fails_clearly() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let bundle = home.path().join("bad-bundle");
+            std::fs::create_dir_all(&bundle).expect("bundle dir");
+            std::fs::write(bundle.join("manifest.json"), "not json").expect("manifest");
+
+            let err = match import_runs(RunsImportArgs { input: bundle }) {
+                Ok(_) => panic!("malformed bundle should fail"),
+                Err(err) => err,
+            };
+
+            assert_eq!(err.code.as_str(), "validation.invalid_json");
+        });
+    }
+
+    #[test]
+    fn conflicting_existing_rows_fail_clearly() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let bundle = home.path().join("conflict-bundle");
+            export_runs(RunsExportArgs {
+                run: Some(run.id.clone()),
+                since: None,
+                output: bundle.clone(),
+            })
+            .expect("export");
+            let mut runs: Vec<RunRecord> = read_bundle_test_json(&bundle.join("runs.json"));
+            runs[0].status = "pass".to_string();
+            std::fs::write(
+                bundle.join("runs.json"),
+                serde_json::to_string_pretty(&runs).expect("json"),
+            )
+            .expect("rewrite runs");
+
+            let err = match import_runs(RunsImportArgs { input: bundle }) {
+                Ok(_) => panic!("conflicting import should fail"),
+                Err(err) => err,
+            };
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err
+                .message
+                .contains("conflicts with imported bundle record"));
+        });
+    }
+
+    fn read_bundle_test_json<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
+        serde_json::from_str(&std::fs::read_to_string(path).expect("read json")).expect("json")
     }
 }

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -1,0 +1,313 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use clap::Args;
+use serde::{Deserialize, Serialize};
+
+use homeboy::observation::{ArtifactRecord, ObservationStore, RunRecord, TraceSpanRecord};
+use homeboy::Error;
+
+use super::{require_run, CmdResult, RunsExportOutput, RunsImportOutput, RunsOutput};
+
+const BUNDLE_FORMAT: &str = "homeboy-observations";
+const BUNDLE_VERSION: u32 = 1;
+
+#[derive(Args, Clone)]
+pub(super) struct RunsExportArgs {
+    /// Export one run by id
+    #[arg(long, conflicts_with = "since")]
+    pub run: Option<String>,
+    /// Export runs started within a duration, e.g. 24h, 7d, 30m
+    #[arg(long, conflicts_with = "run")]
+    pub since: Option<String>,
+    /// Output bundle directory. Zip output is intentionally out of scope for v1.
+    #[arg(long, value_name = "DIR")]
+    pub output: PathBuf,
+}
+
+#[derive(Args, Clone)]
+pub(super) struct RunsImportArgs {
+    /// Bundle directory produced by `homeboy runs export`
+    pub input: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObservationBundleManifest {
+    pub format: String,
+    pub version: u32,
+    pub created_at: String,
+    pub homeboy_version: String,
+    pub run_count: usize,
+    pub artifact_count: usize,
+    pub trace_span_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct ObservationBundle {
+    manifest: ObservationBundleManifest,
+    runs: Vec<RunRecord>,
+    artifacts: Vec<ArtifactRecord>,
+    trace_spans: Vec<TraceSpanRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ObservationBundleImportSummary {
+    pub runs: usize,
+    pub artifacts: usize,
+    pub trace_spans: usize,
+}
+
+pub(super) fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
+    if args
+        .output
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+    {
+        return Err(Error::validation_invalid_argument(
+            "output",
+            "zip output is out of scope for observation bundle v1; pass a directory path",
+            Some(args.output.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+
+    let store = ObservationStore::open_initialized()?;
+    let runs = if let Some(run_id) = args.run.as_deref() {
+        vec![require_run(&store, run_id)?]
+    } else if let Some(since) = args.since.as_deref() {
+        let threshold = since_threshold(since)?;
+        store.list_runs_started_since(&threshold)?
+    } else {
+        return Err(Error::validation_missing_argument(vec![
+            "--run <run-id> or --since <duration>".to_string(),
+        ]));
+    };
+
+    let bundle = build_bundle(&store, runs)?;
+    write_bundle_dir(&args.output, &bundle)?;
+
+    Ok((
+        RunsOutput::Export(RunsExportOutput {
+            command: "runs.export",
+            output: args.output.to_string_lossy().to_string(),
+            run_count: bundle.runs.len(),
+            artifact_count: bundle.artifacts.len(),
+            trace_span_count: bundle.trace_spans.len(),
+            manifest: bundle.manifest,
+        }),
+        0,
+    ))
+}
+
+pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
+    let bundle = read_bundle_dir(&args.input)?;
+    let store = ObservationStore::open_initialized()?;
+    for run in &bundle.runs {
+        store.import_run(run)?;
+    }
+    for artifact in &bundle.artifacts {
+        store.import_artifact(artifact)?;
+    }
+    for span in &bundle.trace_spans {
+        store.import_trace_span(span)?;
+    }
+
+    Ok((
+        RunsOutput::Import(RunsImportOutput {
+            command: "runs.import",
+            input: args.input.to_string_lossy().to_string(),
+            imported: ObservationBundleImportSummary {
+                runs: bundle.runs.len(),
+                artifacts: bundle.artifacts.len(),
+                trace_spans: bundle.trace_spans.len(),
+            },
+        }),
+        0,
+    ))
+}
+
+fn build_bundle(
+    store: &ObservationStore,
+    runs: Vec<RunRecord>,
+) -> homeboy::Result<ObservationBundle> {
+    let mut artifacts = Vec::new();
+    let mut trace_spans = Vec::new();
+    for run in &runs {
+        artifacts.extend(store.list_artifacts(&run.id)?);
+        trace_spans.extend(store.list_trace_spans(&run.id)?);
+    }
+    let manifest = ObservationBundleManifest {
+        format: BUNDLE_FORMAT.to_string(),
+        version: BUNDLE_VERSION,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        homeboy_version: env!("CARGO_PKG_VERSION").to_string(),
+        run_count: runs.len(),
+        artifact_count: artifacts.len(),
+        trace_span_count: trace_spans.len(),
+    };
+    Ok(ObservationBundle {
+        manifest,
+        runs,
+        artifacts,
+        trace_spans,
+    })
+}
+
+fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::Result<()> {
+    if path.exists() && !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "output",
+            "observation bundle output must be a directory",
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    fs::create_dir_all(path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("create observation bundle dir {}", path.display())),
+        )
+    })?;
+    write_json(path.join("manifest.json"), &bundle.manifest)?;
+    write_json(path.join("runs.json"), &bundle.runs)?;
+    write_json(path.join("artifacts.json"), &bundle.artifacts)?;
+    write_json(path.join("trace_spans.json"), &bundle.trace_spans)?;
+    Ok(())
+}
+
+fn read_bundle_dir(path: &Path) -> homeboy::Result<ObservationBundle> {
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "input",
+            "observation bundle input must be a directory",
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    let manifest: ObservationBundleManifest = read_json(path.join("manifest.json"))?;
+    if manifest.format != BUNDLE_FORMAT {
+        return Err(Error::validation_invalid_argument(
+            "manifest.format",
+            format!("expected {BUNDLE_FORMAT}, got {}", manifest.format),
+            Some(manifest.format),
+            None,
+        ));
+    }
+    if manifest.version != BUNDLE_VERSION {
+        return Err(Error::validation_invalid_argument(
+            "manifest.version",
+            format!(
+                "expected version {BUNDLE_VERSION}, got {}",
+                manifest.version
+            ),
+            Some(manifest.version.to_string()),
+            None,
+        ));
+    }
+
+    let runs: Vec<RunRecord> = read_json(path.join("runs.json"))?;
+    let artifacts: Vec<ArtifactRecord> = read_json(path.join("artifacts.json"))?;
+    let trace_spans: Vec<TraceSpanRecord> = read_json(path.join("trace_spans.json"))?;
+    if manifest.run_count != runs.len()
+        || manifest.artifact_count != artifacts.len()
+        || manifest.trace_span_count != trace_spans.len()
+    {
+        return Err(Error::validation_invalid_argument(
+            "manifest",
+            "bundle manifest counts do not match record files",
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    Ok(ObservationBundle {
+        manifest,
+        runs,
+        artifacts,
+        trace_spans,
+    })
+}
+
+fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::Result<()> {
+    let json = serde_json::to_string_pretty(value).map_err(|e| {
+        Error::internal_json(e.to_string(), Some(format!("serialize {}", path.display())))
+    })?;
+    fs::write(&path, json).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("write observation bundle file {}", path.display())),
+        )
+    })
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::Result<T> {
+    let raw = fs::read_to_string(&path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read observation bundle file {}", path.display())),
+        )
+    })?;
+    serde_json::from_str(&raw).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse observation bundle file {}", path.display())),
+            Some(raw),
+        )
+    })
+}
+
+fn since_threshold(raw: &str) -> homeboy::Result<String> {
+    let duration = parse_duration(raw)?;
+    let chrono_duration = chrono::Duration::from_std(duration).map_err(|e| {
+        Error::validation_invalid_argument("since", e.to_string(), Some(raw.to_string()), None)
+    })?;
+    Ok((chrono::Utc::now() - chrono_duration).to_rfc3339())
+}
+
+fn parse_duration(raw: &str) -> homeboy::Result<Duration> {
+    let trimmed = raw.trim();
+    let split = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (amount, unit) = trimmed.split_at(split);
+    if amount.is_empty() || unit.is_empty() || !unit.chars().all(|ch| ch.is_ascii_alphabetic()) {
+        return Err(Error::validation_invalid_argument(
+            "since",
+            "expected duration like 30m, 24h, or 7d",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    let amount = amount.parse::<u64>().map_err(|_| {
+        Error::validation_invalid_argument(
+            "since",
+            "duration amount must be a positive integer",
+            Some(raw.to_string()),
+            None,
+        )
+    })?;
+    if amount == 0 {
+        return Err(Error::validation_invalid_argument(
+            "since",
+            "duration amount must be greater than zero",
+            Some(raw.to_string()),
+            None,
+        ));
+    }
+    let seconds = match unit {
+        "s" | "sec" | "secs" | "second" | "seconds" => amount,
+        "m" | "min" | "mins" | "minute" | "minutes" => amount * 60,
+        "h" | "hr" | "hrs" | "hour" | "hours" => amount * 60 * 60,
+        "d" | "day" | "days" => amount * 60 * 60 * 24,
+        _ => {
+            return Err(Error::validation_invalid_argument(
+                "since",
+                "duration unit must be one of s, m, h, or d",
+                Some(raw.to_string()),
+                None,
+            ))
+        }
+    };
+    Ok(Duration::from_secs(seconds))
+}

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum RunStatus {
@@ -33,7 +33,7 @@ pub struct NewRunRecord {
     pub metadata_json: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunRecord {
     pub id: String,
     pub kind: String,
@@ -58,7 +58,7 @@ pub struct RunListFilter {
     pub limit: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArtifactRecord {
     pub id: String,
     pub run_id: String,
@@ -103,7 +103,7 @@ pub struct NewTraceSpanRecord {
     pub metadata_json: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TraceSpanRecord {
     pub id: String,
     pub run_id: String,

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -276,6 +276,104 @@ impl ObservationStore {
         collect_rows(rows, "collect run records")
     }
 
+    pub fn list_runs_started_since(&self, started_at: &str) -> Result<Vec<RunRecord>> {
+        validate_required("started_at", started_at)?;
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, kind, component_id, started_at, finished_at, status, command, cwd,
+                       homeboy_version, git_sha, rig_id, metadata_json
+                FROM runs
+                WHERE started_at >= ?1
+                ORDER BY started_at DESC
+                "#,
+            )
+            .map_err(sqlite_error("prepare list recent run records"))?;
+        let rows = statement
+            .query_map([started_at], row_to_run_record)
+            .map_err(sqlite_error("list recent run records"))?;
+
+        collect_rows(rows, "collect recent run records")
+    }
+
+    pub fn import_run(&self, run: &RunRecord) -> Result<()> {
+        validate_required("run.id", &run.id)?;
+        if let Some(existing) = self.get_run(&run.id)? {
+            return ensure_identical("run", &run.id, &existing, run);
+        }
+        let metadata_json = serialize_metadata(&run.metadata_json)?;
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO runs(
+                    id,
+                    kind,
+                    component_id,
+                    started_at,
+                    finished_at,
+                    status,
+                    command,
+                    cwd,
+                    homeboy_version,
+                    git_sha,
+                    rig_id,
+                    metadata_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                "#,
+                params![
+                    run.id,
+                    run.kind,
+                    run.component_id,
+                    run.started_at,
+                    run.finished_at,
+                    run.status,
+                    run.command,
+                    run.cwd,
+                    run.homeboy_version,
+                    run.git_sha,
+                    run.rig_id,
+                    metadata_json,
+                ],
+            )
+            .map_err(sqlite_error("import run record"))?;
+        Ok(())
+    }
+
+    pub fn import_artifact(&self, artifact: &ArtifactRecord) -> Result<()> {
+        validate_required("artifact.id", &artifact.id)?;
+        if self.get_run(&artifact.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "artifact.run_id",
+                format!("referenced run record not found: {}", artifact.run_id),
+                Some(artifact.run_id.clone()),
+                None,
+            ));
+        }
+        if let Some(existing) = self.get_artifact(&artifact.id)? {
+            return ensure_identical("artifact", &artifact.id, &existing, artifact);
+        }
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO artifacts(id, run_id, kind, path, sha256, size_bytes, mime, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                "#,
+                params![
+                    artifact.id,
+                    artifact.run_id,
+                    artifact.kind,
+                    artifact.path,
+                    artifact.sha256,
+                    artifact.size_bytes,
+                    artifact.mime,
+                    artifact.created_at,
+                ],
+            )
+            .map_err(sqlite_error("import artifact record"))?;
+        Ok(())
+    }
+
     pub fn record_artifact(
         &self,
         run_id: &str,
@@ -371,6 +469,22 @@ impl ObservationStore {
             .map_err(sqlite_error("list artifact records"))?;
 
         collect_rows(rows, "collect artifact records")
+    }
+
+    pub fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
+        validate_required("artifact_id", artifact_id)?;
+        self.connection
+            .query_row(
+                r#"
+                SELECT id, run_id, kind, path, sha256, size_bytes, mime, created_at
+                FROM artifacts
+                WHERE id = ?1
+                "#,
+                [artifact_id],
+                row_to_artifact_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read artifact record"))
     }
 
     pub fn record_trace_run(&self, record: NewTraceRunRecord) -> Result<TraceRunRecord> {
@@ -511,6 +625,66 @@ impl ObservationStore {
             .map_err(sqlite_error("list trace span records"))?;
 
         collect_rows(rows, "collect trace span records")
+    }
+
+    pub fn get_trace_span(&self, trace_span_id: &str) -> Result<Option<TraceSpanRecord>> {
+        validate_required("trace_span_id", trace_span_id)?;
+        self.connection
+            .query_row(
+                r#"
+                SELECT id, run_id, span_id, status, duration_ms, from_event, to_event,
+                       metadata_json
+                FROM trace_spans
+                WHERE id = ?1
+                "#,
+                [trace_span_id],
+                row_to_trace_span_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read trace span record"))
+    }
+
+    pub fn import_trace_span(&self, span: &TraceSpanRecord) -> Result<()> {
+        validate_required("trace_span.id", &span.id)?;
+        if self.get_run(&span.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "trace_span.run_id",
+                format!("referenced run record not found: {}", span.run_id),
+                Some(span.run_id.clone()),
+                None,
+            ));
+        }
+        if let Some(existing) = self.get_trace_span(&span.id)? {
+            return ensure_identical("trace_span", &span.id, &existing, span);
+        }
+        let metadata_json = serialize_metadata(&span.metadata_json)?;
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO trace_spans(
+                    id,
+                    run_id,
+                    span_id,
+                    status,
+                    duration_ms,
+                    from_event,
+                    to_event,
+                    metadata_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                "#,
+                params![
+                    span.id,
+                    span.run_id,
+                    span.span_id,
+                    span.status,
+                    span.duration_ms,
+                    span.from_event,
+                    span.to_event,
+                    metadata_json,
+                ],
+            )
+            .map_err(sqlite_error("import trace span record"))?;
+        Ok(())
     }
 }
 
@@ -666,6 +840,18 @@ fn validate_required(field: &str, value: &str) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn ensure_identical<T: PartialEq>(kind: &str, id: &str, existing: &T, incoming: &T) -> Result<()> {
+    if existing == incoming {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        format!("{kind}.id"),
+        format!("existing {kind} record conflicts with imported bundle record: {id}"),
+        Some(id.to_string()),
+        None,
+    ))
 }
 
 fn serialize_metadata(metadata_json: &serde_json::Value) -> Result<String> {

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -471,7 +471,7 @@ impl ObservationStore {
         collect_rows(rows, "collect artifact records")
     }
 
-    pub fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
+    fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
         validate_required("artifact_id", artifact_id)?;
         self.connection
             .query_row(
@@ -627,7 +627,7 @@ impl ObservationStore {
         collect_rows(rows, "collect trace span records")
     }
 
-    pub fn get_trace_span(&self, trace_span_id: &str) -> Result<Option<TraceSpanRecord>> {
+    fn get_trace_span(&self, trace_span_id: &str) -> Result<Option<TraceSpanRecord>> {
         validate_required("trace_span_id", trace_span_id)?;
         self.connection
             .query_row(
@@ -1095,6 +1095,33 @@ mod api_coverage_tests {
     }
 
     #[test]
+    fn test_list_runs_started_since() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run("bench")).expect("start");
+            let recent = store
+                .list_runs_started_since("1970-01-01T00:00:00Z")
+                .expect("recent");
+            assert_eq!(recent.len(), 1);
+            assert_eq!(recent[0].id, run.id);
+        });
+    }
+
+    #[test]
+    fn test_import_run() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run("bench")).expect("start");
+            let imported = ObservationStore::open_initialized().expect("second handle");
+
+            imported.import_run(&run).expect("idempotent import");
+            assert_eq!(imported.get_run(&run.id).expect("get"), Some(run));
+        });
+    }
+
+    #[test]
     fn test_record_artifact() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
@@ -1121,6 +1148,29 @@ mod api_coverage_tests {
                 .record_artifact(&run.id, "log", &path)
                 .expect("artifact");
             assert_eq!(store.list_artifacts(&run.id).expect("list"), vec![artifact]);
+        });
+    }
+
+    #[test]
+    fn test_import_artifact() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let source = ObservationStore::open_initialized().expect("source");
+            let run = source.start_run(new_run("trace")).expect("run");
+            let path = home.path().join("artifact.json");
+            fs::write(&path, b"{}").expect("write artifact");
+            let artifact = source
+                .record_artifact(&run.id, "json", &path)
+                .expect("artifact");
+
+            let target = ObservationStore::open_initialized().expect("target");
+            target
+                .import_artifact(&artifact)
+                .expect("idempotent import");
+            assert_eq!(
+                target.list_artifacts(&run.id).expect("list"),
+                vec![artifact]
+            );
         });
     }
 
@@ -1172,6 +1222,30 @@ mod api_coverage_tests {
             let spans = store.list_trace_spans(&run.id).expect("spans");
             assert_eq!(spans, vec![span]);
             assert_eq!(spans[0].duration_ms, Some(125.0));
+        });
+    }
+
+    #[test]
+    fn test_import_trace_span() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let source = ObservationStore::open_initialized().expect("source");
+            let run = source.start_run(new_run("trace")).expect("run");
+            let span = source
+                .record_trace_span(NewTraceSpanRecord {
+                    run_id: run.id.clone(),
+                    span_id: "boot".to_string(),
+                    status: "ok".to_string(),
+                    duration_ms: Some(42.0),
+                    from_event: Some("start".to_string()),
+                    to_event: Some("ready".to_string()),
+                    metadata_json: serde_json::json!({ "source": "import-test" }),
+                })
+                .expect("span");
+
+            let target = ObservationStore::open_initialized().expect("target");
+            target.import_trace_span(&span).expect("idempotent import");
+            assert_eq!(target.list_trace_spans(&run.id).expect("spans"), vec![span]);
         });
     }
 


### PR DESCRIPTION
## Summary
- Adds directory-based observation bundle export/import for persisted runs, artifact metadata, and trace spans.
- Keeps v1 intentionally inspectable and metadata-only; zip/file-byte export is deferred.
- Adds idempotent observation-store import helpers with clear conflict errors for mismatched existing records.

## CLI surface
- `homeboy runs export --run <run-id> --output <dir>`
- `homeboy runs export --since <duration> --output <dir>`
- `homeboy runs import <dir>`

## Bundle format
- `manifest.json`
- `runs.json`
- `artifacts.json`
- `trace_spans.json`

## Import behavior
- Importing the same bundle twice is idempotent.
- Existing identical rows are accepted.
- Existing rows with the same primary key but different contents fail with a validation error.
- Malformed JSON and manifest count mismatches fail before import.

## Tests
- `cargo fmt`
- `cargo test runs -- --test-threads=1`
- `cargo test observation -- --test-threads=1`
- `homeboy audit homeboy --path "/Users/chubes/Developer/homeboy@obs-store-export-import" --changed-since origin/main`

## Out of scope
- Zip/compressed bundle support.
- Artifact file-byte export/import.
- GitHub Actions/Homeboy Action wiring.
- Hosted sync or SQLite replacement.

Closes #2022

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bundle export/import code, tests, documentation, and local verification; Chris remains responsible for review and merge decisions.