### PR TITLE
Add side-by-side bench reports

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -55,6 +55,10 @@ the other capabilities.
 - `--path <PATH>`: Override the component's `local_path` for this run.
 - `--json-summary`: Include a compact machine-readable summary in the
   JSON output envelope (for CI wrappers).
+- `--report side-by-side`: Select the combined side-by-side comparison
+  report for a multi-rig bench envelope. The report is emitted under
+  `reports.side_by_side` and includes each rig's status, elapsed time,
+  key metrics, artifact paths/URLs, and failure reason.
 - `--rig <RIG_ID[,RIG_ID...]>`: Pin the run to one or more rigs. Single
   rig pins the rig and stores its baseline under a rig-scoped key. If
   that rig declares `bench.components`, the command fans out across those
@@ -156,7 +160,9 @@ homeboy bench --rig mdi-substrates --shared-state /tmp/mdi-bench
 # Cross-rig comparison: same workload, two rigs, side-by-side report.
 # First rig (`studio-trunk`) is the reference; the diff table expresses
 # every other rig's metrics as percent deltas vs the reference.
-homeboy bench studio --rig studio-trunk,studio-combined-fixes --iterations 10
+homeboy bench studio --rig studio-trunk,studio-combined-fixes \
+    --iterations 10 \
+    --report side-by-side
 
 # Three-rig comparison to isolate one PR's contribution.
 homeboy bench studio \
@@ -187,6 +193,15 @@ After every rig finishes, results are aggregated into a
 **first rig in the list is the reference**: per-metric percent deltas
 in the `diff` table express each subsequent rig as `(current -
 reference) / reference * 100`.
