### PR TITLE
Fix component registration pointer sync

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -207,19 +207,7 @@ pub fn run(
 
             let remote_path = remote_path.unwrap_or_default();
             let repo_path = Path::new(&local_path);
-            let dir_name = repo_path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .ok_or_else(|| {
-                    homeboy::Error::validation_invalid_argument(
-                        "local_path",
-                        "Could not derive component ID from local path",
-                        Some(local_path.clone()),
-                        None,
-                    )
-                })?;
-
-            let id = homeboy::engine::identifier::slugify_id(dir_name, "component_id")?;
+            let id = derive_component_id_for_create(repo_path, &local_path)?;
             let mut new_component =
                 Component::new(id.clone(), local_path.clone(), remote_path, build_artifact);
 
@@ -361,6 +349,26 @@ fn suggest_project_for_path(local_path: &str) -> Option<String> {
     }
 
     None
+}
+
+fn derive_component_id_for_create(repo_path: &Path, local_path: &str) -> homeboy::Result<String> {
+    if repo_path.join("homeboy.json").exists() {
+        return component::infer_portable_component_id(repo_path);
+    }
+
+    let dir_name = repo_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "local_path",
+                "Could not derive component ID from local path",
+                Some(local_path.to_string()),
+                None,
+            )
+        })?;
+
+    homeboy::engine::identifier::slugify_id(dir_name, "component_id")
 }
 
 fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
@@ -1061,6 +1069,19 @@ mod tests {
 
         assert_eq!(obj["local_path"], serde_json::json!("/override"));
         assert_eq!(obj["remote_path"], serde_json::json!("/keep-this"));
+    }
+
+    #[test]
+    fn component_create_id_prefers_existing_portable_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("homeboy@fix-triage-default-workspace");
+        fs::create_dir_all(&repo).expect("repo dir");
+        fs::write(repo.join("homeboy.json"), r#"{"id":"homeboy"}"#).expect("homeboy.json");
+
+        let id = derive_component_id_for_create(&repo, &repo.to_string_lossy())
+            .expect("portable id should be used");
+
+        assert_eq!(id, "homeboy");
     }
 
     #[test]

--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -350,6 +350,48 @@ pub fn write_standalone_registration(component: &Component) -> Result<()> {
     )
 }
 
+/// Move the standalone pointer file when a component ID changes, then rewrite it.
+pub fn rename_standalone_registration(old_id: &str, component: &Component) -> Result<()> {
+    if old_id == component.id {
+        return write_standalone_registration(component);
+    }
+
+    let dir = crate::paths::components()?;
+    crate::engine::local_files::local().ensure_dir(&dir)?;
+
+    let old_path = dir.join(format!("{}.json", old_id));
+    let new_path = dir.join(format!("{}.json", component.id));
+
+    if old_path.exists() && !new_path.exists() {
+        std::fs::rename(&old_path, &new_path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "rename standalone registration {} to {}",
+                    old_path.display(),
+                    new_path.display()
+                )),
+            )
+        })?;
+    }
+
+    write_standalone_registration(component)?;
+
+    if old_path.exists() {
+        std::fs::remove_file(&old_path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "remove stale standalone registration {}",
+                    old_path.display()
+                )),
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -733,6 +775,56 @@ mod tests {
             json.get("extra_field").and_then(|v| v.as_str()),
             Some("preserve-me"),
             "unknown fields should be preserved"
+        );
+    }
+
+    #[test]
+    fn rename_standalone_moves_pointer_to_new_component_id() {
+        let dir = TempDir::new().unwrap();
+        let config_components = dir
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("components");
+        fs::create_dir_all(&config_components).unwrap();
+
+        let existing = serde_json::json!({
+            "local_path": "/old/path",
+            "remote_path": "target/release/old-id",
+            "extra_field": "preserve-me"
+        });
+        fs::write(
+            config_components.join("old-id.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .unwrap();
+
+        let _home = with_home_override(dir.path());
+
+        let component = Component::new(
+            "new-id".to_string(),
+            "/new/path".to_string(),
+            "target/release/new-id".to_string(),
+            None,
+        );
+
+        rename_standalone_registration("old-id", &component).unwrap();
+
+        assert!(!config_components.join("old-id.json").exists());
+        let content = fs::read_to_string(config_components.join("new-id.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(
+            json.get("local_path").and_then(|v| v.as_str()),
+            Some("/new/path")
+        );
+        assert_eq!(
+            json.get("remote_path").and_then(|v| v.as_str()),
+            Some("target/release/new-id")
+        );
+        assert_eq!(
+            json.get("extra_field").and_then(|v| v.as_str()),
+            Some("preserve-me")
         );
     }
 }

--- a/src/core/component/relationships.rs
+++ b/src/core/component/relationships.rs
@@ -65,6 +65,7 @@ pub fn rename_component(id: &str, new_id: &str) -> Result<Component> {
         component.id = resolved_new_id.clone();
         Ok(())
     })?;
+    crate::component::inventory::rename_standalone_registration(id, &component)?;
     update_project_references(id, &resolved_new_id)?;
     Ok(component)
 }


### PR DESCRIPTION
## Summary
- Prefer an existing repo-owned `homeboy.json` ID when `homeboy component create --local-path` initializes a repo.
- Keep standalone component pointer files in sync when `homeboy component rename` changes a component ID.
- Add regressions for worktree-style directory names and standalone pointer renames.

## Testing
- `cargo test component_create_id_prefers_existing_portable_config`
- `cargo test rename_standalone_moves_pointer_to_new_component_id`
- `cargo test standalone_prefers_portable_config_when_available`
- Manual temp-`HOME` regression from a non-Homeboy cwd
- `cargo test component -- --test-threads=1`
- `git diff --check`

## Notes
- `cargo test component` in parallel hit existing global `HOME`/config race failures; the serial run passed.
- `cargo test --lib` has an unrelated failing audit test: `commands::audit::tests::audit_detects_outliers_in_convention_group`.
- `homeboy test homeboy` failed because the local config cannot resolve extension `rust`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the component registration failure, drafting and implementing the focused fix, adding regression coverage, and running verification. Chris requested the change and remains responsible for review and merge.