### PR TITLE
feat(trace): add standard probe library

### DIFF
--- a/docs/architecture/trace-probes.md
+++ b/docs/architecture/trace-probes.md
@@ -25,7 +25,11 @@ Probes are declared on detailed `trace_workloads` entries:
         "path": "${package.root}/trace/create-site.trace.mjs",
         "trace_probes": [
           { "type": "log.tail", "path": "${components.app.path}/app.log", "grep": "invalid_grant" },
-          { "type": "process.snapshot", "pattern": "opencode.*serve", "interval_ms": 250 }
+          { "type": "process.snapshot", "pattern": "opencode.*serve", "interval_ms": 250 },
+          { "type": "file.watch", "path": "${components.app.path}/auth.json" },
+          { "type": "port.snapshot", "port": 3000 },
+          { "type": "http.poll", "url": "http://127.0.0.1:3000/health", "assert-status": 200 },
+          { "type": "cmd.run", "command": "kimaki", "args": ["send", "--thread", "123", "--prompt", "test"] }
         ]
       }
     ]
@@ -66,6 +70,73 @@ Events:
 
 Data includes `pattern` and `processes` for list events, and `pid` plus `command` for delta events.
 
+### `file.watch`
+
+Inputs:
+
+- `path`: file path to poll for existence, size, or modification-time changes.
+- `interval_ms`: optional polling interval, default `250`.
+
+Events:
+
+- `fs.create`: path appeared after the probe started.
+- `fs.write`: existing path changed size or modification time.
+- `fs.delete`: path disappeared after the probe started.
+
+Data includes `path`, `exists`, and `len` when the file exists.
+
+The v1 implementation is polling-based and portable. It does not yet provide PID-of-writer attribution or rename pairing.
+
+### `port.snapshot`
+
+Inputs:
+
+- `port`: one TCP port to monitor on `127.0.0.1`.
+- `port-range`: inclusive `start-end` TCP port range.
+- `interval_ms`: optional polling interval, default `500`.
+
+Events:
+
+- `net.listening`: matching ports that appear to be bound/listening.
+- `net.bind`: matching port became bound since the previous snapshot.
+- `net.unbind`: matching port became unbound since the previous snapshot.
+
+Data includes `ports` for list events and `port` for delta events.
+
+The v1 implementation uses a bind probe for portability. It detects whether a port is available, not the owning process or active connection flows.
+
+### `http.poll`
+
+Inputs:
+
+- `url`: URL to fetch.
+- `interval_ms`: optional polling interval, default `1000`.
+- `assert-status`: optional expected HTTP status code.
+
+Events:
+
+- `http.response`: request completed with a response.
+- `http.error`: request failed.
+
+Data includes `url`, `status`, `latency_ms`, and `ok` when `assert-status` is configured.
+
+### `cmd.run`
+
+Inputs:
+
+- `command`: executable to run.
+- `args`: optional argument array.
+
+Events:
+
+- `cmd.start`: command was invoked.
+- `cmd.stdout`: one event per stdout line collected from the command.
+- `cmd.stderr`: one event per stderr line collected from the command.
+- `cmd.exit`: command exited successfully or unsuccessfully.
+- `cmd.error`: command could not be spawned.
+
+Data includes `command` and `args` on start, `line` on output events, and `exit_code`, `success`, and `duration_ms` on exit.
+
 ## Deferred
 
-This substrate intentionally does not implement fanotify, PID-of-writer attribution, systemd integration, port owner detection, or the full six-probe inventory from issue #2163. Those can layer onto the same collection and merge contract later.
+This substrate intentionally does not implement fanotify, PID-of-writer attribution, systemd integration, port owner detection, active connection flow reporting, streaming command output before process exit, or rename pairing. Those can layer onto the same collection and merge contract later.

--- a/src/commands/trace/probes.rs
+++ b/src/commands/trace/probes.rs
@@ -56,6 +56,39 @@ fn expand_trace_probe(
             pattern: expand_trace_probe_value(context, pattern),
             interval_ms: *interval_ms,
         },
+        extension_trace::TraceProbeConfig::FileWatch { path, interval_ms } => {
+            extension_trace::TraceProbeConfig::FileWatch {
+                path: expand_trace_probe_value(context, path),
+                interval_ms: *interval_ms,
+            }
+        }
+        extension_trace::TraceProbeConfig::PortSnapshot {
+            port,
+            port_range,
+            interval_ms,
+        } => extension_trace::TraceProbeConfig::PortSnapshot {
+            port: *port,
+            port_range: port_range.clone(),
+            interval_ms: *interval_ms,
+        },
+        extension_trace::TraceProbeConfig::HttpPoll {
+            url,
+            interval_ms,
+            assert_status,
+        } => extension_trace::TraceProbeConfig::HttpPoll {
+            url: expand_trace_probe_value(context, url),
+            interval_ms: *interval_ms,
+            assert_status: *assert_status,
+        },
+        extension_trace::TraceProbeConfig::CmdRun { command, args } => {
+            extension_trace::TraceProbeConfig::CmdRun {
+                command: expand_trace_probe_value(context, command),
+                args: args
+                    .iter()
+                    .map(|arg| expand_trace_probe_value(context, arg))
+                    .collect(),
+            }
+        }
     })
 }
 

--- a/src/core/extension/trace/probes.rs
+++ b/src/core/extension/trace/probes.rs
@@ -3,18 +3,27 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{File, Metadata};
+use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use crate::error::{Error, Result};
 
 use super::parsing::TraceEvent;
+
+mod cmd_run;
+mod file_watch;
+mod http_poll;
+mod port_snapshot;
+
+use cmd_run::run_cmd_run;
+use file_watch::{file_state, run_file_watch, FileState};
+use http_poll::run_http_poll;
+use port_snapshot::{ports_for_snapshot, run_port_snapshot};
 
 const DEFAULT_PROCESS_INTERVAL_MS: u64 = 1_000;
 const DEFAULT_FILE_INTERVAL_MS: u64 = 250;
