### PR TITLE
Generalize component runtime requirements

### DIFF
--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -65,6 +65,24 @@ Component configuration defines buildable and deployable units stored in `compon
   - **`steps`** (array): Release step definitions
   - **`settings`** (object): Release pipeline settings
 
+### Runtime Requirements
+
+`homeboy component env` reports runtime requirements in a generic `runtimes` map:
+
+```json
+{
+  "command": "component.env",
+  "id": "example",
+  "extension": "example-extension",
+  "runtimes": {
+    "php": { "version": "8.2", "source": "component" },
+    "node": { "version": "22", "source": "extension:example-extension" }
+  }
+}
+```
+
+Runtime IDs are extension-owned strings. `source` is `component` for component config or detector output and `extension:<id>` for extension-provided defaults. Legacy component extension settings such as `{ "php": "8.2", "node": "22" }` are still parsed for compatibility; new config should use `runtimes`.
+
 ### Hook Fields
 
 - **`pre_version_bump_commands`** (array of strings): Commands to run BEFORE version targets are updated

--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -206,6 +206,33 @@ Runtime configuration defines how executable extensions are executed.
   - Values can use template variables
   - Example: `{"MY_VAR": "{{extensionPath}}/data"}`
 
+## Runtime Requirements
+
+Extension manifests and `component_env.detect_script` output can declare runtime requirements with a generic `runtimes` map:
+
+```json
+{
+  "runtime": {
+    "runtimes": {
+      "php": { "version": "8.2" },
+      "node": { "version": "22" }
+    }
+  }
+}
+```
+
+Detector output uses the same shape without the outer `runtime` field:
+
+```json
+{
+  "runtimes": {
+    "python": { "version": "3.12" }
+  }
+}
+```
+
+Runtime IDs are extension-owned strings. Legacy detector or manifest requirement objects with top-level `php` or `node` string fields are still accepted for compatibility; new manifests should use `runtimes`.
+
 ## Platform Configuration
 
 Platform configuration defines database, deployment, and version detection behaviors.

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use homeboy::component::{self, Component};
@@ -128,9 +129,9 @@ enum ComponentCommand {
     },
     /// Detect runtime environment requirements from the component's source files.
     ///
-    /// Reads extension-specific metadata (e.g., WordPress "Requires PHP" header)
-    /// to determine what runtime versions the component needs. Outputs JSON
-    /// suitable for CI environment setup.
+    /// Reads extension-specific metadata to determine what runtime versions the
+    /// component needs. Outputs generic runtime requirement JSON suitable for CI
+    /// environment setup.
     Env {
         /// Component ID (optional when --path is provided)
         id: Option<String>,
@@ -431,14 +432,14 @@ struct ComponentEnvOutput {
     command: String,
     id: String,
     extension: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    php: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    php_source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    node: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    node_source: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    runtimes: BTreeMap<String, ComponentRuntimeRequirement>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ComponentRuntimeRequirement {
+    version: String,
+    source: String,
 }
 
 fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
@@ -479,26 +480,25 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         .as_ref()
         .and_then(|exts| exts.keys().next().cloned());
 
-    let mut php_version: Option<String> = None;
-    let mut node_version: Option<String> = None;
-    let mut php_source: Option<String> = None;
-    let mut node_source: Option<String> = None;
+    let mut runtimes: BTreeMap<String, ComponentRuntimeRequirement> = BTreeMap::new();
 
-    // Read node version from raw homeboy.json (the Rust struct drops unknown
-    // fields like "php" and "node" from the extension config during deserialization).
+    // Read component-scoped runtime requirements from raw homeboy.json; the typed
+    // extension settings intentionally preserve extension-owned unknown fields.
     if let Some(ref ext_id) = extension_id {
         let config_path = local_path.join("homeboy.json");
         if let Ok(raw) = std::fs::read_to_string(&config_path) {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) {
                 if let Some(ext_obj) = json.get("extensions").and_then(|e| e.get(ext_id.as_str())) {
-                    if let Some(v) = ext_obj.get("node").and_then(|v| v.as_str()) {
-                        node_version = Some(v.to_string());
-                        node_source = Some("component".to_string());
-                    }
-                    // Read php from homeboy.json as fallback (overridden below by header detection)
-                    if let Some(v) = ext_obj.get("php").and_then(|v| v.as_str()) {
-                        php_version = Some(v.to_string());
-                        php_source = Some("component".to_string());
+                    if let Ok(requirements) = serde_json::from_value::<
+                        homeboy::extension::RuntimeRequirementsConfig,
+                    >(ext_obj.clone())
+                    {
+                        apply_component_runtime_requirements(
+                            requirements,
+                            &mut runtimes,
+                            "component",
+                            true,
+                        );
                     }
                 }
             }
@@ -513,26 +513,13 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
 
     if let Some(ref extension) = extension {
         if let Some(detected) = run_component_env_detector(extension, local_path)? {
-            apply_component_env_detector_output(
-                detected,
-                &mut node_version,
-                &mut node_source,
-                &mut php_version,
-                &mut php_source,
-            );
+            apply_component_env_detector_output(detected, &mut runtimes);
         }
     }
 
     if let (Some(ext_id), Some(extension)) = (extension_id.as_ref(), extension.as_ref()) {
         if let Some(runtime) = extension.runtime.as_ref() {
-            apply_extension_runtime_requirements(
-                ext_id,
-                runtime,
-                &mut node_version,
-                &mut node_source,
-                &mut php_version,
-                &mut php_source,
-            );
+            apply_extension_runtime_requirements(ext_id, runtime, &mut runtimes);
         }
     }
 
@@ -540,10 +527,7 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         command: "component.env".to_string(),
         id: comp_id.clone(),
         extension: extension_id,
-        php: php_version,
-        php_source,
-        node: node_version,
-        node_source,
+        runtimes,
     };
 
     let entity = serde_json::to_value(&env_output).map_err(|error| {
@@ -635,39 +619,35 @@ fn run_component_env_detector(
 
 fn apply_component_env_detector_output(
     detected: homeboy::extension::RuntimeRequirementsConfig,
-    node_version: &mut Option<String>,
-    node_source: &mut Option<String>,
-    php_version: &mut Option<String>,
-    php_source: &mut Option<String>,
+    runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
 ) {
-    if let Some(php) = detected.php {
-        *php_version = Some(php);
-        *php_source = Some("component".to_string());
-    }
-    if let Some(node) = detected.node {
-        *node_version = Some(node);
-        *node_source = Some("component".to_string());
-    }
+    apply_component_runtime_requirements(detected, runtimes, "component", true);
 }
 
 fn apply_extension_runtime_requirements(
     extension_id: &str,
     runtime: &homeboy::extension::RuntimeRequirementsConfig,
-    node_version: &mut Option<String>,
-    node_source: &mut Option<String>,
-    php_version: &mut Option<String>,
-    php_source: &mut Option<String>,
+    runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
 ) {
-    if node_version.is_none() {
-        if let Some(node) = runtime.node.as_ref() {
-            *node_version = Some(node.clone());
-            *node_source = Some(format!("extension:{}", extension_id));
-        }
-    }
-    if php_version.is_none() {
-        if let Some(php) = runtime.php.as_ref() {
-            *php_version = Some(php.clone());
-            *php_source = Some(format!("extension:{}", extension_id));
+    let source = format!("extension:{}", extension_id);
+    apply_component_runtime_requirements(runtime.clone(), runtimes, &source, false);
+}
+
+fn apply_component_runtime_requirements(
+    requirements: homeboy::extension::RuntimeRequirementsConfig,
+    runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
+    source: &str,
+    overwrite: bool,
+) {
+    for (id, requirement) in requirements.runtimes {
+        if overwrite || !runtimes.contains_key(&id) {
+            runtimes.insert(
+                id,
+                ComponentRuntimeRequirement {
+                    version: requirement.version,
+                    source: source.to_string(),
+                },
+            );
         }
     }
 }
@@ -1086,28 +1066,22 @@ mod tests {
 
     #[test]
     fn extension_runtime_requirements_fill_missing_component_versions() {
-        let runtime = homeboy::extension::RuntimeRequirementsConfig {
-            node: Some("24".to_string()),
-            php: Some("8.3".to_string()),
-        };
-        let mut node = None;
-        let mut node_source = None;
-        let mut php = None;
-        let mut php_source = None;
+        let runtime: homeboy::extension::RuntimeRequirementsConfig =
+            serde_json::from_value(serde_json::json!({
+                "runtimes": {
+                    "node": { "version": "24" },
+                    "php": { "version": "8.3" }
+                }
+            }))
+            .expect("runtime requirements");
+        let mut runtimes = BTreeMap::new();
 
-        apply_extension_runtime_requirements(
-            "nodejs",
-            &runtime,
-            &mut node,
-            &mut node_source,
-            &mut php,
-            &mut php_source,
-        );
+        apply_extension_runtime_requirements("nodejs", &runtime, &mut runtimes);
 
-        assert_eq!(node.as_deref(), Some("24"));
-        assert_eq!(node_source.as_deref(), Some("extension:nodejs"));
-        assert_eq!(php.as_deref(), Some("8.3"));
-        assert_eq!(php_source.as_deref(), Some("extension:nodejs"));
+        assert_eq!(runtimes["node"].version, "24");
+        assert_eq!(runtimes["node"].source, "extension:nodejs");
+        assert_eq!(runtimes["php"].version, "8.3");
+        assert_eq!(runtimes["php"].source, "extension:nodejs");
     }
 
     #[test]
@@ -1121,7 +1095,7 @@ mod tests {
         let script = extension_dir.join("scripts/env/detect.sh");
         fs::write(
             &script,
-            "#!/bin/sh\nprintf '{\"php\":\"8.2\",\"node\":\"22\"}'\n",
+            "#!/bin/sh\nprintf '{\"runtimes\":{\"php\":{\"version\":\"8.2\"},\"node\":{\"version\":\"22\"}}}'\n",
         )
         .expect("write detector");
         let mut perms = fs::metadata(&script)
@@ -1144,69 +1118,106 @@ mod tests {
             .expect("detector should run")
             .expect("detector output");
 
-        assert_eq!(detected.php.as_deref(), Some("8.2"));
-        assert_eq!(detected.node.as_deref(), Some("22"));
+        assert_eq!(detected.runtimes["php"].version, "8.2");
+        assert_eq!(detected.runtimes["node"].version, "22");
+    }
+
+    #[test]
+    fn runtime_requirements_accept_generic_and_legacy_shapes() {
+        let generic: homeboy::extension::RuntimeRequirementsConfig =
+            serde_json::from_value(serde_json::json!({
+                "runtimes": {
+                    "python": { "version": "3.12" },
+                    "ruby": "3.3"
+                }
+            }))
+            .expect("generic requirements");
+
+        assert_eq!(generic.runtimes["python"].version, "3.12");
+        assert_eq!(generic.runtimes["ruby"].version, "3.3");
+
+        let legacy: homeboy::extension::RuntimeRequirementsConfig =
+            serde_json::from_value(serde_json::json!({ "php": "8.2", "node": "22" }))
+                .expect("legacy requirements");
+
+        assert_eq!(legacy.runtimes["php"].version, "8.2");
+        assert_eq!(legacy.runtimes["node"].version, "22");
     }
 
     #[test]
     fn component_env_detector_output_overrides_component_values_before_runtime_defaults() {
-        let runtime = homeboy::extension::RuntimeRequirementsConfig {
-            node: Some("24".to_string()),
-            php: Some("8.4".to_string()),
-        };
-        let mut node = Some("20".to_string());
-        let mut node_source = Some("component".to_string());
-        let mut php = Some("8.0".to_string());
-        let mut php_source = Some("component".to_string());
+        let runtime: homeboy::extension::RuntimeRequirementsConfig =
+            serde_json::from_value(serde_json::json!({
+                "runtimes": {
+                    "node": { "version": "24" },
+                    "php": { "version": "8.4" }
+                }
+            }))
+            .expect("runtime requirements");
+        let mut runtimes = BTreeMap::from([
+            (
+                "node".to_string(),
+                ComponentRuntimeRequirement {
+                    version: "20".to_string(),
+                    source: "component".to_string(),
+                },
+            ),
+            (
+                "php".to_string(),
+                ComponentRuntimeRequirement {
+                    version: "8.0".to_string(),
+                    source: "component".to_string(),
+                },
+            ),
+        ]);
 
         apply_component_env_detector_output(
-            homeboy::extension::RuntimeRequirementsConfig {
-                php: Some("8.2".to_string()),
-                node: None,
-            },
-            &mut node,
-            &mut node_source,
-            &mut php,
-            &mut php_source,
+            serde_json::from_value(serde_json::json!({
+                "runtimes": { "php": { "version": "8.2" } }
+            }))
+            .expect("detected requirements"),
+            &mut runtimes,
         );
-        apply_extension_runtime_requirements(
-            "demo",
-            &runtime,
-            &mut node,
-            &mut node_source,
-            &mut php,
-            &mut php_source,
-        );
+        apply_extension_runtime_requirements("demo", &runtime, &mut runtimes);
 
-        assert_eq!(php.as_deref(), Some("8.2"));
-        assert_eq!(php_source.as_deref(), Some("component"));
-        assert_eq!(node.as_deref(), Some("20"));
-        assert_eq!(node_source.as_deref(), Some("component"));
+        assert_eq!(runtimes["php"].version, "8.2");
+        assert_eq!(runtimes["php"].source, "component");
+        assert_eq!(runtimes["node"].version, "20");
+        assert_eq!(runtimes["node"].source, "component");
     }
 
     #[test]
     fn component_versions_win_over_extension_runtime_requirements() {
-        let runtime = homeboy::extension::RuntimeRequirementsConfig {
-            node: Some("24".to_string()),
-            php: Some("8.3".to_string()),
-        };
-        let mut node = Some("22".to_string());
-        let mut node_source = Some("component".to_string());
-        let mut php = Some("8.2".to_string());
-        let mut php_source = Some("component".to_string());
+        let runtime: homeboy::extension::RuntimeRequirementsConfig =
+            serde_json::from_value(serde_json::json!({
+                "runtimes": {
+                    "node": { "version": "24" },
+                    "php": { "version": "8.3" }
+                }
+            }))
+            .expect("runtime requirements");
+        let mut runtimes = BTreeMap::from([
+            (
+                "node".to_string(),
+                ComponentRuntimeRequirement {
+                    version: "22".to_string(),
+                    source: "component".to_string(),
+                },
+            ),
+            (
+                "php".to_string(),
+                ComponentRuntimeRequirement {
+                    version: "8.2".to_string(),
+                    source: "component".to_string(),
+                },
+            ),
+        ]);
 
-        apply_extension_runtime_requirements(
-            "nodejs",
-            &runtime,
-            &mut node,
-            &mut node_source,
-            &mut php,
-            &mut php_source,
-        );
+        apply_extension_runtime_requirements("nodejs", &runtime, &mut runtimes);
 
-        assert_eq!(node.as_deref(), Some("22"));
-        assert_eq!(node_source.as_deref(), Some("component"));
-        assert_eq!(php.as_deref(), Some("8.2"));
-        assert_eq!(php_source.as_deref(), Some("component"));
+        assert_eq!(runtimes["node"].version, "22");
+        assert_eq!(runtimes["node"].source, "component");
+        assert_eq!(runtimes["php"].version, "8.2");
+        assert_eq!(runtimes["php"].source, "component");
     }
 }

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -4,7 +4,7 @@ use crate::engine::output_parse::ParseSpec;
 use crate::engine::run_dir;
 use crate::error::{Error, Result};
 use crate::paths;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -932,12 +932,66 @@ pub struct StructuredSidecarDeclaration {
     pub schema_version: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
 pub struct RuntimeRequirementsConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub node: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub php: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub runtimes: HashMap<String, RuntimeRequirementConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeRequirementConfig {
+    pub version: String,
+}
+
+impl<'de> Deserialize<'de> for RuntimeRequirementsConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RuntimeRequirementsWire {
+            #[serde(default)]
+            runtimes: HashMap<String, RuntimeRequirementWire>,
+            #[serde(default)]
+            node: Option<RuntimeRequirementWire>,
+            #[serde(default)]
+            php: Option<RuntimeRequirementWire>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RuntimeRequirementWire {
+            Version(String),
+            Object { version: String },
+        }
+
+        impl RuntimeRequirementWire {
+            fn into_config(self) -> RuntimeRequirementConfig {
+                match self {
+                    RuntimeRequirementWire::Version(version) => {
+                        RuntimeRequirementConfig { version }
+                    }
+                    RuntimeRequirementWire::Object { version } => {
+                        RuntimeRequirementConfig { version }
+                    }
+                }
+            }
+        }
+
+        let wire = RuntimeRequirementsWire::deserialize(deserializer)?;
+        let mut runtimes = HashMap::new();
+        if let Some(requirement) = wire.node {
+            runtimes.insert("node".to_string(), requirement.into_config());
+        }
+        if let Some(requirement) = wire.php {
+            runtimes.insert("php".to_string(), requirement.into_config());
+        }
+        for (id, requirement) in wire.runtimes {
+            runtimes.insert(id, requirement.into_config());
+        }
+
+        Ok(Self { runtimes })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -1172,7 +1172,7 @@ mod tests {
         let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
             "name": "Example",
             "version": "0.0.0",
-            "runtime": { "node": "24" },
+            "runtime": { "runtimes": { "node": { "version": "24" } } },
             "lint": { "extension_script": "lint.sh" },
             "test": {
                 "extension_script": "test.sh",
@@ -1190,7 +1190,8 @@ mod tests {
             manifest
                 .runtime
                 .as_ref()
-                .and_then(|runtime| runtime.node.as_deref()),
+                .and_then(|runtime| runtime.runtimes.get("node"))
+                .map(|runtime| runtime.version.as_str()),
             Some("24")
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- Replace `component env` php/node-specific output with a generic `runtimes` map carrying version and source.
- Generalize extension runtime requirement parsing while accepting legacy top-level `php` and `node` fields for compatibility.
- Document the generic runtime requirements shape for components, manifests, and detector output.

## Tests
- `cargo test component::tests::`
- `cargo test extension::tests::extension_capability_owns_labels_and_scripts`

## Compatibility
- Existing detector or manifest requirement objects with top-level `php` / `node` strings are still parsed.
- New manifests and detector outputs should use `runtimes` with extension-owned runtime IDs.

## Issues
- Supports #2240
- Fixes #2244

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.