### PR TITLE
Persist audit findings in observations

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -6,7 +6,9 @@ use homeboy::code_audit::{
 };
 use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::git::short_head_revision_at;
-use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
+use homeboy::observation::{
+    finding_records_from_audit, NewRunRecord, ObservationStore, RunRecord, RunStatus,
+};
 
 use super::utils::args::{BaselineArgs, PositionalComponentArgs};
 use super::{CmdResult, GlobalArgs};
@@ -182,6 +184,8 @@ fn finish_audit_observation(
             "summary": audit_observation_summary(&workflow.output),
         }),
     );
+    let records = finding_records_from_audit(&observation.audit_run.id, &workflow.findings);
+    let _ = observation.store.record_findings(&records);
     let status = if workflow.exit_code == 0 {
         RunStatus::Pass
     } else {
@@ -515,6 +519,72 @@ mod tests {
             assert_eq!(run.component_id.as_deref(), Some("homeboy"));
             assert_eq!(run.metadata_json["changed_since"], "origin/main");
             assert_eq!(run.metadata_json["observation_status"], "error");
+        });
+    }
+
+    #[test]
+    fn audit_observation_finish_persists_findings() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let args = sample_args();
+            let observation =
+                start_audit_observation("homeboy", &home.path().to_string_lossy(), &args)
+                    .expect("observation should start");
+            let run_id = observation.audit_run.id.clone();
+            let finding = code_audit::Finding {
+                convention: "command modules".to_string(),
+                severity: code_audit::Severity::Warning,
+                file: "src/commands/foo.rs".to_string(),
+                description: "Missing run function".to_string(),
+                suggestion: "Add run()".to_string(),
+                kind: code_audit::AuditFinding::MissingMethod,
+            };
+            let workflow = code_audit::AuditRunWorkflowResult {
+                output: AuditCommandOutput::Full {
+                    passed: false,
+                    result: code_audit::CodeAuditResult {
+                        component_id: "homeboy".to_string(),
+                        source_path: home.path().to_string_lossy().to_string(),
+                        summary: code_audit::AuditSummary {
+                            files_scanned: 1,
+                            conventions_detected: 1,
+                            outliers_found: 1,
+                            alignment_score: Some(0.5),
+                            files_skipped: 0,
+                            warnings: vec![],
+                        },
+                        conventions: vec![],
+                        directory_conventions: vec![],
+                        findings: vec![finding.clone()],
+                        duplicate_groups: vec![],
+                    },
+                    fixability: None,
+                },
+                exit_code: 1,
+                findings: vec![finding],
+            };
+
+            finish_audit_observation(Some(observation), &workflow);
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let findings = store
+                .list_findings(homeboy::observation::FindingListFilter {
+                    run_id: Some(run_id),
+                    tool: Some("audit".to_string()),
+                    ..homeboy::observation::FindingListFilter::default()
+                })
+                .expect("list findings");
+
+            assert_eq!(findings.len(), 1);
+            assert_eq!(findings[0].rule.as_deref(), Some("missing_method"));
+            assert_eq!(
+                findings[0].fingerprint.as_deref(),
+                Some("src/commands/foo.rs:missing_method:command modules:Missing run function")
+            );
+            assert_eq!(
+                findings[0].metadata_json["source_sidecar"],
+                "audit-findings"
+            );
         });
     }
 

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -33,6 +33,7 @@ pub struct AuditRunWorkflowArgs {
 pub struct AuditRunWorkflowResult {
     pub output: AuditCommandOutput,
     pub exit_code: i32,
+    pub findings: Vec<code_audit::Finding>,
 }
 
 /// Run the main audit workflow.
@@ -68,6 +69,7 @@ pub fn run_main_audit_workflow(
                     fixability: None,
                 },
                 exit_code: 0,
+                findings: Vec::new(),
             });
         }
     };