@@ -116,13 +125,6 @@ enum RunningTraceProbeConfig {
         command: String,
         args: Vec<String>,
     },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct FileState {
-    exists: bool,
-    len: u64,
-    modified_ms: Option<u128>,
 }
 
 impl ActiveTraceProbes {
@@ -632,370 +634,6 @@ fn process_delta_event(
     event(started_at, "process.snapshot", event_name, data)
 }
 
-fn run_file_watch(
-    path: String,
-    interval_ms: u64,
-    mut previous: FileState,
-    started_at: Instant,
-    events: Arc<Mutex<Vec<TraceEvent>>>,
-    stop: mpsc::Receiver<()>,
-) {
-    let path_buf = PathBuf::from(&path);
-    let interval = Duration::from_millis(interval_ms.max(1));
-
-    loop {
-        let current = file_state(&path_buf);
-        emit_file_watch_events(&path, &previous, &current, started_at, &events);
-        previous = current;
-        if stop.recv_timeout(interval).is_ok() {
-            let current = file_state(&path_buf);
-            emit_file_watch_events(&path, &previous, &current, started_at, &events);
-            break;
-        }
-    }
-}
-
-fn file_state(path: &PathBuf) -> FileState {
-    let Ok(metadata) = std::fs::metadata(path) else {
-        return FileState {
-            exists: false,
-            len: 0,
-            modified_ms: None,
-        };
-    };
-    file_state_from_metadata(&metadata)
-}
-
-fn file_state_from_metadata(metadata: &Metadata) -> FileState {
-    FileState {
-        exists: true,
-        len: metadata.len(),
-        modified_ms: metadata
-            .modified()
-            .ok()
-            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
-            .map(|modified| modified.as_millis()),
-    }
-}
-
-fn emit_file_watch_events(
-    path: &str,
-    previous: &FileState,
-    current: &FileState,
-    started_at: Instant,
-    events: &Arc<Mutex<Vec<TraceEvent>>>,
-) {
-    let event_name = if !previous.exists && current.exists {
-        Some("fs.create")
-    } else if previous.exists && !current.exists {
-        Some("fs.delete")
-    } else if previous.exists
-        && current.exists
-        && (previous.len != current.len || previous.modified_ms != current.modified_ms)
-    {
-        Some("fs.write")
-    } else {
-        None
-    };
-
-    let Some(event_name) = event_name else {
-        return;
-    };
-    let mut data = BTreeMap::new();
-    data.insert(
-        "path".to_string(),
-        serde_json::Value::String(path.to_string()),
-    );
-    data.insert("exists".to_string(), serde_json::json!(current.exists));
-    if current.exists {
-        data.insert("len".to_string(), serde_json::json!(current.len));
-    }
-    push_event(events, event(started_at, "file.watch", event_name, data));
-}
-
-fn run_port_snapshot(
-    ports: Vec<u16>,
-    interval_ms: u64,
-    started_at: Instant,
-    events: Arc<Mutex<Vec<TraceEvent>>>,
-    stop: mpsc::Receiver<()>,
-) {
-    let interval = Duration::from_millis(interval_ms.max(1));
-    let mut previous: Option<BTreeSet<u16>> = None;
-
-    loop {
-        let current = listening_ports(&ports);
-        emit_port_events(previous.as_ref(), &current, started_at, &events);
-        previous = Some(current);
-        if stop.recv_timeout(interval).is_ok() {
-            let current = listening_ports(&ports);
-            emit_port_events(previous.as_ref(), &current, started_at, &events);
-            break;
-        }
-    }
-}
-
-fn listening_ports(ports: &[u16]) -> BTreeSet<u16> {
-    ports
-        .iter()
-        .copied()
-        .filter(|port| TcpListener::bind(("127.0.0.1", *port)).is_err())
-        .collect()
-}
-
-fn emit_port_events(
-    previous: Option<&BTreeSet<u16>>,
-    current: &BTreeSet<u16>,
-    started_at: Instant,
-    events: &Arc<Mutex<Vec<TraceEvent>>>,
-) {
-    let mut data = BTreeMap::new();
-    data.insert(
-        "ports".to_string(),
-        serde_json::Value::Array(current.iter().map(|port| serde_json::json!(port)).collect()),
-    );
-    push_event(
-        events,
-        event(started_at, "port.snapshot", "net.listening", data),
-    );
-
-    let Some(previous) = previous else {
-        return;
-    };
-    for port in current.difference(previous) {
-        push_event(events, port_delta_event(started_at, "net.bind", *port));
-    }
-    for port in previous.difference(current) {
-        push_event(events, port_delta_event(started_at, "net.unbind", *port));
-    }
-}
-
-fn port_delta_event(started_at: Instant, event_name: &str, port: u16) -> TraceEvent {
-    let mut data = BTreeMap::new();
-    data.insert("port".to_string(), serde_json::json!(port));
-    event(started_at, "port.snapshot", event_name, data)
-}
-
-fn ports_for_snapshot(port: Option<u16>, port_range: Option<&str>) -> Result<Vec<u16>> {
-    let mut ports = BTreeSet::new();
-    if let Some(port) = port {
-        ports.insert(port);
-    }
-    if let Some(port_range) = port_range {
-        let Some((start, end)) = port_range.split_once('-') else {
-            return Err(Error::validation_invalid_argument(
-                "trace_probes.port-range",
-                "port.snapshot port-range must be formatted as start-end".to_string(),
-                None,
-                None,
-            ));
-        };
-        let start: u16 = start.trim().parse().map_err(|_| {
-            Error::validation_invalid_argument(
-                "trace_probes.port-range",
-                "port.snapshot port-range start must be a port number".to_string(),
-                None,
-                None,
-            )
-        })?;
-        let end: u16 = end.trim().parse().map_err(|_| {
-            Error::validation_invalid_argument(
-                "trace_probes.port-range",
-                "port.snapshot port-range end must be a port number".to_string(),
-                None,
-                None,
-            )
-        })?;
-        if start > end {
-            return Err(Error::validation_invalid_argument(
-                "trace_probes.port-range",
-                "port.snapshot port-range start must be <= end".to_string(),
-                None,
-                None,
-            ));
-        }
-        ports.extend(start..=end);
-    }
-    if ports.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "trace_probes.port",
-            "port.snapshot requires port or port-range".to_string(),
-            None,
-            None,
-        ));
-    }
-    Ok(ports.into_iter().collect())
-}
-
-fn run_http_poll(
-    url: String,
-    interval_ms: u64,
-    assert_status: Option<u16>,
-    started_at: Instant,
-    events: Arc<Mutex<Vec<TraceEvent>>>,
-    stop: mpsc::Receiver<()>,
-) {
-    let interval = Duration::from_millis(interval_ms.max(1));
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(5))
-        .build()
-        .ok();
-
-    loop {
-        emit_http_poll_event(client.as_ref(), &url, assert_status, started_at, &events);
-        if stop.recv_timeout(interval).is_ok() {
-            emit_http_poll_event(client.as_ref(), &url, assert_status, started_at, &events);
-            break;
-        }
-    }
-}
-
-fn emit_http_poll_event(
-    client: Option<&reqwest::blocking::Client>,
-    url: &str,
-    assert_status: Option<u16>,
-    started_at: Instant,
-    events: &Arc<Mutex<Vec<TraceEvent>>>,
-) {
-    let Some(client) = client else {
-        push_http_error(url, "failed to build HTTP client", started_at, events);
-        return;
-    };
-    let request_started = Instant::now();
-    match client.get(url).send() {
-        Ok(response) => {
-            let status = response.status().as_u16();
-            let mut data = BTreeMap::new();
-            data.insert(
-                "url".to_string(),
-                serde_json::Value::String(url.to_string()),
-            );
-            data.insert("status".to_string(), serde_json::json!(status));
-            data.insert(
-                "latency_ms".to_string(),
-                serde_json::json!(request_started.elapsed().as_millis() as u64),
-            );
-            if let Some(assert_status) = assert_status {
-                data.insert(
-                    "assert_status".to_string(),
-                    serde_json::json!(assert_status),
-                );
-                data.insert("ok".to_string(), serde_json::json!(status == assert_status));
-            }
-            push_event(
-                events,
-                event(started_at, "http.poll", "http.response", data),
-            );
-        }
-        Err(error) => push_http_error(url, &error.to_string(), started_at, events),
-    }
-}
-
-fn push_http_error(
-    url: &str,
-    error: &str,
-    started_at: Instant,
-    events: &Arc<Mutex<Vec<TraceEvent>>>,
-) {
-    let mut data = BTreeMap::new();
-    data.insert(
-        "url".to_string(),
-        serde_json::Value::String(url.to_string()),
-    );
-    data.insert(
-        "error".to_string(),
-        serde_json::Value::String(error.to_string()),
-    );
-    push_event(events, event(started_at, "http.poll", "http.error", data));
-}
-
-fn run_cmd_run(
-    command: String,
-    args: Vec<String>,
-    started_at: Instant,
-    events: Arc<Mutex<Vec<TraceEvent>>>,
-    stop: mpsc::Receiver<()>,
-) {
-    let mut start_data = BTreeMap::new();
-    start_data.insert(
-        "command".to_string(),
-        serde_json::Value::String(command.clone()),
-    );
-    start_data.insert(
-        "args".to_string(),
-        serde_json::Value::Array(
-            args.iter()
-                .map(|arg| serde_json::Value::String(arg.clone()))
-                .collect(),
-        ),
-    );
-    push_event(
-        &events,
-        event(started_at, "cmd.run", "cmd.start", start_data),
-    );
-
-    let command_started = Instant::now();
-    match Command::new(&command).args(&args).output() {
-        Ok(output) => {
-            emit_cmd_lines(
-                "cmd.stdout",
-                &String::from_utf8_lossy(&output.stdout),
-                started_at,
-                &events,
-            );
-            emit_cmd_lines(
-                "cmd.stderr",
-                &String::from_utf8_lossy(&output.stderr),
-                started_at,
-                &events,
-            );
-            let mut data = BTreeMap::new();
-            data.insert(
-                "exit_code".to_string(),
-                serde_json::json!(output.status.code()),
-            );
-            data.insert(
-                "success".to_string(),
-                serde_json::json!(output.status.success()),
-            );
-            data.insert(
-                "duration_ms".to_string(),
-                serde_json::json!(command_started.elapsed().as_millis() as u64),
-            );
-            push_event(&events, event(started_at, "cmd.run", "cmd.exit", data));
-        }
-        Err(error) => {
-            let mut data = BTreeMap::new();
-            data.insert(
-                "error".to_string(),
-                serde_json::Value::String(error.to_string()),
-            );
-            data.insert(
-                "duration_ms".to_string(),
-                serde_json::json!(command_started.elapsed().as_millis() as u64),
-            );
-            push_event(&events, event(started_at, "cmd.run", "cmd.error", data));
-        }
-    }
-    let _ = stop.recv_timeout(Duration::from_millis(1));
-}
-
-fn emit_cmd_lines(
-    event_name: &str,
-    output: &str,
-    started_at: Instant,
-    events: &Arc<Mutex<Vec<TraceEvent>>>,
-) {
-    for line in output.lines() {
-        let mut data = BTreeMap::new();
-        data.insert(
-            "line".to_string(),
-            serde_json::Value::String(line.to_string()),
-        );
-        push_event(events, event(started_at, "cmd.run", event_name, data));
-    }
-}
-
 fn event(
     started_at: Instant,
     source: &str,
@@ -1020,8 +658,6 @@ fn push_event(events: &Arc<Mutex<Vec<TraceEvent>>>, event: TraceEvent) {
 mod tests {
     use super::*;
     use std::fs;
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
 
     #[test]
     fn active_trace_probes_start_rejects_invalid_regex() {
@@ -1117,123 +753,5 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.source == "process.snapshot" && event.event == "proc.list"));
-    }
-
-    #[test]
-    fn file_watch_emits_create_write_and_delete_events() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("watched.txt");
-        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::FileWatch {
-            path: path.to_string_lossy().to_string(),
-            interval_ms: Some(25),
-        }])
-        .expect("start probes");
-
-        fs::write(&path, "created").expect("create file");
-        thread::sleep(Duration::from_millis(60));
-        fs::write(&path, "updated with a different length").expect("update file");
-        thread::sleep(Duration::from_millis(60));
-        fs::remove_file(&path).expect("delete file");
-        thread::sleep(Duration::from_millis(60));
-
-        let events = probes.stop();
-        assert!(events
-            .iter()
-            .any(|event| event.source == "file.watch" && event.event == "fs.create"));
-        assert!(events
-            .iter()
-            .any(|event| event.source == "file.watch" && event.event == "fs.write"));
-        assert!(events
-            .iter()
-            .any(|event| event.source == "file.watch" && event.event == "fs.delete"));
-    }
-
-    #[test]
-    fn port_snapshot_emits_listening_events() {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test listener");
-        let port = listener.local_addr().expect("local addr").port();
-        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
-            port: Some(port),
-            port_range: None,
-            interval_ms: Some(25),
-        }])
-        .expect("start probes");
-        thread::sleep(Duration::from_millis(60));
-
-        let events = probes.stop();
-        assert!(events.iter().any(|event| event.source == "port.snapshot"
-            && event.event == "net.listening"
-            && event
-                .data
-                .get("ports")
-                .and_then(|value| value.as_array())
-                .is_some_and(|ports| ports
-                    .iter()
-                    .any(|value| value.as_u64() == Some(u64::from(port))))));
-    }
-
-    #[test]
-    fn http_poll_emits_response_events() {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test server");
-        let url = format!("http://{}", listener.local_addr().expect("local addr"));
-        let server = thread::spawn(move || {
-            for stream in listener.incoming().take(1) {
-                let mut stream = stream.expect("accept connection");
-                let mut buffer = [0; 512];
-                let _ = stream.read(&mut buffer);
-                stream
-                    .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
-                    .expect("write response");
-            }
-        });
-        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::HttpPoll {
-            url,
-            interval_ms: Some(25),
-            assert_status: Some(204),
-        }])
-        .expect("start probes");
-        thread::sleep(Duration::from_millis(80));
-
-        let events = probes.stop();
-        let _ = server.join();
-        assert!(events.iter().any(|event| event.source == "http.poll"
-            && event.event == "http.response"
-            && event.data.get("status").and_then(|value| value.as_u64()) == Some(204)
-            && event.data.get("ok").and_then(|value| value.as_bool()) == Some(true)));
-    }
-
-    #[test]
-    fn cmd_run_emits_command_lifecycle_events() {
-        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::CmdRun {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), "printf probe-output".to_string()],
-        }])
-        .expect("start probes");
-        thread::sleep(Duration::from_millis(60));
-
-        let events = probes.stop();
-        assert!(events
-            .iter()
-            .any(|event| event.source == "cmd.run" && event.event == "cmd.start"));
-        assert!(events.iter().any(|event| event.source == "cmd.run"
-            && event.event == "cmd.stdout"
-            && event.data.get("line").and_then(|value| value.as_str()) == Some("probe-output")));
-        assert!(events.iter().any(|event| event.source == "cmd.run"
-            && event.event == "cmd.exit"
-            && event.data.get("success").and_then(|value| value.as_bool()) == Some(true)));
-    }
-
-    #[test]
-    fn port_range_parser_rejects_invalid_ranges() {
-        let result = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
-            port: None,
-            port_range: Some("9002-9001".to_string()),
-            interval_ms: Some(25),
-        }]);
-        let error = result.err().expect("invalid range should fail start");
-
-        assert!(error
-            .to_string()
-            .contains("port-range start must be <= end"));
     }
 }

