### PR TITLE
Surface persisted bench run history

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -81,6 +81,17 @@ script.
 
 ## Observation History
 
+Every `homeboy bench` run is persisted to the local observation store. The
+normal bench output includes hints with the persisted run ID, the observation DB
+path, and follow-up commands such as:
+
+```bash
+homeboy runs show <run-id>
+homeboy runs list --kind bench --component <component> --rig <rig>
+```
+
+Omit `--rig <rig>` from the list command for unpinned bench runs.
+
 `homeboy bench history <component>` lists persisted benchmark runs from the local observation store. `--scenario` filters to runs whose stored metadata includes the scenario, and `--rig` narrows to rig-pinned runs.
 
 `homeboy bench compare --from-run <run-id> --to-run <run-id>` compares numeric metrics recorded in two persisted benchmark runs. It matches scenario + metric rows, reports absolute deltas and percent changes, and lists metrics that exist in only one run. The command is read-only and exits successfully for a valid comparison even when the numbers regress.
@@ -130,6 +141,12 @@ Failed gates add `gate_results`, set the scenario's `passed` field to
 ```bash
 # Benchmark a component with defaults (10 iterations, 5% regression threshold)
 homeboy bench my-component
+
+# Inspect the persisted observation from a completed bench run
+homeboy runs show <run-id>
+
+# List related persisted bench runs for comparison loops
+homeboy runs list --kind bench --component my-component --rig studio-trunk
 
 # List declared scenarios without executing them
 homeboy bench list my-component

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -459,8 +459,11 @@ fn run_component_with_rig_context(
         return Err(error);
     }
     let workflow = match workflow {
-        Ok(workflow) => {
-            observation::finish_success(observation, &workflow, &run_dir);
+        Ok(mut workflow) => {
+            if let Some(summary) = observation::finish_success(observation, &workflow, &run_dir) {
+                let hints = workflow.hints.get_or_insert_with(Vec::new);
+                hints.extend(observation::history_hints(&summary));
+            }
             workflow
         }
         Err(error) => {

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -15,6 +15,13 @@ pub(super) struct BenchObservation {
     initial_metadata: serde_json::Value,
 }
 
+pub(super) struct BenchObservationSummary {
+    pub run_id: String,
+    pub component_id: String,
+    pub rig_id: Option<String>,
+    pub store_path: String,
+}
+
 pub(super) struct BenchObservationStart<'a> {
     pub component_id: &'a str,
     pub component_label: &'a str,
@@ -63,10 +70,8 @@ pub(super) fn finish_success(
     observation: Option<BenchObservation>,
     workflow: &BenchRunWorkflowResult,
     run_dir: &RunDir,
-) {
-    let Some(observation) = observation else {
-        return;
-    };
+) -> Option<BenchObservationSummary> {
+    let observation = observation?;
 
     record_bench_observation_artifacts(&observation, workflow, run_dir);
     let metadata = bench_observation_finish_metadata(observation.initial_metadata, workflow);
@@ -75,9 +80,37 @@ pub(super) fn finish_success(
     } else {
         RunStatus::Fail
     };
+    let summary = BenchObservationSummary {
+        run_id: observation.run.id.clone(),
+        component_id: observation.run.component_id.clone().unwrap_or_default(),
+        rig_id: observation.run.rig_id.clone(),
+        store_path: observation
+            .store
+            .status()
+            .map(|status| status.path)
+            .unwrap_or_else(|_| "<unavailable>".to_string()),
+    };
     let _ = observation
         .store
         .finish_run(&observation.run.id, status, Some(metadata));
+    Some(summary)
+}
+
+pub(super) fn history_hints(summary: &BenchObservationSummary) -> Vec<String> {
+    let mut list_command = format!(
+        "homeboy runs list --kind bench --component {}",
+        summary.component_id
+    );
+    if let Some(rig_id) = &summary.rig_id {
+        list_command.push_str(&format!(" --rig {rig_id}"));
+    }
+
+    vec![
+        format!("Persisted benchmark run ID: {}", summary.run_id),
+        format!("View this run: homeboy runs show {}", summary.run_id),
+        format!("List related bench runs: {list_command}"),
+        format!("Observation store: {}", summary.store_path),
+    ]
 }
 
 pub(super) fn finish_error(
@@ -419,7 +452,21 @@ mod tests {
             })
             .expect("start observation");
             let run_id = observation.run.id.clone();
-            finish_success(Some(observation), &workflow, &run_dir);
+            let summary = finish_success(Some(observation), &workflow, &run_dir)
+                .expect("observation summary");
+            assert_eq!(summary.run_id, run_id);
+            assert_eq!(summary.component_id, "homeboy");
+            assert_eq!(summary.rig_id, None);
+
+            let hints = history_hints(&summary);
+            assert!(hints
+                .iter()
+                .any(|hint| hint == &format!("View this run: homeboy runs show {run_id}")));
+            assert!(hints.iter().any(|hint| hint
+                == "List related bench runs: homeboy runs list --kind bench --component homeboy"));
+            assert!(hints
+                .iter()
+                .any(|hint| hint.starts_with("Observation store: ")));
 
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.get_run(&run_id).expect("read run").expect("run");
@@ -491,5 +538,18 @@ mod tests {
                 .contains("synthetic bench error"));
             assert_eq!(store.list_artifacts(&run_id).expect("artifacts").len(), 1);
         });
+    }
+
+    #[test]
+    fn history_hints_include_rig_filter_when_present() {
+        let hints = history_hints(&BenchObservationSummary {
+            run_id: "run-123".to_string(),
+            component_id: "studio".to_string(),
+            rig_id: Some("studio-trunk".to_string()),
+            store_path: "/tmp/homeboy.sqlite".to_string(),
+        });
+
+        assert!(hints.iter().any(|hint| hint
+            == "List related bench runs: homeboy runs list --kind bench --component studio --rig studio-trunk"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds persisted benchmark history hints to successful `homeboy bench` output after the observation run is recorded.
- Includes the persisted run ID, `homeboy runs show <id>`, a filtered `homeboy runs list --kind bench --component ... --rig ...` command, and the observation store path.
- Updates bench command docs with the new discovery flow.

Fixes #2123

## Verification
- `cargo test commands::bench::observation`
- `cargo test bench`
- `homeboy lint`

## Notes
- `cargo clippy --all-targets --all-features -- -D warnings` still fails on existing repository-wide Clippy warnings unrelated to this change; `homeboy lint` passes with the repo's configured lint behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs update, and verification commands for Chris to review.