### PR TITLE
trace: support named variants in rig configuration

### DIFF
--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -189,6 +189,7 @@ mod tests {
                 bench: None,
                 bench_workloads: Default::default(),
                 trace_workloads: Default::default(),
+                trace_variants: Default::default(),
                 bench_profiles: Default::default(),
                 app_launcher: None,
             },

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -8,7 +8,8 @@ use homeboy::engine::execution_context::{self, ResolveOptions};
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::trace as extension_trace;
 use homeboy::extension::trace::{
-    TraceCommandOutput, TraceListWorkflowArgs, TraceRunWorkflowArgs, TraceSpanDefinition,
+    TraceCommandOutput, TraceListWorkflowArgs, TraceOverlayRequest, TraceRunWorkflowArgs,
+    TraceSpanDefinition,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::observation::{
@@ -96,6 +97,10 @@ pub struct TraceArgs {
     /// Apply a patch file for this trace run, then reverse it afterward.
     #[arg(long = "overlay", value_name = "PATCH_FILE")]
     pub overlays: Vec<String>,
+
+    /// Apply a named trace variant declared by the selected rig/workload.
+    #[arg(long = "variant", value_name = "NAME")]
+    pub variants: Vec<String>,
 
     /// Leave overlay changes in place after the trace run.
     #[arg(long)]
@@ -266,6 +271,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
             && args.phases.is_empty()
             && args.spans.is_empty(),
     )?;
+    let overlays = trace_overlays_for_args(&args, rig_context.as_ref(), &effective_id)?;
 
     let rig_state = rig_context
         .as_ref()
@@ -274,6 +280,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
     let scenario_id = args.scenario.clone();
     let rig_id = args.rig.clone();
     let requested_overlays = args.overlays.clone();
+    let requested_variants = args.variants.clone();
     let component_path_for_observation = path_override
         .clone()
         .unwrap_or_else(|| ctx.component.local_path.clone());
@@ -295,6 +302,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
                     "scenario_id": scenario_id,
                     "component_path": component_path_for_observation,
                     "requested_overlays": requested_overlays,
+                    "requested_variants": requested_variants,
                     "span_definitions": span_definitions.clone(),
                     "phase_preset": args.phase_preset.clone(),
                     "phase_milestones": args.phases.clone().into_iter().map(|phase| {
@@ -342,7 +350,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
             scenario_id: args.scenario,
             json_summary: args.json_summary,
             rig_id: args.rig,
-            overlays: args.overlays,
+            overlays,
             keep_overlay: args.keep_overlay,
             extra_workloads,
             span_definitions,
@@ -715,6 +723,7 @@ fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
 struct TraceRigContext {
     rig_spec: RigSpec,
     rig_package_root: Option<PathBuf>,
+    rig_config_root: Option<PathBuf>,
 }
 
 fn load_rig_context(rig_id: Option<&str>) -> homeboy::Result<Option<TraceRigContext>> {
@@ -724,10 +733,125 @@ fn load_rig_context(rig_id: Option<&str>) -> homeboy::Result<Option<TraceRigCont
     let spec = rig::load(rig_id)?;
     let package_root =
         rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
+    let config_root = homeboy::paths::rig_config(&spec.id)
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf));
     Ok(Some(TraceRigContext {
         rig_spec: spec,
         rig_package_root: package_root,
+        rig_config_root: config_root,
     }))
+}
+
+fn trace_overlays_for_args(
+    args: &TraceArgs,
+    rig_context: Option<&TraceRigContext>,
+    component_id: &str,
+) -> homeboy::Result<Vec<TraceOverlayRequest>> {
+    let mut overlays = Vec::new();
+    if !args.variants.is_empty() {
+        let context = rig_context.ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "--variant",
+                "trace variants require --rig so Homeboy can read rig/workload metadata",
+                None,
+                None,
+            )
+        })?;
+        let variants = trace_variants_for_args(args, context, component_id);
+        let available = variants.keys().cloned().collect::<Vec<_>>();
+        for name in &args.variants {
+            let variant = variants.get(name).ok_or_else(|| {
+                homeboy::Error::validation_invalid_argument(
+                    "--variant",
+                    format!(
+                        "unknown trace variant '{}' for component '{}' and scenario '{}'",
+                        name, component_id, args.scenario
+                    ),
+                    Some(format!(
+                        "available variants: {}",
+                        if available.is_empty() {
+                            "none".to_string()
+                        } else {
+                            available.join(", ")
+                        }
+                    )),
+                    None,
+                )
+            })?;
+            overlays.push(TraceOverlayRequest {
+                variant: Some(name.clone()),
+                path: resolve_trace_variant_overlay(context, &variant.overlay),
+            });
+        }
+    }
+    overlays.extend(
+        args.overlays
+            .iter()
+            .cloned()
+            .map(|path| TraceOverlayRequest {
+                variant: None,
+                path,
+            }),
+    );
+    Ok(overlays)
+}
+
+fn trace_variants_for_args<'a>(
+    args: &TraceArgs,
+    context: &'a TraceRigContext,
+    component_id: &str,
+) -> BTreeMap<String, &'a rig::TraceVariantSpec> {
+    let mut variants = BTreeMap::new();
+    for (name, variant) in &context.rig_spec.trace_variants {
+        if trace_variant_matches_component(variant, component_id) {
+            variants.insert(name.clone(), variant);
+        }
+    }
+    for workload in context
+        .rig_spec
+        .trace_workloads
+        .values()
+        .flat_map(|workloads| workloads.iter())
+    {
+        if trace_workload_scenario_id(workload.path()) != args.scenario {
+            continue;
+        }
+        if let Some(workload_variants) = workload.trace_variants() {
+            for (name, variant) in workload_variants {
+                if trace_variant_matches_component(variant, component_id) {
+                    variants.insert(name.clone(), variant);
+                }
+            }
+        }
+    }
+    variants
+}
+
+fn trace_variant_matches_component(variant: &rig::TraceVariantSpec, component_id: &str) -> bool {
+    variant
+        .component
+        .as_deref()
+        .map_or(true, |id| id == component_id)
+}
+
+fn resolve_trace_variant_overlay(context: &TraceRigContext, overlay: &str) -> String {
+    let expanded = rig::expand::expand_vars(&context.rig_spec, overlay);
+    let expanded = if let Some(root) = context.rig_package_root.as_ref() {
+        expanded.replace("${package.root}", &root.to_string_lossy())
+    } else {
+        expanded
+    };
+    let path = PathBuf::from(&expanded);
+    if path.is_absolute() {
+        return path.to_string_lossy().to_string();
+    }
+    context
+        .rig_package_root
+        .as_ref()
+        .or(context.rig_config_root.as_ref())
+        .map(|root| root.join(path).to_string_lossy().to_string())
+        .unwrap_or(expanded)
 }
 
 fn run_rig_workload_preflight(

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -107,6 +107,7 @@ fn rig_trace_list_uses_rig_default_component_and_workloads() {
             regression_threshold: extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             overlays: Vec::new(),
+            variants: Vec::new(),
             keep_overlay: false,
         })
         .expect("rig trace list should run");
