### PR TITLE
feat(trace): add temporal assertion shapes

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -140,11 +140,15 @@ When a timeline contains repeated events with the same key, Homeboy resolves the
 
 Runners can declare `temporal_assertions` for timeline-level checks. Homeboy evaluates them after the runner exits, appends the evaluated result to the existing `assertions` list, and marks the trace failed when any evaluated assertion fails. Existing simple runner-emitted assertions still work unchanged.
 
-V1 supports three assertion kinds:
+V1 supports these assertion kinds:
 
 - `count`: count matching timeline keys and enforce optional `min` / `max` bounds.
 - `forbidden-event`: fail when a timeline key appears at least once.
 - `max-concurrent`: track a start/end event pair and fail when live concurrency exceeds `max`.
+- `no-overlap`: fail when two matching events with different `by` data values occur within `window_ms`.
+- `ordering`: for each `before` event, require a later `after` event, optionally `within_ms` and with the same `by` data value.
+- `latency-bound`: pair each `from` event with the first later `to` event and enforce optional `p50_ms`, `p95_ms`, and `p99_ms` bounds using the same R-7 percentile calculation as `homeboy bench`.
+- `required-sequence`: require the listed `source.event` keys to occur as an ordered subsequence in the timeline.
 
 Timeline keys use the same `source.event` format as spans. Failed assertions include a structured `details` object with the observed counts and matching events.
 
@@ -172,6 +176,33 @@ Timeline keys use the same `source.event` format as spans. Failed assertions inc
       "kind": "max-concurrent",
       "track": ["proc.spawn", "proc.exit"],
       "max": 1
+    },
+    {
+      "id": "no-auth-write-race",
+      "kind": "no-overlap",
+      "events": ["fs.write"],
+      "by": "pid",
+      "window_ms": 100
+    },
+    {
+      "id": "response-before-write",
+      "kind": "ordering",
+      "before": "http.response",
+      "after": "fs.write",
+      "within_ms": 100,
+      "by": "request_id"
+    },
+    {
+      "id": "request-latency",
+      "kind": "latency-bound",
+      "from": "request.start",
+      "to": "request.end",
+      "p95_ms": 250
+    },
+    {
+      "id": "boot-flow",
+      "kind": "required-sequence",
+      "sequence": ["app.boot", "auth.login", "app.ready"]
     }
   ]
 }

--- a/src/core/extension/trace/assertions.rs
+++ b/src/core/extension/trace/assertions.rs
@@ -1,5 +1,6 @@
 //! Temporal trace assertion evaluation over timeline events.
 
+use crate::extension::bench::distribution::percentile;
 use serde_json::json;
 
 use super::parsing::{
@@ -53,6 +54,52 @@ fn evaluate_temporal_assertion(
             max,
             message,
         } => evaluate_max_concurrent(id, track, *max, message.as_deref(), timeline),
+        TraceTemporalAssertionDefinition::NoOverlap {
+            id,
+            events,
+            by,
+            window_ms,
+            message,
+        } => evaluate_no_overlap(id, events, by, *window_ms, message.as_deref(), timeline),
+        TraceTemporalAssertionDefinition::Ordering {
+            id,
+            before,
+            after,
+            within_ms,
+            by,
+            message,
+        } => evaluate_ordering(
+            id,
+            before,
+            after,
+            *within_ms,
+            by.as_deref(),
+            message.as_deref(),
+            timeline,
+        ),
+        TraceTemporalAssertionDefinition::LatencyBound {
+            id,
+            from,
+            to,
+            p50_ms,
+            p95_ms,
+            p99_ms,
+            message,
+        } => evaluate_latency_bound(
+            id,
+            from,
+            to,
+            *p50_ms,
+            *p95_ms,
+            *p99_ms,
+            message.as_deref(),
+            timeline,
+        ),
+        TraceTemporalAssertionDefinition::RequiredSequence {
+            id,
+            sequence,
+            message,
+        } => evaluate_required_sequence(id, sequence, message.as_deref(), timeline),
     }
 }
 
