### PR TITLE
Fix audit false-positive cluster

### DIFF
--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -334,10 +334,11 @@ fn is_framework_entry_point(name: &str, fp: &FileFingerprint, audit_config: &Aud
 
 fn is_runtime_entrypoint_file(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
     let extends = fp.extends.as_deref().unwrap_or("");
-    audit_config
-        .runtime_entrypoint_extends
-        .iter()
-        .any(|expected| extends.ends_with(expected))
+    extends.ends_with("WP_CLI_Command")
+        || audit_config
+            .runtime_entrypoint_extends
+            .iter()
+            .any(|expected| extends.ends_with(expected))
         || audit_config
             .runtime_entrypoint_markers
             .iter()
@@ -1099,5 +1100,45 @@ class EmailCommand {
             "docblock-only @subcommand must not imply runtime registration"
         );
         assert!(unreferenced[0].description.contains("test_connection"));
+    }
+
+    #[test]
+    fn wp_cli_command_base_suppresses_public_subcommand_methods() {
+        let mut command_fp = make_fingerprint(
+            "inc/Cli/Commands/EmailCommand.php",
+            vec!["test_connection"],
+            vec!["test_connection"],
+            vec![],
+            vec![],
+        );
+        command_fp.language = Language::Php;
+        command_fp.extends = Some("WP_CLI_Command".to_string());
+        command_fp.content = r#"<?php
+class EmailCommand extends WP_CLI_Command {
+    /**
+     * ## EXAMPLES
+     *
+     *     wp datamachine email test-connection
+     *
+     * @subcommand test-connection
+     */
+    public function test_connection( array $args, array $assoc_args ): void {}
+}
+"#
+        .to_string();
+
+        let findings = analyze_dead_code(&[&command_fp], &[]);
+        let unreferenced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::UnreferencedExport)
+            .collect();
+        assert!(
+            unreferenced.is_empty(),
+            "WP-CLI command methods are runtime subcommands, got: {:?}",
+            unreferenced
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/core/code_audit/field_patterns.rs
+++ b/src/core/code_audit/field_patterns.rs
@@ -153,6 +153,9 @@ fn detect_repeated_field_patterns(root: &Path) -> Vec<Finding> {
         if is_boundary_dto_group_across_layers(locations) {
             continue;
         }
+        if is_low_value_boundary_coordinate_group(&sorted_fields, locations) {
+            continue;
+        }
         if is_low_value_generic_group(&sorted_fields, locations) {
             continue;
         }
@@ -520,11 +523,35 @@ fn is_boundary_dto_group_across_layers(locations: &[(String, String)]) -> bool {
 fn is_boundary_dto_name(name: &str) -> bool {
     matches!(
         name,
-        "Args" | "Options" | "WorkflowArgs" | "WorkflowOptions"
+        "Args" | "Options" | "Record" | "WorkflowArgs" | "WorkflowOptions"
     ) || name.ends_with("Args")
         || name.ends_with("Options")
+        || name.ends_with("Record")
         || name.ends_with("WorkflowArgs")
         || name.ends_with("WorkflowOptions")
+}
+
+fn is_low_value_boundary_coordinate_group(
+    fields: &[FieldSignature],
+    locations: &[(String, String)],
+) -> bool {
+    if fields.len() != 2 || locations.len() < MIN_OCCURRENCES {
+        return false;
+    }
+
+    let mut names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    names.sort_unstable();
+    if names != ["fixable", "line"] {
+        return false;
+    }
+
+    let Some((first_file, _)) = locations.first() else {
+        return false;
+    };
+
+    locations
+        .iter()
+        .all(|(file, name)| file == first_file && is_boundary_dto_name(name))
 }
 
 fn boundary_layer(file: &str) -> Option<&'static str> {
@@ -871,6 +898,44 @@ class {} {{
         assert!(
             findings.is_empty(),
             "PHP self::class registration arguments should not be reported as fields"
+        );
+    }
+
+    #[test]
+    fn does_not_report_repeated_boundary_record_coordinates() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src/core/observation");
+        std::fs::create_dir_all(&src).unwrap();
+
+        std::fs::write(
+            src.join("records.rs"),
+            r#"
+struct AnnotationFindingRecord {
+    line: Option<u32>,
+    fixable: bool,
+    annotation_id: String,
+}
+
+struct NewFindingRecord {
+    line: Option<u32>,
+    fixable: bool,
+    run_id: String,
+}
+
+struct FindingRecord {
+    line: Option<u32>,
+    fixable: bool,
+    id: String,
+}
+"#,
+        )
+        .unwrap();
+
+        let findings = detect_repeated_field_patterns(dir.path());
+        assert!(
+            findings.is_empty(),
+            "small scalar coordinate overlaps across boundary records are not extractable: {:?}",
+            findings
         );
     }
 

--- a/src/core/code_audit/idiomatic.rs
+++ b/src/core/code_audit/idiomatic.rs
@@ -119,10 +119,8 @@ pub(super) fn is_trivial_method(name: &str) -> bool {
 /// on the right) or `foobar_test` covering `foo` (alphanumeric `b` on the
 /// right).
 ///
-/// Used only by MissingTestMethod / coverage-presence checks. Orphaned-test
-/// detection (`find_orphaned_test_methods`) intentionally keeps the strict
-/// prefix match — it needs to know which test was supposed to map to which
-/// source method by name.
+/// Used by MissingTestMethod / coverage-presence checks and by Rust
+/// orphaned-test suppression for behavior-style test names.
 pub(super) fn test_covers_method(test_name: &str, source_method: &str, prefix: &str) -> bool {
     // Literal-prefix path
     if let Some(stripped) = test_name.strip_prefix(prefix) {

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -619,6 +619,15 @@ fn find_orphaned_test_methods(
             continue;
         }
 
+        if config.inline_tests
+            && source_methods.iter().any(|source_method| {
+                test_covers_method(test_method, source_method, &config.method_prefix)
+                    || source_method.starts_with(&format!("{expected_source}_"))
+            })
+        {
+            continue;
+        }
+
         // Behavior-driven test names: test_detects_exact_duplicate describes a
         // behavior, not a method reference. Short names (1-2 segments like
         // "old_function" or "pause") are likely real method references. But
@@ -1435,6 +1444,43 @@ fn test_chat_tools() {
             "Behavioral test name should NOT be flagged as orphaned. Orphaned: {:?}",
             orphaned_names
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn short_rust_behavior_test_names_not_flagged_as_orphaned() {
+        let config = make_rust_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_short_behavioral");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/core/extension")).unwrap();
+
+        let source = make_fp_split(
+            "src/core/extension/version.rs",
+            vec!["matches", "parse_php_import_path"],
+            vec![
+                "test_gt_matches",
+                "test_lt_matches",
+                "test_parse_php_import",
+                "test_old_function",
+            ],
+        );
+
+        let findings = analyze_test_coverage(&dir, &[&source], &config);
+        let orphaned: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| {
+                f.kind == AuditFinding::OrphanedTest && f.description.contains("no longer exists")
+            })
+            .collect();
+
+        assert_eq!(
+            orphaned.len(),
+            1,
+            "short behavior names that cover live Rust source methods should not be orphaned: {:?}",
+            orphaned.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+        assert!(orphaned[0].description.contains("old_function"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary

- Suppress repeated field-pattern findings for the low-value `[fixable, line]` scalar overlap across same-file boundary record DTOs.
- Treat Rust behavior-style tests as non-orphaned when their names cover or abbreviate a live source method.
- Recognize PHP classes extending `WP_CLI_Command` as runtime entry points so public subcommand methods are not flagged as unreferenced exports.

Fixes #2088.
Fixes #1743.
Fixes #1544.

## Tests

- `cargo test --release field_patterns`
- `cargo test --release test_coverage`
- `cargo test --release dead_code`
- `cargo test --release test_covers_method`

## AI Assistance

- AI assistance: Yes
- Tool/model: OpenCode (gpt-5.5)
- Used for: implementation, targeted test runs, and PR preparation