### PR TITLE
fix: move release ecosystem behavior to extension contracts

### DIFF
--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -70,7 +70,7 @@ Component configuration defines buildable and deployable units stored in `compon
 - **`pre_version_bump_commands`** (array of strings): Commands to run BEFORE version targets are updated
   - Execution: Sequential, runs in `local_path` directory
   - Failure behavior: **Fatal** - stops version bump on non-zero exit code
-  - Use case: Stage build artifacts (e.g., `cargo build --release` to update Cargo.lock)
+  - Use case: Validate generated sources before changing version files
 
 - **`post_version_bump_commands`** (array of strings): Commands to run AFTER version files are updated
   - Execution: Sequential, runs in `local_path` directory
@@ -116,10 +116,10 @@ Setting `local_path` to the same directory as the deploy target is a misconfigur
   ],
   "changelog_target": "CHANGELOG.md",
   "pre_version_bump_commands": [
-    "cargo build --release"
+    "./scripts/verify-generated-sources"
   ],
   "post_version_bump_commands": [
-    "git add Cargo.lock"
+    "./scripts/refresh-versioned-artifacts"
   ],
   "post_release_commands": [
     "echo 'Release complete!'"

--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -399,6 +399,25 @@ Release actions define steps for release pipelines.
 - **`extension.run`**: Execute extension runtime command
 - **`extension.action`**: Execute extension action
 
+### Release Action Output Contract
+
+Release actions should return JSON that is generic to the action outcome, not to a language or package manager. Core release rendering understands these status values:
+
+- **`success: true`**: The action completed successfully.
+- **`status: "skipped"`** with `success: false`: The action intentionally did nothing.
+- **`status: "missing_secret"`** with `success: false`: A required token or credential is not configured.
+- **`status: "auth_required"`** with `success: false`: The user must authenticate before the action can run.
+
+For skipped or authentication-related results, include **`reason`** or **`message`** with the human-readable explanation. Core surfaces that explanation in the release step warning without parsing ecosystem-specific command output.
+
+```json
+{
+  "success": false,
+  "status": "missing_secret",
+  "reason": "Registry token is not configured"
+}
+```
+
 #### Example
 
 ```json
