### PR TITLE
Persist lint findings in observation store

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -11,6 +11,7 @@ use homeboy::extension::ExtensionCapability;
 use homeboy::git;
 use homeboy::observation::{NewFindingRecord, NewRunRecord, ObservationStore, RunStatus};
 use homeboy::refactor::plan::{collect_refactor_sources, lint_refactor_request, LintSourceOptions};
+use serde_json::Value;
 
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
@@ -104,23 +105,15 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             &source_ctx.source_path,
             lint_command_label(&source_ctx.component_id, &args),
         );
-        let workflow = match run_self_check_lint_workflow(
-            &source_ctx.component,
-            &source_ctx.source_path,
-            source_ctx.component_id.clone(),
-            args.json_summary,
-        ) {
-            Ok(workflow) => workflow,
-            Err(error) => {
-                if let Some(observation) = observation {
-                    observation.finish_error();
-                }
-                return Err(error);
-            }
-        };
-        if let Some(observation) = observation {
-            observation.finish_workflow(&workflow);
-        }
+        let workflow = finish_lint_workflow(
+            observation,
+            run_self_check_lint_workflow(
+                &source_ctx.component,
+                &source_ctx.source_path,
+                source_ctx.component_id.clone(),
+                args.json_summary,
+            ),
+        )?;
 
         return Ok(report::from_main_workflow(workflow));
     }
@@ -195,20 +188,29 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         &run_dir,
     );
     resource_run.write_to_run_dir(&run_dir)?;
-    let workflow = match workflow {
-        Ok(workflow) => workflow,
+    let workflow = finish_lint_workflow(observation, workflow)?;
+
+    Ok(report::from_main_workflow(workflow))
+}
+
+fn finish_lint_workflow(
+    observation: Option<LintObservation>,
+    workflow: homeboy::Result<homeboy::extension::lint::LintRunWorkflowResult>,
+) -> homeboy::Result<homeboy::extension::lint::LintRunWorkflowResult> {
+    match workflow {
+        Ok(workflow) => {
+            if let Some(observation) = observation {
+                observation.finish_workflow(&workflow);
+            }
+            Ok(workflow)
+        }
         Err(error) => {
             if let Some(observation) = observation {
                 observation.finish_error();
             }
-            return Err(error);
+            Err(error)
         }
-    };
-    if let Some(observation) = observation {
-        observation.finish_workflow(&workflow);
     }
-
-    Ok(report::from_main_workflow(workflow))
 }
 
 struct LintObservation {
@@ -271,17 +273,30 @@ fn finding_record(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
     NewFindingRecord {
         run_id: run_id.to_string(),
         tool: finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
-        rule: finding
-            .rule
-            .clone()
-            .or_else(|| Some(finding.category.clone())),
+        rule: extra_string(finding, "rule").or_else(|| Some(finding.category.clone())),
         file: finding.file.clone(),
-        line: finding.line,
+        line: extra_i64(finding, "line"),
         severity: finding.severity.clone(),
         fingerprint: Some(finding.id.clone()),
         message: finding.message.clone(),
-        fixable: finding.fixable,
+        fixable: extra_bool(finding, "fixable"),
         metadata_json: serde_json::json!({ "category": finding.category }),
+    }
+}
+
+fn extra_string(finding: &LintFinding, key: &str) -> Option<String> {
+    finding.extra.get(key)?.as_str().map(str::to_string)
+}
+
+fn extra_i64(finding: &LintFinding, key: &str) -> Option<i64> {
+    finding.extra.get(key)?.as_i64()
+}
+
+fn extra_bool(finding: &LintFinding, key: &str) -> Option<bool> {
+    match finding.extra.get(key)? {
+        Value::Bool(value) => Some(*value),
+        Value::String(value) => value.parse().ok(),
+        _ => None,
     }
 }
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -2,12 +2,14 @@ use clap::Args;
 
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
+use homeboy::extension::lint::LintFinding;
 use homeboy::extension::lint::{
     report, run_main_lint_workflow, run_self_check_lint_workflow, LintCommandOutput,
     LintRunWorkflowArgs,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::git;
+use homeboy::observation::{NewFindingRecord, NewRunRecord, ObservationStore, RunStatus};
 use homeboy::refactor::plan::{collect_refactor_sources, lint_refactor_request, LintSourceOptions};
 
 use super::utils::args::{
@@ -97,12 +99,28 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             .component
             .has_self_check(ExtensionCapability::Lint)
     {
-        let workflow = run_self_check_lint_workflow(
+        let observation = LintObservation::start(
+            source_ctx.component_id.clone(),
+            &source_ctx.source_path,
+            lint_command_label(&source_ctx.component_id, &args),
+        );
+        let workflow = match run_self_check_lint_workflow(
             &source_ctx.component,
             &source_ctx.source_path,
             source_ctx.component_id.clone(),
             args.json_summary,
-        )?;
+        ) {
+            Ok(workflow) => workflow,
+            Err(error) => {
+                if let Some(observation) = observation {
+                    observation.finish_error();
+                }
+                return Err(error);
+            }
+        };
+        if let Some(observation) = observation {
+            observation.finish_workflow(&workflow);
+        }
 
         return Ok(report::from_main_workflow(workflow));
     }
@@ -144,6 +162,11 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         "lint {}",
         effective_id
     )));
+    let observation = LintObservation::start(
+        ctx.component_id.clone(),
+        &ctx.source_path,
+        lint_command_label(&effective_id, &args),
+    );
 
     let workflow = run_main_lint_workflow(
         &ctx.component,
@@ -172,9 +195,122 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         &run_dir,
     );
     resource_run.write_to_run_dir(&run_dir)?;
-    let workflow = workflow?;
+    let workflow = match workflow {
+        Ok(workflow) => workflow,
+        Err(error) => {
+            if let Some(observation) = observation {
+                observation.finish_error();
+            }
+            return Err(error);
+        }
+    };
+    if let Some(observation) = observation {
+        observation.finish_workflow(&workflow);
+    }
 
     Ok(report::from_main_workflow(workflow))
