### PR TITLE
fix(bench): lease rig resources during benchmark runs

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -11,6 +11,7 @@ use homeboy::extension::bench::{
     BenchRunWorkflowResult,
 };
 use homeboy::extension::ExtensionCapability;
+use homeboy::rig::lease::ActiveRigRunLease;
 use homeboy::rig::{self, BenchSpec, RigSpec, RigStateSnapshot};
 
 use super::observation::{self, BenchObservationStart};
@@ -21,10 +22,12 @@ struct RigBenchContext {
     spec: RigSpec,
     package_root: Option<PathBuf>,
     snapshot: RigStateSnapshot,
+    _lease: Option<ActiveRigRunLease>,
 }
 
 fn prepare_rig_bench_context(rig_id: &str) -> homeboy::Result<RigBenchContext> {
     let spec = rig::load(rig_id)?;
+    let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
     let snapshot = rig::snapshot_state(&spec);
     let package_root =
         rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
@@ -33,6 +36,7 @@ fn prepare_rig_bench_context(rig_id: &str) -> homeboy::Result<RigBenchContext> {
         spec,
         package_root,
         snapshot,
+        _lease: lease,
     })
 }
 

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::test_support::with_isolated_home;
 use clap::Parser;
+use homeboy::error::ErrorCode;
 use homeboy::extension::bench::aggregate_comparison;
 use std::fs;
 #[cfg(unix)]
@@ -230,6 +231,23 @@ fn set_rig_warmup(home: &TempDir, rig_id: &str, warmup: u64) {
     .expect("write rig");
 }
 
+fn set_rig_resources(home: &TempDir, rig_id: &str, resources: serde_json::Value) {
+    let rig_path = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("rigs")
+        .join(format!("{}.json", rig_id));
+    let mut rig_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&rig_path).expect("read rig")).expect("parse rig");
+    rig_json["resources"] = resources;
+    fs::write(
+        &rig_path,
+        serde_json::to_string(&rig_json).expect("serialize rig"),
+    )
+    .expect("write rig");
+}
+
 fn first_warmup_metric(output: BenchOutput) -> f64 {
     match output {
         BenchOutput::Single(result) => result.results.expect("results").scenarios[0]
@@ -380,6 +398,67 @@ fn run_list_uses_rig_default_component_and_workloads() {
             }
             _ => panic!("expected list output"),
         }
+    });
+}
+
+#[test]
+fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let active_component = tempfile::TempDir::new().expect("active component");
+        let blocked_component = tempfile::TempDir::new().expect("blocked component");
+        write_rig(home, "studio", "studio", active_component.path());
+        write_rig(home, "studio-bfb", "studio", blocked_component.path());
+        let resources = serde_json::json!({
+            "exclusive": ["studio-runtime"],
+            "paths": ["~/Developer/studio"],
+            "ports": [9724],
+            "process_patterns": ["wordpress-server-child.mjs"]
+        });
+        set_rig_resources(home, "studio", resources.clone());
+        set_rig_resources(home, "studio-bfb", resources);
+
+        let active_spec = homeboy::rig::load("studio").expect("load active rig");
+        let _lease = homeboy::rig::lease::acquire_active_run_lease(&active_spec, "bench")
+            .expect("acquire active lease")
+            .expect("resourceful rig leases");
+
+        let error = match run(
+            run_args(None, vec!["studio-bfb".to_string()], Vec::new()),
+            &GlobalArgs {},
+        ) {
+            Ok(_) => panic!("bench should fail before running with conflicting rig resources"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code, ErrorCode::RigResourceConflict);
+        assert!(error.message.contains("studio-bfb"));
+        assert!(error.message.contains("studio"));
+        assert!(error.message.contains("studio-runtime"));
+        assert!(error.message.contains("bench"));
+    });
+}
+
+#[test]
+fn run_single_rig_bench_without_resources_does_not_create_lease() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_rig(home, "studio-lite", "studio", component_dir.path());
+
+        let (_output, exit_code) = run(
+            run_args(None, vec!["studio-lite".to_string()], Vec::new()),
+            &GlobalArgs {},
+        )
+        .expect("non-resourceful rig bench should run");
+
+        assert_eq!(exit_code, 0);
+        assert!(homeboy::rig::lease::active_run_leases()
+            .expect("list active leases")
+            .is_empty());
+        assert!(!homeboy::paths::rig_leases_dir()
+            .expect("lease dir path")
+            .exists());
     });
 }
 

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::test_support::with_isolated_home;
 use clap::Parser;