--- a/src/core/extension/trace/probes.rs
+++ b/src/core/extension/trace/probes.rs
@@ -3,19 +3,23 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::File;
+use std::fs::{File, Metadata};
 use std::io::{Read, Seek, SeekFrom};
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::error::{Error, Result};
 
 use super::parsing::TraceEvent;
 
 const DEFAULT_PROCESS_INTERVAL_MS: u64 = 1_000;
+const DEFAULT_FILE_INTERVAL_MS: u64 = 250;
+const DEFAULT_PORT_INTERVAL_MS: u64 = 500;
+const DEFAULT_HTTP_INTERVAL_MS: u64 = 1_000;
 const LOG_POLL_INTERVAL_MS: u64 = 50;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,6 +38,45 @@ pub enum TraceProbeConfig {
         pattern: String,
         #[serde(default, alias = "interval", skip_serializing_if = "Option::is_none")]
         interval_ms: Option<u64>,
+    },
+    #[serde(rename = "file.watch")]
+    FileWatch {
+        path: String,
+        #[serde(default, alias = "interval", skip_serializing_if = "Option::is_none")]
+        interval_ms: Option<u64>,
+    },
+    #[serde(rename = "port.snapshot")]
+    PortSnapshot {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        port: Option<u16>,
+        #[serde(
+            default,
+            rename = "port-range",
+            alias = "port_range",
+            skip_serializing_if = "Option::is_none"
+        )]
+        port_range: Option<String>,
+        #[serde(default, alias = "interval", skip_serializing_if = "Option::is_none")]
+        interval_ms: Option<u64>,
+    },
+    #[serde(rename = "http.poll")]
+    HttpPoll {
+        url: String,
+        #[serde(default, alias = "interval", skip_serializing_if = "Option::is_none")]
+        interval_ms: Option<u64>,
+        #[serde(
+            default,
+            rename = "assert-status",
+            alias = "assert_status",
+            skip_serializing_if = "Option::is_none"
+        )]
+        assert_status: Option<u16>,
+    },
+    #[serde(rename = "cmd.run")]
+    CmdRun {
+        command: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
     },
 }
 
@@ -55,6 +98,31 @@ enum RunningTraceProbeConfig {
         pattern: String,
         interval_ms: Option<u64>,
     },
