### PR TITLE
Add observation pointers to review output

### DIFF
--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -142,6 +142,39 @@ The `next_steps` array contains context-aware actionable guidance based on the c
 
 On success, `data` is the command-specific output struct (varies by command).
 
+## Observation-backed payloads
+
+`--output` remains the per-invocation command-result artifact. It must continue
+to work for CI wrappers, scripts, and environments where the local observation
+SQLite database is unavailable.
+
+Observation-backed commands may add an optional `observation` field using the
+`homeboy/observation-pointer/v1` shape:
+
+```json
+{
+  "observation": {
+    "schema": "homeboy/observation-pointer/v1",
+    "run_id": "abc123",
+    "kind": "review",
+    "details": {
+      "query": "homeboy runs show abc123",
+      "artifacts": "homeboy runs artifacts abc123",
+      "export_bundle": "homeboy runs export --run abc123 --output homeboy-observations"
+    }
+  }
+}
+```
+
+Rules:
+
+- The field is additive and optional; absence means the best-effort observation
+  write was unavailable or the command is not observation-backed.
+- Existing command payload fields stay intact for backward compatibility.
+- Heavy evidence should live in observation records when available; command
+  output should keep summary/counts/status and include exact drill-down commands.
+- Observation store failures must not fail an otherwise successful command.
+
 ## Command payload conventions
 
 Many command outputs include a `command` string field:

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -23,6 +23,7 @@ use homeboy::code_audit::AuditCommandOutput;
 use homeboy::extension::lint::LintCommandOutput;
 use homeboy::extension::test::TestCommandOutput;
 use homeboy::git;
+use homeboy::ObservationOutputMetadata;
 
 use super::parse_key_val;
 use super::utils::args::{BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs};
