### PR TITLE
Add extension repair workflow

### DIFF
--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -63,13 +63,22 @@ homeboy extension setup <extension_id>
 ### `install`
 
 ```sh
-homeboy extension install <source> [--id <extension_id>]
+homeboy extension install <source> [--id <extension_id>] [--replace]
 ```
 
 Installs a extension into Homeboy's extensions directory.
 
 - If `<source>` is a git URL, Homeboy clones it and writes `sourceUrl` into the installed extension's `<extension_id>.json` manifest.
 - If `<source>` is a local path, Homeboy symlinks the directory into the extensions directory.
+- By default, install refuses to overwrite an existing extension. Use `--replace` to explicitly replace an existing install or link.
+
+### `relink`
+
+```sh
+homeboy extension relink <extension_id> <source>
+```
+
+Repoints an existing symlinked extension to a new local source path. This command only repairs linked extensions; use `install --replace` for copied or cloned installs.
 
 ### `update`
 
@@ -178,6 +187,7 @@ Top-level variants (`data.command`):
 - `extension.run`: `{ extension_id, project_id? }`
 - `extension.setup`: `{ extension_id }`
 - `extension.install`: `{ extension_id, source, path, linked }`
+- `extension.replace`: `{ extension_id, old_path, new_path, source, linked, source_revision? }`
 - `extension.update`: `{ extension_id, url, path }`
 - `extension.update_all`: `{ updated: UpdateEntry[], skipped: string[] }`
 - `extension.uninstall`: `{ extension_id, path, was_linked }`

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -70,6 +70,16 @@ enum ExtensionCommand {
         /// Override extension id
         #[arg(long)]
         id: Option<String>,
+        /// Replace an existing extension install/link
+        #[arg(long)]
+        replace: bool,
+    },
+    /// Relink an installed symlinked extension to a new local source path
+    Relink {
+        /// Extension ID
+        extension_id: String,
+        /// Local path to extension directory
+        source: String,
     },
     /// Install every extension configured by a component
     InstallForComponent {
@@ -163,7 +173,15 @@ pub fn run(
             skip,
         ),
         ExtensionCommand::Setup { extension_id } => setup_extension(&extension_id),
-        ExtensionCommand::Install { source, id } => install_extension(&source, id),
+        ExtensionCommand::Install {
+            source,
+            id,
+            replace,
+        } => install_extension(&source, id, replace),
+        ExtensionCommand::Relink {
+            extension_id,
+            source,
+        } => relink_extension(&extension_id, &source),
         ExtensionCommand::InstallForComponent { source, path } => {
             install_for_component(&source, path.as_deref())
         }
@@ -219,6 +237,16 @@ pub enum ExtensionOutput {
         extension_id: String,
         source: String,
         path: String,
+        linked: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source_revision: Option<String>,
+    },
+    #[serde(rename = "extension.replace")]
+    Replace {
+        extension_id: String,
+        old_path: String,
+        new_path: String,
+        source: String,
         linked: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         source_revision: Option<String>,
@@ -488,7 +516,26 @@ fn run_extension(
     ))
 }
 
-fn install_extension(source: &str, id: Option<String>) -> CmdResult<ExtensionOutput> {
+fn install_extension(
+    source: &str,
+    id: Option<String>,
+    replace: bool,
+) -> CmdResult<ExtensionOutput> {
+    if replace {
+        let result = homeboy::extension::replace(source, id.as_deref())?;
+        return Ok((
+            ExtensionOutput::Replace {
+                extension_id: result.extension_id,
+                old_path: result.old_path.to_string_lossy().to_string(),
+                new_path: result.new_path.to_string_lossy().to_string(),
+                source: result.source,
+                linked: result.linked,
+                source_revision: result.source_revision,
+            },
+            0,
+        ));
+    }
+
     let result = homeboy::extension::install(source, id.as_deref())?;
     let linked = is_extension_linked(&result.extension_id);
 
@@ -498,6 +545,22 @@ fn install_extension(source: &str, id: Option<String>) -> CmdResult<ExtensionOut
             source: result.url,
             path: result.path.to_string_lossy().to_string(),
             linked,
+            source_revision: result.source_revision,
+        },
+        0,
+    ))
+}
+
+fn relink_extension(extension_id: &str, source: &str) -> CmdResult<ExtensionOutput> {
+    let result = homeboy::extension::relink(extension_id, source)?;
+
+    Ok((
+        ExtensionOutput::Replace {
+            extension_id: result.extension_id,
+            old_path: result.old_path.to_string_lossy().to_string(),
+            new_path: result.new_path.to_string_lossy().to_string(),
+            source: result.source,
+            linked: result.linked,
             source_revision: result.source_revision,
         },
         0,

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -20,16 +20,6 @@ pub struct InstallResult {
 }
 
 #[derive(Debug, Clone)]
-pub struct ReplaceResult {
-    pub extension_id: String,
-    pub old_path: PathBuf,
-    pub new_path: PathBuf,
-    pub source: String,
-    pub linked: bool,
-    pub source_revision: Option<String>,
-}
-
-#[derive(Debug, Clone)]
 pub struct InstallForComponentResult {
     pub component_id: String,
     pub source: String,
@@ -121,18 +111,6 @@ pub fn install(source: &str, id_override: Option<&str>) -> Result<InstallResult>
     } else {
         install_from_path(source, id_override)
     }
-}
-
-pub fn replace(source: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
-    if is_git_url(source) {
-        replace_from_url(source, id_override)
-    } else {
-        replace_from_path(source, id_override, false)
-    }
-}
-
-pub fn relink(extension_id: &str, source: &str) -> Result<ReplaceResult> {
-    replace_from_path(source, Some(extension_id), true)
 }
 
 /// Install every extension declared by a component from the same source.
@@ -278,65 +256,11 @@ fn install_from_url(url: &str, id_override: Option<&str>) -> Result<InstallResul
     })
 }
 
