### PR TITLE
Add latest observation query helpers

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -8,7 +8,9 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::observation::{
+    ArtifactRecord, FindingRecord, ObservationStore, RunListFilter, RunRecord,
+};
 use homeboy::Error;
 
 use super::{CmdResult, GlobalArgs};
@@ -31,6 +33,8 @@ pub struct RunsArgs {
 enum RunsCommand {
     /// List persisted observation runs
     List(RunsListArgs),
+    /// Show the latest persisted observation run matching filters
+    LatestRun(RunsLatestRunArgs),
     /// Mark orphaned running observation records stale
     Reconcile(RunsReconcileArgs),
     /// Show one persisted observation run
@@ -41,6 +45,8 @@ enum RunsCommand {
     Findings(findings::RunsFindingsArgs),
     /// Show one recorded finding
     Finding { finding_id: String },
+    /// Show the latest finding from the latest run matching filters
+    LatestFinding(findings::RunsLatestFindingArgs),
     /// Export observation records as an inspectable directory bundle
     Export(RunsExportArgs),
     /// Import an observation bundle into the local observation store
@@ -66,14 +72,32 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
+#[derive(Args, Clone, Default)]
+pub struct RunsLatestRunArgs {
+    /// Run kind: bench, rig, trace, etc.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Component ID
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Run status
+    #[arg(long)]
+    pub status: Option<String>,
+}
+
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
     List(RunsListOutput),
+    LatestRun(RunsLatestRunOutput),
     Show(RunsShowOutput),
     Artifacts(RunsArtifactsOutput),
     Findings(RunsFindingsOutput),
     Finding(RunsFindingOutput),
+    LatestFinding(RunsLatestFindingOutput),
     BenchHistory(BenchHistoryOutput),
     BenchCompare(BenchCompareOutput),
     Reconcile(RunsReconcileOutput),
@@ -91,6 +115,19 @@ pub struct RunsListOutput {
 pub struct RunsShowOutput {
     pub command: &'static str,
     pub run: RunDetail,
+}
+
+#[derive(Serialize)]
+pub struct RunsLatestRunOutput {
+    pub command: &'static str,
+    pub run: RunSummary,
+}
+
+#[derive(Serialize)]
+pub struct RunsLatestFindingOutput {
+    pub command: &'static str,
+    pub run: RunSummary,
+    pub finding: FindingRecord,
 }
 
 #[derive(Serialize)]
@@ -182,14 +219,29 @@ pub struct BenchMissingMetric {
 pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
     match args.command {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
+        RunsCommand::LatestRun(args) => latest_run(args),
         RunsCommand::Reconcile(args) => reconcile_runs(args),
         RunsCommand::Show { run_id } => show_run(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
         RunsCommand::Findings(args) => findings::findings(args),
         RunsCommand::Finding { finding_id } => findings::finding(&finding_id),
+        RunsCommand::LatestFinding(args) => findings::latest_finding(args),
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
     }
+}
+
+pub fn latest_run(args: RunsLatestRunArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let run = require_latest_run(&store, run_filter_from_latest_args(args))?;
+
+    Ok((
+        RunsOutput::LatestRun(RunsLatestRunOutput {
+            command: "runs.latest-run",
+            run: run_summary(run),
+        }),
+        0,
+    ))
 }
 
 pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOutput> {
@@ -219,6 +271,30 @@ fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+pub(crate) fn require_latest_run(
+    store: &ObservationStore,
+    filter: RunListFilter,
+) -> homeboy::Result<RunRecord> {
+    store.latest_run(filter)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "filter",
+            "no observation run matched the provided filters",
+            None,
+            None,
+        )
+    })
+}
+
+pub(crate) fn run_filter_from_latest_args(args: RunsLatestRunArgs) -> RunListFilter {
+    RunListFilter {
+        kind: args.kind,
+        component_id: args.component_id,
+        status: args.status,
+        rig_id: args.rig,
+        limit: Some(1),
+    }
 }
 
 pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
@@ -360,7 +436,7 @@ fn run_detail(store: &ObservationStore, run: RunRecord) -> homeboy::Result<RunDe
     })
 }
 