@@ -195,6 +196,7 @@ fn rig_trace_list_uses_scoped_workload_preflight() {
             regression_threshold: extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             overlays: Vec::new(),
+            variants: Vec::new(),
             keep_overlay: false,
         })
         .expect("scoped rig trace list should bypass unrelated failed check");
@@ -241,6 +243,7 @@ fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -293,6 +296,7 @@ fn trace_run_persists_observation_history() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -368,6 +372,7 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -451,6 +456,7 @@ fn trace_repeat_reports_overlay_touched_files_at_top_level() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: vec![patch_path.to_string_lossy().to_string()],
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -477,6 +483,146 @@ fn trace_repeat_reports_overlay_touched_files_at_top_level() {
             }
             _ => panic!("expected aggregate output"),
         }
+    });
+}
+
+#[test]
+fn trace_run_applies_named_variant_from_rig_package_root() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::without_xdg_data_home();
+        write_trace_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        init_overlay_component(component_dir.path());
+        let package_dir = tempfile::TempDir::new().expect("package dir");
+        write_trace_rig_source_metadata(home, "studio-rig", package_dir.path());
+        write_trace_rig_with_variant(
+            home,
+            package_dir.path(),
+            "studio-rig",
+            "studio",
+            component_dir.path(),
+        );
+
+        let (output, exit_code) = run(
+            TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("studio".to_string()),
+                    path: None,
+                },
+                scenario: "studio-app-create-site".to_string(),
+                compare_after: None,
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                report: None,
+                repeat: 1,
+                aggregate: None,
+                spans: Vec::new(),
+                phases: Vec::new(),
+                phase_preset: None,
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                overlays: Vec::new(),
+                variants: vec!["fresh-install-mode".to_string()],
+                keep_overlay: false,
+            },
+            &GlobalArgs {},
+        )
+        .expect("variant trace should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            TraceCommandOutput::Run(result) => {
+                assert_eq!(result.overlays.len(), 1);
+                let overlay = &result.overlays[0];
+                assert_eq!(overlay.variant.as_deref(), Some("fresh-install-mode"));
+                assert_eq!(
+                    overlay.path,
+                    package_dir
+                        .path()
+                        .join("overlays/fresh-install-mode.patch")
+                        .to_string_lossy()
+                );
+                assert_eq!(overlay.touched_files, vec!["scenario.txt"]);
+                let value = serde_json::to_value(&result).expect("result serializes");
+                assert_eq!(value["overlays"][0]["variant"], "fresh-install-mode");
+                assert_eq!(
+                    value["overlays"][0]["path"],
+                    package_dir
+                        .path()
+                        .join("overlays/fresh-install-mode.patch")
+                        .to_string_lossy()
+                        .as_ref()
+                );
+            }
+            _ => panic!("expected run output"),
+        }
+        assert_eq!(
+            fs::read_to_string(component_dir.path().join("scenario.txt")).unwrap(),
+            "base\n"
+        );
+    });
+}
+
+#[test]
+fn trace_run_unknown_variant_reports_available_names() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::without_xdg_data_home();
+        write_trace_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        init_overlay_component(component_dir.path());
+        let package_dir = tempfile::TempDir::new().expect("package dir");
+        write_trace_rig_source_metadata(home, "studio-rig", package_dir.path());
+        write_trace_rig_with_variant(
+            home,
+            package_dir.path(),
+            "studio-rig",
+            "studio",
+            component_dir.path(),
+        );
+
+        let err = match run(
+            TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("studio".to_string()),
+                    path: None,
+                },
+                scenario: "studio-app-create-site".to_string(),
+                compare_after: None,
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                report: None,
+                repeat: 1,
+                aggregate: None,
+                spans: Vec::new(),
+                phases: Vec::new(),
+                phase_preset: None,
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                overlays: Vec::new(),
+                variants: vec!["missing".to_string()],
+                keep_overlay: false,
+            },
+            &GlobalArgs {},
+        ) {
+            Ok(_) => panic!("unknown variant should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err.message.contains("unknown trace variant 'missing'"));
+        assert!(err
+            .details
+            .get("id")
+            .and_then(|value| value.as_str())
+            .expect("details id")
+            .contains("fresh-install-mode"));
     });
 }
 
