### PR TITLE
feat(trace): evaluate temporal assertions

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -91,6 +91,64 @@ If an endpoint is missing, Homeboy emits a skipped result with `missing` keys in
 
 When a timeline contains repeated events with the same key, Homeboy resolves the span to the nearest valid `from`/`to` pair where the `to` event occurs at or after the `from` event. This keeps simple `source.event` span definitions stable for common lifecycle events that naturally repeat.
 
+## Temporal Assertions
+
+Runners can declare `temporal_assertions` for timeline-level checks. Homeboy evaluates them after the runner exits, appends the evaluated result to the existing `assertions` list, and marks the trace failed when any evaluated assertion fails. Existing simple runner-emitted assertions still work unchanged.
+
+V1 supports three assertion kinds:
+
+- `count`: count matching timeline keys and enforce optional `min` / `max` bounds.
+- `forbidden-event`: fail when a timeline key appears at least once.
+- `max-concurrent`: track a start/end event pair and fail when live concurrency exceeds `max`.
+
+Timeline keys use the same `source.event` format as spans. Failed assertions include a structured `details` object with the observed counts and matching events.
+
+```json
+{
+  "timeline": [
+    { "t_ms": 0, "source": "proc", "event": "spawn" },
+    { "t_ms": 5, "source": "proc", "event": "spawn" },
+    { "t_ms": 10, "source": "proc", "event": "exit" }
+  ],
+  "temporal_assertions": [
+    {
+      "id": "no-invalid-grant",
+      "kind": "count",
+      "events": ["log.invalid_grant"],
+      "max": 0
+    },
+    {
+      "id": "no-window-reopen",
+      "kind": "forbidden-event",
+      "pattern": "desktop.window.reopened"
+    },
+    {
+      "id": "max-one-proc",
+      "kind": "max-concurrent",
+      "track": ["proc.spawn", "proc.exit"],
+      "max": 1
+    }
+  ]
+}
+```
+
+The evaluated assertion list keeps the normal assertion shape and adds `details` when Homeboy has structured evidence:
+
+```json
+{
+  "id": "max-one-proc",
+  "status": "fail",
+  "message": "max concurrency for `proc.spawn` exceeded 1: observed 2",
+  "details": {
+    "kind": "max-concurrent",
+    "track": ["proc.spawn", "proc.exit"],
+    "max": 1,
+    "max_observed": 2,
+    "at_t_ms": 5
+  }
+}
+```
+
 ## Phases
 
 Use repeatable `--phase [label:]source.event` flags to provide an ordered milestone chain. Homeboy expands the chain into adjacent span results plus a `phase.total` span from the first milestone to the last milestone:

--- a/src/core/extension/trace/assertions.rs
+++ b/src/core/extension/trace/assertions.rs
@@ -295,6 +295,28 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_temporal_assertions() {
+        let mut results = results(
+            vec![event(10, "runner", "ready")],
+            vec![TraceTemporalAssertionDefinition::Count {
+                id: "ready-once".to_string(),
+                events: vec!["runner.ready".to_string()],
+                min: Some(1),
+                max: Some(1),
+                message: None,
+            }],
+        );
+
+        assert!(!apply_temporal_assertions(&mut results));
+        assert_eq!(results.status, TraceStatus::Pass);
+        assert!(results.temporal_assertions.is_empty());
+        assert_eq!(results.assertions.len(), 1);
+        assert_eq!(results.assertions[0].id, "ready-once");
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Pass);
+        assert_eq!(results.assertions[0].details.as_ref().unwrap()["actual"], 1);
+    }
+
+    #[test]
     fn count_assertion_fails_when_count_exceeds_max() {
         let mut results = results(
             vec![

--- a/src/core/extension/trace/assertions.rs
+++ b/src/core/extension/trace/assertions.rs
@@ -1,0 +1,359 @@
+//! Temporal trace assertion evaluation over timeline events.
+
+use serde_json::json;
+
+use super::parsing::{
+    TraceAssertion, TraceAssertionStatus, TraceResults, TraceStatus,
+    TraceTemporalAssertionDefinition,
+};
+use super::spans::{event_matches_key, reporting_timeline};
+
+pub(crate) fn apply_temporal_assertions(results: &mut TraceResults) -> bool {
+    if results.temporal_assertions.is_empty() {
+        return false;
+    }
+
+    let definitions = std::mem::take(&mut results.temporal_assertions);
+    let timeline = reporting_timeline(&results.timeline);
+    let mut has_failure = false;
+    for definition in &definitions {
+        let assertion = evaluate_temporal_assertion(definition, &timeline);
+        if assertion.status != TraceAssertionStatus::Pass {
+            has_failure = true;
+        }
+        results.assertions.push(assertion);
+    }
+
+    if has_failure {
+        results.status = TraceStatus::Fail;
+    }
+    has_failure
+}
+
+fn evaluate_temporal_assertion(
+    definition: &TraceTemporalAssertionDefinition,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    match definition {
+        TraceTemporalAssertionDefinition::Count {
+            id,
+            events,
+            min,
+            max,
+            message,
+        } => evaluate_count(id, events, *min, *max, message.as_deref(), timeline),
+        TraceTemporalAssertionDefinition::ForbiddenEvent {
+            id,
+            pattern,
+            message,
+        } => evaluate_forbidden_event(id, pattern, message.as_deref(), timeline),
+        TraceTemporalAssertionDefinition::MaxConcurrent {
+            id,
+            track,
+            max,
+            message,
+        } => evaluate_max_concurrent(id, track, *max, message.as_deref(), timeline),
+    }
+}
+
+fn evaluate_count(
+    id: &str,
+    events: &[String],
+    min: Option<usize>,
+    max: Option<usize>,
+    message: Option<&str>,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    let matches = timeline
+        .iter()
+        .filter(|event| events.iter().any(|key| event_matches_key(event, key)))
+        .collect::<Vec<_>>();
+    let actual = matches.len();
+    let passed = min.is_none_or(|value| actual >= value) && max.is_none_or(|value| actual <= value);
+
+    TraceAssertion {
+        id: id.to_string(),
+        status: if passed {
+            TraceAssertionStatus::Pass
+        } else {
+            TraceAssertionStatus::Fail
+        },
+        message: Some(
+            message
+                .map(str::to_string)
+                .unwrap_or_else(|| count_message(events, min, max, actual, passed)),
+        ),
+        details: Some(json!({
+            "kind": "count",
+            "events": events,
+            "min": min,
+            "max": max,
+            "actual": actual,
+            "matches": event_details(&matches),
+        })),
+    }
+}
+
+fn evaluate_forbidden_event(
+    id: &str,
+    pattern: &str,
+    message: Option<&str>,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    let matches = timeline
+        .iter()
+        .filter(|event| event_matches_key(event, pattern))
+        .collect::<Vec<_>>();
+    let passed = matches.is_empty();
+
+    TraceAssertion {
+        id: id.to_string(),
+        status: if passed {
+            TraceAssertionStatus::Pass
+        } else {
+            TraceAssertionStatus::Fail
+        },
+        message: Some(
+            message
+                .map(str::to_string)
+                .unwrap_or_else(|| forbidden_event_message(pattern, matches.len(), passed)),
+        ),
+        details: Some(json!({
+            "kind": "forbidden-event",
+            "pattern": pattern,
+            "actual": matches.len(),
+            "matches": event_details(&matches),
+        })),
+    }
+}
+
+fn evaluate_max_concurrent(
+    id: &str,
+    track: &[String],
+    max: usize,
+    message: Option<&str>,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    if track.len() != 2 {
+        return TraceAssertion {
+            id: id.to_string(),
+            status: TraceAssertionStatus::Error,
+            message: Some(
+                "max-concurrent requires exactly two track events: start and end".to_string(),
+            ),
+            details: Some(json!({
+                "kind": "max-concurrent",
+                "track": track,
+                "max": max,
+            })),
+        };
+    }
+
+    let mut changes = timeline
+        .iter()
+        .filter_map(|event| {
+            if event_matches_key(event, &track[0]) {
+                Some((event.t_ms, 1_i64, event))
+            } else if event_matches_key(event, &track[1]) {
+                Some((event.t_ms, -1_i64, event))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    changes.sort_by_key(|(t_ms, delta, _)| (*t_ms, *delta));
+
+    let mut current = 0_i64;
+    let mut max_observed = 0_i64;
+    let mut max_t_ms = None;
+    for (t_ms, delta, _) in &changes {
+        current = (current + delta).max(0);
+        if current > max_observed {
+            max_observed = current;
+            max_t_ms = Some(*t_ms);
+        }
+    }
+
+    let passed = max_observed <= max as i64;
+    TraceAssertion {
+        id: id.to_string(),
+        status: if passed {
+            TraceAssertionStatus::Pass
+        } else {
+            TraceAssertionStatus::Fail
+        },
+        message: Some(
+            message
+                .map(str::to_string)
+                .unwrap_or_else(|| max_concurrent_message(&track[0], max, max_observed, passed)),
+        ),
+        details: Some(json!({
+            "kind": "max-concurrent",
+            "track": track,
+            "max": max,
+            "max_observed": max_observed,
+            "at_t_ms": max_t_ms,
+            "events": event_details(&changes.iter().map(|(_, _, event)| *event).collect::<Vec<_>>()),
+        })),
+    }
+}
+
+fn count_message(
+    events: &[String],
+    min: Option<usize>,
+    max: Option<usize>,
+    actual: usize,
+    passed: bool,
+) -> String {
+    if passed {
+        return format!(
+            "event count for `{}` satisfied: observed {actual}",
+            events.join(", ")
+        );
+    }
+
+    match (min, max) {
+        (Some(min), Some(max)) => format!(
+            "event count for `{}` outside range {min}..={max}: observed {actual}",
+            events.join(", ")
+        ),
+        (Some(min), None) => format!(
+            "event count for `{}` below minimum {min}: observed {actual}",
+            events.join(", ")
+        ),
+        (None, Some(max)) => format!(
+            "event count for `{}` exceeded maximum {max}: observed {actual}",
+            events.join(", ")
+        ),
+        (None, None) => format!("event count for `{}` observed {actual}", events.join(", ")),
+    }
+}
+
+fn forbidden_event_message(pattern: &str, actual: usize, passed: bool) -> String {
+    if passed {
+        format!("forbidden event `{pattern}` did not occur")
+    } else {
+        format!("forbidden event `{pattern}` occurred {actual} time(s)")
+    }
+}
+
+fn max_concurrent_message(start: &str, max: usize, max_observed: i64, passed: bool) -> String {
+    if passed {
+        format!("max concurrency for `{start}` stayed within {max}: observed {max_observed}")
+    } else {
+        format!("max concurrency for `{start}` exceeded {max}: observed {max_observed}")
+    }
+}
+
+fn event_details(events: &[&super::parsing::TraceEvent]) -> Vec<serde_json::Value> {
+    events
+        .iter()
+        .map(|event| {
+            json!({
+                "t_ms": event.t_ms,
+                "source": event.source,
+                "event": event.event,
+                "data": event.data,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extension::trace::parsing::TraceEvent;
+    use std::collections::BTreeMap;
+
+    fn event(t_ms: u64, source: &str, event: &str) -> TraceEvent {
+        TraceEvent {
+            t_ms,
+            source: source.to_string(),
+            event: event.to_string(),
+            data: BTreeMap::new(),
+        }
+    }
+
+    fn results(
+        timeline: Vec<TraceEvent>,
+        temporal_assertions: Vec<TraceTemporalAssertionDefinition>,
+    ) -> TraceResults {
+        TraceResults {
+            component_id: "example".to_string(),
+            scenario_id: "synthetic".to_string(),
+            status: TraceStatus::Pass,
+            summary: None,
+            failure: None,
+            rig: None,
+            timeline,
+            span_definitions: Vec::new(),
+            span_results: Vec::new(),
+            assertions: Vec::new(),
+            temporal_assertions,
+            artifacts: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn count_assertion_fails_when_count_exceeds_max() {
+        let mut results = results(
+            vec![
+                event(1, "log", "invalid_grant"),
+                event(2, "log", "invalid_grant"),
+            ],
+            vec![TraceTemporalAssertionDefinition::Count {
+                id: "no-invalid-grant".to_string(),
+                events: vec!["log.invalid_grant".to_string()],
+                min: None,
+                max: Some(0),
+                message: None,
+            }],
+        );
+
+        assert!(apply_temporal_assertions(&mut results));
+        assert_eq!(results.status, TraceStatus::Fail);
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Fail);
+        assert_eq!(results.assertions[0].details.as_ref().unwrap()["actual"], 2);
+    }
+
+    #[test]
+    fn forbidden_event_assertion_fails_on_match() {
+        let mut results = results(
+            vec![event(10, "desktop", "window.reopened")],
+            vec![TraceTemporalAssertionDefinition::ForbiddenEvent {
+                id: "no-window-reopen".to_string(),
+                pattern: "desktop.window.reopened".to_string(),
+                message: None,
+            }],
+        );
+
+        assert!(apply_temporal_assertions(&mut results));
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Fail);
+        assert_eq!(results.assertions[0].details.as_ref().unwrap()["actual"], 1);
+    }
+
+    #[test]
+    fn max_concurrent_assertion_fails_when_overlap_exceeds_max() {
+        let mut results = results(
+            vec![
+                event(0, "proc", "spawn"),
+                event(5, "proc", "spawn"),
+                event(10, "proc", "exit"),
+                event(15, "proc", "exit"),
+            ],
+            vec![TraceTemporalAssertionDefinition::MaxConcurrent {
+                id: "max-one-proc".to_string(),
+                track: vec!["proc.spawn".to_string(), "proc.exit".to_string()],
+                max: 1,
+                message: None,
+            }],
+        );
+
+        assert!(apply_temporal_assertions(&mut results));
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Fail);
+        assert_eq!(
+            results.assertions[0].details.as_ref().unwrap()["max_observed"],
+            2
+        );
+    }
+}

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -212,6 +212,7 @@ mod tests {
                 message: None,
             }],
             assertions: Vec::new(),
+            temporal_assertions: Vec::new(),
             artifacts: Vec::new(),
         }
     }

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -8,6 +8,7 @@
 //! `source.event` intervals without teaching core about product-specific
 //! milestones.
 
+pub mod assertions;
 pub mod baseline;
 mod overlay;
 mod overlay_lock;

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -54,6 +54,8 @@ pub struct TraceResults {
     pub span_results: Vec<TraceSpanResult>,
     #[serde(default)]
     pub assertions: Vec<TraceAssertion>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub temporal_assertions: Vec<TraceTemporalAssertionDefinition>,
     #[serde(default)]
     pub artifacts: Vec<TraceArtifact>,
 }
@@ -108,13 +110,43 @@ pub struct TraceEvent {
     pub data: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TraceAssertion {
     pub id: String,
     pub status: TraceAssertionStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum TraceTemporalAssertionDefinition {
+    Count {
+        id: String,
+        events: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+    ForbiddenEvent {
+        id: String,
+        pattern: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+    MaxConcurrent {
+        id: String,
+        track: Vec<String>,
+        max: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -573,6 +573,7 @@ mod tests {
                 span_definitions: Vec::new(),
                 span_results: Vec::new(),
                 assertions: Vec::new(),
+                temporal_assertions: Vec::new(),
                 artifacts: vec![TraceArtifact {
                     label: "main log".to_string(),
                     path: "artifacts/main.log".to_string(),
@@ -640,6 +641,7 @@ mod tests {
                     message: None,
                 }],
                 assertions: Vec::new(),
+                temporal_assertions: Vec::new(),
                 artifacts: Vec::new(),
             }),
             failure: None,
@@ -720,6 +722,7 @@ mod tests {
                 message: None,
             }],
             assertions: Vec::new(),
+            temporal_assertions: Vec::new(),
             artifacts: Vec::new(),
         };
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -145,6 +145,13 @@ fn run_trace_workflow_with_context(
     } else {
         None
     };
+    let failure = (!runner_output.success).then(|| failure_from_output(&args, &runner_output));
+    if let Some(parsed) = results.as_mut() {
+        super::spans::apply_span_definitions(parsed, &args.span_definitions);
+        super::assertions::apply_temporal_assertions(parsed);
+        persist_trace_results(&results_path, parsed)?;
+    }
+
     let status = results
         .as_ref()
         .map(|r| r.status.as_str().to_string())
@@ -165,10 +172,6 @@ fn run_trace_workflow_with_context(
     } else {
         runner_output.exit_code
     };
-    let failure = (!runner_output.success).then(|| failure_from_output(&args, &runner_output));
-    if let Some(parsed) = results.as_mut() {
-        super::spans::apply_span_definitions(parsed, &args.span_definitions);
-    }
 
     let rig_id = args.rig_id.as_deref();
     let source_path = Path::new(component_path);
@@ -258,6 +261,25 @@ fn run_trace_workflow_with_context(
             .collect(),
         baseline_comparison,
         hints: if hints.is_empty() { None } else { Some(hints) },
+    })
+}
+
+fn persist_trace_results(path: &Path, results: &TraceResults) -> Result<()> {
+    let content = serde_json::to_string_pretty(results).map_err(|e| {
+        Error::internal_json(
+            format!("Failed to serialize trace results JSON: {}", e),
+            Some("trace.results.serialize".to_string()),
+        )
+    })?;
+    std::fs::write(path, content).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to write trace results file {}: {}",
+                path.display(),
+                e
+            ),
+            Some("trace.results.write".to_string()),
+        )
     })
 }
 

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -111,7 +111,7 @@ pub(crate) fn apply_span_definitions(
     results.span_results = summarize_spans(&reporting_timeline, &definitions);
 }
 
-fn reporting_timeline(timeline: &[TraceEvent]) -> Vec<TraceEvent> {
+pub(crate) fn reporting_timeline(timeline: &[TraceEvent]) -> Vec<TraceEvent> {
     let mut events = Vec::new();
     for event in timeline {
         push_reporting_event(&mut events, event.clone());
@@ -203,7 +203,7 @@ fn merge_definitions(
     merged
 }
 
-fn event_matches_key(event: &TraceEvent, key: &str) -> bool {
+pub(crate) fn event_matches_key(event: &TraceEvent, key: &str) -> bool {
     event.source.len() + 1 + event.event.len() == key.len()
         && key.starts_with(&event.source)
         && key.as_bytes().get(event.source.len()) == Some(&b'.')
@@ -521,6 +521,7 @@ mod tests {
             span_definitions: Vec::new(),
             span_results: Vec::new(),
             assertions: Vec::new(),
+            temporal_assertions: Vec::new(),
             artifacts: Vec::new(),
         };
 
@@ -569,6 +570,7 @@ mod tests {
             span_definitions: Vec::new(),
             span_results: Vec::new(),
             assertions: Vec::new(),
+            temporal_assertions: Vec::new(),
             artifacts: Vec::new(),
         };
 
@@ -612,6 +614,7 @@ mod tests {
             span_definitions: Vec::new(),
             span_results: Vec::new(),
             assertions: Vec::new(),
+            temporal_assertions: Vec::new(),
             artifacts: Vec::new(),
         };
         let phases = phase_span_definitions(&[

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -345,6 +345,49 @@ mod tests {
     }
 
     #[test]
+    fn test_reporting_timeline() {
+        let timeline = reporting_timeline(&[
+            event(50, "runner", "later"),
+            event_with_data(
+                10,
+                "runner",
+                "details",
+                serde_json::json!({
+                    "events": [
+                        {"source": "nested", "event": "first", "t": 5, "data": {"ok": true}},
+                        {"source": "nested", "event": "second", "t": 20}
+                    ]
+                }),
+            ),
+        ]);
+
+        let keys = timeline
+            .iter()
+            .map(|event| format!("{}:{}.{}", event.t_ms, event.source, event.event))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            keys,
+            vec![
+                "10:runner.details",
+                "15:nested.first",
+                "30:nested.second",
+                "50:runner.later"
+            ]
+        );
+        assert_eq!(timeline[1].data.get("ok"), Some(&serde_json::json!(true)));
+    }
+
+    #[test]
+    fn test_event_matches_key() {
+        let event = event(0, "desktop", "window.closed");
+
+        assert!(event_matches_key(&event, "desktop.window.closed"));
+        assert!(!event_matches_key(&event, "desktop.window"));
+        assert!(!event_matches_key(&event, "runner.window.closed"));
+        assert!(!event_matches_key(&event, "desktop.window.closed.extra"));
+    }
+
+    #[test]
     fn test_parse_span_definition() {
         let definition = parse_span_definition("submit:ui.clicked:cli.started").unwrap();
 


### PR DESCRIPTION
## Summary
- Add v1 `temporal_assertions` schema and evaluation for `count`, `forbidden-event`, and `max-concurrent` over normalized trace timeline events.
- Append evaluated temporal results to the existing trace `assertions` list with optional structured `details`, while preserving existing simple assertions.
- Document the v1 trace assertion shapes and add synthetic timeline tests for each supported kind.

Refs #2167.

## Tests
- `cargo test extension::trace`
- `cargo test -- --test-threads=1`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the temporal assertion evaluator, schema updates, tests, and docs; Chris remains responsible for review and validation.