+    FileWatch {
+        path: String,
+        interval_ms: Option<u64>,
+        initial_state: FileState,
+    },
+    PortSnapshot {
+        ports: Vec<u16>,
+        interval_ms: Option<u64>,
+    },
+    HttpPoll {
+        url: String,
+        interval_ms: Option<u64>,
+        assert_status: Option<u16>,
+    },
+    CmdRun {
+        command: String,
+        args: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileState {
+    exists: bool,
+    len: u64,
+    modified_ms: Option<u128>,
 }
 
 impl ActiveTraceProbes {
@@ -120,6 +188,32 @@ fn running_probe_config(config: &TraceProbeConfig) -> RunningTraceProbeConfig {
             pattern: pattern.clone(),
             interval_ms: *interval_ms,
         },
+        TraceProbeConfig::FileWatch { path, interval_ms } => RunningTraceProbeConfig::FileWatch {
+            path: path.clone(),
+            interval_ms: *interval_ms,
+            initial_state: file_state(&PathBuf::from(path)),
+        },
+        TraceProbeConfig::PortSnapshot {
+            port,
+            port_range,
+            interval_ms,
+        } => RunningTraceProbeConfig::PortSnapshot {
+            ports: ports_for_snapshot(*port, port_range.as_deref()).unwrap_or_default(),
+            interval_ms: *interval_ms,
+        },
+        TraceProbeConfig::HttpPoll {
+            url,
+            interval_ms,
+            assert_status,
+        } => RunningTraceProbeConfig::HttpPoll {
+            url: url.clone(),
+            interval_ms: *interval_ms,
+            assert_status: *assert_status,
+        },
+        TraceProbeConfig::CmdRun { command, args } => RunningTraceProbeConfig::CmdRun {
+            command: command.clone(),
+            args: args.clone(),
+        },
     }
 }
 
@@ -150,6 +244,41 @@ fn validate_probe(config: &TraceProbeConfig) -> Result<()> {
                     None,
                 )
             })?;
+        }
+        TraceProbeConfig::FileWatch { path, .. } => {
+            if path.trim().is_empty() {
+                return Err(Error::validation_invalid_argument(
+                    "trace_probes.path",
+                    "file.watch path cannot be empty".to_string(),
+                    None,
+                    None,
+                ));
+            }
+        }
+        TraceProbeConfig::PortSnapshot {
+            port, port_range, ..
+        } => {
+            ports_for_snapshot(*port, port_range.as_deref())?;
+        }
+        TraceProbeConfig::HttpPoll { url, .. } => {
+            reqwest::Url::parse(url).map_err(|e| {
+                Error::validation_invalid_argument(
+                    "trace_probes.url",
+                    format!("invalid http.poll url: {}", e),
+                    None,
+                    None,
+                )
+            })?;
+        }
+        TraceProbeConfig::CmdRun { command, .. } => {
+            if command.trim().is_empty() {
+                return Err(Error::validation_invalid_argument(
+                    "trace_probes.command",
+                    "cmd.run command cannot be empty".to_string(),
+                    None,
+                    None,
+                ));
+            }
         }
     }
     Ok(())
@@ -185,6 +314,40 @@ fn run_probe(
             events,
             stop,
         ),
+        RunningTraceProbeConfig::FileWatch {
+            path,
+            interval_ms,
+            initial_state,
+        } => run_file_watch(
+            path,
+            interval_ms.unwrap_or(DEFAULT_FILE_INTERVAL_MS),
+            initial_state,
+            started_at,
+            events,
+            stop,
+        ),
+        RunningTraceProbeConfig::PortSnapshot { ports, interval_ms } => run_port_snapshot(
+            ports,
+            interval_ms.unwrap_or(DEFAULT_PORT_INTERVAL_MS),
+            started_at,
+            events,
+            stop,
+        ),
+        RunningTraceProbeConfig::HttpPoll {
+            url,
+            interval_ms,
+            assert_status,
+        } => run_http_poll(
+            url,
+            interval_ms.unwrap_or(DEFAULT_HTTP_INTERVAL_MS),
+            assert_status,
+            started_at,
+            events,
+            stop,
+        ),
+        RunningTraceProbeConfig::CmdRun { command, args } => {
+            run_cmd_run(command, args, started_at, events, stop)
+        }
     }
 }
 
@@ -469,6 +632,370 @@ fn process_delta_event(
     event(started_at, "process.snapshot", event_name, data)
 }
 