+}
+
+struct LintObservation {
+    store: ObservationStore,
+    run_id: String,
+}
+
+impl LintObservation {
+    fn start(component_id: String, source_path: &std::path::Path, command: String) -> Option<Self> {
+        let store = ObservationStore::open_initialized().ok()?;
+        let run = store
+            .start_run(NewRunRecord {
+                kind: "lint".to_string(),
+                component_id: Some(component_id),
+                command: Some(command),
+                cwd: Some(source_path.to_string_lossy().to_string()),
+                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({ "source": "homeboy lint" }),
+            })
+            .ok()?;
+
+        Some(Self {
+            store,
+            run_id: run.id,
+        })
+    }
+
+    fn finish_workflow(self, workflow: &homeboy::extension::lint::LintRunWorkflowResult) {
+        if let Some(findings) = &workflow.lint_findings {
+            let records: Vec<NewFindingRecord> = findings
+                .iter()
+                .map(|finding| finding_record(&self.run_id, finding))
+                .collect();
+            let _ = self.store.record_findings(&records);
+        }
+
+        let status = if workflow.status == "passed" {
+            RunStatus::Pass
+        } else {
+            RunStatus::Fail
+        };
+        let _ = self.store.finish_run(
+            &self.run_id,
+            status,
+            Some(serde_json::json!({
+                "exit_code": workflow.exit_code,
+                "finding_count": workflow.lint_findings.as_ref().map(Vec::len).unwrap_or(0),
+            })),
+        );
+    }
+
+    fn finish_error(self) {
+        let _ = self.store.finish_run(&self.run_id, RunStatus::Error, None);
+    }
+}
+
+fn finding_record(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
+        rule: finding
+            .rule
+            .clone()
+            .or_else(|| Some(finding.category.clone())),
+        file: finding.file.clone(),
+        line: finding.line,
+        severity: finding.severity.clone(),
+        fingerprint: Some(finding.id.clone()),
+        message: finding.message.clone(),
+        fixable: finding.fixable,
+        metadata_json: serde_json::json!({ "category": finding.category }),
+    }
+}
+
+fn lint_command_label(component_id: &str, args: &LintArgs) -> String {
+    let mut parts = vec![
+        "homeboy".to_string(),
+        "lint".to_string(),
+        component_id.to_string(),
+    ];
+    if let Some(path) = &args.comp.path {
+        parts.push("--path".to_string());
+        parts.push(path.clone());
+    }
+    if let Some(file) = &args.file {
+        parts.push("--file".to_string());
+        parts.push(file.clone());
+    }
+    if let Some(glob) = &args.glob {
+        parts.push("--glob".to_string());
+        parts.push(glob.clone());
+    }
+    if args.changed_only {
+        parts.push("--changed-only".to_string());
+    }
+    if let Some(changed_since) = &args.changed_since {
+        parts.push("--changed-since".to_string());
+        parts.push(changed_since.clone());
+    }
+    parts.join(" ")
 }
 
 /// Dispatch `homeboy lint --fix` to the canonical refactor sources pipeline.
@@ -280,11 +416,13 @@ mod tests {
                 id: "src/foo.php::WordPress.Security.EscapeOutput".to_string(),
                 message: "Missing esc_html()".to_string(),
                 category: "security".to_string(),
+                ..LintFinding::default()
             },
             LintFinding {
                 id: "src/bar.php::WordPress.WP.I18n".to_string(),
                 message: "Untranslated string".to_string(),
                 category: "i18n".to_string(),
+                ..LintFinding::default()
             },
         ];
 

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -415,6 +415,7 @@ mod tests {
                 id: format!("lint-{}", idx),
                 message: msg.to_string(),
                 category: category.to_string(),
+                ..LintFinding::default()
             })
             .collect();
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,4 +1,5 @@
 mod bundle;
+mod findings;
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -6,9 +7,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{
-    ArtifactRecord, FindingListFilter, FindingRecord, ObservationStore, RunListFilter, RunRecord,
-};
+use homeboy::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
 use homeboy::Error;
 
 use super::{CmdResult, GlobalArgs};
@@ -16,6 +15,7 @@ use bundle::{
     export_runs, import_runs, ObservationBundleImportSummary, ObservationBundleManifest,
     RunsExportArgs, RunsImportArgs,
 };
+use findings::{RunsFindingOutput, RunsFindingsOutput};
 
 const DEFAULT_LIMIT: i64 = 20;
 
@@ -34,7 +34,7 @@ enum RunsCommand {
     /// List artifacts recorded for one run
     Artifacts { run_id: String },
     /// List findings recorded for one run
-    Findings(RunsFindingsArgs),
+    Findings(findings::RunsFindingsArgs),
     /// Show one recorded finding
     Finding { finding_id: String },
     /// Export observation records as an inspectable directory bundle
@@ -59,21 +59,6 @@ pub struct RunsListArgs {
     pub status: Option<String>,
     /// Maximum runs to return
     #[arg(long, default_value_t = DEFAULT_LIMIT)]
-    pub limit: i64,
-}
-
-#[derive(Args, Clone, Default)]
-pub struct RunsFindingsArgs {
-    /// Observation run ID
-    pub run_id: String,
-    /// Finding tool, for example lint
-    #[arg(long)]
-    pub tool: Option<String>,
-    /// Finding file path
-    #[arg(long)]
-    pub file: Option<String>,
-    /// Maximum findings to return
-    #[arg(long, default_value_t = 100)]
     pub limit: i64,
 }
 
@@ -108,19 +93,6 @@ pub struct RunsArtifactsOutput {
     pub command: &'static str,
     pub run_id: String,
     pub artifacts: Vec<ArtifactRecord>,
-}
-
-#[derive(Serialize)]
-pub struct RunsFindingsOutput {
-    pub command: &'static str,
-    pub run_id: String,
-    pub findings: Vec<FindingSummary>,
-}
-
-#[derive(Serialize)]
-pub struct RunsFindingOutput {
-    pub command: &'static str,
-    pub finding: FindingRecord,
 }
 
 #[derive(Serialize)]
@@ -183,20 +155,6 @@ pub struct RunDetail {
     pub artifacts: Vec<ArtifactRecord>,
 }
 
-#[derive(Serialize)]
-pub struct FindingSummary {
-    pub id: String,
-    pub run_id: String,
-    pub tool: String,
-    pub rule: Option<String>,
-    pub file: Option<String>,
-    pub line: Option<i64>,
-    pub severity: Option<String>,
-    pub fingerprint: Option<String>,
-    pub message: String,
-    pub fixable: Option<bool>,
-}
-
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct BenchMetricComparison {
     pub scenario_id: String,
@@ -219,8 +177,8 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
         RunsCommand::Show { run_id } => show_run(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
-        RunsCommand::Findings(args) => findings(args),
-        RunsCommand::Finding { finding_id } => finding(&finding_id),
+        RunsCommand::Findings(args) => findings::findings(args),
+        RunsCommand::Finding { finding_id } => findings::finding(&finding_id),
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
     }
@@ -263,50 +221,6 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
             command: "runs.artifacts",
             run_id: run_id.to_string(),
             artifacts: store.list_artifacts(run_id)?,
-        }),
-        0,
-    ))
-}
-
-pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    require_run(&store, &args.run_id)?;
-    let findings = store
-        .list_findings(FindingListFilter {
-            run_id: Some(args.run_id.clone()),
-            tool: args.tool,
-            file: args.file,
-            limit: Some(args.limit),
-        })?
-        .into_iter()
-        .map(finding_summary)
-        .collect();
-
-    Ok((
-        RunsOutput::Findings(RunsFindingsOutput {
-            command: "runs.findings",
-            run_id: args.run_id,
-            findings,
-        }),
-        0,
-    ))
-}
-
-pub fn finding(finding_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let finding = store.get_finding(finding_id)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "finding_id",
-            format!("finding not found: {finding_id}"),
-            Some(finding_id.to_string()),
-            None,
-        )
-    })?;
-
-    Ok((
-        RunsOutput::Finding(RunsFindingOutput {
-            command: "runs.finding",
-            finding,
         }),
         0,
     ))
