### PR TITLE
Expose daemon observation run readers

### DIFF
--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -45,6 +45,14 @@ contract and return the same JSON envelope shape as other daemon responses.
 - `GET /stacks`
 - `GET /stacks/:id`
 - `POST /stacks/:id/status`
+- `GET /runs?kind=bench|audit&component=<id>&rig=<id>&status=<status>&limit=<n>`
+- `GET /runs/:id`
+- `GET /runs/:id/artifacts`
+- `GET /audit/runs?component=<id>&rig=<id>&status=<status>&limit=<n>`
+- `GET /bench/runs?component=<id>&rig=<id>&status=<status>&limit=<n>`
+
+The run readers expose persisted observation-store evidence from previous
+analysis runs. They do not start audit, lint, test, bench, rig, or stack work.
 
 The analysis entry points `POST /audit`, `POST /lint`, `POST /test`, and
 `POST /bench` are reserved by the contract, but intentionally return a job-model

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::error::{Error, Result};
+use crate::observation::{ObservationStore, RunListFilter, RunRecord};
 use crate::{component, git, rig, stack};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -45,7 +46,35 @@ pub enum HttpEndpoint {
     Stacks,
     Stack { id: String },
     StackStatus { id: String },
+    Runs,
+    Run { id: String },
+    RunArtifacts { id: String },
+    AuditRuns,
+    BenchRuns,
     JobReadyRun { kind: JobReadyRunKind },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunSummary {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub component_id: Option<String>,
+    pub rig_id: Option<String>,
+    pub git_sha: Option<String>,
+    pub command: Option<String>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunDetail {
+    #[serde(flatten)]
+    pub summary: RunSummary,
+    pub homeboy_version: Option<String>,
+    pub metadata: Value,
+    pub artifacts: Vec<crate::observation::ArtifactRecord>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -70,6 +99,11 @@ impl HttpEndpoint {
             Self::Stacks => "stacks.list",
             Self::Stack { .. } => "stacks.show",
             Self::StackStatus { .. } => "stacks.status",
+            Self::Runs => "runs.list",
+            Self::Run { .. } => "runs.show",
+            Self::RunArtifacts { .. } => "runs.artifacts",
+            Self::AuditRuns => "audit.runs",
+            Self::BenchRuns => "bench.runs",
             Self::JobReadyRun { .. } => "jobs.required",
         }
     }
@@ -104,6 +138,15 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
         (HttpMethod::Post, ["stacks", id, "status"]) => Ok(HttpEndpoint::StackStatus {
             id: (*id).to_string(),
         }),
+        (HttpMethod::Get, ["runs"]) => Ok(HttpEndpoint::Runs),
+        (HttpMethod::Get, ["runs", id]) => Ok(HttpEndpoint::Run {
+            id: (*id).to_string(),
+        }),
+        (HttpMethod::Get, ["runs", id, "artifacts"]) => Ok(HttpEndpoint::RunArtifacts {
+            id: (*id).to_string(),
+        }),
+        (HttpMethod::Get, ["audit", "runs"]) => Ok(HttpEndpoint::AuditRuns),
+        (HttpMethod::Get, ["bench", "runs"]) => Ok(HttpEndpoint::BenchRuns),
         (HttpMethod::Post, ["audit"]) => Ok(HttpEndpoint::JobReadyRun {
             kind: JobReadyRunKind::Audit,
         }),
@@ -131,6 +174,11 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "POST /rigs/:id/check".to_string(),
                 "GET /stacks".to_string(),
                 "POST /stacks/:id/status".to_string(),
+                "GET /runs".to_string(),
+                "GET /runs/:id".to_string(),
+                "GET /runs/:id/artifacts".to_string(),
+                "GET /audit/runs".to_string(),
+                "GET /bench/runs".to_string(),
             ]),
         )),
     }
@@ -186,6 +234,31 @@ pub fn handle(request: HttpApiRequest) -> Result<HttpApiResponse> {
                 "report": stack::status(&spec)?,
             })
         }
