### PR TITLE
feat: add trace probe substrate

### DIFF
--- a/docs/architecture/trace-probes.md
+++ b/docs/architecture/trace-probes.md
@@ -1,0 +1,71 @@
+# Trace Probes
+
+Trace probes are passive observation helpers that run beside a trace workload and emit events into the existing trace timeline shape:
+
+```json
+{ "t_ms": 12, "source": "log.tail", "event": "log.match", "data": { "line": "..." } }
+```
+
+## Contract
+
+- Probes never append to `HOMEBOY_TRACE_RESULTS_FILE` directly.
+- Homeboy starts probes before invoking the trace runner and stops them after the runner exits.
+- Probe events are collected internally, sorted by `t_ms`, and merged into the runner's final `timeline` before span processing.
+- Runner-owned events and probe-owned events share the same envelope, so existing span definitions can target either source.
+
+## Rig Workload Configuration
+
+Probes are declared on detailed `trace_workloads` entries:
+
+```jsonc
+{
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/trace/create-site.trace.mjs",
+        "trace_probes": [
+          { "type": "log.tail", "path": "${components.app.path}/app.log", "grep": "invalid_grant" },
+          { "type": "process.snapshot", "pattern": "opencode.*serve", "interval_ms": 250 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Probe values support the same `${components.<id>.path}` and `${package.root}` expansion as rig workload paths.
+
+## v1 Probes
+
+### `log.tail`
+
+Inputs:
+
+- `path`: log file to tail.
+- `grep` or `match`: optional regex.
+
+Events:
+
+- `log.line`: emitted for each new line appended after the probe starts.
+- `log.match`: emitted when the optional regex matches a line.
+
+Data includes `path`, `line`, and `pattern` for match events.
+
+### `process.snapshot`
+
+Inputs:
+
+- `pattern`: regex matched against process command lines.
+- `interval_ms`: optional polling interval, default `1000`.
+
+Events:
+
+- `proc.list`: full matching process snapshot for each poll.
+- `proc.spawn`: matching PID appeared since the previous snapshot.
+- `proc.exit`: matching PID disappeared since the previous snapshot.
+
+Data includes `pattern` and `processes` for list events, and `pid` plus `command` for delta events.
+
+## Deferred
+
+This substrate intentionally does not implement fanotify, PID-of-writer attribution, systemd integration, port owner detection, or the full six-probe inventory from issue #2163. Those can layer onto the same collection and merge contract later.

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -57,6 +57,10 @@ Generic workloads are dispatched by extension:
 - `HOMEBOY_TRACE_COMPONENT_PATH` when Homeboy resolves a path override
 - `HOMEBOY_RUN_DIR`
 
+## Probes
+
+Rig-owned trace workloads can declare passive `trace_probes` that Homeboy runs beside the trace runner and merges into the final `timeline`. See [Trace Probes](../architecture/trace-probes.md).
+
 ## Results Envelope
 
 ```json

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -124,6 +124,7 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
         span_definitions: Vec::new(),
         span_results: Vec::new(),
         assertions: Vec::new(),
+        temporal_assertions: Vec::new(),
         artifacts: vec![TraceArtifact {
             label: "observe timeline".to_string(),
             path: trace_path.to_string_lossy().to_string(),

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -28,6 +28,7 @@ mod matrix;
 mod metadata;
 mod observations;
 mod output;
+mod probes;
 mod schedule;
 #[cfg(test)]
 mod test_fixture;
@@ -46,6 +47,7 @@ use output::{
     aggregate_span, attach_span_metadata, classification_summaries, render_aggregate_markdown,
     render_compare_markdown, render_matrix_markdown, run_compare, TraceAggregateSpanSample,
 };
+use probes::trace_probes_for_args;
 use schedule::{TraceSchedule, TraceVariantMatrixMode};
 
 #[cfg(test)]
@@ -864,70 +866,6 @@ fn default_trace_phase_preset_for_args<'a>(
             .trace_phase_preset(DEFAULT_TRACE_PHASE_PRESET)
             .map(|_| DEFAULT_TRACE_PHASE_PRESET)
     })