@@ -450,21 +364,6 @@ fn run_summary(run: RunRecord) -> RunSummary {
         git_sha: run.git_sha,
         command: run.command,
         cwd: run.cwd,
-    }
-}
-
-fn finding_summary(finding: FindingRecord) -> FindingSummary {
-    FindingSummary {
-        id: finding.id,
-        run_id: finding.run_id,
-        tool: finding.tool,
-        rule: finding.rule,
-        file: finding.file,
-        line: finding.line,
-        severity: finding.severity,
-        fingerprint: finding.fingerprint,
-        message: finding.message,
-        fixable: finding.fixable,
     }
 }
 
@@ -694,7 +593,7 @@ mod tests {
                 })
                 .expect("finding");
 
-            let (output, _) = findings(RunsFindingsArgs {
+            let (output, _) = findings::findings(findings::RunsFindingsArgs {
                 run_id: run.id,
                 tool: Some("lint".to_string()),
                 file: Some("src/foo.php".to_string()),
@@ -708,7 +607,7 @@ mod tests {
             assert_eq!(output.findings[0].id, recorded.id);
             assert_eq!(output.findings[0].message, "Missing escaping");
 
-            let (output, _) = finding(&recorded.id).expect("show finding");
+            let (output, _) = findings::finding(&recorded.id).expect("show finding");
             let RunsOutput::Finding(output) = output else {
                 panic!("expected finding output");
             };

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -6,7 +6,9 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::observation::{
+    ArtifactRecord, FindingListFilter, FindingRecord, ObservationStore, RunListFilter, RunRecord,
+};
 use homeboy::Error;
 
 use super::{CmdResult, GlobalArgs};
@@ -31,6 +33,10 @@ enum RunsCommand {
     Show { run_id: String },
     /// List artifacts recorded for one run
     Artifacts { run_id: String },
+    /// List findings recorded for one run
+    Findings(RunsFindingsArgs),
+    /// Show one recorded finding
+    Finding { finding_id: String },
     /// Export observation records as an inspectable directory bundle
     Export(RunsExportArgs),
     /// Import an observation bundle into the local observation store
@@ -56,12 +62,29 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
+#[derive(Args, Clone, Default)]
+pub struct RunsFindingsArgs {
+    /// Observation run ID
+    pub run_id: String,
+    /// Finding tool, for example lint
+    #[arg(long)]
+    pub tool: Option<String>,
+    /// Finding file path
+    #[arg(long)]
+    pub file: Option<String>,
+    /// Maximum findings to return
+    #[arg(long, default_value_t = 100)]
+    pub limit: i64,
+}
+
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
     List(RunsListOutput),
     Show(RunsShowOutput),
     Artifacts(RunsArtifactsOutput),
+    Findings(RunsFindingsOutput),
+    Finding(RunsFindingOutput),
     BenchHistory(BenchHistoryOutput),
     BenchCompare(BenchCompareOutput),
     Export(RunsExportOutput),
@@ -85,6 +108,19 @@ pub struct RunsArtifactsOutput {
     pub command: &'static str,
     pub run_id: String,
     pub artifacts: Vec<ArtifactRecord>,
+}
+
+#[derive(Serialize)]
+pub struct RunsFindingsOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub findings: Vec<FindingSummary>,
+}
+
+#[derive(Serialize)]
+pub struct RunsFindingOutput {
+    pub command: &'static str,
+    pub finding: FindingRecord,
 }
 
 #[derive(Serialize)]
@@ -147,6 +183,20 @@ pub struct RunDetail {
     pub artifacts: Vec<ArtifactRecord>,
 }
 
+#[derive(Serialize)]
+pub struct FindingSummary {
+    pub id: String,
+    pub run_id: String,
+    pub tool: String,
+    pub rule: Option<String>,
+    pub file: Option<String>,
+    pub line: Option<i64>,
+    pub severity: Option<String>,
+    pub fingerprint: Option<String>,
+    pub message: String,
+    pub fixable: Option<bool>,
+}
+
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct BenchMetricComparison {
     pub scenario_id: String,
@@ -169,6 +219,8 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
         RunsCommand::Show { run_id } => show_run(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
+        RunsCommand::Findings(args) => findings(args),
+        RunsCommand::Finding { finding_id } => finding(&finding_id),
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
     }
@@ -211,6 +263,50 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
             command: "runs.artifacts",
             run_id: run_id.to_string(),
             artifacts: store.list_artifacts(run_id)?,
+        }),
+        0,
+    ))
+}
+
+pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    require_run(&store, &args.run_id)?;
+    let findings = store
+        .list_findings(FindingListFilter {
+            run_id: Some(args.run_id.clone()),
+            tool: args.tool,
+            file: args.file,
+            limit: Some(args.limit),
+        })?
+        .into_iter()
+        .map(finding_summary)
+        .collect();
+
+    Ok((
+        RunsOutput::Findings(RunsFindingsOutput {
+            command: "runs.findings",
+            run_id: args.run_id,
+            findings,
+        }),
+        0,
+    ))
+}
+
+pub fn finding(finding_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let finding = store.get_finding(finding_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "finding_id",
+            format!("finding not found: {finding_id}"),
+            Some(finding_id.to_string()),
+            None,
+        )
+    })?;
+
+    Ok((
+        RunsOutput::Finding(RunsFindingOutput {
+            command: "runs.finding",
+            finding,
         }),
         0,
     ))
@@ -357,6 +453,21 @@ fn run_summary(run: RunRecord) -> RunSummary {
     }
 }
 
+fn finding_summary(finding: FindingRecord) -> FindingSummary {
+    FindingSummary {
+        id: finding.id,
+        run_id: finding.run_id,
+        tool: finding.tool,
+        rule: finding.rule,
+        file: finding.file,
+        line: finding.line,
+        severity: finding.severity,
+        fingerprint: finding.fingerprint,
+        message: finding.message,
+        fixable: finding.fixable,
+    }
+}
+
 fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
     if run.metadata_json["selected_scenarios"]
         .as_array()
@@ -428,7 +539,9 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    use homeboy::observation::{NewRunRecord, NewTraceSpanRecord, RunStatus, TraceSpanRecord};
+    use homeboy::observation::{
+        NewFindingRecord, NewRunRecord, NewTraceSpanRecord, RunStatus, TraceSpanRecord,
+    };
     use homeboy::test_support::with_isolated_home;
     use serde::Deserialize;
 
@@ -555,6 +668,52 @@ mod tests {
             };
             assert_eq!(output.artifacts.len(), 1);
             assert_eq!(output.artifacts[0].path, artifact_path.to_string_lossy());