+        HttpEndpoint::Runs => json!({
+            "command": "api.runs.list",
+            "runs": list_runs(&request.path, None)?,
+        }),
+        HttpEndpoint::Run { id } => json!({
+            "command": "api.runs.show",
+            "run": show_run(id)?,
+        }),
+        HttpEndpoint::RunArtifacts { id } => {
+            let store = ObservationStore::open_initialized()?;
+            require_run(&store, id)?;
+            json!({
+                "command": "api.runs.artifacts",
+                "run_id": id,
+                "artifacts": store.list_artifacts(id)?,
+            })
+        }
+        HttpEndpoint::AuditRuns => json!({
+            "command": "api.audit.runs",
+            "runs": list_runs(&request.path, Some("audit"))?,
+        }),
+        HttpEndpoint::BenchRuns => json!({
+            "command": "api.bench.runs",
+            "runs": list_runs(&request.path, Some("bench"))?,
+        }),
         HttpEndpoint::JobReadyRun { kind } => {
             return Err(Error::validation_invalid_argument(
                 "endpoint",
@@ -219,6 +292,71 @@ fn path_segments(path: &str) -> Vec<String> {
         .filter(|segment| !segment.is_empty())
         .map(str::to_string)
         .collect()
+}
+
+fn list_runs(path: &str, kind_override: Option<&str>) -> Result<Vec<RunSummary>> {
+    let store = ObservationStore::open_initialized()?;
+    let filter = RunListFilter {
+        kind: kind_override
+            .map(str::to_string)
+            .or_else(|| query_value(path, "kind")),
+        component_id: query_value(path, "component").or_else(|| query_value(path, "component_id")),
+        status: query_value(path, "status"),
+        rig_id: query_value(path, "rig").or_else(|| query_value(path, "rig_id")),
+        limit: query_value(path, "limit")
+            .and_then(|value| value.parse::<i64>().ok())
+            .map(|limit| limit.clamp(1, 1000)),
+    };
+
+    Ok(store
+        .list_runs(filter)?
+        .into_iter()
+        .map(run_summary)
+        .collect())
+}
+
+fn show_run(run_id: &str) -> Result<RunDetail> {
+    let store = ObservationStore::open_initialized()?;
+    let run = require_run(&store, run_id)?;
+    Ok(RunDetail {
+        summary: run_summary(run.clone()),
+        homeboy_version: run.homeboy_version,
+        metadata: run.metadata_json,
+        artifacts: store.list_artifacts(run_id)?,
+    })
+}
+
+fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> {
+    store.get_run(run_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "run_id",
+            format!("run record not found: {run_id}"),
+            Some(run_id.to_string()),
+            None,
+        )
+    })
+}
+
+fn run_summary(run: RunRecord) -> RunSummary {
+    RunSummary {
+        id: run.id,
+        kind: run.kind,
+        status: run.status,
+        started_at: run.started_at,
+        finished_at: run.finished_at,
+        component_id: run.component_id,
+        rig_id: run.rig_id,
+        git_sha: run.git_sha,
+        command: run.command,
+        cwd: run.cwd,
+    }
+}
+
+fn query_value(path: &str, key: &str) -> Option<String> {
+    path.split_once('?')?.1.split('&').find_map(|pair| {
+        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+        (name == key && !value.is_empty()).then(|| value.to_string())
+    })
 }
 
 fn method_label(method: HttpMethod) -> &'static str {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -56,6 +56,16 @@ fn routes_read_only_http_api_contract() {
         .as_str()
         .unwrap()
         .contains("#1764"));
+
+    let runs = route("GET", "/runs?kind=bench&limit=1");
+    assert_eq!(runs.status_code, 200);
+    assert_eq!(runs.body["endpoint"], "runs.list");
+    assert!(runs.body["body"]["runs"].is_array());
+
+    let bench_runs = route("GET", "/bench/runs?component=homeboy");
+    assert_eq!(bench_runs.status_code, 200);
+    assert_eq!(bench_runs.body["endpoint"], "bench.runs");
+    assert!(bench_runs.body["body"]["runs"].is_array());
 }
 
 #[test]

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -1,4 +1,28 @@
 use homeboy::http_api::{self, HttpApiRequest, HttpEndpoint, HttpMethod, JobReadyRunKind};
