### PR TITLE
Clarify daemon job routing blocker

### DIFF
--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -30,7 +30,7 @@ multi-user service.
 - `GET /version` — Homeboy version
 - `GET /config/paths` — local Homeboy config paths
 
-### Read-Only Contract Endpoints
+### Completed Read-Only Contract Endpoints
 
 These endpoints dispatch through Homeboy's transport-free read-only HTTP API
 contract and return the same JSON envelope shape as other daemon responses.
@@ -55,8 +55,9 @@ The run readers expose persisted observation-store evidence from previous
 analysis runs. They do not start audit, lint, test, bench, rig, or stack work.
 
 The analysis entry points `POST /audit`, `POST /lint`, `POST /test`, and
-`POST /bench` are reserved by the contract, but intentionally return a job-model
-blocker until the long-running job/event API lands.
+`POST /bench` are reserved by the contract, but intentionally return a daemon
+HTTP job-routing blocker until the existing `src/core/api_jobs.rs` job model is
+wired into daemon routes.
 
 Mutating operations such as deploy, release, rig up/down, stack apply, git
 writes, and SSH execution are not exposed by this daemon slice.

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -3,7 +3,7 @@
 //! This module is intentionally transport-free: the daemon can hand it a
 //! method/path pair and serialize the returned JSON without duplicating Homeboy
 //! command behavior. Long-running analysis endpoints are routed here, but they
-//! wait for the job model before execution.
+//! wait for daemon HTTP job routing before execution.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -263,12 +263,12 @@ pub fn handle(request: HttpApiRequest) -> Result<HttpApiResponse> {
             return Err(Error::validation_invalid_argument(
                 "endpoint",
                 format!(
-                    "POST /{} requires the HTTP API job model from Extra-Chill/homeboy#1764 before it can run safely",
+                    "POST /{} requires daemon HTTP job routing through src/core/api_jobs.rs before it can run safely",
                     job_ready_slug(*kind)
                 ),
                 Some(job_ready_slug(*kind).to_string()),
                 Some(vec![
-                    "Implement the job/event model from Extra-Chill/homeboy#1764 first"
+                    "Wire the existing src/core/api_jobs.rs job model into the daemon HTTP routes"
                         .to_string(),
                     "Then wire this endpoint to enqueue the long-running analysis job".to_string(),
                 ]),

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -55,7 +55,7 @@ fn routes_read_only_http_api_contract() {
     assert!(job_ready.body["message"]
         .as_str()
         .unwrap()
-        .contains("#1764"));
+        .contains("daemon HTTP job routing"));
 
     let runs = route("GET", "/runs?kind=bench&limit=1");
     assert_eq!(runs.status_code, 200);

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -209,17 +209,18 @@ fn rejects_mutating_endpoint_shapes() {
 }
 
 #[test]
-fn job_ready_endpoint_reports_job_model_blocker() {
+fn job_ready_endpoint_reports_daemon_job_routing_blocker() {
     let err = http_api::handle(HttpApiRequest {
         method: HttpMethod::Post,
         path: "/audit".to_string(),
         body: None,
     })
-    .expect_err("job model blocker");
+    .expect_err("daemon job routing blocker");
 
     let rendered = err.to_string();
-    assert!(rendered.contains("job model"), "{rendered}");
-    assert!(rendered.contains("#1764"), "{rendered}");
+    assert!(rendered.contains("daemon HTTP job routing"), "{rendered}");
+    assert!(rendered.contains("src/core/api_jobs.rs"), "{rendered}");
+    assert!(!rendered.contains("Extra-Chill/homeboy#"), "{rendered}");
 }
 
 fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {


### PR DESCRIPTION
## Summary
- Update daemon HTTP analysis endpoint blocker text to point at daemon HTTP job routing through `src/core/api_jobs.rs`, not closed issue #1764.
- Clarify daemon docs so completed read-only endpoints are distinct from reserved job-backed analysis endpoints.
- Update targeted daemon/http API tests to assert the new user-visible blocker wording while preserving refusal behavior.

## Tests
- `cargo test http_api`
- `cargo test daemon`
- `cargo test api_jobs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the small docs/test/error-message cleanup and ran targeted verification; Chris remains responsible for review and merge.