### PR TITLE
Add trace critical path span classification

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -31,8 +31,8 @@ mod test_fixture;
 use compare_variant::run_compare_variant;
 
 use output::{
-    aggregate_span, render_aggregate_markdown, render_compare_markdown, render_matrix_markdown,
-    run_compare, TraceAggregateSpanSample,
+    aggregate_span, attach_span_metadata, classification_summaries, render_aggregate_markdown,
+    render_compare_markdown, render_matrix_markdown, run_compare, TraceAggregateSpanSample,
 };
 
 #[cfg(test)]
@@ -620,6 +620,7 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         .collect();
     let mut rig_state = None;
     let mut component = None;
+    let span_metadata = trace_span_metadata_for_args(&args)?;
     let mut failure_count = 0;
 
     let run_order = plan_trace_run_order(repeat, args.schedule, &["run"]);
@@ -725,7 +726,7 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         }
     }
 
-    let spans = all_span_ids
+    let mut spans = all_span_ids
         .into_iter()
         .map(|id| {
             let samples = span_samples.remove(&id).unwrap_or_default();
@@ -733,6 +734,8 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
             aggregate_span(id, samples, failures)
         })
         .collect::<Vec<_>>();
+    let unmatched_span_metadata_ids = attach_span_metadata(&mut spans, &span_metadata);
+    let classification_summaries = classification_summaries(&spans);
     let focus_spans = focus_aggregate_spans(&spans, &args.focus_spans);
     let exit_code = if failure_count == 0 { 0 } else { 1 };
     let output = extension_trace::TraceAggregateOutput {
@@ -761,6 +764,8 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         spans,
         focus_span_ids: args.focus_spans.clone(),
         focus_spans,
+        classification_summaries,
+        unmatched_span_metadata_ids,
     };
 
     Ok((TraceCommandOutput::Aggregate(output), exit_code))
@@ -831,6 +836,53 @@ fn span_definitions_for_args(
         })?;
     definitions.extend(phase_definitions);
     Ok(definitions)
+}
+
+fn trace_span_metadata_for_args(
+    args: &TraceArgs,
+) -> homeboy::Result<BTreeMap<String, extension_trace::TraceSpanMetadata>> {
+    let Some(context) = load_rig_context(args.rig.as_deref())? else {
+        return Ok(BTreeMap::new());
+    };
+    let effective_id = resolve_component_id(&args.comp, Some(&context.rig_spec))?;
+    let path_override = args
+        .comp
+        .path
+        .clone()
+        .or_else(|| rig_component_path(&context.rig_spec, &effective_id));
+    let component_override = rig_component_for_trace(&context.rig_spec, &effective_id);
+    let ctx = execution_context::resolve_with_component(
+        &ResolveOptions::with_capability_and_json(
+            &effective_id,
+            path_override,
+            ExtensionCapability::Trace,
+            args.setting_args.setting.clone(),
+            args.setting_args.setting_json.clone(),
+        ),
+        component_override,
+    )?;
+    let Some(extension_id) = ctx.extension_id.as_deref() else {
+        return Ok(BTreeMap::new());
+    };
+    let scenario = trace_scenario(args)?;
+    let workloads = context
+        .rig_spec
+        .trace_workloads
+        .get(extension_id)
+        .map(|workloads| workloads.as_slice())
+        .unwrap_or(&[]);
+    let Some(workload) = workloads
+        .iter()
+        .find(|workload| trace_workload_scenario_id(workload.path()) == scenario)
+    else {
+        return Ok(BTreeMap::new());
+    };
+    Ok(workload
+        .trace_span_metadata()
+        .into_iter()
+        .flat_map(|metadata| metadata.iter())
+        .map(|(id, metadata)| (id.clone(), metadata.clone()))
+        .collect())
 }
 
 fn default_trace_phase_preset_for_args<'a>(

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -24,11 +24,13 @@ use super::{CmdResult, GlobalArgs};
 mod bundle;
 mod compare_variant;
 mod matrix;
+mod metadata;
 mod output;
 #[cfg(test)]
 mod test_fixture;
 
 use compare_variant::run_compare_variant;
+use metadata::trace_span_metadata_for_args;
 
 use output::{
     aggregate_span, attach_span_metadata, classification_summaries, render_aggregate_markdown,
@@ -836,53 +838,6 @@ fn span_definitions_for_args(
         })?;
     definitions.extend(phase_definitions);
     Ok(definitions)
