### PR TITLE
feat(triage): accept --path to bypass component registry

### DIFF
--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -12,7 +12,7 @@ When no command is provided, `homeboy triage` defaults to `homeboy triage worksp
 
 ## Subcommands
 
-- `component` — triage one registered component
+- `component` — triage one registered component, or any checkout via `--path`
 - `project` — triage every component attached to a project
 - `fleet` — triage unique components used across a fleet
 - `rig` — triage components declared in a local rig spec
@@ -28,12 +28,34 @@ When no command is provided, `homeboy triage` defaults to `homeboy triage worksp
 - `--failing-checks` — restrict PRs to failing-check items
 - `--drilldown` — include compact failing check names and URLs
 
+## `--path` (component)
+
+`homeboy triage component --path <CHECKOUT>` skips the registry entirely and
+resolves the GitHub remote directly from the checkout's `origin`. Useful for:
+
+- unregistered checkouts (CI runners, ad-hoc clones, worktrees)
+- repos whose registry record is broken or stale (e.g. a leftover worktree
+  pinned as `local_path`, or a non-URL `remote_url`) — the escape hatch lets
+  you triage the checkout without first reconciling the registry
+- one-off triage from a directory you do not want to register
+
+The `COMPONENT_ID` positional becomes optional when `--path` is given. When both
+are supplied, they must agree: if a registry record exists for `COMPONENT_ID`
+and its `local_path` does not canonicalize to `<CHECKOUT>`, the command errors
+clearly rather than silently picking one side.
+
+The checkout must exist and be a git repository, and `git remote get-url origin`
+must return a parseable GitHub URL — otherwise the command surfaces the same
+`remote_url_is_not_github` reason as the registry-driven path.
+
 ## Examples
 
 ```sh
 homeboy triage
 homeboy triage --mine --drilldown
 homeboy triage component homeboy --failing-checks --drilldown
+homeboy triage component --path /Users/me/Developer/homeboy
+homeboy triage component homeboy --path ./homeboy --failing-checks
 ```
 
 ## Related

--- a/src/commands/triage.rs
+++ b/src/commands/triage.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Subcommand};
 use homeboy::triage::{self, TriageOptions, TriageOutput, TriageTarget};
+use homeboy::Error;
 use std::path::PathBuf;
 
 use super::CmdResult;
