### PR TITLE
fix(bench): improve empty artifact path diagnostics

### DIFF
--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -142,7 +142,7 @@ cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
   "scenarios": []
 }
 JSON
-printf 'WORKLOAD_ERROR: studio-agent-site-build - warmup iteration threw: Studio site-build eval failed\n' >&2
+printf 'WORKLOAD_ERROR: studio-agent-site-build - warmup iteration 1/1 returned artifact "visual_comparison_dir" with empty path\n' >&2
 exit 7
 "#,
     )
@@ -482,7 +482,20 @@ fn selected_scenario_workload_failure_preserves_runner_error() {
                     Some("studio-agent-site-build")
                 );
                 assert!(failure.stderr_tail.contains("WORKLOAD_ERROR"));
-                assert!(failure.stderr_tail.contains("warmup iteration threw"));
+                assert!(failure.stderr_tail.contains("warmup iteration 1/1"));
+                assert!(failure.stderr_tail.contains("component id `studio`"));
+                assert!(failure
+                    .stderr_tail
+                    .contains("workload id `studio-agent-site-build`"));
+                assert!(failure
+                    .stderr_tail
+                    .contains("scenario id `studio-agent-site-build`"));
+                assert!(failure.stderr_tail.contains("phase `warmup`"));
+                assert!(failure.stderr_tail.contains("iteration 1/1"));
+                assert!(failure
+                    .stderr_tail
+                    .contains("artifact key `visual_comparison_dir`"));
+                assert!(failure.stderr_tail.contains("Omit optional artifacts"));
             }
             _ => panic!("expected single output"),
         }