@@ -691,6 +837,7 @@ fn trace_run_expands_phase_chain_into_adjacent_and_total_spans() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -750,6 +897,7 @@ fn trace_run_expands_named_workload_phase_preset() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -809,6 +957,7 @@ fn trace_aggregate_spans_uses_workload_default_phase_preset() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -955,6 +1104,7 @@ fn failed_trace_run_persists_observation_history() {
                     extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
                 overlays: Vec::new(),
+                variants: Vec::new(),
                 keep_overlay: false,
             },
             &GlobalArgs {},
@@ -1166,6 +1316,80 @@ fn write_trace_rig_with_phase_preset(
                             }}
                         }}
                     ] }}
+                }}"#,
+            path.display()
+        ),
+    )
+    .expect("write rig");
+}
+
+fn write_trace_rig_source_metadata(
+    home: &tempfile::TempDir,
+    rig_id: &str,
+    package_path: &std::path::Path,
+) {
+    let sources_dir = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("rig-sources");
+    fs::create_dir_all(&sources_dir).expect("mkdir rig sources");
+    fs::write(
+        sources_dir.join(format!("{}.json", rig_id)),
+        format!(
+            r#"{{
+                "source": "{}",
+                "package_path": "{}",
+                "rig_path": "{}/rig.json",
+                "linked": true,
+                "source_revision": null
+            }}"#,
+            package_path.display(),
+            package_path.display(),
+            package_path.display()
+        ),
+    )
+    .expect("write rig source metadata");
+}
+
+fn write_trace_rig_with_variant(
+    home: &tempfile::TempDir,
+    package_path: &std::path::Path,
+    rig_id: &str,
+    component_id: &str,
+    path: &std::path::Path,
+) {
+    let overlay_dir = package_path.join("overlays");
+    fs::create_dir_all(&overlay_dir).expect("mkdir overlays");
+    fs::write(
+        overlay_dir.join("fresh-install-mode.patch"),
+        r#"diff --git a/scenario.txt b/scenario.txt
+--- a/scenario.txt
++++ b/scenario.txt
+@@ -1 +1 @@
+-base
++overlay
+"#,
+    )
+    .expect("write variant overlay");
+    let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+    fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+    fs::write(
+        rig_dir.join(format!("{}.json", rig_id)),
+        format!(
+            r#"{{
+                    "components": {{
+                        "{component_id}": {{ "path": "{}" }}
+                    }},
+                    "trace_workloads": {{ "nodejs": [
+                        "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs"
+                    ] }},
+                    "trace_variants": {{
+                        "fresh-install-mode": {{
+                            "component": "{component_id}",
+                            "overlay": "overlays/fresh-install-mode.patch"
+                        }}
+                    }}
                 }}"#,
             path.display()
         ),

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -487,14 +487,13 @@ fn trace_repeat_reports_overlay_touched_files_at_top_level() {
 }
 
 #[test]