+        });
+    }
+
+    #[test]
+    fn findings_commands_list_and_show_records() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let recorded = store
+                .record_finding(&NewFindingRecord {
+                    run_id: run.id.clone(),
+                    tool: "lint".to_string(),
+                    rule: Some("security".to_string()),
+                    file: Some("src/foo.php".to_string()),
+                    line: Some(12),
+                    severity: Some("error".to_string()),
+                    fingerprint: Some("src/foo.php::security".to_string()),
+                    message: "Missing escaping".to_string(),
+                    fixable: Some(true),
+                    metadata_json: serde_json::json!({ "category": "security" }),
+                })
+                .expect("finding");
+
+            let (output, _) = findings(RunsFindingsArgs {
+                run_id: run.id,
+                tool: Some("lint".to_string()),
+                file: Some("src/foo.php".to_string()),
+                limit: 20,
+            })
+            .expect("list findings");
+            let RunsOutput::Findings(output) = output else {
+                panic!("expected findings output");
+            };
+            assert_eq!(output.findings.len(), 1);
+            assert_eq!(output.findings[0].id, recorded.id);
+            assert_eq!(output.findings[0].message, "Missing escaping");
+
+            let (output, _) = finding(&recorded.id).expect("show finding");
+            let RunsOutput::Finding(output) = output else {
+                panic!("expected finding output");
+            };
+            assert_eq!(output.finding.metadata_json["category"], "security");
+            assert_eq!(output.finding.fixable, Some(true));
         });
     }
 

--- a/src/commands/runs/findings.rs
+++ b/src/commands/runs/findings.rs
@@ -1,0 +1,87 @@
+use clap::Args;
+use serde::Serialize;
+
+use homeboy::observation::{FindingListFilter, FindingRecord, ObservationStore};
+use homeboy::Error;
+
+use crate::commands::{runs::RunsOutput, CmdResult};
+
+#[derive(Args, Clone, Default)]
+pub struct RunsFindingsArgs {
+    /// Observation run ID
+    pub run_id: String,
+    /// Finding tool, for example lint
+    #[arg(long)]
+    pub tool: Option<String>,
+    /// Finding file path
+    #[arg(long)]
+    pub file: Option<String>,
+    /// Maximum findings to return
+    #[arg(long, default_value_t = 100)]
+    pub limit: i64,
+}
+
+#[derive(Serialize)]
+pub struct RunsFindingsOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub findings: Vec<FindingRecord>,
+}
+
+#[derive(Serialize)]
+pub struct RunsFindingOutput {
+    pub command: &'static str,
+    pub finding: FindingRecord,
+}
+
+pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    require_run(&store, &args.run_id)?;
+    let findings = store.list_findings(FindingListFilter {
+        run_id: Some(args.run_id.clone()),
+        tool: args.tool,
+        file: args.file,
+        limit: Some(args.limit),
+    })?;
+
+    Ok((
+        RunsOutput::Findings(RunsFindingsOutput {
+            command: "runs.findings",
+            run_id: args.run_id,
+            findings,
+        }),
+        0,
+    ))
+}
+
+pub fn finding(finding_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let finding = store.get_finding(finding_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "finding_id",
+            format!("finding not found: {finding_id}"),
+            Some(finding_id.to_string()),
+            None,
+        )
+    })?;
+
+    Ok((
+        RunsOutput::Finding(RunsFindingOutput {
+            command: "runs.finding",
+            finding,
+        }),
+        0,
+    ))
+}
+
+fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::Result<()> {
+    if store.get_run(run_id)?.is_some() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "run_id",
+        format!("run record not found: {run_id}"),
+        Some(run_id.to_string()),
+        None,
+    ))
+}

--- a/src/core/extension/lint/baseline.rs
+++ b/src/core/extension/lint/baseline.rs
@@ -6,6 +6,8 @@
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
 
 use crate::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
 
@@ -19,15 +21,11 @@ pub struct LintFinding {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rule: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub line: Option<i64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub fixable: Option<bool>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,5 +143,83 @@ mod tests {
         };
         let fp = LintFingerprint(&finding);
         assert_eq!(fp.context_label(), "lint:security");
+    }
+
+    #[test]
+    fn test_save_baseline() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let finding = LintFinding {
+            id: "id-1".to_string(),
+            message: "message".to_string(),
+            category: "security".to_string(),
+            ..LintFinding::default()
+        };
+
+        let saved = save_baseline(dir.path(), "homeboy", &[finding]).expect("baseline saved");
+
+        assert!(saved.exists());
+    }
+
+    #[test]
+    fn test_load_baseline() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let finding = LintFinding {
+            id: "id-1".to_string(),
+            message: "message".to_string(),
+            category: "security".to_string(),
+            ..LintFinding::default()
+        };
+        save_baseline(dir.path(), "homeboy", &[finding]).expect("baseline saved");
+
+        let loaded = load_baseline(dir.path()).expect("baseline loaded");
+
+        assert_eq!(loaded.context_id, "homeboy");
+        assert_eq!(loaded.item_count, 1);
+    }
+
+    #[test]
+    fn test_compare() {
+        let baseline = generic::Baseline {
+            context_id: "homeboy".to_string(),
+            created_at: "2026-05-01T00:00:00Z".to_string(),
+            item_count: 1,
+            known_fingerprints: vec!["id-1".to_string()],
+            metadata: LintBaselineMetadata { findings_count: 1 },
+        };
+        let findings = vec![
+            LintFinding {
+                id: "id-1".to_string(),
+                message: "message".to_string(),
+                category: "security".to_string(),
+                ..LintFinding::default()
+            },
+            LintFinding {
+                id: "id-2".to_string(),
+                message: "message 2".to_string(),
+                category: "i18n".to_string(),
+                ..LintFinding::default()
+            },
+        ];
+
+        let comparison = compare(&findings, &baseline);
+
+        assert_eq!(comparison.new_items.len(), 1);
+        assert_eq!(comparison.new_items[0].fingerprint, "id-2");
+    }
+
+    #[test]
+    fn test_parse_findings_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("lint-findings.json");
+        std::fs::write(
+            &path,
+            r#"[{"id":"id-1","message":"message","category":"security","file":"src/lib.rs"}]"#,
+        )
+        .expect("findings file written");
+
+        let findings = parse_findings_file(&path).expect("findings parsed");
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file.as_deref(), Some("src/lib.rs"));
     }
 }

