### PR TITLE
Stream compact bench progress events

### DIFF
--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -839,7 +839,11 @@ fn build_runner(
         .settings_json(&args.settings_json)
         .with_run_dir(run_dir)
         .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
-        .script_args(&args.passthrough_args);
+        .env("HOMEBOY_BENCH_PROGRESS", bench_progress_env_value())
+        .env("HOMEBOY_BENCH_PROGRESS_STREAM", "stderr")
+        .script_args(&args.passthrough_args)
+        .passthrough(false)
+        .stderr_passthrough(bench_progress_enabled());
 
     if let Some(warmup_iterations) = args.warmup_iterations {
         runner = runner.env(
@@ -875,6 +879,24 @@ fn build_runner(
     }
 
     Ok(runner)
+}
+
+fn bench_progress_enabled() -> bool {
+    match std::env::var("HOMEBOY_BENCH_PROGRESS") {
+        Ok(value) => matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => std::env::var_os("CI").is_none(),
+    }
+}
+
+fn bench_progress_env_value() -> &'static str {
+    if bench_progress_enabled() {
+        "1"
+    } else {
+        "0"
+    }
 }
 
 fn extra_workloads_env_value(paths: &[PathBuf]) -> Result<String> {

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -10,7 +10,9 @@ use crate::server::http::ApiClient;
 use crate::server::{
     execute_local_command_in_dir, execute_local_command_in_dir_with_process_cleanup,
     execute_local_command_interactive, execute_local_command_passthrough,
-    execute_local_command_passthrough_with_process_cleanup, CommandOutput,
+    execute_local_command_passthrough_with_process_cleanup,
+    execute_local_command_stderr_passthrough,
+    execute_local_command_stderr_passthrough_with_process_cleanup, CommandOutput,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -533,6 +535,36 @@ pub(crate) fn execute_capability_script(
     };
 
     if let Some(dir) = working_dir {
+        if options.passthrough {
+            if options.cleanup_process_group {
+                return Ok(execute_local_command_passthrough_with_process_cleanup(
+                    &command,
+                    Some(dir),
+                    env_opt,
+                ));
+            }
+            return Ok(execute_local_command_passthrough(
+                &command,
+                Some(dir),
+                env_opt,
+            ));
+        }
+        if options.stderr_passthrough {
+            if options.cleanup_process_group {
+                return Ok(
+                    execute_local_command_stderr_passthrough_with_process_cleanup(
+                        &command,
+                        Some(dir),
+                        env_opt,
+                    ),
+                );
+            }
+            return Ok(execute_local_command_stderr_passthrough(
+                &command,
+                Some(dir),
+                env_opt,
+            ));
+        }
         if options.cleanup_process_group {
             return Ok(execute_local_command_in_dir_with_process_cleanup(
                 &command,
@@ -548,6 +580,17 @@ pub(crate) fn execute_capability_script(
             ));
         }
         Ok(execute_local_command_passthrough(&command, None, env_opt))
+    } else if options.stderr_passthrough {
+        if options.cleanup_process_group {
+            return Ok(
+                execute_local_command_stderr_passthrough_with_process_cleanup(
+                    &command, None, env_opt,
+                ),
+            );
+        }
+        Ok(execute_local_command_stderr_passthrough(
+            &command, None, env_opt,
+        ))
     } else {
         if options.cleanup_process_group {
             return Ok(execute_local_command_in_dir_with_process_cleanup(
@@ -560,6 +603,7 @@ pub(crate) fn execute_capability_script(
 
 pub(crate) struct CapabilityScriptOptions {
     pub passthrough: bool,
+    pub stderr_passthrough: bool,
     pub cleanup_process_group: bool,
 }
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -11,8 +11,7 @@ use crate::server::{
     execute_local_command_in_dir, execute_local_command_in_dir_with_process_cleanup,
     execute_local_command_interactive, execute_local_command_passthrough,
     execute_local_command_passthrough_with_process_cleanup,
-    execute_local_command_stderr_passthrough,
-    execute_local_command_stderr_passthrough_with_process_cleanup, CommandOutput,
+    execute_local_command_stderr_passthrough, CommandOutput,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -550,19 +549,11 @@ pub(crate) fn execute_capability_script(
             env_opt,
         ))
     } else if options.stderr_passthrough {
-        if options.cleanup_process_group {
-            return Ok(
-                execute_local_command_stderr_passthrough_with_process_cleanup(
-                    &command,
-                    current_dir,
-                    env_opt,
-                ),
-            );
-        }
         Ok(execute_local_command_stderr_passthrough(
             &command,
             current_dir,
             env_opt,
+            options.cleanup_process_group,
         ))
     } else {
         if options.cleanup_process_group {

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -534,70 +534,45 @@ pub(crate) fn execute_capability_script(
         Some(env_refs.as_slice())
     };
 
-    if let Some(dir) = working_dir {
-        if options.passthrough {
-            if options.cleanup_process_group {
-                return Ok(execute_local_command_passthrough_with_process_cleanup(
-                    &command,
-                    Some(dir),
-                    env_opt,
-                ));
-            }
-            return Ok(execute_local_command_passthrough(
-                &command,
-                Some(dir),
-                env_opt,
-            ));
-        }
-        if options.stderr_passthrough {
-            if options.cleanup_process_group {
-                return Ok(
-                    execute_local_command_stderr_passthrough_with_process_cleanup(
-                        &command,
-                        Some(dir),
-                        env_opt,
-                    ),
-                );
-            }
-            return Ok(execute_local_command_stderr_passthrough(
-                &command,
-                Some(dir),
-                env_opt,
-            ));
-        }
-        if options.cleanup_process_group {
-            return Ok(execute_local_command_in_dir_with_process_cleanup(
-                &command,
-                Some(dir),
-                env_opt,
-            ));
-        }
-        Ok(execute_local_command_in_dir(&command, Some(dir), env_opt))
-    } else if options.passthrough {
+    let current_dir = working_dir;
+
+    if options.passthrough {
         if options.cleanup_process_group {
             return Ok(execute_local_command_passthrough_with_process_cleanup(
-                &command, None, env_opt,
+                &command,
+                current_dir,
+                env_opt,
             ));
         }
-        Ok(execute_local_command_passthrough(&command, None, env_opt))
+        Ok(execute_local_command_passthrough(
+            &command,
+            current_dir,
+            env_opt,
+        ))
     } else if options.stderr_passthrough {
         if options.cleanup_process_group {
             return Ok(
                 execute_local_command_stderr_passthrough_with_process_cleanup(
-                    &command, None, env_opt,
+                    &command,
+                    current_dir,
+                    env_opt,
                 ),
             );
         }
         Ok(execute_local_command_stderr_passthrough(
-            &command, None, env_opt,
+            &command,
+            current_dir,
+            env_opt,
         ))
     } else {
         if options.cleanup_process_group {
             return Ok(execute_local_command_in_dir_with_process_cleanup(
-                &command, None, env_opt,
+                &command,
+                current_dir,
+                env_opt,
             ));
         }
-        Ok(execute_local_command_in_dir(&command, None, env_opt))
+        Ok(execute_local_command_in_dir(&command, current_dir, env_opt))
     }
 }
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -1291,4 +1291,27 @@ mod tests {
             .any(|(k, v)| k == "HOMEBOY_STEP" && v == "lint,test"));
         assert!(env.iter().any(|(k, v)| k == "HOMEBOY_SKIP" && v == "lint"));
     }
+
+    #[test]
+    fn test_execute_capability_script_supports_stderr_only_passthrough() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = execute_capability_script(
+            dir.path(),
+            "unused.sh",
+            &[],
+            &[],
+            None,
+            Some("printf '{\"ok\":true}\n'; printf 'progress turn=1\n' >&2"),
+            CapabilityScriptOptions {
+                passthrough: false,
+                stderr_passthrough: true,
+                cleanup_process_group: false,
+            },
+        )
+        .expect("script should run");
+
+        assert!(output.success);
+        assert_eq!(output.stdout, "{\"ok\":true}\n");
+        assert_eq!(output.stderr, "progress turn=1\n");
+    }
 }

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -39,6 +39,8 @@ pub struct ExtensionRunner {
     command_override: Option<String>,
     /// Tee runner stdout/stderr to the terminal while capturing it.
     passthrough: bool,
+    /// Tee only runner stderr to the terminal while capturing stdout/stderr.
+    stderr_passthrough: bool,
     /// Run the child shell in a process group and clean up lingering descendants.
     cleanup_process_group: bool,
     /// Run directory path for recording machine-local child process evidence.
@@ -68,6 +70,7 @@ impl ExtensionRunner {
             working_dir: None,
             command_override: None,
             passthrough: true,
+            stderr_passthrough: false,
             cleanup_process_group: false,
             run_dir_path: None,
         }
@@ -157,6 +160,13 @@ impl ExtensionRunner {
         self
     }
 
+    /// Stream stderr without streaming stdout. Useful for commands that emit
+    /// live human progress while the parent process owns stdout JSON.
+    pub(crate) fn stderr_passthrough(mut self, stderr_passthrough: bool) -> Self {
+        self.stderr_passthrough = stderr_passthrough;
+        self
+    }
+
     /// Clean up the full process group after this runner exits or is interrupted.
     pub(crate) fn cleanup_process_group(mut self, cleanup: bool) -> Self {
         self.cleanup_process_group = cleanup;
@@ -238,6 +248,7 @@ impl ExtensionRunner {
             self.command_override.as_deref(),
             super::execution::CapabilityScriptOptions {
                 passthrough: self.passthrough,
+                stderr_passthrough: self.stderr_passthrough,
                 cleanup_process_group: self.cleanup_process_group,
             },
         )

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -292,4 +292,11 @@ mod tests {
 
         run_dir.cleanup();
     }
+
+    #[test]
+    fn test_stderr_passthrough() {
+        let runner = ExtensionRunner::for_context(context()).stderr_passthrough(true);
+
+        assert!(runner.stderr_passthrough);
+    }
 }

--- a/src/core/extension/runtime/bench-helper.mjs
+++ b/src/core/extension/runtime/bench-helper.mjs
@@ -1,6 +1,8 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { basename, dirname } from 'node:path';
 
+const homeboyBenchProgressStart = Date.now();
+
 // R-7 percentile, the runner contract used by Homeboy BenchResults producers.
 export function homeboyBenchPercentile(sortedValues, p) {
     const n = sortedValues.length;
@@ -42,4 +44,45 @@ export async function homeboyWriteBenchResults(resultsFile, componentId, iterati
 
 export async function homeboyWriteEmptyBenchResults(resultsFile, componentId, iterations = 0) {
     await homeboyWriteBenchResults(resultsFile, componentId, iterations, []);
+}
+
+export function homeboyBenchProgress(event = {}) {
+    if (!homeboyBenchProgressEnabled()) return;
+
+    const elapsedMs = Number.isFinite(event.elapsed_ms)
+        ? event.elapsed_ms
+        : Date.now() - homeboyBenchProgressStart;
+    const parts = [event.scenario || event.workload || 'bench', homeboyFormatBenchElapsed(elapsedMs)];
+
+    if (event.run || event.run_id) parts.splice(1, 0, `[${event.run || event.run_id}]`);
+    if (event.phase) parts.push(`phase=${event.phase}`);
+    if (event.turn !== undefined) parts.push(`turn=${event.turn}`);
+    if (event.tools !== undefined) parts.push(`tools=${event.tools}`);
+    if (event.tool_count !== undefined && event.tools === undefined) parts.push(`tools=${event.tool_count}`);
+    if (event.tool) parts.push(`tool=${homeboyBenchProgressText(event.tool)}`);
+    if (event.last) parts.push(`last=${homeboyBenchProgressText(event.last)}`);
+    if (event.message) parts.push(homeboyBenchProgressText(event.message));
+
+    const line = `${parts.join(' ')}\n`;
+    if ((process.env.HOMEBOY_BENCH_PROGRESS_STREAM || 'stderr') === 'stdout') {
+        process.stdout.write(line);
+    } else {
+        process.stderr.write(line);
+    }
+}
+
+function homeboyBenchProgressEnabled() {
+    const value = (process.env.HOMEBOY_BENCH_PROGRESS || '').trim().toLowerCase();
+    return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
+function homeboyFormatBenchElapsed(ms) {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, '0');
+    const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+    return `${minutes}:${seconds}`;
+}
+
+function homeboyBenchProgressText(value) {
+    return String(value).replace(/[\r\n\t]+/g, ' ').trim();
 }

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -163,6 +163,64 @@ fn bench_shell_helper_writes_empty_envelope() {
 }
 
 #[test]
+fn bench_js_helper_emits_compact_progress_to_stderr() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("bench-helper.mjs");
+    let runner_path = dir.path().join("runner.mjs");
+    std::fs::write(&helper_path, assets::BENCH_HELPER_JS).expect("write helper");
+    std::fs::write(
+        &runner_path,
+        r#"import { homeboyBenchProgress } from './bench-helper.mjs';
+homeboyBenchProgress({ scenario: 'studio-agent-site-build', run: 'bfb', elapsed_ms: 252000, turn: 18, tools: 23, last: 'wp_cli page_update' });
+"#,
+    )
+    .expect("write runner");
+
+    let output = std::process::Command::new("node")
+        .arg(&runner_path)
+        .env("HOMEBOY_BENCH_PROGRESS", "1")
+        .env("HOMEBOY_BENCH_PROGRESS_STREAM", "stderr")
+        .output()
+        .expect("run node");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "studio-agent-site-build [bfb] 04:12 turn=18 tools=23 last=wp_cli page_update\n"
+    );
+}
+
+#[test]
+fn bench_js_helper_keeps_progress_quiet_when_disabled() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("bench-helper.mjs");
+    let runner_path = dir.path().join("runner.mjs");
+    std::fs::write(&helper_path, assets::BENCH_HELPER_JS).expect("write helper");
+    std::fs::write(
+        &runner_path,
+        r#"import { homeboyBenchProgress } from './bench-helper.mjs';
+homeboyBenchProgress({ scenario: 'studio-agent-site-build', phase: 'setup' });
+"#,
+    )
+    .expect("write runner");
+
+    let output = std::process::Command::new("node")
+        .arg(&runner_path)
+        .env("HOMEBOY_BENCH_PROGRESS", "0")
+        .output()
+        .expect("run node");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+}
+
+#[test]
 fn bench_runtime_helpers_document_shared_contract() {
     for content in [assets::BENCH_HELPER_JS, assets::BENCH_HELPER_PHP] {
         assert!(

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -411,22 +411,6 @@ pub fn execute_local_command_passthrough_with_process_cleanup(
     execute_local_command_passthrough_impl(command, current_dir, env, true)
 }
 
-pub fn execute_local_command_stderr_passthrough(
-    command: &str,
-    current_dir: Option<&str>,
-    env: Option<&[(&str, &str)]>,
-) -> CommandOutput {
-    execute_local_command_stderr_passthrough_impl(command, current_dir, env, false)
-}
-
-pub fn execute_local_command_stderr_passthrough_with_process_cleanup(
-    command: &str,
-    current_dir: Option<&str>,
-    env: Option<&[(&str, &str)]>,
-) -> CommandOutput {
-    execute_local_command_stderr_passthrough_impl(command, current_dir, env, true)
-}
-
 fn execute_local_command_passthrough_impl(
     command: &str,
     current_dir: Option<&str>,
@@ -539,7 +523,7 @@ fn execute_local_command_passthrough_impl(
     output
 }
 
-fn execute_local_command_stderr_passthrough_impl(
+pub(crate) fn execute_local_command_stderr_passthrough(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
@@ -1042,11 +1026,26 @@ mod tests {
     }
 
     #[test]
-    fn stderr_passthrough_captures_stdout_without_rewriting_it() {
+    fn test_execute_local_command_stderr_passthrough() {
         let output = execute_local_command_stderr_passthrough(
             "printf '{\"ok\":true}\n'; printf 'progress turn=1\n' >&2",
             None,
             None,
+            false,
+        );
+
+        assert!(output.success);
+        assert_eq!(output.stdout, "{\"ok\":true}\n");
+        assert_eq!(output.stderr, "progress turn=1\n");
+    }
+
+    #[test]
+    fn stderr_passthrough_with_process_cleanup_preserves_stdout() {
+        let output = execute_local_command_stderr_passthrough(
+            "printf '{\"ok\":true}\n'; printf 'progress turn=1\n' >&2",
+            None,
+            None,
+            true,
         );
 
         assert!(output.success);

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -411,6 +411,22 @@ pub fn execute_local_command_passthrough_with_process_cleanup(
     execute_local_command_passthrough_impl(command, current_dir, env, true)
 }
 
+pub fn execute_local_command_stderr_passthrough(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+) -> CommandOutput {
+    execute_local_command_stderr_passthrough_impl(command, current_dir, env, false)
+}
+
+pub fn execute_local_command_stderr_passthrough_with_process_cleanup(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+) -> CommandOutput {
+    execute_local_command_stderr_passthrough_impl(command, current_dir, env, true)
+}
+
 fn execute_local_command_passthrough_impl(
     command: &str,
     current_dir: Option<&str>,
@@ -493,6 +509,125 @@ fn execute_local_command_passthrough_impl(
         .stderr
         .take()
         .map(|pipe| thread::spawn(move || tee_to(pipe, std::io::stderr())));
+
+    let status = child.wait();
+
+    let stdout = stdout_handle
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr_handle
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
+
+    let output = match status {
+        Ok(status) => CommandOutput {
+            stdout,
+            stderr,
+            success: status.success(),
+            exit_code: status.code().unwrap_or(-1),
+            child_resource: Some(monitor.finish()),
+        },
+        Err(e) => CommandOutput {
+            stdout,
+            stderr: format!("{stderr}\nCommand error: {}", e),
+            success: false,
+            exit_code: -1,
+            child_resource: Some(monitor.finish()),
+        },
+    };
+    cleanup_guard.cleanup();
+    output
+}
+
+fn execute_local_command_stderr_passthrough_impl(
+    command: &str,
+    current_dir: Option<&str>,
+    env: Option<&[(&str, &str)]>,
+    cleanup_process_group: bool,
+) -> CommandOutput {
+    use std::io::{Read, Write};
+    use std::thread;
+
+    #[cfg(windows)]
+    let mut cmd = {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    };
+
+    #[cfg(not(windows))]
+    let mut cmd = {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", command]);
+        cmd
+    };
+
+    if let Some(dir) = current_dir {
+        cmd.current_dir(dir);
+    }
+
+    if let Some(env_pairs) = env {
+        cmd.envs(env_pairs.iter().copied());
+    }
+
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    configure_process_group_cleanup(&mut cmd, cleanup_process_group);
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            return CommandOutput {
+                stdout: String::new(),
+                stderr: format!("Command error: {}", e),
+                success: false,
+                exit_code: -1,
+                child_resource: None,
+            };
+        }
+    };
+    let cleanup_guard = ProcessGroupCleanupGuard::new(child.id(), cleanup_process_group);
+    let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
+
+    fn read_all<R: Read>(mut src: R) -> String {
+        let mut captured = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            match src.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => captured.extend_from_slice(&buf[..n]),
+                Err(_) => break,
+            }
+        }
+        String::from_utf8_lossy(&captured).to_string()
+    }
+
+    fn tee_to_stderr<R: Read>(mut src: R) -> String {
+        let mut captured = Vec::new();
+        let mut buf = [0u8; 4096];
+        let mut sink = std::io::stderr();
+        loop {
+            match src.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = sink.write_all(&buf[..n]);
+                    let _ = sink.flush();
+                    captured.extend_from_slice(&buf[..n]);
+                }
+                Err(_) => break,
+            }
+        }
+        String::from_utf8_lossy(&captured).to_string()
+    }
+
+    let stdout_handle = child
+        .stdout
+        .take()
+        .map(|pipe| thread::spawn(move || read_all(pipe)));
+    let stderr_handle = child
+        .stderr
+        .take()
+        .map(|pipe| thread::spawn(move || tee_to_stderr(pipe)));
 
     let status = child.wait();
 
@@ -904,6 +1039,19 @@ mod tests {
             child.sampled_peak_rss_bytes.is_some() || !child.warnings.is_empty(),
             "resource probes should either sample RSS or explain why they could not"
         );
+    }
+
+    #[test]
+    fn stderr_passthrough_captures_stdout_without_rewriting_it() {
+        let output = execute_local_command_stderr_passthrough(
+            "printf '{\"ok\":true}\n'; printf 'progress turn=1\n' >&2",
+            None,
+            None,
+        );
+
+        assert!(output.success);
+        assert_eq!(output.stdout, "{\"ok\":true}\n");
+        assert_eq!(output.stderr, "progress turn=1\n");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Add a bench progress env path for Node workloads via `homeboyBenchProgress(...)`.
- Keep benchmark child stdout captured while optionally streaming stderr progress, so Homeboy JSON output stays clean.
- Add focused tests for compact progress rendering, capability dispatch, and stdout-safe stderr passthrough.

Closes #2061

## Testing
- `cargo test core::extension::runtime_helper::tests::bench_js_helper`
- `cargo test core::extension::bench::run::tests`
- `cargo test core::extension::execution::tests::test_execute_capability_script_supports_stderr_only_passthrough`
- `cargo test core::server::client::tests::stderr_passthrough_captures_stdout_without_rewriting_it`
- `cargo check`

## Notes
- `cargo test` currently fails in unrelated trace/component tests that require local `nodejs` extension/path setup.
- `cargo clippy --all-targets -- -D warnings` currently fails on existing repository-wide lints unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, focused tests, and validation notes; Chris remains responsible for review and merge.