### PR TITLE
Add trace focus span reporting

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -12,8 +12,8 @@ homeboy trace <component> <scenario> --json-summary
 homeboy trace <component> <scenario> --span submit_to_cli:ui.submit:cli.start
 homeboy trace <component> <scenario> --phase submit:ui.submit --phase cli:cli.start --phase ready:server.ready
 homeboy trace <component> <scenario> --rig <rig-id> --phase-preset create-site
-homeboy trace <component> <scenario> --repeat 5 --aggregate spans
-homeboy trace compare before.json after.json
+homeboy trace <component> <scenario> --repeat 5 --aggregate spans --schedule interleaved
+homeboy trace compare before.json after.json --focus-span phase.wp_boot_start_to_wp_boot_ready
 homeboy trace <component> <scenario> --report=markdown
 homeboy trace <component> <scenario> --baseline
 homeboy trace <component> <scenario> --ratchet
@@ -140,14 +140,20 @@ homeboy trace studio studio-app-create-site --repeat 5 --aggregate spans
 
 Each repeat uses a fresh Homeboy run directory, so completed run data is preserved even when a later repeat fails.
 
+Use `--schedule grouped` or `--schedule interleaved` to record the intended run order in the aggregate manifest. The current single-scenario repeat runner records one `run` group; the planner is shared with future baseline/variant runners so paired experiments can use grouped order (`baseline...variant...`) or interleaved order (`baseline, variant, baseline, variant`).
+
+Use repeatable `--focus-span <span-id>` to add a focused span section while keeping the full span table in the JSON and Markdown report.
+
 ## Compare Aggregates
 
 Use `trace compare` to compare two aggregate span JSON outputs. The comparison reports each span's before/after median and average, absolute deltas, and percentage deltas. Spans are sorted by absolute median delta descending so the largest changes are first; spans that only exist in one file are included with unavailable deltas after comparable spans. Markdown reports bold non-zero absolute deltas to make regressions and improvements easier to scan.
 
 ```sh
 homeboy trace compare before.json after.json
-homeboy trace compare before.json after.json --report=markdown
+homeboy trace compare before.json after.json --focus-span phase.wp_boot_start_to_wp_boot_ready --report=markdown
 ```