-use homeboy::error::ErrorCode;
 use homeboy::extension::bench::aggregate_comparison;
 use std::fs;
 #[cfg(unix)]
@@ -231,23 +230,6 @@ fn set_rig_warmup(home: &TempDir, rig_id: &str, warmup: u64) {
     .expect("write rig");
 }
 
-fn set_rig_resources(home: &TempDir, rig_id: &str, resources: serde_json::Value) {
-    let rig_path = home
-        .path()
-        .join(".config")
-        .join("homeboy")
-        .join("rigs")
-        .join(format!("{}.json", rig_id));
-    let mut rig_json: serde_json::Value =
-        serde_json::from_str(&fs::read_to_string(&rig_path).expect("read rig")).expect("parse rig");
-    rig_json["resources"] = resources;
-    fs::write(
-        &rig_path,
-        serde_json::to_string(&rig_json).expect("serialize rig"),
-    )
-    .expect("write rig");
-}
-
 fn first_warmup_metric(output: BenchOutput) -> f64 {
     match output {
         BenchOutput::Single(result) => result.results.expect("results").scenarios[0]
@@ -398,67 +380,6 @@ fn run_list_uses_rig_default_component_and_workloads() {
             }
             _ => panic!("expected list output"),
         }
-    });
-}
-
-#[test]
-fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
-    with_isolated_home(|home| {
-        write_bench_extension(home);
-        let active_component = tempfile::TempDir::new().expect("active component");
-        let blocked_component = tempfile::TempDir::new().expect("blocked component");
-        write_rig(home, "studio", "studio", active_component.path());
-        write_rig(home, "studio-bfb", "studio", blocked_component.path());
-        let resources = serde_json::json!({
-            "exclusive": ["studio-runtime"],
-            "paths": ["~/Developer/studio"],
-            "ports": [9724],
-            "process_patterns": ["wordpress-server-child.mjs"]
-        });
-        set_rig_resources(home, "studio", resources.clone());
-        set_rig_resources(home, "studio-bfb", resources);
-
-        let active_spec = homeboy::rig::load("studio").expect("load active rig");
-        let _lease = homeboy::rig::lease::acquire_active_run_lease(&active_spec, "bench")
-            .expect("acquire active lease")
-            .expect("resourceful rig leases");
-
-        let error = match run(
-            run_args(None, vec!["studio-bfb".to_string()], Vec::new()),
-            &GlobalArgs {},
-        ) {
-            Ok(_) => panic!("bench should fail before running with conflicting rig resources"),
-            Err(error) => error,
-        };
-
-        assert_eq!(error.code, ErrorCode::RigResourceConflict);
-        assert!(error.message.contains("studio-bfb"));
-        assert!(error.message.contains("studio"));
-        assert!(error.message.contains("studio-runtime"));
-        assert!(error.message.contains("bench"));
-    });
-}
-
-#[test]
-fn run_single_rig_bench_without_resources_does_not_create_lease() {
-    with_isolated_home(|home| {
-        write_bench_extension(home);
-        let component_dir = tempfile::TempDir::new().expect("component dir");
-        write_rig(home, "studio-lite", "studio", component_dir.path());
-
-        let (_output, exit_code) = run(
-            run_args(None, vec!["studio-lite".to_string()], Vec::new()),
-            &GlobalArgs {},
-        )
-        .expect("non-resourceful rig bench should run");
-
-        assert_eq!(exit_code, 0);
-        assert!(homeboy::rig::lease::active_run_leases()
-            .expect("list active leases")
-            .is_empty());
-        assert!(!homeboy::paths::rig_leases_dir()
-            .expect("lease dir path")
-            .exists());
     });
 }
 
@@ -1496,6 +1417,9 @@ mod bench_default_baseline_dispatch_test;
 #[cfg(test)]
 #[path = "../../../tests/core/rig/bench_default_baseline_output_test.rs"]
 mod bench_default_baseline_output_test;
