### PR TITLE
Surface bench URL artifacts

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -245,8 +245,16 @@ fn record_bench_observation_artifacts(
         return;
     };
     for artifact in collect_artifacts(results) {
-        let path = resolve_bench_artifact_path(&artifact.path, run_dir);
-        record_if_exists(observation, "bench_artifact", path);
+        if let Some(url) = artifact.url.as_deref() {
+            let kind = artifact.kind.as_deref().unwrap_or(&artifact.name);
+            let _ = observation
+                .store
+                .record_url_artifact(&observation.run.id, kind, url);
+        }
+        if let Some(path) = artifact.path.as_deref() {
+            let path = resolve_bench_artifact_path(path, run_dir);
+            record_if_exists(observation, "bench_artifact", path);
+        }
     }
 }
 
@@ -366,10 +374,21 @@ mod tests {
             results.scenarios[0].artifacts.insert(
                 "transcript".to_string(),
                 BenchArtifact {
-                    path: "bench-artifacts/cold/transcript.json".to_string(),
+                    path: Some("bench-artifacts/cold/transcript.json".to_string()),
                     url: None,
+                    artifact_type: None,
                     kind: Some("json".to_string()),
                     label: Some("Transcript".to_string()),
+                },
+            );
+            results.scenarios[0].artifacts.insert(
+                "admin".to_string(),
+                BenchArtifact {
+                    path: None,
+                    url: Some("https://example.test/wp-admin/".to_string()),
+                    artifact_type: Some("url".to_string()),
+                    kind: Some("admin_url".to_string()),
+                    label: Some("Admin".to_string()),
                 },
             );
             let workflow = BenchRunWorkflowResult {
@@ -423,6 +442,11 @@ mod tests {
             assert!(kinds.contains(&"bench_results"));
             assert!(kinds.contains(&"resource_summary"));
             assert!(kinds.contains(&"bench_artifact"));
+            assert!(kinds.contains(&"admin_url"));
+            assert!(artifacts
+                .iter()
+                .any(|artifact| artifact.artifact_type == "url"
+                    && artifact.url.as_deref() == Some("https://example.test/wp-admin/")));
         });
     }
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -581,6 +581,32 @@ mod tests {
     }
 
     #[test]
