### PR TITLE
Refactor command output policies

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -261,6 +261,12 @@ fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<Command
 mod tests {
     use super::*;
 
+    fn parsed_command(args: &[&str]) -> Commands {
+        Cli::try_parse_from(args)
+            .expect("CLI args should parse")
+            .command
+    }
+
     #[test]
     fn test_current_command_surface() {
         let surface = current_command_surface();
@@ -287,5 +293,45 @@ mod tests {
 
         assert!(surface.contains_path(&["self"]));
         assert!(!surface.contains_path(&["self", "missing"]));
+    }
+
+    #[test]
+    fn test_response_mode() {
+        assert_eq!(
+            parsed_command(&["homeboy", "status"]).response_mode(false),
+            CommandResponseMode::Json
+        );
+        assert_eq!(
+            parsed_command(&["homeboy", "review", "--report", "pr-comment"]).response_mode(false),
+            CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+        );
+        assert_eq!(
+            parsed_command(&["homeboy", "trace", "--report", "markdown"]).response_mode(false),
+            CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+        );
+        assert_eq!(
+            Commands::List.response_mode(false),
+            CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+        );
+    }
+
+    #[test]
+    fn test_output_artifact_policy() {
+        assert_eq!(
+            parsed_command(&["homeboy", "status"]).output_artifact_policy(true),
+            CommandOutputArtifactPolicy::GenericEnvelope
+        );
+        assert_eq!(
+            parsed_command(&["homeboy", "review"]).output_artifact_policy(true),
+            CommandOutputArtifactPolicy::ReviewStableArtifact
+        );
+        assert_eq!(
+            parsed_command(&["homeboy", "trace", "--json-summary"]).output_artifact_policy(true),
+            CommandOutputArtifactPolicy::TraceJsonSummaryArtifact
+        );
+        assert_eq!(
+            parsed_command(&["homeboy", "trace", "--json-summary"]).output_artifact_policy(false),
+            CommandOutputArtifactPolicy::GenericEnvelope
+        );
     }
 }

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -125,6 +125,73 @@ pub enum Commands {
     List,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandResponseMode {
+    Json,
+    Raw(CommandRawOutputMode),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandRawOutputMode {
+    InteractivePassthrough,
+    Markdown,
+    PlainText,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOutputArtifactPolicy {
+    GenericEnvelope,
+    ReviewStableArtifact,
+    TraceJsonSummaryArtifact,
+}
+
+impl Commands {
+    pub fn response_mode(&self, has_output_file: bool) -> CommandResponseMode {
+        match self {
+            Commands::Ssh(args) if args.subcommand.is_none() && args.command.is_empty() => {
+                CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough)
+            }
+            Commands::Logs(args) if logs::is_interactive(args) => {
+                CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough)
+            }
+            Commands::File(args) if file::is_raw_read(args) => {
+                CommandResponseMode::Raw(CommandRawOutputMode::PlainText)
+            }
+            Commands::Docs(args) if crate::commands::docs::is_json_mode(args) => {
+                CommandResponseMode::Json
+            }
+            Commands::Docs(_) => CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
+            Commands::Changelog(args) if changelog::is_show_markdown(args) => {
+                CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+            }
+            Commands::Review(args) if review::is_markdown_mode(args) => {
+                CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+            }
+            Commands::Trace(args) if trace::is_markdown_mode(args) => {
+                CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+            }
+            Commands::Runs(args) if !has_output_file && args.is_markdown_mode() => {
+                CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+            }
+            Commands::Report(args) if report::is_markdown_mode(args) => {
+                CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+            }
+            Commands::List => CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
+            _ => CommandResponseMode::Json,
+        }
+    }
+
+    pub fn output_artifact_policy(&self, has_output_file: bool) -> CommandOutputArtifactPolicy {
+        match self {
+            Commands::Review(_) => CommandOutputArtifactPolicy::ReviewStableArtifact,
+            Commands::Trace(args) if has_output_file && args.json_summary => {
+                CommandOutputArtifactPolicy::TraceJsonSummaryArtifact
+            }
+            _ => CommandOutputArtifactPolicy::GenericEnvelope,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandSurface {
     pub commands: Vec<CommandSurfaceEntry>,

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -16,7 +16,8 @@ use homeboy::extension::ExtensionCapability;
 use homeboy::rig::{self, RigSpec};
 
 use super::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
+    filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs,
+    PassthroughCommand, PositionalComponentArgs, SettingArgs,
 };
 use super::{runs, CmdResult, GlobalArgs};
 
@@ -262,66 +263,7 @@ pub enum BenchReportFormat {
 /// including flags that also got parsed into named fields. Without
 /// filtering, homeboy-owned flags leak into the extension runner script.
 fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
-    const HOMEBOY_FLAGS: &[&str] = &[
-        "--baseline",
-        "--ignore-baseline",
-        "--ignore-default-baseline",
-        "--ratchet",
-        "--force-hot",
-        "--json-summary",
-        "--json",
-    ];
-
-    const HOMEBOY_VALUE_FLAGS: &[&str] = &[
-        "--iterations",
-        "--warmup",
-        "--runs",
-        "--shared-state",
-        "--concurrency",
-        "--regression-threshold",
-        "--rig-concurrency",
-        "--scenario",
-        "--profile",
-        "--rig-order",
-        "--report",
-        "--rig",
-        "--setting",
-        "--path",
-        "--extension",
-    ];
-
-    let mut filtered = Vec::new();
-    let mut skip_next = false;
-
-    for arg in args {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-
-        if HOMEBOY_FLAGS.contains(&arg.as_str()) {
-            continue;
-        }
-
-        let is_value_flag = HOMEBOY_VALUE_FLAGS.iter().any(|f| {
-            if arg.starts_with(&format!("{}=", f)) {
-                return true;
-            }
-            if arg == *f {
-                skip_next = true;
-                return true;
-            }
-            false
-        });
-
-        if is_value_flag {
-            continue;
-        }
-
-        filtered.push(arg.clone());
-    }
-
-    filtered
+    filter_passthrough_args(PassthroughCommand::Bench, args)
 }
 
 /// Output envelope for `homeboy bench`.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -338,6 +338,26 @@ pub fn run_markdown(
     }
 }
 
+pub fn run_plain_text(
+    command: crate::cli_surface::Commands,
+    global: &GlobalArgs,
+) -> homeboy::Result<(String, i32)> {
+    match command {
+        crate::cli_surface::Commands::File(args) => match file::run(args, global)? {
+            (file::FileCommandOutput::Raw(content), exit_code) => Ok((content, exit_code)),
+            _ => Err(homeboy::Error::internal_unexpected(
+                "Unexpected output type for raw mode",
+            )),
+        },
+        _ => Err(homeboy::Error::validation_invalid_argument(
+            "output_mode",
+            "Command does not support plain text output",
+            None,
+            None,
+        )),
+    }
+}
+
 /// Dispatch a command to its handler and map result to JSON.
 macro_rules! dispatch {
     ($args:expr, $global:expr, $extension:ident) => {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -15,7 +15,8 @@ use homeboy::observation::{
 use std::path::Path;
 
 use super::utils::args::{
-    BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
+    filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs,
+    PassthroughCommand, PositionalComponentArgs, SettingArgs,
 };
 use super::{CmdResult, GlobalArgs};
 
@@ -88,64 +89,7 @@ pub struct TestArgs {
 /// This function strips homeboy-owned flags so only genuine passthrough args (like
 /// `--filter=TestName`) reach the extension script.
 fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
-    // Homeboy-owned boolean flags that should never reach the extension runner
-    const HOMEBOY_FLAGS: &[&str] = &[
-        "--analyze",
-        "--drift",
-        "--write",
-        "--json-summary",
-        "--baseline",
-        "--ignore-baseline",
-        "--ratchet",
-        "--skip-lint",
-        "--coverage",
-        "--json",
-    ];
-
-    // Homeboy-owned flags that take a value (--flag value or --flag=value)
-    const HOMEBOY_VALUE_FLAGS: &[&str] = &[
-        "--coverage-min",
-        "--since",
-        "--changed-since",
-        "--setting",
-        "--path",
-        "--extension",
-    ];
-
-    let mut filtered = Vec::new();
-    let mut skip_next = false;
-
-    for arg in args {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-
-        // Check boolean flags (exact match)
-        if HOMEBOY_FLAGS.contains(&arg.as_str()) {
-            continue;
-        }
-
-        // Check value flags: --flag=value (single arg) or --flag value (two args)
-        let is_value_flag = HOMEBOY_VALUE_FLAGS.iter().any(|f| {
-            if arg.starts_with(&format!("{}=", f)) {
-                return true; // --flag=value form, skip this arg only
-            }
-            if arg == *f {
-                skip_next = true; // --flag value form, skip this and next
-                return true;
-            }
-            false
-        });
-
-        if is_value_flag {
-            continue;
-        }
-
-        filtered.push(arg.clone());
-    }
-
-    filtered
+    filter_passthrough_args(PassthroughCommand::Test, args)
 }
 
 pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput> {

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -79,6 +79,27 @@ const TEST_FLAGS: &[&str] = &[
     "--help",
     "-h",
 ];
+const TEST_PASSTHROUGH_BOOL_FLAGS: &[&str] = &[
+    "--skip-lint",
+    "--coverage",
+    "--baseline",
+    "--ignore-baseline",
+    "--ratchet",
+    "--analyze",
+    "--drift",
+    "--write",
+    "--force-hot",
+    "--json-summary",
+    "--json",
+];
+const TEST_PASSTHROUGH_VALUE_FLAGS: &[&str] = &[
+    "--coverage-min",
+    "--since",
+    "--changed-since",
+    "--setting",
+    "--path",
+    "--extension",
+];
 const BENCH_FLAGS: &[&str] = &[
     "--iterations",
     "--warmup",
@@ -101,6 +122,32 @@ const BENCH_FLAGS: &[&str] = &[
     "--json",
     "--help",
     "-h",
+];
+const BENCH_PASSTHROUGH_BOOL_FLAGS: &[&str] = &[
+    "--baseline",
+    "--ignore-baseline",
+    "--ignore-default-baseline",
+    "--ratchet",
+    "--force-hot",
+    "--json-summary",
+    "--json",
+];
+const BENCH_PASSTHROUGH_VALUE_FLAGS: &[&str] = &[
+    "--iterations",
+    "--warmup",
+    "--runs",
+    "--shared-state",
+    "--concurrency",
+    "--regression-threshold",
+    "--rig-concurrency",
+    "--scenario",
+    "--profile",
+    "--rig-order",
+    "--report",
+    "--rig",
+    "--setting",
+    "--path",
+    "--extension",
 ];
 const DOCS_AUDIT_FLAGS: &[&str] = &[
     "--path",
@@ -132,6 +179,71 @@ const LINT_FLAGS: &[&str] = &[
     "--help",
     "-h",
 ];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PassthroughCommand {
+    Bench,
+    Test,
+}
+
+impl PassthroughCommand {
+    fn owned_bool_flags(self) -> &'static [&'static str] {
+        match self {
+            PassthroughCommand::Bench => BENCH_PASSTHROUGH_BOOL_FLAGS,
+            PassthroughCommand::Test => TEST_PASSTHROUGH_BOOL_FLAGS,
+        }
+    }
+
+    fn owned_value_flags(self) -> &'static [&'static str] {
+        match self {
+            PassthroughCommand::Bench => BENCH_PASSTHROUGH_VALUE_FLAGS,
+            PassthroughCommand::Test => TEST_PASSTHROUGH_VALUE_FLAGS,
+        }
+    }
+}
+
+/// Strip Homeboy-owned flags from runner passthrough args.
+///
+/// Clap's `last = true` capture can include flags that also parsed into named
+/// Homeboy fields when those flags appear after a positional. Keeping this
+/// policy next to the trailing-arg normalizer makes command-owned flags easier
+/// to update without drifting separate bench/test filters.
+pub(crate) fn filter_passthrough_args(command: PassthroughCommand, args: &[String]) -> Vec<String> {
+    let bool_flags = command.owned_bool_flags();
+    let value_flags = command.owned_value_flags();
+    let mut filtered = Vec::new();
+    let mut skip_next = false;
+
+    for arg in args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+
+        if bool_flags.contains(&arg.as_str()) {
+            continue;
+        }
+
+        let is_value_flag = value_flags.iter().any(|flag| {
+            if arg.starts_with(&format!("{}=", flag)) {
+                return true;
+            }
+            if arg == *flag {
+                skip_next = true;
+                return true;
+            }
+            false
+        });
+
+        if is_value_flag {
+            continue;
+        }
+
+        filtered.push(arg.clone());
+    }
+
+    filtered
+}
 
 /// Auto-insert '--' separator before unknown flags for trailing_var_arg commands.
 pub(crate) fn normalize_trailing_flags(args: Vec<String>) -> Vec<String> {
@@ -634,6 +746,36 @@ mod normalize_tests {
             "--output",
             "/tmp/y.json",
             "--ratchet",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    #[test]
+    fn test_owned_flag_after_component_and_explicit_passthrough_stay_distinct() {
+        let input = argv(&[
+            "homeboy",
+            "test",
+            "my-comp",
+            "--changed-since",
+            "origin/main",
+            "--",
+            "--filter=SmokeTest",
+        ]);
+        let expected = input.clone();
+        assert_eq!(normalize_trailing_flags(input), expected);
+    }
+
+    #[test]
+    fn bench_owned_flag_after_component_and_explicit_passthrough_stay_distinct() {
+        let input = argv(&[
+            "homeboy",
+            "bench",
+            "my-comp",
+            "--iterations",
+            "1",
+            "--",
+            "--filter=Scenario",
         ]);
         let expected = input.clone();
         assert_eq!(normalize_trailing_flags(input), expected);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,58 +1,14 @@
 use clap::{ArgMatches, Command, CommandFactory, FromArgMatches};
 
-use homeboy::cli_surface::{Cli, Commands};
+use homeboy::cli_surface::{
+    Cli, CommandOutputArtifactPolicy, CommandRawOutputMode, CommandResponseMode, Commands,
+};
 use homeboy::commands::GlobalArgs;
-
-#[derive(Debug, Clone, Copy)]
-enum ResponseMode {
-    Json,
-    Raw(RawOutputMode),
-}
-
-#[derive(Debug, Clone, Copy)]
-enum RawOutputMode {
-    InteractivePassthrough,
-    Markdown,
-    PlainText,
-}
 
 use homeboy::commands;
 use homeboy::commands::utils::{args, entity_suggest, resource_policy, response as output, tty};
-use homeboy::commands::{changelog, cli, file, logs, report, review, trace};
+use homeboy::commands::{cli, review, trace};
 use homeboy::extension::load_all_extensions;
-
-fn response_mode(command: &Commands, has_output_file: bool) -> ResponseMode {
-    match command {
-        Commands::Ssh(args) if args.subcommand.is_none() && args.command.is_empty() => {
-            ResponseMode::Raw(RawOutputMode::InteractivePassthrough)
-        }
-        Commands::Logs(args) if logs::is_interactive(args) => {
-            ResponseMode::Raw(RawOutputMode::InteractivePassthrough)
-        }
-        Commands::File(args) if file::is_raw_read(args) => {
-            ResponseMode::Raw(RawOutputMode::PlainText)
-        }
-        Commands::Docs(args) if homeboy::commands::docs::is_json_mode(args) => ResponseMode::Json,
-        Commands::Docs(_) => ResponseMode::Raw(RawOutputMode::Markdown),
-        Commands::Changelog(args) if changelog::is_show_markdown(args) => {
-            ResponseMode::Raw(RawOutputMode::Markdown)
-        }
-        Commands::Review(args) if review::is_markdown_mode(args) => {
-            ResponseMode::Raw(RawOutputMode::Markdown)
-        }
-        Commands::Trace(args) if trace::is_markdown_mode(args) => {
-            ResponseMode::Raw(RawOutputMode::Markdown)
-        }
-        Commands::Runs(args) if !has_output_file && args.is_markdown_mode() => {
-            ResponseMode::Raw(RawOutputMode::Markdown)
-        }
-        Commands::Report(args) if report::is_markdown_mode(args) => {
-            ResponseMode::Raw(RawOutputMode::Markdown)
-        }
-        Commands::List => ResponseMode::Raw(RawOutputMode::Markdown),
-        _ => ResponseMode::Json,
-    }
-}
 
 struct ExtensionCliCommand {
     tool: String,
@@ -230,12 +186,12 @@ fn main() -> std::process::ExitCode {
         homeboy::extension::update_check::run_startup_check();
     }
 
-    let mode = response_mode(&cli.command, output_file.is_some());
-    let is_review_command = matches!(cli.command, Commands::Review(_));
+    let mode = cli.command.response_mode(output_file.is_some());
+    let output_artifact_policy = cli.command.output_artifact_policy(output_file.is_some());
 
     match mode {
-        ResponseMode::Json => {}
-        ResponseMode::Raw(RawOutputMode::InteractivePassthrough) => {
+        CommandResponseMode::Json => {}
+        CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough) => {
             if !tty::require_tty_for_interactive() {
                 let err = homeboy::Error::validation_invalid_argument(
                     "tty",
@@ -247,8 +203,8 @@ fn main() -> std::process::ExitCode {
                 return std::process::ExitCode::from(exit_code_to_u8(2));
             }
         }
-        ResponseMode::Raw(RawOutputMode::Markdown) => {}
-        ResponseMode::Raw(RawOutputMode::PlainText) => {}
+        CommandResponseMode::Raw(CommandRawOutputMode::Markdown) => {}
+        CommandResponseMode::Raw(CommandRawOutputMode::PlainText) => {}
     }
 
     if matches!(cli.command, Commands::List) {
@@ -270,7 +226,7 @@ fn main() -> std::process::ExitCode {
         }
     }
 
-    if let ResponseMode::Raw(RawOutputMode::Markdown) = mode {
+    if let CommandResponseMode::Raw(CommandRawOutputMode::Markdown) = mode {
         let markdown_result = commands::run_markdown(cli.command, &global);
 
         match markdown_result {
@@ -285,60 +241,59 @@ fn main() -> std::process::ExitCode {
         }
     }
 
-    if let ResponseMode::Raw(RawOutputMode::PlainText) = mode {
-        if let Commands::File(args) = cli.command {
-            let result = file::run(args, &global);
-            match result {
-                Ok((file::FileCommandOutput::Raw(content), exit_code)) => {
-                    print!("{}", content);
-                    return std::process::ExitCode::from(exit_code_to_u8(exit_code));
-                }
-                Ok(_) => {
-                    let err =
-                        homeboy::Error::internal_unexpected("Unexpected output type for raw mode");
-                    output::print_result::<serde_json::Value>(Err(err)).ok();
-                    return std::process::ExitCode::from(exit_code_to_u8(1));
-                }
-                Err(err) => {
-                    output::print_result::<serde_json::Value>(Err(err)).ok();
-                    return std::process::ExitCode::from(exit_code_to_u8(1));
-                }
+    if let CommandResponseMode::Raw(CommandRawOutputMode::PlainText) = mode {
+        match commands::run_plain_text(cli.command, &global) {
+            Ok((content, exit_code)) => {
+                print!("{}", content);
+                return std::process::ExitCode::from(exit_code_to_u8(exit_code));
+            }
+            Err(err) => {
+                output::print_result::<serde_json::Value>(Err(err)).ok();
+                return std::process::ExitCode::from(exit_code_to_u8(1));
             }
         }
     }
 
-    let (json_result, exit_code, output_json_result) = match cli.command {
-        Commands::Trace(args) if output_file.is_some() && args.json_summary => {
+    let (json_result, exit_code, output_json_result) = match (output_artifact_policy, cli.command) {
+        (CommandOutputArtifactPolicy::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
             let (json_result, exit_code, output_json_result) =
                 trace::run_json_with_output_artifact(args, &global);
             (json_result, exit_code, output_json_result)
         }
-        command => {
+        (_, command) => {
             let (json_result, exit_code) = commands::run_json(command, &global);
             (json_result, exit_code, None)
         }
     };
 
     // Write JSON to --output file if specified (before printing to stdout).
-    // Review writes its stable machine-readable artifact directly; other
-    // commands retain the generic CLI envelope.
     if let Some(ref path) = output_file {
-        if !is_review_command || !review::write_artifact_to_file(&json_result, path, exit_code) {
-            output::write_json_to_file(
-                output_json_result.as_ref().unwrap_or(&json_result),
-                path,
-                exit_code,
-            );
+        match output_artifact_policy {
+            CommandOutputArtifactPolicy::ReviewStableArtifact => {
+                if !review::write_artifact_to_file(&json_result, path, exit_code) {
+                    output::write_json_to_file(&json_result, path, exit_code);
+                }
+            }
+            CommandOutputArtifactPolicy::TraceJsonSummaryArtifact => {
+                output::write_json_to_file(
+                    output_json_result.as_ref().unwrap_or(&json_result),
+                    path,
+                    exit_code,
+                );
+            }
+            CommandOutputArtifactPolicy::GenericEnvelope => {
+                output::write_json_to_file(&json_result, path, exit_code);
+            }
         }
     }
 
     match mode {
-        ResponseMode::Json => {
+        CommandResponseMode::Json => {
             output::print_json_result(json_result, exit_code).ok();
         }
-        ResponseMode::Raw(RawOutputMode::InteractivePassthrough) => {}
-        ResponseMode::Raw(RawOutputMode::Markdown) => {}
-        ResponseMode::Raw(RawOutputMode::PlainText) => {}
+        CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough) => {}
+        CommandResponseMode::Raw(CommandRawOutputMode::Markdown) => {}
+        CommandResponseMode::Raw(CommandRawOutputMode::PlainText) => {}
     }
 
     std::process::ExitCode::from(exit_code_to_u8(exit_code))


### PR DESCRIPTION
## Summary
- Move command response mode and output artifact policy onto `Commands` so top-level orchestration no longer owns those command-specific decisions.
- Add a small plain-text dispatch seam for raw file output while preserving current CLI output contracts.
- Centralize bench/test passthrough filtering in one helper and add regression coverage for owned flags after positionals plus explicit passthrough args after `--`.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test normalize_tests --lib`
- `cargo test filter_ --lib`
- `cargo run --bin homeboy -- --help`
- `cargo run --bin homeboy -- test --help`
- `cargo run --bin homeboy -- bench --help`

## Remaining work
- This is the smaller safe seam for #2249 and #2250.
- Full command-owned execution descriptors/trait-based dispatch and deeper JSON/markdown dispatch unification remain follow-up work.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.