### PR TITLE
Share audit analysis for fixability planning

### DIFF
--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -111,6 +111,19 @@ pub struct CodeAuditResult {
     pub duplicate_groups: Vec<duplication::DuplicateGroup>,
 }
 
+/// Shared analysis state built during an audit run and reused by downstream
+/// consumers that would otherwise re-walk and re-fingerprint the codebase.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AuditAnalysisContext {
+    pub(crate) fingerprints: Vec<fingerprint::FileFingerprint>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuditWithAnalysis {
+    pub(crate) result: CodeAuditResult,
+    pub(crate) analysis: AuditAnalysisContext,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AuditExecutionPlan {
     pub(crate) run_conventions: bool,
@@ -468,13 +481,14 @@ pub fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeA
         &ref_paths,
         &AuditExecutionPlan::full(),
     )
+    .map(|audit| audit.result)
 }
 
-pub(crate) fn audit_path_with_id_with_plan(
+pub(crate) fn audit_path_with_id_with_plan_and_analysis(
     component_id: &str,
     source_path: &str,
     plan: &AuditExecutionPlan,
-) -> Result<CodeAuditResult> {
+) -> Result<AuditWithAnalysis> {
     let ref_paths = read_reference_paths_from_env();
     audit_internal(component_id, source_path, None, None, &ref_paths, plan)
 }
@@ -504,15 +518,16 @@ pub fn audit_path_scoped(
         &ref_paths,
         &AuditExecutionPlan::full(),
     )
+    .map(|audit| audit.result)
 }
 