-fn trace_run_applies_named_variant_from_rig_package_root() {
+fn trace_run_resolves_named_variants_and_reports_unknown_names() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         init_overlay_component(component_dir.path());
         let package_dir = tempfile::TempDir::new().expect("package dir");
-        write_trace_rig_source_metadata(home, "studio-rig", package_dir.path());
         write_trace_rig_with_variant(
             home,
             package_dir.path(),
@@ -503,35 +502,33 @@ fn trace_run_applies_named_variant_from_rig_package_root() {
             component_dir.path(),
         );
 
-        let (output, exit_code) = run(
-            TraceArgs {
-                comp: PositionalComponentArgs {
-                    component: Some("studio".to_string()),
-                    path: None,
-                },
-                scenario: "studio-app-create-site".to_string(),
-                compare_after: None,
-                rig: Some("studio-rig".to_string()),
-                setting_args: SettingArgs::default(),
-                _json: HiddenJsonArgs::default(),
-                json_summary: false,
-                report: None,
-                repeat: 1,
-                aggregate: None,
-                spans: Vec::new(),
-                phases: Vec::new(),
-                phase_preset: None,
-                baseline_args: BaselineArgs::default(),
-                regression_threshold:
-                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-                overlays: Vec::new(),
-                variants: vec!["fresh-install-mode".to_string()],
-                keep_overlay: false,
+        let valid_args = TraceArgs {
+            comp: PositionalComponentArgs {
+                component: Some("studio".to_string()),
+                path: None,
             },
-            &GlobalArgs {},
-        )
-        .expect("variant trace should run");
+            scenario: "studio-app-create-site".to_string(),
+            compare_after: None,
+            rig: Some("studio-rig".to_string()),
+            setting_args: SettingArgs::default(),
+            _json: HiddenJsonArgs::default(),
+            json_summary: false,
+            report: None,
+            repeat: 1,
+            aggregate: None,
+            spans: Vec::new(),
+            phases: Vec::new(),
+            phase_preset: None,
+            baseline_args: BaselineArgs::default(),
+            regression_threshold: extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+            overlays: Vec::new(),
+            variants: vec!["fresh-install-mode".to_string()],
+            keep_overlay: false,
+        };
+
+        let (output, exit_code) =
+            run(valid_args.clone(), &GlobalArgs {}).expect("variant trace should run");
 
         assert_eq!(exit_code, 0);
         match output {
@@ -564,54 +561,10 @@ fn trace_run_applies_named_variant_from_rig_package_root() {
             fs::read_to_string(component_dir.path().join("scenario.txt")).unwrap(),
             "base\n"
         );
-    });
-}
 
-#[test]
-fn trace_run_unknown_variant_reports_available_names() {
-    with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
-        write_trace_extension(home);
-        let component_dir = tempfile::TempDir::new().expect("component dir");
-        init_overlay_component(component_dir.path());
-        let package_dir = tempfile::TempDir::new().expect("package dir");
-        write_trace_rig_source_metadata(home, "studio-rig", package_dir.path());
-        write_trace_rig_with_variant(
-            home,
-            package_dir.path(),
-            "studio-rig",
-            "studio",
-            component_dir.path(),
-        );
-
-        let err = match run(
-            TraceArgs {
-                comp: PositionalComponentArgs {
-                    component: Some("studio".to_string()),
-                    path: None,
-                },
-                scenario: "studio-app-create-site".to_string(),
-                compare_after: None,
-                rig: Some("studio-rig".to_string()),
-                setting_args: SettingArgs::default(),
-                _json: HiddenJsonArgs::default(),
-                json_summary: false,
-                report: None,
-                repeat: 1,
-                aggregate: None,
-                spans: Vec::new(),
-                phases: Vec::new(),
-                phase_preset: None,
-                baseline_args: BaselineArgs::default(),
-                regression_threshold:
-                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-                overlays: Vec::new(),
-                variants: vec!["missing".to_string()],
-                keep_overlay: false,
-            },
-            &GlobalArgs {},
-        ) {
+        let mut invalid_args = valid_args;
+        invalid_args.variants = vec!["missing".to_string()];
+        let err = match run(invalid_args, &GlobalArgs {}) {
             Ok(_) => panic!("unknown variant should fail"),
             Err(err) => err,
         };
@@ -1323,10 +1276,12 @@ fn write_trace_rig_with_phase_preset(
     .expect("write rig");
 }
 
-fn write_trace_rig_source_metadata(
+fn write_trace_rig_with_variant(
     home: &tempfile::TempDir,
-    rig_id: &str,
     package_path: &std::path::Path,
+    rig_id: &str,
+    component_id: &str,
+    path: &std::path::Path,
 ) {
     let sources_dir = home
         .path()
@@ -1350,15 +1305,7 @@ fn write_trace_rig_source_metadata(
         ),
     )
     .expect("write rig source metadata");
-}
 
-fn write_trace_rig_with_variant(
-    home: &tempfile::TempDir,
-    package_path: &std::path::Path,
-    rig_id: &str,
-    component_id: &str,
-    path: &std::path::Path,
-) {
     let overlay_dir = package_path.join("overlays");
     fs::create_dir_all(&overlay_dir).expect("mkdir overlays");
     fs::write(

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -29,7 +29,7 @@ pub use report::{
 };
 pub use report::{push_overlay_markdown, render_markdown};
 pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};
-pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult};
+pub use run::{TraceOverlayRequest, TraceRunWorkflowArgs, TraceRunWorkflowResult};
 
 pub fn resolve_trace_command(
     component: &Component,

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -338,7 +338,15 @@ pub fn push_overlay_markdown(out: &mut String, overlays: &[TraceOverlay]) {
     out.push_str("\n## Trace Overlays\n\n");
     for overlay in overlays {
         let status = if overlay.kept { "kept" } else { "reverted" };
-        out.push_str(&format!("- **Patch:** `{}` (`{}`)\n", overlay.path, status));
+        let variant = overlay
+            .variant
+            .as_ref()
+            .map(|name| format!(" variant `{name}`,"))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "- **Patch:**{} `{}` (`{}`)\n",
+            variant, overlay.path, status
+        ));
         out.push_str(&format!(
             "  - Applied relative to: `{}`\n",
             overlay.component_path
@@ -424,6 +432,7 @@ mod tests {
             }),
             failure: None,
             overlays: vec![TraceOverlay {
+                variant: Some("disable-install-mail".to_string()),
                 path: "/tmp/overlay.patch".to_string(),
                 component_path: "/tmp/studio".to_string(),
                 touched_files: vec!["scenario.txt".to_string()],
@@ -443,6 +452,7 @@ mod tests {
         assert_eq!(value["artifact_count"], 1);
         assert_eq!(value["span_count"], 0);
         assert_eq!(value["overlays"][0]["path"], "/tmp/overlay.patch");
+        assert_eq!(value["overlays"][0]["variant"], "disable-install-mail");
         assert_eq!(value["overlays"][0]["component_path"], "/tmp/studio");
         assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
         assert_eq!(value["overlays"][0]["kept"], false);
@@ -532,6 +542,7 @@ mod tests {
         };
 
         let overlays = vec![TraceOverlay {
+            variant: None,
             path: "/tmp/overlay.patch".to_string(),
             component_path: "/tmp/studio".to_string(),
             touched_files: vec!["apps/studio/out/app.js".to_string()],

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -557,4 +557,21 @@ mod tests {
         assert!(markdown.contains("- `apps/studio/out/app.js`"));
         assert!(markdown.contains("| `submit_to_cli` | `ui.submit` | `cli.start` | 42ms | ok |"));
     }
+
+    #[test]
+    fn test_push_overlay_markdown() {
+        let overlays = vec![TraceOverlay {
+            variant: Some("fresh-install-mode".to_string()),
+            path: "/tmp/overlay.patch".to_string(),
+            component_path: "/tmp/studio".to_string(),
+            touched_files: Vec::new(),
+            kept: true,
+        }];
+        let mut markdown = String::new();
+
+        push_overlay_markdown(&mut markdown, &overlays);
+
+        assert!(markdown.contains("variant `fresh-install-mode`"));
+        assert!(markdown.contains("`/tmp/overlay.patch` (`kept`)"));
+    }
 }

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -32,7 +32,7 @@ pub struct TraceRunWorkflowArgs {
     pub scenario_id: String,
     pub json_summary: bool,
     pub rig_id: Option<String>,
-    pub overlays: Vec<String>,
+    pub overlays: Vec<TraceOverlayRequest>,
     pub keep_overlay: bool,
     pub extra_workloads: Vec<PathBuf>,
     pub span_definitions: Vec<TraceSpanDefinition>,
@@ -71,10 +71,18 @@ pub struct TraceRunWorkflowResult {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TraceOverlay {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
     pub path: String,
     pub component_path: String,
     pub touched_files: Vec<String>,
     pub kept: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceOverlayRequest {
+    pub variant: Option<String>,
+    pub path: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -242,6 +250,7 @@ fn run_trace_workflow_with_context(
             .into_iter()
             .map(|overlay| TraceOverlay {
                 path: overlay.patch_path.to_string_lossy().to_string(),
+                variant: overlay.variant,
                 component_path: overlay.component_path.to_string_lossy().to_string(),
                 touched_files: overlay.touched_files,
                 kept: overlay.keep,
@@ -550,6 +559,7 @@ fn trace_overlay_holder_summary(holder: &serde_json::Value) -> Option<String> {
 
 #[derive(Debug, Clone)]
 struct AppliedTraceOverlay {
+    variant: Option<String>,
     component_path: PathBuf,
     patch_path: PathBuf,
     touched_files: Vec<String>,
@@ -558,13 +568,13 @@ struct AppliedTraceOverlay {
 
 fn apply_trace_overlays(
     component_path: &str,
-    overlay_paths: &[String],
+    overlays: &[TraceOverlayRequest],
     keep: bool,
 ) -> Result<Vec<AppliedTraceOverlay>> {
     let component_path = PathBuf::from(component_path);
     let mut applied = Vec::new();
-    for overlay_path in overlay_paths {
-        let patch_path = PathBuf::from(overlay_path);
+    for overlay in overlays {
+        let patch_path = PathBuf::from(&overlay.path);
         let touched_files = match overlay_touched_files(&component_path, &patch_path) {
             Ok(files) => files,
             Err(error) => return cleanup_after_overlay_error(&applied, keep, error),
@@ -579,6 +589,7 @@ fn apply_trace_overlays(
         }
         print_trace_overlay("applied", &patch_path, &touched_files, keep);
         applied.push(AppliedTraceOverlay {
+            variant: overlay.variant.clone(),
             component_path: component_path.clone(),
             patch_path,
             touched_files,
@@ -995,7 +1006,10 @@ JSON
 
         let err = apply_trace_overlays(
             fixture.component_dir.to_str().unwrap(),
-            &[fixture.patch_path.to_string_lossy().to_string()],
+            &[TraceOverlayRequest {
+                variant: None,
+                path: fixture.patch_path.to_string_lossy().to_string(),
+            }],
             false,
         )
         .unwrap_err();
@@ -1168,7 +1182,10 @@ JSON
             scenario_id: "overlay".to_string(),
             json_summary: false,
             rig_id: None,
-            overlays: vec![patch_path.to_string_lossy().to_string()],
+            overlays: vec![TraceOverlayRequest {
+                variant: None,
+                path: patch_path.to_string_lossy().to_string(),
+            }],
             keep_overlay,
             extra_workloads: Vec::new(),
             span_definitions: Vec::new(),

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -670,7 +670,7 @@ fn overlay_touched_files(component_path: &Path, patch_path: &Path) -> Result<Vec
     Ok(String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter_map(|line| line.split('\t').nth(2))
-        .map(unquote_numstat_path)
+        .map(|path| path.trim().trim_matches('"').to_string())
         .filter(|path| !path.is_empty())
         .collect())
 }
@@ -758,10 +758,6 @@ fn run_git_apply(component_path: &Path, patch_path: &Path, reverse: bool) -> Res
         Some(String::from_utf8_lossy(&output.stderr).to_string()),
         None,
     ))
-}
-
-fn unquote_numstat_path(path: &str) -> String {
-    path.trim().trim_matches('"').to_string()
 }
 
 #[cfg(test)]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -57,7 +57,7 @@ pub use spec::{
     AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, BenchSpec, CheckSpec,
     ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep, RigResourcesSpec, RigSpec,
     ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource,
-    WorkloadEntry, WorkloadSpec,
+    TraceVariantSpec, WorkloadEntry, WorkloadSpec,
 };
 pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -77,6 +77,10 @@ pub struct RigSpec {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub trace_workloads: HashMap<String, Vec<WorkloadSpec>>,
 
+    /// Named trace overlay variants keyed by user-facing variant name.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub trace_variants: HashMap<String, TraceVariantSpec>,
+
     /// Named bench scenario suites keyed by profile name.
     ///
     /// `homeboy bench --rig <id> --profile <name>` resolves the profile to
@@ -250,6 +254,17 @@ pub struct WorkloadEntry {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_default_phase_preset: Option<String>,
+
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub trace_variants: HashMap<String, TraceVariantSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceVariantSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+
+    pub overlay: String,
 }
 
 impl WorkloadSpec {
@@ -281,6 +296,13 @@ impl WorkloadSpec {
         match self {
             WorkloadSpec::Path(_) => None,
             WorkloadSpec::Detailed(entry) => entry.trace_default_phase_preset.as_deref(),
+        }
+    }
+
+    pub fn trace_variants(&self) -> Option<&HashMap<String, TraceVariantSpec>> {
+        match self {
+            WorkloadSpec::Path(_) => None,
+            WorkloadSpec::Detailed(entry) => Some(&entry.trace_variants),
         }
     }
 }

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -34,6 +34,7 @@ fn rig_with_launcher(install_dir: &str) -> RigSpec {
         bench: None,
         bench_workloads: Default::default(),
         trace_workloads: Default::default(),
+        trace_variants: Default::default(),
         bench_profiles: Default::default(),
         app_launcher: Some(AppLauncherSpec {
             platform: AppLauncherPlatform::Macos,

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -20,6 +20,7 @@ fn minimal_rig() -> RigSpec {
         bench: None,
         bench_workloads: Default::default(),
         trace_workloads: Default::default(),
+        trace_variants: Default::default(),
         bench_profiles: Default::default(),
         app_launcher: None,
     }

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -23,6 +23,7 @@ fn rig_with(id: &str, components: HashMap<String, ComponentSpec>) -> RigSpec {
         bench: None,
         bench_workloads: Default::default(),
         trace_workloads: Default::default(),
+        trace_variants: Default::default(),
         bench_profiles: Default::default(),
         app_launcher: None,
     }

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -19,6 +19,7 @@ fn rig(id: &str, resources: RigResourcesSpec) -> RigSpec {
         bench: None,
         bench_workloads: Default::default(),
         trace_workloads: Default::default(),
+        trace_variants: Default::default(),
         bench_profiles: Default::default(),
         app_launcher: None,
     }

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -143,6 +143,7 @@ mod dag {
             app_launcher: None,
             bench_workloads: Default::default(),
             trace_workloads: Default::default(),
+            trace_variants: Default::default(),
             bench_profiles: Default::default(),
         }
     }
@@ -411,6 +412,7 @@ mod extension_lifecycle {
             app_launcher: None,
             bench_workloads: Default::default(),
             trace_workloads: Default::default(),
+            trace_variants: Default::default(),
             bench_profiles: Default::default(),
         }
     }
@@ -532,6 +534,7 @@ mod command_env {
             bench: None,
             bench_workloads: Default::default(),
             trace_workloads: Default::default(),
+            trace_variants: Default::default(),
             bench_profiles: Default::default(),
             app_launcher: None,
         }
@@ -633,6 +636,7 @@ mod patch {
             bench: None,
             bench_workloads: Default::default(),
             trace_workloads: Default::default(),
+            trace_variants: Default::default(),
             bench_profiles: Default::default(),
             app_launcher: None,
         }
@@ -845,6 +849,7 @@ mod shared_path {
             bench: None,
             bench_workloads: Default::default(),
             trace_workloads: Default::default(),
+            trace_variants: Default::default(),
             bench_profiles: Default::default(),
             app_launcher: None,
         }

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -23,6 +23,7 @@ fn observation_spec(id: &str) -> RigSpec {
         bench: None,
         bench_workloads: HashMap::new(),
         trace_workloads: HashMap::new(),
+        trace_variants: HashMap::new(),
         bench_profiles: HashMap::new(),
         app_launcher: None,
     }

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -49,6 +49,7 @@ fn minimal_spec(id: &str) -> RigSpec {
         bench: None,
         bench_workloads: HashMap::new(),
         trace_workloads: HashMap::new(),
+        trace_variants: HashMap::new(),
         bench_profiles: HashMap::new(),
         app_launcher: None,
     }
@@ -498,6 +499,7 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             bench: None,
             bench_workloads: HashMap::new(),
             trace_workloads: HashMap::new(),
+            trace_variants: HashMap::new(),
             bench_profiles: HashMap::new(),
             app_launcher: None,
         };
@@ -560,6 +562,7 @@ fn test_run_status() {
             app_launcher: None,
             bench_workloads: HashMap::new(),
             trace_workloads: HashMap::new(),
+            trace_variants: HashMap::new(),
             bench_profiles: HashMap::new(),
         };
 
@@ -716,6 +719,7 @@ fn test_snapshot_state() {
         bench: None,
         bench_workloads: HashMap::new(),
         trace_workloads: HashMap::new(),
+        trace_variants: HashMap::new(),
         bench_profiles: HashMap::new(),
         app_launcher: None,
     };

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -43,6 +43,7 @@ mod lifecycle {
             app_launcher: None,
             bench_workloads: HashMap::new(),
             trace_workloads: HashMap::new(),
+            trace_variants: HashMap::new(),
             bench_profiles: HashMap::new(),
         }
     }
@@ -63,6 +64,7 @@ mod lifecycle {
             app_launcher: None,
             bench_workloads: HashMap::new(),
             trace_workloads: HashMap::new(),
+            trace_variants: HashMap::new(),
             bench_profiles: HashMap::new(),
         }
     }

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -3,7 +3,7 @@
 
 use crate::rig::{
     PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec,
-    WorkloadEntry, WorkloadSpec,
+    TraceVariantSpec, WorkloadEntry, WorkloadSpec,
 };
 
 /// Canonical fixture matching the studio-playground-dev shape used as the
@@ -247,18 +247,75 @@ fn test_check_groups() {
     assert_eq!(legacy.path(), "/tmp/legacy.trace.mjs");
     assert!(legacy.check_groups().is_none());
 
-    let detailed = WorkloadSpec::Detailed(WorkloadEntry {
-        path: "/tmp/scoped.trace.mjs".to_string(),
-        check_groups: Some(vec!["desktop-app".to_string()]),
-        trace_phase_presets: std::collections::HashMap::new(),
-        trace_default_phase_preset: None,
-        trace_variants: std::collections::HashMap::new(),
-    });
+    let detailed: WorkloadSpec = serde_json::from_str(
+        r#"{
+            "path": "/tmp/scoped.trace.mjs",
+            "check_groups": ["desktop-app"]
+        }"#,
+    )
+    .expect("parse detailed workload");
     assert_eq!(detailed.path(), "/tmp/scoped.trace.mjs");
     assert_eq!(
         detailed.check_groups(),
         Some(&["desktop-app".to_string()][..])
     );
+}
+
+#[test]
+fn test_trace_phase_preset() {
+    let workload = workload_with_trace_metadata();
+
+    assert_eq!(
+        workload.trace_phase_preset("startup"),
+        Some(&["boot:runner.boot".to_string()][..])
+    );
+    assert!(workload.trace_phase_preset("missing").is_none());
+}
+
+#[test]
+fn test_trace_default_phase_preset() {
+    let workload = workload_with_trace_metadata();
+
+    assert_eq!(workload.trace_default_phase_preset(), Some("startup"));
+    assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
+        .trace_default_phase_preset()
+        .is_none());
+}
+
+#[test]
+fn test_trace_variants() {
+    let workload = workload_with_trace_metadata();
+    let variants = workload.trace_variants().expect("variants");
+
+    assert_eq!(
+        variants.get("fresh-install-mode"),
+        Some(&TraceVariantSpec {
+            component: Some("studio".to_string()),
+            overlay: "overlays/fresh-install-mode.patch".to_string(),
+        })
+    );
+    assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
+        .trace_variants()
+        .is_none());
+}
+
+fn workload_with_trace_metadata() -> WorkloadSpec {
+    WorkloadSpec::Detailed(WorkloadEntry {
+        path: "/tmp/scoped.trace.mjs".to_string(),
+        check_groups: Some(vec!["desktop-app".to_string()]),
+        trace_phase_presets: std::collections::HashMap::from([(
+            "startup".to_string(),
+            vec!["boot:runner.boot".to_string()],
+        )]),
+        trace_default_phase_preset: Some("startup".to_string()),
+        trace_variants: std::collections::HashMap::from([(
+            "fresh-install-mode".to_string(),
+            TraceVariantSpec {
+                component: Some("studio".to_string()),
+                overlay: "overlays/fresh-install-mode.patch".to_string(),
+            },
+        )]),
+    })
 }
 
 #[test]

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -252,6 +252,7 @@ fn test_check_groups() {
         check_groups: Some(vec!["desktop-app".to_string()]),
         trace_phase_presets: std::collections::HashMap::new(),
         trace_default_phase_preset: None,
+        trace_variants: std::collections::HashMap::new(),
     });
     assert_eq!(detailed.path(), "/tmp/scoped.trace.mjs");
     assert_eq!(

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -32,6 +32,7 @@ fn rig_with_components(components: HashMap<String, ComponentSpec>) -> RigSpec {
         bench: None,
         bench_workloads: Default::default(),
         trace_workloads: Default::default(),
+        trace_variants: Default::default(),
         bench_profiles: Default::default(),
         app_launcher: None,
     }


### PR DESCRIPTION
## Summary
- Add `--variant <name>` for trace runs, resolving named rig/workload trace variants into overlay requests alongside existing `--overlay` paths.
- Resolve relative variant overlay paths from the installed rig package root, falling back to the rig config directory for local rigs.
- Record variant names and resolved overlay paths in trace JSON and surface unknown variant errors with available names.

## Tests
- `cargo test trace::tests --lib`
- `cargo test extension::trace::run::tests --lib`
- `cargo test workloads_test --lib`
- `cargo test --lib` (fails one pre-existing environment-sensitive PATH-order assertion: `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused tests; Chris remains responsible for review and validation.

Closes #2125.