--- a/src/core/extension/lint/baseline.rs
+++ b/src/core/extension/lint/baseline.rs
@@ -11,11 +11,23 @@ use crate::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
 
 const BASELINE_KEY: &str = "lint";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LintFinding {
     pub id: String,
     pub message: String,
     pub category: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,6 +117,7 @@ mod tests {
             id: "id-1".to_string(),
             message: "message".to_string(),
             category: "security".to_string(),
+            ..LintFinding::default()
         };
         let fp = LintFingerprint(&finding);
         assert_eq!(fp.fingerprint(), "id-1");
@@ -116,6 +129,7 @@ mod tests {
             id: "id-1".to_string(),
             message: "message".to_string(),
             category: "security".to_string(),
+            ..LintFinding::default()
         };
         let fp = LintFingerprint(&finding);
         assert_eq!(fp.description(), "message");
@@ -127,6 +141,7 @@ mod tests {
             id: "id-1".to_string(),
             message: "message".to_string(),
             category: "security".to_string(),
+            ..LintFinding::default()
         };
         let fp = LintFingerprint(&finding);
         assert_eq!(fp.context_label(), "lint:security");

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -641,6 +641,31 @@ mod tests {
     }
 
     #[test]
+    fn test_run_main_lint_workflow() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git init should run");
+        let run_dir = RunDir::create().expect("run dir");
+        let mut args = lint_args();
+        args.changed_only = true;
+
+        let result = run_main_lint_workflow(
+            &component(&dir.path().to_string_lossy()),
+            &dir.path().to_path_buf(),
+            args,
+            &run_dir,
+        )
+        .expect("unchanged git repo should skip lint runner");
+
+        assert_eq!(result.status, "passed");
+        assert_eq!(result.exit_code, 0);
+        assert!(result.lint_findings.is_none());
+    }
+
+    #[test]
     fn lint_summary_counts_categories_and_caps_top_findings() {
         let findings = (0..25)
             .map(|index| LintFinding {

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -651,6 +651,7 @@ mod tests {
                 } else {
                     "correctness".to_string()
                 },
+                ..LintFinding::default()
             })
             .collect::<Vec<_>>();
 

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -8,7 +8,8 @@ pub mod records;
 pub mod store;
 
 pub use records::{
-    ArtifactRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord,
-    RunStatus, TraceRunRecord, TraceSpanRecord,
+    ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
+    NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
+    TraceSpanRecord,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -71,6 +71,44 @@ pub struct ArtifactRecord {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct NewFindingRecord {
+    pub run_id: String,
+    pub tool: String,
+    pub rule: Option<String>,
+    pub file: Option<String>,
+    pub line: Option<i64>,
+    pub severity: Option<String>,
+    pub fingerprint: Option<String>,
+    pub message: String,
+    pub fixable: Option<bool>,
+    pub metadata_json: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingRecord {
+    pub id: String,
+    pub run_id: String,
+    pub tool: String,
+    pub rule: Option<String>,
+    pub file: Option<String>,
+    pub line: Option<i64>,
+    pub severity: Option<String>,
+    pub fingerprint: Option<String>,
+    pub message: String,
+    pub fixable: Option<bool>,
+    pub metadata_json: serde_json::Value,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FindingListFilter {
+    pub run_id: Option<String>,
+    pub tool: Option<String>,
+    pub file: Option<String>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct NewTraceRunRecord {
     pub run_id: String,
     pub component_id: String,

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -6,6 +6,8 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+mod findings;
+
 use super::records::{
     ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
     NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
@@ -499,115 +501,6 @@ impl ObservationStore {
         collect_rows(rows, "collect artifact records")
     }
 
-    pub fn record_findings(&self, findings: &[NewFindingRecord]) -> Result<Vec<FindingRecord>> {
-        let mut records = Vec::with_capacity(findings.len());
-        for finding in findings {
-            records.push(self.record_finding(finding)?);
-        }
-        Ok(records)
-    }
-
-    pub fn record_finding(&self, finding: &NewFindingRecord) -> Result<FindingRecord> {
-        validate_required("finding.run_id", &finding.run_id)?;
-        validate_required("finding.tool", &finding.tool)?;
-        validate_required("finding.message", &finding.message)?;
-        if self.get_run(&finding.run_id)?.is_none() {
-            return Err(Error::validation_invalid_argument(
-                "finding.run_id",
-                format!("referenced run record not found: {}", finding.run_id),
-                Some(finding.run_id.clone()),
-                None,
-            ));
-        }
-
-        let id = Uuid::new_v4().to_string();
-        let created_at = chrono::Utc::now().to_rfc3339();
-        let metadata_json = serialize_metadata(&finding.metadata_json)?;
-        let fixable = finding
-            .fixable
-            .map(|value| if value { 1_i64 } else { 0_i64 });
-
-        self.connection
-            .execute(
-                r#"
-                INSERT INTO findings(
-                    id, run_id, tool, rule, file, line, severity, fingerprint, message,
-                    fixable, metadata_json, created_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-                "#,
-                params![
-                    id,
-                    finding.run_id,
-                    finding.tool,
-                    finding.rule,
-                    finding.file,
-                    finding.line,
-                    finding.severity,
-                    finding.fingerprint,
-                    finding.message,
-                    fixable,
-                    metadata_json,
-                    created_at,
-                ],
-            )
-            .map_err(sqlite_error("insert finding record"))?;
-
-        self.get_finding(&id)?.ok_or_else(|| {
-            Error::internal_unexpected(format!(
-                "Inserted finding record {id} but could not read it back"
-            ))
-        })
-    }
-
-    pub fn get_finding(&self, finding_id: &str) -> Result<Option<FindingRecord>> {
-        validate_required("finding_id", finding_id)?;
-        self.connection
-            .query_row(
-                r#"
-                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
-                       fixable, metadata_json, created_at
-                FROM findings
-                WHERE id = ?1
-                "#,
-                [finding_id],
-                row_to_finding_record,
-            )
-            .optional()
-            .map_err(sqlite_error("read finding record"))
-    }
-
-    pub fn list_findings(&self, filter: FindingListFilter) -> Result<Vec<FindingRecord>> {
-        let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
-        let mut statement = self
-            .connection
-            .prepare(
-                r#"
-                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
-                       fixable, metadata_json, created_at
-                FROM findings
-                WHERE (?1 IS NULL OR run_id = ?1)
-                  AND (?2 IS NULL OR tool = ?2)
-                  AND (?3 IS NULL OR file = ?3)
-                ORDER BY created_at ASC, rowid ASC
-                LIMIT ?4
-                "#,
-            )
-            .map_err(sqlite_error("prepare list finding records"))?;
-        let rows = statement
-            .query_map(
-                params![
-                    filter.run_id.as_deref(),
-                    filter.tool.as_deref(),
-                    filter.file.as_deref(),
-                    limit,
-                ],
-                row_to_finding_record,
-            )
-            .map_err(sqlite_error("list finding records"))?;
-
-        collect_rows(rows, "collect finding records")
-    }
-
     fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
         validate_required("artifact_id", artifact_id)?;
         self.connection
@@ -1034,24 +927,6 @@ fn row_to_artifact_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArtifactR
         size_bytes: row.get(5)?,
         mime: row.get(6)?,
         created_at: row.get(7)?,
-    })
-}
-
-fn row_to_finding_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<FindingRecord> {
-    let fixable: Option<i64> = row.get(9)?;
-    Ok(FindingRecord {
-        id: row.get(0)?,
-        run_id: row.get(1)?,
-        tool: row.get(2)?,
-        rule: row.get(3)?,
-        file: row.get(4)?,
-        line: row.get(5)?,
-        severity: row.get(6)?,
-        fingerprint: row.get(7)?,
-        message: row.get(8)?,
-        fixable: fixable.map(|value| value != 0),
-        metadata_json: parse_metadata(row.get(10)?)?,
-        created_at: row.get(11)?,
     })
 }
 

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -7,12 +7,13 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::records::{
-    ArtifactRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord,
-    RunStatus, TraceRunRecord, TraceSpanRecord,
+    ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
+    NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
+    TraceSpanRecord,
 };
 use crate::{paths, Error, Result};
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 2;
+pub const CURRENT_SCHEMA_VERSION: i64 = 3;
 
 struct Migration {
     version: i64,
@@ -88,6 +89,33 @@ const MIGRATIONS: &[Migration] = &[
             ON trace_runs(rig_id);
         CREATE INDEX IF NOT EXISTS idx_trace_spans_run
             ON trace_spans(run_id);
+    "#,
+    },
+    Migration {
+        version: 3,
+        sql: r#"
+        CREATE TABLE IF NOT EXISTS findings (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            tool TEXT NOT NULL,
+            rule TEXT,
+            file TEXT,
+            line INTEGER,
+            severity TEXT,
+            fingerprint TEXT,
+            message TEXT NOT NULL,
+            fixable INTEGER,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_findings_run
+            ON findings(run_id);
+        CREATE INDEX IF NOT EXISTS idx_findings_tool_file
+            ON findings(tool, file);
+        CREATE INDEX IF NOT EXISTS idx_findings_fingerprint
+            ON findings(fingerprint);
     "#,
     },
 ];
@@ -469,6 +497,115 @@ impl ObservationStore {
             .map_err(sqlite_error("list artifact records"))?;
 
         collect_rows(rows, "collect artifact records")
+    }
+
+    pub fn record_findings(&self, findings: &[NewFindingRecord]) -> Result<Vec<FindingRecord>> {
+        let mut records = Vec::with_capacity(findings.len());
+        for finding in findings {
+            records.push(self.record_finding(finding)?);
+        }
+        Ok(records)
+    }
+
+    pub fn record_finding(&self, finding: &NewFindingRecord) -> Result<FindingRecord> {
+        validate_required("finding.run_id", &finding.run_id)?;
+        validate_required("finding.tool", &finding.tool)?;
+        validate_required("finding.message", &finding.message)?;
+        if self.get_run(&finding.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "finding.run_id",
+                format!("referenced run record not found: {}", finding.run_id),
+                Some(finding.run_id.clone()),
+                None,
+            ));
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+        let metadata_json = serialize_metadata(&finding.metadata_json)?;
+        let fixable = finding
+            .fixable
+            .map(|value| if value { 1_i64 } else { 0_i64 });
+
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO findings(
+                    id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                    fixable, metadata_json, created_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                "#,
+                params![
+                    id,
+                    finding.run_id,
+                    finding.tool,
+                    finding.rule,
+                    finding.file,
+                    finding.line,
+                    finding.severity,
+                    finding.fingerprint,
+                    finding.message,
+                    fixable,
+                    metadata_json,
+                    created_at,
+                ],
+            )
+            .map_err(sqlite_error("insert finding record"))?;
+
+        self.get_finding(&id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Inserted finding record {id} but could not read it back"
+            ))
+        })
+    }
+
+    pub fn get_finding(&self, finding_id: &str) -> Result<Option<FindingRecord>> {
+        validate_required("finding_id", finding_id)?;
+        self.connection
+            .query_row(
+                r#"
+                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                       fixable, metadata_json, created_at
+                FROM findings
+                WHERE id = ?1
+                "#,
+                [finding_id],
+                row_to_finding_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read finding record"))
+    }
+
+    pub fn list_findings(&self, filter: FindingListFilter) -> Result<Vec<FindingRecord>> {
+        let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                       fixable, metadata_json, created_at
+                FROM findings
+                WHERE (?1 IS NULL OR run_id = ?1)
+                  AND (?2 IS NULL OR tool = ?2)
+                  AND (?3 IS NULL OR file = ?3)
+                ORDER BY created_at ASC, rowid ASC
+                LIMIT ?4
+                "#,
+            )
+            .map_err(sqlite_error("prepare list finding records"))?;
+        let rows = statement
+            .query_map(
+                params![
+                    filter.run_id.as_deref(),
+                    filter.tool.as_deref(),
+                    filter.file.as_deref(),
+                    limit,
+                ],
+                row_to_finding_record,
+            )
+            .map_err(sqlite_error("list finding records"))?;
+
+        collect_rows(rows, "collect finding records")
     }
 
     fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
@@ -897,6 +1034,24 @@ fn row_to_artifact_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArtifactR
         size_bytes: row.get(5)?,
         mime: row.get(6)?,
         created_at: row.get(7)?,
+    })
+}
+
+fn row_to_finding_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<FindingRecord> {
+    let fixable: Option<i64> = row.get(9)?;
+    Ok(FindingRecord {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        tool: row.get(2)?,
+        rule: row.get(3)?,
+        file: row.get(4)?,
+        line: row.get(5)?,
+        severity: row.get(6)?,
+        fingerprint: row.get(7)?,
+        message: row.get(8)?,
+        fixable: fixable.map(|value| value != 0),
+        metadata_json: parse_metadata(row.get(10)?)?,
+        created_at: row.get(11)?,
     })
 }
 

