### PR TITLE
Surface trace overlay touched files

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -113,7 +113,10 @@ pub fn run_markdown(args: TraceArgs, global: &GlobalArgs) -> CmdResult<String> {
             let Some(results) = run_output.results else {
                 return Ok(("# Trace\n\nNo trace results were produced.\n".to_string(), exit_code));
             };
-            Ok((extension_trace::render_markdown(&results), exit_code))
+            Ok((
+                extension_trace::render_markdown(&results, &run_output.overlays),
+                exit_code,
+            ))
         }
         TraceCommandOutput::Summary(summary) => Ok((
             format!(
@@ -377,6 +380,7 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     let repeat = args.repeat;
     let scenario_id = args.scenario.clone();
     let mut runs = Vec::new();
+    let mut overlays = Vec::new();
     let mut span_samples: BTreeMap<String, Vec<TraceAggregateSpanSample>> = BTreeMap::new();
     let mut span_failures: BTreeMap<String, usize> = BTreeMap::new();
     let mut all_span_ids: BTreeSet<String> = cli_span_definitions_for_args(&args)?
@@ -397,6 +401,9 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
                 }
                 if component.is_none() {
                     component = Some(execution.workflow.component.clone());
+                }
+                if overlays.is_empty() && !execution.workflow.overlays.is_empty() {
+                    overlays = execution.workflow.overlays.clone();
                 }
                 let passed =
                     execution.workflow.exit_code == 0 && execution.workflow.status == "pass";
@@ -504,6 +511,7 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         failure_count,
         exit_code,
         rig_state,
+        overlays,
         runs,
         spans,
     };

--- a/src/commands/trace/output.rs
+++ b/src/commands/trace/output.rs
@@ -256,6 +256,7 @@ pub(super) fn render_aggregate_markdown(
     out.push_str(&format!("- **Status:** `{}`\n", aggregate.status));
     out.push_str(&format!("- **Runs:** `{}`\n", aggregate.run_count));
     out.push_str(&format!("- **Failures:** `{}`\n", aggregate.failure_count));
+    extension_trace::push_overlay_markdown(&mut out, &aggregate.overlays);
 
     if !aggregate.spans.is_empty() {
         out.push_str("\n## Spans\n\n");

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::process::Command;
 
 use crate::test_support::with_isolated_home;
 
@@ -400,6 +401,79 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
                     .runs
                     .iter()
                     .all(|run| std::path::Path::new(&run.artifact_path).is_file()));
+            }
+            _ => panic!("expected aggregate output"),
+        }
+    });
+}
+
+#[test]
+fn trace_repeat_reports_overlay_touched_files_at_top_level() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::without_xdg_data_home();
+        write_trace_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        init_overlay_component(component_dir.path());
+        let patch_path = component_dir.path().join("overlay.patch");
+        fs::write(
+            &patch_path,
+            r#"diff --git a/scenario.txt b/scenario.txt
+--- a/scenario.txt
++++ b/scenario.txt
+@@ -1 +1 @@
+-base
++overlay
+"#,
+        )
+        .expect("write patch");
+        write_trace_rig(home, "studio-rig", "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("studio".to_string()),
+                    path: None,
+                },
+                scenario: "studio-app-create-site".to_string(),
+                compare_after: None,
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                report: None,
+                repeat: 2,
+                aggregate: Some("spans".to_string()),
+                spans: Vec::new(),
+                phases: Vec::new(),
+                phase_preset: None,
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                overlays: vec![patch_path.to_string_lossy().to_string()],
+                keep_overlay: false,
+            },
+            &GlobalArgs {},
+        )
+        .expect("repeat trace should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            TraceCommandOutput::Aggregate(aggregate) => {
+                assert_eq!(aggregate.overlays.len(), 1);
+                let component_path = component_dir.path().to_string_lossy();
+                assert_eq!(
+                    aggregate.overlays[0].component_path,
+                    component_path.as_ref()
+                );
+                assert_eq!(aggregate.overlays[0].touched_files, vec!["scenario.txt"]);
+                assert!(!aggregate.overlays[0].kept);
+                let value = serde_json::to_value(&aggregate).expect("aggregate serializes");
+                assert_eq!(
+                    value["overlays"][0]["component_path"],
+                    component_path.as_ref()
+                );
+                assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
             }
             _ => panic!("expected aggregate output"),
         }
