### PR TITLE
fix(trace): tolerate tiny baseline deltas

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -96,5 +96,8 @@ Trace spans can use the same lifecycle flags as other baseline-aware commands:
 - `--ratchet` updates the stored baseline when spans improve.
 - `--ignore-baseline` skips comparison.
 - `--regression-threshold=<PCT>` controls the allowed duration slowdown. Default is `5`.
+- `--regression-min-delta-ms=<MS>` controls the minimum absolute slowdown before a regression can fail. Default is `50`.
+
+Both regression thresholds must trip before Homeboy fails the run. For example, `9ms -> 15ms` exceeds the default percentage threshold but stays below the default `50ms` minimum delta, so it does not fail as a trace baseline regression.
 
 Rig-pinned traces store separate baselines under `trace.rig.<rig-id>` so bare and rig-owned traces do not collide.

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -55,6 +55,10 @@ pub struct TraceArgs {
     #[arg(long, value_name = "PERCENT", default_value_t = extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT)]
     pub regression_threshold: f64,
 
+    /// Minimum span slowdown in milliseconds before a regression can fail.
+    #[arg(long, value_name = "MS", default_value_t = extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS)]
+    pub regression_min_delta_ms: u64,
+
     /// Apply a patch file for this trace run, then reverse it afterward.
     #[arg(long = "overlay", value_name = "PATCH_FILE")]
     pub overlays: Vec<String>,
@@ -165,7 +169,8 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
                         "baseline": args.baseline_args.baseline,
                         "ignore_baseline": args.baseline_args.ignore_baseline,
                         "ratchet": args.baseline_args.ratchet,
-                        "regression_threshold_percent": args.regression_threshold
+                        "regression_threshold_percent": args.regression_threshold,
+                        "regression_min_delta_ms": args.regression_min_delta_ms
                     }
                 }),
             })
@@ -212,6 +217,7 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
                 ratchet: args.baseline_args.ratchet,
             },
             regression_threshold_percent: args.regression_threshold,
+            regression_min_delta_ms: args.regression_min_delta_ms,
         },
         &run_dir,
         rig_state.clone(),
@@ -661,6 +667,7 @@ mod tests {
                 baseline_args: BaselineArgs::default(),
                 regression_threshold:
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
                 keep_overlay: false,
             })
@@ -744,6 +751,7 @@ mod tests {
                 baseline_args: BaselineArgs::default(),
                 regression_threshold:
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
                 keep_overlay: false,
             })
@@ -784,6 +792,8 @@ mod tests {
                     baseline_args: BaselineArgs::default(),
                     regression_threshold:
                         extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    regression_min_delta_ms:
+                        extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                     overlays: Vec::new(),
                     keep_overlay: false,
                 },
@@ -830,6 +840,8 @@ mod tests {
                     baseline_args: BaselineArgs::default(),
                     regression_threshold:
                         extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    regression_min_delta_ms:
+                        extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                     overlays: Vec::new(),
                     keep_overlay: false,
                 },
@@ -899,6 +911,8 @@ mod tests {
                     baseline_args: BaselineArgs::default(),
                     regression_threshold:
                         extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    regression_min_delta_ms:
+                        extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                     overlays: Vec::new(),
                     keep_overlay: false,
                 },

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -12,6 +12,7 @@ use super::parsing::TraceResults;
 
 const BASELINE_KEY: &str = "trace";
 pub const DEFAULT_REGRESSION_THRESHOLD_PERCENT: f64 = 5.0;