--- a/src/core/observation/store/findings.rs
+++ b/src/core/observation/store/findings.rs
@@ -1,0 +1,244 @@
+use rusqlite::{params, OptionalExtension};
+use uuid::Uuid;
+
+use super::*;
+
+impl ObservationStore {
+    pub fn record_findings(&self, findings: &[NewFindingRecord]) -> Result<Vec<FindingRecord>> {
+        let mut records = Vec::with_capacity(findings.len());
+        for finding in findings {
+            records.push(self.record_finding(finding)?);
+        }
+        Ok(records)
+    }
+
+    pub fn record_finding(&self, finding: &NewFindingRecord) -> Result<FindingRecord> {
+        validate_required("finding.run_id", &finding.run_id)?;
+        validate_required("finding.tool", &finding.tool)?;
+        validate_required("finding.message", &finding.message)?;
+        if self.get_run(&finding.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "finding.run_id",
+                format!("referenced run record not found: {}", finding.run_id),
+                Some(finding.run_id.clone()),
+                None,
+            ));
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+        let metadata_json = serialize_metadata(&finding.metadata_json)?;
+        let fixable = finding
+            .fixable
+            .map(|value| if value { 1_i64 } else { 0_i64 });
+
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO findings(
+                    id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                    fixable, metadata_json, created_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                "#,
+                params![
+                    id,
+                    finding.run_id,
+                    finding.tool,
+                    finding.rule,
+                    finding.file,
+                    finding.line,
+                    finding.severity,
+                    finding.fingerprint,
+                    finding.message,
+                    fixable,
+                    metadata_json,
+                    created_at,
+                ],
+            )
+            .map_err(sqlite_error("insert finding record"))?;
+
+        self.get_finding(&id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Inserted finding record {id} but could not read it back"
+            ))
+        })
+    }
+
+    pub fn get_finding(&self, finding_id: &str) -> Result<Option<FindingRecord>> {
+        validate_required("finding_id", finding_id)?;
+        self.connection
+            .query_row(
+                r#"
+                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                       fixable, metadata_json, created_at
+                FROM findings
+                WHERE id = ?1
+                "#,
+                [finding_id],
+                row_to_finding_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read finding record"))
+    }
+
+    pub fn list_findings(&self, filter: FindingListFilter) -> Result<Vec<FindingRecord>> {
+        let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                       fixable, metadata_json, created_at
+                FROM findings
+                WHERE (?1 IS NULL OR run_id = ?1)
+                  AND (?2 IS NULL OR tool = ?2)
+                  AND (?3 IS NULL OR file = ?3)
+                ORDER BY created_at ASC, rowid ASC
+                LIMIT ?4
+                "#,
+            )
+            .map_err(sqlite_error("prepare list finding records"))?;
+        let rows = statement
+            .query_map(
+                params![
+                    filter.run_id.as_deref(),
+                    filter.tool.as_deref(),
+                    filter.file.as_deref(),
+                    limit,
+                ],
+                row_to_finding_record,
+            )
+            .map_err(sqlite_error("list finding records"))?;
+
+        collect_rows(rows, "collect finding records")
+    }
+}
+
+fn row_to_finding_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<FindingRecord> {
+    let fixable: Option<i64> = row.get(9)?;
+    Ok(FindingRecord {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        tool: row.get(2)?,
+        rule: row.get(3)?,
+        file: row.get(4)?,
+        line: row.get(5)?,
+        severity: row.get(6)?,
+        fingerprint: row.get(7)?,
+        message: row.get(8)?,
+        fixable: fixable.map(|value| value != 0),
+        metadata_json: parse_metadata(row.get(10)?)?,
+        created_at: row.get(11)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+
+    struct XdgGuard(Option<String>);
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    fn new_run() -> NewRunRecord {
+        NewRunRecord {
+            kind: "lint".to_string(),
+            component_id: Some("homeboy".to_string()),
+            command: Some("homeboy lint".to_string()),
+            cwd: Some("/tmp/homeboy".to_string()),
+            homeboy_version: Some("test".to_string()),
+            git_sha: None,
+            rig_id: None,
+            metadata_json: serde_json::json!({}),
+        }
+    }
+
+    fn new_finding(run_id: &str, rule: &str) -> NewFindingRecord {
+        NewFindingRecord {
+            run_id: run_id.to_string(),
+            tool: "lint".to_string(),
+            rule: Some(rule.to_string()),
+            file: Some(format!("src/{rule}.rs")),
+            line: Some(1),
+            severity: Some("warning".to_string()),
+            fingerprint: Some(format!("src/{rule}.rs::{rule}")),
+            message: format!("{rule} finding"),
+            fixable: Some(false),
+            metadata_json: serde_json::json!({ "category": rule }),
+        }
+    }
+
+    #[test]
+    fn test_record_finding() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run()).expect("start");
+
+            let finding = store
+                .record_finding(&new_finding(&run.id, "security"))
+                .expect("finding");
+
+            assert_eq!(finding.rule.as_deref(), Some("security"));
+        });
+    }
+
+    #[test]
+    fn test_record_findings() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run()).expect("start");
+
+            let findings = store
+                .record_findings(&[
+                    new_finding(&run.id, "security"),
+                    new_finding(&run.id, "i18n"),
+                ])
+                .expect("findings");
+
+            assert_eq!(findings.len(), 2);
+        });
+    }
+
+    #[test]
+    fn test_list_findings() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run()).expect("start");
+            store
+                .record_findings(&[
+                    new_finding(&run.id, "security"),
+                    new_finding(&run.id, "i18n"),
+                ])
+                .expect("findings");
+
+            let findings = store
+                .list_findings(FindingListFilter {
+                    run_id: Some(run.id),
+                    tool: Some("lint".to_string()),
+                    ..FindingListFilter::default()
+                })
+                .expect("list");
+
+            assert_eq!(findings.len(), 2);
+        });
+    }
+}

