### PR TITLE
Support component self-hosted scripts

### DIFF
--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -1,8 +1,8 @@
-# Extension runner contract
+# Runner contract
 
-The contract between Homeboy core and extension runner scripts: what
-capabilities exist, what env vars flow in, what sidecar files extensions
-are expected to write, and what exit codes mean.
+The contract between Homeboy core and runner scripts: what capabilities
+exist, what env vars flow in, what sidecar files scripts are expected to
+write, and what exit codes mean.
 
 This is the authoritative reference for extension authors wiring a new
 runner and for core maintainers improving the cross-extension surface.
@@ -13,8 +13,13 @@ For the cross-command verification phase model (`syntax`, `lint`, `typecheck`,
 
 ## Capability model
 
-Each extension declares scripts per-capability in its manifest
-(`<extension-id>.json`). Four capabilities are first-class in core:
+Each extension can declare scripts per-capability in its manifest
+(`<extension-id>.json`). Components can also declare self-hosted scripts
+directly in `homeboy.json` under `scripts.<capability>`. Component scripts
+resolve first, linked extension behavior resolves second, and missing support
+is not-applicable.
+
+Four capabilities are first-class in core:
 
 | Capability | Manifest field | Typical script | Invoked by |
 |------------|---------------|----------------|------------|
@@ -27,6 +32,11 @@ Each extension declares scripts per-capability in its manifest
 the runtime. `audit` is a core-owned framework (pattern detectors, shared
 scaffolding checks, orphaned-test detection, etc.) — extensions don't
 implement it directly.
+
+Component-owned scripts use the same capability contract without extension
+claiming. They run sequentially in the component root and set
+`HOMEBOY_EXTENSION_ID=component-script` plus `HOMEBOY_EXTENSION_PATH` to the
+component path so existing runner helpers can identify the source.
 
 Extensions may omit any capability. Detection uses `has_lint()` /
 `has_test()` / `has_build()` accessors on the manifest (see

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -30,13 +30,14 @@ This is useful for:
 
 The override is transient — it does not modify the stored component config.
 
-Requires exactly one linked extension with build support. Component-level `build_command` is not supported as configuration; the `build_command` field in command output is the command Homeboy resolved from the linked extension for this run.
+Build resolution checks component-owned `scripts.build` first. If absent, it requires exactly one linked extension with build support. Component-level `build_command` is not supported as configuration; the `build_command` field in command output is the command Homeboy resolved for this run.
 
 Useful remediation paths when a component is not buildable:
 
 - Link a build-capable extension: `homeboy component set <id> --extension <extension_id>`
+- Add a component-owned shell build: `"scripts": { "build": ["npm run build"] }`
 - Inspect installed extensions: `homeboy extension list`
-- Use a rig `command` step for local or private build workflows that do not belong in an extension.
+- Use a rig `command` step for workflows that are environment orchestration rather than component build behavior.
 
 ## Pre-Build Validation
 
@@ -65,14 +66,14 @@ Example extension configuration:
 {
   "command": "build.run",
   "component_id": "<component_id>",
-  "build_command": "<extension-resolved command string>",
+  "build_command": "<resolved command string>",
   "stdout": "<stdout>",
   "stderr": "<stderr>",
   "success": true
 }
 ```
 
-`stdout` and `stderr` are omitted when empty. `build_command` is diagnostic output from extension resolution, not a component-level config field.
+`stdout` and `stderr` are omitted when empty. `build_command` is diagnostic output from command resolution, not a component-level config field.
 
 ### Bulk (`--json`)
 

--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -96,7 +96,7 @@ Components also define extension usage via `extensions`:
 homeboy component set <id> --json '{"extensions": {"github": {"settings": {}}, "rust": {"settings": {}}}}'
 ```
 
-`homeboy build`, `homeboy lint`, `homeboy test`, and `homeboy review` run through linked extensions. Components do not support a standalone `build_command` field; use an extension for component workflows or a rig `command` step for one-off shell commands.
+`homeboy build`, `homeboy lint`, `homeboy test`, `homeboy bench`, and `homeboy trace` check component-owned `scripts.<capability>` first, then linked extensions. Components do not support a standalone `build_command` field; use `scripts.build` for component-owned shell builds.
 
 ```json
 {

--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -19,6 +19,13 @@ Component configuration defines buildable and deployable units stored in `compon
     }
   ],
   "changelog_target": "string",
+  "scripts": {
+    "lint": ["shell command"],
+    "test": ["shell command"],
+    "build": ["shell command"],
+    "bench": ["shell command"],
+    "trace": ["shell command"]
+  },
   "extensions": {},
   "release": {}
 }
