### PR TITLE
fix(issues): remove review-only issue policy

### DIFF
--- a/docs/audit/repeated-literal-shape.md
+++ b/docs/audit/repeated-literal-shape.md
@@ -38,9 +38,9 @@ component. The finding description lists:
 
 ## Severity
 
-`Info` — the detector's output is review-only. It reports the repeated shape,
-candidate files, and estimated LOC reduction, but no automated fixer is
-registered and no rewrites are applied automatically.
+`Info` — the detector reports the repeated shape, candidate files, and
+estimated LOC reduction, but no automated fixer is registered and no rewrites
+are applied automatically.
 
 ## Related
 

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::io::Read;
-use std::path::PathBuf;
 
 use homeboy::code_audit::FindingConfidence;
 use homeboy::issues::{
@@ -76,28 +75,6 @@ enum IssuesCommand {
         /// `--from-output`.
         #[arg(long, value_name = "URL")]
         run_url: Option<String>,
-
-        /// Read suppressions from `homeboy.json`'s `audit.suppressed_categories`
-        /// and `issues.suppression_labels`. When false, suppression must be
-        /// passed explicitly via the flags below.
-        #[arg(long, default_value_t = true)]
-        suppress_from_config: bool,
-
-        /// Override category suppressions (repeatable). Replaces the
-        /// homeboy.json list when both are set.
-        #[arg(long, value_name = "CATEGORY")]
-        suppress_category: Vec<String>,
-
-        /// Override label suppressions (repeatable). Replaces the
-        /// homeboy.json list when both are set.
-        #[arg(long, value_name = "LABEL")]
-        suppress_label: Vec<String>,
-
-        /// Override review-only categories (repeatable). Replaces the default
-        /// heuristic/threshold list and homeboy.json's
-        /// `issues.review_only_categories` when set.
-        #[arg(long, value_name = "CATEGORY")]
-        review_only_category: Vec<String>,
 
         /// Don't refresh the body of closed-not_planned issues with the
         /// latest finding count. Default is to refresh (so the closed
@@ -177,10 +154,6 @@ pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCom
             findings,
             from_output,
             run_url,
-            suppress_from_config,
-            suppress_category,
-            suppress_label,
-            review_only_category,
             no_refresh_closed,
             list_limit,
             apply,
@@ -190,17 +163,7 @@ pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCom
             let command_label = findings_input.command.clone();
             let groups = into_issue_groups(findings_input, &component_id);
 
-            // Build reconcile config: CLI overrides take priority; otherwise
-            // read homeboy.json when the flag is set; otherwise empty.
-            let config = build_reconcile_config(
-                &component_id,
-                path.as_deref(),
-                suppress_from_config,
-                suppress_category,
-                suppress_label,
-                review_only_category,
-                no_refresh_closed,
-            )?;
+            let config = build_reconcile_config(no_refresh_closed);
 
             // Default tracker = GitHub against the component's remote.
             let tracker_impl = GithubTracker::new(component_id.clone()).with_path(path.clone());
@@ -462,105 +425,10 @@ fn parse_confidence(raw: &str) -> Option<FindingConfidence> {
 // homeboy.json suppression read
 // ---------------------------------------------------------------------------
 
-fn build_reconcile_config(
-    component_id: &str,
-    path: Option<&str>,
-    suppress_from_config: bool,
-    cli_categories: Vec<String>,
-    cli_labels: Vec<String>,
-    cli_review_only_categories: Vec<String>,
-    no_refresh_closed: bool,
-) -> homeboy::Result<ReconcileConfig> {
-    let mut config = ReconcileConfig {
+fn build_reconcile_config(no_refresh_closed: bool) -> ReconcileConfig {
+    ReconcileConfig {
         refresh_closed_not_planned: !no_refresh_closed,
         ..ReconcileConfig::default()
-    };
-
-    if suppress_from_config {
-        if let Some(reconcile_config) = read_suppressions(component_id, path)? {
-            let (suppressed, labels, review_only) = reconcile_config;
-            config.suppressed_categories = suppressed;
-            config.suppression_labels = labels;
-            if let Some(review_only) = review_only {
-                config.review_only_categories = review_only;
-            }
-        }
-    }
-
-    // CLI flags override homeboy.json when present.
-    if !cli_categories.is_empty() {
-        config.suppressed_categories = cli_categories;
-    }
-    if !cli_labels.is_empty() {
-        config.suppression_labels = cli_labels;
-    }
-    if !cli_review_only_categories.is_empty() {
-        config.review_only_categories = cli_review_only_categories;
-    }
-
-    // Sane default for suppression_labels when neither config nor CLI set
-    // them. Mirrors the documented defaults in #1551.
-    if config.suppression_labels.is_empty() {
-        config.suppression_labels = vec![
-            "wontfix".into(),
-            "upstream-bug".into(),
-            "audit-suppressed".into(),
-        ];
-    }
-
-    Ok(config)
-}
-
-fn read_suppressions(
-    component_id: &str,
-    path: Option<&str>,
-) -> homeboy::Result<Option<(Vec<String>, Vec<String>, Option<Vec<String>>)>> {
-    let component_dir = match path {
-        Some(p) => PathBuf::from(p),
-        None => match homeboy::component::resolve_effective(Some(component_id), None, None) {
-            Ok(c) => PathBuf::from(c.local_path),
-            Err(_) => return Ok(None),
-        },
-    };
-
-    let raw = match homeboy::component::read_portable_config(&component_dir)? {
-        Some(v) => v,
-        None => return Ok(None),
-    };
-
-    let categories = raw
-        .pointer("/audit/suppressed_categories")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|x| x.as_str().map(String::from))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    let labels = raw
-        .pointer("/issues/suppression_labels")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|x| x.as_str().map(String::from))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    let review_only = raw
-        .pointer("/issues/review_only_categories")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|x| x.as_str().map(String::from))
-                .collect::<Vec<_>>()
-        });
-
-    if categories.is_empty() && labels.is_empty() && review_only.is_none() {
-        Ok(None)
-    } else {
-        Ok(Some((categories, labels, review_only)))
     }
 }
 