@@ -198,6 +245,217 @@ fn evaluate_max_concurrent(
     }
 }
 
+fn evaluate_no_overlap(
+    id: &str,
+    events: &[String],
+    by: &str,
+    window_ms: u64,
+    message: Option<&str>,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    let matches = timeline
+        .iter()
+        .filter(|event| events.iter().any(|key| event_matches_key(event, key)))
+        .collect::<Vec<_>>();
+    let mut overlaps = Vec::new();
+    for (index, first) in matches.iter().enumerate() {
+        let Some(first_group) = event_data_string(first, by) else {
+            continue;
+        };
+        for second in matches.iter().skip(index + 1) {
+            if second.t_ms.saturating_sub(first.t_ms) > window_ms {
+                break;
+            }
+            let Some(second_group) = event_data_string(second, by) else {
+                continue;
+            };
+            if first_group != second_group {
+                overlaps.push(json!({
+                    "delta_ms": second.t_ms.saturating_sub(first.t_ms),
+                    "first": event_detail(first),
+                    "second": event_detail(second),
+                    "first_group": first_group,
+                    "second_group": second_group,
+                }));
+            }
+        }
+    }
+
+    let passed = overlaps.is_empty();
+    TraceAssertion {
+        id: id.to_string(),
+        status: if passed {
+            TraceAssertionStatus::Pass
+        } else {
+            TraceAssertionStatus::Fail
+        },
+        message: Some(
+            message.map(str::to_string).unwrap_or_else(|| {
+                no_overlap_message(events, by, window_ms, overlaps.len(), passed)
+            }),
+        ),
+        details: Some(json!({
+            "kind": "no-overlap",
+            "events": events,
+            "by": by,
+            "window_ms": window_ms,
+            "overlap_count": overlaps.len(),
+            "overlaps": overlaps,
+        })),
+    }
+}
+
+fn evaluate_ordering(
+    id: &str,
+    before: &str,
+    after: &str,
+    within_ms: Option<u64>,
+    by: Option<&str>,
+    message: Option<&str>,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    let before_events = timeline
+        .iter()
+        .filter(|event| event_matches_key(event, before))
+        .collect::<Vec<_>>();
+    let after_events = timeline
+        .iter()
+        .filter(|event| event_matches_key(event, after))
+        .collect::<Vec<_>>();
+    let mut violations = Vec::new();
+
+    for before_event in &before_events {
+        let matched = after_events.iter().any(|after_event| {
+            after_event.t_ms >= before_event.t_ms
+                && within_ms.is_none_or(|limit| after_event.t_ms - before_event.t_ms <= limit)
+                && same_group(before_event, after_event, by)
+        });
+        if !matched {
+            violations.push(event_detail(before_event));
+        }
+    }
+
+    let passed = violations.is_empty();
+    TraceAssertion {
+        id: id.to_string(),
+        status: if passed {
+            TraceAssertionStatus::Pass
+        } else {
+            TraceAssertionStatus::Fail
+        },
+        message: Some(
+            message
+                .map(str::to_string)
+                .unwrap_or_else(|| ordering_message(before, after, violations.len(), passed)),
+        ),
+        details: Some(json!({
+            "kind": "ordering",
+            "before": before,
+            "after": after,
+            "within_ms": within_ms,
+            "by": by,
+            "checked": before_events.len(),
+            "violation_count": violations.len(),
+            "violations": violations,
+        })),
+    }
+}
+
+fn evaluate_latency_bound(
+    id: &str,
+    from: &str,
+    to: &str,
+    p50_ms: Option<u64>,
+    p95_ms: Option<u64>,
+    p99_ms: Option<u64>,
+    message: Option<&str>,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    let durations = paired_durations(timeline, from, to);
+    let samples = durations
+        .iter()
+        .map(|duration| *duration as f64)
+        .collect::<Vec<_>>();
+    let actual_p50 = (!samples.is_empty()).then(|| percentile(&samples, 50.0));
+    let actual_p95 = (!samples.is_empty()).then(|| percentile(&samples, 95.0));
+    let actual_p99 = (!samples.is_empty()).then(|| percentile(&samples, 99.0));
+    let passed = !samples.is_empty()
+        && p50_ms.is_none_or(|limit| actual_p50.is_some_and(|actual| actual <= limit as f64))
+        && p95_ms.is_none_or(|limit| actual_p95.is_some_and(|actual| actual <= limit as f64))
+        && p99_ms.is_none_or(|limit| actual_p99.is_some_and(|actual| actual <= limit as f64));
+
+    TraceAssertion {
+        id: id.to_string(),
+        status: if passed {
+            TraceAssertionStatus::Pass
+        } else {
+            TraceAssertionStatus::Fail
+        },
+        message: Some(
+            message
+                .map(str::to_string)
+                .unwrap_or_else(|| latency_bound_message(from, to, durations.len(), passed)),
+        ),
+        details: Some(json!({
+            "kind": "latency-bound",
+            "from": from,
+            "to": to,
+            "p50_ms": p50_ms,
+            "p95_ms": p95_ms,
+            "p99_ms": p99_ms,
+            "actual_p50_ms": actual_p50,
+            "actual_p95_ms": actual_p95,
+            "actual_p99_ms": actual_p99,
+            "sample_count": durations.len(),
+            "durations_ms": durations,
+        })),
+    }
+}
+
+fn evaluate_required_sequence(
+    id: &str,
+    sequence: &[String],
+    message: Option<&str>,
+    timeline: &[super::parsing::TraceEvent],
+) -> TraceAssertion {
+    let mut position = 0;
+    let mut matched = Vec::new();
+    for event in timeline {
+        if sequence
+            .get(position)
+            .is_some_and(|key| event_matches_key(event, key))
+        {
+            matched.push(event_detail(event));
+            position += 1;
+            if position == sequence.len() {
+                break;
+            }
+        }
+    }
+    let passed = position == sequence.len();
+
+    TraceAssertion {
+        id: id.to_string(),
+        status: if passed {
+            TraceAssertionStatus::Pass
+        } else {
+            TraceAssertionStatus::Fail
+        },
+        message: Some(
+            message
+                .map(str::to_string)
+                .unwrap_or_else(|| required_sequence_message(sequence, position, passed)),
+        ),
+        details: Some(json!({
+            "kind": "required-sequence",
+            "sequence": sequence,
+            "matched_count": position,
+            "missing": sequence.get(position),
+            "matches": matched,
+        })),
+    }
+}
+
 fn count_message(
     events: &[String],
     min: Option<usize>,
@@ -245,18 +503,102 @@ fn max_concurrent_message(start: &str, max: usize, max_observed: i64, passed: bo
     }
 }
 