@@ -58,10 +59,22 @@ pub struct TriageArgs {
     limit: usize,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 enum TriageCommand {
     /// Triage one registered component.
-    Component { component_id: String },
+    ///
+    /// When `--path <CHECKOUT>` is supplied, the registry is bypassed and the
+    /// GitHub remote is resolved directly from the checkout's `origin`. Useful
+    /// for unregistered checkouts (CI runners, ad-hoc clones, worktrees) or
+    /// when a component's registry record is broken.
+    Component {
+        /// Component ID. Optional when `--path` is supplied.
+        component_id: Option<String>,
+
+        /// Workspace path to triage directly, bypassing the registry.
+        #[arg(long, value_name = "CHECKOUT")]
+        path: Option<String>,
+    },
     /// Triage every component attached to a project.
     Project { project_id: String },
     /// Triage unique components used across a fleet.
@@ -100,7 +113,9 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageOut
     };
 
     let target = match args.command.unwrap_or(TriageCommand::Workspace) {
-        TriageCommand::Component { component_id } => TriageTarget::Component(component_id),
+        TriageCommand::Component { component_id, path } => {
+            resolve_component_target(component_id, path)?
+        }
         TriageCommand::Project { project_id } => TriageTarget::Project(project_id),
         TriageCommand::Fleet { fleet_id } => TriageTarget::Fleet(fleet_id),
         TriageCommand::Rig { rig_id } => TriageTarget::Rig(rig_id),
@@ -110,10 +125,56 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageOut
     Ok((triage::run(target, options)?, 0))
 }
 
+fn resolve_component_target(
+    component_id: Option<String>,
+    path: Option<String>,
+) -> Result<TriageTarget, Error> {
+    match (component_id, path) {
+        (None, None) => Err(Error::validation_missing_argument(vec![
+            "component_id".into(),
+            "path".into(),
+        ])),
+        (Some(component_id), None) => Ok(TriageTarget::Component(component_id)),
+        (component_id, Some(path)) => {
+            // When both are supplied, verify the registry record (if any) points at
+            // the same checkout. If it does not, surface a clear error rather than
+            // silently picking one side. If the component is not registered, we
+            // accept the explicit id as the synthetic component_id.
+            if let Some(ref id) = component_id {
+                if let Ok(comp) = homeboy::component::load(id) {
+                    let registered = canonicalize_for_compare(&comp.local_path);
+                    let supplied = canonicalize_for_compare(&path);
+                    if registered != supplied {
+                        return Err(Error::validation_invalid_argument(
+                            "path",
+                            format!(
+                                "Disagrees with registered component '{id}' (local_path={})",
+                                comp.local_path
+                            ),
+                            Some(path),
+                            None,
+                        ));
+                    }
+                }
+            }
+            Ok(TriageTarget::Path { path, component_id })
+        }
+    }
+}
+
+fn canonicalize_for_compare(path: &str) -> String {
+    std::path::Path::new(path)
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| path.to_string())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{TriageArgs, TriageCommand};
+    use super::{resolve_component_target, TriageArgs, TriageCommand};
     use clap::Parser;
+    use homeboy::triage::TriageTarget;
 
     #[derive(Parser)]
     struct TestCli {
@@ -133,5 +194,50 @@ mod tests {
         let cli = TestCli::parse_from(["triage", "workspace"]);
 
         assert!(matches!(cli.args.command, Some(TriageCommand::Workspace)));
+    }
+
+    #[test]
+    fn component_subcommand_accepts_path_without_id() {
+        let cli = TestCli::parse_from(["triage", "component", "--path", "/tmp/checkout"]);
+
+        match cli.args.command {
+            Some(TriageCommand::Component { component_id, path }) => {
+                assert_eq!(component_id, None);
+                assert_eq!(path.as_deref(), Some("/tmp/checkout"));
+            }
+            other => panic!("expected Component subcommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn component_subcommand_accepts_id_and_path() {
+        let cli =
+            TestCli::parse_from(["triage", "component", "homeboy", "--path", "/tmp/checkout"]);
+
+        match cli.args.command {
+            Some(TriageCommand::Component { component_id, path }) => {
+                assert_eq!(component_id.as_deref(), Some("homeboy"));
+                assert_eq!(path.as_deref(), Some("/tmp/checkout"));
+            }
+            other => panic!("expected Component subcommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn component_subcommand_requires_id_or_path() {
+        let err = resolve_component_target(None, None).unwrap_err();
+        assert_eq!(err.code.as_str(), "validation.missing_argument");
+    }
+
+    #[test]
+    fn component_subcommand_routes_path_to_path_target() {
+        let target = resolve_component_target(None, Some("/tmp/some-checkout".into())).unwrap();
+        match target {
+            TriageTarget::Path { path, component_id } => {
+                assert_eq!(path, "/tmp/some-checkout");
+                assert_eq!(component_id, None);
+            }
+            other => panic!("expected TriageTarget::Path, got {other:?}"),
+        }
     }
 }

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -25,6 +25,12 @@ pub enum TriageTarget {
     Fleet(String),
     Rig(String),
     Workspace,
+    /// Triage an unregistered checkout directly. Skips the component registry
+    /// and resolves the GitHub remote from `git remote get-url origin`.
+    Path {
+        path: String,
+        component_id: Option<String>,
+    },
 }
 
 impl TriageTarget {
@@ -35,6 +41,7 @@ impl TriageTarget {
             TriageTarget::Fleet(_) => "fleet",
             TriageTarget::Rig(_) => "rig",
             TriageTarget::Workspace => "workspace",
+            TriageTarget::Path { .. } => "path",
         }
     }
 
@@ -45,6 +52,9 @@ impl TriageTarget {
             | TriageTarget::Fleet(id)
             | TriageTarget::Rig(id) => id,
             TriageTarget::Workspace => "workspace",
+            TriageTarget::Path { path, component_id } => {
+                component_id.as_deref().unwrap_or(path.as_str())
+            }
         }
     }
 
@@ -55,6 +65,10 @@ impl TriageTarget {
             TriageTarget::Fleet(_) => "triage.fleet",
             TriageTarget::Rig(_) => "triage.rig",
             TriageTarget::Workspace => "triage.workspace",
+            // `--path` is an escape hatch on subcommands (currently `component`); keep
+            // the same command identity so JSON consumers don't see a phantom
+            // `triage.path` verb.
+            TriageTarget::Path { .. } => "triage.component",
         }
     }
 }
@@ -374,7 +388,60 @@ fn resolve_target_components(target: &TriageTarget) -> Result<Vec<ComponentRef>>
             Ok(refs)
         }
         TriageTarget::Workspace => resolve_workspace_components(),
+        TriageTarget::Path { path, component_id } => {
+            resolve_path_component(path, component_id.as_deref())
+        }
     }