-fn run_summary(run: RunRecord) -> RunSummary {
+pub(crate) fn run_summary(run: RunRecord) -> RunSummary {
     let status_note = reconcile::running_status_note(&run);
     RunSummary {
         id: run.id,
@@ -649,6 +725,100 @@ mod tests {
             };
             assert_eq!(output.finding.metadata_json["category"], "security");
             assert_eq!(output.finding.fixable, Some(true));
+        });
+    }
+
+    #[test]
+    fn latest_run_command_returns_newest_matching_run() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let old = store
+                .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
+                .expect("old");
+            store
+                .finish_run(&old.id, RunStatus::Pass, None)
+                .expect("finish old");
+            let latest = store
+                .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
+                .expect("latest");
+            store
+                .finish_run(&latest.id, RunStatus::Fail, None)
+                .expect("finish latest");
+
+            let (output, _) = latest_run(RunsLatestRunArgs {
+                kind: Some("lint".to_string()),
+                component_id: Some("homeboy".to_string()),
+                rig: Some("studio".to_string()),
+                status: None,
+            })
+            .expect("latest run");
+
+            let RunsOutput::LatestRun(output) = output else {
+                panic!("expected latest run output");
+            };
+            assert_eq!(output.command, "runs.latest-run");
+            assert_eq!(output.run.id, latest.id);
+        });
+    }
+
+    #[test]
+    fn latest_finding_command_uses_latest_matching_run() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let old_run = store
+                .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
+                .expect("old run");
+            store
+                .record_finding(&NewFindingRecord {
+                    run_id: old_run.id.clone(),
+                    tool: "lint".to_string(),
+                    rule: Some("security".to_string()),
+                    file: Some("src/foo.php".to_string()),
+                    line: Some(12),
+                    severity: Some("error".to_string()),
+                    fingerprint: Some("old".to_string()),
+                    message: "Old finding".to_string(),
+                    fixable: Some(true),
+                    metadata_json: serde_json::json!({}),
+                })
+                .expect("old finding");
+            let latest_run = store
+                .start_run(sample_run("lint", "homeboy", "studio", Value::Null))
+                .expect("latest run");
+            let latest_finding = store
+                .record_finding(&NewFindingRecord {
+                    run_id: latest_run.id.clone(),
+                    tool: "lint".to_string(),
+                    rule: Some("security".to_string()),
+                    file: Some("src/foo.php".to_string()),
+                    line: Some(12),
+                    severity: Some("error".to_string()),
+                    fingerprint: Some("latest".to_string()),
+                    message: "Latest finding".to_string(),
+                    fixable: Some(true),
+                    metadata_json: serde_json::json!({}),
+                })
+                .expect("latest finding");
+
+            let (output, _) = findings::latest_finding(findings::RunsLatestFindingArgs {
+                kind: Some("lint".to_string()),
+                component_id: Some("homeboy".to_string()),
+                rig: Some("studio".to_string()),
+                status: None,
+                tool: Some("lint".to_string()),
+                file: Some("src/foo.php".to_string()),
+            })
+            .expect("latest finding command");
+
+            let RunsOutput::LatestFinding(output) = output else {
+                panic!("expected latest finding output");
+            };
+            assert_eq!(output.command, "runs.latest-finding");
+            assert_eq!(output.run.id, latest_run.id);
+            assert_eq!(output.finding.id, latest_finding.id);
+            assert_eq!(output.finding.message, "Latest finding");
         });
     }
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,5 +1,6 @@
 mod bundle;
 mod findings;
+mod latest;
 mod reconcile;
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -8,9 +9,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{
-    ArtifactRecord, FindingRecord, ObservationStore, RunListFilter, RunRecord,
-};
+use homeboy::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
 use homeboy::Error;
 
 use super::{CmdResult, GlobalArgs};
@@ -19,6 +18,7 @@ use bundle::{
     RunsExportArgs, RunsImportArgs,
 };
 use findings::{RunsFindingOutput, RunsFindingsOutput};
+use latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
 
 const DEFAULT_LIMIT: i64 = 20;
