### PR TITLE
feat(audit): group compact summary findings

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -107,6 +107,31 @@ homeboy audit my-plugin --path /var/lib/datamachine/workspace/my-plugin
 
 ## JSON Output
 
+`--json-summary` keeps large audit runs compact by returning grouped finding buckets in
+`finding_groups`. Each bucket includes count/severity totals, a few sample files, and a
+ready-to-run drill-down command scoped to that finding kind.
+
+```json
+{
+  "command": "audit.summary",
+  "total_findings": 87,
+  "warnings": 80,
+  "info": 7,
+  "finding_groups": [
+    {
+      "kind": "missing_test_file",
+      "count": 34,
+      "warnings": 34,
+      "info": 0,
+      "confidence": "heuristic",
+      "sample_files": ["src/commands/audit.rs", "src/core/code_audit/report.rs"],
+      "drilldown_command": "homeboy audit homeboy --only missing_test_file"
+    }
+  ],
+  "exit_code": 1
+}
+```
+
 ```json
 {
   "success": true,

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -24,12 +24,35 @@ pub struct AuditSummaryOutput {
     pub warnings: usize,
     pub info: usize,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub finding_groups: Vec<AuditSummaryGroup>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub top_findings: Vec<AuditSummaryFinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fixability: Option<AuditFixability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub changed_since: Option<AuditChangedSinceSummary>,
     pub exit_code: i32,
+}
+
+/// Aggregated finding bucket for compact summaries.
+#[derive(Serialize)]
+pub struct AuditSummaryGroup {
+    pub kind: String,
+    pub count: usize,
+    pub warnings: usize,
+    pub info: usize,
+    pub confidence: FindingConfidence,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sample_files: Vec<String>,
+    pub drilldown_command: String,
+}
+
+struct AuditSummaryGroupAccumulator {
+    kind: AuditFinding,
+    count: usize,
+    warnings: usize,
+    info: usize,
+    sample_files: Vec<String>,
 }
 
 /// Changed-since audit classification.
@@ -159,17 +182,61 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
             suggestion: f.suggestion.clone(),
         })
         .collect();
+    let finding_groups = build_finding_groups(result);
 
     AuditSummaryOutput {
         alignment_score: result.summary.alignment_score,
         total_findings: result.findings.len(),
         warnings,
         info,
+        finding_groups,
         top_findings,
         fixability: None,
         changed_since: None,
         exit_code,
     }
+}
+
+fn build_finding_groups(result: &CodeAuditResult) -> Vec<AuditSummaryGroup> {
+    let mut groups: BTreeMap<String, AuditSummaryGroupAccumulator> = BTreeMap::new();
+
+    for finding in &result.findings {
+        let kind = finding_kind_key(&finding.kind);
+        let group = groups
+            .entry(kind)
+            .or_insert_with(|| AuditSummaryGroupAccumulator {
+                kind: finding.kind.clone(),
+                count: 0,
+                warnings: 0,
+                info: 0,
+                sample_files: Vec::new(),
+            });
+
+        group.count += 1;
+        match finding.severity {
+            Severity::Warning => group.warnings += 1,
+            Severity::Info => group.info += 1,
+        }
+        if group.sample_files.len() < 5 && !group.sample_files.contains(&finding.file) {
+            group.sample_files.push(finding.file.clone());
+        }
+    }
+
+    let mut grouped: Vec<_> = groups
+        .into_iter()
+        .map(|(kind, group)| AuditSummaryGroup {
+            drilldown_command: format!("homeboy audit {} --only {}", result.component_id, kind),
+            confidence: group.kind.confidence(),
+            kind,
+            count: group.count,
+            warnings: group.warnings,
+            info: group.info,
+            sample_files: group.sample_files,
+        })
+        .collect();
+
+    grouped.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.kind.cmp(&b.kind)));
+    grouped
 }
 
 pub fn build_changed_since_summary(

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -47,11 +47,16 @@ pub struct AuditSummaryGroup {
     pub drilldown_command: String,
 }
 
+#[derive(Default)]
+struct AuditSummarySeverityCounts {
+    warnings: usize,
+    info: usize,
+}
+
 struct AuditSummaryGroupAccumulator {
     kind: AuditFinding,
     count: usize,
-    warnings: usize,
-    info: usize,
+    severities: AuditSummarySeverityCounts,
     sample_files: Vec<String>,
 }
 
@@ -207,15 +212,14 @@ fn build_finding_groups(result: &CodeAuditResult) -> Vec<AuditSummaryGroup> {
             .or_insert_with(|| AuditSummaryGroupAccumulator {
                 kind: finding.kind.clone(),
                 count: 0,
-                warnings: 0,
-                info: 0,
+                severities: AuditSummarySeverityCounts::default(),
                 sample_files: Vec::new(),
             });
 
         group.count += 1;
         match finding.severity {
-            Severity::Warning => group.warnings += 1,
-            Severity::Info => group.info += 1,
+            Severity::Warning => group.severities.warnings += 1,
+            Severity::Info => group.severities.info += 1,
         }
         if group.sample_files.len() < 5 && !group.sample_files.contains(&finding.file) {
             group.sample_files.push(finding.file.clone());
@@ -229,8 +233,8 @@ fn build_finding_groups(result: &CodeAuditResult) -> Vec<AuditSummaryGroup> {
             confidence: group.kind.confidence(),
             kind,
             count: group.count,
-            warnings: group.warnings,
-            info: group.info,
+            warnings: group.severities.warnings,
+            info: group.severities.info,
             sample_files: group.sample_files,
         })
         .collect();

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -48,34 +48,35 @@ fn test_build_audit_summary_groups_findings_for_drilldown() {
     let mut result = empty_result();
     result.component_id = "homeboy".to_string();
     result.findings.push(Finding {
-        convention: "test_coverage".to_string(),
+        convention: "structural".to_string(),
         severity: Severity::Warning,
         file: "src/a.rs".to_string(),
-        description: "Missing test file".to_string(),
-        suggestion: "Add a focused test file".to_string(),
-        kind: AuditFinding::MissingTestFile,
+        description: "File exceeds the size threshold".to_string(),
+        suggestion: "Split the module into focused pieces".to_string(),
+        kind: AuditFinding::GodFile,
     });
     result.findings.push(Finding {
-        convention: "test_coverage".to_string(),
+        convention: "structural".to_string(),
         severity: Severity::Info,
         file: "src/b.rs".to_string(),
-        description: "Missing test file".to_string(),
-        suggestion: "Add a focused test file".to_string(),
-        kind: AuditFinding::MissingTestFile,
+        description: "File exceeds the size threshold".to_string(),
+        suggestion: "Split the module into focused pieces".to_string(),
+        kind: AuditFinding::GodFile,
     });
     result.findings.push(Finding {
         convention: "structural".to_string(),
         severity: Severity::Warning,
         file: "src/large.rs".to_string(),
-        description: "File is large".to_string(),
-        suggestion: "Consider decomposing it".to_string(),
-        kind: AuditFinding::GodFile,
+        description: "Module has too many items".to_string(),
+        suggestion: "Move related items into submodules".to_string(),
+        kind: AuditFinding::HighItemCount,
     });
 
     let summary = build_audit_summary(&result, 1);
+    let grouped_json = serde_json::to_value(&summary.finding_groups).expect("groups serialize");
 
     assert_eq!(summary.finding_groups.len(), 2);
-    assert_eq!(summary.finding_groups[0].kind, "missing_test_file");
+    assert_eq!(summary.finding_groups[0].kind, "god_file");
     assert_eq!(summary.finding_groups[0].count, 2);
     assert_eq!(summary.finding_groups[0].warnings, 1);
     assert_eq!(summary.finding_groups[0].info, 1);
@@ -89,9 +90,14 @@ fn test_build_audit_summary_groups_findings_for_drilldown() {
     );
     assert_eq!(
         summary.finding_groups[0].drilldown_command,
-        "homeboy audit homeboy --only missing_test_file"
+        "homeboy audit homeboy --only god_file"
     );
-    assert_eq!(summary.finding_groups[1].kind, "god_file");
+    assert_eq!(summary.finding_groups[1].kind, "high_item_count");
+    assert_eq!(grouped_json[0]["sample_files"][1], "src/b.rs");
+    assert_eq!(
+        grouped_json[1]["drilldown_command"],
+        "homeboy audit homeboy --only high_item_count"
+    );
 }
 
 #[test]

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -14,6 +14,7 @@ fn test_build_audit_summary_empty_result() {
     assert_eq!(summary.warnings, 0);
     assert_eq!(summary.info, 0);
     assert_eq!(summary.exit_code, 0);
+    assert!(summary.finding_groups.is_empty());
     assert!(summary.top_findings.is_empty());
     assert_eq!(summary.alignment_score, None);
 }
@@ -40,6 +41,57 @@ fn test_build_audit_summary_counts_severities() {
     assert_eq!(summary.warnings, 2);
     assert_eq!(summary.info, 1);
     assert_eq!(summary.exit_code, 1);
+}
+
+#[test]
+fn test_build_audit_summary_groups_findings_for_drilldown() {
+    let mut result = empty_result();
+    result.component_id = "homeboy".to_string();
+    result.findings.push(Finding {
+        convention: "test_coverage".to_string(),
+        severity: Severity::Warning,
+        file: "src/a.rs".to_string(),
+        description: "Missing test file".to_string(),
+        suggestion: "Add a focused test file".to_string(),
+        kind: AuditFinding::MissingTestFile,
+    });
+    result.findings.push(Finding {
+        convention: "test_coverage".to_string(),
+        severity: Severity::Info,
+        file: "src/b.rs".to_string(),
+        description: "Missing test file".to_string(),
+        suggestion: "Add a focused test file".to_string(),
+        kind: AuditFinding::MissingTestFile,
+    });
+    result.findings.push(Finding {
+        convention: "structural".to_string(),
+        severity: Severity::Warning,
+        file: "src/large.rs".to_string(),
+        description: "File is large".to_string(),
+        suggestion: "Consider decomposing it".to_string(),
+        kind: AuditFinding::GodFile,
+    });
+
+    let summary = build_audit_summary(&result, 1);
+
+    assert_eq!(summary.finding_groups.len(), 2);
+    assert_eq!(summary.finding_groups[0].kind, "missing_test_file");
+    assert_eq!(summary.finding_groups[0].count, 2);
+    assert_eq!(summary.finding_groups[0].warnings, 1);
+    assert_eq!(summary.finding_groups[0].info, 1);
+    assert_eq!(
+        summary.finding_groups[0].confidence,
+        FindingConfidence::Heuristic
+    );
+    assert_eq!(
+        summary.finding_groups[0].sample_files,
+        vec!["src/a.rs", "src/b.rs"]
+    );
+    assert_eq!(
+        summary.finding_groups[0].drilldown_command,
+        "homeboy audit homeboy --only missing_test_file"
+    );
+    assert_eq!(summary.finding_groups[1].kind, "god_file");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `finding_groups` to `audit.summary` so large audit result sets are grouped by finding kind with severity counts, confidence, sample files, and a scoped drill-down command.
- Preserve existing `top_findings` behavior while making compact JSON output more actionable for CI and future audit/refactor workflows.
- Document the grouped summary contract and cover it with focused report tests.

Fixes #2050.

## Testing
- `cargo fmt --check`
- `cargo test report_test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and PR description; Chris remains responsible for review and validation.