-pub(crate) fn audit_path_scoped_with_plan(
+pub(crate) fn audit_path_scoped_with_plan_and_analysis(
     component_id: &str,
     source_path: &str,
     file_filter: &[String],
     git_ref: Option<&str>,
     plan: &AuditExecutionPlan,
-) -> Result<CodeAuditResult> {
+) -> Result<AuditWithAnalysis> {
     let ref_paths = read_reference_paths_from_env();
     audit_internal(
         component_id,
@@ -560,7 +575,7 @@ fn audit_internal(
     git_ref: Option<&str>,
     reference_paths: &[String],
     plan: &AuditExecutionPlan,
-) -> Result<CodeAuditResult> {
+) -> Result<AuditWithAnalysis> {
     let root = Path::new(source_path);
     let audit_config = audit_config_for(component_id, root);
 
@@ -576,7 +591,10 @@ fn audit_internal(
     }
 
     if !plan.requires_discovery() {
-        return Ok(audit_root_only(component_id, source_path, root, plan));
+        return Ok(AuditWithAnalysis {
+            result: audit_root_only(component_id, source_path, root, plan),
+            analysis: AuditAnalysisContext::default(),
+        });
     }
 
     // Phase 1: Auto-discover file groups (always full codebase for convention detection)
@@ -631,21 +649,24 @@ fn audit_internal(
             );
         }
 
-        return Ok(CodeAuditResult {
-            component_id: component_id.to_string(),
-            source_path: source_path.to_string(),
-            summary: AuditSummary {
-                files_scanned: 0,
-                conventions_detected: 0,
-                outliers_found: stale_cli_findings.len() + cli_argument_findings.len(),
-                alignment_score: None,
-                files_skipped: total_skipped,
-                warnings,
+        return Ok(AuditWithAnalysis {
+            result: CodeAuditResult {
+                component_id: component_id.to_string(),
+                source_path: source_path.to_string(),
+                summary: AuditSummary {
+                    files_scanned: 0,
+                    conventions_detected: 0,
+                    outliers_found: stale_cli_findings.len() + cli_argument_findings.len(),
+                    alignment_score: None,
+                    files_skipped: total_skipped,
+                    warnings,
+                },
+                conventions: vec![],
+                directory_conventions: vec![],
+                findings: [stale_cli_findings, cli_argument_findings].concat(),
+                duplicate_groups: vec![],
             },
-            conventions: vec![],
-            directory_conventions: vec![],
-            findings: [stale_cli_findings, cli_argument_findings].concat(),
-            duplicate_groups: vec![],
+            analysis: AuditAnalysisContext::default(),
         });
     }
 
@@ -711,6 +732,9 @@ fn audit_internal(
         .iter()
         .flat_map(|(_, _, fps)| fps.iter())
         .collect();
+    let analysis = AuditAnalysisContext {
+        fingerprints: all_fingerprints.iter().map(|fp| (*fp).clone()).collect(),
+    };
 
     // Build convention method set ONCE — used by duplication, near-duplicate, and parallel detectors.
     // Convention-expected methods are excluded from duplication/parallel findings because identical
@@ -1217,21 +1241,24 @@ fn audit_internal(
         );
     }
 
-    Ok(CodeAuditResult {
-        component_id: component_id.to_string(),
-        source_path: source_path.to_string(),
-        summary: AuditSummary {
-            files_scanned: total_files,
-            conventions_detected: convention_reports.len(),
-            outliers_found: total_outliers,
-            alignment_score,
-            files_skipped,
-            warnings,
+    Ok(AuditWithAnalysis {
+        result: CodeAuditResult {
+            component_id: component_id.to_string(),
+            source_path: source_path.to_string(),
+            summary: AuditSummary {
+                files_scanned: total_files,
+                conventions_detected: convention_reports.len(),
+                outliers_found: total_outliers,
+                alignment_score,
+                files_skipped,
+                warnings,
+            },
+            conventions: convention_reports,
+            directory_conventions,
+            findings: all_findings,
+            duplicate_groups,
         },
-        conventions: convention_reports,
-        directory_conventions,
-        findings: all_findings,
-        duplicate_groups,
+        analysis,
     })
 }
 

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -273,6 +273,20 @@ pub(crate) fn finding_kind_key(finding: &AuditFinding) -> String {
 /// have automated fixes at each safety tier. This is cheap — no writes,
 /// no convergence loop, just planning + policy annotation.
 pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
+    compute_fixability_impl(result, None)
+}
+
+pub(crate) fn compute_fixability_with_analysis(
+    result: &CodeAuditResult,
+    analysis: &crate::code_audit::AuditAnalysisContext,
+) -> Option<AuditFixability> {
+    compute_fixability_impl(result, Some(analysis))
+}
+
+fn compute_fixability_impl(
+    result: &CodeAuditResult,
+    analysis: Option<&crate::code_audit::AuditAnalysisContext>,
+) -> Option<AuditFixability> {
     let source_path = Path::new(&result.source_path);
     if !source_path.is_dir() {
         return None;
@@ -293,11 +307,20 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
     }
 
     // Generate fix plan (dry-run — never writes)
-    let mut fix_result = crate::refactor::plan::generate::generate_audit_fixes(
-        result,
-        source_path,
-        &crate::refactor::auto::FixPolicy::default(),
-    );
+    let fix_policy = crate::refactor::auto::FixPolicy::default();
+    let mut fix_result = match analysis {
+        Some(analysis) if !analysis.fingerprints.is_empty() => {
+            crate::refactor::plan::generate::generate_audit_fixes_with_fingerprints(
+                result,
+                source_path,
+                &fix_policy,
+                &analysis.fingerprints,
+            )
+        }
+        _ => {
+            crate::refactor::plan::generate::generate_audit_fixes(result, source_path, &fix_policy)
+        }
+    };
 
     if fix_result.fixes.is_empty() && fix_result.new_files.is_empty() {
         return None;

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -3,7 +3,7 @@
 //! Mirrors `core/extension/lint/run.rs` and `core/extension/test/run.rs` — the command
 //! layer provides CLI args, this module owns all business logic and returns structured results.
 
-use crate::code_audit::{self, baseline, CodeAuditResult};
+use crate::code_audit::{self, baseline, AuditWithAnalysis, CodeAuditResult};
 use crate::git;
 use std::collections::HashSet;
 use std::path::Path;
@@ -44,8 +44,8 @@ pub fn run_main_audit_workflow(
     let result = run_audit(&args)?;
 
     // Early return: no-change shortcut already handled by run_audit returning None
-    let mut result = match result {
-        Some(r) => r,
+    let audit = match result {
+        Some(audit) => audit,
         None => {
             return Ok(audit_run_workflow_result(
                 AuditCommandOutput::Full {
@@ -73,6 +73,8 @@ pub fn run_main_audit_workflow(
             ));
         }
     };
+    let mut result = audit.result;
+    let analysis = audit.analysis;
 
     // --conventions: just show conventions
     if args.conventions {
@@ -107,7 +109,7 @@ pub fn run_main_audit_workflow(
     }
 
     // Default: compare against baseline or return full result
-    run_comparison_workflow(result, &args)
+    run_comparison_workflow(result, &analysis, &args)
 }
 
 fn audit_run_workflow_result(
@@ -187,7 +189,7 @@ fn scope_convention_outliers_to_findings(result: &mut CodeAuditResult) {
 }
 
 /// Run the audit scan (scoped or full). Returns None if changed-since found no files.
-fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<CodeAuditResult>> {
+fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<AuditWithAnalysis>> {
     let plan = if args.baseline_flags.baseline {
         code_audit::AuditExecutionPlan::full()
     } else {
@@ -200,7 +202,7 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<CodeAuditResul
             crate::log_status!("audit", "No files changed since {}", git_ref);
             return Ok(None);
         }
-        Ok(Some(code_audit::audit_path_scoped_with_plan(
+        Ok(Some(code_audit::audit_path_scoped_with_plan_and_analysis(
             &args.component_id,
             &args.source_path,
             &changed,
@@ -208,7 +210,7 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<CodeAuditResul
             &plan,
         )?))
     } else {
-        Ok(Some(code_audit::audit_path_with_id_with_plan(
+        Ok(Some(code_audit::audit_path_with_id_with_plan_and_analysis(
             &args.component_id,
             &args.source_path,
             &plan,
@@ -277,19 +279,20 @@ fn run_baseline_save(
 /// Comparison workflow — compare against file baseline, git-ref baseline, or return full.
 fn run_comparison_workflow(
     result: CodeAuditResult,
+    analysis: &code_audit::AuditAnalysisContext,
     args: &AuditRunWorkflowArgs,
 ) -> crate::Result<AuditRunWorkflowResult> {
     // Try file-based baseline
     if !args.baseline_flags.ignore_baseline {
         if let Some(existing_baseline) = baseline::load_baseline(Path::new(&result.source_path)) {
-            return build_comparison_output(result, existing_baseline, args);
+            return build_comparison_output(result, analysis, existing_baseline, args);
         }
     }
 
     // Try git-ref differential
     if let Some(ref git_ref) = args.changed_since {
         if let Some(ref_baseline) = baseline::load_baseline_from_ref(&result.source_path, git_ref) {
-            return build_comparison_output(result, ref_baseline, args);
+            return build_comparison_output(result, analysis, ref_baseline, args);
         }
     }
 
@@ -309,14 +312,14 @@ fn run_comparison_workflow(
     if args.json_summary {
         let findings = result.findings.clone();
         let mut summary = report::build_audit_summary(&result, exit_code);
-        summary.fixability = compute_fixability_if_requested(&result, args);
+        summary.fixability = compute_fixability_if_requested(&result, analysis, args);
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
             exit_code,
             findings,
         })
     } else {
-        let fixability = compute_fixability_if_requested(&result, args);
+        let fixability = compute_fixability_if_requested(&result, analysis, args);
         let findings = result.findings.clone();
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Full {
@@ -333,6 +336,7 @@ fn run_comparison_workflow(
 /// Build comparison output from a result and baseline.
 fn build_comparison_output(
     result: CodeAuditResult,
+    analysis: &code_audit::AuditAnalysisContext,
     existing_baseline: baseline::AuditBaseline,
     args: &AuditRunWorkflowArgs,
 ) -> crate::Result<AuditRunWorkflowResult> {
@@ -375,7 +379,7 @@ fn build_comparison_output(
     if args.json_summary {
         let findings = result.findings.clone();
         let mut summary = report::build_audit_summary(&result, exit_code);
-        summary.fixability = compute_fixability_if_requested(&result, args);
+        summary.fixability = compute_fixability_if_requested(&result, analysis, args);
         summary.changed_since = changed_since_summary;
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
@@ -383,7 +387,7 @@ fn build_comparison_output(
             findings,
         })
     } else {
-        let fixability = compute_fixability_if_requested(&result, args);
+        let fixability = compute_fixability_if_requested(&result, analysis, args);
         let findings = result.findings.clone();
 
         Ok(AuditRunWorkflowResult {
@@ -403,10 +407,11 @@ fn build_comparison_output(
 
 fn compute_fixability_if_requested(
     result: &CodeAuditResult,
+    analysis: &code_audit::AuditAnalysisContext,
     args: &AuditRunWorkflowArgs,
 ) -> Option<report::AuditFixability> {
     args.include_fixability
-        .then(|| report::compute_fixability(result))
+        .then(|| report::compute_fixability_with_analysis(result, analysis))
         .flatten()
 }
 

--- a/src/core/engine/symbol_graph.rs
+++ b/src/core/engine/symbol_graph.rs
@@ -54,6 +54,82 @@ pub struct CallerRef {
     pub has_call_site: bool,
 }
 
+#[derive(Debug, Clone)]
+struct IndexedFileRefs {
+    file: String,
+    content: String,
+    imports: Vec<ImportRef>,
+}
+
+/// Parsed symbol-reference view of a set of already-fingerprinted files.
+///
+/// This avoids `trace_symbol_callers()`'s per-symbol walk/read/import-parse loop
+/// when a caller already has audit fingerprints in memory.
+#[derive(Debug, Clone, Default)]
+pub struct SymbolReferenceIndex {
+    files: Vec<IndexedFileRefs>,
+}
+
+impl SymbolReferenceIndex {
+    pub fn from_files<'a, I>(files: I) -> Self
+    where
+        I: IntoIterator<Item = (&'a str, &'a str)>,
+    {
+        let files = files
+            .into_iter()
+            .map(|(relative_path, content)| {
+                let ext = Path::new(relative_path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("");
+                let imports = load_grammar_for_ext(ext)
+                    .map(|grammar| parse_imports(content, &grammar, relative_path))
+                    .unwrap_or_default();
+
+                IndexedFileRefs {
+                    file: relative_path.to_string(),
+                    content: content.to_string(),
+                    imports,
+                }
+            })
+            .collect();
+
+        Self { files }
+    }
+
+    pub fn trace_symbol_callers(&self, symbol_name: &str, source_module: &str) -> Vec<CallerRef> {
+        let mut callers = Vec::new();
+        let symbol = symbol_name.to_string();
+
+        for file in &self.files {
+            if !file.content.contains(symbol_name) {
+                continue;
+            }
+
+            let matching_import = file.imports.iter().find_map(|imp| {
+                (imp.imported_names.contains(&symbol)
+                    && import_matches_module(&imp.module_path, source_module))
+                .then(|| imp.clone())
+            });
+
+            let has_import = matching_import.is_some();
+            let has_call_site = file.content.contains(&format!("{}(", symbol_name))
+                || file.content.contains(&format!("{}::", symbol_name))
+                || file.content.contains(&format!(".{}", symbol_name));
+
+            if has_import || has_call_site {
+                callers.push(CallerRef {
+                    file: file.file.clone(),
+                    import: matching_import,
+                    has_call_site,
+                });
+            }
+        }
+
+        callers
+    }
+}
+
 /// Result of rewriting an import line.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ImportRewrite {

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -11,7 +11,7 @@ mod orphaned_test_fixes;
 mod parameter_fixes;
 mod signatures;
 
-use crate::code_audit::{AuditFinding, CodeAuditResult};
+use crate::code_audit::{fingerprint::FileFingerprint, AuditFinding, CodeAuditResult};
 use crate::core::refactor::auto::{DecomposeFixPlan, Fix, FixPolicy, FixResult, SkippedFile};
 use crate::core::refactor::decompose;
 use crate::core::refactor::plan::file_intent::{FileIntent, FileIntentMap};
@@ -40,7 +40,16 @@ pub fn generate_audit_fixes(
     root: &Path,
     policy: &FixPolicy,
 ) -> FixResult {
-    generate_fixes_impl(result, root, policy)
+    generate_fixes_impl(result, root, policy, None)
+}
+
+pub fn generate_audit_fixes_with_fingerprints(
+    result: &CodeAuditResult,
+    root: &Path,
+    policy: &FixPolicy,
+    fingerprints: &[FileFingerprint],
+) -> FixResult {
+    generate_fixes_impl(result, root, policy, Some(fingerprints))
 }
 
 pub(crate) fn merge_fixes_per_file(fixes: Vec<Fix>) -> Vec<Fix> {
@@ -76,10 +85,13 @@ pub(crate) fn generate_fixes_impl(
     result: &CodeAuditResult,
     root: &Path,
     policy: &FixPolicy,
+    fingerprints: Option<&[FileFingerprint]>,
 ) -> FixResult {
     let mut fixes = Vec::new();
     let mut skipped = Vec::new();
-    let module_surfaces = ModuleSurfaceIndex::build(root);
+    let module_surfaces = fingerprints
+        .map(|fps| ModuleSurfaceIndex::from_fingerprints(root, fps))
+        .unwrap_or_else(|| ModuleSurfaceIndex::build(root));
     let finding_enabled = |finding: &AuditFinding| {
         policy
             .only

--- a/src/core/refactor/plan/generate/module_surface.rs
+++ b/src/core/refactor/plan/generate/module_surface.rs
@@ -61,14 +61,29 @@ pub struct ModuleSurfaceIndex {
 
 impl ModuleSurfaceIndex {
     pub fn build(root: &Path) -> Self {
-        let mut by_file = HashMap::new();
         let files = walker::walk_source_files(root).unwrap_or_default();
+        let mut fingerprints = Vec::new();
 
         for file_path in files {
             let Some(fp) = fingerprint::fingerprint_file(&file_path, root) else {
                 continue;
             };
-            let surface = build_surface_for_fingerprint(root, &fp);
+            fingerprints.push(fp);
+        }
+
+        Self::from_fingerprints(root, &fingerprints)
+    }
+
+    pub fn from_fingerprints(root: &Path, fingerprints: &[FileFingerprint]) -> Self {
+        let symbol_refs = symbol_graph::SymbolReferenceIndex::from_files(
+            fingerprints
+                .iter()
+                .map(|fp| (fp.relative_path.as_str(), fp.content.as_str())),
+        );
+        let mut by_file = HashMap::new();
+
+        for fp in fingerprints {
+            let surface = build_surface_for_fingerprint_with_symbols(root, fp, &symbol_refs);
             by_file.insert(surface.file.clone(), surface);
         }
 
@@ -89,7 +104,11 @@ impl ModuleSurfaceIndex {
     }
 }
 
-fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSurface {
+fn build_surface_for_fingerprint_with_symbols(
+    root: &Path,
+    fp: &FileFingerprint,
+    symbol_refs: &symbol_graph::SymbolReferenceIndex,
+) -> ModuleSurface {
     let file = fp.relative_path.clone();
     let module_path = symbol_graph::module_path_from_file(&file);
     let role = classify_file_role(&file);
@@ -100,11 +119,10 @@ fn build_surface_for_fingerprint(root: &Path, fp: &FileFingerprint) -> ModuleSur
         .iter()
         .map(|site| site.target.clone())
         .collect();
-    let extensions = file_extensions_for(&fp.language);
 
     let mut symbols = HashMap::new();
     for symbol in &public_api {
-        let callers = symbol_graph::trace_symbol_callers(symbol, &module_path, root, &extensions);
+        let callers = symbol_refs.trace_symbol_callers(symbol, &module_path);
         let mut incoming_callers = Vec::new();
         let mut incoming_importers = Vec::new();
         for caller in callers {
@@ -151,16 +169,6 @@ fn classify_file_role(file: &str) -> FileRole {
         return FileRole::PublicApi;
     }
     FileRole::Regular
-}
-
-fn file_extensions_for(language: &crate::code_audit::conventions::Language) -> Vec<&'static str> {
-    match language {
-        crate::code_audit::conventions::Language::Rust => vec!["rs"],
-        crate::code_audit::conventions::Language::Php => vec!["php"],
-        crate::code_audit::conventions::Language::JavaScript => vec!["js", "mjs", "jsx"],
-        crate::code_audit::conventions::Language::TypeScript => vec!["ts", "tsx"],
-        crate::code_audit::conventions::Language::Unknown => vec!["rs", "php", "js", "ts"],
-    }
 }
 
 fn find_reexport_files_for_symbol(root: &Path, file_path: &str, symbol: &str) -> Vec<String> {

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -1,6 +1,7 @@
 use crate::code_audit::report::{
-    build_audit_summary, build_changed_since_summary, compute_fixability, finding_kind_key,
-    from_main_workflow, AuditChangedSinceSummary, AuditCommandOutput,
+    build_audit_summary, build_changed_since_summary, compute_fixability,
+    compute_fixability_with_analysis, finding_kind_key, from_main_workflow,
+    AuditChangedSinceSummary, AuditCommandOutput,
 };
 use crate::code_audit::test_helpers::{empty_result, make_finding};
 use crate::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
@@ -286,6 +287,54 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
     }
     // Note: fixability may also be None if the minimal codebase doesn't trigger
     // enough conventions — that's acceptable for this test.
+}
+
+#[test]
+fn test_compute_fixability_reuses_audit_analysis_context() {
+    use std::fs;
+
+    let _audit_guard = crate::test_support::AuditGuard::new();
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+
+    fs::create_dir_all(root.join("commands")).unwrap();
+    fs::write(
+        root.join("commands/good_one.rs"),
+        "pub fn run() {}\npub fn helper() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("commands/good_two.rs"),
+        "pub fn run() {}\npub fn helper() {}\n",
+    )
+    .unwrap();
+    fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
+
+    let audit = crate::code_audit::audit_path_with_id_with_plan_and_analysis(
+        "fixability-context-test",
+        &root.to_string_lossy(),
+        &crate::code_audit::AuditExecutionPlan::full(),
+    )
+    .expect("audit should run with analysis");
+
+    assert!(
+        !audit.analysis.fingerprints.is_empty(),
+        "audit analysis should retain fingerprints for fixability planning"
+    );
+
+    let from_context = compute_fixability_with_analysis(&audit.result, &audit.analysis);
+    let from_wrapper = compute_fixability(&audit.result);
+
+    assert_eq!(from_context.is_some(), from_wrapper.is_some());
+    if let (Some(context), Some(wrapper)) = (from_context, from_wrapper) {
+        assert_eq!(context.fixable_count, wrapper.fixable_count);
+        assert_eq!(context.automated_count, wrapper.automated_count);
+        assert_eq!(context.manual_only_count, wrapper.manual_only_count);
+        assert_eq!(
+            serde_json::to_value(&context.by_kind).unwrap(),
+            serde_json::to_value(&wrapper.by_kind).unwrap()
+        );
+    }
 }
 
 #[test]

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -290,7 +290,7 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
 }
 
 #[test]
-fn test_compute_fixability_reuses_audit_analysis_context() {
+fn test_compute_fixability_with_analysis() {
     use std::fs;
 
     let _audit_guard = crate::test_support::AuditGuard::new();

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -10,7 +10,8 @@ use crate::code_audit::checks::CheckStatus;
 use crate::code_audit::conventions::{Deviation, Outlier};
 use crate::code_audit::findings::{Finding, Severity};
 use crate::code_audit::{
-    AuditExecutionPlan, AuditFinding, AuditSummary, CodeAuditResult, ConventionReport,
+    AuditAnalysisContext, AuditExecutionPlan, AuditFinding, AuditSummary, CodeAuditResult,
+    ConventionReport,
 };
 
 fn make_finding(kind: AuditFinding, file: &str) -> Finding {
@@ -42,6 +43,10 @@ fn make_result(findings: Vec<Finding>) -> CodeAuditResult {
         findings,
         duplicate_groups: vec![],
     }
+}
+
+fn make_analysis() -> AuditAnalysisContext {
+    AuditAnalysisContext::default()
 }
 
 fn make_convention_report(name: &str, outliers: Vec<Outlier>) -> ConventionReport {
@@ -240,8 +245,13 @@ fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
         },
     };
 
-    let workflow = build_comparison_output(result, baseline, &make_changed_since_args())
-        .expect("comparison output builds");
+    let workflow = build_comparison_output(
+        result,
+        &make_analysis(),
+        baseline,
+        &make_changed_since_args(),
+    )
+    .expect("comparison output builds");
 
     assert_eq!(workflow.exit_code, 0);
     match workflow.output {
@@ -285,8 +295,13 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
         },
     };
 
-    let workflow = build_comparison_output(result, baseline, &make_changed_since_args())
-        .expect("comparison output builds");
+    let workflow = build_comparison_output(
+        result,
+        &make_analysis(),
+        baseline,
+        &make_changed_since_args(),
+    )
+    .expect("comparison output builds");
 
     assert_eq!(workflow.exit_code, 1);
     match workflow.output {
@@ -352,7 +367,7 @@ fn fixability_is_skipped_unless_requested() {
     let result = make_result(vec![make_finding(AuditFinding::TodoMarker, "a.rs")]);
     let args = make_args(false);
 
-    let fixability = compute_fixability_if_requested(&result, &args);
+    let fixability = compute_fixability_if_requested(&result, &make_analysis(), &args);
 
     assert!(fixability.is_none());
 }
@@ -362,7 +377,7 @@ fn fixability_flag_allows_planning_path() {
     let result = make_result(vec![make_finding(AuditFinding::TodoMarker, "a.rs")]);
     let args = make_args(true);
 
-    let fixability = compute_fixability_if_requested(&result, &args);
+    let fixability = compute_fixability_if_requested(&result, &make_analysis(), &args);
 
     // The fixture path does not exist, so the planner returns None. The test
     // still pins the flag contract: true is the only path that reaches the


### PR DESCRIPTION
## Summary
- Adds audit-run analysis context carrying the fingerprints already produced during audit discovery.
- Lets fixability/refactor planning build module surfaces from those fingerprints instead of re-walking and re-fingerprinting.
- Adds a batched symbol reference index over in-memory file contents so module surfaces avoid per-symbol codebase scans.

## Validation
- `cargo test report_test --lib`
- `cargo test run_test --lib`
- `cargo test symbol_graph --lib`
- `cargo test module_surface --lib`
- `cargo test test_compute_fixability_reuses_audit_analysis_context --lib`
- `cargo test --lib`
- `cargo run --bin homeboy -- audit --fixability --json-summary` (exits 1 due existing audit baseline drift)
- `cargo run --bin homeboy -- test` (fails existing `core_owned_source_stays_language_and_framework_agnostic`: baseline count left 185 vs right 260)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.