### PR TITLE
fix(trace): improve aggregate outlier report

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -236,7 +236,7 @@ When `--repeat <N> --aggregate spans` is used with `--rig` and no explicit `--ph
 
 ## Repeat And Aggregate
 
-Use `--repeat <N> --aggregate spans` to run the same trace scenario multiple times and summarize span timings across runs. The aggregate output includes each run's preserved `trace.json` artifact path plus per-span `min_ms`, `median_ms`, `avg_ms`, percentile fields (`p75_ms`, `p90_ms`, `p95_ms`) when enough samples are available, `max_ms`, and `failures` counts.
+Use `--repeat <N> --aggregate spans` to run the same trace scenario multiple times and summarize span timings across runs. The aggregate output includes each run's preserved `trace.json` artifact path plus per-span `min_ms`, `median_ms`, `avg_ms`, percentile fields (`p75_ms`, `p90_ms`, `p95_ms`) when enough samples are available, `max_ms`, the run index and artifact path for that max sample, and `failures` counts. Markdown aggregate reports also include an outlier table sorted by max duration so the slowest run artifacts are easy to inspect first.
 
 ```sh
 homeboy trace studio studio-app-create-site --repeat 5 --aggregate spans

--- a/src/commands/trace/output.rs
+++ b/src/commands/trace/output.rs
@@ -649,19 +649,27 @@ pub(super) fn render_aggregate_markdown(
             push_aggregate_span_row(&mut out, span);
         }
 
-        let outliers = aggregate
+        let mut outliers = aggregate
             .spans
             .iter()
             .filter(|span| span.max_ms.is_some() && span.max_run_index.is_some())
             .collect::<Vec<_>>();
         if !outliers.is_empty() {
             out.push_str("\n## Outliers\n\n");
+            out.push_str("| Span | max | max run | max artifact |\n");
+            out.push_str("|---|---:|---:|---|\n");
+            outliers.sort_by(|left, right| {
+                right
+                    .max_ms
+                    .cmp(&left.max_ms)
+                    .then_with(|| left.id.cmp(&right.id))
+            });
             for span in outliers {
                 out.push_str(&format!(
-                    "- `{}`: run {}, max={}, artifact=`{}`\n",
+                    "| `{}` | {} | {} | `{}` |\n",
                     span.id,
-                    span.max_run_index.unwrap_or_default(),
                     fmt_ms(span.max_ms),
+                    span.max_run_index.unwrap_or_default(),
                     span.max_artifact_path.as_deref().unwrap_or("")
                 ));
             }

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -1376,8 +1376,8 @@ fn aggregate_markdown_includes_percentile_columns() {
     assert!(markdown.contains(
         "| `boot_to_ready` | 20 | 10ms | 105ms | 105.0ms | 150ms | 180ms | 190ms | 200ms | 0 |"
     ));
-    assert!(markdown
-        .contains("- `boot_to_ready`: run 20, max=200ms, artifact=`/tmp/trace-run-20.json`"));
+    assert!(markdown.contains("| Span | max | max run | max artifact |"));
+    assert!(markdown.contains("| `boot_to_ready` | 200ms | 20 | `/tmp/trace-run-20.json` |"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Render trace aggregate outliers as a sorted Markdown table with span, max duration, max run, and artifact path.
- Document that aggregate span output includes max run/artifact metadata alongside percentile stats.
- Keeps the change scoped to trace aggregate span reporting for #2079/#2082.

Fixes #2082
Refs #2079

## Tests
- `cargo fmt --check`
- `cargo test aggregate_`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the report formatting/docs/test update; Chris remains responsible for review and validation.