### PR TITLE
fix(rig): expand env tokens in exclusive resources

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -115,7 +115,7 @@ Managed services are detached, tracked by PID in rig state, and logged under `~/
 
 | Field | Type | Description |
 |---|---|---|
-| `exclusive` | array | Logical tokens that must not overlap with another active rig. |
+| `exclusive` | array | Logical tokens that must not overlap with another active rig. Supports variable expansion. |
 | `paths` | array | Filesystem paths the rig mutates or requires exclusively. |
 | `ports` | array | TCP ports the rig binds or assumes ownership of. |
 | `process_patterns` | array | Process command-line substrings the rig may stop or inspect. |
@@ -123,13 +123,15 @@ Managed services are detached, tracked by PID in rig state, and logged under `~/
 ```jsonc
 {
   "resources": {
-    "exclusive": ["studio-dev"],
+    "exclusive": ["studio-dev:${env.STUDIO_BENCH_NAMESPACE}"],
     "paths": ["~/Studio/intelligence-chubes4/wp-content/plugins"],
     "ports": [9724],
     "process_patterns": ["wordpress-server-child.mjs"]
   }
 }
 ```
+
+Use `${env.NAME}` in `exclusive` tokens when a rig needs a namespace-scoped logical lock for parallel-safe runs. Unset environment variables expand to an empty string, matching other rig string expansion fields, and unknown token families remain literal.
 
 Leases guard concurrent active commands; they are not long-lived ownership records after the command exits.
 

--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -19,9 +19,15 @@ pub fn expand_vars(rig: &RigSpec, input: &str) -> String {
     expand::expand_with_tilde(input, |token| resolve_token(rig, token))
 }
 
