### PR TITLE
feat(obs-store): record audit and test command runs

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -134,8 +134,8 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
 
 struct AuditObservation {
     store: ObservationStore,
-    run: RunRecord,
-    initial_metadata: serde_json::Value,
+    audit_run: RunRecord,
+    audit_metadata: serde_json::Value,
 }
 
 fn start_audit_observation(
@@ -161,8 +161,8 @@ fn start_audit_observation(
 
     Some(AuditObservation {
         store,
-        run,
-        initial_metadata: metadata,
+        audit_run: run,
+        audit_metadata: metadata,
     })
 }
 
@@ -175,7 +175,7 @@ fn finish_audit_observation(
     };
 
     let metadata = merge_audit_observation_metadata(
-        observation.initial_metadata,
+        observation.audit_metadata,
         serde_json::json!({
             "observation_status": if workflow.exit_code == 0 { "pass" } else { "fail" },
             "exit_code": workflow.exit_code,
@@ -189,7 +189,7 @@ fn finish_audit_observation(
     };
     let _ = observation
         .store
-        .finish_run(&observation.run.id, status, Some(metadata));
+        .finish_run(&observation.audit_run.id, status, Some(metadata));
 }
 
 fn finish_audit_observation_error(observation: Option<AuditObservation>, error: &homeboy::Error) {
@@ -198,15 +198,16 @@ fn finish_audit_observation_error(observation: Option<AuditObservation>, error: 
     };
 
     let metadata = merge_audit_observation_metadata(
-        observation.initial_metadata,
+        observation.audit_metadata,
         serde_json::json!({
             "observation_status": "error",
             "error": error.to_string(),
         }),
     );
-    let _ = observation
-        .store
-        .finish_run(&observation.run.id, RunStatus::Error, Some(metadata));
+    let _ =
+        observation
+            .store
+            .finish_run(&observation.audit_run.id, RunStatus::Error, Some(metadata));
 }
 
 fn audit_observation_command(component_id: &str, args: &AuditArgs) -> String {
@@ -255,15 +256,9 @@ fn audit_observation_initial_metadata(source_path: &str, args: &AuditArgs) -> se
 
 fn audit_observation_summary(output: &AuditCommandOutput) -> serde_json::Value {
     match output {
-        AuditCommandOutput::Full { passed, result, .. } => serde_json::json!({
-            "passed": passed,
-            "component_id": result.component_id,
-            "files_scanned": result.summary.files_scanned,
-            "conventions_detected": result.summary.conventions_detected,
-            "findings": result.findings.len(),
-            "outliers_found": result.summary.outliers_found,
-            "alignment_score": result.summary.alignment_score,
-        }),
+        AuditCommandOutput::Full { passed, result, .. } => {
+            code_audit_result_observation_summary(*passed, result, None)
+        }
         AuditCommandOutput::Conventions {
             component_id,
             conventions,
@@ -291,16 +286,7 @@ fn audit_observation_summary(output: &AuditCommandOutput) -> serde_json::Value {
             result,
             changed_since,
             ..
-        } => serde_json::json!({
-            "passed": passed,
-            "component_id": result.component_id,
-            "files_scanned": result.summary.files_scanned,
-            "conventions_detected": result.summary.conventions_detected,
-            "findings": result.findings.len(),
-            "outliers_found": result.summary.outliers_found,
-            "alignment_score": result.summary.alignment_score,
-            "changed_since": changed_since,
-        }),
+        } => code_audit_result_observation_summary(*passed, result, changed_since.as_ref()),
         AuditCommandOutput::Summary(summary) => serde_json::json!({
             "findings": summary.total_findings,
             "warnings": summary.warnings,
@@ -309,6 +295,28 @@ fn audit_observation_summary(output: &AuditCommandOutput) -> serde_json::Value {
             "exit_code": summary.exit_code,
         }),
     }
+}
+
+fn code_audit_result_observation_summary(
+    passed: bool,
+    result: &code_audit::CodeAuditResult,
+    changed_since: Option<&report::AuditChangedSinceSummary>,
+) -> serde_json::Value {
+    let mut summary = serde_json::json!({
+        "passed": passed,
+        "component_id": result.component_id,
+        "files_scanned": result.summary.files_scanned,
+        "conventions_detected": result.summary.conventions_detected,
+        "findings": result.findings.len(),
+        "outliers_found": result.summary.outliers_found,
+        "alignment_score": result.summary.alignment_score,
+    });
+
+    if let Some(changed_since) = changed_since {
+        summary["changed_since"] = serde_json::json!(changed_since);
+    }
+
+    summary
 }
 
 fn merge_audit_observation_metadata(
@@ -484,7 +492,7 @@ mod tests {
             let observation =
                 start_audit_observation("homeboy", &home.path().to_string_lossy(), &args)
                     .expect("observation should start");
-            let run_id = observation.run.id.clone();
+            let run_id = observation.audit_run.id.clone();
 
             finish_audit_observation_error(
                 Some(observation),

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -5,6 +5,8 @@ use homeboy::code_audit::{
     self, report, run_main_audit_workflow, AuditCommandOutput, AuditRunWorkflowArgs,
 };
 use homeboy::engine::execution_context::{self, ResolveOptions};
+use homeboy::git::short_head_revision_at;
+use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
 
 use super::utils::args::{BaselineArgs, PositionalComponentArgs};
 use super::{CmdResult, GlobalArgs};
@@ -97,9 +99,10 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         (component.id, source_path)
     };
 
+    let observation = start_audit_observation(&resolved_id, &resolved_path, &args);
     let workflow = run_main_audit_workflow(AuditRunWorkflowArgs {
-        component_id: resolved_id,
-        source_path: resolved_path,
+        component_id: resolved_id.clone(),
+        source_path: resolved_path.clone(),
         conventions: args.conventions,
         only_kinds,
         exclude_kinds,
@@ -113,9 +116,211 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         changed_since: args.changed_since,
         json_summary: args.json_summary,
         include_fixability: args.fixability,
-    })?;
+    });
+
+    let workflow = match workflow {
+        Ok(workflow) => {
+            finish_audit_observation(observation, &workflow);
+            workflow
+        }
+        Err(error) => {
+            finish_audit_observation_error(observation, &error);
+            return Err(error);
+        }
+    };
 
     Ok(report::from_main_workflow(workflow))
+}
+
+struct AuditObservation {
+    store: ObservationStore,
+    run: RunRecord,
+    initial_metadata: serde_json::Value,
+}
+
+fn start_audit_observation(
+    component_id: &str,
+    source_path: &str,
+    args: &AuditArgs,
+) -> Option<AuditObservation> {
+    let store = ObservationStore::open_initialized().ok()?;
+    let path = Path::new(source_path);
+    let metadata = audit_observation_initial_metadata(source_path, args);
+    let run = store
+        .start_run(NewRunRecord {
+            kind: "audit".to_string(),
+            component_id: Some(component_id.to_string()),
+            command: Some(audit_observation_command(component_id, args)),
+            cwd: Some(source_path.to_string()),
+            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            git_sha: short_head_revision_at(path),
+            rig_id: None,
+            metadata_json: metadata.clone(),
+        })
+        .ok()?;
+
+    Some(AuditObservation {
+        store,
+        run,
+        initial_metadata: metadata,
+    })
+}
+
+fn finish_audit_observation(
+    observation: Option<AuditObservation>,
+    workflow: &code_audit::AuditRunWorkflowResult,
+) {
+    let Some(observation) = observation else {
+        return;
+    };
+
+    let metadata = merge_audit_observation_metadata(
+        observation.initial_metadata,
+        serde_json::json!({
+            "observation_status": if workflow.exit_code == 0 { "pass" } else { "fail" },
+            "exit_code": workflow.exit_code,
+            "summary": audit_observation_summary(&workflow.output),
+        }),
+    );
+    let status = if workflow.exit_code == 0 {
+        RunStatus::Pass
+    } else {
+        RunStatus::Fail
+    };
+    let _ = observation
+        .store
+        .finish_run(&observation.run.id, status, Some(metadata));
+}
+
+fn finish_audit_observation_error(observation: Option<AuditObservation>, error: &homeboy::Error) {
+    let Some(observation) = observation else {
+        return;
+    };
+
+    let metadata = merge_audit_observation_metadata(
+        observation.initial_metadata,
+        serde_json::json!({
+            "observation_status": "error",
+            "error": error.to_string(),
+        }),
+    );
+    let _ = observation
+        .store
+        .finish_run(&observation.run.id, RunStatus::Error, Some(metadata));
+}
+
+fn audit_observation_command(component_id: &str, args: &AuditArgs) -> String {
+    let mut parts = vec![
+        "homeboy".to_string(),
+        "audit".to_string(),
+        component_id.to_string(),
+    ];
+    if args.conventions {
+        parts.push("--conventions".to_string());
+    }
+    for kind in &args.only {
+        parts.push(format!("--only={kind}"));
+    }
+    for kind in &args.exclude {
+        parts.push(format!("--exclude={kind}"));
+    }
+    if let Some(changed_since) = &args.changed_since {
+        parts.push(format!("--changed-since={changed_since}"));
+    }
+    if args.json_summary {
+        parts.push("--json-summary".to_string());
+    }
+    if args.fixability {
+        parts.push("--fixability".to_string());
+    }
+    parts.join(" ")
+}
+
+fn audit_observation_initial_metadata(source_path: &str, args: &AuditArgs) -> serde_json::Value {
+    serde_json::json!({
+        "source_path": source_path,
+        "mode": if args.conventions { "conventions" } else { "audit" },
+        "only": args.only,
+        "exclude": args.exclude,
+        "baseline": {
+            "baseline": args.baseline_args.baseline,
+            "ignore_baseline": args.baseline_args.ignore_baseline,
+            "ratchet": args.baseline_args.ratchet,
+        },
+        "changed_since": args.changed_since,
+        "json_summary": args.json_summary,
+        "fixability": args.fixability,
+    })
+}
+
+fn audit_observation_summary(output: &AuditCommandOutput) -> serde_json::Value {
+    match output {
+        AuditCommandOutput::Full { passed, result, .. } => serde_json::json!({
+            "passed": passed,
+            "component_id": result.component_id,
+            "files_scanned": result.summary.files_scanned,
+            "conventions_detected": result.summary.conventions_detected,
+            "findings": result.findings.len(),
+            "outliers_found": result.summary.outliers_found,
+            "alignment_score": result.summary.alignment_score,
+        }),
+        AuditCommandOutput::Conventions {
+            component_id,
+            conventions,
+            directory_conventions,
+        } => serde_json::json!({
+            "component_id": component_id,
+            "conventions": conventions.len(),
+            "directory_conventions": directory_conventions.len(),
+        }),
+        AuditCommandOutput::BaselineSaved {
+            component_id,
+            path,
+            findings_count,
+            outliers_count,
+            alignment_score,
+        } => serde_json::json!({
+            "component_id": component_id,
+            "baseline_path": path,
+            "findings": findings_count,
+            "outliers_found": outliers_count,
+            "alignment_score": alignment_score,
+        }),
+        AuditCommandOutput::Compared {
+            passed,
+            result,
+            changed_since,
+            ..
+        } => serde_json::json!({
+            "passed": passed,
+            "component_id": result.component_id,
+            "files_scanned": result.summary.files_scanned,
+            "conventions_detected": result.summary.conventions_detected,
+            "findings": result.findings.len(),
+            "outliers_found": result.summary.outliers_found,
+            "alignment_score": result.summary.alignment_score,
+            "changed_since": changed_since,
+        }),
+        AuditCommandOutput::Summary(summary) => serde_json::json!({
+            "findings": summary.total_findings,
+            "warnings": summary.warnings,
+            "info": summary.info,
+            "alignment_score": summary.alignment_score,
+            "exit_code": summary.exit_code,
+        }),
+    }
+}
+
+fn merge_audit_observation_metadata(
+    mut initial: serde_json::Value,
+    extra: serde_json::Value,
+) -> serde_json::Value {
+    if let (Some(initial), Some(extra)) = (initial.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra {
+            initial.insert(key.clone(), value.clone());
+        }
+    }
+    initial
 }
 
 /// Run the extension's audit reference setup script if configured.
@@ -210,9 +415,37 @@ fn run_audit_reference_setup(component_id_or_path: &str) {
 mod tests {
     use super::*;
     use crate::commands::utils::args::BaselineArgs;
+    use crate::test_support::with_isolated_home;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct XdgGuard {
+        prior: Option<String>,
+    }
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self { prior }
+        }
+
+        fn set(value: &std::path::Path) -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::set_var("XDG_DATA_HOME", value);
+            Self { prior }
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
 
     fn tmp_dir(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -220,6 +453,75 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("homeboy-audit-command-{name}-{nanos}"))
+    }
+
+    fn sample_args() -> AuditArgs {
+        AuditArgs {
+            comp: PositionalComponentArgs {
+                component: Some("homeboy".to_string()),
+                path: None,
+            },
+            conventions: false,
+            only: vec![],
+            exclude: vec![],
+            baseline_args: BaselineArgs {
+                baseline: false,
+                ignore_baseline: false,
+                ratchet: false,
+            },
+            changed_since: Some("origin/main".to_string()),
+            json_summary: true,
+            fixability: false,
+        }
+    }
+
+    #[test]
+    fn audit_observation_start_persists_run_record() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let args = sample_args();
+
+            let observation =
+                start_audit_observation("homeboy", &home.path().to_string_lossy(), &args)
+                    .expect("observation should start");
+            let run_id = observation.run.id.clone();
+
+            finish_audit_observation_error(
+                Some(observation),
+                &homeboy::Error::validation_invalid_argument(
+                    "fixture",
+                    "simulated audit error",
+                    None,
+                    None,
+                ),
+            );
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run exists");
+
+            assert_eq!(run.kind, "audit");
+            assert_eq!(run.status, "error");
+            assert_eq!(run.component_id.as_deref(), Some("homeboy"));
+            assert_eq!(run.metadata_json["changed_since"], "origin/main");
+            assert_eq!(run.metadata_json["observation_status"], "error");
+        });
+    }
+
+    #[test]
+    fn audit_observation_start_is_best_effort_when_store_unavailable() {
+        with_isolated_home(|home| {
+            let bad_data_home = home.path().join("not-a-dir");
+            fs::write(&bad_data_home, "file blocks observation dir").expect("write marker");
+            let _xdg = XdgGuard::set(&bad_data_home);
+
+            let observation =
+                start_audit_observation("homeboy", &home.path().to_string_lossy(), &sample_args());
+
+            assert!(observation.is_none());
+        });
     }
 
     /// End-to-end test of the audit command's read-only mode.
@@ -268,14 +570,12 @@ mod tests {
         let (output, code) = run(args, &crate::commands::GlobalArgs {}).expect("audit should run");
 
         // Audit should detect the outlier and return findings
-        match output {
-            AuditCommandOutput::Full { result, .. } => {
-                assert!(
-                    !result.findings.is_empty(),
-                    "expected findings for the outlier file"
-                );
-            }
-            _ => {} // Summary or other modes are also valid
+        // Summary or other modes are also valid.
+        if let AuditCommandOutput::Full { result, .. } = output {
+            assert!(
+                !result.findings.is_empty(),
+                "expected findings for the outlier file"
+            );
         }
 
         // Non-zero exit expected when outliers are found

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -175,16 +175,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             args.json_summary,
         );
 
-        let workflow = match workflow {
-            Ok(workflow) => {
-                finish_test_observation(observation, &workflow);
-                workflow
-            }
-            Err(error) => {
-                finish_test_observation_error(observation, &error);
-                return Err(error);
-            }
-        };
+        let workflow = finish_test_workflow_observation(observation, workflow)?;
 
         return Ok(report::from_main_workflow(workflow));
     }
@@ -268,24 +259,15 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         &run_dir,
     );
     resource_run.write_to_run_dir(&run_dir)?;
