### PR TITLE
fix: prevent orphan tags from dep-refresh release cascade (#2234)

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -90,6 +90,15 @@ fn step_skipped(
 /// Populates [`ReleaseState::version`], [`tag`][ReleaseState::tag] (default
 /// `v{version}`), and [`notes`][ReleaseState::notes] from the just-written
 /// changelog section.
+///
+/// After the bump, every version target is re-read from disk and compared to
+/// the new version. If any target wasn't updated, the step is marked Failed
+/// so downstream steps (commit, tag, push) bail out before producing the
+/// orphan-tag pattern from issue #2234 — a tag pushed onto an unbumped
+/// commit. Without this invariant a silent no-op bump (e.g. a regression in
+/// the changelog finalization path that swallows the version write) leaves
+/// `state.version` advanced in memory while the working tree stays clean,
+/// `git.commit` skips, and `git.tag` lands on the wrong commit.
 pub(crate) fn run_version(
     component: &Component,
     state: &mut ReleaseState,
@@ -100,11 +109,155 @@ pub(crate) fn run_version(
     let data = serde_json::to_value(&result)
         .map_err(|e| Error::internal_json(e.to_string(), Some("version output".to_string())))?;
 
+    if let Some(mismatches) = collect_version_target_mismatches(component, &result.new_version) {
+        let error_msg = format!(
+            "Version bump verification failed: {} target(s) on disk are not at {} after bump_component_version: {}. \
+             Refusing to continue — tagging now would create an orphan tag (no release: commit, no version-file bump). See issue #2234.",
+            mismatches.len(),
+            result.new_version,
+            mismatches
+                .iter()
+                .map(|m| format!("{} = {}", m.file, m.found.as_deref().unwrap_or("<unreadable>")))
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+        let mut failure_data = data;
+        failure_data["mismatches"] = serde_json::to_value(&mismatches).unwrap_or_default();
+        failure_data["new_version"] = serde_json::Value::String(result.new_version.clone());
+        return Ok(step_failed(
+            "version",
+            "version",
+            Some(failure_data),
+            Some(error_msg),
+            vec![crate::error::Hint {
+                message: "If a previous run partially bumped this component, run `homeboy release <component> --recover` to finish it cleanly.".to_string(),
+            }],
+        ));
+    }
+
     state.version = Some(result.new_version.clone());
     state.tag = Some(format!("v{}", result.new_version));
     state.notes = Some(load_release_notes(component)?);
 
     Ok(step_success("version", "version", Some(data), Vec::new()))
+}
+
+#[derive(Debug, serde::Serialize)]
+struct VersionTargetMismatch {
+    file: String,
+    expected: String,
+    found: Option<String>,
+}
+
+/// Re-read every version target from disk and return any that don't show
+/// `expected_version`. Returns `None` when every target matches (the success
+/// case). Returns `Some(non_empty_vec)` when at least one target failed to
+/// update — caller treats that as a failed bump.
+///
+/// This is a defense-in-depth check around `bump_component_version`: if any
+/// upstream change ever causes the function to return Ok without actually
+/// writing every target, this catches it before `state.version` advances.
+fn collect_version_target_mismatches(
+    component: &Component,
+    expected_version: &str,
+) -> Option<Vec<VersionTargetMismatch>> {
+    let targets = component.version_targets.as_ref()?;
+    if targets.is_empty() {
+        return None;
+    }
+
+    let mut mismatches = Vec::new();
+    for target in targets {
+        let found = version::read_local_version(&component.local_path, target);
+        if found.as_deref() != Some(expected_version) {
+            mismatches.push(VersionTargetMismatch {
+                file: target.file.clone(),
+                expected: expected_version.to_string(),
+                found,
+            });
+        }
+    }
+
+    if mismatches.is_empty() {
+        None
+    } else {
+        Some(mismatches)
+    }
+}
+
+/// Re-read every version target from HEAD's tree (not the working tree) and
+/// return any that don't show `expected_version`. Returns `None` when every
+/// target matches.
+///
+/// Used as the final gate before `git.tag` — confirms the version bump was
+/// actually committed, not just written to the working tree. This catches
+/// the orphan-tag pattern even if `git.commit` is somehow skipped or amended
+/// to the wrong commit.
+fn collect_head_version_mismatches(
+    component: &Component,
+    expected_version: &str,
+) -> Option<Vec<VersionTargetMismatch>> {
+    let targets = component.version_targets.as_ref()?;
+    if targets.is_empty() {
+        return None;
+    }
+
+    let mut mismatches = Vec::new();
+    for target in targets {
+        let found = read_version_at_head(component, target);
+        if found.as_deref() != Some(expected_version) {
+            mismatches.push(VersionTargetMismatch {
+                file: target.file.clone(),
+                expected: expected_version.to_string(),
+                found,
+            });
+        }
+    }
+
+    if mismatches.is_empty() {
+        None
+    } else {
+        Some(mismatches)
+    }
+}
+
+/// Read a version target's content from `HEAD` (committed tree) and parse
+/// the version string out of it. Returns `None` if the file is missing at
+/// HEAD, the git command fails, or the content can't be parsed.
+fn read_version_at_head(
+    component: &Component,
+    target: &crate::component::VersionTarget,
+) -> Option<String> {
+    use crate::release::version::{
+        default_pattern_for_file, parse_version, resolve_version_file_path,
+    };
+
+    let pattern = target
+        .pattern
+        .clone()
+        .or_else(|| default_pattern_for_file(&target.file))?;
+
+    // Resolve the path the same way bump_component_version does, then make it
+    // repo-relative for `git show HEAD:<rel>`. `git show` requires forward
+    // slashes and rejects absolute paths.
+    let full_path = resolve_version_file_path(&component.local_path, &target.file);
+    let local_root = std::path::Path::new(&component.local_path);
+    let rel_path = std::path::Path::new(&full_path)
+        .strip_prefix(local_root)
+        .ok()?
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    let spec = format!("HEAD:{}", rel_path);
+    let output =
+        crate::git::execute_git_for_release(&component.local_path, &["show", &spec]).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let content = String::from_utf8(output.stdout).ok()?;
+    let normalized_pattern = crate::component::normalize_version_pattern(&pattern);
+    parse_version(&content, &normalized_pattern)
 }
 
 /// Commit any staged release artifacts (changelog/version files). Amends the
@@ -180,12 +333,50 @@ pub(crate) fn run_git_commit(
 /// to HEAD; errors when it exists but points elsewhere. Updates
 /// [`ReleaseState::tag`] to the final tag name (may have been overridden by
 /// the caller for monorepo components).
+///
+/// Final invariant before tagging: HEAD's tree must contain every version
+/// target at `state.version`. If HEAD wasn't updated to the new version
+/// (orphan-tag pattern from issue #2234), the step fails *before* creating
+/// the tag instead of pushing a tag onto the wrong commit.
 pub(crate) fn run_git_tag(
     component: &Component,
     component_id: &str,
     state: &mut ReleaseState,
     tag_name: &str,
 ) -> Result<ReleaseStepResult> {
+    if let Some(version) = state.version.as_deref() {
+        if let Some(mismatches) = collect_head_version_mismatches(component, version) {
+            let error_msg = format!(
+                "Tag invariant failed: HEAD does not show version {} for {} target(s): {}. \
+                 Refusing to create tag {} on the wrong commit (would produce the orphan-tag pattern from issue #2234).",
+                version,
+                mismatches.len(),
+                mismatches
+                    .iter()
+                    .map(|m| format!("{} = {}", m.file, m.found.as_deref().unwrap_or("<unreadable>")))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+                tag_name,
+            );
+            return Ok(step_failed(
+                "git.tag",
+                "git.tag",
+                Some(serde_json::json!({
+                    "tag": tag_name,
+                    "expected_version": version,
+                    "mismatches": mismatches,
+                })),
+                Some(error_msg),
+                vec![crate::error::Hint {
+                    message: format!(
+                        "Inspect the failed bump: `git status` then `git log -1`. To finish a partial release, run `homeboy release {} --recover`.",
+                        component_id
+                    ),
+                }],
+            ));
+        }
+    }
+
     if crate::git::tag_exists_locally(&component.local_path, tag_name).unwrap_or(false) {
         let tag_commit = crate::git::get_tag_commit(&component.local_path, tag_name)?;
         let head_commit = crate::git::get_head_commit(&component.local_path)?;
@@ -1023,5 +1214,139 @@ mod tests {
         let result = publish_step_result("publish.npm", "npm", "npm", None, &response);
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
+    }
+
+    // ----- Orphan-tag regression coverage (issue #2234) -----
+
+    use super::{collect_head_version_mismatches, collect_version_target_mismatches, run_git_tag};
+    use crate::component::VersionTarget;
+    use crate::release::types::ReleaseState;
+
+    fn run_in(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+        let output = std::process::Command::new(args[0])
+            .args(&args[1..])
+            .current_dir(dir)
+            .output()
+            .expect("spawn command");
+        assert!(
+            output.status.success(),
+            "command {:?} failed: stdout={:?} stderr={:?}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        output
+    }
+
+    /// Fixture: a git repo with one committed plugin header file at version
+    /// `committed_version`. The working tree is clean. Returns (temp, component).
+    fn plugin_repo_at(committed_version: &str) -> (tempfile::TempDir, Component) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_in(dir, &["git", "init", "-q"]);
+        run_in(dir, &["git", "config", "user.email", "test@example.com"]);
+        run_in(dir, &["git", "config", "user.name", "Test"]);
+        run_in(dir, &["git", "config", "commit.gpgsign", "false"]);
+
+        let plugin = format!(
+            "<?php\n/*\nPlugin Name: Fixture\nVersion: {}\n*/\n",
+            committed_version
+        );
+        std::fs::write(dir.join("plugin.php"), plugin).expect("write plugin");
+        run_in(dir, &["git", "add", "."]);
+        run_in(dir, &["git", "commit", "-q", "-m", "Initial commit"]);
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            version_targets: Some(vec![VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"(?:Version|version)[:=]\s+([0-9]+\.[0-9]+\.[0-9]+)".to_string()),
+            }]),
+            ..Component::default()
+        };
+        (temp, component)
+    }
+
+    #[test]
+    fn collect_version_target_mismatches_returns_none_when_disk_matches_expected() {
+        let (_temp, component) = plugin_repo_at("0.6.13");
+        assert!(collect_version_target_mismatches(&component, "0.6.13").is_none());
+    }
+
+    #[test]
+    fn collect_version_target_mismatches_flags_unbumped_target() {
+        let (_temp, component) = plugin_repo_at("0.6.12");
+        let mismatches = collect_version_target_mismatches(&component, "0.6.13")
+            .expect("expected mismatch on stale version file");
+        assert_eq!(mismatches.len(), 1);
+        assert_eq!(mismatches[0].file, "plugin.php");
+        assert_eq!(mismatches[0].expected, "0.6.13");
+        assert_eq!(mismatches[0].found.as_deref(), Some("0.6.12"));
+    }
+
+    #[test]
+    fn collect_head_version_mismatches_flags_when_head_lacks_new_version() {
+        // HEAD has 0.6.12 committed, but state.version is 0.6.13.
+        // Working tree is also at 0.6.12 (no bump happened). HEAD check fires.
+        let (_temp, component) = plugin_repo_at("0.6.12");
+        let mismatches = collect_head_version_mismatches(&component, "0.6.13")
+            .expect("HEAD should not show 0.6.13");
+        assert_eq!(mismatches.len(), 1);
+        assert_eq!(mismatches[0].found.as_deref(), Some("0.6.12"));
+    }
+
+    #[test]
+    fn collect_head_version_mismatches_returns_none_when_head_matches() {
+        let (_temp, component) = plugin_repo_at("0.6.13");
+        assert!(collect_head_version_mismatches(&component, "0.6.13").is_none());
+    }
+
+    #[test]
+    fn git_tag_step_refuses_to_tag_when_head_lacks_new_version() {
+        // The orphan-tag scenario from issue #2234: the in-memory state.version
+        // says 0.6.13, but HEAD's plugin.php still reads 0.6.12. Without the
+        // invariant check this would happily push a tag onto the wrong commit.
+        let (_temp, component) = plugin_repo_at("0.6.12");
+        let mut state = ReleaseState {
+            version: Some("0.6.13".to_string()),
+            tag: Some("v0.6.13".to_string()),
+            ..ReleaseState::default()
+        };
+
+        let result = run_git_tag(&component, "fixture", &mut state, "v0.6.13")
+            .expect("step should return a result, not propagate Err");
+
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        let err = result.error.expect("expected failure error");
+        assert!(
+            err.contains("issue #2234"),
+            "expected #2234 reference in error, got: {}",
+            err
+        );
+        assert!(err.contains("v0.6.13"), "error should name the tag");
+        assert!(
+            !crate::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(true),
+            "tag must NOT have been created when invariant fails"
+        );
+    }
+
+    #[test]
+    fn git_tag_step_creates_tag_when_head_matches_state_version() {
+        let (_temp, component) = plugin_repo_at("0.6.13");
+        let mut state = ReleaseState {
+            version: Some("0.6.13".to_string()),
+            tag: Some("v0.6.13".to_string()),
+            ..ReleaseState::default()
+        };
+
+        let result = run_git_tag(&component, "fixture", &mut state, "v0.6.13")
+            .expect("step should succeed when HEAD shows the bumped version");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert!(
+            crate::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(false),
+            "tag should have been created on HEAD"
+        );
     }
 }

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -591,6 +591,18 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
     let current_version = &version_info.version;
     let tag_name = format_tag(current_version, monorepo.as_ref());
 
+    // Surface the orphan-tag pattern from issue #2234. When the latest release
+    // tag points at a commit whose subject is *not* `release: vX.Y.Z`, the
+    // previous release was botched (tag without bump). Recover should warn
+    // loudly so the operator can decide whether to delete the orphan tag, hand
+    // back-fill a release: commit, or run `--recover` to commit the version
+    // files at the tagged commit.
+    if let Some(latest_tag) = latest_release_tag(&component.local_path, monorepo.as_ref()) {
+        if let Some(diagnostic) = diagnose_orphan_tag(&component.local_path, &latest_tag) {
+            log_status!("recover", "{}", diagnostic);
+        }
+    }
+
     let tag_exists_local =
         git::tag_exists_locally(&component.local_path, &tag_name).unwrap_or(false);
     let tag_exists_remote =
@@ -684,6 +696,53 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             deployment: None,
         },
         0,
+    ))
+}
+
+/// Resolve the most recent release-shaped tag for the component, honoring
+/// monorepo prefixes. Returns `None` if no matching tag is found.
+fn latest_release_tag(local_path: &str, monorepo: Option<&git::MonorepoContext>) -> Option<String> {
+    match monorepo {
+        Some(ctx) => git::get_latest_tag_with_prefix(&ctx.git_root, Some(&ctx.tag_prefix)).ok()?,
+        None => git::get_latest_tag(local_path).ok()?,
+    }
+}
+
+/// Inspect the latest release tag for the orphan-tag pattern (#2234): a tag
+/// whose tagged commit subject is not `release: vX.Y.Z`. Returns a one-line
+/// warning when the tag looks orphaned, otherwise `None`.
+///
+/// This is intentionally a soft warning — `--recover` may still be the
+/// right move (re-commit the working tree), but the operator deserves to
+/// know they're recovering on top of a misplaced tag before they push more
+/// state to origin.
+fn diagnose_orphan_tag(local_path: &str, tag: &str) -> Option<String> {
+    let tag_commit = git::get_tag_commit(local_path, tag).ok()?;
+    let subject_output =
+        git::execute_git_for_release(local_path, &["log", "-1", "--format=%s", &tag_commit])
+            .ok()?;
+    if !subject_output.status.success() {
+        return None;
+    }
+    let subject = String::from_utf8_lossy(&subject_output.stdout)
+        .trim()
+        .to_string();
+
+    if subject.starts_with("release: v") || subject.starts_with("release:v") {
+        return None;
+    }
+
+    Some(format!(
+        "⚠ Latest tag {} points at commit {} ({}) — not a `release: v...` commit. \
+         This matches the orphan-tag pattern from issue #2234. Inspect the tag/commit before recovering: \
+         `git show {}`. To delete a misplaced tag locally and on origin: \
+         `git tag -d {} && git push origin :refs/tags/{}`",
+        tag,
+        &tag_commit[..8.min(tag_commit.len())],
+        subject,
+        tag,
+        tag,
+        tag,
     ))
 }
 
