### PR TITLE
Expose read-only daemon API contract

### DIFF
--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -15,6 +15,44 @@ homeboy daemon <COMMAND>
 - `stop` — stop the background daemon recorded in the state file
 - `status` — show daemon state and selected local address
 
+## Local HTTP API
+
+The daemon binds to loopback only. `homeboy daemon start` writes the selected
+address and PID to the daemon state file so headless clients can discover it via
+`homeboy daemon status`.
+
+Always treat the API as a local UI contract. It is not a hosted or remote
+multi-user service.
+
+### Built-in Endpoints
+
+- `GET /health` — daemon health and Homeboy version
+- `GET /version` — Homeboy version
+- `GET /config/paths` — local Homeboy config paths
+
+### Read-Only Contract Endpoints
+
+These endpoints dispatch through Homeboy's transport-free read-only HTTP API
+contract and return the same JSON envelope shape as other daemon responses.
+
+- `GET /components`
+- `GET /components/:id`
+- `GET /components/:id/status`
+- `GET /components/:id/changes`
+- `GET /rigs`
+- `GET /rigs/:id`
+- `POST /rigs/:id/check`
+- `GET /stacks`
+- `GET /stacks/:id`
+- `POST /stacks/:id/status`
+
+The analysis entry points `POST /audit`, `POST /lint`, `POST /test`, and
+`POST /bench` are reserved by the contract, but intentionally return a job-model
+blocker until the long-running job/event API lands.
+
+Mutating operations such as deploy, release, rig up/down, stack apply, git
+writes, and SSH execution are not exposed by this daemon slice.
+
 ## Related
 
 - [self](self.md)

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -6,6 +6,7 @@ use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
 
 use crate::error::{Error, Result};
+use crate::http_api::{self, HttpMethod};
 use crate::paths;
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
@@ -153,41 +154,70 @@ pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
 }
 
 pub fn route(method: &str, path: &str) -> HttpResponse {
-    if method != "GET" {
-        return HttpResponse {
-            status_code: 405,
-            body: json!({ "error": "method_not_allowed" }),
-        };
-    }
-
-    match path {
-        "/health" => HttpResponse {
+    match (method, path) {
+        ("GET", "/health") => HttpResponse {
             status_code: 200,
             body: json!({
                 "status": "ok",
                 "version": env!("CARGO_PKG_VERSION"),
             }),
         },
-        "/version" => HttpResponse {
+        ("GET", "/version") => HttpResponse {
             status_code: 200,
             body: json!({
                 "version": env!("CARGO_PKG_VERSION"),
             }),
         },
-        "/config/paths" => match config_paths_body() {
+        ("GET", "/config/paths") => match config_paths_body() {
             Ok(body) => HttpResponse {
                 status_code: 200,
                 body,
             },
-            Err(err) => HttpResponse {
-                status_code: 500,
-                body: json!({ "error": err.message }),
-            },
+            Err(err) => error_response(500, err),
         },
-        _ => HttpResponse {
-            status_code: 404,
-            body: json!({ "error": "not_found" }),
+        ("POST", "/health") | ("POST", "/version") | ("POST", "/config/paths") => HttpResponse {
+            status_code: 405,
+            body: json!({ "error": "method_not_allowed" }),
         },
+        _ => route_read_only_api(method, path),
+    }
+}
+
+fn route_read_only_api(method: &str, path: &str) -> HttpResponse {
+    let method = match method {
+        "GET" => HttpMethod::Get,
+        "POST" => HttpMethod::Post,
+        _ => {
+            return HttpResponse {
+                status_code: 405,
+                body: json!({ "error": "method_not_allowed" }),
+            };
+        }
+    };
+
+    match http_api::handle(http_api::HttpApiRequest {
+        method,
+        path: path.to_string(),
+        body: None,
+    }) {
+        Ok(response) => HttpResponse {
+            status_code: response.status,
+            body: serde_json::to_value(response)
+                .unwrap_or_else(|_| json!({ "error": "internal_json" })),
+        },
+        Err(err) => error_response(404, err),
+    }
+}
+
+fn error_response(status_code: u16, err: Error) -> HttpResponse {
+    HttpResponse {
+        status_code,
+        body: json!({
+            "error": err.code.as_str(),
+            "message": err.message,
+            "details": err.details,
+            "hints": err.hints,
+        }),
     }
 }
 

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -41,9 +41,28 @@ fn routes_health_version_and_config_paths() {
 }
 
 #[test]
+fn routes_read_only_http_api_contract() {
+    let _home = HomeGuard::new();
+
+    let components = route("GET", "/components");
+    assert_eq!(components.status_code, 200);
+    assert_eq!(components.body["endpoint"], "components.list");
+    assert!(components.body["body"]["components"].is_array());
+
+    let job_ready = route("POST", "/audit");
+    assert_eq!(job_ready.status_code, 404);
+    assert_eq!(job_ready.body["error"], "validation.invalid_argument");
+    assert!(job_ready.body["message"]
+        .as_str()
+        .unwrap()
+        .contains("#1764"));
+}
+
+#[test]
 fn route_rejects_unknown_paths_and_methods() {
     assert_eq!(route("GET", "/missing").status_code, 404);
     assert_eq!(route("POST", "/health").status_code, 405);
+    assert_eq!(route("POST", "/release").status_code, 404);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Wire the local daemon router to the existing transport-free `http_api` read-only contract for component, rig, and stack endpoints.
- Keep built-in daemon endpoints intact and continue rejecting mutating shapes such as release/deploy/rig up/stack apply.
- Document the local headless UI endpoint slice and the job-model blocker for long-running analysis endpoints.

## Issues
- Covers a small shippable slice of #1759, #1761, #1762, and #1763.
- Leaves `POST /audit`, `POST /lint`, `POST /test`, and `POST /bench` blocked on the job/event model from #1764.

## Tests
- `cargo test --release daemon_test`
- `cargo test --release http_api_test`

## AI assistance disclosure
- Tool/model: OpenCode (gpt-5.5)