### PR TITLE
fix(trace): preserve full output artifact with json summary

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -115,6 +115,40 @@ pub fn run_markdown(args: TraceArgs, global: &GlobalArgs) -> CmdResult<String> {
 }
 
 pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutput> {
+    let ((stdout_output, _artifact_output), exit_code) = run_outputs(args)?;
+    Ok((stdout_output, exit_code))
+}
+
+pub fn run_json_with_output_artifact(
+    args: TraceArgs,
+    _global: &GlobalArgs,
+) -> (
+    homeboy::Result<serde_json::Value>,
+    i32,
+    Option<homeboy::Result<serde_json::Value>>,
+) {
+    crate::commands::utils::tty::status("homeboy is working...");
+    let output_to_json = |output: TraceCommandOutput| {
+        serde_json::to_value(output).map_err(|err| {
+            homeboy::Error::internal_json(err.to_string(), Some("serialize response".to_string()))
+        })
+    };
+    match run_outputs(args) {
+        Ok(((stdout_output, artifact_output), exit_code)) => (
+            output_to_json(stdout_output),
+            exit_code,
+            artifact_output.map(output_to_json),
+        ),
+        Err(err) => {
+            let (json_result, exit_code) = crate::commands::utils::response::map_cmd_result_to_json::<
+                TraceCommandOutput,
+            >(Err(err));
+            (json_result, exit_code, None)
+        }
+    }
+}
+
+fn run_outputs(args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<TraceCommandOutput>)> {
     if args.repeat == 0 {
         return Err(homeboy::Error::validation_invalid_argument(
             "--repeat",
@@ -125,21 +159,24 @@ pub fn run(args: TraceArgs, _global: &GlobalArgs) -> CmdResult<TraceCommandOutpu
     }
 
     if args.scenario == "list" {
-        return run_list(args);
+        let (output, exit_code) = run_list(args)?;
+        return Ok(((output, None), exit_code));
     }
 
     if args.repeat > 1 || args.aggregate.as_deref() == Some("spans") {
-        return run_repeat(args);
+        let (output, exit_code) = run_repeat(args)?;
+        return Ok(((output, None), exit_code));
     }
 
     let summary_only = args.json_summary;
     let execution = execute_trace_run(args)?;
 
-    Ok(extension_trace::from_main_workflow(
+    let (stdout_output, artifact_output, exit_code) = extension_trace::from_main_workflow_outputs(
         execution.workflow,
         execution.rig_state,
         summary_only,
-    ))
+    );
+    Ok(((stdout_output, artifact_output), exit_code))
 }
 
 struct TraceRunExecution {
@@ -1179,6 +1216,8 @@ mod tests {
                     baseline_args: BaselineArgs::default(),
                     regression_threshold:
                         extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    regression_min_delta_ms:
+                        extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                     overlays: Vec::new(),
                     keep_overlay: false,
                 },

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -24,8 +24,8 @@ pub use parsing::{
 pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, TraceSpanResult};
 pub use report::render_markdown;
 pub use report::{
-    from_list_workflow, from_main_workflow, TraceAggregateOutput, TraceAggregateRunOutput,
-    TraceAggregateSpanOutput, TraceCommandOutput,
+    from_list_workflow, from_main_workflow, from_main_workflow_outputs, TraceAggregateOutput,
+    TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceCommandOutput,
 };
 pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};
 pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult};

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -123,8 +123,18 @@ pub fn from_main_workflow(
     rig_state: Option<RigStateSnapshot>,
     summary_only: bool,
 ) -> (TraceCommandOutput, i32) {
+    let (output, _, exit_code) = from_main_workflow_outputs(result, rig_state, summary_only);
+    (output, exit_code)
+}
+
+pub fn from_main_workflow_outputs(
+    result: TraceRunWorkflowResult,
+    rig_state: Option<RigStateSnapshot>,
+    summary_only: bool,
+) -> (TraceCommandOutput, Option<TraceCommandOutput>, i32) {
     let exit_code = result.exit_code;
     if summary_only {
+        let full_output = from_run_workflow_result(result.clone(), rig_state.clone());
         let output = TraceRunSummaryOutput {
             summary_only: true,
             passed: exit_code == 0 && result.status == "pass",
@@ -152,30 +162,38 @@ pub fn from_main_workflow(
                 .unwrap_or(0),
             hints: result.hints,
         };
-        return (TraceCommandOutput::Summary(output), exit_code);
+        return (
+            TraceCommandOutput::Summary(output),
+            Some(full_output),
+            exit_code,
+        );
     }
 
+    (from_run_workflow_result(result, rig_state), None, exit_code)
+}
+
+fn from_run_workflow_result(
+    result: TraceRunWorkflowResult,
+    rig_state: Option<RigStateSnapshot>,
+) -> TraceCommandOutput {
     let artifacts = result
         .results
         .as_ref()
         .map(|r| r.artifacts.clone())
         .unwrap_or_default();
-    (
-        TraceCommandOutput::Run(Box::new(TraceRunOutput {
-            passed: exit_code == 0 && result.status == "pass",
-            status: result.status,
-            component: result.component,
-            exit_code,
-            artifacts,
-            results: result.results,
-            rig_state,
-            failure: result.failure,
-            overlays: result.overlays,
-            baseline_comparison: result.baseline_comparison,
-            hints: result.hints,
-        })),
-        exit_code,
-    )
+    TraceCommandOutput::Run(Box::new(TraceRunOutput {
+        passed: result.exit_code == 0 && result.status == "pass",
+        status: result.status,
+        component: result.component,
+        exit_code: result.exit_code,
+        artifacts,
+        results: result.results,
+        rig_state,
+        failure: result.failure,
+        overlays: result.overlays,
+        baseline_comparison: result.baseline_comparison,
+        hints: result.hints,
+    }))
 }
 
 pub fn render_markdown(results: &TraceResults) -> String {
@@ -341,6 +359,63 @@ mod tests {
         assert_eq!(value["overlays"][0]["path"], "/tmp/overlay.patch");
         assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
         assert_eq!(value["overlays"][0]["kept"], false);
+    }
+
+    #[test]
+    fn test_from_main_workflow_outputs_keeps_full_output_for_summary_artifact() {
+        let result = TraceRunWorkflowResult {
+            status: "pass".to_string(),
+            component: "Studio".to_string(),
+            exit_code: 0,
+            results: Some(TraceResults {
+                component_id: "studio".to_string(),
+                scenario_id: "create-site".to_string(),
+                status: TraceStatus::Pass,
+                summary: Some("Created a site".to_string()),
+                failure: None,
+                rig: None,
+                timeline: vec![crate::extension::trace::parsing::TraceEvent {
+                    t_ms: 10,
+                    source: "ui".to_string(),
+                    event: "submit".to_string(),
+                    data: std::collections::BTreeMap::new(),
+                }],
+                span_definitions: Vec::new(),
+                span_results: vec![crate::extension::trace::parsing::TraceSpanResult {
+                    id: "submit_to_cli".to_string(),
+                    from: "ui.submit".to_string(),
+                    to: "cli.start".to_string(),
+                    status: crate::extension::trace::parsing::TraceSpanStatus::Ok,
+                    duration_ms: Some(42),
+                    from_t_ms: Some(10),
+                    to_t_ms: Some(52),
+                    missing: Vec::new(),
+                    message: None,
+                }],
+                assertions: Vec::new(),
+                artifacts: Vec::new(),
+            }),
+            failure: None,
+            overlays: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+        };
+
+        let (stdout_output, artifact_output, exit_code) =
+            from_main_workflow_outputs(result, None, true);
+        let stdout_value = serde_json::to_value(stdout_output).expect("summary should serialize");
+        let artifact_value = serde_json::to_value(artifact_output.expect("full artifact output"))
+            .expect("artifact should serialize");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(stdout_value["summary_only"], true);
+        assert_eq!(stdout_value["span_count"], 1);
+        assert!(stdout_value.get("results").is_none());
+        assert_eq!(
+            artifact_value["results"]["span_results"][0]["id"],
+            "submit_to_cli"
+        );
+        assert_eq!(artifact_value["results"]["timeline"][0]["event"], "submit");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,14 +284,28 @@ fn main() -> std::process::ExitCode {
         }
     }
 
-    let (json_result, exit_code) = commands::run_json(cli.command, &global);
+    let (json_result, exit_code, output_json_result) = match cli.command {
+        Commands::Trace(args) if output_file.is_some() && args.json_summary => {
+            let (json_result, exit_code, output_json_result) =
+                trace::run_json_with_output_artifact(args, &global);
+            (json_result, exit_code, output_json_result)
+        }
+        command => {
+            let (json_result, exit_code) = commands::run_json(command, &global);
+            (json_result, exit_code, None)
+        }
+    };
 
     // Write JSON to --output file if specified (before printing to stdout).
     // Review writes its stable machine-readable artifact directly; other
     // commands retain the generic CLI envelope.
     if let Some(ref path) = output_file {
         if !is_review_command || !review::write_artifact_to_file(&json_result, path, exit_code) {
-            output::write_json_to_file(&json_result, path, exit_code);
+            output::write_json_to_file(
+                output_json_result.as_ref().unwrap_or(&json_result),
+                path,
+                exit_code,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep `homeboy trace --json-summary` focused on stdout rendering.
- Write the full trace run JSON envelope to `--output` when summary mode is active, preserving `results.span_results` and timeline data.
- Add a trace report regression test covering compact summary output alongside full artifact output.

Fixes #2037.

## Verification
- `cargo fmt --check`
- `cargo test core::extension::trace::report::tests`
- `cargo test` (fails in this local worktree due existing environment-dependent fixture/config issues: missing `nodejs` extension, missing `studio-rig`, and existing component remote-path assertions)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the trace output routing fix and regression test; Chris remains responsible for review and validation.