-}
-
-fn trace_probes_for_args(
-    args: &TraceArgs,
-    rig_context: Option<&TraceRigContext>,
-    extension_id: Option<&str>,
-) -> homeboy::Result<Vec<extension_trace::TraceProbeConfig>> {
-    let Some(context) = rig_context else {
-        return Ok(Vec::new());
-    };
-    let Some(extension_id) = extension_id else {
-        return Ok(Vec::new());
-    };
-    let scenario = trace_scenario(args)?;
-    let workloads = context
-        .rig_spec
-        .trace_workloads
-        .get(extension_id)
-        .map(|workloads| workloads.as_slice())
-        .unwrap_or(&[]);
-    let Some(workload) = workloads
-        .iter()
-        .find(|workload| trace_workload_scenario_id(workload.path()) == scenario)
-    else {
-        return Ok(Vec::new());
-    };
-
-    workload
-        .trace_probes()
-        .iter()
-        .map(|probe| expand_trace_probe(context, probe))
-        .collect()
-}
-
-fn expand_trace_probe(
-    context: &TraceRigContext,
-    probe: &extension_trace::TraceProbeConfig,
-) -> homeboy::Result<extension_trace::TraceProbeConfig> {
-    Ok(match probe {
-        extension_trace::TraceProbeConfig::LogTail {
-            path,
-            grep,
-            match_pattern,
-        } => extension_trace::TraceProbeConfig::LogTail {
-            path: expand_trace_probe_value(context, path),
-            grep: grep.clone(),
-            match_pattern: match_pattern.clone(),
-        },
-        extension_trace::TraceProbeConfig::ProcessSnapshot {
-            pattern,
-            interval_ms,
-        } => extension_trace::TraceProbeConfig::ProcessSnapshot {
-            pattern: expand_trace_probe_value(context, pattern),
-            interval_ms: *interval_ms,
-        },
-    })
-}
-
-fn expand_trace_probe_value(context: &TraceRigContext, value: &str) -> String {
-    let expanded = rig::expand::expand_vars(&context.rig_spec, value);
-    match context.rig_package_root.as_ref() {
-        Some(root) => expanded.replace("${package.root}", &root.to_string_lossy()),
-        None => expanded,
-    }
 }
 
 fn trace_phase_preset_for_args(

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -530,6 +530,8 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
         .unwrap_or_default();
     let experiment_settings = trace_experiment_settings(experiment_plan.as_ref())?;
     let experiment_env = trace_experiment_env(experiment_plan.as_ref())?;
+    let trace_probes =
+        trace_probes_for_args(&args, rig_context.as_ref(), ctx.extension_id.as_deref())?;
     let mut json_settings = experiment_settings;
     json_settings.extend(settings_as_json(&ctx.settings));
     json_settings.extend(
@@ -548,6 +550,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
                 json_settings,
                 env: experiment_env.clone(),
                 workload_paths: extra_workloads,
+                probes: trace_probes,
             },
             scenario_id,
             json_summary: args.json_summary,
@@ -863,6 +866,70 @@ fn default_trace_phase_preset_for_args<'a>(
     })
 }
 
+fn trace_probes_for_args(
+    args: &TraceArgs,
+    rig_context: Option<&TraceRigContext>,
+    extension_id: Option<&str>,
+) -> homeboy::Result<Vec<extension_trace::TraceProbeConfig>> {
+    let Some(context) = rig_context else {
+        return Ok(Vec::new());
+    };
+    let Some(extension_id) = extension_id else {
+        return Ok(Vec::new());
+    };
+    let scenario = trace_scenario(args)?;
+    let workloads = context
+        .rig_spec
+        .trace_workloads
+        .get(extension_id)
+        .map(|workloads| workloads.as_slice())
+        .unwrap_or(&[]);
+    let Some(workload) = workloads
+        .iter()
+        .find(|workload| trace_workload_scenario_id(workload.path()) == scenario)
+    else {
+        return Ok(Vec::new());
+    };
+
+    workload
+        .trace_probes()
+        .iter()
+        .map(|probe| expand_trace_probe(context, probe))
+        .collect()
+}
+
+fn expand_trace_probe(
+    context: &TraceRigContext,
+    probe: &extension_trace::TraceProbeConfig,
+) -> homeboy::Result<extension_trace::TraceProbeConfig> {
+    Ok(match probe {
+        extension_trace::TraceProbeConfig::LogTail {
+            path,
+            grep,
+            match_pattern,
+        } => extension_trace::TraceProbeConfig::LogTail {
+            path: expand_trace_probe_value(context, path),
+            grep: grep.clone(),
+            match_pattern: match_pattern.clone(),
+        },
+        extension_trace::TraceProbeConfig::ProcessSnapshot {
+            pattern,
+            interval_ms,
+        } => extension_trace::TraceProbeConfig::ProcessSnapshot {
+            pattern: expand_trace_probe_value(context, pattern),
+            interval_ms: *interval_ms,
+        },
+    })
+}
+
+fn expand_trace_probe_value(context: &TraceRigContext, value: &str) -> String {
+    let expanded = rig::expand::expand_vars(&context.rig_spec, value);
+    match context.rig_package_root.as_ref() {
+        Some(root) => expanded.replace("${package.root}", &root.to_string_lossy()),
+        None => expanded,
+    }
+}
+
 fn trace_phase_preset_for_args(
     args: &TraceArgs,
     rig_context: Option<&TraceRigContext>,
@@ -987,6 +1054,7 @@ fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
                 json_settings: settings_as_json(&ctx.settings),
                 env: Vec::new(),
                 workload_paths: extra_workloads,
+                probes: Vec::new(),
             },
             rig_id: args.rig,
         },