+use homeboy::observation::{NewRunRecord, ObservationStore, RunStatus};
+
+use crate::test_support::with_isolated_home;
+
+struct XdgGuard {
+    prior: Option<String>,
+}
+
+impl XdgGuard {
+    fn unset() -> Self {
+        let prior = std::env::var("XDG_DATA_HOME").ok();
+        std::env::remove_var("XDG_DATA_HOME");
+        Self { prior }
+    }
+}
+
+impl Drop for XdgGuard {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+    }
+}
 
 #[test]
 fn routes_component_endpoints() {
@@ -91,6 +115,92 @@ fn routes_job_ready_analysis_endpoints_without_executing_them() {
 }
 
 #[test]
+fn routes_observation_run_readers() {
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/runs?kind=bench").expect("route"),
+        HttpEndpoint::Runs
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/runs/run-123").expect("route"),
+        HttpEndpoint::Run {
+            id: "run-123".to_string()
+        }
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/runs/run-123/artifacts").expect("route"),
+        HttpEndpoint::RunArtifacts {
+            id: "run-123".to_string()
+        }
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/audit/runs").expect("route"),
+        HttpEndpoint::AuditRuns
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/bench/runs").expect("route"),
+        HttpEndpoint::BenchRuns
+    );
+}
+
+#[test]
+fn handles_filtered_observation_run_readers_without_starting_jobs() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let bench = store
+            .start_run(sample_run("bench", "homeboy", "studio"))
+            .expect("bench run");
+        store
+            .finish_run(&bench.id, RunStatus::Pass, None)
+            .expect("finish bench");
+        let audit = store
+            .start_run(sample_run("audit", "homeboy", "studio"))
+            .expect("audit run");
+        store
+            .finish_run(&audit.id, RunStatus::Fail, None)
+            .expect("finish audit");
+        let artifact_path = home.path().join("bench-results.json");
+        std::fs::write(&artifact_path, b"{}").expect("artifact");
+        store
+            .record_artifact(&bench.id, "bench_results", &artifact_path)
+            .expect("record artifact");
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: "/bench/runs?component=homeboy&rig=studio&limit=1".to_string(),
+            body: None,
+        })
+        .expect("bench runs");
+        assert_eq!(response.endpoint, "bench.runs");
+        assert_eq!(response.body["runs"].as_array().unwrap().len(), 1);
+        assert_eq!(response.body["runs"][0]["id"], bench.id);
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/runs/{}", bench.id),
+            body: None,
+        })
+        .expect("show run");
+        assert_eq!(response.endpoint, "runs.show");
+        assert_eq!(response.body["run"]["id"], bench.id);
+        assert_eq!(
+            response.body["run"]["artifacts"][0]["kind"],
+            "bench_results"
+        );
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: "/audit/runs?component=homeboy".to_string(),
+            body: None,
+        })
+        .expect("audit runs");
+        assert_eq!(response.endpoint, "audit.runs");
+        assert_eq!(response.body["runs"].as_array().unwrap().len(), 1);
+        assert_eq!(response.body["runs"][0]["id"], audit.id);
+    });
+}
+
+#[test]
 fn rejects_mutating_endpoint_shapes() {
     assert!(http_api::route(HttpMethod::Post, "/rigs/studio/up").is_err());
     assert!(http_api::route(HttpMethod::Post, "/stacks/studio/apply").is_err());
@@ -110,4 +220,17 @@ fn job_ready_endpoint_reports_job_model_blocker() {
     let rendered = err.to_string();
     assert!(rendered.contains("job model"), "{rendered}");
     assert!(rendered.contains("#1764"), "{rendered}");
+}
+
+fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {
+    NewRunRecord {
+        kind: kind.to_string(),
+        component_id: Some(component_id.to_string()),
+        command: Some(format!("homeboy {kind}")),
+        cwd: Some("/tmp/homeboy-fixture".to_string()),
+        homeboy_version: Some("test-version".to_string()),
+        git_sha: Some("abc123".to_string()),
+        rig_id: Some(rig_id.to_string()),
+        metadata_json: serde_json::json!({ "source": "http-api-test" }),
+    }
 }


### PR DESCRIPTION
## Summary
- Adds read-only daemon routes for persisted observation runs: `GET /runs`, `GET /runs/:id`, and `GET /runs/:id/artifacts`.
- Adds audit/bench-specific reader aliases so clients can inspect existing analysis evidence without starting long-running jobs.
- Documents the run-reader contract and keeps `POST /audit`, `POST /lint`, `POST /test`, and `POST /bench` blocked on the job model.

## Issues
- Builds on #2183 for #1763.
- Does not implement mutating endpoints or capability/confirmation flows.

## Tests
- `cargo test --release http_api_test`
- `cargo test --release daemon_test`
- `homeboy lint homeboy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused daemon API implementation, tests, and docs. Chris remains responsible for review and merge.