@@ -129,6 +130,8 @@ pub struct ReviewSummary {
 #[derive(Serialize)]
 pub struct ReviewCommandOutput {
     pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation: Option<ObservationOutputMetadata>,
     pub artifact: ReviewArtifact,
     pub summary: ReviewSummary,
     pub audit: ReviewStage<AuditCommandOutput>,
@@ -145,6 +148,8 @@ pub struct ReviewArtifact {
     pub generated_at: String,
     pub base_ref: String,
     pub head_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation: Option<ObservationOutputMetadata>,
     pub commands: Vec<ReviewArtifactCommand>,
 }
 
@@ -193,21 +198,36 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         let message = format!("No files changed {} — skipping review", scope_label);
         println!("{}", message);
 
+        let review_observation = observation::start(observation::ReviewObservationStart {
+            component_id: &component.id,
+            component_label: &component_label,
+            source_path: Path::new(&source_path),
+            args: &args,
+            scope: &scope,
+            changed_file_count: Some(0),
+        });
+        let observation_metadata = review_observation.as_ref().map(|o| o.output_metadata());
+
+        let mut artifact = ReviewArtifact {
+            schema: "homeboy/review/v1".to_string(),
+            component: component_label.clone(),
+            status: "skipped".to_string(),
+            generated_at: generated_at_now(),
+            base_ref: args.changed_since.clone().unwrap_or_default(),
+            head_ref: git_ref(&source_path, "HEAD").unwrap_or_default(),
+            observation: None,
+            commands: vec![
+                artifact_command(&stage_skipped::<Value>("audit", "no files changed")),
+                artifact_command(&stage_skipped::<Value>("lint", "no files changed")),
+                artifact_command(&stage_skipped::<Value>("test", "no files changed")),
+            ],
+        };
+        artifact.observation = observation_metadata.clone();
+
         let output = ReviewCommandOutput {
             command: "review".to_string(),
-            artifact: ReviewArtifact {
-                schema: "homeboy/review/v1".to_string(),
-                component: component_label.clone(),
-                status: "skipped".to_string(),
-                generated_at: generated_at_now(),
-                base_ref: args.changed_since.clone().unwrap_or_default(),
-                head_ref: git_ref(&source_path, "HEAD").unwrap_or_default(),
-                commands: vec![
-                    artifact_command(&stage_skipped::<Value>("audit", "no files changed")),
-                    artifact_command(&stage_skipped::<Value>("lint", "no files changed")),
-                    artifact_command(&stage_skipped::<Value>("test", "no files changed")),
-                ],
-            },
+            observation: observation_metadata,
+            artifact,
             summary: ReviewSummary {
                 passed: true,
                 status: "passed".to_string(),
@@ -222,18 +242,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
             lint: stage_skipped("lint", "no files changed"),
             test: stage_skipped("test", "no files changed"),
         };
-        observation::finish_success(
-            observation::start(observation::ReviewObservationStart {
-                component_id: &component.id,
-                component_label: &component_label,
-                source_path: Path::new(&source_path),
-                args: &args,
-                scope: &scope,
-                changed_file_count: Some(0),
-            }),
-            &output,
-            0,
-        );
+        observation::finish_success(review_observation, &output, 0);
         return Ok((output, 0));
     }
 
@@ -401,7 +410,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         hints: top_hints,
     };
 
-    let artifact = build_artifact(
+    let mut artifact = build_artifact(
         &component_label,
         args.changed_since.as_deref().unwrap_or(""),
         git_ref(&source_path, "HEAD").unwrap_or_default().as_str(),
@@ -411,9 +420,12 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
             artifact_command(&test_stage),
         ],
     );
+    let observation_metadata = review_observation.as_ref().map(|o| o.output_metadata());
+    artifact.observation = observation_metadata.clone();
 
     let output = ReviewCommandOutput {
         command: "review".to_string(),
+        observation: observation_metadata,
         artifact,
         summary,
         audit: audit_stage,
@@ -525,6 +537,7 @@ fn build_artifact(
         generated_at: generated_at_now(),
         base_ref: base_ref.to_string(),
         head_ref: head_ref.to_string(),
+        observation: None,
         commands,
     }
 }
@@ -904,6 +917,63 @@ mod tests {
         assert!(
             json.get("success").is_none(),
             "artifact is not CLI envelope"
+        );
+    }
+
+    #[test]
+    fn write_artifact_to_file_preserves_observation_pointer_when_available() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review.json");
+        let result = Ok(serde_json::json!({
+            "command": "review",
+            "observation": {
+                "schema": "homeboy/observation-pointer/v1",
+                "run_id": "run-123",
+                "kind": "review",
+                "details": {
+                    "query": "homeboy runs show run-123",
+                    "artifacts": "homeboy runs artifacts run-123",
+                    "export_bundle": "homeboy runs export --run run-123 --output homeboy-observations"
+                }
+            },
+            "artifact": {
+                "schema": "homeboy/review/v1",
+                "component": "homeboy",
+                "status": "passed",
+                "generated_at": "2026-04-28T00:00:00Z",
+                "base_ref": "origin/main",
+                "head_ref": "abc123",
+                "observation": {
+                    "schema": "homeboy/observation-pointer/v1",
+                    "run_id": "run-123",
+                    "kind": "review",
+                    "details": {
+                        "query": "homeboy runs show run-123",
+                        "artifacts": "homeboy runs artifacts run-123",
+                        "export_bundle": "homeboy runs export --run run-123 --output homeboy-observations"
+                    }
+                },
+                "commands": []
+            }
+        }));
+
+        assert!(write_artifact_to_file(
+            &result,
+            path.to_str().expect("utf8 path"),
+            0
+        ));
+
+        let written = std::fs::read_to_string(path).expect("artifact written");
+        let json: serde_json::Value = serde_json::from_str(&written).expect("valid json");
+        assert_eq!(json["schema"], "homeboy/review/v1");
+        assert_eq!(json["observation"]["run_id"], "run-123");
+        assert_eq!(
+            json["observation"]["details"]["query"],
+            "homeboy runs show run-123"
+        );
+        assert!(
+            json.get("success").is_none(),
+            "artifact remains the direct review artifact, not the CLI envelope"
         );
     }
 

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use homeboy::git::short_head_revision_at;
 use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
