### PR TITLE
Require extensions for write validation and formatting

### DIFF
--- a/docs/development/contracts/compiler-warning-extension.md
+++ b/docs/development/contracts/compiler-warning-extension.md
@@ -1,0 +1,59 @@
+# Compiler Warning Extension Contract Gap
+
+Issue #2242 asks Homeboy core to move compiler-warning collection and compiler-warning fix generation behind extension-owned contracts. Validation and formatting already have extension script contracts (`scripts.validate` and `scripts.format`), but compiler warnings do not.
+
+## Required Upstream Contract
+
+Homeboy core needs an extension manifest contract for two separate capabilities before `src/core/code_audit/compiler_warnings.rs` and `src/core/refactor/plan/generate/compiler_warning_fixes.rs` can be made language-agnostic without dropping behavior.
+
+1. `scripts.compiler_warnings`
+   - Runs from the component root.
+   - Receives JSON on stdin with at least `{ "root": string }`.
+   - Emits a generic warnings envelope on stdout.
+   - Core maps the envelope to `AuditFinding::CompilerWarning` findings.
+
+2. `scripts.compiler_warning_fixes`
+   - Runs from the component root after compiler warning findings exist.
+   - Receives JSON on stdin with `{ "root": string, "findings": [...] }`.
+   - Emits a generic fix-suggestion envelope on stdout.
+   - Core maps line removals and line replacements to existing refactor primitives.
+
+## Proposed Warning Envelope
+
+```json
+{
+  "warnings": [
+    {
+      "code": "unused_imports",
+      "message": "unused import",
+      "file": "src/lib.rs",
+      "line": 3,
+      "suggestion": "Remove the unused import"
+    }
+  ]
+}
+```
+
+## Proposed Fix Envelope
+
+```json
+{
+  "fixes": [
+    {
+      "file": "src/lib.rs",
+      "kind": "line_replacement",
+      "line_start": 6,
+      "line_end": 6,
+      "original_text": "mut ",
+      "replacement": "",
+      "message": "Remove unused mut"
+    }
+  ]
+}
+```
+
+Allowed `kind` values should start with `line_replacement` and `line_removal`, because those map cleanly to Homeboy's existing generic edit primitives. Ecosystem-specific parsing of `cargo check --message-format=json` should move into the Rust extension once this contract exists.
+
+## Blocker
+
+Do not replace the current Cargo compiler-warning implementation with another core fallback. The next upstream PR should add manifest fields, parser structs, extension invocation, and tests with a fake extension script before the Cargo implementation is removed from core.

--- a/src/core/engine/format_write.rs
+++ b/src/core/engine/format_write.rs
@@ -2,16 +2,13 @@
 //!
 //! Any command that writes source code (`refactor --write`) should
 //! call `format_after_write()` after writing files. This runs the project's
-//! language-specific formatter (e.g., `cargo fmt` for Rust, `prettier --write`
-//! for TypeScript) to ensure generated code matches project style.
+//! extension-owned formatter to ensure generated code matches project style.
 //!
 //! Unlike `validate_write`, formatting failure is non-fatal — it logs a warning
 //! but never rolls back. Generated code that compiles but isn't formatted is
 //! better than no code at all.
 //!
-//! The format command is resolved via:
-//! 1. Extension manifest `scripts.format` (if an extension provides one)
-//! 2. Builtin fallbacks based on project marker files (Cargo.toml, tsconfig.json, etc.)
+//! The format command is resolved via extension manifest `scripts.format`.
 
 use std::path::{Path, PathBuf};
 
@@ -99,47 +96,6 @@ pub fn format_after_write(root: &Path, changed_files: &[PathBuf]) -> Result<Form
         return Ok(FormatResult::passed(format_command, changed_files.len()));
     }
 
-    // cargo fmt failed — try rustfmt directly on individual files.
-    // This handles environments where cargo fmt needs target/ for module
-    // resolution but it may not be available.
-    if format_command.starts_with("cargo fmt") {
-        let rust_files: Vec<&PathBuf> = changed_files
-            .iter()
-            .filter(|f| f.extension().and_then(|e| e.to_str()) == Some("rs"))
-            .collect();
-
-        if !rust_files.is_empty() {
-            crate::log_status!(
-                "format",
-                "cargo fmt failed, falling back to rustfmt on {} file(s)",
-                rust_files.len()
-            );
-
-            let mut all_succeeded = true;
-            for file in &rust_files {
-                let rustfmt_output = std::process::Command::new("rustfmt")
-                    .arg(file)
-                    .current_dir(root)
-                    .output();
-
-                match rustfmt_output {
-                    Ok(o) if o.status.success() => {}
-                    _ => {
-                        all_succeeded = false;
-                    }
-                }
-            }
-
-            if all_succeeded {
-                crate::log_status!("format", "rustfmt fallback complete");
-                return Ok(FormatResult::passed(
-                    "rustfmt (fallback)".to_string(),
-                    changed_files.len(),
-                ));
-            }
-        }
-    }
-
     // Formatting failed — log warning but do NOT rollback
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -163,9 +119,8 @@ pub fn format_after_write(root: &Path, changed_files: &[PathBuf]) -> Result<Form
 
 /// Resolve the format command for a set of changed files.
 ///