-}
-
-fn trace_span_metadata_for_args(
-    args: &TraceArgs,
-) -> homeboy::Result<BTreeMap<String, extension_trace::TraceSpanMetadata>> {
-    let Some(context) = load_rig_context(args.rig.as_deref())? else {
-        return Ok(BTreeMap::new());
-    };
-    let effective_id = resolve_component_id(&args.comp, Some(&context.rig_spec))?;
-    let path_override = args
-        .comp
-        .path
-        .clone()
-        .or_else(|| rig_component_path(&context.rig_spec, &effective_id));
-    let component_override = rig_component_for_trace(&context.rig_spec, &effective_id);
-    let ctx = execution_context::resolve_with_component(
-        &ResolveOptions::with_capability_and_json(
-            &effective_id,
-            path_override,
-            ExtensionCapability::Trace,
-            args.setting_args.setting.clone(),
-            args.setting_args.setting_json.clone(),
-        ),
-        component_override,
-    )?;
-    let Some(extension_id) = ctx.extension_id.as_deref() else {
-        return Ok(BTreeMap::new());
-    };
-    let scenario = trace_scenario(args)?;
-    let workloads = context
-        .rig_spec
-        .trace_workloads
-        .get(extension_id)
-        .map(|workloads| workloads.as_slice())
-        .unwrap_or(&[]);
-    let Some(workload) = workloads
-        .iter()
-        .find(|workload| trace_workload_scenario_id(workload.path()) == scenario)
-    else {
-        return Ok(BTreeMap::new());
-    };
-    Ok(workload
-        .trace_span_metadata()
-        .into_iter()
-        .flat_map(|metadata| metadata.iter())
-        .map(|(id, metadata)| (id.clone(), metadata.clone()))
-        .collect())
 }
 
 fn default_trace_phase_preset_for_args<'a>(

--- a/src/commands/trace/compare_tests.rs
+++ b/src/commands/trace/compare_tests.rs
@@ -22,6 +22,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 0,
+                metadata: None,
             },
             TraceAggregateSpanInput {
                 id: "large_improvement".to_string(),
@@ -32,6 +33,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 0,
+                metadata: None,
             },
             TraceAggregateSpanInput {
                 id: "large_regression".to_string(),
@@ -42,6 +44,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 0,
+                metadata: None,
             },
             TraceAggregateSpanInput {
                 id: "before_only".to_string(),
@@ -52,6 +55,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 1,
+                metadata: None,
             },
         ],
     };
@@ -73,6 +77,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 0,
+                metadata: None,
             },
             TraceAggregateSpanInput {
                 id: "large_improvement".to_string(),
@@ -83,6 +88,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 0,
+                metadata: None,
             },
             TraceAggregateSpanInput {
                 id: "large_regression".to_string(),
@@ -93,6 +99,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 0,
+                metadata: None,
             },
             TraceAggregateSpanInput {
                 id: "after_only".to_string(),
@@ -103,6 +110,7 @@ fn trace_compare_reports_median_and_average_deltas() {
                 max_run_index: None,
                 max_artifact_path: None,
                 failures: 0,
+                metadata: None,
             },
         ],
     };

--- a/src/commands/trace/compare_variant.rs
+++ b/src/commands/trace/compare_variant.rs
@@ -181,6 +181,7 @@ fn aggregate_to_compare_input(
                 max_run_index: span.max_run_index,
                 max_artifact_path: span.max_artifact_path.clone(),
                 failures: span.failures,
+                metadata: span.metadata.clone(),
             })
             .collect(),
     }

--- a/src/commands/trace/matrix.rs
+++ b/src/commands/trace/matrix.rs
@@ -267,6 +267,7 @@ fn aggregate_to_compare_input(
                 max_run_index: span.max_run_index,
                 max_artifact_path: span.max_artifact_path.clone(),
                 failures: span.failures,
+                metadata: span.metadata.clone(),
             })
             .collect(),
     }

--- a/src/commands/trace/metadata.rs
+++ b/src/commands/trace/metadata.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+pub(super) fn trace_span_metadata_for_args(
+    args: &TraceArgs,
+) -> homeboy::Result<BTreeMap<String, extension_trace::TraceSpanMetadata>> {
+    let Some(context) = load_rig_context(args.rig.as_deref())? else {
+        return Ok(BTreeMap::new());
+    };
+    let effective_id = resolve_component_id(&args.comp, Some(&context.rig_spec))?;
+    let path_override = args
+        .comp
+        .path
+        .clone()
+        .or_else(|| rig_component_path(&context.rig_spec, &effective_id));
+    let component_override = rig_component_for_trace(&context.rig_spec, &effective_id);
+    let ctx = execution_context::resolve_with_component(
+        &ResolveOptions::with_capability_and_json(
+            &effective_id,
+            path_override,
+            ExtensionCapability::Trace,
+            args.setting_args.setting.clone(),
+            args.setting_args.setting_json.clone(),
+        ),
+        component_override,
+    )?;
+    let Some(extension_id) = ctx.extension_id.as_deref() else {
+        return Ok(BTreeMap::new());
+    };
+    let scenario = trace_scenario(args)?;
+    let workloads = context
+        .rig_spec
+        .trace_workloads
+        .get(extension_id)
+        .map(|workloads| workloads.as_slice())
+        .unwrap_or(&[]);
+    let Some(workload) = workloads
+        .iter()
+        .find(|workload| trace_workload_scenario_id(workload.path()) == scenario)
+    else {
+        return Ok(BTreeMap::new());
+    };
+    Ok(workload
+        .trace_span_metadata()
+        .into_iter()
+        .flat_map(|metadata| metadata.iter())
+        .map(|(id, metadata)| (id.clone(), metadata.clone()))
+        .collect())
+}