@@ -81,6 +83,7 @@ pub fn run_main_audit_workflow(
                 directory_conventions: result.directory_conventions,
             },
             exit_code: 0,
+            findings: Vec::new(),
         });
     }
 
@@ -205,6 +208,7 @@ fn run_baseline_save(
     result: CodeAuditResult,
     args: &AuditRunWorkflowArgs,
 ) -> crate::Result<AuditRunWorkflowResult> {
+    let findings = result.findings.clone();
     let saved = if let Some(ref git_ref) = args.changed_since {
         let changed = git::get_files_changed_since(&args.source_path, git_ref)?;
         if changed.is_empty() {
@@ -253,6 +257,7 @@ fn run_baseline_save(
             alignment_score: baseline_data.metadata.alignment_score,
         },
         exit_code: 0,
+        findings,
     })
 }
 
@@ -289,14 +294,17 @@ fn run_comparison_workflow(
     };
 
     if args.json_summary {
+        let findings = result.findings.clone();
         let mut summary = report::build_audit_summary(&result, exit_code);
         summary.fixability = compute_fixability_if_requested(&result, args);
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
             exit_code,
+            findings,
         })
     } else {
         let fixability = compute_fixability_if_requested(&result, args);
+        let findings = result.findings.clone();
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Full {
                 passed: exit_code == 0,
@@ -304,6 +312,7 @@ fn run_comparison_workflow(
                 fixability,
             },
             exit_code,
+            findings,
         })
     }
 }