@@ -989,5 +1048,63 @@ mod tests {
         };
 
         assert!(has_post_release_warnings(&run));
+    }
+
+    // ----- Recover-time orphan-tag warning (issue #2234 ask #3) -----
+
+    fn run_in(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+        let output = std::process::Command::new(args[0])
+            .args(&args[1..])
+            .current_dir(dir)
+            .output()
+            .expect("spawn command");
+        assert!(
+            output.status.success(),
+            "command {:?} failed: stdout={:?} stderr={:?}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        output
+    }
+
+    #[test]
+    fn diagnose_orphan_tag_warns_when_tag_points_at_non_release_commit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_in(dir, &["git", "init", "-q"]);
+        run_in(dir, &["git", "config", "user.email", "test@example.com"]);
+        run_in(dir, &["git", "config", "user.name", "Test"]);
+        run_in(dir, &["git", "config", "commit.gpgsign", "false"]);
+        std::fs::write(dir.join("README"), "x").expect("write");
+        run_in(dir, &["git", "add", "."]);
+        run_in(
+            dir,
+            &["git", "commit", "-q", "-m", "Update h2bc bundle to v0.6.14"],
+        );
+        run_in(dir, &["git", "tag", "v0.7.6"]);
+
+        let warning = diagnose_orphan_tag(&dir.to_string_lossy(), "v0.7.6")
+            .expect("orphan tag should produce a warning");
+
+        assert!(warning.contains("v0.7.6"));
+        assert!(warning.contains("issue #2234"));
+        assert!(warning.contains("Update h2bc bundle"));
+    }
+
+    #[test]
+    fn diagnose_orphan_tag_silent_when_tag_points_at_release_commit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_in(dir, &["git", "init", "-q"]);
+        run_in(dir, &["git", "config", "user.email", "test@example.com"]);
+        run_in(dir, &["git", "config", "user.name", "Test"]);
+        run_in(dir, &["git", "config", "commit.gpgsign", "false"]);
+        std::fs::write(dir.join("README"), "x").expect("write");
+        run_in(dir, &["git", "add", "."]);
+        run_in(dir, &["git", "commit", "-q", "-m", "release: v0.7.4"]);
+        run_in(dir, &["git", "tag", "v0.7.4"]);
+
+        assert!(diagnose_orphan_tag(&dir.to_string_lossy(), "v0.7.4").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Closes the orphan-tag bug class from #2234 by adding two
defense-in-depth invariants to the release pipeline, plus a
recover-time diagnostic. With this patch, a silent no-op version bump
can never produce the orphan-tag pattern (a tag pushed onto a
non-`release:` commit with no version-file bump and no GH release),
regardless of which upstream change is responsible for the no-op.

Refs: #2234

## What changed

### 1. Post-bump disk check (`run_version`)

After `version::bump_component_version` returns `Ok`, every
`version_target` is re-read from disk and compared to
`state.version`. Any mismatch marks the `version` step `Failed`, which
trips the existing `bail_on_failure!()` in `pipeline::run` *before*
the commit, package, tag, or push steps run.

Failure surfaces with an actionable hint pointing to
`homeboy release <component> --recover` and references #2234 in the
error message so the next operator hits the issue thread directly.

### 2. Pre-tag HEAD check (`run_git_tag`)

The final gate before tag creation: every `version_target` is read
from `HEAD`'s tree (`git show HEAD:<path>`) and compared to
`state.version`. This catches the orphan-tag pattern even if the
working tree somehow ends up with the bumped version but the commit
step was skipped/amended onto the wrong commit. No tag is created
when the invariant fails.

### 3. Recover-time orphan diagnostic (`run_recover`)

When `homeboy release <component> --recover` runs, it now inspects
the latest release tag. If the tagged commit's subject is not
`release: vX.Y.Z`, it emits a one-line warning naming the tag and
offering the cleanup recipe:

```
⚠ Latest tag v0.7.6 points at commit 6933efba (Update h2bc bundle to v0.6.14) — not a `release: v...` commit.
This matches the orphan-tag pattern from issue #2234. Inspect the tag/commit before recovering: `git show v0.7.6`.
To delete a misplaced tag locally and on origin: `git tag -d v0.7.6 && git push origin :refs/tags/v0.7.6`
```

This addresses ask #3 in the issue — `--recover` no longer silently
no-ops on top of misplaced tags.

## In scope vs. out of scope

**In scope:** preventing the bug *class*. The two invariants above
sit at the version and tag gates, so any future regression of similar
shape (a no-op bump returning Ok) gets caught before it produces an
orphan tag. They would have caught the original regression too,
regardless of which upstream change in the v0.151.1 release window
caused the no-op bump.

**Out of scope:** identifying the specific commit in v0.151.1 that
broke the dep-refresh cascade flow. Investigation pointed at the
release window 2026-05-03 12:15 EDT (`#2182 Guard lower release bump
overrides` + four other PRs), but the new invariants don't depend on
attributing root cause — they assert the post-condition the pipeline
*should always* uphold. Pinpointing the originating commit is also
out of scope because the existing 15 orphan tags on
chubes4/{html-to-blocks-converter, block-format-bridge,
static-site-importer} are evidence; cleaning them up is a separate
operational task.

## Tests

89 release-related lib tests pass (was 81), 2568 lib tests total
pass.

Eight new tests:

In `src/core/release/executor.rs`:
- `collect_version_target_mismatches_returns_none_when_disk_matches_expected`
- `collect_version_target_mismatches_flags_unbumped_target`
- `collect_head_version_mismatches_flags_when_head_lacks_new_version`
- `collect_head_version_mismatches_returns_none_when_head_matches`
- `git_tag_step_refuses_to_tag_when_head_lacks_new_version` —
  end-to-end: real git repo with HEAD at v0.6.12, calls \`run_git_tag\`
  with \`state.version = 0.6.13\`, asserts the step fails AND no tag
  was created locally.
- `git_tag_step_creates_tag_when_head_matches_state_version` —
  positive case for the same fixture: when HEAD shows the bumped
  version, the tag is created normally.

In `src/core/release/workflow.rs`:
- `diagnose_orphan_tag_warns_when_tag_points_at_non_release_commit`
- `diagnose_orphan_tag_silent_when_tag_points_at_release_commit`

## Verification

\`\`\`
cargo build              # passes
cargo fmt --check        # clean
cargo test --lib release::   # 89 passed, 0 failed
cargo test --lib             # 2568 passed, 0 failed, 1 ignored
\`\`\`

\`cargo clippy --all-targets -- -D warnings\` produces 64 errors on
\`main\` (pre-existing, repo-wide tech debt in
\`refactor/\`/\`stack/\`/etc.). None of those errors land in the files
this PR touches; the project's CI uses \`homeboy lint\` (baseline-honoring)
rather than raw strict clippy.

## Recovery story for the existing orphan tags

This PR does **not** clean up the 15 orphan tags currently on
chubes4/html-to-blocks-converter (v0.6.13–17),
chubes4/block-format-bridge (v0.7.5–9), and
chubes4/static-site-importer (v0.3.2–6). Those need an operational
decision (delete the orphan tags vs. back-fill release commits +
GH releases) and are tracked separately. With this PR merged and
homeboy upgraded, the next \`homeboy release\` for those repos will:

1. Hit the existing \`validate_release_version_floor\` guard
   (\`Latest release tag vX.Y.Z is ahead of source version ...\`),
   refusing to ship until the tags are reconciled.
2. If \`--recover\` is used, surface the new orphan-tag diagnostic
   pointing at the misplaced tag.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the post-bump and pre-tag invariant helpers
  in \`release/executor.rs\`, the recover-time \`diagnose_orphan_tag\`
  diagnostic in \`release/workflow.rs\`, and the eight new tests. Chris
  reviewed the design (defense-in-depth at version + tag gates rather
  than chasing the originating regression commit), verified the
  existing release test suite still passes, and ran
  \`cargo fmt --check\`.