-/// Checks installed extensions first (via `scripts.format`), then falls back
-/// to builtin project-level formatters.
-fn resolve_format_command(root: &Path, changed_files: &[PathBuf]) -> Option<String> {
+/// Checks installed extensions for `scripts.format`.
+fn resolve_format_command(_root: &Path, changed_files: &[PathBuf]) -> Option<String> {
     // Collect unique file extensions
     let extensions: Vec<String> = changed_files
         .iter()
@@ -196,8 +151,7 @@ fn resolve_format_command(root: &Path, changed_files: &[PathBuf]) -> Option<Stri
         }
     }
 
-    // Fallback: builtin project-level formatters
-    resolve_builtin_format_command(root)
+    None
 }
 
 /// Find an installed extension that handles a file extension and has scripts.format.
@@ -207,34 +161,6 @@ fn find_extension_with_format(file_ext: &str) -> Option<extension::ExtensionMani
             .into_iter()
             .find(|m| m.handles_file_extension(file_ext) && m.format_script().is_some())
     })
-}
-
-/// Fallback formatting using well-known project-level commands.
-fn resolve_builtin_format_command(root: &Path) -> Option<String> {
-    // Rust: Cargo.toml → cargo fmt
-    if root.join("Cargo.toml").exists() {
-        return Some("cargo fmt 2>&1".to_string());
-    }
-
-    // TypeScript/JavaScript: package.json + prettier → npx prettier --write
-    if root.join("tsconfig.json").exists() || root.join("package.json").exists() {
-        // Only use prettier if it's available in the project
-        if root.join("node_modules/.bin/prettier").exists() {
-            return Some("npx prettier --write . 2>&1".to_string());
-        }
-    }
-
-    // Go: go.mod → gofmt
-    if root.join("go.mod").exists() {
-        return Some("gofmt -w . 2>&1".to_string());
-    }
-
-    // PHP: composer.json + phpcbf
-    if root.join("composer.json").exists() && root.join("vendor/bin/phpcbf").exists() {
-        return Some("vendor/bin/phpcbf 2>&1".to_string());
-    }
-
-    None
 }
 
 #[cfg(test)]

--- a/src/core/engine/validate_write.rs
+++ b/src/core/engine/validate_write.rs
@@ -5,9 +5,8 @@
 //! after writing files and before reporting success. If validation fails,
 //! the changed files are rolled back to their pre-write state.
 //!
-//! The validation command is determined by the project's extension — each language
-//! extension can provide a `scripts.validate` command (e.g., `cargo check` for Rust,
-//! `php -l` for PHP, `tsc --noEmit` for TypeScript).
+//! The validation command is determined by the project's extension. Language
+//! extensions can provide a `scripts.validate` command for their own checker.
 //!
 //! When no extension provides a validate script, validation is skipped (no-op success).
 //!
@@ -222,7 +221,7 @@ pub fn validate_only(root: &Path, changed_files: &[PathBuf]) -> Result<Validatio
 /// For project-level validators (Rust, TypeScript), the validate script
 /// is run from the project root. For file-level validators (PHP), individual
 /// files could be checked — but we run the project-level command for simplicity.
-fn resolve_validate_command(root: &Path, changed_files: &[PathBuf]) -> Option<String> {
+fn resolve_validate_command(_root: &Path, changed_files: &[PathBuf]) -> Option<String> {
     // Collect unique file extensions from changed files
     let extensions: Vec<String> = changed_files
         .iter()
@@ -254,8 +253,7 @@ fn resolve_validate_command(root: &Path, changed_files: &[PathBuf]) -> Option<St
         }
     }
 
-    // Fallback: check for well-known project-level validators
-    resolve_builtin_validate_command(root)
+    None
 }
 
 /// Find an installed extension that handles a file extension and has scripts.validate.
@@ -267,32 +265,6 @@ fn find_extension_with_validate(file_ext: &str) -> Option<extension::ExtensionMa
     })
 }
 