--- a/src/core/extension/bench/artifact_validation.rs
+++ b/src/core/extension/bench/artifact_validation.rs
@@ -7,28 +7,22 @@ use super::parsing::{BenchResults, BenchScenario};
 
 pub(crate) fn validate_artifact_paths(results: &BenchResults, rig_id: Option<&str>) -> Result<()> {
     for scenario in &results.scenarios {
-        validate_artifacts(
-            &results.component_id,
-            scenario,
-            ArtifactPathContext {
-                rig_id,
-                phase: "scenario",
-                iteration: None,
-            },
-            scenario.artifacts.iter(),
+        validate_artifacts_for_context(
+            ArtifactPathScope::new(&results.component_id, scenario, rig_id, "scenario", None),
+            &scenario.artifacts,
         )?;
 
         if let Some(runs) = &scenario.runs {
             for (run_index, run) in runs.iter().enumerate() {
-                validate_artifacts(
-                    &results.component_id,
-                    scenario,
-                    ArtifactPathContext {
+                validate_artifacts_for_context(
+                    ArtifactPathScope::new(
+                        &results.component_id,
+                        scenario,
                         rig_id,
-                        phase: "iteration",
-                        iteration: Some(run_index + 1),
-                    },
-                    run.artifacts.iter(),
+                        "iteration",
+                        Some(run_index + 1),
+                    ),
+                    &run.artifacts,
                 )?;
             }
         }
@@ -37,11 +31,9 @@ pub(crate) fn validate_artifact_paths(results: &BenchResults, rig_id: Option<&st
     Ok(())
 }
 
-fn validate_artifacts<'a>(
-    component_id: &str,
-    scenario: &BenchScenario,
-    context: ArtifactPathContext<'_>,
-    artifacts: impl Iterator<Item = (&'a String, &'a BenchArtifact)>,
+fn validate_artifacts_for_context(
+    scope: ArtifactPathScope<'_>,
+    artifacts: &std::collections::BTreeMap<String, BenchArtifact>,
 ) -> Result<()> {
     for (artifact_key, artifact) in artifacts {
         if artifact
@@ -50,16 +42,42 @@ fn validate_artifacts<'a>(
             .is_some_and(|path| path.trim().is_empty())
         {
             return Err(empty_artifact_path_error(
-                context,
-                component_id,
-                &scenario.id,
-                scenario.file.as_deref(),
+                scope.context,
+                scope.component_id,
+                &scope.scenario.id,
+                scope.scenario.file.as_deref(),
                 artifact_key,
             ));
         }
     }
 
     Ok(())
+}
+
+struct ArtifactPathScope<'a> {
+    component_id: &'a str,
+    scenario: &'a BenchScenario,
+    context: ArtifactPathContext<'a>,
+}
+
+impl<'a> ArtifactPathScope<'a> {
+    fn new(
+        component_id: &'a str,
+        scenario: &'a BenchScenario,
+        rig_id: Option<&'a str>,
+        phase: &'a str,
+        iteration: Option<usize>,
+    ) -> Self {
+        Self {
+            component_id,
+            scenario,
+            context: ArtifactPathContext {
+                rig_id,
+                phase,
+                iteration,
+            },
+        }
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/core/extension/bench/artifact_validation.rs
+++ b/src/core/extension/bench/artifact_validation.rs
@@ -1,0 +1,182 @@
+//! Bench artifact contract validation.
+
+use crate::error::{Error, Result};
+
+use super::artifact::BenchArtifact;
+use super::parsing::{BenchResults, BenchScenario};
+
+pub(crate) fn validate_artifact_paths(results: &BenchResults, rig_id: Option<&str>) -> Result<()> {
+    for scenario in &results.scenarios {
+        validate_artifacts(
+            &results.component_id,
+            scenario,
+            ArtifactPathContext {
+                rig_id,
+                phase: "scenario",
+                iteration: None,
+            },
+            scenario.artifacts.iter(),
+        )?;
+
+        if let Some(runs) = &scenario.runs {
+            for (run_index, run) in runs.iter().enumerate() {
+                validate_artifacts(
+                    &results.component_id,
+                    scenario,
+                    ArtifactPathContext {
+                        rig_id,
+                        phase: "iteration",
+                        iteration: Some(run_index + 1),
+                    },
+                    run.artifacts.iter(),
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_artifacts<'a>(
+    component_id: &str,
+    scenario: &BenchScenario,
+    context: ArtifactPathContext<'_>,
+    artifacts: impl Iterator<Item = (&'a String, &'a BenchArtifact)>,
+) -> Result<()> {
+    for (artifact_key, artifact) in artifacts {
+        if artifact
+            .path
+            .as_deref()
+            .is_some_and(|path| path.trim().is_empty())
+        {
+            return Err(empty_artifact_path_error(
+                context,
+                component_id,
+                &scenario.id,
+                scenario.file.as_deref(),
+                artifact_key,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct ArtifactPathContext<'a> {
+    rig_id: Option<&'a str>,
+    phase: &'a str,
+    iteration: Option<usize>,
+}
+
+fn empty_artifact_path_error(
+    context: ArtifactPathContext<'_>,
+    component_id: &str,
+    scenario_id: &str,
+    workload_id: Option<&str>,
+    artifact_key: &str,
+) -> Error {
+    Error::validation_invalid_argument(
+        "artifacts.path",
+        format!(
+            "bench artifact path is empty for {}; artifact paths must be non-empty. Omit optional artifacts, or provide a real diagnostics file/directory when evidence is available.",
+            artifact_context_parts(context, component_id, scenario_id, workload_id, artifact_key).join(", ")
+        ),
+        Some(artifact_key.to_string()),
+        None,
+    )
+}
+
+fn artifact_context_parts(
+    context: ArtifactPathContext<'_>,
+    component_id: &str,
+    scenario_id: &str,
+    workload_id: Option<&str>,
+    artifact_key: &str,
+) -> Vec<String> {
+    let mut parts = Vec::new();
+    if let Some(rig_id) = context.rig_id {
+        parts.push(format!("rig id `{}`", rig_id));
+    }
+    parts.push(format!("component id `{}`", component_id));
+    if let Some(workload_id) = workload_id {
+        parts.push(format!("workload id `{}`", workload_id));
+    }
+    parts.push(format!("scenario id `{}`", scenario_id));
+    parts.push(format!("phase `{}`", context.phase));
+    if let Some(iteration) = context.iteration {
+        parts.push(format!("iteration {}", iteration));
+    }
+    parts.push(format!("artifact key `{}`", artifact_key));
+    parts
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::extension::bench::parsing::{BenchMetrics, BenchRunSnapshot};
+
+    #[test]
+    fn test_validate_artifact_paths() {
+        let mut results = BenchResults {
+            component_id: "studio".to_string(),
+            iterations: 1,
+            run_metadata: None,
+            diagnostics: Vec::new(),
+            scenarios: vec![BenchScenario {
+                id: "site_build".to_string(),
+                file: Some("bench/site-build.bench.mjs".to_string()),
+                source: None,
+                default_iterations: None,
+                tags: Vec::new(),
+                iterations: 1,
+                metrics: BenchMetrics::default(),
+                metric_groups: BTreeMap::new(),
+                gates: Vec::new(),
+                gate_results: Vec::new(),
+                metadata: BTreeMap::new(),
+                passed: true,
+                memory: None,
+                artifacts: BTreeMap::new(),
+                diagnostics: Vec::new(),
+                runs: Some(vec![BenchRunSnapshot {
+                    metrics: BenchMetrics::default(),
+                    metric_groups: BTreeMap::new(),
+                    memory: None,
+                    artifacts: BTreeMap::from([(
+                        "visual_comparison_dir".to_string(),
+                        BenchArtifact {
+                            path: Some("".to_string()),
+                            url: None,
+                            artifact_type: None,
+                            kind: None,
+                            label: None,
+                        },
+                    )]),
+                    diagnostics: Vec::new(),
+                }]),
+                runs_summary: None,
+            }],
+            metric_policies: BTreeMap::new(),
+        };
+
+        let err = validate_artifact_paths(&results, Some("studio-bfb"))
+            .expect_err("empty run artifact path should fail");
+        let message = err.to_string();
+        assert!(message.contains("rig id `studio-bfb`"));
+        assert!(message.contains("component id `studio`"));
+        assert!(message.contains("workload id `bench/site-build.bench.mjs`"));
+        assert!(message.contains("scenario id `site_build`"));
+        assert!(message.contains("phase `iteration`"));
+        assert!(message.contains("iteration 1"));
+        assert!(message.contains("artifact key `visual_comparison_dir`"));
+
+        results.scenarios[0].runs.as_mut().unwrap()[0]
+            .artifacts
+            .clear();
+        validate_artifact_paths(&results, Some("studio-bfb"))
+            .expect("valid artifact handling should remain unchanged");
+    }
+}

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -1,0 +1,134 @@
+//! Bench runner failure diagnostic enrichment.
+
+use crate::extension::stderr_tail;
+
+use super::run::BenchRunWorkflowArgs;
+
+pub(crate) fn bench_failure_stderr_tail(stderr: &str, args: &BenchRunWorkflowArgs) -> String {
+    enrich_empty_artifact_path_error(stderr_tail(stderr), args)
+}
+
+fn enrich_empty_artifact_path_error(tail: String, args: &BenchRunWorkflowArgs) -> String {
+    if !tail.contains("returned artifact") || !tail.contains("with empty path") {
+        return tail;
+    }
+
+    let artifact_key =
+        text_between(&tail, "returned artifact \"", "\" with empty path").unwrap_or("<unknown>");
+    let workload_id = text_between(&tail, "WORKLOAD_ERROR: ", " - ")
+        .or_else(|| text_between(&tail, "WORKLOAD_ERROR: ", " — "));
+    let scenario_id = args
+        .scenario_ids
+        .first()
+        .filter(|_| args.scenario_ids.len() == 1)
+        .cloned()
+        .or_else(|| workload_id.map(str::to_string))
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let phase = if tail.contains("warmup iteration") {
+        "warmup"
+    } else {
+        "iteration"
+    };
+    let iteration = text_after(&tail, &format!("{} iteration ", phase))
+        .and_then(|rest| rest.split_whitespace().next())
+        .unwrap_or("<unknown>");
+    let context = failure_context(
+        args,
+        workload_id,
+        &scenario_id,
+        phase,
+        iteration,
+        artifact_key,
+    );
+
+    format!(
+        "{}\n\nBench artifact path validation context: {}.\nBench artifact contract: artifact paths must be non-empty. Omit optional artifacts, or provide a real diagnostics file/directory when evidence is available.",
+        tail,
+        context.join(", ")
+    )
+}
+
+fn failure_context(
+    args: &BenchRunWorkflowArgs,
+    workload_id: Option<&str>,
+    scenario_id: &str,
+    phase: &str,
+    iteration: &str,
+    artifact_key: &str,
+) -> Vec<String> {
+    let mut context = Vec::new();
+    if let Some(rig_id) = args.rig_id.as_deref() {
+        context.push(format!("rig id `{}`", rig_id));
+    }
+    context.push(format!("component id `{}`", args.component_id));
+    if let Some(workload_id) = workload_id {
+        context.push(format!("workload id `{}`", workload_id));
+    }
+    context.push(format!("scenario id `{}`", scenario_id));
+    context.push(format!("phase `{}`", phase));
+    context.push(format!("iteration {}", iteration));
+    context.push(format!("artifact key `{}`", artifact_key));
+    context
+}
+
+fn text_between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str> {
+    let after_start = text_after(text, start)?;
+    let end_index = after_start.find(end)?;
+    Some(&after_start[..end_index])
+}
+
+fn text_after<'a>(text: &'a str, start: &str) -> Option<&'a str> {
+    let start_index = text.find(start)?;
+    Some(&text[start_index + start.len()..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::baseline::BaselineFlags;
+    use crate::extension::bench::parsing::BenchRunExecution;
+
+    #[test]
+    fn enriches_empty_artifact_path_failure_with_bench_context() {
+        let args = BenchRunWorkflowArgs {
+            component_label: "Studio".to_string(),
+            component_id: "studio".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            iterations: 1,
+            warmup_iterations: Some(1),
+            execution: BenchRunExecution {
+                runs: 1,
+                concurrency: 1,
+            },
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent: 5.0,
+            json_summary: false,
+            passthrough_args: Vec::new(),
+            scenario_ids: vec!["studio-agent-site-build".to_string()],
+            rig_id: Some("studio-bfb".to_string()),
+            shared_state: None,
+            extra_workloads: Vec::new(),
+        };
+
+        let enriched = enrich_empty_artifact_path_error(
+            "WORKLOAD_ERROR: studio-agent-site-build - warmup iteration 1/1 returned artifact \"visual_comparison_dir\" with empty path".to_string(),
+            &args,
+        );
+
+        assert!(enriched.contains("rig id `studio-bfb`"));
+        assert!(enriched.contains("component id `studio`"));
+        assert!(enriched.contains("workload id `studio-agent-site-build`"));
+        assert!(enriched.contains("scenario id `studio-agent-site-build`"));
+        assert!(enriched.contains("phase `warmup`"));
+        assert!(enriched.contains("iteration 1/1"));
+        assert!(enriched.contains("artifact key `visual_comparison_dir`"));
+        assert!(enriched.contains("Omit optional artifacts"));
+        assert!(enriched.contains("real diagnostics file/directory"));
+    }
+}

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -89,8 +89,39 @@ mod tests {
     use crate::extension::bench::parsing::BenchRunExecution;
 
     #[test]
+    fn test_bench_failure_stderr_tail() {
+        let args = bench_args();
+        let tail = bench_failure_stderr_tail(
+            "WORKLOAD_ERROR: studio-agent-site-build - warmup iteration 1/1 returned artifact \"visual_comparison_dir\" with empty path\n",
+            &args,
+        );
+
+        assert!(tail.contains("Bench artifact path validation context"));
+        assert!(tail.contains("component id `studio`"));
+    }
+
+    #[test]
     fn enriches_empty_artifact_path_failure_with_bench_context() {
-        let args = BenchRunWorkflowArgs {
+        let args = bench_args();
+
+        let enriched = enrich_empty_artifact_path_error(
+            "WORKLOAD_ERROR: studio-agent-site-build - warmup iteration 1/1 returned artifact \"visual_comparison_dir\" with empty path".to_string(),
+            &args,
+        );
+
+        assert!(enriched.contains("rig id `studio-bfb`"));
+        assert!(enriched.contains("component id `studio`"));
+        assert!(enriched.contains("workload id `studio-agent-site-build`"));
+        assert!(enriched.contains("scenario id `studio-agent-site-build`"));
+        assert!(enriched.contains("phase `warmup`"));
+        assert!(enriched.contains("iteration 1/1"));
+        assert!(enriched.contains("artifact key `visual_comparison_dir`"));
+        assert!(enriched.contains("Omit optional artifacts"));
+        assert!(enriched.contains("real diagnostics file/directory"));
+    }
+
+    fn bench_args() -> BenchRunWorkflowArgs {
+        BenchRunWorkflowArgs {
             component_label: "Studio".to_string(),
             component_id: "studio".to_string(),
             path_override: None,
@@ -114,21 +145,6 @@ mod tests {
             rig_id: Some("studio-bfb".to_string()),
             shared_state: None,
             extra_workloads: Vec::new(),
-        };
-
-        let enriched = enrich_empty_artifact_path_error(
-            "WORKLOAD_ERROR: studio-agent-site-build - warmup iteration 1/1 returned artifact \"visual_comparison_dir\" with empty path".to_string(),
-            &args,
-        );
-
-        assert!(enriched.contains("rig id `studio-bfb`"));
-        assert!(enriched.contains("component id `studio`"));
-        assert!(enriched.contains("workload id `studio-agent-site-build`"));
-        assert!(enriched.contains("scenario id `studio-agent-site-build`"));
-        assert!(enriched.contains("phase `warmup`"));
-        assert!(enriched.contains("iteration 1/1"));
-        assert!(enriched.contains("artifact key `visual_comparison_dir`"));
-        assert!(enriched.contains("Omit optional artifacts"));
-        assert!(enriched.contains("real diagnostics file/directory"));
+        }
     }
 }

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -21,9 +21,11 @@
 
 pub mod aggregation;
 pub mod artifact;
+pub(crate) mod artifact_validation;
 pub mod baseline;
 pub mod diagnostic;
 pub mod distribution;
+pub(crate) mod failure_diagnostic;
 pub mod metrics;
 pub mod parsing;
 pub mod report;

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -441,6 +441,13 @@ pub struct BenchMemory {
 
 /// Read and parse a `$HOMEBOY_BENCH_RESULTS_FILE` written by an extension.
 pub fn parse_bench_results_file(path: &Path) -> Result<BenchResults> {
+    parse_bench_results_file_with_artifact_context(path, None)
+}
+
+pub fn parse_bench_results_file_with_artifact_context(
+    path: &Path,
+    rig_id: Option<&str>,
+) -> Result<BenchResults> {
     let content = std::fs::read_to_string(path).map_err(|e| {
         Error::internal_io(
             format!(
@@ -451,11 +458,18 @@ pub fn parse_bench_results_file(path: &Path) -> Result<BenchResults> {
             Some("bench.parsing.read".to_string()),
         )
     })?;
-    parse_bench_results_str(&content)
+    parse_bench_results_str_with_artifact_context(&content, rig_id)
 }
 
 /// Parse a raw JSON string into a `BenchResults`.
 pub fn parse_bench_results_str(raw: &str) -> Result<BenchResults> {
+    parse_bench_results_str_with_artifact_context(raw, None)
+}
+
+fn parse_bench_results_str_with_artifact_context(
+    raw: &str,
+    rig_id: Option<&str>,
+) -> Result<BenchResults> {
     let parsed: BenchResults = serde_json::from_str(raw).map_err(|e| {
         Error::internal_json(
             format!("Failed to parse bench results JSON: {}", e),
@@ -464,7 +478,91 @@ pub fn parse_bench_results_str(raw: &str) -> Result<BenchResults> {
     })?;
     validate_unique_scenario_ids(&parsed)?;
     validate_variance_policies(&parsed)?;
+    validate_artifact_paths(&parsed, rig_id)?;
     Ok(parsed)
+}
+
+/// Validate artifact pointers after deserialization so bad paths fail with
+/// bench-domain context instead of a generic JSON or runner error.
+pub fn validate_artifact_paths(results: &BenchResults, rig_id: Option<&str>) -> Result<()> {
+    for scenario in &results.scenarios {
+        for (artifact_key, artifact) in &scenario.artifacts {
+            if artifact
+                .path
+                .as_deref()
+                .is_some_and(|path| path.trim().is_empty())
+            {
+                return Err(empty_artifact_path_error(
+                    rig_id,
+                    &results.component_id,
+                    &scenario.id,
+                    scenario.file.as_deref(),
+                    "scenario",
+                    None,
+                    artifact_key,
+                ));
+            }
+        }
+
+        if let Some(runs) = &scenario.runs {
+            for (run_index, run) in runs.iter().enumerate() {
+                for (artifact_key, artifact) in &run.artifacts {
+                    if artifact
+                        .path
+                        .as_deref()
+                        .is_some_and(|path| path.trim().is_empty())
+                    {
+                        return Err(empty_artifact_path_error(
+                            rig_id,
+                            &results.component_id,
+                            &scenario.id,
+                            scenario.file.as_deref(),
+                            "iteration",
+                            Some(run_index + 1),
+                            artifact_key,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn empty_artifact_path_error(
+    rig_id: Option<&str>,
+    component_id: &str,
+    scenario_id: &str,
+    workload_id: Option<&str>,
+    phase: &str,
+    iteration: Option<usize>,
+    artifact_key: &str,
+) -> Error {
+    let mut context = Vec::new();
+    if let Some(rig_id) = rig_id {
+        context.push(format!("rig id `{}`", rig_id));
+    }
+    context.push(format!("component id `{}`", component_id));
+    if let Some(workload_id) = workload_id {
+        context.push(format!("workload id `{}`", workload_id));
+    }
+    context.push(format!("scenario id `{}`", scenario_id));
+    context.push(format!("phase `{}`", phase));
+    if let Some(iteration) = iteration {
+        context.push(format!("iteration {}", iteration));
+    }
+    context.push(format!("artifact key `{}`", artifact_key));
+
+    Error::validation_invalid_argument(
+        "artifacts.path",
+        format!(
+            "bench artifact path is empty for {}; artifact paths must be non-empty. Omit optional artifacts, or provide a real diagnostics file/directory when evidence is available.",
+            context.join(", ")
+        ),
+        Some(artifact_key.to_string()),
+        None,
+    )
 }
 
 fn validate_unique_scenario_ids(results: &BenchResults) -> Result<()> {
@@ -676,6 +774,98 @@ mod tests {
         assert!(serialized.contains("\"artifacts\""));
         assert!(serialized.contains("artifacts/agent-loop/transcript.json"));
         assert!(serialized.contains("https://example.test/"));
+    }
+
+    #[test]
+    fn rejects_empty_scenario_artifact_path_with_contract_guidance() {
+        let err = parse_bench_results_str(
+            r#"{
+                "component_id": "studio",
+                "iterations": 1,
+                "scenarios": [
+                    {
+                        "id": "site_build",
+                        "file": "bench/site-build.bench.mjs",
+                        "iterations": 1,
+                        "metrics": { "success_rate": 1.0 },
+                        "artifacts": {
+                            "visual_comparison_dir": { "path": "" }
+                        }
+                    }
+                ]
+            }"#,
+        )
+        .expect_err("empty artifact path should fail validation");
+
+        let message = err.to_string();
+        assert!(message.contains("component id `studio`"));
+        assert!(message.contains("workload id `bench/site-build.bench.mjs`"));
+        assert!(message.contains("scenario id `site_build`"));
+        assert!(message.contains("phase `scenario`"));
+        assert!(message.contains("artifact key `visual_comparison_dir`"));
+        assert!(message.contains("Omit optional artifacts"));
+        assert!(message.contains("real diagnostics file/directory"));
+    }
+
+    #[test]
+    fn rejects_empty_measured_iteration_artifact_path_with_iteration_context() {
+        let err = parse_bench_results_str(
+            r#"{
+                "component_id": "studio",
+                "iterations": 2,
+                "scenarios": [
+                    {
+                        "id": "site_build",
+                        "file": "bench/site-build.bench.mjs",
+                        "iterations": 2,
+                        "metrics": { "success_rate": 1.0 },
+                        "runs": [
+                            { "metrics": { "success_rate": 1.0 } },
+                            {
+                                "metrics": { "success_rate": 1.0 },
+                                "artifacts": {
+                                    "visual_comparison_dir": { "path": "   " }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }"#,
+        )
+        .expect_err("empty measured iteration artifact path should fail validation");
+
+        let message = err.to_string();
+        assert!(message.contains("component id `studio`"));
+        assert!(message.contains("workload id `bench/site-build.bench.mjs`"));
+        assert!(message.contains("scenario id `site_build`"));
+        assert!(message.contains("phase `iteration`"));
+        assert!(message.contains("iteration 2"));
+        assert!(message.contains("artifact key `visual_comparison_dir`"));
+        assert!(message.contains("Omit optional artifacts"));
+    }
+
+    #[test]
+    fn empty_artifact_path_diagnostic_includes_rig_when_available() {
+        let err = parse_bench_results_str_with_artifact_context(
+            r#"{
+                "component_id": "studio",
+                "iterations": 1,
+                "scenarios": [
+                    {
+                        "id": "site_build",
+                        "iterations": 1,
+                        "metrics": { "success_rate": 1.0 },
+                        "artifacts": {
+                            "visual_comparison_dir": { "path": "" }
+                        }
+                    }
+                ]
+            }"#,
+            Some("studio-bfb"),
+        )
+        .expect_err("empty artifact path should include rig context");
+
+        assert!(err.to_string().contains("rig id `studio-bfb`"));
     }
 
     #[test]

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -54,6 +54,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Error, Result};
 
 use super::artifact::BenchArtifact;
+use super::artifact_validation;
 use super::diagnostic::BenchDiagnostic;
 use super::distribution::BenchRunDistribution;
 
@@ -478,91 +479,8 @@ fn parse_bench_results_str_with_artifact_context(
     })?;
     validate_unique_scenario_ids(&parsed)?;
     validate_variance_policies(&parsed)?;
-    validate_artifact_paths(&parsed, rig_id)?;
+    artifact_validation::validate_artifact_paths(&parsed, rig_id)?;
     Ok(parsed)
-}
-
-/// Validate artifact pointers after deserialization so bad paths fail with
-/// bench-domain context instead of a generic JSON or runner error.
-pub fn validate_artifact_paths(results: &BenchResults, rig_id: Option<&str>) -> Result<()> {
-    for scenario in &results.scenarios {
-        for (artifact_key, artifact) in &scenario.artifacts {
-            if artifact
-                .path
-                .as_deref()
-                .is_some_and(|path| path.trim().is_empty())
-            {
-                return Err(empty_artifact_path_error(
-                    rig_id,
-                    &results.component_id,
-                    &scenario.id,
-                    scenario.file.as_deref(),
-                    "scenario",
-                    None,
-                    artifact_key,
-                ));
-            }
-        }
-
-        if let Some(runs) = &scenario.runs {
-            for (run_index, run) in runs.iter().enumerate() {
-                for (artifact_key, artifact) in &run.artifacts {
-                    if artifact
-                        .path
-                        .as_deref()
-                        .is_some_and(|path| path.trim().is_empty())
-                    {
-                        return Err(empty_artifact_path_error(
-                            rig_id,
-                            &results.component_id,
-                            &scenario.id,
-                            scenario.file.as_deref(),
-                            "iteration",
-                            Some(run_index + 1),
-                            artifact_key,
-                        ));
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn empty_artifact_path_error(
-    rig_id: Option<&str>,
-    component_id: &str,
-    scenario_id: &str,
-    workload_id: Option<&str>,
-    phase: &str,
-    iteration: Option<usize>,
-    artifact_key: &str,
-) -> Error {
-    let mut context = Vec::new();
-    if let Some(rig_id) = rig_id {
-        context.push(format!("rig id `{}`", rig_id));
-    }
-    context.push(format!("component id `{}`", component_id));
-    if let Some(workload_id) = workload_id {
-        context.push(format!("workload id `{}`", workload_id));
-    }
-    context.push(format!("scenario id `{}`", scenario_id));
-    context.push(format!("phase `{}`", phase));
-    if let Some(iteration) = iteration {
-        context.push(format!("iteration {}", iteration));
-    }
-    context.push(format!("artifact key `{}`", artifact_key));
-
-    Error::validation_invalid_argument(
-        "artifacts.path",
-        format!(
-            "bench artifact path is empty for {}; artifact paths must be non-empty. Omit optional artifacts, or provide a real diagnostics file/directory when evidence is available.",
-            context.join(", ")
-        ),
-        Some(artifact_key.to_string()),
-        None,
-    )
 }
 
 fn validate_unique_scenario_ids(results: &BenchResults) -> Result<()> {
@@ -904,6 +822,35 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_bench_results_file_with_artifact_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bench-results.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "component_id": "studio",
+                "iterations": 1,
+                "scenarios": [
+                    {
+                        "id": "site_build",
+                        "iterations": 1,
+                        "metrics": { "success_rate": 1.0 },
+                        "artifacts": {
+                            "visual_comparison_dir": { "path": "" }
+                        }
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let err = parse_bench_results_file_with_artifact_context(&path, Some("studio-bfb"))
+            .expect_err("empty artifact path should include rig context");
+
+        assert!(err.to_string().contains("rig id `studio-bfb`"));
+    }
+
+    #[test]
     fn parses_arbitrary_numeric_metrics_and_policies() {
         let raw = r#"{
             "component_id": "example",
@@ -1017,7 +964,7 @@ mod tests {
     }
 
     #[test]
-    fn semantic_gate_pass_leaves_scenario_passed() {
+    fn test_evaluate_gates() {
         let raw = r#"{
             "component_id": "example",
             "iterations": 10,

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -15,13 +15,13 @@ use crate::error::{Error, Result};
 use crate::extension::bench::aggregate_runs;
 use crate::extension::bench::baseline::{self, BenchBaselineComparison};
 use crate::extension::bench::diagnostic::{self, BenchDiagnostic};
+use crate::extension::bench::failure_diagnostic::bench_failure_stderr_tail;
 use crate::extension::bench::parsing::{
     self, BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunnerMetadata, BenchScenario,
     BenchWorkloadMetadata,
 };
 use crate::extension::{
-    resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
-    ExtensionRunner,
+    resolve_execution_context, ExtensionCapability, ExtensionExecutionContext, ExtensionRunner,
 };
 
 #[derive(Debug, Clone)]
@@ -733,62 +733,6 @@ fn format_diagnostic_hint(diagnostic: &BenchDiagnostic) -> String {
     }
 }
 
-fn bench_failure_stderr_tail(stderr: &str, args: &BenchRunWorkflowArgs) -> String {
-    enrich_empty_artifact_path_error(stderr_tail(stderr), args)
-}
-
-fn enrich_empty_artifact_path_error(tail: String, args: &BenchRunWorkflowArgs) -> String {
-    if !tail.contains("returned artifact") || !tail.contains("with empty path") {
-        return tail;
-    }
-
-    let artifact_key =
-        text_between(&tail, "returned artifact \"", "\" with empty path").unwrap_or("<unknown>");
-    let workload_id = text_between(&tail, "WORKLOAD_ERROR: ", " - ")
-        .or_else(|| text_between(&tail, "WORKLOAD_ERROR: ", " — "));
-    let scenario_id = failure_scenario_id(&args.scenario_ids)
-        .or_else(|| workload_id.map(str::to_string))
-        .unwrap_or_else(|| "<unknown>".to_string());
-    let phase = if tail.contains("warmup iteration") {
-        "warmup"
-    } else {
-        "iteration"
-    };
-    let iteration = text_after(&tail, &format!("{} iteration ", phase))
-        .and_then(|rest| rest.split_whitespace().next())
-        .unwrap_or("<unknown>");
-
-    let mut context = Vec::new();
-    if let Some(rig_id) = args.rig_id.as_deref() {
-        context.push(format!("rig id `{}`", rig_id));
-    }
-    context.push(format!("component id `{}`", args.component_id));
-    if let Some(workload_id) = workload_id {
-        context.push(format!("workload id `{}`", workload_id));
-    }
-    context.push(format!("scenario id `{}`", scenario_id));
-    context.push(format!("phase `{}`", phase));
-    context.push(format!("iteration {}", iteration));
-    context.push(format!("artifact key `{}`", artifact_key));
-
-    format!(
-        "{}\n\nBench artifact path validation context: {}.\nBench artifact contract: artifact paths must be non-empty. Omit optional artifacts, or provide a real diagnostics file/directory when evidence is available.",
-        tail,
-        context.join(", ")
-    )
-}
-
-fn text_between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str> {
-    let after_start = text_after(text, start)?;
-    let end_index = after_start.find(end)?;
-    Some(&after_start[..end_index])
-}
-
-fn text_after<'a>(text: &'a str, start: &str) -> Option<&'a str> {
-    let start_index = text.find(start)?;
-    Some(&text[start_index + start.len()..])
-}
-
 fn stamp_run_metadata(
     results: &mut BenchResults,
     execution_context: &ExtensionExecutionContext,
@@ -1266,50 +1210,6 @@ mod tests {
             extra_workloads_env_value(&paths).unwrap(),
             "/tmp/bench-one.php:/tmp/bench-two.php"
         );
-    }
-
-    #[test]
-    fn enriches_empty_artifact_path_failure_with_bench_context() {
-        let args = BenchRunWorkflowArgs {
-            component_label: "Studio".to_string(),
-            component_id: "studio".to_string(),
-            path_override: None,
-            settings: Vec::new(),
-            settings_json: Vec::new(),
-            iterations: 1,
-            warmup_iterations: Some(1),
-            execution: BenchRunExecution {
-                runs: 1,
-                concurrency: 1,
-            },
-            baseline_flags: BaselineFlags {
-                baseline: false,
-                ignore_baseline: true,
-                ratchet: false,
-            },
-            regression_threshold_percent: 5.0,
-            json_summary: false,
-            passthrough_args: Vec::new(),
-            scenario_ids: vec!["studio-agent-site-build".to_string()],
-            rig_id: Some("studio-bfb".to_string()),
-            shared_state: None,
-            extra_workloads: Vec::new(),
-        };
-
-        let enriched = enrich_empty_artifact_path_error(
-            "WORKLOAD_ERROR: studio-agent-site-build - warmup iteration 1/1 returned artifact \"visual_comparison_dir\" with empty path".to_string(),
-            &args,
-        );
-
-        assert!(enriched.contains("rig id `studio-bfb`"));
-        assert!(enriched.contains("component id `studio`"));
-        assert!(enriched.contains("workload id `studio-agent-site-build`"));
-        assert!(enriched.contains("scenario id `studio-agent-site-build`"));
-        assert!(enriched.contains("phase `warmup`"));
-        assert!(enriched.contains("iteration 1/1"));
-        assert!(enriched.contains("artifact key `visual_comparison_dir`"));
-        assert!(enriched.contains("Omit optional artifacts"));
-        assert!(enriched.contains("real diagnostics file/directory"));
     }
 
     #[test]

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -323,6 +323,7 @@ fn parse_execution_results_file(
     results_file: &Path,
     scenario_ids: &[String],
     runner_success: bool,
+    rig_id: Option<&str>,
 ) -> Result<Option<BenchResults>> {
     if !results_file.exists() {
         return Ok(None);
@@ -330,12 +331,12 @@ fn parse_execution_results_file(
 
     if runner_success {
         return Ok(Some(apply_scenario_filter(
-            parsing::parse_bench_results_file(results_file)?,
+            parsing::parse_bench_results_file_with_artifact_context(results_file, rig_id)?,
             scenario_ids,
         )?));
     }
 
-    Ok(parsing::parse_bench_results_file(results_file).ok())
+    Ok(parsing::parse_bench_results_file_with_artifact_context(results_file, rig_id).ok())
 }
 
 fn failure_scenario_id(scenario_ids: &[String]) -> Option<String> {
@@ -491,7 +492,12 @@ pub fn run_main_bench_workflow(
         )?;
         let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
         let mut parsed = if results_file.exists() {
-            parse_execution_results_file(&results_file, &args.scenario_ids, script_output.success)?
+            parse_execution_results_file(
+                &results_file,
+                &args.scenario_ids,
+                script_output.success,
+                args.rig_id.as_deref(),
+            )?
         } else {
             None
         };
@@ -527,7 +533,7 @@ pub fn run_main_bench_workflow(
             component_path: Some(source_path.to_string_lossy().to_string()),
             scenario_id: failure_scenario_id(&args.scenario_ids),
             exit_code: script_output.exit_code,
-            stderr_tail: stderr_tail(&script_output.stderr),
+            stderr_tail: bench_failure_stderr_tail(&script_output.stderr, &args),
             diagnostics: Vec::new(),
         });
         return Ok(BenchRunWorkflowResult {
@@ -571,9 +577,13 @@ pub fn run_main_bench_workflow(
                 &results_file,
                 &execution_args.scenario_ids,
                 runner_output.success,
+                execution_args.rig_id.as_deref(),
             )?;
             let failure_stderr_tail = if !runner_output.success {
-                Some(stderr_tail(&runner_output.stderr))
+                Some(bench_failure_stderr_tail(
+                    &runner_output.stderr,
+                    &execution_args,
+                ))
             } else {
                 None
             };
@@ -721,6 +731,62 @@ fn format_diagnostic_hint(diagnostic: &BenchDiagnostic) -> String {
         Some(message) => format!("Diagnostic `{}`: {}", diagnostic.class, message),
         None => format!("Diagnostic `{}`", diagnostic.class),
     }
+}
+
+fn bench_failure_stderr_tail(stderr: &str, args: &BenchRunWorkflowArgs) -> String {
+    enrich_empty_artifact_path_error(stderr_tail(stderr), args)
+}
+
+fn enrich_empty_artifact_path_error(tail: String, args: &BenchRunWorkflowArgs) -> String {
+    if !tail.contains("returned artifact") || !tail.contains("with empty path") {
+        return tail;
+    }
+
+    let artifact_key =
+        text_between(&tail, "returned artifact \"", "\" with empty path").unwrap_or("<unknown>");
+    let workload_id = text_between(&tail, "WORKLOAD_ERROR: ", " - ")
+        .or_else(|| text_between(&tail, "WORKLOAD_ERROR: ", " — "));
+    let scenario_id = failure_scenario_id(&args.scenario_ids)
+        .or_else(|| workload_id.map(str::to_string))
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let phase = if tail.contains("warmup iteration") {
+        "warmup"
+    } else {
+        "iteration"
+    };
+    let iteration = text_after(&tail, &format!("{} iteration ", phase))
+        .and_then(|rest| rest.split_whitespace().next())
+        .unwrap_or("<unknown>");
+
+    let mut context = Vec::new();
+    if let Some(rig_id) = args.rig_id.as_deref() {
+        context.push(format!("rig id `{}`", rig_id));
+    }
+    context.push(format!("component id `{}`", args.component_id));
+    if let Some(workload_id) = workload_id {
+        context.push(format!("workload id `{}`", workload_id));
+    }
+    context.push(format!("scenario id `{}`", scenario_id));
+    context.push(format!("phase `{}`", phase));
+    context.push(format!("iteration {}", iteration));
+    context.push(format!("artifact key `{}`", artifact_key));
+
+    format!(
+        "{}\n\nBench artifact path validation context: {}.\nBench artifact contract: artifact paths must be non-empty. Omit optional artifacts, or provide a real diagnostics file/directory when evidence is available.",
+        tail,
+        context.join(", ")
+    )
+}
+
+fn text_between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str> {
+    let after_start = text_after(text, start)?;
+    let end_index = after_start.find(end)?;
+    Some(&after_start[..end_index])
+}
+
+fn text_after<'a>(text: &'a str, start: &str) -> Option<&'a str> {
+    let start_index = text.find(start)?;
+    Some(&text[start_index + start.len()..])
 }
 
 fn stamp_run_metadata(
@@ -937,10 +1003,14 @@ fn run_single_dispatcher(
     }
 
     let runner_output = build_runner(execution_context, component, args, run_dir, None)?.run()?;
-    let parsed =
-        parse_execution_results_file(&results_file, &args.scenario_ids, runner_output.success)?;
+    let parsed = parse_execution_results_file(
+        &results_file,
+        &args.scenario_ids,
+        runner_output.success,
+        args.rig_id.as_deref(),
+    )?;
     let failure_stderr_tail = if !runner_output.success {
-        Some(stderr_tail(&runner_output.stderr))
+        Some(bench_failure_stderr_tail(&runner_output.stderr, args))
     } else {
         None
     };
@@ -1111,7 +1181,7 @@ fn run_concurrent_instances(
                 first_failure_exit = Some(output.exit_code);
             }
             if first_failure_stderr_tail.is_none() {
-                first_failure_stderr_tail = Some(stderr_tail(&output.stderr));
+                first_failure_stderr_tail = Some(bench_failure_stderr_tail(&output.stderr, args));
             }
         }
     }
@@ -1133,8 +1203,11 @@ fn run_concurrent_instances(
         if !path.exists() {
             continue;
         }
-        let parsed = match parsing::parse_bench_results_file(&path)
-            .and_then(|results| apply_scenario_filter(results, &args.scenario_ids))
+        let parsed = match parsing::parse_bench_results_file_with_artifact_context(
+            &path,
+            args.rig_id.as_deref(),
+        )
+        .and_then(|results| apply_scenario_filter(results, &args.scenario_ids))
         {
             Ok(p) => p,
             Err(_) => continue,
@@ -1193,6 +1266,50 @@ mod tests {
             extra_workloads_env_value(&paths).unwrap(),
             "/tmp/bench-one.php:/tmp/bench-two.php"
         );
+    }
+
+    #[test]
+    fn enriches_empty_artifact_path_failure_with_bench_context() {
+        let args = BenchRunWorkflowArgs {
+            component_label: "Studio".to_string(),
+            component_id: "studio".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            iterations: 1,
+            warmup_iterations: Some(1),
+            execution: BenchRunExecution {
+                runs: 1,
+                concurrency: 1,
+            },
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent: 5.0,
+            json_summary: false,
+            passthrough_args: Vec::new(),
+            scenario_ids: vec!["studio-agent-site-build".to_string()],
+            rig_id: Some("studio-bfb".to_string()),
+            shared_state: None,
+            extra_workloads: Vec::new(),
+        };
+
+        let enriched = enrich_empty_artifact_path_error(
+            "WORKLOAD_ERROR: studio-agent-site-build - warmup iteration 1/1 returned artifact \"visual_comparison_dir\" with empty path".to_string(),
+            &args,
+        );
+
+        assert!(enriched.contains("rig id `studio-bfb`"));
+        assert!(enriched.contains("component id `studio`"));
+        assert!(enriched.contains("workload id `studio-agent-site-build`"));
+        assert!(enriched.contains("scenario id `studio-agent-site-build`"));
+        assert!(enriched.contains("phase `warmup`"));
+        assert!(enriched.contains("iteration 1/1"));
+        assert!(enriched.contains("artifact key `visual_comparison_dir`"));
+        assert!(enriched.contains("Omit optional artifacts"));
+        assert!(enriched.contains("real diagnostics file/directory"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Validate empty bench artifact paths after parsing with component, workload/scenario, phase, iteration, artifact key, and rig context when available.
- Enrich runner failure stderr for warmup/iteration empty artifact path failures with the same bench context and contract guidance.
- Cover warmup failure rendering, measured iteration artifact validation, rig-context diagnostics, and unchanged valid artifact parsing.

Fixes #2220

## Tests
- `cargo test rejects_empty`
- `cargo test selected_scenario_workload_failure_preserves_runner_error`
- `cargo test bench`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the scoped implementation and tests; Chris remains responsible for review and validation.