+}
+
+fn resolve_path_component(path: &str, component_id: Option<&str>) -> Result<Vec<ComponentRef>> {
+    let checkout = Path::new(path);
+    if !checkout.exists() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "Checkout path does not exist",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    if !checkout.join(".git").exists() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "Checkout path is not a git repository (no `.git` entry)",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    let remote_url = detect_remote_url(checkout).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "path",
+            "Could not read `git remote get-url origin` from checkout",
+            Some(path.to_string()),
+            None,
+        )
+    })?;
+    let canonical = checkout
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| path.to_string());
+    let synthesized_id = component_id
+        .map(|id| id.to_string())
+        .or_else(|| {
+            checkout
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.to_string())
+        })
+        .unwrap_or_else(|| "path".to_string());
+    let source = format!("path:{canonical}");
+    Ok(vec![ComponentRef::new(
+        synthesized_id,
+        canonical,
+        Some(remote_url),
+        None,
+        source,
+    )])
 }
 
 fn resolve_workspace_components() -> Result<Vec<ComponentRef>> {
@@ -2209,6 +2276,135 @@ mod tests {
                 resolve_repo(&refs[0]).unwrap().repo.owner,
                 "WordPress".to_string()
             );
+        });
+    }
+
+    #[test]
+    fn path_target_synthesizes_component_from_git_origin() {
+        crate::test_support::with_isolated_home(|home| {
+            let checkout = home.path().join("ad-hoc-checkout");
+            std::fs::create_dir_all(&checkout).unwrap();
+            let status = std::process::Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(&checkout)
+                .status()
+                .unwrap();
+            assert!(status.success());
+            let status = std::process::Command::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/Extra-Chill/homeboy.git",
+                ])
+                .current_dir(&checkout)
+                .status()
+                .unwrap();
+            assert!(status.success());
+
+            let target = TriageTarget::Path {
+                path: checkout.to_string_lossy().into_owned(),
+                component_id: None,
+            };
+            let refs = resolve_target_components(&target).unwrap();
+            assert_eq!(refs.len(), 1);
+            assert_eq!(refs[0].component_id, "ad-hoc-checkout");
+            assert_eq!(
+                refs[0].remote_url.as_deref(),
+                Some("https://github.com/Extra-Chill/homeboy.git")
+            );
+            let repo = resolve_repo(&refs[0]).unwrap().repo;
+            assert_eq!(repo.owner, "Extra-Chill");
+            assert_eq!(repo.repo, "homeboy");
+        });
+    }
+
+    #[test]
+    fn path_target_uses_explicit_component_id_when_provided() {
+        crate::test_support::with_isolated_home(|home| {
+            let checkout = home.path().join("checkout-dir");
+            std::fs::create_dir_all(&checkout).unwrap();
+            let status = std::process::Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(&checkout)
+                .status()
+                .unwrap();
+            assert!(status.success());
+            let status = std::process::Command::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "git@github.com:Extra-Chill/homeboy.git",
+                ])
+                .current_dir(&checkout)
+                .status()
+                .unwrap();
+            assert!(status.success());
+
+            let target = TriageTarget::Path {
+                path: checkout.to_string_lossy().into_owned(),
+                component_id: Some("homeboy".into()),
+            };
+            let refs = resolve_target_components(&target).unwrap();
+            assert_eq!(refs.len(), 1);
+            assert_eq!(refs[0].component_id, "homeboy");
+            let repo = resolve_repo(&refs[0]).unwrap().repo;
+            assert_eq!(repo.owner, "Extra-Chill");
+            assert_eq!(repo.repo, "homeboy");
+        });
+    }
+
+    #[test]
+    fn path_target_surfaces_remote_url_is_not_github_for_non_github_origin() {
+        crate::test_support::with_isolated_home(|home| {
+            let checkout = home.path().join("non-github");
+            std::fs::create_dir_all(&checkout).unwrap();
+            let status = std::process::Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(&checkout)
+                .status()
+                .unwrap();
+            assert!(status.success());
+            let status = std::process::Command::new("git")
+                .args(["remote", "add", "origin", "https://gitlab.com/foo/bar.git"])
+                .current_dir(&checkout)
+                .status()
+                .unwrap();
+            assert!(status.success());
+
+            let target = TriageTarget::Path {
+                path: checkout.to_string_lossy().into_owned(),
+                component_id: None,
+            };
+            let refs = resolve_target_components(&target).unwrap();
+            let err = resolve_repo(&refs[0]).unwrap_err();
+            assert_eq!(err, "remote_url_is_not_github");
+        });
+    }
+
+    #[test]
+    fn path_target_rejects_missing_directory() {
+        let target = TriageTarget::Path {
+            path: "/definitely/does/not/exist/triage-path-test".into(),
+            component_id: None,
+        };
+        let err = resolve_target_components(&target).unwrap_err();
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    }
+
+    #[test]
+    fn path_target_rejects_non_git_directory() {
+        crate::test_support::with_isolated_home(|home| {
+            let checkout = home.path().join("not-a-git-repo");
+            std::fs::create_dir_all(&checkout).unwrap();
+
+            let target = TriageTarget::Path {
+                path: checkout.to_string_lossy().into_owned(),
+                component_id: None,
+            };
+            let err = resolve_target_components(&target).unwrap_err();
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
         });
     }
 }