+
+Multi-rig comparison envelopes include `reports.side_by_side`, a compact
+report artifact for demo and product harnesses. It references every rig
+result and surfaces:
+
+- per-rig status, exit code, and failure reason
+- elapsed time when `elapsed_ms` or `duration_ms` metrics are present
+- flattened key metrics, including grouped metrics like `prompt.hash_match`
+- artifact paths and URLs, including URL-looking artifact paths
 
 ### What's intentionally not done
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -149,6 +149,11 @@ pub struct BenchRunArgs {
     #[arg(long)]
     json_summary: bool,
 
+    /// Include a combined comparison report artifact. Currently supports
+    /// `side-by-side` for multi-rig bench comparisons.
+    #[arg(long = "report", value_enum)]
+    report: Vec<BenchReportFormat>,
+
     /// Run bench against one or more homeboy rigs.
     ///
     /// **Single rig** (`--rig <id>`): pins the rig, runs `rig check`
@@ -208,6 +213,11 @@ pub enum BenchRigOrder {
     Reverse,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum BenchReportFormat {
+    SideBySide,
+}
+
 /// Filter out homeboy-owned flags from trailing args before passing to
 /// extension scripts.
 ///
@@ -235,6 +245,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
         "--scenario",
         "--profile",
         "--rig-order",
+        "--report",
         "--rig",
         "--setting",
         "--path",
@@ -321,6 +332,7 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
     // No --rig: legacy single bare run. No rig pinning, no rig
     // snapshot, baseline key untouched. Identical to before this PR.
     if run_args.rig.is_empty() {
+        validate_report_selection_for_single_run(run_args)?;
         let (output, exit) = matrix::run_single(run_args, &passthrough_args, None)?;
         return Ok((BenchOutput::Single(output), exit));
     }
@@ -344,6 +356,7 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
     // one rig-state snapshot. Rigs with only default_component keep the
     // legacy one-component shape.
     if run_args.rig.len() == 1 {
+        validate_report_selection_for_single_run(run_args)?;
         let rig_id = run_args.rig[0].clone();
         let (output, exit) = matrix::run_single_rig(run_args, &passthrough_args, rig_id)?;
         return Ok((BenchOutput::Single(output), exit));
@@ -432,6 +445,19 @@ fn ordered_rig_ids(args: &BenchRunArgs) -> Vec<String> {
         rig_ids.reverse();
     }
     rig_ids
+}
+
+fn validate_report_selection_for_single_run(args: &BenchRunArgs) -> homeboy::Result<()> {
+    if args.report.is_empty() {
+        return Ok(());
+    }
+
+    Err(homeboy::Error::validation_invalid_argument(
+        "--report",
+        "Bench reports are only available for multi-rig comparisons. Pass two or more --rig values, for example: --rig baseline,candidate --report side-by-side.",
+        None,
+        None,
+    ))
 }
 
 fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -563,6 +563,7 @@ mod tests {
             args: Vec::new(),
             _json: HiddenJsonArgs::default(),
             json_summary: false,
+            report: Vec::new(),
             rig: vec!["rig".to_string()],
             rig_order: crate::commands::bench::BenchRigOrder::Input,
             scenario_ids: Vec::new(),

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -341,6 +341,7 @@ mod tests {
             args: Vec::new(),
             _json: HiddenJsonArgs::default(),
             json_summary: false,
+            report: Vec::new(),
             rig: Vec::new(),
             rig_order: BenchRigOrder::Input,
             scenario_ids: Vec::new(),
@@ -366,6 +367,7 @@ mod tests {
                 "transcript".to_string(),
                 BenchArtifact {
                     path: "bench-artifacts/cold/transcript.json".to_string(),
+                    url: None,
                     kind: Some("json".to_string()),
                     label: Some("Transcript".to_string()),
                 },

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -278,6 +278,7 @@ fn run_args(component: Option<&str>, rig: Vec<String>, scenario_ids: Vec<String>
             args: Vec::new(),
             _json: HiddenJsonArgs::default(),
             json_summary: false,
+            report: Vec::new(),
             rig,
             rig_order: BenchRigOrder::Input,
             scenario_ids,
@@ -1032,6 +1033,21 @@ fn parses_warmup_flag() {
 }
 
 #[test]
+fn parses_side_by_side_report_flag() {
+    let cli = TestCli::try_parse_from([
+        "bench",
+        "studio",
+        "--rig",
+        "baseline,candidate",
+        "--report",
+        "side-by-side",
+    ])
+    .expect("bench --report side-by-side should parse");
+
+    assert_eq!(cli.bench.run.report, vec![BenchReportFormat::SideBySide]);
+}
+
+#[test]
 fn rejects_negative_warmup_flag() {
     let err = match TestCli::try_parse_from(["bench", "homeboy", "--warmup", "-1"]) {
         Ok(_) => panic!("negative warmup must fail at parse time"),
@@ -1264,6 +1280,19 @@ fn filter_strips_rig_order_forms() {
     assert_eq!(filter_homeboy_flags(&args), vec!["--filter=Scenario"]);
 
     let args = vec!["--rig-order=reverse".to_string(), "--keep".to_string()];
+    assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+}
+
+#[test]
+fn filter_strips_report_forms() {
+    let args = vec![
+        "--report".to_string(),
+        "side-by-side".to_string(),
+        "--filter=Scenario".to_string(),
+    ];
+    assert_eq!(filter_homeboy_flags(&args), vec!["--filter=Scenario"]);
+
+    let args = vec!["--report=side-by-side".to_string(), "--keep".to_string()];
     assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
 }
 

--- a/src/core/extension/bench/artifact.rs
+++ b/src/core/extension/bench/artifact.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 pub struct BenchArtifact {
     pub path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -124,6 +124,58 @@ pub struct BenchComparisonOutput {
     pub failures: Vec<BenchComparisonFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<Vec<String>>,
+    pub reports: BenchComparisonReports,
+}
+
+#[derive(Serialize)]
+pub struct BenchComparisonReports {
+    pub side_by_side: BenchSideBySideReport,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct BenchSideBySideReport {
+    pub report: &'static str,
+    pub component: String,
+    pub iterations: u64,
+    pub rigs: Vec<BenchSideBySideRigReport>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct BenchSideBySideRigReport {
+    pub rig_id: String,
+    pub passed: bool,
+    pub status: String,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub key_metrics: Vec<BenchSideBySideMetric>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<BenchSideBySideArtifact>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct BenchSideBySideMetric {
+    pub scenario_id: String,
+    pub name: String,
+    pub value: f64,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct BenchSideBySideArtifact {
+    pub scenario_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_index: Option<usize>,
+    pub name: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// Compact cross-rig comparison envelope for operator-facing summary reads.
@@ -251,6 +303,8 @@ pub struct BenchArtifactRef {
     pub name: String,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
@@ -287,6 +341,7 @@ fn artifact_ref(
         run_index,
         name: name.to_string(),
         path: artifact.path.clone(),
+        url: artifact.url.clone(),
         kind: artifact.kind.clone(),
         label: artifact.label.clone(),
     }
@@ -720,6 +775,7 @@ pub fn aggregate_comparison_with_axes(
     };
     let axis_diffs = build_axis_diffs(&entries, axes_by_rig);
     let summary = BenchScenarioComparisonSummary::build(&entries);
+    let side_by_side = build_side_by_side_report(&component, iterations, &entries);
 
     let failures: Vec<BenchComparisonFailure> = entries
         .iter()
@@ -767,9 +823,109 @@ pub fn aggregate_comparison_with_axes(
             summary,
             failures,
             hints: Some(hints),
+            reports: BenchComparisonReports { side_by_side },
         },
         exit_code,
     )
+}
+
+fn build_side_by_side_report(
+    component: &str,
+    iterations: u64,
+    entries: &[RigBenchEntry],
+) -> BenchSideBySideReport {
+    BenchSideBySideReport {
+        report: "side_by_side",
+        component: component.to_string(),
+        iterations,
+        rigs: entries.iter().map(side_by_side_rig_report).collect(),
+    }
+}
+
+fn side_by_side_rig_report(entry: &RigBenchEntry) -> BenchSideBySideRigReport {
+    let key_metrics = entry
+        .results
+        .as_ref()
+        .map(side_by_side_key_metrics)
+        .unwrap_or_default();
+
+    BenchSideBySideRigReport {
+        rig_id: entry.rig_id.clone(),
+        passed: entry.passed,
+        status: entry.status.clone(),
+        exit_code: entry.exit_code,
+        elapsed_ms: entry.results.as_ref().and_then(total_elapsed_ms),
+        key_metrics,
+        artifacts: entry.artifacts.iter().map(side_by_side_artifact).collect(),
+        failure_reason: failure_reason(entry),
+    }
+}
+
+fn side_by_side_key_metrics(results: &BenchResults) -> Vec<BenchSideBySideMetric> {
+    let mut metrics = Vec::new();
+    for scenario in &results.scenarios {
+        for (name, value) in comparison_metrics(scenario) {
+            metrics.push(BenchSideBySideMetric {
+                scenario_id: scenario.id.clone(),
+                name,
+                value,
+            });
+        }
+    }
+    metrics
+}
+
+fn total_elapsed_ms(results: &BenchResults) -> Option<f64> {
+    let mut total = 0.0;
+    let mut found = false;
+    for scenario in &results.scenarios {
+        let elapsed = scenario
+            .metrics
+            .get("elapsed_ms")
+            .or_else(|| scenario.metrics.get("duration_ms"));
+        if let Some(value) = elapsed {
+            total += value;
+            found = true;
+        }
+    }
+    found.then_some(total)
+}
+
+fn side_by_side_artifact(artifact: &BenchArtifactRef) -> BenchSideBySideArtifact {
+    BenchSideBySideArtifact {
+        scenario_id: artifact.scenario_id.clone(),
+        run_index: artifact.run_index,
+        name: artifact.name.clone(),
+        path: artifact.path.clone(),
+        url: artifact
+            .url
+            .clone()
+            .or_else(|| url_from_artifact_path(&artifact.path)),
+        kind: artifact.kind.clone(),
+        label: artifact.label.clone(),
+    }
+}
+
+fn url_from_artifact_path(path: &str) -> Option<String> {
+    (path.starts_with("http://") || path.starts_with("https://")).then(|| path.to_string())
+}
+
+fn failure_reason(entry: &RigBenchEntry) -> Option<String> {
+    if let Some(failure) = &entry.failure {
+        return Some(failure.stderr_tail.clone());
+    }
+
+    entry.results.as_ref().and_then(|results| {
+        results.scenarios.iter().find_map(|scenario| {
+            scenario
+                .gate_results
+                .iter()
+                .find_map(|result| (!result.passed).then(|| result.reason.clone()).flatten())
+                .or_else(|| {
+                    (!scenario.passed).then(|| format!("scenario `{}` failed", scenario.id))
+                })
+        })
+    })
 }
 
 fn build_axis_diffs(
@@ -969,6 +1125,21 @@ mod tests {
     fn artifact(path: &str, kind: Option<&str>, label: Option<&str>) -> BenchArtifact {
         BenchArtifact {
             path: path.to_string(),
+            url: None,
+            kind: kind.map(str::to_string),
+            label: label.map(str::to_string),
+        }
+    }
+
+    fn artifact_with_url(
+        path: &str,
+        url: &str,
+        kind: Option<&str>,
+        label: Option<&str>,
+    ) -> BenchArtifact {
+        BenchArtifact {
+            path: path.to_string(),
+            url: Some(url.to_string()),
             kind: kind.map(str::to_string),
             label: label.map(str::to_string),
         }
@@ -1301,6 +1472,78 @@ mod tests {
             value["rigs"][1]["artifacts"][0]["path"],
             "candidate/run-0/raw.json"
         );
+    }
+
+    #[test]
+    fn side_by_side_report_summarizes_multi_rig_results() {
+        let mut baseline_scenario = scenario_with_metric_groups(
+            "site-build",
+            &[("elapsed_ms", 12_000.0), ("block_count", 42.0)],
+            &[("prompt", &[("hash_match", 1.0)])],
+        );
+        baseline_scenario.artifacts.insert(
+            "site".to_string(),
+            artifact_with_url(
+                "sites/baseline",
+                "https://baseline.example.test",
+                Some("site"),
+                Some("Baseline site"),
+            ),
+        );
+
+        let mut candidate_scenario = scenario_with_metric_groups(
+            "site-build",
+            &[("elapsed_ms", 8_000.0), ("block_count", 43.0)],
+            &[("prompt", &[("hash_match", 1.0)])],
+        );
+        candidate_scenario.artifacts.insert(
+            "site".to_string(),
+            artifact(
+                "https://candidate.example.test",
+                Some("site"),
+                Some("Candidate site"),
+            ),
+        );
+
+        let entries = vec![
+            entry(
+                "studio-agent-sdk",
+                true,
+                Some(results(vec![baseline_scenario])),
+            ),
+            entry("studio-bfb", true, Some(results(vec![candidate_scenario]))),
+            failed_entry_with_stderr("studio-broken"),
+        ];
+
+        let (out, exit) = aggregate_comparison("studio".into(), 10, entries);
+        let report = &out.reports.side_by_side;
+
+        assert_eq!(exit, 2);
+        assert_eq!(report.report, "side_by_side");
+        assert_eq!(report.component, "studio");
+        assert_eq!(report.iterations, 10);
+        assert_eq!(report.rigs.len(), 3);
+        assert_eq!(report.rigs[0].rig_id, "studio-agent-sdk");
+        assert_eq!(report.rigs[0].elapsed_ms, Some(12_000.0));
+        assert!(report.rigs[0].key_metrics.contains(&BenchSideBySideMetric {
+            scenario_id: "site-build".to_string(),
+            name: "prompt.hash_match".to_string(),
+            value: 1.0,
+        }));
+        assert_eq!(
+            report.rigs[0].artifacts[0].url.as_deref(),
+            Some("https://baseline.example.test")
+        );
+        assert_eq!(
+            report.rigs[1].artifacts[0].url.as_deref(),
+            Some("https://candidate.example.test")
+        );
+        assert_eq!(report.rigs[2].status, "failed");
+        assert!(report.rigs[2]
+            .failure_reason
+            .as_deref()
+            .unwrap()
+            .contains("Homeboy bench helper not found"));
     }
 
     #[test]

--- a/tests/core/extension/bench/artifact_test.rs
+++ b/tests/core/extension/bench/artifact_test.rs
@@ -4,6 +4,7 @@ use super::BenchArtifact;
 fn bench_artifact_serializes_optional_fields_when_present() {
     let artifact = BenchArtifact {
         path: "artifacts/run-1/transcript.json".to_string(),
+        url: Some("https://example.test/transcript.json".to_string()),
         kind: Some("json".to_string()),
         label: Some("Run 1 transcript".to_string()),
     };
@@ -12,7 +13,7 @@ fn bench_artifact_serializes_optional_fields_when_present() {
 
     assert_eq!(
         raw,
-        r#"{"path":"artifacts/run-1/transcript.json","kind":"json","label":"Run 1 transcript"}"#
+        r#"{"path":"artifacts/run-1/transcript.json","url":"https://example.test/transcript.json","kind":"json","label":"Run 1 transcript"}"#
     );
 }
 
@@ -20,6 +21,7 @@ fn bench_artifact_serializes_optional_fields_when_present() {
 fn bench_artifact_omits_absent_optional_fields() {
     let artifact = BenchArtifact {
         path: "artifacts/run-1/out.txt".to_string(),
+        url: None,
         kind: None,
         label: None,
     };

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -152,6 +152,7 @@ mod cases {
             "transcript".to_string(),
             BenchArtifact {
                 path: "artifacts/run-1/transcript.json".to_string(),
+                url: None,
                 kind: Some("json".to_string()),
                 label: Some("Run 1 transcript".to_string()),
             },
@@ -161,6 +162,7 @@ mod cases {
             "transcript".to_string(),
             BenchArtifact {
                 path: "artifacts/run-2/transcript.json".to_string(),
+                url: None,
                 kind: Some("json".to_string()),
                 label: Some("Run 2 transcript".to_string()),
             },

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -55,6 +55,7 @@ fn make_args(
             args: Vec::new(),
             _json: HiddenJsonArgs::default(),
             json_summary: false,
+            report: Vec::new(),
             rig,
             rig_order: super::BenchRigOrder::Input,
             scenario_ids: Vec::new(),


### PR DESCRIPTION
## Summary
- Add a `--report side-by-side` bench selector and emit a stable `reports.side_by_side` artifact in multi-rig comparison output.
- Surface each rig's status, elapsed time, flattened key metrics, artifact paths/URLs, and failure reason while preserving existing comparison `rigs`, `diff`, and `summary` output.
- Allow bench artifacts to carry optional URLs and document the side-by-side report shape.

Closes #2062

## Testing
- `cargo fmt --check`
- `cargo test core::extension::bench`
- `cargo test commands::bench`
- `cargo test side_by_side_report_summarizes_multi_rig_results`
- `cargo test bench_artifact`
- `cargo test parses_side_by_side_report_flag`
- `cargo test filter_strips_report_forms`
- `homeboy lint`

## Known validation notes
- `cargo test` full suite currently fails outside this change area in trace tests and one PATH-order rig pipeline test:
  - `commands::trace::tests::failed_trace_run_persists_observation_history`
  - `core::extension::trace::run::tests::test_build_trace_runner`
  - `core::extension::trace::run::tests::test_run_trace_list_workflow`
  - `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and validation notes; Chris remains responsible for review and merge.