+pub const DEFAULT_REGRESSION_MIN_DELTA_MS: u64 = 50;
 
 fn baseline_key_for(rig_id: Option<&str>) -> String {
     rig_id.map_or_else(|| BASELINE_KEY.to_string(), |id| format!("trace.rig.{id}"))
@@ -59,6 +60,7 @@ pub struct TraceSpanDelta {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct TraceBaselineComparison {
     pub threshold_percent: f64,
+    pub min_delta_ms: u64,
     pub spans: Vec<TraceSpanDelta>,
     pub new_span_ids: Vec<String>,
     pub removed_span_ids: Vec<String>,
@@ -93,6 +95,7 @@ pub fn compare(
     current: &TraceResults,
     baseline: &TraceBaseline,
     threshold_percent: f64,
+    min_delta_ms: u64,
 ) -> TraceBaselineComparison {
     let current_snapshots = snapshots_from_results(current);
     let baseline_by_id: HashMap<&str, &TraceSpanSnapshot> = baseline
@@ -123,7 +126,8 @@ pub fn compare(
         } else {
             Some((delta_ms as f64 / prior.duration_ms as f64) * 100.0)
         };
-        let span_regression = delta_pct.is_some_and(|pct| pct > threshold_percent);
+        let span_regression =
+            delta_ms > min_delta_ms as i64 && delta_pct.is_some_and(|pct| pct > threshold_percent);
         let span_improvement = delta_ms < 0;
         if span_regression {
             regression = true;
@@ -158,6 +162,7 @@ pub fn compare(
 
     TraceBaselineComparison {
         threshold_percent,
+        min_delta_ms,
         spans,
         new_span_ids,
         removed_span_ids,
@@ -226,11 +231,45 @@ mod tests {
             },
         };
 
-        let comparison = compare(&results(130), &baseline, 5.0);
+        let comparison = compare(
+            &results(180),
+            &baseline,
+            5.0,
+            DEFAULT_REGRESSION_MIN_DELTA_MS,
+        );
 
         assert!(comparison.regression);
-        assert_eq!(comparison.spans[0].delta_ms, 30);
-        assert_eq!(comparison.spans[0].delta_pct, Some(30.0));
+        assert_eq!(comparison.spans[0].delta_ms, 80);
+        assert_eq!(comparison.spans[0].delta_pct, Some(80.0));
+    }
+
+    #[test]
+    fn test_compare_requires_min_delta_for_regression() {
+        let baseline = TraceBaseline {
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            context_id: "studio".to_string(),
+            item_count: 1,
+            known_fingerprints: vec!["submit_to_cli".to_string()],
+            metadata: TraceBaselineMetadata {
+                spans: vec![TraceSpanSnapshot {
+                    id: "submit_to_cli".to_string(),
+                    duration_ms: 9,
+                }],
+            },
+        };
+
+        let comparison = compare(
+            &results(15),
+            &baseline,
+            5.0,
+            DEFAULT_REGRESSION_MIN_DELTA_MS,
+        );
+
+        assert!(!comparison.regression);
+        assert_eq!(comparison.min_delta_ms, DEFAULT_REGRESSION_MIN_DELTA_MS);
+        assert_eq!(comparison.spans[0].delta_ms, 6);
+        assert_eq!(comparison.spans[0].delta_pct, Some(66.66666666666666));
+        assert!(!comparison.spans[0].regression);
     }
 
     #[test]

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -35,6 +35,7 @@ pub struct TraceRunWorkflowArgs {
     pub span_definitions: Vec<TraceSpanDefinition>,
     pub baseline_flags: BaselineFlags,
     pub regression_threshold_percent: f64,
+    pub regression_min_delta_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -163,8 +164,12 @@ fn run_trace_workflow_with_context(
     if has_span_results && !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
         if let Some(ref parsed) = results {
             if let Some(existing) = super::baseline::load_baseline(source_path, rig_id) {
-                let comparison =
-                    super::baseline::compare(parsed, &existing, args.regression_threshold_percent);
+                let comparison = super::baseline::compare(
+                    parsed,
+                    &existing,
+                    args.regression_threshold_percent,
+                    args.regression_min_delta_ms,
+                );
                 if comparison.regression {
                     baseline_exit_override = Some(1);
                 } else if comparison.has_improvements && args.baseline_flags.ratchet {
@@ -202,8 +207,8 @@ fn run_trace_workflow_with_context(
     if let Some(ref cmp) = baseline_comparison {
         if cmp.regression {
             hints.push(format!(
-                "Trace span regression threshold: {}%. Raise it with --regression-threshold=<PCT> if expected.",
-                cmp.threshold_percent
+                "Trace span regression threshold: {}% and {}ms. Raise them with --regression-threshold=<PCT> or --regression-min-delta-ms=<MS> if expected.",
+                cmp.threshold_percent, cmp.min_delta_ms
             ));
         }
     }
@@ -254,6 +259,7 @@ pub fn run_trace_list_workflow(
             ratchet: false,
         },
         regression_threshold_percent: super::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: super::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
     };
     let output =
         build_trace_runner(&execution_context, component, &runner_args, run_dir, true)?.run()?;
@@ -617,6 +623,8 @@ JSON
             },
             regression_threshold_percent:
                 crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
 
         let output = build_trace_runner(&context, &component, &args, &run_dir, false)
@@ -688,6 +696,8 @@ JSON
             },
             regression_threshold_percent:
                 crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
 
         let output = build_trace_runner(&context, &component, &args, &run_dir, true)
@@ -724,6 +734,8 @@ JSON
             },
             regression_threshold_percent:
                 crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
         let output = RunnerOutput {
             success: false,
@@ -869,6 +881,8 @@ JSON
             },
             regression_threshold_percent:
                 crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
         OverlayFixture {
             _temp: temp,


### PR DESCRIPTION
## Summary
- Add a default `--regression-min-delta-ms=50` threshold for trace span baseline comparisons.
- Require both the percentage threshold and minimum absolute delta to trip before a trace baseline regression fails.
- Cover tiny absolute delta tolerance with a trace baseline unit test and document the new option.

Fixes #2035

## Verification
- `cargo fmt --check`
- `cargo test trace::baseline`
- `cargo test trace`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented trace baseline minimum absolute delta threshold, tests, and PR drafting; Chris remains responsible for review.