+fn run_file_watch(
+    path: String,
+    interval_ms: u64,
+    mut previous: FileState,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let path_buf = PathBuf::from(&path);
+    let interval = Duration::from_millis(interval_ms.max(1));
+
+    loop {
+        let current = file_state(&path_buf);
+        emit_file_watch_events(&path, &previous, &current, started_at, &events);
+        previous = current;
+        if stop.recv_timeout(interval).is_ok() {
+            let current = file_state(&path_buf);
+            emit_file_watch_events(&path, &previous, &current, started_at, &events);
+            break;
+        }
+    }
+}
+
+fn file_state(path: &PathBuf) -> FileState {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return FileState {
+            exists: false,
+            len: 0,
+            modified_ms: None,
+        };
+    };
+    file_state_from_metadata(&metadata)
+}
+
+fn file_state_from_metadata(metadata: &Metadata) -> FileState {
+    FileState {
+        exists: true,
+        len: metadata.len(),
+        modified_ms: metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|modified| modified.as_millis()),
+    }
+}
+
+fn emit_file_watch_events(
+    path: &str,
+    previous: &FileState,
+    current: &FileState,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let event_name = if !previous.exists && current.exists {
+        Some("fs.create")
+    } else if previous.exists && !current.exists {
+        Some("fs.delete")
+    } else if previous.exists
+        && current.exists
+        && (previous.len != current.len || previous.modified_ms != current.modified_ms)
+    {
+        Some("fs.write")
+    } else {
+        None
+    };
+
+    let Some(event_name) = event_name else {
+        return;
+    };
+    let mut data = BTreeMap::new();
+    data.insert(
+        "path".to_string(),
+        serde_json::Value::String(path.to_string()),
+    );
+    data.insert("exists".to_string(), serde_json::json!(current.exists));
+    if current.exists {
+        data.insert("len".to_string(), serde_json::json!(current.len));
+    }
+    push_event(events, event(started_at, "file.watch", event_name, data));
+}
+
+fn run_port_snapshot(
+    ports: Vec<u16>,
+    interval_ms: u64,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let interval = Duration::from_millis(interval_ms.max(1));
+    let mut previous: Option<BTreeSet<u16>> = None;
+
+    loop {
+        let current = listening_ports(&ports);
+        emit_port_events(previous.as_ref(), &current, started_at, &events);
+        previous = Some(current);
+        if stop.recv_timeout(interval).is_ok() {
+            let current = listening_ports(&ports);
+            emit_port_events(previous.as_ref(), &current, started_at, &events);
+            break;
+        }
+    }
+}
+
+fn listening_ports(ports: &[u16]) -> BTreeSet<u16> {
+    ports
+        .iter()
+        .copied()
+        .filter(|port| TcpListener::bind(("127.0.0.1", *port)).is_err())
+        .collect()
+}
+
+fn emit_port_events(
+    previous: Option<&BTreeSet<u16>>,
+    current: &BTreeSet<u16>,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "ports".to_string(),
+        serde_json::Value::Array(current.iter().map(|port| serde_json::json!(port)).collect()),
+    );
+    push_event(
+        events,
+        event(started_at, "port.snapshot", "net.listening", data),
+    );
+
+    let Some(previous) = previous else {
+        return;
+    };
+    for port in current.difference(previous) {
+        push_event(events, port_delta_event(started_at, "net.bind", *port));
+    }
+    for port in previous.difference(current) {
+        push_event(events, port_delta_event(started_at, "net.unbind", *port));
+    }
+}
+
+fn port_delta_event(started_at: Instant, event_name: &str, port: u16) -> TraceEvent {
+    let mut data = BTreeMap::new();
+    data.insert("port".to_string(), serde_json::json!(port));
+    event(started_at, "port.snapshot", event_name, data)
+}
+
+fn ports_for_snapshot(port: Option<u16>, port_range: Option<&str>) -> Result<Vec<u16>> {
+    let mut ports = BTreeSet::new();
+    if let Some(port) = port {
+        ports.insert(port);
+    }
+    if let Some(port_range) = port_range {
+        let Some((start, end)) = port_range.split_once('-') else {
+            return Err(Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range must be formatted as start-end".to_string(),
+                None,
+                None,
+            ));
+        };
+        let start: u16 = start.trim().parse().map_err(|_| {
+            Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range start must be a port number".to_string(),
+                None,
+                None,
+            )
+        })?;
+        let end: u16 = end.trim().parse().map_err(|_| {
+            Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range end must be a port number".to_string(),
+                None,
+                None,
+            )
+        })?;
+        if start > end {
+            return Err(Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range start must be <= end".to_string(),
+                None,
+                None,
+            ));
+        }
+        ports.extend(start..=end);
+    }
+    if ports.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "trace_probes.port",
+            "port.snapshot requires port or port-range".to_string(),
+            None,
+            None,
+        ));
+    }
+    Ok(ports.into_iter().collect())
+}
+
+fn run_http_poll(
+    url: String,
+    interval_ms: u64,
+    assert_status: Option<u16>,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let interval = Duration::from_millis(interval_ms.max(1));
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .ok();
+
+    loop {
+        emit_http_poll_event(client.as_ref(), &url, assert_status, started_at, &events);
+        if stop.recv_timeout(interval).is_ok() {
+            emit_http_poll_event(client.as_ref(), &url, assert_status, started_at, &events);
+            break;
+        }
+    }
+}
+
+fn emit_http_poll_event(
+    client: Option<&reqwest::blocking::Client>,
+    url: &str,
+    assert_status: Option<u16>,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let Some(client) = client else {
+        push_http_error(url, "failed to build HTTP client", started_at, events);
+        return;
+    };
+    let request_started = Instant::now();
+    match client.get(url).send() {
+        Ok(response) => {
+            let status = response.status().as_u16();
+            let mut data = BTreeMap::new();
+            data.insert(
+                "url".to_string(),
+                serde_json::Value::String(url.to_string()),
+            );
+            data.insert("status".to_string(), serde_json::json!(status));
+            data.insert(
+                "latency_ms".to_string(),
+                serde_json::json!(request_started.elapsed().as_millis() as u64),
+            );
+            if let Some(assert_status) = assert_status {
+                data.insert(
+                    "assert_status".to_string(),
+                    serde_json::json!(assert_status),
+                );
+                data.insert("ok".to_string(), serde_json::json!(status == assert_status));
+            }
+            push_event(
+                events,
+                event(started_at, "http.poll", "http.response", data),
+            );
+        }
+        Err(error) => push_http_error(url, &error.to_string(), started_at, events),
+    }
+}
+
+fn push_http_error(
+    url: &str,
+    error: &str,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "url".to_string(),
+        serde_json::Value::String(url.to_string()),
+    );
+    data.insert(
+        "error".to_string(),
+        serde_json::Value::String(error.to_string()),
+    );
+    push_event(events, event(started_at, "http.poll", "http.error", data));
+}
+
+fn run_cmd_run(
+    command: String,
+    args: Vec<String>,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let mut start_data = BTreeMap::new();
+    start_data.insert(
+        "command".to_string(),
+        serde_json::Value::String(command.clone()),
+    );
+    start_data.insert(
+        "args".to_string(),
+        serde_json::Value::Array(
+            args.iter()
+                .map(|arg| serde_json::Value::String(arg.clone()))
+                .collect(),
+        ),
+    );
+    push_event(
+        &events,
+        event(started_at, "cmd.run", "cmd.start", start_data),
+    );
+
+    let command_started = Instant::now();
+    match Command::new(&command).args(&args).output() {
+        Ok(output) => {
+            emit_cmd_lines(
+                "cmd.stdout",
+                &String::from_utf8_lossy(&output.stdout),
+                started_at,
+                &events,
+            );
+            emit_cmd_lines(
+                "cmd.stderr",
+                &String::from_utf8_lossy(&output.stderr),
+                started_at,
+                &events,
+            );
+            let mut data = BTreeMap::new();
+            data.insert(
+                "exit_code".to_string(),
+                serde_json::json!(output.status.code()),
+            );
+            data.insert(
+                "success".to_string(),
+                serde_json::json!(output.status.success()),
+            );
+            data.insert(
+                "duration_ms".to_string(),
+                serde_json::json!(command_started.elapsed().as_millis() as u64),
+            );
+            push_event(&events, event(started_at, "cmd.run", "cmd.exit", data));
+        }
+        Err(error) => {
+            let mut data = BTreeMap::new();
+            data.insert(
+                "error".to_string(),
+                serde_json::Value::String(error.to_string()),
+            );
+            data.insert(
+                "duration_ms".to_string(),
+                serde_json::json!(command_started.elapsed().as_millis() as u64),
+            );
+            push_event(&events, event(started_at, "cmd.run", "cmd.error", data));
+        }
+    }
+    let _ = stop.recv_timeout(Duration::from_millis(1));
+}
+
+fn emit_cmd_lines(
+    event_name: &str,
+    output: &str,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    for line in output.lines() {
+        let mut data = BTreeMap::new();
+        data.insert(
+            "line".to_string(),
+            serde_json::Value::String(line.to_string()),
+        );
+        push_event(events, event(started_at, "cmd.run", event_name, data));
+    }
+}
+
 fn event(
     started_at: Instant,
     source: &str,
@@ -493,6 +1020,8 @@ fn push_event(events: &Arc<Mutex<Vec<TraceEvent>>>, event: TraceEvent) {
 mod tests {
     use super::*;
     use std::fs;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
 
     #[test]
     fn active_trace_probes_start_rejects_invalid_regex() {
@@ -588,5 +1117,123 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.source == "process.snapshot" && event.event == "proc.list"));
+    }
+
+    #[test]
+    fn file_watch_emits_create_write_and_delete_events() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("watched.txt");
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::FileWatch {
+            path: path.to_string_lossy().to_string(),
+            interval_ms: Some(25),
+        }])
+        .expect("start probes");
+
+        fs::write(&path, "created").expect("create file");
+        thread::sleep(Duration::from_millis(60));
+        fs::write(&path, "updated with a different length").expect("update file");
+        thread::sleep(Duration::from_millis(60));
+        fs::remove_file(&path).expect("delete file");
+        thread::sleep(Duration::from_millis(60));
+
+        let events = probes.stop();
+        assert!(events
+            .iter()
+            .any(|event| event.source == "file.watch" && event.event == "fs.create"));
+        assert!(events
+            .iter()
+            .any(|event| event.source == "file.watch" && event.event == "fs.write"));
+        assert!(events
+            .iter()
+            .any(|event| event.source == "file.watch" && event.event == "fs.delete"));
+    }
+
+    #[test]
+    fn port_snapshot_emits_listening_events() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test listener");
+        let port = listener.local_addr().expect("local addr").port();
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
+            port: Some(port),
+            port_range: None,
+            interval_ms: Some(25),
+        }])
+        .expect("start probes");
+        thread::sleep(Duration::from_millis(60));
+
+        let events = probes.stop();
+        assert!(events.iter().any(|event| event.source == "port.snapshot"
+            && event.event == "net.listening"
+            && event
+                .data
+                .get("ports")
+                .and_then(|value| value.as_array())
+                .is_some_and(|ports| ports
+                    .iter()
+                    .any(|value| value.as_u64() == Some(u64::from(port))))));
+    }
+
+    #[test]
+    fn http_poll_emits_response_events() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test server");
+        let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let server = thread::spawn(move || {
+            for stream in listener.incoming().take(1) {
+                let mut stream = stream.expect("accept connection");
+                let mut buffer = [0; 512];
+                let _ = stream.read(&mut buffer);
+                stream
+                    .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                    .expect("write response");
+            }
+        });
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::HttpPoll {
+            url,
+            interval_ms: Some(25),
+            assert_status: Some(204),
+        }])
+        .expect("start probes");
+        thread::sleep(Duration::from_millis(80));
+
+        let events = probes.stop();
+        let _ = server.join();
+        assert!(events.iter().any(|event| event.source == "http.poll"
+            && event.event == "http.response"
+            && event.data.get("status").and_then(|value| value.as_u64()) == Some(204)
+            && event.data.get("ok").and_then(|value| value.as_bool()) == Some(true)));
+    }
+
+    #[test]
+    fn cmd_run_emits_command_lifecycle_events() {
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::CmdRun {
+            command: "sh".to_string(),
+            args: vec!["-c".to_string(), "printf probe-output".to_string()],
+        }])
+        .expect("start probes");
+        thread::sleep(Duration::from_millis(60));
+
+        let events = probes.stop();
+        assert!(events
+            .iter()
+            .any(|event| event.source == "cmd.run" && event.event == "cmd.start"));
+        assert!(events.iter().any(|event| event.source == "cmd.run"
+            && event.event == "cmd.stdout"
+            && event.data.get("line").and_then(|value| value.as_str()) == Some("probe-output")));
+        assert!(events.iter().any(|event| event.source == "cmd.run"
+            && event.event == "cmd.exit"
+            && event.data.get("success").and_then(|value| value.as_bool()) == Some(true)));
+    }
+
+    #[test]
+    fn port_range_parser_rejects_invalid_ranges() {
+        let result = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
+            port: None,
+            port_range: Some("9002-9001".to_string()),
+            interval_ms: Some(25),
+        }]);
+        let error = result.err().expect("invalid range should fail start");
+
+        assert!(error
+            .to_string()
+            .contains("port-range start must be <= end"));
     }
 }