-/// Fallback validation using well-known project-level commands.
-///
-/// If no extension provides a validate script, we check for common build tools
-/// that can validate without a full build.
-fn resolve_builtin_validate_command(root: &Path) -> Option<String> {
-    // Rust: Cargo.toml → cargo check --tests
-    // --tests includes #[cfg(test)] modules so auto-generated test code
-    // is validated before committing. Without it, broken test signatures,
-    // duplicate names, and bad format strings slip through.
-    if root.join("Cargo.toml").exists() {
-        return Some("cargo check --tests 2>&1".to_string());
-    }
-
-    // TypeScript: tsconfig.json → tsc --noEmit
-    if root.join("tsconfig.json").exists() {
-        return Some("npx tsc --noEmit 2>&1".to_string());
-    }
-
-    // Go: go.mod → go vet
-    if root.join("go.mod").exists() {
-        return Some("go vet ./... 2>&1".to_string());
-    }
-
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,34 +272,12 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn resolve_builtin_for_rust_project() {
+    fn validation_skips_unknown_project_without_extension_validator() {
         let dir = TempDir::new().expect("temp dir");
-        fs::write(dir.path().join("Cargo.toml"), "[package]\nname=\"t\"").unwrap();
-        let cmd = resolve_builtin_validate_command(dir.path());
-        assert_eq!(cmd, Some("cargo check --tests 2>&1".to_string()));
-    }
-
-    #[test]
-    fn resolve_builtin_for_typescript_project() {
-        let dir = TempDir::new().expect("temp dir");
-        fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
-        let cmd = resolve_builtin_validate_command(dir.path());
-        assert_eq!(cmd, Some("npx tsc --noEmit 2>&1".to_string()));
-    }
-
-    #[test]
-    fn resolve_builtin_for_go_project() {
-        let dir = TempDir::new().expect("temp dir");
-        fs::write(dir.path().join("go.mod"), "module example.com/t").unwrap();
-        let cmd = resolve_builtin_validate_command(dir.path());
-        assert_eq!(cmd, Some("go vet ./... 2>&1".to_string()));
-    }
-
-    #[test]
-    fn resolve_builtin_returns_none_for_unknown() {
-        let dir = TempDir::new().expect("temp dir");
-        let cmd = resolve_builtin_validate_command(dir.path());
-        assert!(cmd.is_none());
+        let files = vec![dir.path().join("unknown.xyz")];
+        let result = validate_only(dir.path(), &files).unwrap();
+        assert!(result.success);
+        assert!(result.command.is_none());
     }
 
     #[test]
@@ -403,36 +353,29 @@ mod tests {
     }
 
     #[test]
-    fn validate_write_rolls_back_on_failure() {
+    fn validate_write_without_extension_validator_is_success() {
         let dir = TempDir::new().expect("temp dir");
         let root = dir.path();
-
-        // Create a Rust project with intentionally broken code
-        fs::write(
-            root.join("Cargo.toml"),
-            "[package]\nname = \"validate-test\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-        )
-        .unwrap();
         fs::create_dir_all(root.join("src")).unwrap();
-        fs::write(root.join("src/lib.rs"), "pub fn good() {}\n").unwrap();
+        fs::write(root.join("src/lib.rs"), "pub fn broken( {}\n").unwrap();
 
-        // Capture good state
         let mut rollback = InMemoryRollback::new();
         let lib_path = root.join("src/lib.rs");
         rollback.capture(&lib_path);
 
-        // Write broken code
-        fs::write(&lib_path, "pub fn broken( {}\n").unwrap();
-
         let changed = vec![lib_path.clone()];
         let result = validate_write(root, &changed, &rollback).expect("should not error");
 
-        assert!(!result.success, "validation should fail for broken code");
-        assert!(result.rolled_back, "should have rolled back");
-        assert!(result.output.is_some(), "should have compiler output");
-
-        // Verify rollback happened — file should be restored
+        assert!(
+            result.success,
+            "validation should skip without extension contract"
+        );
+        assert!(
+            !result.rolled_back,
+            "skipped validation should not roll back"
+        );
+        assert!(result.command.is_none());
         let content = fs::read_to_string(&lib_path).unwrap();
-        assert_eq!(content, "pub fn good() {}\n", "file should be restored");
+        assert_eq!(content, "pub fn broken( {}\n");
     }
 }

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -1,0 +1,34 @@
+fn source_file(relative_path: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+    std::fs::read_to_string(path).expect("read source file")
+}
+
+#[test]
+fn validate_and_format_writes_do_not_select_ecosystem_commands() {
+    let files = [
+        "src/core/engine/validate_write.rs",
+        "src/core/engine/format_write.rs",
+    ];
+    let forbidden = [
+        "Cargo.toml",
+        "cargo check",
+        "cargo fmt",
+        "tsconfig.json",
+        "npx tsc",
+        "prettier",
+        "go vet",
+        "gofmt",
+        "phpcbf",
+        "rustfmt",
+    ];
+
+    for file in files {
+        let source = source_file(file);
+        for term in forbidden {
+            assert!(
+                !source.contains(term),
+                "{file} must not hardcode ecosystem command or marker `{term}`"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Remove core validate/format ecosystem command fallbacks so post-write validation and formatting run only through extension-owned `scripts.validate` and `scripts.format` contracts.
- Add a core-agnostic regression test for validate/format runtime files.
- Document the missing compiler-warning extension contract needed before moving Cargo warning collection/fixes out of core.

## Tests
- `cargo test validate_write`
- `cargo test format_write`
- `cargo test --test architecture_core_agnostic_test`

## Upstream blocker
- `src/core/code_audit/compiler_warnings.rs` and `src/core/refactor/plan/generate/compiler_warning_fixes.rs` still need a new extension contract before their Cargo hardcodes can be removed without dropping behavior.
- Proposed shape is documented in `docs/development/contracts/compiler-warning-extension.md`: `scripts.compiler_warnings` and `scripts.compiler_warning_fixes` with generic warning/fix envelopes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.