-    let workflow = match workflow {
-        Ok(workflow) => {
-            finish_test_observation(observation, &workflow);
-            workflow
-        }
-        Err(error) => {
-            finish_test_observation_error(observation, &error);
-            return Err(error);
-        }
-    };
+    let workflow = finish_test_workflow_observation(observation, workflow)?;
 
     Ok(report::from_main_workflow(workflow))
 }
 
 struct TestObservation {
     store: ObservationStore,
-    run: RunRecord,
-    initial_metadata: serde_json::Value,
+    test_run: RunRecord,
+    test_metadata: serde_json::Value,
 }
 
 fn start_test_observation(
@@ -312,9 +294,25 @@ fn start_test_observation(
 
     Some(TestObservation {
         store,
-        run,
-        initial_metadata: metadata,
+        test_run: run,
+        test_metadata: metadata,
     })
+}
+
+fn finish_test_workflow_observation(
+    observation: Option<TestObservation>,
+    workflow: homeboy::Result<extension_test::TestRunWorkflowResult>,
+) -> homeboy::Result<extension_test::TestRunWorkflowResult> {
+    match workflow {
+        Ok(workflow) => {
+            finish_test_observation(observation, &workflow);
+            Ok(workflow)
+        }
+        Err(error) => {
+            finish_test_observation_error(observation, &error);
+            Err(error)
+        }
+    }
 }
 
 fn finish_test_observation(
@@ -326,7 +324,7 @@ fn finish_test_observation(
     };
 
     let metadata = merge_test_observation_metadata(
-        observation.initial_metadata,
+        observation.test_metadata,
         serde_json::json!({
             "observation_status": workflow.status,
             "exit_code": workflow.exit_code,
@@ -346,7 +344,7 @@ fn finish_test_observation(
     };
     let _ = observation
         .store
-        .finish_run(&observation.run.id, status, Some(metadata));
+        .finish_run(&observation.test_run.id, status, Some(metadata));
 }
 
 fn finish_test_drift_observation(
@@ -358,7 +356,7 @@ fn finish_test_drift_observation(
     };
 
     let metadata = merge_test_observation_metadata(
-        observation.initial_metadata,
+        observation.test_metadata,
         serde_json::json!({
             "observation_status": if workflow.exit_code == 0 { "pass" } else { "fail" },
             "exit_code": workflow.exit_code,
@@ -372,7 +370,7 @@ fn finish_test_drift_observation(
     };
     let _ = observation
         .store
-        .finish_run(&observation.run.id, status, Some(metadata));
+        .finish_run(&observation.test_run.id, status, Some(metadata));
 }
 
 fn finish_test_observation_error(observation: Option<TestObservation>, error: &homeboy::Error) {
@@ -381,15 +379,16 @@ fn finish_test_observation_error(observation: Option<TestObservation>, error: &h
     };
 
     let metadata = merge_test_observation_metadata(
-        observation.initial_metadata,
+        observation.test_metadata,
         serde_json::json!({
             "observation_status": "error",
             "error": error.to_string(),
         }),
     );
-    let _ = observation
-        .store
-        .finish_run(&observation.run.id, RunStatus::Error, Some(metadata));
+    let _ =
+        observation
+            .store
+            .finish_run(&observation.test_run.id, RunStatus::Error, Some(metadata));
 }
 
 fn test_observation_command(component_id: &str, args: &TestArgs) -> String {
@@ -533,7 +532,7 @@ mod tests {
 
             let observation = start_test_observation("homeboy", home.path(), &args, "test", None)
                 .expect("observation should start");
-            let run_id = observation.run.id.clone();
+            let run_id = observation.test_run.id.clone();
 
             finish_test_observation_error(
                 Some(observation),

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -7,6 +7,9 @@ use homeboy::extension::test::{
     detect_test_drift, report, run_self_check_test_workflow, TestCommandOutput, TestRunWorkflowArgs,
 };
 use homeboy::extension::ExtensionCapability;
+use homeboy::git::short_head_revision_at;
+use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
+use std::path::Path;
 
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
@@ -158,12 +161,30 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             .component
             .has_self_check(ExtensionCapability::Test)
     {
+        let observation = start_test_observation(
+            &source_ctx.component_id,
+            &source_ctx.source_path,
+            &args,
+            "self-check",
+            None,
+        );
         let workflow = run_self_check_test_workflow(
             &source_ctx.component,
             &source_ctx.source_path,
             source_ctx.component_id.clone(),
             args.json_summary,
-        )?;
+        );
+
+        let workflow = match workflow {
+            Ok(workflow) => {
+                finish_test_observation(observation, &workflow);
+                workflow
+            }
+            Err(error) => {
+                finish_test_observation_error(observation, &error);
+                return Err(error);
+            }
+        };
 
         return Ok(report::from_main_workflow(workflow));
     }
@@ -181,12 +202,31 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     // Drift detection mode — delegate to core drift workflow (read-only)
     // Fixes are owned by `homeboy refactor --from test --write`.
     if args.drift {
-        let result = detect_test_drift(&effective_id, &ctx.component, &args.since)?;
+        let observation =
+            start_test_observation(&ctx.component_id, &ctx.source_path, &args, "drift", None);
+        let result = detect_test_drift(&effective_id, &ctx.component, &args.since);
+        let result = match result {
+            Ok(result) => {
+                finish_test_drift_observation(observation, &result);
+                result
+            }
+            Err(error) => {
+                finish_test_observation_error(observation, &error);
+                return Err(error);
+            }
+        };
         return Ok(report::from_drift_workflow(result));
     }
 
     // Main test workflow — delegate to core
     let run_dir = RunDir::create()?;
+    let observation = start_test_observation(
+        &ctx.component_id,
+        &ctx.source_path,
+        &args,
+        "test",
+        Some(&run_dir),
+    );
     let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
         "test {}",
         effective_id
@@ -228,23 +268,313 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         &run_dir,
     );
     resource_run.write_to_run_dir(&run_dir)?;
-    let workflow = workflow?;
+    let workflow = match workflow {
+        Ok(workflow) => {
+            finish_test_observation(observation, &workflow);
+            workflow
+        }
+        Err(error) => {
+            finish_test_observation_error(observation, &error);
+            return Err(error);
+        }
+    };
 
     Ok(report::from_main_workflow(workflow))
+}
+
+struct TestObservation {
+    store: ObservationStore,
+    run: RunRecord,
+    initial_metadata: serde_json::Value,
+}
+
+fn start_test_observation(
+    component_id: &str,
+    source_path: &Path,
+    args: &TestArgs,
+    mode: &str,
+    run_dir: Option<&RunDir>,
+) -> Option<TestObservation> {
+    let store = ObservationStore::open_initialized().ok()?;
+    let metadata = test_observation_initial_metadata(source_path, args, mode, run_dir);
+    let run = store
+        .start_run(NewRunRecord {
+            kind: "test".to_string(),
+            component_id: Some(component_id.to_string()),
+            command: Some(test_observation_command(component_id, args)),
+            cwd: Some(source_path.to_string_lossy().to_string()),
+            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            git_sha: short_head_revision_at(source_path),
+            rig_id: None,
+            metadata_json: metadata.clone(),
+        })
+        .ok()?;
+
+    Some(TestObservation {
+        store,
+        run,
+        initial_metadata: metadata,
+    })
+}
+
+fn finish_test_observation(
+    observation: Option<TestObservation>,
+    workflow: &extension_test::TestRunWorkflowResult,
+) {
+    let Some(observation) = observation else {
+        return;
+    };
+
+    let metadata = merge_test_observation_metadata(
+        observation.initial_metadata,
+        serde_json::json!({
+            "observation_status": workflow.status,
+            "exit_code": workflow.exit_code,
+            "test_counts": workflow.test_counts,
+            "failure_count": workflow.failed_tests.as_ref().map(Vec::len).unwrap_or(0),
+            "coverage": workflow.coverage,
+            "baseline_regression": workflow.baseline_comparison.as_ref().map(|comparison| comparison.regression),
+            "analysis_clusters": workflow.analysis.as_ref().map(|analysis| analysis.clusters.len()).unwrap_or(0),
+            "test_scope": workflow.test_scope,
+            "summary": workflow.summary,
+        }),
+    );
+    let status = if workflow.exit_code == 0 {
+        RunStatus::Pass
+    } else {
+        RunStatus::Fail
+    };
+    let _ = observation
+        .store
+        .finish_run(&observation.run.id, status, Some(metadata));
+}
+
+fn finish_test_drift_observation(
+    observation: Option<TestObservation>,
+    workflow: &extension_test::DriftWorkflowResult,
+) {
+    let Some(observation) = observation else {
+        return;
+    };
+
+    let metadata = merge_test_observation_metadata(
+        observation.initial_metadata,
+        serde_json::json!({
+            "observation_status": if workflow.exit_code == 0 { "pass" } else { "fail" },
+            "exit_code": workflow.exit_code,
+            "drift": workflow.report,
+        }),
+    );
+    let status = if workflow.exit_code == 0 {
+        RunStatus::Pass
+    } else {
+        RunStatus::Fail
+    };
+    let _ = observation
+        .store
+        .finish_run(&observation.run.id, status, Some(metadata));
+}
+
+fn finish_test_observation_error(observation: Option<TestObservation>, error: &homeboy::Error) {
+    let Some(observation) = observation else {
+        return;
+    };
+
+    let metadata = merge_test_observation_metadata(
+        observation.initial_metadata,
+        serde_json::json!({
+            "observation_status": "error",
+            "error": error.to_string(),
+        }),
+    );
+    let _ = observation
+        .store
+        .finish_run(&observation.run.id, RunStatus::Error, Some(metadata));
+}
+
+fn test_observation_command(component_id: &str, args: &TestArgs) -> String {
+    let mut parts = vec![
+        "homeboy".to_string(),
+        "test".to_string(),
+        component_id.to_string(),
+    ];
+    if args.skip_lint {
+        parts.push("--skip-lint".to_string());
+    }
+    if args.coverage {
+        parts.push("--coverage".to_string());
+    }
+    if let Some(coverage_min) = args.coverage_min {
+        parts.push(format!("--coverage-min={coverage_min}"));
+    }
+    if args.analyze {
+        parts.push("--analyze".to_string());
+    }
+    if args.drift {
+        parts.push("--drift".to_string());
+    }
+    if let Some(changed_since) = &args.changed_since {
+        parts.push(format!("--changed-since={changed_since}"));
+    }
+    if args.json_summary {
+        parts.push("--json-summary".to_string());
+    }
+    let passthrough_args = filter_homeboy_flags(&args.args);
+    if !passthrough_args.is_empty() {
+        parts.push("--".to_string());
+        parts.extend(passthrough_args);
+    }
+    parts.join(" ")
+}
+
+fn test_observation_initial_metadata(
+    source_path: &Path,
+    args: &TestArgs,
+    mode: &str,
+    run_dir: Option<&RunDir>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "source_path": source_path.to_string_lossy(),
+        "mode": mode,
+        "skip_lint": args.skip_lint,
+        "coverage": args.coverage,
+        "coverage_min": args.coverage_min,
+        "analyze": args.analyze,
+        "drift": args.drift,
+        "baseline": {
+            "baseline": args.baseline_args.baseline,
+            "ignore_baseline": args.baseline_args.ignore_baseline,
+            "ratchet": args.baseline_args.ratchet,
+        },
+        "changed_since": args.changed_since,
+        "since": args.since,
+        "json_summary": args.json_summary,
+        "passthrough_args": filter_homeboy_flags(&args.args),
+        "run_dir": run_dir.map(|run_dir| run_dir.path().to_string_lossy().to_string()),
+    })
+}
+
+fn merge_test_observation_metadata(
+    mut initial: serde_json::Value,
+    extra: serde_json::Value,
+) -> serde_json::Value {
+    if let (Some(initial), Some(extra)) = (initial.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra {
+            initial.insert(key.clone(), value.clone());
+        }
+    }
+    initial
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_isolated_home;
     use clap::Parser;
     use homeboy::component::Component;
+    use homeboy::observation::ObservationStore;
     use homeboy::refactor::plan::{build_test_refactor_request, TestSourceOptions};
+    use std::fs;
     use std::path::PathBuf;
+
+    struct XdgGuard {
+        prior: Option<String>,
+    }
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self { prior }
+        }
+
+        fn set(value: &std::path::Path) -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::set_var("XDG_DATA_HOME", value);
+            Self { prior }
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
 
     #[derive(Parser)]
     struct TestCli {
         #[command(flatten)]
         test: TestArgs,
+    }
+
+    fn sample_args() -> TestArgs {
+        TestCli::try_parse_from([
+            "test",
+            "homeboy",
+            "--skip-lint",
+            "--json-summary",
+            "--changed-since",
+            "origin/main",
+            "--",
+            "--filter=SmokeTest",
+        ])
+        .expect("parse sample args")
+        .test
+    }
+
+    #[test]
+    fn test_observation_start_persists_run_record() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let args = sample_args();
+
+            let observation = start_test_observation("homeboy", home.path(), &args, "test", None)
+                .expect("observation should start");
+            let run_id = observation.run.id.clone();
+
+            finish_test_observation_error(
+                Some(observation),
+                &homeboy::Error::validation_invalid_argument(
+                    "fixture",
+                    "simulated test error",
+                    None,
+                    None,
+                ),
+            );
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run exists");
+
+            assert_eq!(run.kind, "test");
+            assert_eq!(run.status, "error");
+            assert_eq!(run.component_id.as_deref(), Some("homeboy"));
+            assert_eq!(run.metadata_json["changed_since"], "origin/main");
+            assert_eq!(
+                run.metadata_json["passthrough_args"][0],
+                "--filter=SmokeTest"
+            );
+            assert_eq!(run.metadata_json["observation_status"], "error");
+        });
+    }
+
+    #[test]
+    fn test_observation_start_is_best_effort_when_store_unavailable() {
+        with_isolated_home(|home| {
+            let bad_data_home = home.path().join("not-a-dir");
+            fs::write(&bad_data_home, "file blocks observation dir").expect("write marker");
+            let _xdg = XdgGuard::set(&bad_data_home);
+
+            let observation =
+                start_test_observation("homeboy", home.path(), &sample_args(), "test", None);
+
+            assert!(observation.is_none());
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add best-effort observation run records for `homeboy audit`, including concise mode/filter metadata and final pass/fail/error summaries.
- Add best-effort observation run records for `homeboy test` across self-check, drift, and main test paths, including concise counts/scope/analysis metadata when available.
- Cover run creation and unavailable-store behavior for audit/test observation writes.

## Validation
- `homeboy lint`
- `cargo test audit_observation`
- `cargo test test_observation`
- `homeboy test --skip-lint -- test_observation` ran the targeted Rust tests successfully, then failed in Homeboy wrapper post-processing with macOS/BSD `grep: invalid option -- P`.
- `cargo test` reached 2283 passing tests, then failed 10 existing fixture/environment-dependent tests involving missing `nodejs` extension, missing `studio-rig`, helper path setup, and component remote path inference.

## Follow-ups
- #2043 still needs normalized/queryable audit finding records and query filters.
- #2044 still needs normalized/queryable test failure and cluster records.
- The Homeboy test wrapper appears to rely on GNU `grep -P` in a path that fails on macOS BSD grep.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and tests; Chris remains responsible for review and final validation.