### PR DESCRIPTION
## Summary

- Add `--path <CHECKOUT>` to `homeboy triage component` so triage can run against an unregistered checkout, bypassing the component registry.
- The `COMPONENT_ID` positional becomes optional when `--path` is given; when both are supplied they must agree (registry `local_path` must canonicalize to `<CHECKOUT>`) or the command errors clearly.
- GitHub remote is resolved via the existing `detect_remote_url` + `parse_github_url` helpers — no new URL parser. Non-GitHub origins surface the existing `remote_url_is_not_github` reason rather than a new error code.

## Why

Useful for unregistered checkouts (CI runners, ad-hoc clones, worktrees), and as an escape hatch when a component's registry record is broken or stale — e.g. a leftover worktree pinned as `local_path`, or a non-URL `remote_url` (the exact failure mode in #2233). With `--path`, you can triage the checkout without first reconciling the registry.

This does **not** fix the underlying registry hygiene issues described in #2233 (worktree-as-canonical, non-URL `remote_url` accepted at write time, silent `unresolved` bucketing). Those are separate fixes; this PR adds the operator escape hatch only.

## Scope

- `triage component --path` only. The other subcommands (`workspace`, `project`, `fleet`, `rig`) all triage **multiple** components by definition, so a single `--path` does not extend cleanly to them. Punted intentionally.
- `TriageTarget::Path` is added to the core enum so the resolver can synthesize a `ComponentRef` from the checkout. `kind()` reports `"path"`; `command()` keeps `"triage.component"` so JSON consumers don't see a phantom verb.

## Linked issue

Refs #2233 (operator escape hatch only — does not close the upstream registry-hygiene work).

## Testing

- 5 new core tests in `core::triage::tests`:
  - `path_target_synthesizes_component_from_git_origin` (HTTPS origin)
  - `path_target_uses_explicit_component_id_when_provided` (SSH origin + explicit id)
  - `path_target_surfaces_remote_url_is_not_github_for_non_github_origin`
  - `path_target_rejects_missing_directory`
  - `path_target_rejects_non_git_directory`
- 4 new CLI parsing tests in `commands::triage::tests` covering `--path` with and without `COMPONENT_ID`, missing-args validation, and `TriageTarget::Path` routing.
- Smoke test against a live checkout: `homeboy triage component --path /Users/chubes/Developer/homeboy --limit 3` returned the expected `triage.component` JSON envelope and pulled real GitHub state for `Extra-Chill/homeboy`.
- Error paths verified: `--path /tmp/missing` returns `validation.invalid_argument`; `homeboy triage component` (no id, no path) returns `validation.missing_argument`.

```
cargo fmt
cargo test --release triage    # 39 passed (was 34)
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted and implemented the `--path` flag on `homeboy triage`. Chris is reviewing.