--- a/src/core/extension/trace/probes/cmd_run.rs
+++ b/src/core/extension/trace/probes/cmd_run.rs
@@ -12,14 +12,11 @@ pub(super) fn run_cmd_run(
     events: Arc<Mutex<Vec<TraceEvent>>>,
     stop: mpsc::Receiver<()>,
 ) {
-    push_event(
+    push_cmd_event(
         &events,
-        event(
-            started_at,
-            "cmd.run",
-            "cmd.start",
-            command_start_data(&command, &args),
-        ),
+        started_at,
+        "cmd.start",
+        command_start_data(&command, &args),
     );
 
     let command_started = Instant::now();
@@ -37,17 +34,14 @@ pub(super) fn run_cmd_run(
                 started_at,
                 &events,
             );
-            push_event(
+            push_cmd_event(
                 &events,
-                event(
-                    started_at,
-                    "cmd.run",
-                    "cmd.exit",
-                    command_finish_data(
-                        command_started,
-                        output.status.code(),
-                        output.status.success(),
-                    ),
+                started_at,
+                "cmd.exit",
+                command_finish_data(
+                    command_started,
+                    output.status.code(),
+                    output.status.success(),
                 ),
             );
         }
@@ -61,6 +55,15 @@ pub(super) fn run_cmd_run(
         }
     }
     let _ = stop.recv_timeout(Duration::from_millis(1));
+}
+
+fn push_cmd_event(
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+    started_at: Instant,
+    event_name: &str,
+    data: BTreeMap<String, serde_json::Value>,
+) {
+    push_event(events, event(started_at, "cmd.run", event_name, data));
 }
 
 fn command_start_data(command: &str, args: &[String]) -> BTreeMap<String, serde_json::Value> {
@@ -112,7 +115,7 @@ fn emit_cmd_lines(
             "line".to_string(),
             serde_json::Value::String(line.to_string()),
         );
-        push_event(events, event(started_at, "cmd.run", event_name, data));
+        push_cmd_event(events, started_at, event_name, data);
     }
 }
 
@@ -124,7 +127,7 @@ mod tests {
     use super::super::{ActiveTraceProbes, TraceProbeConfig};
 
     #[test]
-    fn cmd_run_emits_command_lifecycle_events() {
+    fn test_run_cmd_run() {
         let probes = ActiveTraceProbes::start(&[TraceProbeConfig::CmdRun {
             command: "sh".to_string(),
             args: vec!["-c".to_string(), "printf probe-output".to_string()],

--- a/src/core/extension/trace/probes/cmd_run.rs
+++ b/src/core/extension/trace/probes/cmd_run.rs
@@ -1,0 +1,146 @@
+use std::collections::BTreeMap;
+use std::process::Command;
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use super::{event, push_event, TraceEvent};
+
+pub(super) fn run_cmd_run(
+    command: String,
+    args: Vec<String>,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    push_event(
+        &events,
+        event(
+            started_at,
+            "cmd.run",
+            "cmd.start",
+            command_start_data(&command, &args),
+        ),
+    );
+
+    let command_started = Instant::now();
+    match Command::new(&command).args(&args).output() {
+        Ok(output) => {
+            emit_cmd_lines(
+                "cmd.stdout",
+                &String::from_utf8_lossy(&output.stdout),
+                started_at,
+                &events,
+            );
+            emit_cmd_lines(
+                "cmd.stderr",
+                &String::from_utf8_lossy(&output.stderr),
+                started_at,
+                &events,
+            );
+            push_event(
+                &events,
+                event(
+                    started_at,
+                    "cmd.run",
+                    "cmd.exit",
+                    command_finish_data(
+                        command_started,
+                        output.status.code(),
+                        output.status.success(),
+                    ),
+                ),
+            );
+        }
+        Err(error) => {
+            let mut data = command_duration_data(command_started);
+            data.insert(
+                "error".to_string(),
+                serde_json::Value::String(error.to_string()),
+            );
+            push_event(&events, event(started_at, "cmd.run", "cmd.error", data));
+        }
+    }
+    let _ = stop.recv_timeout(Duration::from_millis(1));
+}
+
+fn command_start_data(command: &str, args: &[String]) -> BTreeMap<String, serde_json::Value> {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "command".to_string(),
+        serde_json::Value::String(command.to_string()),
+    );
+    data.insert(
+        "args".to_string(),
+        serde_json::Value::Array(
+            args.iter()
+                .map(|arg| serde_json::Value::String(arg.clone()))
+                .collect(),
+        ),
+    );
+    data
+}
+
+fn command_finish_data(
+    started_at: Instant,
+    exit_code: Option<i32>,
+    success: bool,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut data = command_duration_data(started_at);
+    data.insert("exit_code".to_string(), serde_json::json!(exit_code));
+    data.insert("success".to_string(), serde_json::json!(success));
+    data
+}
+
+fn command_duration_data(started_at: Instant) -> BTreeMap<String, serde_json::Value> {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "duration_ms".to_string(),
+        serde_json::json!(started_at.elapsed().as_millis() as u64),
+    );
+    data
+}
+
+fn emit_cmd_lines(
+    event_name: &str,
+    output: &str,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    for line in output.lines() {
+        let mut data = BTreeMap::new();
+        data.insert(
+            "line".to_string(),
+            serde_json::Value::String(line.to_string()),
+        );
+        push_event(events, event(started_at, "cmd.run", event_name, data));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::{ActiveTraceProbes, TraceProbeConfig};
+
+    #[test]
+    fn cmd_run_emits_command_lifecycle_events() {
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::CmdRun {
+            command: "sh".to_string(),
+            args: vec!["-c".to_string(), "printf probe-output".to_string()],
+        }])
+        .expect("start probes");
+        thread::sleep(Duration::from_millis(60));
+
+        let events = probes.stop();
+        assert!(events
+            .iter()
+            .any(|event| event.source == "cmd.run" && event.event == "cmd.start"));
+        assert!(events.iter().any(|event| event.source == "cmd.run"
+            && event.event == "cmd.stdout"
+            && event.data.get("line").and_then(|value| value.as_str()) == Some("probe-output")));
+        assert!(events.iter().any(|event| event.source == "cmd.run"
+            && event.event == "cmd.exit"
+            && event.data.get("success").and_then(|value| value.as_bool()) == Some(true)));
+    }
+}

--- a/src/core/extension/trace/probes/file_watch.rs
+++ b/src/core/extension/trace/probes/file_watch.rs
@@ -1,0 +1,133 @@
+use std::collections::BTreeMap;
+use std::fs::Metadata;
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant, UNIX_EPOCH};
+
+use super::{event, push_event, TraceEvent};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct FileState {
+    exists: bool,
+    len: u64,
+    modified_ms: Option<u128>,
+}
+
+pub(super) fn run_file_watch(
+    path: String,
+    interval_ms: u64,
+    mut previous: FileState,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let path_buf = PathBuf::from(&path);
+    let interval = Duration::from_millis(interval_ms.max(1));
+
+    loop {
+        let current = file_state(&path_buf);
+        emit_file_watch_events(&path, &previous, &current, started_at, &events);
+        previous = current;
+        if stop.recv_timeout(interval).is_ok() {
+            let current = file_state(&path_buf);
+            emit_file_watch_events(&path, &previous, &current, started_at, &events);
+            break;
+        }
+    }
+}
+
+pub(super) fn file_state(path: &PathBuf) -> FileState {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return FileState {
+            exists: false,
+            len: 0,
+            modified_ms: None,
+        };
+    };
+    file_state_from_metadata(&metadata)
+}
+
+fn file_state_from_metadata(metadata: &Metadata) -> FileState {
+    FileState {
+        exists: true,
+        len: metadata.len(),
+        modified_ms: metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|modified| modified.as_millis()),
+    }
+}
+
+fn emit_file_watch_events(
+    path: &str,
+    previous: &FileState,
+    current: &FileState,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let event_name = if !previous.exists && current.exists {
+        Some("fs.create")
+    } else if previous.exists && !current.exists {
+        Some("fs.delete")
+    } else if previous.exists
+        && current.exists
+        && (previous.len != current.len || previous.modified_ms != current.modified_ms)
+    {
+        Some("fs.write")
+    } else {
+        None
+    };
+
+    let Some(event_name) = event_name else {
+        return;
+    };
+    let mut data = BTreeMap::new();
+    data.insert(
+        "path".to_string(),
+        serde_json::Value::String(path.to_string()),
+    );
+    data.insert("exists".to_string(), serde_json::json!(current.exists));
+    if current.exists {
+        data.insert("len".to_string(), serde_json::json!(current.len));
+    }
+    push_event(events, event(started_at, "file.watch", event_name, data));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::{ActiveTraceProbes, TraceProbeConfig};
+
+    #[test]
+    fn file_watch_emits_create_write_and_delete_events() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("watched.txt");
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::FileWatch {
+            path: path.to_string_lossy().to_string(),
+            interval_ms: Some(25),
+        }])
+        .expect("start probes");
+
+        fs::write(&path, "created").expect("create file");
+        thread::sleep(Duration::from_millis(200));
+        fs::write(&path, "updated with a different length").expect("update file");
+        thread::sleep(Duration::from_millis(200));
+        fs::remove_file(&path).expect("delete file");
+        thread::sleep(Duration::from_millis(200));
+
+        let events = probes.stop();
+        assert!(events
+            .iter()
+            .any(|event| event.source == "file.watch" && event.event == "fs.create"));
+        assert!(events
+            .iter()
+            .any(|event| event.source == "file.watch" && event.event == "fs.write"));
+        assert!(events
+            .iter()
+            .any(|event| event.source == "file.watch" && event.event == "fs.delete"));
+    }
+}

