### PR TITLE
Allow trace compare-variant to use named variants

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1067,6 +1067,29 @@ fn trace_overlays_for_args(
     Ok(overlays)
 }
 
+pub(super) fn validate_trace_variants_for_args(args: &TraceArgs) -> homeboy::Result<()> {
+    if args.variants.is_empty() {
+        return Ok(());
+    }
+    let rig_context = load_rig_context(args.rig.as_deref())?;
+    let effective_id = resolve_component_id(
+        &args.comp,
+        rig_context.as_ref().map(|context| &context.rig_spec),
+    )?;
+    let component_path = args
+        .comp
+        .path
+        .clone()
+        .or_else(|| {
+            rig_context
+                .as_ref()
+                .and_then(|context| rig_component_path(&context.rig_spec, &effective_id))
+        })
+        .unwrap_or_default();
+    trace_overlays_for_args(args, rig_context.as_ref(), &effective_id, &component_path)?;
+    Ok(())
+}
+
 fn trace_variant_overlay_requests(
     context: &TraceRigContext,
     variant_name: &str,

--- a/src/commands/trace/compare_variant.rs
+++ b/src/commands/trace/compare_variant.rs
@@ -10,7 +10,7 @@ use super::output::{
     compare_trace_aggregates_with_focus, TraceAggregateInput, TraceAggregateRunInput,
     TraceAggregateSpanInput, TraceOverlayInput,
 };
-use super::{run_repeat, TraceArgs};
+use super::{run_repeat, validate_trace_variants_for_args, TraceArgs};
 use crate::commands::CmdResult;
 
 const TRACE_COMPARE_VARIANT_BASELINE_FILE: &str = "baseline.json";
@@ -22,10 +22,18 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
     let output_dir = args.output_dir.clone().ok_or_else(|| {
         homeboy::Error::validation_missing_argument(vec!["--output-dir".to_string()])
     })?;
-    if args.overlays.is_empty() {
+    if !args.variants.is_empty() && !args.overlays.is_empty() {
+        return Err(homeboy::Error::validation_invalid_argument(
+            "--variant",
+            "mixing --variant and --overlay would make stack order ambiguous; use one ordered stack source",
+            None,
+            None,
+        ));
+    }
+    if args.overlays.is_empty() && args.variants.is_empty() {
         return Err(homeboy::Error::validation_invalid_argument(
             "--overlay",
-            "trace compare-variant requires at least one --overlay for the variant run",
+            "trace compare-variant requires at least one --overlay or --variant for the variant run",
             None,
             None,
         ));
@@ -44,12 +52,14 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
     args.json_summary = false;
     args.report = None;
     args.compare_after = None;
+    validate_trace_variants_for_args(&args)?;
     let focus_spans = args.focus_spans.clone();
     let regression_threshold = args.regression_threshold;
     let regression_min_delta_ms = args.regression_min_delta_ms;
 
     let mut baseline_args = args.clone();
     baseline_args.overlays.clear();
+    baseline_args.variants.clear();
     let baseline = run_repeat_output(baseline_args)?;
 
     let variant = run_repeat_output(args)?;

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -808,6 +808,162 @@ fn trace_compare_variant_writes_experiment_bundle() {
 }
 
 #[test]
+fn trace_compare_variant_resolves_named_variants() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::without_xdg_data_home();
+        write_trace_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        init_overlay_component(component_dir.path());
+        let package_dir = tempfile::TempDir::new().expect("package dir");
+        write_trace_rig_with_variant(
+            home,
+            package_dir.path(),
+            "studio-rig",
+            "studio",
+            component_dir.path(),
+        );
+        let output_dir = tempfile::TempDir::new().expect("output dir");
+
+        let (output, exit_code) = run(
+            TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("compare-variant".to_string()),
+                    path: None,
+                },
+                scenario: Some("studio-app-create-site".to_string()),
+                scenario_arg: None,
+                compare_after: None,
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                report: None,
+                experiment: None,
+                repeat: 2,
+                aggregate: None,
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
+                spans: Vec::new(),
+                phases: Vec::new(),
+                phase_preset: None,
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                overlays: Vec::new(),
+                variants: vec!["fresh-install-mode".to_string()],
+                matrix: TraceVariantMatrixMode::None,
+                output_dir: Some(output_dir.path().to_path_buf()),
+                keep_overlay: false,
+                stale: false,
+                force: false,
+            },
+            &GlobalArgs {},
+        )
+        .expect("named variant compare-variant should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            TraceCommandOutput::Compare(compare) => {
+                assert_eq!(compare.span_count, 1);
+                assert!(compare.before_path.ends_with("baseline.json"));
+                assert!(compare.after_path.ends_with("variant.json"));
+            }
+            _ => panic!("expected compare output"),
+        }
+        let baseline: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(output_dir.path().join("baseline.json")).expect("baseline"),
+        )
+        .expect("baseline json");
+        let variant: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(output_dir.path().join("variant.json")).expect("variant"),
+        )
+        .expect("variant json");
+        assert!(baseline
+            .get("overlays")
+            .and_then(|overlays| overlays.as_array())
+            .map(|overlays| overlays.is_empty())
+            .unwrap_or(true));
+        assert_eq!(variant["overlays"][0]["variant"], "fresh-install-mode");
+        assert_eq!(
+            variant["overlays"][0]["path"],
+            package_dir
+                .path()
+                .join("overlays/fresh-install-mode.patch")
+                .to_string_lossy()
+                .as_ref()
+        );
+    });
+}
+
+#[test]
+fn trace_compare_variant_reports_unknown_named_variants() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::without_xdg_data_home();
+        write_trace_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        init_overlay_component(component_dir.path());
+        let package_dir = tempfile::TempDir::new().expect("package dir");
+        write_trace_rig_with_variant(
+            home,
+            package_dir.path(),
+            "studio-rig",
+            "studio",
+            component_dir.path(),
+        );
+        let output_dir = tempfile::TempDir::new().expect("output dir");
+
+        let err = match run(
+            TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("compare-variant".to_string()),
+                    path: None,
+                },
+                scenario: Some("studio-app-create-site".to_string()),
+                scenario_arg: None,
+                compare_after: None,
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                report: None,
+                experiment: None,
+                repeat: 2,
+                aggregate: None,
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
+                spans: Vec::new(),
+                phases: Vec::new(),
+                phase_preset: None,
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                overlays: Vec::new(),
+                variants: vec!["missing".to_string()],
+                matrix: TraceVariantMatrixMode::None,
+                output_dir: Some(output_dir.path().to_path_buf()),
+                keep_overlay: false,
+                stale: false,
+                force: false,
+            },
+            &GlobalArgs {},
+        ) {
+            Ok(_) => panic!("unknown variant should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err.message.contains("unknown trace variant 'missing'"));
+        assert!(err
+            .details
+            .get("id")
+            .and_then(|value| value.as_str())
+            .expect("details id")
+            .contains("fresh-install-mode"));
+    });
+}
+
+#[test]
 fn trace_run_expands_phase_chain_into_adjacent_and_total_spans() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::without_xdg_data_home();


### PR DESCRIPTION
## Summary
- Allow non-matrix `homeboy trace compare-variant` to accept rig/workload named variants via `--variant`.
- Keep `--overlay` behavior intact, reject mixed `--variant`/`--overlay`, and clear variants from the baseline run.
- Prevalidate named variants so unknown names produce the normal clear validation error.

Fixes #2148.

## Tests
- `cargo test trace_compare_variant -- --test-threads=1`
- `cargo test trace_run_resolves_named_variants_and_reports_unknown_names -- --test-threads=1`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementation and tests; Chris remains responsible for review and merge.