@@ -829,6 +903,7 @@ fn aggregate_markdown_includes_percentile_columns() {
         failure_count: 0,
         exit_code: 0,
         rig_state: None,
+        overlays: Vec::new(),
         runs: Vec::new(),
         spans: vec![aggregate_span(
             "boot_to_ready".to_string(),
@@ -1006,6 +1081,38 @@ printf 'trace log\n' > "$HOMEBOY_TRACE_ARTIFACT_DIR/trace-log.txt"
         permissions.set_mode(0o755);
         fs::set_permissions(&script_path, permissions).expect("chmod script");
     }
+}
+
+fn init_overlay_component(path: &std::path::Path) {
+    fs::write(path.join("scenario.txt"), "base\n").expect("write scenario");
+    run_git(path, &["init"]);
+    run_git(path, &["add", "scenario.txt"]);
+    run_git(
+        path,
+        &[
+            "-c",
+            "user.name=Homeboy Test",
+            "-c",
+            "user.email=homeboy@example.test",
+            "commit",
+            "-m",
+            "initial",
+        ],
+    );
+}
+
+fn run_git(path: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn write_trace_rig(

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -22,12 +22,12 @@ pub use parsing::{
     TraceArtifact, TraceAssertion, TraceEvent, TraceList, TraceScenario, TraceStatus,
 };
 pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, TraceSpanResult};
-pub use report::render_markdown;
 pub use report::{
     from_list_workflow, from_main_workflow, from_main_workflow_outputs, TraceAggregateOutput,
     TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceCommandOutput, TraceCompareOutput,
     TraceCompareSpanOutput,
 };
+pub use report::{push_overlay_markdown, render_markdown};
 pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};
 pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult};
 

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -85,6 +85,8 @@ pub struct TraceAggregateOutput {
     pub exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_state: Option<RigStateSnapshot>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlays: Vec<TraceOverlay>,
     pub runs: Vec<TraceAggregateRunOutput>,
     pub spans: Vec<TraceAggregateSpanOutput>,
 }
@@ -253,7 +255,7 @@ fn from_run_workflow_result(
     }))
 }
 
