### PR TITLE
Expose daemon job inspection routes

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -4,12 +4,16 @@ use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
+use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
 use crate::http_api::{self, HttpMethod};
 use crate::paths;
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
+
+static DAEMON_JOB_STORE: OnceLock<JobStore> = OnceLock::new();
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonState {
@@ -135,11 +139,12 @@ pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
         Error::internal_io(e.to_string(), Some("read daemon local address".to_string()))
     })?;
     let state = write_state(local_addr)?;
+    let job_store = JobStore::default();
 
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                let _ = handle_connection(stream);
+                let _ = handle_connection(stream, &job_store);
             }
             Err(err) => {
                 return Err(Error::internal_io(
@@ -154,6 +159,10 @@ pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
 }
 
 pub fn route(method: &str, path: &str) -> HttpResponse {
+    route_with_job_store(method, path, daemon_job_store())
+}
+
+pub fn route_with_job_store(method: &str, path: &str, job_store: &JobStore) -> HttpResponse {
     match (method, path) {
         ("GET", "/health") => HttpResponse {
             status_code: 200,
@@ -179,11 +188,15 @@ pub fn route(method: &str, path: &str) -> HttpResponse {
             status_code: 405,
             body: json!({ "error": "method_not_allowed" }),
         },
-        _ => route_read_only_api(method, path),
+        _ => route_read_only_api(method, path, job_store),
     }
 }
 
-fn route_read_only_api(method: &str, path: &str) -> HttpResponse {
+fn daemon_job_store() -> &'static JobStore {
+    DAEMON_JOB_STORE.get_or_init(JobStore::default)
+}
+
+fn route_read_only_api(method: &str, path: &str, job_store: &JobStore) -> HttpResponse {
     let method = match method {
         "GET" => HttpMethod::Get,
         "POST" => HttpMethod::Post,
@@ -195,11 +208,14 @@ fn route_read_only_api(method: &str, path: &str) -> HttpResponse {
         }
     };
 
-    match http_api::handle(http_api::HttpApiRequest {
-        method,
-        path: path.to_string(),
-        body: None,
-    }) {
+    match http_api::handle_with_jobs(
+        http_api::HttpApiRequest {
+            method,
+            path: path.to_string(),
+            body: None,
+        },
+        job_store,
+    ) {
         Ok(response) => HttpResponse {
             status_code: response.status,
             body: serde_json::to_value(response)
@@ -257,7 +273,7 @@ fn write_state(addr: SocketAddr) -> Result<DaemonState> {
     Ok(state)
 }
 
-fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
+fn handle_connection(mut stream: TcpStream, job_store: &JobStore) -> std::io::Result<()> {
     let mut buffer = [0; 2048];
     let bytes = stream.read(&mut buffer)?;
     let request = String::from_utf8_lossy(&buffer[..bytes]);
@@ -268,7 +284,7 @@ fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
         .split_whitespace();
     let method = parts.next().unwrap_or_default();
     let path = parts.next().unwrap_or_default();
-    let response = route(method, path);
+    let response = route_with_job_store(method, path, job_store);
     let body = serde_json::to_string_pretty(&json!({
         "success": (200..300).contains(&response.status_code),
         "data": response.body,

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -7,7 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use uuid::Uuid;
 
+use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
 use crate::observation::{ObservationStore, RunListFilter, RunRecord};
 use crate::{component, git, rig, stack};
@@ -51,6 +53,10 @@ pub enum HttpEndpoint {
     RunArtifacts { id: String },
     AuditRuns,
     BenchRuns,
+    Jobs,
+    Job { id: String },
+    JobEvents { id: String },
+    JobCancel { id: String },
     JobReadyRun { kind: JobReadyRunKind },
 }
 
@@ -104,6 +110,10 @@ impl HttpEndpoint {
             Self::RunArtifacts { .. } => "runs.artifacts",
             Self::AuditRuns => "audit.runs",
             Self::BenchRuns => "bench.runs",
+            Self::Jobs => "jobs.list",
+            Self::Job { .. } => "jobs.show",
+            Self::JobEvents { .. } => "jobs.events",
+            Self::JobCancel { .. } => "jobs.cancel",
             Self::JobReadyRun { .. } => "jobs.required",
         }
     }
@@ -147,6 +157,16 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
         }),
         (HttpMethod::Get, ["audit", "runs"]) => Ok(HttpEndpoint::AuditRuns),
         (HttpMethod::Get, ["bench", "runs"]) => Ok(HttpEndpoint::BenchRuns),
+        (HttpMethod::Get, ["jobs"]) => Ok(HttpEndpoint::Jobs),
+        (HttpMethod::Get, ["jobs", id]) => Ok(HttpEndpoint::Job {
+            id: (*id).to_string(),
+        }),
+        (HttpMethod::Get, ["jobs", id, "events"]) => Ok(HttpEndpoint::JobEvents {
+            id: (*id).to_string(),
+        }),
+        (HttpMethod::Post, ["jobs", id, "cancel"]) => Ok(HttpEndpoint::JobCancel {
+            id: (*id).to_string(),
+        }),
         (HttpMethod::Post, ["audit"]) => Ok(HttpEndpoint::JobReadyRun {
             kind: JobReadyRunKind::Audit,
         }),
@@ -179,6 +199,10 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "GET /runs/:id/artifacts".to_string(),
                 "GET /audit/runs".to_string(),
                 "GET /bench/runs".to_string(),
+                "GET /jobs".to_string(),
+                "GET /jobs/:id".to_string(),
+                "GET /jobs/:id/events".to_string(),
+                "POST /jobs/:id/cancel".to_string(),
             ]),
         )),
     }
@@ -186,6 +210,11 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
 
 /// Execute a routed read-only API request through existing Homeboy core code.
 pub fn handle(request: HttpApiRequest) -> Result<HttpApiResponse> {
+    handle_with_jobs(request, &JobStore::default())
+}
+
+/// Execute a routed HTTP API request against the daemon-owned in-memory job store.
+pub fn handle_with_jobs(request: HttpApiRequest, job_store: &JobStore) -> Result<HttpApiResponse> {
     let endpoint = route(request.method, &request.path)?;
     let body = match &endpoint {
         HttpEndpoint::Components => json!({
@@ -259,18 +288,34 @@ pub fn handle(request: HttpApiRequest) -> Result<HttpApiResponse> {
             "command": "api.bench.runs",
             "runs": list_runs(&request.path, Some("bench"))?,
         }),
+        HttpEndpoint::Jobs => json!({
+            "command": "api.jobs.list",
+            "jobs": job_store.list(),
+        }),
+        HttpEndpoint::Job { id } => json!({
+            "command": "api.jobs.show",
+            "job": job_store.get(parse_job_id(id)?)?,
+        }),
+        HttpEndpoint::JobEvents { id } => json!({
+            "command": "api.jobs.events",
+            "job_id": id,
+            "events": job_store.events(parse_job_id(id)?)?,
+        }),
+        HttpEndpoint::JobCancel { id } => json!({
+            "command": "api.jobs.cancel",
+            "job": job_store.cancel(parse_job_id(id)?, "cancel requested via HTTP API")?,
+        }),
         HttpEndpoint::JobReadyRun { kind } => {
             return Err(Error::validation_invalid_argument(
                 "endpoint",
                 format!(
-                    "POST /{} requires the HTTP API job model from Extra-Chill/homeboy#1764 before it can run safely",
+                    "POST /{} requires analysis enqueue wiring before it can run safely",
                     job_ready_slug(*kind)
                 ),
                 Some(job_ready_slug(*kind).to_string()),
                 Some(vec![
-                    "Implement the job/event model from Extra-Chill/homeboy#1764 first"
+                    "Wire this endpoint to enqueue a long-running analysis job in a follow-up PR"
                         .to_string(),
-                    "Then wire this endpoint to enqueue the long-running analysis job".to_string(),
                 ]),
             ));
         }
@@ -332,6 +377,17 @@ fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> {
             "run_id",
             format!("run record not found: {run_id}"),
             Some(run_id.to_string()),
+            None,
+        )
+    })
+}
+
+fn parse_job_id(job_id: &str) -> Result<Uuid> {
+    Uuid::parse_str(job_id).map_err(|_| {
+        Error::validation_invalid_argument(
+            "job_id",
+            format!("invalid job id: {job_id}"),
+            Some(job_id.to_string()),
             None,
         )
     })

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api_jobs::JobStore;
 use crate::test_support::HomeGuard;
 
 #[test]
@@ -55,7 +56,7 @@ fn routes_read_only_http_api_contract() {
     assert!(job_ready.body["message"]
         .as_str()
         .unwrap()
-        .contains("#1764"));
+        .contains("analysis enqueue"));
 
     let runs = route("GET", "/runs?kind=bench&limit=1");
     assert_eq!(runs.status_code, 200);
@@ -66,6 +67,32 @@ fn routes_read_only_http_api_contract() {
     assert_eq!(bench_runs.status_code, 200);
     assert_eq!(bench_runs.body["endpoint"], "bench.runs");
     assert!(bench_runs.body["body"]["runs"].is_array());
+}
+
+#[test]
+fn routes_job_inspection_against_daemon_job_store() {
+    let store = JobStore::default();
+    let job = store.create("lint");
+
+    let list = route_with_job_store("GET", "/jobs", &store);
+    assert_eq!(list.status_code, 200);
+    assert_eq!(list.body["endpoint"], "jobs.list");
+    assert_eq!(list.body["body"]["jobs"].as_array().unwrap().len(), 1);
+
+    let show = route_with_job_store("GET", &format!("/jobs/{}", job.id), &store);
+    assert_eq!(show.status_code, 200);
+    assert_eq!(show.body["endpoint"], "jobs.show");
+    assert_eq!(show.body["body"]["job"]["operation"], "lint");
+
+    let events = route_with_job_store("GET", &format!("/jobs/{}/events", job.id), &store);
+    assert_eq!(events.status_code, 200);
+    assert_eq!(events.body["endpoint"], "jobs.events");
+    assert_eq!(events.body["body"]["events"].as_array().unwrap().len(), 1);
+
+    let cancel = route_with_job_store("POST", &format!("/jobs/{}/cancel", job.id), &store);
+    assert_eq!(cancel.status_code, 200);
+    assert_eq!(cancel.body["endpoint"], "jobs.cancel");
+    assert_eq!(cancel.body["body"]["job"]["status"], "cancelled");
 }
 
 #[test]

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -1,3 +1,4 @@
+use homeboy::api_jobs::{JobStatus, JobStore};
 use homeboy::http_api::{self, HttpApiRequest, HttpEndpoint, HttpMethod, JobReadyRunKind};
 use homeboy::observation::{NewRunRecord, ObservationStore, RunStatus};
 
@@ -143,6 +144,97 @@ fn routes_observation_run_readers() {
 }
 
 #[test]
+fn routes_job_inspection_endpoints() {
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/jobs").expect("route"),
+        HttpEndpoint::Jobs
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/jobs/abc").expect("route"),
+        HttpEndpoint::Job {
+            id: "abc".to_string()
+        }
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/jobs/abc/events").expect("route"),
+        HttpEndpoint::JobEvents {
+            id: "abc".to_string()
+        }
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Post, "/jobs/abc/cancel").expect("route"),
+        HttpEndpoint::JobCancel {
+            id: "abc".to_string()
+        }
+    );
+}
+
+#[test]
+fn handles_job_inspection_routes_against_shared_store() {
+    let store = JobStore::default();
+    let job = store.create("audit");
+    store.start(job.id).expect("job starts");
+    store
+        .append_event(
+            job.id,
+            homeboy::api_jobs::JobEventKind::Stdout,
+            Some("audit output".to_string()),
+            None,
+        )
+        .expect("stdout event");
+
+    let list = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Get,
+            path: "/jobs".to_string(),
+            body: None,
+        },
+        &store,
+    )
+    .expect("list jobs");
+    assert_eq!(list.endpoint, "jobs.list");
+    assert_eq!(list.body["jobs"].as_array().unwrap().len(), 1);
+    assert_eq!(list.body["jobs"][0]["id"], job.id.to_string());
+
+    let show = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/jobs/{}", job.id),
+            body: None,
+        },
+        &store,
+    )
+    .expect("show job");
+    assert_eq!(show.endpoint, "jobs.show");
+    assert_eq!(show.body["job"]["operation"], "audit");
+
+    let events = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/jobs/{}/events", job.id),
+            body: None,
+        },
+        &store,
+    )
+    .expect("job events");
+    assert_eq!(events.endpoint, "jobs.events");
+    assert!(events.body["events"].as_array().unwrap().len() >= 3);
+
+    let cancel = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: format!("/jobs/{}/cancel", job.id),
+            body: None,
+        },
+        &store,
+    )
+    .expect("cancel job");
+    assert_eq!(cancel.endpoint, "jobs.cancel");
+    assert_eq!(cancel.body["job"]["status"], "cancelled");
+    assert_eq!(store.get(job.id).expect("job").status, JobStatus::Cancelled);
+}
+
+#[test]
 fn handles_filtered_observation_run_readers_without_starting_jobs() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();
@@ -218,8 +310,7 @@ fn job_ready_endpoint_reports_job_model_blocker() {
     .expect_err("job model blocker");
 
     let rendered = err.to_string();
-    assert!(rendered.contains("job model"), "{rendered}");
-    assert!(rendered.contains("#1764"), "{rendered}");
+    assert!(rendered.contains("analysis enqueue"), "{rendered}");
 }
 
 fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {


### PR DESCRIPTION
## Summary
- Adds daemon HTTP routes for listing jobs, reading a job, reading job events, and cancelling a job.
- Threads a daemon-owned in-memory `JobStore` through HTTP routing while keeping jobs local and ephemeral.
- Leaves `POST /audit`, `/lint`, `/test`, and `/bench` as non-executing job-ready stubs for a follow-up enqueue PR.

## Verification
- `cargo test api_jobs`
- `cargo test http_api`
- `cargo test daemon`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the additive HTTP route skeleton, route/handler tests, and verification; Chris remains responsible for review and merge.