--- a/tests/core/lint_baseline_test.rs
+++ b/tests/core/lint_baseline_test.rs
@@ -9,13 +9,11 @@ fn test_save_baseline() {
             id: "a".to_string(),
             message: "m1".to_string(),
             category: "cat1".to_string(),
-            ..LintFinding::default()
         },
         LintFinding {
             id: "b".to_string(),
             message: "m2".to_string(),
             category: "cat2".to_string(),
-            ..LintFinding::default()
         },
     ];
 
@@ -31,7 +29,6 @@ fn test_load_baseline() {
         id: "a".to_string(),
         message: "m1".to_string(),
         category: "cat1".to_string(),
-        ..LintFinding::default()
     }];
     lint_baseline::save_baseline(dir.path(), "homeboy", &findings).expect("baseline saved");
 
@@ -47,7 +44,6 @@ fn test_compare() {
         id: "a".to_string(),
         message: "m1".to_string(),
         category: "cat1".to_string(),
-        ..LintFinding::default()
     }];
     lint_baseline::save_baseline(dir.path(), "homeboy", &base).expect("baseline saved");
     let loaded = lint_baseline::load_baseline(dir.path()).expect("baseline should load");
@@ -58,7 +54,6 @@ fn test_compare() {
             id: "b".to_string(),
             message: "m2".to_string(),
             category: "cat2".to_string(),
-            ..LintFinding::default()
         },
     ];
 

--- a/tests/core/lint_baseline_test.rs
+++ b/tests/core/lint_baseline_test.rs
@@ -9,11 +9,13 @@ fn test_save_baseline() {
             id: "a".to_string(),
             message: "m1".to_string(),
             category: "cat1".to_string(),
+            ..LintFinding::default()
         },
         LintFinding {
             id: "b".to_string(),
             message: "m2".to_string(),
             category: "cat2".to_string(),
+            ..LintFinding::default()
         },
     ];
 
@@ -29,6 +31,7 @@ fn test_load_baseline() {
         id: "a".to_string(),
         message: "m1".to_string(),
         category: "cat1".to_string(),
+        ..LintFinding::default()
     }];
     lint_baseline::save_baseline(dir.path(), "homeboy", &findings).expect("baseline saved");
 
@@ -44,6 +47,7 @@ fn test_compare() {
         id: "a".to_string(),
         message: "m1".to_string(),
         category: "cat1".to_string(),
+        ..LintFinding::default()
     }];
     lint_baseline::save_baseline(dir.path(), "homeboy", &base).expect("baseline saved");
     let loaded = lint_baseline::load_baseline(dir.path()).expect("baseline should load");
@@ -54,6 +58,7 @@ fn test_compare() {
             id: "b".to_string(),
             message: "m2".to_string(),
             category: "cat2".to_string(),
+            ..LintFinding::default()
         },
     ];
 

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -103,7 +103,29 @@ fn initialization_is_idempotent() {
 }
 
 #[test]
