### PR TITLE
fix: make extension discovery metadata-driven

### DIFF
--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -61,7 +61,11 @@ Declares what file types and capabilities this extension handles. Used by the au
 {
   "provides": {
     "file_extensions": ["php", "inc"],
-    "capabilities": ["fingerprint", "refactor"]
+    "capabilities": ["fingerprint", "refactor"],
+    "discovery_markers": [
+      { "all": ["style.css", "functions.php"] },
+      { "all": ["package.json"], "any": ["src/**/*.ts", "*.ts"] }
+    ]
   }
 }
 ```
@@ -70,6 +74,37 @@ Declares what file types and capabilities this extension handles. Used by the au
 
 - **`file_extensions`** (array): File extensions this extension can process (e.g., `["php", "inc"]`, `["rs"]`)
 - **`capabilities`** (array): Capabilities this extension supports (e.g., `["fingerprint", "refactor"]`)
+- **`discovery_markers`** (array): Component-root marker rules used by `homeboy context` gap reporting to suggest an extension without core knowing ecosystem-specific files.
+
+Each `discovery_markers` rule supports:
+
+- **`all`** (array): Relative marker paths/globs that must all exist.
+- **`any`** (array): Relative marker paths/globs where at least one must exist when supplied.
+
+Core treats marker strings generically. Exact strings are checked as paths relative to the component root; strings containing `*`, `?`, or `[` are evaluated as globs relative to the component root.
+
+## Grammar Fingerprint Metadata Contract
+
+Extension-owned `grammar.toml` files may declare fingerprint metadata consumed by Homeboy's generic fingerprint engine. Language and framework semantics belong here, not in core.
+
+Path-derived namespaces are declared with `fingerprint.namespace_derivation`:
+
+```toml
+[fingerprint.namespace_derivation]
+prefix = "crate::"
+strip_leading_segments = 1
+separator = "::"
+include_file_stem_when_root = true
+```
+
+### Namespace Derivation Fields
+
+- **`prefix`** (string): Optional prefix prepended to the derived namespace.
+- **`strip_leading_segments`** (integer): Number of leading path segments to remove before deriving the namespace.
+- **`separator`** (string): Separator used to join remaining namespace segments. Defaults to `::`.
+- **`include_file_stem_when_root`** (boolean): Whether a root-level source file contributes its file stem as the namespace.
+
+If an extension needs path-derived namespaces, it must ship this grammar metadata. Core does not provide language-specific fallbacks.
 
 ## Scripts Configuration
 

--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -172,7 +172,7 @@ pub fn fingerprint_from_grammar(
     let implements = extract_implements(&symbols);
 
     // --- Namespace ---
-    let namespace = extract_namespace(&symbols, relative_path, lang_id);
+    let namespace = extract_namespace(&symbols, relative_path, grammar);
 
     // --- Imports ---
     let imports = extract_imports(&symbols);
@@ -779,8 +779,8 @@ fn extract_implements(symbols: &[Symbol]) -> Vec<String> {
     implements
 }
 
-/// Extract namespace from symbols or derive from path.
-fn extract_namespace(symbols: &[Symbol], relative_path: &str, lang_id: &str) -> Option<String> {
+/// Extract namespace from symbols or derive from grammar-owned path metadata.
+fn extract_namespace(symbols: &[Symbol], relative_path: &str, grammar: &Grammar) -> Option<String> {
     // Direct namespace symbol (PHP: namespace DataMachine\Abilities;)
     for s in symbols.iter().filter(|s| s.concept == "namespace") {
         if let Some(name) = s.name() {
@@ -788,19 +788,38 @@ fn extract_namespace(symbols: &[Symbol], relative_path: &str, lang_id: &str) -> 
         }
     }
 
-    // Rust module namespace is determined by file location. `crate::...`
-    // imports are cross-module references, not declarations of this file's module.
-    if lang_id == "rust" {
-        let parts: Vec<&str> = relative_path.trim_end_matches(".rs").split('/').collect();
-        if parts.len() > 2 {
-            let ns = parts[1..parts.len() - 1].join("::");
-            return Some(format!("crate::{}", ns));
-        } else if parts.len() == 2 {
-            return Some(format!("crate::{}", parts.last().unwrap_or(&"")));
-        }
+    derive_namespace_from_path(relative_path, grammar)
+}
+
+fn derive_namespace_from_path(relative_path: &str, grammar: &Grammar) -> Option<String> {
+    let rule = grammar.fingerprint.namespace_derivation.as_ref()?;
+    let path_without_extension = Path::new(relative_path)
+        .with_extension("")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let parts: Vec<&str> = path_without_extension
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect();
+    let stripped = parts.get(rule.strip_leading_segments..)?;
+
+    let namespace_parts = if stripped.len() > 1 {
+        &stripped[..stripped.len() - 1]
+    } else if rule.include_file_stem_when_root {
+        stripped
+    } else {
+        &[]
+    };
+
+    if namespace_parts.is_empty() {
+        return None;
     }
 
-    None
+    Some(format!(
+        "{}{}",
+        rule.prefix.as_deref().unwrap_or(""),
+        namespace_parts.join(&rule.separator)
+    ))
 }
 
 /// Extract imports from symbols.
@@ -1268,6 +1287,11 @@ mod tests {
                 registration_concepts = ["macro_invocation"]
                 registration_skip_names = ["println", "assert", "write"]
                 registration_skip_prefixes = ["test"]
+                [fingerprint.namespace_derivation]
+                prefix = "crate::"
+                strip_leading_segments = 1
+                separator = "::"
+                include_file_stem_when_root = true
                 [patterns.function]
                 regex = '^\s*(pub(?:\(crate\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+(\w+)\s*\(([^)]*)\)'
                 context = "any"
@@ -1311,7 +1335,13 @@ mod tests {
 
     #[test]
     fn rust_namespace_comes_from_file_path_not_crate_imports() {
-        let grammar = rust_grammar();
+        let mut grammar = rust_grammar();
+        grammar.fingerprint.namespace_derivation = Some(grammar::NamespaceDerivationConfig {
+            prefix: Some("crate::".to_string()),
+            strip_leading_segments: 1,
+            separator: "::".to_string(),
+            include_file_stem_when_root: true,
+        });
 
         let command_content = r#"
 use crate::help_topics;

--- a/src/core/context/mod.rs
+++ b/src/core/context/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::component;
 use crate::error::{Error, Result};
-use crate::extension;
+use crate::extension::{self, DiscoveryMarkerConfig, ExtensionManifest};
 use crate::project::{self, Project};
 use crate::server::SshClient;
 use crate::server::{self, Server};
@@ -297,23 +297,24 @@ pub fn build_component_info(component: &component::Component) -> ContainedCompon
     // Check for missing extension configuration
     if component.extensions.is_none() || component.extensions.as_ref().is_none_or(|m| m.is_empty())
     {
-        // Suggest a extension based on project file indicators
-        let suggestion =
-            if local_path.join("style.css").exists() && local_path.join("functions.php").exists() {
-                Some("wordpress")
-            } else if local_path.join("Cargo.toml").exists() {
-                Some("rust")
-            } else if local_path.join("package.json").exists() {
-                Some("nodejs")
-            } else {
-                None
-            };
-
-        let extension_hint = suggestion.unwrap_or("EXTENSION_ID");
+        let suggestions = extension_suggestions_for_path(&local_path);
+        let extension_hint = if suggestions.len() == 1 {
+            suggestions[0].as_str()
+        } else {
+            "EXTENSION_ID"
+        };
+        let reason = if suggestions.len() > 1 {
+            format!(
+                "No extension configured. Matching extension manifests: {}.",
+                suggestions.join(", ")
+            )
+        } else {
+            "No extension configured. Extension commands (lint, test, build) require a extension."
+                .to_string()
+        };
         gaps.push(ComponentGap {
             field: "extensions".to_string(),
-            reason: "No extension configured. Extension commands (lint, test, build) require a extension."
-                .to_string(),
+            reason,
             command: format!(
                 "homeboy component set {} --extension {}",
                 component.id, extension_hint
@@ -351,6 +352,59 @@ pub fn build_component_info(component: &component::Component) -> ContainedCompon
         build_artifact: component.build_artifact.clone().unwrap_or_default(),
         remote_path: component.remote_path.clone(),
         gaps,
+    }
+}
+
+fn extension_suggestions_for_path(local_path: &Path) -> Vec<String> {
+    extension::load_all_extensions()
+        .map(|extensions| extension_suggestions_from_manifests(local_path, &extensions))
+        .unwrap_or_default()
+}
+
+fn extension_suggestions_from_manifests(
+    local_path: &Path,
+    extensions: &[ExtensionManifest],
+) -> Vec<String> {
+    let mut suggestions: Vec<String> = extensions
+        .iter()
+        .filter(|manifest| {
+            manifest
+                .discovery_markers()
+                .iter()
+                .any(|rule| discovery_marker_matches(local_path, rule))
+        })
+        .map(|manifest| manifest.id.clone())
+        .collect();
+    suggestions.sort();
+    suggestions.dedup();
+    suggestions
+}
+
+fn discovery_marker_matches(local_path: &Path, rule: &DiscoveryMarkerConfig) -> bool {
+    if rule.all.is_empty() && rule.any.is_empty() {
+        return false;
+    }
+    let all_match = rule
+        .all
+        .iter()
+        .all(|marker| marker_exists(local_path, marker));
+    let any_match = rule.any.is_empty()
+        || rule
+            .any
+            .iter()
+            .any(|marker| marker_exists(local_path, marker));
+
+    all_match && any_match
+}
+
+fn marker_exists(local_path: &Path, marker: &str) -> bool {
+    if marker.contains('*') || marker.contains('?') || marker.contains('[') {
+        let pattern = local_path.join(marker).to_string_lossy().to_string();
+        glob::glob(&pattern)
+            .ok()
+            .is_some_and(|mut matches| matches.any(|entry| entry.is_ok()))
+    } else {
+        local_path.join(marker).exists()
     }
 }
 
@@ -414,4 +468,65 @@ pub fn resolve_project_ssh_with_base_path(
     let ctx = resolve_project_ssh(project_id)?;
     let base_path = require_project_base_path(project_id, &ctx.project)?;
     Ok((ctx, base_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(id: &str, markers: serde_json::Value) -> ExtensionManifest {
+        let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": id,
+            "version": "1.0.0",
+            "provides": {
+                "discovery_markers": markers
+            }
+        }))
+        .expect("manifest parses");
+        manifest.id = id.to_string();
+        manifest
+    }
+
+    #[test]
+    fn extension_suggestions_are_manifest_driven() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]").expect("cargo marker");
+
+        let suggestions = extension_suggestions_from_manifests(
+            dir.path(),
+            &[
+                manifest("rust-like", serde_json::json!([{ "all": ["Cargo.toml"] }])),
+                manifest(
+                    "wordpress-like",
+                    serde_json::json!([{ "all": ["style.css", "functions.php"] }]),
+                ),
+            ],
+        );
+
+        assert_eq!(suggestions, vec!["rust-like"]);
+    }
+
+    #[test]
+    fn extension_suggestions_support_globs_and_ambiguity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("src")).expect("src dir");
+        std::fs::write(dir.path().join("package.json"), "{}").expect("package marker");
+        std::fs::write(dir.path().join("src/index.ts"), "export {};").expect("ts marker");
+
+        let suggestions = extension_suggestions_from_manifests(
+            dir.path(),
+            &[
+                manifest(
+                    "node-like",
+                    serde_json::json!([{ "all": ["package.json"] }]),
+                ),
+                manifest(
+                    "typescript-like",
+                    serde_json::json!([{ "all": ["package.json"], "any": ["src/**/*.ts"] }]),
+                ),
+            ],
+        );
+
+        assert_eq!(suggestions, vec!["node-like", "typescript-like"]);
+    }
 }

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -106,6 +106,28 @@ pub struct FingerprintGrammar {
     /// Registration name prefixes to suppress.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub registration_skip_prefixes: Vec<String>,
+
+    /// Optional grammar-owned namespace derivation rule. Use this for languages
+    /// where the declaring namespace/module is implied by the file path rather
+    /// than a parsed source symbol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace_derivation: Option<NamespaceDerivationConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamespaceDerivationConfig {
+    /// Prefix prepended to the derived namespace, e.g. `crate::`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+    /// Path segments to drop before deriving a namespace, e.g. `1` to drop `src`.
+    #[serde(default)]
+    pub strip_leading_segments: usize,
+    /// Separator used between remaining path segments.
+    #[serde(default = "default_namespace_separator")]
+    pub separator: String,
+    /// Whether a root-level file contributes its file stem as the namespace.
+    #[serde(default)]
+    pub include_file_stem_when_root: bool,
 }
 
 impl FingerprintGrammar {
@@ -118,7 +140,12 @@ impl FingerprintGrammar {
             && self.registration_concepts.is_empty()
             && self.registration_skip_names.is_empty()
             && self.registration_skip_prefixes.is_empty()
+            && self.namespace_derivation.is_none()
     }
+}
+
+fn default_namespace_separator() -> String {
+    "::".to_string()
 }
 
 /// Grammar section for function contract extraction.

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -1133,6 +1133,13 @@ pub(crate) fn extract_block_body<'a>(
 mod tests {
     use super::*;
 
+    fn captures(entries: &[(&str, usize)]) -> HashMap<String, usize> {
+        entries
+            .iter()
+            .map(|(name, index)| ((*name).to_string(), *index))
+            .collect()
+    }
+
     fn rust_grammar() -> Grammar {
         Grammar {
             language: LanguageMeta {
@@ -1160,12 +1167,7 @@ mod tests {
                     ConceptPattern {
                         regex: r"(?:pub(?:\(crate\))?\s+)?(?:async\s+)?fn\s+(\w+)\s*\(([^)]*)\)"
                             .to_string(),
-                        captures: {
-                            let mut c = HashMap::new();
-                            c.insert("name".to_string(), 1);
-                            c.insert("params".to_string(), 2);
-                            c
-                        },
+                        captures: captures(&[("name", 1), ("params", 2)]),
                         context: "any".to_string(),
                         skip_comments: true,
                         skip_strings: true,
@@ -1177,11 +1179,7 @@ mod tests {
                     ConceptPattern {
                         regex: r"(?:pub(?:\(crate\))?\s+)?(?:struct|enum|trait)\s+(\w+)"
                             .to_string(),
-                        captures: {
-                            let mut c = HashMap::new();
-                            c.insert("name".to_string(), 1);
-                            c
-                        },
+                        captures: captures(&[("name", 1)]),
                         context: "top_level".to_string(),
                         skip_comments: true,
                         skip_strings: true,
@@ -1192,11 +1190,7 @@ mod tests {
                     "import".to_string(),
                     ConceptPattern {
                         regex: r"use\s+([\w:]+(?:::\{[^}]+\})?);".to_string(),
-                        captures: {
-                            let mut c = HashMap::new();
-                            c.insert("path".to_string(), 1);
-                            c
-                        },
+                        captures: captures(&[("path", 1)]),
                         context: "top_level".to_string(),
                         skip_comments: true,
                         skip_strings: true,
@@ -1234,12 +1228,7 @@ mod tests {
                     "method".to_string(),
                     ConceptPattern {
                         regex: r"(?:(?:public|protected|private|static|abstract|final)\s+)*function\s+(\w+)\s*\(([^)]*)\)".to_string(),
-                        captures: {
-                            let mut c = HashMap::new();
-                            c.insert("name".to_string(), 1);
-                            c.insert("params".to_string(), 2);
-                            c
-                        },
+                        captures: captures(&[("name", 1), ("params", 2)]),
                         context: "any".to_string(),
                         skip_comments: true,
                         skip_strings: true,
@@ -1251,12 +1240,7 @@ mod tests {
                     ConceptPattern {
                         regex: r"(?:abstract\s+)?(?:final\s+)?(class|trait|interface)\s+(\w+)"
                             .to_string(),
-                        captures: {
-                            let mut c = HashMap::new();
-                            c.insert("kind".to_string(), 1);
-                            c.insert("name".to_string(), 2);
-                            c
-                        },
+                        captures: captures(&[("kind", 1), ("name", 2)]),
                         context: "top_level".to_string(),
                         skip_comments: true,
                         skip_strings: true,
@@ -1267,11 +1251,7 @@ mod tests {
                     "namespace".to_string(),
                     ConceptPattern {
                         regex: r"namespace\s+([\w\\]+);".to_string(),
-                        captures: {
-                            let mut c = HashMap::new();
-                            c.insert("name".to_string(), 1);
-                            c
-                        },
+                        captures: captures(&[("name", 1)]),
                         context: "top_level".to_string(),
                         skip_comments: true,
                         skip_strings: true,

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -55,17 +55,6 @@ pub mod source_metadata {
         pub(super) repair: Option<SourceMetadataRepair>,
     }
 
-    pub(super) const OFFICIAL_EXTENSION_SOURCE_URL: &str =
-        "https://github.com/Extra-Chill/homeboy-extensions";
-    const OFFICIAL_EXTENSION_IDS: &[&str] = &[
-        "rust",
-        "wordpress",
-        "php",
-        "javascript",
-        "typescript",
-        "nodejs",
-    ];
-
     pub(super) fn resolve_source_url(extension_id: &str) -> Result<SourceMetadataResolution> {
         let extension = load_extension(extension_id)?;
         let extension_dir = paths::extension(extension_id)?;
@@ -113,22 +102,6 @@ pub mod source_metadata {
             });
         }
 
-        if let Some(source_url) = official_source_url_for_id(extension_id) {
-            write_source_metadata(
-                &extension_dir,
-                source_url,
-                read_source_revision(extension_id),
-            );
-            return Ok(SourceMetadataResolution {
-                url: source_url.to_string(),
-                repair: Some(SourceMetadataRepair {
-                    source_url: source_url.to_string(),
-                    reason: "restored .source-url for known official Homeboy extension".to_string(),
-                    repair_command: repair_command(extension_id, source_url),
-                }),
-            });
-        }
-
         let mut err = Error::validation_invalid_argument(
             "extension_id",
             format!(
@@ -141,10 +114,6 @@ pub mod source_metadata {
         .with_hint(format!(
             "Repair by reinstalling from the original source: homeboy extension install <url> --id {}",
             extension_id
-        ))
-        .with_hint(format!(
-            "If this is an official extension, use: {}",
-            repair_command(extension_id, OFFICIAL_EXTENSION_SOURCE_URL)
         ));
 
         if let Some(path) = extension.extension_path {
@@ -152,12 +121,6 @@ pub mod source_metadata {
         }
 
         Err(err)
-    }
-
-    fn official_source_url_for_id(extension_id: &str) -> Option<&'static str> {
-        OFFICIAL_EXTENSION_IDS
-            .contains(&extension_id)
-            .then_some(OFFICIAL_EXTENSION_SOURCE_URL)
     }
 
     fn repair_command(extension_id: &str, source_url: &str) -> String {
@@ -1473,27 +1436,39 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn copied_official_extension_missing_source_metadata_repairs_source_url() {
+    fn copied_extension_manifest_source_metadata_repairs_source_url() {
         with_isolated_home(|home| {
             let extensions_dir = home.path().join(".config/homeboy/extensions");
-            write_extension_fixture(&extensions_dir, "rust");
             let extension_dir = extensions_dir.join("rust");
+            fs::create_dir_all(&extension_dir).expect("extension dir");
+            fs::write(
+                extension_dir.join("rust.json"),
+                r#"{
+  "name": "rust extension",
+  "version": "1.0.0",
+  "source_url": "https://github.com/Extra-Chill/homeboy-extensions"
+}"#,
+            )
+            .expect("extension manifest");
 
             let source =
-                source_metadata::resolve_source_url("rust").expect("official source repair");
+                source_metadata::resolve_source_url("rust").expect("manifest source repair");
 
-            assert_eq!(source.url, source_metadata::OFFICIAL_EXTENSION_SOURCE_URL);
+            assert_eq!(
+                source.url,
+                "https://github.com/Extra-Chill/homeboy-extensions"
+            );
             let repair = source.repair.expect("repair result");
             assert_eq!(
                 repair.source_url,
-                source_metadata::OFFICIAL_EXTENSION_SOURCE_URL
+                "https://github.com/Extra-Chill/homeboy-extensions"
             );
-            assert!(repair.reason.contains("official Homeboy extension"));
+            assert!(repair.reason.contains("manifest sourceUrl"));
             assert_eq!(
                 fs::read_to_string(extension_dir.join(".source-url"))
                     .expect("source url marker")
                     .trim(),
-                source_metadata::OFFICIAL_EXTENSION_SOURCE_URL
+                "https://github.com/Extra-Chill/homeboy-extensions"
             );
         });
     }
@@ -1547,7 +1522,6 @@ exec '{}' "$@"
 
             assert!(text.contains("no sourceUrl or .source-url metadata"));
             assert!(hints.contains("homeboy extension install <url> --id custom"));
-            assert!(hints.contains("homeboy extension install https://github.com/Extra-Chill/homeboy-extensions --id custom"));
             assert!(hints.contains(&extension_dir.to_string_lossy().to_string()));
         });
     }

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -236,6 +236,26 @@ pub struct ProvidesConfig {
     /// Capabilities this extension supports (e.g., ["fingerprint", "refactor"]).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub capabilities: Vec<String>,
+    /// Component-root marker rules used to suggest this extension for an
+    /// unattached component. Core evaluates these generically; extension
+    /// manifests own the ecosystem-specific file/glob knowledge.
+    #[serde(
+        default,
+        alias = "discoveryMarkers",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub discovery_markers: Vec<DiscoveryMarkerConfig>,
+}
+
+/// Component-root marker rule for extension discovery suggestions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DiscoveryMarkerConfig {
+    /// Marker paths/globs that must all match relative to the component root.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub all: Vec<String>,
+    /// Marker paths/globs where any single match is sufficient.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub any: Vec<String>,
 }
 
 /// Scripts that implement extension capabilities.
@@ -664,6 +684,14 @@ impl ExtensionManifest {
         self.provides
             .as_ref()
             .map(|p| p.capabilities.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Get component discovery marker rules (empty if not specified).
+    pub fn discovery_markers(&self) -> &[DiscoveryMarkerConfig] {
+        self.provides
+            .as_ref()
+            .map(|p| p.discovery_markers.as_slice())
             .unwrap_or(&[])
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -33,12 +33,12 @@ pub use manifest::{
     ActionConfig, ActionType, AuditCapability, AutofixVerifyConfig, BenchConfig, BuildConfig,
     CliAutoFlag, CliAutoFlagCondition, CliConfig, CliHelpConfig, ComponentEnvConfig,
     DatabaseCliConfig, DatabaseConfig, DeployCapability, DeployOverride, DeployVerification,
-    DiscoveryConfig, DocTarget, ExecutableCapability, ExtensionManifest, FeatureContextRule,
-    FileContainsCondition, HttpMethod, InputConfig, LintChangedFileRoute, LintConfig, OutputConfig,
-    OutputSchema, PlatformCapability, ProvidesConfig, RemotePathInferenceRule, RequirementsConfig,
-    RuntimeConfig, RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig,
-    SinceTagConfig, StructuredSidecarDeclaration, TestConfig, TestDriftConfig, TestMappingConfig,
-    TraceConfig, VersionPatternConfig,
+    DiscoveryConfig, DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionManifest,
+    FeatureContextRule, FileContainsCondition, HttpMethod, InputConfig, LintChangedFileRoute,
+    LintConfig, OutputConfig, OutputSchema, PlatformCapability, ProvidesConfig,
+    RemotePathInferenceRule, RequirementsConfig, RuntimeConfig, RuntimeRequirementsConfig,
+    ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig, StructuredSidecarDeclaration,
+    TestConfig, TestDriftConfig, TestMappingConfig, TraceConfig, VersionPatternConfig,
 };
 
 // Re-export version types


### PR DESCRIPTION
## Summary
- Remove hardcoded official extension ID repair behavior from core; source repair now relies on manifest or installed metadata.
- Move component extension suggestions to manifest-declared discovery markers with generic matching and ambiguity handling.
- Move path-derived namespace behavior behind grammar fingerprint metadata and document the extension contract.

## Tests
- `cargo test core::context::tests`
- `cargo test copied_extension_manifest_source_metadata_repairs_source_url`
- `cargo test copied_unknown_extension_missing_source_metadata_is_actionable_error`
- `cargo test manifest_parses_declared_structured_sidecar_schema_versions`
- `cargo test rust_namespace_comes_from_file_path_not_crate_imports`

## Issues
- Closes #2245
- Closes #2246
- Closes #2247
- Related: #2240, #1948

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.