### PR TITLE
Centralize extension plumbing

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -691,22 +691,8 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
             component_label: effective_id,
             component_id: ctx.component_id.clone(),
             path_override,
-            settings: ctx
-                .settings
-                .iter()
-                .filter_map(|(k, v)| match v {
-                    serde_json::Value::String(s) => Some((k.clone(), s.clone())),
-                    _ => None,
-                })
-                .collect(),
-            settings_json: ctx
-                .settings
-                .iter()
-                .filter_map(|(k, v)| match v {
-                    serde_json::Value::String(_) => None,
-                    other => Some((k.clone(), other.clone())),
-                })
-                .collect(),
+            settings: ctx.resolved_settings().string_overrides(),
+            settings_json: ctx.resolved_settings().json_overrides(),
             passthrough_args,
             scenario_ids: args.scenario_ids.clone(),
             extra_workloads,

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -474,22 +474,8 @@ fn run_component_with_rig_context(
             component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override,
-            settings: ctx
-                .settings
-                .iter()
-                .filter_map(|(k, v)| match v {
-                    serde_json::Value::String(s) => Some((k.clone(), s.clone())),
-                    _ => None,
-                })
-                .collect(),
-            settings_json: ctx
-                .settings
-                .iter()
-                .filter_map(|(k, v)| match v {
-                    serde_json::Value::String(_) => None,
-                    other => Some((k.clone(), other.clone())),
-                })
-                .collect(),
+            settings: ctx.resolved_settings().string_overrides(),
+            settings_json: ctx.resolved_settings().json_overrides(),
             iterations: args.iterations,
             warmup_iterations: effective_warmup_iterations(args, rig_spec),
             execution: BenchRunExecution {

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -4,15 +4,17 @@ use homeboy::engine::run_dir::{self, RunDir};
 use homeboy::extension::bench::report::collect_artifacts;
 use homeboy::extension::bench::{BenchResults, BenchRunWorkflowResult};
 use homeboy::git::short_head_revision_at;
-use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
+use homeboy::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::rig::RigStateSnapshot;
 
 use super::BenchRunArgs;
 
-pub(super) struct BenchObservation {
-    store: ObservationStore,
-    run: RunRecord,
-    initial_metadata: serde_json::Value,
+pub(super) struct BenchObservation(ActiveObservation);
+
+impl BenchObservation {
+    fn run_id(&self) -> &str {
+        self.0.run_id()
+    }
 }
 
 pub(super) struct BenchObservationSummary {
@@ -34,7 +36,6 @@ pub(super) struct BenchObservationStart<'a> {
 }
 
 pub(super) fn start(start: BenchObservationStart<'_>) -> Option<BenchObservation> {
-    let store = ObservationStore::open_initialized().ok()?;
     let metadata = bench_observation_initial_metadata(
         start.component_label,
         start.args,
@@ -42,28 +43,21 @@ pub(super) fn start(start: BenchObservationStart<'_>) -> Option<BenchObservation
         start.rig_snapshot,
         start.run_dir,
     );
-    let run = store
-        .start_run(NewRunRecord {
-            kind: "bench".to_string(),
-            component_id: Some(start.component_id.to_string()),
-            command: Some(bench_observation_command(
-                start.component_id,
-                start.args,
-                start.rig_id,
-            )),
-            cwd: Some(start.source_path.to_string_lossy().to_string()),
-            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            git_sha: short_head_revision_at(start.source_path),
-            rig_id: start.rig_id.map(str::to_string),
-            metadata_json: metadata.clone(),
-        })
-        .ok()?;
-
-    Some(BenchObservation {
-        store,
-        run,
-        initial_metadata: metadata,
+    ActiveObservation::start_best_effort(NewRunRecord {
+        kind: "bench".to_string(),
+        component_id: Some(start.component_id.to_string()),
+        command: Some(bench_observation_command(
+            start.component_id,
+            start.args,
+            start.rig_id,
+        )),
+        cwd: Some(start.source_path.to_string_lossy().to_string()),
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_sha: short_head_revision_at(start.source_path),
+        rig_id: start.rig_id.map(str::to_string),
+        metadata_json: metadata.clone(),
     })
+    .map(BenchObservation)
 }
 
 pub(super) fn finish_success(
@@ -74,25 +68,20 @@ pub(super) fn finish_success(
     let observation = observation?;
 
     record_bench_observation_artifacts(&observation, workflow, run_dir);
-    let metadata = bench_observation_finish_metadata(observation.initial_metadata, workflow);
+    let metadata =
+        bench_observation_finish_metadata(observation.0.initial_metadata().clone(), workflow);
     let status = if workflow.exit_code == 0 {
         RunStatus::Pass
     } else {
         RunStatus::Fail
     };
     let summary = BenchObservationSummary {
-        run_id: observation.run.id.clone(),
-        component_id: observation.run.component_id.clone().unwrap_or_default(),
-        rig_id: observation.run.rig_id.clone(),
-        store_path: observation
-            .store
-            .status()
-            .map(|status| status.path)
-            .unwrap_or_else(|_| "<unavailable>".to_string()),
+        run_id: observation.run_id().to_string(),
+        component_id: observation.0.component_id().unwrap_or_default().to_string(),
+        rig_id: observation.0.rig_id().map(str::to_string),
+        store_path: observation.0.store_path(),
     };
-    let _ = observation
-        .store
-        .finish_run(&observation.run.id, status, Some(metadata));
+    observation.0.finish(status, Some(metadata));
     Some(summary)
 }
 
@@ -132,16 +121,14 @@ pub(super) fn finish_error(
         "resource_summary",
         run_dir.step_file(run_dir::files::RESOURCE_SUMMARY),
     );
-    let metadata = merge_observation_metadata(
-        observation.initial_metadata,
+    let metadata = merge_metadata(
+        observation.0.initial_metadata().clone(),
         serde_json::json!({
             "observation_status": "error",
             "error": error.to_string(),
         }),
     );
-    let _ = observation
-        .store
-        .finish_run(&observation.run.id, RunStatus::Error, Some(metadata));
+    observation.0.finish_error(Some(metadata));
 }
 
 fn bench_observation_command(
@@ -200,7 +187,7 @@ fn bench_observation_finish_metadata(
     initial_metadata: serde_json::Value,
     workflow: &BenchRunWorkflowResult,
 ) -> serde_json::Value {
-    merge_observation_metadata(
+    merge_metadata(
         initial_metadata,
         serde_json::json!({
             "observation_status": workflow.status,
@@ -212,18 +199,6 @@ fn bench_observation_finish_metadata(
             "scenario_metrics": workflow.results.as_ref().map(scenario_metric_summaries).unwrap_or_default(),
         }),
     )
-}
-
-fn merge_observation_metadata(
-    mut initial: serde_json::Value,
-    finish: serde_json::Value,
-) -> serde_json::Value {
-    if let (Some(initial), Some(finish)) = (initial.as_object_mut(), finish.as_object()) {
-        for (key, value) in finish {
-            initial.insert(key.clone(), value.clone());
-        }
-    }
-    initial
 }
 
 fn baseline_status(workflow: &BenchRunWorkflowResult) -> Option<&'static str> {
@@ -282,8 +257,9 @@ fn record_bench_observation_artifacts(
         if let Some(url) = artifact.url.as_deref() {
             let kind = artifact.kind.as_deref().unwrap_or(&artifact.name);
             let _ = observation
-                .store
-                .record_url_artifact(&observation.run.id, kind, url);
+                .0
+                .store()
+                .record_url_artifact(observation.run_id(), kind, url);
         }
         if let Some(path) = artifact.path.as_deref() {
             let path = resolve_bench_artifact_path(path, run_dir);
@@ -293,11 +269,7 @@ fn record_bench_observation_artifacts(
 }
 
 fn record_if_exists(observation: &BenchObservation, kind: &str, path: PathBuf) {
-    if path.is_file() {
-        let _ = observation
-            .store
-            .record_artifact(&observation.run.id, kind, path);
-    }
+    observation.0.record_artifact_if_file(kind, &path);
 }
 
 fn resolve_bench_artifact_path(path: &str, run_dir: &RunDir) -> PathBuf {
@@ -452,7 +424,7 @@ mod tests {
                 run_dir: &run_dir,
             })
             .expect("start observation");
-            let run_id = observation.run.id.clone();
+            let run_id = observation.run_id().to_string();
             let summary = finish_success(Some(observation), &workflow, &run_dir)
                 .expect("observation summary");
             assert_eq!(summary.run_id, run_id);
@@ -520,7 +492,7 @@ mod tests {
                 run_dir: &run_dir,
             })
             .expect("start observation");
-            let run_id = observation.run.id.clone();
+            let run_id = observation.run_id().to_string();
             let error = homeboy::Error::validation_invalid_argument(
                 "bench",
                 "synthetic bench error",

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -8,7 +8,7 @@ use homeboy::extension::lint::{
 };
 use homeboy::extension::ExtensionCapability;
 use homeboy::git;
-use homeboy::observation::{finding_records_from_lint, NewRunRecord, ObservationStore, RunStatus};
+use homeboy::observation::{finding_records_from_lint, ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::refactor::plan::{collect_refactor_sources, lint_refactor_request, LintSourceOptions};
 
 use super::utils::args::{
@@ -130,19 +130,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     })?;
     let effective_id = ctx.component_id.clone();
 
-    let stringified_settings: Vec<(String, String)> = ctx
-        .settings
-        .iter()
-        .map(|(k, v)| {
-            (
-                k.clone(),
-                match v {
-                    serde_json::Value::String(s) => s.clone(),
-                    other => other.to_string(),
-                },
-            )
-        })
-        .collect();
+    let stringified_settings = ctx.resolved_settings().string_lossy_overrides();
 
     // --fix dispatches to the canonical refactor sources pipeline.
     // The fixer pipeline already exists; this flag connects the existing wire
@@ -215,37 +203,27 @@ fn finish_lint_workflow(
     }
 }
 
-struct LintObservation {
-    store: ObservationStore,
-    run_id: String,
-}
+struct LintObservation(ActiveObservation);
 
 impl LintObservation {
     fn start(component_id: String, source_path: &std::path::Path, command: String) -> Option<Self> {
-        let store = ObservationStore::open_initialized().ok()?;
-        let run = store
-            .start_run(NewRunRecord {
-                kind: "lint".to_string(),
-                component_id: Some(component_id),
-                command: Some(command),
-                cwd: Some(source_path.to_string_lossy().to_string()),
-                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-                git_sha: None,
-                rig_id: None,
-                metadata_json: serde_json::json!({ "source": "homeboy lint" }),
-            })
-            .ok()?;
-
-        Some(Self {
-            store,
-            run_id: run.id,
+        ActiveObservation::start_best_effort(NewRunRecord {
+            kind: "lint".to_string(),
+            component_id: Some(component_id),
+            command: Some(command),
+            cwd: Some(source_path.to_string_lossy().to_string()),
+            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            git_sha: None,
+            rig_id: None,
+            metadata_json: serde_json::json!({ "source": "homeboy lint" }),
         })
+        .map(Self)
     }
 
     fn finish_workflow(self, workflow: &homeboy::extension::lint::LintRunWorkflowResult) {
         if let Some(findings) = &workflow.lint_findings {
-            let records = finding_records_from_lint(&self.run_id, findings);
-            let _ = self.store.record_findings(&records);
+            let records = finding_records_from_lint(self.0.run_id(), findings);
+            self.0.record_findings(&records);
         }
 
         let status = if workflow.status == "passed" {
@@ -253,8 +231,7 @@ impl LintObservation {
         } else {
             RunStatus::Fail
         };
-        let _ = self.store.finish_run(
-            &self.run_id,
+        self.0.finish(
             status,
             Some(serde_json::json!({
                 "exit_code": workflow.exit_code,
@@ -264,7 +241,7 @@ impl LintObservation {
     }
 
     fn finish_error(self) {
-        let _ = self.store.finish_run(&self.run_id, RunStatus::Error, None);
+        self.0.finish_error(None);
     }
 }
 

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -1,20 +1,16 @@
 use std::path::Path;
 
 use homeboy::git::short_head_revision_at;
-use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
+use homeboy::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::ObservationOutputMetadata;
 
 use super::{artifact_command, ReviewArgs, ReviewCommandOutput, ReviewStage};
 
-pub(super) struct ReviewObservation {
-    store: ObservationStore,
-    run: RunRecord,
-    initial_metadata: serde_json::Value,
-}
+pub(super) struct ReviewObservation(ActiveObservation);
 
 impl ReviewObservation {
     pub(super) fn output_metadata(&self) -> ObservationOutputMetadata {
-        ObservationOutputMetadata::for_run(&self.run.kind, &self.run.id)
+        ObservationOutputMetadata::for_run(&self.0.run().kind, self.0.run_id())
     }
 }
 
@@ -28,31 +24,23 @@ pub(super) struct ReviewObservationStart<'a> {
 }
 
 pub(super) fn start(start: ReviewObservationStart<'_>) -> Option<ReviewObservation> {
-    let store = ObservationStore::open_initialized().ok()?;
     let metadata = review_observation_initial_metadata(
         start.component_label,
         start.args,
         start.scope,
         start.changed_file_count,
     );
-    let run = store
-        .start_run(NewRunRecord {
-            kind: "review".to_string(),
-            component_id: Some(start.component_id.to_string()),
-            command: Some(review_observation_command(start.component_id, start.args)),
-            cwd: Some(start.source_path.to_string_lossy().to_string()),
-            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            git_sha: short_head_revision_at(start.source_path),
-            rig_id: None,
-            metadata_json: metadata.clone(),
-        })
-        .ok()?;
-
-    Some(ReviewObservation {
-        store,
-        run,
-        initial_metadata: metadata,
+    ActiveObservation::start_best_effort(NewRunRecord {
+        kind: "review".to_string(),
+        component_id: Some(start.component_id.to_string()),
+        command: Some(review_observation_command(start.component_id, start.args)),
+        cwd: Some(start.source_path.to_string_lossy().to_string()),
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_sha: short_head_revision_at(start.source_path),
+        rig_id: None,
+        metadata_json: metadata.clone(),
     })
+    .map(ReviewObservation)
 }
 
 pub(super) fn finish_success(
@@ -71,11 +59,13 @@ pub(super) fn finish_success(
     } else {
         RunStatus::Fail
     };
-    let metadata =
-        review_observation_finish_metadata(observation.initial_metadata, output, exit_code, None);
-    let _ = observation
-        .store
-        .finish_run(&observation.run.id, status, Some(metadata));
+    let metadata = review_observation_finish_metadata(
+        observation.0.initial_metadata().clone(),
+        output,
+        exit_code,
+        None,
+    );
+    observation.0.finish(status, Some(metadata));
 }
 
 pub(super) fn finish_error(observation: Option<ReviewObservation>, error: &homeboy::Error) {
@@ -83,16 +73,14 @@ pub(super) fn finish_error(observation: Option<ReviewObservation>, error: &homeb
         return;
     };
 
-    let metadata = merge_observation_metadata(
-        observation.initial_metadata,
+    let metadata = merge_metadata(
+        observation.0.initial_metadata().clone(),
         serde_json::json!({
             "observation_status": "error",
             "error": error.to_string(),
         }),
     );
-    let _ = observation
-        .store
-        .finish_run(&observation.run.id, RunStatus::Error, Some(metadata));
+    observation.0.finish_error(Some(metadata));
 }
 
 fn review_observation_command(component_id: &str, args: &ReviewArgs) -> String {
@@ -141,7 +129,7 @@ pub(super) fn review_observation_finish_metadata(
     exit_code: i32,
     error: Option<&str>,
 ) -> serde_json::Value {
-    merge_observation_metadata(
+    merge_metadata(
         initial_metadata,
         serde_json::json!({
             "observation_status": output.artifact.status,
@@ -176,18 +164,6 @@ fn stage_observation<T: serde::Serialize>(stage: &ReviewStage<T>) -> serde_json:
         "skipped_reason": stage.skipped_reason,
         "run_id": null,
     })
-}
-
-fn merge_observation_metadata(
-    mut initial: serde_json::Value,
-    finish: serde_json::Value,
-) -> serde_json::Value {
-    if let (Some(initial), Some(finish)) = (initial.as_object_mut(), finish.as_object()) {
-        for (key, value) in finish {
-            initial.insert(key.clone(), value.clone());
-        }
-    }
-    initial
 }
 
 #[cfg(test)]

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -10,7 +10,7 @@ use homeboy::extension::test::{FailureCategory, FailureCluster, TestAnalysisInpu
 use homeboy::extension::ExtensionCapability;
 use homeboy::git::short_head_revision_at;
 use homeboy::observation::{
-    NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
+    merge_metadata, ActiveObservation, NewFindingRecord, NewRunRecord, RunStatus,
 };
 use std::path::Path;
 
@@ -228,19 +228,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
-            settings: ctx
-                .settings
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        match v {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        },
-                    )
-                })
-                .collect(),
+            settings: ctx.resolved_settings().string_lossy_overrides(),
             skip_lint: args.skip_lint,
             coverage: args.coverage,
             coverage_min: args.coverage_min,
@@ -262,11 +250,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     Ok(report::from_main_workflow(workflow))
 }
 
-struct TestObservation {
-    store: ObservationStore,
-    test_run: RunRecord,
-    test_metadata: serde_json::Value,
-}
+struct TestObservation(ActiveObservation);
 
 fn start_test_observation(
     component_id: &str,
@@ -275,26 +259,18 @@ fn start_test_observation(
     mode: &str,
     run_dir: Option<&RunDir>,
 ) -> Option<TestObservation> {
-    let store = ObservationStore::open_initialized().ok()?;
     let metadata = test_observation_initial_metadata(source_path, args, mode, run_dir);
-    let run = store
-        .start_run(NewRunRecord {
-            kind: "test".to_string(),
-            component_id: Some(component_id.to_string()),
-            command: Some(test_observation_command(component_id, args)),
-            cwd: Some(source_path.to_string_lossy().to_string()),
-            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            git_sha: short_head_revision_at(source_path),
-            rig_id: None,
-            metadata_json: metadata.clone(),
-        })
-        .ok()?;
-
-    Some(TestObservation {
-        store,
-        test_run: run,
-        test_metadata: metadata,
+    ActiveObservation::start_best_effort(NewRunRecord {
+        kind: "test".to_string(),
+        component_id: Some(component_id.to_string()),
+        command: Some(test_observation_command(component_id, args)),
+        cwd: Some(source_path.to_string_lossy().to_string()),
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_sha: short_head_revision_at(source_path),
+        rig_id: None,
+        metadata_json: metadata.clone(),
     })
+    .map(TestObservation)
 }
 
 fn finish_test_workflow_observation(
@@ -321,8 +297,8 @@ fn finish_test_observation(
         return;
     };
 
-    let metadata = merge_test_observation_metadata(
-        observation.test_metadata.clone(),
+    let metadata = merge_metadata(
+        observation.0.initial_metadata().clone(),
         serde_json::json!({
             "observation_status": workflow.status,
             "exit_code": workflow.exit_code,
@@ -341,9 +317,7 @@ fn finish_test_observation(
         RunStatus::Fail
     };
     persist_test_findings(&observation, workflow);
-    let _ = observation
-        .store
-        .finish_run(&observation.test_run.id, status, Some(metadata));
+    observation.0.finish(status, Some(metadata));
 }
 
 fn persist_test_findings(
@@ -352,20 +326,17 @@ fn persist_test_findings(
 ) {
     let mut records = Vec::new();
     if let Some(input) = &workflow.failure_analysis_input {
-        records.extend(test_failure_finding_records(
-            &observation.test_run.id,
-            input,
-        ));
+        records.extend(test_failure_finding_records(observation.0.run_id(), input));
     }
     if let Some(analysis) = &workflow.analysis {
         records.extend(
             analysis
                 .clusters
                 .iter()
-                .map(|cluster| test_cluster_finding_record(&observation.test_run.id, cluster)),
+                .map(|cluster| test_cluster_finding_record(observation.0.run_id(), cluster)),
         );
     }
-    let _ = observation.store.record_findings(&records);
+    observation.0.record_findings(&records);
 }
 
 fn test_failure_finding_records(run_id: &str, input: &TestAnalysisInput) -> Vec<NewFindingRecord> {
@@ -473,8 +444,8 @@ fn finish_test_drift_observation(
         return;
     };
 
-    let metadata = merge_test_observation_metadata(
-        observation.test_metadata,
+    let metadata = merge_metadata(
+        observation.0.initial_metadata().clone(),
         serde_json::json!({
             "observation_status": if workflow.exit_code == 0 { "pass" } else { "fail" },
             "exit_code": workflow.exit_code,
@@ -486,9 +457,7 @@ fn finish_test_drift_observation(
     } else {
         RunStatus::Fail
     };
-    let _ = observation
-        .store
-        .finish_run(&observation.test_run.id, status, Some(metadata));
+    observation.0.finish(status, Some(metadata));
 }
 
 fn finish_test_observation_error(observation: Option<TestObservation>, error: &homeboy::Error) {
@@ -496,17 +465,14 @@ fn finish_test_observation_error(observation: Option<TestObservation>, error: &h
         return;
     };
 
-    let metadata = merge_test_observation_metadata(
-        observation.test_metadata,
+    let metadata = merge_metadata(
+        observation.0.initial_metadata().clone(),
         serde_json::json!({
             "observation_status": "error",
             "error": error.to_string(),
         }),
     );
-    let _ =
-        observation
-            .store
-            .finish_run(&observation.test_run.id, RunStatus::Error, Some(metadata));
+    observation.0.finish_error(Some(metadata));
 }
 
 fn test_observation_command(component_id: &str, args: &TestArgs) -> String {
@@ -569,18 +535,6 @@ fn test_observation_initial_metadata(
         "passthrough_args": filter_homeboy_flags(&args.args),
         "run_dir": run_dir.map(|run_dir| run_dir.path().to_string_lossy().to_string()),
     })
-}
-
-fn merge_test_observation_metadata(
-    mut initial: serde_json::Value,
-    extra: serde_json::Value,
-) -> serde_json::Value {
-    if let (Some(initial), Some(extra)) = (initial.as_object_mut(), extra.as_object()) {
-        for (key, value) in extra {
-            initial.insert(key.clone(), value.clone());
-        }
-    }
-    initial
 }
 
 #[cfg(test)]
@@ -650,7 +604,7 @@ mod tests {
 
             let observation = start_test_observation("homeboy", home.path(), &args, "test", None)
                 .expect("observation should start");
-            let run_id = observation.test_run.id.clone();
+            let run_id = observation.0.run_id().to_string();
 
             finish_test_observation_error(
                 Some(observation),
@@ -687,7 +641,7 @@ mod tests {
             let args = sample_args();
             let observation = start_test_observation("homeboy", home.path(), &args, "test", None)
                 .expect("observation should start");
-            let run_id = observation.test_run.id.clone();
+            let run_id = observation.0.run_id().to_string();
             let input = TestAnalysisInput {
                 failures: vec![TestFailure {
                     test_name: "tests::fails".to_string(),

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -532,10 +532,12 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
     let trace_probes =
         trace_probes_for_args(&args, rig_context.as_ref(), ctx.extension_id.as_deref())?;
     let attachments = TraceAttachment::parse_all(&args.attachments)?;
+    let resolved_settings = ctx.resolved_settings();
     let mut json_settings = experiment_settings;
-    json_settings.extend(settings_as_json(&ctx.settings));
+    json_settings.extend(resolved_settings.json_overrides());
     json_settings.extend(
-        settings_as_strings(&ctx.settings)
+        resolved_settings
+            .string_overrides()
             .into_iter()
             .map(|(key, value)| (key, serde_json::Value::String(value))),
     );
@@ -545,7 +547,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
             component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override,
-            settings: settings_as_strings(&ctx.settings),
+            settings: resolved_settings.string_overrides(),
             runner_inputs: TraceRunnerInputs {
                 json_settings,
                 env: experiment_env.clone(),
@@ -986,9 +988,9 @@ fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
             component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override,
-            settings: settings_as_strings(&ctx.settings),
+            settings: ctx.resolved_settings().string_overrides(),
             runner_inputs: TraceRunnerInputs {
-                json_settings: settings_as_json(&ctx.settings),
+                json_settings: ctx.resolved_settings().json_overrides(),
                 env: Vec::new(),
                 workload_paths: extra_workloads,
                 probes: Vec::new(),
@@ -1326,26 +1328,6 @@ fn rig_component_for_trace(spec: &RigSpec, component_id: &str) -> Option<Compone
         },
         ..Default::default()
     })
-}
-
-fn settings_as_strings(settings: &[(String, serde_json::Value)]) -> Vec<(String, String)> {
-    settings
-        .iter()
-        .filter_map(|(key, value)| match value {
-            serde_json::Value::String(s) => Some((key.clone(), s.clone())),
-            _ => None,
-        })
-        .collect()
-}
-
-fn settings_as_json(settings: &[(String, serde_json::Value)]) -> Vec<(String, serde_json::Value)> {
-    settings
-        .iter()
-        .filter_map(|(key, value)| match value {
-            serde_json::Value::String(_) => None,
-            other => Some((key.clone(), other.clone())),
-        })
-        .collect()
 }
 
 struct ActiveTraceObservation {

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -255,6 +255,11 @@ pub fn resolve_with_component(
 }
 
 impl ExecutionContext {
+    /// Return an explicit view over resolved extension settings.
+    pub fn resolved_settings(&self) -> ResolvedSettings<'_> {
+        ResolvedSettings::new(&self.settings)
+    }
+
     /// Get the effective working directory for command execution.
     ///
     /// Returns the source path as a string reference.
@@ -301,6 +306,58 @@ impl ExecutionContext {
                     .join(", ")
             );
         }
+    }
+}
+
+/// Explicit conversions for resolved extension settings.
+///
+/// Resolved settings are stored as typed JSON so command callers must choose
+/// whether they need string-only settings, typed JSON settings, or intentionally
+/// lossy stringification for legacy runner contracts.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedSettings<'a> {
+    settings: &'a [(String, serde_json::Value)],
+}
+
+impl<'a> ResolvedSettings<'a> {
+    pub fn new(settings: &'a [(String, serde_json::Value)]) -> Self {
+        Self { settings }
+    }
+
+    /// Return only settings that are already strings.
+    pub fn string_overrides(&self) -> Vec<(String, String)> {
+        self.settings
+            .iter()
+            .filter_map(|(key, value)| match value {
+                serde_json::Value::String(value) => Some((key.clone(), value.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Return only settings that must stay typed JSON.
+    pub fn json_overrides(&self) -> Vec<(String, serde_json::Value)> {
+        self.settings
+            .iter()
+            .filter_map(|(key, value)| match value {
+                serde_json::Value::String(_) => None,
+                value => Some((key.clone(), value.clone())),
+            })
+            .collect()
+    }
+
+    /// Return every setting as a string, stringifying non-string JSON values.
+    pub fn string_lossy_overrides(&self) -> Vec<(String, String)> {
+        self.settings
+            .iter()
+            .map(|(key, value)| {
+                let value = match value {
+                    serde_json::Value::String(value) => value.clone(),
+                    value => value.to_string(),
+                };
+                (key.clone(), value)
+            })
+            .collect()
     }
 }
 
@@ -644,6 +701,36 @@ mod tests {
         };
 
         assert_eq!(ctx.working_dir(), dir.path().to_str().unwrap());
+    }
+
+    #[test]
+    fn resolved_settings_split_string_json_and_lossy_views() {
+        let entries = [
+            ("string".to_string(), serde_json::json!("value")),
+            ("object".to_string(), serde_json::json!({ "enabled": true })),
+            ("number".to_string(), serde_json::json!(3)),
+        ];
+        let settings = ResolvedSettings::new(&entries);
+
+        assert_eq!(
+            settings.string_overrides(),
+            vec![("string".to_string(), "value".to_string())]
+        );
+        assert_eq!(
+            settings.json_overrides(),
+            vec![
+                ("object".to_string(), serde_json::json!({ "enabled": true })),
+                ("number".to_string(), serde_json::json!(3)),
+            ]
+        );
+        assert_eq!(
+            settings.string_lossy_overrides(),
+            vec![
+                ("string".to_string(), "value".to_string()),
+                ("object".to_string(), r#"{"enabled":true}"#.to_string()),
+                ("number".to_string(), "3".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -703,6 +703,54 @@ mod tests {
         assert_eq!(ctx.working_dir(), dir.path().to_str().unwrap());
     }
 
+    fn resolved_settings_entries() -> Vec<(String, serde_json::Value)> {
+        vec![
+            ("string".to_string(), serde_json::json!("value")),
+            ("object".to_string(), serde_json::json!({ "enabled": true })),
+            ("number".to_string(), serde_json::json!(3)),
+        ]
+    }
+
+    #[test]
+    fn test_string_overrides() {
+        let entries = resolved_settings_entries();
+        let settings = ResolvedSettings::new(&entries);
+
+        assert_eq!(
+            settings.string_overrides(),
+            vec![("string".to_string(), "value".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_json_overrides() {
+        let entries = resolved_settings_entries();
+        let settings = ResolvedSettings::new(&entries);
+
+        assert_eq!(
+            settings.json_overrides(),
+            vec![
+                ("object".to_string(), serde_json::json!({ "enabled": true })),
+                ("number".to_string(), serde_json::json!(3)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_string_lossy_overrides() {
+        let entries = resolved_settings_entries();
+        let settings = ResolvedSettings::new(&entries);
+
+        assert_eq!(
+            settings.string_lossy_overrides(),
+            vec![
+                ("string".to_string(), "value".to_string()),
+                ("object".to_string(), r#"{"enabled":true}"#.to_string()),
+                ("number".to_string(), "3".to_string()),
+            ]
+        );
+    }
+
     #[test]
     fn resolved_settings_split_string_json_and_lossy_views() {
         let entries = [

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -21,7 +21,8 @@ use crate::extension::bench::parsing::{
     BenchWorkloadMetadata,
 };
 use crate::extension::{
-    resolve_execution_context, ExtensionCapability, ExtensionExecutionContext, ExtensionRunner,
+    build_scenario_runner, resolve_execution_context, ExtensionCapability,
+    ExtensionExecutionContext, ExtensionRunner, ScenarioRunnerOptions,
 };
 
 #[derive(Debug, Clone)]
@@ -988,30 +989,35 @@ fn build_runner(
     run_dir: &RunDir,
     instance: Option<(u32, u32)>,
 ) -> Result<ExtensionRunner> {
-    let mut runner = ExtensionRunner::for_context(execution_context.clone())
-        .component(component.clone())
-        .path_override(args.path_override.clone())
-        .settings(&args.settings)
-        .settings_json(&args.settings_json)
-        .with_run_dir(run_dir)
-        .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
-        .env("HOMEBOY_BENCH_PROGRESS", bench_progress_env_value())
-        .env("HOMEBOY_BENCH_PROGRESS_STREAM", "stderr")
-        .script_args(&args.passthrough_args)
-        .passthrough(false)
-        .stderr_passthrough(bench_progress_enabled());
+    let mut runner = build_scenario_runner(ScenarioRunnerOptions {
+        execution_context,
+        component,
+        path_override: args.path_override.clone(),
+        settings: &args.settings,
+        settings_json: &args.settings_json,
+        run_dir,
+        cleanup_process_group: false,
+        results_env: None,
+        scenario_env: None,
+        artifact_env: None,
+        list_only_env: None,
+        extra_workloads_env: Some((
+            "HOMEBOY_BENCH_EXTRA_WORKLOADS",
+            &args.extra_workloads,
+            "bench_workloads",
+        )),
+    })?
+    .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
+    .env("HOMEBOY_BENCH_PROGRESS", bench_progress_env_value())
+    .env("HOMEBOY_BENCH_PROGRESS_STREAM", "stderr")
+    .script_args(&args.passthrough_args)
+    .passthrough(false)
+    .stderr_passthrough(bench_progress_enabled());
 
     if let Some(warmup_iterations) = args.warmup_iterations {
         runner = runner.env(
             "HOMEBOY_BENCH_WARMUP_ITERATIONS",
             &warmup_iterations.to_string(),
-        );
-    }
-
-    if !args.extra_workloads.is_empty() {
-        runner = runner.env(
-            "HOMEBOY_BENCH_EXTRA_WORKLOADS",
-            &extra_workloads_env_value(&args.extra_workloads)?,
         );
     }
 
@@ -1053,21 +1059,6 @@ fn bench_progress_env_value() -> &'static str {
     } else {
         "0"
     }
-}
-
-fn extra_workloads_env_value(paths: &[PathBuf]) -> Result<String> {
-    let joined = std::env::join_paths(paths)
-        .map_err(|e| {
-            Error::validation_invalid_argument(
-                "bench_workloads",
-                format!("bench workload path cannot be exported: {}", e),
-                None,
-                None,
-            )
-        })?
-        .to_string_lossy()
-        .to_string();
-    Ok(joined)
 }
 
 /// Spawn N runner instances in parallel, wait for all, aggregate.
@@ -1190,6 +1181,7 @@ fn run_concurrent_instances(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::path_list_env_value;
     use std::collections::BTreeMap;
 
     #[test]
@@ -1207,7 +1199,7 @@ mod tests {
         ];
 
         assert_eq!(
-            extra_workloads_env_value(&paths).unwrap(),
+            path_list_env_value("bench_workloads", &paths).unwrap(),
             "/tmp/bench-one.php:/tmp/bench-two.php"
         );
     }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -78,12 +78,13 @@ pub(crate) fn stderr_tail(stderr: &str) -> String {
 
 use crate::component::Component;
 use crate::config;
+use crate::engine::run_dir::RunDir;
 use crate::error::Result;
 use crate::error::{Error, ErrorCode};
 use crate::output::MergeOutput;
 use crate::paths;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn load_extension(id: &str) -> Result<ExtensionManifest> {
     let mut manifest = config::load::<ExtensionManifest>(id)?;
@@ -186,6 +187,71 @@ pub struct ExtensionExecutionContext {
     pub extension_path: PathBuf,
     pub script_path: String,
     pub settings: Vec<(String, serde_json::Value)>,
+}
+
+pub struct ScenarioRunnerOptions<'a> {
+    pub execution_context: &'a ExtensionExecutionContext,
+    pub component: &'a Component,
+    pub path_override: Option<String>,
+    pub settings: &'a [(String, String)],
+    pub settings_json: &'a [(String, serde_json::Value)],
+    pub run_dir: &'a RunDir,
+    pub cleanup_process_group: bool,
+    pub results_env: Option<(&'a str, PathBuf)>,
+    pub scenario_env: Option<(&'a str, &'a str)>,
+    pub artifact_env: Option<(&'a str, &'a Path)>,
+    pub list_only_env: Option<(&'a str, bool)>,
+    pub extra_workloads_env: Option<(&'a str, &'a [PathBuf], &'a str)>,
+}
+
+pub fn build_scenario_runner(options: ScenarioRunnerOptions<'_>) -> Result<ExtensionRunner> {
+    let mut runner = ExtensionRunner::for_context(options.execution_context.clone())
+        .component(options.component.clone())
+        .path_override(options.path_override)
+        .settings(options.settings)
+        .settings_json(options.settings_json)
+        .with_run_dir(options.run_dir);
+
+    if options.cleanup_process_group {
+        runner = runner.cleanup_process_group(true);
+    }
+    if let Some((key, path)) = options.results_env {
+        runner = runner.env(key, &path.to_string_lossy());
+    }
+    if let Some((key, value)) = options.scenario_env {
+        runner = runner.env(key, value);
+    }
+    if let Some((key, path)) = options.artifact_env {
+        runner = runner.env(key, &path.to_string_lossy());
+    }
+    if let Some((key, list_only)) = options.list_only_env {
+        runner = runner.env(key, if list_only { "1" } else { "0" });
+    }
+    if let Some((key, paths, error_field)) = options.extra_workloads_env {
+        if !paths.is_empty() {
+            runner = runner.env(key, &path_list_env_value(error_field, paths)?);
+        }
+    }
+
+    Ok(runner)
+}
+
+pub fn path_list_env_value(error_field: &str, paths: &[PathBuf]) -> Result<String> {
+    let path_description = error_field
+        .strip_suffix("_workloads")
+        .map(|prefix| format!("{prefix} workload path"))
+        .unwrap_or_else(|| "workload path".to_string());
+
+    std::env::join_paths(paths)
+        .map_err(|e| {
+            Error::validation_invalid_argument(
+                error_field,
+                format!("{path_description} cannot be exported: {e}"),
+                None,
+                None,
+            )
+        })
+        .map(|joined| joined.to_string_lossy().to_string())
 }
 
 fn no_extensions_error(component: &Component) -> Error {

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -10,10 +10,11 @@ use crate::engine::baseline::BaselineFlags;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, ErrorCode, Result};
 use crate::extension::trace::baseline::TraceBaselineComparison;
+use crate::extension::RunnerOutput;
 use crate::extension::{
-    resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
+    build_scenario_runner, path_list_env_value, resolve_execution_context, stderr_tail,
+    ExtensionCapability, ExtensionExecutionContext, ScenarioRunnerOptions,
 };
-use crate::extension::{ExtensionRunner, RunnerOutput};
 use crate::rig::RigStateSnapshot;
 
 use super::attach::{append_attach_observations, observe_trace_attachments, TraceAttachment};
@@ -571,37 +572,33 @@ pub(crate) fn build_trace_runner(
         return run_generic_trace_runner(component, args, run_dir, &artifact_dir, list_only);
     };
 
-    let mut runner = ExtensionRunner::for_context(execution_context.clone())
-        .component(component.clone())
-        .path_override(args.path_override.clone())
-        .settings(&args.settings)
-        .settings_json(&args.runner_inputs.json_settings)
-        .with_run_dir(run_dir)
-        .cleanup_process_group(true)
-        .env(
+    let mut runner = build_scenario_runner(ScenarioRunnerOptions {
+        execution_context,
+        component,
+        path_override: args.path_override.clone(),
+        settings: &args.settings,
+        settings_json: &args.runner_inputs.json_settings,
+        run_dir,
+        cleanup_process_group: true,
+        results_env: Some((
             "HOMEBOY_TRACE_RESULTS_FILE",
-            &run_dir
-                .step_file(run_dir::files::TRACE_RESULTS)
-                .to_string_lossy(),
-        )
-        .env("HOMEBOY_TRACE_SCENARIO", &args.scenario_id)
-        .env(
-            "HOMEBOY_TRACE_ARTIFACT_DIR",
-            &artifact_dir.to_string_lossy(),
-        )
-        .env("HOMEBOY_TRACE_LIST_ONLY", if list_only { "1" } else { "0" });
+            run_dir.step_file(run_dir::files::TRACE_RESULTS),
+        )),
+        scenario_env: Some(("HOMEBOY_TRACE_SCENARIO", &args.scenario_id)),
+        artifact_env: Some(("HOMEBOY_TRACE_ARTIFACT_DIR", &artifact_dir)),
+        list_only_env: Some(("HOMEBOY_TRACE_LIST_ONLY", list_only)),
+        extra_workloads_env: Some((
+            "HOMEBOY_TRACE_EXTRA_WORKLOADS",
+            &args.runner_inputs.workload_paths,
+            "trace_workloads",
+        )),
+    })?;
 
     if let Some(rig_id) = &args.rig_id {
         runner = runner.env("HOMEBOY_TRACE_RIG_ID", rig_id);
     }
     if let Some(path) = &args.path_override {
         runner = runner.env("HOMEBOY_TRACE_COMPONENT_PATH", path);
-    }
-    if !args.runner_inputs.workload_paths.is_empty() {
-        runner = runner.env(
-            "HOMEBOY_TRACE_EXTRA_WORKLOADS",
-            &extra_workloads_env_value(&args.runner_inputs.workload_paths)?,
-        );
     }
     if !args.runner_inputs.attachments.is_empty() {
         let attachments_json =
@@ -895,16 +892,7 @@ fn generic_trace_env(
 }
 
 fn extra_workloads_env_value(paths: &[PathBuf]) -> Result<String> {
-    std::env::join_paths(paths)
-        .map_err(|e| {
-            Error::validation_invalid_argument(
-                "trace_workloads",
-                format!("trace workload path cannot be exported: {}", e),
-                None,
-                None,
-            )
-        })
-        .map(|joined| joined.to_string_lossy().to_string())
+    path_list_env_value("trace_workloads", paths)
 }
 
 fn failure_from_output(args: &TraceRunWorkflowArgs, output: &RunnerOutput) -> TraceRunFailure {

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -49,16 +49,8 @@ impl ActiveObservation {
         &self.initial_metadata
     }
 
-    pub fn merged_metadata(&self, finish: serde_json::Value) -> serde_json::Value {
-        merge_metadata(self.initial_metadata.clone(), finish)
-    }
-
     pub fn finish(&self, status: RunStatus, metadata: Option<serde_json::Value>) {
         let _ = self.store.finish_run(self.run_id(), status, metadata);
-    }
-
-    pub fn finish_merged(&self, status: RunStatus, finish_metadata: serde_json::Value) {
-        self.finish(status, Some(self.merged_metadata(finish_metadata)));
     }
 
     pub fn finish_error(&self, metadata: Option<serde_json::Value>) {
@@ -98,6 +90,26 @@ pub fn merge_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::observation::FindingListFilter;
+    use crate::test_support::with_isolated_home;
+    use std::fs;
+
+    fn run_record() -> NewRunRecord {
+        NewRunRecord {
+            kind: "test".to_string(),
+            component_id: Some("homeboy".to_string()),
+            command: Some("homeboy test homeboy".to_string()),
+            cwd: Some("/tmp/homeboy".to_string()),
+            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: Some("studio".to_string()),
+            metadata_json: serde_json::json!({ "status": "running" }),
+        }
+    }
+
+    fn active_observation() -> ActiveObservation {
+        ActiveObservation::start(run_record()).expect("active observation")
+    }
 
     #[test]
     fn merge_metadata_preserves_initial_and_overwrites_finish_keys() {
@@ -109,5 +121,165 @@ mod tests {
         assert_eq!(merged["component"], "homeboy");
         assert_eq!(merged["status"], "pass");
         assert_eq!(merged["exit_code"], 0);
+    }
+
+    #[test]
+    fn test_start() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert_eq!(observation.run().kind, "test");
+            assert_eq!(observation.run().status, "running");
+        });
+    }
+
+    #[test]
+    fn test_start_best_effort() {
+        with_isolated_home(|_| {
+            assert!(ActiveObservation::start_best_effort(run_record()).is_some());
+        });
+    }
+
+    #[test]
+    fn test_store() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert!(observation.store().status().expect("status").exists);
+        });
+    }
+
+    #[test]
+    fn test_run() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert_eq!(observation.run().component_id.as_deref(), Some("homeboy"));
+        });
+    }
+
+    #[test]
+    fn test_run_id() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert!(!observation.run_id().is_empty());
+        });
+    }
+
+    #[test]
+    fn test_component_id() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert_eq!(observation.component_id(), Some("homeboy"));
+        });
+    }
+
+    #[test]
+    fn test_rig_id() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert_eq!(observation.rig_id(), Some("studio"));
+        });
+    }
+
+    #[test]
+    fn test_initial_metadata() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert_eq!(observation.initial_metadata()["status"], "running");
+        });
+    }
+
+    #[test]
+    fn test_finish() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+            let run_id = observation.run_id().to_string();
+            observation.finish(RunStatus::Pass, Some(serde_json::json!({ "exit_code": 0 })));
+
+            let run = observation
+                .store()
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run");
+            assert_eq!(run.status, "pass");
+            assert_eq!(run.metadata_json["exit_code"], 0);
+        });
+    }
+
+    #[test]
+    fn test_finish_error() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+            let run_id = observation.run_id().to_string();
+            observation.finish_error(Some(serde_json::json!({ "error": "boom" })));
+
+            let run = observation
+                .store()
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run");
+            assert_eq!(run.status, "error");
+            assert_eq!(run.metadata_json["error"], "boom");
+        });
+    }
+
+    #[test]
+    fn test_record_findings() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+            observation.record_findings(&[NewFindingRecord {
+                run_id: observation.run_id().to_string(),
+                tool: "test".to_string(),
+                rule: Some("rule".to_string()),
+                file: Some("src/lib.rs".to_string()),
+                line: Some(1),
+                severity: Some("error".to_string()),
+                fingerprint: Some("fingerprint".to_string()),
+                message: "message".to_string(),
+                fixable: Some(false),
+                metadata_json: serde_json::json!({}),
+            }]);
+
+            let findings = observation
+                .store()
+                .list_findings(FindingListFilter {
+                    run_id: Some(observation.run_id().to_string()),
+                    ..FindingListFilter::default()
+                })
+                .expect("findings");
+            assert_eq!(findings.len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_record_artifact_if_file() {
+        with_isolated_home(|home| {
+            let observation = active_observation();
+            let artifact = home.path().join("artifact.json");
+            fs::write(&artifact, b"{}").expect("write artifact");
+
+            observation.record_artifact_if_file("artifact", &artifact);
+
+            let artifacts = observation
+                .store()
+                .list_artifacts(observation.run_id())
+                .expect("artifacts");
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].kind, "artifact");
+        });
+    }
+
+    #[test]
+    fn test_store_path() {
+        with_isolated_home(|_| {
+            let observation = active_observation();
+
+            assert!(observation.store_path().ends_with("homeboy.sqlite"));
+        });
     }
 }

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -1,0 +1,113 @@
+use std::path::Path;
+
+use super::{NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus};
+
+pub struct ActiveObservation {
+    store: ObservationStore,
+    run: RunRecord,
+    initial_metadata: serde_json::Value,
+}
+
+impl ActiveObservation {
+    pub fn start(record: NewRunRecord) -> crate::Result<Self> {
+        let store = ObservationStore::open_initialized()?;
+        let initial_metadata = record.metadata_json.clone();
+        let run = store.start_run(record)?;
+
+        Ok(Self {
+            store,
+            run,
+            initial_metadata,
+        })
+    }
+
+    pub fn start_best_effort(record: NewRunRecord) -> Option<Self> {
+        Self::start(record).ok()
+    }
+
+    pub fn store(&self) -> &ObservationStore {
+        &self.store
+    }
+
+    pub fn run(&self) -> &RunRecord {
+        &self.run
+    }
+
+    pub fn run_id(&self) -> &str {
+        &self.run.id
+    }
+
+    pub fn component_id(&self) -> Option<&str> {
+        self.run.component_id.as_deref()
+    }
+
+    pub fn rig_id(&self) -> Option<&str> {
+        self.run.rig_id.as_deref()
+    }
+
+    pub fn initial_metadata(&self) -> &serde_json::Value {
+        &self.initial_metadata
+    }
+
+    pub fn merged_metadata(&self, finish: serde_json::Value) -> serde_json::Value {
+        merge_metadata(self.initial_metadata.clone(), finish)
+    }
+
+    pub fn finish(&self, status: RunStatus, metadata: Option<serde_json::Value>) {
+        let _ = self.store.finish_run(self.run_id(), status, metadata);
+    }
+
+    pub fn finish_merged(&self, status: RunStatus, finish_metadata: serde_json::Value) {
+        self.finish(status, Some(self.merged_metadata(finish_metadata)));
+    }
+
+    pub fn finish_error(&self, metadata: Option<serde_json::Value>) {
+        self.finish(RunStatus::Error, metadata);
+    }
+
+    pub fn record_findings(&self, records: &[NewFindingRecord]) {
+        let _ = self.store.record_findings(records);
+    }
+
+    pub fn record_artifact_if_file(&self, kind: &str, path: &Path) {
+        if path.is_file() {
+            let _ = self.store.record_artifact(self.run_id(), kind, path);
+        }
+    }
+
+    pub fn store_path(&self) -> String {
+        self.store
+            .status()
+            .map(|status| status.path)
+            .unwrap_or_else(|_| "<unavailable>".to_string())
+    }
+}
+
+pub fn merge_metadata(
+    mut initial: serde_json::Value,
+    finish: serde_json::Value,
+) -> serde_json::Value {
+    if let (Some(initial), Some(finish)) = (initial.as_object_mut(), finish.as_object()) {
+        for (key, value) in finish {
+            initial.insert(key.clone(), value.clone());
+        }
+    }
+    initial
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_metadata_preserves_initial_and_overwrites_finish_keys() {
+        let merged = merge_metadata(
+            serde_json::json!({ "status": "running", "component": "homeboy" }),
+            serde_json::json!({ "status": "pass", "exit_code": 0 }),
+        );
+
+        assert_eq!(merged["component"], "homeboy");
+        assert_eq!(merged["status"], "pass");
+        assert_eq!(merged["exit_code"], 0);
+    }
+}

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -4,8 +4,11 @@
 //! stack specs, baselines). SQLite stores observed state from command runs and
 //! generated artifacts. This module only provides the storage substrate.
 
+mod lifecycle;
 pub mod records;
 pub mod store;
+
+pub use lifecycle::{merge_metadata, ActiveObservation};
 
 pub use records::{
     finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,


### PR DESCRIPTION
## Summary
- Centralize resolved extension settings conversion behind explicit string, typed JSON, and lossy string views.
- Add a shared `ActiveObservation` lifecycle helper and migrate lint/test/bench/review observation plumbing to it.
- Share common bench/trace extension scenario runner setup while preserving domain-specific envs and parsing.

## Tests
- `cargo check --lib`
- `cargo test resolved_settings_split_string_json_and_lossy_views --lib`
- `cargo test merge_metadata_preserves_initial_and_overwrites_finish_keys --lib`
- `cargo test bench_observation --lib`
- `cargo test test_observation --lib`
- `cargo test extra_workloads_env_value --lib`

Closes #2251.
Closes #2252.
Closes #2253.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.