@@ -72,22 +72,6 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
-#[derive(Args, Clone, Default)]
-pub struct RunsLatestRunArgs {
-    /// Run kind: bench, rig, trace, etc.
-    #[arg(long)]
-    pub kind: Option<String>,
-    /// Component ID
-    #[arg(long = "component")]
-    pub component_id: Option<String>,
-    /// Rig ID
-    #[arg(long)]
-    pub rig: Option<String>,
-    /// Run status
-    #[arg(long)]
-    pub status: Option<String>,
-}
-
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
@@ -115,19 +99,6 @@ pub struct RunsListOutput {
 pub struct RunsShowOutput {
     pub command: &'static str,
     pub run: RunDetail,
-}
-
-#[derive(Serialize)]
-pub struct RunsLatestRunOutput {
-    pub command: &'static str,
-    pub run: RunSummary,
-}
-
-#[derive(Serialize)]
-pub struct RunsLatestFindingOutput {
-    pub command: &'static str,
-    pub run: RunSummary,
-    pub finding: FindingRecord,
 }
 
 #[derive(Serialize)]
@@ -219,7 +190,7 @@ pub struct BenchMissingMetric {
 pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
     match args.command {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
-        RunsCommand::LatestRun(args) => latest_run(args),
+        RunsCommand::LatestRun(args) => latest::latest_run(args),
         RunsCommand::Reconcile(args) => reconcile_runs(args),
         RunsCommand::Show { run_id } => show_run(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
@@ -229,19 +200,6 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
     }
-}
-
-pub fn latest_run(args: RunsLatestRunArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let run = require_latest_run(&store, run_filter_from_latest_args(args))?;
-
-    Ok((
-        RunsOutput::LatestRun(RunsLatestRunOutput {
-            command: "runs.latest-run",
-            run: run_summary(run),
-        }),
-        0,
-    ))
 }
 
 pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOutput> {
@@ -271,30 +229,6 @@ fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
-}
-
-pub(crate) fn require_latest_run(
-    store: &ObservationStore,
-    filter: RunListFilter,
-) -> homeboy::Result<RunRecord> {
-    store.latest_run(filter)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "filter",
-            "no observation run matched the provided filters",
-            None,
-            None,
-        )
-    })
-}
-
-pub(crate) fn run_filter_from_latest_args(args: RunsLatestRunArgs) -> RunListFilter {
-    RunListFilter {
-        kind: args.kind,
-        component_id: args.component_id,
-        status: args.status,
-        rig_id: args.rig,
-        limit: Some(1),
-    }
 }
 
 pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
