### PR TITLE
Classify AI provider bench failures

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -399,6 +399,7 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
             results: single_output.results,
             rig_state: single_output.rig_state,
             failure: single_output.failure,
+            provider_failures: single_output.provider_failures,
         });
     }
 

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -304,6 +304,10 @@ pub(super) fn run_single_rig(
             hints: if hints.is_empty() { None } else { Some(hints) },
             rig_state: Some(context.snapshot),
             failure: None,
+            provider_failures: outputs
+                .iter()
+                .flat_map(|output| output.provider_failures.clone())
+                .collect(),
         },
         exit_code,
     ))
@@ -744,6 +748,7 @@ mod tests {
             hints: None,
             rig_state: None,
             failure: None,
+            provider_failures: Vec::new(),
         }
     }
 

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -380,6 +380,7 @@ mod tests {
                 baseline_comparison: None,
                 hints: None,
                 failure: None,
+                provider_failures: Vec::new(),
             };
 
             let args = bench_args();

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1334,6 +1334,7 @@ fn bench_output_single_serializes_without_wrapper_key() {
         hints: None,
         rig_state: None,
         failure: None,
+        provider_failures: Vec::new(),
     };
     let value = serde_json::to_value(BenchOutput::Single(single)).unwrap();
     assert!(value.get("comparison").is_none());

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -25,6 +25,7 @@ pub mod baseline;
 pub mod distribution;
 pub mod metrics;
 pub mod parsing;
+pub mod provider_failure;
 pub mod report;
 pub mod run;
 #[cfg(test)]
