### PR TITLE
trace: support multi-component variants

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -10,7 +10,7 @@ use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::trace as extension_trace;
 use homeboy::extension::trace::{
     TraceCommandOutput, TraceListWorkflowArgs, TraceOverlayRequest, TraceRunWorkflowArgs,
-    TraceSpanDefinition,
+    TraceRunnerInputs, TraceSpanDefinition,
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::observation::{
@@ -559,13 +559,15 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
             component_id: ctx.component_id.clone(),
             path_override,
             settings: settings_as_strings(&ctx.settings),
-            settings_json: settings_as_json(&ctx.settings),
+            runner_inputs: TraceRunnerInputs {
+                json_settings: settings_as_json(&ctx.settings),
+                workload_paths: extra_workloads,
+            },
             scenario_id,
             json_summary: args.json_summary,
             rig_id: args.rig,
             overlays,
             keep_overlay: args.keep_overlay,
-            extra_workloads,
             span_definitions,
             baseline_flags: BaselineFlags {
                 baseline: args.baseline_args.baseline,
@@ -970,9 +972,11 @@ fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
             component_id: ctx.component_id.clone(),
             path_override,
             settings: settings_as_strings(&ctx.settings),
-            settings_json: settings_as_json(&ctx.settings),
+            runner_inputs: TraceRunnerInputs {
+                json_settings: settings_as_json(&ctx.settings),
+                workload_paths: extra_workloads,
+            },
             rig_id: args.rig,
-            extra_workloads,
         },
         &run_dir,
     )?;
@@ -1054,6 +1058,7 @@ fn trace_overlays_for_args(
             .iter()
             .cloned()
             .map(|overlay_path| TraceOverlayRequest {
+                variant: None,
                 component_id: Some(component_id.to_string()),
                 component_path: component_path.to_string(),
                 overlay_path,
@@ -1107,6 +1112,7 @@ fn trace_overlay_request_for_component(
         )
     })?;
     Ok(TraceOverlayRequest {
+        variant: Some(variant_name.to_string()),
         component_id: Some(component_id.to_string()),
         component_path,
         overlay_path: resolve_trace_variant_overlay(context, overlay),

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -476,7 +476,15 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
             && args.phases.is_empty()
             && args.spans.is_empty(),
     )?;
-    let overlays = trace_overlays_for_args(&args, rig_context.as_ref(), &effective_id)?;
+    let component_path_for_overlays = path_override
+        .clone()
+        .unwrap_or_else(|| ctx.component.local_path.clone());
+    let overlays = trace_overlays_for_args(
+        &args,
+        rig_context.as_ref(),
+        &effective_id,
+        &component_path_for_overlays,
+    )?;
 
     let rig_state = rig_context
         .as_ref()
@@ -999,6 +1007,7 @@ fn trace_overlays_for_args(
     args: &TraceArgs,
     rig_context: Option<&TraceRigContext>,
     component_id: &str,
+    component_path: &str,
 ) -> homeboy::Result<Vec<TraceOverlayRequest>> {
     let mut overlays = Vec::new();
     if !args.variants.is_empty() {
@@ -1032,22 +1041,76 @@ fn trace_overlays_for_args(
                     None,
                 )
             })?;
-            overlays.push(TraceOverlayRequest {
-                variant: Some(name.clone()),
-                path: resolve_trace_variant_overlay(context, &variant.overlay),
-            });
+            overlays.extend(trace_variant_overlay_requests(
+                context,
+                name,
+                variant,
+                component_id,
+            )?);
         }
     }
     overlays.extend(
         args.overlays
             .iter()
             .cloned()
-            .map(|path| TraceOverlayRequest {
-                variant: None,
-                path,
+            .map(|overlay_path| TraceOverlayRequest {
+                component_id: Some(component_id.to_string()),
+                component_path: component_path.to_string(),
+                overlay_path,
             }),
     );
     Ok(overlays)
+}
+
+fn trace_variant_overlay_requests(
+    context: &TraceRigContext,
+    variant_name: &str,
+    variant: &rig::TraceVariantSpec,
+    default_component_id: &str,
+) -> homeboy::Result<Vec<TraceOverlayRequest>> {
+    let mut requests = Vec::new();
+    if let Some(overlay) = variant.overlay.as_deref() {
+        let component_id = variant.component.as_deref().unwrap_or(default_component_id);
+        requests.push(trace_overlay_request_for_component(
+            context,
+            variant_name,
+            component_id,
+            overlay,
+        )?);
+    }
+    for overlay in &variant.overlays {
+        requests.push(trace_overlay_request_for_component(
+            context,
+            variant_name,
+            &overlay.component,
+            &overlay.overlay,
+        )?);
+    }
+    Ok(requests)
+}
+
+fn trace_overlay_request_for_component(
+    context: &TraceRigContext,
+    variant_name: &str,
+    component_id: &str,
+    overlay: &str,
+) -> homeboy::Result<TraceOverlayRequest> {
+    let component_path = rig_component_path(&context.rig_spec, component_id).ok_or_else(|| {
+        homeboy::Error::validation_invalid_argument(
+            "--variant",
+            format!(
+                "trace variant '{}' overlay references unknown component '{}'",
+                variant_name, component_id
+            ),
+            None,
+            None,
+        )
+    })?;
+    Ok(TraceOverlayRequest {
+        component_id: Some(component_id.to_string()),
+        component_path,
+        overlay_path: resolve_trace_variant_overlay(context, overlay),
+    })
 }
 
 fn trace_variants_for_args<'a>(
@@ -1082,6 +1145,12 @@ fn trace_variants_for_args<'a>(
 }
 
 fn trace_variant_matches_component(variant: &rig::TraceVariantSpec, component_id: &str) -> bool {
+    if !variant.overlays.is_empty() {
+        return variant
+            .overlays
+            .iter()
+            .any(|overlay| overlay.component == component_id);
+    }
     variant
         .component
         .as_deref()

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -684,7 +684,7 @@ fn trace_run_resolves_named_variants_and_reports_unknown_names() {
             TraceCommandOutput::Run(result) => {
                 assert_eq!(result.overlays.len(), 1);
                 let overlay = &result.overlays[0];
-                assert_eq!(overlay.component_id.as_deref(), Some("studio"));
+                assert_eq!(overlay.variant.as_deref(), Some("fresh-install-mode"));
                 assert_eq!(
                     overlay.path,
                     package_dir
@@ -694,7 +694,7 @@ fn trace_run_resolves_named_variants_and_reports_unknown_names() {
                 );
                 assert_eq!(overlay.touched_files, vec!["scenario.txt"]);
                 let value = serde_json::to_value(&result).expect("result serializes");
-                assert_eq!(value["overlays"][0]["component_id"], "studio");
+                assert_eq!(value["overlays"][0]["variant"], "fresh-install-mode");
                 assert_eq!(
                     value["overlays"][0]["path"],
                     package_dir

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -684,7 +684,7 @@ fn trace_run_resolves_named_variants_and_reports_unknown_names() {
             TraceCommandOutput::Run(result) => {
                 assert_eq!(result.overlays.len(), 1);
                 let overlay = &result.overlays[0];
-                assert_eq!(overlay.variant.as_deref(), Some("fresh-install-mode"));
+                assert_eq!(overlay.component_id.as_deref(), Some("studio"));
                 assert_eq!(
                     overlay.path,
                     package_dir
@@ -694,7 +694,7 @@ fn trace_run_resolves_named_variants_and_reports_unknown_names() {
                 );
                 assert_eq!(overlay.touched_files, vec!["scenario.txt"]);
                 let value = serde_json::to_value(&result).expect("result serializes");
-                assert_eq!(value["overlays"][0]["variant"], "fresh-install-mode");
+                assert_eq!(value["overlays"][0]["component_id"], "studio");
                 assert_eq!(
                     value["overlays"][0]["path"],
                     package_dir

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -9,6 +9,7 @@
 //! milestones.
 
 pub mod baseline;
+mod overlay;
 mod overlay_lock;
 pub mod parsing;
 pub mod report;
@@ -22,6 +23,7 @@ pub use overlay_lock::{cleanup_stale_trace_overlay_locks, list_trace_overlay_loc
 pub use overlay_lock::{
     TraceOverlayLockCleanupResult, TraceOverlayLockRecord, TraceOverlayLockStatus,
 };
+pub use overlay::TraceOverlayRequest;
 pub use parsing::{parse_trace_list_str, parse_trace_results_file};
 pub use parsing::{
     TraceArtifact, TraceAssertion, TraceEvent, TraceList, TraceScenario, TraceStatus,
@@ -35,7 +37,7 @@ pub use report::{
 };
 pub use report::{push_overlay_markdown, render_markdown};
 pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};
-pub use run::{TraceOverlayRequest, TraceRunWorkflowArgs, TraceRunWorkflowResult};
+pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult};
 
 pub fn resolve_trace_command(
     component: &Component,

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -37,7 +37,7 @@ pub use report::{
 };
 pub use report::{push_overlay_markdown, render_markdown};
 pub use run::{run_trace_list_workflow, run_trace_workflow, TraceListWorkflowArgs};
-pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult};
+pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult, TraceRunnerInputs};
 
 pub fn resolve_trace_command(
     component: &Component,

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -19,11 +19,11 @@ pub mod spans;
 use crate::component::Component;
 use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
 
+pub use overlay::TraceOverlayRequest;
 pub use overlay_lock::{cleanup_stale_trace_overlay_locks, list_trace_overlay_locks};
 pub use overlay_lock::{
     TraceOverlayLockCleanupResult, TraceOverlayLockRecord, TraceOverlayLockStatus,
 };
-pub use overlay::TraceOverlayRequest;
 pub use parsing::{parse_trace_list_str, parse_trace_results_file};
 pub use parsing::{
     TraceArtifact, TraceAssertion, TraceEvent, TraceList, TraceScenario, TraceStatus,

--- a/src/core/extension/trace/overlay.rs
+++ b/src/core/extension/trace/overlay.rs
@@ -1,19 +1,17 @@
-//! Trace overlay application and locking.
+//! Trace overlay application and cleanup.
 
-use serde::Serialize;
 use std::collections::BTreeMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::engine::run_dir::RunDir;
-use crate::error::{Error, ErrorCode, Result};
-use crate::paths;
+use crate::error::{Error, Result};
 
 use super::overlay_lock;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraceOverlayRequest {
+    pub variant: Option<String>,
     pub component_id: Option<String>,
     pub component_path: String,
     pub overlay_path: String,
@@ -21,6 +19,7 @@ pub struct TraceOverlayRequest {
 
 #[derive(Debug, Clone)]
 pub(super) struct AppliedTraceOverlay {
+    pub variant: Option<String>,
     pub component_id: Option<String>,
     pub component_path: PathBuf,
     pub patch_path: PathBuf,
@@ -28,163 +27,28 @@ pub(super) struct AppliedTraceOverlay {
     pub keep: bool,
 }
 
-#[derive(Debug)]
-pub(super) struct TraceOverlayLock {
-    pub(super) path: PathBuf,
-}
-
-#[derive(Debug, Serialize)]
-struct TraceOverlayLockHolder {
-    pid: u32,
-    component_path: String,
-    run_dir: String,
-    acquired_at: String,
-    command: String,
-}
-
-impl TraceOverlayLock {
-    pub(super) fn acquire_all(
-        requests: &[TraceOverlayRequest],
-        run_dir: &RunDir,
-    ) -> Result<Vec<Self>> {
-        let mut component_paths = BTreeMap::new();
-        for request in requests {
-            let normalized = normalize_component_path(Path::new(&request.component_path));
-            component_paths
-                .entry(normalized.to_string_lossy().to_string())
-                .or_insert(normalized);
-        }
-
-        let mut locks = Vec::new();
-        for component_path in component_paths.values() {
-            locks.push(Self::acquire(component_path, run_dir)?);
-        }
-        Ok(locks)
-    }
-
-    pub(super) fn acquire(component_path: &Path, run_dir: &RunDir) -> Result<Self> {
-        let lock_dir = paths::homeboy_data()?.join("trace-overlay-locks");
-        fs::create_dir_all(&lock_dir).map_err(|e| {
-            Error::internal_io(
-                format!(
-                    "Failed to create trace overlay lock dir {}: {}",
-                    lock_dir.display(),
-                    e
-                ),
-                Some("trace.overlay.lock.create_dir".to_string()),
-            )
-        })?;
-
-        let normalized_component_path = normalize_component_path(component_path);
-        let path = lock_dir.join(format!(
-            "{}.lock",
-            overlay_lock::trace_overlay_lock_id(&normalized_component_path)
-        ));
-
-        match fs::create_dir(&path) {
-            Ok(()) => {
-                let holder = TraceOverlayLockHolder {
-                    pid: std::process::id(),
-                    component_path: normalized_component_path.to_string_lossy().to_string(),
-                    run_dir: run_dir.path().to_string_lossy().to_string(),
-                    acquired_at: chrono::Utc::now().to_rfc3339(),
-                    command: std::env::args().collect::<Vec<_>>().join(" "),
-                };
-                let holder_path = path.join("holder.json");
-                if let Err(error) = write_trace_overlay_lock_holder(&holder_path, &holder) {
-                    let _ = fs::remove_dir_all(&path);
-                    return Err(error);
-                }
-                Ok(Self { path })
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                Err(trace_overlay_lock_error(
-                    &normalized_component_path,
-                    &path,
-                    run_dir,
-                    overlay_lock::read_trace_overlay_lock_holder(&path)
-                        .and_then(|holder| serde_json::to_value(holder).ok()),
-                ))
-            }
-            Err(e) => Err(Error::internal_io(
-                format!(
-                    "Failed to acquire trace overlay lock {}: {}",
-                    path.display(),
-                    e
-                ),
-                Some("trace.overlay.lock.acquire".to_string()),
-            )),
-        }
-    }
-}
-
-impl Drop for TraceOverlayLock {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
-}
-
-pub(super) fn normalize_component_path(component_path: &Path) -> PathBuf {
-    fs::canonicalize(component_path).unwrap_or_else(|_| component_path.to_path_buf())
-}
-
-fn write_trace_overlay_lock_holder(path: &Path, holder: &TraceOverlayLockHolder) -> Result<()> {
-    let content = serde_json::to_string_pretty(holder).map_err(|e| {
-        Error::internal_json(e.to_string(), Some("trace.overlay.lock.holder".to_string()))
-    })?;
-    fs::write(path, content).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to write trace overlay lock holder {}: {}",
-                path.display(),
-                e
-            ),
-            Some("trace.overlay.lock.write_holder".to_string()),
-        )
-    })
-}
-
-fn trace_overlay_lock_error(
-    component_path: &Path,
-    lock_path: &Path,
+pub(super) fn acquire_trace_overlay_locks(
+    requests: &[TraceOverlayRequest],
     run_dir: &RunDir,
-    holder: Option<serde_json::Value>,
-) -> Error {
-    let holder_summary = holder
-        .as_ref()
-        .and_then(trace_overlay_holder_summary)
-        .unwrap_or_else(|| "unavailable".to_string());
-    Error::new(
-        ErrorCode::ValidationInvalidArgument,
-        format!(
-            "Trace overlay already active for component path {}. Lock path: {}. Active holder: {}. Current run directory: {}",
-            component_path.display(),
-            lock_path.display(),
-            holder_summary,
-            run_dir.path().display()
-        ),
-        serde_json::json!({
-            "field": "--overlay",
-            "component_path": component_path.to_string_lossy(),
-            "lock_path": lock_path.to_string_lossy(),
-            "run_dir": run_dir.path().to_string_lossy(),
-            "active_holder": holder,
-        }),
-    )
-}
+) -> Result<Vec<overlay_lock::TraceOverlayLock>> {
+    let mut component_requests: BTreeMap<String, (PathBuf, Vec<String>)> = BTreeMap::new();
+    for request in requests {
+        let normalized = overlay_lock::normalize_component_path(Path::new(&request.component_path));
+        let (_, overlay_paths) = component_requests
+            .entry(normalized.to_string_lossy().to_string())
+            .or_insert_with(|| (normalized, Vec::new()));
+        overlay_paths.push(request.overlay_path.clone());
+    }
 
-fn trace_overlay_holder_summary(holder: &serde_json::Value) -> Option<String> {
-    let pid = holder.get("pid").and_then(|value| value.as_u64())?;
-    let run_dir = holder.get("run_dir").and_then(|value| value.as_str());
-    let acquired_at = holder.get("acquired_at").and_then(|value| value.as_str());
-    Some(match (run_dir, acquired_at) {
-        (Some(run_dir), Some(acquired_at)) => {
-            format!("pid {pid}, run directory {run_dir}, acquired at {acquired_at}")
-        }
-        (Some(run_dir), None) => format!("pid {pid}, run directory {run_dir}"),
-        (None, Some(acquired_at)) => format!("pid {pid}, acquired at {acquired_at}"),
-        (None, None) => format!("pid {pid}"),
-    })
+    let mut locks = Vec::new();
+    for (component_path, overlay_paths) in component_requests.values() {
+        locks.push(overlay_lock::TraceOverlayLock::acquire(
+            component_path,
+            overlay_paths,
+            run_dir,
+        )?);
+    }
+    Ok(locks)
 }
 
 pub(super) fn apply_trace_overlays(
@@ -209,6 +73,7 @@ pub(super) fn apply_trace_overlays(
         }
         print_trace_overlay("applied", &patch_path, &touched_files, keep);
         applied.push(AppliedTraceOverlay {
+            variant: request.variant.clone(),
             component_id: request.component_id.clone(),
             component_path: component_path.clone(),
             patch_path,
@@ -443,47 +308,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_acquire() {
+    fn test_acquire_trace_overlay_locks() {
         with_isolated_home(|_| {
-            let component_dir = tempfile::tempdir().unwrap();
             let run_dir = RunDir::create().unwrap();
-            let lock_path;
+            let first = overlay_fixture("first");
+            let second = overlay_fixture("second");
 
-            {
-                let lock = TraceOverlayLock::acquire(component_dir.path(), &run_dir).unwrap();
-                lock_path = lock.path.clone();
-                assert!(lock_path.exists());
-                assert!(lock_path.join("holder.json").exists());
-            }
-
-            assert!(!lock_path.exists());
-            run_dir.cleanup();
-        });
-    }
-
-    #[test]
-    fn test_acquire_all() {
-        with_isolated_home(|_| {
-            let first = tempfile::tempdir().unwrap();
-            let second = tempfile::tempdir().unwrap();
-            let run_dir = RunDir::create().unwrap();
-            let requests = vec![
-                TraceOverlayRequest {
-                    component_id: Some("first".to_string()),
-                    component_path: first.path().to_string_lossy().to_string(),
-                    overlay_path: "/tmp/first.patch".to_string(),
-                },
-                TraceOverlayRequest {
-                    component_id: Some("second".to_string()),
-                    component_path: second.path().to_string_lossy().to_string(),
-                    overlay_path: "/tmp/second.patch".to_string(),
-                },
-            ];
-
-            let locks = TraceOverlayLock::acquire_all(&requests, &run_dir).unwrap();
+            let locks = acquire_trace_overlay_locks(
+                &[first.request.clone(), second.request.clone()],
+                &run_dir,
+            )
+            .unwrap();
 
             assert_eq!(locks.len(), 2);
-            assert!(locks.iter().all(|lock| lock.path.exists()));
             run_dir.cleanup();
         });
     }
@@ -527,24 +364,6 @@ mod tests {
         assert_eq!(touched, vec!["scenario.txt"]);
     }
 
-    #[test]
-    fn test_normalize_component_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let normalized = super::normalize_component_path(dir.path());
-
-        assert!(normalized.is_absolute());
-        assert_eq!(normalized, fs::canonicalize(dir.path()).unwrap());
-    }
-
-    #[test]
-    fn test_trace_overlay_lock_id() {
-        let first = overlay_lock::trace_overlay_lock_id(Path::new("/tmp/component-a"));
-        let second = overlay_lock::trace_overlay_lock_id(Path::new("/tmp/component-b"));
-
-        assert_eq!(first.len(), 24);
-        assert_ne!(first, second);
-    }
-
     struct OverlayFixture {
         _temp: tempfile::TempDir,
         component_dir: PathBuf,
@@ -575,6 +394,7 @@ mod tests {
             _temp: temp,
             component_dir: component_dir.clone(),
             request: TraceOverlayRequest {
+                variant: None,
                 component_id: Some("component".to_string()),
                 component_path: component_dir.to_string_lossy().to_string(),
                 overlay_path: patch_path.to_string_lossy().to_string(),

--- a/src/core/extension/trace/overlay.rs
+++ b/src/core/extension/trace/overlay.rs
@@ -1,7 +1,6 @@
 //! Trace overlay application and locking.
 
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -10,6 +9,8 @@ use std::process::Command;
 use crate::engine::run_dir::RunDir;
 use crate::error::{Error, ErrorCode, Result};
 use crate::paths;
+
+use super::overlay_lock;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraceOverlayRequest {
@@ -77,7 +78,7 @@ impl TraceOverlayLock {
         let normalized_component_path = normalize_component_path(component_path);
         let path = lock_dir.join(format!(
             "{}.lock",
-            trace_overlay_lock_id(&normalized_component_path)
+            overlay_lock::trace_overlay_lock_id(&normalized_component_path)
         ));
 
         match fs::create_dir(&path) {
@@ -101,7 +102,8 @@ impl TraceOverlayLock {
                     &normalized_component_path,
                     &path,
                     run_dir,
-                    read_trace_overlay_lock_holder(&path),
+                    overlay_lock::read_trace_overlay_lock_holder(&path)
+                        .and_then(|holder| serde_json::to_value(holder).ok()),
                 ))
             }
             Err(e) => Err(Error::internal_io(
@@ -126,17 +128,6 @@ pub(super) fn normalize_component_path(component_path: &Path) -> PathBuf {
     fs::canonicalize(component_path).unwrap_or_else(|_| component_path.to_path_buf())
 }
 
-pub(super) fn trace_overlay_lock_id(component_path: &Path) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(component_path.to_string_lossy().as_bytes());
-    let digest = hasher.finalize();
-    let hex = digest
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
-    hex[..24].to_string()
-}
-
 fn write_trace_overlay_lock_holder(path: &Path, holder: &TraceOverlayLockHolder) -> Result<()> {
     let content = serde_json::to_string_pretty(holder).map_err(|e| {
         Error::internal_json(e.to_string(), Some("trace.overlay.lock.holder".to_string()))
@@ -151,12 +142,6 @@ fn write_trace_overlay_lock_holder(path: &Path, holder: &TraceOverlayLockHolder)
             Some("trace.overlay.lock.write_holder".to_string()),
         )
     })
-}
-
-fn read_trace_overlay_lock_holder(lock_path: &Path) -> Option<serde_json::Value> {
-    let holder_path = lock_path.join("holder.json");
-    let content = fs::read_to_string(holder_path).ok()?;
-    serde_json::from_str(&content).ok()
 }
 
 fn trace_overlay_lock_error(
@@ -323,7 +308,10 @@ fn print_trace_overlay(action: &str, patch_path: &Path, touched_files: &[String]
     }
 }
 
-fn overlay_touched_files(component_path: &Path, patch_path: &Path) -> Result<Vec<String>> {
+pub(super) fn overlay_touched_files(
+    component_path: &Path,
+    patch_path: &Path,
+) -> Result<Vec<String>> {
     let output = Command::new("git")
         .args(["apply", "--numstat"])
         .arg(patch_path)
@@ -449,11 +437,9 @@ mod tests {
     use std::fs;
     use std::process::Command;
 
-    use crate::engine::baseline::BaselineFlags;
     use crate::engine::run_dir::RunDir;
     use crate::test_support::with_isolated_home;
 
-    use super::super::run::{TraceRunWorkflowArgs, TraceWorkflowInputs};
     use super::*;
 
     #[test]
@@ -529,6 +515,19 @@ mod tests {
     }
 
     #[test]
+    fn test_overlay_touched_files() {
+        let fixture = overlay_fixture("overlay");
+
+        let touched = overlay_touched_files(
+            &fixture.component_dir,
+            Path::new(&fixture.request.overlay_path),
+        )
+        .unwrap();
+
+        assert_eq!(touched, vec!["scenario.txt"]);
+    }
+
+    #[test]
     fn test_normalize_component_path() {
         let dir = tempfile::tempdir().unwrap();
         let normalized = super::normalize_component_path(dir.path());
@@ -539,49 +538,11 @@ mod tests {
 
     #[test]
     fn test_trace_overlay_lock_id() {
-        let first = super::trace_overlay_lock_id(Path::new("/tmp/component-a"));
-        let second = super::trace_overlay_lock_id(Path::new("/tmp/component-b"));
+        let first = overlay_lock::trace_overlay_lock_id(Path::new("/tmp/component-a"));
+        let second = overlay_lock::trace_overlay_lock_id(Path::new("/tmp/component-b"));
 
         assert_eq!(first.len(), 24);
         assert_ne!(first, second);
-    }
-
-    #[test]
-    fn test_trace_overlay_requests() {
-        let variant_request = TraceOverlayRequest {
-            component_id: Some("secondary".to_string()),
-            component_path: "/tmp/secondary".to_string(),
-            overlay_path: "/tmp/secondary.patch".to_string(),
-        };
-        let args = TraceRunWorkflowArgs {
-            component_label: "primary".to_string(),
-            component_id: "primary".to_string(),
-            path_override: Some("/tmp/primary".to_string()),
-            workflow: TraceWorkflowInputs::default(),
-            scenario_id: "scenario".to_string(),
-            json_summary: false,
-            rig_id: Some("rig".to_string()),
-            overlays: vec!["/tmp/primary.patch".to_string()],
-            variant_overlays: vec![variant_request.clone()],
-            keep_overlay: false,
-            span_definitions: Vec::new(),
-            baseline_flags: BaselineFlags {
-                baseline: false,
-                ignore_baseline: true,
-                ratchet: false,
-            },
-            regression_threshold_percent:
-                super::super::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-            regression_min_delta_ms: super::super::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-        };
-
-        let requests = super::trace_overlay_requests("/tmp/primary", &args);
-
-        assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0], variant_request);
-        assert_eq!(requests[1].component_id.as_deref(), Some("primary"));
-        assert_eq!(requests[1].component_path, "/tmp/primary");
-        assert_eq!(requests[1].overlay_path, "/tmp/primary.patch");
     }
 
     struct OverlayFixture {

--- a/src/core/extension/trace/overlay.rs
+++ b/src/core/extension/trace/overlay.rs
@@ -443,3 +443,212 @@ fn run_git_apply(component_path: &Path, patch_path: &Path, reverse: bool) -> Res
 fn unquote_numstat_path(path: &str) -> String {
     path.trim().trim_matches('"').to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::process::Command;
+
+    use crate::engine::baseline::BaselineFlags;
+    use crate::engine::run_dir::RunDir;
+    use crate::test_support::with_isolated_home;
+
+    use super::super::run::{TraceRunWorkflowArgs, TraceWorkflowInputs};
+    use super::*;
+
+    #[test]
+    fn test_acquire() {
+        with_isolated_home(|_| {
+            let component_dir = tempfile::tempdir().unwrap();
+            let run_dir = RunDir::create().unwrap();
+            let lock_path;
+
+            {
+                let lock = TraceOverlayLock::acquire(component_dir.path(), &run_dir).unwrap();
+                lock_path = lock.path.clone();
+                assert!(lock_path.exists());
+                assert!(lock_path.join("holder.json").exists());
+            }
+
+            assert!(!lock_path.exists());
+            run_dir.cleanup();
+        });
+    }
+
+    #[test]
+    fn test_acquire_all() {
+        with_isolated_home(|_| {
+            let first = tempfile::tempdir().unwrap();
+            let second = tempfile::tempdir().unwrap();
+            let run_dir = RunDir::create().unwrap();
+            let requests = vec![
+                TraceOverlayRequest {
+                    component_id: Some("first".to_string()),
+                    component_path: first.path().to_string_lossy().to_string(),
+                    overlay_path: "/tmp/first.patch".to_string(),
+                },
+                TraceOverlayRequest {
+                    component_id: Some("second".to_string()),
+                    component_path: second.path().to_string_lossy().to_string(),
+                    overlay_path: "/tmp/second.patch".to_string(),
+                },
+            ];
+
+            let locks = TraceOverlayLock::acquire_all(&requests, &run_dir).unwrap();
+
+            assert_eq!(locks.len(), 2);
+            assert!(locks.iter().all(|lock| lock.path.exists()));
+            run_dir.cleanup();
+        });
+    }
+
+    #[test]
+    fn test_apply_trace_overlays() {
+        let fixture = overlay_fixture("overlay");
+        let applied = apply_trace_overlays(&[fixture.request.clone()], true).unwrap();
+
+        assert_eq!(applied.len(), 1);
+        assert_eq!(applied[0].touched_files, vec!["scenario.txt"]);
+        assert_eq!(
+            fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
+            "overlay\n"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_trace_overlays() {
+        let fixture = overlay_fixture("overlay");
+        let applied = apply_trace_overlays(&[fixture.request.clone()], true).unwrap();
+
+        cleanup_trace_overlays(&applied).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
+            "base\n"
+        );
+    }
+
+    #[test]
+    fn test_normalize_component_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let normalized = super::normalize_component_path(dir.path());
+
+        assert!(normalized.is_absolute());
+        assert_eq!(normalized, fs::canonicalize(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn test_trace_overlay_lock_id() {
+        let first = super::trace_overlay_lock_id(Path::new("/tmp/component-a"));
+        let second = super::trace_overlay_lock_id(Path::new("/tmp/component-b"));
+
+        assert_eq!(first.len(), 24);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn test_trace_overlay_requests() {
+        let variant_request = TraceOverlayRequest {
+            component_id: Some("secondary".to_string()),
+            component_path: "/tmp/secondary".to_string(),
+            overlay_path: "/tmp/secondary.patch".to_string(),
+        };
+        let args = TraceRunWorkflowArgs {
+            component_label: "primary".to_string(),
+            component_id: "primary".to_string(),
+            path_override: Some("/tmp/primary".to_string()),
+            workflow: TraceWorkflowInputs::default(),
+            scenario_id: "scenario".to_string(),
+            json_summary: false,
+            rig_id: Some("rig".to_string()),
+            overlays: vec!["/tmp/primary.patch".to_string()],
+            variant_overlays: vec![variant_request.clone()],
+            keep_overlay: false,
+            span_definitions: Vec::new(),
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent:
+                super::super::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms: super::super::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        };
+
+        let requests = super::trace_overlay_requests("/tmp/primary", &args);
+
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0], variant_request);
+        assert_eq!(requests[1].component_id.as_deref(), Some("primary"));
+        assert_eq!(requests[1].component_path, "/tmp/primary");
+        assert_eq!(requests[1].overlay_path, "/tmp/primary.patch");
+    }
+
+    struct OverlayFixture {
+        _temp: tempfile::TempDir,
+        component_dir: PathBuf,
+        request: TraceOverlayRequest,
+    }
+
+    fn overlay_fixture(replacement: &str) -> OverlayFixture {
+        let temp = tempfile::tempdir().unwrap();
+        let component_dir = temp.path().join("component");
+        fs::create_dir_all(&component_dir).unwrap();
+        fs::write(component_dir.join("scenario.txt"), "base\n").unwrap();
+        init_git_repo(&component_dir);
+        let patch_path = temp.path().join("overlay.patch");
+        fs::write(
+            &patch_path,
+            format!(
+                r#"--- a/scenario.txt
++++ b/scenario.txt
+@@ -1 +1 @@
+-base
++{replacement}
+"#
+            ),
+        )
+        .unwrap();
+
+        OverlayFixture {
+            _temp: temp,
+            component_dir: component_dir.clone(),
+            request: TraceOverlayRequest {
+                component_id: Some("component".to_string()),
+                component_path: component_dir.to_string_lossy().to_string(),
+                overlay_path: patch_path.to_string_lossy().to_string(),
+            },
+        }
+    }
+
+    fn init_git_repo(path: &Path) {
+        git(path, &["init"]);
+        git(path, &["add", "scenario.txt"]);
+        git(
+            path,
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "init",
+            ],
+        );
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/src/core/extension/trace/overlay.rs
+++ b/src/core/extension/trace/overlay.rs
@@ -1,0 +1,445 @@
+//! Trace overlay application and locking.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::engine::run_dir::RunDir;
+use crate::error::{Error, ErrorCode, Result};
+use crate::paths;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceOverlayRequest {
+    pub component_id: Option<String>,
+    pub component_path: String,
+    pub overlay_path: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AppliedTraceOverlay {
+    pub component_id: Option<String>,
+    pub component_path: PathBuf,
+    pub patch_path: PathBuf,
+    pub touched_files: Vec<String>,
+    pub keep: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct TraceOverlayLock {
+    pub(super) path: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct TraceOverlayLockHolder {
+    pid: u32,
+    component_path: String,
+    run_dir: String,
+    acquired_at: String,
+    command: String,
+}
+
+impl TraceOverlayLock {
+    pub(super) fn acquire_all(
+        requests: &[TraceOverlayRequest],
+        run_dir: &RunDir,
+    ) -> Result<Vec<Self>> {
+        let mut component_paths = BTreeMap::new();
+        for request in requests {
+            let normalized = normalize_component_path(Path::new(&request.component_path));
+            component_paths
+                .entry(normalized.to_string_lossy().to_string())
+                .or_insert(normalized);
+        }
+
+        let mut locks = Vec::new();
+        for component_path in component_paths.values() {
+            locks.push(Self::acquire(component_path, run_dir)?);
+        }
+        Ok(locks)
+    }
+
+    pub(super) fn acquire(component_path: &Path, run_dir: &RunDir) -> Result<Self> {
+        let lock_dir = paths::homeboy_data()?.join("trace-overlay-locks");
+        fs::create_dir_all(&lock_dir).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to create trace overlay lock dir {}: {}",
+                    lock_dir.display(),
+                    e
+                ),
+                Some("trace.overlay.lock.create_dir".to_string()),
+            )
+        })?;
+
+        let normalized_component_path = normalize_component_path(component_path);
+        let path = lock_dir.join(format!(
+            "{}.lock",
+            trace_overlay_lock_id(&normalized_component_path)
+        ));
+
+        match fs::create_dir(&path) {
+            Ok(()) => {
+                let holder = TraceOverlayLockHolder {
+                    pid: std::process::id(),
+                    component_path: normalized_component_path.to_string_lossy().to_string(),
+                    run_dir: run_dir.path().to_string_lossy().to_string(),
+                    acquired_at: chrono::Utc::now().to_rfc3339(),
+                    command: std::env::args().collect::<Vec<_>>().join(" "),
+                };
+                let holder_path = path.join("holder.json");
+                if let Err(error) = write_trace_overlay_lock_holder(&holder_path, &holder) {
+                    let _ = fs::remove_dir_all(&path);
+                    return Err(error);
+                }
+                Ok(Self { path })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                Err(trace_overlay_lock_error(
+                    &normalized_component_path,
+                    &path,
+                    run_dir,
+                    read_trace_overlay_lock_holder(&path),
+                ))
+            }
+            Err(e) => Err(Error::internal_io(
+                format!(
+                    "Failed to acquire trace overlay lock {}: {}",
+                    path.display(),
+                    e
+                ),
+                Some("trace.overlay.lock.acquire".to_string()),
+            )),
+        }
+    }
+}
+
+impl Drop for TraceOverlayLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+pub(super) fn normalize_component_path(component_path: &Path) -> PathBuf {
+    fs::canonicalize(component_path).unwrap_or_else(|_| component_path.to_path_buf())
+}
+
+pub(super) fn trace_overlay_lock_id(component_path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(component_path.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let hex = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    hex[..24].to_string()
+}
+
+fn write_trace_overlay_lock_holder(path: &Path, holder: &TraceOverlayLockHolder) -> Result<()> {
+    let content = serde_json::to_string_pretty(holder).map_err(|e| {
+        Error::internal_json(e.to_string(), Some("trace.overlay.lock.holder".to_string()))
+    })?;
+    fs::write(path, content).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to write trace overlay lock holder {}: {}",
+                path.display(),
+                e
+            ),
+            Some("trace.overlay.lock.write_holder".to_string()),
+        )
+    })
+}
+
+fn read_trace_overlay_lock_holder(lock_path: &Path) -> Option<serde_json::Value> {
+    let holder_path = lock_path.join("holder.json");
+    let content = fs::read_to_string(holder_path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn trace_overlay_lock_error(
+    component_path: &Path,
+    lock_path: &Path,
+    run_dir: &RunDir,
+    holder: Option<serde_json::Value>,
+) -> Error {
+    let holder_summary = holder
+        .as_ref()
+        .and_then(trace_overlay_holder_summary)
+        .unwrap_or_else(|| "unavailable".to_string());
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Trace overlay already active for component path {}. Lock path: {}. Active holder: {}. Current run directory: {}",
+            component_path.display(),
+            lock_path.display(),
+            holder_summary,
+            run_dir.path().display()
+        ),
+        serde_json::json!({
+            "field": "--overlay",
+            "component_path": component_path.to_string_lossy(),
+            "lock_path": lock_path.to_string_lossy(),
+            "run_dir": run_dir.path().to_string_lossy(),
+            "active_holder": holder,
+        }),
+    )
+}
+
+fn trace_overlay_holder_summary(holder: &serde_json::Value) -> Option<String> {
+    let pid = holder.get("pid").and_then(|value| value.as_u64())?;
+    let run_dir = holder.get("run_dir").and_then(|value| value.as_str());
+    let acquired_at = holder.get("acquired_at").and_then(|value| value.as_str());
+    Some(match (run_dir, acquired_at) {
+        (Some(run_dir), Some(acquired_at)) => {
+            format!("pid {pid}, run directory {run_dir}, acquired at {acquired_at}")
+        }
+        (Some(run_dir), None) => format!("pid {pid}, run directory {run_dir}"),
+        (None, Some(acquired_at)) => format!("pid {pid}, acquired at {acquired_at}"),
+        (None, None) => format!("pid {pid}"),
+    })
+}
+
+pub(super) fn apply_trace_overlays(
+    requests: &[TraceOverlayRequest],
+    keep: bool,
+) -> Result<Vec<AppliedTraceOverlay>> {
+    let mut applied = Vec::new();
+    for request in requests {
+        let component_path = PathBuf::from(&request.component_path);
+        let patch_path = PathBuf::from(&request.overlay_path);
+        let touched_files = match overlay_touched_files(&component_path, &patch_path) {
+            Ok(files) => files,
+            Err(error) => return cleanup_with_overlay_error(&applied, keep, error, request),
+        };
+        if let Err(error) =
+            ensure_overlay_targets_clean(&component_path, &patch_path, &touched_files)
+        {
+            return cleanup_with_overlay_error(&applied, keep, error, request);
+        }
+        if let Err(error) = run_git_apply(&component_path, &patch_path, false) {
+            return cleanup_with_overlay_error(&applied, keep, error, request);
+        }
+        print_trace_overlay("applied", &patch_path, &touched_files, keep);
+        applied.push(AppliedTraceOverlay {
+            component_id: request.component_id.clone(),
+            component_path: component_path.clone(),
+            patch_path,
+            touched_files,
+            keep,
+        });
+    }
+    Ok(applied)
+}
+
+fn cleanup_with_overlay_error<T>(
+    applied: &[AppliedTraceOverlay],
+    keep: bool,
+    error: Error,
+    request: &TraceOverlayRequest,
+) -> Result<T> {
+    cleanup_after_overlay_error(applied, keep, trace_overlay_request_error(error, request))
+}
+
+fn trace_overlay_request_error(mut error: Error, request: &TraceOverlayRequest) -> Error {
+    let component = request
+        .component_id
+        .as_deref()
+        .unwrap_or("<unknown-component>");
+    error.message = format!(
+        "Trace overlay failed for component '{}' at {} using {}: {}",
+        component, request.component_path, request.overlay_path, error.message
+    );
+    if let Some(details) = error.details.as_object_mut() {
+        details.insert(
+            "component_id".to_string(),
+            serde_json::json!(request.component_id.clone()),
+        );
+        details.insert(
+            "component_path".to_string(),
+            serde_json::json!(request.component_path.clone()),
+        );
+        details.insert(
+            "overlay_path".to_string(),
+            serde_json::json!(request.overlay_path.clone()),
+        );
+    }
+    error
+}
+
+pub(super) fn cleanup_after_overlay_error<T>(
+    applied: &[AppliedTraceOverlay],
+    keep: bool,
+    error: Error,
+) -> Result<T> {
+    if !keep {
+        let _ = cleanup_trace_overlays(applied);
+    }
+    Err(error)
+}
+
+pub(super) fn cleanup_trace_overlays(applied: &[AppliedTraceOverlay]) -> Result<()> {
+    let mut first_error = None;
+    for overlay in applied.iter().rev() {
+        match run_git_apply(&overlay.component_path, &overlay.patch_path, true) {
+            Ok(()) => print_trace_overlay(
+                "reverted",
+                &overlay.patch_path,
+                &overlay.touched_files,
+                overlay.keep,
+            ),
+            Err(error) => {
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+    }
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn print_trace_overlay(action: &str, patch_path: &Path, touched_files: &[String], keep: bool) {
+    eprintln!("trace overlay {action}: {}", patch_path.display());
+    let retention = if action == "reverted" {
+        "overlay changes reverted"
+    } else if keep {
+        "overlay changes will be kept"
+    } else {
+        "overlay changes will be reverted after the run"
+    };
+    eprintln!("  status: {retention}");
+    if touched_files.is_empty() {
+        eprintln!("  touched files: none reported by git apply --numstat");
+        return;
+    }
+    eprintln!("  touched files:");
+    for file in touched_files {
+        eprintln!("    - {file}");
+    }
+}
+
+fn overlay_touched_files(component_path: &Path, patch_path: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["apply", "--numstat"])
+        .arg(patch_path)
+        .current_dir(component_path)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to inspect trace overlay {}: {}",
+                    patch_path.display(),
+                    e
+                ),
+                Some("trace.overlay.inspect".to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "--overlay",
+            format!("trace overlay {} cannot be inspected", patch_path.display()),
+            Some(String::from_utf8_lossy(&output.stderr).to_string()),
+            None,
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split('\t').nth(2))
+        .map(unquote_numstat_path)
+        .filter(|path| !path.is_empty())
+        .collect())
+}
+
+fn ensure_overlay_targets_clean(
+    component_path: &Path,
+    patch_path: &Path,
+    touched_files: &[String],
+) -> Result<()> {
+    if touched_files.is_empty() {
+        return Ok(());
+    }
+    let mut command = Command::new("git");
+    command
+        .args(["status", "--porcelain=v1", "--"])
+        .args(touched_files)
+        .current_dir(component_path);
+    let output = command.output().map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to check trace overlay targets for {}: {}",
+                patch_path.display(),
+                e
+            ),
+            Some("trace.overlay.status".to_string()),
+        )
+    })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "--overlay",
+            format!(
+                "failed to check overlay target status for {}",
+                patch_path.display()
+            ),
+            Some(String::from_utf8_lossy(&output.stderr).to_string()),
+            None,
+        ));
+    }
+    let dirty = String::from_utf8_lossy(&output.stdout);
+    if !dirty.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "--overlay",
+            format!(
+                "trace overlay {} touches files with pre-existing changes",
+                patch_path.display()
+            ),
+            Some(dirty.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn run_git_apply(component_path: &Path, patch_path: &Path, reverse: bool) -> Result<()> {
+    let mut command = Command::new("git");
+    command.arg("apply");
+    if reverse {
+        command.arg("--reverse");
+    }
+    let output = command
+        .arg(patch_path)
+        .current_dir(component_path)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to apply trace overlay {}: {}",
+                    patch_path.display(),
+                    e
+                ),
+                Some("trace.overlay.apply".to_string()),
+            )
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let action = if reverse { "revert" } else { "apply" };
+    Err(Error::validation_invalid_argument(
+        "--overlay",
+        format!(
+            "failed to {} trace overlay {}",
+            action,
+            patch_path.display()
+        ),
+        Some(String::from_utf8_lossy(&output.stderr).to_string()),
+        None,
+    ))
+}
+
+fn unquote_numstat_path(path: &str) -> String {
+    path.trim().trim_matches('"').to_string()
+}

--- a/src/core/extension/trace/overlay_lock.rs
+++ b/src/core/extension/trace/overlay_lock.rs
@@ -233,11 +233,11 @@ fn process_is_alive(_pid: u32) -> bool {
     true
 }
 
-fn normalize_component_path(component_path: &Path) -> PathBuf {
+pub(super) fn normalize_component_path(component_path: &Path) -> PathBuf {
     fs::canonicalize(component_path).unwrap_or_else(|_| component_path.to_path_buf())
 }
 
-fn trace_overlay_lock_id(component_path: &Path) -> String {
+pub(super) fn trace_overlay_lock_id(component_path: &Path) -> String {
     let mut hasher = Sha256::new();
     hasher.update(component_path.to_string_lossy().as_bytes());
     let digest = hasher.finalize();
@@ -264,7 +264,7 @@ fn write_trace_overlay_lock_holder(path: &Path, holder: &TraceOverlayLockHolder)
     })
 }
 
-fn read_trace_overlay_lock_holder(lock_path: &Path) -> Option<TraceOverlayLockHolder> {
+pub(super) fn read_trace_overlay_lock_holder(lock_path: &Path) -> Option<TraceOverlayLockHolder> {
     let holder_path = lock_path.join("holder.json");
     let content = fs::read_to_string(holder_path).ok()?;
     serde_json::from_str(&content).ok()
@@ -339,7 +339,7 @@ fn trace_overlay_touched_files_for_paths(
     let mut touched_files = Vec::new();
     for overlay_path in overlay_paths {
         for touched_file in
-            super::run::overlay_touched_files(component_path, Path::new(overlay_path))?
+            super::overlay::overlay_touched_files(component_path, Path::new(overlay_path))?
         {
             if !touched_files.contains(&touched_file) {
                 touched_files.push(touched_file);

--- a/src/core/extension/trace/overlay_lock.rs
+++ b/src/core/extension/trace/overlay_lock.rs
@@ -435,6 +435,41 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_component_path() {
+        let component_dir = tempfile::tempdir().unwrap();
+
+        let normalized = normalize_component_path(component_dir.path());
+
+        assert!(normalized.is_absolute());
+        assert_eq!(normalized, fs::canonicalize(component_dir.path()).unwrap());
+    }
+
+    #[test]
+    fn test_trace_overlay_lock_id() {
+        let first = trace_overlay_lock_id(Path::new("/tmp/component-a"));
+        let second = trace_overlay_lock_id(Path::new("/tmp/component-b"));
+
+        assert_eq!(first.len(), 24);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn test_read_trace_overlay_lock_holder() {
+        with_isolated_home(|_| {
+            let component_dir = tempfile::tempdir().unwrap();
+            let run_dir = RunDir::create().unwrap();
+            let lock = TraceOverlayLock::acquire(component_dir.path(), &[], &run_dir).unwrap();
+
+            let holder = read_trace_overlay_lock_holder(&lock.path).unwrap();
+
+            assert_eq!(holder.pid, std::process::id());
+            assert_eq!(holder.run_dir, run_dir.path().to_string_lossy());
+            drop(lock);
+            run_dir.cleanup();
+        });
+    }
+
+    #[test]
     fn trace_overlay_lock_contention_fails_fast_with_context() {
         with_isolated_home(|_| {
             let component_dir = tempfile::tempdir().unwrap();

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -412,7 +412,15 @@ pub fn push_overlay_markdown(out: &mut String, overlays: &[TraceOverlay]) {
     out.push_str("\n## Trace Overlays\n\n");
     for overlay in overlays {
         let status = if overlay.kept { "kept" } else { "reverted" };
-        out.push_str(&format!("- **Patch:** `{}` (`{}`)\n", overlay.path, status));
+        let variant = overlay
+            .variant
+            .as_ref()
+            .map(|name| format!(" variant `{name}`,"))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "- **Patch:**{} `{}` (`{}`)\n",
+            variant, overlay.path, status
+        ));
         out.push_str(&format!(
             "  - Applied relative to: `{}`\n",
             overlay.component_path
@@ -498,6 +506,7 @@ mod tests {
             }),
             failure: None,
             overlays: vec![TraceOverlay {
+                variant: Some("disable-install-mail".to_string()),
                 component_id: Some("studio".to_string()),
                 path: "/tmp/overlay.patch".to_string(),
                 component_path: "/tmp/studio".to_string(),
@@ -518,6 +527,7 @@ mod tests {
         assert_eq!(value["artifact_count"], 1);
         assert_eq!(value["span_count"], 0);
         assert_eq!(value["overlays"][0]["path"], "/tmp/overlay.patch");
+        assert_eq!(value["overlays"][0]["variant"], "disable-install-mail");
         assert_eq!(value["overlays"][0]["component_id"], "studio");
         assert_eq!(value["overlays"][0]["component_path"], "/tmp/studio");
         assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
@@ -586,6 +596,7 @@ mod tests {
         let mut markdown = String::new();
         let overlays = vec![
             TraceOverlay {
+                variant: None,
                 component_id: Some("studio".to_string()),
                 path: "/tmp/overlay.patch".to_string(),
                 component_path: "/tmp/studio".to_string(),
@@ -593,6 +604,7 @@ mod tests {
                 kept: false,
             },
             TraceOverlay {
+                variant: None,
                 component_id: Some("studio".to_string()),
                 path: "/tmp/kept.patch".to_string(),
                 component_path: "/tmp/studio".to_string(),
@@ -638,6 +650,7 @@ mod tests {
         };
 
         let overlays = vec![TraceOverlay {
+            variant: None,
             component_id: Some("studio".to_string()),
             path: "/tmp/overlay.patch".to_string(),
             component_path: "/tmp/studio".to_string(),

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -412,10 +412,7 @@ pub fn push_overlay_markdown(out: &mut String, overlays: &[TraceOverlay]) {
     out.push_str("\n## Trace Overlays\n\n");
     for overlay in overlays {
         let status = if overlay.kept { "kept" } else { "reverted" };
-        out.push_str(&format!(
-            "- **Patch:** `{}` (`{}`)\n",
-            overlay.path, status
-        ));
+        out.push_str(&format!("- **Patch:** `{}` (`{}`)\n", overlay.path, status));
         out.push_str(&format!(
             "  - Applied relative to: `{}`\n",
             overlay.component_path
@@ -656,5 +653,4 @@ mod tests {
         assert!(markdown.contains("- `apps/studio/out/app.js`"));
         assert!(markdown.contains("| `submit_to_cli` | `ui.submit` | `cli.start` | 42ms | ok |"));
     }
-
 }

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -412,14 +412,9 @@ pub fn push_overlay_markdown(out: &mut String, overlays: &[TraceOverlay]) {
     out.push_str("\n## Trace Overlays\n\n");
     for overlay in overlays {
         let status = if overlay.kept { "kept" } else { "reverted" };
-        let variant = overlay
-            .variant
-            .as_ref()
-            .map(|name| format!(" variant `{name}`,"))
-            .unwrap_or_default();
         out.push_str(&format!(
-            "- **Patch:**{} `{}` (`{}`)\n",
-            variant, overlay.path, status
+            "- **Patch:** `{}` (`{}`)\n",
+            overlay.path, status
         ));
         out.push_str(&format!(
             "  - Applied relative to: `{}`\n",
@@ -506,7 +501,7 @@ mod tests {
             }),
             failure: None,
             overlays: vec![TraceOverlay {
-                variant: Some("disable-install-mail".to_string()),
+                component_id: Some("studio".to_string()),
                 path: "/tmp/overlay.patch".to_string(),
                 component_path: "/tmp/studio".to_string(),
                 touched_files: vec!["scenario.txt".to_string()],
@@ -526,7 +521,7 @@ mod tests {
         assert_eq!(value["artifact_count"], 1);
         assert_eq!(value["span_count"], 0);
         assert_eq!(value["overlays"][0]["path"], "/tmp/overlay.patch");
-        assert_eq!(value["overlays"][0]["variant"], "disable-install-mail");
+        assert_eq!(value["overlays"][0]["component_id"], "studio");
         assert_eq!(value["overlays"][0]["component_path"], "/tmp/studio");
         assert_eq!(value["overlays"][0]["touched_files"][0], "scenario.txt");
         assert_eq!(value["overlays"][0]["kept"], false);
@@ -594,14 +589,14 @@ mod tests {
         let mut markdown = String::new();
         let overlays = vec![
             TraceOverlay {
-                variant: None,
+                component_id: Some("studio".to_string()),
                 path: "/tmp/overlay.patch".to_string(),
                 component_path: "/tmp/studio".to_string(),
                 touched_files: vec!["apps/studio/out/app.js".to_string()],
                 kept: false,
             },
             TraceOverlay {
-                variant: None,
+                component_id: Some("studio".to_string()),
                 path: "/tmp/kept.patch".to_string(),
                 component_path: "/tmp/studio".to_string(),
                 touched_files: Vec::new(),
@@ -646,7 +641,7 @@ mod tests {
         };
 
         let overlays = vec![TraceOverlay {
-            variant: None,
+            component_id: Some("studio".to_string()),
             path: "/tmp/overlay.patch".to_string(),
             component_path: "/tmp/studio".to_string(),
             touched_files: vec!["apps/studio/out/app.js".to_string()],
@@ -662,20 +657,4 @@ mod tests {
         assert!(markdown.contains("| `submit_to_cli` | `ui.submit` | `cli.start` | 42ms | ok |"));
     }
 
-    #[test]
-    fn test_push_overlay_markdown_variant_label() {
-        let overlays = vec![TraceOverlay {
-            variant: Some("fresh-install-mode".to_string()),
-            path: "/tmp/overlay.patch".to_string(),
-            component_path: "/tmp/studio".to_string(),
-            touched_files: Vec::new(),
-            kept: true,
-        }];
-        let mut markdown = String::new();
-
-        push_overlay_markdown(&mut markdown, &overlays);
-
-        assert!(markdown.contains("variant `fresh-install-mode`"));
-        assert!(markdown.contains("`/tmp/overlay.patch` (`kept`)"));
-    }
 }

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -113,6 +113,10 @@ fn run_trace_workflow_with_context(
     run_dir: &RunDir,
     rig_state: Option<RigStateSnapshot>,
 ) -> Result<TraceRunWorkflowResult> {
+    let component_path = args
+        .path_override
+        .as_deref()
+        .unwrap_or(component.local_path.as_str());
     let _overlay_locks = if args.overlays.is_empty() {
         None
     } else {

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use super::overlay_lock::TraceOverlayLock;
 use crate::component::Component;
 use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
@@ -15,6 +14,11 @@ use crate::extension::{
 };
 use crate::extension::{ExtensionRunner, RunnerOutput};
 use crate::rig::RigStateSnapshot;
+
+use super::overlay::{
+    apply_trace_overlays, cleanup_after_overlay_error, cleanup_trace_overlays, TraceOverlayLock,
+    TraceOverlayRequest,
+};
 
 use super::parsing::{
     parse_trace_list_str, parse_trace_results_file, TraceList, TraceResults, TraceSpanDefinition,
@@ -70,17 +74,11 @@ pub struct TraceRunWorkflowResult {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TraceOverlay {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub variant: Option<String>,
+    pub component_id: Option<String>,
     pub path: String,
     pub component_path: String,
     pub touched_files: Vec<String>,
     pub kept: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TraceOverlayRequest {
-    pub variant: Option<String>,
-    pub path: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -110,25 +108,12 @@ fn run_trace_workflow_with_context(
     run_dir: &RunDir,
     rig_state: Option<RigStateSnapshot>,
 ) -> Result<TraceRunWorkflowResult> {
-    let component_path = args
-        .path_override
-        .as_deref()
-        .unwrap_or(component.local_path.as_str());
-    let _overlay_lock = if args.overlays.is_empty() {
+    let _overlay_locks = if args.overlays.is_empty() {
         None
     } else {
-        let overlay_paths = args
-            .overlays
-            .iter()
-            .map(|overlay| overlay.path.clone())
-            .collect::<Vec<_>>();
-        Some(TraceOverlayLock::acquire(
-            Path::new(component_path),
-            &overlay_paths,
-            run_dir,
-        )?)
+        Some(TraceOverlayLock::acquire_all(&args.overlays, run_dir)?)
     };
-    let applied_overlays = apply_trace_overlays(component_path, &args.overlays, args.keep_overlay)?;
+    let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
     let runner = match build_trace_runner(execution_context, component, &args, run_dir, false) {
         Ok(runner) => runner,
         Err(error) => {
@@ -253,8 +238,8 @@ fn run_trace_workflow_with_context(
         overlays: applied_overlays
             .into_iter()
             .map(|overlay| TraceOverlay {
+                component_id: overlay.component_id,
                 path: overlay.patch_path.to_string_lossy().to_string(),
-                variant: overlay.variant,
                 component_path: overlay.component_path.to_string_lossy().to_string(),
                 touched_files: overlay.touched_files,
                 kept: overlay.keep,
@@ -403,212 +388,6 @@ fn failure_from_output(args: &TraceRunWorkflowArgs, output: &RunnerOutput) -> Tr
         exit_code: output.exit_code,
         stderr_excerpt: stderr_tail(&output.stderr),
     }
-}
-
-#[derive(Debug, Clone)]
-struct AppliedTraceOverlay {
-    variant: Option<String>,
-    component_path: PathBuf,
-    patch_path: PathBuf,
-    touched_files: Vec<String>,
-    keep: bool,
-}
-
-fn apply_trace_overlays(
-    component_path: &str,
-    overlays: &[TraceOverlayRequest],
-    keep: bool,
-) -> Result<Vec<AppliedTraceOverlay>> {
-    let component_path = PathBuf::from(component_path);
-    let mut applied = Vec::new();
-    for overlay in overlays {
-        let patch_path = PathBuf::from(&overlay.path);
-        let touched_files = match overlay_touched_files(&component_path, &patch_path) {
-            Ok(files) => files,
-            Err(error) => return cleanup_after_overlay_error(&applied, keep, error),
-        };
-        if let Err(error) =
-            ensure_overlay_targets_clean(&component_path, &patch_path, &touched_files)
-        {
-            return cleanup_after_overlay_error(&applied, keep, error);
-        }
-        if let Err(error) = run_git_apply(&component_path, &patch_path, false) {
-            return cleanup_after_overlay_error(&applied, keep, error);
-        }
-        print_trace_overlay("applied", &patch_path, &touched_files, keep);
-        applied.push(AppliedTraceOverlay {
-            variant: overlay.variant.clone(),
-            component_path: component_path.clone(),
-            patch_path,
-            touched_files,
-            keep,
-        });
-    }
-    Ok(applied)
-}
-
-fn cleanup_after_overlay_error<T>(
-    applied: &[AppliedTraceOverlay],
-    keep: bool,
-    error: Error,
-) -> Result<T> {
-    if !keep {
-        let _ = cleanup_trace_overlays(applied);
-    }
-    Err(error)
-}
-
-fn cleanup_trace_overlays(applied: &[AppliedTraceOverlay]) -> Result<()> {
-    for overlay in applied.iter().rev() {
-        run_git_apply(&overlay.component_path, &overlay.patch_path, true)?;
-        print_trace_overlay(
-            "reverted",
-            &overlay.patch_path,
-            &overlay.touched_files,
-            overlay.keep,
-        );
-    }
-    Ok(())
-}
-
-fn print_trace_overlay(action: &str, patch_path: &Path, touched_files: &[String], keep: bool) {
-    eprintln!("trace overlay {action}: {}", patch_path.display());
-    let retention = if action == "reverted" {
-        "overlay changes reverted"
-    } else if keep {
-        "overlay changes will be kept"
-    } else {
-        "overlay changes will be reverted after the run"
-    };
-    eprintln!("  status: {retention}");
-    if touched_files.is_empty() {
-        eprintln!("  touched files: none reported by git apply --numstat");
-        return;
-    }
-    eprintln!("  touched files:");
-    for file in touched_files {
-        eprintln!("    - {file}");
-    }
-}
-
-pub(super) fn overlay_touched_files(
-    component_path: &Path,
-    patch_path: &Path,
-) -> Result<Vec<String>> {
-    let output = Command::new("git")
-        .args(["apply", "--numstat"])
-        .arg(patch_path)
-        .current_dir(component_path)
-        .output()
-        .map_err(|e| {
-            Error::internal_io(
-                format!(
-                    "Failed to inspect trace overlay {}: {}",
-                    patch_path.display(),
-                    e
-                ),
-                Some("trace.overlay.inspect".to_string()),
-            )
-        })?;
-    if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
-            "--overlay",
-            format!("trace overlay {} cannot be inspected", patch_path.display()),
-            Some(String::from_utf8_lossy(&output.stderr).to_string()),
-            None,
-        ));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| line.split('\t').nth(2))
-        .map(|path| path.trim().trim_matches('"').to_string())
-        .filter(|path| !path.is_empty())
-        .collect())
-}
-
-fn ensure_overlay_targets_clean(
-    component_path: &Path,
-    patch_path: &Path,
-    touched_files: &[String],
-) -> Result<()> {
-    if touched_files.is_empty() {
-        return Ok(());
-    }
-    let mut command = Command::new("git");
-    command
-        .args(["status", "--porcelain=v1", "--"])
-        .args(touched_files)
-        .current_dir(component_path);
-    let output = command.output().map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to check trace overlay targets for {}: {}",
-                patch_path.display(),
-                e
-            ),
-            Some("trace.overlay.status".to_string()),
-        )
-    })?;
-    if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
-            "--overlay",
-            format!(
-                "failed to check overlay target status for {}",
-                patch_path.display()
-            ),
-            Some(String::from_utf8_lossy(&output.stderr).to_string()),
-            None,
-        ));
-    }
-    let dirty = String::from_utf8_lossy(&output.stdout);
-    if !dirty.trim().is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "--overlay",
-            format!(
-                "trace overlay {} touches files with pre-existing changes",
-                patch_path.display()
-            ),
-            Some(dirty.to_string()),
-            None,
-        ));
-    }
-    Ok(())
-}
-
-fn run_git_apply(component_path: &Path, patch_path: &Path, reverse: bool) -> Result<()> {
-    let mut command = Command::new("git");
-    command.arg("apply");
-    if reverse {
-        command.arg("--reverse");
-    }
-    let output = command
-        .arg(patch_path)
-        .current_dir(component_path)
-        .output()
-        .map_err(|e| {
-            Error::internal_io(
-                format!(
-                    "Failed to apply trace overlay {}: {}",
-                    patch_path.display(),
-                    e
-                ),
-                Some("trace.overlay.apply".to_string()),
-            )
-        })?;
-    if output.status.success() {
-        return Ok(());
-    }
-    let action = if reverse { "revert" } else { "apply" };
-    Err(Error::validation_invalid_argument(
-        "--overlay",
-        format!(
-            "failed to {} trace overlay {}",
-            action,
-            patch_path.display()
-        ),
-        Some(String::from_utf8_lossy(&output.stderr).to_string()),
-        None,
-    ))
 }
 
 #[cfg(test)]
@@ -852,10 +631,10 @@ JSON
         fs::write(fixture.component_dir.join("scenario.txt"), "dirty\n").unwrap();
 
         let err = apply_trace_overlays(
-            fixture.component_dir.to_str().unwrap(),
             &[TraceOverlayRequest {
-                variant: None,
-                path: fixture.patch_path.to_string_lossy().to_string(),
+                component_id: Some("example".to_string()),
+                component_path: fixture.component_dir.to_string_lossy().to_string(),
+                overlay_path: fixture.patch_path.to_string_lossy().to_string(),
             }],
             false,
         )
@@ -866,15 +645,6 @@ JSON
             fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
             "dirty\n"
         );
-    }
-
-    #[test]
-    fn test_overlay_touched_files() {
-        let fixture = overlay_fixture(false);
-
-        let touched = overlay_touched_files(&fixture.component_dir, &fixture.patch_path).unwrap();
-
-        assert_eq!(touched, vec!["scenario.txt"]);
     }
 
     #[test]
@@ -974,8 +744,9 @@ JSON
             json_summary: false,
             rig_id: None,
             overlays: vec![TraceOverlayRequest {
-                variant: None,
-                path: patch_path.to_string_lossy().to_string(),
+                component_id: Some("example".to_string()),
+                component_path: component_dir.to_string_lossy().to_string(),
+                overlay_path: patch_path.to_string_lossy().to_string(),
             }],
             keep_overlay,
             extra_workloads: Vec::new(),

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -15,8 +15,8 @@ use crate::extension::{ExtensionRunner, RunnerOutput};
 use crate::rig::RigStateSnapshot;
 
 use super::overlay::{
-    apply_trace_overlays, cleanup_after_overlay_error, cleanup_trace_overlays, TraceOverlayLock,
-    TraceOverlayRequest,
+    acquire_trace_overlay_locks, apply_trace_overlays, cleanup_after_overlay_error,
+    cleanup_trace_overlays, TraceOverlayRequest,
 };
 
 use super::parsing::{
@@ -29,13 +29,12 @@ pub struct TraceRunWorkflowArgs {
     pub component_id: String,
     pub path_override: Option<String>,
     pub settings: Vec<(String, String)>,
-    pub settings_json: Vec<(String, serde_json::Value)>,
+    pub runner_inputs: TraceRunnerInputs,
     pub scenario_id: String,
     pub json_summary: bool,
     pub rig_id: Option<String>,
     pub overlays: Vec<TraceOverlayRequest>,
     pub keep_overlay: bool,
-    pub extra_workloads: Vec<PathBuf>,
     pub span_definitions: Vec<TraceSpanDefinition>,
     pub baseline_flags: BaselineFlags,
     pub regression_threshold_percent: f64,
@@ -48,9 +47,14 @@ pub struct TraceListWorkflowArgs {
     pub component_id: String,
     pub path_override: Option<String>,
     pub settings: Vec<(String, String)>,
-    pub settings_json: Vec<(String, serde_json::Value)>,
+    pub runner_inputs: TraceRunnerInputs,
     pub rig_id: Option<String>,
-    pub extra_workloads: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TraceRunnerInputs {
+    pub json_settings: Vec<(String, serde_json::Value)>,
+    pub workload_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -72,6 +76,8 @@ pub struct TraceRunWorkflowResult {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TraceOverlay {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_id: Option<String>,
     pub path: String,
@@ -110,7 +116,7 @@ fn run_trace_workflow_with_context(
     let _overlay_locks = if args.overlays.is_empty() {
         None
     } else {
-        Some(TraceOverlayLock::acquire_all(&args.overlays, run_dir)?)
+        Some(acquire_trace_overlay_locks(&args.overlays, run_dir)?)
     };
     let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
     let runner = match build_trace_runner(execution_context, component, &args, run_dir, false) {
@@ -237,6 +243,7 @@ fn run_trace_workflow_with_context(
         overlays: applied_overlays
             .into_iter()
             .map(|overlay| TraceOverlay {
+                variant: overlay.variant,
                 component_id: overlay.component_id,
                 path: overlay.patch_path.to_string_lossy().to_string(),
                 component_path: overlay.component_path.to_string_lossy().to_string(),
@@ -260,13 +267,12 @@ pub fn run_trace_list_workflow(
         component_id: args.component_id,
         path_override: args.path_override,
         settings: args.settings,
-        settings_json: args.settings_json,
+        runner_inputs: args.runner_inputs,
         scenario_id: String::new(),
         json_summary: false,
         rig_id: args.rig_id,
         overlays: Vec::new(),
         keep_overlay: false,
-        extra_workloads: args.extra_workloads,
         span_definitions: Vec::new(),
         baseline_flags: BaselineFlags {
             baseline: false,
@@ -334,7 +340,7 @@ pub(crate) fn build_trace_runner(
         .component(component.clone())
         .path_override(args.path_override.clone())
         .settings(&args.settings)
-        .settings_json(&args.settings_json)
+        .settings_json(&args.runner_inputs.json_settings)
         .with_run_dir(run_dir)
         .cleanup_process_group(true)
         .env(
@@ -356,10 +362,10 @@ pub(crate) fn build_trace_runner(
     if let Some(path) = &args.path_override {
         runner = runner.env("HOMEBOY_TRACE_COMPONENT_PATH", path);
     }
-    if !args.extra_workloads.is_empty() {
+    if !args.runner_inputs.workload_paths.is_empty() {
         runner = runner.env(
             "HOMEBOY_TRACE_EXTRA_WORKLOADS",
-            &extra_workloads_env_value(&args.extra_workloads)?,
+            &extra_workloads_env_value(&args.runner_inputs.workload_paths)?,
         );
     }
 
@@ -447,13 +453,15 @@ JSON
             component_id: "example".to_string(),
             path_override: Some(component_dir.to_string_lossy().to_string()),
             settings: Vec::new(),
-            settings_json: Vec::new(),
+            runner_inputs: TraceRunnerInputs {
+                json_settings: Vec::new(),
+                workload_paths: vec![component_dir.join("trace-fixture.trace.mjs")],
+            },
             scenario_id: "close-window".to_string(),
             json_summary: false,
             rig_id: Some("studio".to_string()),
             overlays: Vec::new(),
             keep_overlay: false,
-            extra_workloads: vec![component_dir.join("trace-fixture.trace.mjs")],
             span_definitions: Vec::new(),
             baseline_flags: BaselineFlags {
                 baseline: false,
@@ -521,13 +529,12 @@ JSON
             component_id: "example".to_string(),
             path_override: Some(component_dir.to_string_lossy().to_string()),
             settings: Vec::new(),
-            settings_json: Vec::new(),
+            runner_inputs: TraceRunnerInputs::default(),
             scenario_id: String::new(),
             json_summary: false,
             rig_id: None,
             overlays: Vec::new(),
             keep_overlay: false,
-            extra_workloads: Vec::new(),
             span_definitions: Vec::new(),
             baseline_flags: BaselineFlags {
                 baseline: false,
@@ -559,13 +566,12 @@ JSON
             component_id: "example".to_string(),
             path_override: Some("/tmp/example".to_string()),
             settings: Vec::new(),
-            settings_json: Vec::new(),
+            runner_inputs: TraceRunnerInputs::default(),
             scenario_id: "close-window".to_string(),
             json_summary: false,
             rig_id: None,
             overlays: Vec::new(),
             keep_overlay: false,
-            extra_workloads: Vec::new(),
             span_definitions: Vec::new(),
             baseline_flags: BaselineFlags {
                 baseline: false,
@@ -631,6 +637,7 @@ JSON
 
         let err = apply_trace_overlays(
             &[TraceOverlayRequest {
+                variant: None,
                 component_id: Some("example".to_string()),
                 component_path: fixture.component_dir.to_string_lossy().to_string(),
                 overlay_path: fixture.patch_path.to_string_lossy().to_string(),
@@ -738,17 +745,17 @@ JSON
             component_id: "example".to_string(),
             path_override: Some(component_dir.to_string_lossy().to_string()),
             settings: Vec::new(),
-            settings_json: Vec::new(),
+            runner_inputs: TraceRunnerInputs::default(),
             scenario_id: "overlay".to_string(),
             json_summary: false,
             rig_id: None,
             overlays: vec![TraceOverlayRequest {
+                variant: None,
                 component_id: Some("example".to_string()),
                 component_path: component_dir.to_string_lossy().to_string(),
                 overlay_path: patch_path.to_string_lossy().to_string(),
             }],
             keep_overlay,
-            extra_workloads: Vec::new(),
             span_definitions: Vec::new(),
             baseline_flags: BaselineFlags {
                 baseline: false,

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -2,7 +2,6 @@
 
 use serde::Serialize;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use crate::component::Component;
 use crate::engine::baseline::BaselineFlags;

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -78,7 +78,7 @@ pub struct RigSpec {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub trace_workloads: HashMap<String, Vec<WorkloadSpec>>,
 
-    /// Named trace overlay variants keyed by user-facing variant name.
+    /// Named trace variants that can apply overlays across rig components.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub trace_variants: HashMap<String, TraceVariantSpec>,
 
@@ -311,6 +311,16 @@ pub struct TraceVariantSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub component: Option<String>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overlay: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlays: Vec<TraceVariantOverlaySpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceVariantOverlaySpec {
+    pub component: String,
     pub overlay: String,
 }
 

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -321,7 +321,8 @@ fn test_trace_variants() {
         variants.get("fresh-install-mode"),
         Some(&TraceVariantSpec {
             component: Some("studio".to_string()),
-            overlay: "overlays/fresh-install-mode.patch".to_string(),
+            overlay: Some("overlays/fresh-install-mode.patch".to_string()),
+            overlays: Vec::new(),
         })
     );
     assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
@@ -342,7 +343,8 @@ fn workload_with_trace_metadata() -> WorkloadSpec {
             "fresh-install-mode".to_string(),
             TraceVariantSpec {
                 component: Some("studio".to_string()),
-                overlay: "overlays/fresh-install-mode.patch".to_string(),
+                overlay: Some("overlays/fresh-install-mode.patch".to_string()),
+                overlays: Vec::new(),
             },
         )]),
     })

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -130,6 +130,36 @@ fn test_spec_minimal_only_required_fields() {
 }
 
 #[test]
+fn test_spec_trace_variants_parse_multi_component_overlays() {
+    let json = r#"{
+        "id": "studio-playground-dev",
+        "components": {
+            "studio": { "path": "/tmp/studio" },
+            "wordpress-playground": { "path": "/tmp/playground" }
+        },
+        "trace_variants": {
+            "fast-create-site": {
+                "overlays": [
+                    { "component": "studio", "overlay": "overlays/studio.patch" },
+                    { "component": "wordpress-playground", "overlay": "overlays/playground.patch" }
+                ]
+            }
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+    let variant = spec
+        .trace_variants
+        .get("fast-create-site")
+        .expect("variant");
+
+    assert_eq!(variant.overlays.len(), 2);
+    assert_eq!(variant.overlays[0].component, "studio");
+    assert_eq!(variant.overlays[0].overlay, "overlays/studio.patch");
+    assert_eq!(variant.overlays[1].component, "wordpress-playground");
+    assert_eq!(variant.overlays[1].overlay, "overlays/playground.patch");
+}
+
+#[test]
 fn test_spec_resources_block_parses_full_shape() {
     let json = r#"{
         "id": "studio-bfb",


### PR DESCRIPTION
## Summary
- Add rig-level `trace_variants` with component-scoped overlay declarations.
- Resolve named variants through `homeboy trace --variant <name> --rig <rig>` and report per-component overlay metadata.
- Acquire all target component overlay locks before applying patches, and clean up applied overlays in reverse order with best-effort cleanup across components.

Fixes #2127

## Tests
- `cargo test test_spec_trace_variants_parse_multi_component_overlays`
- `cargo test trace_variant_overlays_apply_multiple_components_and_revert_in_reverse_order`
- `cargo test rig_trace_variant_applies_overlays_across_components`
- `cargo test command_surface`
- `cargo test trace_overlay`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the core/data-model and trace application path, added tests, and ran targeted verification. Chris remains responsible for review and validation.