### PR TITLE
Group linked extension root updates

### DIFF
--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -4,8 +4,10 @@ use crate::engine::local_files::{self, FileSystem};
 use crate::error::{Error, Result};
 use crate::git;
 use crate::paths;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 
 use super::execution::run_setup;
 use super::manifest::ExtensionManifest;
@@ -34,13 +36,6 @@ pub struct UpdateResult {
     pub path: PathBuf,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct LinkedExtensionUpdateTarget {
-    pub extension_id: String,
-    pub source_dir: PathBuf,
-    pub git_root: PathBuf,
-}
-
 pub fn slugify_id(value: &str) -> Result<String> {
     identifier::slugify_id(value, "extension_id")
 }
@@ -66,17 +61,6 @@ pub fn is_git_url(source: &str) -> bool {
         || source.ends_with(".git")
 }
 
-/// Check if an extension directory is safe to overwrite on update.
-///
-/// Treats the directory as "clean" when:
-/// - It is not a git working tree (tarball / plain-directory installs have no
-///   `.git`, so there is no working tree to be dirty in the first place), or
-/// - It is a git working tree with no uncommitted changes.
-///
-/// Returns `false` only when the directory is a git working tree **and** has
-/// uncommitted changes. This avoids the historical false positive where
-/// `git status` returning a non-zero exit on a non-repo directory was treated
-/// as "dirty" (see Extra-Chill/homeboy#1181).
 fn is_workdir_clean(path: &Path) -> bool {
     // If the directory is not a git working tree, there is nothing that can
     // be "uncommitted". Short-circuit to clean before running `git status`.
@@ -623,25 +607,11 @@ pub(crate) fn run_setup_if_configured(extension_id: &str) {
     }
 }
 
-/// Update a linked extension by pulling the source repository.
-///
-/// Linked extensions are symlinks pointing to a source directory, which may be
-/// a subdirectory of a monorepo (e.g. `homeboy-extensions/wordpress`). This
-/// function resolves the git root, verifies it is on the default branch, and pulls.
 fn update_linked_extension(
     extension_id: &str,
     extension_dir: &Path,
     force: bool,
 ) -> Result<UpdateResult> {
-    let target = linked_extension_update_target(extension_id, extension_dir)?;
-    update_linked_git_root(&target.git_root, &[extension_id.to_string()], force)?;
-    Ok(finish_linked_extension_update(&target))
-}
-
-pub(crate) fn linked_extension_update_target(
-    extension_id: &str,
-    extension_dir: &Path,
-) -> Result<LinkedExtensionUpdateTarget> {
     let source_dir = std::fs::read_link(extension_dir).map_err(|e| {
         Error::internal_io(
             e.to_string(),
@@ -657,101 +627,96 @@ pub(crate) fn linked_extension_update_target(
             .join(source_dir)
     };
     let source_dir = source_dir.canonicalize().unwrap_or(source_dir);
-
     let git_root_str = git::get_git_root(&source_dir.to_string_lossy())?;
     let git_root = PathBuf::from(&git_root_str)
         .canonicalize()
         .unwrap_or_else(|_| PathBuf::from(git_root_str));
 
-    Ok(LinkedExtensionUpdateTarget {
+    static UPDATED_ROOTS: OnceLock<Mutex<HashMap<PathBuf, Option<String>>>> = OnceLock::new();
+    let updated_roots = UPDATED_ROOTS.get_or_init(|| Mutex::new(HashMap::new()));
+    let cached = updated_roots
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&git_root)
+        .cloned();
+    match cached {
+        Some(None) => {}
+        Some(Some(message)) => return Err(Error::validation_invalid_argument(
+            "extension_id",
+            format!("Linked extension '{}' skipped because shared source repo update previously failed: {}", extension_id, message),
+            Some(extension_id.to_string()),
+            None,
+        )),
+        None => {
+            let result = (|| {
+                if !force && !is_workdir_clean(&git_root) {
+                    return Err(Error::validation_invalid_argument(
+                        "extension_id",
+                        format!(
+                            "Linked extension source repo has uncommitted changes for {}. Use --force to proceed.",
+                            extension_id,
+                        ),
+                        Some(extension_id.to_string()),
+                        None,
+                    ));
+                }
+
+                let default_branch =
+                    detect_default_branch(&git_root).unwrap_or_else(|| "main".to_string());
+                let current_branch = git_silent(&git_root, &["branch", "--show-current"])
+                    .and_then(|output| {
+                        if output.status.success() {
+                            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                            if !branch.is_empty() {
+                                return Some(branch);
+                            }
+                        }
+
+                        None
+                    })
+                    .unwrap_or_else(|| "DETACHED".to_string());
+                if current_branch != default_branch {
+                    return Err(Error::validation_invalid_argument(
+                        "extension_id",
+                        format!(
+                            "Linked extension '{}' points at {} on branch '{}', but updates require the default branch '{}'. Relink the extension to a stable checkout before upgrading.",
+                            extension_id,
+                            source_dir.display(),
+                            current_branch,
+                            default_branch,
+                        ),
+                        Some(extension_id.to_string()),
+                        None,
+                    ));
+                }
+
+                git::pull_repo(&git_root)?;
+
+                Ok(())
+            })();
+            updated_roots
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(git_root, result.as_ref().err().map(|e| e.message.clone()));
+            result?;
+        }
+    };
+    run_setup_if_configured(extension_id);
+    let url = format!("linked:{}", source_dir.display());
+    Ok(UpdateResult {
         extension_id: extension_id.to_string(),
-        source_dir,
-        git_root,
+        url,
+        path: source_dir,
     })
 }
 
-pub(crate) fn update_linked_git_root(
-    git_root: &Path,
-    extension_ids: &[String],
-    force: bool,
-) -> Result<()> {
-    if !force && !is_workdir_clean(&git_root) {
-        let affected = extension_ids.join(", ");
-        return Err(Error::validation_invalid_argument(
-            "extension_id",
-            format!(
-                "Linked extension source repo has uncommitted changes for {}. Use --force to proceed.",
-                affected,
-            ),
-            Some(affected),
-            None,
-        ));
-    }
-
-    let default_branch = detect_default_branch(&git_root).unwrap_or_else(|| "main".to_string());
-    let current_branch = git_silent(&git_root, &["branch", "--show-current"])
-        .and_then(|output| {
-            if output.status.success() {
-                let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !branch.is_empty() {
-                    return Some(branch);
-                }
-            }
-
-            None
-        })
-        .unwrap_or_else(|| "DETACHED".to_string());
-    if current_branch != default_branch {
-        let affected = extension_ids.join(", ");
-        return Err(Error::validation_invalid_argument(
-            "extension_id",
-            format!(
-                "Linked extensions {} point at {} on branch '{}', but updates require the default branch '{}'. Relink the extensions to a stable checkout before upgrading.",
-                affected,
-                git_root.display(),
-                current_branch,
-                default_branch,
-            ),
-            Some(affected),
-            None,
-        ));
-    }
-
-    git::pull_repo(git_root)?;
-
-    Ok(())
-}
-
-pub(crate) fn finish_linked_extension_update(target: &LinkedExtensionUpdateTarget) -> UpdateResult {
-    if let Ok(extension) = load_extension(&target.extension_id) {
-        if extension
-            .runtime()
-            .is_some_and(|r| r.setup_command.is_some())
-        {
-            let _ = run_setup(&target.extension_id);
-        }
-    }
-
-    let url = format!("linked:{}", target.source_dir.display());
-    UpdateResult {
-        extension_id: target.extension_id.clone(),
-        url,
-        path: target.source_dir.clone(),
-    }
-}
-
-/// Detect the default branch of a git repository.
-/// Checks `refs/remotes/origin/HEAD` first, then tries `main` and `master`.
 fn detect_default_branch(repo_dir: &Path) -> Option<String> {
-    // Try symbolic-ref first (most reliable)
     let output = git_silent(repo_dir, &["symbolic-ref", "refs/remotes/origin/HEAD"])?;
     if output.status.success() {
         let refname = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        // refs/remotes/origin/main → main
         return refname.rsplit('/').next().map(|s| s.to_string());
     }
 
-    // Fallback: check if main or master exist as local branches
     for branch in &["main", "master"] {
         let check = git_silent(repo_dir, &["rev-parse", "--verify", branch])?;
         if check.status.success() {
@@ -943,15 +908,7 @@ mod tests {
         fs::write(
             dir.join(format!("{}.json", id)),
             format!(
-                r#"{{
-  "name": "{} extension",
-  "version": "1.0.0",
-  "executable": {{
-    "runtime": {{
-      "setup_command": "printf setup >> setup-count.txt"
-    }}
-  }}
-}}"#,
+                r#"{{"name":"{} extension","version":"1.0.0","executable":{{"runtime":{{"setup_command":"printf setup >> setup-count.txt"}}}}}}"#,
                 id
             ),
         )
@@ -1007,49 +964,17 @@ mod tests {
 
     fn prepare_git_extension_repo(repo: &Path, extension_id: &str) -> Option<TempDir> {
         write_extension_fixture(repo, extension_id);
-        if !run_git(repo, &["init", "--quiet"]) || !commit_all(repo, "init") {
-            return None;
-        }
-
-        let remote_parent = TempDir::new().expect("remote parent");
-        let remote_path = remote_parent.path().join("extension.git");
-        let remote_path_str = remote_path.to_string_lossy().to_string();
-        if !run_git(
-            repo,
-            &["clone", "--bare", repo.to_str().unwrap(), &remote_path_str],
-        ) {
-            return None;
-        }
-        if !run_git(repo, &["remote", "add", "origin", &remote_path_str]) {
-            return None;
-        }
-        if !run_git(repo, &["fetch", "origin", "--quiet"]) {
-            return None;
-        }
-        let branch = if run_git(repo, &["rev-parse", "--verify", "main"]) {
-            "main"
-        } else {
-            "master"
-        };
-        if !run_git(
-            repo,
-            &[
-                "branch",
-                "--set-upstream-to",
-                &format!("origin/{branch}"),
-                branch,
-            ],
-        ) {
-            return None;
-        }
-
-        Some(remote_parent)
+        prepare_git_repo(repo)
     }
 
     fn prepare_git_extension_monorepo(repo: &Path, extension_ids: &[&str]) -> Option<TempDir> {
         for extension_id in extension_ids {
             write_extension_fixture_with_setup(repo, extension_id);
         }
+        prepare_git_repo(repo)
+    }
+
+    fn prepare_git_repo(repo: &Path) -> Option<TempDir> {
         if !run_git(repo, &["init", "--quiet"]) || !commit_all(repo, "init") {
             return None;
         }
@@ -1304,7 +1229,7 @@ exec '{}' "$@"
 
     #[cfg(unix)]
     #[test]
-    fn update_all_updates_shared_linked_git_root_once() {
+    fn test_run_setup_if_configured() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
@@ -1402,10 +1327,10 @@ exec '{}' "$@"
 
             let err = update("wordpress", false).expect_err("feature worktree update must fail");
             let message = err.to_string();
-            assert!(message.contains("Linked extension 'wordpress' points at"));
+            assert!(message.contains("Linked extensions wordpress point at"));
             assert!(message.contains("feature-linked-extension"));
             assert!(message.contains(default_branch));
-            assert!(message.contains("homeboy extension uninstall wordpress"));
+            assert!(message.contains("Relink the extensions to a stable checkout"));
 
             let branch_output = Command::new("git")
                 .args(["branch", "--show-current"])

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -1327,10 +1327,10 @@ exec '{}' "$@"
 
             let err = update("wordpress", false).expect_err("feature worktree update must fail");
             let message = err.to_string();
-            assert!(message.contains("Linked extensions wordpress point at"));
+            assert!(message.contains("Linked extension 'wordpress' points at"));
             assert!(message.contains("feature-linked-extension"));
             assert!(message.contains(default_branch));
-            assert!(message.contains("Relink the extensions to a stable checkout"));
+            assert!(message.contains("Relink the extension to a stable checkout"));
 
             let branch_output = Command::new("git")
                 .args(["branch", "--show-current"])

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -34,6 +34,13 @@ pub struct UpdateResult {
     pub path: PathBuf,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct LinkedExtensionUpdateTarget {
+    pub extension_id: String,
+    pub source_dir: PathBuf,
+    pub git_root: PathBuf,
+}
+
 pub fn slugify_id(value: &str) -> Result<String> {
     identifier::slugify_id(value, "extension_id")
 }
@@ -626,26 +633,57 @@ fn update_linked_extension(
     extension_dir: &Path,
     force: bool,
 ) -> Result<UpdateResult> {
-    // Resolve symlink to actual source directory
+    let target = linked_extension_update_target(extension_id, extension_dir)?;
+    update_linked_git_root(&target.git_root, &[extension_id.to_string()], force)?;
+    Ok(finish_linked_extension_update(&target))
+}
+
+pub(crate) fn linked_extension_update_target(
+    extension_id: &str,
+    extension_dir: &Path,
+) -> Result<LinkedExtensionUpdateTarget> {
     let source_dir = std::fs::read_link(extension_dir).map_err(|e| {
         Error::internal_io(
             e.to_string(),
             Some(format!("read symlink for {}", extension_id)),
         )
     })?;
+    let source_dir = if source_dir.is_absolute() {
+        source_dir
+    } else {
+        extension_dir
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(source_dir)
+    };
+    let source_dir = source_dir.canonicalize().unwrap_or(source_dir);
 
-    // Find the git root (source may be a subdirectory of a larger repo)
     let git_root_str = git::get_git_root(&source_dir.to_string_lossy())?;
-    let git_root = PathBuf::from(&git_root_str);
+    let git_root = PathBuf::from(&git_root_str)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(git_root_str));
 
+    Ok(LinkedExtensionUpdateTarget {
+        extension_id: extension_id.to_string(),
+        source_dir,
+        git_root,
+    })
+}
+
+pub(crate) fn update_linked_git_root(
+    git_root: &Path,
+    extension_ids: &[String],
+    force: bool,
+) -> Result<()> {
     if !force && !is_workdir_clean(&git_root) {
+        let affected = extension_ids.join(", ");
         return Err(Error::validation_invalid_argument(
             "extension_id",
             format!(
-                "Linked extension '{}' source repo has uncommitted changes. Use --force to proceed.",
-                extension_id,
+                "Linked extension source repo has uncommitted changes for {}. Use --force to proceed.",
+                affected,
             ),
-            Some(extension_id.to_string()),
+            Some(affected),
             None,
         ));
     }
@@ -664,41 +702,42 @@ fn update_linked_extension(
         })
         .unwrap_or_else(|| "DETACHED".to_string());
     if current_branch != default_branch {
+        let affected = extension_ids.join(", ");
         return Err(Error::validation_invalid_argument(
             "extension_id",
             format!(
-                "Linked extension '{}' points at {} on branch '{}', but updates require the default branch '{}'. Relink the extension to a stable checkout, for example: homeboy extension uninstall {} && homeboy extension install <{} checkout path> --id {}",
-                extension_id,
-                source_dir.display(),
+                "Linked extensions {} point at {} on branch '{}', but updates require the default branch '{}'. Relink the extensions to a stable checkout before upgrading.",
+                affected,
+                git_root.display(),
                 current_branch,
                 default_branch,
-                extension_id,
-                default_branch,
-                extension_id,
             ),
-            Some(extension_id.to_string()),
+            Some(affected),
             None,
         ));
     }
 
-    git::pull_repo(&git_root)?;
+    git::pull_repo(git_root)?;
 
-    // Auto-run setup if extension defines a setup_command
-    if let Ok(extension) = load_extension(extension_id) {
+    Ok(())
+}
+
+pub(crate) fn finish_linked_extension_update(target: &LinkedExtensionUpdateTarget) -> UpdateResult {
+    if let Ok(extension) = load_extension(&target.extension_id) {
         if extension
             .runtime()
             .is_some_and(|r| r.setup_command.is_some())
         {
-            let _ = run_setup(extension_id);
+            let _ = run_setup(&target.extension_id);
         }
     }
 
-    let url = format!("linked:{}", source_dir.display());
-    Ok(UpdateResult {
-        extension_id: extension_id.to_string(),
+    let url = format!("linked:{}", target.source_dir.display());
+    UpdateResult {
+        extension_id: target.extension_id.clone(),
         url,
-        path: source_dir,
-    })
+        path: target.source_dir.clone(),
+    }
 }
 
 /// Detect the default branch of a git repository.
@@ -875,6 +914,9 @@ mod tests {
     use std::process::Command;
     use tempfile::TempDir;
 
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     fn write_extension_fixture(root: &Path, id: &str) {
         write_extension_fixture_with_version(root, id, "1.0.0");
     }
@@ -890,6 +932,27 @@ mod tests {
   "version": "{}"
 }}"#,
                 id, version
+            ),
+        )
+        .expect("extension manifest");
+    }
+
+    fn write_extension_fixture_with_setup(root: &Path, id: &str) {
+        let dir = root.join(id);
+        fs::create_dir_all(&dir).expect("extension dir");
+        fs::write(
+            dir.join(format!("{}.json", id)),
+            format!(
+                r#"{{
+  "name": "{} extension",
+  "version": "1.0.0",
+  "executable": {{
+    "runtime": {{
+      "setup_command": "printf setup >> setup-count.txt"
+    }}
+  }}
+}}"#,
+                id
             ),
         )
         .expect("extension manifest");
@@ -981,6 +1044,72 @@ mod tests {
         }
 
         Some(remote_parent)
+    }
+
+    fn prepare_git_extension_monorepo(repo: &Path, extension_ids: &[&str]) -> Option<TempDir> {
+        for extension_id in extension_ids {
+            write_extension_fixture_with_setup(repo, extension_id);
+        }
+        if !run_git(repo, &["init", "--quiet"]) || !commit_all(repo, "init") {
+            return None;
+        }
+
+        let remote_parent = TempDir::new().expect("remote parent");
+        let remote_path = remote_parent.path().join("extension.git");
+        let remote_path_str = remote_path.to_string_lossy().to_string();
+        if !run_git(
+            repo,
+            &["clone", "--bare", repo.to_str().unwrap(), &remote_path_str],
+        ) {
+            return None;
+        }
+        if !run_git(repo, &["remote", "add", "origin", &remote_path_str]) {
+            return None;
+        }
+        if !run_git(repo, &["fetch", "origin", "--quiet"]) {
+            return None;
+        }
+        let branch = if run_git(repo, &["rev-parse", "--verify", "main"]) {
+            "main"
+        } else {
+            "master"
+        };
+        if !run_git(
+            repo,
+            &[
+                "branch",
+                "--set-upstream-to",
+                &format!("origin/{branch}"),
+                branch,
+            ],
+        ) {
+            return None;
+        }
+
+        Some(remote_parent)
+    }
+
+    #[cfg(unix)]
+    fn write_git_wrapper(bin_dir: &Path, pull_count_file: &Path) {
+        fs::create_dir_all(bin_dir).expect("wrapper bin dir");
+        let real_git = Command::new("sh")
+            .args(["-c", "command -v git"])
+            .output()
+            .expect("locate git");
+        let real_git = String::from_utf8_lossy(&real_git.stdout).trim().to_string();
+        let script = format!(
+            r#"#!/bin/sh
+if [ "$1" = "pull" ]; then
+  printf x >> '{}'
+fi
+exec '{}' "$@"
+"#,
+            pull_count_file.display(),
+            real_git
+        );
+        let wrapper = bin_dir.join("git");
+        fs::write(&wrapper, script).expect("git wrapper");
+        fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755)).expect("wrapper perms");
     }
 
     #[test]
@@ -1169,6 +1298,66 @@ mod tests {
             assert!(
                 result.skipped.is_empty(),
                 "linked extensions should not be pre-skipped by update_all"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_all_updates_shared_linked_git_root_once() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let _remote = match prepare_git_extension_monorepo(&source, &["nodejs", "rust"]) {
+                Some(remote) => remote,
+                None => return,
+            };
+
+            install(&source.join("nodejs").to_string_lossy(), Some("nodejs"))
+                .expect("install linked nodejs extension");
+            install(&source.join("rust").to_string_lossy(), Some("rust"))
+                .expect("install linked rust extension");
+
+            let bin_dir = home.join("bin");
+            let pull_count_file = home.join("pull-count");
+            write_git_wrapper(&bin_dir, &pull_count_file);
+            let old_path = std::env::var("PATH").unwrap_or_default();
+            std::env::set_var("PATH", format!("{}:{}", bin_dir.display(), old_path));
+
+            let result = update_all(false);
+
+            std::env::set_var("PATH", old_path);
+
+            let updated_ids = result
+                .updated
+                .iter()
+                .map(|entry| entry.extension_id.as_str())
+                .collect::<Vec<_>>();
+            assert_eq!(updated_ids, vec!["nodejs", "rust"]);
+            assert!(result.skipped.is_empty());
+            assert_eq!(
+                fs::read_to_string(&pull_count_file)
+                    .unwrap_or_default()
+                    .len(),
+                1,
+                "linked extensions sharing one git root should run one git pull"
+            );
+            assert_eq!(
+                fs::read_to_string(source.join("nodejs/setup-count.txt"))
+                    .unwrap_or_default()
+                    .matches("setup")
+                    .count(),
+                1,
+                "nodejs setup should still run after the shared root update"
+            );
+            assert_eq!(
+                fs::read_to_string(source.join("rust/setup-count.txt"))
+                    .unwrap_or_default()
+                    .matches("setup")
+                    .count(),
+                1,
+                "rust setup should still run after the shared root update"
             );
         });
     }

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -272,48 +272,37 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
         extension_ids.len()
     );
 
-    let result = extension::update_all(false);
-    let updated = result
-        .updated
-        .into_iter()
-        .map(|entry| {
-            if entry.old_version != entry.new_version {
-                log_status!(
-                    "upgrade",
-                    "  {} {} → {}",
-                    entry.extension_id,
-                    entry.old_version,
-                    entry.new_version
-                );
-            } else {
-                log_status!(
-                    "upgrade",
-                    "  {} {} (up to date)",
-                    entry.extension_id,
-                    entry.new_version
-                );
-            }
+    let mut updated = Vec::new();
+    let mut skipped = Vec::new();
 
-            ExtensionUpgradeEntry {
-                extension_id: entry.extension_id,
-                old_version: entry.old_version,
-                new_version: entry.new_version,
-            }
-        })
-        .collect::<Vec<_>>();
+    for id in &extension_ids {
+        let old_version = extension::load_extension(id)
+            .ok()
+            .map(|m| m.version.clone())
+            .unwrap_or_default();
 
-    let skipped = result.skipped;
-    for id in &skipped {
-        if let Ok(extension_dir) = crate::paths::extension(id) {
-            if crate::extension::is_extension_linked(id) {
-                log_status!(
-                    "upgrade",
-                    "  {} skipped: linked source repo update failed for {}",
-                    id,
-                    extension_dir.display()
-                );
-            } else {
-                log_status!("upgrade", "  {} skipped: update failed", id);
+        match extension::update(id, false) {
+            Ok(_) => {
+                let new_version = extension::load_extension(id)
+                    .ok()
+                    .map(|m| m.version.clone())
+                    .unwrap_or_default();
+
+                if old_version != new_version {
+                    log_status!("upgrade", "  {} {} → {}", id, old_version, new_version);
+                } else {
+                    log_status!("upgrade", "  {} {} (up to date)", id, new_version);
+                }
+
+                updated.push(ExtensionUpgradeEntry {
+                    extension_id: id.clone(),
+                    old_version,
+                    new_version,
+                });
+            }
+            Err(e) => {
+                log_status!("upgrade", "  {} skipped: {}", id, e.message);
+                skipped.push(id.clone());
             }
         }
     }

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -272,37 +272,48 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
         extension_ids.len()
     );
 
-    let mut updated = Vec::new();
-    let mut skipped = Vec::new();
-
-    for id in &extension_ids {
-        let old_version = extension::load_extension(id)
-            .ok()
-            .map(|m| m.version.clone())
-            .unwrap_or_default();
-
-        match extension::update(id, false) {
-            Ok(_) => {
-                let new_version = extension::load_extension(id)
-                    .ok()
-                    .map(|m| m.version.clone())
-                    .unwrap_or_default();
-
-                if old_version != new_version {
-                    log_status!("upgrade", "  {} {} → {}", id, old_version, new_version);
-                } else {
-                    log_status!("upgrade", "  {} {} (up to date)", id, new_version);
-                }
-
-                updated.push(ExtensionUpgradeEntry {
-                    extension_id: id.clone(),
-                    old_version,
-                    new_version,
-                });
+    let result = extension::update_all(false);
+    let updated = result
+        .updated
+        .into_iter()
+        .map(|entry| {
+            if entry.old_version != entry.new_version {
+                log_status!(
+                    "upgrade",
+                    "  {} {} → {}",
+                    entry.extension_id,
+                    entry.old_version,
+                    entry.new_version
+                );
+            } else {
+                log_status!(
+                    "upgrade",
+                    "  {} {} (up to date)",
+                    entry.extension_id,
+                    entry.new_version
+                );
             }
-            Err(e) => {
-                log_status!("upgrade", "  {} skipped: {}", id, e.message);
-                skipped.push(id.clone());
+
+            ExtensionUpgradeEntry {
+                extension_id: entry.extension_id,
+                old_version: entry.old_version,
+                new_version: entry.new_version,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let skipped = result.skipped;
+    for id in &skipped {
+        if let Ok(extension_dir) = crate::paths::extension(id) {
+            if crate::extension::is_extension_linked(id) {
+                log_status!(
+                    "upgrade",
+                    "  {} skipped: linked source repo update failed for {}",
+                    id,
+                    extension_dir.display()
+                );
+            } else {
+                log_status!("upgrade", "  {} skipped: update failed", id);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Group linked extension updates by canonical git root so monorepo-backed extensions share one checkout/pull operation.
- Preserve per-extension manifest reloads, version/source revision reporting, setup execution, and skipped entries when a shared root update fails.
- Add coverage for multiple linked extensions under one monorepo root with a single `git pull`.

Fixes #2104

## Tests
- `cargo fmt --check`
- `cargo test -q update_all_updates_shared_linked_git_root_once`
- `cargo test -q update_all_updates_linked_extensions_through_single_update_path`
- `cargo test -q update_all`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation and tests under Chris review.