@@ -47,7 +54,12 @@ Component configuration defines buildable and deployable units stored in `compon
 - **`extensions`** (object): Extension-specific settings
   - Keys are extension IDs (e.g., `"wordpress"`, `"rust"`)
   - Values are extension setting objects
-  - Build, lint, test, bench, and review support comes from linked extensions; component-level `build_command` is not supported.
+- **`scripts`** (object): Component-owned shell commands for extension-shaped capabilities
+  - Supported keys: `lint`, `test`, `build`, `bench`, `trace`
+  - Each value is an array of shell commands run sequentially in `local_path`
+  - Resolution order is `scripts.<capability>` first, then linked extension support, then not-applicable
+  - Scripts receive the same runner env paths (`HOMEBOY_COMPONENT_ID`, `HOMEBOY_COMPONENT_PATH`, `HOMEBOY_RUN_DIR` and sidecar file vars when relevant) as extension runners, with `HOMEBOY_EXTENSION_ID=component-script`
+  - Use `scripts.build`, not `build_command`; `build_command` is still only a diagnostic output field.
 - **`release`** (object): Component-scoped release configuration
   - **`enabled`** (boolean): Whether release pipeline is enabled
   - **`steps`** (array): Release step definitions

--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -73,9 +73,10 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 | `extract_command` | Post-upload command (supports `{artifact}`, `{targetDir}`) |
 | `version_targets` | Version detection patterns |
 | `changelog_target` | Path to changelog file |
+| `scripts` | Optional component-owned `lint`, `test`, `build`, `bench`, and `trace` shell commands |
 | `extensions` | Extension configuration (e.g., `{"wordpress": {}}`) |
 
-Build, lint, test, bench, and review behavior comes from linked extensions. For one-off shell commands, use a rig `command` step; component-level `build_command` is not supported.
+Build, lint, test, bench, and trace behavior resolves from `scripts.<capability>` first, then linked extensions. Use `scripts.build` for component-owned shell builds; component-level `build_command` is not supported.
 
 ## Precedence
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -92,12 +92,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         extension_overrides: args.extension_override.extensions.clone(),
     })?;
 
-    if args.extension_override.extensions.is_empty()
-        && !args.fix
-        && source_ctx
-            .component
-            .has_self_check(ExtensionCapability::Lint)
-    {
+    if !args.fix && source_ctx.component.has_script(ExtensionCapability::Lint) {
         let observation = LintObservation::start(
             source_ctx.component_id.clone(),
             &source_ctx.source_path,

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -158,12 +158,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         extension_overrides: args.extension_override.extensions.clone(),
     })?;
 
-    if args.extension_override.extensions.is_empty()
-        && !args.drift
-        && source_ctx
-            .component
-            .has_self_check(ExtensionCapability::Test)
-    {
+    if !args.drift && source_ctx.component.has_script(ExtensionCapability::Test) {
         let observation = start_test_observation(
             &source_ctx.component_id,
             &source_ctx.source_path,

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -128,6 +128,20 @@ pub struct SelfCheckConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ComponentScriptsConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lint: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub test: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub build: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bench: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(from = "RawComponent", into = "RawComponent")]
 pub struct Component {
     pub id: String,
@@ -162,6 +176,11 @@ pub struct Component {
     pub scopes: Option<ScopeConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub self_checks: Option<SelfCheckConfig>,
+    /// Component-owned shell scripts that satisfy Homeboy command capabilities
+    /// without requiring an extension. Resolution order is `scripts.*` first,
+    /// then extension-claimed behavior, then not-applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit: Option<AuditConfig>,
     /// Override the CLI path used by extension deploy install steps.
@@ -231,6 +250,8 @@ struct RawComponent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     self_checks: Option<SelfCheckConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    scripts: Option<ComponentScriptsConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     audit: Option<AuditConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cli_path: Option<String>,
@@ -282,6 +303,7 @@ impl From<RawComponent> for Component {
             docs_dirs: raw.docs_dirs,
             scopes: raw.scopes,
             self_checks: raw.self_checks,
+            scripts: raw.scripts,
             audit: raw.audit,
             cli_path: raw.cli_path,
         }
@@ -317,6 +339,7 @@ impl From<Component> for RawComponent {
             docs_dirs: c.docs_dirs,
             scopes: c.scopes,
             self_checks: c.self_checks,
+            scripts: c.scripts,
             audit: c.audit,
             cli_path: c.cli_path,
         }
@@ -389,6 +412,7 @@ impl Component {
             docs_dirs: Vec::new(),
             scopes: None,
             self_checks: None,
+            scripts: None,
             audit: None,
             cli_path: None,
         }
@@ -491,6 +515,28 @@ impl Component {
 
     pub fn has_self_check(&self, capability: crate::extension::ExtensionCapability) -> bool {
         !self.self_check_commands(capability).is_empty()
+    }
+
+    pub fn script_commands(&self, capability: crate::extension::ExtensionCapability) -> &[String] {
+        if let Some(scripts) = self.scripts.as_ref() {
+            let commands = match capability {
+                crate::extension::ExtensionCapability::Lint => &scripts.lint,
+                crate::extension::ExtensionCapability::Test => &scripts.test,
+                crate::extension::ExtensionCapability::Build => &scripts.build,
+                crate::extension::ExtensionCapability::Bench => &scripts.bench,
+                crate::extension::ExtensionCapability::Trace => &scripts.trace,
+            };
+            if !commands.is_empty() {
+                return commands;
+            }
+        }
+
+        // Existing `self_checks` remains a lint/test compatibility source.
+        self.self_check_commands(capability)
+    }
+
+    pub fn has_script(&self, capability: crate::extension::ExtensionCapability) -> bool {
+        !self.script_commands(capability).is_empty()
     }
 
     /// Ensure `remote_path` is populated. If empty, attempt auto-resolution.

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -122,6 +122,48 @@ pub fn run_bench_list_workflow(
     args: BenchListWorkflowArgs,
     run_dir: &RunDir,
 ) -> Result<BenchListWorkflowResult> {
+    if component.has_script(ExtensionCapability::Bench) {
+        let source_path = crate::extension::component_script::source_path(
+            component,
+            args.path_override.as_deref(),
+        );
+        let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+        let output = crate::extension::component_script::run_component_scripts_with_run_dir(
+            component,
+            ExtensionCapability::Bench,
+            &source_path,
+            run_dir,
+            true,
+            &[("HOMEBOY_BENCH_LIST_ONLY".to_string(), "1".to_string())],
+            &args.passthrough_args,
+        )?;
+        if !output.success {
+            return Err(Error::validation_invalid_argument(
+                "bench_list",
+                format!(
+                    "bench scenario discovery failed with exit code {}",
+                    output.exit_code
+                ),
+                Some(format!(
+                    "stdout:\n{}\n\nstderr:\n{}",
+                    output.stdout, output.stderr
+                )),
+                None,
+            ));
+        }
+        let parsed = apply_scenario_filter(
+            parsing::parse_bench_results_file(&results_file)?,
+            &args.scenario_ids,
+        )?;
+        let count = parsed.scenarios.len();
+        return Ok(BenchListWorkflowResult {
+            component: args.component_label,
+            component_id: parsed.component_id,
+            scenarios: parsed.scenarios,
+            count,
+        });
+    }
+
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
     let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
 
@@ -425,6 +467,84 @@ pub fn run_main_bench_workflow(
                 Some("bench.run.shared_state".to_string()),
             )
         })?;
+    }
+
+    if component.has_script(ExtensionCapability::Bench) {
+        let script_output = crate::extension::component_script::run_component_scripts_with_run_dir(
+            component,
+            ExtensionCapability::Bench,
+            source_path,
+            run_dir,
+            true,
+            &[
+                (
+                    "HOMEBOY_BENCH_ITERATIONS".to_string(),
+                    args.iterations.to_string(),
+                ),
+                (
+                    "HOMEBOY_BENCH_WARMUP_ITERATIONS".to_string(),
+                    args.warmup_iterations.unwrap_or(0).to_string(),
+                ),
+                (
+                    "HOMEBOY_BENCH_SCENARIOS".to_string(),
+                    args.scenario_ids.join(","),
+                ),
+            ],
+            &args.passthrough_args,
+        )?;
+        let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
+        let mut parsed = if results_file.exists() {
+            parse_execution_results_file(&results_file, &args.scenario_ids, script_output.success)?
+        } else {
+            None
+        };
+        if let Some(results) = parsed.as_mut() {
+            results.run_metadata = Some(BenchRunMetadata {
+                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                started_at: started_at.clone(),
+                shared_state: args
+                    .shared_state
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string()),
+                iterations: args.iterations,
+                execution: args.execution,
+                warmup_iterations: args.warmup_iterations,
+                selected_scenarios: args.scenario_ids.clone(),
+                env_overrides: BTreeMap::new(),
+                workloads: Vec::new(),
+                runner: Some(BenchRunnerMetadata {
+                    extension: "component-script".to_string(),
+                    path: source_path.to_string_lossy().to_string(),
+                    source_revision: None,
+                }),
+                diagnostics: Vec::new(),
+            });
+        }
+        let status = if script_output.success {
+            "passed"
+        } else {
+            "failed"
+        };
+        let failure = (!script_output.success).then(|| BenchRunFailure {
+            component_id: args.component_id.clone(),
+            component_path: Some(source_path.to_string_lossy().to_string()),
+            scenario_id: failure_scenario_id(&args.scenario_ids),
+            exit_code: script_output.exit_code,
+            stderr_tail: stderr_tail(&script_output.stderr),
+            diagnostics: Vec::new(),
+        });
+        return Ok(BenchRunWorkflowResult {
+            status: status.to_string(),
+            component: args.component_label,
+            exit_code: script_output.exit_code,
+            iterations: args.iterations,
+            results: parsed,
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: Some(vec!["Component scripts use the extension runner env contract without extension resolution.".to_string()]),
+            failure,
+            diagnostics: Vec::new(),
+        });
     }
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -122,12 +122,12 @@ pub fn run_bench_list_workflow(
     args: BenchListWorkflowArgs,
     run_dir: &RunDir,
 ) -> Result<BenchListWorkflowResult> {
+    let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
     if component.has_script(ExtensionCapability::Bench) {
         let source_path = crate::extension::component_script::source_path(
             component,
             args.path_override.as_deref(),
         );
-        let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
         let output = crate::extension::component_script::run_component_scripts_with_run_dir(
             component,
             ExtensionCapability::Bench,
@@ -137,36 +137,16 @@ pub fn run_bench_list_workflow(
             &[("HOMEBOY_BENCH_LIST_ONLY".to_string(), "1".to_string())],
             &args.passthrough_args,
         )?;
-        if !output.success {
-            return Err(Error::validation_invalid_argument(
-                "bench_list",
-                format!(
-                    "bench scenario discovery failed with exit code {}",
-                    output.exit_code
-                ),
-                Some(format!(
-                    "stdout:\n{}\n\nstderr:\n{}",
-                    output.stdout, output.stderr
-                )),
-                None,
-            ));
-        }
-        let parsed = apply_scenario_filter(
-            parsing::parse_bench_results_file(&results_file)?,
-            &args.scenario_ids,
+        ensure_bench_list_success(
+            output.exit_code,
+            output.success,
+            &output.stdout,
+            &output.stderr,
         )?;
-        let count = parsed.scenarios.len();
-        return Ok(BenchListWorkflowResult {
-            component: args.component_label,
-            component_id: parsed.component_id,
-            scenarios: parsed.scenarios,
-            count,
-        });
+        return bench_list_result(args.component_label, results_file, &args.scenario_ids);
     }
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Bench)?;
-    let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
-
     let runner_output = build_runner(
         &execution_context,
         component,
@@ -201,29 +181,46 @@ pub fn run_bench_list_workflow(
     .env("HOMEBOY_BENCH_LIST_ONLY", "1")
     .run()?;
 
-    if !runner_output.success {
-        return Err(Error::validation_invalid_argument(
-            "bench_list",
-            format!(
-                "bench scenario discovery failed with exit code {}",
-                runner_output.exit_code
-            ),
-            Some(format!(
-                "stdout:\n{}\n\nstderr:\n{}",
-                runner_output.stdout, runner_output.stderr
-            )),
-            None,
-        ));
+    ensure_bench_list_success(
+        runner_output.exit_code,
+        runner_output.success,
+        &runner_output.stdout,
+        &runner_output.stderr,
+    )?;
+    bench_list_result(args.component_label, results_file, &args.scenario_ids)
+}
+
+fn ensure_bench_list_success(
+    exit_code: i32,
+    success: bool,
+    stdout: &str,
+    stderr: &str,
+) -> Result<()> {
+    if success {
+        return Ok(());
     }
 
+    Err(Error::validation_invalid_argument(
+        "bench_list",
+        format!("bench scenario discovery failed with exit code {exit_code}"),
+        Some(format!("stdout:\n{stdout}\n\nstderr:\n{stderr}")),
+        None,
+    ))
+}
+
+fn bench_list_result(
+    component_label: String,
+    results_file: PathBuf,
+    scenario_ids: &[String],
+) -> Result<BenchListWorkflowResult> {
     let parsed = apply_scenario_filter(
         parsing::parse_bench_results_file(&results_file)?,
-        &args.scenario_ids,
+        scenario_ids,
     )?;
     let count = parsed.scenarios.len();
 
     Ok(BenchListWorkflowResult {
-        component: args.component_label,
+        component: component_label,
         component_id: parsed.component_id,
         scenarios: parsed.scenarios,
         count,

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -20,6 +20,9 @@ pub use artifact::{resolve_artifact_path, resolve_artifact_path_from_root};
 
 #[derive(Debug, Clone)]
 pub enum ResolvedBuildCommand {
+    ComponentScript {
+        command: String,
+    },
     ExtensionProvided {
         context: ExtensionExecutionContext,
         command: String,
@@ -34,6 +37,7 @@ pub enum ResolvedBuildCommand {
 impl ResolvedBuildCommand {
     pub fn command(&self) -> &str {
         match self {
+            ResolvedBuildCommand::ComponentScript { command } => command,
             ResolvedBuildCommand::ExtensionProvided { command, .. } => command,
             ResolvedBuildCommand::LocalScript { command, .. } => command,
         }
@@ -43,9 +47,17 @@ impl ResolvedBuildCommand {
 /// Resolve build command for a component using extension-managed build configuration.
 ///
 /// Priority:
-/// 1. Extension's bundled script (`extension.build.extension_script`)
-/// 2. Local script matching the extension's `script_names` pattern
+/// 1. Component-owned `scripts.build`
+/// 2. Extension's bundled script (`extension.build.extension_script`)
+/// 3. Local script matching the extension's `script_names` pattern
 pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBuildCommand> {
+    let component_scripts = component.script_commands(ExtensionCapability::Build);
+    if !component_scripts.is_empty() {
+        return Ok(ResolvedBuildCommand::ComponentScript {
+            command: component_scripts.join(" && "),
+        });
+    }
+
     // 1. Check exactly one build-capable extension for bundled script or local script patterns
     if let Ok(context) = extension::resolve_execution_context(component, ExtensionCapability::Build)
     {
@@ -381,6 +393,7 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
     let resolved = resolve_build_command(comp)?;
     let build_cmd = resolved.command().to_string();
     let build_context = match &resolved {
+        ResolvedBuildCommand::ComponentScript { .. } => None,
         ResolvedBuildCommand::ExtensionProvided { context, .. } => Some(context),
         _ => None,
     };
@@ -406,7 +419,15 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
 
     // Execute via ExtensionRunner — uses the full exec context protocol (settings,
     // project info, context version) instead of the minimal env var set.
-    let runner_output = if let Some(context) = build_context {
+    let runner_output = if let ResolvedBuildCommand::ComponentScript { .. } = &resolved {
+        crate::extension::component_script::run_component_scripts(
+            comp,
+            extension::ExtensionCapability::Build,
+            &validated_path,
+            true,
+        )?
+        .into()
+    } else if let Some(context) = build_context {
         extension::ExtensionRunner::for_context(context.clone())
             .component(comp.clone())
             .working_dir(&local_path_str)

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -185,3 +185,7 @@ pub(crate) fn source_path(component: &Component, path_override: Option<&str>) ->
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(&component.local_path))
 }
+
+#[cfg(test)]
+#[path = "../../../tests/core/extension/component_script_test.rs"]
+mod component_script_test;

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -1,0 +1,187 @@
+use std::path::{Path, PathBuf};
+
+use crate::component::Component;
+use crate::engine::run_dir::RunDir;
+use crate::error::{Error, Result};
+use crate::extension::{exec_context, ExtensionCapability, RunnerOutput};
+
+#[derive(Debug, Clone)]
+pub struct ComponentScriptOutput {
+    pub exit_code: i32,
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl From<RunnerOutput> for ComponentScriptOutput {
+    fn from(output: RunnerOutput) -> Self {
+        Self {
+            exit_code: output.exit_code,
+            success: output.success,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }
+    }
+}
+
+impl From<ComponentScriptOutput> for RunnerOutput {
+    fn from(output: ComponentScriptOutput) -> Self {
+        Self {
+            exit_code: output.exit_code,
+            success: output.success,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }
+    }
+}
+
+pub fn run_component_scripts(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    passthrough: bool,
+) -> Result<ComponentScriptOutput> {
+    run_component_scripts_with_env(component, capability, source_path, passthrough, &[], &[])
+}
+
+pub(crate) fn run_component_scripts_with_env(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    passthrough: bool,
+    extra_env: &[(String, String)],
+    script_args: &[String],
+) -> Result<ComponentScriptOutput> {
+    let commands = component.script_commands(capability);
+    if commands.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "scripts",
+            format!(
+                "Component '{}' has no scripts.{} commands configured",
+                component.id,
+                capability.label()
+            ),
+            None,
+            None,
+        ));
+    }
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let env = component_script_env(component, source_path, extra_env);
+
+    for command in commands {
+        if passthrough {
+            crate::log_status!(
+                "component-script",
+                "running {} script for {}: {}",
+                capability.label(),
+                component.id,
+                command
+            );
+        }
+
+        let command = command_with_args(command, script_args);
+        let output = super::execution::execute_capability_script(
+            source_path,
+            "",
+            &[],
+            &env,
+            Some(&source_path.to_string_lossy()),
+            Some(&command),
+            super::execution::CapabilityScriptOptions {
+                passthrough,
+                stderr_passthrough: false,
+                cleanup_process_group: matches!(
+                    capability,
+                    ExtensionCapability::Bench | ExtensionCapability::Trace
+                ),
+            },
+        )?;
+
+        stdout.push_str(&output.stdout);
+        stderr.push_str(&output.stderr);
+
+        if !output.success {
+            return Ok(ComponentScriptOutput {
+                exit_code: output.exit_code,
+                success: false,
+                stdout,
+                stderr,
+            });
+        }
+    }
+
+    Ok(ComponentScriptOutput {
+        exit_code: 0,
+        success: true,
+        stdout,
+        stderr,
+    })
+}
+
+pub(crate) fn run_component_scripts_with_run_dir(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    run_dir: &RunDir,
+    passthrough: bool,
+    extra_env: &[(String, String)],
+    script_args: &[String],
+) -> Result<ComponentScriptOutput> {
+    let mut env = run_dir.legacy_env_vars();
+    env.extend(extra_env.iter().cloned());
+    run_component_scripts_with_env(
+        component,
+        capability,
+        source_path,
+        passthrough,
+        &env,
+        script_args,
+    )
+}
+
+fn component_script_env(
+    component: &Component,
+    source_path: &Path,
+    extra_env: &[(String, String)],
+) -> Vec<(String, String)> {
+    let source_path = source_path.to_string_lossy().to_string();
+    let mut env = vec![
+        (
+            exec_context::VERSION.to_string(),
+            exec_context::CURRENT_VERSION.to_string(),
+        ),
+        (
+            exec_context::EXTENSION_ID.to_string(),
+            "component-script".to_string(),
+        ),
+        (
+            exec_context::EXTENSION_PATH.to_string(),
+            source_path.clone(),
+        ),
+        (exec_context::COMPONENT_ID.to_string(), component.id.clone()),
+        (exec_context::COMPONENT_PATH.to_string(), source_path),
+        (exec_context::SETTINGS_JSON.to_string(), "{}".to_string()),
+    ];
+    env.extend(extra_env.iter().cloned());
+    env
+}
+
+fn command_with_args(command: &str, script_args: &[String]) -> String {
+    if script_args.is_empty() {
+        return command.to_string();
+    }
+
+    format!(
+        "{} {}",
+        command,
+        crate::engine::shell::quote_args(script_args)
+    )
+}
+
+pub(crate) fn source_path(component: &Component, path_override: Option<&str>) -> PathBuf {
+    path_override
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(&component.local_path))
+}

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -1,5 +1,6 @@
 pub mod bench;
 pub mod build;
+pub mod component_script;
 mod execution;
 pub mod grammar;
 pub mod grammar_items;

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -28,7 +28,7 @@ pub(crate) fn run_self_checks_with_passthrough(
     source_path: &Path,
     passthrough: bool,
 ) -> Result<SelfCheckOutput> {
-    let commands = component.self_check_commands(capability);
+    let commands = component.script_commands(capability);
     if commands.is_empty() {
         return Err(Error::validation_invalid_argument(
             "self_checks",

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -386,35 +386,7 @@ pub fn run_trace_list_workflow(
             &[("HOMEBOY_TRACE_LIST_ONLY".to_string(), "1".to_string())],
             &[],
         )?;
-        if !output.success {
-            return Err(Error::validation_invalid_argument(
-                "trace_list",
-                format!(
-                    "trace scenario discovery failed with exit code {}",
-                    output.exit_code
-                ),
-                Some(format!(
-                    "stdout:\n{}\n\nstderr:\n{}",
-                    output.stdout, output.stderr
-                )),
-                None,
-            ));
-        }
-        let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
-        if results_path.exists() {
-            let content = std::fs::read_to_string(&results_path).map_err(|e| {
-                Error::internal_io(
-                    format!(
-                        "Failed to read trace list file {}: {}",
-                        results_path.display(),
-                        e
-                    ),
-                    Some("trace.list.read".to_string()),
-                )
-            })?;
-            return parse_trace_list_str(&content);
-        }
-        return parse_trace_list_str(&output.stdout);
+        return trace_list_from_output(run_dir, TraceListOutput::from(output));
     }
 
     let execution_context = resolve_execution_context(component, ExtensionCapability::Trace)?;
@@ -440,21 +412,60 @@ pub fn run_trace_list_workflow(
     };
     let output =
         build_trace_runner(&execution_context, component, &runner_args, run_dir, true)?.run()?;
-    if !output.success {
-        return Err(Error::validation_invalid_argument(
-            "trace_list",
-            format!(
-                "trace scenario discovery failed with exit code {}",
-                output.exit_code
-            ),
-            Some(format!(
-                "stdout:\n{}\n\nstderr:\n{}",
-                output.stdout, output.stderr
-            )),
-            None,
-        ));
+    trace_list_from_output(run_dir, TraceListOutput::from(output))
+}
+
+struct TraceListOutput {
+    exit_code: i32,
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+impl From<crate::extension::component_script::ComponentScriptOutput> for TraceListOutput {
+    fn from(output: crate::extension::component_script::ComponentScriptOutput) -> Self {
+        Self {
+            exit_code: output.exit_code,
+            success: output.success,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }
+    }
+}
+
+impl From<RunnerOutput> for TraceListOutput {
+    fn from(output: RunnerOutput) -> Self {
+        Self {
+            exit_code: output.exit_code,
+            success: output.success,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }
+    }
+}
+
+fn trace_list_from_output(run_dir: &RunDir, output: TraceListOutput) -> Result<TraceList> {
+    if output.success {
+        return parse_trace_list_output(run_dir, &output.stdout);
     }
 
+    Err(trace_list_error(
+        output.exit_code,
+        &output.stdout,
+        &output.stderr,
+    ))
+}
+
+fn trace_list_error(exit_code: i32, stdout: &str, stderr: &str) -> Error {
+    Error::validation_invalid_argument(
+        "trace_list",
+        format!("trace scenario discovery failed with exit code {exit_code}"),
+        Some(format!("stdout:\n{stdout}\n\nstderr:\n{stderr}")),
+        None,
+    )
+}
+
+fn parse_trace_list_output(run_dir: &RunDir, stdout: &str) -> Result<TraceList> {
     let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
     if results_path.exists() {
         let content = std::fs::read_to_string(&results_path).map_err(|e| {
@@ -470,7 +481,7 @@ pub fn run_trace_list_workflow(
         return parse_trace_list_str(&content);
     }
 
-    parse_trace_list_str(&output.stdout)
+    parse_trace_list_str(stdout)
 }
 
 pub(crate) fn build_trace_runner(

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -103,8 +103,114 @@ pub fn run_trace_workflow(
     run_dir: &RunDir,
     rig_state: Option<RigStateSnapshot>,
 ) -> Result<TraceRunWorkflowResult> {
+    if component.has_script(ExtensionCapability::Trace) {
+        return run_trace_workflow_with_component_script(component, args, run_dir, rig_state);
+    }
+
     let execution_context = resolve_execution_context(component, ExtensionCapability::Trace)?;
     run_trace_workflow_with_context(&execution_context, component, args, run_dir, rig_state)
+}
+
+fn run_trace_workflow_with_component_script(
+    component: &Component,
+    args: TraceRunWorkflowArgs,
+    run_dir: &RunDir,
+    rig_state: Option<RigStateSnapshot>,
+) -> Result<TraceRunWorkflowResult> {
+    let component_path = args
+        .path_override
+        .as_deref()
+        .unwrap_or(component.local_path.as_str());
+    let source_path = Path::new(component_path);
+    let _overlay_locks = if args.overlays.is_empty() {
+        None
+    } else {
+        Some(acquire_trace_overlay_locks(&args.overlays, run_dir)?)
+    };
+    let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
+    let script_output = crate::extension::component_script::run_component_scripts_with_run_dir(
+        component,
+        ExtensionCapability::Trace,
+        source_path,
+        run_dir,
+        true,
+        &[
+            (
+                "HOMEBOY_TRACE_SCENARIO".to_string(),
+                args.scenario_id.clone(),
+            ),
+            ("HOMEBOY_TRACE_LIST_ONLY".to_string(), "0".to_string()),
+        ],
+        &[],
+    );
+    if !args.keep_overlay {
+        cleanup_trace_overlays(&applied_overlays)?
+    }
+    let script_output = script_output?;
+    let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
+    let mut results = if results_path.exists() {
+        let mut parsed = parse_trace_results_file(&results_path)?;
+        if parsed.rig.is_none() {
+            parsed.rig = rig_state;
+        }
+        Some(parsed)
+    } else {
+        None
+    };
+    let status = results
+        .as_ref()
+        .map(|r| r.status.as_str().to_string())
+        .unwrap_or_else(|| {
+            if script_output.success {
+                "pass"
+            } else {
+                "error"
+            }
+            .to_string()
+        });
+    if let Some(parsed) = results.as_mut() {
+        super::spans::apply_span_definitions(parsed, &args.span_definitions);
+    }
+    let exit_code = if script_output.success {
+        if status == "pass" {
+            0
+        } else {
+            1
+        }
+    } else {
+        script_output.exit_code
+    };
+    let failure = (!script_output.success).then(|| TraceRunFailure {
+        component_id: args.component_id.clone(),
+        path_override: args.path_override.clone(),
+        scenario_id: args.scenario_id.clone(),
+        exit_code: script_output.exit_code,
+        stderr_excerpt: stderr_tail(&script_output.stderr),
+    });
+
+    Ok(TraceRunWorkflowResult {
+        status,
+        component: args.component_label,
+        exit_code,
+        results,
+        failure,
+        overlays: applied_overlays
+            .into_iter()
+            .map(|overlay| TraceOverlay {
+                variant: overlay.variant,
+                component_id: overlay.component_id,
+                path: overlay.patch_path.to_string_lossy().to_string(),
+                component_path: overlay.component_path.to_string_lossy().to_string(),
+                touched_files: overlay.touched_files,
+                kept: overlay.keep,
+            })
+            .collect(),
+        baseline_comparison: None,
+        hints: Some(vec![
+            "Component scripts use the extension runner env contract without extension resolution."
+                .to_string(),
+        ]),
+    })
 }
 
 fn run_trace_workflow_with_context(
@@ -266,6 +372,51 @@ pub fn run_trace_list_workflow(
     args: TraceListWorkflowArgs,
     run_dir: &RunDir,
 ) -> Result<TraceList> {
+    if component.has_script(ExtensionCapability::Trace) {
+        let source_path = crate::extension::component_script::source_path(
+            component,
+            args.path_override.as_deref(),
+        );
+        let output = crate::extension::component_script::run_component_scripts_with_run_dir(
+            component,
+            ExtensionCapability::Trace,
+            &source_path,
+            run_dir,
+            true,
+            &[("HOMEBOY_TRACE_LIST_ONLY".to_string(), "1".to_string())],
+            &[],
+        )?;
+        if !output.success {
+            return Err(Error::validation_invalid_argument(
+                "trace_list",
+                format!(
+                    "trace scenario discovery failed with exit code {}",
+                    output.exit_code
+                ),
+                Some(format!(
+                    "stdout:\n{}\n\nstderr:\n{}",
+                    output.stdout, output.stderr
+                )),
+                None,
+            ));
+        }
+        let results_path = run_dir.step_file(run_dir::files::TRACE_RESULTS);
+        if results_path.exists() {
+            let content = std::fs::read_to_string(&results_path).map_err(|e| {
+                Error::internal_io(
+                    format!(
+                        "Failed to read trace list file {}: {}",
+                        results_path.display(),
+                        e
+                    ),
+                    Some("trace.list.read".to_string()),
+                )
+            })?;
+            return parse_trace_list_str(&content);
+        }
+        return parse_trace_list_str(&output.stdout);
+    }
+
     let execution_context = resolve_execution_context(component, ExtensionCapability::Trace)?;
     let runner_args = TraceRunWorkflowArgs {
         component_label: args.component_label.clone(),

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -1,0 +1,213 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use crate::commands::test::{run as run_test, TestArgs};
+use crate::commands::utils::args::{
+    BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
+};
+use crate::commands::GlobalArgs;
+use crate::component::{Component, ComponentScriptsConfig};
+use crate::engine::run_dir::RunDir;
+use crate::extension::component_script::{
+    run_component_scripts, run_component_scripts_with_env, run_component_scripts_with_run_dir,
+    source_path,
+};
+use crate::extension::ExtensionCapability;
+use crate::test_support::with_isolated_home;
+
+fn component_script_args(root: &Path) -> PositionalComponentArgs {
+    PositionalComponentArgs {
+        component: Some("fixture".to_string()),
+        path: Some(root.to_string_lossy().to_string()),
+    }
+}
+
+fn test_command_args(root: &Path) -> TestArgs {
+    TestArgs {
+        comp: component_script_args(root),
+        extension_override: ExtensionOverrideArgs::default(),
+        skip_lint: false,
+        coverage: false,
+        coverage_min: None,
+        baseline_args: BaselineArgs::default(),
+        analyze: false,
+        drift: false,
+        write: false,
+        since: "HEAD~10".to_string(),
+        changed_since: None,
+        setting_args: SettingArgs::default(),
+        args: Vec::new(),
+        _json: HiddenJsonArgs::default(),
+        json_summary: false,
+    }
+}
+
+fn write_component_script(root: &Path, name: &str, body: &str) {
+    let script_dir = root.join("scripts");
+    fs::create_dir_all(&script_dir).expect("script dir should be created");
+    fs::write(script_dir.join(name), body).expect("script should be written");
+}
+
+fn script_component(root: &Path, command: &str) -> Component {
+    let mut component = Component::new(
+        "fixture".to_string(),
+        root.to_string_lossy().to_string(),
+        String::new(),
+        None,
+    );
+    component.scripts = Some(ComponentScriptsConfig {
+        test: vec![command.to_string()],
+        ..Default::default()
+    });
+    component
+}
+
+#[test]
+fn test_run_component_scripts() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let component = script_component(dir.path(), "printf ok > marker");
+
+    let output = run_component_scripts(&component, ExtensionCapability::Test, dir.path(), false)
+        .expect("component script should run");
+
+    assert!(output.success);
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(fs::read_to_string(dir.path().join("marker")).unwrap(), "ok");
+}
+
+#[test]
+fn test_run_component_scripts_with_env() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let component = script_component(dir.path(), "printf \"$EXTRA_VALUE\" > marker");
+
+    let output = run_component_scripts_with_env(
+        &component,
+        ExtensionCapability::Test,
+        dir.path(),
+        false,
+        &[("EXTRA_VALUE".to_string(), "ok".to_string())],
+        &[],
+    )
+    .expect("component script should run with env");
+
+    assert!(output.success);
+    assert_eq!(fs::read_to_string(dir.path().join("marker")).unwrap(), "ok");
+}
+
+#[test]
+fn test_run_component_scripts_with_run_dir() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let run_dir = RunDir::create().expect("run dir");
+    let component = script_component(
+        dir.path(),
+        "test -n \"$HOMEBOY_RUN_DIR\" && printf ok > marker",
+    );
+
+    let output = run_component_scripts_with_run_dir(
+        &component,
+        ExtensionCapability::Test,
+        dir.path(),
+        &run_dir,
+        false,
+        &[],
+        &[],
+    )
+    .expect("component script should run with run dir");
+
+    assert!(output.success);
+    assert_eq!(fs::read_to_string(dir.path().join("marker")).unwrap(), "ok");
+    run_dir.cleanup();
+}
+
+#[test]
+fn test_source_path() {
+    let component = Component::new(
+        "fixture".to_string(),
+        "/component/path".to_string(),
+        String::new(),
+        None,
+    );
+
+    assert_eq!(source_path(&component, None), Path::new("/component/path"));
+    assert_eq!(
+        source_path(&component, Some("/override")),
+        Path::new("/override")
+    );
+}
+
+#[test]
+fn command_dispatch_runs_component_script_before_extension_resolution() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(
+        dir.path().join("homeboy.json"),
+        r#"{
+  "id": "fixture",
+  "scripts": { "test": ["sh scripts/test.sh"] }
+}"#,
+    )
+    .expect("homeboy.json should be written");
+    write_component_script(
+        dir.path(),
+        "test.sh",
+        "printf 'component script ran\n' > component-script-marker\n",
+    );
+
+    let (output, exit_code) =
+        run_test(test_command_args(dir.path()), &GlobalArgs {}).expect("test script should run");
+
+    assert_eq!(exit_code, 0);
+    assert!(output.passed);
+    assert!(dir.path().join("component-script-marker").exists());
+}
+
+#[test]
+fn command_dispatch_falls_back_to_extension_when_component_script_is_absent() {
+    with_isolated_home(|home| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+  "id": "fixture",
+  "extensions": { "fixture-extension": {} }
+}"#,
+        )
+        .expect("homeboy.json should be written");
+
+        let extension_dir = home
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("extensions")
+            .join("fixture-extension");
+        fs::create_dir_all(&extension_dir).expect("extension dir should be created");
+        fs::write(
+            extension_dir.join("fixture-extension.json"),
+            r#"{
+  "name": "Fixture extension",
+  "version": "1.0.0",
+  "test": { "extension_script": "test.sh" }
+}"#,
+        )
+        .expect("extension manifest should be written");
+        let extension_script = extension_dir.join("test.sh");
+        fs::write(
+            &extension_script,
+            "#!/bin/sh\nprintf 'extension ran\n' > \"$HOMEBOY_COMPONENT_PATH/extension-marker\"\n",
+        )
+        .expect("extension script should be written");
+        let mut perms = fs::metadata(&extension_script)
+            .expect("extension script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&extension_script, perms)
+            .expect("extension script should be executable");
+
+        let (output, exit_code) = run_test(test_command_args(dir.path()), &GlobalArgs {})
+            .expect("extension test should run");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.passed);
+        assert!(dir.path().join("extension-marker").exists());
+    });
+}

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -5,11 +5,7 @@ use homeboy::commands::utils::args::{
 };
 use homeboy::commands::GlobalArgs;
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::sync::Mutex;
-
-static HOME_LOCK: Mutex<()> = Mutex::new(());
 
 fn write_component(root: &Path, self_checks: &str) {
     fs::write(
@@ -23,37 +19,6 @@ fn write_component(root: &Path, self_checks: &str) {
         ),
     )
     .expect("homeboy.json should be written");
-}
-
-fn write_component_with_scripts(root: &Path, scripts: &str) {
-    fs::write(
-        root.join("homeboy.json"),
-        format!(
-            r#"{{
-  "id": "fixture",
-  "scripts": {}
-}}"#,
-            scripts
-        ),
-    )
-    .expect("homeboy.json should be written");
-}
-
-fn with_isolated_home<T>(f: impl FnOnce(&Path) -> T) -> T {
-    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    let old_home = std::env::var_os("HOME");
-    let home = tempfile::tempdir().expect("home tempdir");
-
-    std::env::set_var("HOME", home.path());
-    let result = f(home.path());
-
-    if let Some(value) = old_home {
-        std::env::set_var("HOME", value);
-    } else {
-        std::env::remove_var("HOME");
-    }
-
-    result
 }
 
 fn write_script(root: &Path, name: &str, body: &str) {
@@ -136,74 +101,6 @@ fn test_runs_declared_self_check_without_extensions() {
     assert_eq!(exit_code, 0);
     assert!(output.passed);
     assert_eq!(output.component, "fixture");
-}
-
-#[test]
-fn test_runs_component_script_before_extension_resolution() {
-    let dir = tempfile::tempdir().expect("temp dir");
-    write_component_with_scripts(dir.path(), r#"{ "test": ["sh scripts/test.sh"] }"#);
-    write_script(
-        dir.path(),
-        "test.sh",
-        "printf 'component script ran\n' > component-script-marker\n",
-    );
-
-    let (output, exit_code) =
-        run_test(test_args(dir.path()), &GlobalArgs {}).expect("test script should run");
-
-    assert_eq!(exit_code, 0);
-    assert!(output.passed);
-    assert!(dir.path().join("component-script-marker").exists());
-}
-
-#[test]
-fn test_falls_back_to_extension_when_component_script_is_absent() {
-    with_isolated_home(|home| {
-        let dir = tempfile::tempdir().expect("temp dir");
-        fs::write(
-            dir.path().join("homeboy.json"),
-            r#"{
-  "id": "fixture",
-  "extensions": { "fixture-extension": {} }
-}"#,
-        )
-        .expect("homeboy.json should be written");
-
-        let extension_dir = home
-            .join(".config")
-            .join("homeboy")
-            .join("extensions")
-            .join("fixture-extension");
-        fs::create_dir_all(&extension_dir).expect("extension dir should be created");
-        fs::write(
-            extension_dir.join("fixture-extension.json"),
-            r#"{
-  "name": "Fixture extension",
-  "version": "1.0.0",
-  "test": { "extension_script": "test.sh" }
-}"#,
-        )
-        .expect("extension manifest should be written");
-        let extension_script = extension_dir.join("test.sh");
-        fs::write(
-            &extension_script,
-            "#!/bin/sh\nprintf 'extension ran\n' > \"$HOMEBOY_COMPONENT_PATH/extension-marker\"\n",
-        )
-        .expect("extension script should be written");
-        let mut perms = fs::metadata(&extension_script)
-            .expect("extension script metadata")
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&extension_script, perms)
-            .expect("extension script should be executable");
-
-        let (output, exit_code) =
-            run_test(test_args(dir.path()), &GlobalArgs {}).expect("extension test should run");
-
-        assert_eq!(exit_code, 0);
-        assert!(output.passed);
-        assert!(dir.path().join("extension-marker").exists());
-    });
 }
 
 #[test]

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -5,7 +5,11 @@ use homeboy::commands::utils::args::{
 };
 use homeboy::commands::GlobalArgs;
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use std::sync::Mutex;
+
+static HOME_LOCK: Mutex<()> = Mutex::new(());
 
 fn write_component(root: &Path, self_checks: &str) {
     fs::write(
@@ -19,6 +23,37 @@ fn write_component(root: &Path, self_checks: &str) {
         ),
     )
     .expect("homeboy.json should be written");
+}
+
+fn write_component_with_scripts(root: &Path, scripts: &str) {
+    fs::write(
+        root.join("homeboy.json"),
+        format!(
+            r#"{{
+  "id": "fixture",
+  "scripts": {}
+}}"#,
+            scripts
+        ),
+    )
+    .expect("homeboy.json should be written");
+}
+
+fn with_isolated_home<T>(f: impl FnOnce(&Path) -> T) -> T {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let old_home = std::env::var_os("HOME");
+    let home = tempfile::tempdir().expect("home tempdir");
+
+    std::env::set_var("HOME", home.path());
+    let result = f(home.path());
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+
+    result
 }
 
 fn write_script(root: &Path, name: &str, body: &str) {
@@ -101,6 +136,74 @@ fn test_runs_declared_self_check_without_extensions() {
     assert_eq!(exit_code, 0);
     assert!(output.passed);
     assert_eq!(output.component, "fixture");
+}
+
+#[test]
+fn test_runs_component_script_before_extension_resolution() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_component_with_scripts(dir.path(), r#"{ "test": ["sh scripts/test.sh"] }"#);
+    write_script(
+        dir.path(),
+        "test.sh",
+        "printf 'component script ran\n' > component-script-marker\n",
+    );
+
+    let (output, exit_code) =
+        run_test(test_args(dir.path()), &GlobalArgs {}).expect("test script should run");
+
+    assert_eq!(exit_code, 0);
+    assert!(output.passed);
+    assert!(dir.path().join("component-script-marker").exists());
+}
+
+#[test]
+fn test_falls_back_to_extension_when_component_script_is_absent() {
+    with_isolated_home(|home| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+  "id": "fixture",
+  "extensions": { "fixture-extension": {} }
+}"#,
+        )
+        .expect("homeboy.json should be written");
+
+        let extension_dir = home
+            .join(".config")
+            .join("homeboy")
+            .join("extensions")
+            .join("fixture-extension");
+        fs::create_dir_all(&extension_dir).expect("extension dir should be created");
+        fs::write(
+            extension_dir.join("fixture-extension.json"),
+            r#"{
+  "name": "Fixture extension",
+  "version": "1.0.0",
+  "test": { "extension_script": "test.sh" }
+}"#,
+        )
+        .expect("extension manifest should be written");
+        let extension_script = extension_dir.join("test.sh");
+        fs::write(
+            &extension_script,
+            "#!/bin/sh\nprintf 'extension ran\n' > \"$HOMEBOY_COMPONENT_PATH/extension-marker\"\n",
+        )
+        .expect("extension script should be written");
+        let mut perms = fs::metadata(&extension_script)
+            .expect("extension script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&extension_script, perms)
+            .expect("extension script should be executable");
+
+        let (output, exit_code) =
+            run_test(test_args(dir.path()), &GlobalArgs {}).expect("extension test should run");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.passed);
+        assert!(dir.path().join("extension-marker").exists());
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `scripts.lint`, `scripts.test`, `scripts.build`, `scripts.bench`, and `scripts.trace` support to component config with component scripts resolving before linked extensions.
- Preserve existing extension dispatch and existing lint/test `self_checks` compatibility.
- Document the component schema and runner contract for self-hosted scripts.

## Tests
- `cargo test --test self_checks_test`
- `cargo test --lib core::extension::self_check`
- `cargo test` compiled and ran 2442 tests, with one unrelated existing failure in `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path` due PATH ordering in this shell.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the component script dispatch changes, tests, and docs; Chris remains responsible for review and merge.

Fixes #2164