--- a/src/commands/trace/output.rs
+++ b/src/commands/trace/output.rs
@@ -47,6 +47,8 @@ pub(super) struct TraceAggregateSpanInput {
     #[serde(default)]
     pub(super) max_artifact_path: Option<String>,
     pub(super) failures: usize,
+    #[serde(default)]
+    pub(super) metadata: Option<extension_trace::TraceSpanMetadata>,
 }
 
 #[derive(Deserialize)]
@@ -227,6 +229,7 @@ pub(super) fn compare_trace_aggregates_with_focus(
         })
         .collect::<Vec<_>>();
     spans.sort_by(compare_trace_span_impact);
+    let classification_summaries = compare_classification_summaries(&before_spans, &after_spans);
 
     let focus_spans = focus_compare_spans(&spans, focus_span_ids);
     let focus_regression_count = focus_spans
@@ -262,6 +265,73 @@ pub(super) fn compare_trace_aggregates_with_focus(
         focus_regression_count,
         focus_failure_count,
         focus_status,
+        classification_summaries,
+    }
+}
+
+fn compare_classification_summaries(
+    before_spans: &BTreeMap<String, TraceAggregateSpanInput>,
+    after_spans: &BTreeMap<String, TraceAggregateSpanInput>,
+) -> Vec<extension_trace::TraceCompareClassificationSummaryOutput> {
+    let mut totals: BTreeMap<String, (usize, Option<u64>, Option<u64>)> = BTreeMap::new();
+    for (id, before_span) in before_spans {
+        let metadata = after_spans
+            .get(id)
+            .and_then(|span| span.metadata.as_ref())
+            .or(before_span.metadata.as_ref());
+        add_compare_classification_totals(
+            &mut totals,
+            metadata,
+            before_span.median_ms,
+            after_spans.get(id).and_then(|span| span.median_ms),
+        );
+    }
+    for (id, after_span) in after_spans {
+        if before_spans.contains_key(id) {
+            continue;
+        }
+        add_compare_classification_totals(
+            &mut totals,
+            after_span.metadata.as_ref(),
+            None,
+            after_span.median_ms,
+        );
+    }
+    totals
+        .into_iter()
+        .map(
+            |(classification, (span_count, before_total_median_ms, after_total_median_ms))| {
+                extension_trace::TraceCompareClassificationSummaryOutput {
+                    classification,
+                    span_count,
+                    before_total_median_ms,
+                    after_total_median_ms,
+                    median_delta_ms: option_delta_i64(
+                        before_total_median_ms,
+                        after_total_median_ms,
+                    ),
+                }
+            },
+        )
+        .collect()
+}
+
+fn add_compare_classification_totals(
+    totals: &mut BTreeMap<String, (usize, Option<u64>, Option<u64>)>,
+    metadata: Option<&extension_trace::TraceSpanMetadata>,
+    before_median_ms: Option<u64>,
+    after_median_ms: Option<u64>,
+) {
+    let Some(metadata) = metadata else {
+        return;
+    };
+    for classification in span_classifications(metadata) {
+        let entry = totals
+            .entry(classification)
+            .or_insert((0, Some(0), Some(0)));
+        entry.0 += 1;
+        entry.1 = option_sum(entry.1, before_median_ms);
+        entry.2 = option_sum(entry.2, after_median_ms);
     }
 }
 
@@ -369,7 +439,107 @@ pub(super) fn aggregate_span(
         max_run_index: max_sample.as_ref().map(|sample| sample.run_index),
         max_artifact_path: max_sample.map(|sample| sample.artifact_path),
         failures,
+        metadata: None,
     }
