### PR TITLE
trace: diagnose non-monotonic phase spans

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -117,7 +117,7 @@ Each repeat uses a fresh Homeboy run directory, so completed run data is preserv
 
 ## Compare Aggregates
 
-Use `trace compare` to compare two aggregate span JSON outputs. The comparison reports each span's before/after median and average, absolute deltas, and percentage deltas. Spans are sorted by absolute median delta descending so the largest changes are first; spans that only exist in one file are included with unavailable deltas after comparable spans. Markdown reports bold non-zero absolute deltas to make regressions and improvements easier to scan.
+Use `trace compare` to compare two aggregate span JSON outputs. The comparison reports each span's before/after median and average, absolute deltas, and percentage deltas. Spans that only exist in one file are included with unavailable deltas.
 
 ```sh
 homeboy trace compare before.json after.json

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -103,6 +103,8 @@ homeboy trace studio create-site \
 
 The example above produces span rows for `phase.submit_to_cli`, `phase.cli_to_ready`, and `phase.total`. Existing `--span` definitions still work and can be mixed with phase milestones.
 
+Phase spans keep the same ordering semantics as normal spans: a phase interval is only `ok` when the later milestone occurs at or after the previous milestone. If both phase milestones exist but the later milestone was first observed before the previous milestone, Homeboy reports the span as skipped with a non-monotonic phase-chain diagnostic instead of treating the out-of-order interval as successful. Markdown reports include that diagnostic in the span status column so asynchronous readiness events are easier to distinguish from missing events.
+
 ## Repeat And Aggregate
 
 Use `--repeat <N> --aggregate spans` to run the same trace scenario multiple times and summarize span timings across runs. The aggregate output includes each run's preserved `trace.json` artifact path plus per-span `min_ms`, `median_ms`, `avg_ms`, percentile fields (`p75_ms`, `p90_ms`, `p95_ms`) when enough samples are available, `max_ms`, and `failures` counts.
@@ -115,7 +117,7 @@ Each repeat uses a fresh Homeboy run directory, so completed run data is preserv
 
 ## Compare Aggregates
 
-Use `trace compare` to compare two aggregate span JSON outputs. The comparison reports each span's before/after median and average, absolute deltas, and percentage deltas. Spans that only exist in one file are included with unavailable deltas.
+Use `trace compare` to compare two aggregate span JSON outputs. The comparison reports each span's before/after median and average, absolute deltas, and percentage deltas. Spans are sorted by absolute median delta descending so the largest changes are first; spans that only exist in one file are included with unavailable deltas after comparable spans. Markdown reports bold non-zero absolute deltas to make regressions and improvements easier to scan.
 
 ```sh
 homeboy trace compare before.json after.json

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -174,6 +174,21 @@ fn nearest_valid_pair(timeline: &[TraceEvent], from_key: &str, to_key: &str) -> 
     best
 }
 
+fn out_of_order_span_message(
+    definition: &TraceSpanDefinition,
+    from_t_ms: u64,
+    to_t_ms: u64,
+) -> String {
+    if definition.id.starts_with("phase.") {
+        format!(
+            "phase milestone `{}` occurred at {}ms before previous milestone `{}` at {}ms; phase chain is non-monotonic",
+            definition.to, to_t_ms, definition.from, from_t_ms
+        )
+    } else {
+        "span end occurred before span start".to_string()
+    }
+}
+
 fn summarize_span(definition: &TraceSpanDefinition, timeline: &[TraceEvent]) -> TraceSpanResult {
     let from_t_ms = first_event_time(timeline, &definition.from);
     let to_t_ms = first_event_time(timeline, &definition.to);
@@ -201,6 +216,12 @@ fn summarize_span(definition: &TraceSpanDefinition, timeline: &[TraceEvent]) -> 
     let Some((from_value, to_value)) =
         nearest_valid_pair(timeline, &definition.from, &definition.to)
     else {
+        let message = match (from_t_ms, to_t_ms) {
+            (Some(from_value), Some(to_value)) => {
+                out_of_order_span_message(definition, from_value, to_value)
+            }
+            _ => "span end occurred before span start".to_string(),
+        };
         return TraceSpanResult {
             id: definition.id.clone(),
             from: definition.from.clone(),
@@ -210,7 +231,7 @@ fn summarize_span(definition: &TraceSpanDefinition, timeline: &[TraceEvent]) -> 
             from_t_ms,
             to_t_ms,
             missing: Vec::new(),
-            message: Some("span end occurred before span start".to_string()),
+            message: Some(message),
         };
     };
 
@@ -378,6 +399,29 @@ mod tests {
         assert_eq!(
             results[0].message.as_deref(),
             Some("span end occurred before span start")
+        );
+    }
+
+    #[test]
+    fn out_of_order_phase_span_reports_non_monotonic_chain() {
+        let results = summarize_spans(
+            &[event(10, "runner", "ready"), event(50, "runner", "boot")],
+            &[TraceSpanDefinition {
+                id: "phase.boot_to_ready".to_string(),
+                from: "runner.boot".to_string(),
+                to: "runner.ready".to_string(),
+            }],
+        );
+
+        assert_eq!(results[0].status, TraceSpanStatus::Skipped);
+        assert_eq!(results[0].duration_ms, None);
+        assert_eq!(results[0].from_t_ms, Some(50));
+        assert_eq!(results[0].to_t_ms, Some(10));
+        assert_eq!(
+            results[0].message.as_deref(),
+            Some(
+                "phase milestone `runner.ready` occurred at 10ms before previous milestone `runner.boot` at 50ms; phase chain is non-monotonic"
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- Keep out-of-order phase spans skipped, but add a phase-specific diagnostic that names both milestones and timestamps.
- Document that phase chains require monotonic milestone ordering and that Markdown span reports surface the diagnostic.

Fixes #2091

## Testing
- cargo fmt --check
- cargo test core::extension::trace::spans
- cargo test commands::trace::tests::trace_run_expands_phase_chain_into_adjacent_and_total_spans

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementing the requested Homeboy trace phase diagnostics change under Chris's review.