@@ -746,7 +680,7 @@ mod tests {
                 .finish_run(&latest.id, RunStatus::Fail, None)
                 .expect("finish latest");
 
-            let (output, _) = latest_run(RunsLatestRunArgs {
+            let (output, _) = latest::latest_run(latest::RunsLatestRunArgs {
                 kind: Some("lint".to_string()),
                 component_id: Some("homeboy".to_string()),
                 rig: Some("studio".to_string()),

--- a/src/commands/runs/findings.rs
+++ b/src/commands/runs/findings.rs
@@ -6,8 +6,8 @@ use homeboy::Error;
 
 use crate::commands::{
     runs::{
-        require_latest_run, run_filter_from_latest_args, run_summary, RunsLatestFindingOutput,
-        RunsLatestRunArgs, RunsOutput,
+        latest::require_latest_run, latest::run_filter_from_latest_args,
+        latest::RunsLatestFindingOutput, latest::RunsLatestRunArgs, run_summary, RunsOutput,
     },
     CmdResult,
 };

--- a/src/commands/runs/findings.rs
+++ b/src/commands/runs/findings.rs
@@ -4,7 +4,13 @@ use serde::Serialize;
 use homeboy::observation::{FindingListFilter, FindingRecord, ObservationStore};
 use homeboy::Error;
 
-use crate::commands::{runs::RunsOutput, CmdResult};
+use crate::commands::{
+    runs::{
+        require_latest_run, run_filter_from_latest_args, run_summary, RunsLatestFindingOutput,
+        RunsLatestRunArgs, RunsOutput,
+    },
+    CmdResult,
+};
 
 #[derive(Args, Clone, Default)]
 pub struct RunsFindingsArgs {
@@ -19,6 +25,28 @@ pub struct RunsFindingsArgs {
     /// Maximum findings to return
     #[arg(long, default_value_t = 100)]
     pub limit: i64,
+}
+
+#[derive(Args, Clone, Default)]
+pub struct RunsLatestFindingArgs {
+    /// Run kind: bench, rig, trace, etc.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Component ID
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Run status
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Finding tool, for example lint
+    #[arg(long)]
+    pub tool: Option<String>,
+    /// Finding file path
+    #[arg(long)]
+    pub file: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -68,6 +96,46 @@ pub fn finding(finding_id: &str) -> CmdResult<RunsOutput> {
     Ok((
         RunsOutput::Finding(RunsFindingOutput {
             command: "runs.finding",
+            finding,
+        }),
+        0,
+    ))
+}
+
+pub fn latest_finding(args: RunsLatestFindingArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let run = require_latest_run(
+        &store,
+        run_filter_from_latest_args(RunsLatestRunArgs {
+            kind: args.kind,
+            component_id: args.component_id,
+            rig: args.rig,
+            status: args.status,
+        }),
+    )?;
+    let finding = store
+        .latest_finding(FindingListFilter {
+            run_id: Some(run.id.clone()),
+            tool: args.tool,
+            file: args.file,
+            limit: Some(1),
+        })?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "filter",
+                format!(
+                    "no finding matched the provided filters in latest run {}",
+                    run.id
+                ),
+                Some(run.id.clone()),
+                None,
+            )
+        })?;
+
+    Ok((
+        RunsOutput::LatestFinding(RunsLatestFindingOutput {
+            command: "runs.latest-finding",
+            run: run_summary(run),
             finding,
         }),
         0,

--- a/src/commands/runs/latest.rs
+++ b/src/commands/runs/latest.rs
@@ -1,0 +1,76 @@
+use clap::Args;
+use serde::Serialize;
+
+use homeboy::observation::{FindingRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::Error;
+
+use crate::commands::{
+    runs::{run_summary, RunSummary, RunsOutput},
+    CmdResult,
+};
+
+#[derive(Args, Clone, Default)]
+pub struct RunsLatestRunArgs {
+    /// Run kind: bench, rig, trace, etc.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Component ID
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Run status
+    #[arg(long)]
+    pub status: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RunsLatestRunOutput {
+    pub command: &'static str,
+    pub run: RunSummary,
+}
+
+#[derive(Serialize)]
+pub struct RunsLatestFindingOutput {
+    pub command: &'static str,
+    pub run: RunSummary,
+    pub finding: FindingRecord,
+}
+
+pub fn latest_run(args: RunsLatestRunArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let run = require_latest_run(&store, run_filter_from_latest_args(args))?;
+
+    Ok((
+        RunsOutput::LatestRun(RunsLatestRunOutput {
+            command: "runs.latest-run",
+            run: run_summary(run),
+        }),
+        0,
+    ))
+}
+
+pub(crate) fn require_latest_run(
+    store: &ObservationStore,
+    filter: RunListFilter,
+) -> homeboy::Result<RunRecord> {
+    store.latest_run(filter)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "filter",
+            "no observation run matched the provided filters",
+            None,
+            None,
+        )
+    })
+}
+
+pub(crate) fn run_filter_from_latest_args(args: RunsLatestRunArgs) -> RunListFilter {
+    RunListFilter {
+        kind: args.kind,
+        component_id: args.component_id,
+        status: args.status,
+        rig_id: args.rig,
+        limit: Some(1),
+    }
+}

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1213,6 +1213,28 @@ mod api_coverage_tests {
     }
 
     #[test]
+    fn test_latest_run() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let old = store.start_run(new_run("lint")).expect("old");
+            let latest = store.start_run(new_run("lint")).expect("latest");
+
+            let selected = store
+                .latest_run(RunListFilter {
+                    kind: Some("lint".to_string()),
+                    component_id: Some("homeboy".to_string()),
+                    ..RunListFilter::default()
+                })
+                .expect("latest run")
+                .expect("run exists");
+
+            assert_eq!(selected.id, latest.id);
+            assert_ne!(selected.id, old.id);
+        });
+    }
+
+    #[test]
     fn test_list_runs_started_since() {
         with_isolated_home(|_| {
             let _xdg = XdgGuard::unset();

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -292,7 +292,7 @@ impl ObservationStore {
                   AND (?2 IS NULL OR component_id = ?2)
                   AND (?3 IS NULL OR status = ?3)
                   AND (?4 IS NULL OR rig_id = ?4)
-                ORDER BY started_at DESC
+                ORDER BY started_at DESC, rowid DESC
                 LIMIT ?5
                 "#,
             )
@@ -311,6 +311,11 @@ impl ObservationStore {
             .map_err(sqlite_error("list run records"))?;
 
         collect_rows(rows, "collect run records")
+    }
+
+    pub fn latest_run(&self, mut filter: RunListFilter) -> Result<Option<RunRecord>> {
+        filter.limit = Some(1);
+        Ok(self.list_runs(filter)?.into_iter().next())
     }
 
     pub fn list_runs_started_since(&self, started_at: &str) -> Result<Vec<RunRecord>> {

--- a/src/core/observation/store/findings.rs
+++ b/src/core/observation/store/findings.rs
@@ -112,6 +112,36 @@ impl ObservationStore {
 
         collect_rows(rows, "collect finding records")
     }
+
+    pub fn latest_finding(&self, filter: FindingListFilter) -> Result<Option<FindingRecord>> {
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                       fixable, metadata_json, created_at
+                FROM findings
+                WHERE (?1 IS NULL OR run_id = ?1)
+                  AND (?2 IS NULL OR tool = ?2)
+                  AND (?3 IS NULL OR file = ?3)
+                ORDER BY created_at DESC, rowid DESC
+                LIMIT 1
+                "#,
+            )
+            .map_err(sqlite_error("prepare latest finding record"))?;
+
+        statement
+            .query_row(
+                params![
+                    filter.run_id.as_deref(),
+                    filter.tool.as_deref(),
+                    filter.file.as_deref(),
+                ],
+                row_to_finding_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read latest finding record"))
+    }
 }
 
 fn row_to_finding_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<FindingRecord> {
@@ -239,6 +269,44 @@ mod tests {
                 .expect("list");
 
             assert_eq!(findings.len(), 2);
+        });
+    }
+
+    #[test]
+    fn test_latest_finding_uses_filters_and_deterministic_tie_break() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run()).expect("start");
+            let old = store
+                .record_finding(&new_finding(&run.id, "security"))
+                .expect("old finding");
+            let latest = store
+                .record_finding(&new_finding(&run.id, "security"))
+                .expect("latest finding");
+            store
+                .record_finding(&new_finding(&run.id, "i18n"))
+                .expect("other finding");
+
+            let selected = store
+                .latest_finding(FindingListFilter {
+                    run_id: Some(run.id),
+                    tool: Some("lint".to_string()),
+                    file: Some("src/security.rs".to_string()),
+                    ..FindingListFilter::default()
+                })
+                .expect("latest finding")
+                .expect("finding exists");
+            let missing = store
+                .latest_finding(FindingListFilter {
+                    file: Some("src/missing.rs".to_string()),
+                    ..FindingListFilter::default()
+                })
+                .expect("missing latest");
+
+            assert_eq!(selected.id, latest.id);
+            assert_ne!(selected.id, old.id);
+            assert!(missing.is_none());
         });
     }
 }

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -311,7 +311,7 @@ fn test_list_runs() {
 }
 
 #[test]
