### PR TITLE
Fix bench force-hot placement

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -267,6 +267,7 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
         "--ignore-baseline",
         "--ignore-default-baseline",
         "--ratchet",
+        "--force-hot",
         "--json-summary",
         "--json",
     ];

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -343,6 +343,45 @@ fn parses_profile_flag() {
 }
 
 #[test]
+fn parses_force_hot_after_bench_without_losing_settings() {
+    let normalized = crate::commands::utils::args::normalize(
+        [
+            "homeboy",
+            "bench",
+            "--rig",
+            "studio-bfb",
+            "--iterations",
+            "1",
+            "--force-hot",
+            "--setting",
+            "studio_site_build_prompt_variant=astro-docs-content-collection",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+    );
+
+    let cli = crate::cli_surface::Cli::try_parse_from(normalized)
+        .expect("bench --force-hot --setting should parse");
+
+    assert!(cli.force_hot);
+    let crate::cli_surface::Commands::Bench(args) = cli.command else {
+        panic!("expected bench command");
+    };
+    assert_eq!(
+        args.run.setting_args.setting,
+        vec![(
+            "studio_site_build_prompt_variant".to_string(),
+            "astro-docs-content-collection".to_string()
+        )]
+    );
+    assert!(
+        !args.run.args.iter().any(|arg| arg == "--force-hot"),
+        "--force-hot must not be forwarded to bench workloads"
+    );
+}
+
+#[test]
 fn scenario_and_profile_conflict() {
     let err = match TestCli::try_parse_from([
         "bench",

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -49,7 +49,7 @@ pub(crate) fn normalize_version_show(args: Vec<String>) -> Vec<String> {
 ///
 /// Adding a new global flag to `Cli` requires adding the long form here
 /// and the equals-form lookup happens automatically.
-const GLOBAL_FLAGS: &[&str] = &["--output", "-h", "--help"];
+const GLOBAL_FLAGS: &[&str] = &["--output", "--force-hot", "-h", "--help"];
 const COMPONENT_SET_MERGE_FLAGS: &[&str] = &[
     "--json",
     "--base64",
@@ -511,6 +511,23 @@ mod normalize_tests {
             "--profile",
             "smoke",
             "--iterations=1",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    #[test]
+    fn bench_force_hot_after_subcommand_is_not_separated() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "--rig",
+            "studio-bfb",
+            "--iterations",
+            "1",
+            "--force-hot",
+            "--setting",
+            "studio_site_build_prompt_variant=astro-docs-content-collection",
         ]);
         let expected = input.clone();
         assert_eq!(normalize_trailing_flags(input), expected);


### PR DESCRIPTION
## Summary
- Treat `--force-hot` as a known global flag during trailing-argument normalization so `homeboy bench --force-hot ...` binds to the global parser instead of inserting `--` and swallowing later bench flags.
- Filter `--force-hot` from bench workload passthrough defensively.
- Add regression coverage for post-`bench` `--force-hot` and preservation of `--setting studio_site_build_prompt_variant=...`.

Fixes #2259.

## Testing
- `cargo fmt --check`
- `cargo test force_hot`
- `cargo test setting`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal parser fix and targeted regression tests; Chris remains responsible for review and validation.