--- a/src/commands/trace/probes.rs
+++ b/src/commands/trace/probes.rs
@@ -1,0 +1,68 @@
+use homeboy::extension::trace as extension_trace;
+use homeboy::rig;
+
+use super::{trace_scenario, trace_workload_scenario_id, TraceArgs, TraceRigContext};
+
+pub(super) fn trace_probes_for_args(
+    args: &TraceArgs,
+    rig_context: Option<&TraceRigContext>,
+    extension_id: Option<&str>,
+) -> homeboy::Result<Vec<extension_trace::TraceProbeConfig>> {
+    let Some(context) = rig_context else {
+        return Ok(Vec::new());
+    };
+    let Some(extension_id) = extension_id else {
+        return Ok(Vec::new());
+    };
+    let scenario = trace_scenario(args)?;
+    let workloads = context
+        .rig_spec
+        .trace_workloads
+        .get(extension_id)
+        .map(|workloads| workloads.as_slice())
+        .unwrap_or(&[]);
+    let Some(workload) = workloads
+        .iter()
+        .find(|workload| trace_workload_scenario_id(workload.path()) == scenario)
+    else {
+        return Ok(Vec::new());
+    };
+
+    workload
+        .trace_probes()
+        .iter()
+        .map(|probe| expand_trace_probe(context, probe))
+        .collect()
+}
+
+fn expand_trace_probe(
+    context: &TraceRigContext,
+    probe: &extension_trace::TraceProbeConfig,
+) -> homeboy::Result<extension_trace::TraceProbeConfig> {
+    Ok(match probe {
+        extension_trace::TraceProbeConfig::LogTail {
+            path,
+            grep,
+            match_pattern,
+        } => extension_trace::TraceProbeConfig::LogTail {
+            path: expand_trace_probe_value(context, path),
+            grep: grep.clone(),
+            match_pattern: match_pattern.clone(),
+        },
+        extension_trace::TraceProbeConfig::ProcessSnapshot {
+            pattern,
+            interval_ms,
+        } => extension_trace::TraceProbeConfig::ProcessSnapshot {
+            pattern: expand_trace_probe_value(context, pattern),
+            interval_ms: *interval_ms,
+        },
+    })
+}
+
+fn expand_trace_probe_value(context: &TraceRigContext, value: &str) -> String {
+    let expanded = rig::expand::expand_vars(&context.rig_spec, value);
+    match context.rig_package_root.as_ref() {
+        Some(root) => expanded.replace("${package.root}", &root.to_string_lossy()),
+        None => expanded,
+    }
+}

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -13,6 +13,7 @@ pub mod baseline;
 mod overlay;
 mod overlay_lock;
 pub mod parsing;
+pub mod probes;
 pub mod report;
 pub mod run;
 pub mod spans;
@@ -30,6 +31,7 @@ pub use parsing::{
     TraceArtifact, TraceAssertion, TraceEvent, TraceList, TraceScenario, TraceStatus,
 };
 pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, TraceSpanResult};
