### PR TITLE
feat(trace): support fswatch attachments

### DIFF
--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -98,7 +98,7 @@ Trace runners also receive trace-specific variables when invoked by `homeboy tra
 | `HOMEBOY_TRACE_ARTIFACT_DIR` | core | Directory for runner artifacts |
 | `HOMEBOY_TRACE_ATTACHMENTS` | CLI | JSON array of observation-only attach targets from repeatable `--attach KIND:TARGET` |
 
-`HOMEBOY_TRACE_ATTACHMENTS` v1 supports local `logfile`, `pid`, `port`, and `http` targets. HTTP attachments accept `http:<url>` or a direct `http://` / `https://` URL. Core observes attachments before and after the scenario and writes timeline events plus an attachment observation artifact in the run directory; runners may also read the same JSON to correlate their own scenario events. Attachments are explicitly observation-only: runners and core must not start, stop, restart, or kill attached targets as part of attach handling.
+`HOMEBOY_TRACE_ATTACHMENTS` v1 supports local `logfile`, `fswatch`, `pid`, `port`, and `http` targets. HTTP attachments accept `http:<url>` or a direct `http://` / `https://` URL. Core observes attachments before and after the scenario and writes timeline events plus an attachment observation artifact in the run directory; runners may also read the same JSON to correlate their own scenario events. `fswatch:<path>` is a safe file metadata snapshot in v1, not a streaming filesystem event probe. Attachments are explicitly observation-only: runners and core must not start, stop, restart, or kill attached targets as part of attach handling.
 
 ## Core-provided runtime helpers
 

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -95,6 +95,7 @@ Use repeatable `--attach KIND:TARGET` flags to observe already-running local sys
 Supported v1 attachment kinds:
 
 - `logfile:<path>` records whether the file exists and its byte length before and after the scenario.
+- `fswatch:<path>` records whether a watched file exists, its byte length, and its last-modified timestamp before and after the scenario. V1 is a safe snapshot, not a streaming filesystem event probe.
 - `pid:<n>` records whether a local process exists before and after the scenario.
 - `port:<n>` checks whether `127.0.0.1:<n>` accepts TCP connections before and after the scenario.
 - `http:<url>` or a direct `http://` / `https://` URL performs a local HTTP GET before and after the scenario and records the response status or connection error.
@@ -104,6 +105,7 @@ Example:
 ```sh
 homeboy trace wp-coding-agents auth-multi-session-race \
   --attach logfile:/root/.kimaki/kimaki.log \
+  --attach fswatch:/home/opencode/.local/share/opencode/auth.json \
   --attach pid:3679661 \
   --attach http://127.0.0.1:46227/health
 ```

--- a/src/core/extension/trace/attach.rs
+++ b/src/core/extension/trace/attach.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::{SocketAddr, TcpStream};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::engine::run_dir::RunDir;
 use crate::error::{Error, Result};
