### PR TITLE
Support parallel rig bench comparisons

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -66,6 +66,9 @@ the other capabilities.
   run the same component + workload + iteration count against each rig in
   sequence and emit a cross-rig comparison envelope. See "Cross-rig
   comparison" below.
+- `--rig-concurrency <N>`: For multi-rig comparisons, run up to `N` rigs
+  concurrently. Default `1` preserves sequential CI behavior. Values greater
+  than `1` are opt-in and preserve output ordering by the selected rig order.
 - `--scenario <SCENARIO_ID>`: Run or list only the exact scenario id. May
   be repeated. Homeboy validates selected ids against discovery before
   execution and forwards the comma-separated selector to runners via
@@ -164,6 +167,11 @@ homeboy bench studio --rig studio-trunk,studio-combined-fixes \
     --iterations 10 \
     --report side-by-side
 
+# Opt into parallel cross-rig execution for side-by-side exploratory runs.
+homeboy bench studio --rig studio-agent-sdk,studio-bfb \
+    --scenario studio-agent-site-build \
+    --rig-concurrency 2
+
 # Three-rig comparison to isolate one PR's contribution.
 homeboy bench studio \
     --rig trunk,combined-fixes,combined-fixes-without-3120 \
@@ -173,13 +181,16 @@ homeboy bench studio \
 ## Cross-rig comparison
 
 `--rig <a>,<b>[,<c>...]` runs the same component + workload + iteration
-count against each rig in sequence and emits a single comparison
-envelope. Useful for "is my fix actually faster than trunk?" — same
-question, two rigs differing only in component commit state.
+count against each rig and emits a single comparison envelope. By default,
+rigs run in sequence for stable CI behavior. Pass `--rig-concurrency <N>`
+to opt into bounded parallel rig execution for exploratory or product-demo
+workflows where fresh isolated sites should be built in the same wall-clock
+window.
 
 ### How it runs
 
-For each rig, in input order:
+For each rig, in input order by default, or in bounded parallel batches when
+`--rig-concurrency` is greater than `1`:
 
 1. Load the rig spec and run `rig check`. Failure aborts the entire
    comparison — comparing against an unhealthy rig would produce
@@ -202,6 +213,10 @@ result and surfaces:
 - elapsed time when `elapsed_ms` or `duration_ms` metrics are present
 - flattened key metrics, including grouped metrics like `prompt.hash_match`
 - artifact paths and URLs, including URL-looking artifact paths
