### PR TITLE
Unify finding sidecar mapping

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -2,16 +2,14 @@ use clap::Args;
 
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::lint::LintFinding;
 use homeboy::extension::lint::{
     report, run_main_lint_workflow, run_self_check_lint_workflow, LintCommandOutput,
     LintRunWorkflowArgs,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::git;
-use homeboy::observation::{NewFindingRecord, NewRunRecord, ObservationStore, RunStatus};
+use homeboy::observation::{finding_records_from_lint, NewRunRecord, ObservationStore, RunStatus};
 use homeboy::refactor::plan::{collect_refactor_sources, lint_refactor_request, LintSourceOptions};
-use serde_json::Value;
 
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
@@ -242,10 +240,7 @@ impl LintObservation {
 
     fn finish_workflow(self, workflow: &homeboy::extension::lint::LintRunWorkflowResult) {
         if let Some(findings) = &workflow.lint_findings {
-            let records: Vec<NewFindingRecord> = findings
-                .iter()
-                .map(|finding| finding_record(&self.run_id, finding))
-                .collect();
+            let records = finding_records_from_lint(&self.run_id, findings);
             let _ = self.store.record_findings(&records);
         }
 
@@ -266,37 +261,6 @@ impl LintObservation {
 
     fn finish_error(self) {
         let _ = self.store.finish_run(&self.run_id, RunStatus::Error, None);
-    }
-}
-
-fn finding_record(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
-        rule: extra_string(finding, "rule").or_else(|| Some(finding.category.clone())),
-        file: finding.file.clone(),
-        line: extra_i64(finding, "line"),
-        severity: finding.severity.clone(),
-        fingerprint: Some(finding.id.clone()),
-        message: finding.message.clone(),
-        fixable: extra_bool(finding, "fixable"),
-        metadata_json: serde_json::json!({ "category": finding.category }),
-    }
-}
-
-fn extra_string(finding: &LintFinding, key: &str) -> Option<String> {
-    finding.extra.get(key)?.as_str().map(str::to_string)
-}
-
-fn extra_i64(finding: &LintFinding, key: &str) -> Option<i64> {
-    finding.extra.get(key)?.as_i64()
-}
-
-fn extra_bool(finding: &LintFinding, key: &str) -> Option<bool> {
-    match finding.extra.get(key)? {
-        Value::Bool(value) => Some(*value),
-        Value::String(value) => value.parse().ok(),
-        _ => None,
     }
 }
 

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -8,6 +8,8 @@ pub mod records;
 pub mod store;
 
 pub use records::{
+    finding_record_from_annotation, finding_record_from_lint, finding_records_from_annotation_file,
+    finding_records_from_annotations_dir, finding_records_from_lint, AnnotationFindingRecord,
     ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
     NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
     TraceSpanRecord,

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -1,4 +1,8 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{collections::BTreeMap, path::Path};
+
+use crate::extension::lint::LintFinding;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum RunStatus {
@@ -118,6 +122,189 @@ pub struct FindingListFilter {
     pub limit: Option<i64>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnnotationFindingRecord {
+    pub file: Option<String>,
+    pub line: Option<i64>,
+    pub message: String,
+    pub source: Option<String>,
+    pub severity: Option<String>,
+    pub code: Option<String>,
+    pub fixable: Option<bool>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+pub fn finding_record_from_lint(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
+        rule: lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone())),
+        file: finding.file.clone(),
+        line: lint_extra_i64(finding, "line"),
+        severity: finding.severity.clone(),
+        fingerprint: Some(finding.id.clone()),
+        message: finding.message.clone(),
+        fixable: lint_extra_bool(finding, "fixable"),
+        metadata_json: serde_json::json!({
+            "category": finding.category,
+            "source_sidecar": "lint-findings",
+            "raw": finding,
+        }),
+    }
+}
+
+pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<NewFindingRecord> {
+    findings
+        .iter()
+        .map(|finding| finding_record_from_lint(run_id, finding))
+        .collect()
+}
+
+pub fn finding_records_from_annotations_dir(
+    run_id: &str,
+    annotations_dir: &Path,
+) -> crate::error::Result<Vec<NewFindingRecord>> {
+    if !annotations_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = std::fs::read_dir(annotations_dir)
+        .map_err(|e| {
+            crate::Error::internal_io(
+                format!(
+                    "Failed to read annotations dir {}: {}",
+                    annotations_dir.display(),
+                    e
+                ),
+                Some("observation.findings.annotations".to_string()),
+            )
+        })?
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|e| {
+            crate::Error::internal_io(
+                format!(
+                    "Failed to list annotations dir {}: {}",
+                    annotations_dir.display(),
+                    e
+                ),
+                Some("observation.findings.annotations".to_string()),
+            )
+        })?;
+    entries.sort_by_key(|entry| entry.path());
+
+    let mut records = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        records.extend(finding_records_from_annotation_file(run_id, &path)?);
+    }
+    Ok(records)
+}
+
+pub fn finding_records_from_annotation_file(
+    run_id: &str,
+    path: &Path,
+) -> crate::error::Result<Vec<NewFindingRecord>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        crate::Error::internal_io(
+            format!("Failed to read annotations file {}: {}", path.display(), e),
+            Some("observation.findings.annotations".to_string()),
+        )
+    })?;
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let annotations: Vec<AnnotationFindingRecord> =
+        serde_json::from_str(&content).map_err(|e| {
+            crate::Error::internal_io(
+                format!("Malformed annotations JSON in {}: {}", path.display(), e),
+                Some("observation.findings.annotations".to_string()),
+            )
+        })?;
+    let source_file = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("annotations.json");
+
+    Ok(annotations
+        .iter()
+        .map(|annotation| finding_record_from_annotation(run_id, annotation, source_file))
+        .collect())
+}
+
+pub fn finding_record_from_annotation(
+    run_id: &str,
+    annotation: &AnnotationFindingRecord,
+    source_file: &str,
+) -> NewFindingRecord {
+    let tool = annotation
+        .source
+        .clone()
+        .unwrap_or_else(|| annotation_file_stem(source_file));
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool,
+        rule: annotation.code.clone(),
+        file: annotation.file.clone(),
+        line: annotation.line,
+        severity: annotation.severity.clone(),
+        fingerprint: annotation_fingerprint(annotation),
+        message: annotation.message.clone(),
+        fixable: annotation.fixable,
+        metadata_json: serde_json::json!({
+            "source_sidecar": "annotations",
+            "annotation_file": source_file,
+            "raw": annotation,
+        }),
+    }
+}
+
+fn annotation_file_stem(source_file: &str) -> String {
+    Path::new(source_file)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("annotations")
+        .to_string()
+}
+
+fn annotation_fingerprint(annotation: &AnnotationFindingRecord) -> Option<String> {
+    if let Some(id) = annotation.extra.get("id").and_then(Value::as_str) {
+        return Some(id.to_string());
+    }
+    Some(format!(
+        "{}:{}:{}:{}:{}",
+        annotation.file.as_deref().unwrap_or_default(),
+        annotation.line.unwrap_or_default(),
+        annotation.source.as_deref().unwrap_or_default(),
+        annotation.code.as_deref().unwrap_or_default(),
+        annotation.message
+    ))
+}
+
+fn lint_extra_string(finding: &LintFinding, key: &str) -> Option<String> {
+    finding.extra.get(key)?.as_str().map(str::to_string)
+}
+
+fn lint_extra_i64(finding: &LintFinding, key: &str) -> Option<i64> {
+    finding.extra.get(key)?.as_i64()
+}
+
+fn lint_extra_bool(finding: &LintFinding, key: &str) -> Option<bool> {
+    match finding.extra.get(key)? {
+        Value::Bool(value) => Some(*value),
+        Value::String(value) => value.parse().ok(),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct NewTraceRunRecord {
     pub run_id: String,
@@ -175,5 +362,85 @@ mod tests {
         assert_eq!(RunStatus::Error.as_str(), "error");
         assert_eq!(RunStatus::Skipped.as_str(), "skipped");
         assert_eq!(RunStatus::Stale.as_str(), "stale");
+    }
+
+    #[test]
+    fn maps_lint_sidecar_finding_to_common_record() {
+        let finding = LintFinding {
+            id: "src/lib.rs:10:lint/security".to_string(),
+            message: "escape output".to_string(),
+            category: "security".to_string(),
+            tool: Some("phpcs".to_string()),
+            file: Some("src/lib.rs".to_string()),
+            severity: Some("error".to_string()),
+            extra: BTreeMap::from([
+                ("line".to_string(), serde_json::json!(10)),
+                ("rule".to_string(), serde_json::json!("WordPress.Security")),
+                ("fixable".to_string(), serde_json::json!(true)),
+            ]),
+        };
+
+        let record = finding_record_from_lint("run-1", &finding);
+
+        assert_eq!(record.run_id, "run-1");
+        assert_eq!(record.tool, "phpcs");
+        assert_eq!(record.rule.as_deref(), Some("WordPress.Security"));
+        assert_eq!(record.file.as_deref(), Some("src/lib.rs"));
+        assert_eq!(record.line, Some(10));
+        assert_eq!(record.severity.as_deref(), Some("error"));
+        assert_eq!(
+            record.fingerprint.as_deref(),
+            Some("src/lib.rs:10:lint/security")
+        );
+        assert_eq!(record.fixable, Some(true));
+        assert_eq!(record.metadata_json["category"], "security");
+        assert_eq!(record.metadata_json["source_sidecar"], "lint-findings");
+    }
+
+    #[test]
+    fn maps_annotation_sidecar_file_to_common_records() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("phpcs.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string(&serde_json::json!([
+                {
+                    "file": "src/lib.rs",
+                    "line": 12,
+                    "message": "escape output",
+                    "source": "phpcs",
+                    "severity": "warning",
+                    "code": "WordPress.Security.EscapeOutput",
+                    "fixable": true,
+                    "github_level": "warning"
+                }
+            ]))
+            .expect("json"),
+        )
+        .expect("write");
+
+        let records = finding_records_from_annotation_file("run-1", &path).expect("records");
+
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record.run_id, "run-1");
+        assert_eq!(record.tool, "phpcs");
+        assert_eq!(
+            record.rule.as_deref(),
+            Some("WordPress.Security.EscapeOutput")
+        );
+        assert_eq!(record.file.as_deref(), Some("src/lib.rs"));
+        assert_eq!(record.line, Some(12));
+        assert_eq!(record.severity.as_deref(), Some("warning"));
+        assert_eq!(record.message, "escape output");
+        assert_eq!(record.fixable, Some(true));
+        assert!(record
+            .fingerprint
+            .as_deref()
+            .expect("fingerprint")
+            .contains("WordPress.Security.EscapeOutput"));
+        assert_eq!(record.metadata_json["source_sidecar"], "annotations");
+        assert_eq!(record.metadata_json["annotation_file"], "phpcs.json");
+        assert_eq!(record.metadata_json["raw"]["github_level"], "warning");
     }
 }


### PR DESCRIPTION
## Summary
- Add shared observation mapping helpers that normalize lint findings sidecars and annotation JSON files into `NewFindingRecord`.
- Preserve source-specific payloads in finding metadata so downstream persistence/query work can retain raw sidecar details.
- Route lint observation persistence through the shared mapper while leaving audit/test persistence unwired for follow-up issues.

## Tests
- `cargo test core::observation::records`
- `cargo test core::observation::store`
- `cargo check`
- `cargo run --bin homeboy -- lint homeboy --path . --summary`

## Notes
- `cargo test` full-suite currently fails on unrelated environment/baseline issues: missing `nodejs` extension trace fixtures and component inventory path assertions.
- `cargo clippy --all-targets -- -D warnings` currently fails on existing repository-wide clippy warnings; `homeboy lint` passes with the repository's normal warning-tolerant clippy invocation.

## Follow-ups
- #2043/#2044 can wire audit/test persistence through this mapper without adding another finding shape.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the shared finding mapping seam; Chris remains responsible for review and merge.

Closes #2049.