+}
+
+pub(super) fn attach_span_metadata(
+    spans: &mut [extension_trace::TraceAggregateSpanOutput],
+    span_metadata: &BTreeMap<String, extension_trace::TraceSpanMetadata>,
+) -> Vec<String> {
+    if span_metadata.is_empty() {
+        return Vec::new();
+    }
+    let mut matched = BTreeSet::new();
+    for span in spans {
+        if let Some(metadata) = span_metadata.get(&span.id) {
+            span.metadata = Some(metadata.clone());
+            matched.insert(span.id.clone());
+        }
+    }
+    span_metadata
+        .keys()
+        .filter(|id| !matched.contains(*id))
+        .cloned()
+        .collect()
+}
+
+pub(super) fn classification_summaries(
+    spans: &[extension_trace::TraceAggregateSpanOutput],
+) -> Vec<extension_trace::TraceClassificationSummaryOutput> {
+    let mut totals: BTreeMap<String, (usize, Option<u64>, Option<f64>)> = BTreeMap::new();
+    for span in spans {
+        let Some(metadata) = span.metadata.as_ref() else {
+            continue;
+        };
+        for classification in span_classifications(metadata) {
+            let entry = totals
+                .entry(classification)
+                .or_insert((0, Some(0), Some(0.0)));
+            entry.0 += 1;
+            entry.1 = option_sum(entry.1, span.median_ms);
+            entry.2 = option_sum_f64(entry.2, span.avg_ms);
+        }
+    }
+    totals
+        .into_iter()
+        .map(
+            |(classification, (span_count, total_median_ms, total_avg_ms))| {
+                extension_trace::TraceClassificationSummaryOutput {
+                    classification,
+                    span_count,
+                    total_median_ms,
+                    total_avg_ms,
+                }
+            },
+        )
+        .collect()
+}
+
+fn span_classifications(metadata: &extension_trace::TraceSpanMetadata) -> Vec<String> {
+    let mut classifications = Vec::new();
+    if metadata.critical {
+        classifications.push("critical".to_string());
+    }
+    if metadata.blocking {
+        classifications.push("blocking".to_string());
+    }
+    if metadata.cacheable {
+        classifications.push("cacheable".to_string());
+        if metadata.critical {
+            classifications.push("cacheable_critical".to_string());
+        }
+    }
+    if metadata.prewarmable {
+        classifications.push("prewarmable".to_string());
+        if metadata.critical {
+            classifications.push("prewarmable_critical".to_string());
+        }
+    }
+    if metadata.deferrable {
+        classifications.push("deferrable".to_string());
+        if metadata.critical {
+            classifications.push("deferrable_critical".to_string());
+        }
+    }
+    if let Some(category) = metadata.category.as_deref() {
+        classifications.push(format!("category:{category}"));
+    }
+    if let Some(blocks) = metadata.blocks.as_deref() {
+        classifications.push(format!("blocks:{blocks}"));
+    }
+    classifications
+}
+
+fn option_sum<T>(left: Option<T>, right: Option<T>) -> Option<T>
+where
+    T: std::ops::Add<Output = T>,
+{
+    Some(left? + right?)
+}
+
+fn option_sum_f64(left: Option<f64>, right: Option<f64>) -> Option<f64> {
+    Some(left? + right?)
 }
 
 #[derive(Clone)]
@@ -415,6 +585,17 @@ pub(super) fn render_aggregate_markdown(
         out.push_str(&format!("- **Schedule:** `{}`\n", schedule));
     }
     extension_trace::push_overlay_markdown(&mut out, &aggregate.overlays);
