### PR TITLE
Interleave trace compare variant runs

### DIFF
--- a/src/commands/trace/compare_variant.rs
+++ b/src/commands/trace/compare_variant.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use serde::Serialize;
@@ -7,17 +8,19 @@ use homeboy::extension::trace::TraceCommandOutput;
 use homeboy::rig;
 
 use super::output::{
-    compare_trace_aggregates_with_focus, TraceAggregateInput, TraceAggregateRunInput,
-    TraceAggregateSpanInput, TraceOverlayInput,
+    aggregate_span, compare_trace_aggregates_with_focus, TraceAggregateInput,
+    TraceAggregateRunInput, TraceAggregateSpanInput, TraceAggregateSpanSample, TraceOverlayInput,
 };
 use super::{
-    apply_command_target_component, run_repeat, validate_trace_variants_for_args, TraceArgs,
+    apply_command_target_component, focus_aggregate_spans, plan_trace_run_order, run_repeat,
+    validate_trace_variants_for_args, TraceArgs, TraceRunPlanEntry, TraceSchedule,
 };
 use crate::commands::CmdResult;
 
 const TRACE_COMPARE_VARIANT_BASELINE_FILE: &str = "baseline.json";
 const TRACE_COMPARE_VARIANT_VARIANT_FILE: &str = "variant.json";
 const TRACE_COMPARE_VARIANT_COMPARE_FILE: &str = "compare.json";
+const TRACE_COMPARE_VARIANT_RUN_ORDER_FILE: &str = "run-order.json";
 const TRACE_COMPARE_VARIANT_SUMMARY_FILE: &str = "summary.md";
 
 pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommandOutput> {
@@ -59,21 +62,18 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
     let regression_threshold = args.regression_threshold;
     let regression_min_delta_ms = args.regression_min_delta_ms;
 
-    let mut baseline_args = args.clone();
-    baseline_args.overlays.clear();
-    baseline_args.variants.clear();
-    let baseline = run_repeat_output(baseline_args)?;
-
-    let variant = run_repeat_output(args)?;
+    let (baseline, variant, run_order) = run_compare_variant_pair(args)?;
 
     create_trace_compare_variant_output_dir(&output_dir)?;
     let baseline_path = output_dir.join(TRACE_COMPARE_VARIANT_BASELINE_FILE);
     let variant_path = output_dir.join(TRACE_COMPARE_VARIANT_VARIANT_FILE);
     let compare_path = output_dir.join(TRACE_COMPARE_VARIANT_COMPARE_FILE);
+    let run_order_path = output_dir.join(TRACE_COMPARE_VARIANT_RUN_ORDER_FILE);
     let summary_path = output_dir.join(TRACE_COMPARE_VARIANT_SUMMARY_FILE);
 
     write_trace_compare_variant_json(&baseline_path, &baseline)?;
     write_trace_compare_variant_json(&variant_path, &variant)?;
+    write_trace_compare_variant_json(&run_order_path, &run_order)?;
 
     let compare = compare_trace_aggregates_with_focus(
         &baseline_path,
@@ -85,7 +85,14 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
         regression_min_delta_ms,
     );
     write_trace_compare_variant_json(&compare_path, &compare)?;
-    write_trace_compare_variant_summary(&summary_path, &output_dir, &baseline, &variant, &compare)?;
+    write_trace_compare_variant_summary(
+        &summary_path,
+        &output_dir,
+        &baseline,
+        &variant,
+        &compare,
+        &run_order,
+    )?;
 
     let exit_code = if baseline.exit_code == 0
         && variant.exit_code == 0
@@ -96,6 +103,187 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
         1
     };
     Ok((TraceCommandOutput::Compare(compare), exit_code))
