### PR TITLE
Default triage to workspace view

### DIFF
--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -5,8 +5,10 @@ Produce a read-only attention report for components, projects, fleets, rigs, or 
 ## Synopsis
 
 ```sh
-homeboy triage [OPTIONS] <COMMAND>
+homeboy triage [OPTIONS] [COMMAND]
 ```
+
+When no command is provided, `homeboy triage` defaults to `homeboy triage workspace`.
 
 ## Subcommands
 
@@ -25,6 +27,14 @@ homeboy triage [OPTIONS] <COMMAND>
 - `--needs-review` — restrict PRs to review-required items
 - `--failing-checks` — restrict PRs to failing-check items
 - `--drilldown` — include compact failing check names and URLs
+
+## Examples
+
+```sh
+homeboy triage
+homeboy triage --mine --drilldown
+homeboy triage component homeboy --failing-checks --drilldown
+```
 
 ## Related
 

--- a/src/commands/triage.rs
+++ b/src/commands/triage.rs
@@ -7,7 +7,7 @@ use super::CmdResult;
 #[derive(Args)]
 pub struct TriageArgs {
     #[command(subcommand)]
-    command: TriageCommand,
+    command: Option<TriageCommand>,
 
     /// Include issues in the report. Defaults to issues + PRs when neither is set.
     #[arg(long, global = true)]
@@ -99,7 +99,7 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageOut
         limit: args.limit,
     };
 
-    let target = match args.command {
+    let target = match args.command.unwrap_or(TriageCommand::Workspace) {
         TriageCommand::Component { component_id } => TriageTarget::Component(component_id),
         TriageCommand::Project { project_id } => TriageTarget::Project(project_id),
         TriageCommand::Fleet { fleet_id } => TriageTarget::Fleet(fleet_id),
@@ -108,4 +108,30 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageOut
     };
 
     Ok((triage::run(target, options)?, 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TriageArgs, TriageCommand};
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: TriageArgs,
+    }
+
+    #[test]
+    fn bare_triage_defaults_to_workspace() {
+        let cli = TestCli::parse_from(["triage"]);
+
+        assert!(matches!(cli.args.command, None));
+    }
+
+    #[test]
+    fn explicit_triage_subcommand_still_parses() {
+        let cli = TestCli::parse_from(["triage", "workspace"]);
+
+        assert!(matches!(cli.args.command, Some(TriageCommand::Workspace)));
+    }
 }


### PR DESCRIPTION
## Summary
- Make bare `homeboy triage` default to the workspace portfolio view.
- Keep explicit scoped triage subcommands unchanged.
- Document the optional subcommand and common examples.

## Tests
- `cargo test triage -- --test-threads=1`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Preserving the triage default follow-up from local uncommitted work, rebasing it onto a clean Homeboy worktree, adding focused parser tests, and opening this PR for Chris's review.