### PR TITLE
fix(bench): identify implicit default baseline failures

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -442,7 +442,15 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
     }
 
     let ordered_rigs = ordered_rig_ids(run_args);
-    let rig_outputs = run_cross_rig_benches(run_args, &passthrough_args, ordered_rigs)?;
+    let rig_outputs = match run_cross_rig_benches(run_args, &passthrough_args, ordered_rigs) {
+        Ok(outputs) => outputs,
+        Err(error) => {
+            return Err(add_default_baseline_failure_hint(
+                error,
+                default_baseline_expansion.as_ref(),
+            ));
+        }
+    };
 
     let mut entries = Vec::with_capacity(rig_outputs.len());
     let mut effective_component_label: Option<String> = None;
@@ -475,7 +483,10 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
 
     let (mut output, exit) =
         aggregate_comparison_with_axes(component, run_args.iterations, entries, &axes_by_rig);
-    output.default_baseline_expansion = default_baseline_expansion;
+    if let Some(metadata) = default_baseline_expansion {
+        apply_default_baseline_failure_context(&mut output, &metadata);
+        output.default_baseline_expansion = Some(metadata);
+    }
     if run_args.json_summary {
         return Ok((BenchOutput::ComparisonSummary(output.into()), exit));
     }
@@ -486,6 +497,56 @@ struct CrossRigBenchOutput {
     rig_id: String,
     axes: Option<BTreeMap<String, String>>,
     output: BenchCommandOutput,
+}
+
+fn add_default_baseline_failure_hint(
+    error: homeboy::Error,
+    metadata: Option<&BenchDefaultBaselineExpansion>,
+) -> homeboy::Error {
+    let Some(metadata) = metadata else {
+        return error;
+    };
+    if error.details.get("rig_id").and_then(|value| value.as_str())
+        != Some(metadata.baseline_rig.as_str())
+    {
+        return error;
+    }
+
+    error.with_hint(format!(
+        "Implicit default baseline rig '{}' failed before requested rig '{}' could complete. The run plan was injected by bench.default_baseline_rig; pass {} to run only '{}'.",
+        metadata.baseline_rig,
+        metadata.candidate_rig,
+        metadata.opt_out_flag,
+        metadata.candidate_rig,
+    ))
+}
+
+fn apply_default_baseline_failure_context(
+    output: &mut BenchComparisonOutput,
+    metadata: &BenchDefaultBaselineExpansion,
+) {
+    let mut baseline_failed = false;
+    for failure in &mut output.failures {
+        if failure.rig_id == metadata.baseline_rig {
+            failure.implicit_default_baseline = true;
+            baseline_failed = true;
+        }
+    }
+    if !baseline_failed {
+        return;
+    }
+
+    let hints = output.hints.get_or_insert_with(Vec::new);
+    hints.insert(
+        0,
+        format!(
+            "Implicit default baseline rig '{}' failed while preparing comparison for requested rig '{}'. The baseline was injected by bench.default_baseline_rig; pass {} to run only '{}'.",
+            metadata.baseline_rig,
+            metadata.candidate_rig,
+            metadata.opt_out_flag,
+            metadata.candidate_rig,
+        ),
+    );
 }
 
 fn run_cross_rig_benches(

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -242,6 +242,8 @@ pub struct BenchDiagnosticClassSummary {
 #[derive(Serialize, Clone, Debug, PartialEq)]
 pub struct BenchComparisonFailure {
     pub rig_id: String,
+    #[serde(skip_serializing_if = "is_false")]
+    pub implicit_default_baseline: bool,
     pub component_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_path: Option<String>,
@@ -251,6 +253,10 @@ pub struct BenchComparisonFailure {
     pub stderr_tail: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<BenchDiagnostic>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Serialize)]
@@ -826,6 +832,7 @@ pub fn aggregate_comparison_with_axes(
                 .as_ref()
                 .map(|failure| BenchComparisonFailure {
                     rig_id: entry.rig_id.clone(),
+                    implicit_default_baseline: false,
                     component_id: failure.component_id.clone(),
                     component_path: failure.component_path.clone(),
                     scenario_id: failure.scenario_id.clone(),

--- a/tests/core/rig/bench_default_baseline_output_test.rs
+++ b/tests/core/rig/bench_default_baseline_output_test.rs
@@ -150,3 +150,81 @@ fn default_baseline_expansion_notice_names_order_and_opt_out() {
         "got: {notice}"
     );
 }
+
+#[test]
+fn default_baseline_failure_summary_marks_implicit_baseline() {
+    let metadata = BenchDefaultBaselineExpansion {
+        baseline_rig: "studio-agent-sdk".to_string(),
+        candidate_rig: "studio-bfb".to_string(),
+        execution_order: vec!["studio-agent-sdk".to_string(), "studio-bfb".to_string()],
+        opt_out_flag: "--ignore-default-baseline",
+    };
+    let entries = vec![
+        RigBenchEntry {
+            rig_id: "studio-agent-sdk".to_string(),
+            passed: false,
+            status: "failed".to_string(),
+            exit_code: 7,
+            artifacts: Vec::new(),
+            results: None,
+            rig_state: None,
+            failure: Some(homeboy::extension::bench::run::BenchRunFailure {
+                component_id: "studio".to_string(),
+                component_path: None,
+                scenario_id: None,
+                exit_code: 7,
+                stderr_tail: "baseline setup failed".to_string(),
+                diagnostics: Vec::new(),
+            }),
+            diagnostics: Vec::new(),
+        },
+        RigBenchEntry {
+            rig_id: "studio-bfb".to_string(),
+            passed: true,
+            status: "passed".to_string(),
+            exit_code: 0,
+            artifacts: Vec::new(),
+            results: None,
+            rig_state: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        },
+    ];
+    let (mut output, _) = aggregate_comparison("studio".to_string(), 10, entries);
+
+    apply_default_baseline_failure_context(&mut output, &metadata);
+
+    assert!(output.failures[0].implicit_default_baseline);
+    let hints = output.hints.as_ref().expect("hints");
+    assert!(hints[0].contains("Implicit default baseline rig 'studio-agent-sdk'"));
+    assert!(hints[0].contains("requested rig 'studio-bfb'"));
+
+    let value = serde_json::to_value(&output).expect("serialize output");
+    assert_eq!(
+        value["failures"][0]["implicit_default_baseline"],
+        serde_json::Value::Bool(true)
+    );
+}
+
+#[test]
+fn default_baseline_early_error_hint_names_requested_rig() {
+    let metadata = BenchDefaultBaselineExpansion {
+        baseline_rig: "studio-agent-sdk".to_string(),
+        candidate_rig: "studio-bfb".to_string(),
+        execution_order: vec!["studio-agent-sdk".to_string(), "studio-bfb".to_string()],
+        opt_out_flag: "--ignore-default-baseline",
+    };
+    let error = homeboy::Error::rig_pipeline_failed(
+        "studio-agent-sdk",
+        "check",
+        "rig check failed; refusing to run bench against an unhealthy rig",
+    );
+
+    let error = add_default_baseline_failure_hint(error, Some(&metadata));
+
+    assert_eq!(error.hints.len(), 1);
+    assert!(error.hints[0]
+        .message
+        .contains("failed before requested rig 'studio-bfb'"));
+    assert!(error.hints[0].message.contains("--ignore-default-baseline"));
+}


### PR DESCRIPTION
## Summary
- Mark no-results failures from an injected `bench.default_baseline_rig` as `implicit_default_baseline` in comparison output.
- Add a leading failure hint when the implicit baseline fails during comparison output, including the requested rig and `--ignore-default-baseline` opt-out.
- Add an early-error hint when the implicit baseline rig aborts before the requested rig can complete.

Fixes #2221.

## Testing
- `cargo test bench_default_baseline`
- `cargo test commands::bench::tests`
- `cargo test core::extension::bench`
- `cargo test` failed on unrelated existing PATH-order assertion: `core::rig::pipeline::pipeline_test::command_env::test_command_step_uses_bootstrapped_toolchain_path`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the scoped bench output/failure summary change and tests; Chris remains responsible for review and validation.