### PR TITLE
Make trace compare deltas easier to scan

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -115,7 +115,7 @@ Each repeat uses a fresh Homeboy run directory, so completed run data is preserv
 
 ## Compare Aggregates
 
-Use `trace compare` to compare two aggregate span JSON outputs. The comparison reports each span's before/after median and average, absolute deltas, and percentage deltas. Spans that only exist in one file are included with unavailable deltas.
+Use `trace compare` to compare two aggregate span JSON outputs. The comparison reports each span's before/after median and average, absolute deltas, and percentage deltas. Spans are sorted by absolute median delta descending so the largest changes are first; spans that only exist in one file are included with unavailable deltas after comparable spans. Markdown reports bold non-zero absolute deltas to make regressions and improvements easier to scan.
 
 ```sh
 homeboy trace compare before.json after.json

--- a/src/commands/trace/output.rs
+++ b/src/commands/trace/output.rs
@@ -95,7 +95,7 @@ pub(super) fn compare_trace_aggregates(
         .cloned()
         .collect::<BTreeSet<_>>();
 
-    let spans = span_ids
+    let mut spans = span_ids
         .into_iter()
         .map(|id| {
             let before_span = before_spans.get(&id);
@@ -125,6 +125,7 @@ pub(super) fn compare_trace_aggregates(
             }
         })
         .collect::<Vec<_>>();
+    spans.sort_by(compare_trace_span_impact);
 
     extension_trace::TraceCompareOutput {
         command: "trace.compare.spans",
@@ -137,6 +138,24 @@ pub(super) fn compare_trace_aggregates(
         span_count: spans.len(),
         spans,
     }
+}
+
+fn compare_trace_span_impact(
+    left: &extension_trace::TraceCompareSpanOutput,
+    right: &extension_trace::TraceCompareSpanOutput,
+) -> std::cmp::Ordering {
+    right
+        .median_delta_ms
+        .map(i64::abs)
+        .cmp(&left.median_delta_ms.map(i64::abs))
+        .then_with(|| {
+            right
+                .avg_delta_ms
+                .map(f64::abs)
+                .partial_cmp(&left.avg_delta_ms.map(f64::abs))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .then_with(|| left.id.cmp(&right.id))
 }
 
 fn option_delta_i64(before: Option<u64>, after: Option<u64>) -> Option<i64> {
@@ -308,11 +327,11 @@ pub(super) fn render_compare_markdown(compare: &extension_trace::TraceCompareOut
                 span.id,
                 fmt_ms(span.before_median_ms),
                 fmt_ms(span.after_median_ms),
-                fmt_delta_ms(span.median_delta_ms),
+                fmt_signal_delta_ms(span.median_delta_ms),
                 fmt_percent(span.median_delta_percent),
                 fmt_avg_ms(span.before_avg_ms),
                 fmt_avg_ms(span.after_avg_ms),
-                fmt_delta_avg_ms(span.avg_delta_ms),
+                fmt_signal_delta_avg_ms(span.avg_delta_ms),
                 fmt_percent(span.avg_delta_percent),
             ));
         }
@@ -339,10 +358,28 @@ fn fmt_delta_ms(value: Option<i64>) -> String {
         .unwrap_or_else(|| "-".to_string())
 }
 
+fn fmt_signal_delta_ms(value: Option<i64>) -> String {
+    let formatted = fmt_delta_ms(value);
+    if value.is_some_and(|value| value != 0) {
+        format!("**{}**", formatted)
+    } else {
+        formatted
+    }
+}
+
 fn fmt_delta_avg_ms(value: Option<f64>) -> String {
     value
         .map(|value| format!("{:+.1}ms", value))
         .unwrap_or_else(|| "-".to_string())
+}
+
+fn fmt_signal_delta_avg_ms(value: Option<f64>) -> String {
+    let formatted = fmt_delta_avg_ms(value);
+    if value.is_some_and(|value| value.abs() >= f64::EPSILON) {
+        format!("**{}**", formatted)
+    } else {
+        formatted
+    }
 }
 
 fn fmt_percent(value: Option<f64>) -> String {

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -415,6 +415,20 @@ fn trace_compare_reports_median_and_average_deltas() {
                 failures: 0,
             },
             TraceAggregateSpanInput {
+                id: "large_improvement".to_string(),
+                n: 5,
+                median_ms: Some(300),
+                avg_ms: Some(300.0),
+                failures: 0,
+            },
+            TraceAggregateSpanInput {
+                id: "large_regression".to_string(),
+                n: 5,
+                median_ms: Some(80),
+                avg_ms: Some(80.0),
+                failures: 0,
+            },
+            TraceAggregateSpanInput {
                 id: "before_only".to_string(),
                 n: 5,
                 median_ms: Some(25),
@@ -435,6 +449,20 @@ fn trace_compare_reports_median_and_average_deltas() {
                 failures: 0,
             },
             TraceAggregateSpanInput {
+                id: "large_improvement".to_string(),
+                n: 5,
+                median_ms: Some(100),
+                avg_ms: Some(100.0),
+                failures: 0,
+            },
+            TraceAggregateSpanInput {
+                id: "large_regression".to_string(),
+                n: 5,
+                median_ms: Some(200),
+                avg_ms: Some(200.0),
+                failures: 0,
+            },
+            TraceAggregateSpanInput {
                 id: "after_only".to_string(),
                 n: 3,
                 median_ms: Some(75),
@@ -452,7 +480,10 @@ fn trace_compare_reports_median_and_average_deltas() {
     );
 
     assert_eq!(compare.command, "trace.compare.spans");
-    assert_eq!(compare.span_count, 3);
+    assert_eq!(compare.span_count, 5);
+    assert_eq!(compare.spans[0].id, "large_improvement");
+    assert_eq!(compare.spans[1].id, "large_regression");
+    assert_eq!(compare.spans[2].id, "boot_to_ready");
     let changed = compare
         .spans
         .iter()
@@ -537,8 +568,8 @@ fn trace_compare_markdown_renders_span_table() {
     assert!(markdown.contains("# Trace Compare"));
     assert!(markdown.contains("| Span | before median | after median | median delta | median % | before avg | after avg | avg delta | avg % |"));
     assert!(markdown.contains(
-            "| `boot_to_ready` | 100ms | 125ms | +25ms | +25.0% | 110.0ms | 121.0ms | +11.0ms | +10.0% |"
-        ));
+        "| `boot_to_ready` | 100ms | 125ms | **+25ms** | +25.0% | 110.0ms | 121.0ms | **+11.0ms** | +10.0% |"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Sort `homeboy trace compare` spans by absolute median delta so the largest changes are emitted first in JSON/markdown output.
- Bold non-zero median and average deltas in markdown compare tables.
- Document the scanability behavior and cover ordering/highlighting in focused trace compare tests.

## Tests
- `cargo test trace_compare`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** implementing the requested Homeboy trace compare scanability change under Chris's review.