### PR TITLE
Guard lower release bump overrides

### DIFF
--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -20,6 +20,7 @@ Legacy positional bump syntax is still accepted for compatibility: `homeboy rele
 - `--recover`: Recover from an interrupted release
 - `--skip-checks`: Skip pre-release lint/test checks
 - `--bump <BUMP>`: Force `major`, `minor`, `patch`, or an explicit version like `2.0.0`
+- `--force-lower-bump`: Allow a forced bump lower than the commit-derived recommendation
 - `--skip-publish`: Skip publish/package steps; useful when CI publishes after the tag is pushed
 - `--no-github-release`: Skip GitHub Release creation while still tagging and pushing
 - `--git-identity <IDENTITY>`: Configure git identity for release commits/tags; use `bot` or `Name <email>`
@@ -27,6 +28,8 @@ Legacy positional bump syntax is still accepted for compatibility: `homeboy rele
 ## Description
 
 `homeboy release` executes component releases: detects or applies a version bump, finalizes generated changelog entries, commits, tags, pushes, and optionally publishes release artifacts. Use `--dry-run` to preview the release plan without making changes.
+
+When `--bump` requests a lower keyword bump than Homeboy detects from releasable commits, release execution requires confirmation in an interactive terminal. Non-interactive runs must pass `--force-lower-bump`; otherwise Homeboy refuses before creating release artifacts, commits, tags, or pushes. Dry-run still returns the plan and semver recommendation for review.
 
 ## Recommended Workflow
 