@@ -351,15 +360,18 @@ fn build_comparison_output(
     }
 
     if args.json_summary {
+        let findings = result.findings.clone();
         let mut summary = report::build_audit_summary(&result, exit_code);
         summary.fixability = compute_fixability_if_requested(&result, args);
         summary.changed_since = changed_since_summary;
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
             exit_code,
+            findings,
         })
     } else {
         let fixability = compute_fixability_if_requested(&result, args);
+        let findings = result.findings.clone();
 
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Compared {
@@ -371,6 +383,7 @@ fn build_comparison_output(
                 fixability,
             },
             exit_code,
+            findings,
         })
     }
 }

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -47,8 +47,8 @@ pub fn run_main_audit_workflow(
     let mut result = match result {
         Some(r) => r,
         None => {
-            return Ok(AuditRunWorkflowResult {
-                output: AuditCommandOutput::Full {
+            return Ok(audit_run_workflow_result(
+                AuditCommandOutput::Full {
                     passed: true,
                     result: CodeAuditResult {
                         component_id: args.component_id,
@@ -68,23 +68,24 @@ pub fn run_main_audit_workflow(
                     },
                     fixability: None,
                 },
-                exit_code: 0,
-                findings: Vec::new(),
-            });
+                0,
+                Vec::new(),
+            ));
         }
     };
 
     // --conventions: just show conventions
     if args.conventions {
-        return Ok(AuditRunWorkflowResult {
-            output: AuditCommandOutput::Conventions {
+        let findings = Vec::new();
+        return Ok(audit_run_workflow_result(
+            AuditCommandOutput::Conventions {
                 component_id: result.component_id,
                 conventions: result.conventions,
                 directory_conventions: result.directory_conventions,
             },
-            exit_code: 0,
-            findings: Vec::new(),
-        });
+            0,
+            findings,
+        ));
     }
 
     // --baseline: save current state. Saved baselines record the *full* finding
@@ -107,6 +108,18 @@ pub fn run_main_audit_workflow(
 
     // Default: compare against baseline or return full result
     run_comparison_workflow(result, &args)
+}
+
+fn audit_run_workflow_result(
+    output: AuditCommandOutput,
+    exit_code: i32,
+    findings: Vec<code_audit::Finding>,
+) -> AuditRunWorkflowResult {
+    AuditRunWorkflowResult {
+        output,
+        exit_code,
+        findings,
+    }
 }
 
 /// Filter `result.findings` by kind allow/deny lists and refresh

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -8,10 +8,10 @@ pub mod records;
 pub mod store;
 
 pub use records::{
-    finding_record_from_annotation, finding_record_from_lint, finding_records_from_annotation_file,
-    finding_records_from_annotations_dir, finding_records_from_lint, AnnotationFindingRecord,
-    ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
-    NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
-    TraceSpanRecord,
+    finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
+    finding_records_from_annotation_file, finding_records_from_annotations_dir,
+    finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
+    FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord,
+    NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
+use crate::code_audit::{self, report::finding_kind_key};
 use crate::extension::lint::LintFinding;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -159,6 +160,56 @@ pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<
         .iter()
         .map(|finding| finding_record_from_lint(run_id, finding))
         .collect()
+}
+
+pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
+    let kind = finding_kind_key(&finding.kind);
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: "audit".to_string(),
+        rule: Some(kind.clone()),
+        file: Some(finding.file.clone()),
+        line: None,
+        severity: Some(audit_severity_key(&finding.severity)),
+        fingerprint: Some(audit_finding_fingerprint(finding)),
+        message: finding.description.clone(),
+        fixable: None,
+        metadata_json: serde_json::json!({
+            "source_sidecar": "audit-findings",
+            "convention": finding.convention,
+            "suggestion": finding.suggestion,
+            "confidence": finding.kind.confidence(),
+            "kind": kind,
+            "raw": finding,
+        }),
+    }
+}
+
+pub fn finding_records_from_audit(
+    run_id: &str,
+    findings: &[code_audit::Finding],
+) -> Vec<NewFindingRecord> {
+    findings
+        .iter()
+        .map(|finding| finding_record_from_audit(run_id, finding))
+        .collect()
+}
+
+fn audit_finding_fingerprint(finding: &code_audit::Finding) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        finding.file,
+        finding_kind_key(&finding.kind),
+        finding.convention,
+        finding.description
+    )
+}
+
+fn audit_severity_key(severity: &code_audit::Severity) -> String {
+    serde_json::to_value(severity)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{severity:?}").to_lowercase())
 }
 
 pub fn finding_records_from_annotations_dir(
@@ -405,6 +456,32 @@ mod tests {
         assert_eq!(records[0].tool, "phpcs");
         assert_eq!(records[1].fingerprint.as_deref(), Some("two"));
         assert_eq!(records[1].tool, "lint");
+    }
+
+    #[test]
+    fn test_finding_record_from_audit() {
+        let finding = code_audit::Finding {
+            convention: "command modules".to_string(),
+            severity: code_audit::Severity::Warning,
+            file: "src/commands/foo.rs".to_string(),
+            description: "Missing run function".to_string(),
+            suggestion: "Add run()".to_string(),
+            kind: code_audit::AuditFinding::MissingMethod,
+        };
+
+        let first = finding_record_from_audit("run-1", &finding);
+        let second = finding_record_from_audit("run-2", &finding);
+
+        assert_eq!(first.run_id, "run-1");
+        assert_eq!(first.tool, "audit");
+        assert_eq!(first.rule.as_deref(), Some("missing_method"));
+        assert_eq!(first.file.as_deref(), Some("src/commands/foo.rs"));
+        assert_eq!(first.severity.as_deref(), Some("warning"));
+        assert_eq!(first.message, "Missing run function");
+        assert_eq!(first.fingerprint, second.fingerprint);
+        assert_eq!(first.metadata_json["source_sidecar"], "audit-findings");
+        assert_eq!(first.metadata_json["convention"], "command modules");
+        assert_eq!(first.metadata_json["kind"], "missing_method");
     }
 
     #[test]

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -460,28 +460,31 @@ mod tests {
 
     #[test]
     fn test_finding_record_from_audit() {
-        let finding = code_audit::Finding {
-            convention: "command modules".to_string(),
-            severity: code_audit::Severity::Warning,
-            file: "src/commands/foo.rs".to_string(),
-            description: "Missing run function".to_string(),
-            suggestion: "Add run()".to_string(),
-            kind: code_audit::AuditFinding::MissingMethod,
-        };
+        let finding = audit_finding();
 
-        let first = finding_record_from_audit("run-1", &finding);
-        let second = finding_record_from_audit("run-2", &finding);
+        let record = finding_record_from_audit("run-1", &finding);
 
-        assert_eq!(first.run_id, "run-1");
-        assert_eq!(first.tool, "audit");
-        assert_eq!(first.rule.as_deref(), Some("missing_method"));
-        assert_eq!(first.file.as_deref(), Some("src/commands/foo.rs"));
-        assert_eq!(first.severity.as_deref(), Some("warning"));
-        assert_eq!(first.message, "Missing run function");
-        assert_eq!(first.fingerprint, second.fingerprint);
-        assert_eq!(first.metadata_json["source_sidecar"], "audit-findings");
-        assert_eq!(first.metadata_json["convention"], "command modules");
-        assert_eq!(first.metadata_json["kind"], "missing_method");
+        assert_eq!(record.run_id, "run-1");
+        assert_eq!(record.tool, "audit");
+        assert_eq!(record.rule.as_deref(), Some("missing_method"));
+        assert_eq!(record.file.as_deref(), Some("src/commands/foo.rs"));
+        assert_eq!(record.severity.as_deref(), Some("warning"));
+        assert_eq!(record.message, "Missing run function");
+        assert_eq!(record.metadata_json["source_sidecar"], "audit-findings");
+        assert_eq!(record.metadata_json["convention"], "command modules");
+        assert_eq!(record.metadata_json["kind"], "missing_method");
+    }
+
+    #[test]
+    fn test_finding_records_from_audit() {
+        let finding = audit_finding();
+
+        let first = finding_records_from_audit("run-1", std::slice::from_ref(&finding));
+        let second = finding_records_from_audit("run-2", &[finding]);
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_eq!(first[0].fingerprint, second[0].fingerprint);
     }
 
     #[test]
@@ -583,6 +586,17 @@ mod tests {
             file: Some("src/lib.rs".to_string()),
             severity: Some("error".to_string()),
             extra: BTreeMap::new(),
+        }
+    }
+
+    fn audit_finding() -> code_audit::Finding {
+        code_audit::Finding {
+            convention: "command modules".to_string(),
+            severity: code_audit::Severity::Warning,
+            file: "src/commands/foo.rs".to_string(),
+            description: "Missing run function".to_string(),
+            suggestion: "Add run()".to_string(),
+            kind: code_audit::AuditFinding::MissingMethod,
         }
     }
 

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -291,6 +291,7 @@ fn test_from_main_workflow() {
     let (output, exit_code) = from_main_workflow(crate::code_audit::run::AuditRunWorkflowResult {
         output,
         exit_code: 3,
+        findings: Vec::new(),
     });
 
     assert_eq!(exit_code, 3);


### PR DESCRIPTION
## Summary
- Persist normalized `homeboy audit` findings into the observation store's queryable findings table.
- Carry audit findings through summary output paths so `--json-summary` runs can still persist full finding records.
- Add coverage for audit finding normalization, stable fingerprints, and audit observation persistence.

Fixes #2043

## Tests
- `cargo test commands::audit::tests::audit_observation_finish_persists_findings`
- `cargo test core::observation::records::tests::test_finding_record_from_audit`
- `cargo test core::code_audit::report::report_test::test_from_main_workflow`
- `cargo test commands::audit::tests`
- `cargo test core::observation::records::tests`
- `cargo check`
- `git diff --check`
- `XDG_DATA_HOME=\"$PWD/target/tmp-observation-check\" target/debug/homeboy audit homeboy --only=missing-method --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the focused implementation; Chris remains responsible for review and final validation.