### PR TITLE
Support rig-declared bench metric gates

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -136,6 +136,28 @@ Supported operators are `eq`, `gte`, and `lte`:
 Failed gates add `gate_results`, set the scenario's `passed` field to
 `false`, and add top-level `gate_failures` to the bench output.
 
+Rigs can also declare gates for scenario metrics when the workload output is
+owned elsewhere. The keys under `metric_gates` are exact scenario ids:
+
+```json
+{
+  "bench": {
+    "default_component": "studio",
+    "metric_gates": {
+      "wordpress-is-dead": {
+        "native_block_quality_pass": { "equals": 1 },
+        "tool_error_count": { "equals": 0 },
+        "success_rate": { "equals": 1 }
+      }
+    }
+  }
+}
+```
+
+Rig-declared metric gates are merged with workload-emitted `gates` before
+Homeboy evaluates scenario status. Supported rig operators are `equals`, `gte`,
+and `lte`.
+
 ## Examples
 
 ```bash

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use homeboy::component::Component;
@@ -6,7 +7,7 @@ use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::bench as extension_bench;
 use homeboy::extension::bench::report::collect_artifacts;
 use homeboy::extension::bench::{
-    BenchCommandOutput, BenchResults, BenchRunExecution, BenchRunWorkflowArgs,
+    BenchCommandOutput, BenchGate, BenchResults, BenchRunExecution, BenchRunWorkflowArgs,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::rig::{self, BenchSpec, RigSpec, RigStateSnapshot};
@@ -175,6 +176,25 @@ fn effective_warmup_iterations(args: &BenchRunArgs, rig_spec: Option<&RigSpec>) 
             .and_then(|spec| spec.bench.as_ref())
             .and_then(|bench| bench.warmup_iterations)
     })
+}
+
+fn declared_scenario_gates(rig_spec: Option<&RigSpec>) -> BTreeMap<String, Vec<BenchGate>> {
+    rig_spec
+        .and_then(|spec| spec.bench.as_ref())
+        .map(|bench| {
+            bench
+                .metric_gates
+                .iter()
+                .filter_map(|(scenario_id, metric_gates)| {
+                    let gates: Vec<BenchGate> = metric_gates
+                        .iter()
+                        .flat_map(|(metric, condition)| condition.to_gates(metric))
+                        .collect();
+                    (!gates.is_empty()).then(|| (scenario_id.clone(), gates))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn suffix_component_results(mut results: BenchResults, component_id: &str) -> BenchResults {
@@ -451,6 +471,7 @@ fn run_component_with_rig_context(
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
             extra_workloads,
+            scenario_gates: declared_scenario_gates(rig_spec),
         },
         &run_dir,
     );
@@ -595,6 +616,42 @@ mod tests {
 
         args.shared_state = None;
         assert_eq!(component_shared_state(&args, "mdi-primary", 3), None);
+    }
+
+    #[test]
+    fn declared_scenario_gates_parse_from_rig_bench_spec() {
+        let rig_spec: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "studio-bfb",
+                "bench": {
+                    "default_component": "studio",
+                    "metric_gates": {
+                        "wordpress-is-dead": {
+                            "native_block_quality_pass": { "equals": 1 },
+                            "tool_error_count": { "lte": 0 }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .expect("parse rig spec");
+
+        let gates = declared_scenario_gates(Some(&rig_spec));
+        let scenario_gates = gates
+            .get("wordpress-is-dead")
+            .expect("scenario gates should be declared");
+
+        assert_eq!(scenario_gates.len(), 2);
+        assert!(scenario_gates.iter().any(|gate| {
+            gate.metric == "native_block_quality_pass"
+                && gate.op == homeboy::extension::bench::BenchGateOp::Eq
+                && gate.value == 1.0
+        }));
+        assert!(scenario_gates.iter().any(|gate| {
+            gate.metric == "tool_error_count"
+                && gate.op == homeboy::extension::bench::BenchGateOp::Lte
+                && gate.value == 0.0
+        }));
     }
 
     #[test]

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -8,6 +8,7 @@ use homeboy::extension::bench as extension_bench;
 use homeboy::extension::bench::report::collect_artifacts;
 use homeboy::extension::bench::{
     BenchCommandOutput, BenchGate, BenchResults, BenchRunExecution, BenchRunWorkflowArgs,
+    BenchRunWorkflowResult,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::rig::{self, BenchSpec, RigSpec, RigStateSnapshot};
@@ -195,6 +196,38 @@ fn declared_scenario_gates(rig_spec: Option<&RigSpec>) -> BTreeMap<String, Vec<B
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn apply_declared_scenario_gates(
+    workflow: &mut BenchRunWorkflowResult,
+    scenario_gates: BTreeMap<String, Vec<BenchGate>>,
+) {
+    if scenario_gates.is_empty() {
+        return;
+    }
+
+    let Some(results) = workflow.results.as_mut() else {
+        return;
+    };
+
+    for scenario in &mut results.scenarios {
+        if let Some(gates) = scenario_gates.get(&scenario.id) {
+            scenario.gates.extend(gates.clone());
+        }
+    }
+
+    let failures = extension_bench::evaluate_gates(results);
+    if failures.is_empty() {
+        return;
+    }
+
+    workflow.gate_failures.extend(failures.iter().cloned());
+    let hints = workflow.hints.get_or_insert_with(Vec::new);
+    hints.extend(failures);
+    workflow.status = "failed".to_string();
+    if workflow.exit_code == 0 {
+        workflow.exit_code = 1;
+    }
 }
 
 fn suffix_component_results(mut results: BenchResults, component_id: &str) -> BenchResults {
@@ -471,7 +504,6 @@ fn run_component_with_rig_context(
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
             extra_workloads,
-            scenario_gates: declared_scenario_gates(rig_spec),
         },
         &run_dir,
     );
@@ -481,6 +513,7 @@ fn run_component_with_rig_context(
     }
     let workflow = match workflow {
         Ok(mut workflow) => {
+            apply_declared_scenario_gates(&mut workflow, declared_scenario_gates(rig_spec));
             if let Some(summary) = observation::finish_success(observation, &workflow, &run_dir) {
                 let hints = workflow.hints.get_or_insert_with(Vec::new);
                 hints.extend(observation::history_hints(&summary));

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -16,8 +16,8 @@ use crate::extension::bench::aggregate_runs;
 use crate::extension::bench::baseline::{self, BenchBaselineComparison};
 use crate::extension::bench::diagnostic::{self, BenchDiagnostic};
 use crate::extension::bench::parsing::{
-    self, BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunnerMetadata, BenchScenario,
-    BenchWorkloadMetadata,
+    self, BenchGate, BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunnerMetadata,
+    BenchScenario, BenchWorkloadMetadata,
 };
 use crate::extension::{
     resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
@@ -64,6 +64,9 @@ pub struct BenchRunWorkflowArgs {
     /// Rig-declared out-of-tree workloads to run alongside in-tree discovery.
     /// Exported to dispatchers as `HOMEBOY_BENCH_EXTRA_WORKLOADS`.
     pub extra_workloads: Vec<PathBuf>,
+    /// Homeboy-owned scenario gates declared outside the workload output.
+    /// Keys are exact scenario ids after filtering and before matrix suffixes.
+    pub scenario_gates: BTreeMap<String, Vec<BenchGate>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -152,6 +155,7 @@ pub fn run_bench_list_workflow(
             rig_id: None,
             shared_state: None,
             extra_workloads: args.extra_workloads,
+            scenario_gates: BTreeMap::new(),
         },
         run_dir,
         None,
@@ -471,6 +475,7 @@ pub fn run_main_bench_workflow(
         };
 
     if let Some(results) = parsed.as_mut() {
+        apply_scenario_gates(results, &execution_args.scenario_gates);
         stamp_run_metadata(
             results,
             &execution_context,
@@ -597,6 +602,21 @@ pub fn run_main_bench_workflow(
         failure,
         diagnostics,
     })
+}
+
+fn apply_scenario_gates(
+    results: &mut BenchResults,
+    scenario_gates: &BTreeMap<String, Vec<BenchGate>>,
+) {
+    if scenario_gates.is_empty() {
+        return;
+    }
+
+    for scenario in &mut results.scenarios {
+        if let Some(gates) = scenario_gates.get(&scenario.id) {
+            scenario.gates.extend(gates.clone());
+        }
+    }
 }
 
 fn format_diagnostic_hint(diagnostic: &BenchDiagnostic) -> String {
@@ -1104,6 +1124,54 @@ mod tests {
     }
 
     #[test]
+    fn declared_scenario_gates_attach_before_evaluation() {
+        let mut results = BenchResults {
+            component_id: "studio".to_string(),
+            iterations: 1,
+            run_metadata: None,
+            diagnostics: Vec::new(),
+            scenarios: vec![BenchScenario {
+                id: "import-wordpress-is-dead".to_string(),
+                file: None,
+                source: None,
+                default_iterations: None,
+                tags: Vec::new(),
+                iterations: 1,
+                metrics: parsing::BenchMetrics {
+                    values: BTreeMap::from([("native_block_quality_pass".to_string(), 0.0)]),
+                    distributions: BTreeMap::new(),
+                },
+                metric_groups: BTreeMap::new(),
+                gates: Vec::new(),
+                gate_results: Vec::new(),
+                passed: true,
+                memory: None,
+                artifacts: BTreeMap::new(),
+                diagnostics: Vec::new(),
+                runs: None,
+                runs_summary: None,
+            }],
+            metric_policies: BTreeMap::new(),
+        };
+        let gates = BTreeMap::from([(
+            "import-wordpress-is-dead".to_string(),
+            vec![BenchGate {
+                metric: "native_block_quality_pass".to_string(),
+                op: parsing::BenchGateOp::Eq,
+                value: 1.0,
+            }],
+        )]);
+
+        apply_scenario_gates(&mut results, &gates);
+        let failures = parsing::evaluate_gates(&mut results);
+
+        assert_eq!(results.scenarios[0].gates.len(), 1);
+        assert_eq!(failures.len(), 1);
+        assert!(!results.scenarios[0].passed);
+        assert!(failures[0].contains("native_block_quality_pass eq 1"));
+    }
+
+    #[test]
     fn test_run_bench_list_workflow() {
         let result = BenchListWorkflowResult {
             component: "homeboy".to_string(),
@@ -1168,6 +1236,7 @@ mod tests {
                 rig_id: None,
                 shared_state: None,
                 extra_workloads: Vec::new(),
+                scenario_gates: BTreeMap::new(),
             },
             &run_dir,
         )
@@ -1222,6 +1291,7 @@ mod tests {
             rig_id: Some("studio".to_string()),
             shared_state: Some(component_dir.path().join("shared")),
             extra_workloads: Vec::new(),
+            scenario_gates: BTreeMap::new(),
         };
         let mut results = BenchResults {
             component_id: "homeboy".to_string(),

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -475,7 +475,11 @@ pub fn run_main_bench_workflow(
         };
 
     if let Some(results) = parsed.as_mut() {
-        apply_scenario_gates(results, &execution_args.scenario_gates);
+        for scenario in &mut results.scenarios {
+            if let Some(gates) = execution_args.scenario_gates.get(&scenario.id) {
+                scenario.gates.extend(gates.clone());
+            }
+        }
         stamp_run_metadata(
             results,
             &execution_context,
@@ -602,21 +606,6 @@ pub fn run_main_bench_workflow(
         failure,
         diagnostics,
     })
-}
-
-fn apply_scenario_gates(
-    results: &mut BenchResults,
-    scenario_gates: &BTreeMap<String, Vec<BenchGate>>,
-) {
-    if scenario_gates.is_empty() {
-        return;
-    }
-
-    for scenario in &mut results.scenarios {
-        if let Some(gates) = scenario_gates.get(&scenario.id) {
-            scenario.gates.extend(gates.clone());
-        }
-    }
 }
 
 fn format_diagnostic_hint(diagnostic: &BenchDiagnostic) -> String {
@@ -1121,54 +1110,6 @@ mod tests {
                 PathBuf::from("/tmp/bench/WpAdminLoad.php"),
             ]
         );
-    }
-
-    #[test]
-    fn declared_scenario_gates_attach_before_evaluation() {
-        let mut results = BenchResults {
-            component_id: "studio".to_string(),
-            iterations: 1,
-            run_metadata: None,
-            diagnostics: Vec::new(),
-            scenarios: vec![BenchScenario {
-                id: "import-wordpress-is-dead".to_string(),
-                file: None,
-                source: None,
-                default_iterations: None,
-                tags: Vec::new(),
-                iterations: 1,
-                metrics: parsing::BenchMetrics {
-                    values: BTreeMap::from([("native_block_quality_pass".to_string(), 0.0)]),
-                    distributions: BTreeMap::new(),
-                },
-                metric_groups: BTreeMap::new(),
-                gates: Vec::new(),
-                gate_results: Vec::new(),
-                passed: true,
-                memory: None,
-                artifacts: BTreeMap::new(),
-                diagnostics: Vec::new(),
-                runs: None,
-                runs_summary: None,
-            }],
-            metric_policies: BTreeMap::new(),
-        };
-        let gates = BTreeMap::from([(
-            "import-wordpress-is-dead".to_string(),
-            vec![BenchGate {
-                metric: "native_block_quality_pass".to_string(),
-                op: parsing::BenchGateOp::Eq,
-                value: 1.0,
-            }],
-        )]);
-
-        apply_scenario_gates(&mut results, &gates);
-        let failures = parsing::evaluate_gates(&mut results);
-
-        assert_eq!(results.scenarios[0].gates.len(), 1);
-        assert_eq!(failures.len(), 1);
-        assert!(!results.scenarios[0].passed);
-        assert!(failures[0].contains("native_block_quality_pass eq 1"));
     }
 
     #[test]

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -16,8 +16,8 @@ use crate::extension::bench::aggregate_runs;
 use crate::extension::bench::baseline::{self, BenchBaselineComparison};
 use crate::extension::bench::diagnostic::{self, BenchDiagnostic};
 use crate::extension::bench::parsing::{
-    self, BenchGate, BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunnerMetadata,
-    BenchScenario, BenchWorkloadMetadata,
+    self, BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunnerMetadata, BenchScenario,
+    BenchWorkloadMetadata,
 };
 use crate::extension::{
     resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
@@ -64,9 +64,6 @@ pub struct BenchRunWorkflowArgs {
     /// Rig-declared out-of-tree workloads to run alongside in-tree discovery.
     /// Exported to dispatchers as `HOMEBOY_BENCH_EXTRA_WORKLOADS`.
     pub extra_workloads: Vec<PathBuf>,
-    /// Homeboy-owned scenario gates declared outside the workload output.
-    /// Keys are exact scenario ids after filtering and before matrix suffixes.
-    pub scenario_gates: BTreeMap<String, Vec<BenchGate>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -155,7 +152,6 @@ pub fn run_bench_list_workflow(
             rig_id: None,
             shared_state: None,
             extra_workloads: args.extra_workloads,
-            scenario_gates: BTreeMap::new(),
         },
         run_dir,
         None,
@@ -475,11 +471,6 @@ pub fn run_main_bench_workflow(
         };
 
     if let Some(results) = parsed.as_mut() {
-        for scenario in &mut results.scenarios {
-            if let Some(gates) = execution_args.scenario_gates.get(&scenario.id) {
-                scenario.gates.extend(gates.clone());
-            }
-        }
         stamp_run_metadata(
             results,
             &execution_context,
@@ -1177,7 +1168,6 @@ mod tests {
                 rig_id: None,
                 shared_state: None,
                 extra_workloads: Vec::new(),
-                scenario_gates: BTreeMap::new(),
             },
             &run_dir,
         )
@@ -1232,7 +1222,6 @@ mod tests {
             rig_id: Some("studio".to_string()),
             shared_state: Some(component_dir.path().join("shared")),
             extra_workloads: Vec::new(),
-            scenario_gates: BTreeMap::new(),
         };
         let mut results = BenchResults {
             component_id: "homeboy".to_string(),

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::component::ScopedExtensionConfig;
+use crate::extension::bench::{BenchGate, BenchGateOp};
 
 /// A rig: components + services + pipelines.
 ///
@@ -225,6 +226,52 @@ pub struct BenchSpec {
     /// can emit supplemental pairwise diffs grouped by the non-varying axes.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub axes: BTreeMap<String, String>,
+
+    /// Scenario-level metric gates declared by the rig. Keys are bench
+    /// scenario ids; values map metric names to pass/fail conditions.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metric_gates: BTreeMap<String, BTreeMap<String, BenchMetricGateCondition>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BenchMetricGateCondition {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub equals: Option<f64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gte: Option<f64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lte: Option<f64>,
+}
+
+impl BenchMetricGateCondition {
+    pub fn to_gates(&self, metric: &str) -> Vec<BenchGate> {
+        let mut gates = Vec::new();
+        if let Some(value) = self.equals {
+            gates.push(BenchGate {
+                metric: metric.to_string(),
+                op: BenchGateOp::Eq,
+                value,
+            });
+        }
+        if let Some(value) = self.gte {
+            gates.push(BenchGate {
+                metric: metric.to_string(),
+                op: BenchGateOp::Gte,
+                value,
+            });
+        }
+        if let Some(value) = self.lte {
+            gates.push(BenchGate {
+                metric: metric.to_string(),
+                op: BenchGateOp::Lte,
+                value,
+            });
+        }
+        gates
+    }
 }
 
 /// Rig-owned extension workload declaration.

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -332,6 +332,85 @@ impl WorkloadSpec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_gates() {
+        let condition = BenchMetricGateCondition {
+            equals: Some(1.0),
+            gte: Some(0.5),
+            lte: Some(2.0),
+        };
+
+        let gates = condition.to_gates("native_block_quality_pass");
+
+        assert_eq!(gates.len(), 3);
+        assert!(gates.iter().any(|gate| {
+            gate.metric == "native_block_quality_pass"
+                && gate.op == BenchGateOp::Eq
+                && gate.value == 1.0
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.metric == "native_block_quality_pass"
+                && gate.op == BenchGateOp::Gte
+                && gate.value == 0.5
+        }));
+        assert!(gates.iter().any(|gate| {
+            gate.metric == "native_block_quality_pass"
+                && gate.op == BenchGateOp::Lte
+                && gate.value == 2.0
+        }));
+        assert!(BenchMetricGateCondition {
+            equals: None,
+            gte: None,
+            lte: None,
+        }
+        .to_gates("metric")
+        .is_empty());
+    }
+
+    #[test]
+    fn test_trace_phase_preset() {
+        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+            path: "trace.mjs".to_string(),
+            check_groups: None,
+            trace_phase_presets: HashMap::from([(
+                "startup".to_string(),
+                vec!["launch".to_string(), "ready".to_string()],
+            )]),
+            trace_default_phase_preset: None,
+        });
+
+        assert_eq!(workload.trace_phase_preset("missing"), None);
+        assert_eq!(
+            workload.trace_phase_preset("startup"),
+            Some(["launch".to_string(), "ready".to_string()].as_slice())
+        );
+        assert_eq!(
+            WorkloadSpec::Path("trace.mjs".to_string()).trace_phase_preset("startup"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_trace_default_phase_preset() {
+        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+            path: "trace.mjs".to_string(),
+            check_groups: None,
+            trace_phase_presets: HashMap::new(),
+            trace_default_phase_preset: Some("startup".to_string()),
+        });
+
+        assert_eq!(workload.trace_default_phase_preset(), Some("startup"));
+        assert_eq!(
+            WorkloadSpec::Path("trace.mjs".to_string()).trace_default_phase_preset(),
+            None
+        );
+    }
+}
+
 /// Component reference inside a rig spec. Decoupled from the global component
 /// registry because rigs should work even when a component isn't registered.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -4,7 +4,8 @@
 //! the field serializes — consumers (rig spec authors, downstream
 //! tooling) read this directly off disk.
 
-use crate::rig::spec::{BenchSpec, RigSpec};
+use crate::extension::bench::BenchGateOp;
+use crate::rig::spec::{BenchMetricGateCondition, BenchSpec, RigSpec, WorkloadSpec};
 
 /// Parses a minimal RigSpec JSON via serde and returns the embedded
 /// `BenchSpec` (or panics).
@@ -147,6 +148,107 @@ fn test_rig_spec_deserializes_trace_workloads_by_extension() {
         .map(|workload| workload.path())
         .collect();
     assert_eq!(wordpress, vec!["/private/traces/wp-admin-load.trace.php"]);
+}
+
+#[test]
+fn test_trace_phase_preset() {
+    let spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "studio",
+            "trace_workloads": {
+                "nodejs": [
+                    {
+                        "path": "${package.root}/bench/studio.trace.mjs",
+                        "trace_phase_presets": {
+                            "startup": ["launch", "ready"]
+                        }
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse RigSpec");
+
+    let workload = spec
+        .trace_workloads
+        .get("nodejs")
+        .and_then(|workloads| workloads.first())
+        .expect("nodejs trace workload");
+
+    assert_eq!(workload.trace_phase_preset("missing"), None);
+    assert_eq!(
+        workload.trace_phase_preset("startup"),
+        Some(["launch".to_string(), "ready".to_string()].as_slice())
+    );
+    assert_eq!(
+        WorkloadSpec::Path("trace.mjs".to_string()).trace_phase_preset("startup"),
+        None
+    );
+}
+
+#[test]
+fn test_trace_default_phase_preset() {
+    let spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "studio",
+            "trace_workloads": {
+                "nodejs": [
+                    {
+                        "path": "${package.root}/bench/studio.trace.mjs",
+                        "trace_default_phase_preset": "startup"
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse RigSpec");
+
+    let workload = spec
+        .trace_workloads
+        .get("nodejs")
+        .and_then(|workloads| workloads.first())
+        .expect("nodejs trace workload");
+
+    assert_eq!(workload.trace_default_phase_preset(), Some("startup"));
+    assert_eq!(
+        WorkloadSpec::Path("trace.mjs".to_string()).trace_default_phase_preset(),
+        None
+    );
+}
+
+#[test]
+fn test_to_gates() {
+    let condition = BenchMetricGateCondition {
+        equals: Some(1.0),
+        gte: Some(0.5),
+        lte: Some(2.0),
+    };
+
+    let gates = condition.to_gates("native_block_quality_pass");
+
+    assert_eq!(gates.len(), 3);
+    assert!(gates.iter().any(|gate| {
+        gate.metric == "native_block_quality_pass"
+            && gate.op == BenchGateOp::Eq
+            && gate.value == 1.0
+    }));
+    assert!(gates.iter().any(|gate| {
+        gate.metric == "native_block_quality_pass"
+            && gate.op == BenchGateOp::Gte
+            && gate.value == 0.5
+    }));
+    assert!(gates.iter().any(|gate| {
+        gate.metric == "native_block_quality_pass"
+            && gate.op == BenchGateOp::Lte
+            && gate.value == 2.0
+    }));
+    assert!(BenchMetricGateCondition {
+        equals: None,
+        gte: None,
+        lte: None,
+    }
+    .to_gates("metric")
+    .is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `bench.metric_gates` to rig specs so rigs can declare scenario-level quality gates without changing workload output.
- Merges rig-declared gates with workload-emitted `gates` before Homeboy evaluates scenario/run pass/fail.
- Documents the rig gate shape and adds coverage for rig parsing plus gate application.

Fixes #2120

## Verification
- `cargo test declared_scenario_gates`
- `cargo test semantic_gate`
- `cargo check`
- `homeboy lint`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and PR description; Chris remains responsible for review and merge.