### PR TITLE
Include findings in observation bundles

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -61,8 +61,10 @@ homeboy-observations/
   runs.json
   artifacts.json
   trace_spans.json
+  findings.json
+  test_failures.json
 ```
 
-The v1 bundle is metadata-only: artifact records are exported, but artifact file bytes are not copied. Zip output is intentionally out of scope for v1; pass a directory path to `--output`.
+The v1 bundle is metadata-only: artifact records are exported, but artifact file bytes are not copied. `findings.json` contains normalized observation findings, and `test_failures.json` is an additive subset of findings where test commands recorded individual failures. Zip output is intentionally out of scope for v1; pass a directory path to `--output`.
 
 `homeboy runs import` is idempotent. Existing identical records are accepted, while conflicting records with the same primary key fail clearly.

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -478,7 +478,8 @@ mod tests {
     use std::path::Path;
 
     use homeboy::observation::{
-        NewFindingRecord, NewRunRecord, NewTraceSpanRecord, RunRecord, RunStatus, TraceSpanRecord,
+        FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceSpanRecord,
+        RunRecord, RunStatus, TraceSpanRecord,
     };
     use homeboy::test_support::with_isolated_home;
     use serde::Deserialize;
@@ -991,9 +992,72 @@ mod tests {
             assert!(output.join("runs.json").exists());
             assert!(output.join("artifacts.json").exists());
             assert!(output.join("trace_spans.json").exists());
+            assert!(output.join("findings.json").exists());
+            assert!(output.join("test_failures.json").exists());
             let runs: Vec<RunRecord> = read_bundle_test_json(&output.join("runs.json"));
             assert_eq!(runs.len(), 1);
             assert_eq!(runs[0].id, run.id);
+        });
+    }
+
+    #[test]
+    fn export_includes_findings_and_test_failures() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("test", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let lint = store
+                .record_finding(&NewFindingRecord {
+                    run_id: run.id.clone(),
+                    tool: "lint".to_string(),
+                    rule: Some("style".to_string()),
+                    file: Some("src/lib.rs".to_string()),
+                    line: Some(3),
+                    severity: Some("warning".to_string()),
+                    fingerprint: Some("lint::src/lib.rs".to_string()),
+                    message: "style drift".to_string(),
+                    fixable: Some(true),
+                    metadata_json: serde_json::json!({ "record_kind": "lint" }),
+                })
+                .expect("lint finding");
+            let failure = store
+                .record_finding(&NewFindingRecord {
+                    run_id: run.id.clone(),
+                    tool: "test".to_string(),
+                    rule: Some("assertion".to_string()),
+                    file: Some("tests/fail.rs".to_string()),
+                    line: Some(42),
+                    severity: Some("error".to_string()),
+                    fingerprint: Some("test::fails".to_string()),
+                    message: "assertion failed".to_string(),
+                    fixable: None,
+                    metadata_json: serde_json::json!({
+                        "record_kind": "failure",
+                        "source_sidecar": "test-failures",
+                    }),
+                })
+                .expect("test failure");
+            let output = home.path().join("findings-bundle");
+
+            let (result, _) = export_runs(RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            })
+            .expect("export");
+
+            let RunsOutput::Export(result) = result else {
+                panic!("expected export output");
+            };
+            assert_eq!(result.finding_count, 2);
+            assert_eq!(result.test_failure_count, 1);
+            let findings: Vec<FindingRecord> = read_bundle_test_json(&output.join("findings.json"));
+            let test_failures: Vec<FindingRecord> =
+                read_bundle_test_json(&output.join("test_failures.json"));
+            assert_eq!(findings, vec![lint, failure.clone()]);
+            assert_eq!(test_failures, vec![failure]);
         });
     }
 
@@ -1115,6 +1179,20 @@ mod tests {
                         metadata_json: serde_json::json!({}),
                     })
                     .expect("span");
+                store
+                    .record_finding(&NewFindingRecord {
+                        run_id: run.id.clone(),
+                        tool: "test".to_string(),
+                        rule: Some("assertion".to_string()),
+                        file: Some("tests/fail.rs".to_string()),
+                        line: Some(42),
+                        severity: Some("error".to_string()),
+                        fingerprint: Some("test::fails".to_string()),
+                        message: "assertion failed".to_string(),
+                        fixable: None,
+                        metadata_json: serde_json::json!({ "record_kind": "failure" }),
+                    })
+                    .expect("finding");
                 export_runs(RunsExportArgs {
                     run: Some(run.id.clone()),
                     since: None,
@@ -1139,6 +1217,16 @@ mod tests {
             assert!(store.get_run(&run_id).expect("get").is_some());
             assert_eq!(store.list_artifacts(&run_id).expect("artifacts").len(), 1);
             assert_eq!(store.list_trace_spans(&run_id).expect("spans").len(), 1);
+            assert_eq!(
+                store
+                    .list_findings(FindingListFilter {
+                        run_id: Some(run_id),
+                        ..FindingListFilter::default()
+                    })
+                    .expect("findings")
+                    .len(),
+                1
+            );
         });
     }
 

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 
-use homeboy::observation::{ArtifactRecord, ObservationStore, RunRecord, TraceSpanRecord};
+use homeboy::observation::{
+    ArtifactRecord, FindingRecord, ObservationStore, RunRecord, TraceSpanRecord,
+};
 use homeboy::Error;
 
 use super::{require_run, CmdResult, RunsOutput};
@@ -41,6 +43,10 @@ pub struct ObservationBundleManifest {
     pub run_count: usize,
     pub artifact_count: usize,
     pub trace_span_count: usize,
+    #[serde(default)]
+    pub finding_count: usize,
+    #[serde(default)]
+    pub test_failure_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -49,6 +55,8 @@ struct ObservationBundle {
     runs: Vec<RunRecord>,
     artifacts: Vec<ArtifactRecord>,
     trace_spans: Vec<TraceSpanRecord>,
+    findings: Vec<FindingRecord>,
+    test_failures: Vec<FindingRecord>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -56,6 +64,8 @@ pub struct ObservationBundleImportSummary {
     pub runs: usize,
     pub artifacts: usize,
     pub trace_spans: usize,
+    pub findings: usize,
+    pub test_failures: usize,
 }
 
 #[derive(Serialize)]
@@ -66,6 +76,8 @@ pub struct RunsExportOutput {
     pub run_count: usize,
     pub artifact_count: usize,
     pub trace_span_count: usize,
+    pub finding_count: usize,
+    pub test_failure_count: usize,
 }
 
 #[derive(Serialize)]
@@ -112,6 +124,8 @@ pub(super) fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
             run_count: bundle.runs.len(),
             artifact_count: bundle.artifacts.len(),
             trace_span_count: bundle.trace_spans.len(),
+            finding_count: bundle.findings.len(),
+            test_failure_count: bundle.test_failures.len(),
             manifest: bundle.manifest,
         }),
         0,
@@ -130,6 +144,9 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
     for span in &bundle.trace_spans {
         store.import_trace_span(span)?;
     }
+    for finding in bundle.findings.iter().chain(bundle.test_failures.iter()) {
+        store.import_finding(finding)?;
+    }
 
     Ok((
         RunsOutput::Import(RunsImportOutput {
@@ -139,6 +156,8 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
                 runs: bundle.runs.len(),
                 artifacts: bundle.artifacts.len(),
                 trace_spans: bundle.trace_spans.len(),
+                findings: bundle.findings.len(),
+                test_failures: bundle.test_failures.len(),
             },
         }),
         0,
@@ -151,10 +170,17 @@ fn build_bundle(
 ) -> homeboy::Result<ObservationBundle> {
     let mut artifacts = Vec::new();
     let mut trace_spans = Vec::new();
+    let mut findings = Vec::new();
     for run in &runs {
         artifacts.extend(store.list_artifacts(&run.id)?);
         trace_spans.extend(store.list_trace_spans(&run.id)?);
+        findings.extend(store.list_findings_for_run(&run.id)?);
     }
+    let test_failures = findings
+        .iter()
+        .filter(|finding| is_test_failure_finding(finding))
+        .cloned()
+        .collect::<Vec<_>>();
     let manifest = ObservationBundleManifest {
         format: BUNDLE_FORMAT.to_string(),
         version: BUNDLE_VERSION,
@@ -163,12 +189,16 @@ fn build_bundle(
         run_count: runs.len(),
         artifact_count: artifacts.len(),
         trace_span_count: trace_spans.len(),
+        finding_count: findings.len(),
+        test_failure_count: test_failures.len(),
     };
     Ok(ObservationBundle {
         manifest,
         runs,
         artifacts,
         trace_spans,
+        findings,
+        test_failures,
     })
 }
 
@@ -191,6 +221,8 @@ fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::Result<
     write_json(path.join("runs.json"), &bundle.runs)?;
     write_json(path.join("artifacts.json"), &bundle.artifacts)?;
     write_json(path.join("trace_spans.json"), &bundle.trace_spans)?;
+    write_json(path.join("findings.json"), &bundle.findings)?;
+    write_json(path.join("test_failures.json"), &bundle.test_failures)?;
     Ok(())
 }
 
@@ -227,9 +259,18 @@ fn read_bundle_dir(path: &Path) -> homeboy::Result<ObservationBundle> {
     let runs: Vec<RunRecord> = read_json(path.join("runs.json"))?;
     let artifacts: Vec<ArtifactRecord> = read_json(path.join("artifacts.json"))?;
     let trace_spans: Vec<TraceSpanRecord> = read_json(path.join("trace_spans.json"))?;
+    let mut findings: Vec<FindingRecord> = read_optional_json(path.join("findings.json"))?;
+    let test_failures: Vec<FindingRecord> = read_optional_json(path.join("test_failures.json"))?;
+    for test_failure in &test_failures {
+        if !findings.iter().any(|finding| finding.id == test_failure.id) {
+            findings.push(test_failure.clone());
+        }
+    }
     if manifest.run_count != runs.len()
         || manifest.artifact_count != artifacts.len()
         || manifest.trace_span_count != trace_spans.len()
+        || manifest.finding_count != findings.len()
+        || manifest.test_failure_count != test_failures.len()
     {
         return Err(Error::validation_invalid_argument(
             "manifest",
@@ -243,7 +284,23 @@ fn read_bundle_dir(path: &Path) -> homeboy::Result<ObservationBundle> {
         runs,
         artifacts,
         trace_spans,
+        findings,
+        test_failures,
     })
+}
+
+fn is_test_failure_finding(finding: &FindingRecord) -> bool {
+    finding.tool == "test"
+        && (finding
+            .metadata_json
+            .get("record_kind")
+            .and_then(|value| value.as_str())
+            == Some("failure")
+            || finding
+                .metadata_json
+                .get("source_sidecar")
+                .and_then(|value| value.as_str())
+                == Some("test-failures"))
 }
 
 fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::Result<()> {
@@ -272,6 +329,13 @@ fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::Result<T> 
             Some(raw),
         )
     })
+}
+
+fn read_optional_json<T: for<'de> Deserialize<'de> + Default>(path: PathBuf) -> homeboy::Result<T> {
+    if !path.exists() {
+        return Ok(T::default());
+    }
+    read_json(path)
 }
 
 fn since_threshold(raw: &str) -> homeboy::Result<String> {

--- a/src/core/observation/store/findings.rs
+++ b/src/core/observation/store/findings.rs
@@ -81,6 +81,53 @@ impl ObservationStore {
             .map_err(sqlite_error("read finding record"))
     }
 
+    pub fn import_finding(&self, finding: &FindingRecord) -> Result<()> {
+        validate_required("finding.id", &finding.id)?;
+        validate_required("finding.run_id", &finding.run_id)?;
+        validate_required("finding.tool", &finding.tool)?;
+        validate_required("finding.message", &finding.message)?;
+        if self.get_run(&finding.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "finding.run_id",
+                format!("referenced run record not found: {}", finding.run_id),
+                Some(finding.run_id.clone()),
+                None,
+            ));
+        }
+        if let Some(existing) = self.get_finding(&finding.id)? {
+            return ensure_identical("finding", &finding.id, &existing, finding);
+        }
+        let metadata_json = serialize_metadata(&finding.metadata_json)?;
+        let fixable = finding
+            .fixable
+            .map(|value| if value { 1_i64 } else { 0_i64 });
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO findings(
+                    id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                    fixable, metadata_json, created_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                "#,
+                params![
+                    finding.id,
+                    finding.run_id,
+                    finding.tool,
+                    finding.rule,
+                    finding.file,
+                    finding.line,
+                    finding.severity,
+                    finding.fingerprint,
+                    finding.message,
+                    fixable,
+                    metadata_json,
+                    finding.created_at,
+                ],
+            )
+            .map_err(sqlite_error("import finding record"))?;
+        Ok(())
+    }
+
     pub fn list_findings(&self, filter: FindingListFilter) -> Result<Vec<FindingRecord>> {
         let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
         let mut statement = self
@@ -113,6 +160,27 @@ impl ObservationStore {
             .map_err(sqlite_error("list finding records"))?;
 
         collect_rows(rows, "collect finding records")
+    }
+
+    pub fn list_findings_for_run(&self, run_id: &str) -> Result<Vec<FindingRecord>> {
+        validate_required("run_id", run_id)?;
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, run_id, tool, rule, file, line, severity, fingerprint, message,
+                       fixable, metadata_json, created_at
+                FROM findings
+                WHERE run_id = ?1
+                ORDER BY created_at ASC, rowid ASC
+                "#,
+            )
+            .map_err(sqlite_error("prepare list run finding records"))?;
+        let rows = statement
+            .query_map([run_id], row_to_finding_record)
+            .map_err(sqlite_error("list run finding records"))?;
+
+        collect_rows(rows, "collect run finding records")
     }
 
     pub fn latest_finding(&self, filter: FindingListFilter) -> Result<Option<FindingRecord>> {


### PR DESCRIPTION
## Summary
- Export `findings.json` and `test_failures.json` alongside existing observation bundle files.
- Import bundle findings idempotently with the same conflict behavior as runs, artifacts, and trace spans.
- Document the additive bundle files and cover export/import behavior with focused tests.

Fixes #2047.

## Testing
- `cargo test commands::runs::tests`
- `cargo test core::observation::store::findings::tests`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused implementation, tests, docs, and command verification; Chris remains responsible for review and merge.