+
+    if !aggregate.classification_summaries.is_empty() {
+        out.push_str("\n## Critical Path Classification\n\n");
+        push_classification_summary_table(&mut out, &aggregate.classification_summaries);
+    }
+    if !aggregate.unmatched_span_metadata_ids.is_empty() {
+        out.push_str("\n## Unmatched Span Metadata\n\n");
+        for id in &aggregate.unmatched_span_metadata_ids {
+            out.push_str(&format!("- `{id}`\n"));
+        }
+    }
 
     if !aggregate.focus_span_ids.is_empty() {
         out.push_str("\n## Focus Spans\n\n");
@@ -466,6 +647,23 @@ pub(super) fn render_aggregate_markdown(
     out
 }
 
+fn push_classification_summary_table(
+    out: &mut String,
+    summaries: &[extension_trace::TraceClassificationSummaryOutput],
+) {
+    out.push_str("| Classification | spans | total median | total avg |\n");
+    out.push_str("|---|---:|---:|---:|\n");
+    for summary in summaries {
+        out.push_str(&format!(
+            "| `{}` | {} | {} | {} |\n",
+            summary.classification,
+            summary.span_count,
+            fmt_ms(summary.total_median_ms),
+            fmt_avg_ms(summary.total_avg_ms),
+        ));
+    }
+}
+
 fn push_aggregate_span_row(out: &mut String, span: &extension_trace::TraceAggregateSpanOutput) {
     out.push_str(&format!(
         "| `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
@@ -509,6 +707,24 @@ pub(super) fn render_compare_markdown(compare: &extension_trace::TraceCompareOut
                 fmt_avg_ms(span.after_avg_ms),
                 fmt_signal_delta_avg_ms(span.avg_delta_ms),
                 fmt_percent(span.avg_delta_percent),
+            ));
+        }
+    }
+
+    if !compare.classification_summaries.is_empty() {
+        out.push_str("\n## Critical Path Classification\n\n");
+        out.push_str(
+            "| Classification | spans | before median total | after median total | delta |\n",
+        );
+        out.push_str("|---|---:|---:|---:|---:|\n");
+        for summary in &compare.classification_summaries {
+            out.push_str(&format!(
+                "| `{}` | {} | {} | {} | {} |\n",
+                summary.classification,
+                summary.span_count,
+                fmt_ms(summary.before_total_median_ms),
+                fmt_ms(summary.after_total_median_ms),
+                fmt_signal_delta_ms(summary.median_delta_ms),
             ));
         }
     }

--- a/src/commands/trace/output_tests.rs
+++ b/src/commands/trace/output_tests.rs
@@ -125,6 +125,62 @@ fn trace_compare_focus_spans_report_independent_regression_status() {
 }
 
 #[test]
+fn trace_compare_includes_classification_summary_output() {
+    let metadata = extension_trace::TraceSpanMetadata {
+        critical: true,
+        blocking: true,
+        cacheable: true,
+        prewarmable: false,
+        deferrable: false,
+        blocks: Some("first_site_render".to_string()),
+        category: None,
+    };
+    let before = TraceAggregateInput {
+        component: Some("studio".to_string()),
+        scenario_id: Some("create-site".to_string()),
+        phase_preset: None,
+        repeat: None,
+        rig_state: None,
+        overlays: Vec::new(),
+        runs: Vec::new(),
+        spans: vec![TraceAggregateSpanInput {
+            metadata: Some(metadata.clone()),
+            ..span_input("boot_to_ready", 5, Some(100), Some(100.0), 0)
+        }],
+    };
+    let after = TraceAggregateInput {
+        component: Some("studio".to_string()),
+        scenario_id: Some("create-site".to_string()),
+        phase_preset: None,
+        repeat: None,
+        rig_state: None,
+        overlays: Vec::new(),
+        runs: Vec::new(),
+        spans: vec![TraceAggregateSpanInput {
+            metadata: Some(metadata),
+            ..span_input("boot_to_ready", 5, Some(125), Some(125.0), 0)
+        }],
+    };
+
+    let compare = compare_trace_aggregates(
+        Path::new("before.json"),
+        before,
+        Path::new("after.json"),
+        after,
+    );
+
+    assert!(compare.classification_summaries.iter().any(|summary| {
+        summary.classification == "cacheable_critical"
+            && summary.before_total_median_ms == Some(100)
+            && summary.after_total_median_ms == Some(125)
+            && summary.median_delta_ms == Some(25)
+    }));
+    let markdown = render_compare_markdown(&compare);
+    assert!(markdown.contains("## Critical Path Classification"));
+    assert!(markdown.contains("| `cacheable_critical` | 1 | 100ms | 125ms | **+25ms** |"));
+}
+
+#[test]
 fn trace_compare_accepts_json_summary_envelope_outputs() {
     let input = parse_trace_aggregate_input(
         r#"{
@@ -185,6 +241,7 @@ fn trace_compare_markdown_and_experiment_bundle_render_artifacts() {
         focus_regression_count: 0,
         focus_failure_count: 0,
         focus_status: None,
+        classification_summaries: Vec::new(),
     };
 
     let markdown = render_compare_markdown(&compare);
@@ -328,5 +385,6 @@ fn span_input(
         max_run_index: None,
         max_artifact_path: None,
         failures,
+        metadata: None,
     }
 }

--- a/src/commands/trace/test_fixture.rs
+++ b/src/commands/trace/test_fixture.rs
@@ -190,6 +190,49 @@ pub(super) fn write_trace_rig_with_phase_preset(
     .expect("write rig");
 }
 
+pub(super) fn write_trace_rig_with_span_metadata(
+    home: &tempfile::TempDir,
+    rig_id: &str,
+    component_id: &str,
+    path: &std::path::Path,
+) {
+    let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+    fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+    fs::write(
+        rig_dir.join(format!("{}.json", rig_id)),
+        format!(
+            r#"{{
+                    "components": {{
+                        "{component_id}": {{ "path": "{}" }}
+                    }},
+                    "trace_workloads": {{ "nodejs": [
+                        {{
+                            "path": "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs",
+                            "check_groups": [],
+                            "trace_default_phase_preset": "startup",
+                            "trace_phase_presets": {{
+                                "startup": ["boot:runner.boot", "ready:runner.ready"]
+                            }},
+                            "trace_span_metadata": {{
+                                "phase.boot_to_ready": {{
+                                    "critical": true,
+                                    "blocking": true,
+                                    "cacheable": true,
+                                    "prewarmable": true,
+                                    "blocks": "first_site_render",
+                                    "category": "wordpress_boot"
+                                }},
+                                "missing_span": {{ "deferrable": true }}
+                            }}
+                        }}
+                    ] }}
+                }}"#,
+            path.display()
+        ),
+    )
+    .expect("write rig");
+}
+
 pub(super) fn write_trace_rig_with_variant(
     home: &tempfile::TempDir,
     package_path: &std::path::Path,

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -8,7 +8,8 @@ use homeboy::rig::ComponentSpec;
 
 use super::test_fixture::{
     init_overlay_component, write_trace_extension, write_trace_rig,
-    write_trace_rig_with_phase_preset, write_trace_rig_with_variant, XdgGuard,
+    write_trace_rig_with_phase_preset, write_trace_rig_with_span_metadata,
+    write_trace_rig_with_variant, XdgGuard,
 };
 use super::*;
 
@@ -461,6 +462,86 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
                     .runs
                     .iter()
                     .all(|run| std::path::Path::new(&run.artifact_path).is_file()));
