### PR TITLE
test: cover weighted audit scoring

### DIFF
--- a/src/core/code_audit/compare.rs
+++ b/src/core/code_audit/compare.rs
@@ -146,6 +146,39 @@ mod tests {
     }
 
     #[test]
+    fn test_weighted_finding_score_with() {
+        let result = mk_result_with_findings(vec![
+            Finding {
+                convention: "Test".to_string(),
+                severity: Severity::Warning,
+                file: "src/a.rs".to_string(),
+                description: "Warning finding".to_string(),
+                suggestion: "Fix it".to_string(),
+                kind: AuditFinding::MissingMethod,
+            },
+            Finding {
+                convention: "Test".to_string(),
+                severity: Severity::Info,
+                file: "src/b.rs".to_string(),
+                description: "Info finding".to_string(),
+                suggestion: "Investigate".to_string(),
+                kind: AuditFinding::MissingImport,
+            },
+        ]);
+
+        assert_eq!(
+            weighted_finding_score_with(
+                &result,
+                AuditConvergenceScoring {
+                    warning_weight: 5,
+                    info_weight: 2,
+                }
+            ),
+            7
+        );
+    }
+
+    #[test]
     fn score_delta_zero_means_no_progress() {
         let result = mk_result_with_findings(vec![Finding {
             convention: "Test".to_string(),


### PR DESCRIPTION
## Summary
- Adds direct coverage for `weighted_finding_score_with` so the `missing_test_method` audit bucket no longer flags that method.
- Keeps the audit cleanup focused to one true-positive finding from #1451 instead of broad mechanical test renames.

## Verification
- `cargo test code_audit::compare::tests::test_weighted_finding_score_with`
- `cargo run --quiet --bin homeboy -- audit --only missing_test_method --ignore-baseline --json-summary` (bucket count dropped 404 -> 403; command still exits 1 because remaining findings exist)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** triaged the audit bucket, classified representative findings, drafted the focused unit test, and ran verification; Chris remains responsible for review and merge.

Fixes one finding from #1451.