+    fn artifacts_command_reports_url_artifacts() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            store
+                .record_url_artifact(&run.id, "frontend_url", "https://example.test/")
+                .expect("record URL artifact");
+
+            let (output, _) = artifacts(&run.id).expect("artifacts");
+            let RunsOutput::Artifacts(output) = output else {
+                panic!("expected artifacts output");
+            };
+            assert_eq!(output.artifacts.len(), 1);
+            assert_eq!(output.artifacts[0].kind, "frontend_url");
+            assert_eq!(output.artifacts[0].artifact_type, "url");
+            assert_eq!(
+                output.artifacts[0].url.as_deref(),
+                Some("https://example.test/")
+            );
+        });
+    }
+
+    #[test]
     fn findings_commands_list_and_show_records() {
         with_isolated_home(|_home| {
             let _xdg = XdgGuard::unset();

--- a/src/core/extension/bench/artifact.rs
+++ b/src/core/extension/bench/artifact.rs
@@ -5,9 +5,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BenchArtifact {
-    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub artifact_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -178,11 +178,11 @@ pub struct BenchScenario {
     pub passed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<BenchMemory>,
-    /// Optional local artifact pointers produced by the scenario.
+    /// Optional artifact pointers produced by the scenario.
     ///
-    /// Homeboy preserves paths and metadata but does not upload, retain, or
-    /// diff artifact contents. Consumers can correlate artifacts by scenario,
-    /// rig, and run without scraping logs or side-channel files.
+    /// Homeboy preserves paths/URLs and metadata but does not upload, retain,
+    /// or diff artifact contents. Consumers can correlate artifacts by
+    /// scenario, rig, and run without scraping logs or side-channel files.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub artifacts: BTreeMap<String, BenchArtifact>,
     /// Per-run raw metric snapshots when `homeboy bench --runs N` is used.
@@ -585,6 +585,12 @@ mod tests {
                         },
                         "final_output": {
                             "path": "artifacts/agent-loop/final.md"
+                        },
+                        "frontend": {
+                            "type": "url",
+                            "kind": "frontend_url",
+                            "url": "https://example.test/",
+                            "label": "Frontend"
                         }
                     }
                 }
@@ -594,10 +600,10 @@ mod tests {
         let parsed = parse_bench_results_str(raw).unwrap();
         let artifacts = &parsed.scenarios[0].artifacts;
 
-        assert_eq!(artifacts.len(), 2);
+        assert_eq!(artifacts.len(), 3);
         assert_eq!(
-            artifacts["transcript"].path,
-            "artifacts/agent-loop/transcript.json"
+            artifacts["transcript"].path.as_deref(),
+            Some("artifacts/agent-loop/transcript.json")
         );
         assert_eq!(artifacts["transcript"].kind.as_deref(), Some("json"));
         assert_eq!(
@@ -605,14 +611,21 @@ mod tests {
             Some("Agent transcript")
         );
         assert_eq!(
-            artifacts["final_output"].path,
-            "artifacts/agent-loop/final.md"
+            artifacts["final_output"].path.as_deref(),
+            Some("artifacts/agent-loop/final.md")
         );
         assert_eq!(artifacts["final_output"].kind, None);
+        assert_eq!(artifacts["frontend"].artifact_type.as_deref(), Some("url"));
+        assert_eq!(artifacts["frontend"].kind.as_deref(), Some("frontend_url"));
+        assert_eq!(
+            artifacts["frontend"].url.as_deref(),
+            Some("https://example.test/")
+        );
 
         let serialized = serde_json::to_string(&parsed).unwrap();
         assert!(serialized.contains("\"artifacts\""));
         assert!(serialized.contains("artifacts/agent-loop/transcript.json"));
+        assert!(serialized.contains("https://example.test/"));
     }
 
     #[test]

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -169,7 +169,8 @@ pub struct BenchSideBySideArtifact {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_index: Option<usize>,
     pub name: String,
-    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -904,7 +905,7 @@ fn side_by_side_artifact(artifact: &BenchArtifactRef) -> BenchSideBySideArtifact
         url: artifact
             .url
             .clone()
-            .or_else(|| url_from_artifact_path(&artifact.path)),
+            .or_else(|| artifact.path.as_deref().and_then(url_from_artifact_path)),
         kind: artifact.kind.clone(),
         label: artifact.label.clone(),
     }

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -301,9 +301,12 @@ pub struct BenchArtifactRef {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_index: Option<usize>,
     pub name: String,
-    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub artifact_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -342,6 +345,7 @@ fn artifact_ref(
         name: name.to_string(),
         path: artifact.path.clone(),
         url: artifact.url.clone(),
+        artifact_type: artifact.artifact_type.clone(),
         kind: artifact.kind.clone(),
         label: artifact.label.clone(),
     }
@@ -1124,8 +1128,9 @@ mod tests {
 
     fn artifact(path: &str, kind: Option<&str>, label: Option<&str>) -> BenchArtifact {
         BenchArtifact {
-            path: path.to_string(),
+            path: Some(path.to_string()),
             url: None,
+            artifact_type: None,
             kind: kind.map(str::to_string),
             label: label.map(str::to_string),
         }
@@ -1138,8 +1143,9 @@ mod tests {
         label: Option<&str>,
     ) -> BenchArtifact {
         BenchArtifact {
-            path: path.to_string(),
+            path: Some(path.to_string()),
             url: Some(url.to_string()),
+            artifact_type: None,
             kind: kind.map(str::to_string),
             label: label.map(str::to_string),
         }
@@ -1421,14 +1427,38 @@ mod tests {
         assert_eq!(indexed[0].scenario_id, "agent-runtime");
         assert_eq!(indexed[0].run_index, None);
         assert_eq!(indexed[0].name, "summary");
-        assert_eq!(indexed[0].path, "artifacts/summary.json");
+        assert_eq!(indexed[0].path.as_deref(), Some("artifacts/summary.json"));
         assert_eq!(indexed[0].kind.as_deref(), Some("json"));
         assert_eq!(indexed[0].label.as_deref(), Some("Summary"));
         assert_eq!(indexed[1].run_index, Some(0));
         assert_eq!(indexed[1].name, "raw_result");
-        assert_eq!(indexed[1].path, "artifacts/run-0/raw.json");
+        assert_eq!(indexed[1].path.as_deref(), Some("artifacts/run-0/raw.json"));
         assert_eq!(indexed[2].run_index, Some(1));
-        assert_eq!(indexed[2].path, "artifacts/run-1/raw.json");
+        assert_eq!(indexed[2].path.as_deref(), Some("artifacts/run-1/raw.json"));
+    }
+
+    #[test]
+    fn test_collect_url_artifacts() {
+        let mut scenario = scenario("site-build", &[("p95_ms", 100.0)]);
+        scenario.artifacts.insert(
+            "frontend".to_string(),
+            BenchArtifact {
+                path: None,
+                url: Some("https://example.test/".to_string()),
+                artifact_type: Some("url".to_string()),
+                kind: Some("frontend_url".to_string()),
+                label: Some("Frontend".to_string()),
+            },
+        );
+
+        let indexed = collect_artifacts(&results(vec![scenario]));
+
+        assert_eq!(indexed.len(), 1);
+        assert_eq!(indexed[0].name, "frontend");
+        assert_eq!(indexed[0].path, None);
+        assert_eq!(indexed[0].url.as_deref(), Some("https://example.test/"));
+        assert_eq!(indexed[0].artifact_type.as_deref(), Some("url"));
+        assert_eq!(indexed[0].kind.as_deref(), Some("frontend_url"));
     }
 
     #[test]
@@ -1498,7 +1528,8 @@ mod tests {
         );
         candidate_scenario.artifacts.insert(
             "site".to_string(),
-            artifact(
+            artifact_with_url(
+                "sites/candidate",
                 "https://candidate.example.test",
                 Some("site"),
                 Some("Candidate site"),

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -65,11 +65,19 @@ pub struct ArtifactRecord {
     pub id: String,
     pub run_id: String,
     pub kind: String,
+    #[serde(rename = "type", default = "default_artifact_type")]
+    pub artifact_type: String,
     pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
     pub sha256: Option<String>,
     pub size_bytes: Option<i64>,
     pub mime: Option<String>,
     pub created_at: String,
+}
+
+fn default_artifact_type() -> String {
+    "file".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -15,7 +15,7 @@ use super::records::{
 };
 use crate::{paths, Error, Result};
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 3;
+pub const CURRENT_SCHEMA_VERSION: i64 = 4;
 
 struct Migration {
     version: i64,
@@ -118,6 +118,13 @@ const MIGRATIONS: &[Migration] = &[
             ON findings(tool, file);
         CREATE INDEX IF NOT EXISTS idx_findings_fingerprint
             ON findings(fingerprint);
+    "#,
+    },
+    Migration {
+        version: 4,
+        sql: r#"
+        ALTER TABLE artifacts
+            ADD COLUMN artifact_type TEXT NOT NULL DEFAULT 'file';
     "#,
     },
 ];
@@ -386,13 +393,14 @@ impl ObservationStore {
         self.connection
             .execute(
                 r#"
-                INSERT INTO artifacts(id, run_id, kind, path, sha256, size_bytes, mime, created_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                INSERT INTO artifacts(id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
                 "#,
                 params![
                     artifact.id,
                     artifact.run_id,
                     artifact.kind,
+                    artifact.artifact_type,
                     artifact.path,
                     artifact.sha256,
                     artifact.size_bytes,
@@ -455,13 +463,14 @@ impl ObservationStore {
         self.connection
             .execute(
                 r#"
-                INSERT INTO artifacts(id, run_id, kind, path, sha256, size_bytes, mime, created_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                INSERT INTO artifacts(id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
                 "#,
                 params![
                     id,
                     run_id,
                     kind,
+                    "file",
                     path_string,
                     sha256,
                     size_bytes,
@@ -481,13 +490,64 @@ impl ObservationStore {
             })
     }
 
+    pub fn record_url_artifact(
+        &self,
+        run_id: &str,
+        kind: &str,
+        url: &str,
+    ) -> Result<ArtifactRecord> {
+        validate_required("run_id", run_id)?;
+        validate_required("kind", kind)?;
+        validate_required("url", url)?;
+        if self.get_run(run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                format!("run record not found: {run_id}"),
+                Some(run_id.to_string()),
+                None,
+            ));
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO artifacts(id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                "#,
+                params![
+                    id,
+                    run_id,
+                    kind,
+                    "url",
+                    url,
+                    Option::<String>::None,
+                    Option::<i64>::None,
+                    Option::<String>::None,
+                    created_at,
+                ],
+            )
+            .map_err(sqlite_error("insert URL artifact record"))?;
+
+        self.list_artifacts(run_id)?
+            .into_iter()
+            .find(|artifact| artifact.id == id)
+            .ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "Inserted artifact record {id} but could not read it back"
+                ))
+            })
+    }
+
     pub fn list_artifacts(&self, run_id: &str) -> Result<Vec<ArtifactRecord>> {
         validate_required("run_id", run_id)?;
         let mut statement = self
             .connection
             .prepare(
                 r#"
-                SELECT id, run_id, kind, path, sha256, size_bytes, mime, created_at
+                SELECT id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, created_at
                 FROM artifacts
                 WHERE run_id = ?1
                 ORDER BY created_at ASC
@@ -506,7 +566,7 @@ impl ObservationStore {
         self.connection
             .query_row(
                 r#"
-                SELECT id, run_id, kind, path, sha256, size_bytes, mime, created_at
+                SELECT id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, created_at
                 FROM artifacts
                 WHERE id = ?1
                 "#,
@@ -939,11 +999,17 @@ fn row_to_artifact_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArtifactR
         id: row.get(0)?,
         run_id: row.get(1)?,
         kind: row.get(2)?,
-        path: row.get(3)?,
-        sha256: row.get(4)?,
-        size_bytes: row.get(5)?,
-        mime: row.get(6)?,
-        created_at: row.get(7)?,
+        artifact_type: row.get(3)?,
+        path: row.get(4)?,
+        url: if row.get_ref(3)?.as_str()? == "url" {
+            Some(row.get(4)?)
+        } else {
+            None
+        },
+        sha256: row.get(5)?,
+        size_bytes: row.get(6)?,
+        mime: row.get(7)?,
+        created_at: row.get(8)?,
     })
 }
 

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1250,6 +1250,21 @@ mod api_coverage_tests {
     }
 
     #[test]
+    fn test_record_url_artifact() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run("bench")).expect("start");
+            let artifact = store
+                .record_url_artifact(&run.id, "frontend_url", "https://example.test/")
+                .expect("artifact");
+
+            assert_eq!(artifact.artifact_type, "url");
+            assert_eq!(artifact.url.as_deref(), Some("https://example.test/"));
+        });
+    }
+
+    #[test]
     fn test_list_artifacts() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();

--- a/tests/core/extension/bench/artifact_test.rs
+++ b/tests/core/extension/bench/artifact_test.rs
@@ -3,8 +3,9 @@ use super::BenchArtifact;
 #[test]
 fn bench_artifact_serializes_optional_fields_when_present() {
     let artifact = BenchArtifact {
-        path: "artifacts/run-1/transcript.json".to_string(),
+        path: Some("artifacts/run-1/transcript.json".to_string()),
         url: Some("https://example.test/transcript.json".to_string()),
+        artifact_type: None,
         kind: Some("json".to_string()),
         label: Some("Run 1 transcript".to_string()),
     };
@@ -20,8 +21,9 @@ fn bench_artifact_serializes_optional_fields_when_present() {
 #[test]
 fn bench_artifact_omits_absent_optional_fields() {
     let artifact = BenchArtifact {
-        path: "artifacts/run-1/out.txt".to_string(),
+        path: Some("artifacts/run-1/out.txt".to_string()),
         url: None,
+        artifact_type: None,
         kind: None,
         label: None,
     };
@@ -29,6 +31,24 @@ fn bench_artifact_omits_absent_optional_fields() {
     let raw = serde_json::to_string(&artifact).unwrap();
 
     assert_eq!(raw, r#"{"path":"artifacts/run-1/out.txt"}"#);
+}
+
+#[test]
+fn bench_artifact_serializes_url_fields_when_present() {
+    let artifact = BenchArtifact {
+        path: None,
+        url: Some("https://example.test/wp-admin/".to_string()),
+        artifact_type: Some("url".to_string()),
+        kind: Some("admin_url".to_string()),
+        label: Some("Admin".to_string()),
+    };
+
+    let raw = serde_json::to_string(&artifact).unwrap();
+
+    assert_eq!(
+        raw,
+        r#"{"url":"https://example.test/wp-admin/","type":"url","kind":"admin_url","label":"Admin"}"#
+    );
 }
 
 #[test]

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -151,8 +151,9 @@ mod cases {
         first.artifacts.insert(
             "transcript".to_string(),
             BenchArtifact {
-                path: "artifacts/run-1/transcript.json".to_string(),
+                path: Some("artifacts/run-1/transcript.json".to_string()),
                 url: None,
+                artifact_type: None,
                 kind: Some("json".to_string()),
                 label: Some("Run 1 transcript".to_string()),
             },
@@ -161,8 +162,9 @@ mod cases {
         second.artifacts.insert(
             "transcript".to_string(),
             BenchArtifact {
-                path: "artifacts/run-2/transcript.json".to_string(),
+                path: Some("artifacts/run-2/transcript.json".to_string()),
                 url: None,
+                artifact_type: None,
                 kind: Some("json".to_string()),
                 label: Some("Run 2 transcript".to_string()),
             },
@@ -173,12 +175,12 @@ mod cases {
 
         assert_eq!(runs.len(), 2);
         assert_eq!(
-            runs[0].artifacts["transcript"].path,
-            "artifacts/run-1/transcript.json"
+            runs[0].artifacts["transcript"].path.as_deref(),
+            Some("artifacts/run-1/transcript.json")
         );
         assert_eq!(
-            runs[1].artifacts["transcript"].path,
-            "artifacts/run-2/transcript.json"
+            runs[1].artifacts["transcript"].path.as_deref(),
+            Some("artifacts/run-2/transcript.json")
         );
     }
 }

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -82,7 +82,7 @@ fn test_open_initialized() {
 
         assert!(status.exists);
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 3);
+        assert_eq!(status.migration_count, 4);
         assert_eq!(status.table_count, 6);
     });
 }
@@ -97,7 +97,7 @@ fn initialization_is_idempotent() {
         let status = second.status().expect("status");
 
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 3);
+        assert_eq!(status.migration_count, 4);
         assert_eq!(status.table_count, 6);
     });
 }
@@ -329,13 +329,40 @@ fn test_record_artifact() {
         assert_eq!(artifacts, vec![artifact.clone()]);
         assert_eq!(artifact.run_id, run.id);
         assert_eq!(artifact.kind, "trace-results");
+        assert_eq!(artifact.artifact_type, "file");
         assert_eq!(artifact.path, artifact_path.to_string_lossy());
+        assert_eq!(artifact.url, None);
         assert_eq!(artifact.size_bytes, Some(17));
         assert_eq!(artifact.mime.as_deref(), Some("application/json"));
         assert_eq!(
             artifact.sha256.as_deref(),
             Some("117367705c6e7ef5d779dd71de15a95ee62339e1ef635f08246f8e1ec99167e2")
         );
+    });
+}
+
+#[test]
+fn test_record_url_artifact() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+
+        let artifact = store
+            .record_url_artifact(&run.id, "frontend_url", "https://example.test/")
+            .expect("record URL artifact");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+
+        assert_eq!(artifacts, vec![artifact.clone()]);
+        assert_eq!(artifact.kind, "frontend_url");
+        assert_eq!(artifact.artifact_type, "url");
+        assert_eq!(artifact.path, "https://example.test/");
+        assert_eq!(artifact.url.as_deref(), Some("https://example.test/"));
+        assert_eq!(artifact.sha256, None);
+        assert_eq!(artifact.size_bytes, None);
+        assert_eq!(artifact.mime, None);
     });
 }
 


### PR DESCRIPTION
## Summary
- Add URL-capable bench artifact records while keeping existing file-path artifacts compatible.
- Surface URL artifacts in the compact bench artifact index and persist them in run artifact listings with a `type: url` discriminator.
- Cover URL artifact serialization, collection, persistence, and `runs artifacts` output.

Closes #2065

## Tests
- `cargo test -- --test-threads=1`
- `homeboy lint --changed-only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused tests; Chris reviews and remains responsible for the final change.