+            }
+            _ => panic!("expected aggregate output"),
+        }
+    });
+}
+
+#[test]
+fn trace_repeat_loads_span_metadata_and_reports_unknown_ids() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::without_xdg_data_home();
+        write_trace_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_trace_rig_with_span_metadata(home, "studio-rig", "studio", component_dir.path());
+
+        let (output, exit_code) = run(
+            TraceArgs {
+                comp: PositionalComponentArgs {
+                    component: Some("studio".to_string()),
+                    path: None,
+                },
+                component_arg: None,
+                scenario: Some("studio-app-create-site".to_string()),
+                scenario_arg: None,
+                compare_after: None,
+                rig: Some("studio-rig".to_string()),
+                setting_args: SettingArgs::default(),
+                _json: HiddenJsonArgs::default(),
+                json_summary: false,
+                report: None,
+                experiment: None,
+                repeat: 2,
+                aggregate: Some("spans".to_string()),
+                schedule: TraceSchedule::Grouped,
+                focus_spans: Vec::new(),
+                spans: Vec::new(),
+                phases: Vec::new(),
+                phase_preset: None,
+                baseline_args: BaselineArgs::default(),
+                regression_threshold:
+                    extension_trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                regression_min_delta_ms: extension_trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                overlays: Vec::new(),
+                variants: Vec::new(),
+                matrix: TraceVariantMatrixMode::None,
+                output_dir: None,
+                keep_overlay: false,
+                stale: false,
+                force: false,
+            },
+            &GlobalArgs {},
+        )
+        .expect("repeat trace should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            TraceCommandOutput::Aggregate(aggregate) => {
+                let span = aggregate
+                    .spans
+                    .iter()
+                    .find(|span| span.id == "phase.boot_to_ready")
+                    .expect("boot span");
+                let metadata = span.metadata.as_ref().expect("span metadata");
+                assert!(metadata.critical);
+                assert!(metadata.blocking);
+                assert!(metadata.cacheable);
+                assert!(metadata.prewarmable);
+                assert_eq!(metadata.blocks.as_deref(), Some("first_site_render"));
+                assert_eq!(metadata.category.as_deref(), Some("wordpress_boot"));
+                assert_eq!(aggregate.unmatched_span_metadata_ids, vec!["missing_span"]);
+                assert!(aggregate.classification_summaries.iter().any(|summary| {
+                    summary.classification == "cacheable_critical"
+                        && summary.span_count == 1
+                        && summary.total_median_ms == Some(125)
+                }));
+
+                let markdown = render_aggregate_markdown(&aggregate);
+                assert!(markdown.contains("## Critical Path Classification"));
+                assert!(markdown.contains("| `cacheable_critical` | 1 | 125ms | 125.0ms |"));
+                assert!(markdown.contains("## Unmatched Span Metadata"));
+                assert!(markdown.contains("- `missing_span`"));
             }
             _ => panic!("expected aggregate output"),
         }
@@ -1267,6 +1348,8 @@ fn aggregate_markdown_includes_percentile_columns() {
         )],
         focus_span_ids: Vec::new(),
         focus_spans: Vec::new(),
+        classification_summaries: Vec::new(),
+        unmatched_span_metadata_ids: Vec::new(),
     };
 
     let markdown = render_aggregate_markdown(&aggregate);

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -31,8 +31,9 @@ pub use parsing::{
 pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, TraceSpanResult};
 pub use report::{
     from_list_workflow, from_main_workflow, from_main_workflow_outputs, TraceAggregateOutput,
-    TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceCommandOutput, TraceCompareOutput,
-    TraceCompareSpanOutput, TraceOverlayLocksOutput, TraceRunOrderEntryOutput,
+    TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceClassificationSummaryOutput,
+    TraceCommandOutput, TraceCompareClassificationSummaryOutput, TraceCompareOutput,
+    TraceCompareSpanOutput, TraceOverlayLocksOutput, TraceRunOrderEntryOutput, TraceSpanMetadata,
     TraceVariantMatrixOutput, TraceVariantMatrixRunOutput,
 };
 pub use report::{push_overlay_markdown, render_markdown};

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -1,6 +1,6 @@
 //! Trace command output envelopes.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::baseline::TraceBaselineComparison;
 use super::overlay_lock::TraceOverlayLockRecord;