+}
+
+fn run_compare_variant_pair(
+    args: TraceArgs,
+) -> homeboy::Result<(
+    extension_trace::TraceAggregateOutput,
+    extension_trace::TraceAggregateOutput,
+    Vec<extension_trace::TraceRunOrderEntryOutput>,
+)> {
+    if args.schedule == TraceSchedule::Grouped {
+        let mut baseline_args = args.clone();
+        baseline_args.overlays.clear();
+        baseline_args.variants.clear();
+        let baseline = run_repeat_output(baseline_args)?;
+        let variant = run_repeat_output(args)?;
+        let run_order = plan_trace_run_order(
+            variant.repeat,
+            TraceSchedule::Grouped,
+            &["baseline", "variant"],
+        )
+        .into_iter()
+        .map(trace_run_order_entry_output)
+        .collect();
+        return Ok((baseline, variant, run_order));
+    }
+
+    let plan = plan_trace_run_order(args.repeat, args.schedule, &["baseline", "variant"]);
+    let mut baseline_args = args.clone();
+    baseline_args.overlays.clear();
+    baseline_args.variants.clear();
+    let mut baseline = TraceCompareVariantAggregateBuilder::new("baseline", &baseline_args);
+    let mut variant = TraceCompareVariantAggregateBuilder::new("variant", &args);
+
+    for entry in &plan {
+        let mut run_args = if entry.group == "baseline" {
+            baseline_args.clone()
+        } else {
+            args.clone()
+        };
+        run_args.repeat = 1;
+        let single = run_repeat_output(run_args)?;
+        if entry.group == "baseline" {
+            baseline.push(entry, single);
+        } else {
+            variant.push(entry, single);
+        }
+    }
+
+    Ok((
+        baseline.finish(),
+        variant.finish(),
+        plan.into_iter().map(trace_run_order_entry_output).collect(),
+    ))
+}
+
+fn trace_run_order_entry_output(
+    entry: TraceRunPlanEntry,
+) -> extension_trace::TraceRunOrderEntryOutput {
+    extension_trace::TraceRunOrderEntryOutput {
+        index: entry.index,
+        group: entry.group,
+        iteration: entry.iteration,
+    }
+}
+
+struct TraceCompareVariantAggregateBuilder {
+    group: &'static str,
+    args: TraceArgs,
+    template: Option<extension_trace::TraceAggregateOutput>,
+    runs: Vec<extension_trace::TraceAggregateRunOutput>,
+    run_order: Vec<extension_trace::TraceRunOrderEntryOutput>,
+    span_samples: BTreeMap<String, Vec<TraceAggregateSpanSample>>,
+    span_failures: BTreeMap<String, usize>,
+    all_span_ids: BTreeSet<String>,
+    overlays: Vec<extension_trace::run::TraceOverlay>,
+    failure_count: usize,
+}
+
+impl TraceCompareVariantAggregateBuilder {
+    fn new(group: &'static str, args: &TraceArgs) -> Self {
+        Self {
+            group,
+            args: args.clone(),
+            template: None,
+            runs: Vec::new(),
+            run_order: Vec::new(),
+            span_samples: BTreeMap::new(),
+            span_failures: BTreeMap::new(),
+            all_span_ids: BTreeSet::new(),
+            overlays: Vec::new(),
+            failure_count: 0,
+        }
+    }
+
+    fn push(&mut self, plan: &TraceRunPlanEntry, aggregate: extension_trace::TraceAggregateOutput) {
+        if self.template.is_none() {
+            self.template = Some(aggregate.clone());
+        }
+        if self.overlays.is_empty() && !aggregate.overlays.is_empty() {
+            self.overlays = aggregate.overlays.clone();
+        }
+        self.failure_count += aggregate.failure_count;
+        self.run_order
+            .push(extension_trace::TraceRunOrderEntryOutput {
+                index: plan.index,
+                group: self.group.to_string(),
+                iteration: plan.iteration,
+            });
+
+        for mut run in aggregate.runs {
+            run.index = plan.index;
+            self.runs.push(run);
+        }
+
+        for span in aggregate.spans {
+            self.all_span_ids.insert(span.id.clone());
+            if let Some(duration) = span.median_ms {
+                self.span_samples.entry(span.id.clone()).or_default().push(
+                    TraceAggregateSpanSample {
+                        duration_ms: duration,
+                        run_index: plan.index,
+                        artifact_path: span.max_artifact_path.clone().unwrap_or_default(),
+                    },
+                );
+            }
+            if span.failures > 0 {
+                *self.span_failures.entry(span.id).or_default() += span.failures;
+            }
+        }
+    }
+
+    fn finish(mut self) -> extension_trace::TraceAggregateOutput {
+        let template = self.template.take();
+        let spans = self
+            .all_span_ids
+            .into_iter()
+            .map(|id| {
+                let samples = self.span_samples.remove(&id).unwrap_or_default();
+                let failures = self.span_failures.remove(&id).unwrap_or(0);
+                aggregate_span(id, samples, failures)
+            })
+            .collect::<Vec<_>>();
+        let focus_spans = focus_aggregate_spans(&spans, &self.args.focus_spans);
+        extension_trace::TraceAggregateOutput {
+            command: "trace.aggregate.spans",
+            passed: self.failure_count == 0,
+            status: if self.failure_count == 0 {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            component: template
+                .as_ref()
+                .map(|aggregate| aggregate.component.clone())
+                .or_else(|| self.args.comp.component.clone())
+                .unwrap_or_default(),
+            scenario_id: template
+                .as_ref()
+                .map(|aggregate| aggregate.scenario_id.clone())
+                .or_else(|| self.args.scenario_arg.clone())
+                .or_else(|| self.args.scenario.clone())
+                .unwrap_or_default(),
+            phase_preset: template
+                .as_ref()
+                .and_then(|aggregate| aggregate.phase_preset.clone())
+                .or_else(|| self.args.phase_preset.clone()),
+            repeat: self.args.repeat,
+            run_count: self.runs.len(),
+            failure_count: self.failure_count,
+            exit_code: if self.failure_count == 0 { 0 } else { 1 },
+            schedule: Some(self.args.schedule.as_str().to_string()),
+            run_order: self.run_order,
+            rig_state: template.and_then(|aggregate| aggregate.rig_state),
+            overlays: self.overlays,
+            runs: self.runs,
+            spans,
+            focus_span_ids: self.args.focus_spans.clone(),
+            focus_spans,
+        }
+    }
 }
 
 fn run_repeat_output(args: TraceArgs) -> homeboy::Result<extension_trace::TraceAggregateOutput> {
@@ -192,6 +380,7 @@ fn write_trace_compare_variant_summary(
     baseline: &extension_trace::TraceAggregateOutput,
     variant: &extension_trace::TraceAggregateOutput,
     compare: &extension_trace::TraceCompareOutput,
+    run_order: &[extension_trace::TraceRunOrderEntryOutput],
 ) -> homeboy::Result<()> {
     let mut out = String::new();
     out.push_str(&format!(
@@ -202,18 +391,25 @@ fn write_trace_compare_variant_summary(
     out.push_str(&format!("- **Output dir:** `{}`\n", output_dir.display()));
     out.push_str(&format!("- **Baseline runs:** `{}`\n", baseline.run_count));
     out.push_str(&format!("- **Variant runs:** `{}`\n", variant.run_count));
+    out.push_str(&format!(
+        "- **Schedule:** `{}`\n",
+        baseline.schedule.as_deref().unwrap_or("grouped")
+    ));
     out.push_str(&format!("- **Baseline status:** `{}`\n", baseline.status));
     out.push_str(&format!("- **Variant status:** `{}`\n", variant.status));
     out.push_str(&format!(
-        "- **Files:** `{}`, `{}`, `{}`\n",
+        "- **Files:** `{}`, `{}`, `{}`, `{}`\n",
         TRACE_COMPARE_VARIANT_BASELINE_FILE,
         TRACE_COMPARE_VARIANT_VARIANT_FILE,
-        TRACE_COMPARE_VARIANT_COMPARE_FILE
+        TRACE_COMPARE_VARIANT_COMPARE_FILE,
+        TRACE_COMPARE_VARIANT_RUN_ORDER_FILE
     ));
 
+    push_run_order_summary(&mut out, run_order);
     push_component_sha_summary(&mut out, "Baseline", baseline.rig_state.as_ref());
     push_component_sha_summary(&mut out, "Variant", variant.rig_state.as_ref());
     push_overlay_summary(&mut out, &variant.overlays);
+    push_focus_span_summary(&mut out, baseline, variant, compare);
     push_compare_variant_span_summary(&mut out, compare);
 
     std::fs::write(path, out).map_err(|err| {
@@ -222,6 +418,141 @@ fn write_trace_compare_variant_summary(
             Some("trace.compare_variant.summary".to_string()),
         )
     })
+}
+
+fn push_run_order_summary(
+    out: &mut String,
+    run_order: &[extension_trace::TraceRunOrderEntryOutput],
+) {
+    out.push_str("\n## Run Order\n\n");
+    if run_order.is_empty() {
+        out.push_str("No run order was recorded.\n");
+        return;
+    }
+    out.push_str("| Index | Group | Iteration |\n");
+    out.push_str("|---:|---|---:|\n");
+    for run in run_order {
+        out.push_str(&format!(
+            "| {} | `{}` | {} |\n",
+            run.index, run.group, run.iteration
+        ));
+    }
+}
+
+fn push_focus_span_summary(
+    out: &mut String,
+    baseline: &extension_trace::TraceAggregateOutput,
+    variant: &extension_trace::TraceAggregateOutput,
+    compare: &extension_trace::TraceCompareOutput,
+) {
+    if compare.focus_span_ids.is_empty() {
+        return;
+    }
+    out.push_str("\n## Focus Spans\n\n");
+    out.push_str(&format!(
+        "- **Status:** `{}`\n",
+        compare.focus_status.as_deref().unwrap_or("pass")
+    ));
+    out.push_str(&format!(
+        "- **Regressions:** `{}`\n",
+        compare.focus_regression_count
+    ));
+    out.push_str(&format!(
+        "- **Failures:** `{}`\n",
+        compare.focus_failure_count
+    ));
+    if compare.focus_spans.is_empty() {
+        out.push_str("\nNo focused spans matched the compared aggregates.\n");
+        return;
+    }
+    out.push_str(&format!(
+        "- **Noise context:** {}\n",
+        focus_noise_context(baseline, variant, compare)
+    ));
+    out.push_str("\n| Span | baseline median | variant median | delta | delta % | baseline failures | variant failures |\n");
+    out.push_str("|---|---:|---:|---:|---:|---:|---:|\n");
+    for span in &compare.focus_spans {
+        out.push_str(&format!(
+            "| `{}` | {} | {} | {} | {} | {} | {} |\n",
+            span.id,
+            fmt_summary_ms(span.before_median_ms),
+            fmt_summary_ms(span.after_median_ms),
+            span.median_delta_ms
+                .map(|value| format!("{:+}ms", value))
+                .unwrap_or_else(|| "-".to_string()),
+            span.median_delta_percent
+                .map(|value| format!("{:+.1}%", value))
+                .unwrap_or_else(|| "-".to_string()),
+            span.before_failures
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            span.after_failures
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string())
+        ));
+    }
+
+    out.push_str("\n### Focus Variance And Outliers\n\n");
+    out.push_str("| Group | Span | min | median | max | max run | max artifact |\n");
+    out.push_str("|---|---|---:|---:|---:|---:|---|\n");
+    push_focus_variance_rows(out, "baseline", &baseline.focus_spans);
+    push_focus_variance_rows(out, "variant", &variant.focus_spans);
+}
+
+fn push_focus_variance_rows(
+    out: &mut String,
+    group: &str,
+    spans: &[extension_trace::TraceAggregateSpanOutput],
+) {
+    for span in spans {
+        out.push_str(&format!(
+            "| `{}` | `{}` | {} | {} | {} | {} | `{}` |\n",
+            group,
+            span.id,
+            fmt_summary_ms(span.min_ms),
+            fmt_summary_ms(span.median_ms),
+            fmt_summary_ms(span.max_ms),
+            span.max_run_index
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            span.max_artifact_path.as_deref().unwrap_or("-")
+        ));
+    }
+}
+
+fn focus_noise_context(
+    baseline: &extension_trace::TraceAggregateOutput,
+    variant: &extension_trace::TraceAggregateOutput,
+    compare: &extension_trace::TraceCompareOutput,
+) -> &'static str {
+    if compare.focus_regression_count > 0 || compare.focus_failure_count > 0 {
+        return "focused span threshold failed; inspect outlier artifacts before trusting the delta";
+    }
+    let mut noisy = false;
+    for span in &compare.focus_spans {
+        let delta = span.median_delta_ms.map(i64::abs).unwrap_or(0) as u64;
+        if delta == 0 {
+            continue;
+        }
+        let baseline_spread = span_spread_ms(&baseline.focus_spans, &span.id);
+        let variant_spread = span_spread_ms(&variant.focus_spans, &span.id);
+        if baseline_spread.max(variant_spread) >= delta {
+            noisy = true;
+        }
+    }
+    if noisy {
+        "focused medians passed thresholds, but within-group spread overlaps at least one delta"
+    } else {
+        "focused medians passed thresholds and observed spread does not dominate the deltas"
+    }
+}
+
+fn span_spread_ms(spans: &[extension_trace::TraceAggregateSpanOutput], id: &str) -> u64 {
+    spans
+        .iter()
+        .find(|span| span.id == id)
+        .and_then(|span| Some(span.max_ms? - span.min_ms?))
+        .unwrap_or(0)
 }
 
 fn push_component_sha_summary(

--- a/src/commands/trace/compare_variant_tests.rs
+++ b/src/commands/trace/compare_variant_tests.rs
@@ -13,6 +13,136 @@ use super::test_fixture::{init_overlay_component, write_trace_extension, XdgGuar
 use super::{run, TraceArgs, TraceSchedule, TraceVariantMatrixMode};
 
 #[test]
+fn trace_compare_variant_interleaves_run_order_and_reports_focus_spans() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::without_xdg_data_home();
+        write_trace_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        init_overlay_component(component_dir.path());
+        let patch_path = component_dir.path().join("overlay.patch");
+        fs::write(
+            &patch_path,
+            r#"diff --git a/scenario.txt b/scenario.txt
+--- a/scenario.txt
++++ b/scenario.txt
+@@ -1 +1 @@
+-base
++overlay
+"#,
+        )
+        .expect("write patch");
+        super::test_fixture::write_trace_rig(home, "studio-rig", "studio", component_dir.path());
+        let output_dir = tempfile::TempDir::new().expect("output dir");
+
+        let (output, exit_code) = run(
+            TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("compare-variant".to_string()),
+                    path: None,
+                },
+                component_arg: Some("studio".to_string()),
+                scenario: Some("studio-app-create-site".to_string()),
+                scenario_arg: None,
+                compare_after: None,
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                report: None,
+                experiment: None,
+                repeat: 2,
+                aggregate: None,
+                schedule: TraceSchedule::Interleaved,
+                focus_spans: vec!["boot_to_ready".to_string()],
+                spans: Vec::new(),
+                phases: Vec::new(),
+                phase_preset: None,
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                overlays: vec![patch_path.to_string_lossy().to_string()],
+                variants: Vec::new(),
+                matrix: TraceVariantMatrixMode::None,
+                output_dir: Some(output_dir.path().to_path_buf()),
+                keep_overlay: false,
+                stale: false,
+                force: false,
+            },
+            &GlobalArgs {},
+        )
+        .expect("interleaved compare-variant should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            TraceCommandOutput::Compare(compare) => {
+                assert_eq!(compare.focus_span_ids, vec!["boot_to_ready"]);
+                assert_eq!(compare.focus_spans.len(), 1);
+                assert_eq!(compare.focus_status.as_deref(), Some("pass"));
+            }
+            _ => panic!("expected compare output"),
+        }
+
+        assert!(output_dir.path().join("baseline.json").is_file());
+        assert!(output_dir.path().join("variant.json").is_file());
+        assert!(output_dir.path().join("compare.json").is_file());
+        assert!(output_dir.path().join("run-order.json").is_file());
+
+        let run_order: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(output_dir.path().join("run-order.json")).expect("run order"),
+        )
+        .expect("run order json");
+        let observed = run_order
+            .as_array()
+            .expect("run order array")
+            .iter()
+            .map(|entry| {
+                (
+                    entry["index"].as_u64().expect("index"),
+                    entry["group"].as_str().expect("group").to_string(),
+                    entry["iteration"].as_u64().expect("iteration"),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            observed,
+            vec![
+                (1, "baseline".to_string(), 1),
+                (2, "variant".to_string(), 1),
+                (3, "baseline".to_string(), 2),
+                (4, "variant".to_string(), 2),
+            ]
+        );
+
+        let baseline: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(output_dir.path().join("baseline.json")).expect("baseline"),
+        )
+        .expect("baseline json");
+        let variant: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(output_dir.path().join("variant.json")).expect("variant"),
+        )
+        .expect("variant json");
+        assert_eq!(baseline["schedule"], "interleaved");
+        assert_eq!(variant["schedule"], "interleaved");
+        assert_eq!(baseline["run_order"][0]["index"], 1);
+        assert_eq!(baseline["run_order"][1]["index"], 3);
+        assert_eq!(variant["run_order"][0]["index"], 2);
+        assert_eq!(variant["run_order"][1]["index"], 4);
+        assert!(baseline["runs"]
+            .as_array()
+            .expect("baseline runs")
+            .iter()
+            .all(|run| std::path::Path::new(run["artifact_path"].as_str().unwrap()).is_file()));
+
+        let summary = fs::read_to_string(output_dir.path().join("summary.md")).expect("summary");
+        assert!(summary.contains("## Run Order"));
+        assert!(summary.contains("| 2 | `variant` | 1 |"));
+        assert!(summary.contains("## Focus Spans"));
+        assert!(summary.contains("`boot_to_ready`"));
+    });
+}
+
+#[test]
 fn trace_compare_variant_uses_component_arg_for_multi_component_named_variants() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::without_xdg_data_home();


### PR DESCRIPTION
## Summary
- Honor `--schedule interleaved` in `homeboy trace compare-variant` by alternating baseline and variant single-run aggregates before recombining them.
- Write `run-order.json` and include run order, focused span status, and focused variance/outlier context in the compare-variant summary.
- Cover interleaved run order, artifact files, aggregate run indexes, and focused-span reporting in trace compare-variant tests.

Fixes #2152

## Tests
- `cargo test trace_compare_variant --lib`
- `cargo test commands::trace --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the compare-variant scheduling changes, added targeted tests, ran verification, and drafted this PR description. Chris remains responsible for review and merge.