--- a/src/core/extension/trace/probes/file_watch.rs
+++ b/src/core/extension/trace/probes/file_watch.rs
@@ -97,13 +97,29 @@ fn emit_file_watch_events(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::PathBuf;
     use std::thread;
     use std::time::Duration;
 
     use super::super::{ActiveTraceProbes, TraceProbeConfig};
+    use super::file_state;
 
     #[test]
-    fn file_watch_emits_create_write_and_delete_events() {
+    fn test_file_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let missing = file_state(&PathBuf::from(temp.path().join("missing.txt")));
+        assert!(!missing.exists);
+
+        let path = temp.path().join("present.txt");
+        fs::write(&path, "content").expect("write file");
+        let present = file_state(&path);
+        assert!(present.exists);
+        assert_eq!(present.len, 7);
+        assert!(present.modified_ms.is_some());
+    }
+
+    #[test]
+    fn test_run_file_watch() {
         let temp = tempfile::tempdir().expect("tempdir");
         let path = temp.path().join("watched.txt");
         let probes = ActiveTraceProbes::start(&[TraceProbeConfig::FileWatch {

--- a/src/core/extension/trace/probes/http_poll.rs
+++ b/src/core/extension/trace/probes/http_poll.rs
@@ -1,0 +1,127 @@
+use std::collections::BTreeMap;
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use super::{event, push_event, TraceEvent};
+
+pub(super) fn run_http_poll(
+    url: String,
+    interval_ms: u64,
+    assert_status: Option<u16>,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let interval = Duration::from_millis(interval_ms.max(1));
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .ok();
+
+    loop {
+        emit_http_poll_event(client.as_ref(), &url, assert_status, started_at, &events);
+        if stop.recv_timeout(interval).is_ok() {
+            emit_http_poll_event(client.as_ref(), &url, assert_status, started_at, &events);
+            break;
+        }
+    }
+}
+
+fn emit_http_poll_event(
+    client: Option<&reqwest::blocking::Client>,
+    url: &str,
+    assert_status: Option<u16>,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let Some(client) = client else {
+        push_http_error(url, "failed to build HTTP client", started_at, events);
+        return;
+    };
+    let request_started = Instant::now();
+    match client.get(url).send() {
+        Ok(response) => {
+            let status = response.status().as_u16();
+            let mut data = BTreeMap::new();
+            data.insert(
+                "url".to_string(),
+                serde_json::Value::String(url.to_string()),
+            );
+            data.insert("status".to_string(), serde_json::json!(status));
+            data.insert(
+                "latency_ms".to_string(),
+                serde_json::json!(request_started.elapsed().as_millis() as u64),
+            );
+            if let Some(assert_status) = assert_status {
+                data.insert(
+                    "assert_status".to_string(),
+                    serde_json::json!(assert_status),
+                );
+                data.insert("ok".to_string(), serde_json::json!(status == assert_status));
+            }
+            push_event(
+                events,
+                event(started_at, "http.poll", "http.response", data),
+            );
+        }
+        Err(error) => push_http_error(url, &error.to_string(), started_at, events),
+    }
+}
+
+fn push_http_error(
+    url: &str,
+    error: &str,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "url".to_string(),
+        serde_json::Value::String(url.to_string()),
+    );
+    data.insert(
+        "error".to_string(),
+        serde_json::Value::String(error.to_string()),
+    );
+    push_event(events, event(started_at, "http.poll", "http.error", data));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::{ActiveTraceProbes, TraceProbeConfig};
+
+    #[test]
+    fn http_poll_emits_response_events() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test server");
+        let url = format!("http://{}", listener.local_addr().expect("local addr"));
+        let server = thread::spawn(move || {
+            for stream in listener.incoming().take(1) {
+                let mut stream = stream.expect("accept connection");
+                let mut buffer = [0; 512];
+                let _ = stream.read(&mut buffer);
+                stream
+                    .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                    .expect("write response");
+            }
+        });
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::HttpPoll {
+            url,
+            interval_ms: Some(25),
+            assert_status: Some(204),
+        }])
+        .expect("start probes");
+        thread::sleep(Duration::from_millis(80));
+
+        let events = probes.stop();
+        let _ = server.join();
+        assert!(events.iter().any(|event| event.source == "http.poll"
+            && event.event == "http.response"
+            && event.data.get("status").and_then(|value| value.as_u64()) == Some(204)
+            && event.data.get("ok").and_then(|value| value.as_bool()) == Some(true)));
+    }
+}

--- a/src/core/extension/trace/probes/http_poll.rs
+++ b/src/core/extension/trace/probes/http_poll.rs
@@ -96,7 +96,7 @@ mod tests {
     use super::super::{ActiveTraceProbes, TraceProbeConfig};
 
     #[test]
-    fn http_poll_emits_response_events() {
+    fn test_run_http_poll() {
         let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test server");
         let url = format!("http://{}", listener.local_addr().expect("local addr"));
         let server = thread::spawn(move || {

--- a/src/core/extension/trace/probes/port_snapshot.rs
+++ b/src/core/extension/trace/probes/port_snapshot.rs
@@ -1,0 +1,169 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::TcpListener;
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::error::{Error, Result};
+
+use super::{event, push_event, TraceEvent};
+
+pub(super) fn run_port_snapshot(
+    ports: Vec<u16>,
+    interval_ms: u64,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let interval = Duration::from_millis(interval_ms.max(1));
+    let mut previous: Option<BTreeSet<u16>> = None;
+
+    loop {
+        let current = listening_ports(&ports);
+        emit_port_events(previous.as_ref(), &current, started_at, &events);
+        previous = Some(current);
+        if stop.recv_timeout(interval).is_ok() {
+            let current = listening_ports(&ports);
+            emit_port_events(previous.as_ref(), &current, started_at, &events);
+            break;
+        }
+    }
+}
+
+fn listening_ports(ports: &[u16]) -> BTreeSet<u16> {
+    ports
+        .iter()
+        .copied()
+        .filter(|port| TcpListener::bind(("127.0.0.1", *port)).is_err())
+        .collect()
+}
+
+fn emit_port_events(
+    previous: Option<&BTreeSet<u16>>,
+    current: &BTreeSet<u16>,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let mut data = BTreeMap::new();
+    data.insert(
+        "ports".to_string(),
+        serde_json::Value::Array(current.iter().map(|port| serde_json::json!(port)).collect()),
+    );
+    push_event(
+        events,
+        event(started_at, "port.snapshot", "net.listening", data),
+    );
+
+    let Some(previous) = previous else {
+        return;
+    };
+    for port in current.difference(previous) {
+        push_event(events, port_delta_event(started_at, "net.bind", *port));
+    }
+    for port in previous.difference(current) {
+        push_event(events, port_delta_event(started_at, "net.unbind", *port));
+    }
+}
+
+fn port_delta_event(started_at: Instant, event_name: &str, port: u16) -> TraceEvent {
+    let mut data = BTreeMap::new();
+    data.insert("port".to_string(), serde_json::json!(port));
+    event(started_at, "port.snapshot", event_name, data)
+}
+
+pub(super) fn ports_for_snapshot(port: Option<u16>, port_range: Option<&str>) -> Result<Vec<u16>> {
+    let mut ports = BTreeSet::new();
+    if let Some(port) = port {
+        ports.insert(port);
+    }
+    if let Some(port_range) = port_range {
+        let Some((start, end)) = port_range.split_once('-') else {
+            return Err(Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range must be formatted as start-end".to_string(),
+                None,
+                None,
+            ));
+        };
+        let start: u16 = start.trim().parse().map_err(|_| {
+            Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range start must be a port number".to_string(),
+                None,
+                None,
+            )
+        })?;
+        let end: u16 = end.trim().parse().map_err(|_| {
+            Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range end must be a port number".to_string(),
+                None,
+                None,
+            )
+        })?;
+        if start > end {
+            return Err(Error::validation_invalid_argument(
+                "trace_probes.port-range",
+                "port.snapshot port-range start must be <= end".to_string(),
+                None,
+                None,
+            ));
+        }
+        ports.extend(start..=end);
+    }
+    if ports.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "trace_probes.port",
+            "port.snapshot requires port or port-range".to_string(),
+            None,
+            None,
+        ));
+    }
+    Ok(ports.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::super::{ActiveTraceProbes, TraceProbeConfig};
+
+    #[test]
+    fn port_snapshot_emits_listening_events() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test listener");
+        let port = listener.local_addr().expect("local addr").port();
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
+            port: Some(port),
+            port_range: None,
+            interval_ms: Some(25),
+        }])
+        .expect("start probes");
+        thread::sleep(Duration::from_millis(60));
+
+        let events = probes.stop();
+        assert!(events.iter().any(|event| event.source == "port.snapshot"
+            && event.event == "net.listening"
+            && event
+                .data
+                .get("ports")
+                .and_then(|value| value.as_array())
+                .is_some_and(|ports| ports
+                    .iter()
+                    .any(|value| value.as_u64() == Some(u64::from(port))))));
+    }
+
+    #[test]
+    fn port_range_parser_rejects_invalid_ranges() {
+        let result = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
+            port: None,
+            port_range: Some("9002-9001".to_string()),
+            interval_ms: Some(25),
+        }]);
+        let error = result.err().expect("invalid range should fail start");
+
+        assert!(error
+            .to_string()
+            .contains("port-range start must be <= end"));
+    }
+}

