### PR TITLE
test(trace): cover aggregate percentile serialization

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -236,7 +236,7 @@ When `--repeat <N> --aggregate spans` is used with `--rig` and no explicit `--ph
 
 ## Repeat And Aggregate
 
-Use `--repeat <N> --aggregate spans` to run the same trace scenario multiple times and summarize span timings across runs. The aggregate output includes each run's preserved `trace.json` artifact path plus per-span `min_ms`, `median_ms`, `avg_ms`, percentile fields (`p75_ms`, `p90_ms`, `p95_ms`) when enough samples are available, `max_ms`, the run index and artifact path for that max sample, and `failures` counts. Markdown aggregate reports also include an outlier table sorted by max duration so the slowest run artifacts are easy to inspect first.
+Use `--repeat <N> --aggregate spans` to run the same trace scenario multiple times and summarize span timings across runs. The aggregate output includes each run's preserved `trace.json` artifact path plus per-span `min_ms`, `median_ms`, `avg_ms`, percentile fields (`p75_ms` with at least 4 samples, `p90_ms` with at least 10, and `p95_ms` with at least 20), `max_ms`, the run index and artifact path for that max sample, and `failures` counts. Markdown aggregate reports also include those percentile columns and an outlier table sorted by max duration so the slowest run artifacts are easy to inspect first.
 
 ```sh
 homeboy trace studio studio-app-create-site --repeat 5 --aggregate spans

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -1381,6 +1381,32 @@ fn aggregate_markdown_includes_percentile_columns() {
 }
 
 #[test]
+fn aggregate_json_serializes_available_percentiles() {
+    let span = aggregate_span(
+        "boot_to_ready".to_string(),
+        aggregate_samples(&((1..=20).map(|value| value * 10).collect::<Vec<_>>())),
+        0,
+    );
+
+    let value = serde_json::to_value(&span).expect("span serializes");
+
+    assert_eq!(value["p75_ms"], 150);
+    assert_eq!(value["p90_ms"], 180);
+    assert_eq!(value["p95_ms"], 190);
+}
+
+#[test]
+fn aggregate_json_omits_unavailable_percentiles() {
+    let span = aggregate_span("boot_to_ready".to_string(), aggregate_samples(&[10, 20]), 0);
+
+    let value = serde_json::to_value(&span).expect("span serializes");
+
+    assert!(value.get("p75_ms").is_none());
+    assert!(value.get("p90_ms").is_none());
+    assert!(value.get("p95_ms").is_none());
+}
+
+#[test]
 fn failed_trace_run_persists_observation_history() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::without_xdg_data_home();


### PR DESCRIPTION
## Summary
- Add JSON serialization coverage for aggregate span percentile fields so `p75_ms`, `p90_ms`, and `p95_ms` stay present when enough samples exist.
- Assert unavailable percentile fields are omitted from JSON for small sample sets.
- Document the sample thresholds and note that Markdown aggregate reports render percentile columns.

Closes #2079
Refs #2189

## Tests
- `cargo fmt --check`
- `cargo test aggregate_json`
- `cargo test aggregate_markdown_includes_percentile_columns`
- `cargo test aggregate_span`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated issue #2079 and prior PR #2189, added targeted JSON percentile serialization tests and docs, and ran validation. Chris remains responsible for review and validation.