### PR TITLE
fix(trace): collect file watch events for fswatch attachments

### DIFF
--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -98,7 +98,7 @@ Trace runners also receive trace-specific variables when invoked by `homeboy tra
 | `HOMEBOY_TRACE_ARTIFACT_DIR` | core | Directory for runner artifacts |
 | `HOMEBOY_TRACE_ATTACHMENTS` | CLI | JSON array of observation-only attach targets from repeatable `--attach KIND:TARGET` |
 
-`HOMEBOY_TRACE_ATTACHMENTS` v1 supports local `logfile`, `fswatch`, `pid`, `port`, and `http` targets. HTTP attachments accept `http:<url>` or a direct `http://` / `https://` URL. Core observes attachments before and after the scenario and writes timeline events plus an attachment observation artifact in the run directory; runners may also read the same JSON to correlate their own scenario events. `fswatch:<path>` is a safe file metadata snapshot in v1, not a streaming filesystem event probe. Attachments are explicitly observation-only: runners and core must not start, stop, restart, or kill attached targets as part of attach handling.
+`HOMEBOY_TRACE_ATTACHMENTS` v1 supports local `logfile`, `fswatch`, `pid`, `port`, and `http` targets. HTTP attachments accept `http:<url>` or a direct `http://` / `https://` URL. Core observes attachments before and after the scenario and writes timeline events plus an attachment observation artifact in the run directory; runners may also read the same JSON to correlate their own scenario events. `fswatch:<path>` keeps the safe file metadata snapshots and also starts the same passive polling `file.watch` probe used by rig workloads, deduplicated against explicit rig probes for the same path. Attachments are explicitly observation-only: runners and core must not start, stop, restart, or kill attached targets as part of attach handling.
 
 ## Core-provided runtime helpers
 
@@ -284,7 +284,7 @@ artifacts, version targets) — see [release-pipeline.md](release-pipeline.md).
 
 Invokes `trace.extension_script` with the trace-specific sidecar and artifact variables documented above. The runner drives the requested scenario and writes a trace results envelope to `HOMEBOY_TRACE_RESULTS_FILE`.
 
-When `--attach` is present, core observes the declared already-running local targets before and after the runner executes. This augments the trace evidence but does not replace the scenario: the extension script still runs normally, and attach handling does not own the target lifecycle.
+When `--attach` is present, core observes the declared already-running local targets before and after the runner executes. `fswatch` attachments also collect passive `file.watch` timeline events during the run. This augments the trace evidence but does not replace the scenario: the extension script still runs normally, and attach handling does not own the target lifecycle.
 
 ### `homeboy audit`
 

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -96,7 +96,7 @@ Use repeatable `--attach KIND:TARGET` flags to observe already-running local sys
 Supported v1 attachment kinds:
 
 - `logfile:<path>` records whether the file exists and its byte length before and after the scenario.
-- `fswatch:<path>` records whether a watched file exists, its byte length, and its last-modified timestamp before and after the scenario. V1 is a safe snapshot, not a streaming filesystem event probe.
+- `fswatch:<path>` records whether a watched file exists, its byte length, and its last-modified timestamp before and after the scenario. It also enables the same passive `file.watch` probe used by rig workloads, so creates, writes, and deletes observed during the scenario are emitted as `file.watch.fs.*` timeline events. V1 is polling-based and does not attribute the writer PID.
 - `pid:<n>` records whether a local process exists before and after the scenario.
 - `port:<n>` checks whether `127.0.0.1:<n>` accepts TCP connections before and after the scenario.
 - `http:<url>` or a direct `http://` / `https://` URL performs a local HTTP GET before and after the scenario and records the response status or connection error.