-/// Return a copy of the rig resource declarations with path entries expanded.
+/// Return a copy of the rig resource declarations with expandable string entries expanded.
 pub fn expand_resources(rig: &RigSpec) -> RigResourcesSpec {
     let mut resources = rig.resources.clone();
+    resources.exclusive = merge_expanded_strings(
+        rig,
+        resources.exclusive.iter().map(String::as_str),
+        std::iter::empty(),
+    );
+
     let derived_paths = rig.symlinks.iter().map(|symlink| symlink.link.as_str());
     resources.paths = merge_expanded_strings(
         rig,

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -79,10 +79,12 @@ fn test_expand_vars_unterminated_braces() {
 }
 
 #[test]
-fn test_expand_resources_expands_path_entries_only() {
+fn test_expand_resources_expands_string_entries() {
     with_isolated_home(|home| {
         let previous_resource_path = std::env::var("RIG_RESOURCE_PATH").ok();
+        let previous_resource_namespace = std::env::var("RIG_RESOURCE_NAMESPACE").ok();
         std::env::set_var("RIG_RESOURCE_PATH", "studio@resources");
+        std::env::set_var("RIG_RESOURCE_NAMESPACE", "bench-a");
 
         let mut components = HashMap::new();
         components.insert(
@@ -97,7 +99,10 @@ fn test_expand_resources_expands_path_entries_only() {
             },
         );
         let mut rig = rig_with("t", components);
-        rig.resources.exclusive = vec!["studio-runtime".to_string()];
+        rig.resources.exclusive = vec![
+            "studio-runtime".to_string(),
+            "studio-runtime:${env.RIG_RESOURCE_NAMESPACE}".to_string(),
+        ];
         rig.resources.paths = vec![
             "~/Developer/${env.RIG_RESOURCE_PATH}".to_string(),
             "${components.studio.path}/apps/cli".to_string(),
@@ -121,8 +126,15 @@ fn test_expand_resources_expands_path_entries_only() {
             Some(value) => std::env::set_var("RIG_RESOURCE_PATH", value),
             None => std::env::remove_var("RIG_RESOURCE_PATH"),
         }
+        match previous_resource_namespace {
+            Some(value) => std::env::set_var("RIG_RESOURCE_NAMESPACE", value),
+            None => std::env::remove_var("RIG_RESOURCE_NAMESPACE"),
+        }
 
-        assert_eq!(resources.exclusive, vec!["studio-runtime"]);
+        assert_eq!(
+            resources.exclusive,
+            vec!["studio-runtime", "studio-runtime:bench-a"]
+        );
         assert_eq!(resources.ports, vec![9724]);
         assert_eq!(
             resources.process_patterns,
@@ -130,6 +142,30 @@ fn test_expand_resources_expands_path_entries_only() {
         );
         assert_eq!(resources.paths, expected_paths);
     });
+}
+
+#[test]
+fn test_expand_resources_unset_env_in_exclusive_becomes_empty() {
+    let previous = std::env::var("RIG_RESOURCE_NAMESPACE_NEVER_SET_XYZ").ok();
+    std::env::remove_var("RIG_RESOURCE_NAMESPACE_NEVER_SET_XYZ");
+
+    let mut rig = rig_with("t", HashMap::new());
+    rig.resources.exclusive = vec![
+        "studio-runtime".to_string(),
+        "studio-runtime:${env.RIG_RESOURCE_NAMESPACE_NEVER_SET_XYZ}".to_string(),
+    ];
+
+    let resources = expand_resources(&rig);
+
+    match previous {
+        Some(value) => std::env::set_var("RIG_RESOURCE_NAMESPACE_NEVER_SET_XYZ", value),
+        None => std::env::remove_var("RIG_RESOURCE_NAMESPACE_NEVER_SET_XYZ"),
+    }
+
+    assert_eq!(
+        resources.exclusive,
+        vec!["studio-runtime", "studio-runtime:"]
+    );
 }
 
 #[test]

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -36,6 +36,15 @@ fn resources() -> RigResourcesSpec {
     }
 }
 
+fn namespaced_resources(namespace_env: &str) -> RigResourcesSpec {
+    RigResourcesSpec {
+        exclusive: vec![format!("studio-runtime:${{env.{}}}", namespace_env)],
+        paths: Vec::new(),
+        ports: Vec::new(),
+        process_patterns: Vec::new(),
+    }
+}
+
 #[test]
 fn test_acquire_active_run_lease_blocks_overlapping_resources_until_drop() {
     with_isolated_home(|_| {
@@ -55,6 +64,33 @@ fn test_acquire_active_run_lease_blocks_overlapping_resources_until_drop() {
         assert!(acquire_active_run_lease(&studio_bfb, "up")
             .expect("lease after drop")
             .is_some());
+    });
+}
+
+#[test]
+fn test_acquire_active_run_lease_blocks_env_expanded_exclusive_resources() {
+    with_isolated_home(|_| {
+        let previous = std::env::var("RIG_LEASE_NAMESPACE").ok();
+        std::env::set_var("RIG_LEASE_NAMESPACE", "bench-a");
+
+        let studio = rig("studio", namespaced_resources("RIG_LEASE_NAMESPACE"));
+        let studio_bfb = rig("studio-bfb", namespaced_resources("RIG_LEASE_NAMESPACE"));
+
+        let lease = acquire_active_run_lease(&studio, "up")
+            .expect("first lease")
+            .expect("resourceful rig leases");
+        let conflict =
+            acquire_active_run_lease(&studio_bfb, "up").expect_err("expanded token conflicts");
+
+        match previous {
+            Some(value) => std::env::set_var("RIG_LEASE_NAMESPACE", value),
+            None => std::env::remove_var("RIG_LEASE_NAMESPACE"),
+        }
+
+        assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
+        assert!(conflict.message.contains("studio-runtime:bench-a"));
+
+        drop(lease);
     });
 }
 


### PR DESCRIPTION
## Summary
- Expand `${env.NAME}` tokens in `resources.exclusive` before leases are written or compared.
- Preserve static exclusive tokens and existing missing-env behavior, where unset env vars expand to an empty string.
- Document namespaced exclusive tokens for parallel-safe rigs.

## Tests
- `cargo test test_expand_resources -- --test-threads=1`
- `cargo test test_acquire_active_run_lease -- --test-threads=1`
- `cargo test rig -- --test-threads=1`

Closes #2222.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, focused tests, docs update, and verification commands; Chris remains responsible for review and merge.