### PR TITLE
audit: detect configurable core boundary leaks

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -239,6 +239,8 @@ pub enum AuditFinding {
     /// Multiple files hand-roll the same observation lifecycle scaffolding
     /// instead of delegating lifecycle ownership to a shared wrapper/helper.
     ObservationLifecycleScaffolding,
+    /// Configured ecosystem/language/framework term appears in core-owned source.
+    CoreBoundaryLeak,
 }
 
 impl AuditFinding {
@@ -299,6 +301,7 @@ impl AuditFinding {
             "parallel_runner_setup",
             "command_output_policy",
             "observation_lifecycle_scaffolding",
+            "core_boundary_leak",
         ]
     }
 }

--- a/src/core/code_audit/core_boundary_leak.rs
+++ b/src/core/code_audit/core_boundary_leak.rs
@@ -146,6 +146,13 @@ mod tests {
     }
 
     #[test]
+    fn test_run() {
+        let fp = rust_fp("src/core/engine.rs", "fn dispatch() {}");
+
+        assert!(run(&[&fp], &CoreBoundaryLeakConfig::default()).is_empty());
+    }
+
+    #[test]
     fn reports_configured_synthetic_ecosystem_terms_in_core_source() {
         let fp = rust_fp(
             "src/core/engine.rs",

--- a/src/core/code_audit/core_boundary_leak.rs
+++ b/src/core/code_audit/core_boundary_leak.rs
@@ -1,0 +1,195 @@
+//! Configurable detector for ecosystem terms leaking into core-owned source.
+
+use regex::Regex;
+
+use crate::component::CoreBoundaryLeakConfig;
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+
+pub(super) fn run(
+    fingerprints: &[&FileFingerprint],
+    config: &CoreBoundaryLeakConfig,
+) -> Vec<Finding> {
+    if config.terms.is_empty() || config.scan_path_contains.is_empty() {
+        return Vec::new();
+    }
+
+    let terms = config
+        .terms
+        .iter()
+        .filter_map(|term| TermMatcher::new(term))
+        .collect::<Vec<_>>();
+    if terms.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for fp in fingerprints {
+        if !path_matches(&fp.relative_path, &config.scan_path_contains)
+            || path_matches(&fp.relative_path, &config.allow_path_contains)
+        {
+            continue;
+        }
+
+        for (index, line) in fp.content.lines().enumerate() {
+            if line_matches(line, &config.allow_line_contains) {
+                continue;
+            }
+
+            for term in &terms {
+                if term.matches(line) {
+                    let line_number = index + 1;
+                    let classification =
+                        if path_matches(&fp.relative_path, &config.example_path_contains) {
+                            "example-only"
+                        } else {
+                            "behavioral"
+                        };
+                    let context = enclosing_context(&fp.content, index).unwrap_or("top-level");
+                    findings.push(Finding {
+                        convention: "core_boundary_leak".to_string(),
+                        severity: Severity::Warning,
+                        file: fp.relative_path.clone(),
+                        description: format!(
+                            "Core boundary leak: configured ecosystem term `{}` appears at line {} in {} context `{}`",
+                            term.label, line_number, classification, context
+                        ),
+                        suggestion: "Move ecosystem-specific behavior into extension metadata/rules, or add an explicit audit allowlist for intentional examples.".to_string(),
+                        kind: AuditFinding::CoreBoundaryLeak,
+                    });
+                }
+            }
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+struct TermMatcher {
+    label: String,
+    regex: Regex,
+}
+
+impl TermMatcher {
+    fn new(term: &str) -> Option<Self> {
+        let label = term.trim();
+        if label.is_empty() {
+            return None;
+        }
+
+        let pattern = if label
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        {
+            format!(
+                r"(?i)(^|[^A-Za-z0-9_]){}([^A-Za-z0-9_]|$)",
+                regex::escape(label)
+            )
+        } else {
+            format!(r"(?i){}", regex::escape(label))
+        };
+
+        Regex::new(&pattern).ok().map(|regex| Self {
+            label: label.to_string(),
+            regex,
+        })
+    }
+
+    fn matches(&self, line: &str) -> bool {
+        self.regex.is_match(line)
+    }
+}
+
+fn path_matches(path: &str, needles: &[String]) -> bool {
+    needles.iter().any(|needle| path.contains(needle))
+}
+
+fn line_matches(line: &str, needles: &[String]) -> bool {
+    needles.iter().any(|needle| line.contains(needle))
+}
+
+fn enclosing_context(content: &str, line_index: usize) -> Option<&str> {
+    let fn_regex = Regex::new(r"\bfn\s+([A-Za-z_][A-Za-z0-9_]*)").expect("fn regex compiles");
+    let lines = content.lines().take(line_index + 1).collect::<Vec<_>>();
+    lines
+        .into_iter()
+        .rev()
+        .filter_map(|line| fn_regex.captures(line))
+        .find_map(|captures| captures.get(1).map(|name| name.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code_audit::Language;
+
+    fn rust_fp(path: &str, content: &str) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Rust,
+            content: content.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn config() -> CoreBoundaryLeakConfig {
+        CoreBoundaryLeakConfig {
+            terms: vec!["florpstack".to_string(), "florp-run".to_string()],
+            scan_path_contains: vec!["src/core/".to_string()],
+            allow_path_contains: vec!["src/core/fixtures/allowed".to_string()],
+            allow_line_contains: vec!["homeboy-audit: allow-core-boundary-example".to_string()],
+            example_path_contains: vec!["/fixtures/".to_string(), "/examples/".to_string()],
+        }
+    }
+
+    #[test]
+    fn reports_configured_synthetic_ecosystem_terms_in_core_source() {
+        let fp = rust_fp(
+            "src/core/engine.rs",
+            r#"fn dispatch() {
+    run_tool("florp-run");
+}
+"#,
+        );
+
+        let findings = run(&[&fp], &config());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::CoreBoundaryLeak);
+        assert!(findings[0].description.contains("florp-run"));
+        assert!(findings[0].description.contains("behavioral"));
+        assert!(findings[0].description.contains("dispatch"));
+    }
+
+    #[test]
+    fn reports_unallowlisted_fixture_references_as_example_only() {
+        let fp = rust_fp(
+            "src/core/fixtures/leaky.rs",
+            r#"const SAMPLE: &str = "florpstack";"#,
+        );
+
+        let findings = run(&[&fp], &config());
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("example-only"));
+    }
+
+    #[test]
+    fn skips_explicit_path_and_line_allowlists() {
+        let path_allowed = rust_fp(
+            "src/core/fixtures/allowed/sample.rs",
+            r#"const SAMPLE: &str = "florpstack";"#,
+        );
+        let line_allowed = rust_fp(
+            "src/core/sample.rs",
+            r#"// homeboy-audit: allow-core-boundary-example florpstack"#,
+        );
+
+        let findings = run(&[&path_allowed, &line_allowed], &config());
+
+        assert!(findings.is_empty());
+    }
+}

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -21,6 +21,7 @@ mod comment_hygiene;
 pub mod compare;
 mod compiler_warnings;
 pub(crate) mod conventions;
+mod core_boundary_leak;
 pub(crate) mod core_fingerprint;
 mod dead_code;
 mod dead_guard;
@@ -152,6 +153,7 @@ pub(crate) struct AuditExecutionPlan {
     pub(crate) run_deprecation_age: bool,
     pub(crate) run_dead_guard: bool,
     pub(crate) run_requested_detectors: bool,
+    pub(crate) run_core_boundary_leaks: bool,
     pub(crate) run_global_env_guard: bool,
     pub(crate) run_shared_scaffolding: bool,
     pub(crate) run_parallel_runner_setup: bool,
@@ -184,6 +186,7 @@ impl AuditExecutionPlan {
             run_deprecation_age: true,
             run_dead_guard: true,
             run_requested_detectors: true,
+            run_core_boundary_leaks: true,
             run_global_env_guard: true,
             run_shared_scaffolding: true,
             run_parallel_runner_setup: true,
@@ -341,6 +344,11 @@ impl AuditExecutionPlan {
                     AuditFinding::OptionScopeDrift,
                 ],
             ),
+            run_core_boundary_leaks: Self::family_enabled(
+                only,
+                exclude,
+                &[AuditFinding::CoreBoundaryLeak],
+            ),
             run_global_env_guard: Self::family_enabled(
                 only,
                 exclude,
@@ -394,6 +402,7 @@ impl AuditExecutionPlan {
             || self.run_deprecation_age
             || self.run_dead_guard
             || self.run_requested_detectors
+            || self.run_core_boundary_leaks
             || self.run_global_env_guard
             || self.run_shared_scaffolding
             || self.run_parallel_runner_setup
@@ -1136,6 +1145,21 @@ fn audit_internal(
             requested_findings.len()
         );
         all_findings.extend(requested_findings);
+    }
+
+    // Phase 4t2: Configured core-boundary ecosystem leak detection.
+    let core_boundary_findings = if plan.run_core_boundary_leaks {
+        core_boundary_leak::run(&all_fingerprints, &audit_config.core_boundary_leaks)
+    } else {
+        Vec::new()
+    };
+    if !core_boundary_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Core boundary leaks: {} finding(s) (configured ecosystem terms in core source)",
+            core_boundary_findings.len()
+        );
+        all_findings.extend(core_boundary_findings);
     }
 
     // Phase 4v: Process-global environment mutation guard consistency in tests.

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -24,6 +24,50 @@ pub struct AuditConfig {
     /// Extension-owned text detector rules that emit audit findings.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requested_detectors: Vec<RequestedDetectorRule>,
+    /// Configurable ecosystem-term checks for core-owned source boundaries.
+    #[serde(default, skip_serializing_if = "CoreBoundaryLeakConfig::is_empty")]
+    pub core_boundary_leaks: CoreBoundaryLeakConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CoreBoundaryLeakConfig {
+    /// Language, framework, runtime, tool, or extension identifiers that should
+    /// not become first-class concepts in the configured core source paths.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub terms: Vec<String>,
+    /// Path substrings that identify core-owned source to scan.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scan_path_contains: Vec<String>,
+    /// Path substrings that are intentionally exempt, such as generated data.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_path_contains: Vec<String>,
+    /// Line substrings that explicitly mark a local example as allowed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_line_contains: Vec<String>,
+    /// Path substrings treated as example-only when not otherwise allowlisted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub example_path_contains: Vec<String>,
+}
+
+impl CoreBoundaryLeakConfig {
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+            && self.scan_path_contains.is_empty()
+            && self.allow_path_contains.is_empty()
+            && self.allow_line_contains.is_empty()
+            && self.example_path_contains.is_empty()
+    }
+
+    fn merge(&mut self, other: &CoreBoundaryLeakConfig) {
+        extend_unique(&mut self.terms, &other.terms);
+        extend_unique(&mut self.scan_path_contains, &other.scan_path_contains);
+        extend_unique(&mut self.allow_path_contains, &other.allow_path_contains);
+        extend_unique(&mut self.allow_line_contains, &other.allow_line_contains);
+        extend_unique(
+            &mut self.example_path_contains,
+            &other.example_path_contains,
+        );
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -171,6 +215,7 @@ impl AuditConfig {
             && self.convention_exception_globs.is_empty()
             && self.known_symbols.is_empty()
             && self.requested_detectors.is_empty()
+            && self.core_boundary_leaks.is_empty()
     }
 
     pub fn merge(&mut self, other: &AuditConfig) {
@@ -189,6 +234,7 @@ impl AuditConfig {
             &other.convention_exception_globs,
         );
         self.known_symbols.merge(&other.known_symbols);
+        self.core_boundary_leaks.merge(&other.core_boundary_leaks);
         for rule in &other.requested_detectors {
             if !self
                 .requested_detectors
@@ -206,5 +252,59 @@ fn extend_unique<T: Clone + PartialEq>(target: &mut Vec<T>, source: &[T]) {
         if !target.contains(value) {
             target.push(value.clone());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_boundary_leak_config_marks_audit_config_non_empty() {
+        let config = AuditConfig {
+            core_boundary_leaks: CoreBoundaryLeakConfig {
+                terms: vec!["florpstack".to_string()],
+                scan_path_contains: vec!["src/core/".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(!config.is_empty());
+    }
+
+    #[test]
+    fn merge_dedupes_core_boundary_leak_config() {
+        let mut config = AuditConfig {
+            core_boundary_leaks: CoreBoundaryLeakConfig {
+                terms: vec!["florpstack".to_string()],
+                scan_path_contains: vec!["src/core/".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        config.merge(&AuditConfig {
+            core_boundary_leaks: CoreBoundaryLeakConfig {
+                terms: vec!["florpstack".to_string(), "widgetlang".to_string()],
+                scan_path_contains: vec!["src/core/".to_string(), "src/commands/".to_string()],
+                allow_line_contains: vec!["allow-core-boundary-example".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert_eq!(
+            config.core_boundary_leaks.terms,
+            vec!["florpstack", "widgetlang"]
+        );
+        assert_eq!(
+            config.core_boundary_leaks.scan_path_contains,
+            vec!["src/core/", "src/commands/"]
+        );
+        assert_eq!(
+            config.core_boundary_leaks.allow_line_contains,
+            vec!["allow-core-boundary-example"]
+        );
     }
 }

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -11,8 +11,8 @@ pub mod scope;
 pub mod versioning;
 
 pub use audit::{
-    AuditConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
-    KnownSymbolVersionedEntry, RequestedDetectorRule, RequestedDetectorRuleBody,
+    AuditConfig, CoreBoundaryLeakConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider,
+    KnownSymbolKind, KnownSymbolVersionedEntry, RequestedDetectorRule, RequestedDetectorRuleBody,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,


### PR DESCRIPTION
## Summary
- Adds a data-driven `core_boundary_leak` audit detector that scans configured core-owned paths for configured ecosystem terms.
- Supports path allowlists, line allowlists, and example-path classification so docs/fixtures/examples can be reviewed separately from behavioral leaks.
- Keeps the hard core-agnostic regression test intact and refreshes its occurrence count to the current narrowed baseline.

Closes #2276.

## Validation
- `cargo test core_boundary_leak --lib`
- `cargo test core_boundary_leak_config --lib`
- `cargo test merge_dedupes_core_boundary_leak_config --lib`
- `cargo test --test core_agnostic_test`
- `cargo test --test architecture_core_agnostic_test`
- `cargo fmt --check`
- `cargo run --bin homeboy -- audit --only core_boundary_leak`
- `cargo run --bin homeboy -- test`

Note: a later raw `cargo test --lib` rerun had two trace fixture failures (`trace_aggregate_spans_uses_workload_default_phase_preset`, `trace_compare_variant_reports_unknown_named_variants`); both passed when rerun individually.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.