### PR TITLE
Add runs compare command for observation metrics

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -6,6 +6,7 @@ Inspect persisted observation-store runs and artifacts.
 
 ```bash
 homeboy runs list [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20]
+homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs show <run-id>
 homeboy runs artifacts <run-id>
 homeboy runs export --run <run-id> --output <dir>
@@ -18,6 +19,23 @@ homeboy runs import <dir>
 `homeboy runs` is a read-only query surface over Homeboy's local observation store. Producers such as `bench`, `rig`, and `trace` write run and artifact records; this command lets humans and agents inspect that evidence without opening SQLite directly.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
+
+## Compare Metrics Across History
+
+`homeboy runs compare` compares selected persisted metrics across recent observation runs. It defaults to benchmark history and the `total_elapsed_ms` metric:
+
+```bash
+homeboy runs compare --kind bench --component studio --metric total_elapsed_ms --limit 20
+homeboy runs compare --kind bench --component studio --rig studio-bfb --scenario studio-agent-site-build --metric total_elapsed_ms --metric p95_ms
+```
+
+The default output is a Markdown table with run id, status, start time, git SHA, rig id, artifact count, scenario, and selected metric columns. Use `--format=json` for structured output, or pair it with global `--output <file>` to write command JSON to disk:
+
+```bash
+homeboy runs compare --kind bench --component studio --metric total_elapsed_ms --format=json --output runs-compare.json
+```
+
+Metric lookup supports top-level run metadata such as `results.total_elapsed_ms`, direct dotted paths, and benchmark scenario metrics recorded under `scenario_metrics[].metrics` or `metric_groups`.
 
 ## Related Readers
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1,4 +1,5 @@
 use clap::{Command, CommandFactory, Parser, Subcommand};
+use std::path::PathBuf;
 
 use crate::commands::{
     api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
@@ -17,7 +18,7 @@ pub struct Cli {
     /// Write structured JSON output to a file (in addition to stdout).
     /// The file contains command-specific JSON — no log text.
     #[arg(long, global = true, value_name = "PATH")]
-    pub output: Option<String>,
+    pub output: Option<PathBuf>,
 
     #[command(subcommand)]
     pub command: Commands,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -326,6 +326,7 @@ pub fn run_markdown(
         crate::cli_surface::Commands::Changelog(args) => changelog::run_markdown(args),
         crate::cli_surface::Commands::Review(args) => review::run_markdown(args, global),
         crate::cli_surface::Commands::Trace(args) => trace::run_markdown(args, global),
+        crate::cli_surface::Commands::Runs(args) => runs::run_markdown(args, global),
         crate::cli_surface::Commands::Report(args) => report::run_markdown(args),
         _ => Err(homeboy::Error::validation_invalid_argument(
             "output_mode",

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,11 +1,12 @@
 mod bundle;
+mod compare;
 mod findings;
 mod latest;
 mod reconcile;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use clap::{Args, Subcommand, ValueEnum};
+use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -14,9 +15,9 @@ use homeboy::Error;
 
 use super::{CmdResult, GlobalArgs};
 use bundle::{
-    export_runs, import_runs, ObservationBundleImportSummary, ObservationBundleManifest,
-    RunsExportArgs, RunsImportArgs,
+    export_runs, import_runs, RunsExportArgs, RunsExportOutput, RunsImportArgs, RunsImportOutput,
 };
+use compare::{compare_runs, RunsCompareArgs, RunsCompareOutput};
 use findings::{RunsFindingOutput, RunsFindingsOutput};
 use latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
@@ -74,40 +75,6 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
-#[derive(Args, Clone)]
-pub struct RunsCompareArgs {
-    /// Run kind: bench, rig, trace, etc.
-    #[arg(long, default_value = "bench")]
-    pub kind: String,
-    /// Component ID
-    #[arg(long = "component")]
-    pub component_id: Option<String>,
-    /// Rig ID
-    #[arg(long)]
-    pub rig: Option<String>,
-    /// Scenario ID for scenario-scoped metrics
-    #[arg(long = "scenario")]
-    pub scenario_id: Option<String>,
-    /// Run status
-    #[arg(long)]
-    pub status: Option<String>,
-    /// Metric to include. Repeat to compare multiple metrics.
-    #[arg(long = "metric", default_value = "total_elapsed_ms")]
-    pub metrics: Vec<String>,
-    /// Maximum runs to inspect
-    #[arg(long, default_value_t = DEFAULT_LIMIT)]
-    pub limit: i64,
-    /// Output format
-    #[arg(long, value_enum, default_value_t = RunsCompareFormat::Table)]
-    pub format: RunsCompareFormat,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-pub enum RunsCompareFormat {
-    Table,
-    Json,
-}
-
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
@@ -130,26 +97,6 @@ pub enum RunsOutput {
 pub struct RunsListOutput {
     pub command: &'static str,
     pub runs: Vec<RunSummary>,
-}
-
-#[derive(Serialize)]
-pub struct RunsCompareOutput {
-    pub command: &'static str,
-    pub kind: String,
-    pub component_id: Option<String>,
-    pub rig_id: Option<String>,
-    pub scenario_id: Option<String>,
-    pub metrics: Vec<String>,
-    pub rows: Vec<RunsCompareRow>,
-}
-
-#[derive(Serialize, Clone)]
-pub struct RunsCompareRow {
-    pub run: RunSummary,
-    pub artifact_count: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scenario_id: Option<String>,
-    pub metrics: BTreeMap<String, Option<f64>>,
 }
 
 #[derive(Serialize)]
@@ -183,23 +130,6 @@ pub struct BenchCompareOutput {
     pub to_run: RunSummary,
     pub comparisons: Vec<BenchMetricComparison>,
     pub missing: Vec<BenchMissingMetric>,
-}
-
-#[derive(Serialize)]
-pub struct RunsExportOutput {
-    pub command: &'static str,
-    pub output: String,
-    pub manifest: ObservationBundleManifest,
-    pub run_count: usize,
-    pub artifact_count: usize,
-    pub trace_span_count: usize,
-}
-
-#[derive(Serialize)]
-pub struct RunsImportOutput {
-    pub command: &'static str,
-    pub input: String,
-    pub imported: ObservationBundleImportSummary,
 }
 
 #[derive(Serialize, Clone)]
@@ -260,14 +190,19 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
     }
 }
 
-pub fn is_markdown_mode(args: &RunsArgs) -> bool {
-    matches!(args.command, RunsCommand::Compare(ref compare) if compare.format == RunsCompareFormat::Table)
+impl RunsArgs {
+    pub fn is_markdown_mode(&self) -> bool {
+        matches!(self.command, RunsCommand::Compare(ref compare) if compare::is_table_mode(compare))
+    }
+
+    pub fn is_bundle_export(&self) -> bool {
+        matches!(self.command, RunsCommand::Export(_))
+    }
 }
 
-pub fn run_markdown(args: RunsArgs, global: &GlobalArgs) -> CmdResult<String> {
-    let (output, exit_code) = run(args, global)?;
-    match output {
-        RunsOutput::Compare(output) => Ok((render_compare_table(&output), exit_code)),
+pub fn run_markdown(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<String> {
+    match args.command {
+        RunsCommand::Compare(args) => compare::run_markdown(args),
         _ => Err(Error::validation_invalid_argument(
             "output_mode",
             "Only `homeboy runs compare --format=table` supports table output",
@@ -293,68 +228,6 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
         .collect();
 
     Ok((RunsOutput::List(RunsListOutput { command, runs }), 0))
-}
-
-pub fn compare_runs(args: RunsCompareArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let limit = args.limit.clamp(1, 1000);
-    let runs = store.list_runs(RunListFilter {
-        kind: Some(args.kind.clone()),
-        component_id: args.component_id.clone(),
-        status: args.status.clone(),
-        rig_id: args.rig.clone(),
-        limit: Some(limit),
-    })?;
-
-    let mut rows = Vec::new();
-    for run in runs {
-        if args
-            .scenario_id
-            .as_deref()
-            .is_some_and(|scenario| !run_contains_scenario(&run, scenario))
-        {
-            continue;
-        }
-
-        let artifact_count = store.list_artifacts(&run.id)?.len();
-        let scenario_ids = compare_scenarios_for_run(
-            &run.metadata_json,
-            args.scenario_id.as_deref(),
-            &args.metrics,
-        );
-        for scenario_id in scenario_ids {
-            let metrics = args
-                .metrics
-                .iter()
-                .map(|metric| {
-                    (
-                        metric.clone(),
-                        run_metric_value(&run.metadata_json, scenario_id.as_deref(), metric),
-                    )
-                })
-                .collect::<BTreeMap<_, _>>();
-
-            rows.push(RunsCompareRow {
-                run: run_summary(run.clone()),
-                artifact_count,
-                scenario_id,
-                metrics,
-            });
-        }
-    }
-
-    Ok((
-        RunsOutput::Compare(RunsCompareOutput {
-            command: "runs.compare",
-            kind: args.kind,
-            component_id: args.component_id,
-            rig_id: args.rig,
-            scenario_id: args.scenario_id,
-            metrics: args.metrics,
-            rows: rows.into_iter().take(limit as usize).collect(),
-        }),
-        0,
-    ))
 }
 
 fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
@@ -535,133 +408,6 @@ fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
     bench_numeric_metrics(&run.metadata_json)
         .keys()
         .any(|(scenario, _)| scenario == scenario_id)
-}
-
-fn compare_scenarios_for_run(
-    metadata: &Value,
-    scenario_id: Option<&str>,
-    metrics: &[String],
-) -> Vec<Option<String>> {
-    if let Some(scenario_id) = scenario_id {
-        return vec![Some(scenario_id.to_string())];
-    }
-
-    let bench_metrics = bench_numeric_metrics(metadata);
-    let mut scenario_ids = bench_metrics
-        .keys()
-        .filter(|(_, metric)| metrics.iter().any(|requested| requested == metric))
-        .map(|(scenario, _)| scenario.clone())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .map(Some)
-        .collect::<Vec<_>>();
-
-    if metrics
-        .iter()
-        .any(|metric| top_level_metric_value(metadata, metric).is_some())
-    {
-        scenario_ids.insert(0, None);
-    }
-
-    if scenario_ids.is_empty() {
-        vec![None]
-    } else {
-        scenario_ids
-    }
-}
-
-fn run_metric_value(metadata: &Value, scenario_id: Option<&str>, metric: &str) -> Option<f64> {
-    if let Some(scenario_id) = scenario_id {
-        let key = (scenario_id.to_string(), metric.to_string());
-        if let Some(value) = bench_numeric_metrics(metadata).get(&key) {
-            return Some(*value);
-        }
-    }
-
-    top_level_metric_value(metadata, metric)
-}
-
-fn top_level_metric_value(metadata: &Value, metric: &str) -> Option<f64> {
-    dotted_value(metadata, metric)
-        .and_then(Value::as_f64)
-        .or_else(|| dotted_value(&metadata["results"], metric).and_then(Value::as_f64))
-}
-
-fn dotted_value<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
-    let mut current = value;
-    for part in path.split('.') {
-        current = current.get(part)?;
-    }
-    Some(current)
-}
-
-fn render_compare_table(output: &RunsCompareOutput) -> String {
-    let mut out = String::new();
-    out.push_str("# Runs Compare\n\n");
-    out.push_str(&format!("- **Kind:** `{}`\n", output.kind));
-    if let Some(component_id) = &output.component_id {
-        out.push_str(&format!("- **Component:** `{component_id}`\n"));
-    }
-    if let Some(rig_id) = &output.rig_id {
-        out.push_str(&format!("- **Rig:** `{rig_id}`\n"));
-    }
-    if let Some(scenario_id) = &output.scenario_id {
-        out.push_str(&format!("- **Scenario:** `{scenario_id}`\n"));
-    }
-
-    out.push_str("\n| Run | Status | Started | Git SHA | Rig | Artifacts | Scenario |");
-    for metric in &output.metrics {
-        out.push_str(&format!(" {} |", escape_table_cell(metric)));
-    }
-    out.push('\n');
-    out.push_str("|---|---|---|---|---|---:|---|");
-    for _ in &output.metrics {
-        out.push_str("---:|");
-    }
-    out.push('\n');
-
-    for row in &output.rows {
-        let git_sha = row.run.git_sha.as_deref().map(short_sha).unwrap_or("-");
-        out.push_str(&format!(
-            "| `{}` | `{}` | {} | `{}` | `{}` | {} | `{}` |",
-            short_sha(&row.run.id),
-            row.run.status,
-            row.run.started_at,
-            git_sha,
-            row.run.rig_id.as_deref().unwrap_or("-"),
-            row.artifact_count,
-            row.scenario_id.as_deref().unwrap_or("-")
-        ));
-        for metric in &output.metrics {
-            out.push_str(&format!(
-                " {} |",
-                fmt_metric(row.metrics.get(metric).copied().flatten())
-            ));
-        }
-        out.push('\n');
-    }
-
-    out
-}
-
-fn short_sha(value: &str) -> &str {
-    value.get(..8).unwrap_or(value)
-}
-
-fn fmt_metric(value: Option<f64>) -> String {
-    value
-        .map(|value| {
-            if value.fract().abs() < f64::EPSILON {
-                format!("{value:.0}")
-            } else {
-                format!("{value:.3}")
-            }
-        })
-        .unwrap_or_else(|| "-".to_string())
-}
-
-fn escape_table_cell(value: &str) -> String {
-    value.replace('|', "\\|")
 }
 
 fn bench_numeric_metrics(metadata: &Value) -> BTreeMap<(String, String), f64> {
@@ -1186,112 +932,6 @@ mod tests {
                 .iter()
                 .any(|row| row.metric == "only_to" && row.missing_from == "from_run"));
         });
-    }
-
-    #[test]
-    fn runs_compare_filters_history_and_reports_selected_metrics() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            let old = store
-                .start_run(sample_run(
-                    "bench",
-                    "studio",
-                    "studio-bfb",
-                    serde_json::json!({
-                        "results": { "total_elapsed_ms": 177754.0 },
-                        "scenario_metrics": [{
-                            "scenario_id": "site-build",
-                            "metrics": { "p95_ms": 90.0 }
-                        }]
-                    }),
-                ))
-                .expect("old");
-            store
-                .finish_run(&old.id, RunStatus::Pass, None)
-                .expect("finish old");
-            let new = store
-                .start_run(sample_run(
-                    "bench",
-                    "studio",
-                    "studio-bfb",
-                    serde_json::json!({
-                        "results": { "total_elapsed_ms": 213151.0 },
-                        "scenario_metrics": [{
-                            "scenario_id": "site-build",
-                            "metrics": { "p95_ms": 120.0 }
-                        }]
-                    }),
-                ))
-                .expect("new");
-            store
-                .finish_run(&new.id, RunStatus::Fail, None)
-                .expect("finish new");
-            let other = store
-                .start_run(sample_run("trace", "studio", "studio-bfb", Value::Null))
-                .expect("trace");
-            store
-                .finish_run(&other.id, RunStatus::Pass, None)
-                .expect("finish trace");
-
-            let (output, _) = compare_runs(RunsCompareArgs {
-                kind: "bench".to_string(),
-                component_id: Some("studio".to_string()),
-                rig: Some("studio-bfb".to_string()),
-                scenario_id: Some("site-build".to_string()),
-                status: None,
-                metrics: vec!["total_elapsed_ms".to_string(), "p95_ms".to_string()],
-                limit: 20,
-                format: RunsCompareFormat::Json,
-            })
-            .expect("compare");
-
-            let RunsOutput::Compare(output) = output else {
-                panic!("expected compare output");
-            };
-            assert_eq!(output.rows.len(), 2);
-            assert_eq!(output.rows[0].run.id, new.id);
-            assert_eq!(output.rows[0].metrics["total_elapsed_ms"], Some(213151.0));
-            assert_eq!(output.rows[0].metrics["p95_ms"], Some(120.0));
-            assert_eq!(output.rows[1].run.id, old.id);
-        });
-    }
-
-    #[test]
-    fn runs_compare_table_renders_metric_columns() {
-        let output = RunsCompareOutput {
-            command: "runs.compare",
-            kind: "bench".to_string(),
-            component_id: Some("studio".to_string()),
-            rig_id: Some("studio-bfb".to_string()),
-            scenario_id: None,
-            metrics: vec!["total_elapsed_ms".to_string()],
-            rows: vec![RunsCompareRow {
-                run: RunSummary {
-                    id: "38f271b9-0000".to_string(),
-                    kind: "bench".to_string(),
-                    status: "pass".to_string(),
-                    started_at: "2026-05-02T00:00:00Z".to_string(),
-                    finished_at: None,
-                    component_id: Some("studio".to_string()),
-                    rig_id: Some("studio-bfb".to_string()),
-                    git_sha: Some("abcdef123456".to_string()),
-                    command: None,
-                    cwd: None,
-                    status_note: None,
-                },
-                artifact_count: 3,
-                scenario_id: None,
-                metrics: BTreeMap::from([("total_elapsed_ms".to_string(), Some(213151.0))]),
-            }],
-        };
-
-        let table = render_compare_table(&output);
-        assert!(table.contains(
-            "| Run | Status | Started | Git SHA | Rig | Artifacts | Scenario | total_elapsed_ms |"
-        ));
-        assert!(table.contains("| `38f271b9` | `pass`"));
-        assert!(table.contains("| 213151 |"));
     }
 
     #[test]

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -5,7 +5,7 @@ mod reconcile;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -23,18 +23,20 @@ use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
 
 const DEFAULT_LIMIT: i64 = 20;
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct RunsArgs {
     #[command(subcommand)]
     command: RunsCommand,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Clone)]
 enum RunsCommand {
     /// List persisted observation runs
     List(RunsListArgs),
     /// Show the latest persisted observation run matching filters
     LatestRun(RunsLatestRunArgs),
+    /// Compare selected metrics across persisted run history
+    Compare(RunsCompareArgs),
     /// Mark orphaned running observation records stale
     Reconcile(RunsReconcileArgs),
     /// Show one persisted observation run
@@ -72,11 +74,46 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
+#[derive(Args, Clone)]
+pub struct RunsCompareArgs {
+    /// Run kind: bench, rig, trace, etc.
+    #[arg(long, default_value = "bench")]
+    pub kind: String,
+    /// Component ID
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Scenario ID for scenario-scoped metrics
+    #[arg(long = "scenario")]
+    pub scenario_id: Option<String>,
+    /// Run status
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Metric to include. Repeat to compare multiple metrics.
+    #[arg(long = "metric", default_value = "total_elapsed_ms")]
+    pub metrics: Vec<String>,
+    /// Maximum runs to inspect
+    #[arg(long, default_value_t = DEFAULT_LIMIT)]
+    pub limit: i64,
+    /// Output format
+    #[arg(long, value_enum, default_value_t = RunsCompareFormat::Table)]
+    pub format: RunsCompareFormat,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum RunsCompareFormat {
+    Table,
+    Json,
+}
+
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
     List(RunsListOutput),
     LatestRun(RunsLatestRunOutput),
+    Compare(RunsCompareOutput),
     Show(RunsShowOutput),
     Artifacts(RunsArtifactsOutput),
     Findings(RunsFindingsOutput),
@@ -93,6 +130,26 @@ pub enum RunsOutput {
 pub struct RunsListOutput {
     pub command: &'static str,
     pub runs: Vec<RunSummary>,
+}
+
+#[derive(Serialize)]
+pub struct RunsCompareOutput {
+    pub command: &'static str,
+    pub kind: String,
+    pub component_id: Option<String>,
+    pub rig_id: Option<String>,
+    pub scenario_id: Option<String>,
+    pub metrics: Vec<String>,
+    pub rows: Vec<RunsCompareRow>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct RunsCompareRow {
+    pub run: RunSummary,
+    pub artifact_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    pub metrics: BTreeMap<String, Option<f64>>,
 }
 
 #[derive(Serialize)]
@@ -145,7 +202,7 @@ pub struct RunsImportOutput {
     pub imported: ObservationBundleImportSummary,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct RunSummary {
     pub id: String,
     pub kind: String,
@@ -191,6 +248,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
     match args.command {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
         RunsCommand::LatestRun(args) => latest::latest_run(args),
+        RunsCommand::Compare(args) => compare_runs(args),
         RunsCommand::Reconcile(args) => reconcile_runs(args),
         RunsCommand::Show { run_id } => show_run(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
@@ -199,6 +257,23 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::LatestFinding(args) => findings::latest_finding(args),
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
+    }
+}
+
+pub fn is_markdown_mode(args: &RunsArgs) -> bool {
+    matches!(args.command, RunsCommand::Compare(ref compare) if compare.format == RunsCompareFormat::Table)
+}
+
+pub fn run_markdown(args: RunsArgs, global: &GlobalArgs) -> CmdResult<String> {
+    let (output, exit_code) = run(args, global)?;
+    match output {
+        RunsOutput::Compare(output) => Ok((render_compare_table(&output), exit_code)),
+        _ => Err(Error::validation_invalid_argument(
+            "output_mode",
+            "Only `homeboy runs compare --format=table` supports table output",
+            None,
+            None,
+        )),
     }
 }
 
@@ -218,6 +293,68 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
         .collect();
 
     Ok((RunsOutput::List(RunsListOutput { command, runs }), 0))
+}
+
+pub fn compare_runs(args: RunsCompareArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let limit = args.limit.clamp(1, 1000);
+    let runs = store.list_runs(RunListFilter {
+        kind: Some(args.kind.clone()),
+        component_id: args.component_id.clone(),
+        status: args.status.clone(),
+        rig_id: args.rig.clone(),
+        limit: Some(limit),
+    })?;
+
+    let mut rows = Vec::new();
+    for run in runs {
+        if args
+            .scenario_id
+            .as_deref()
+            .is_some_and(|scenario| !run_contains_scenario(&run, scenario))
+        {
+            continue;
+        }
+
+        let artifact_count = store.list_artifacts(&run.id)?.len();
+        let scenario_ids = compare_scenarios_for_run(
+            &run.metadata_json,
+            args.scenario_id.as_deref(),
+            &args.metrics,
+        );
+        for scenario_id in scenario_ids {
+            let metrics = args
+                .metrics
+                .iter()
+                .map(|metric| {
+                    (
+                        metric.clone(),
+                        run_metric_value(&run.metadata_json, scenario_id.as_deref(), metric),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+
+            rows.push(RunsCompareRow {
+                run: run_summary(run.clone()),
+                artifact_count,
+                scenario_id,
+                metrics,
+            });
+        }
+    }
+
+    Ok((
+        RunsOutput::Compare(RunsCompareOutput {
+            command: "runs.compare",
+            kind: args.kind,
+            component_id: args.component_id,
+            rig_id: args.rig,
+            scenario_id: args.scenario_id,
+            metrics: args.metrics,
+            rows: rows.into_iter().take(limit as usize).collect(),
+        }),
+        0,
+    ))
 }
 
 fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
@@ -398,6 +535,133 @@ fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
     bench_numeric_metrics(&run.metadata_json)
         .keys()
         .any(|(scenario, _)| scenario == scenario_id)
+}
+
+fn compare_scenarios_for_run(
+    metadata: &Value,
+    scenario_id: Option<&str>,
+    metrics: &[String],
+) -> Vec<Option<String>> {
+    if let Some(scenario_id) = scenario_id {
+        return vec![Some(scenario_id.to_string())];
+    }
+
+    let bench_metrics = bench_numeric_metrics(metadata);
+    let mut scenario_ids = bench_metrics
+        .keys()
+        .filter(|(_, metric)| metrics.iter().any(|requested| requested == metric))
+        .map(|(scenario, _)| scenario.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(Some)
+        .collect::<Vec<_>>();
+
+    if metrics
+        .iter()
+        .any(|metric| top_level_metric_value(metadata, metric).is_some())
+    {
+        scenario_ids.insert(0, None);
+    }
+
+    if scenario_ids.is_empty() {
+        vec![None]
+    } else {
+        scenario_ids
+    }
+}
+
+fn run_metric_value(metadata: &Value, scenario_id: Option<&str>, metric: &str) -> Option<f64> {
+    if let Some(scenario_id) = scenario_id {
+        let key = (scenario_id.to_string(), metric.to_string());
+        if let Some(value) = bench_numeric_metrics(metadata).get(&key) {
+            return Some(*value);
+        }
+    }
+
+    top_level_metric_value(metadata, metric)
+}
+
+fn top_level_metric_value(metadata: &Value, metric: &str) -> Option<f64> {
+    dotted_value(metadata, metric)
+        .and_then(Value::as_f64)
+        .or_else(|| dotted_value(&metadata["results"], metric).and_then(Value::as_f64))
+}
+
+fn dotted_value<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = value;
+    for part in path.split('.') {
+        current = current.get(part)?;
+    }
+    Some(current)
+}
+
+fn render_compare_table(output: &RunsCompareOutput) -> String {
+    let mut out = String::new();
+    out.push_str("# Runs Compare\n\n");
+    out.push_str(&format!("- **Kind:** `{}`\n", output.kind));
+    if let Some(component_id) = &output.component_id {
+        out.push_str(&format!("- **Component:** `{component_id}`\n"));
+    }
+    if let Some(rig_id) = &output.rig_id {
+        out.push_str(&format!("- **Rig:** `{rig_id}`\n"));
+    }
+    if let Some(scenario_id) = &output.scenario_id {
+        out.push_str(&format!("- **Scenario:** `{scenario_id}`\n"));
+    }
+
+    out.push_str("\n| Run | Status | Started | Git SHA | Rig | Artifacts | Scenario |");
+    for metric in &output.metrics {
+        out.push_str(&format!(" {} |", escape_table_cell(metric)));
+    }
+    out.push('\n');
+    out.push_str("|---|---|---|---|---|---:|---|");
+    for _ in &output.metrics {
+        out.push_str("---:|");
+    }
+    out.push('\n');
+
+    for row in &output.rows {
+        let git_sha = row.run.git_sha.as_deref().map(short_sha).unwrap_or("-");
+        out.push_str(&format!(
+            "| `{}` | `{}` | {} | `{}` | `{}` | {} | `{}` |",
+            short_sha(&row.run.id),
+            row.run.status,
+            row.run.started_at,
+            git_sha,
+            row.run.rig_id.as_deref().unwrap_or("-"),
+            row.artifact_count,
+            row.scenario_id.as_deref().unwrap_or("-")
+        ));
+        for metric in &output.metrics {
+            out.push_str(&format!(
+                " {} |",
+                fmt_metric(row.metrics.get(metric).copied().flatten())
+            ));
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+fn short_sha(value: &str) -> &str {
+    value.get(..8).unwrap_or(value)
+}
+
+fn fmt_metric(value: Option<f64>) -> String {
+    value
+        .map(|value| {
+            if value.fract().abs() < f64::EPSILON {
+                format!("{value:.0}")
+            } else {
+                format!("{value:.3}")
+            }
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', "\\|")
 }
 
 fn bench_numeric_metrics(metadata: &Value) -> BTreeMap<(String, String), f64> {
@@ -922,6 +1186,112 @@ mod tests {
                 .iter()
                 .any(|row| row.metric == "only_to" && row.missing_from == "from_run"));
         });
+    }
+
+    #[test]
+    fn runs_compare_filters_history_and_reports_selected_metrics() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let old = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "studio-bfb",
+                    serde_json::json!({
+                        "results": { "total_elapsed_ms": 177754.0 },
+                        "scenario_metrics": [{
+                            "scenario_id": "site-build",
+                            "metrics": { "p95_ms": 90.0 }
+                        }]
+                    }),
+                ))
+                .expect("old");
+            store
+                .finish_run(&old.id, RunStatus::Pass, None)
+                .expect("finish old");
+            let new = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "studio-bfb",
+                    serde_json::json!({
+                        "results": { "total_elapsed_ms": 213151.0 },
+                        "scenario_metrics": [{
+                            "scenario_id": "site-build",
+                            "metrics": { "p95_ms": 120.0 }
+                        }]
+                    }),
+                ))
+                .expect("new");
+            store
+                .finish_run(&new.id, RunStatus::Fail, None)
+                .expect("finish new");
+            let other = store
+                .start_run(sample_run("trace", "studio", "studio-bfb", Value::Null))
+                .expect("trace");
+            store
+                .finish_run(&other.id, RunStatus::Pass, None)
+                .expect("finish trace");
+
+            let (output, _) = compare_runs(RunsCompareArgs {
+                kind: "bench".to_string(),
+                component_id: Some("studio".to_string()),
+                rig: Some("studio-bfb".to_string()),
+                scenario_id: Some("site-build".to_string()),
+                status: None,
+                metrics: vec!["total_elapsed_ms".to_string(), "p95_ms".to_string()],
+                limit: 20,
+                format: RunsCompareFormat::Json,
+            })
+            .expect("compare");
+
+            let RunsOutput::Compare(output) = output else {
+                panic!("expected compare output");
+            };
+            assert_eq!(output.rows.len(), 2);
+            assert_eq!(output.rows[0].run.id, new.id);
+            assert_eq!(output.rows[0].metrics["total_elapsed_ms"], Some(213151.0));
+            assert_eq!(output.rows[0].metrics["p95_ms"], Some(120.0));
+            assert_eq!(output.rows[1].run.id, old.id);
+        });
+    }
+
+    #[test]
+    fn runs_compare_table_renders_metric_columns() {
+        let output = RunsCompareOutput {
+            command: "runs.compare",
+            kind: "bench".to_string(),
+            component_id: Some("studio".to_string()),
+            rig_id: Some("studio-bfb".to_string()),
+            scenario_id: None,
+            metrics: vec!["total_elapsed_ms".to_string()],
+            rows: vec![RunsCompareRow {
+                run: RunSummary {
+                    id: "38f271b9-0000".to_string(),
+                    kind: "bench".to_string(),
+                    status: "pass".to_string(),
+                    started_at: "2026-05-02T00:00:00Z".to_string(),
+                    finished_at: None,
+                    component_id: Some("studio".to_string()),
+                    rig_id: Some("studio-bfb".to_string()),
+                    git_sha: Some("abcdef123456".to_string()),
+                    command: None,
+                    cwd: None,
+                    status_note: None,
+                },
+                artifact_count: 3,
+                scenario_id: None,
+                metrics: BTreeMap::from([("total_elapsed_ms".to_string(), Some(213151.0))]),
+            }],
+        };
+
+        let table = render_compare_table(&output);
+        assert!(table.contains(
+            "| Run | Status | Started | Git SHA | Rig | Artifacts | Scenario | total_elapsed_ms |"
+        ));
+        assert!(table.contains("| `38f271b9` | `pass`"));
+        assert!(table.contains("| 213151 |"));
     }
 
     #[test]

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use homeboy::observation::{ArtifactRecord, ObservationStore, RunRecord, TraceSpanRecord};
 use homeboy::Error;
 
-use super::{require_run, CmdResult, RunsExportOutput, RunsImportOutput, RunsOutput};
+use super::{require_run, CmdResult, RunsOutput};
 
 const BUNDLE_FORMAT: &str = "homeboy-observations";
 const BUNDLE_VERSION: u32 = 1;
@@ -56,6 +56,23 @@ pub struct ObservationBundleImportSummary {
     pub runs: usize,
     pub artifacts: usize,
     pub trace_spans: usize,
+}
+
+#[derive(Serialize)]
+pub struct RunsExportOutput {
+    pub command: &'static str,
+    pub output: String,
+    pub manifest: ObservationBundleManifest,
+    pub run_count: usize,
+    pub artifact_count: usize,
+    pub trace_span_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct RunsImportOutput {
+    pub command: &'static str,
+    pub input: String,
+    pub imported: ObservationBundleImportSummary,
 }
 
 pub(super) fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {

--- a/src/commands/runs/compare.rs
+++ b/src/commands/runs/compare.rs
@@ -1,0 +1,417 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+
+use homeboy::observation::{ObservationStore, RunListFilter};
+use homeboy::Error;
+
+use crate::commands::CmdResult;
+
+use super::{bench_numeric_metrics, run_contains_scenario, run_summary, RunSummary, RunsOutput};
+
+#[derive(Args, Clone)]
+pub struct RunsCompareArgs {
+    /// Run kind: bench, rig, trace, etc.
+    #[arg(long, default_value = "bench")]
+    pub kind: String,
+    /// Component ID
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Scenario ID for scenario-scoped metrics
+    #[arg(long = "scenario")]
+    pub scenario_id: Option<String>,
+    /// Run status
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Metric to include. Repeat to compare multiple metrics.
+    #[arg(long = "metric", default_value = "total_elapsed_ms")]
+    pub metrics: Vec<String>,
+    /// Maximum runs to inspect
+    #[arg(long, default_value_t = super::DEFAULT_LIMIT)]
+    pub limit: i64,
+    /// Output format
+    #[arg(long, value_enum, default_value_t = RunsCompareFormat::Table)]
+    pub format: RunsCompareFormat,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum RunsCompareFormat {
+    Table,
+    Json,
+}
+
+#[derive(Serialize)]
+pub struct RunsCompareOutput {
+    pub command: &'static str,
+    pub kind: String,
+    pub component_id: Option<String>,
+    pub rig_id: Option<String>,
+    pub scenario_id: Option<String>,
+    pub metrics: Vec<String>,
+    pub rows: Vec<RunsCompareRow>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct RunsCompareRow {
+    pub run: RunSummary,
+    pub artifact_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    pub metrics: BTreeMap<String, Option<f64>>,
+}
+
+pub fn is_table_mode(args: &RunsCompareArgs) -> bool {
+    args.format == RunsCompareFormat::Table
+}
+
+pub fn run_markdown(args: RunsCompareArgs) -> CmdResult<String> {
+    let (output, exit_code) = compare_runs(args)?;
+    match output {
+        RunsOutput::Compare(output) => Ok((render_compare_table(&output), exit_code)),
+        _ => Err(Error::validation_invalid_argument(
+            "output_mode",
+            "Only `homeboy runs compare --format=table` supports table output",
+            None,
+            None,
+        )),
+    }
+}
+
+pub(super) fn compare_runs(args: RunsCompareArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let limit = args.limit.clamp(1, 1000);
+    let runs = store.list_runs(RunListFilter {
+        kind: Some(args.kind.clone()),
+        component_id: args.component_id.clone(),
+        status: args.status.clone(),
+        rig_id: args.rig.clone(),
+        limit: Some(limit),
+    })?;
+
+    let mut rows = Vec::new();
+    for run in runs {
+        if args
+            .scenario_id
+            .as_deref()
+            .is_some_and(|scenario| !run_contains_scenario(&run, scenario))
+        {
+            continue;
+        }
+
+        let artifact_count = store.list_artifacts(&run.id)?.len();
+        let scenario_ids = compare_scenarios_for_run(
+            &run.metadata_json,
+            args.scenario_id.as_deref(),
+            &args.metrics,
+        );
+        for scenario_id in scenario_ids {
+            let metrics = args
+                .metrics
+                .iter()
+                .map(|metric| {
+                    (
+                        metric.clone(),
+                        run_metric_value(&run.metadata_json, scenario_id.as_deref(), metric),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+
+            rows.push(RunsCompareRow {
+                run: run_summary(run.clone()),
+                artifact_count,
+                scenario_id,
+                metrics,
+            });
+        }
+    }
+
+    Ok((
+        RunsOutput::Compare(RunsCompareOutput {
+            command: "runs.compare",
+            kind: args.kind,
+            component_id: args.component_id,
+            rig_id: args.rig,
+            scenario_id: args.scenario_id,
+            metrics: args.metrics,
+            rows: rows.into_iter().take(limit as usize).collect(),
+        }),
+        0,
+    ))
+}
+
+fn compare_scenarios_for_run(
+    metadata: &Value,
+    scenario_id: Option<&str>,
+    metrics: &[String],
+) -> Vec<Option<String>> {
+    if let Some(scenario_id) = scenario_id {
+        return vec![Some(scenario_id.to_string())];
+    }
+
+    let bench_metrics = bench_numeric_metrics(metadata);
+    let mut scenario_ids = bench_metrics
+        .keys()
+        .filter(|(_, metric)| metrics.iter().any(|requested| requested == metric))
+        .map(|(scenario, _)| scenario.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(Some)
+        .collect::<Vec<_>>();
+
+    if metrics
+        .iter()
+        .any(|metric| top_level_metric_value(metadata, metric).is_some())
+    {
+        scenario_ids.insert(0, None);
+    }
+
+    if scenario_ids.is_empty() {
+        vec![None]
+    } else {
+        scenario_ids
+    }
+}
+
+fn run_metric_value(metadata: &Value, scenario_id: Option<&str>, metric: &str) -> Option<f64> {
+    if let Some(scenario_id) = scenario_id {
+        let key = (scenario_id.to_string(), metric.to_string());
+        if let Some(value) = bench_numeric_metrics(metadata).get(&key) {
+            return Some(*value);
+        }
+    }
+
+    top_level_metric_value(metadata, metric)
+}
+
+fn top_level_metric_value(metadata: &Value, metric: &str) -> Option<f64> {
+    dotted_value(metadata, metric)
+        .and_then(Value::as_f64)
+        .or_else(|| dotted_value(&metadata["results"], metric).and_then(Value::as_f64))
+}
+
+fn dotted_value<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = value;
+    for part in path.split('.') {
+        current = current.get(part)?;
+    }
+    Some(current)
+}
+
+fn render_compare_table(output: &RunsCompareOutput) -> String {
+    let mut out = String::new();
+    out.push_str("# Runs Compare\n\n");
+    out.push_str(&format!("- **Kind:** `{}`\n", output.kind));
+    if let Some(component_id) = &output.component_id {
+        out.push_str(&format!("- **Component:** `{component_id}`\n"));
+    }
+    if let Some(rig_id) = &output.rig_id {
+        out.push_str(&format!("- **Rig:** `{rig_id}`\n"));
+    }
+    if let Some(scenario_id) = &output.scenario_id {
+        out.push_str(&format!("- **Scenario:** `{scenario_id}`\n"));
+    }
+
+    out.push_str("\n| Run | Status | Started | Git SHA | Rig | Artifacts | Scenario |");
+    for metric in &output.metrics {
+        out.push_str(&format!(" {} |", escape_table_cell(metric)));
+    }
+    out.push('\n');
+    out.push_str("|---|---|---|---|---|---:|---|");
+    for _ in &output.metrics {
+        out.push_str("---:|");
+    }
+    out.push('\n');
+
+    for row in &output.rows {
+        let git_sha = row.run.git_sha.as_deref().map(short_sha).unwrap_or("-");
+        out.push_str(&format!(
+            "| `{}` | `{}` | {} | `{}` | `{}` | {} | `{}` |",
+            short_sha(&row.run.id),
+            row.run.status,
+            row.run.started_at,
+            git_sha,
+            row.run.rig_id.as_deref().unwrap_or("-"),
+            row.artifact_count,
+            row.scenario_id.as_deref().unwrap_or("-")
+        ));
+        for metric in &output.metrics {
+            out.push_str(&format!(
+                " {} |",
+                fmt_metric(row.metrics.get(metric).copied().flatten())
+            ));
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+fn short_sha(value: &str) -> &str {
+    value.get(..8).unwrap_or(value)
+}
+
+fn fmt_metric(value: Option<f64>) -> String {
+    value
+        .map(|value| {
+            if value.fract().abs() < f64::EPSILON {
+                format!("{value:.0}")
+            } else {
+                format!("{value:.3}")
+            }
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', "\\|")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy::observation::{NewRunRecord, RunStatus};
+    use homeboy::test_support::with_isolated_home;
+
+    struct XdgGuard(Option<String>);
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
+        NewRunRecord {
+            kind: kind.to_string(),
+            component_id: Some(component_id.to_string()),
+            command: Some(format!("homeboy {kind} {component_id}")),
+            cwd: Some("/tmp/homeboy-fixture".to_string()),
+            homeboy_version: Some("test-version".to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: Some(rig_id.to_string()),
+            metadata_json: metadata,
+        }
+    }
+
+    #[test]
+    fn runs_compare_filters_history_and_reports_selected_metrics() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let old = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "studio-bfb",
+                    serde_json::json!({
+                        "results": { "total_elapsed_ms": 177754.0 },
+                        "scenario_metrics": [{
+                            "scenario_id": "site-build",
+                            "metrics": { "p95_ms": 90.0 }
+                        }]
+                    }),
+                ))
+                .expect("old");
+            store
+                .finish_run(&old.id, RunStatus::Pass, None)
+                .expect("finish old");
+            let new = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "studio-bfb",
+                    serde_json::json!({
+                        "results": { "total_elapsed_ms": 213151.0 },
+                        "scenario_metrics": [{
+                            "scenario_id": "site-build",
+                            "metrics": { "p95_ms": 120.0 }
+                        }]
+                    }),
+                ))
+                .expect("new");
+            store
+                .finish_run(&new.id, RunStatus::Fail, None)
+                .expect("finish new");
+            let other = store
+                .start_run(sample_run("trace", "studio", "studio-bfb", Value::Null))
+                .expect("trace");
+            store
+                .finish_run(&other.id, RunStatus::Pass, None)
+                .expect("finish trace");
+
+            let (output, _) = compare_runs(RunsCompareArgs {
+                kind: "bench".to_string(),
+                component_id: Some("studio".to_string()),
+                rig: Some("studio-bfb".to_string()),
+                scenario_id: Some("site-build".to_string()),
+                status: None,
+                metrics: vec!["total_elapsed_ms".to_string(), "p95_ms".to_string()],
+                limit: 20,
+                format: RunsCompareFormat::Json,
+            })
+            .expect("compare");
+
+            let RunsOutput::Compare(output) = output else {
+                panic!("expected compare output");
+            };
+            assert_eq!(output.rows.len(), 2);
+            assert_eq!(output.rows[0].run.id, new.id);
+            assert_eq!(output.rows[0].metrics["total_elapsed_ms"], Some(213151.0));
+            assert_eq!(output.rows[0].metrics["p95_ms"], Some(120.0));
+            assert_eq!(output.rows[1].run.id, old.id);
+        });
+    }
+
+    #[test]
+    fn runs_compare_table_renders_metric_columns() {
+        let output = RunsCompareOutput {
+            command: "runs.compare",
+            kind: "bench".to_string(),
+            component_id: Some("studio".to_string()),
+            rig_id: Some("studio-bfb".to_string()),
+            scenario_id: None,
+            metrics: vec!["total_elapsed_ms".to_string()],
+            rows: vec![RunsCompareRow {
+                run: RunSummary {
+                    id: "38f271b9-0000".to_string(),
+                    kind: "bench".to_string(),
+                    status: "pass".to_string(),
+                    started_at: "2026-05-02T00:00:00Z".to_string(),
+                    finished_at: None,
+                    component_id: Some("studio".to_string()),
+                    rig_id: Some("studio-bfb".to_string()),
+                    git_sha: Some("abcdef123456".to_string()),
+                    command: None,
+                    cwd: None,
+                    status_note: None,
+                },
+                artifact_count: 3,
+                scenario_id: None,
+                metrics: BTreeMap::from([("total_elapsed_ms".to_string(), Some(213151.0))]),
+            }],
+        };
+
+        let table = render_compare_table(&output);
+        assert!(table.contains(
+            "| Run | Status | Started | Git SHA | Rig | Artifacts | Scenario | total_elapsed_ms |"
+        ));
+        assert!(table.contains("| `38f271b9` | `pass`"));
+        assert!(table.contains("| 213151 |"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use homeboy::commands::utils::{args, entity_suggest, response as output, tty};
 use homeboy::commands::{changelog, cli, file, logs, report, review, trace};
 use homeboy::extension::load_all_extensions;
 
-fn response_mode(command: &Commands) -> ResponseMode {
+fn response_mode(command: &Commands, has_output_file: bool) -> ResponseMode {
     match command {
         Commands::Ssh(args) if args.subcommand.is_none() && args.command.is_empty() => {
             ResponseMode::Raw(RawOutputMode::InteractivePassthrough)
@@ -41,6 +41,9 @@ fn response_mode(command: &Commands) -> ResponseMode {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
         Commands::Trace(args) if trace::is_markdown_mode(args) => {
+            ResponseMode::Raw(RawOutputMode::Markdown)
+        }
+        Commands::Runs(args) if !has_output_file && commands::runs::is_markdown_mode(args) => {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
         Commands::Report(args) if report::is_markdown_mode(args) => {
@@ -207,7 +210,7 @@ fn main() -> std::process::ExitCode {
         homeboy::extension::update_check::run_startup_check();
     }
 
-    let mode = response_mode(&cli.command);
+    let mode = response_mode(&cli.command, output_file.is_some());
     let is_review_command = matches!(cli.command, Commands::Review(_));
 
     match mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn response_mode(command: &Commands, has_output_file: bool) -> ResponseMode {
         Commands::Trace(args) if trace::is_markdown_mode(args) => {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
-        Commands::Runs(args) if !has_output_file && commands::runs::is_markdown_mode(args) => {
+        Commands::Runs(args) if !has_output_file && args.is_markdown_mode() => {
             ResponseMode::Raw(RawOutputMode::Markdown)
         }
         Commands::Report(args) if report::is_markdown_mode(args) => {
@@ -178,7 +178,11 @@ fn main() -> std::process::ExitCode {
 
     // Extract --output early so it's available for all code paths (including
     // extension CLI commands which exit before Cli::from_arg_matches).
-    let output_file: Option<String> = matches.get_one::<String>("output").cloned();
+    let mut output_file: Option<String> = matches
+        .try_get_one::<std::path::PathBuf>("output")
+        .ok()
+        .flatten()
+        .map(|path| path.to_string_lossy().to_string());
 
     if let Some(extension_cmd) = try_parse_extension_cli_command(&matches, &extension_info) {
         let cli_args = cli::CliArgs {
@@ -200,6 +204,10 @@ fn main() -> std::process::ExitCode {
         Ok(cli) => cli,
         Err(e) => e.exit(),
     };
+
+    if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
+        output_file = None;
+    }
 
     // Startup update checks — skip for upgrade (it handles this itself)
     if !matches!(


### PR DESCRIPTION
## Summary
- Add `homeboy runs compare` for comparing persisted observation metrics across run history, defaulting to benchmark `total_elapsed_ms`.
- Support filtering by kind, component, rig, scenario, status, limit, and repeatable metrics with Markdown table output by default.
- Preserve machine-readable usage with `--format=json` and global `--output`, plus docs and tests.

## Verification
- `cargo fmt --check`
- `cargo test commands::runs`
- `cargo test runs_compare`
- `cargo test command_surface`
- `cargo check`
- `cargo run --bin homeboy -- runs compare --help`
- `target/debug/homeboy lint homeboy`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and verification commands; Chris remains responsible for review and merge.

Fixes #2122.