@@ -190,7 +193,7 @@ Example payload:
 }
 ```
 
-Use this in CI to inspect Homeboy's commit-derived recommendation before tagging/publish. Pass `--bump` when automation or a maintainer needs to override the detected bump.
+Use this in CI to inspect Homeboy's commit-derived recommendation before tagging/publish. Pass `--bump` when automation or a maintainer needs to override the detected bump. If automation intentionally publishes a lower keyword bump than `recommended_bump`, pass `--force-lower-bump` with the release command.
 
 Without `--dry-run`:
 

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -49,6 +49,10 @@ pub struct ReleaseArgs {
     #[arg(long)]
     bump: Option<String>,
 
+    /// Allow an explicit bump lower than Homeboy's commit-derived recommendation.
+    #[arg(long)]
+    force_lower_bump: bool,
+
     /// Skip publish/package steps (version bump + tag + push only).
     /// Use when CI handles publishing after the tag is pushed.
     #[arg(long)]
@@ -111,6 +115,7 @@ impl ReleaseArgs {
             recover,
             skip_checks,
             bump,
+            force_lower_bump: false,
             skip_publish,
             no_github_release: false,
             git_identity: None,
@@ -138,6 +143,7 @@ pub fn run(
             recover: args.recover,
             skip_checks: args.skip_checks,
             bump_override: bump_override.clone(),
+            force_lower_bump: args.force_lower_bump,
             skip_publish: args.skip_publish,
             skip_github_release: args.no_github_release,
             git_identity: args.git_identity.clone(),
@@ -175,6 +181,7 @@ pub fn run(
         recover: false,
         skip_checks: args.skip_checks,
         bump_override,
+        force_lower_bump: args.force_lower_bump,
         skip_publish: args.skip_publish,
         skip_github_release: args.no_github_release,
         git_identity: args.git_identity.clone(),

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -278,3 +278,15 @@ pub struct BatchReleaseSummary {
     pub skipped: u32,
     pub failed: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_command_input_defaults_do_not_force_lower_bumps() {
+        let input = ReleaseCommandInput::default();
+
+        assert!(!input.force_lower_bump);
+    }
+}

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -192,6 +192,9 @@ pub struct ReleaseCommandInput {
     /// When set, overrides auto-detection from commit history.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bump_override: Option<String>,
+    /// Permit a keyword bump lower than the commit-derived recommendation.
+    #[serde(default)]
+    pub force_lower_bump: bool,
     #[serde(default)]
     pub skip_publish: bool,
     /// Skip the GitHub Release creation step (tag + notes on github.com).

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -787,6 +787,26 @@ struct LowerBumpOverride {
     releasable_count: usize,
 }
 
+impl LowerBumpOverride {
+    fn commit_suffix(&self) -> &'static str {
+        if self.releasable_count == 1 {
+            ""
+        } else {
+            "s"
+        }
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "Requested {} bump is lower than detected {} impact from {} releasable commit{}",
+            self.requested,
+            self.detected,
+            self.releasable_count,
+            self.commit_suffix()
+        )
+    }
+}
+
 fn detect_lower_bump_override(
     requested_bump: &str,
     detected_bump: &str,
@@ -817,18 +837,7 @@ fn guard_lower_bump_override(
     dry_run: bool,
 ) -> Result<()> {
     if dry_run {
-        log_status!(
-            "release",
-            "Requested {} bump is lower than detected {} impact from {} releasable commit{}",
-            under_bump.requested,
-            under_bump.detected,
-            under_bump.releasable_count,
-            if under_bump.releasable_count == 1 {
-                ""
-            } else {
-                "s"
-            }
-        );
+        log_status!("release", "{}", under_bump.message());
         return Ok(());
     }
 
@@ -837,18 +846,7 @@ fn guard_lower_bump_override(
     }
 
     if io::stdin().is_terminal() && io::stdout().is_terminal() {
-        log_status!(
-            "release",
-            "Requested {} bump is lower than detected {} impact from {} releasable commit{}.",
-            under_bump.requested,
-            under_bump.detected,
-            under_bump.releasable_count,
-            if under_bump.releasable_count == 1 {
-                ""
-            } else {
-                "s"
-            }
-        );
+        log_status!("release", "{}.", under_bump.message());
         eprint!("Continue with lower bump? [y/N] ");
         io::stderr().flush().ok();
 
@@ -868,17 +866,7 @@ fn guard_lower_bump_override(
 fn lower_bump_error(component_id: &str, under_bump: &LowerBumpOverride) -> Error {
     Error::validation_invalid_argument(
         "bump",
-        format!(
-            "Requested {} bump is lower than detected {} impact from {} releasable commit{}",
-            under_bump.requested,
-            under_bump.detected,
-            under_bump.releasable_count,
-            if under_bump.releasable_count == 1 {
-                ""
-            } else {
-                "s"
-            }
-        ),
+        under_bump.message(),
         Some(under_bump.requested.clone()),
         None,
     )

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -3,6 +3,7 @@ use crate::deploy::{self, DeployConfig};
 use crate::engine::command;
 use crate::error::{Error, Result};
 use crate::git;
+use std::io::{self, BufRead, IsTerminal, Write};
 
 use super::pipeline::load_component;
 use super::types::{
@@ -104,13 +105,25 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
                 ));
             }
 
-            // Warn if overriding to a lower bump than auto-detected
-            if has_breaking_commits && bump != "major" {
+            let mut forced_lower_bump = false;
+            if let Some(under_bump) =
+                detect_lower_bump_override(&bump, &auto_bump_type, releasable_count)?
+            {
+                guard_lower_bump_override(
+                    &input.component_id,
+                    &under_bump,
+                    input.force_lower_bump,
+                    input.dry_run,
+                )?;
+                forced_lower_bump = input.force_lower_bump && !input.dry_run;
+            }
+
+            if forced_lower_bump {
                 log_status!(
                     "release",
-                    "⚠ Breaking changes detected in commits, but --bump {} overrides to {} bump",
+                    "Forced lower bump: requested {} while commits indicate {}",
                     bump,
-                    bump
+                    auto_bump_type
                 );
             }
 
@@ -704,6 +717,7 @@ pub fn run_batch(
             recover: input_template.recover,
             skip_checks: input_template.skip_checks,
             bump_override: input_template.bump_override.clone(),
+            force_lower_bump: input_template.force_lower_bump,
             skip_publish: input_template.skip_publish,
             skip_github_release: input_template.skip_github_release,
             git_identity: input_template.git_identity.clone(),
@@ -766,11 +780,175 @@ pub fn run_batch(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LowerBumpOverride {
+    requested: String,
+    detected: String,
+    releasable_count: usize,
+}
+
+fn detect_lower_bump_override(
+    requested_bump: &str,
+    detected_bump: &str,
+    releasable_count: usize,
+) -> Result<Option<LowerBumpOverride>> {
+    let Some(requested) = git::SemverBump::parse(requested_bump) else {
+        return Ok(None);
+    };
+    let Some(detected) = git::SemverBump::parse(detected_bump) else {
+        return Ok(None);
+    };
+
+    if requested.rank() >= detected.rank() {
+        return Ok(None);
+    }
+
+    Ok(Some(LowerBumpOverride {
+        requested: requested.as_str().to_string(),
+        detected: detected.as_str().to_string(),
+        releasable_count,
+    }))
+}
+
+fn guard_lower_bump_override(
+    component_id: &str,
+    under_bump: &LowerBumpOverride,
+    force_lower_bump: bool,
+    dry_run: bool,
+) -> Result<()> {
+    if dry_run {
+        log_status!(
+            "release",
+            "Requested {} bump is lower than detected {} impact from {} releasable commit{}",
+            under_bump.requested,
+            under_bump.detected,
+            under_bump.releasable_count,
+            if under_bump.releasable_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+        return Ok(());
+    }
+
+    if force_lower_bump {
+        return Ok(());
+    }
+
+    if io::stdin().is_terminal() && io::stdout().is_terminal() {
+        log_status!(
+            "release",
+            "Requested {} bump is lower than detected {} impact from {} releasable commit{}.",
+            under_bump.requested,
+            under_bump.detected,
+            under_bump.releasable_count,
+            if under_bump.releasable_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+        eprint!("Continue with lower bump? [y/N] ");
+        io::stderr().flush().ok();
+
+        let mut answer = String::new();
+        io::stdin().lock().read_line(&mut answer).map_err(|e| {
+            Error::internal_unexpected(format!("Failed to read confirmation: {}", e))
+        })?;
+
+        if matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+            return Ok(());
+        }
+    }
+
+    Err(lower_bump_error(component_id, under_bump))
+}
+
+fn lower_bump_error(component_id: &str, under_bump: &LowerBumpOverride) -> Error {
+    Error::validation_invalid_argument(
+        "bump",
+        format!(
+            "Requested {} bump is lower than detected {} impact from {} releasable commit{}",
+            under_bump.requested,
+            under_bump.detected,
+            under_bump.releasable_count,
+            if under_bump.releasable_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        ),
+        Some(under_bump.requested.clone()),
+        None,
+    )
+    .with_hint(format!(
+        "Use the detected bump: homeboy release {} --bump {}",
+        component_id, under_bump.detected
+    ))
+    .with_hint("If the lower release is intentional, re-run with --force-lower-bump")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
     use std::collections::HashMap;
+
+    #[test]
+    fn detects_keyword_under_bump_override() {
+        let under_bump = detect_lower_bump_override("patch", "minor", 3)
+            .expect("valid bump comparison")
+            .expect("patch should under-bump minor");
+
+        assert_eq!(under_bump.requested, "patch");
+        assert_eq!(under_bump.detected, "minor");
+        assert_eq!(under_bump.releasable_count, 3);
+    }
+
+    #[test]
+    fn lower_bump_detection_allows_equal_or_higher_bump() {
+        assert!(detect_lower_bump_override("minor", "minor", 1)
+            .unwrap()
+            .is_none());
+        assert!(detect_lower_bump_override("major", "minor", 1)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn lower_bump_detection_ignores_explicit_versions_and_none() {
+        assert!(detect_lower_bump_override("2.0.0", "minor", 1)
+            .unwrap()
+            .is_none());
+        assert!(detect_lower_bump_override("patch", "none", 0)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn lower_bump_error_points_to_detected_bump_and_force_flag() {
+        let under_bump = LowerBumpOverride {
+            requested: "patch".to_string(),
+            detected: "minor".to_string(),
+            releasable_count: 2,
+        };
+
+        let err = lower_bump_error("demo", &under_bump);
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err
+            .message
+            .contains("Requested patch bump is lower than detected minor impact"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy release demo --bump minor")));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("--force-lower-bump")));
+    }
 
     #[test]
     fn extracts_new_version_from_plan() {


### PR DESCRIPTION
## Summary
- Add `--force-lower-bump` for explicit release bump overrides below Homeboy's commit-derived recommendation.
- Refuse non-interactive under-bumps unless forced, while interactive terminals require confirmation before execution proceeds.
- Document the lower-bump guard and add targeted workflow tests.

## Tests
- `cargo test --release release::workflow`
- `cargo test --release release::pipeline`
- `cargo test --release` failed in unrelated existing trace test: `commands::trace::tests::trace_compare_markdown_renders_span_table`.

## AI Assistance Disclosure
Implemented with AI assistance using OpenCode (gpt-5.5).

Fixes #2175