@@ -600,9 +468,6 @@ fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
             homeboy::issues::ReconcileAction::Close {
                 number, category, ..
             } => format!("close         {} → #{}", category, number),
-            homeboy::issues::ReconcileAction::CloseReviewOnly {
-                number, category, ..
-            } => format!("close_review  {} → #{} (not planned)", category, number),
             homeboy::issues::ReconcileAction::CloseDuplicate {
                 number,
                 keep,
@@ -658,27 +523,9 @@ mod tests {
     }
 
     #[test]
-    fn default_reconcile_config_marks_thresholds_and_heuristics_review_only() {
-        let config = ReconcileConfig::default();
+    fn reconcile_config_only_controls_closed_refresh_behavior() {
+        let config = build_reconcile_config(true);
 
-        assert!(config.review_only_categories.contains(&"god_file".into()));
-        assert!(config
-            .review_only_categories
-            .contains(&"directory_sprawl".into()));
-        assert!(config
-            .review_only_categories
-            .contains(&"missing_test_file".into()));
-        assert!(config
-            .review_only_categories
-            .contains(&"parallel_implementation".into()));
-        assert!(config
-            .review_only_categories
-            .contains(&"unused_parameter".into()));
-        assert!(!config
-            .review_only_categories
-            .contains(&"unreferenced_export".into()));
-        assert!(!config
-            .review_only_categories
-            .contains(&"compiler_warning".into()));
+        assert!(!config.refresh_closed_not_planned);
     }
 }

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -89,7 +89,7 @@ impl AuditFinding {
             | AuditFinding::DeprecationAge
             | AuditFinding::DeadGuard => FindingConfidence::Graph,
 
-            // Convention, naming, body-shape, and similarity findings remain review-only.
+            // Convention, naming, body-shape, and similarity findings require judgment.
             _ => FindingConfidence::Heuristic,
         }
     }

--- a/src/core/code_audit/structural.rs
+++ b/src/core/code_audit/structural.rs
@@ -415,7 +415,7 @@ export default function main() {}
     }
 
     #[test]
