### PR TITLE
Fix legacy review-only audit issue cleanup

### DIFF
--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -600,6 +600,9 @@ fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
             homeboy::issues::ReconcileAction::Close {
                 number, category, ..
             } => format!("close         {} → #{}", category, number),
+            homeboy::issues::ReconcileAction::CloseReviewOnly {
+                number, category, ..
+            } => format!("close_review  {} → #{} (not planned)", category, number),
             homeboy::issues::ReconcileAction::CloseDuplicate {
                 number,
                 keep,

--- a/src/core/issues/apply.rs
+++ b/src/core/issues/apply.rs
@@ -73,6 +73,12 @@ fn execute_action(action: &ReconcileAction, tracker: &dyn Tracker) -> ReconcileE
             Ok(()) => ExecutionOutcome::Closed { number: *number },
             Err(e) => ExecutionOutcome::failed(&e),
         },
+        ReconcileAction::CloseReviewOnly {
+            number, comment, ..
+        } => match tracker.close_issue(*number, CloseReason::NotPlanned, Some(comment)) {
+            Ok(()) => ExecutionOutcome::Closed { number: *number },
+            Err(e) => ExecutionOutcome::failed(&e),
+        },
         ReconcileAction::CloseDuplicate {
             number,
             keep,
@@ -121,6 +127,9 @@ fn summary_for(action: &ReconcileAction) -> String {
         ReconcileAction::Close {
             number, category, ..
         } => format!("close         {} → #{}", category, number),
+        ReconcileAction::CloseReviewOnly {
+            number, category, ..
+        } => format!("close_review  {} → #{} [not planned]", category, number),
         ReconcileAction::CloseDuplicate {
             number,
             keep,

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -179,6 +179,14 @@ pub enum ReconcileAction {
         category: String,
         comment: String,
     },
+    /// Close an advisory/review-only issue that was filed by an older policy.
+    /// Reason is always `not_planned` because findings still exist, but the
+    /// category is intentionally not tracker-actionable.
+    CloseReviewOnly {
+        number: u64,
+        category: String,
+        comment: String,
+    },
     /// Close a duplicate of another open issue for the same category.
     /// Reason is always `not_planned` — caller intent is "this is the same
     /// thing as #N." Caller keeps the lowest-numbered match.
@@ -233,6 +241,7 @@ impl ReconcilePlan {
                 ReconcileAction::Update { .. } => c.update += 1,
                 ReconcileAction::UpdateClosed { .. } => c.update_closed += 1,
                 ReconcileAction::Close { .. } => c.close += 1,
+                ReconcileAction::CloseReviewOnly { .. } => c.close += 1,
                 ReconcileAction::CloseDuplicate { .. } => c.close_duplicate += 1,
                 ReconcileAction::Skip { .. } => c.skip += 1,
             }

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -175,6 +175,17 @@ fn reconcile_with_scope(
         }
 
         if !open_matches.is_empty() {
+            if review_only {
+                for issue in &open_matches {
+                    actions.push(ReconcileAction::CloseReviewOnly {
+                        number: issue.number,
+                        category: group.category.clone(),
+                        comment: close_review_only_comment(&group.label_or_category()),
+                    });
+                }
+                continue;
+            }
+
             // Update the lowest-numbered open match.
             let keep = open_matches[0].number;
             actions.push(ReconcileAction::Update {
@@ -462,6 +473,17 @@ fn close_resolved_comment(label: &str) -> String {
     )
 }
 
+fn close_review_only_comment(label: &str) -> String {
+    format!(
+        "**{}** findings are still present, but this category is review-only in the current \
+         reconcile policy. Closing as not planned so advisory heuristic findings do not keep \
+         tracker issues open indefinitely.\n\n\
+         The findings remain visible in `homeboy audit`; reopen or file a focused issue if a \
+         specific refactor becomes actionable.",
+        label
+    )
+}
+
 fn close_dedupe_comment(keep: u64) -> String {
     format!(
         "Closing as duplicate of #{} — consolidated by `homeboy issues reconcile`.\n\n\
@@ -737,7 +759,7 @@ mod tests {
     }
 
     #[test]
-    fn review_only_category_still_updates_existing_open_issue() {
+    fn review_only_category_closes_existing_open_issue_not_planned() {
         let mut config = cfg();
         config.review_only_categories = vec!["god_file".into()];
         let groups = vec![group("god_file", 23)];
@@ -746,9 +768,16 @@ mod tests {
         let plan = reconcile(&groups, &existing, &config);
 
         assert_eq!(plan.actions.len(), 1);
-        assert!(
-            matches!(&plan.actions[0], ReconcileAction::Update { number, .. } if *number == 675)
-        );
+        match &plan.actions[0] {
+            ReconcileAction::CloseReviewOnly {
+                number, comment, ..
+            } => {
+                assert_eq!(*number, 675);
+                assert!(comment.contains("review-only"));
+                assert!(comment.contains("not planned"));
+            }
+            other => panic!("expected CloseReviewOnly, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Close existing open review-only audit issues as not planned instead of updating them forever.
- Keep heuristic findings visible in `homeboy audit` while preventing legacy automated tracker issues from staying open indefinitely.
- Add reconcile coverage for the legacy open review-only case and render the new action in CLI dry-run output.

Fixes #2216.

## Verification
- `cargo test core::issues`
- `cargo check`
- `git diff --check`
- `cargo run --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@audit-1447 --only high_item_count --json-summary --output /tmp/homeboy-audit-1447.json`
- `cargo run --bin homeboy -- issues reconcile homeboy --path /Users/chubes/Developer/homeboy@audit-1447 --tracker github://Extra-Chill/homeboy --from-output audit=/tmp/homeboy-audit-1447.json --list-limit 50`

## Notes
- Full `cargo test` was attempted. It reached 2528 passing tests and failed `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path` due to an environment PATH-order assertion unrelated to this change.
- Triage issue #1447 was closed as not planned after verifying `high_item_count` still reproduces as heuristic/info review-only output.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** triaging the automated audit issue, reproducing the finding, drafting the reconciler fix, and running verification; Chris remains responsible for review and merge.