@@ -111,7 +111,7 @@ homeboy trace wp-coding-agents auth-multi-session-race \
   --attach http://127.0.0.1:46227/health
 ```
 
-Core also exports the parsed attachments to the runner through `HOMEBOY_TRACE_ATTACHMENTS` so extension-owned scenarios can correlate their own events with the same observation surfaces. V1 intentionally omits `systemd:` and remote attach targets; those require reliable platform-specific probes.
+Core also exports the parsed attachments to the runner through `HOMEBOY_TRACE_ATTACHMENTS` so extension-owned scenarios can correlate their own events with the same observation surfaces. `fswatch` attachments are deduplicated with explicit `file.watch` rig probes for the same path. V1 intentionally omits `systemd:` and remote attach targets; those require reliable platform-specific probes.
 
 ## Spans
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -248,7 +248,11 @@ fn run_trace_workflow_with_context(
         Some(acquire_trace_overlay_locks(&args.overlays, run_dir)?)
     };
     let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
-    let active_probes = ActiveTraceProbes::start(&args.runner_inputs.probes)?;
+    let probe_configs = trace_probes_with_fswatch_attachments(
+        &args.runner_inputs.probes,
+        &args.runner_inputs.attachments,
+    );
+    let active_probes = ActiveTraceProbes::start(&probe_configs)?;
     let started_at = Instant::now();
     let mut attach_observations =
         observe_trace_attachments(&args.runner_inputs.attachments, "before", started_at);
@@ -624,6 +628,29 @@ pub fn trace_is_unclaimed(error: &Error) -> bool {
                 .contains("has no linked extensions that provide trace support"))
 }
 
+fn trace_probes_with_fswatch_attachments(
+    probes: &[TraceProbeConfig],
+    attachments: &[TraceAttachment],
+) -> Vec<TraceProbeConfig> {
+    let mut merged = probes.to_vec();
+    for attachment in attachments {
+        if attachment.kind != "fswatch" {
+            continue;
+        }
+        let already_watched = merged.iter().any(|probe| match probe {
+            TraceProbeConfig::FileWatch { path, .. } => path == &attachment.target,
+            _ => false,
+        });
+        if !already_watched {
+            merged.push(TraceProbeConfig::FileWatch {
+                path: attachment.target.clone(),
+                interval_ms: None,
+            });
+        }
+    }
+    merged
+}
+
 fn run_generic_trace_runner(
     component: &Component,
     args: &TraceRunWorkflowArgs,
@@ -959,6 +986,28 @@ mod tests {
             serde_json::json!({}),
         );
         assert!(trace_is_unclaimed(&unsupported));
+    }
+
+    #[test]
+    fn fswatch_attachments_add_file_watch_probes_without_duplicates() {
+        let attachment = TraceAttachment::parse("fswatch:/tmp/auth.json").unwrap();
+        let existing_probe = TraceProbeConfig::FileWatch {
+            path: "/tmp/auth.json".to_string(),
+            interval_ms: Some(50),
+        };
+
+        let merged =
+            trace_probes_with_fswatch_attachments(&[existing_probe.clone()], &[attachment.clone()]);
+        assert_eq!(merged, vec![existing_probe]);
+
+        let merged = trace_probes_with_fswatch_attachments(&[], &[attachment]);
+        assert_eq!(
+            merged,
+            vec![TraceProbeConfig::FileWatch {
+                path: "/tmp/auth.json".to_string(),
+                interval_ms: None,
+            }]
+        );
     }
 
     fn test_component(path: &std::path::Path) -> Component {


### PR DESCRIPTION
## Summary
- Starts the existing passive `file.watch` probe automatically for `fswatch:<path>` trace attachments.
- Keeps the before/after attachment snapshots and deduplicates against explicit rig `file.watch` probes for the same path.
- Updates trace docs and runner contract wording to clarify the polling-based live file events and remaining non-goals.

Refs #2166.

## Testing
- `cargo fmt`
- `cargo test core::extension::trace::run::tests::fswatch_attachments_add_file_watch_probes_without_duplicates`
- `cargo test core::extension::trace::attach::tests`
- `cargo test core::extension::trace::probes::file_watch::tests`
- `cargo test core::extension::trace::run::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating and implementing the Homeboy trace-attach gap; Chris remains responsible for review and merge.