@@ -424,7 +443,7 @@ Extensions can declare lifecycle hooks that run at named events. Extension hooks
 ```json
 {
   "hooks": {
-    "pre:version:bump": ["cargo generate-lockfile"],
+    "post:version:bump": ["package-manager refresh-lockfile"],
     "post:deploy": [
       "wp cache flush --path={{base_path}} --allow-root 2>/dev/null || true"
     ]
@@ -437,6 +456,8 @@ Extensions can declare lifecycle hooks that run at named events. Extension hooks
 - **`hooks`** (object): Map of event names to command arrays
   - Keys: event name (e.g., `pre:version:bump`, `post:version:bump`, `post:release`, `post:deploy`)
   - Values: array of shell command strings
+
+Use `post:version:bump` for generated artifacts that must reflect the new version before the release commit, such as lockfiles, generated manifests, or version-derived build metadata.
 
 Most hooks execute locally in the component's directory. `post:deploy` hooks execute **remotely via SSH** with template variable expansion:
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -518,8 +518,7 @@ pub(crate) fn run_package(
                 "No extension provides release.package action",
                 None,
                 Some(vec![
-                    "Add a extension with release.package action to the component".to_string(),
-                    "For Rust projects, add: \"extensions\": { \"rust\": {} }".to_string(),
+                    "Add an extension with a release.package action to the component".to_string(),
                 ]),
             )
         })?;
@@ -611,12 +610,15 @@ fn publish_step_result(
         return step_success(step_id, step_id, data, Vec::new());
     }
 
-    if is_missing_cargo_token_publish_response(target, extension_id, response) {
+    if let Some(reason) = extension_skip_reason(response) {
         return step_skipped(
             step_id,
             step_id,
             data,
-            "Skipped Rust publish: no Cargo registry token is configured",
+            format!(
+                "Skipped publish to {} via {}: {}",
+                target, extension_id, reason
+            ),
         );
     }
 
@@ -629,18 +631,25 @@ fn publish_step_result(
     )
 }
 
-fn is_missing_cargo_token_publish_response(
-    target: &str,
-    extension_id: &str,
-    response: &serde_json::Value,
-) -> bool {
-    if target != "rust" && extension_id != "rust" {
-        return false;
+fn extension_skip_reason(response: &serde_json::Value) -> Option<String> {
+    let status = response.get("status").and_then(|v| v.as_str())?;
+    if !matches!(status, "skipped" | "missing_secret" | "auth_required") {
+        return None;
     }
 
-    let output = publish_response_output(response).to_ascii_lowercase();
-    output.contains("no token found")
-        && (output.contains("cargo login") || output.contains("cargo_registry_token"))
+    response
+        .get("reason")
+        .or_else(|| response.get("message"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            let output = publish_response_output(response);
+            let detail = output.trim();
+            (!detail.is_empty()).then(|| detail.to_string())
+        })
+        .or_else(|| Some(status.replace('_', " ")))
 }
 
 fn publish_response_output(response: &serde_json::Value) -> String {
@@ -1053,7 +1062,7 @@ fn store_artifacts_from_output(
         } else if exit_code != 0 {
             format!(
                 "Package command failed (exit {}) with no output. \
-                 Check that the required packaging tool is installed (e.g., cargo-dist)",
+                 Check that the required packaging tool is installed and configured.",
                 exit_code
             )
         } else {
@@ -1114,6 +1123,7 @@ fn sanitize_tag_for_filename(tag: &str) -> String {
 mod tests {
     use super::{
         fallback_gh_command, publish_step_result, run_git_push, sanitize_tag_for_filename,
+        store_artifacts_from_output,
     };
     use crate::component::Component;
     use crate::release::ReleaseStepStatus;
@@ -1171,49 +1181,75 @@ mod tests {
     }
 
     #[test]
-    fn publish_step_skips_rust_when_cargo_token_is_missing() {
+    fn publish_step_skips_when_extension_reports_missing_secret() {
         let response = serde_json::json!({
             "success": false,
-            "exitCode": 101,
+            "status": "missing_secret",
+            "reason": "registry token is not configured",
             "stdout": "",
-            "stderr": "error: no token found, please run cargo login\nor use environment variable CARGO_REGISTRY_TOKEN",
+            "stderr": "",
         });
         let data = serde_json::json!({ "response": response.clone() });
 
-        let result = publish_step_result("publish.rust", "rust", "rust", Some(data), &response);
+        let result = publish_step_result(
+            "publish.registry",
+            "registry",
+            "registry",
+            Some(data),
+            &response,
+        );
 
         assert_eq!(result.status, ReleaseStepStatus::Skipped);
         assert!(result.error.is_none());
         assert_eq!(result.warnings.len(), 1);
-        assert!(result.warnings[0].contains("no Cargo registry token"));
+        assert!(result.warnings[0].contains("registry token is not configured"));
     }
 
     #[test]
-    fn publish_step_fails_rust_when_error_is_not_missing_token() {
+    fn publish_step_skips_when_extension_reports_auth_required() {
         let response = serde_json::json!({
             "success": false,
-            "exitCode": 101,
-            "stdout": "",
+            "status": "auth_required",
+            "message": "run the extension login command",
+        });
+
+        let result =
+            publish_step_result("publish.registry", "registry", "registry", None, &response);
+
+        assert_eq!(result.status, ReleaseStepStatus::Skipped);
+        assert!(result.warnings[0].contains("run the extension login command"));
+    }
+
+    #[test]
+    fn publish_step_fails_when_extension_error_has_no_skip_status() {
+        let response = serde_json::json!({
+            "success": false,
+            "exitCode": 1,
             "stderr": "error: failed to upload package: 500 server error",
         });
 
-        let result = publish_step_result("publish.rust", "rust", "rust", None, &response);
+        let result =
+            publish_step_result("publish.registry", "registry", "registry", None, &response);
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
         assert!(result.error.unwrap().contains("500 server error"));
     }
 
     #[test]
-    fn publish_step_fails_non_rust_missing_token_text() {
+    fn package_error_message_is_extension_generic() {
         let response = serde_json::json!({
             "success": false,
             "exitCode": 1,
-            "stderr": "error: no token found, please run cargo login",
+            "stdout": "",
+            "stderr": "",
         });
+        let mut state = crate::release::types::ReleaseState::default();
 
-        let result = publish_step_result("publish.npm", "npm", "npm", None, &response);
+        let err = store_artifacts_from_output(&mut state, &response)
+            .expect_err("empty failing package output should fail");
 
-        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        assert!(err.message.contains("required packaging tool"));
+        assert!(!err.message.contains("example-package-manager"));
     }
 
     // ----- Orphan-tag regression coverage (issue #2234) -----

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -1184,7 +1184,7 @@ fn build_release_steps(
     if !publish_targets.is_empty() && !has_package_capability(extensions) {
         warnings.push(
             "Publish targets derived from extensions but no extension provides 'release.package'. \
-             Add a extension like 'rust' that provides packaging."
+             Add an extension that provides packaging."
                 .to_string(),
         );
     }
@@ -1575,13 +1575,6 @@ fn get_release_allowed_files(
         if let Ok(relative) = std::path::Path::new(target).strip_prefix(repo_root) {
             let rel_str = relative.to_string_lossy().to_string();
             allowed.push(rel_str.clone());
-
-            // If a Cargo.toml is a version target, also allow Cargo.lock
-            // (version bump regenerates the lockfile to keep it in sync)
-            if rel_str.ends_with("Cargo.toml") {
-                let lock_path = relative.with_file_name("Cargo.lock");
-                allowed.push(lock_path.to_string_lossy().to_string());
-            }
         }
     }
 
@@ -1615,7 +1608,7 @@ fn get_unexpected_uncommitted_files(
 mod tests {
     use super::{
         code_quality_failure_message, ensure_changelog_initialized, filter_homeboy_managed,
-        get_unexpected_uncommitted_files, is_homeboy_managed_path,
+        get_release_allowed_files, get_unexpected_uncommitted_files, is_homeboy_managed_path,
         is_runner_infrastructure_failure, read_changelog_for_release, strip_pr_reference,
         validate_release_version_floor,
     };
@@ -1779,10 +1772,10 @@ mod tests {
             ".homeboy-build/artifact.zip".to_string(),
             "src/main.rs".to_string(),
             ".homeboy-bin/homeboy".to_string(),
-            "Cargo.toml".to_string(),
+            "manifest.toml".to_string(),
         ];
         let filtered = filter_homeboy_managed(files);
-        assert_eq!(filtered, vec!["src/main.rs", "Cargo.toml"]);
+        assert_eq!(filtered, vec!["src/main.rs", "manifest.toml"]);
     }
 
     fn uncommitted(staged: &[&str], unstaged: &[&str], untracked: &[&str]) -> UncommittedChanges {
@@ -1818,17 +1811,53 @@ mod tests {
     #[test]
     fn unexpected_files_honor_allowed_list_alongside_homeboy_filter() {
         let changes = uncommitted(
-            &["docs/changelog.md", "Cargo.toml"],
+            &["docs/changelog.md", "manifest.toml"],
             &[],
             &[".homeboy-build/foo"],
         );
-        let allowed = vec!["docs/changelog.md".to_string(), "Cargo.toml".to_string()];
+        let allowed = vec!["docs/changelog.md".to_string(), "manifest.toml".to_string()];
         let unexpected = get_unexpected_uncommitted_files(&changes, &allowed);
         assert!(
             unexpected.is_empty(),
             "allowed files + homeboy scratch should yield clean result, got: {:?}",
             unexpected
         );
+    }
+
+    #[test]
+    fn release_allowed_files_are_only_declared_targets() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_root = temp_dir.path();
+        let changelog = repo_root.join("docs/changelog.md");
+        let manifest = repo_root.join("manifest.toml");
+
+        let allowed = get_release_allowed_files(
+            &changelog,
+            &[manifest.to_string_lossy().to_string()],
+            repo_root,
+        );
+
+        assert_eq!(allowed, vec!["docs/changelog.md", "manifest.toml"]);
+    }
+
+    #[test]
+    fn release_runtime_core_stays_ecosystem_agnostic() {
+        let files = [
+            ("executor.rs", include_str!("executor.rs")),
+            ("pipeline.rs", include_str!("pipeline.rs")),
+            ("version.rs", include_str!("version.rs")),
+        ];
+        let forbidden_terms = ["Cargo", "cargo", "Rust", "rust"];
+
+        for (file, source) in files {
+            let runtime_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+            for term in forbidden_terms {
+                assert!(
+                    !runtime_source.contains(term),
+                    "release runtime core must not branch on ecosystem-specific term {term:?} in {file}"
+                );
+            }
+        }
     }
 
     fn component_with_changelog_target(

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -440,24 +440,6 @@ pub(crate) fn bump_component_version(
         }
     }
 
-    // If any version target is Cargo.toml, regenerate Cargo.lock so it stays in sync.
-    // Without this, the release commit only includes Cargo.toml and post-release hooks
-    // like `cargo publish` fail because Cargo.lock is dirty.
-    let has_cargo_target = target_infos.iter().any(|t| t.file.ends_with("Cargo.toml"));
-    if has_cargo_target {
-        log_status!(
-            "version",
-            "Regenerating Cargo.lock after Cargo.toml version bump"
-        );
-        let lockfile_result = std::process::Command::new("cargo")
-            .args(["generate-lockfile"])
-            .current_dir(&component.local_path)
-            .output();
-        if let Err(e) = lockfile_result {
-            log_status!("warning", "Failed to regenerate Cargo.lock: {}", e);
-        }
-    }
-
     // Replace @since placeholder tags with the new version (extension-driven).
     let since_tags_replaced = replace_since_tag_placeholders(component, &new_version)?;
 
@@ -591,5 +573,44 @@ mod tests {
             "expected first version section, got: {}",
             finalized
         );
+    }
+
+    #[test]
+    fn bump_component_version_runs_post_version_hook_after_version_file_update() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            "{\n  \"version\": \"0.1.0\"\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## Unreleased\n\n",
+        )
+        .unwrap();
+
+        let mut component = make_test_component(&temp_dir);
+        component.version_targets = Some(vec![VersionTarget {
+            file: "package.json".to_string(),
+            pattern: Some(r#""version"\s*:\s*"([^"]+)""#.to_string()),
+        }]);
+        component.hooks.insert(
+            hooks::events::POST_VERSION_BUMP.to_string(),
+            vec!["sh -c 'grep 0.1.1 package.json > generated.lock'".to_string()],
+        );
+
+        let mut entries: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        entries.insert(
+            "fixed".to_string(),
+            vec!["release hook contract".to_string()],
+        );
+
+        let result = bump_component_version(&component, "patch", Some(&entries))
+            .expect("post-version hook should run after version write");
+
+        assert_eq!(result.new_version, "0.1.1");
+        let generated = fs::read_to_string(temp_dir.path().join("generated.lock")).unwrap();
+        assert!(generated.contains("0.1.1"));
     }
 }


### PR DESCRIPTION
## Summary
- Removes Rust/Cargo-specific release behavior from core release runtime paths.
- Adds generic extension publish skip statuses for `skipped`, `missing_secret`, and `auth_required` responses.
- Documents the release action output contract and `post:version:bump` hook path for version-derived artifacts.

## Tests
- `cargo test core::release:: --lib`

## Issues
- Supports #2240
- Fixes #2243

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.