+pub use probes::TraceProbeConfig;
 pub use report::{
     from_list_workflow, from_main_workflow, from_main_workflow_outputs, TraceAggregateOutput,
     TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceClassificationSummaryOutput,

--- a/src/core/extension/trace/probes.rs
+++ b/src/core/extension/trace/probes.rs
@@ -1,0 +1,508 @@
+//! Passive trace probes that emit core timeline events.
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::error::{Error, Result};
+
+use super::parsing::TraceEvent;
+
+const DEFAULT_PROCESS_INTERVAL_MS: u64 = 1_000;
+const LOG_POLL_INTERVAL_MS: u64 = 50;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum TraceProbeConfig {
+    #[serde(rename = "log.tail")]
+    LogTail {
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        grep: Option<String>,
+        #[serde(default, rename = "match", skip_serializing_if = "Option::is_none")]
+        match_pattern: Option<String>,
+    },
+    #[serde(rename = "process.snapshot")]
+    ProcessSnapshot {
+        pattern: String,
+        #[serde(default, alias = "interval", skip_serializing_if = "Option::is_none")]
+        interval_ms: Option<u64>,
+    },
+}
+
+pub struct ActiveTraceProbes {
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stops: Vec<mpsc::Sender<()>>,
+    handles: Vec<thread::JoinHandle<()>>,
+}
+
+#[derive(Debug, Clone)]
+enum RunningTraceProbeConfig {
+    LogTail {
+        path: String,
+        grep: Option<String>,
+        match_pattern: Option<String>,
+        initial_position: u64,
+    },
+    ProcessSnapshot {
+        pattern: String,
+        interval_ms: Option<u64>,
+    },
+}
+
+impl ActiveTraceProbes {
+    pub fn start(configs: &[TraceProbeConfig]) -> Result<Self> {
+        let started_at = Instant::now();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut stops = Vec::new();
+        let mut handles = Vec::new();
+
+        for config in configs {
+            validate_probe(config)?;
+            let (stop_tx, stop_rx) = mpsc::channel();
+            let events_for_thread = Arc::clone(&events);
+            let config = running_probe_config(config);
+            let handle =
+                thread::spawn(move || run_probe(config, started_at, events_for_thread, stop_rx));
+            stops.push(stop_tx);
+            handles.push(handle);
+        }
+
+        Ok(Self {
+            events,
+            stops,
+            handles,
+        })
+    }
+
+    pub fn stop(mut self) -> Vec<TraceEvent> {
+        for stop in self.stops.drain(..) {
+            let _ = stop.send(());
+        }
+        for handle in self.handles.drain(..) {
+            let _ = handle.join();
+        }
+        let mut events = self
+            .events
+            .lock()
+            .map(|events| events.clone())
+            .unwrap_or_default();
+        events.sort_by_key(|event| event.t_ms);
+        events
+    }
+}
+
+fn running_probe_config(config: &TraceProbeConfig) -> RunningTraceProbeConfig {
+    match config {
+        TraceProbeConfig::LogTail {
+            path,
+            grep,
+            match_pattern,
+        } => RunningTraceProbeConfig::LogTail {
+            path: path.clone(),
+            grep: grep.clone(),
+            match_pattern: match_pattern.clone(),
+            initial_position: std::fs::metadata(path)
+                .map(|metadata| metadata.len())
+                .unwrap_or(0),
+        },
+        TraceProbeConfig::ProcessSnapshot {
+            pattern,
+            interval_ms,
+        } => RunningTraceProbeConfig::ProcessSnapshot {
+            pattern: pattern.clone(),
+            interval_ms: *interval_ms,
+        },
+    }
+}
+
+fn validate_probe(config: &TraceProbeConfig) -> Result<()> {
+    match config {
+        TraceProbeConfig::LogTail {
+            grep,
+            match_pattern,
+            ..
+        } => {
+            if let Some(pattern) = grep.as_ref().or(match_pattern.as_ref()) {
+                Regex::new(pattern).map_err(|e| {
+                    Error::validation_invalid_argument(
+                        "trace_probes.grep",
+                        format!("invalid log.tail regex: {}", e),
+                        None,
+                        None,
+                    )
+                })?;
+            }
+        }
+        TraceProbeConfig::ProcessSnapshot { pattern, .. } => {
+            Regex::new(pattern).map_err(|e| {
+                Error::validation_invalid_argument(
+                    "trace_probes.pattern",
+                    format!("invalid process.snapshot regex: {}", e),
+                    None,
+                    None,
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn run_probe(
+    config: RunningTraceProbeConfig,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    match config {
+        RunningTraceProbeConfig::LogTail {
+            path,
+            grep,
+            match_pattern,
+            initial_position,
+        } => run_log_tail(
+            path,
+            grep.or(match_pattern),
+            initial_position,
+            started_at,
+            events,
+            stop,
+        ),
+        RunningTraceProbeConfig::ProcessSnapshot {
+            pattern,
+            interval_ms,
+        } => run_process_snapshot(
+            pattern,
+            interval_ms.unwrap_or(DEFAULT_PROCESS_INTERVAL_MS),
+            started_at,
+            events,
+            stop,
+        ),
+    }
+}
+
+fn run_log_tail(
+    path: String,
+    pattern: Option<String>,
+    initial_position: u64,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let matcher = pattern
+        .as_deref()
+        .and_then(|pattern| Regex::new(pattern).ok());
+    let path_buf = PathBuf::from(&path);
+    let mut position = initial_position;
+    let mut partial = String::new();
+
+    loop {
+        read_new_log_lines(
+            &path_buf,
+            &path,
+            &mut position,
+            &mut partial,
+            matcher.as_ref(),
+            started_at,
+            &events,
+        );
+        if stop
+            .recv_timeout(Duration::from_millis(LOG_POLL_INTERVAL_MS))
+            .is_ok()
+        {
+            read_new_log_lines(
+                &path_buf,
+                &path,
+                &mut position,
+                &mut partial,
+                matcher.as_ref(),
+                started_at,
+                &events,
+            );
+            if !partial.is_empty() {
+                emit_log_line(
+                    &path,
+                    std::mem::take(&mut partial),
+                    matcher.as_ref(),
+                    started_at,
+                    &events,
+                );
+            }
+            break;
+        }
+    }
+}
+
+fn read_new_log_lines(
+    path_buf: &PathBuf,
+    path: &str,
+    position: &mut u64,
+    partial: &mut String,
+    matcher: Option<&Regex>,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let Ok(mut file) = File::open(path_buf) else {
+        *position = 0;
+        return;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return;
+    };
+    if metadata.len() < *position {
+        *position = 0;
+        partial.clear();
+    }
+    if file.seek(SeekFrom::Start(*position)).is_err() {
+        return;
+    }
+    let mut chunk = String::new();
+    if file.read_to_string(&mut chunk).is_err() || chunk.is_empty() {
+        return;
+    }
+    *position = position.saturating_add(chunk.len() as u64);
+    partial.push_str(&chunk);
+    while let Some(index) = partial.find('\n') {
+        let mut line = partial.drain(..=index).collect::<String>();
+        while line.ends_with(['\n', '\r']) {
+            line.pop();
+        }
+        emit_log_line(path, line, matcher, started_at, events);
+    }
+}
+
+fn emit_log_line(
+    path: &str,
+    line: String,
+    matcher: Option<&Regex>,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "path".to_string(),
+        serde_json::Value::String(path.to_string()),
+    );
+    data.insert("line".to_string(), serde_json::Value::String(line.clone()));
+    push_event(events, event(started_at, "log.tail", "log.line", data));
+
+    if let Some(matcher) = matcher.filter(|matcher| matcher.is_match(&line)) {
+        let mut data = BTreeMap::new();
+        data.insert(
+            "path".to_string(),
+            serde_json::Value::String(path.to_string()),
+        );
+        data.insert("line".to_string(), serde_json::Value::String(line));
+        data.insert(
+            "pattern".to_string(),
+            serde_json::Value::String(matcher.as_str().to_string()),
+        );
+        push_event(events, event(started_at, "log.tail", "log.match", data));
+    }
+}
+
+fn run_process_snapshot(
+    pattern: String,
+    interval_ms: u64,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let Ok(matcher) = Regex::new(&pattern) else {
+        return;
+    };
+    let interval = Duration::from_millis(interval_ms.max(1));
+    let mut previous: Option<BTreeMap<u32, String>> = None;
+
+    loop {
+        let current = matching_processes(&matcher);
+        emit_process_events(&pattern, previous.as_ref(), &current, started_at, &events);
+        previous = Some(current);
+        if stop.recv_timeout(interval).is_ok() {
+            let current = matching_processes(&matcher);
+            emit_process_events(&pattern, previous.as_ref(), &current, started_at, &events);
+            break;
+        }
+    }
+}
+
+fn matching_processes(matcher: &Regex) -> BTreeMap<u32, String> {
+    process_snapshot()
+        .into_iter()
+        .filter(|(_, command)| matcher.is_match(command))
+        .collect()
+}
+
+fn process_snapshot() -> BTreeMap<u32, String> {
+    let output = Command::new("ps").args(["-eo", "pid=,command="]).output();
+    let Ok(output) = output else {
+        return BTreeMap::new();
+    };
+    if !output.status.success() {
+        return BTreeMap::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(parse_ps_line)
+        .collect()
+}
+
+fn parse_ps_line(line: &str) -> Option<(u32, String)> {
+    let trimmed = line.trim_start();
+    let split_at = trimmed.find(char::is_whitespace)?;
+    let (pid, command) = trimmed.split_at(split_at);
+    Some((pid.parse().ok()?, command.trim().to_string()))
+}
+
+fn emit_process_events(
+    pattern: &str,
+    previous: Option<&BTreeMap<u32, String>>,
+    current: &BTreeMap<u32, String>,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "pattern".to_string(),
+        serde_json::Value::String(pattern.to_string()),
+    );
+    data.insert(
+        "processes".to_string(),
+        serde_json::Value::Array(
+            current
+                .iter()
+                .map(|(pid, command)| serde_json::json!({ "pid": pid, "command": command }))
+                .collect(),
+        ),
+    );
+    push_event(
+        events,
+        event(started_at, "process.snapshot", "proc.list", data),
+    );
+
+    let Some(previous) = previous else {
+        return;
+    };
+    let previous_pids = previous.keys().copied().collect::<BTreeSet<_>>();
+    let current_pids = current.keys().copied().collect::<BTreeSet<_>>();
+
+    for pid in current_pids.difference(&previous_pids) {
+        if let Some(command) = current.get(pid) {
+            push_event(
+                events,
+                process_delta_event(started_at, "proc.spawn", *pid, command),
+            );
+        }
+    }
+    for pid in previous_pids.difference(&current_pids) {
+        if let Some(command) = previous.get(pid) {
+            push_event(
+                events,
+                process_delta_event(started_at, "proc.exit", *pid, command),
+            );
+        }
+    }
+}
+
+fn process_delta_event(
+    started_at: Instant,
+    event_name: &str,
+    pid: u32,
+    command: &str,
+) -> TraceEvent {
+    let mut data = BTreeMap::new();
+    data.insert("pid".to_string(), serde_json::json!(pid));
+    data.insert(
+        "command".to_string(),
+        serde_json::Value::String(command.to_string()),
+    );
+    event(started_at, "process.snapshot", event_name, data)
+}
+
+fn event(
+    started_at: Instant,
+    source: &str,
+    event: &str,
+    data: BTreeMap<String, serde_json::Value>,
+) -> TraceEvent {
+    TraceEvent {
+        t_ms: started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        source: source.to_string(),
+        event: event.to_string(),
+        data,
+    }
+}
+
+fn push_event(events: &Arc<Mutex<Vec<TraceEvent>>>, event: TraceEvent) {
+    if let Ok(mut events) = events.lock() {
+        events.push(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn log_tail_emits_line_and_match_events() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let log_path = temp.path().join("app.log");
+        fs::write(&log_path, "old line\n").expect("write initial log");
+
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::LogTail {
+            path: log_path.to_string_lossy().to_string(),
+            grep: Some("needle".to_string()),
+            match_pattern: None,
+        }])
+        .expect("start probes");
+
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&log_path)
+            .and_then(|mut file| {
+                use std::io::Write;
+                writeln!(file, "new needle line")
+            })
+            .expect("append log");
+        thread::sleep(Duration::from_millis(150));
+
+        let events = probes.stop();
+        assert!(events.iter().any(|event| event.event == "log.line"
+            && event.data.get("line").and_then(|value| value.as_str()) == Some("new needle line")));
+        assert!(events.iter().any(|event| event.event == "log.match"));
+        assert!(!events.iter().any(|event| event
+            .data
+            .get("line")
+            .and_then(|value| value.as_str())
+            == Some("old line")));
+    }
+
+    #[test]
+    fn process_snapshot_emits_list_events() {
+        let pattern = std::env::current_exe()
+            .expect("current exe")
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("homeboy")
+            .to_string();
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::ProcessSnapshot {
+            pattern,
+            interval_ms: Some(25),
+        }])
+        .expect("start probes");
+        thread::sleep(Duration::from_millis(80));
+
+        let events = probes.stop();
+        assert!(events
+            .iter()
+            .any(|event| event.source == "process.snapshot" && event.event == "proc.list"));
+    }
+}

--- a/src/core/extension/trace/probes.rs
+++ b/src/core/extension/trace/probes.rs
@@ -202,41 +202,58 @@ fn run_log_tail(
     let path_buf = PathBuf::from(&path);
     let mut position = initial_position;
     let mut partial = String::new();
+    let drain = LogTailDrain {
+        path_buf: &path_buf,
+        path: &path,
+        matcher: matcher.as_ref(),
+        started_at,
+        events: &events,
+    };
 
     loop {
-        read_new_log_lines(
-            &path_buf,
-            &path,
-            &mut position,
-            &mut partial,
-            matcher.as_ref(),
-            started_at,
-            &events,
-        );
+        drain_log_tail_once(drain, &mut position, &mut partial, false);
         if stop
             .recv_timeout(Duration::from_millis(LOG_POLL_INTERVAL_MS))
             .is_ok()
         {
-            read_new_log_lines(
-                &path_buf,
-                &path,
-                &mut position,
-                &mut partial,
-                matcher.as_ref(),
-                started_at,
-                &events,
-            );
-            if !partial.is_empty() {
-                emit_log_line(
-                    &path,
-                    std::mem::take(&mut partial),
-                    matcher.as_ref(),
-                    started_at,
-                    &events,
-                );
-            }
+            drain_log_tail_once(drain, &mut position, &mut partial, true);
             break;
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LogTailDrain<'a> {
+    path_buf: &'a PathBuf,
+    path: &'a str,
+    matcher: Option<&'a Regex>,
+    started_at: Instant,
+    events: &'a Arc<Mutex<Vec<TraceEvent>>>,
+}
+
+fn drain_log_tail_once(
+    drain: LogTailDrain<'_>,
+    position: &mut u64,
+    partial: &mut String,
+    flush_partial: bool,
+) {
+    read_new_log_lines(
+        drain.path_buf,
+        drain.path,
+        position,
+        partial,
+        drain.matcher,
+        drain.started_at,
+        drain.events,
+    );
+    if flush_partial && !partial.is_empty() {
+        emit_log_line(
+            drain.path,
+            std::mem::take(partial),
+            drain.matcher,
+            drain.started_at,
+            drain.events,
+        );
     }
 }
 
@@ -285,27 +302,53 @@ fn emit_log_line(
     started_at: Instant,
     events: &Arc<Mutex<Vec<TraceEvent>>>,
 ) {
+    push_log_event(
+        events,
+        started_at,
+        "log.line",
+        log_line_data(path, &line, None),
+    );
+
+    if let Some(matcher) = matcher.filter(|matcher| matcher.is_match(&line)) {
+        push_log_event(
+            events,
+            started_at,
+            "log.match",
+            log_line_data(path, &line, Some(matcher.as_str())),
+        );
+    }
+}
+
+fn push_log_event(
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+    started_at: Instant,
+    event_name: &str,
+    data: BTreeMap<String, serde_json::Value>,
+) {
+    push_event(events, event(started_at, "log.tail", event_name, data));
+}
+
+fn log_line_data(
+    path: &str,
+    line: &str,
+    pattern: Option<&str>,
+) -> BTreeMap<String, serde_json::Value> {
     let mut data = BTreeMap::new();
     data.insert(
         "path".to_string(),
         serde_json::Value::String(path.to_string()),
     );
-    data.insert("line".to_string(), serde_json::Value::String(line.clone()));
-    push_event(events, event(started_at, "log.tail", "log.line", data));
-
-    if let Some(matcher) = matcher.filter(|matcher| matcher.is_match(&line)) {
-        let mut data = BTreeMap::new();
-        data.insert(
-            "path".to_string(),
-            serde_json::Value::String(path.to_string()),
-        );
-        data.insert("line".to_string(), serde_json::Value::String(line));
+    data.insert(
+        "line".to_string(),
+        serde_json::Value::String(line.to_string()),
+    );
+    if let Some(pattern) = pattern {
         data.insert(
             "pattern".to_string(),
-            serde_json::Value::String(matcher.as_str().to_string()),
+            serde_json::Value::String(pattern.to_string()),
         );
-        push_event(events, event(started_at, "log.tail", "log.match", data));
     }
+    data
 }
 
 fn run_process_snapshot(
@@ -450,6 +493,47 @@ fn push_event(events: &Arc<Mutex<Vec<TraceEvent>>>, event: TraceEvent) {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn active_trace_probes_start_rejects_invalid_regex() {
+        let result = ActiveTraceProbes::start(&[TraceProbeConfig::ProcessSnapshot {
+            pattern: "(".to_string(),
+            interval_ms: Some(25),
+        }]);
+        let error = result.err().expect("invalid regex should fail start");
+
+        assert!(error.to_string().contains("invalid process.snapshot regex"));
+    }
+
+    #[test]
+    fn active_trace_probes_stop_returns_sorted_events() {
+        let events = Arc::new(Mutex::new(vec![
+            TraceEvent {
+                t_ms: 20,
+                source: "test".to_string(),
+                event: "later".to_string(),
+                data: BTreeMap::new(),
+            },
+            TraceEvent {
+                t_ms: 10,
+                source: "test".to_string(),
+                event: "earlier".to_string(),
+                data: BTreeMap::new(),
+            },
+        ]));
+        let probes = ActiveTraceProbes {
+            events,
+            stops: Vec::new(),
+            handles: Vec::new(),
+        };
+
+        let events = probes.stop();
+
+        assert_eq!(
+            events.iter().map(|event| event.t_ms).collect::<Vec<_>>(),
+            vec![10, 20]
+        );
+    }
 
     #[test]
     fn log_tail_emits_line_and_match_events() {

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -138,12 +138,13 @@ fn run_trace_workflow_with_context(
     };
     let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
     let active_probes = ActiveTraceProbes::start(&args.runner_inputs.probes)?;
-    let runner_output = match build_trace_runner(execution_context, component, &args, run_dir, false) {
-        Ok(output) => output,
-        Err(error) => {
-            return cleanup_after_overlay_error(&applied_overlays, args.keep_overlay, error)
-        }
-    };
+    let runner_output =
+        match build_trace_runner(execution_context, component, &args, run_dir, false) {
+            Ok(output) => output,
+            Err(error) => {
+                return cleanup_after_overlay_error(&applied_overlays, args.keep_overlay, error)
+            }
+        };
     let probe_events = active_probes.stop();
     if !args.keep_overlay {
         cleanup_trace_overlays(&applied_overlays)?
@@ -1044,8 +1045,9 @@ JSON
                 crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
 
-        let output = run_trace_workflow_with_context(&context, &component, args, &run_dir, None)
-            .expect("trace workflow");
+        let output =
+            run_trace_workflow_with_context(Some(&context), &component, args, &run_dir, None)
+                .expect("trace workflow");
         let results = output.results.expect("results");
         assert!(results
             .timeline

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -23,6 +23,7 @@ use super::overlay::{
 use super::parsing::{
     parse_trace_list_str, parse_trace_results_file, TraceList, TraceResults, TraceSpanDefinition,
 };
+use super::probes::{ActiveTraceProbes, TraceProbeConfig};
 
 #[derive(Debug, Clone)]
 pub struct TraceRunWorkflowArgs {
@@ -57,6 +58,7 @@ pub struct TraceRunnerInputs {
     pub json_settings: Vec<(String, serde_json::Value)>,
     pub env: Vec<(String, String)>,
     pub workload_paths: Vec<PathBuf>,
+    pub probes: Vec<TraceProbeConfig>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -135,13 +137,14 @@ fn run_trace_workflow_with_context(
         Some(acquire_trace_overlay_locks(&args.overlays, run_dir)?)
     };
     let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
-    let runner_output =
-        match build_trace_runner(execution_context, component, &args, run_dir, false) {
-            Ok(runner) => runner,
-            Err(error) => {
-                return cleanup_after_overlay_error(&applied_overlays, args.keep_overlay, error)
-            }
-        };
+    let active_probes = ActiveTraceProbes::start(&args.runner_inputs.probes)?;
+    let runner_output = match build_trace_runner(execution_context, component, &args, run_dir, false) {
+        Ok(output) => output,
+        Err(error) => {
+            return cleanup_after_overlay_error(&applied_overlays, args.keep_overlay, error)
+        }
+    };
+    let probe_events = active_probes.stop();
     if !args.keep_overlay {
         cleanup_trace_overlays(&applied_overlays)?
     }
@@ -157,6 +160,8 @@ fn run_trace_workflow_with_context(
     };
     let failure = (!runner_output.success).then(|| failure_from_output(&args, &runner_output));
     if let Some(parsed) = results.as_mut() {
+        parsed.timeline.extend(probe_events);
+        parsed.timeline.sort_by_key(|event| event.t_ms);
         super::spans::apply_span_definitions(parsed, &args.span_definitions);
         super::assertions::apply_temporal_assertions(parsed);
         persist_trace_results(&results_path, parsed)?;
@@ -182,7 +187,6 @@ fn run_trace_workflow_with_context(
     } else {
         runner_output.exit_code
     };
-
     let rig_id = args.rig_id.as_deref();
     let source_path = Path::new(component_path);
     let mut baseline_comparison = None;
@@ -771,6 +775,7 @@ JSON
                 json_settings: Vec::new(),
                 env: Vec::new(),
                 workload_paths: vec![component_dir.join("trace-fixture.trace.mjs")],
+                probes: Vec::new(),
             },
             scenario_id: "close-window".to_string(),
             json_summary: false,
@@ -970,6 +975,83 @@ JSON
         assert_eq!(failure.exit_code, 2);
         assert!(failure.stderr_excerpt.contains("line 24"));
         assert!(!failure.stderr_excerpt.contains("line 0"));
+    }
+
+    #[test]
+    fn run_trace_workflow_merges_probe_events_into_results() {
+        let _home_env_guard = crate::test_support::home_env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let extension_dir = temp.path().join("extension");
+        let component_dir = temp.path().join("component");
+        let log_path = temp.path().join("probe.log");
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::create_dir_all(&component_dir).unwrap();
+        fs::write(&log_path, "before\n").unwrap();
+        write_extension_manifest(&extension_dir);
+        let script = extension_dir.join("trace-runner.sh");
+        fs::write(
+            &script,
+            format!(
+                r#"#!/usr/bin/env bash
+set -euo pipefail
+printf 'probe needle\n' >> '{}'
+cat > "$HOMEBOY_TRACE_RESULTS_FILE" <<JSON
+{{"component_id":"example","scenario_id":"probes","status":"pass","timeline":[],"assertions":[],"artifacts":[]}}
+JSON
+"#,
+                log_path.display()
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script, perms).unwrap();
+        }
+
+        let component = component_with_extension("example", &component_dir);
+        let context = trace_context(&component, &extension_dir);
+        let run_dir = RunDir::create().unwrap();
+        let args = TraceRunWorkflowArgs {
+            component_label: "example".to_string(),
+            component_id: "example".to_string(),
+            path_override: Some(component_dir.to_string_lossy().to_string()),
+            settings: Vec::new(),
+            runner_inputs: TraceRunnerInputs {
+                probes: vec![TraceProbeConfig::LogTail {
+                    path: log_path.to_string_lossy().to_string(),
+                    grep: Some("needle".to_string()),
+                    match_pattern: None,
+                }],
+                ..TraceRunnerInputs::default()
+            },
+            scenario_id: "probes".to_string(),
+            json_summary: false,
+            rig_id: None,
+            overlays: Vec::new(),
+            keep_overlay: false,
+            span_definitions: Vec::new(),
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        };
+
+        let output = run_trace_workflow_with_context(&context, &component, args, &run_dir, None)
+            .expect("trace workflow");
+        let results = output.results.expect("results");
+        assert!(results
+            .timeline
+            .iter()
+            .any(|event| event.event == "log.match"));
+        run_dir.cleanup();
     }
 
     #[test]

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::extension::trace::TraceProbeConfig;
 use crate::extension::trace::TraceSpanMetadata;
 use std::collections::{BTreeMap, HashMap};
 
@@ -322,6 +323,9 @@ pub struct WorkloadEntry {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub trace_guardrails: Vec<TraceGuardrailSpec>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace_probes: Vec<TraceProbeConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -442,6 +446,13 @@ impl WorkloadSpec {
             WorkloadSpec::Detailed(entry) => &entry.trace_guardrails,
         }
     }
+
+    pub fn trace_probes(&self) -> &[TraceProbeConfig] {
+        match self {
+            WorkloadSpec::Path(_) => &[],
+            WorkloadSpec::Detailed(entry) => &entry.trace_probes,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -496,6 +507,7 @@ mod tests {
             trace_default_phase_preset: None,
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
+            trace_probes: Vec::new(),
         });
 
         assert_eq!(workload.trace_phase_preset("missing"), None);
@@ -554,6 +566,7 @@ mod tests {
             trace_default_phase_preset: Some("startup".to_string()),
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
+            trace_probes: Vec::new(),
         });
 
         assert_eq!(workload.trace_default_phase_preset(), Some("startup"));

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -557,6 +557,35 @@ mod tests {
     }
 
     #[test]
+    fn test_trace_probes() {
+        let workload: WorkloadSpec = serde_json::from_str(
+            r#"{
+                "path": "/tmp/scoped.trace.mjs",
+                "trace_probes": [
+                    { "type": "log.tail", "path": "/tmp/app.log", "grep": "ready" },
+                    { "type": "process.snapshot", "pattern": "node.*serve", "interval_ms": 250 }
+                ]
+            }"#,
+        )
+        .expect("parse detailed workload probes");
+
+        assert_eq!(workload.trace_probes().len(), 2);
+        assert!(matches!(
+            &workload.trace_probes()[0],
+            TraceProbeConfig::LogTail { path, grep, .. }
+                if path == "/tmp/app.log" && grep.as_deref() == Some("ready")
+        ));
+        assert!(matches!(
+            &workload.trace_probes()[1],
+            TraceProbeConfig::ProcessSnapshot { pattern, interval_ms }
+                if pattern == "node.*serve" && *interval_ms == Some(250)
+        ));
+        assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
+            .trace_probes()
+            .is_empty());
+    }
+
+    #[test]
     fn test_trace_default_phase_preset() {
         let workload = WorkloadSpec::Detailed(WorkloadEntry {
             path: "trace.mjs".to_string(),

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -351,6 +351,7 @@ fn workload_with_trace_metadata() -> WorkloadSpec {
             },
         )]),
         trace_guardrails: Vec::new(),
+        trace_probes: Vec::new(),
     })
 }
 


### PR DESCRIPTION
## Summary
- Add a minimal trace probe substrate that runs passive probes beside trace workloads and merges collected events into the existing timeline envelope.
- Implement portable v1 `log.tail` and `process.snapshot` probes only, with rig workload `trace_probes` configuration.
- Document the probe contract under architecture and link it from `homeboy trace` docs.

## Tests
- `cargo test trace`
- `cargo test core::rig::spec::spec_test::test_spec_trace_variants_parse_multi_component_overlays`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the minimal probe substrate, docs, and smoke coverage; Chris remains responsible for review and merge.