+
+Parallel execution preserves the selected rig order in the output envelope,
+so the reference rig and diff interpretation do not change when concurrency
+is enabled.
 
 ### What's intentionally not done
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -2,6 +2,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::thread;
 
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
@@ -164,7 +165,7 @@ pub struct BenchRunArgs {
     ///
     /// **Multiple rigs** (`--rig <a>,<b>[,<c>...]`): runs the same
     /// component + workload + iteration count against each rig in
-    /// sequence and emits a `BenchComparisonOutput` envelope with
+    /// sequence by default and emits a `BenchComparisonOutput` envelope with
     /// per-rig results plus a `diff` table of per-metric percent deltas
     /// vs the first rig (the reference). Cross-rig runs are
     /// **comparison-only**: `--baseline` and `--ratchet` are rejected,
@@ -186,6 +187,12 @@ pub struct BenchRunArgs {
     /// external daemon or cache state.
     #[arg(long, value_enum, default_value_t = BenchRigOrder::Input)]
     rig_order: BenchRigOrder,
+
+    /// Number of rigs to run concurrently during a multi-rig comparison.
+    /// Default 1 preserves stable sequential CI behavior. Values greater
+    /// than 1 opt into bounded parallel rig execution.
+    #[arg(long, default_value_t = 1)]
+    rig_concurrency: u32,
 
     /// Only run matching benchmark scenario ids. Repeat to select multiple.
     #[arg(
@@ -242,6 +249,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
         "--shared-state",
         "--concurrency",
         "--regression-threshold",
+        "--rig-concurrency",
         "--scenario",
         "--profile",
         "--rig-order",
@@ -363,8 +371,8 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
     }
 
     // --rig with two or more values: cross-rig comparison. Run each rig
-    // in sequence, collect per-rig outputs, aggregate into a
-    // BenchComparisonOutput.
+    // in sequence by default, or in bounded parallel batches when the user
+    // explicitly opts in with --rig-concurrency.
     if run_args.baseline_args.baseline {
         return Err(homeboy::Error::validation_invalid_argument(
             "--baseline",
@@ -388,23 +396,23 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
         matrix::validate_profile_available_for_rigs(&run_args.rig, profile)?;
     }
 
-    let mut entries = Vec::with_capacity(run_args.rig.len());
+    let ordered_rigs = ordered_rig_ids(run_args);
+    let rig_outputs = run_cross_rig_benches(run_args, &passthrough_args, ordered_rigs)?;
+
+    let mut entries = Vec::with_capacity(rig_outputs.len());
     let mut effective_component_label: Option<String> = None;
     let mut axes_by_rig = BTreeMap::new();
 
-    let ordered_rigs = ordered_rig_ids(run_args);
-
-    for rig_id in ordered_rigs {
-        if let Some(axes) = rig_axes(&rig_id)? {
-            axes_by_rig.insert(rig_id.clone(), axes);
+    for rig_output in rig_outputs {
+        if let Some(axes) = rig_output.axes {
+            axes_by_rig.insert(rig_output.rig_id.clone(), axes);
         }
-        let (single_output, _exit) =
-            matrix::run_single(run_args, &passthrough_args, Some(rig_id.clone()))?;
+        let single_output = rig_output.output;
         if effective_component_label.is_none() {
             effective_component_label = Some(single_output.component.clone());
         }
         entries.push(RigBenchEntry {
-            rig_id: rig_id.clone(),
+            rig_id: rig_output.rig_id,
             passed: single_output.passed,
             status: single_output.status,
             exit_code: single_output.exit_code,
@@ -425,6 +433,66 @@ pub fn run(args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
         return Ok((BenchOutput::ComparisonSummary(output.into()), exit));
     }
     Ok((BenchOutput::Comparison(output), exit))
+}
+
+struct CrossRigBenchOutput {
+    rig_id: String,
+    axes: Option<BTreeMap<String, String>>,
+    output: BenchCommandOutput,
+}
+
+fn run_cross_rig_benches(
+    run_args: &BenchRunArgs,
+    passthrough_args: &[String],
+    ordered_rigs: Vec<String>,
+) -> homeboy::Result<Vec<CrossRigBenchOutput>> {
+    if run_args.rig_concurrency <= 1 || ordered_rigs.len() <= 1 {
+        return ordered_rigs
+            .into_iter()
+            .map(|rig_id| run_cross_rig_bench(run_args, passthrough_args, rig_id))
+            .collect();
+    }
+
+    let concurrency = run_args.rig_concurrency as usize;
+    let mut outputs = Vec::with_capacity(ordered_rigs.len());
+
+    for chunk in ordered_rigs.chunks(concurrency) {
+        let mut chunk_outputs = thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(chunk.len());
+            for rig_id in chunk.iter().cloned() {
+                handles.push(
+                    scope.spawn(move || run_cross_rig_bench(run_args, passthrough_args, rig_id)),
+                );
+            }
+
+            handles
+                .into_iter()
+                .map(|handle| match handle.join() {
+                    Ok(result) => result,
+                    Err(_) => Err(homeboy::Error::internal_unexpected(
+                        "bench rig worker panicked during parallel comparison",
+                    )),
+                })
+                .collect::<homeboy::Result<Vec<_>>>()
+        })?;
+        outputs.append(&mut chunk_outputs);
+    }
+
+    Ok(outputs)
+}
+
+fn run_cross_rig_bench(
+    run_args: &BenchRunArgs,
+    passthrough_args: &[String],
+    rig_id: String,
+) -> homeboy::Result<CrossRigBenchOutput> {
+    let axes = rig_axes(&rig_id)?;
+    let (output, _exit) = matrix::run_single(run_args, passthrough_args, Some(rig_id.clone()))?;
+    Ok(CrossRigBenchOutput {
+        rig_id,
+        axes,
+        output,
+    })
 }
 
 fn rig_axes(rig_id: &str) -> homeboy::Result<Option<BTreeMap<String, String>>> {

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -566,6 +566,7 @@ mod tests {
             report: Vec::new(),
             rig: vec!["rig".to_string()],
             rig_order: crate::commands::bench::BenchRigOrder::Input,
+            rig_concurrency: 1,
             scenario_ids: Vec::new(),
             profile: None,
             ignore_default_baseline: false,

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -344,6 +344,7 @@ mod tests {
             report: Vec::new(),
             rig: Vec::new(),
             rig_order: BenchRigOrder::Input,
+            rig_concurrency: 1,
             scenario_ids: Vec::new(),
             profile: None,
             ignore_default_baseline: false,

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -281,6 +281,7 @@ fn run_args(component: Option<&str>, rig: Vec<String>, scenario_ids: Vec<String>
             report: Vec::new(),
             rig,
             rig_order: BenchRigOrder::Input,
+            rig_concurrency: 1,
             scenario_ids,
             profile: None,
             ignore_default_baseline: false,
@@ -525,6 +526,20 @@ fn parses_rig_order_flag() {
     .expect("bench --rig-order should parse");
 
     assert_eq!(cli.bench.run.rig_order, BenchRigOrder::Reverse);
+}
+
+#[test]
+fn parses_rig_concurrency_flag() {
+    let cli = TestCli::try_parse_from([
+        "bench",
+        "--rig",
+        "studio-agent-sdk,studio-agent-pi",
+        "--rig-concurrency",
+        "2",
+    ])
+    .expect("bench --rig-concurrency should parse");
+
+    assert_eq!(cli.bench.run.rig_concurrency, 2);
 }
 
 #[test]
@@ -1297,6 +1312,19 @@ fn filter_strips_report_forms() {
 }
 
 #[test]
+fn filter_strips_rig_concurrency_forms() {
+    let args = vec![
+        "--rig-concurrency".to_string(),
+        "2".to_string(),
+        "--filter=Scenario".to_string(),
+    ];
+    assert_eq!(filter_homeboy_flags(&args), vec!["--filter=Scenario"]);
+
+    let args = vec!["--rig-concurrency=2".to_string(), "--keep".to_string()];
+    assert_eq!(filter_homeboy_flags(&args), vec!["--keep"]);
+}
+
+#[test]
 fn filter_strips_regression_threshold_forms() {
     let args = vec![
         "--regression-threshold".to_string(),
@@ -1385,3 +1413,6 @@ fn bench_output_comparison_serializes_with_discriminator() {
 #[cfg(test)]
 #[path = "../../../tests/core/rig/bench_default_baseline_dispatch_test.rs"]
 mod bench_default_baseline_dispatch_test;
+#[cfg(test)]
+#[path = "../../../tests/core/rig/bench_rig_concurrency_dispatch_test.rs"]
+mod bench_rig_concurrency_dispatch_test;

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -153,6 +153,7 @@ pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
                 "--regression-threshold",
                 "--shared-state",
                 "--concurrency",
+                "--rig-concurrency",
                 "--rig",
                 "--scenario",
                 "--profile",
@@ -519,6 +520,8 @@ mod normalize_tests {
             "--shared-state",
             "/tmp/homeboy-bench",
             "--concurrency=4",
+            "--rig-concurrency",
+            "2",
         ]);
         let expected = input.clone();
         assert_eq!(normalize_trailing_flags(input), expected);

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -58,6 +58,7 @@ fn make_args(
             report: Vec::new(),
             rig,
             rig_order: super::BenchRigOrder::Input,
+            rig_concurrency: 1,
             scenario_ids: Vec::new(),
             profile: None,
             ignore_default_baseline,

--- a/tests/core/rig/bench_rig_concurrency_dispatch_test.rs
+++ b/tests/core/rig/bench_rig_concurrency_dispatch_test.rs
@@ -1,0 +1,123 @@
+use super::*;
+use crate::test_support::with_isolated_home;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
+
+fn write_ordering_bench_extension(home: &TempDir) {
+    let extension_dir = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("extensions")
+        .join("nodejs");
+    fs::create_dir_all(&extension_dir).expect("mkdir extension");
+    fs::write(
+        extension_dir.join("nodejs.json"),
+        r#"{"name":"Node.js","version":"0.0.0","bench":{"extension_script":"bench-runner.sh"}}"#,
+    )
+    .expect("write extension manifest");
+
+    let script_path = extension_dir.join("bench-runner.sh");
+    fs::write(
+        &script_path,
+        r#"#!/bin/sh
+id="$(basename "$HOMEBOY_COMPONENT_PATH")"
+log="$HOMEBOY_BENCH_SHARED_STATE/order.log"
+mkdir -p "$(dirname "$log")"
+printf '%s start\n' "$id" >> "$log"
+sleep 0.3
+printf '%s end\n' "$id" >> "$log"
+cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+{"component_id":"$HOMEBOY_COMPONENT_ID","iterations":${HOMEBOY_BENCH_ITERATIONS:-0},"scenarios":[{"id":"ordered","iterations":${HOMEBOY_BENCH_ITERATIONS:-0},"metrics":{"p95_ms":1.0}}],"metric_policies":{"p95_ms":{"direction":"lower_is_better"}}}
+JSON
+"#,
+    )
+    .expect("write bench script");
+
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&script_path)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod script");
+    }
+}
+
+fn bench_order_events(shared_state: &TempDir) -> Vec<String> {
+    fs::read_to_string(shared_state.path().join("order.log"))
+        .expect("order log")
+        .lines()
+        .map(|line| line.split_whitespace().last().expect("event").to_string())
+        .collect()
+}
+
+#[test]
+fn cross_rig_default_runs_rigs_sequentially() {
+    with_isolated_home(|home| {
+        write_ordering_bench_extension(home);
+        let component_a = tempfile::TempDir::new().expect("component a");
+        let component_b = tempfile::TempDir::new().expect("component b");
+        let shared_state = tempfile::TempDir::new().expect("shared state");
+        write_rig(home, "rig-a", "studio", component_a.path());
+        write_rig(home, "rig-b", "studio", component_b.path());
+
+        let mut args = run_args(
+            None,
+            vec!["rig-a".to_string(), "rig-b".to_string()],
+            Vec::new(),
+        );
+        args.run.shared_state = Some(shared_state.path().to_path_buf());
+
+        let (_output, exit_code) = run(args, &GlobalArgs {}).expect("cross-rig bench should run");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            bench_order_events(&shared_state),
+            vec!["start", "end", "start", "end"]
+        );
+    });
+}
+
+#[test]
+fn cross_rig_concurrency_runs_rigs_in_parallel() {
+    with_isolated_home(|home| {
+        write_ordering_bench_extension(home);
+        let component_a = tempfile::TempDir::new().expect("component a");
+        let component_b = tempfile::TempDir::new().expect("component b");
+        let shared_state = tempfile::TempDir::new().expect("shared state");
+        write_rig(home, "rig-a", "studio", component_a.path());
+        write_rig(home, "rig-b", "studio", component_b.path());
+
+        let mut args = run_args(
+            None,
+            vec!["rig-a".to_string(), "rig-b".to_string()],
+            Vec::new(),
+        );
+        args.run.shared_state = Some(shared_state.path().to_path_buf());
+        args.run.rig_concurrency = 2;
+
+        let (output, exit_code) = run(args, &GlobalArgs {}).expect("cross-rig bench should run");
+
+        assert_eq!(exit_code, 0);
+        let BenchOutput::Comparison(result) = output else {
+            panic!("expected comparison output")
+        };
+        assert_eq!(result.rigs[0].rig_id, "rig-a");
+        assert_eq!(result.rigs[1].rig_id, "rig-b");
+
+        let events = bench_order_events(&shared_state);
+        assert_eq!(events.len(), 4, "events: {events:?}");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.as_str() == "start")
+                .count(),
+            2
+        );
+        assert_eq!(events[0], "start", "events: {events:?}");
+        assert_eq!(events[1], "start", "events: {events:?}");
+    });
+}


### PR DESCRIPTION
## Summary
- Add opt-in `--rig-concurrency` for bounded parallel execution of multi-rig bench comparisons while keeping sequential execution as the default.
- Preserve comparison output ordering, reference-rig semantics, rig state snapshots, artifacts, metrics, and per-rig run IDs.
- Document the new flag and cover sequential default vs parallel opt-in scheduling.

Closes #2059

## Validation
- `cargo fmt`
- `cargo check`
- `cargo test commands::bench::tests::`
- `cargo test commands::utils::args::normalize_tests::bench_shared_state_flags_after_component_are_not_separated`
- `cargo test` *(fails in unrelated existing tests: trace tests cannot find `nodejs`, trace run workflow missing temp file, and `core::component::tests::resolve_remote_path_fills_empty` remote path assertion)*
- `cargo clippy --all-targets -- -D warnings` *(fails on existing broad clippy warnings unrelated to this change, including duplicate test modules, large enum variants, type complexity, and sort/loop suggestions)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the `--rig-concurrency` dispatcher path, tests, docs, and local validation; Chris remains responsible for review and merge.