-fn replace_from_url(url: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
-    let extension_id = match id_override {
-        Some(id) => slugify_id(id)?,
-        None => derive_id_from_url(url)?,
-    };
-
-    config::check_id_collision(&extension_id, "extension")?;
-
-    let extension_dir = paths::extension(&extension_id)?;
-    if !path_exists_or_symlink(&extension_dir) {
-        return Err(Error::extension_not_found(extension_id, vec![]));
-    }
-
-    local_files::ensure_app_dirs()?;
-    let extensions_dir = paths::extensions()?;
-    let clone_dir = extensions_dir.join(format!(".replace-clone-tmp-{}", extension_id));
-    let staged_dir = extensions_dir.join(format!(".replace-stage-tmp-{}", extension_id));
-    let backup_dir = extensions_dir.join(format!(".replace-backup-tmp-{}", extension_id));
-
-    clean_replace_temp(&clone_dir)?;
-    clean_replace_temp(&staged_dir)?;
-    clean_replace_temp(&backup_dir)?;
-
-    git::clone_repo(url, &clone_dir)?;
-    let source_revision = get_short_head_revision(&clone_dir);
-
-    let result = resolve_cloned_extension(&clone_dir, &extension_id, &staged_dir, url);
-    if clone_dir.exists() {
-        let _ = std::fs::remove_dir_all(&clone_dir);
-    }
-    result?;
-
-    write_source_metadata(&staged_dir, url, source_revision.clone());
-
-    let old_path = installed_source_path(&extension_dir);
-    move_existing_install(&extension_dir, &backup_dir)?;
-    if let Err(err) = rename_dir(&staged_dir, &extension_dir) {
-        let _ = restore_existing_install(&backup_dir, &extension_dir);
-        return Err(err);
-    }
-
-    remove_existing_install(&backup_dir)?;
-    run_setup_if_configured(&extension_id);
-
-    Ok(ReplaceResult {
-        extension_id,
-        old_path,
-        new_path: extension_dir,
-        source: url.to_string(),
-        linked: false,
-        source_revision,
-    })
-}
-
 /// After cloning a repo to a temp dir, figure out whether it's a single-extension
 /// repo or a monorepo and move the right content to the final extension directory.
 ///
 /// Returns the installed extension ID on success.
-fn resolve_cloned_extension(
+pub(crate) fn resolve_cloned_extension(
     temp_dir: &Path,
     extension_id: &str,
     extension_dir: &Path,
@@ -424,7 +348,7 @@ fn scan_available_extensions(repo_dir: &Path) -> Vec<String> {
 
 /// Move a directory, falling back to recursive copy + delete if rename fails
 /// (e.g., across filesystem boundaries).
-fn rename_dir(from: &Path, to: &Path) -> Result<()> {
+pub(crate) fn rename_dir(from: &Path, to: &Path) -> Result<()> {
     if std::fs::rename(from, to).is_ok() {
         return Ok(());
     }
@@ -549,216 +473,6 @@ fn install_from_path(source_path: &str, id_override: Option<&str>) -> Result<Ins
     })
 }
 
-fn replace_from_path(
-    source_path: &str,
-    id_override: Option<&str>,
-    require_existing_link: bool,
-) -> Result<ReplaceResult> {
-    let source = resolve_local_source(source_path)?;
-
-    let extension_id = local_extension_id(&source, source_path, id_override)?;
-    config::check_id_collision(&extension_id, "extension")?;
-    validate_local_extension_source(&source, source_path, &extension_id)?;
-
-    let extension_dir = paths::extension(&extension_id)?;
-    if !path_exists_or_symlink(&extension_dir) {
-        return Err(Error::extension_not_found(extension_id, vec![]));
-    }
-    if require_existing_link && !extension_dir.is_symlink() {
-        return Err(Error::validation_invalid_argument(
-            "extension_id",
-            format!(
-                "Extension '{}' is not linked; use 'homeboy extension install --replace <source> --id {}' to replace copied installs.",
-                extension_id, extension_id
-            ),
-            Some(extension_id),
-            None,
-        ));
-    }
-
-    local_files::ensure_app_dirs()?;
-
-    let old_path = installed_source_path(&extension_dir);
-    let source_revision = get_short_head_revision(&source);
-    let staged_link = extension_dir.with_file_name(format!(".replace-link-tmp-{}", extension_id));
-    if path_exists_or_symlink(&staged_link) {
-        std::fs::remove_file(&staged_link).map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some("clean stale replacement symlink".to_string()),
-            )
-        })?;
-    }
-
-    create_symlink(&source, &staged_link)?;
-    move_existing_install(
-        &extension_dir,
-        &extension_dir.with_file_name(format!(".replace-backup-tmp-{}", extension_id)),
-    )?;
-    let backup_dir = extension_dir.with_file_name(format!(".replace-backup-tmp-{}", extension_id));
-    if let Err(err) = std::fs::rename(&staged_link, &extension_dir).map_err(|e| {
-        Error::internal_io(e.to_string(), Some("replace extension symlink".to_string()))
-    }) {
-        let _ = restore_existing_install(&backup_dir, &extension_dir);
-        return Err(err);
-    }
-
-    remove_existing_install(&backup_dir)?;
-    run_setup_if_configured(&extension_id);
-
-    Ok(ReplaceResult {
-        extension_id,
-        old_path,
-        new_path: source.clone(),
-        source: source.to_string_lossy().to_string(),
-        linked: true,
-        source_revision,
-    })
-}
-
-fn resolve_local_source(source_path: &str) -> Result<PathBuf> {
-    let source = Path::new(source_path);
-
-    let source = if source.is_absolute() {
-        source.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .map_err(|e| Error::internal_io(e.to_string(), Some("get current dir".to_string())))?
-            .join(source)
-    };
-
-    if !source.exists() {
-        return Err(Error::validation_invalid_argument(
-            "source",
-            format!("Path does not exist: {}", source.display()),
-            Some(source_path.to_string()),
-            None,
-        ));
-    }
-
-    Ok(source)
-}
-
-fn local_extension_id(
-    source: &Path,
-    source_path: &str,
-    id_override: Option<&str>,
-) -> Result<String> {
-    let dir_name = source.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "source",
-            "Could not determine directory name",
-            Some(source_path.to_string()),
-            None,
-        )
-    })?;
-
-    match id_override {
-        Some(id) => slugify_id(id),
-        None => slugify_id(dir_name),
-    }
-}
-
-fn validate_local_extension_source(
-    source: &Path,
-    source_path: &str,
-    extension_id: &str,
-) -> Result<()> {
-    let manifest_path = manifest_path_for_extension(source, extension_id);
-    if !manifest_path.exists() {
-        return Err(Error::validation_invalid_argument(
-            "source",
-            format!("No {}.json found at {}", extension_id, source.display()),
-            Some(source_path.to_string()),
-            None,
-        ));
-    }
-
-    let manifest_content = local_files::local().read(&manifest_path)?;
-    let _manifest: ExtensionManifest = from_str(&manifest_content)?;
-    Ok(())
-}
-
-fn create_symlink(source: &Path, target: &Path) -> Result<()> {
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(source, target)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("create symlink".to_string())))?;
-
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(source, target)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("create symlink".to_string())))?;
-
-    Ok(())
-}
-
-fn path_exists_or_symlink(path: &Path) -> bool {
-    path.exists() || std::fs::symlink_metadata(path).is_ok()
-}
-
-fn installed_source_path(extension_dir: &Path) -> PathBuf {
-    std::fs::read_link(extension_dir).unwrap_or_else(|_| extension_dir.to_path_buf())
-}
-
-fn move_existing_install(from: &Path, backup: &Path) -> Result<()> {
-    if path_exists_or_symlink(backup) {
-        remove_existing_install(backup)?;
-    }
-
-    if from.is_symlink() {
-        std::fs::rename(from, backup).map_err(|e| {
-            Error::internal_io(e.to_string(), Some("backup extension symlink".to_string()))
-        })?;
-    } else {
-        rename_dir(from, backup)?;
-    }
-
-    Ok(())
-}
-
-fn restore_existing_install(backup: &Path, to: &Path) -> Result<()> {
-    if !path_exists_or_symlink(backup) {
-        return Ok(());
-    }
-
-    if backup.is_symlink() {
-        std::fs::rename(backup, to).map_err(|e| {
-            Error::internal_io(e.to_string(), Some("restore extension symlink".to_string()))
-        })?;
-    } else {
-        rename_dir(backup, to)?;
-    }
-
-    Ok(())
-}
-
-fn remove_existing_install(path: &Path) -> Result<()> {
-    if !path_exists_or_symlink(path) {
-        return Ok(());
-    }
-
-    if path.is_symlink() || path.is_file() {
-        std::fs::remove_file(path).map_err(|e| {
-            Error::internal_io(e.to_string(), Some("remove extension path".to_string()))
-        })?;
-    } else {
-        std::fs::remove_dir_all(path).map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some("remove extension directory".to_string()),
-            )
-        })?;
-    }
-
-    Ok(())
-}
-
-fn clean_replace_temp(path: &Path) -> Result<()> {
-    if path_exists_or_symlink(path) {
-        remove_existing_install(path)?;
-    }
-    Ok(())
-}
-
 /// Update an installed extension by pulling latest changes.
 pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
     let extension_dir = paths::extension(extension_id)?;