@@ -45,6 +46,9 @@ pub use metrics::MetricDelta;
 pub use parsing::{
     evaluate_gates, parse_bench_results_file, parse_bench_results_str, BenchGate, BenchGateOp,
     BenchGateResult, BenchMemory, BenchMetrics, BenchResults, BenchRunExecution, BenchScenario,
+};
+pub use provider_failure::{
+    BenchProviderFailure, BenchProviderFailureClass, BenchProviderFailureSource,
 };
 pub use report::{
     aggregate_comparison, aggregate_comparison_with_axes, from_main_workflow,

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -55,6 +55,7 @@ use crate::error::{Error, Result};
 
 use super::artifact::BenchArtifact;
 use super::distribution::BenchRunDistribution;
+use super::provider_failure::BenchProviderFailure;
 
 fn default_true() -> bool {
     true
@@ -103,6 +104,8 @@ pub struct BenchRunMetadata {
     pub workloads: Vec<BenchWorkloadMetadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner: Option<BenchRunnerMetadata>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_failures: Vec<BenchProviderFailure>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]

--- a/src/core/extension/bench/provider_failure.rs
+++ b/src/core/extension/bench/provider_failure.rs
@@ -59,9 +59,26 @@ pub enum BenchProviderFailureSource {
 pub fn classify_text(text: &str) -> Option<(BenchProviderFailureClass, &'static str)> {
     let normalized = text.to_ascii_lowercase();
 
-    if contains_any(
-        &normalized,
-        &[
+    for pattern in FAILURE_PATTERNS {
+        if contains_any(&normalized, pattern.needles) {
+            return Some((pattern.class, pattern.reason));
+        }
+    }
+
+    None
+}
+
+struct FailurePattern {
+    class: BenchProviderFailureClass,
+    reason: &'static str,
+    needles: &'static [&'static str],
+}
+
+const FAILURE_PATTERNS: &[FailurePattern] = &[
+    FailurePattern {
+        class: BenchProviderFailureClass::MissingApiKey,
+        reason: "missing API key",
+        needles: &[
             "no api key available",
             "missing api key",
             "api key is missing",
@@ -71,28 +88,21 @@ pub fn classify_text(text: &str) -> Option<(BenchProviderFailureClass, &'static 
             "google_api_key is not set",
             "gemini_api_key is not set",
         ],
-    ) {
-        return Some((BenchProviderFailureClass::MissingApiKey, "missing API key"));
-    }
-
-    if contains_any(
-        &normalized,
-        &[
+    },
+    FailurePattern {
+        class: BenchProviderFailureClass::ConcurrencyLimit,
+        reason: "provider concurrency limit",
+        needles: &[
             "concurrency limit",
             "concurrent request limit",
             "too many concurrent requests",
             "too many simultaneous requests",
         ],
-    ) {
-        return Some((
-            BenchProviderFailureClass::ConcurrencyLimit,
-            "provider concurrency limit",
-        ));
-    }
-
-    if contains_any(
-        &normalized,
-        &[
+    },
+    FailurePattern {
+        class: BenchProviderFailureClass::RateLimit,
+        reason: "provider rate limit",
+        needles: &[
             "rate limit",
             "rate_limit",
             "too many requests",
@@ -100,13 +110,11 @@ pub fn classify_text(text: &str) -> Option<(BenchProviderFailureClass, &'static 
             "status 429",
             "429 too many requests",
         ],
-    ) {
-        return Some((BenchProviderFailureClass::RateLimit, "provider rate limit"));
-    }
-
-    if contains_any(
-        &normalized,
-        &[
+    },
+    FailurePattern {
+        class: BenchProviderFailureClass::GatewayTimeout,
+        reason: "provider gateway timeout",
+        needles: &[
             "gateway timeout",
             "504 gateway",
             "http 504",
@@ -114,44 +122,30 @@ pub fn classify_text(text: &str) -> Option<(BenchProviderFailureClass, &'static 
             "upstream request timeout",
             "upstream timed out",
         ],
-    ) {
-        return Some((
-            BenchProviderFailureClass::GatewayTimeout,
-            "provider gateway timeout",
-        ));
-    }
-
-    if contains_any(
-        &normalized,
-        &[
+    },
+    FailurePattern {
+        class: BenchProviderFailureClass::StreamTruncation,
+        reason: "provider stream truncation",
+        needles: &[
             "stream truncated",
             "truncated stream",
             "response stream ended early",
             "stream ended unexpectedly",
             "premature close",
         ],
-    ) {
-        return Some((
-            BenchProviderFailureClass::StreamTruncation,
-            "provider stream truncation",
-        ));
-    }
-
-    if contains_any(
-        &normalized,
-        &[
+    },
+    FailurePattern {
+        class: BenchProviderFailureClass::Auth,
+        reason: "provider auth failure",
+        needles: &[
             "auth error",
             "authentication failed",
             "invalid api key",
             "unauthorized api key",
             "401 unauthorized",
         ],
-    ) {
-        return Some((BenchProviderFailureClass::Auth, "provider auth failure"));
-    }
-
-    None
-}
+    },
+];
 
 pub fn collect_provider_failures(
     results: Option<&BenchResults>,
@@ -274,7 +268,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     #[test]
-    fn classifies_representative_provider_failures() {
+    fn test_classify_text() {
         let cases = [
             (
                 "Auth error: No API key available",
@@ -321,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn scans_stderr_and_artifact_contents() {
+    fn test_collect_provider_failures() {
         let run_dir = tempfile::TempDir::new().expect("run dir");
         let artifact_dir = run_dir.path().join("bench-artifacts/agent");
         std::fs::create_dir_all(&artifact_dir).expect("artifact dir");

--- a/src/core/extension/bench/provider_failure.rs
+++ b/src/core/extension/bench/provider_failure.rs
@@ -1,0 +1,377 @@
+//! Conservative AI provider/auth failure classification for bench runs.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::parsing::BenchResults;
+
+const MAX_ARTIFACT_BYTES: u64 = 256 * 1024;
+const MAX_EXCERPT_CHARS: usize = 240;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum BenchProviderFailureClass {
+    MissingApiKey,
+    Auth,
+    StreamTruncation,
+    GatewayTimeout,
+    RateLimit,
+    ConcurrencyLimit,
+}
+
+impl BenchProviderFailureClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BenchProviderFailureClass::MissingApiKey => "missing_api_key",
+            BenchProviderFailureClass::Auth => "auth",
+            BenchProviderFailureClass::StreamTruncation => "stream_truncation",
+            BenchProviderFailureClass::GatewayTimeout => "gateway_timeout",
+            BenchProviderFailureClass::RateLimit => "rate_limit",
+            BenchProviderFailureClass::ConcurrencyLimit => "concurrency_limit",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchProviderFailure {
+    pub class: BenchProviderFailureClass,
+    pub reason: String,
+    pub source: BenchProviderFailureSource,
+    pub excerpt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum BenchProviderFailureSource {
+    Stderr,
+    Artifact {
+        scenario_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        run_index: Option<usize>,
+        name: String,
+        path: String,
+    },
+}
+
+pub fn classify_text(text: &str) -> Option<(BenchProviderFailureClass, &'static str)> {
+    let normalized = text.to_ascii_lowercase();
+
+    if contains_any(
+        &normalized,
+        &[
+            "no api key available",
+            "missing api key",
+            "api key is missing",
+            "no api key provided",
+            "openai_api_key is not set",
+            "anthropic_api_key is not set",
+            "google_api_key is not set",
+            "gemini_api_key is not set",
+        ],
+    ) {
+        return Some((BenchProviderFailureClass::MissingApiKey, "missing API key"));
+    }
+
+    if contains_any(
+        &normalized,
+        &[
+            "concurrency limit",
+            "concurrent request limit",
+            "too many concurrent requests",
+            "too many simultaneous requests",
+        ],
+    ) {
+        return Some((
+            BenchProviderFailureClass::ConcurrencyLimit,
+            "provider concurrency limit",
+        ));
+    }
+
+    if contains_any(
+        &normalized,
+        &[
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "http 429",
+            "status 429",
+            "429 too many requests",
+        ],
+    ) {
+        return Some((BenchProviderFailureClass::RateLimit, "provider rate limit"));
+    }
+
+    if contains_any(
+        &normalized,
+        &[
+            "gateway timeout",
+            "504 gateway",
+            "http 504",
+            "status 504",
+            "upstream request timeout",
+            "upstream timed out",
+        ],
+    ) {
+        return Some((
+            BenchProviderFailureClass::GatewayTimeout,
+            "provider gateway timeout",
+        ));
+    }
+
+    if contains_any(
+        &normalized,
+        &[
+            "stream truncated",
+            "truncated stream",
+            "response stream ended early",
+            "stream ended unexpectedly",
+            "premature close",
+        ],
+    ) {
+        return Some((
+            BenchProviderFailureClass::StreamTruncation,
+            "provider stream truncation",
+        ));
+    }
+
+    if contains_any(
+        &normalized,
+        &[
+            "auth error",
+            "authentication failed",
+            "invalid api key",
+            "unauthorized api key",
+            "401 unauthorized",
+        ],
+    ) {
+        return Some((BenchProviderFailureClass::Auth, "provider auth failure"));
+    }
+
+    None
+}
+
+pub fn collect_provider_failures(
+    results: Option<&BenchResults>,
+    stderr_tail: Option<&str>,
+    run_dir: &Path,
+) -> Vec<BenchProviderFailure> {
+    let mut failures = Vec::new();
+
+    if let Some(stderr_tail) = stderr_tail {
+        if let Some((class, reason)) = classify_text(stderr_tail) {
+            failures.push(BenchProviderFailure {
+                class,
+                reason: reason.to_string(),
+                source: BenchProviderFailureSource::Stderr,
+                excerpt: excerpt(stderr_tail),
+            });
+        }
+    }
+
+    if let Some(results) = results {
+        for scenario in &results.scenarios {
+            for (name, artifact) in &scenario.artifacts {
+                collect_artifact_failure(
+                    &mut failures,
+                    run_dir,
+                    &scenario.id,
+                    None,
+                    name,
+                    &artifact.path,
+                );
+            }
+            if let Some(runs) = &scenario.runs {
+                for (run_index, run) in runs.iter().enumerate() {
+                    for (name, artifact) in &run.artifacts {
+                        collect_artifact_failure(
+                            &mut failures,
+                            run_dir,
+                            &scenario.id,
+                            Some(run_index),
+                            name,
+                            &artifact.path,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    failures
+}
+
+fn collect_artifact_failure(
+    failures: &mut Vec<BenchProviderFailure>,
+    run_dir: &Path,
+    scenario_id: &str,
+    run_index: Option<usize>,
+    name: &str,
+    artifact_path: &str,
+) {
+    let Some(text) = read_artifact_text(run_dir, artifact_path) else {
+        return;
+    };
+    let Some((class, reason)) = classify_text(&text) else {
+        return;
+    };
+
+    failures.push(BenchProviderFailure {
+        class,
+        reason: reason.to_string(),
+        source: BenchProviderFailureSource::Artifact {
+            scenario_id: scenario_id.to_string(),
+            run_index,
+            name: name.to_string(),
+            path: artifact_path.to_string(),
+        },
+        excerpt: excerpt(&text),
+    });
+}
+
+fn read_artifact_text(run_dir: &Path, artifact_path: &str) -> Option<String> {
+    let path = resolve_artifact_path(run_dir, artifact_path);
+    let file = std::fs::File::open(path).ok()?;
+    let mut bytes = Vec::new();
+    file.take(MAX_ARTIFACT_BYTES).read_to_end(&mut bytes).ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+fn resolve_artifact_path(run_dir: &Path, artifact_path: &str) -> PathBuf {
+    let path = PathBuf::from(artifact_path);
+    if path.is_absolute() {
+        path
+    } else {
+        run_dir.join(path)
+    }
+}
+
+fn contains_any(value: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| value.contains(needle))
+}
+
+fn excerpt(text: &str) -> String {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX_EXCERPT_CHARS {
+        return compact;
+    }
+
+    let mut clipped = compact
+        .chars()
+        .take(MAX_EXCERPT_CHARS.saturating_sub(1))
+        .collect::<String>();
+    clipped.push_str("...");
+    clipped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extension::bench::artifact::BenchArtifact;
+    use crate::extension::bench::parsing::{BenchMetrics, BenchScenario};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn classifies_representative_provider_failures() {
+        let cases = [
+            (
+                "Auth error: No API key available",
+                BenchProviderFailureClass::MissingApiKey,
+            ),
+            (
+                "OpenAI stream truncated before final chunk",
+                BenchProviderFailureClass::StreamTruncation,
+            ),
+            (
+                "provider returned 504 Gateway Timeout",
+                BenchProviderFailureClass::GatewayTimeout,
+            ),
+            (
+                "HTTP 429: too many requests",
+                BenchProviderFailureClass::RateLimit,
+            ),
+            (
+                "Too many concurrent requests for this model",
+                BenchProviderFailureClass::ConcurrencyLimit,
+            ),
+            (
+                "Authentication failed for provider account",
+                BenchProviderFailureClass::Auth,
+            ),
+        ];
+
+        for (text, class) in cases {
+            assert_eq!(classify_text(text).map(|(class, _)| class), Some(class));
+        }
+    }
+
+    #[test]
+    fn does_not_classify_workload_assertion_failures() {
+        assert_eq!(
+            classify_text("assertion failed: expected title to be visible"),
+            None
+        );
+        assert_eq!(classify_text("scenario gate failed: p95_ms lte 1000"), None);
+        assert_eq!(
+            classify_text("test failed because selector .submit was missing"),
+            None
+        );
+    }
+
+    #[test]
+    fn scans_stderr_and_artifact_contents() {
+        let run_dir = tempfile::TempDir::new().expect("run dir");
+        let artifact_dir = run_dir.path().join("bench-artifacts/agent");
+        std::fs::create_dir_all(&artifact_dir).expect("artifact dir");
+        std::fs::write(
+            artifact_dir.join("transcript.txt"),
+            "provider failed with 429 too many requests",
+        )
+        .expect("write artifact");
+
+        let mut artifacts = BTreeMap::new();
+        artifacts.insert(
+            "transcript".to_string(),
+            BenchArtifact {
+                path: "bench-artifacts/agent/transcript.txt".to_string(),
+                kind: Some("text".to_string()),
+                label: None,
+            },
+        );
+        let results = BenchResults {
+            component_id: "studio".to_string(),
+            iterations: 1,
+            run_metadata: None,
+            scenarios: vec![BenchScenario {
+                id: "agent".to_string(),
+                file: None,
+                source: None,
+                default_iterations: None,
+                tags: Vec::new(),
+                iterations: 1,
+                metrics: BenchMetrics::default(),
+                metric_groups: BTreeMap::new(),
+                gates: Vec::new(),
+                gate_results: Vec::new(),
+                passed: true,
+                memory: None,
+                artifacts,
+                runs: None,
+                runs_summary: None,
+            }],
+            metric_policies: BTreeMap::new(),
+        };
+
+        let failures = collect_provider_failures(
+            Some(&results),
+            Some("Auth error: No API key available"),
+            run_dir.path(),
+        );
+
+        assert_eq!(failures.len(), 2);
+        assert_eq!(failures[0].class, BenchProviderFailureClass::MissingApiKey);
+        assert_eq!(failures[1].class, BenchProviderFailureClass::RateLimit);
+    }
+}

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -8,6 +8,7 @@ use super::artifact::BenchArtifact;
 use super::baseline::BenchBaselineComparison;
 use super::distribution::BenchRunDistribution;
 use super::parsing::{BenchMetricPhase, BenchResults, BenchScenario};
+use super::provider_failure::{BenchProviderFailure, BenchProviderFailureClass};
 use super::run::{BenchRunFailure, BenchRunWorkflowResult};
 use crate::rig::RigStateSnapshot;
 
@@ -36,6 +37,8 @@ pub struct BenchCommandOutput {
     pub rig_state: Option<RigStateSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<BenchRunFailure>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failures: Vec<BenchProviderFailure>,
 }
 
 pub fn from_main_workflow(result: BenchRunWorkflowResult) -> (BenchCommandOutput, i32) {
@@ -69,6 +72,7 @@ pub fn from_main_workflow_with_rig(
             hints: result.hints,
             rig_state,
             failure: result.failure,
+            provider_failures: result.provider_failures,
         },
         exit_code,
     )
@@ -122,6 +126,8 @@ pub struct BenchComparisonOutput {
     pub summary: Vec<BenchScenarioComparisonSummary>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub failures: Vec<BenchComparisonFailure>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failure_classes: Vec<BenchProviderFailureClassSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<Vec<String>>,
 }
@@ -146,6 +152,8 @@ pub struct BenchComparisonSummaryOutput {
     pub axis_diffs: Vec<BenchAxisComparisonSummary>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub failures: Vec<BenchComparisonFailure>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failure_classes: Vec<BenchProviderFailureClassSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<Vec<String>>,
 }
@@ -156,6 +164,14 @@ pub struct BenchComparisonRigSummary {
     pub passed: bool,
     pub status: String,
     pub exit_code: i32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failures: Vec<BenchProviderFailure>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct BenchProviderFailureClassSummary {
+    pub class: BenchProviderFailureClass,
+    pub rigs: Vec<String>,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
@@ -168,6 +184,8 @@ pub struct BenchComparisonFailure {
     pub scenario_id: Option<String>,
     pub exit_code: i32,
     pub stderr_tail: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failures: Vec<BenchProviderFailure>,
 }
 
 #[derive(Serialize)]
@@ -184,6 +202,8 @@ pub struct RigBenchEntry {
     pub rig_state: Option<RigStateSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<BenchRunFailure>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failures: Vec<BenchProviderFailure>,
 }
 
 impl From<BenchComparisonOutput> for BenchComparisonSummaryOutput {
@@ -203,6 +223,7 @@ impl From<BenchComparisonOutput> for BenchComparisonSummaryOutput {
                     passed: rig.passed,
                     status: rig.status,
                     exit_code: rig.exit_code,
+                    provider_failures: rig.provider_failures,
                 })
                 .collect(),
             summary: output.summary,
@@ -212,6 +233,7 @@ impl From<BenchComparisonOutput> for BenchComparisonSummaryOutput {
                 .map(BenchAxisComparisonSummary::from)
                 .collect(),
             failures: output.failures,
+            provider_failure_classes: output.provider_failure_classes,
             hints: output.hints,
         }
     }
@@ -735,11 +757,22 @@ pub fn aggregate_comparison_with_axes(
                     scenario_id: failure.scenario_id.clone(),
                     exit_code: failure.exit_code,
                     stderr_tail: failure.stderr_tail.clone(),
+                    provider_failures: failure.provider_failures.clone(),
                 })
         })
         .collect();
+    let provider_failure_classes = summarize_provider_failure_classes(&entries);
 
     let mut hints = Vec::new();
+    for summary in &provider_failure_classes {
+        if summary.rigs.len() > 1 {
+            hints.push(format!(
+                "AI provider failure `{}` occurred in multiple rigs: {}",
+                summary.class.as_str(),
+                summary.rigs.join(", ")
+            ));
+        }
+    }
     for failure in &failures {
         hints.push(format_failure_hint(failure));
     }
@@ -766,10 +799,30 @@ pub fn aggregate_comparison_with_axes(
             axis_diffs,
             summary,
             failures,
+            provider_failure_classes,
             hints: Some(hints),
         },
         exit_code,
     )
+}
+
+fn summarize_provider_failure_classes(
+    entries: &[RigBenchEntry],
+) -> Vec<BenchProviderFailureClassSummary> {
+    let mut by_class: BTreeMap<BenchProviderFailureClass, Vec<String>> = BTreeMap::new();
+    for entry in entries {
+        for failure in &entry.provider_failures {
+            let rigs = by_class.entry(failure.class).or_default();
+            if !rigs.contains(&entry.rig_id) {
+                rigs.push(entry.rig_id.clone());
+            }
+        }
+    }
+
+    by_class
+        .into_iter()
+        .map(|(class, rigs)| BenchProviderFailureClassSummary { class, rigs })
+        .collect()
 }
 
 fn build_axis_diffs(
@@ -862,13 +915,26 @@ fn format_failure_hint(failure: &BenchComparisonFailure) -> String {
         .unwrap_or_default();
 
     format!(
-        "Rig failed before producing parseable bench results:\n- rig: {}\n- component: {}{}\n- exit: {}\n- stderr: {}",
-        failure.rig_id, component, scenario, failure.exit_code, failure.stderr_tail
+        "Rig failed before producing parseable bench results:\n- rig: {}\n- component: {}{}\n- exit: {}{}\n- stderr: {}",
+        failure.rig_id,
+        component,
+        scenario,
+        failure.exit_code,
+        format_provider_failure_hint_suffix(&failure.provider_failures),
+        failure.stderr_tail
     )
+}
+
+fn format_provider_failure_hint_suffix(failures: &[BenchProviderFailure]) -> String {
+    failures
+        .first()
+        .map(|failure| format!("\n- provider_failure: {}", failure.class.as_str()))
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::provider_failure::BenchProviderFailureSource;
     use super::*;
     use crate::extension::bench::artifact::BenchArtifact;
     use crate::extension::bench::parsing::{
@@ -984,6 +1050,7 @@ mod tests {
             results,
             rig_state: None,
             failure: None,
+            provider_failures: Vec::new(),
         }
     }
 
@@ -1002,7 +1069,18 @@ mod tests {
                 scenario_id: None,
                 exit_code: 2,
                 stderr_tail: "ERROR: Homeboy bench helper not found at /Users/chubes/.homeboy/runtime/bench-helper.sh".to_string(),
+                provider_failures: Vec::new(),
             }),
+            provider_failures: Vec::new(),
+        }
+    }
+
+    fn provider_failure(class: BenchProviderFailureClass) -> BenchProviderFailure {
+        BenchProviderFailure {
+            class,
+            reason: "provider auth failure".to_string(),
+            source: BenchProviderFailureSource::Stderr,
+            excerpt: "Auth error: No API key available".to_string(),
         }
     }
 
@@ -1018,6 +1096,7 @@ mod tests {
             baseline_comparison: None,
             hints: None,
             failure: None,
+            provider_failures: Vec::new(),
         });
 
         assert!(out.passed);
@@ -1039,6 +1118,7 @@ mod tests {
                 baseline_comparison: None,
                 hints: Some(vec!["check output".to_string()]),
                 failure: None,
+                provider_failures: Vec::new(),
             },
             None,
         );
@@ -1482,6 +1562,37 @@ mod tests {
         let (out, _) = aggregate_comparison("studio".into(), 10, entries);
         let hints = out.hints.as_ref().unwrap();
         assert!(hints.iter().any(|h| h.contains("no parseable results")));
+    }
+
+    #[test]
+    fn aggregate_groups_shared_provider_failure_classes_by_rig() {
+        let r = results(vec![scenario("boot", &[("p95_ms", 100.0)])]);
+        let mut baseline = entry("baseline", false, Some(r.clone()));
+        baseline
+            .provider_failures
+            .push(provider_failure(BenchProviderFailureClass::MissingApiKey));
+        let mut candidate = entry("candidate", false, Some(r));
+        candidate
+            .provider_failures
+            .push(provider_failure(BenchProviderFailureClass::MissingApiKey));
+
+        let (out, _) = aggregate_comparison("studio".into(), 10, vec![baseline, candidate]);
+
+        assert_eq!(out.provider_failure_classes.len(), 1);
+        assert_eq!(
+            out.provider_failure_classes[0].class,
+            BenchProviderFailureClass::MissingApiKey
+        );
+        assert_eq!(
+            out.provider_failure_classes[0].rigs,
+            vec!["baseline".to_string(), "candidate".to_string()]
+        );
+        assert!(out
+            .hints
+            .as_ref()
+            .unwrap()
+            .iter()
+            .any(|hint| hint.contains("occurred in multiple rigs")));
     }
 
     #[test]

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -18,6 +18,7 @@ use crate::extension::bench::parsing::{
     self, BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunnerMetadata, BenchScenario,
     BenchWorkloadMetadata,
 };
+use crate::extension::bench::provider_failure::{self, BenchProviderFailure};
 use crate::extension::{
     resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
     ExtensionRunner,
@@ -78,6 +79,8 @@ pub struct BenchRunWorkflowResult {
     pub hints: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<BenchRunFailure>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failures: Vec<BenchProviderFailure>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -89,6 +92,8 @@ pub struct BenchRunFailure {
     pub scenario_id: Option<String>,
     pub exit_code: i32,
     pub stderr_tail: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_failures: Vec<BenchProviderFailure>,
 }
 
 #[derive(Debug, Clone)]
@@ -480,6 +485,17 @@ pub fn run_main_bench_workflow(
         .map(parsing::evaluate_gates)
         .unwrap_or_default();
     let gates_passed = gate_failures.is_empty();
+    let provider_failures = provider_failure::collect_provider_failures(
+        parsed.as_ref(),
+        failure_stderr_tail.as_deref(),
+        run_dir.path(),
+    );
+
+    if let Some(results) = parsed.as_mut() {
+        if let Some(metadata) = results.run_metadata.as_mut() {
+            metadata.provider_failures = provider_failures.clone();
+        }
+    }
 
     let status = if runner_success && gates_passed {
         "passed"
@@ -543,6 +559,13 @@ pub fn run_main_bench_workflow(
     for failure in &gate_failures {
         hints.push(failure.clone());
     }
+    for failure in &provider_failures {
+        hints.push(format!(
+            "AI provider failure classified as `{}`: {}",
+            failure.class.as_str(),
+            failure.reason
+        ));
+    }
     hints.push("Full options: homeboy docs commands/bench".to_string());
 
     let hints = if hints.is_empty() { None } else { Some(hints) };
@@ -564,6 +587,7 @@ pub fn run_main_bench_workflow(
             scenario_id: failure_scenario_id(&execution_args.scenario_ids),
             exit_code: runner_exit_code,
             stderr_tail,
+            provider_failures: provider_failures.clone(),
         })
     } else {
         None
@@ -579,6 +603,7 @@ pub fn run_main_bench_workflow(
         baseline_comparison,
         hints,
         failure,
+        provider_failures,
     })
 }
 
@@ -613,6 +638,7 @@ fn stamp_run_metadata(
                 .to_string(),
             source_revision: source_revision_at(&execution_context.extension_path),
         }),
+        provider_failures: Vec::new(),
     });
 }
 


### PR DESCRIPTION
## Summary
- Adds conservative bench classification for common AI provider/auth failures found in runner stderr and referenced artifact contents.
- Surfaces provider failure details in single-run output, run metadata, failure blocks, and cross-rig summaries.
- Preserves existing workload metrics and artifact references while grouping shared provider failure classes across rigs.

Closes #2064

## Testing
- `cargo test provider_failure --lib`
- `cargo test bench --lib`
- `homeboy lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the classifier, metadata/report wiring, and tests; Chris remains responsible for review and validation.