### PR TITLE
Fix linked extension updates in feature worktrees

### DIFF
--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -647,7 +647,18 @@ fn update_linked_extension(
     }
 
     let default_branch = detect_default_branch(&git_root).unwrap_or_else(|| "main".to_string());
-    let current_branch = current_branch(&git_root).unwrap_or_else(|| "DETACHED".to_string());
+    let current_branch = git_silent(&git_root, &["branch", "--show-current"])
+        .and_then(|output| {
+            if output.status.success() {
+                let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !branch.is_empty() {
+                    return Some(branch);
+                }
+            }
+
+            None
+        })
+        .unwrap_or_else(|| "DETACHED".to_string());
     if current_branch != default_branch {
         return Err(Error::validation_invalid_argument(
             "extension_id",
@@ -684,19 +695,6 @@ fn update_linked_extension(
         url,
         path: source_dir,
     })
-}
-
-/// Return the currently checked out branch for a git repository.
-fn current_branch(repo_dir: &Path) -> Option<String> {
-    let output = git_silent(repo_dir, &["branch", "--show-current"])?;
-    if output.status.success() {
-        let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !branch.is_empty() {
-            return Some(branch);
-        }
-    }
-
-    None
 }
 
 /// Detect the default branch of a git repository.
@@ -862,8 +860,8 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        current_branch, install, install_for_component, is_workdir_clean, load_extension,
-        read_source_revision, update,
+        install, install_for_component, is_workdir_clean, load_extension, read_source_revision,
+        update,
     };
     use crate::component;
     use crate::extension::update_all;
@@ -1164,7 +1162,11 @@ mod tests {
                 Some(remote) => remote,
                 None => return,
             };
-            let default_branch = current_branch(&source).expect("default branch");
+            let default_branch = if run_git(&source, &["rev-parse", "--verify", "main"]) {
+                "main"
+            } else {
+                "master"
+            };
 
             assert!(run_git(
                 &source,
@@ -1178,7 +1180,7 @@ mod tests {
                     "add",
                     "--quiet",
                     stable_checkout.to_str().expect("stable checkout path"),
-                    &default_branch,
+                    default_branch,
                 ]
             ));
 
@@ -1192,12 +1194,17 @@ mod tests {
             let message = err.to_string();
             assert!(message.contains("Linked extension 'wordpress' points at"));
             assert!(message.contains("feature-linked-extension"));
-            assert!(message.contains(&default_branch));
+            assert!(message.contains(default_branch));
             assert!(message.contains("homeboy extension uninstall wordpress"));
 
+            let branch_output = Command::new("git")
+                .args(["branch", "--show-current"])
+                .current_dir(&source)
+                .output()
+                .expect("current branch");
             assert_eq!(
-                current_branch(&source).as_deref(),
-                Some("feature-linked-extension"),
+                String::from_utf8_lossy(&branch_output.stdout).trim(),
+                "feature-linked-extension",
                 "linked update must not checkout the default branch in the feature worktree"
             );
         });

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -616,7 +616,7 @@ fn run_setup_if_configured(extension_id: &str) {
 ///
 /// Linked extensions are symlinks pointing to a source directory, which may be
 /// a subdirectory of a monorepo (e.g. `homeboy-extensions/wordpress`). This
-/// function resolves the git root, checks out the default branch, and pulls.
+/// function resolves the git root, verifies it is on the default branch, and pulls.
 fn update_linked_extension(
     extension_id: &str,
     extension_dir: &Path,
@@ -646,28 +646,24 @@ fn update_linked_extension(
         ));
     }
 
-    // Checkout the default branch before pulling.
-    // Try main first, fall back to master.
     let default_branch = detect_default_branch(&git_root).unwrap_or_else(|| "main".to_string());
-    let checkout_output = Command::new("git")
-        .args(["checkout", &default_branch])
-        .current_dir(&git_root)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .output();
-
-    if let Ok(output) = &checkout_output {
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            log_status!(
-                "extension",
-                "Warning: could not checkout {} for {}: {}",
+    let current_branch = current_branch(&git_root).unwrap_or_else(|| "DETACHED".to_string());
+    if current_branch != default_branch {
+        return Err(Error::validation_invalid_argument(
+            "extension_id",
+            format!(
+                "Linked extension '{}' points at {} on branch '{}', but updates require the default branch '{}'. Relink the extension to a stable checkout, for example: homeboy extension uninstall {} && homeboy extension install <{} checkout path> --id {}",
+                extension_id,
+                source_dir.display(),
+                current_branch,
                 default_branch,
                 extension_id,
-                stderr.trim()
-            );
-            // Continue anyway — pull on current branch is better than nothing
-        }
+                default_branch,
+                extension_id,
+            ),
+            Some(extension_id.to_string()),
+            None,
+        ));
     }
 
     git::pull_repo(&git_root)?;
@@ -688,6 +684,19 @@ fn update_linked_extension(
         url,
         path: source_dir,
     })
+}
+
+/// Return the currently checked out branch for a git repository.
+fn current_branch(repo_dir: &Path) -> Option<String> {
+    let output = git_silent(repo_dir, &["branch", "--show-current"])?;
+    if output.status.success() {
+        let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !branch.is_empty() {
+            return Some(branch);
+        }
+    }
+
+    None
 }
 
 /// Detect the default branch of a git repository.
@@ -853,8 +862,8 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        install, install_for_component, is_workdir_clean, load_extension, read_source_revision,
-        update,
+        current_branch, install, install_for_component, is_workdir_clean, load_extension,
+        read_source_revision, update,
     };
     use crate::component;
     use crate::extension::update_all;
@@ -1141,6 +1150,55 @@ mod tests {
             assert!(
                 result.skipped.is_empty(),
                 "linked extensions should not be pre-skipped by update_all"
+            );
+        });
+    }
+
+    #[test]
+    fn linked_update_fails_instead_of_checking_out_default_branch_in_feature_worktree() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let _remote = match prepare_git_extension_repo(&source, "wordpress") {
+                Some(remote) => remote,
+                None => return,
+            };
+            let default_branch = current_branch(&source).expect("default branch");
+
+            assert!(run_git(
+                &source,
+                &["checkout", "-b", "feature-linked-extension"]
+            ));
+            let stable_checkout = home.join("stable-checkout");
+            assert!(run_git(
+                &source,
+                &[
+                    "worktree",
+                    "add",
+                    "--quiet",
+                    stable_checkout.to_str().expect("stable checkout path"),
+                    &default_branch,
+                ]
+            ));
+
+            install(
+                &source.join("wordpress").to_string_lossy(),
+                Some("wordpress"),
+            )
+            .expect("install linked extension");
+
+            let err = update("wordpress", false).expect_err("feature worktree update must fail");
+            let message = err.to_string();
+            assert!(message.contains("Linked extension 'wordpress' points at"));
+            assert!(message.contains("feature-linked-extension"));
+            assert!(message.contains(&default_branch));
+            assert!(message.contains("homeboy extension uninstall wordpress"));
+
+            assert_eq!(
+                current_branch(&source).as_deref(),
+                Some("feature-linked-extension"),
+                "linked update must not checkout the default branch in the feature worktree"
             );
         });
     }


### PR DESCRIPTION
## Summary
- Stop linked extension updates from force-checking out the default branch before pulling.
- Fail explicitly when a linked extension source is on a non-default branch, including the extension, source path, current branch, desired branch, and relink guidance.
- Add regression coverage for the default-branch worktree conflict path.

## Tests
- cargo test core::extension::lifecycle::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode GPT-5.5
- **Used for:** Implementation and tests under Chris review.