+
+Focused compare spans are evaluated independently from the full span table. When a focused span's median slowdown exceeds both `--regression-threshold` and `--regression-min-delta-ms`, or its failure count increases, `trace compare` returns a failing exit code and records `focus_status`, `focus_regression_count`, and `focus_failure_count` in JSON output. All compared spans remain present in `spans`.
 
 ## Markdown Reports
 

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1,4 +1,4 @@
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
@@ -28,8 +28,8 @@ use output::{
 
 #[cfg(test)]
 use output::{
-    compare_trace_aggregates, parse_trace_aggregate_input, TraceAggregateInput,
-    TraceAggregateSpanInput,
+    compare_trace_aggregates, compare_trace_aggregates_with_focus, parse_trace_aggregate_input,
+    TraceAggregateInput, TraceAggregateSpanInput,
 };
 
 #[derive(Args, Clone)]
@@ -70,6 +70,14 @@ pub struct TraceArgs {
     #[arg(long, value_parser = ["spans"])]
     pub aggregate: Option<String>,
 
+    /// Run order for repeated trace executions.
+    #[arg(long, value_enum, default_value_t = TraceSchedule::Grouped)]
+    pub schedule: TraceSchedule,
+
+    /// Highlight a span in aggregate and compare reports. Repeatable.
+    #[arg(long = "focus-span", value_name = "SPAN_ID")]
+    pub focus_spans: Vec<String>,
+
     /// Add a span definition as `id:source.event:source.event`.
     #[arg(long = "span", value_name = "ID:FROM:TO", value_parser = extension_trace::spans::parse_span_definition)]
     pub spans: Vec<TraceSpanDefinition>,
@@ -100,6 +108,61 @@ pub struct TraceArgs {
     /// Leave overlay changes in place after the trace run.
     #[arg(long)]
     pub keep_overlay: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum TraceSchedule {
+    Grouped,
+    Interleaved,
+}
+
+impl TraceSchedule {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Grouped => "grouped",
+            Self::Interleaved => "interleaved",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TraceRunPlanEntry {
+    index: usize,
+    group: String,
+    iteration: usize,
+}
+
+fn plan_trace_run_order(
+    repeat: usize,
+    schedule: TraceSchedule,
+    groups: &[&str],
+) -> Vec<TraceRunPlanEntry> {
+    let mut entries = Vec::new();
+    match schedule {
+        TraceSchedule::Grouped => {
+            for group in groups {
+                for iteration in 1..=repeat {
+                    entries.push(TraceRunPlanEntry {
+                        index: entries.len() + 1,
+                        group: (*group).to_string(),
+                        iteration,
+                    });
+                }
+            }
+        }
+        TraceSchedule::Interleaved => {
+            for iteration in 1..=repeat {
+                for group in groups {
+                    entries.push(TraceRunPlanEntry {
+                        index: entries.len() + 1,
+                        group: (*group).to_string(),
+                        iteration,
+                    });
+                }
+            }
+        }
+    }
+    entries
 }
 
 pub fn is_markdown_mode(args: &TraceArgs) -> bool {
@@ -391,7 +454,10 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     let mut component = None;
     let mut failure_count = 0;
 
-    for index in 1..=repeat {
+    let run_order = plan_trace_run_order(repeat, args.schedule, &["run"]);
+
+    for plan_entry in &run_order {
+        let index = plan_entry.index;
         let mut run_args = args.clone();
         run_args.repeat = 1;
         match execute_trace_run(run_args) {
@@ -499,6 +565,7 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
             aggregate_span(id, samples, failures)
         })
         .collect::<Vec<_>>();
+    let focus_spans = focus_aggregate_spans(&spans, &args.focus_spans);
     let exit_code = if failure_count == 0 { 0 } else { 1 };
     let output = extension_trace::TraceAggregateOutput {
         command: "trace.aggregate.spans",
@@ -510,13 +577,39 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         run_count: runs.len(),
         failure_count,
         exit_code,
+        schedule: Some(args.schedule.as_str().to_string()),
+        run_order: run_order
+            .into_iter()
+            .map(|entry| extension_trace::TraceRunOrderEntryOutput {
+                index: entry.index,
+                group: entry.group,
+                iteration: entry.iteration,
+            })
+            .collect(),
         rig_state,
         overlays,
         runs,
         spans,
+        focus_span_ids: args.focus_spans.clone(),
+        focus_spans,
     };
 
     Ok((TraceCommandOutput::Aggregate(output), exit_code))
+}
+
+fn focus_aggregate_spans(
+    spans: &[extension_trace::TraceAggregateSpanOutput],
+    focus_span_ids: &[String],
+) -> Vec<extension_trace::TraceAggregateSpanOutput> {
+    if focus_span_ids.is_empty() {
+        return Vec::new();
+    }
+    let focus = focus_span_ids.iter().collect::<BTreeSet<_>>();
+    spans
+        .iter()
+        .filter(|span| focus.contains(&span.id))
+        .cloned()
+        .collect()
 }
 
 const DEFAULT_TRACE_PHASE_PRESET: &str = "default";

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -138,26 +138,25 @@ fn plan_trace_run_order(
     groups: &[&str],
 ) -> Vec<TraceRunPlanEntry> {
     let mut entries = Vec::new();
+    let mut push_entry = |group: &str, iteration: usize| {
+        entries.push(TraceRunPlanEntry {
+            index: entries.len() + 1,
+            group: group.to_string(),
+            iteration,
+        });
+    };
     match schedule {
         TraceSchedule::Grouped => {
             for group in groups {
                 for iteration in 1..=repeat {
-                    entries.push(TraceRunPlanEntry {
-                        index: entries.len() + 1,
-                        group: (*group).to_string(),
-                        iteration,
-                    });
+                    push_entry(group, iteration);
                 }
             }
         }
         TraceSchedule::Interleaved => {
             for iteration in 1..=repeat {
                 for group in groups {
-                    entries.push(TraceRunPlanEntry {
-                        index: entries.len() + 1,
-                        group: (*group).to_string(),
-                        iteration,
-                    });
+                    push_entry(group, iteration);
                 }
             }
         }

--- a/src/commands/trace/output.rs
+++ b/src/commands/trace/output.rs
@@ -43,8 +43,21 @@ pub(super) fn run_compare(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
 
     let before = read_trace_aggregate(&before_path)?;
     let after = read_trace_aggregate(&after_path)?;
-    let output = compare_trace_aggregates(&before_path, before, &after_path, after);
-    Ok((TraceCommandOutput::Compare(output), 0))
+    let output = compare_trace_aggregates_with_focus(
+        &before_path,
+        before,
+        &after_path,
+        after,
+        &args.focus_spans,
+        args.regression_threshold,
+        args.regression_min_delta_ms,
+    );
+    let exit_code = if output.focus_status.as_deref() == Some("fail") {
+        1
+    } else {
+        0
+    };
+    Ok((TraceCommandOutput::Compare(output), exit_code))
 }
 
 fn read_trace_aggregate(path: &Path) -> homeboy::Result<TraceAggregateInput> {
@@ -73,11 +86,32 @@ pub(super) fn parse_trace_aggregate_input(
     }
 }
 
+#[cfg(test)]
 pub(super) fn compare_trace_aggregates(
     before_path: &Path,
     before: TraceAggregateInput,
     after_path: &Path,
     after: TraceAggregateInput,
+) -> extension_trace::TraceCompareOutput {
+    compare_trace_aggregates_with_focus(
+        before_path,
+        before,
+        after_path,
+        after,
+        &[],
+        extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+    )
+}
+
+pub(super) fn compare_trace_aggregates_with_focus(
+    before_path: &Path,
+    before: TraceAggregateInput,
+    after_path: &Path,
+    after: TraceAggregateInput,
+    focus_span_ids: &[String],
+    regression_threshold_percent: f64,
+    regression_min_delta_ms: u64,
 ) -> extension_trace::TraceCompareOutput {
     let before_spans = before
         .spans
@@ -127,6 +161,25 @@ pub(super) fn compare_trace_aggregates(
         .collect::<Vec<_>>();
     spans.sort_by(compare_trace_span_impact);
 
+    let focus_spans = focus_compare_spans(&spans, focus_span_ids);
+    let focus_regression_count = focus_spans
+        .iter()
+        .filter(|span| {
+            is_focused_span_regression(span, regression_threshold_percent, regression_min_delta_ms)
+        })
+        .count();
+    let focus_failure_count = focus_spans
+        .iter()
+        .filter(|span| span.after_failures.unwrap_or(0) > span.before_failures.unwrap_or(0))
+        .count();
+    let focus_status = if focus_span_ids.is_empty() {
+        None
+    } else if focus_regression_count > 0 || focus_failure_count > 0 {
+        Some("fail".to_string())
+    } else {
+        Some("pass".to_string())
+    };
+
     extension_trace::TraceCompareOutput {
         command: "trace.compare.spans",
         before_path: before_path.display().to_string(),
@@ -137,7 +190,42 @@ pub(super) fn compare_trace_aggregates(
         after_scenario_id: after.scenario_id,
         span_count: spans.len(),
         spans,
+        focus_span_ids: focus_span_ids.to_vec(),
+        focus_spans,
+        focus_regression_count,
+        focus_failure_count,
+        focus_status,
     }
+}
+
+fn focus_compare_spans(
+    spans: &[extension_trace::TraceCompareSpanOutput],
+    focus_span_ids: &[String],
+) -> Vec<extension_trace::TraceCompareSpanOutput> {
+    if focus_span_ids.is_empty() {
+        return Vec::new();
+    }
+    let focus = focus_span_ids.iter().collect::<BTreeSet<_>>();
+    spans
+        .iter()
+        .filter(|span| focus.contains(&span.id))
+        .cloned()
+        .collect()
+}
+
+fn is_focused_span_regression(
+    span: &extension_trace::TraceCompareSpanOutput,
+    regression_threshold_percent: f64,
+    regression_min_delta_ms: u64,
+) -> bool {
+    let Some(delta_ms) = span.median_delta_ms else {
+        return false;
+    };
+    if delta_ms <= 0 || delta_ms < regression_min_delta_ms as i64 {
+        return false;
+    }
+    span.median_delta_percent
+        .is_some_and(|percent| percent >= regression_threshold_percent)
 }
 
 fn compare_trace_span_impact(
@@ -256,28 +344,30 @@ pub(super) fn render_aggregate_markdown(
     out.push_str(&format!("- **Status:** `{}`\n", aggregate.status));
     out.push_str(&format!("- **Runs:** `{}`\n", aggregate.run_count));
     out.push_str(&format!("- **Failures:** `{}`\n", aggregate.failure_count));
+    if let Some(schedule) = aggregate.schedule.as_deref() {
+        out.push_str(&format!("- **Schedule:** `{}`\n", schedule));
+    }
     extension_trace::push_overlay_markdown(&mut out, &aggregate.overlays);
+
+    if !aggregate.focus_span_ids.is_empty() {
+        out.push_str("\n## Focus Spans\n\n");
+        if aggregate.focus_spans.is_empty() {
+            out.push_str("No focused spans matched the aggregate output.\n");
+        } else {
+            out.push_str("| Span | n | min | median | avg | p75 | p90 | p95 | max | failures |\n");
+            out.push_str("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n");
+            for span in &aggregate.focus_spans {
+                push_aggregate_span_row(&mut out, span);
+            }
+        }
+    }
 
     if !aggregate.spans.is_empty() {
         out.push_str("\n## Spans\n\n");
         out.push_str("| Span | n | min | median | avg | p75 | p90 | p95 | max | failures |\n");
         out.push_str("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n");
         for span in &aggregate.spans {
-            out.push_str(&format!(
-                "| `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
-                span.id,
-                span.n,
-                fmt_ms(span.min_ms),
-                fmt_ms(span.median_ms),
-                span.avg_ms
-                    .map(|value| format!("{:.1}ms", value))
-                    .unwrap_or_else(|| "-".to_string()),
-                fmt_ms(span.p75_ms),
-                fmt_ms(span.p90_ms),
-                fmt_ms(span.p95_ms),
-                fmt_ms(span.max_ms),
-                span.failures
-            ));
+            push_aggregate_span_row(&mut out, span);
         }
 
         let outliers = aggregate
@@ -309,6 +399,24 @@ pub(super) fn render_aggregate_markdown(
     out
 }
 
+fn push_aggregate_span_row(out: &mut String, span: &extension_trace::TraceAggregateSpanOutput) {
+    out.push_str(&format!(
+        "| `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+        span.id,
+        span.n,
+        fmt_ms(span.min_ms),
+        fmt_ms(span.median_ms),
+        span.avg_ms
+            .map(|value| format!("{:.1}ms", value))
+            .unwrap_or_else(|| "-".to_string()),
+        fmt_ms(span.p75_ms),
+        fmt_ms(span.p90_ms),
+        fmt_ms(span.p95_ms),
+        fmt_ms(span.max_ms),
+        span.failures
+    ));
+}
+
 pub(super) fn render_compare_markdown(compare: &extension_trace::TraceCompareOutput) -> String {
     let mut out = String::new();
     out.push_str("# Trace Compare\n\n");
@@ -338,7 +446,51 @@ pub(super) fn render_compare_markdown(compare: &extension_trace::TraceCompareOut
         }
     }
 
+    if !compare.focus_span_ids.is_empty() {
+        out.push_str("\n## Focus Spans\n\n");
+        out.push_str(&format!(
+            "- **Status:** `{}`\n",
+            compare.focus_status.as_deref().unwrap_or("pass")
+        ));
+        out.push_str(&format!(
+            "- **Regressions:** `{}`\n",
+            compare.focus_regression_count
+        ));
+        out.push_str(&format!(
+            "- **Failures:** `{}`\n",
+            compare.focus_failure_count
+        ));
+        if compare.focus_spans.is_empty() {
+            out.push_str("\nNo focused spans matched the compared aggregates.\n");
+        } else {
+            out.push_str("\n| Span | before median | after median | median delta | median % | before avg | after avg | avg delta | avg % | before failures | after failures |\n");
+            out.push_str("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n");
+            for span in &compare.focus_spans {
+                out.push_str(&format!(
+                    "| `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+                    span.id,
+                    fmt_ms(span.before_median_ms),
+                    fmt_ms(span.after_median_ms),
+                    fmt_signal_delta_ms(span.median_delta_ms),
+                    fmt_percent(span.median_delta_percent),
+                    fmt_avg_ms(span.before_avg_ms),
+                    fmt_avg_ms(span.after_avg_ms),
+                    fmt_signal_delta_avg_ms(span.avg_delta_ms),
+                    fmt_percent(span.avg_delta_percent),
+                    fmt_count(span.before_failures),
+                    fmt_count(span.after_failures),
+                ));
+            }
+        }
+    }
+
     out
+}
+
+fn fmt_count(value: Option<usize>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
 }
 
 fn fmt_ms(value: Option<u64>) -> String {

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -100,6 +100,8 @@ fn rig_trace_list_uses_rig_default_component_and_workloads() {
             report: None,
             repeat: 1,
             aggregate: None,
+            schedule: TraceSchedule::Grouped,
+            focus_spans: Vec::new(),
             spans: Vec::new(),
             phases: Vec::new(),
             phase_preset: None,
@@ -188,6 +190,8 @@ fn rig_trace_list_uses_scoped_workload_preflight() {
             report: None,
             repeat: 1,
             aggregate: None,
+            schedule: TraceSchedule::Grouped,
+            focus_spans: Vec::new(),
             spans: Vec::new(),
             phases: Vec::new(),
             phase_preset: None,
@@ -233,6 +237,8 @@ fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
                 report: None,
                 repeat: 1,
                 aggregate: None,
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
                 spans: Vec::new(),
                 phases: Vec::new(),
                 phase_preset: None,
@@ -285,6 +291,8 @@ fn trace_run_persists_observation_history() {
                 report: None,
                 repeat: 1,
                 aggregate: None,
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
                 spans: Vec::new(),
                 phases: Vec::new(),
                 phase_preset: None,
@@ -360,6 +368,8 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
                 report: None,
                 repeat: 3,
                 aggregate: Some("spans".to_string()),
+                schedule: TraceSchedule::Interleaved,
+                focus_spans: vec!["boot_to_ready".to_string()],
                 spans: Vec::new(),
                 phases: Vec::new(),
                 phase_preset: None,
@@ -380,7 +390,14 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
                 assert_eq!(aggregate.repeat, 3);
                 assert_eq!(aggregate.run_count, 3);
                 assert_eq!(aggregate.failure_count, 0);
+                assert_eq!(aggregate.schedule.as_deref(), Some("interleaved"));
+                assert_eq!(aggregate.run_order.len(), 3);
+                assert_eq!(aggregate.run_order[0].index, 1);
+                assert_eq!(aggregate.run_order[0].group, "run");
+                assert_eq!(aggregate.run_order[0].iteration, 1);
                 assert_eq!(aggregate.spans.len(), 1);
+                assert_eq!(aggregate.focus_span_ids, vec!["boot_to_ready"]);
+                assert_eq!(aggregate.focus_spans.len(), 1);
                 let span = &aggregate.spans[0];
                 assert_eq!(span.id, "boot_to_ready");
                 assert_eq!(span.n, 3);
@@ -405,6 +422,37 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
             _ => panic!("expected aggregate output"),
         }
     });
+}
+
+#[test]
+fn trace_run_order_planner_supports_grouped_and_interleaved_variants() {
+    let grouped = plan_trace_run_order(2, TraceSchedule::Grouped, &["baseline", "variant"]);
+    assert_eq!(
+        grouped
+            .iter()
+            .map(|entry| (entry.index, entry.group.as_str(), entry.iteration))
+            .collect::<Vec<_>>(),
+        vec![
+            (1, "baseline", 1),
+            (2, "baseline", 2),
+            (3, "variant", 1),
+            (4, "variant", 2),
+        ]
+    );
+
+    let interleaved = plan_trace_run_order(2, TraceSchedule::Interleaved, &["baseline", "variant"]);
+    assert_eq!(
+        interleaved
+            .iter()
+            .map(|entry| (entry.index, entry.group.as_str(), entry.iteration))
+            .collect::<Vec<_>>(),
+        vec![
+            (1, "baseline", 1),
+            (2, "variant", 1),
+            (3, "baseline", 2),
+            (4, "variant", 2),
+        ]
+    );
 }
 
 #[test]
@@ -443,6 +491,8 @@ fn trace_repeat_reports_overlay_touched_files_at_top_level() {
                 report: None,
                 repeat: 2,
                 aggregate: Some("spans".to_string()),
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
                 spans: Vec::new(),
                 phases: Vec::new(),
                 phase_preset: None,
@@ -585,6 +635,69 @@ fn trace_compare_reports_median_and_average_deltas() {
 }
 
 #[test]
+fn trace_compare_focus_spans_report_independent_regression_status() {
+    let before = TraceAggregateInput {
+        component: Some("studio".to_string()),
+        scenario_id: Some("create-site".to_string()),
+        spans: vec![
+            TraceAggregateSpanInput {
+                id: "focused".to_string(),
+                n: 6,
+                median_ms: Some(100),
+                avg_ms: Some(100.0),
+                failures: 0,
+            },
+            TraceAggregateSpanInput {
+                id: "unfocused".to_string(),
+                n: 6,
+                median_ms: Some(100),
+                avg_ms: Some(100.0),
+                failures: 0,
+            },
+        ],
+    };
+    let after = TraceAggregateInput {
+        component: Some("studio".to_string()),
+        scenario_id: Some("create-site".to_string()),
+        spans: vec![
+            TraceAggregateSpanInput {
+                id: "focused".to_string(),
+                n: 6,
+                median_ms: Some(130),
+                avg_ms: Some(130.0),
+                failures: 0,
+            },
+            TraceAggregateSpanInput {
+                id: "unfocused".to_string(),
+                n: 6,
+                median_ms: Some(250),
+                avg_ms: Some(250.0),
+                failures: 0,
+            },
+        ],
+    };
+
+    let compare = compare_trace_aggregates_with_focus(
+        Path::new("before.json"),
+        before,
+        Path::new("after.json"),
+        after,
+        &["focused".to_string()],
+        20.0,
+        10,
+    );
+
+    assert_eq!(compare.span_count, 2);
+    assert_eq!(compare.spans.len(), 2);
+    assert_eq!(compare.focus_span_ids, vec!["focused"]);
+    assert_eq!(compare.focus_spans.len(), 1);
+    assert_eq!(compare.focus_spans[0].id, "focused");
+    assert_eq!(compare.focus_regression_count, 1);
+    assert_eq!(compare.focus_failure_count, 0);
+    assert_eq!(compare.focus_status.as_deref(), Some("fail"));
+}
+
+#[test]
 fn trace_compare_accepts_json_summary_envelope_outputs() {
     let input = parse_trace_aggregate_input(
         r#"{
@@ -640,6 +753,11 @@ fn trace_compare_markdown_renders_span_table() {
             before_failures: Some(0),
             after_failures: Some(0),
         }],
+        focus_span_ids: Vec::new(),
+        focus_spans: Vec::new(),
+        focus_regression_count: 0,
+        focus_failure_count: 0,
+        focus_status: None,
     };
 
     let markdown = render_compare_markdown(&compare);
@@ -674,6 +792,8 @@ fn trace_run_expands_phase_chain_into_adjacent_and_total_spans() {
                 report: None,
                 repeat: 1,
                 aggregate: None,
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
                 spans: Vec::new(),
                 phases: vec![
                     extension_trace::spans::TracePhaseMilestone {
@@ -742,6 +862,8 @@ fn trace_run_expands_named_workload_phase_preset() {
                 report: None,
                 repeat: 1,
                 aggregate: None,
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
                 spans: Vec::new(),
                 phases: Vec::new(),
                 phase_preset: Some("startup".to_string()),
@@ -801,6 +923,8 @@ fn trace_aggregate_spans_uses_workload_default_phase_preset() {
                 report: None,
                 repeat: 2,
                 aggregate: Some("spans".to_string()),
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
                 spans: Vec::new(),
                 phases: Vec::new(),
                 phase_preset: None,
@@ -903,6 +1027,8 @@ fn aggregate_markdown_includes_percentile_columns() {
         failure_count: 0,
         exit_code: 0,
         rig_state: None,
+        schedule: None,
+        run_order: Vec::new(),
         overlays: Vec::new(),
         runs: Vec::new(),
         spans: vec![aggregate_span(
@@ -910,6 +1036,8 @@ fn aggregate_markdown_includes_percentile_columns() {
             aggregate_samples(&((1..=20).map(|value| value * 10).collect::<Vec<_>>())),
             0,
         )],
+        focus_span_ids: Vec::new(),
+        focus_spans: Vec::new(),
     };
 
     let markdown = render_aggregate_markdown(&aggregate);
@@ -947,6 +1075,8 @@ fn failed_trace_run_persists_observation_history() {
                 report: None,
                 repeat: 1,
                 aggregate: None,
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
                 spans: Vec::new(),
                 phases: Vec::new(),
                 phase_preset: None,

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -25,7 +25,7 @@ pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, Trace
 pub use report::{
     from_list_workflow, from_main_workflow, from_main_workflow_outputs, TraceAggregateOutput,
     TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceCommandOutput, TraceCompareOutput,
-    TraceCompareSpanOutput,
+    TraceCompareSpanOutput, TraceRunOrderEntryOutput,
 };
 pub use report::{push_overlay_markdown, render_markdown};
 pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -72,7 +72,7 @@ pub struct TraceListOutput {
     pub scenarios: Vec<super::parsing::TraceScenario>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct TraceAggregateOutput {
     pub command: &'static str,
     pub passed: bool,
@@ -84,14 +84,29 @@ pub struct TraceAggregateOutput {
     pub failure_count: usize,
     pub exit_code: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub run_order: Vec<TraceRunOrderEntryOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_state: Option<RigStateSnapshot>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub overlays: Vec<TraceOverlay>,
     pub runs: Vec<TraceAggregateRunOutput>,
     pub spans: Vec<TraceAggregateSpanOutput>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub focus_span_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub focus_spans: Vec<TraceAggregateSpanOutput>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
+pub struct TraceRunOrderEntryOutput {
+    pub index: usize,
+    pub group: String,
+    pub iteration: usize,
+}
+
+#[derive(Serialize, Clone)]
 pub struct TraceAggregateRunOutput {
     pub index: usize,
     pub passed: bool,
@@ -106,7 +121,7 @@ pub struct TraceAggregateRunOutput {
     pub failure: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct TraceAggregateSpanOutput {
     pub id: String,
     pub n: usize,
@@ -131,7 +146,7 @@ pub struct TraceAggregateSpanOutput {
     pub failures: usize,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct TraceCompareOutput {
     pub command: &'static str,
     pub before_path: String,
@@ -146,9 +161,19 @@ pub struct TraceCompareOutput {
     pub after_scenario_id: Option<String>,
     pub span_count: usize,
     pub spans: Vec<TraceCompareSpanOutput>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub focus_span_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub focus_spans: Vec<TraceCompareSpanOutput>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub focus_regression_count: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub focus_failure_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focus_status: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct TraceCompareSpanOutput {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -175,6 +200,10 @@ pub struct TraceCompareSpanOutput {
     pub before_failures: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after_failures: Option<usize>,
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 pub fn from_main_workflow(

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -165,9 +165,9 @@ pub struct TraceCompareOutput {
     pub focus_span_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub focus_spans: Vec<TraceCompareSpanOutput>,
-    #[serde(default, skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_default_usize")]
     pub focus_regression_count: usize,
-    #[serde(default, skip_serializing_if = "is_zero")]
+    #[serde(default, skip_serializing_if = "is_default_usize")]
     pub focus_failure_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub focus_status: Option<String>,
@@ -202,8 +202,8 @@ pub struct TraceCompareSpanOutput {
     pub after_failures: Option<usize>,
 }
 
-fn is_zero(value: &usize) -> bool {
-    *value == 0
+fn is_default_usize(value: &usize) -> bool {
+    value.eq(&usize::default())
 }
 
 pub fn from_main_workflow(
@@ -532,6 +532,34 @@ mod tests {
             "submit_to_cli"
         );
         assert_eq!(artifact_value["results"]["timeline"][0]["event"], "submit");
+    }
+
+    #[test]
+    fn test_push_overlay_markdown() {
+        let mut markdown = String::new();
+        let overlays = vec![
+            TraceOverlay {
+                path: "/tmp/overlay.patch".to_string(),
+                component_path: "/tmp/studio".to_string(),
+                touched_files: vec!["apps/studio/out/app.js".to_string()],
+                kept: false,
+            },
+            TraceOverlay {
+                path: "/tmp/kept.patch".to_string(),
+                component_path: "/tmp/studio".to_string(),
+                touched_files: Vec::new(),
+                kept: true,
+            },
+        ];
+
+        push_overlay_markdown(&mut markdown, &overlays);
+
+        assert!(markdown.contains("## Trace Overlays"));
+        assert!(markdown.contains("- **Patch:** `/tmp/overlay.patch` (`reverted`)"));
+        assert!(markdown.contains("- Applied relative to: `/tmp/studio`"));
+        assert!(markdown.contains("- `apps/studio/out/app.js`"));
+        assert!(markdown.contains("- **Patch:** `/tmp/kept.patch` (`kept`)"));
+        assert!(markdown.contains("Touched files: none reported by `git apply --numstat`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `--schedule grouped|interleaved` planning for repeated trace runs and record run order in aggregate JSON.
- Add repeatable `--focus-span` support for aggregate and compare JSON/Markdown output while preserving the full span table.
- Make focused compare spans independently fail on thresholded median regressions or increased failures.

Fixes #2129

## Tests
- `cargo test commands::trace`
- `cargo test command_surface`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the trace scheduling/reporting implementation, tests, and docs; Chris remains responsible for review and validation.