-    fn count_only_god_file_is_review_only_info() {
+    fn count_only_god_file_is_info() {
         let dir = std::env::temp_dir().join("homeboy_structural_count_only_god_test");
         let _ = std::fs::create_dir_all(&dir);
 
@@ -432,7 +432,11 @@ export default function main() {}
             .filter(|f| f.kind == AuditFinding::GodFile)
             .collect();
 
-        assert_eq!(god_findings.len(), 1, "Should keep review-only visibility");
+        assert_eq!(
+            god_findings.len(),
+            1,
+            "Should keep low-confidence visibility"
+        );
         assert_eq!(god_findings[0].file, "large.rs");
         assert_eq!(god_findings[0].severity, Severity::Info);
         assert!(god_findings[0].suggestion.contains("line count alone"));
@@ -448,7 +452,7 @@ export default function main() {}
 
     #[test]
     fn count_only_structural_smells_below_actionable_threshold_are_ignored() {
-        let dir = std::env::temp_dir().join("homeboy_structural_review_only_test");
+        let dir = std::env::temp_dir().join("homeboy_structural_low_confidence_test");
         let root = dir.join("src/core");
         let _ = std::fs::create_dir_all(&root);
 
@@ -473,7 +477,7 @@ export default function main() {}
         let findings = analyze_structure(&dir);
         assert!(
             findings.is_empty(),
-            "Moderate count-only smells should stay review-only instead of producing audit findings"
+            "Moderate count-only smells should stay below the audit finding threshold"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/core/issues/apply.rs
+++ b/src/core/issues/apply.rs
@@ -73,12 +73,6 @@ fn execute_action(action: &ReconcileAction, tracker: &dyn Tracker) -> ReconcileE
             Ok(()) => ExecutionOutcome::Closed { number: *number },
             Err(e) => ExecutionOutcome::failed(&e),
         },
-        ReconcileAction::CloseReviewOnly {
-            number, comment, ..
-        } => match tracker.close_issue(*number, CloseReason::NotPlanned, Some(comment)) {
-            Ok(()) => ExecutionOutcome::Closed { number: *number },
-            Err(e) => ExecutionOutcome::failed(&e),
-        },
         ReconcileAction::CloseDuplicate {
             number,
             keep,
@@ -127,9 +121,6 @@ fn summary_for(action: &ReconcileAction) -> String {
         ReconcileAction::Close {
             number, category, ..
         } => format!("close         {} → #{}", category, number),
-        ReconcileAction::CloseReviewOnly {
-            number, category, ..
-        } => format!("close_review  {} → #{} [not planned]", category, number),
         ReconcileAction::CloseDuplicate {
             number,
             keep,
@@ -339,12 +330,12 @@ mod tests {
                 ReconcileAction::Skip {
                     category: "x".into(),
                     component_id: "c".into(),
-                    reason: ReconcileSkipReason::SuppressedByConfig,
+                    reason: ReconcileSkipReason::NoFindingsNoIssue,
                 },
                 ReconcileAction::Skip {
                     category: "y".into(),
                     component_id: "c".into(),
-                    reason: ReconcileSkipReason::SuppressedByLabel,
+                    reason: ReconcileSkipReason::ClosedNotPlannedNoRefresh,
                 },
             ],
         };

--- a/src/core/issues/mod.rs
+++ b/src/core/issues/mod.rs
@@ -42,8 +42,8 @@ pub mod tracker;
 
 pub use apply::{apply_plan, ReconcileExecution, ReconcileResult};
 pub use plan::{
-    default_review_only_categories, IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan,
-    ReconcileSkipReason, TrackedIssue, TrackedIssueState,
+    IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
+    TrackedIssueState,
 };
 pub use reconcile::{reconcile, reconcile_scoped};
 pub use render::{

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::code_audit::{AuditFinding, FindingConfidence};
+use crate::code_audit::FindingConfidence;
 
 /// One row of incoming findings: "command produced N findings of category X
 /// for component Y." This is the input grain reconcile reasons over.
@@ -81,26 +81,6 @@ impl TrackedIssueState {
 /// Configuration that affects reconcile decisions but not finding shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReconcileConfig {
-    /// Categories whose findings are unconditionally muted. No new issue is
-    /// filed; existing OPEN issues for these categories are left alone.
-    /// Existing CLOSED issues stay closed. Sourced from `homeboy.json`'s
-    /// `audit.suppressed_categories` (or a CLI override).
-    #[serde(default)]
-    pub suppressed_categories: Vec<String>,
-
-    /// Labels that, when present on a closed issue, suppress re-filing the
-    /// same category. Defaults to `["wontfix", "upstream-bug",
-    /// "audit-suppressed"]`. Sourced from `homeboy.json`'s
-    /// `issues.suppression_labels`.
-    #[serde(default)]
-    pub suppression_labels: Vec<String>,
-
-    /// Categories that should remain visible in reports but should not file
-    /// brand-new tracker issues by default. Existing open issues can still be
-    /// updated/closed so old tracker state converges naturally.
-    #[serde(default = "default_review_only_categories")]
-    pub review_only_categories: Vec<String>,
-
     /// When true, also refresh the body of closed-not_planned issues with
     /// the latest finding count + run link. This keeps the closed issue
     /// useful as a "current state" reference even though it stays closed.
@@ -112,9 +92,6 @@ pub struct ReconcileConfig {
 impl Default for ReconcileConfig {
     fn default() -> Self {
         Self {
-            suppressed_categories: Vec::new(),
-            suppression_labels: Vec::new(),
-            review_only_categories: default_review_only_categories(),
             refresh_closed_not_planned: default_refresh_closed(),
         }
     }
@@ -122,22 +99,6 @@ impl Default for ReconcileConfig {
 
 fn default_refresh_closed() -> bool {
     true
-}
-
-pub fn default_review_only_categories() -> Vec<String> {
-    AuditFinding::all_names()
-        .iter()
-        .copied()
-        .filter(|name| {
-            let Ok(finding) = name.parse::<AuditFinding>() else {
-                return false;
-            };
-
-            finding.confidence() == FindingConfidence::Heuristic
-                || matches!(finding, AuditFinding::UnusedParameter)
-        })
-        .map(String::from)
-        .collect()
 }
 
 /// One concrete action the reconciler decided on. Order matters in the plan:
@@ -179,14 +140,6 @@ pub enum ReconcileAction {
         category: String,
         comment: String,
     },
-    /// Close an advisory/review-only issue that was filed by an older policy.
-    /// Reason is always `not_planned` because findings still exist, but the
-    /// category is intentionally not tracker-actionable.
-    CloseReviewOnly {
-        number: u64,
-        category: String,
-        comment: String,
-    },
     /// Close a duplicate of another open issue for the same category.
     /// Reason is always `not_planned` — caller intent is "this is the same
     /// thing as #N." Caller keeps the lowest-numbered match.
@@ -204,24 +157,15 @@ pub enum ReconcileAction {
     },
 }
 
-/// Why the reconciler decided to skip a group. Surfaces in dry-run output
-/// so the user can see whether suppression came from config, label, or
-/// close-state.
+/// Why the reconciler decided to skip a group. Surfaces in dry-run output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReconcileSkipReason {
-    /// Category was in `suppressed_categories`.
-    SuppressedByConfig,
-    /// A closed-not_planned issue carried a `suppression_labels` label.
-    SuppressedByLabel,
-    /// A closed-not_planned issue without a suppression label, AND
-    /// `refresh_closed_not_planned = false`. Less common.
+    /// A closed-not_planned issue and `refresh_closed_not_planned = false`.
+    /// Less common.
     ClosedNotPlannedNoRefresh,
     /// No findings AND no existing open issue → nothing to do.
     NoFindingsNoIssue,
-    /// Category is advisory/review-only, so reconcile will not file a brand-new
-    /// tracker issue for it by default.
-    ReviewOnlyCategory,
 }
 
 /// The full reconciliation plan: every action, in execution order.
@@ -241,7 +185,6 @@ impl ReconcilePlan {
                 ReconcileAction::Update { .. } => c.update += 1,
                 ReconcileAction::UpdateClosed { .. } => c.update_closed += 1,
                 ReconcileAction::Close { .. } => c.close += 1,
-                ReconcileAction::CloseReviewOnly { .. } => c.close += 1,
                 ReconcileAction::CloseDuplicate { .. } => c.close_duplicate += 1,
                 ReconcileAction::Skip { .. } => c.skip += 1,
             }

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -6,8 +6,6 @@
 
 use std::collections::BTreeMap;
 
-use crate::code_audit::FindingConfidence;
-
 use super::plan::{
     IssueGroup, ReconcileAction, ReconcileConfig, ReconcilePlan, ReconcileSkipReason, TrackedIssue,
     TrackedIssueState,
@@ -67,21 +65,6 @@ fn reconcile_with_scope(
     let mut seen_keys: Vec<(String, String, String)> = Vec::new();
 
     for group in groups {
-        // Phase 1: suppression by config (highest precedence — short-circuits
-        // every other consideration).
-        if config
-            .suppressed_categories
-            .iter()
-            .any(|c| c == &group.category)
-        {
-            actions.push(ReconcileAction::Skip {
-                category: group.category.clone(),
-                component_id: group.component_id.clone(),
-                reason: ReconcileSkipReason::SuppressedByConfig,
-            });
-            continue;
-        }
-
         let key = (
             group.command.clone(),
             group.component_id.clone(),
@@ -89,7 +72,6 @@ fn reconcile_with_scope(
         );
         seen_keys.push(key.clone());
         let matches = collect_matches(&by_category, group, &key);
-        let review_only = is_review_only(group, config);
 
         // Phase 2: dispatch on (existing-issue-shape, count).
         let (open_matches, closed_matches): (Vec<_>, Vec<_>) =
@@ -141,8 +123,7 @@ fn reconcile_with_scope(
             // A human closing the category as not_planned is stronger than any
             // open duplicate left behind by an older action run. Keep the
             // closed issue as the canonical record and fold open dupes into it.
-            let suppressed_by_label = has_suppression_label(closed, config);
-            if !suppressed_by_label && config.refresh_closed_not_planned {
+            if config.refresh_closed_not_planned {
                 actions.push(ReconcileAction::UpdateClosed {
                     number: closed.number,
                     body: body_with_issue_key(group),
@@ -158,13 +139,7 @@ fn reconcile_with_scope(
                     comment: close_dedupe_comment(closed.number),
                 });
             }
-            if suppressed_by_label {
-                actions.push(ReconcileAction::Skip {
-                    category: group.category.clone(),
-                    component_id: group.component_id.clone(),
-                    reason: ReconcileSkipReason::SuppressedByLabel,
-                });
-            } else if !config.refresh_closed_not_planned {
+            if !config.refresh_closed_not_planned {
                 actions.push(ReconcileAction::Skip {
                     category: group.category.clone(),
                     component_id: group.component_id.clone(),
@@ -175,17 +150,6 @@ fn reconcile_with_scope(
         }
 
         if !open_matches.is_empty() {
-            if review_only {
-                for issue in &open_matches {
-                    actions.push(ReconcileAction::CloseReviewOnly {
-                        number: issue.number,
-                        category: group.category.clone(),
-                        comment: close_review_only_comment(&group.label_or_category()),
-                    });
-                }
-                continue;
-            }
-
             // Update the lowest-numbered open match.
             let keep = open_matches[0].number;
             actions.push(ReconcileAction::Update {
@@ -207,21 +171,10 @@ fn reconcile_with_scope(
             continue;
         }
 
-        // No open match. Check the closed issues for suppression / refresh.
+        // No open match. Check closed issue history before filing a fresh one.
         if let Some(closed) = preferred_closed {
             match closed.state {
                 TrackedIssueState::ClosedNotPlanned => {
-                    let suppressed_by_label = has_suppression_label(closed, config);
-                    if suppressed_by_label {
-                        // Phase 3 suppression — a label on a closed-not_planned
-                        // issue mutes re-filing.
-                        actions.push(ReconcileAction::Skip {
-                            category: group.category.clone(),
-                            component_id: group.component_id.clone(),
-                            reason: ReconcileSkipReason::SuppressedByLabel,
-                        });
-                        continue;
-                    }
                     if !config.refresh_closed_not_planned {
                         actions.push(ReconcileAction::Skip {
                             category: group.category.clone(),
@@ -240,15 +193,6 @@ fn reconcile_with_scope(
                 }
                 TrackedIssueState::ClosedCompleted => {
                     // Resolved-then-returned: file a fresh issue.
-                    if review_only {
-                        actions.push(ReconcileAction::Skip {
-                            category: group.category.clone(),
-                            component_id: group.component_id.clone(),
-                            reason: ReconcileSkipReason::ReviewOnlyCategory,
-                        });
-                        continue;
-                    }
-
                     actions.push(ReconcileAction::FileNew {
                         command: group.command.clone(),
                         component_id: group.component_id.clone(),
@@ -265,15 +209,6 @@ fn reconcile_with_scope(
         }
 
         // No issue ever existed (open or closed) for this category.
-        if review_only {
-            actions.push(ReconcileAction::Skip {
-                category: group.category.clone(),
-                component_id: group.component_id.clone(),
-                reason: ReconcileSkipReason::ReviewOnlyCategory,
-            });
-            continue;
-        }
-
         actions.push(ReconcileAction::FileNew {
             command: group.command.clone(),
             component_id: group.component_id.clone(),
@@ -290,7 +225,6 @@ fn reconcile_with_scope(
             &mut actions,
             &by_category,
             &seen_keys,
-            config,
             command,
             component_id,
         );
@@ -303,7 +237,6 @@ fn close_absent_open_issues(
     actions: &mut Vec<ReconcileAction>,
     by_category: &BTreeMap<(String, String, String), Vec<&TrackedIssue>>,
     seen_keys: &[(String, String, String)],
-    config: &ReconcileConfig,
     command: &str,
     component_id: &str,
 ) {
@@ -318,14 +251,6 @@ fn close_absent_open_issues(
         )) {
             continue;
         }
-        if config
-            .suppressed_categories
-            .iter()
-            .any(|suppressed| suppressed == category)
-        {
-            continue;
-        }
-
         let mut open_matches: Vec<_> = matches
             .iter()
             .copied()
@@ -384,23 +309,6 @@ fn collect_matches<'a>(
     }
 
     matches
-}
-
-fn is_review_only(group: &IssueGroup, config: &ReconcileConfig) -> bool {
-    config
-        .review_only_categories
-        .iter()
-        .any(|category| category == &group.category)
-        || matches!(group.confidence, Some(FindingConfidence::Heuristic))
-}
-
-fn has_suppression_label(issue: &TrackedIssue, config: &ReconcileConfig) -> bool {
-    issue.labels.iter().any(|label| {
-        config
-            .suppression_labels
-            .iter()
-            .any(|suppressed| suppressed == label)
-    })
 }
 
 fn pick_preferred_closed<'a>(closed: &[&'a TrackedIssue]) -> Option<&'a TrackedIssue> {
@@ -473,17 +381,6 @@ fn close_resolved_comment(label: &str) -> String {
     )
 }
 
-fn close_review_only_comment(label: &str) -> String {
-    format!(
-        "**{}** findings are still present, but this category is review-only in the current \
-         reconcile policy. Closing as not planned so advisory heuristic findings do not keep \
-         tracker issues open indefinitely.\n\n\
-         The findings remain visible in `homeboy audit`; reopen or file a focused issue if a \
-         specific refactor becomes actionable.",
-        label
-    )
-}
-
 fn close_dedupe_comment(keep: u64) -> String {
     format!(
         "Closing as duplicate of #{} — consolidated by `homeboy issues reconcile`.\n\n\
@@ -534,12 +431,13 @@ impl IssueGroup {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — the 8-row behavior table + suppression precedence
+// Tests — the 8-row behavior table and edge cases
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::code_audit::FindingConfidence;
 
     fn group(category: &str, count: usize) -> IssueGroup {
         IssueGroup {
@@ -583,9 +481,6 @@ mod tests {
 
     fn cfg() -> ReconcileConfig {
         ReconcileConfig {
-            suppressed_categories: vec![],
-            suppression_labels: vec!["wontfix".into(), "upstream-bug".into()],
-            review_only_categories: vec![],
             refresh_closed_not_planned: true,
         }
     }
@@ -703,7 +598,7 @@ mod tests {
     // --------------------------------------------------------------- ROW 6
 
     #[test]
-    fn row6_closed_not_planned_with_suppression_label_skips() {
+    fn row6_closed_not_planned_with_labels_still_refreshes_body() {
         let groups = vec![group("missing_test_method", 334)];
         let existing = vec![issue_with_labels(
             802,
@@ -715,110 +610,40 @@ mod tests {
         let plan = reconcile(&groups, &existing, &cfg());
         assert_eq!(plan.actions.len(), 1);
         match &plan.actions[0] {
-            ReconcileAction::Skip { reason, .. } => {
-                assert_eq!(*reason, ReconcileSkipReason::SuppressedByLabel);
+            ReconcileAction::UpdateClosed { number, count, .. } => {
+                assert_eq!(*number, 802);
+                assert_eq!(*count, 334);
             }
-            other => panic!("expected Skip(SuppressedByLabel), got {:?}", other),
+            other => panic!("expected UpdateClosed, got {:?}", other),
         }
     }
 
     // --------------------------------------------------------------- ROW 7
 
     #[test]
-    fn row7_suppressed_categories_in_config_skips() {
-        let mut config = cfg();
-        config.suppressed_categories = vec!["god_file".into()];
+    fn row7_open_issue_with_findings_updates_even_for_noisy_categories() {
         let groups = vec![group("god_file", 99)];
-        // Even with an open issue present, config-level suppression wins.
         let existing = vec![issue(675, "god file", TrackedIssueState::Open, 17)];
-        let plan = reconcile(&groups, &existing, &config);
+        let plan = reconcile(&groups, &existing, &cfg());
         assert_eq!(plan.actions.len(), 1);
         match &plan.actions[0] {
-            ReconcileAction::Skip { reason, .. } => {
-                assert_eq!(*reason, ReconcileSkipReason::SuppressedByConfig);
-            }
-            other => panic!("expected Skip(SuppressedByConfig), got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn review_only_category_skips_brand_new_issue() {
-        let mut config = cfg();
-        config.review_only_categories = vec!["god_file".into()];
-        let groups = vec![group("god_file", 23)];
-
-        let plan = reconcile(&groups, &[], &config);
-
-        assert_eq!(plan.actions.len(), 1);
-        match &plan.actions[0] {
-            ReconcileAction::Skip { reason, .. } => {
-                assert_eq!(*reason, ReconcileSkipReason::ReviewOnlyCategory);
-            }
-            other => panic!("expected Skip(ReviewOnlyCategory), got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn review_only_category_closes_existing_open_issue_not_planned() {
-        let mut config = cfg();
-        config.review_only_categories = vec!["god_file".into()];
-        let groups = vec![group("god_file", 23)];
-        let existing = vec![issue(675, "god file", TrackedIssueState::Open, 17)];
-
-        let plan = reconcile(&groups, &existing, &config);
-
-        assert_eq!(plan.actions.len(), 1);
-        match &plan.actions[0] {
-            ReconcileAction::CloseReviewOnly {
-                number, comment, ..
-            } => {
+            ReconcileAction::Update { number, count, .. } => {
                 assert_eq!(*number, 675);
-                assert!(comment.contains("review-only"));
-                assert!(comment.contains("not planned"));
+                assert_eq!(*count, 99);
             }
-            other => panic!("expected CloseReviewOnly, got {:?}", other),
+            other => panic!("expected Update, got {:?}", other),
         }
     }
 
     #[test]
-    fn review_only_category_does_not_refile_closed_completed_issue() {
-        let mut config = cfg();
-        config.review_only_categories = vec!["god_file".into()];
-        let groups = vec![group("god_file", 23)];
-        let existing = vec![issue(
-            675,
-            "god file",
-            TrackedIssueState::ClosedCompleted,
-            0,
-        )];
-
-        let plan = reconcile(&groups, &existing, &config);
-
-        assert_eq!(plan.actions.len(), 1);
-        assert!(matches!(
-            &plan.actions[0],
-            ReconcileAction::Skip {
-                reason: ReconcileSkipReason::ReviewOnlyCategory,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn heuristic_confidence_group_is_review_only_even_when_category_is_unknown() {
+    fn heuristic_confidence_group_files_issue() {
         let mut heuristic = group("extension_specific_hint", 3);
         heuristic.confidence = Some(FindingConfidence::Heuristic);
 
         let plan = reconcile(&[heuristic], &[], &cfg());
 
         assert_eq!(plan.actions.len(), 1);
-        assert!(matches!(
-            &plan.actions[0],
-            ReconcileAction::Skip {
-                reason: ReconcileSkipReason::ReviewOnlyCategory,
-                ..
-            }
-        ));
+        assert!(matches!(&plan.actions[0], ReconcileAction::FileNew { count, .. } if *count == 3));
     }
 
     // --------------------------------------------------------------- ROW 8
@@ -850,27 +675,15 @@ mod tests {
     // ----------------------------------------------- precedence ladder
 
     #[test]
-    fn precedence_config_beats_open_issue() {
-        // Already covered by row7, but keeps the precedence story explicit.
-        let mut config = cfg();
-        config.suppressed_categories = vec!["x".into()];
+    fn open_issue_with_findings_updates_for_any_category() {
         let groups = vec![group("x", 5)];
         let existing = vec![issue(1, "x", TrackedIssueState::Open, 5)];
-        let plan = reconcile(&groups, &existing, &config);
-        assert!(matches!(
-            &plan.actions[0],
-            ReconcileAction::Skip {
-                reason: ReconcileSkipReason::SuppressedByConfig,
-                ..
-            }
-        ));
+        let plan = reconcile(&groups, &existing, &cfg());
+        assert!(matches!(&plan.actions[0], ReconcileAction::Update { .. }));
     }
 
     #[test]
-    fn precedence_label_only_applies_when_closed_not_planned() {
-        // A `wontfix` label on an OPEN issue should NOT suppress — the
-        // label-precedence rule is gated on closed-not_planned per #1551
-        // (option 2). Open + label = update normally.
+    fn labels_do_not_mute_open_issue_updates() {
         let groups = vec![group("x", 5)];
         let existing = vec![issue_with_labels(
             1,
@@ -962,7 +775,7 @@ mod tests {
     }
 
     #[test]
-    fn closed_not_planned_with_suppression_label_closes_later_open_duplicate() {
+    fn closed_not_planned_with_labels_updates_and_closes_later_open_duplicate() {
         let groups = vec![group("unreferenced_export", 1)];
         let existing = vec![
             issue_with_labels(
@@ -980,19 +793,16 @@ mod tests {
         assert_eq!(plan.actions.len(), 2);
         assert!(matches!(
             &plan.actions[0],
+            ReconcileAction::UpdateClosed { number: 1366, .. }
+        ));
+        assert!(matches!(
+            &plan.actions[1],
             ReconcileAction::CloseDuplicate {
                 number: 1400,
                 keep: 1366,
                 category,
                 ..
             } if category == "unreferenced_export"
-        ));
-        assert!(matches!(
-            &plan.actions[1],
-            ReconcileAction::Skip {
-                reason: ReconcileSkipReason::SuppressedByLabel,
-                ..
-            }
         ));
     }
 
@@ -1205,7 +1015,7 @@ mod tests {
     }
 
     #[test]
-    fn scoped_absent_issue_honors_component_and_suppression_scope() {
+    fn scoped_absent_issue_honors_component_scope() {
         let mut other_component = issue(10, "dead guard", TrackedIssueState::Open, 4);
         other_component.title = "audit: dead guard in other-component (4)".into();
         let existing = vec![
@@ -1213,14 +1023,19 @@ mod tests {
             issue(20, "god file", TrackedIssueState::Open, 9),
             issue(30, "unreferenced export", TrackedIssueState::Open, 2),
         ];
-        let mut config = cfg();
-        config.suppressed_categories = vec!["god_file".into()];
+        let plan = reconcile_scoped(&[], &existing, &cfg(), "audit", "data-machine");
 
-        let plan = reconcile_scoped(&[], &existing, &config, "audit", "data-machine");
-
-        assert_eq!(plan.actions.len(), 1);
+        assert_eq!(plan.actions.len(), 2);
         assert!(matches!(
             &plan.actions[0],
+            ReconcileAction::Close {
+                number: 20,
+                category,
+                ..
+            } if category == "god_file"
+        ));
+        assert!(matches!(
+            &plan.actions[1],
             ReconcileAction::Close {
                 number: 30,
                 category,

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -785,16 +785,16 @@ fn plan_audit_stage(
         let policy_summary = fixer::apply_fix_policy(&mut fix_result, false, &policy);
         let changed_files = collect_audit_changed_files(&fix_result);
 
-        // Surface findings whose collected edits are all manual/review-only — these
+        // Surface findings whose collected edits are all manual-only — these
         // are visible in preview but `--write` will decline to apply them.
         // Without this hint the divergence between dry-run and --write is
         // invisible (homeboy#1159).
-        let review_only_count = count_review_only_fixes(&fix_result);
-        let stage_warnings = if review_only_count > 0 {
+        let manual_only_count = count_manual_only_fixes(&fix_result);
+        let stage_warnings = if manual_only_count > 0 {
             vec![format!(
-                "{} finding(s) produced manual/review-only edits — visible in preview but will NOT be applied by --write. \
+                "{} finding(s) produced manual-only edits — visible in preview but will NOT be applied by --write. \
                  Resolve manually or acknowledge via baseline.",
-                review_only_count
+                manual_only_count
             )]
         } else {
             Vec::new()
@@ -1227,20 +1227,20 @@ fn run_test_stage(
 /// dropped entirely by `apply_fix_policy(write=true)`. Used to surface a warning
 /// when dry-run previews edits that `--write` will silently decline.
 /// (homeboy#1159, homeboy#1478)
-fn count_review_only_fixes(fix_result: &fixer::FixResult) -> usize {
-    let review_only_fixes = fix_result
+fn count_manual_only_fixes(fix_result: &fixer::FixResult) -> usize {
+    let manual_only_fixes = fix_result
         .fixes
         .iter()
         .filter(|fix| {
             !fix.insertions.is_empty() && fix.insertions.iter().all(|ins| !ins.auto_apply)
         })
         .count();
-    let review_only_new_files = fix_result
+    let manual_only_new_files = fix_result
         .new_files
         .iter()
         .filter(|nf| !nf.auto_apply)
         .count();
-    review_only_fixes + review_only_new_files
+    manual_only_fixes + manual_only_new_files
 }
 
 /// Count only files that `--write` mode would actually modify.
@@ -1868,7 +1868,7 @@ mod tests {
         }
     }
 
-    fn review_only_insertion() -> Insertion {
+    fn heuristic_manual_only_insertion() -> Insertion {
         Insertion {
             primitive: None,
             kind: InsertionKind::MethodStub,
@@ -1880,7 +1880,7 @@ mod tests {
                     .to_string(),
             ),
             code: String::new(),
-            description: "review-only orphaned test flag".to_string(),
+            description: "manual-only orphaned test flag".to_string(),
         }
     }
 
@@ -1920,18 +1920,18 @@ mod tests {
     }
 
     #[test]
-    fn collect_audit_changed_files_excludes_review_only_only_fixes() {
+    fn collect_audit_changed_files_excludes_heuristic_manual_only_fixes() {
         let fix = Fix {
             file: "tests/core/process_test.rs".to_string(),
             required_methods: Vec::new(),
             required_registrations: Vec::new(),
-            insertions: vec![review_only_insertion()],
+            insertions: vec![heuristic_manual_only_insertion()],
             applied: false,
         };
         let result = fix_result_with(vec![fix], Vec::new());
         assert!(
             collect_audit_changed_files(&result).is_empty(),
-            "Review-only heuristic fixes should not count as would-modify"
+            "Manual-only heuristic fixes should not count as would-modify"
         );
     }
 
@@ -2047,6 +2047,6 @@ mod tests {
         let result = fix_result_with(vec![manual_fix, mixed_fix, auto_fix], vec![manual_nf]);
         // Only the entirely-manual-only fix + the manual-only new file count.
         // The mixed fix survives --write, the fully-auto fix is normal.
-        assert_eq!(count_review_only_fixes(&result), 2);
+        assert_eq!(count_manual_only_fixes(&result), 2);
     }
 }


### PR DESCRIPTION
## Summary
- Remove review-only and suppression policy from `homeboy issues reconcile`, so audit findings either reconcile into tracker issues or are muted by a human closing the category as `not_planned`.
- Keep closed `not_planned` issues as the intentional human mute while removing config/CLI category and label suppression paths.
- Rename remaining non-auto-applied refactor language from review-only to manual-only.

## Testing
- `cargo test core::issues`
- `cargo test commands::issues`
- `cargo test core::refactor::plan::sources`
- `cargo test core::code_audit::structural`
- `cargo test core::code_audit::report::report_test::test_compute_fixability_with_analysis`
- `cargo fmt`

Full `cargo test` was also run locally, but the suite was not clean because of existing/local-environment failures unrelated to this change: missing `studio-rig` trace fixture, one runtime helper path assertion, and one fixability test that passed when run in isolation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.