-fn test_latest_run_uses_filters_and_deterministic_tie_break() {
+fn test_latest_run() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("init store");

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -311,6 +311,50 @@ fn test_list_runs() {
 }
 
 #[test]
+fn test_latest_run_uses_filters_and_deterministic_tie_break() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+
+        let old = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start old");
+        store
+            .finish_run(&old.id, RunStatus::Pass, None)
+            .expect("finish old");
+        let latest = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start latest");
+        store
+            .finish_run(&latest.id, RunStatus::Fail, None)
+            .expect("finish latest");
+        let other_kind = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start bench");
+
+        let selected = store
+            .latest_run(RunListFilter {
+                kind: Some("lint".to_string()),
+                component_id: Some("homeboy".to_string()),
+                ..RunListFilter::default()
+            })
+            .expect("latest run")
+            .expect("run exists");
+        let missing = store
+            .latest_run(RunListFilter {
+                status: Some("stale".to_string()),
+                ..RunListFilter::default()
+            })
+            .expect("missing latest");
+
+        assert_eq!(selected.id, latest.id);
+        assert_ne!(selected.id, old.id);
+        assert_ne!(selected.id, other_kind.id);
+        assert!(missing.is_none());
+    });
+}
+
+#[test]
 fn test_record_artifact() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
- Add observation-store helpers for the latest run and latest finding, with deterministic tie-breaking.
- Expose `homeboy runs latest-run` and `homeboy runs latest-finding` for agent-friendly JSON query flows.
- Cover latest run/finding store behavior and command output selection in unit tests.

## Testing
- `cargo fmt`
- `cargo fmt --check`
- `cargo test latest --lib`
- `cargo test commands::runs::tests --lib`
- `cargo test core::observation::store --lib`
- `cargo test core::extension::trace::run::tests --lib -- --nocapture`
- `cargo test --lib -- --test-threads=1`

## Notes
- `cargo test --lib` with default parallelism failed on two trace extension tests that pass in isolation and pass when the full library suite is run serially. This appears to be existing parallel test interference, not related to the observation query changes.
- `cargo clippy --lib -- -D warnings` currently fails on existing repository-wide lints outside this PR's touched code.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused implementation, added tests, ran verification, and prepared this PR. Chris remains responsible for review and merge decisions.

Fixes #2046