+#[cfg(test)]
+#[path = "../../../tests/core/rig/bench_resource_lease_test.rs"]
+mod bench_resource_lease_test;
 #[cfg(test)]
 #[path = "../../../tests/core/rig/bench_rig_concurrency_dispatch_test.rs"]
 mod bench_rig_concurrency_dispatch_test;

--- a/tests/core/rig/bench_resource_lease_test.rs
+++ b/tests/core/rig/bench_resource_lease_test.rs
@@ -1,0 +1,81 @@
+use super::*;
+use homeboy::error::ErrorCode;
+use std::fs;
+
+fn set_rig_resources(home: &tempfile::TempDir, rig_id: &str, resources: serde_json::Value) {
+    let rig_path = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("rigs")
+        .join(format!("{}.json", rig_id));
+    let mut rig_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&rig_path).expect("read rig")).expect("parse rig");
+    rig_json["resources"] = resources;
+    fs::write(
+        &rig_path,
+        serde_json::to_string(&rig_json).expect("serialize rig"),
+    )
+    .expect("write rig");
+}
+
+#[test]
+fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let active_component = tempfile::TempDir::new().expect("active component");
+        let blocked_component = tempfile::TempDir::new().expect("blocked component");
+        write_rig(home, "studio", "studio", active_component.path());
+        write_rig(home, "studio-bfb", "studio", blocked_component.path());
+        let resources = serde_json::json!({
+            "exclusive": ["studio-runtime"],
+            "paths": ["~/Developer/studio"],
+            "ports": [9724],
+            "process_patterns": ["wordpress-server-child.mjs"]
+        });
+        set_rig_resources(home, "studio", resources.clone());
+        set_rig_resources(home, "studio-bfb", resources);
+
+        let active_spec = homeboy::rig::load("studio").expect("load active rig");
+        let _lease = homeboy::rig::lease::acquire_active_run_lease(&active_spec, "bench")
+            .expect("acquire active lease")
+            .expect("resourceful rig leases");
+
+        let error = match run(
+            run_args(None, vec!["studio-bfb".to_string()], Vec::new()),
+            &GlobalArgs {},
+        ) {
+            Ok(_) => panic!("bench should fail before running with conflicting rig resources"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code, ErrorCode::RigResourceConflict);
+        assert!(error.message.contains("studio-bfb"));
+        assert!(error.message.contains("studio"));
+        assert!(error.message.contains("studio-runtime"));
+        assert!(error.message.contains("bench"));
+    });
+}
+
+#[test]
+fn run_single_rig_bench_without_resources_does_not_create_lease() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_rig(home, "studio-lite", "studio", component_dir.path());
+
+        let (_output, exit_code) = run(
+            run_args(None, vec!["studio-lite".to_string()], Vec::new()),
+            &GlobalArgs {},
+        )
+        .expect("non-resourceful rig bench should run");
+
+        assert_eq!(exit_code, 0);
+        assert!(homeboy::rig::lease::active_run_leases()
+            .expect("list active leases")
+            .is_empty());
+        assert!(!homeboy::paths::rig_leases_dir()
+            .expect("lease dir path")
+            .exists());
+    });
+}


### PR DESCRIPTION
## Summary
- Acquire the existing active rig run lease while preparing rig-backed benchmark contexts, holding it for the full bench run.
- Add coverage for blocked resourceful rig benchmarks and non-resourceful rigs that should not create lease state.

Fixes #2219.

## Testing
- `cargo test commands::bench::tests::run_single_rig_bench --lib`
- `cargo test commands::bench::tests --lib`
- `cargo test core::rig::lease::lease_test --lib`
- `cargo test --lib` failed once in unrelated `core::refactor::plan::sources::tests::collect_refactor_sources_audit_write_uses_audit_refactor_engine` with `create homeboy runtime tmp directory: No such file or directory`; rerunning that test alone passed.
- `cargo test core::refactor::plan::sources::tests::collect_refactor_sources_audit_write_uses_audit_refactor_engine --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the scoped bench lease acquisition change, added tests, ran verification, and prepared this PR. Chris remains responsible for review and merge.