### PR TITLE
fix(audit): suppress orphaned test false positives

### DIFF
--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -350,6 +350,14 @@ pub(crate) fn analyze_test_coverage(
                     let correct_test_path =
                         source_to_test_path(actual_source_path, config).unwrap_or_default();
 
+                    if is_include_wrapper_for_test_path(
+                        &test_fp.relative_path,
+                        &test_fp.content,
+                        &correct_test_path,
+                    ) {
+                        continue;
+                    }
+
                     findings.push(Finding {
                         convention: "test_coverage".to_string(),
                         severity: Severity::Info,
@@ -628,6 +636,10 @@ fn find_orphaned_test_methods(
             continue;
         }
 
+        if config.inline_tests && is_rust_behavior_scenario_name(expected_source) {
+            continue;
+        }
+
         // Behavior-driven test names: test_detects_exact_duplicate describes a
         // behavior, not a method reference. Short names (1-2 segments like
         // "old_function" or "pause") are likely real method references. But
@@ -668,6 +680,55 @@ fn find_orphaned_test_methods(
             kind: AuditFinding::OrphanedTest,
         });
     }
+}
+
+fn is_include_wrapper_for_test_path(
+    wrapper_path: &str,
+    wrapper_content: &str,
+    target_test_path: &str,
+) -> bool {
+    if !wrapper_path.ends_with(".rs") || !target_test_path.ends_with(".rs") {
+        return false;
+    }
+
+    let wrapper_dir = Path::new(wrapper_path)
+        .parent()
+        .unwrap_or_else(|| Path::new(""));
+    let target_path = Path::new(target_test_path);
+    let Ok(relative_target) = target_path.strip_prefix(wrapper_dir) else {
+        return false;
+    };
+
+    let relative_target = relative_target.to_string_lossy().replace('\\', "/");
+    let normalized_content: String = wrapper_content
+        .trim()
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect();
+    let expected = format!("include!(\"{}\");", relative_target);
+
+    normalized_content == expected
+}
+
+fn is_rust_behavior_scenario_name(name: &str) -> bool {
+    let behavior_prefixes = [
+        "accepts_",
+        "detects_",
+        "emits_",
+        "handles_",
+        "ignores_",
+        "rejects_",
+        "skips_",
+        "translates_",
+    ];
+    let behavior_suffixes = ["_roundtrip", "_roundtrips"];
+
+    behavior_prefixes
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+        || behavior_suffixes
+            .iter()
+            .any(|suffix| name.ends_with(suffix))
 }
 
 // ============================================================================
