### PR TITLE
Add run metadata distribution reporting

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -9,6 +9,7 @@ deltas against a stored baseline.
 homeboy bench <component> [options] [-- <runner-args>]
 homeboy bench list <component> [options] [-- <runner-args>]
 homeboy bench history <component> [--scenario <id>] [--rig <id>] [--limit 20]
+homeboy bench distribution <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
 homeboy bench compare --from-run <run-id> --to-run <run-id>
 ```
 
@@ -93,6 +94,8 @@ homeboy runs list --kind bench --component <component> --rig <rig>
 Omit `--rig <rig>` from the list command for unpinned bench runs.
 
 `homeboy bench history <component>` lists persisted benchmark runs from the local observation store. `--scenario` filters to runs whose stored metadata includes the scenario, and `--rig` narrows to rig-pinned runs.
+
+`homeboy bench distribution <component> --field <metadata.path>` summarizes repeated categorical values from persisted benchmark run metadata. It is generic over metadata shape: scalar string, number, and boolean values are counted directly, and arrays are flattened. Use `--scenario`, `--rig`, `--status`, and `--limit` to narrow the persisted run window before aggregation.
 
 `homeboy bench compare --from-run <run-id> --to-run <run-id>` compares numeric metrics recorded in two persisted benchmark runs. It matches scenario + metric rows, reports absolute deltas and percent changes, and lists metrics that exist in only one run. The command is read-only and exits successfully for a valid comparison even when the numbers regress.
 

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -6,6 +6,7 @@ Inspect persisted observation-store runs and artifacts.
 
 ```bash
 homeboy runs list [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20]
+homeboy runs distribution --field <metadata.path> [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--status <status>] [--limit 20]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs show <run-id>
 homeboy runs artifacts <run-id>
@@ -19,6 +20,8 @@ homeboy runs import <dir>
 `homeboy runs` is a read-only query surface over Homeboy's local observation store. Producers such as `bench`, `rig`, and `trace` write run and artifact records; this command lets humans and agents inspect that evidence without opening SQLite directly.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
+
+`homeboy runs distribution` aggregates categorical values from dot-separated JSON metadata paths. Scalar string, number, and boolean values are counted directly; arrays are flattened and counted by scalar element. The output reports inspected runs, matched/missing runs per field, total and unique value counts, value percentages, and repeated values.
 
 ## Compare Metrics Across History
 
@@ -41,6 +44,7 @@ Metric lookup supports top-level run metadata such as `results.total_elapsed_ms`
 
 ```bash
 homeboy bench history <component> [--scenario <id>] [--rig <id>] [--limit 20]
+homeboy bench distribution <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
 homeboy bench compare --from-run <run-id> --to-run <run-id>
 homeboy rig runs <id> [--limit 20]
 ```

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -38,6 +38,8 @@ enum BenchCommand {
     List(BenchListArgs),
     /// List persisted benchmark runs for a component
     History(BenchHistoryArgs),
+    /// Aggregate categorical values from persisted benchmark metadata
+    Distribution(BenchDistributionArgs),
     /// Compare two persisted benchmark runs
     Compare(BenchCompareArgs),
 }
@@ -53,6 +55,27 @@ struct BenchHistoryArgs {
     #[arg(long)]
     rig: Option<String>,
     /// Maximum runs to return
+    #[arg(long, default_value_t = 20)]
+    limit: i64,
+}
+
+#[derive(Args)]
+struct BenchDistributionArgs {
+    /// Component ID
+    component: String,
+    /// Scenario ID
+    #[arg(long = "scenario")]
+    scenario_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    rig: Option<String>,
+    /// Run status
+    #[arg(long)]
+    status: Option<String>,
+    /// Dot-separated metadata path to aggregate
+    #[arg(long = "field", required = true)]
+    fields: Vec<String>,
+    /// Maximum runs to inspect before scenario filtering
     #[arg(long, default_value_t = 20)]
     limit: i64,
 }
@@ -323,6 +346,21 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
                     history_args.scenario_id.as_deref(),
                     history_args.rig.as_deref(),
                     history_args.limit,
