### PR TITLE
fix(audit): filter parallel implementation plumbing

### DIFF
--- a/src/commands/runs/findings.rs
+++ b/src/commands/runs/findings.rs
@@ -6,8 +6,8 @@ use homeboy::Error;
 
 use crate::commands::{
     runs::{
-        latest::require_latest_run, latest::run_filter_from_latest_args,
-        latest::RunsLatestFindingOutput, latest::RunsLatestRunArgs, run_summary, RunsOutput,
+        latest::latest_run_context, latest::RunsLatestFindingOutput, latest::RunsLatestRunArgs,
+        run_summary, RunsOutput,
     },
     CmdResult,
 };
@@ -107,16 +107,12 @@ pub fn finding(finding_id: &str) -> CmdResult<RunsOutput> {
 }
 
 pub fn latest_finding(args: RunsLatestFindingArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let run = require_latest_run(
-        &store,
-        run_filter_from_latest_args(RunsLatestRunArgs {
-            kind: args.kind,
-            component_id: args.component_id,
-            rig: args.rig,
-            status: args.status,
-        }),
-    )?;
+    let (store, run) = latest_run_context(RunsLatestRunArgs {
+        kind: args.kind,
+        component_id: args.component_id,
+        rig: args.rig,
+        status: args.status,
+    })?;
     let finding = store
         .latest_finding(FindingListFilter {
             run_id: Some(run.id.clone()),

--- a/src/commands/runs/latest.rs
+++ b/src/commands/runs/latest.rs
@@ -39,8 +39,7 @@ pub struct RunsLatestFindingOutput {
 }
 
 pub fn latest_run(args: RunsLatestRunArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let run = require_latest_run(&store, run_filter_from_latest_args(args))?;
+    let (_, run) = latest_run_context(args)?;
 
     Ok((
         RunsOutput::LatestRun(RunsLatestRunOutput {
@@ -49,6 +48,14 @@ pub fn latest_run(args: RunsLatestRunArgs) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+pub(crate) fn latest_run_context(
+    args: RunsLatestRunArgs,
+) -> homeboy::Result<(ObservationStore, RunRecord)> {
+    let store = ObservationStore::open_initialized()?;
+    let run = require_latest_run(&store, run_filter_from_latest_args(args))?;
+    Ok((store, run))
 }
 
 pub(crate) fn require_latest_run(

--- a/src/commands/trace/compare_variant_tests.rs
+++ b/src/commands/trace/compare_variant_tests.rs
@@ -9,13 +9,12 @@ use crate::test_support::with_isolated_home;
 use homeboy::extension::trace as extension_trace;
 use homeboy::extension::trace::TraceCommandOutput;
 
-use super::test_fixture::{init_overlay_component, write_trace_extension, XdgGuard};
+use super::test_fixture::{init_overlay_component, write_trace_extension};
 use super::{run, TraceArgs, TraceSchedule, TraceVariantMatrixMode};
 
 #[test]
 fn trace_compare_variant_interleaves_run_order_and_reports_focus_spans() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         init_overlay_component(component_dir.path());
@@ -146,7 +145,6 @@ fn trace_compare_variant_interleaves_run_order_and_reports_focus_spans() {
 #[test]
 fn trace_compare_variant_uses_component_arg_for_multi_component_named_variants() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let studio_dir = tempfile::TempDir::new().expect("studio dir");
         init_overlay_component(studio_dir.path());
@@ -242,7 +240,6 @@ fn trace_compare_variant_uses_component_arg_for_multi_component_named_variants()
 #[test]
 fn trace_compare_variant_reports_unknown_named_variant_for_component_arg() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let studio_dir = tempfile::TempDir::new().expect("studio dir");
         init_overlay_component(studio_dir.path());

--- a/src/commands/trace/experiment_tests.rs
+++ b/src/commands/trace/experiment_tests.rs
@@ -7,7 +7,6 @@ use crate::test_support::with_isolated_home;
 
 use homeboy::extension::trace as extension_trace;
 
-use super::test_fixture::XdgGuard;
 use super::{execute_trace_run, TraceArgs, TraceSchedule, TraceVariantMatrixMode};
 
 fn trace_args_for_rig(rig_id: &str, scenario: &str) -> TraceArgs {
@@ -145,7 +144,6 @@ fn write_trace_experiment_rig(home: &tempfile::TempDir, component_path: &std::pa
 #[test]
 fn trace_experiment_runs_setup_settings_artifacts_and_teardown() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_experiment_extension(home, false);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_experiment_rig(home, component_dir.path());
@@ -196,7 +194,6 @@ fn trace_experiment_runs_setup_settings_artifacts_and_teardown() {
 #[test]
 fn trace_experiment_runs_teardown_when_trace_fails() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_experiment_extension(home, true);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_experiment_rig(home, component_dir.path());

--- a/src/commands/trace/guardrail_tests.rs
+++ b/src/commands/trace/guardrail_tests.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use crate::test_support::with_isolated_home;
 
-use super::test_fixture::{write_trace_extension, write_trace_rig, XdgGuard};
+use super::test_fixture::{write_trace_extension, write_trace_rig};
 use super::*;
 
 fn trace_args_for_rig(rig_id: &str) -> TraceArgs {
@@ -45,7 +45,6 @@ fn trace_args_for_rig(rig_id: &str) -> TraceArgs {
 #[test]
 fn trace_aggregate_runs_passing_guardrails() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig(home, "studio-rig", "studio", component_dir.path());
@@ -88,7 +87,6 @@ fn trace_aggregate_runs_passing_guardrails() {
 #[test]
 fn trace_aggregate_fails_guardrails_without_losing_timing_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig(home, "studio-rig", "studio", component_dir.path());

--- a/src/commands/trace/test_fixture.rs
+++ b/src/commands/trace/test_fixture.rs
@@ -1,25 +1,6 @@
 use std::fs;
 use std::process::Command;
 
-pub(super) struct XdgGuard(Option<String>);
-
-impl XdgGuard {
-    pub(super) fn without_xdg_data_home() -> Self {
-        let prior = std::env::var("XDG_DATA_HOME").ok();
-        std::env::remove_var("XDG_DATA_HOME");
-        Self(prior)
-    }
-}
-
-impl Drop for XdgGuard {
-    fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-    }
-}
-
 pub(super) fn write_trace_extension(home: &tempfile::TempDir) {
     let extension_dir = home
         .path()

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -9,7 +9,7 @@ use homeboy::rig::ComponentSpec;
 use super::test_fixture::{
     init_overlay_component, write_trace_extension, write_trace_rig,
     write_trace_rig_with_phase_preset, write_trace_rig_with_span_metadata,
-    write_trace_rig_with_variant, XdgGuard,
+    write_trace_rig_with_variant,
 };
 use super::*;
 
@@ -239,7 +239,6 @@ fn rig_trace_list_uses_scoped_workload_preflight() {
 #[test]
 fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig(home, "studio-rig", "studio", component_dir.path());
@@ -302,7 +301,6 @@ fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
 #[test]
 fn trace_run_persists_observation_history() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig(home, "studio-rig", "studio", component_dir.path());
@@ -388,7 +386,6 @@ fn trace_run_persists_observation_history() {
 #[test]
 fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig(home, "studio-rig", "studio", component_dir.path());
@@ -476,7 +473,6 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
 #[test]
 fn trace_repeat_loads_span_metadata_and_reports_unknown_ids() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig_with_span_metadata(home, "studio-rig", "studio", component_dir.path());
@@ -640,7 +636,6 @@ fn trace_run_order_planner_supports_grouped_and_interleaved_variants() {
 #[test]
 fn trace_repeat_reports_overlay_touched_files_at_top_level() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         init_overlay_component(component_dir.path());
@@ -724,7 +719,6 @@ fn trace_repeat_reports_overlay_touched_files_at_top_level() {
 #[test]
 fn trace_run_resolves_named_variants_and_reports_unknown_names() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         init_overlay_component(component_dir.path());
@@ -827,7 +821,6 @@ fn trace_run_resolves_named_variants_and_reports_unknown_names() {
 #[test]
 fn trace_compare_variant_writes_experiment_bundle() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         init_overlay_component(component_dir.path());
@@ -908,7 +901,6 @@ fn trace_compare_variant_writes_experiment_bundle() {
 #[test]
 fn trace_compare_variant_resolves_named_variants() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         init_overlay_component(component_dir.path());
@@ -999,7 +991,6 @@ fn trace_compare_variant_resolves_named_variants() {
 #[test]
 fn trace_compare_variant_reports_unknown_named_variants() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         init_overlay_component(component_dir.path());
@@ -1068,7 +1059,6 @@ fn trace_compare_variant_reports_unknown_named_variants() {
 #[test]
 fn trace_run_expands_phase_chain_into_adjacent_and_total_spans() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig(home, "studio-rig", "studio", component_dir.path());
@@ -1147,7 +1137,6 @@ fn trace_run_expands_phase_chain_into_adjacent_and_total_spans() {
 #[test]
 fn trace_run_expands_named_workload_phase_preset() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig_with_phase_preset(home, "preset-rig", "studio", component_dir.path());
@@ -1217,7 +1206,6 @@ fn trace_run_expands_named_workload_phase_preset() {
 #[test]
 fn trace_aggregate_spans_uses_workload_default_phase_preset() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig_with_phase_preset(home, "preset-rig", "studio", component_dir.path());
@@ -1409,7 +1397,6 @@ fn aggregate_json_omits_unavailable_percentiles() {
 #[test]
 fn failed_trace_run_persists_observation_history() {
     with_isolated_home(|home| {
-        let _xdg = XdgGuard::without_xdg_data_home();
         write_trace_extension(home);
         let component_dir = tempfile::TempDir::new().expect("component dir");
         write_trace_rig(home, "studio-rig", "studio", component_dir.path());

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -919,14 +919,19 @@ const MIN_SHARED_CALLS: usize = 3;
 const PLUMBING_CALLS: &[&str] = &[
     "args",
     "current_dir",
+    "execute",
+    "failure",
+    "fix_deployed_permissions",
     "from_utf8_lossy",
     "is_dir",
     "is_terminal",
     "max",
     "output",
     "path",
+    "quote_path",
     "read_dir",
     "read_to_string",
+    "render_map",
     "run_git",
     "stderr",
     "success",
@@ -955,6 +960,9 @@ const TRIVIAL_CALLS: &[&str] = &[
     "unwrap_or_default",
     "unwrap_or_else",
     "expect",
+    "lines",
+    "next",
+    "ok_or_else",
     "as_str",
     "as_ref",
     "as_deref",
@@ -976,6 +984,7 @@ const TRIVIAL_CALLS: &[&str] = &[
     "extend",
     "join",
     "split",
+    "split_whitespace",
     "trim",
     "starts_with",
     "ends_with",
@@ -2429,6 +2438,54 @@ fn rebuild_twice(items: &[Item]) -> Result<()> {
         assert!(
             findings.is_empty(),
             "Shared Command setup/result checks are plumbing, not a workflow"
+        );
+    }
+
+    #[test]
+    fn no_parallel_for_text_parsing_plumbing() {
+        let http_handler = make_fingerprint_with_content(
+            "src/core/daemon.rs",
+            &["handle_connection"],
+            "fn handle_connection() {\n    request.lines().next().split_whitespace();\n    route();\n    write_response();\n}",
+        );
+        let process_probe = make_fingerprint_with_content(
+            "src/core/server/client.rs",
+            &["probe_child_resources"],
+            "fn probe_child_resources() {\n    stdout.lines().next().split_whitespace();\n    parse_rss();\n    parse_cpu();\n}",
+        );
+
+        let findings = detect_parallel_implementations(
+            &[&http_handler, &process_probe],
+            &std::collections::HashSet::new(),
+        );
+
+        assert!(
+            findings.is_empty(),
+            "Shared line tokenization is parsing plumbing, not a reusable workflow"
+        );
+    }
+
+    #[test]
+    fn no_parallel_for_deploy_plumbing_only_patterns() {
+        let artifact_deploy = make_fingerprint_with_content(
+            "src/core/deploy/safety_and_artifact.rs",
+            &["deploy_artifact"],
+            "fn deploy_artifact() {\n    quote_path();\n    execute();\n    failure();\n    render_map();\n    fix_deployed_permissions();\n}",
+        );
+        let override_deploy = make_fingerprint_with_content(
+            "src/core/deploy/version_overrides.rs",
+            &["deploy_with_override"],
+            "fn deploy_with_override() {\n    quote_path();\n    execute();\n    failure();\n    render_map();\n    fix_deployed_permissions();\n}",
+        );
+
+        let findings = detect_parallel_implementations(
+            &[&artifact_deploy, &override_deploy],
+            &std::collections::HashSet::new(),
+        );
+
+        assert!(
+            findings.is_empty(),
+            "Shared SSH/deploy epilogue calls should not imply an extractable workflow"
         );
     }
 

--- a/src/core/stack/pr_meta.rs
+++ b/src/core/stack/pr_meta.rs
@@ -142,6 +142,7 @@ fn nested_string_field(parsed: &serde_json::Value, key: &str, child: &str) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::home_env_guard;
     use crate::ErrorCode;
     use std::fs;
 
@@ -171,6 +172,7 @@ mod tests {
 
     #[test]
     fn test_fetch_pr_meta() {
+        let _guard = home_env_guard();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let gh = dir.path().join("gh");
         fs::write(

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -4,6 +4,7 @@ use tempfile::TempDir;
 
 pub(crate) struct HomeGuard {
     prior: Option<String>,
+    prior_xdg_data_home: Option<String>,
     dir: TempDir,
     _guard: MutexGuard<'static, ()>,
 }
@@ -28,10 +29,13 @@ impl HomeGuard {
     pub(crate) fn new() -> Self {
         let guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("HOME").ok();
+        let prior_xdg_data_home = std::env::var("XDG_DATA_HOME").ok();
         let dir = TempDir::new().expect("home tempdir");
         std::env::set_var("HOME", dir.path());
+        std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
         Self {
             prior,
+            prior_xdg_data_home,
             dir,
             _guard: guard,
         }
@@ -43,6 +47,10 @@ impl Drop for HomeGuard {
         match &self.prior {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
+        }
+        match &self.prior_xdg_data_home {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
         }
     }
 }

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -511,6 +511,7 @@ mod command_env {
     use crate::rig::pipeline::run_pipeline;
     use crate::rig::spec::{PipelineStep, RigSpec};
     use crate::rig::toolchain;
+    use crate::test_support::home_env_guard;
 
     fn rig_with_command(cmd: String, env: HashMap<String, String>) -> RigSpec {
         let mut pipeline = HashMap::new();
@@ -568,6 +569,7 @@ mod command_env {
 
     #[test]
     fn test_command_step_uses_bootstrapped_toolchain_path() {
+        let _guard = home_env_guard();
         let expected = toolchain::command_step_path().expect("toolchain path");
         let tmp = tempfile::tempdir().expect("tmpdir");
         let path_file = tmp.path().join("path.txt");


### PR DESCRIPTION
## Summary
- Filters generic parsing and deploy/SSH plumbing calls out of `parallel_implementation` scoring so #1455 no longer reports incidental call-vocabulary matches.
- Adds regression coverage for the line-tokenization and deploy-plumbing false positives.
- Extracts shared latest-run command context so the tuned detector reaches zero current `parallel_implementation` findings instead of shifting #1455 to the runs commands.
- Fixes the env-backed test isolation race exposed during verification by making isolated test homes own `XDG_DATA_HOME` and guarding PATH-sensitive assertions.

## Verification
- `cargo fmt --check`
- `cargo test parallel`
- `cargo test commands::trace::tests::trace_ -- --test-threads=1`
- `cargo test core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path`
- `cargo test -q` → 2531 passed, 0 failed, 1 ignored
- `target/debug/homeboy audit homeboy --path /Users/chubes/Developer/homeboy@audit-1455 --ignore-baseline --only parallel_implementation --json-summary --force-hot` → `total_findings: 0`

Fixes #2205.
Addresses #1455.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** triaging and implementing the automated audit issue fix; Chris remains responsible for review and merge.