-fn event_details(events: &[&super::parsing::TraceEvent]) -> Vec<serde_json::Value> {
-    events
+fn no_overlap_message(
+    events: &[String],
+    by: &str,
+    window_ms: u64,
+    overlap_count: usize,
+    passed: bool,
+) -> String {
+    if passed {
+        format!(
+            "events `{}` did not overlap across `{by}` within {window_ms}ms",
+            events.join(", ")
+        )
+    } else {
+        format!(
+            "events `{}` overlapped across `{by}` within {window_ms}ms {overlap_count} time(s)",
+            events.join(", ")
+        )
+    }
+}
+
+fn ordering_message(before: &str, after: &str, violations: usize, passed: bool) -> String {
+    if passed {
+        format!("ordering `{before}` before `{after}` satisfied")
+    } else {
+        format!("ordering `{before}` before `{after}` failed for {violations} event(s)")
+    }
+}
+
+fn latency_bound_message(from: &str, to: &str, samples: usize, passed: bool) -> String {
+    if passed {
+        format!("latency bound `{from}` to `{to}` satisfied across {samples} sample(s)")
+    } else {
+        format!("latency bound `{from}` to `{to}` failed across {samples} sample(s)")
+    }
+}
+
+fn required_sequence_message(sequence: &[String], matched: usize, passed: bool) -> String {
+    if passed {
+        format!("required sequence `{}` occurred", sequence.join(" -> "))
+    } else {
+        format!(
+            "required sequence `{}` stopped after {matched} matched event(s)",
+            sequence.join(" -> ")
+        )
+    }
+}
+
+fn same_group(
+    first: &super::parsing::TraceEvent,
+    second: &super::parsing::TraceEvent,
+    by: Option<&str>,
+) -> bool {
+    by.is_none_or(|key| {
+        event_data_string(first, key).is_some_and(|first_value| {
+            event_data_string(second, key).is_some_and(|second_value| first_value == second_value)
+        })
+    })
+}
+
+fn event_data_string(event: &super::parsing::TraceEvent, key: &str) -> Option<String> {
+    match event.data.get(key)? {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn paired_durations(timeline: &[super::parsing::TraceEvent], from: &str, to: &str) -> Vec<u64> {
+    let to_events = timeline
         .iter()
-        .map(|event| {
-            json!({
-                "t_ms": event.t_ms,
-                "source": event.source,
-                "event": event.event,
-                "data": event.data,
-            })
+        .filter(|event| event_matches_key(event, to))
+        .collect::<Vec<_>>();
+    timeline
+        .iter()
+        .filter(|event| event_matches_key(event, from))
+        .filter_map(|from_event| {
+            to_events
+                .iter()
+                .find(|to_event| to_event.t_ms >= from_event.t_ms)
+                .map(|to_event| to_event.t_ms - from_event.t_ms)
         })
         .collect()
+}
+
+fn event_detail(event: &super::parsing::TraceEvent) -> serde_json::Value {
+    json!({
+        "t_ms": event.t_ms,
+        "source": event.source,
+        "event": event.event,
+        "data": event.data,
+    })
+}
+
+fn event_details(events: &[&super::parsing::TraceEvent]) -> Vec<serde_json::Value> {
+    events.iter().map(|event| event_detail(event)).collect()
 }
 
 #[cfg(test)]
@@ -271,6 +613,23 @@ mod tests {
             source: source.to_string(),
             event: event.to_string(),
             data: BTreeMap::new(),
+        }
+    }
+
+    fn event_with_data(
+        t_ms: u64,
+        source: &str,
+        event: &str,
+        data: serde_json::Value,
+    ) -> TraceEvent {
+        let serde_json::Value::Object(data) = data else {
+            panic!("test event data must be an object");
+        };
+        TraceEvent {
+            t_ms,
+            source: source.to_string(),
+            event: event.to_string(),
+            data: data.into_iter().collect(),
         }
     }
 
@@ -376,6 +735,113 @@ mod tests {
         assert_eq!(
             results.assertions[0].details.as_ref().unwrap()["max_observed"],
             2
+        );
+    }
+
+    #[test]
+    fn no_overlap_assertion_fails_for_different_groups_inside_window() {
+        let mut results = results(
+            vec![
+                event_with_data(0, "fs", "write", json!({ "pid": 1 })),
+                event_with_data(50, "fs", "write", json!({ "pid": 2 })),
+                event_with_data(200, "fs", "write", json!({ "pid": 3 })),
+            ],
+            vec![TraceTemporalAssertionDefinition::NoOverlap {
+                id: "no-auth-race".to_string(),
+                events: vec!["fs.write".to_string()],
+                by: "pid".to_string(),
+                window_ms: 100,
+                message: None,
+            }],
+        );
+
+        assert!(apply_temporal_assertions(&mut results));
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Fail);
+        assert_eq!(
+            results.assertions[0].details.as_ref().unwrap()["overlap_count"],
+            1
+        );
+    }
+
+    #[test]
+    fn ordering_assertion_fails_when_grouped_after_event_is_missing() {
+        let mut results = results(
+            vec![
+                event_with_data(0, "http", "response", json!({ "request_id": "a" })),
+                event_with_data(20, "fs", "write", json!({ "request_id": "b" })),
+            ],
+            vec![TraceTemporalAssertionDefinition::Ordering {
+                id: "response-before-write".to_string(),
+                before: "http.response".to_string(),
+                after: "fs.write".to_string(),
+                within_ms: Some(100),
+                by: Some("request_id".to_string()),
+                message: None,
+            }],
+        );
+
+        assert!(apply_temporal_assertions(&mut results));
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Fail);
+        assert_eq!(
+            results.assertions[0].details.as_ref().unwrap()["violation_count"],
+            1
+        );
+    }
+
+    #[test]
+    fn latency_bound_assertion_uses_bench_percentile_logic() {
+        let mut results = results(
+            vec![
+                event(0, "request", "start"),
+                event(100, "request", "end"),
+                event(200, "request", "start"),
+                event(400, "request", "end"),
+                event(500, "request", "start"),
+                event(800, "request", "end"),
+            ],
+            vec![TraceTemporalAssertionDefinition::LatencyBound {
+                id: "request-latency".to_string(),
+                from: "request.start".to_string(),
+                to: "request.end".to_string(),
+                p50_ms: Some(200),
+                p95_ms: Some(250),
+                p99_ms: None,
+                message: None,
+            }],
+        );
+
+        assert!(apply_temporal_assertions(&mut results));
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Fail);
+        assert_eq!(
+            results.assertions[0].details.as_ref().unwrap()["actual_p50_ms"],
+            200.0
+        );
+        assert_eq!(
+            results.assertions[0].details.as_ref().unwrap()["actual_p95_ms"],
+            290.0
+        );
+    }
+
+    #[test]
+    fn required_sequence_assertion_fails_when_sequence_is_incomplete() {
+        let mut results = results(
+            vec![event(0, "app", "boot"), event(10, "app", "ready")],
+            vec![TraceTemporalAssertionDefinition::RequiredSequence {
+                id: "boot-flow".to_string(),
+                sequence: vec![
+                    "app.boot".to_string(),
+                    "auth.login".to_string(),
+                    "app.ready".to_string(),
+                ],
+                message: None,
+            }],
+        );
+
+        assert!(apply_temporal_assertions(&mut results));
+        assert_eq!(results.assertions[0].status, TraceAssertionStatus::Fail);
+        assert_eq!(
+            results.assertions[0].details.as_ref().unwrap()["missing"],
+            "auth.login"
         );
     }
 }

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -147,6 +147,44 @@ pub enum TraceTemporalAssertionDefinition {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
     },
+    NoOverlap {
+        id: String,
+        events: Vec<String>,
+        by: String,
+        window_ms: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+    Ordering {
+        id: String,
+        before: String,
+        after: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        within_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+    LatencyBound {
+        id: String,
+        from: String,
+        to: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        p50_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        p95_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        p99_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+    RequiredSequence {
+        id: String,
+        sequence: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- Adds trace temporal assertion schema/evaluator support for `no-overlap`, `ordering`, `latency-bound`, and `required-sequence`.
- Reuses the bench R-7 percentile helper for `latency-bound` p50/p95/p99 evaluation.
- Documents the full v1 assertion inventory and adds synthetic timeline coverage for the new shapes.

Refs #2167.

## Testing
- `cargo fmt --check`
- `cargo test extension::trace::assertions`
- `cargo test core::extension::trace`
- `cargo test` failed on unrelated environment-sensitive PATH assertion: `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the trace assertion schema/evaluator implementation, tests, and documentation updates; Chris to review and validate before merge.