@@ -1481,6 +1542,68 @@ fn test_chat_tools() {
             orphaned.iter().map(|f| &f.description).collect::<Vec<_>>()
         );
         assert!(orphaned[0].description.contains("old_function"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn common_behavior_scenario_names_not_flagged_as_orphaned() {
+        let config = make_rust_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_common_behavior_names");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/core")).unwrap();
+
+        let source = make_fp_split(
+            "src/core/update_check.rs",
+            vec!["read_cache", "write_cache", "github_to_tracked"],
+            vec![
+                "test_cache_roundtrip",
+                "test_display_roundtrip",
+                "test_ignores_subscripts",
+                "test_translates_open",
+            ],
+        );
+
+        let findings = analyze_test_coverage(&dir, &[&source], &config);
+        let orphaned: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| {
+                f.kind == AuditFinding::OrphanedTest && f.description.contains("no longer exists")
+            })
+            .collect();
+
+        assert!(
+            orphaned.is_empty(),
+            "common behavior/scenario names should not be orphaned: {:?}",
+            orphaned.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rust_include_wrapper_for_nested_test_path_is_not_misplaced() {
+        let config = make_rust_config();
+        let dir = std::env::temp_dir().join("homeboy_test_coverage_include_wrapper");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/core")).unwrap();
+        std::fs::create_dir_all(dir.join("tests/core")).unwrap();
+
+        let source = make_fp("src/core/deps.rs", vec!["status"]);
+        let mut wrapper = make_fp("tests/deps_test.rs", vec!["status_reads_manifest"]);
+        wrapper.content = "include!(\"core/deps_test.rs\");".to_string();
+
+        let findings = analyze_test_coverage(&dir, &[&source, &wrapper], &config);
+        let misplaced: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| f.kind == AuditFinding::OrphanedTest && f.description.contains("misplaced"))
+            .collect();
+
+        assert!(
+            misplaced.is_empty(),
+            "include wrappers keep nested Cargo tests discoverable: {:?}",
+            misplaced.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -594,6 +594,59 @@ pub fn find_unclosed_raw_string_on_line(line: &str) -> Option<String> {
     None
 }
 
+fn line_has_unclosed_regular_string(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut pos = 0;
+    let mut in_string = false;
+
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+
+        if byte == b'"' && !is_escaped(bytes, pos) {
+            // Raw string openers are handled separately. Treat the opening
+            // delimiter as non-regular so `r#"..."#` does not toggle us.
+            if !in_string && pos > 0 && bytes[pos - 1] == b'r' {
+                pos += 1;
+                continue;
+            }
+            in_string = !in_string;
+        }
+
+        pos += 1;
+    }
+
+    in_string
+}
+
+fn line_closes_regular_string(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut pos = 0;
+
+    while pos < bytes.len() {
+        if bytes[pos] == b'"' && !is_escaped(bytes, pos) {
+            return true;
+        }
+        pos += 1;
+    }
+
+    false
+}
+
+fn is_escaped(bytes: &[u8], pos: usize) -> bool {
+    if pos == 0 {
+        return false;
+    }
+
+    let mut backslashes = 0;
+    let mut i = pos;
+    while i > 0 && bytes[i - 1] == b'\\' {
+        backslashes += 1;
+        i -= 1;
+    }
+
+    backslashes % 2 == 1
+}
+
 /// Iterate lines with structural context, tracking brace depth and regions.
 ///
 /// This is the core primitive — it walks the file line-by-line, tracking
@@ -606,6 +659,7 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
     let mut block_comment_end = String::new();
     let mut in_raw_string = false;
     let mut raw_string_close = String::new();
+    let mut in_regular_string = false;
 
     for (i, line) in content.lines().enumerate() {
         let trimmed = line.trim();
@@ -616,6 +670,14 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
             // Inside a multi-line raw string — check if closing delimiter appears
             if line.contains(&raw_string_close) {
                 in_raw_string = false;
+            }
+            Region::StringLiteral
+        } else if in_regular_string {
+            // Inside a multi-line regular string. Rust permits newline escapes
+            // in ordinary strings (`let s = "\ ...`), and fixture source in
+            // tests commonly uses that form.
+            if line_closes_regular_string(line) {
+                in_regular_string = false;
             }
             Region::StringLiteral
         } else if in_block_comment {
@@ -652,6 +714,8 @@ pub(crate) fn walk_lines<'a>(content: &'a str, grammar: &Grammar) -> Vec<Context
                 if let Some(close) = find_unclosed_raw_string_on_line(line) {
                     in_raw_string = true;
                     raw_string_close = close;
+                } else if line_has_unclosed_regular_string(line) {
+                    in_regular_string = true;
                 }
                 // The opening line itself is Code (it has real code on it);
                 // subsequent lines inside the string are StringLiteral.
@@ -1433,6 +1497,28 @@ mod tests {
     }
 
     #[test]
+    fn walk_lines_detects_multiline_regular_string_regions() {
+        let content = "fn real() {}\nlet s = \"\\\nfn fake_inside_string() {}\nanother line\n\";\nfn also_real() {}\n";
+        let grammar = rust_grammar();
+        let lines = walk_lines(content, &grammar);
+
+        assert_eq!(lines[0].region, Region::Code, "fn real()");
+        assert_eq!(lines[1].region, Region::Code, "opening line has real code");
+        assert_eq!(
+            lines[2].region,
+            Region::StringLiteral,
+            "inside regular string"
+        );
+        assert_eq!(
+            lines[3].region,
+            Region::StringLiteral,
+            "inside regular string"
+        );
+        assert_eq!(lines[4].region, Region::StringLiteral, "closing delimiter");
+        assert_eq!(lines[5].region, Region::Code, "fn also_real()");
+    }
+
+    #[test]
     fn extract_skips_functions_inside_raw_strings() {
         // Regression: the grammar extracted fn declarations from inside raw
         // strings used as test fixtures, polluting the fingerprint with fake
@@ -1459,6 +1545,34 @@ mod tests {
         assert!(
             !fn_names.contains(&"another_fake"),
             "Should NOT find another_fake inside raw string. Found: {:?}",
+            fn_names
+        );
+    }
+
+    #[test]
+    fn extract_skips_functions_inside_multiline_regular_strings() {
+        let content = "pub fn real_function() -> bool {\n    true\n}\nlet fixture = \"\\\npub fn fake_function() -> bool {\n    false\n}\nfn another_fake() {}\n\";\n";
+        let grammar = rust_grammar();
+        let symbols = extract(content, &grammar);
+        let fn_names: Vec<&str> = symbols
+            .iter()
+            .filter(|s| s.concept == "function")
+            .filter_map(|s| s.name())
+            .collect();
+
+        assert!(
+            fn_names.contains(&"real_function"),
+            "Should find real_function. Found: {:?}",
+            fn_names
+        );
+        assert!(
+            !fn_names.contains(&"fake_function"),
+            "Should NOT find fake_function inside regular string. Found: {:?}",
+            fn_names
+        );
+        assert!(
+            !fn_names.contains(&"another_fake"),
+            "Should NOT find another_fake inside regular string. Found: {:?}",
             fn_names
         );
     }


### PR DESCRIPTION
## Summary

- Stop Rust grammar extraction from treating functions inside multiline regular fixture strings as real symbols.
- Suppress `orphaned_test` false positives for common Rust behavior/scenario test names and Cargo include wrappers for nested test files.
- Add regression coverage for the false-positive shapes reported by the automated audit issue.

## Verification

- `cargo test common_behavior_scenario_names_not_flagged_as_orphaned`
- `cargo test rust_include_wrapper_for_nested_test_path_is_not_misplaced`
- `cargo test walk_lines_detects_multiline_regular_string_regions`
- `cargo test extract_skips_functions_inside_multiline_regular_strings`
- `cargo run --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@audit-1454 --only orphaned_test --json-summary --force-hot` → `total_findings: 0`

## Notes

- Full `cargo test` was run; it hit one unrelated environment-sensitive failure in `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path` because PATH ordering in this shell differs from the test expectation.

Closes #2213.
Refs #1454.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** triaging and implementing the automated audit issue fix; Chris remains responsible for review and merge.