@@ -112,6 +112,10 @@ pub struct TraceAggregateOutput {
     pub focus_span_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub focus_spans: Vec<TraceAggregateSpanOutput>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub classification_summaries: Vec<TraceClassificationSummaryOutput>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unmatched_span_metadata_ids: Vec<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -159,6 +163,36 @@ pub struct TraceAggregateSpanOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_artifact_path: Option<String>,
     pub failures: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<TraceSpanMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+pub struct TraceSpanMetadata {
+    #[serde(default, skip_serializing_if = "is_default_bool")]
+    pub critical: bool,
+    #[serde(default, skip_serializing_if = "is_default_bool")]
+    pub blocking: bool,
+    #[serde(default, skip_serializing_if = "is_default_bool")]
+    pub cacheable: bool,
+    #[serde(default, skip_serializing_if = "is_default_bool")]
+    pub prewarmable: bool,
+    #[serde(default, skip_serializing_if = "is_default_bool")]
+    pub deferrable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocks: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TraceClassificationSummaryOutput {
+    pub classification: String,
+    pub span_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_median_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_avg_ms: Option<f64>,
 }
 
 #[derive(Serialize, Clone)]
@@ -186,6 +220,20 @@ pub struct TraceCompareOutput {
     pub focus_failure_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub focus_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub classification_summaries: Vec<TraceCompareClassificationSummaryOutput>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct TraceCompareClassificationSummaryOutput {
+    pub classification: String,
+    pub span_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_total_median_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_total_median_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub median_delta_ms: Option<i64>,
 }
 
 #[derive(Serialize, Clone)]
@@ -249,6 +297,10 @@ pub struct TraceCompareSpanOutput {
 
 fn is_default_usize(value: &usize) -> bool {
     value.eq(&usize::default())
+}
+
+fn is_default_bool(value: &bool) -> bool {
+    !*value
 }
 
 pub fn from_main_workflow(

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -441,6 +441,41 @@ mod tests {
     }
 
     #[test]
+    fn test_trace_span_metadata() {
+        let workload: WorkloadSpec = serde_json::from_str(
+            r#"{
+                "path": "/tmp/scoped.trace.mjs",
+                "trace_span_metadata": {
+                    "phase.boot_to_ready": {
+                        "critical": true,
+                        "blocking": true,
+                        "cacheable": true,
+                        "prewarmable": true,
+                        "blocks": "first_site_render",
+                        "category": "wordpress_boot"
+                    }
+                }
+            }"#,
+        )
+        .expect("parse detailed workload metadata");
+
+        let metadata = workload
+            .trace_span_metadata()
+            .expect("metadata")
+            .get("phase.boot_to_ready")
+            .expect("span metadata");
+        assert!(metadata.critical);
+        assert!(metadata.blocking);
+        assert!(metadata.cacheable);
+        assert!(metadata.prewarmable);
+        assert_eq!(metadata.blocks.as_deref(), Some("first_site_render"));
+        assert_eq!(metadata.category.as_deref(), Some("wordpress_boot"));
+        assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
+            .trace_span_metadata()
+            .is_none());
+    }
+
+    #[test]
     fn test_trace_default_phase_preset() {
         let workload = WorkloadSpec::Detailed(WorkloadEntry {
             path: "trace.mjs".to_string(),

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -1,6 +1,8 @@
 //! Rig spec types — the JSON schema on disk.
 
 use serde::{Deserialize, Serialize};
+
+use crate::extension::trace::TraceSpanMetadata;
 use std::collections::{BTreeMap, HashMap};
 
 use crate::component::ScopedExtensionConfig;
@@ -299,6 +301,9 @@ pub struct WorkloadEntry {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub trace_phase_presets: HashMap<String, Vec<String>>,
 
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub trace_span_metadata: HashMap<String, TraceSpanMetadata>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_default_phase_preset: Option<String>,
 
@@ -346,6 +351,13 @@ impl WorkloadSpec {
                 .trace_phase_presets
                 .get(name)
                 .map(|phases| phases.as_slice()),
+        }
+    }
+
+    pub fn trace_span_metadata(&self) -> Option<&HashMap<String, TraceSpanMetadata>> {
+        match self {
+            WorkloadSpec::Path(_) => None,
+            WorkloadSpec::Detailed(entry) => Some(&entry.trace_span_metadata),
         }
     }
 
@@ -412,6 +424,7 @@ mod tests {
                 "startup".to_string(),
                 vec!["launch".to_string(), "ready".to_string()],
             )]),
+            trace_span_metadata: HashMap::new(),
             trace_default_phase_preset: None,
             trace_variants: HashMap::new(),
         });
@@ -433,6 +446,7 @@ mod tests {
             path: "trace.mjs".to_string(),
             check_groups: None,
             trace_phase_presets: HashMap::new(),
+            trace_span_metadata: HashMap::new(),
             trace_default_phase_preset: Some("startup".to_string()),
             trace_variants: HashMap::new(),
         });

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -330,6 +330,41 @@ fn test_trace_variants() {
         .is_none());
 }
 