--- a/src/core/extension/trace/probes/port_snapshot.rs
+++ b/src/core/extension/trace/probes/port_snapshot.rs
@@ -128,9 +128,10 @@ mod tests {
     use std::time::Duration;
 
     use super::super::{ActiveTraceProbes, TraceProbeConfig};
+    use super::ports_for_snapshot;
 
     #[test]
-    fn port_snapshot_emits_listening_events() {
+    fn test_run_port_snapshot() {
         let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test listener");
         let port = listener.local_addr().expect("local addr").port();
         let probes = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
@@ -154,7 +155,12 @@ mod tests {
     }
 
     #[test]
-    fn port_range_parser_rejects_invalid_ranges() {
+    fn test_ports_for_snapshot() {
+        assert_eq!(
+            ports_for_snapshot(Some(3000), Some("3002-3003")).expect("ports"),
+            vec![3000, 3002, 3003]
+        );
+
         let result = ActiveTraceProbes::start(&[TraceProbeConfig::PortSnapshot {
             port: None,
             port_range: Some("9002-9001".to_string()),

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -563,13 +563,17 @@ mod tests {
                 "path": "/tmp/scoped.trace.mjs",
                 "trace_probes": [
                     { "type": "log.tail", "path": "/tmp/app.log", "grep": "ready" },
-                    { "type": "process.snapshot", "pattern": "node.*serve", "interval_ms": 250 }
+                    { "type": "process.snapshot", "pattern": "node.*serve", "interval_ms": 250 },
+                    { "type": "file.watch", "path": "/tmp/auth.json", "interval_ms": 100 },
+                    { "type": "port.snapshot", "port": 3000 },
+                    { "type": "http.poll", "url": "http://127.0.0.1:3000/health", "assert-status": 200 },
+                    { "type": "cmd.run", "command": "kimaki", "args": ["--help"] }
                 ]
             }"#,
         )
         .expect("parse detailed workload probes");
 
-        assert_eq!(workload.trace_probes().len(), 2);
+        assert_eq!(workload.trace_probes().len(), 6);
         assert!(matches!(
             &workload.trace_probes()[0],
             TraceProbeConfig::LogTail { path, grep, .. }
@@ -579,6 +583,26 @@ mod tests {
             &workload.trace_probes()[1],
             TraceProbeConfig::ProcessSnapshot { pattern, interval_ms }
                 if pattern == "node.*serve" && *interval_ms == Some(250)
+        ));
+        assert!(matches!(
+            &workload.trace_probes()[2],
+            TraceProbeConfig::FileWatch { path, interval_ms }
+                if path == "/tmp/auth.json" && *interval_ms == Some(100)
+        ));
+        assert!(matches!(
+            &workload.trace_probes()[3],
+            TraceProbeConfig::PortSnapshot { port, .. }
+                if *port == Some(3000)
+        ));
+        assert!(matches!(
+            &workload.trace_probes()[4],
+            TraceProbeConfig::HttpPoll { url, assert_status, .. }
+                if url == "http://127.0.0.1:3000/health" && *assert_status == Some(200)
+        ));
+        assert!(matches!(
+            &workload.trace_probes()[5],
+            TraceProbeConfig::CmdRun { command, args }
+                if command == "kimaki" && args == &vec!["--help".to_string()]
         ));
         assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
             .trace_probes()


### PR DESCRIPTION
## Summary
- Extends the trace probe config and runner with portable v1 `file.watch`, `port.snapshot`, `http.poll`, and `cmd.run` probes alongside the existing `log.tail` and `process.snapshot` probes.
- Expands rig trace probe value interpolation and config parsing coverage for the six-probe inventory from #2163.
- Updates `docs/architecture/trace-probes.md` with probe inputs, event contracts, and v1 limitations.

Refs #2163.

## Tests
- `cargo test core::extension::trace::probes` passed.
- `cargo test core::rig::spec::tests::test_trace_probes` passed.
- `cargo test` compiled and ran, but failed one pre-existing environment-sensitive PATH ordering assertion: `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the trace probe variants, documentation updates, and tests; Chris to review and validate before merge.