+                )?;
+                Ok((BenchOutput::Observation(output), exit_code))
+            }
+            BenchCommand::Distribution(distribution_args) => {
+                let (output, exit_code) = runs::runs_distribution(
+                    runs::RunsDistributionArgs {
+                        kind: Some("bench".to_string()),
+                        component_id: Some(distribution_args.component.clone()),
+                        rig: distribution_args.rig.clone(),
+                        scenario_id: distribution_args.scenario_id.clone(),
+                        status: distribution_args.status.clone(),
+                        fields: distribution_args.fields.clone(),
+                        limit: distribution_args.limit,
+                    },
+                    "bench.distribution",
                 )?;
                 Ok((BenchOutput::Observation(output), exit_code))
             }

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -34,6 +34,8 @@ pub struct RunsArgs {
 enum RunsCommand {
     /// List persisted observation runs
     List(RunsListArgs),
+    /// Aggregate categorical values from persisted run metadata
+    Distribution(RunsDistributionArgs),
     /// Show the latest persisted observation run matching filters
     LatestRun(RunsLatestRunArgs),
     /// Compare selected metrics across persisted run history
@@ -75,10 +77,36 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
+#[derive(Args, Clone, Default)]
+pub struct RunsDistributionArgs {
+    /// Run kind: bench, rig, trace, etc.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Component ID
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Benchmark scenario ID. Only applies to bench metadata.
+    #[arg(long = "scenario")]
+    pub scenario_id: Option<String>,
+    /// Run status
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Dot-separated metadata path to aggregate
+    #[arg(long = "field", required = true)]
+    pub fields: Vec<String>,
+    /// Maximum runs to inspect before scenario filtering
+    #[arg(long, default_value_t = DEFAULT_LIMIT)]
+    pub limit: i64,
+}
+
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
     List(RunsListOutput),
+    Distribution(RunsDistributionOutput),
     LatestRun(RunsLatestRunOutput),
     Compare(RunsCompareOutput),
     Show(RunsShowOutput),
@@ -97,6 +125,43 @@ pub enum RunsOutput {
 pub struct RunsListOutput {
     pub command: &'static str,
     pub runs: Vec<RunSummary>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct RunsDistributionOutput {
+    pub command: &'static str,
+    pub filters: RunsDistributionFilters,
+    pub fields: Vec<FieldDistributionOutput>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct RunsDistributionFilters {
+    pub kind: Option<String>,
+    pub component_id: Option<String>,
+    pub rig_id: Option<String>,
+    pub scenario_id: Option<String>,
+    pub status: Option<String>,
+    pub limit: i64,
+    pub inspected_run_count: usize,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct FieldDistributionOutput {
+    pub field: String,
+    pub matched_run_count: usize,
+    pub missing_run_count: usize,
+    pub total_value_count: usize,
+    pub unique_value_count: usize,
+    pub values: Vec<CategoryDistributionValue>,
+    pub repeated_values: Vec<CategoryDistributionValue>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct CategoryDistributionValue {
+    pub value: String,
+    pub count: usize,
+    pub percent: f64,
+    pub run_count: usize,
 }
 
 #[derive(Serialize)]
@@ -177,6 +242,7 @@ pub struct BenchMissingMetric {
 pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
     match args.command {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
+        RunsCommand::Distribution(args) => runs_distribution(args, "runs.distribution"),
         RunsCommand::LatestRun(args) => latest::latest_run(args),
         RunsCommand::Compare(args) => compare_runs(args),
         RunsCommand::Reconcile(args) => reconcile_runs(args),
@@ -188,6 +254,52 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
     }
+}
+
+pub fn runs_distribution(
+    args: RunsDistributionArgs,
+    command: &'static str,
+) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let limit = args.limit.clamp(1, 1000);
+    let runs = store
+        .list_runs(RunListFilter {
+            kind: args.kind.clone(),
+            component_id: args.component_id.clone(),
+            status: args.status.clone(),
+            rig_id: args.rig.clone(),
+            limit: Some(limit),
+        })?
+        .into_iter()
+        .filter(|run| {
+            args.scenario_id
+                .as_deref()
+                .is_none_or(|scenario| run_contains_scenario(run, scenario))
+        })
+        .collect::<Vec<_>>();
+
+    let fields = args
+        .fields
+        .iter()
+        .map(|field| distribution_for_field(field, &runs))
+        .collect();
+
+    Ok((
+        RunsOutput::Distribution(RunsDistributionOutput {
+            command,
+            filters: RunsDistributionFilters {
+                kind: args.kind,
+                component_id: args.component_id,
+                rig_id: args.rig,
+                scenario_id: args.scenario_id,
+                status: args.status,
+                limit,
+                inspected_run_count: runs.len(),
+            },
+            fields,
+        }),
+        0,
+    ))
 }
 
 impl RunsArgs {
@@ -408,6 +520,81 @@ fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
     bench_numeric_metrics(&run.metadata_json)
         .keys()
         .any(|(scenario, _)| scenario == scenario_id)
+}
+
+fn distribution_for_field(field: &str, runs: &[RunRecord]) -> FieldDistributionOutput {
+    let mut counts = BTreeMap::<String, (usize, BTreeSet<String>)>::new();
+    let mut matched_run_count = 0;
+    let mut total_value_count = 0;
+
+    for run in runs {
+        let values = metadata_path_values(&run.metadata_json, field);
+        if values.is_empty() {
+            continue;
+        }
+        matched_run_count += 1;
+        total_value_count += values.len();
+
+        for value in values {
+            let entry = counts.entry(value).or_insert_with(|| (0, BTreeSet::new()));
+            entry.0 += 1;
+            entry.1.insert(run.id.clone());
+        }
+    }
+
+    let mut values = counts
+        .into_iter()
+        .map(|(value, (count, run_ids))| CategoryDistributionValue {
+            value,
+            count,
+            percent: if total_value_count == 0 {
+                0.0
+            } else {
+                (count as f64 / total_value_count as f64) * 100.0
+            },
+            run_count: run_ids.len(),
+        })
+        .collect::<Vec<_>>();
+    values.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.value.cmp(&b.value)));
+    let repeated_values = values
+        .iter()
+        .filter(|value| value.count > 1)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    FieldDistributionOutput {
+        field: field.to_string(),
+        matched_run_count,
+        missing_run_count: runs.len().saturating_sub(matched_run_count),
+        total_value_count,
+        unique_value_count: values.len(),
+        values,
+        repeated_values,
+    }
+}
+
+fn metadata_path_values(metadata: &Value, field: &str) -> Vec<String> {
+    let Some(value) = field
+        .split('.')
+        .filter(|part| !part.is_empty())
+        .try_fold(metadata, |value, part| value.get(part))
+    else {
+        return Vec::new();
+    };
+
+    match value {
+        Value::Array(items) => items.iter().filter_map(categorical_value).collect(),
+        value => categorical_value(value).into_iter().collect(),
+    }
+}
+
+fn categorical_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    }
 }
 
 fn bench_numeric_metrics(metadata: &Value) -> BTreeMap<(String, String), f64> {
@@ -875,6 +1062,230 @@ mod tests {
     }
 
     #[test]
+    fn distribution_counts_scalar_metadata_values() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            for family in ["serif", "sans", "serif"] {
+                let run = store
+                    .start_run(sample_run(
+                        "bench",
+                        "studio",
+                        "rig-a",
+                        serde_json::json!({ "fingerprint": { "font": family } }),
+                    ))
+                    .expect("run");
+                store
+                    .finish_run(&run.id, RunStatus::Pass, None)
+                    .expect("finish");
+            }
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["fingerprint.font".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(field.matched_run_count, 3);
+            assert_eq!(field.missing_run_count, 0);
+            assert_eq!(field.total_value_count, 3);
+            assert_eq!(field.unique_value_count, 2);
+            assert_eq!(field.values[0].value, "serif");
+            assert_eq!(field.values[0].count, 2);
+            assert_eq!(field.values[0].run_count, 2);
+            assert!((field.values[0].percent - (100.0 * 2.0 / 3.0)).abs() < 0.000_000_001);
+            assert_eq!(field.repeated_values.len(), 1);
+        });
+    }
+
+    #[test]
+    fn distribution_flattens_array_metadata_values() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            for motifs in [
+                serde_json::json!(["grid", "cards"]),
+                serde_json::json!(["grid", "hero"]),
+            ] {
+                let run = store
+                    .start_run(sample_run(
+                        "bench",
+                        "studio",
+                        "rig-a",
+                        serde_json::json!({ "fingerprint": { "motifs": motifs } }),
+                    ))
+                    .expect("run");
+                store
+                    .finish_run(&run.id, RunStatus::Pass, None)
+                    .expect("finish");
+            }
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["fingerprint.motifs".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(field.matched_run_count, 2);
+            assert_eq!(field.total_value_count, 4);
+            assert_eq!(field.unique_value_count, 3);
+            assert_eq!(field.values[0].value, "grid");
+            assert_eq!(field.values[0].count, 2);
+            assert_eq!(field.values[0].run_count, 2);
+        });
+    }
+
+    #[test]
+    fn distribution_reports_missing_fields() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            for metadata in [
+                serde_json::json!({ "category": "timeout" }),
+                serde_json::json!({ "other": "value" }),
+            ] {
+                let run = store
+                    .start_run(sample_run("bench", "studio", "rig-a", metadata))
+                    .expect("run");
+                store
+                    .finish_run(&run.id, RunStatus::Pass, None)
+                    .expect("finish");
+            }
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["category".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(field.matched_run_count, 1);
+            assert_eq!(field.missing_run_count, 1);
+            assert_eq!(field.values[0].value, "timeout");
+        });
+    }
+
+    #[test]
+    fn distribution_applies_run_filters_and_scenario_filter() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let matching = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "kept",
+                        "selected_scenarios": ["build"]
+                    }),
+                ))
+                .expect("matching");
+            store
+                .finish_run(&matching.id, RunStatus::Pass, None)
+                .expect("finish matching");
+            let wrong_status = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "failed",
+                        "selected_scenarios": ["build"]
+                    }),
+                ))
+                .expect("wrong status");
+            store
+                .finish_run(&wrong_status.id, RunStatus::Fail, None)
+                .expect("finish wrong status");
+            let wrong_scenario = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "other-scenario",
+                        "selected_scenarios": ["deploy"]
+                    }),
+                ))
+                .expect("wrong scenario");
+            store
+                .finish_run(&wrong_scenario.id, RunStatus::Pass, None)
+                .expect("finish wrong scenario");
+            let wrong_component = store
+                .start_run(sample_run(
+                    "bench",
+                    "homeboy",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "other-component",
+                        "selected_scenarios": ["build"]
+                    }),
+                ))
+                .expect("wrong component");
+            store
+                .finish_run(&wrong_component.id, RunStatus::Pass, None)
+                .expect("finish wrong component");
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                rig: Some("rig-a".to_string()),
+                scenario_id: Some("build".to_string()),
+                status: Some("pass".to_string()),
+                fields: vec!["category".to_string()],
+                limit: 20,
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(output.filters.inspected_run_count, 1);
+            assert_eq!(field.values.len(), 1);
+            assert_eq!(field.values[0].value, "kept");
+        });
+    }
+
+    #[test]
+    fn distribution_reports_repeated_categories_by_occurrence() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({ "choices": ["sqlite", "sqlite", "mysql"] }),
+                ))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish");
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["choices".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let repeated = &output.fields[0].repeated_values;
+            assert_eq!(repeated.len(), 1);
+            assert_eq!(repeated[0].value, "sqlite");
+            assert_eq!(repeated[0].count, 2);
+            assert_eq!(repeated[0].run_count, 1);
+        });
+    }
+
+    #[test]
     fn bench_compare_reports_deltas_and_missing_metrics() {
         with_isolated_home(|_home| {
             let _xdg = XdgGuard::unset();
@@ -1188,5 +1599,13 @@ mod tests {
 
     fn read_bundle_test_json<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
         serde_json::from_str(&std::fs::read_to_string(path).expect("read json")).expect("json")
+    }
+
+    fn distribution_output(args: RunsDistributionArgs) -> RunsDistributionOutput {
+        let (output, _) = runs_distribution(args, "runs.distribution").expect("distribution");
+        let RunsOutput::Distribution(output) = output else {
+            panic!("expected distribution output");
+        };
+        output
     }
 }

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,5 +1,6 @@
 mod bundle;
 mod compare;
+mod distribution;
 mod findings;
 mod latest;
 mod reconcile;
@@ -18,6 +19,7 @@ use bundle::{
     export_runs, import_runs, RunsExportArgs, RunsExportOutput, RunsImportArgs, RunsImportOutput,
 };
 use compare::{compare_runs, RunsCompareArgs, RunsCompareOutput};
+pub use distribution::{runs_distribution, RunsDistributionArgs, RunsDistributionOutput};
 use findings::{RunsFindingOutput, RunsFindingsOutput};
 use latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
@@ -77,31 +79,6 @@ pub struct RunsListArgs {
     pub limit: i64,
 }
 
-#[derive(Args, Clone, Default)]
-pub struct RunsDistributionArgs {
-    /// Run kind: bench, rig, trace, etc.
-    #[arg(long)]
-    pub kind: Option<String>,
-    /// Component ID
-    #[arg(long = "component")]
-    pub component_id: Option<String>,
-    /// Rig ID
-    #[arg(long)]
-    pub rig: Option<String>,
-    /// Benchmark scenario ID. Only applies to bench metadata.
-    #[arg(long = "scenario")]
-    pub scenario_id: Option<String>,
-    /// Run status
-    #[arg(long)]
-    pub status: Option<String>,
-    /// Dot-separated metadata path to aggregate
-    #[arg(long = "field", required = true)]
-    pub fields: Vec<String>,
-    /// Maximum runs to inspect before scenario filtering
-    #[arg(long, default_value_t = DEFAULT_LIMIT)]
-    pub limit: i64,
-}
-
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum RunsOutput {
@@ -125,43 +102,6 @@ pub enum RunsOutput {
 pub struct RunsListOutput {
     pub command: &'static str,
     pub runs: Vec<RunSummary>,
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq)]
-pub struct RunsDistributionOutput {
-    pub command: &'static str,
-    pub filters: RunsDistributionFilters,
-    pub fields: Vec<FieldDistributionOutput>,
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
-pub struct RunsDistributionFilters {
-    pub kind: Option<String>,
-    pub component_id: Option<String>,
-    pub rig_id: Option<String>,
-    pub scenario_id: Option<String>,
-    pub status: Option<String>,
-    pub limit: i64,
-    pub inspected_run_count: usize,
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq)]
-pub struct FieldDistributionOutput {
-    pub field: String,
-    pub matched_run_count: usize,
-    pub missing_run_count: usize,
-    pub total_value_count: usize,
-    pub unique_value_count: usize,
-    pub values: Vec<CategoryDistributionValue>,
-    pub repeated_values: Vec<CategoryDistributionValue>,
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq)]
-pub struct CategoryDistributionValue {
-    pub value: String,
-    pub count: usize,
-    pub percent: f64,
-    pub run_count: usize,
 }
 
 #[derive(Serialize)]
@@ -242,7 +182,9 @@ pub struct BenchMissingMetric {
 pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
     match args.command {
         RunsCommand::List(args) => list_runs(args, "runs.list"),
-        RunsCommand::Distribution(args) => runs_distribution(args, "runs.distribution"),
+        RunsCommand::Distribution(args) => {
+            distribution::runs_distribution(args, "runs.distribution")
+        }
         RunsCommand::LatestRun(args) => latest::latest_run(args),
         RunsCommand::Compare(args) => compare_runs(args),
         RunsCommand::Reconcile(args) => reconcile_runs(args),
@@ -254,52 +196,6 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
     }
-}
-
-pub fn runs_distribution(
-    args: RunsDistributionArgs,
-    command: &'static str,
-) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let limit = args.limit.clamp(1, 1000);
-    let runs = store
-        .list_runs(RunListFilter {
-            kind: args.kind.clone(),
-            component_id: args.component_id.clone(),
-            status: args.status.clone(),
-            rig_id: args.rig.clone(),
-            limit: Some(limit),
-        })?
-        .into_iter()
-        .filter(|run| {
-            args.scenario_id
-                .as_deref()
-                .is_none_or(|scenario| run_contains_scenario(run, scenario))
-        })
-        .collect::<Vec<_>>();
-
-    let fields = args
-        .fields
-        .iter()
-        .map(|field| distribution_for_field(field, &runs))
-        .collect();
-
-    Ok((
-        RunsOutput::Distribution(RunsDistributionOutput {
-            command,
-            filters: RunsDistributionFilters {
-                kind: args.kind,
-                component_id: args.component_id,
-                rig_id: args.rig,
-                scenario_id: args.scenario_id,
-                status: args.status,
-                limit,
-                inspected_run_count: runs.len(),
-            },
-            fields,
-        }),
-        0,
-    ))
 }
 
 impl RunsArgs {
@@ -510,7 +406,7 @@ pub(crate) fn run_summary(run: RunRecord) -> RunSummary {
     }
 }
 
-fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
+pub(super) fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
     if run.metadata_json["selected_scenarios"]
         .as_array()
         .is_some_and(|items| items.iter().any(|item| item.as_str() == Some(scenario_id)))
@@ -520,81 +416,6 @@ fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
     bench_numeric_metrics(&run.metadata_json)
         .keys()
         .any(|(scenario, _)| scenario == scenario_id)
-}
-
-fn distribution_for_field(field: &str, runs: &[RunRecord]) -> FieldDistributionOutput {
-    let mut counts = BTreeMap::<String, (usize, BTreeSet<String>)>::new();
-    let mut matched_run_count = 0;
-    let mut total_value_count = 0;
-
-    for run in runs {
-        let values = metadata_path_values(&run.metadata_json, field);
-        if values.is_empty() {
-            continue;
-        }
-        matched_run_count += 1;
-        total_value_count += values.len();
-
-        for value in values {
-            let entry = counts.entry(value).or_insert_with(|| (0, BTreeSet::new()));
-            entry.0 += 1;
-            entry.1.insert(run.id.clone());
-        }
-    }
-
-    let mut values = counts
-        .into_iter()
-        .map(|(value, (count, run_ids))| CategoryDistributionValue {
-            value,
-            count,
-            percent: if total_value_count == 0 {
-                0.0
-            } else {
-                (count as f64 / total_value_count as f64) * 100.0
-            },
-            run_count: run_ids.len(),
-        })
-        .collect::<Vec<_>>();
-    values.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.value.cmp(&b.value)));
-    let repeated_values = values
-        .iter()
-        .filter(|value| value.count > 1)
-        .cloned()
-        .collect::<Vec<_>>();
-
-    FieldDistributionOutput {
-        field: field.to_string(),
-        matched_run_count,
-        missing_run_count: runs.len().saturating_sub(matched_run_count),
-        total_value_count,
-        unique_value_count: values.len(),
-        values,
-        repeated_values,
-    }
-}
-
-fn metadata_path_values(metadata: &Value, field: &str) -> Vec<String> {
-    let Some(value) = field
-        .split('.')
-        .filter(|part| !part.is_empty())
-        .try_fold(metadata, |value, part| value.get(part))
-    else {
-        return Vec::new();
-    };
-
-    match value {
-        Value::Array(items) => items.iter().filter_map(categorical_value).collect(),
-        value => categorical_value(value).into_iter().collect(),
-    }
-}
-
-fn categorical_value(value: &Value) -> Option<String> {
-    match value {
-        Value::String(value) => Some(value.clone()),
-        Value::Number(value) => Some(value.to_string()),
-        Value::Bool(value) => Some(value.to_string()),
-        Value::Null | Value::Array(_) | Value::Object(_) => None,
-    }
 }
 
 fn bench_numeric_metrics(metadata: &Value) -> BTreeMap<(String, String), f64> {
@@ -1062,230 +883,6 @@ mod tests {
     }
 
     #[test]
-    fn distribution_counts_scalar_metadata_values() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            for family in ["serif", "sans", "serif"] {
-                let run = store
-                    .start_run(sample_run(
-                        "bench",
-                        "studio",
-                        "rig-a",
-                        serde_json::json!({ "fingerprint": { "font": family } }),
-                    ))
-                    .expect("run");
-                store
-                    .finish_run(&run.id, RunStatus::Pass, None)
-                    .expect("finish");
-            }
-
-            let output = distribution_output(RunsDistributionArgs {
-                kind: Some("bench".to_string()),
-                component_id: Some("studio".to_string()),
-                fields: vec!["fingerprint.font".to_string()],
-                limit: 20,
-                ..RunsDistributionArgs::default()
-            });
-
-            let field = &output.fields[0];
-            assert_eq!(field.matched_run_count, 3);
-            assert_eq!(field.missing_run_count, 0);
-            assert_eq!(field.total_value_count, 3);
-            assert_eq!(field.unique_value_count, 2);
-            assert_eq!(field.values[0].value, "serif");
-            assert_eq!(field.values[0].count, 2);
-            assert_eq!(field.values[0].run_count, 2);
-            assert!((field.values[0].percent - (100.0 * 2.0 / 3.0)).abs() < 0.000_000_001);
-            assert_eq!(field.repeated_values.len(), 1);
-        });
-    }
-
-    #[test]
-    fn distribution_flattens_array_metadata_values() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            for motifs in [
-                serde_json::json!(["grid", "cards"]),
-                serde_json::json!(["grid", "hero"]),
-            ] {
-                let run = store
-                    .start_run(sample_run(
-                        "bench",
-                        "studio",
-                        "rig-a",
-                        serde_json::json!({ "fingerprint": { "motifs": motifs } }),
-                    ))
-                    .expect("run");
-                store
-                    .finish_run(&run.id, RunStatus::Pass, None)
-                    .expect("finish");
-            }
-
-            let output = distribution_output(RunsDistributionArgs {
-                kind: Some("bench".to_string()),
-                component_id: Some("studio".to_string()),
-                fields: vec!["fingerprint.motifs".to_string()],
-                limit: 20,
-                ..RunsDistributionArgs::default()
-            });
-
-            let field = &output.fields[0];
-            assert_eq!(field.matched_run_count, 2);
-            assert_eq!(field.total_value_count, 4);
-            assert_eq!(field.unique_value_count, 3);
-            assert_eq!(field.values[0].value, "grid");
-            assert_eq!(field.values[0].count, 2);
-            assert_eq!(field.values[0].run_count, 2);
-        });
-    }
-
-    #[test]
-    fn distribution_reports_missing_fields() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            for metadata in [
-                serde_json::json!({ "category": "timeout" }),
-                serde_json::json!({ "other": "value" }),
-            ] {
-                let run = store
-                    .start_run(sample_run("bench", "studio", "rig-a", metadata))
-                    .expect("run");
-                store
-                    .finish_run(&run.id, RunStatus::Pass, None)
-                    .expect("finish");
-            }
-
-            let output = distribution_output(RunsDistributionArgs {
-                kind: Some("bench".to_string()),
-                component_id: Some("studio".to_string()),
-                fields: vec!["category".to_string()],
-                limit: 20,
-                ..RunsDistributionArgs::default()
-            });
-
-            let field = &output.fields[0];
-            assert_eq!(field.matched_run_count, 1);
-            assert_eq!(field.missing_run_count, 1);
-            assert_eq!(field.values[0].value, "timeout");
-        });
-    }
-
-    #[test]
-    fn distribution_applies_run_filters_and_scenario_filter() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            let matching = store
-                .start_run(sample_run(
-                    "bench",
-                    "studio",
-                    "rig-a",
-                    serde_json::json!({
-                        "category": "kept",
-                        "selected_scenarios": ["build"]
-                    }),
-                ))
-                .expect("matching");
-            store
-                .finish_run(&matching.id, RunStatus::Pass, None)
-                .expect("finish matching");
-            let wrong_status = store
-                .start_run(sample_run(
-                    "bench",
-                    "studio",
-                    "rig-a",
-                    serde_json::json!({
-                        "category": "failed",
-                        "selected_scenarios": ["build"]
-                    }),
-                ))
-                .expect("wrong status");
-            store
-                .finish_run(&wrong_status.id, RunStatus::Fail, None)
-                .expect("finish wrong status");
-            let wrong_scenario = store
-                .start_run(sample_run(
-                    "bench",
-                    "studio",
-                    "rig-a",
-                    serde_json::json!({
-                        "category": "other-scenario",
-                        "selected_scenarios": ["deploy"]
-                    }),
-                ))
-                .expect("wrong scenario");
-            store
-                .finish_run(&wrong_scenario.id, RunStatus::Pass, None)
-                .expect("finish wrong scenario");
-            let wrong_component = store
-                .start_run(sample_run(
-                    "bench",
-                    "homeboy",
-                    "rig-a",
-                    serde_json::json!({
-                        "category": "other-component",
-                        "selected_scenarios": ["build"]
-                    }),
-                ))
-                .expect("wrong component");
-            store
-                .finish_run(&wrong_component.id, RunStatus::Pass, None)
-                .expect("finish wrong component");
-
-            let output = distribution_output(RunsDistributionArgs {
-                kind: Some("bench".to_string()),
-                component_id: Some("studio".to_string()),
-                rig: Some("rig-a".to_string()),
-                scenario_id: Some("build".to_string()),
-                status: Some("pass".to_string()),
-                fields: vec!["category".to_string()],
-                limit: 20,
-            });
-
-            let field = &output.fields[0];
-            assert_eq!(output.filters.inspected_run_count, 1);
-            assert_eq!(field.values.len(), 1);
-            assert_eq!(field.values[0].value, "kept");
-        });
-    }
-
-    #[test]
-    fn distribution_reports_repeated_categories_by_occurrence() {
-        with_isolated_home(|_home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            let run = store
-                .start_run(sample_run(
-                    "bench",
-                    "studio",
-                    "rig-a",
-                    serde_json::json!({ "choices": ["sqlite", "sqlite", "mysql"] }),
-                ))
-                .expect("run");
-            store
-                .finish_run(&run.id, RunStatus::Pass, None)
-                .expect("finish");
-
-            let output = distribution_output(RunsDistributionArgs {
-                kind: Some("bench".to_string()),
-                component_id: Some("studio".to_string()),
-                fields: vec!["choices".to_string()],
-                limit: 20,
-                ..RunsDistributionArgs::default()
-            });
-
-            let repeated = &output.fields[0].repeated_values;
-            assert_eq!(repeated.len(), 1);
-            assert_eq!(repeated[0].value, "sqlite");
-            assert_eq!(repeated[0].count, 2);
-            assert_eq!(repeated[0].run_count, 1);
-        });
-    }
-
-    #[test]
     fn bench_compare_reports_deltas_and_missing_metrics() {
         with_isolated_home(|_home| {
             let _xdg = XdgGuard::unset();
@@ -1599,13 +1196,5 @@ mod tests {
 
     fn read_bundle_test_json<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
         serde_json::from_str(&std::fs::read_to_string(path).expect("read json")).expect("json")
-    }
-
-    fn distribution_output(args: RunsDistributionArgs) -> RunsDistributionOutput {
-        let (output, _) = runs_distribution(args, "runs.distribution").expect("distribution");
-        let RunsOutput::Distribution(output) = output else {
-            panic!("expected distribution output");
-        };
-        output
     }
 }

--- a/src/commands/runs/distribution.rs
+++ b/src/commands/runs/distribution.rs
@@ -1,0 +1,465 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use clap::Args;
+use serde::Serialize;
+use serde_json::Value;
+
+use homeboy::observation::{ObservationStore, RunListFilter, RunRecord};
+
+use crate::commands::CmdResult;
+
+use super::{run_contains_scenario, RunsOutput, DEFAULT_LIMIT};
+
+#[derive(Args, Clone, Default)]
+pub struct RunsDistributionArgs {
+    /// Run kind: bench, rig, trace, etc.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Component ID
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Rig ID
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Benchmark scenario ID. Only applies to bench metadata.
+    #[arg(long = "scenario")]
+    pub scenario_id: Option<String>,
+    /// Run status
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Dot-separated metadata path to aggregate
+    #[arg(long = "field", required = true)]
+    pub fields: Vec<String>,
+    /// Maximum runs to inspect before scenario filtering
+    #[arg(long, default_value_t = DEFAULT_LIMIT)]
+    pub limit: i64,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct RunsDistributionOutput {
+    pub command: &'static str,
+    pub filters: RunsDistributionFilters,
+    pub fields: Vec<FieldDistributionOutput>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct RunsDistributionFilters {
+    pub kind: Option<String>,
+    pub component_id: Option<String>,
+    pub rig_id: Option<String>,
+    pub scenario_id: Option<String>,
+    pub status: Option<String>,
+    pub limit: i64,
+    pub inspected_run_count: usize,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct FieldDistributionOutput {
+    pub field: String,
+    pub matched_run_count: usize,
+    pub missing_run_count: usize,
+    pub total_value_count: usize,
+    pub unique_value_count: usize,
+    pub values: Vec<CategoryDistributionValue>,
+    pub repeated_values: Vec<CategoryDistributionValue>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct CategoryDistributionValue {
+    pub value: String,
+    pub count: usize,
+    pub percent: f64,
+    pub run_count: usize,
+}
+
+pub fn runs_distribution(
+    args: RunsDistributionArgs,
+    command: &'static str,
+) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let limit = args.limit.clamp(1, 1000);
+    let runs = store
+        .list_runs(RunListFilter {
+            kind: args.kind.clone(),
+            component_id: args.component_id.clone(),
+            status: args.status.clone(),
+            rig_id: args.rig.clone(),
+            limit: Some(limit),
+        })?
+        .into_iter()
+        .filter(|run| {
+            args.scenario_id
+                .as_deref()
+                .is_none_or(|scenario| run_contains_scenario(run, scenario))
+        })
+        .collect::<Vec<_>>();
+
+    let fields = args
+        .fields
+        .iter()
+        .map(|field| distribution_for_field(field, &runs))
+        .collect();
+
+    Ok((
+        RunsOutput::Distribution(RunsDistributionOutput {
+            command,
+            filters: RunsDistributionFilters {
+                kind: args.kind,
+                component_id: args.component_id,
+                rig_id: args.rig,
+                scenario_id: args.scenario_id,
+                status: args.status,
+                limit,
+                inspected_run_count: runs.len(),
+            },
+            fields,
+        }),
+        0,
+    ))
+}
+
+fn distribution_for_field(field: &str, runs: &[RunRecord]) -> FieldDistributionOutput {
+    let mut counts = BTreeMap::<String, (usize, BTreeSet<String>)>::new();
+    let mut matched_run_count = 0;
+    let mut total_value_count = 0;
+
+    for run in runs {
+        let values = metadata_path_values(&run.metadata_json, field);
+        if values.is_empty() {
+            continue;
+        }
+        matched_run_count += 1;
+        total_value_count += values.len();
+
+        for value in values {
+            let entry = counts.entry(value).or_insert_with(|| (0, BTreeSet::new()));
+            entry.0 += 1;
+            entry.1.insert(run.id.clone());
+        }
+    }
+
+    let mut values = counts
+        .into_iter()
+        .map(|(value, (count, run_ids))| CategoryDistributionValue {
+            value,
+            count,
+            percent: if total_value_count == 0 {
+                0.0
+            } else {
+                (count as f64 / total_value_count as f64) * 100.0
+            },
+            run_count: run_ids.len(),
+        })
+        .collect::<Vec<_>>();
+    values.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.value.cmp(&b.value)));
+    let repeated_values = values
+        .iter()
+        .filter(|value| value.count > 1)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    FieldDistributionOutput {
+        field: field.to_string(),
+        matched_run_count,
+        missing_run_count: runs.len().saturating_sub(matched_run_count),
+        total_value_count,
+        unique_value_count: values.len(),
+        values,
+        repeated_values,
+    }
+}
+
+fn metadata_path_values(metadata: &Value, field: &str) -> Vec<String> {
+    let Some(value) = field
+        .split('.')
+        .filter(|part| !part.is_empty())
+        .try_fold(metadata, |value, part| value.get(part))
+    else {
+        return Vec::new();
+    };
+
+    match value.as_array() {
+        Some(items) => items.iter().filter_map(scalar_metadata_label).collect(),
+        None => scalar_metadata_label(value).into_iter().collect(),
+    }
+}
+
+fn scalar_metadata_label(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| value.as_bool().map(|bool_value| bool_value.to_string()))
+        .or_else(|| value.as_number().map(ToString::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use homeboy::observation::{NewRunRecord, RunStatus};
+    use homeboy::test_support::with_isolated_home;
+
+    struct XdgGuard(Option<String>);
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prior = std::env::var("XDG_DATA_HOME").ok();
+            std::env::remove_var("XDG_DATA_HOME");
+            Self(prior)
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
+        NewRunRecord {
+            kind: kind.to_string(),
+            component_id: Some(component_id.to_string()),
+            command: Some(format!("homeboy {kind} {component_id}")),
+            cwd: Some("/tmp/homeboy-fixture".to_string()),
+            homeboy_version: Some("test-version".to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: Some(rig_id.to_string()),
+            metadata_json: metadata,
+        }
+    }
+
+    #[test]
+    fn distribution_counts_scalar_metadata_values() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            for family in ["serif", "sans", "serif"] {
+                let run = store
+                    .start_run(sample_run(
+                        "bench",
+                        "studio",
+                        "rig-a",
+                        serde_json::json!({ "fingerprint": { "font": family } }),
+                    ))
+                    .expect("run");
+                store
+                    .finish_run(&run.id, RunStatus::Pass, None)
+                    .expect("finish");
+            }
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["fingerprint.font".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(field.matched_run_count, 3);
+            assert_eq!(field.missing_run_count, 0);
+            assert_eq!(field.total_value_count, 3);
+            assert_eq!(field.unique_value_count, 2);
+            assert_eq!(field.values[0].value, "serif");
+            assert_eq!(field.values[0].count, 2);
+            assert_eq!(field.values[0].run_count, 2);
+            assert!((field.values[0].percent - (100.0 * 2.0 / 3.0)).abs() < 0.000_000_001);
+            assert_eq!(field.repeated_values.len(), 1);
+        });
+    }
+
+    #[test]
+    fn distribution_flattens_array_metadata_values() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            for motifs in [
+                serde_json::json!(["grid", "cards"]),
+                serde_json::json!(["grid", "hero"]),
+            ] {
+                let run = store
+                    .start_run(sample_run(
+                        "bench",
+                        "studio",
+                        "rig-a",
+                        serde_json::json!({ "fingerprint": { "motifs": motifs } }),
+                    ))
+                    .expect("run");
+                store
+                    .finish_run(&run.id, RunStatus::Pass, None)
+                    .expect("finish");
+            }
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["fingerprint.motifs".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(field.matched_run_count, 2);
+            assert_eq!(field.total_value_count, 4);
+            assert_eq!(field.unique_value_count, 3);
+            assert_eq!(field.values[0].value, "grid");
+            assert_eq!(field.values[0].count, 2);
+            assert_eq!(field.values[0].run_count, 2);
+        });
+    }
+
+    #[test]
+    fn distribution_reports_missing_fields() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            for metadata in [
+                serde_json::json!({ "category": "timeout" }),
+                serde_json::json!({ "other": "value" }),
+            ] {
+                let run = store
+                    .start_run(sample_run("bench", "studio", "rig-a", metadata))
+                    .expect("run");
+                store
+                    .finish_run(&run.id, RunStatus::Pass, None)
+                    .expect("finish");
+            }
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["category".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(field.matched_run_count, 1);
+            assert_eq!(field.missing_run_count, 1);
+            assert_eq!(field.values[0].value, "timeout");
+        });
+    }
+
+    #[test]
+    fn distribution_applies_run_filters_and_scenario_filter() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let matching = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "kept",
+                        "selected_scenarios": ["build"]
+                    }),
+                ))
+                .expect("matching");
+            store
+                .finish_run(&matching.id, RunStatus::Pass, None)
+                .expect("finish matching");
+            let wrong_status = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "failed",
+                        "selected_scenarios": ["build"]
+                    }),
+                ))
+                .expect("wrong status");
+            store
+                .finish_run(&wrong_status.id, RunStatus::Fail, None)
+                .expect("finish wrong status");
+            let wrong_scenario = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "other-scenario",
+                        "selected_scenarios": ["deploy"]
+                    }),
+                ))
+                .expect("wrong scenario");
+            store
+                .finish_run(&wrong_scenario.id, RunStatus::Pass, None)
+                .expect("finish wrong scenario");
+            let wrong_component = store
+                .start_run(sample_run(
+                    "bench",
+                    "homeboy",
+                    "rig-a",
+                    serde_json::json!({
+                        "category": "other-component",
+                        "selected_scenarios": ["build"]
+                    }),
+                ))
+                .expect("wrong component");
+            store
+                .finish_run(&wrong_component.id, RunStatus::Pass, None)
+                .expect("finish wrong component");
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                rig: Some("rig-a".to_string()),
+                scenario_id: Some("build".to_string()),
+                status: Some("pass".to_string()),
+                fields: vec!["category".to_string()],
+                limit: 20,
+            });
+
+            let field = &output.fields[0];
+            assert_eq!(output.filters.inspected_run_count, 1);
+            assert_eq!(field.values.len(), 1);
+            assert_eq!(field.values[0].value, "kept");
+        });
+    }
+
+    #[test]
+    fn distribution_reports_repeated_categories_by_occurrence() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "bench",
+                    "studio",
+                    "rig-a",
+                    serde_json::json!({ "choices": ["sqlite", "sqlite", "mysql"] }),
+                ))
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish");
+
+            let output = distribution_output(RunsDistributionArgs {
+                kind: Some("bench".to_string()),
+                component_id: Some("studio".to_string()),
+                fields: vec!["choices".to_string()],
+                limit: 20,
+                ..RunsDistributionArgs::default()
+            });
+
+            let repeated = &output.fields[0].repeated_values;
+            assert_eq!(repeated.len(), 1);
+            assert_eq!(repeated[0].value, "sqlite");
+            assert_eq!(repeated[0].count, 2);
+            assert_eq!(repeated[0].run_count, 1);
+        });
+    }
+
+    fn distribution_output(args: RunsDistributionArgs) -> RunsDistributionOutput {
+        let (output, _) = runs_distribution(args, "runs.distribution").expect("distribution");
+        let RunsOutput::Distribution(output) = output else {
+            panic!("expected distribution output");
+        };
+        output
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `homeboy runs distribution` for generic categorical aggregation over persisted run metadata paths.
- Adds `homeboy bench distribution <component>` as a bench-specific wrapper with component, rig, scenario, status, and limit filters.
- Reports matched/missing runs, total/unique values, value counts, percentages, run counts, and repeated values for scalar and array metadata values.

Fixes #2177.

## Testing
- `cargo test commands::runs::tests::distribution --lib`
- `cargo test command_surface --test command_surface_test`
- `cargo check --bin homeboy`
- `cargo test --lib` *(fails one unrelated PATH-ordering test: `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path`)*

## Deferred
- Artifact JSON traversal is not included in v1; this implementation focuses on persisted run metadata paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI/reporting path, tests, docs, and local verification; Chris remains responsible for review and merge.