+#[test]
+fn test_trace_span_metadata() {
+    let workload: WorkloadSpec = serde_json::from_str(
+        r#"{
+            "path": "/tmp/scoped.trace.mjs",
+            "trace_span_metadata": {
+                "phase.boot_to_ready": {
+                    "critical": true,
+                    "blocking": true,
+                    "cacheable": true,
+                    "prewarmable": true,
+                    "blocks": "first_site_render",
+                    "category": "wordpress_boot"
+                }
+            }
+        }"#,
+    )
+    .expect("parse detailed workload metadata");
+
+    let metadata = workload
+        .trace_span_metadata()
+        .expect("metadata")
+        .get("phase.boot_to_ready")
+        .expect("span metadata");
+    assert!(metadata.critical);
+    assert!(metadata.blocking);
+    assert!(metadata.cacheable);
+    assert!(metadata.prewarmable);
+    assert_eq!(metadata.blocks.as_deref(), Some("first_site_render"));
+    assert_eq!(metadata.category.as_deref(), Some("wordpress_boot"));
+    assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
+        .trace_span_metadata()
+        .is_none());
+}
+
 fn workload_with_trace_metadata() -> WorkloadSpec {
     WorkloadSpec::Detailed(WorkloadEntry {
         path: "/tmp/scoped.trace.mjs".to_string(),
@@ -338,6 +373,7 @@ fn workload_with_trace_metadata() -> WorkloadSpec {
             "startup".to_string(),
             vec!["boot:runner.boot".to_string()],
         )]),
+        trace_span_metadata: std::collections::HashMap::new(),
         trace_default_phase_preset: Some("startup".to_string()),
         trace_variants: std::collections::HashMap::from([(
             "fresh-install-mode".to_string(),

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -330,41 +330,6 @@ fn test_trace_variants() {
         .is_none());
 }
 
-#[test]
-fn test_trace_span_metadata() {
-    let workload: WorkloadSpec = serde_json::from_str(
-        r#"{
-            "path": "/tmp/scoped.trace.mjs",
-            "trace_span_metadata": {
-                "phase.boot_to_ready": {
-                    "critical": true,
-                    "blocking": true,
-                    "cacheable": true,
-                    "prewarmable": true,
-                    "blocks": "first_site_render",
-                    "category": "wordpress_boot"
-                }
-            }
-        }"#,
-    )
-    .expect("parse detailed workload metadata");
-
-    let metadata = workload
-        .trace_span_metadata()
-        .expect("metadata")
-        .get("phase.boot_to_ready")
-        .expect("span metadata");
-    assert!(metadata.critical);
-    assert!(metadata.blocking);
-    assert!(metadata.cacheable);
-    assert!(metadata.prewarmable);
-    assert_eq!(metadata.blocks.as_deref(), Some("first_site_render"));
-    assert_eq!(metadata.category.as_deref(), Some("wordpress_boot"));
-    assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
-        .trace_span_metadata()
-        .is_none());
-}
-
 fn workload_with_trace_metadata() -> WorkloadSpec {
     WorkloadSpec::Detailed(WorkloadEntry {
         path: "/tmp/scoped.trace.mjs".to_string(),


### PR DESCRIPTION
## Summary
- Adds `trace_span_metadata` to detailed rig/workload trace specs so named and phase-derived spans can be marked critical, blocking, cacheable, prewarmable, deferrable, categorized, or tied to a blocked milestone.
- Carries matched metadata into aggregate span output and emits aggregate/compare classification summaries, while leaving runs without metadata free of the new fields.
- Reports unmatched metadata IDs so stale or misspelled span metadata is visible without failing the trace.

Closes #2155.

## Tests
- `cargo test trace::tests::trace_repeat_loads_span_metadata_and_reports_unknown_ids`
- `cargo test trace::output_tests::trace_compare_includes_classification_summary_output`
- `cargo test test_trace_span_metadata`
- `cargo test trace::tests::trace_repeat_aggregates_span_timings_and_preserves_artifacts`
- `cargo test trace::output_tests`
- `cargo test trace::compare_tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the trace metadata schema, aggregate/compare classification summaries, report rendering, and targeted coverage. Chris remains responsible for review and merge.