### PR TITLE
test: cover audit naming inflection helpers

### DIFF
--- a/src/core/code_audit/naming.rs
+++ b/src/core/code_audit/naming.rs
@@ -154,4 +154,21 @@ mod tests {
         assert!(!suffix_matches("BlockSanitizer", "Ability"));
         assert!(!suffix_matches("EngineHelpers", "Tool"));
     }
+
+    #[test]
+    fn test_pluralize() {
+        assert_eq!(pluralize("Ability"), "Abilities");
+        assert_eq!(pluralize("Box"), "Boxes");
+        assert_eq!(pluralize("Branch"), "Branches");
+        assert_eq!(pluralize("Provider"), "Providers");
+    }
+
+    #[test]
+    fn test_singularize() {
+        assert_eq!(singularize("Abilities"), Some("Ability".to_string()));
+        assert_eq!(singularize("Boxes"), Some("Box".to_string()));
+        assert_eq!(singularize("Branches"), Some("Branch".to_string()));
+        assert_eq!(singularize("Providers"), Some("Provider".to_string()));
+        assert_eq!(singularize("Class"), None);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds direct tests for the audit naming `pluralize` and `singularize` helpers.
- Narrows automated audit issue #1451 by converting two legitimate `missing_test_method` findings into covered methods.

## Verification
- `cargo fmt --check`
- `cargo test code_audit::naming::tests`
- `cargo test`
- `cargo run --quiet --bin homeboy -- audit --only missing_test_method --ignore-baseline --json-summary` reduced `missing_test_method` from 403 to 401.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** triaging and implementing the automated audit issue fix.

Fixes part of #1451.