+use homeboy::ObservationOutputMetadata;
 
 use super::{artifact_command, ReviewArgs, ReviewCommandOutput, ReviewStage};
 
@@ -9,6 +10,12 @@ pub(super) struct ReviewObservation {
     store: ObservationStore,
     run: RunRecord,
     initial_metadata: serde_json::Value,
+}
+
+impl ReviewObservation {
+    pub(super) fn output_metadata(&self) -> ObservationOutputMetadata {
+        ObservationOutputMetadata::for_run(&self.run.kind, &self.run.id)
+    }
 }
 
 pub(super) struct ReviewObservationStart<'a> {
@@ -274,6 +281,7 @@ mod tests {
         );
         let output = ReviewCommandOutput {
             command: "review".to_string(),
+            observation: None,
             artifact,
             summary: super::super::ReviewSummary {
                 passed: false,

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -301,6 +301,7 @@ mod tests {
     fn passing_envelope() -> ReviewCommandOutput {
         ReviewCommandOutput {
             command: "review".to_string(),
+            observation: None,
             artifact: super::super::build_artifact("my-comp", "", "abc123", Vec::new()),
             summary: super::super::ReviewSummary {
                 passed: true,
@@ -572,6 +573,7 @@ mod tests {
     fn renders_all_stages_skipped() {
         let env = ReviewCommandOutput {
             command: "review".to_string(),
+            observation: None,
             artifact: super::super::build_artifact("my-comp", "main", "abc123", Vec::new()),
             summary: super::super::ReviewSummary {
                 passed: true,

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1179,6 +1179,8 @@ mod tests {
                     baseline_args: BaselineArgs::default(),
                     regression_threshold:
                         extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    regression_min_delta_ms:
+                        extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                     overlays: Vec::new(),
                     keep_overlay: false,
                 },

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -51,5 +51,6 @@ pub use server::auth;
 pub use error::{Error, ErrorCode, Result};
 pub use output::{
     BatchResult, BatchResultItem, BulkResult, BulkSummary, CreateOutput, CreateResult,
-    EntityCrudOutput, ItemOutcome, MergeOutput, MergeResult, NoExtra, RemoveResult,
+    EntityCrudOutput, ItemOutcome, MergeOutput, MergeResult, NoExtra, ObservationOutputDetails,
+    ObservationOutputMetadata, RemoveResult,
 };

--- a/src/core/output.rs
+++ b/src/core/output.rs
@@ -7,6 +7,74 @@
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
+// Observation-backed Outputs
+// ============================================================================
+
+/// Compact pointer from a command result to its persisted observation record.
+///
+/// Command outputs keep their existing fields for compatibility. Observation-
+/// backed commands can add this metadata when the best-effort observation store
+/// is available, giving wrappers a stable run ID and exact drill-down commands
+/// without forcing every `--output` artifact to duplicate the full evidence set.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObservationOutputMetadata {
+    pub schema: String,
+    pub run_id: String,
+    pub kind: String,
+    pub details: ObservationOutputDetails,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObservationOutputDetails {
+    pub query: String,
+    pub artifacts: String,
+    pub export_bundle: String,
+}
+
+impl ObservationOutputMetadata {
+    pub fn for_run(kind: impl Into<String>, run_id: impl Into<String>) -> Self {
+        let kind = kind.into();
+        let run_id = run_id.into();
+        Self {
+            schema: "homeboy/observation-pointer/v1".to_string(),
+            run_id: run_id.clone(),
+            kind,
+            details: ObservationOutputDetails {
+                query: format!("homeboy runs show {run_id}"),
+                artifacts: format!("homeboy runs artifacts {run_id}"),
+                export_bundle: format!(
+                    "homeboy runs export --run {run_id} --output homeboy-observations"
+                ),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observation_output_metadata_serializes_drill_down_commands() {
+        let metadata = ObservationOutputMetadata::for_run("review", "run-123");
+        let json = serde_json::to_value(metadata).expect("serialize observation metadata");
+
+        assert_eq!(json["schema"], "homeboy/observation-pointer/v1");
+        assert_eq!(json["run_id"], "run-123");
+        assert_eq!(json["kind"], "review");
+        assert_eq!(json["details"]["query"], "homeboy runs show run-123");
+        assert_eq!(
+            json["details"]["artifacts"],
+            "homeboy runs artifacts run-123"
+        );
+        assert_eq!(
+            json["details"]["export_bundle"],
+            "homeboy runs export --run run-123 --output homeboy-observations"
+        );
+    }
+}
+
+// ============================================================================
 // Create Operations
 // ============================================================================
 

--- a/src/core/output.rs
+++ b/src/core/output.rs
@@ -55,7 +55,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn observation_output_metadata_serializes_drill_down_commands() {
+    fn test_for_run() {
         let metadata = ObservationOutputMetadata::for_run("review", "run-123");
         let json = serde_json::to_value(metadata).expect("serialize observation metadata");
 
@@ -71,6 +71,60 @@ mod tests {
             json["details"]["export_bundle"],
             "homeboy runs export --run run-123 --output homeboy-observations"
         );
+    }
+
+    #[test]
+    fn test_exit_code() {
+        let clean = BatchResult::new();
+        assert_eq!(clean.exit_code(), 0);
+
+        let mut failed = BatchResult::new();
+        failed.record_error("item".to_string(), "failed".to_string());
+        assert_eq!(failed.exit_code(), 1);
+    }
+
+    #[test]
+    fn test_record_created() {
+        let mut result = BatchResult::new();
+        result.record_created("alpha".to_string());
+
+        assert_eq!(result.created, 1);
+        assert_eq!(result.items[0].id, "alpha");
+        assert_eq!(result.items[0].status, "created");
+        assert_eq!(result.items[0].error, None);
+    }
+
+    #[test]
+    fn test_record_updated() {
+        let mut result = BatchResult::new();
+        result.record_updated("alpha".to_string());
+
+        assert_eq!(result.updated, 1);
+        assert_eq!(result.items[0].id, "alpha");
+        assert_eq!(result.items[0].status, "updated");
+        assert_eq!(result.items[0].error, None);
+    }
+
+    #[test]
+    fn test_record_skipped() {
+        let mut result = BatchResult::new();
+        result.record_skipped("alpha".to_string());
+
+        assert_eq!(result.skipped, 1);
+        assert_eq!(result.items[0].id, "alpha");
+        assert_eq!(result.items[0].status, "skipped");
+        assert_eq!(result.items[0].error, None);
+    }
+
+    #[test]
+    fn test_record_error() {
+        let mut result = BatchResult::new();
+        result.record_error("alpha".to_string(), "boom".to_string());
+
+        assert_eq!(result.errors, 1);
+        assert_eq!(result.items[0].id, "alpha");
+        assert_eq!(result.items[0].status, "error");
+        assert_eq!(result.items[0].error.as_deref(), Some("boom"));
     }
 }
 


### PR DESCRIPTION
## Summary
- Documents the `--output`/observation-store boundary and the additive `homeboy/observation-pointer/v1` shape.
- Adds reusable observation pointer metadata with run drill-down commands.
- Attaches the pointer to `review` JSON output and the direct review `--output` artifact when best-effort observation storage is available, without removing existing fields.
- Fixes a stale trace test fixture initializer so the suite compiles with the current `TraceArgs` shape.

Closes #2057.

## Tests
- `cargo test core::output::tests::observation_output_metadata_serializes_drill_down_commands`
- `cargo test commands::review::tests::write_artifact_to_file_preserves_observation_pointer_when_available`
- `cargo test commands::review::observation::tests::finish_metadata_captures_aggregate_and_linkable_stages`
- `cargo test commands::review`
- `cargo test core::output`
- `homeboy test homeboy --path . --changed-since=origin/main`
- `homeboy lint homeboy --path . --changed-since=origin/main`
- `cargo test -- --test-threads=1`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the first slice, added tests/docs, and ran validation. Chris remains responsible for review and merge.