### PR TITLE
fix(trace): baseline temporal assertions

### DIFF
--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -365,16 +365,18 @@ The bundle contains `baseline.json`, `variant.json`, `compare.json`, and `summar
 
 Use `--report=markdown` to render a skim-friendly report from the same trace run. The report includes status, span table, assertions, artifacts, and timeline events.
 
-## Span Baselines
+## Trace Baselines
 
-Trace spans can use the same lifecycle flags as other baseline-aware commands:
+Trace spans and evaluated assertions can use the same lifecycle flags as other baseline-aware commands:
 
-- `--baseline` stores the current span durations in `homeboy.json` under `baselines.trace`.
-- `--ratchet` updates the stored baseline when spans improve.
+- `--baseline` stores the current span durations and evaluated assertion snapshots in `homeboy.json` under `baselines.trace`.
+- `--ratchet` updates the stored baseline when spans or assertion metrics improve.
 - `--ignore-baseline` skips comparison.
 - `--regression-threshold=<PCT>` controls the allowed duration slowdown. Default is `5`.
 - `--regression-min-delta-ms=<MS>` controls the minimum absolute slowdown before a regression can fail. Default is `50`.
 
 Both regression thresholds must trip before Homeboy fails the run. For example, `9ms -> 15ms` exceeds the default percentage threshold but stays below the default `50ms` minimum delta, so it does not fail as a trace baseline regression.
+
+Assertion baselines compare evaluated assertion status plus lower-is-better metrics when a temporal assertion exposes one, such as `count.actual`, `forbidden-event.actual`, `max-concurrent.max_observed`, `no-overlap.overlap_count`, `ordering.violation_count`, and `latency-bound` percentile values. This supports assertion-only race checks, for example stderr event counts, without requiring synthetic spans.
 
 Rig-pinned traces store separate baselines under `trace.rig.<rig-id>` so bare and rig-owned traces do not collide.

--- a/src/core/engine/baseline.rs
+++ b/src/core/engine/baseline.rs
@@ -132,12 +132,24 @@ pub fn save<M: Serialize + for<'de> Deserialize<'de>>(
 ) -> Result<PathBuf> {
     let mut known_fingerprints: Vec<String> = items.iter().map(|item| item.fingerprint()).collect();
     known_fingerprints.sort();
+    let metadata_value = serde_json::to_value(&metadata).map_err(|error| {
+        Error::internal_io(
+            format!("Failed to serialize baseline metadata: {}", error),
+            Some("baseline.save".to_string()),
+        )
+    })?;
 
     if !known_fingerprints.is_empty() {
         if let Ok(Some(existing)) = load::<M>(config) {
             let mut existing_sorted = existing.known_fingerprints.clone();
             existing_sorted.sort();
-            if existing_sorted == known_fingerprints {
+            let existing_metadata = serde_json::to_value(&existing.metadata).map_err(|error| {
+                Error::internal_io(
+                    format!("Failed to serialize existing baseline metadata: {}", error),
+                    Some("baseline.save".to_string()),
+                )
+            })?;
+            if existing_sorted == known_fingerprints && existing_metadata == metadata_value {
                 return Ok(config.json_path());
             }
         }

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::engine::baseline::{self as generic, BaselineConfig};
 use crate::error::Result;
 
-use super::parsing::TraceResults;
+use super::parsing::{TraceAssertion, TraceAssertionStatus, TraceResults};
 
 const BASELINE_KEY: &str = "trace";
 pub const DEFAULT_REGRESSION_THRESHOLD_PERCENT: f64 = 5.0;
@@ -39,8 +39,51 @@ impl generic::Fingerprintable for TraceSpanSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TraceAssertionSnapshot {
+    pub id: String,
+    pub status: TraceAssertionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric: Option<f64>,
+}
+
+impl generic::Fingerprintable for TraceAssertionSnapshot {
+    fn fingerprint(&self) -> String {
+        format!("trace-assertion:{}", self.id)
+    }
+
+    fn description(&self) -> String {
+        match self.metric {
+            Some(metric) => format!("{:?} ({metric:.2})", self.status),
+            None => format!("{:?}", self.status),
+        }
+    }
+
+    fn context_label(&self) -> String {
+        format!("trace assertion {}", self.id)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TraceAssertionDelta {
+    pub id: String,
+    pub baseline_status: TraceAssertionStatus,
+    pub current_status: TraceAssertionStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_metric: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_metric: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metric_delta: Option<f64>,
+    pub regression: bool,
+    pub improvement: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TraceBaselineMetadata {
+    #[serde(default)]
     pub spans: Vec<TraceSpanSnapshot>,
+    #[serde(default)]
+    pub assertions: Vec<TraceAssertionSnapshot>,
 }
 
 pub type TraceBaseline = generic::Baseline<TraceBaselineMetadata>;
@@ -62,8 +105,14 @@ pub struct TraceBaselineComparison {
     pub threshold_percent: f64,
     pub min_delta_ms: u64,
     pub spans: Vec<TraceSpanDelta>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub assertions: Vec<TraceAssertionDelta>,
     pub new_span_ids: Vec<String>,
     pub removed_span_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub new_assertion_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_assertion_ids: Vec<String>,
     pub regression: bool,
     pub has_improvements: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -77,12 +126,17 @@ pub fn save_baseline(
     rig_id: Option<&str>,
 ) -> Result<std::path::PathBuf> {
     let snapshots = snapshots_from_results(results);
+    let assertion_snapshots = assertion_snapshots_from_results(results);
+    let mut items = Vec::with_capacity(snapshots.len() + assertion_snapshots.len());
+    items.extend(snapshots.iter().map(TraceBaselineItem::Span));
+    items.extend(assertion_snapshots.iter().map(TraceBaselineItem::Assertion));
     let metadata = TraceBaselineMetadata {
         spans: snapshots.clone(),
+        assertions: assertion_snapshots.clone(),
     };
     let key = baseline_key_for(rig_id);
     let config = BaselineConfig::new(source_path, key);
-    generic::save(&config, component_id, &snapshots, metadata)
+    generic::save(&config, component_id, &items, metadata)
 }
 
 pub fn load_baseline(source_path: &Path, rig_id: Option<&str>) -> Option<TraceBaseline> {
@@ -108,9 +162,23 @@ pub fn compare(
         .iter()
         .map(|span| (span.id.as_str(), span))
         .collect();
+    let current_assertion_snapshots = assertion_snapshots_from_results(current);
+    let baseline_assertions_by_id: HashMap<&str, &TraceAssertionSnapshot> = baseline
+        .metadata
+        .assertions
+        .iter()
+        .map(|assertion| (assertion.id.as_str(), assertion))
+        .collect();
+    let current_assertions_by_id: HashMap<&str, &TraceAssertionSnapshot> =
+        current_assertion_snapshots
+            .iter()
+            .map(|assertion| (assertion.id.as_str(), assertion))
+            .collect();
 
     let mut spans = Vec::new();
+    let mut assertions = Vec::new();
     let mut new_span_ids = Vec::new();
+    let mut new_assertion_ids = Vec::new();
     let mut reasons = Vec::new();
     let mut regression = false;
     let mut has_improvements = false;
@@ -152,6 +220,51 @@ pub fn compare(
         });
     }
 
+    for current_assertion in &current_assertion_snapshots {
+        let Some(prior) = baseline_assertions_by_id.get(current_assertion.id.as_str()) else {
+            new_assertion_ids.push(current_assertion.id.clone());
+            continue;
+        };
+        let metric_delta = current_assertion
+            .metric
+            .zip(prior.metric)
+            .map(|(current, baseline)| current - baseline);
+        let status_regression = prior.status == TraceAssertionStatus::Pass
+            && current_assertion.status != TraceAssertionStatus::Pass;
+        let metric_regression = metric_delta.is_some_and(|delta| delta > 0.0);
+        let assertion_regression = status_regression || metric_regression;
+        let assertion_improvement = (prior.status != TraceAssertionStatus::Pass
+            && current_assertion.status == TraceAssertionStatus::Pass)
+            || metric_delta.is_some_and(|delta| delta < 0.0);
+        if assertion_regression {
+            regression = true;
+            if status_regression {
+                reasons.push(format!(
+                    "{} assertion regressed from {:?} to {:?}",
+                    current_assertion.id, prior.status, current_assertion.status
+                ));
+            } else if let Some(delta) = metric_delta {
+                reasons.push(format!(
+                    "{} assertion metric regressed by {:.2}",
+                    current_assertion.id, delta
+                ));
+            }
+        }
+        if assertion_improvement {
+            has_improvements = true;
+        }
+        assertions.push(TraceAssertionDelta {
+            id: current_assertion.id.clone(),
+            baseline_status: prior.status.clone(),
+            current_status: current_assertion.status.clone(),
+            baseline_metric: prior.metric,
+            current_metric: current_assertion.metric,
+            metric_delta,
+            regression: assertion_regression,
+            improvement: assertion_improvement,
+        });
+    }
+
     let removed_span_ids = baseline
         .metadata
         .spans
@@ -159,13 +272,23 @@ pub fn compare(
         .filter(|span| !current_by_id.contains_key(span.id.as_str()))
         .map(|span| span.id.clone())
         .collect();
+    let removed_assertion_ids = baseline
+        .metadata
+        .assertions
+        .iter()
+        .filter(|assertion| !current_assertions_by_id.contains_key(assertion.id.as_str()))
+        .map(|assertion| assertion.id.clone())
+        .collect();
 
     TraceBaselineComparison {
         threshold_percent,
         min_delta_ms,
         spans,
+        assertions,
         new_span_ids,
         removed_span_ids,
+        new_assertion_ids,
+        removed_assertion_ids,
         regression,
         has_improvements,
         reasons,
@@ -185,10 +308,68 @@ fn snapshots_from_results(results: &TraceResults) -> Vec<TraceSpanSnapshot> {
         .collect()
 }
 
+fn assertion_snapshots_from_results(results: &TraceResults) -> Vec<TraceAssertionSnapshot> {
+    results
+        .assertions
+        .iter()
+        .map(|assertion| TraceAssertionSnapshot {
+            id: assertion.id.clone(),
+            status: assertion.status.clone(),
+            metric: assertion_metric(assertion),
+        })
+        .collect()
+}
+
+fn assertion_metric(assertion: &TraceAssertion) -> Option<f64> {
+    let details = assertion.details.as_ref()?;
+    match details.get("kind")?.as_str()? {
+        "count" | "forbidden-event" => details.get("actual")?.as_f64(),
+        "max-concurrent" => details.get("max_observed")?.as_f64(),
+        "no-overlap" => details.get("overlap_count")?.as_f64(),
+        "ordering" => details.get("violation_count")?.as_f64(),
+        "latency-bound" => details
+            .get("actual_p95_ms")
+            .or_else(|| details.get("actual_p99_ms"))
+            .or_else(|| details.get("actual_p50_ms"))?
+            .as_f64(),
+        _ => None,
+    }
+}
+
+enum TraceBaselineItem<'a> {
+    Span(&'a TraceSpanSnapshot),
+    Assertion(&'a TraceAssertionSnapshot),
+}
+
+impl generic::Fingerprintable for TraceBaselineItem<'_> {
+    fn fingerprint(&self) -> String {
+        match self {
+            TraceBaselineItem::Span(span) => span.fingerprint(),
+            TraceBaselineItem::Assertion(assertion) => assertion.fingerprint(),
+        }
+    }
+
+    fn description(&self) -> String {
+        match self {
+            TraceBaselineItem::Span(span) => span.description(),
+            TraceBaselineItem::Assertion(assertion) => assertion.description(),
+        }
+    }
+
+    fn context_label(&self) -> String {
+        match self {
+            TraceBaselineItem::Span(span) => span.context_label(),
+            TraceBaselineItem::Assertion(assertion) => assertion.context_label(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::trace::parsing::{TraceSpanResult, TraceSpanStatus, TraceStatus};
+    use crate::extension::trace::parsing::{
+        TraceAssertion, TraceSpanResult, TraceSpanStatus, TraceStatus,
+    };
 
     fn results(duration_ms: u64) -> TraceResults {
         TraceResults {
@@ -229,6 +410,7 @@ mod tests {
                     id: "submit_to_cli".to_string(),
                     duration_ms: 100,
                 }],
+                assertions: Vec::new(),
             },
         };
 
@@ -256,6 +438,7 @@ mod tests {
                     id: "submit_to_cli".to_string(),
                     duration_ms: 9,
                 }],
+                assertions: Vec::new(),
             },
         };
 
@@ -281,6 +464,94 @@ mod tests {
         let loaded = load_baseline(temp.path(), None).expect("baseline loads");
         assert_eq!(loaded.metadata.spans[0].id, "submit_to_cli");
         assert_eq!(loaded.known_fingerprints[0], "trace-span:submit_to_cli");
+    }
+
+    #[test]
+    fn test_compare_assertion_metric_regression() {
+        let baseline = TraceBaseline {
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            context_id: "studio".to_string(),
+            item_count: 1,
+            known_fingerprints: vec!["trace-assertion:invalid-grant-count".to_string()],
+            metadata: TraceBaselineMetadata {
+                spans: Vec::new(),
+                assertions: vec![TraceAssertionSnapshot {
+                    id: "invalid-grant-count".to_string(),
+                    status: TraceAssertionStatus::Pass,
+                    metric: Some(0.0),
+                }],
+            },
+        };
+        let mut current = results(100);
+        current.span_results.clear();
+        current.assertions.push(TraceAssertion {
+            id: "invalid-grant-count".to_string(),
+            status: TraceAssertionStatus::Pass,
+            message: None,
+            details: Some(serde_json::json!({
+                "kind": "count",
+                "actual": 1,
+            })),
+        });
+
+        let comparison = compare(&current, &baseline, 5.0, DEFAULT_REGRESSION_MIN_DELTA_MS);
+
+        assert!(comparison.regression);
+        assert_eq!(comparison.assertions[0].metric_delta, Some(1.0));
+        assert!(comparison.assertions[0].regression);
+    }
+
+    #[test]
+    fn test_save_baseline_includes_assertions() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut current = results(100);
+        current.span_results.clear();
+        current.assertions.push(TraceAssertion {
+            id: "no-invalid-grant".to_string(),
+            status: TraceAssertionStatus::Pass,
+            message: None,
+            details: Some(serde_json::json!({
+                "kind": "forbidden-event",
+                "actual": 0,
+            })),
+        });
+
+        save_baseline(temp.path(), "studio", &current, None).unwrap();
+
+        let loaded = load_baseline(temp.path(), None).expect("baseline loads");
+        assert!(loaded.metadata.spans.is_empty());
+        assert_eq!(loaded.metadata.assertions[0].id, "no-invalid-grant");
+        assert_eq!(loaded.metadata.assertions[0].metric, Some(0.0));
+        assert_eq!(
+            loaded.known_fingerprints[0],
+            "trace-assertion:no-invalid-grant"
+        );
+    }
+
+    #[test]
+    fn test_save_baseline_updates_assertion_metadata_for_same_fingerprint() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut current = results(100);
+        current.span_results.clear();
+        current.assertions.push(TraceAssertion {
+            id: "invalid-grant-count".to_string(),
+            status: TraceAssertionStatus::Pass,
+            message: None,
+            details: Some(serde_json::json!({
+                "kind": "count",
+                "actual": 2,
+            })),
+        });
+        save_baseline(temp.path(), "studio", &current, None).unwrap();
+
+        current.assertions[0].details = Some(serde_json::json!({
+            "kind": "count",
+            "actual": 0,
+        }));
+        save_baseline(temp.path(), "studio", &current, None).unwrap();
+
+        let loaded = load_baseline(temp.path(), None).expect("baseline loads");
+        assert_eq!(loaded.metadata.assertions[0].metric, Some(0.0));
     }
 
     #[test]

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -313,17 +313,17 @@ fn run_trace_workflow_with_context(
     let mut baseline_comparison = None;
     let mut baseline_exit_override = None;
     let mut hints = Vec::new();
-    let has_span_results = results
+    let has_baseline_items = results
         .as_ref()
-        .is_some_and(|parsed| !parsed.span_results.is_empty());
+        .is_some_and(|parsed| !parsed.span_results.is_empty() || !parsed.assertions.is_empty());
 
-    if args.baseline_flags.baseline && status == "pass" && has_span_results {
+    if args.baseline_flags.baseline && status == "pass" && has_baseline_items {
         if let Some(ref parsed) = results {
             let _ =
                 super::baseline::save_baseline(source_path, &args.component_id, parsed, rig_id)?;
         }
     }
-    if has_span_results && !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
+    if has_baseline_items && !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
         if let Some(ref parsed) = results {
             if let Some(existing) = super::baseline::load_baseline(source_path, rig_id) {
                 let comparison = super::baseline::compare(
@@ -354,15 +354,15 @@ fn run_trace_workflow_with_context(
         ),
         None => format!("homeboy trace {} {}", args.component_id, args.scenario_id),
     };
-    if has_span_results && !args.baseline_flags.baseline && baseline_comparison.is_none() {
+    if has_baseline_items && !args.baseline_flags.baseline && baseline_comparison.is_none() {
         hints.push(format!(
-            "Save trace span baseline: {} --baseline",
+            "Save trace baseline: {} --baseline",
             trace_invocation
         ));
     }
     if baseline_comparison.is_some() && !args.baseline_flags.ratchet {
         hints.push(format!(
-            "Auto-update trace span baseline on improvement: {} --ratchet",
+            "Auto-update trace baseline on improvement: {} --ratchet",
             trace_invocation
         ));
     }


### PR DESCRIPTION
## Summary
- Store evaluated trace assertions alongside span snapshots in trace baselines.
- Compare assertion status and lower-is-better assertion metrics so assertion-only race checks can use `--baseline` and `--ratchet`.
- Allow generic baseline saves to update metadata when fingerprints stay the same but measured values improve.

## Validation
- `cargo fmt --check`
- `cargo test core::extension::trace --lib`
- `cargo test core::extension::bench::baseline --lib`
- `cargo test core::extension::test::baseline --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating and implementing the Homeboy temporal-assertions gap; Chris remains responsible for review and merge.