@@ -39,7 +39,7 @@ impl TraceAttachment {
             return Err(invalid_attachment(raw, "attachment target cannot be empty"));
         }
         match kind {
-            "logfile" => Ok(Self {
+            "logfile" | "fswatch" => Ok(Self {
                 kind: kind.to_string(),
                 target: target.to_string(),
             }),
@@ -87,7 +87,7 @@ impl TraceAttachment {
             }
             _ => Err(invalid_attachment(
                 raw,
-                "supported attachment kinds are logfile, pid, port, and http",
+                "supported attachment kinds are logfile, fswatch, pid, port, and http",
             )),
         }
     }
@@ -141,6 +141,7 @@ fn observe_trace_attachment(
 ) -> (String, BTreeMap<String, serde_json::Value>) {
     match attachment.kind.as_str() {
         "logfile" => observe_logfile(&attachment.target),
+        "fswatch" => observe_fswatch(&attachment.target),
         "pid" => observe_pid(&attachment.target),
         "port" => observe_port(&attachment.target),
         "http" => observe_http(&attachment.target),
@@ -149,6 +150,14 @@ fn observe_trace_attachment(
 }
 
 fn observe_logfile(path: &str) -> (String, BTreeMap<String, serde_json::Value>) {
+    observe_file_state(path)
+}
+
+fn observe_fswatch(path: &str) -> (String, BTreeMap<String, serde_json::Value>) {
+    observe_file_state(path)
+}
+
+fn observe_file_state(path: &str) -> (String, BTreeMap<String, serde_json::Value>) {
     let mut data = BTreeMap::new();
     data.insert(
         "path".to_string(),
@@ -157,6 +166,16 @@ fn observe_logfile(path: &str) -> (String, BTreeMap<String, serde_json::Value>) 
     match std::fs::metadata(path) {
         Ok(metadata) => {
             data.insert("bytes".to_string(), serde_json::json!(metadata.len()));
+            if let Ok(modified) = metadata.modified() {
+                let modified_ms = modified
+                    .duration_since(UNIX_EPOCH)
+                    .map(|duration| duration.as_millis())
+                    .unwrap_or_default();
+                data.insert(
+                    "modified_unix_ms".to_string(),
+                    serde_json::json!(modified_ms),
+                );
+            }
             ("present".to_string(), data)
         }
         Err(error) => {
@@ -301,17 +320,19 @@ mod tests {
     fn test_parse_all() {
         let attachments = TraceAttachment::parse_all(&[
             "logfile:/tmp/service.log".to_string(),
+            "fswatch:/tmp/auth.json".to_string(),
             "pid:1234".to_string(),
             "port:8080".to_string(),
             "http://127.0.0.1:8080/health".to_string(),
         ])
         .unwrap();
 
-        assert_eq!(attachments.len(), 4);
+        assert_eq!(attachments.len(), 5);
         assert_eq!(attachments[0].kind, "logfile");
-        assert_eq!(attachments[1].target, "1234");
-        assert_eq!(attachments[2].target, "8080");
-        assert_eq!(attachments[3].kind, "http");
+        assert_eq!(attachments[1].kind, "fswatch");
+        assert_eq!(attachments[2].target, "1234");
+        assert_eq!(attachments[3].target, "8080");
+        assert_eq!(attachments[4].kind, "http");
         assert!(TraceAttachment::parse_all(&["systemd:kimaki.service".to_string()]).is_err());
     }
 
@@ -322,6 +343,13 @@ mod tests {
             TraceAttachment {
                 kind: "logfile".to_string(),
                 target: "/tmp/service.log".to_string(),
+            }
+        );
+        assert_eq!(
+            TraceAttachment::parse("fswatch:/tmp/auth.json").unwrap(),
+            TraceAttachment {
+                kind: "fswatch".to_string(),
+                target: "/tmp/auth.json".to_string(),
             }
         );
         assert_eq!(TraceAttachment::parse("pid:1234").unwrap().target, "1234");
@@ -355,6 +383,27 @@ mod tests {
         assert_eq!(observations[0].phase, "before");
         assert_eq!(observations[0].attachment.kind, "logfile");
         assert_eq!(observations[0].status, "present");
+    }
+
+    #[test]
+    fn test_observe_fswatch_attachment_snapshots_file_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let watched_path = temp.path().join("auth.json");
+        std::fs::write(&watched_path, "before\n").unwrap();
+        let attachment =
+            TraceAttachment::parse(&format!("fswatch:{}", watched_path.display())).unwrap();
+
+        let observations = observe_trace_attachments(&[attachment], "before", Instant::now());
+
+        assert_eq!(observations.len(), 1);
+        assert_eq!(observations[0].phase, "before");
+        assert_eq!(observations[0].attachment.kind, "fswatch");
+        assert_eq!(observations[0].status, "present");
+        assert_eq!(
+            observations[0].data.get("bytes"),
+            Some(&serde_json::json!(7))
+        );
+        assert!(observations[0].data.contains_key("modified_unix_ms"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `fswatch:<path>` as a repeatable `homeboy trace --attach` target for already-running local systems.
- Records safe before/after file metadata snapshots (`bytes`, `modified_unix_ms`) without managing target lifecycle or pretending to provide streaming filesystem events.
- Updates trace command and runner contract docs for the expanded v1 attach contract.

## Tests
- `cargo fmt`
- `cargo test extension::trace::attach`
- `cargo test` (failed once in unrelated `core::rig::check::check_test::test_http_check_retries_until_listener_appears`; rerun below passed)
- `cargo test core::rig::check::check_test::test_http_check_retries_until_listener_appears -- --exact`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused implementation, docs, and tests; Chris remains responsible for review and validation.

Refs #2166