-fn test_record_and_list_findings() {
+fn test_record_finding() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start run");
+
+        let record = store
+            .record_finding(&sample_finding(&run.id, "security", "src/foo.php"))
+            .expect("record finding");
+        let fetched = store
+            .get_finding(&record.id)
+            .expect("get finding")
+            .expect("finding exists");
+
+        assert_eq!(fetched.message, "Missing security");
+        assert_eq!(fetched.fixable, Some(true));
+    });
+}
+
+#[test]
+fn test_record_findings() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("init store");
@@ -113,30 +135,29 @@ fn test_record_and_list_findings() {
 
         let records = store
             .record_findings(&[
-                NewFindingRecord {
-                    run_id: run.id.clone(),
-                    tool: "lint".to_string(),
-                    rule: Some("security".to_string()),
-                    file: Some("src/foo.php".to_string()),
-                    line: Some(12),
-                    severity: Some("error".to_string()),
-                    fingerprint: Some("src/foo.php::security".to_string()),
-                    message: "Missing escaping".to_string(),
-                    fixable: Some(true),
-                    metadata_json: serde_json::json!({ "category": "security" }),
-                },
-                NewFindingRecord {
-                    run_id: run.id.clone(),
-                    tool: "lint".to_string(),
-                    rule: Some("i18n".to_string()),
-                    file: Some("src/bar.php".to_string()),
-                    line: None,
-                    severity: Some("warning".to_string()),
-                    fingerprint: Some("src/bar.php::i18n".to_string()),
-                    message: "Untranslated string".to_string(),
-                    fixable: Some(false),
-                    metadata_json: serde_json::json!({ "category": "i18n" }),
-                },
+                sample_finding(&run.id, "security", "src/foo.php"),
+                sample_finding(&run.id, "i18n", "src/bar.php"),
+            ])
+            .expect("record findings");
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].rule.as_deref(), Some("security"));
+        assert_eq!(records[1].rule.as_deref(), Some("i18n"));
+    });
+}
+
+#[test]
+fn test_list_findings() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start run");
+        let records = store
+            .record_findings(&[
+                sample_finding(&run.id, "security", "src/foo.php"),
+                sample_finding(&run.id, "i18n", "src/bar.php"),
             ])
             .expect("record findings");
 
@@ -154,17 +175,26 @@ fn test_record_and_list_findings() {
                 ..FindingListFilter::default()
             })
             .expect("list file findings");
-        let fetched = store
-            .get_finding(&records[0].id)
-            .expect("get finding")
-            .expect("finding exists");
 
         assert_eq!(all.len(), 2);
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].id, records[0].id);
-        assert_eq!(fetched.message, "Missing escaping");
-        assert_eq!(fetched.fixable, Some(true));
     });
+}
+
+fn sample_finding(run_id: &str, rule: &str, file: &str) -> NewFindingRecord {
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: "lint".to_string(),
+        rule: Some(rule.to_string()),
+        file: Some(file.to_string()),
+        line: Some(12),
+        severity: Some("error".to_string()),
+        fingerprint: Some(format!("{file}::{rule}")),
+        message: format!("Missing {rule}"),
+        fixable: Some(true),
+        metadata_json: serde_json::json!({ "category": rule }),
+    }
 }
 
 fn sample_run(kind: &str, component_id: &str) -> NewRunRecord {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -4,7 +4,9 @@
 //! never read or written.
 
 use crate::observation::store::{self, ObservationStore, CURRENT_SCHEMA_VERSION};
-use crate::observation::{NewRunRecord, RunListFilter, RunStatus};
+use crate::observation::{
+    FindingListFilter, NewFindingRecord, NewRunRecord, RunListFilter, RunStatus,
+};
 use crate::test_support::with_isolated_home;
 
 struct XdgGuard {
@@ -80,8 +82,8 @@ fn test_open_initialized() {
 
         assert!(status.exists);
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 2);
-        assert_eq!(status.table_count, 5);
+        assert_eq!(status.migration_count, 3);
+        assert_eq!(status.table_count, 6);
     });
 }
 
@@ -95,8 +97,73 @@ fn initialization_is_idempotent() {
         let status = second.status().expect("status");
 
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 2);
-        assert_eq!(status.table_count, 5);
+        assert_eq!(status.migration_count, 3);
+        assert_eq!(status.table_count, 6);
+    });
+}
+
+#[test]
+fn test_record_and_list_findings() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start run");
+
+        let records = store
+            .record_findings(&[
+                NewFindingRecord {
+                    run_id: run.id.clone(),
+                    tool: "lint".to_string(),
+                    rule: Some("security".to_string()),
+                    file: Some("src/foo.php".to_string()),
+                    line: Some(12),
+                    severity: Some("error".to_string()),
+                    fingerprint: Some("src/foo.php::security".to_string()),
+                    message: "Missing escaping".to_string(),
+                    fixable: Some(true),
+                    metadata_json: serde_json::json!({ "category": "security" }),
+                },
+                NewFindingRecord {
+                    run_id: run.id.clone(),
+                    tool: "lint".to_string(),
+                    rule: Some("i18n".to_string()),
+                    file: Some("src/bar.php".to_string()),
+                    line: None,
+                    severity: Some("warning".to_string()),
+                    fingerprint: Some("src/bar.php::i18n".to_string()),
+                    message: "Untranslated string".to_string(),
+                    fixable: Some(false),
+                    metadata_json: serde_json::json!({ "category": "i18n" }),
+                },
+            ])
+            .expect("record findings");
+
+        let all = store
+            .list_findings(FindingListFilter {
+                run_id: Some(run.id.clone()),
+                tool: Some("lint".to_string()),
+                ..FindingListFilter::default()
+            })
+            .expect("list findings");
+        let filtered = store
+            .list_findings(FindingListFilter {
+                run_id: Some(run.id),
+                file: Some("src/foo.php".to_string()),
+                ..FindingListFilter::default()
+            })
+            .expect("list file findings");
+        let fetched = store
+            .get_finding(&records[0].id)
+            .expect("get finding")
+            .expect("finding exists");
+
+        assert_eq!(all.len(), 2);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, records[0].id);
+        assert_eq!(fetched.message, "Missing escaping");
+        assert_eq!(fetched.fixable, Some(true));
     });
 }
 


### PR DESCRIPTION
## Summary
- Adds observation-store schema support for normalized findings linked to persisted runs.
- Persists `homeboy lint` runs and normalized lint findings best-effort so lint behavior remains stable when observation writes fail.
- Adds narrow read support via `homeboy runs findings <run_id>` and `homeboy runs finding <finding_id>`.

## Tests
- `cargo test test_record_and_list_findings --lib`
- `cargo test findings_commands_list_and_show_records --lib`
- `cargo test lint_baseline --lib`
- `homeboy lint --path . --json-summary`
- `cargo run --bin homeboy -- lint --path . --json-summary`
- `cargo run --bin homeboy -- runs list --kind lint --limit 1`
- `cargo run --bin homeboy -- runs findings 1dc7ee21-11aa-4d89-9c66-6fab5b91d0c4 --tool lint`

## Follow-up
- A broader generic `homeboy findings ...` CLI is still intentionally left for a follow-up.
- Observation bundle export/import does not yet include findings.
- Full `homeboy test --path . --json-summary` was attempted and failed on existing environment-sensitive trace/rig/path-order tests plus the local runner's BSD `grep -P` issue; targeted tests for this change pass.

Fixes #2042.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and tests; Chris remains responsible for review and validation.