@@ -880,14 +594,18 @@ fn update_extracted_extension(
     Ok(())
 }
 
-fn write_source_metadata(extension_dir: &Path, source_url: &str, source_revision: Option<String>) {
+pub(crate) fn write_source_metadata(
+    extension_dir: &Path,
+    source_url: &str,
+    source_revision: Option<String>,
+) {
     if let Some(rev) = source_revision {
         let _ = std::fs::write(extension_dir.join(".source-revision"), rev);
     }
     let _ = std::fs::write(extension_dir.join(".source-url"), source_url);
 }
 
-fn run_setup_if_configured(extension_id: &str) {
+pub(crate) fn run_setup_if_configured(extension_id: &str) {
     if let Ok(extension) = load_extension(extension_id) {
         if extension
             .runtime()
@@ -1094,7 +812,7 @@ pub struct UpdateAvailable {
 
 /// Get the short HEAD revision from a git directory.
 /// Returns None if the directory is not a git repo or the command fails.
-fn get_short_head_revision(dir: &Path) -> Option<String> {
+pub(crate) fn get_short_head_revision(dir: &Path) -> Option<String> {
     let output = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .current_dir(dir)
@@ -1140,7 +858,7 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
 mod tests {
     use super::{
         install, install_for_component, is_workdir_clean, load_extension, read_source_revision,
-        relink, replace, update,
+        update,
     };
     use crate::component;
     use crate::extension::update_all;
@@ -1338,74 +1056,6 @@ mod tests {
 
             assert_eq!(result.component_id, "multi-extension-component");
             assert_eq!(result.installed.len(), 2);
-        });
-    }
-
-    #[test]
-    fn relink_replaces_existing_symlink_source() {
-        with_isolated_home(|home| {
-            let home = home.path();
-            let old_source = home.join("old-source");
-            let new_source = home.join("new-source");
-            write_extension_fixture(&old_source, "swift");
-            write_extension_fixture_with_version(&new_source, "swift", "2.0.0");
-
-            install(&old_source.join("swift").to_string_lossy(), Some("swift"))
-                .expect("install linked extension");
-
-            let result = relink("swift", &new_source.join("swift").to_string_lossy())
-                .expect("relink should replace symlink");
-
-            let installed_path = home.join(".config/homeboy/extensions/swift");
-            assert!(installed_path.is_symlink());
-            assert_eq!(result.extension_id, "swift");
-            assert_eq!(result.old_path, old_source.join("swift"));
-            assert_eq!(result.new_path, new_source.join("swift"));
-            assert!(result.linked);
-            assert_eq!(
-                fs::read_link(installed_path).expect("read replacement link"),
-                new_source.join("swift")
-            );
-
-            let extension = load_extension("swift").expect("load relinked extension");
-            assert_eq!(extension.version, "2.0.0");
-        });
-    }
-
-    #[test]
-    fn replace_updates_copied_extension_from_git_source() {
-        with_isolated_home(|home| {
-            let home = home.path();
-            let source = home.join("source-repo");
-            fs::create_dir_all(&source).expect("source repo");
-            let remote = match prepare_git_extension_repo(&source, "swift") {
-                Some(remote) => remote,
-                None => return,
-            };
-            let remote_url = remote.path().join("extension.git");
-
-            let install_result = install(&remote_url.to_string_lossy(), Some("swift"))
-                .expect("install copied extension");
-            assert!(!install_result.path.is_symlink());
-
-            write_extension_fixture_with_version(&source, "swift", "2.0.0");
-            assert!(commit_all(&source, "update extension"));
-            assert!(run_git(&source, &["push", "origin", "HEAD"]));
-
-            let result = replace(&remote_url.to_string_lossy(), Some("swift"))
-                .expect("replace copied extension");
-
-            assert_eq!(result.extension_id, "swift");
-            assert_eq!(result.old_path, install_result.path);
-            assert_eq!(
-                result.new_path,
-                home.join(".config/homeboy/extensions/swift")
-            );
-            assert!(!result.linked);
-            assert!(result.source_revision.is_some());
-
-            let extension = load_extension("swift").expect("load replaced extension");
-            assert_eq!(extension.version, "2.0.0");
         });
     }
 

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -20,6 +20,16 @@ pub struct InstallResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct ReplaceResult {
+    pub extension_id: String,
+    pub old_path: PathBuf,
+    pub new_path: PathBuf,
+    pub source: String,
+    pub linked: bool,
+    pub source_revision: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct InstallForComponentResult {
     pub component_id: String,
     pub source: String,
@@ -111,6 +121,18 @@ pub fn install(source: &str, id_override: Option<&str>) -> Result<InstallResult>
     } else {
         install_from_path(source, id_override)
     }
+}
+
+pub fn replace(source: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
+    if is_git_url(source) {
+        replace_from_url(source, id_override)
+    } else {
+        replace_from_path(source, id_override, false)
+    }
+}
+
+pub fn relink(extension_id: &str, source: &str) -> Result<ReplaceResult> {
+    replace_from_path(source, Some(extension_id), true)
 }
 
 /// Install every extension declared by a component from the same source.
@@ -252,6 +274,60 @@ fn install_from_url(url: &str, id_override: Option<&str>) -> Result<InstallResul
         extension_id,
         url: url.to_string(),
         path: extension_dir,
+        source_revision,
+    })
+}
+
+fn replace_from_url(url: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
+    let extension_id = match id_override {
+        Some(id) => slugify_id(id)?,
+        None => derive_id_from_url(url)?,
+    };
+
+    config::check_id_collision(&extension_id, "extension")?;
+
+    let extension_dir = paths::extension(&extension_id)?;
+    if !path_exists_or_symlink(&extension_dir) {
+        return Err(Error::extension_not_found(extension_id, vec![]));
+    }
+
+    local_files::ensure_app_dirs()?;
+    let extensions_dir = paths::extensions()?;
+    let clone_dir = extensions_dir.join(format!(".replace-clone-tmp-{}", extension_id));
+    let staged_dir = extensions_dir.join(format!(".replace-stage-tmp-{}", extension_id));
+    let backup_dir = extensions_dir.join(format!(".replace-backup-tmp-{}", extension_id));
+
+    clean_replace_temp(&clone_dir)?;
+    clean_replace_temp(&staged_dir)?;
+    clean_replace_temp(&backup_dir)?;
+
+    git::clone_repo(url, &clone_dir)?;
+    let source_revision = get_short_head_revision(&clone_dir);
+
+    let result = resolve_cloned_extension(&clone_dir, &extension_id, &staged_dir, url);
+    if clone_dir.exists() {
+        let _ = std::fs::remove_dir_all(&clone_dir);
+    }
+    result?;
+
+    write_source_metadata(&staged_dir, url, source_revision.clone());
+
+    let old_path = installed_source_path(&extension_dir);
+    move_existing_install(&extension_dir, &backup_dir)?;
+    if let Err(err) = rename_dir(&staged_dir, &extension_dir) {
+        let _ = restore_existing_install(&backup_dir, &extension_dir);
+        return Err(err);
+    }
+
+    remove_existing_install(&backup_dir)?;
+    run_setup_if_configured(&extension_id);
+
+    Ok(ReplaceResult {
+        extension_id,
+        old_path,
+        new_path: extension_dir,
+        source: url.to_string(),
+        linked: false,
         source_revision,
     })
 }
@@ -471,6 +547,216 @@ fn install_from_path(source_path: &str, id_override: Option<&str>) -> Result<Ins
         path: extension_dir,
         source_revision,
     })
+}
+
+fn replace_from_path(
+    source_path: &str,
+    id_override: Option<&str>,
+    require_existing_link: bool,
+) -> Result<ReplaceResult> {
+    let source = resolve_local_source(source_path)?;
+
+    let extension_id = local_extension_id(&source, source_path, id_override)?;
+    config::check_id_collision(&extension_id, "extension")?;
+    validate_local_extension_source(&source, source_path, &extension_id)?;
+
+    let extension_dir = paths::extension(&extension_id)?;
+    if !path_exists_or_symlink(&extension_dir) {
+        return Err(Error::extension_not_found(extension_id, vec![]));
+    }
+    if require_existing_link && !extension_dir.is_symlink() {
+        return Err(Error::validation_invalid_argument(
+            "extension_id",
+            format!(
+                "Extension '{}' is not linked; use 'homeboy extension install --replace <source> --id {}' to replace copied installs.",
+                extension_id, extension_id
+            ),
+            Some(extension_id),
+            None,
+        ));
+    }
+
+    local_files::ensure_app_dirs()?;
+
+    let old_path = installed_source_path(&extension_dir);
+    let source_revision = get_short_head_revision(&source);
+    let staged_link = extension_dir.with_file_name(format!(".replace-link-tmp-{}", extension_id));
+    if path_exists_or_symlink(&staged_link) {
+        std::fs::remove_file(&staged_link).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("clean stale replacement symlink".to_string()),
+            )
+        })?;
+    }
+
+    create_symlink(&source, &staged_link)?;
+    move_existing_install(
+        &extension_dir,
+        &extension_dir.with_file_name(format!(".replace-backup-tmp-{}", extension_id)),
+    )?;
+    let backup_dir = extension_dir.with_file_name(format!(".replace-backup-tmp-{}", extension_id));
+    if let Err(err) = std::fs::rename(&staged_link, &extension_dir).map_err(|e| {
+        Error::internal_io(e.to_string(), Some("replace extension symlink".to_string()))
+    }) {
+        let _ = restore_existing_install(&backup_dir, &extension_dir);
+        return Err(err);
+    }
+
+    remove_existing_install(&backup_dir)?;
+    run_setup_if_configured(&extension_id);
+
+    Ok(ReplaceResult {
+        extension_id,
+        old_path,
+        new_path: source.clone(),
+        source: source.to_string_lossy().to_string(),
+        linked: true,
+        source_revision,
+    })
+}
+
+fn resolve_local_source(source_path: &str) -> Result<PathBuf> {
+    let source = Path::new(source_path);
+
+    let source = if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| Error::internal_io(e.to_string(), Some("get current dir".to_string())))?
+            .join(source)
+    };
+
+    if !source.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("Path does not exist: {}", source.display()),
+            Some(source_path.to_string()),
+            None,
+        ));
+    }
+
+    Ok(source)
+}
+
+fn local_extension_id(
+    source: &Path,
+    source_path: &str,
+    id_override: Option<&str>,
+) -> Result<String> {
+    let dir_name = source.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source",
+            "Could not determine directory name",
+            Some(source_path.to_string()),
+            None,
+        )
+    })?;
+
+    match id_override {
+        Some(id) => slugify_id(id),
+        None => slugify_id(dir_name),
+    }
+}
+
+fn validate_local_extension_source(
+    source: &Path,
+    source_path: &str,
+    extension_id: &str,
+) -> Result<()> {
+    let manifest_path = manifest_path_for_extension(source, extension_id);
+    if !manifest_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("No {}.json found at {}", extension_id, source.display()),
+            Some(source_path.to_string()),
+            None,
+        ));
+    }
+
+    let manifest_content = local_files::local().read(&manifest_path)?;
+    let _manifest: ExtensionManifest = from_str(&manifest_content)?;
+    Ok(())
+}
+
+fn create_symlink(source: &Path, target: &Path) -> Result<()> {
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create symlink".to_string())))?;
+
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create symlink".to_string())))?;
+
+    Ok(())
+}
+
+fn path_exists_or_symlink(path: &Path) -> bool {
+    path.exists() || std::fs::symlink_metadata(path).is_ok()
+}
+
+fn installed_source_path(extension_dir: &Path) -> PathBuf {
+    std::fs::read_link(extension_dir).unwrap_or_else(|_| extension_dir.to_path_buf())
+}
+
+fn move_existing_install(from: &Path, backup: &Path) -> Result<()> {
+    if path_exists_or_symlink(backup) {
+        remove_existing_install(backup)?;
+    }
+
+    if from.is_symlink() {
+        std::fs::rename(from, backup).map_err(|e| {
+            Error::internal_io(e.to_string(), Some("backup extension symlink".to_string()))
+        })?;
+    } else {
+        rename_dir(from, backup)?;
+    }
+
+    Ok(())
+}
+
+fn restore_existing_install(backup: &Path, to: &Path) -> Result<()> {
+    if !path_exists_or_symlink(backup) {
+        return Ok(());
+    }
+
+    if backup.is_symlink() {
+        std::fs::rename(backup, to).map_err(|e| {
+            Error::internal_io(e.to_string(), Some("restore extension symlink".to_string()))
+        })?;
+    } else {
+        rename_dir(backup, to)?;
+    }
+
+    Ok(())
+}
+
+fn remove_existing_install(path: &Path) -> Result<()> {
+    if !path_exists_or_symlink(path) {
+        return Ok(());
+    }
+
+    if path.is_symlink() || path.is_file() {
+        std::fs::remove_file(path).map_err(|e| {
+            Error::internal_io(e.to_string(), Some("remove extension path".to_string()))
+        })?;
+    } else {
+        std::fs::remove_dir_all(path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("remove extension directory".to_string()),
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn clean_replace_temp(path: &Path) -> Result<()> {
+    if path_exists_or_symlink(path) {
+        remove_existing_install(path)?;
+    }
+    Ok(())
 }
 
 /// Update an installed extension by pulling latest changes.
@@ -854,7 +1140,7 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
 mod tests {
     use super::{
         install, install_for_component, is_workdir_clean, load_extension, read_source_revision,
-        update,
+        relink, replace, update,
     };
     use crate::component;
     use crate::extension::update_all;
@@ -1052,6 +1338,91 @@ mod tests {
 
             assert_eq!(result.component_id, "multi-extension-component");
             assert_eq!(result.installed.len(), 2);
+        });
+    }
+
+    #[test]
+    fn relink_replaces_existing_symlink_source() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let new_source = home.join("new-source");
+            write_extension_fixture(&old_source, "swift");
+            write_extension_fixture_with_version(&new_source, "swift", "2.0.0");
+
+            install(&old_source.join("swift").to_string_lossy(), Some("swift"))
+                .expect("install linked extension");
+
+            let result = relink("swift", &new_source.join("swift").to_string_lossy())
+                .expect("relink should replace symlink");
+
+            let installed_path = home.join(".config/homeboy/extensions/swift");
+            assert!(installed_path.is_symlink());
+            assert_eq!(result.extension_id, "swift");
+            assert_eq!(result.old_path, old_source.join("swift"));
+            assert_eq!(result.new_path, new_source.join("swift"));
+            assert!(result.linked);
+            assert_eq!(
+                fs::read_link(installed_path).expect("read replacement link"),
+                new_source.join("swift")
+            );
+
+            let extension = load_extension("swift").expect("load relinked extension");
+            assert_eq!(extension.version, "2.0.0");
+        });
+    }
+
+    #[test]
+    fn replace_updates_copied_extension_from_git_source() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let remote = match prepare_git_extension_repo(&source, "swift") {
+                Some(remote) => remote,
+                None => return,
+            };
+            let remote_url = remote.path().join("extension.git");
+
+            let install_result = install(&remote_url.to_string_lossy(), Some("swift"))
+                .expect("install copied extension");
+            assert!(!install_result.path.is_symlink());
+
+            write_extension_fixture_with_version(&source, "swift", "2.0.0");
+            assert!(commit_all(&source, "update extension"));
+            assert!(run_git(&source, &["push", "origin", "HEAD"]));
+
+            let result = replace(&remote_url.to_string_lossy(), Some("swift"))
+                .expect("replace copied extension");
+
+            assert_eq!(result.extension_id, "swift");
+            assert_eq!(result.old_path, install_result.path);
+            assert_eq!(
+                result.new_path,
+                home.join(".config/homeboy/extensions/swift")
+            );
+            assert!(!result.linked);
+            assert!(result.source_revision.is_some());
+
+            let extension = load_extension("swift").expect("load replaced extension");
+            assert_eq!(extension.version, "2.0.0");
+        });
+    }
+
+    #[test]
+    fn install_without_replace_remains_non_destructive() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source");
+            write_extension_fixture(&source, "swift");
+
+            install(&source.join("swift").to_string_lossy(), Some("swift"))
+                .expect("initial install");
+
+            let err = install(&source.join("swift").to_string_lossy(), Some("swift"))
+                .expect_err("second install should still fail");
+
+            assert!(err.to_string().contains("already exists"));
         });
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -56,8 +56,8 @@ pub use scope::ExtensionScope;
 // Re-export lifecycle types and functions
 pub use lifecycle::{
     check_update_available, derive_id_from_url, install, install_for_component, is_git_url,
-    read_source_revision, slugify_id, uninstall, update, InstallForComponentResult, InstallResult,
-    UpdateAvailable, UpdateResult,
+    read_source_revision, relink, replace, slugify_id, uninstall, update,
+    InstallForComponentResult, InstallResult, ReplaceResult, UpdateAvailable, UpdateResult,
 };
 
 pub(crate) fn stderr_tail(stderr: &str) -> String {

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -6,6 +6,7 @@ pub mod grammar_items;
 mod lifecycle;
 pub mod lint;
 mod manifest;
+mod repair;
 mod runner;
 mod runner_contract;
 mod runtime_helper;
@@ -56,9 +57,10 @@ pub use scope::ExtensionScope;
 // Re-export lifecycle types and functions
 pub use lifecycle::{
     check_update_available, derive_id_from_url, install, install_for_component, is_git_url,
-    read_source_revision, relink, replace, slugify_id, uninstall, update,
-    InstallForComponentResult, InstallResult, ReplaceResult, UpdateAvailable, UpdateResult,
+    read_source_revision, slugify_id, uninstall, update, InstallForComponentResult, InstallResult,
+    UpdateAvailable, UpdateResult,
 };
+pub use repair::{relink, replace, ReplaceResult};
 
 pub(crate) fn stderr_tail(stderr: &str) -> String {
     const MAX_LINES: usize = 20;

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -1,0 +1,451 @@
+use crate::config::{self, from_str};
+use crate::engine::local_files::{self, FileSystem};
+use crate::error::{Error, Result};
+use crate::git;
+use crate::paths;
+use std::path::{Path, PathBuf};
+
+use super::lifecycle::{
+    derive_id_from_url, get_short_head_revision, is_git_url, rename_dir, resolve_cloned_extension,
+    run_setup_if_configured, slugify_id, write_source_metadata,
+};
+use super::manifest::ExtensionManifest;
+
+#[derive(Debug, Clone)]
+pub struct ReplaceResult {
+    pub extension_id: String,
+    pub old_path: PathBuf,
+    pub new_path: PathBuf,
+    pub source: String,
+    pub linked: bool,
+    pub source_revision: Option<String>,
+}
+
+pub fn replace(source: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
+    if is_git_url(source) {
+        replace_from_url(source, id_override)
+    } else {
+        replace_from_path(source, id_override, false)
+    }
+}
+
+pub fn relink(extension_id: &str, source: &str) -> Result<ReplaceResult> {
+    replace_from_path(source, Some(extension_id), true)
+}
+
+fn replace_from_url(url: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
+    let extension_id = match id_override {
+        Some(id) => slugify_id(id)?,
+        None => derive_id_from_url(url)?,
+    };
+
+    config::check_id_collision(&extension_id, "extension")?;
+
+    let extension_dir = paths::extension(&extension_id)?;
+    if !path_exists_or_symlink(&extension_dir) {
+        return Err(Error::extension_not_found(extension_id, vec![]));
+    }
+
+    local_files::ensure_app_dirs()?;
+    let extensions_dir = paths::extensions()?;
+    let clone_dir = extensions_dir.join(format!(".replace-clone-tmp-{}", extension_id));
+    let staged_dir = extensions_dir.join(format!(".replace-stage-tmp-{}", extension_id));
+    let backup_dir = extensions_dir.join(format!(".replace-backup-tmp-{}", extension_id));
+
+    clean_replace_temp(&clone_dir)?;
+    clean_replace_temp(&staged_dir)?;
+    clean_replace_temp(&backup_dir)?;
+
+    git::clone_repo(url, &clone_dir)?;
+    let source_revision = get_short_head_revision(&clone_dir);
+
+    let result = resolve_cloned_extension(&clone_dir, &extension_id, &staged_dir, url);
+    if clone_dir.exists() {
+        let _ = std::fs::remove_dir_all(&clone_dir);
+    }
+    result?;
+
+    write_source_metadata(&staged_dir, url, source_revision.clone());
+
+    let old_path = installed_source_path(&extension_dir);
+    move_existing_install(&extension_dir, &backup_dir)?;
+    if let Err(err) = rename_dir(&staged_dir, &extension_dir) {
+        let _ = restore_existing_install(&backup_dir, &extension_dir);
+        return Err(err);
+    }
+
+    remove_existing_install(&backup_dir)?;
+    run_setup_if_configured(&extension_id);
+
+    Ok(ReplaceResult {
+        extension_id,
+        old_path,
+        new_path: extension_dir,
+        source: url.to_string(),
+        linked: false,
+        source_revision,
+    })
+}
+
+fn replace_from_path(
+    source_path: &str,
+    id_override: Option<&str>,
+    require_existing_link: bool,
+) -> Result<ReplaceResult> {
+    let source = resolve_local_source(source_path)?;
+    let extension_id = local_extension_id(&source, source_path, id_override)?;
+    config::check_id_collision(&extension_id, "extension")?;
+    validate_local_extension_source(&source, source_path, &extension_id)?;
+
+    let extension_dir = paths::extension(&extension_id)?;
+    if !path_exists_or_symlink(&extension_dir) {
+        return Err(Error::extension_not_found(extension_id, vec![]));
+    }
+    if require_existing_link && !extension_dir.is_symlink() {
+        return Err(Error::validation_invalid_argument(
+            "extension_id",
+            format!(
+                "Extension '{}' is not linked; use 'homeboy extension install --replace <source> --id {}' to replace copied installs.",
+                extension_id, extension_id
+            ),
+            Some(extension_id),
+            None,
+        ));
+    }
+
+    local_files::ensure_app_dirs()?;
+
+    let old_path = installed_source_path(&extension_dir);
+    let source_revision = get_short_head_revision(&source);
+    let staged_link = extension_dir.with_file_name(format!(".replace-link-tmp-{}", extension_id));
+    clean_replace_temp(&staged_link)?;
+
+    create_symlink(&source, &staged_link)?;
+    let backup_dir = extension_dir.with_file_name(format!(".replace-backup-tmp-{}", extension_id));
+    move_existing_install(&extension_dir, &backup_dir)?;
+    if let Err(err) = std::fs::rename(&staged_link, &extension_dir).map_err(|e| {
+        Error::internal_io(e.to_string(), Some("replace extension symlink".to_string()))
+    }) {
+        let _ = restore_existing_install(&backup_dir, &extension_dir);
+        return Err(err);
+    }
+
+    remove_existing_install(&backup_dir)?;
+    run_setup_if_configured(&extension_id);
+
+    Ok(ReplaceResult {
+        extension_id,
+        old_path,
+        new_path: source.clone(),
+        source: source.to_string_lossy().to_string(),
+        linked: true,
+        source_revision,
+    })
+}
+
+fn resolve_local_source(source_path: &str) -> Result<PathBuf> {
+    let source = Path::new(source_path);
+    let source = if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| Error::internal_io(e.to_string(), Some("get current dir".to_string())))?
+            .join(source)
+    };
+
+    if !source.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("Path does not exist: {}", source.display()),
+            Some(source_path.to_string()),
+            None,
+        ));
+    }
+
+    Ok(source)
+}
+
+fn local_extension_id(
+    source: &Path,
+    source_path: &str,
+    id_override: Option<&str>,
+) -> Result<String> {
+    let dir_name = source.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source",
+            "Could not determine directory name",
+            Some(source_path.to_string()),
+            None,
+        )
+    })?;
+
+    match id_override {
+        Some(id) => slugify_id(id),
+        None => slugify_id(dir_name),
+    }
+}
+
+fn validate_local_extension_source(
+    source: &Path,
+    source_path: &str,
+    extension_id: &str,
+) -> Result<()> {
+    let manifest_path = source.join(format!("{}.json", extension_id));
+    if !manifest_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("No {}.json found at {}", extension_id, source.display()),
+            Some(source_path.to_string()),
+            None,
+        ));
+    }
+
+    let manifest_content = local_files::local().read(&manifest_path)?;
+    let _manifest: ExtensionManifest = from_str(&manifest_content)?;
+    Ok(())
+}
+
+fn create_symlink(source: &Path, target: &Path) -> Result<()> {
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create symlink".to_string())))?;
+
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create symlink".to_string())))?;
+
+    Ok(())
+}
+
+fn path_exists_or_symlink(path: &Path) -> bool {
+    path.exists() || std::fs::symlink_metadata(path).is_ok()
+}
+
+fn installed_source_path(extension_dir: &Path) -> PathBuf {
+    std::fs::read_link(extension_dir).unwrap_or_else(|_| extension_dir.to_path_buf())
+}
+
+fn move_existing_install(from: &Path, backup: &Path) -> Result<()> {
+    if path_exists_or_symlink(backup) {
+        remove_existing_install(backup)?;
+    }
+
+    if from.is_symlink() {
+        std::fs::rename(from, backup).map_err(|e| {
+            Error::internal_io(e.to_string(), Some("backup extension symlink".to_string()))
+        })?;
+    } else {
+        rename_dir(from, backup)?;
+    }
+
+    Ok(())
+}
+
+fn restore_existing_install(backup: &Path, to: &Path) -> Result<()> {
+    if !path_exists_or_symlink(backup) {
+        return Ok(());
+    }
+
+    if backup.is_symlink() {
+        std::fs::rename(backup, to).map_err(|e| {
+            Error::internal_io(e.to_string(), Some("restore extension symlink".to_string()))
+        })?;
+    } else {
+        rename_dir(backup, to)?;
+    }
+
+    Ok(())
+}
+
+fn remove_existing_install(path: &Path) -> Result<()> {
+    if !path_exists_or_symlink(path) {
+        return Ok(());
+    }
+
+    if path.is_symlink() || path.is_file() {
+        std::fs::remove_file(path).map_err(|e| {
+            Error::internal_io(e.to_string(), Some("remove extension path".to_string()))
+        })?;
+    } else {
+        std::fs::remove_dir_all(path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("remove extension directory".to_string()),
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn clean_replace_temp(path: &Path) -> Result<()> {
+    if path_exists_or_symlink(path) {
+        remove_existing_install(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{relink, replace};
+    use crate::extension::{install, load_extension};
+    use crate::test_support::with_isolated_home;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn write_extension_fixture(root: &Path, id: &str) {
+        write_extension_fixture_with_version(root, id, "1.0.0");
+    }
+
+    fn write_extension_fixture_with_version(root: &Path, id: &str, version: &str) {
+        let dir = root.join(id);
+        fs::create_dir_all(&dir).expect("extension dir");
+        fs::write(
+            dir.join(format!("{}.json", id)),
+            format!(
+                r#"{{
+  "name": "{} extension",
+  "version": "{}"
+}}"#,
+                id, version
+            ),
+        )
+        .expect("extension manifest");
+    }
+
+    fn run_git(dir: &Path, args: &[&str]) -> bool {
+        Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    fn commit_all(dir: &Path, message: &str) -> bool {
+        run_git(dir, &["add", "."])
+            && run_git(
+                dir,
+                &[
+                    "-c",
+                    "user.name=Test",
+                    "-c",
+                    "user.email=test@example.com",
+                    "commit",
+                    "-m",
+                    message,
+                ],
+            )
+    }
+
+    fn prepare_git_extension_repo(repo: &Path, extension_id: &str) -> Option<TempDir> {
+        write_extension_fixture(repo, extension_id);
+        if !run_git(repo, &["init", "--quiet"]) || !commit_all(repo, "init") {
+            return None;
+        }
+
+        let remote_parent = TempDir::new().expect("remote parent");
+        let remote_path = remote_parent.path().join("extension.git");
+        let remote_path_str = remote_path.to_string_lossy().to_string();
+        if !run_git(
+            repo,
+            &["clone", "--bare", repo.to_str().unwrap(), &remote_path_str],
+        ) {
+            return None;
+        }
+        if !run_git(repo, &["remote", "add", "origin", &remote_path_str]) {
+            return None;
+        }
+        if !run_git(repo, &["fetch", "origin", "--quiet"]) {
+            return None;
+        }
+        let branch = if run_git(repo, &["rev-parse", "--verify", "main"]) {
+            "main"
+        } else {
+            "master"
+        };
+        if !run_git(
+            repo,
+            &[
+                "branch",
+                "--set-upstream-to",
+                &format!("origin/{branch}"),
+                branch,
+            ],
+        ) {
+            return None;
+        }
+
+        Some(remote_parent)
+    }
+
+    #[test]
+    fn relink_replaces_existing_symlink_source() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let new_source = home.join("new-source");
+            write_extension_fixture(&old_source, "swift");
+            write_extension_fixture_with_version(&new_source, "swift", "2.0.0");
+
+            install(&old_source.join("swift").to_string_lossy(), Some("swift"))
+                .expect("install linked extension");
+
+            let result = relink("swift", &new_source.join("swift").to_string_lossy())
+                .expect("relink should replace symlink");
+
+            let installed_path = home.join(".config/homeboy/extensions/swift");
+            assert!(installed_path.is_symlink());
+            assert_eq!(result.extension_id, "swift");
+            assert_eq!(result.old_path, old_source.join("swift"));
+            assert_eq!(result.new_path, new_source.join("swift"));
+            assert!(result.linked);
+            assert_eq!(
+                fs::read_link(installed_path).expect("read replacement link"),
+                new_source.join("swift")
+            );
+
+            let extension = load_extension("swift").expect("load relinked extension");
+            assert_eq!(extension.version, "2.0.0");
+        });
+    }
+
+    #[test]
+    fn replace_updates_copied_extension_from_git_source() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let remote = match prepare_git_extension_repo(&source, "swift") {
+                Some(remote) => remote,
+                None => return,
+            };
+            let remote_url = remote.path().join("extension.git");
+
+            let install_result = install(&remote_url.to_string_lossy(), Some("swift"))
+                .expect("install copied extension");
+            assert!(!install_result.path.is_symlink());
+
+            write_extension_fixture_with_version(&source, "swift", "2.0.0");
+            assert!(commit_all(&source, "update extension"));
+            assert!(run_git(&source, &["push", "origin", "HEAD"]));
+
+            let result = replace(&remote_url.to_string_lossy(), Some("swift"))
+                .expect("replace copied extension");
+
+            assert_eq!(result.extension_id, "swift");
+            assert_eq!(result.old_path, install_result.path);
+            assert_eq!(
+                result.new_path,
+                home.join(".config/homeboy/extensions/swift")
+            );
+            assert!(!result.linked);
+            assert!(result.source_revision.is_some());
+
+            let extension = load_extension("swift").expect("load replaced extension");
+            assert_eq!(extension.version, "2.0.0");
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Add `homeboy extension relink <extension_id> <source>` for repairing symlinked extension installs.
- Add `homeboy extension install --replace <source> [--id <extension_id>]` for explicit replacement of existing linked or copied installs.
- Return structured replacement output with extension ID, old path, new path, linked status, source, and source revision, while keeping default install non-destructive.

Fixes #2103.

## Tests
- `cargo test core::extension::lifecycle`
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode GPT-5.5
- **Used for:** Implementation and tests under Chris review.