-pub fn render_markdown(results: &TraceResults) -> String {
+pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> String {
     let mut out = String::new();
     out.push_str(&format!("# Trace: `{}`\n\n", results.scenario_id));
     out.push_str(&format!("- **Component:** `{}`\n", results.component_id));
@@ -264,6 +266,8 @@ pub fn render_markdown(results: &TraceResults) -> String {
     if let Some(failure) = &results.failure {
         out.push_str(&format!("- **Failure:** {}\n", failure));
     }
+
+    push_overlay_markdown(&mut out, overlays);
 
     if !results.span_results.is_empty() {
         out.push_str("\n## Spans\n\n");
@@ -324,6 +328,30 @@ pub fn render_markdown(results: &TraceResults) -> String {
     }
 
     out
+}
+
+pub fn push_overlay_markdown(out: &mut String, overlays: &[TraceOverlay]) {
+    if overlays.is_empty() {
+        return;
+    }
+
+    out.push_str("\n## Trace Overlays\n\n");
+    for overlay in overlays {
+        let status = if overlay.kept { "kept" } else { "reverted" };
+        out.push_str(&format!("- **Patch:** `{}` (`{}`)\n", overlay.path, status));
+        out.push_str(&format!(
+            "  - Applied relative to: `{}`\n",
+            overlay.component_path
+        ));
+        if overlay.touched_files.is_empty() {
+            out.push_str("  - Touched files: none reported by `git apply --numstat`\n");
+        } else {
+            out.push_str("  - Touched files:\n");
+            for file in &overlay.touched_files {
+                out.push_str(&format!("    - `{}`\n", file));
+            }
+        }
+    }
 }
 
 pub fn from_list_workflow(component: String, list: TraceList) -> (TraceCommandOutput, i32) {
@@ -397,6 +425,7 @@ mod tests {
             failure: None,
             overlays: vec![TraceOverlay {
                 path: "/tmp/overlay.patch".to_string(),
+                component_path: "/tmp/studio".to_string(),
                 touched_files: vec!["scenario.txt".to_string()],
                 kept: false,
             }],
@@ -414,6 +443,7 @@ mod tests {
         assert_eq!(value["artifact_count"], 1);
         assert_eq!(value["span_count"], 0);
         assert_eq!(value["overlays"][0]["path"], "/tmp/overlay.patch");
+        assert_eq!(value["overlays"][0]["component_path"], "/tmp/studio");
         assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
         assert_eq!(value["overlays"][0]["kept"], false);
     }
@@ -501,9 +531,19 @@ mod tests {
             artifacts: Vec::new(),
         };
 
-        let markdown = render_markdown(&results);
+        let overlays = vec![TraceOverlay {
+            path: "/tmp/overlay.patch".to_string(),
+            component_path: "/tmp/studio".to_string(),
+            touched_files: vec!["apps/studio/out/app.js".to_string()],
+            kept: false,
+        }];
+        let markdown = render_markdown(&results, &overlays);
 
         assert!(markdown.contains("# Trace: `create-site`"));
+        assert!(markdown.contains("## Trace Overlays"));
+        assert!(markdown.contains("- **Patch:** `/tmp/overlay.patch` (`reverted`)"));
+        assert!(markdown.contains("- Applied relative to: `/tmp/studio`"));
+        assert!(markdown.contains("- `apps/studio/out/app.js`"));
         assert!(markdown.contains("| `submit_to_cli` | `ui.submit` | `cli.start` | 42ms | ok |"));
     }
 }

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -69,6 +69,7 @@ pub struct TraceRunWorkflowResult {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TraceOverlay {
     pub path: String,
+    pub component_path: String,
     pub touched_files: Vec<String>,
     pub kept: bool,
 }
@@ -225,6 +226,7 @@ fn run_trace_workflow_with_context(
             .into_iter()
             .map(|overlay| TraceOverlay {
                 path: overlay.patch_path.to_string_lossy().to_string(),
+                component_path: overlay.component_path.to_string_lossy().to_string(),
                 touched_files: overlay.touched_files,
                 kept: overlay.keep,
             })
@@ -403,6 +405,7 @@ fn apply_trace_overlays(
         if let Err(error) = run_git_apply(&component_path, &patch_path, false) {
             return cleanup_after_overlay_error(&applied, keep, error);
         }
+        print_trace_overlay("applied", &patch_path, &touched_files, keep);
         applied.push(AppliedTraceOverlay {
             component_path: component_path.clone(),
             patch_path,
@@ -427,8 +430,34 @@ fn cleanup_after_overlay_error<T>(
 fn cleanup_trace_overlays(applied: &[AppliedTraceOverlay]) -> Result<()> {
     for overlay in applied.iter().rev() {
         run_git_apply(&overlay.component_path, &overlay.patch_path, true)?;
+        print_trace_overlay(
+            "reverted",
+            &overlay.patch_path,
+            &overlay.touched_files,
+            overlay.keep,
+        );
     }
     Ok(())
+}
+
+fn print_trace_overlay(action: &str, patch_path: &Path, touched_files: &[String], keep: bool) {
+    eprintln!("trace overlay {action}: {}", patch_path.display());
+    let retention = if action == "reverted" {
+        "overlay changes reverted"
+    } else if keep {
+        "overlay changes will be kept"
+    } else {
+        "overlay changes will be reverted after the run"
+    };
+    eprintln!("  status: {retention}");
+    if touched_files.is_empty() {
+        eprintln!("  touched files: none reported by git apply --numstat");
+        return;
+    }
+    eprintln!("  touched files:");
+    for file in touched_files {
+        eprintln!("    - {file}");
+    }
 }
 
 fn overlay_touched_files(component_path: &Path, patch_path: &Path) -> Result<Vec<String>> {


### PR DESCRIPTION
## Summary
- Print trace overlay patch paths, touched files, and keep/revert status when overlays are applied or reverted.
- Include overlay metadata, including the component path the patch was applied relative to, in single-run and aggregate JSON output.
- Render trace overlay details near the top of Markdown trace reports and aggregate reports.

Fixes #2112.

## Testing
- `cargo test trace::`
- `cargo test --lib -- --test-threads=1`

## Caveats
- `cargo test` in the default parallel mode exposed existing global-state-sensitive failures in unrelated tests (`HOME`/`PATH` collisions). The failed trace tests passed when rerun individually, and the serial library suite passed.
- Homeboy still only reports what it can verify from the overlay patch and resolved component path; it does not claim to know which files the traced runtime loaded.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused trace overlay visibility implementation, tests, and PR description; Chris remains responsible for review and validation.