### PR TITLE
Expose daemon run findings

### DIFF
--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -48,11 +48,18 @@ contract and return the same JSON envelope shape as other daemon responses.
 - `GET /runs?kind=bench|audit&component=<id>&rig=<id>&status=<status>&limit=<n>`
 - `GET /runs/:id`
 - `GET /runs/:id/artifacts`
+- `GET /runs/:id/findings?tool=<tool>&file=<path>&fingerprint=<id>&limit=<n>`
 - `GET /audit/runs?component=<id>&rig=<id>&status=<status>&limit=<n>`
 - `GET /bench/runs?component=<id>&rig=<id>&status=<status>&limit=<n>`
 
 The run readers expose persisted observation-store evidence from previous
 analysis runs. They do not start audit, lint, test, bench, rig, or stack work.
+Run summaries include `status_note` when a running record appears stale or
+cannot be verified with owner metadata, matching the CLI run-history output.
+
+`homeboy runs compare --format=json` remains CLI-only for now. A daemon compare
+endpoint should reuse that implementation rather than duplicating comparison
+logic in the HTTP API contract.
 
 The analysis entry points `POST /audit`, `POST /lint`, `POST /test`, and
 `POST /bench` are reserved by the contract, but intentionally return a daemon

--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -2,12 +2,10 @@ use clap::Args;
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
+use homeboy::observation::{run_owner_pid, ObservationStore, RunListFilter, RunRecord, RunStatus};
 
 use crate::commands::runs::RunsOutput;
 use crate::commands::CmdResult;
-
-const RUN_OWNER_METADATA_KEY: &str = "homeboy_run_owner";
 
 #[derive(Args, Clone, Default)]
 pub struct RunsReconcileArgs {
@@ -120,35 +118,7 @@ where
 }
 
 pub fn running_status_note(run: &RunRecord) -> Option<String> {
-    if run.status != RunStatus::Running.as_str() {
-        return None;
-    }
-
-    let Some(owner_pid) = run_owner_pid(run) else {
-        return Some(
-            "running status has no owner metadata; run may predate reconciliation support"
-                .to_string(),
-        );
-    };
-
-    if pid_is_running(owner_pid) {
-        None
-    } else {
-        Some(
-            "owner process is not running; run may be stale; run `homeboy runs reconcile`"
-                .to_string(),
-        )
-    }
-}
-
-fn run_owner_pid(run: &RunRecord) -> Option<u32> {
-    run.metadata_json
-        .get(RUN_OWNER_METADATA_KEY)
-        .and_then(|owner| owner.get("pid"))
-        .or_else(|| run.metadata_json.get("owner_pid"))
-        .or_else(|| run.metadata_json.get("process_id"))
-        .and_then(|pid| pid.as_u64())
-        .and_then(|pid| u32::try_from(pid).ok())
+    homeboy::observation::running_status_note(run)
 }
 
 fn with_reconcile_metadata(run: &RunRecord, owner_pid: u32, reason: &str) -> Value {

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -14,7 +14,9 @@ use crate::api_jobs::JobStore;
 use crate::cli_surface::{Cli, Commands};
 use crate::commands::{self, GlobalArgs};
 use crate::error::{Error, Result};
-use crate::observation::{ObservationStore, RunListFilter, RunRecord};
+use crate::observation::{
+    running_status_note, FindingListFilter, ObservationStore, RunListFilter, RunRecord,
+};
 use crate::{component, git, rig, stack};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,6 +56,7 @@ pub enum HttpEndpoint {
     Runs,
     Run { id: String },
     RunArtifacts { id: String },
+    RunFindings { id: String },
     AuditRuns,
     BenchRuns,
     Jobs,
@@ -75,6 +78,8 @@ pub struct RunSummary {
     pub git_sha: Option<String>,
     pub command: Option<String>,
     pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_note: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -111,6 +116,7 @@ impl HttpEndpoint {
             Self::Runs => "runs.list",
             Self::Run { .. } => "runs.show",
             Self::RunArtifacts { .. } => "runs.artifacts",
+            Self::RunFindings { .. } => "runs.findings",
             Self::AuditRuns => "audit.runs",
             Self::BenchRuns => "bench.runs",
             Self::Jobs => "jobs.list",
@@ -158,6 +164,9 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
         (HttpMethod::Get, ["runs", id, "artifacts"]) => Ok(HttpEndpoint::RunArtifacts {
             id: (*id).to_string(),
         }),
+        (HttpMethod::Get, ["runs", id, "findings"]) => Ok(HttpEndpoint::RunFindings {
+            id: (*id).to_string(),
+        }),
         (HttpMethod::Get, ["audit", "runs"]) => Ok(HttpEndpoint::AuditRuns),
         (HttpMethod::Get, ["bench", "runs"]) => Ok(HttpEndpoint::BenchRuns),
         (HttpMethod::Get, ["jobs"]) => Ok(HttpEndpoint::Jobs),
@@ -200,6 +209,7 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "GET /runs".to_string(),
                 "GET /runs/:id".to_string(),
                 "GET /runs/:id/artifacts".to_string(),
+                "GET /runs/:id/findings".to_string(),
                 "GET /audit/runs".to_string(),
                 "GET /bench/runs".to_string(),
                 "GET /jobs".to_string(),
@@ -281,6 +291,23 @@ pub fn handle_with_jobs(request: HttpApiRequest, job_store: &JobStore) -> Result
                 "command": "api.runs.artifacts",
                 "run_id": id,
                 "artifacts": store.list_artifacts(id)?,
+            })
+        }
+        HttpEndpoint::RunFindings { id } => {
+            let store = ObservationStore::open_initialized()?;
+            require_run(&store, id)?;
+            json!({
+                "command": "api.runs.findings",
+                "run_id": id,
+                "findings": store.list_findings(FindingListFilter {
+                    run_id: Some(id.clone()),
+                    tool: query_value(&request.path, "tool"),
+                    file: query_value(&request.path, "file"),
+                    fingerprint: query_value(&request.path, "fingerprint"),
+                    limit: query_value(&request.path, "limit")
+                        .and_then(|value| value.parse::<i64>().ok())
+                        .map(|limit| limit.clamp(1, 1000)),
+                })?,
             })
         }
         HttpEndpoint::AuditRuns => json!({
@@ -753,6 +780,7 @@ fn invalid_body_type(key: &str, expected: &str, value: &Value) -> Error {
 }
 
 fn run_summary(run: RunRecord) -> RunSummary {
+    let status_note = running_status_note(&run);
     RunSummary {
         id: run.id,
         kind: run.kind,
@@ -764,6 +792,7 @@ fn run_summary(run: RunRecord) -> RunSummary {
         git_sha: run.git_sha,
         command: run.command,
         cwd: run.cwd,
+        status_note,
     }
 }
 

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -173,9 +173,8 @@ mod tests {
         assert_eq!(merged["exit_code"], 0);
     }
 
-    #[test]
-    fn running_summary_flags_unverifiable_and_dead_owner_records() {
-        let base = RunRecord {
+    fn running_run(metadata_json: serde_json::Value) -> RunRecord {
+        RunRecord {
             id: "run-1".to_string(),
             kind: "bench".to_string(),
             component_id: Some("homeboy".to_string()),
@@ -187,24 +186,36 @@ mod tests {
             homeboy_version: Some("test".to_string()),
             git_sha: Some("abc123".to_string()),
             rig_id: Some("studio".to_string()),
-            metadata_json: serde_json::json!({}),
-        };
+            metadata_json,
+        }
+    }
 
+    #[test]
+    fn test_running_status_note() {
+        let base = running_run(serde_json::json!({}));
         let unverifiable = running_status_note(&base);
         assert!(unverifiable
             .as_deref()
             .expect("status note")
             .contains("no owner metadata"));
 
-        let mut dead_owner = base;
-        dead_owner.metadata_json = serde_json::json!({
+        let dead_owner = running_run(serde_json::json!({
             "homeboy_run_owner": { "pid": u32::MAX }
-        });
+        }));
         let dead_owner = running_status_note(&dead_owner);
         assert!(dead_owner
             .as_deref()
             .expect("status note")
             .contains("owner process is not running"));
+    }
+
+    #[test]
+    fn test_run_owner_pid() {
+        let run = running_run(serde_json::json!({
+            "homeboy_run_owner": { "pid": 1234 }
+        }));
+
+        assert_eq!(run_owner_pid(&run), Some(1234));
     }
 
     #[test]

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 
 use super::{NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus};
 
+const RUN_OWNER_METADATA_KEY: &str = "homeboy_run_owner";
+
 pub struct ActiveObservation {
     store: ObservationStore,
     run: RunRecord,
@@ -87,6 +89,54 @@ pub fn merge_metadata(
     initial
 }
 
+pub fn running_status_note(run: &RunRecord) -> Option<String> {
+    if run.status != RunStatus::Running.as_str() {
+        return None;
+    }
+
+    let Some(owner_pid) = run_owner_pid(run) else {
+        return Some(
+            "running status has no owner metadata; run may predate reconciliation support"
+                .to_string(),
+        );
+    };
+
+    if pid_is_running(owner_pid) {
+        None
+    } else {
+        Some(
+            "owner process is not running; run may be stale; run `homeboy runs reconcile`"
+                .to_string(),
+        )
+    }
+}
+
+pub fn run_owner_pid(run: &RunRecord) -> Option<u32> {
+    run.metadata_json
+        .get(RUN_OWNER_METADATA_KEY)
+        .and_then(|owner| owner.get("pid"))
+        .or_else(|| run.metadata_json.get("owner_pid"))
+        .or_else(|| run.metadata_json.get("process_id"))
+        .and_then(|pid| pid.as_u64())
+        .and_then(|pid| u32::try_from(pid).ok())
+}
+
+fn pid_is_running(pid: u32) -> bool {
+    if pid > i32::MAX as u32 {
+        return false;
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as libc::pid_t, 0) == 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        pid == std::process::id()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +171,40 @@ mod tests {
         assert_eq!(merged["component"], "homeboy");
         assert_eq!(merged["status"], "pass");
         assert_eq!(merged["exit_code"], 0);
+    }
+
+    #[test]
+    fn running_summary_flags_unverifiable_and_dead_owner_records() {
+        let base = RunRecord {
+            id: "run-1".to_string(),
+            kind: "bench".to_string(),
+            component_id: Some("homeboy".to_string()),
+            started_at: "2026-05-01T00:00:00Z".to_string(),
+            finished_at: None,
+            status: "running".to_string(),
+            command: Some("homeboy bench".to_string()),
+            cwd: Some("/tmp".to_string()),
+            homeboy_version: Some("test".to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: Some("studio".to_string()),
+            metadata_json: serde_json::json!({}),
+        };
+
+        let unverifiable = running_status_note(&base);
+        assert!(unverifiable
+            .as_deref()
+            .expect("status note")
+            .contains("no owner metadata"));
+
+        let mut dead_owner = base;
+        dead_owner.metadata_json = serde_json::json!({
+            "homeboy_run_owner": { "pid": u32::MAX }
+        });
+        let dead_owner = running_status_note(&dead_owner);
+        assert!(dead_owner
+            .as_deref()
+            .expect("status note")
+            .contains("owner process is not running"));
     }
 
     #[test]

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -8,7 +8,7 @@ mod lifecycle;
 pub mod records;
 pub mod store;
 
-pub use lifecycle::{merge_metadata, ActiveObservation};
+pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveObservation};
 
 pub use records::{
     finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -68,6 +68,10 @@ fn routes_read_only_http_api_contract() {
     assert_eq!(bench_runs.status_code, 200);
     assert_eq!(bench_runs.body["endpoint"], "bench.runs");
     assert!(bench_runs.body["body"]["runs"].is_array());
+
+    let findings = route("GET", "/runs/run-missing/findings");
+    assert_eq!(findings.status_code, 404);
+    assert_eq!(findings.body["error"], "validation.invalid_argument");
 }
 
 #[test]

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -1,6 +1,8 @@
 use homeboy::api_jobs::{JobEventKind, JobStatus, JobStore};
 use homeboy::http_api::{self, HttpApiRequest, HttpEndpoint, HttpMethod, JobReadyRunKind};
-use homeboy::observation::{NewRunRecord, ObservationStore, RunStatus};
+use homeboy::observation::{
+    NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
+};
 
 use crate::test_support::with_isolated_home;
 
@@ -134,6 +136,12 @@ fn routes_observation_run_readers() {
         }
     );
     assert_eq!(
+        http_api::route(HttpMethod::Get, "/runs/run-123/findings").expect("route"),
+        HttpEndpoint::RunFindings {
+            id: "run-123".to_string()
+        }
+    );
+    assert_eq!(
         http_api::route(HttpMethod::Get, "/audit/runs").expect("route"),
         HttpEndpoint::AuditRuns
     );
@@ -256,6 +264,14 @@ fn handles_filtered_observation_run_readers_without_starting_jobs() {
         store
             .record_artifact(&bench.id, "bench_results", &artifact_path)
             .expect("record artifact");
+        let lint = sample_imported_running_run("lint", "homeboy", "studio");
+        store.import_run(&lint).expect("lint run");
+        store
+            .record_findings(&[
+                sample_finding(&lint.id, "lint", "style", "src/main.rs"),
+                sample_finding(&lint.id, "audit", "security", "src/lib.rs"),
+            ])
+            .expect("record findings");
 
         let response = http_api::handle(HttpApiRequest {
             method: HttpMethod::Get,
@@ -289,6 +305,29 @@ fn handles_filtered_observation_run_readers_without_starting_jobs() {
         assert_eq!(response.endpoint, "audit.runs");
         assert_eq!(response.body["runs"].as_array().unwrap().len(), 1);
         assert_eq!(response.body["runs"][0]["id"], audit.id);
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/runs/{}/findings?tool=lint&limit=1", lint.id),
+            body: None,
+        })
+        .expect("run findings");
+        assert_eq!(response.endpoint, "runs.findings");
+        assert_eq!(response.body["run_id"], lint.id);
+        assert_eq!(response.body["findings"].as_array().unwrap().len(), 1);
+        assert_eq!(response.body["findings"][0]["tool"], "lint");
+        assert_eq!(response.body["findings"][0]["rule"], "style");
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/runs/{}", lint.id),
+            body: None,
+        })
+        .expect("show running run");
+        assert!(response.body["run"]["status_note"]
+            .as_str()
+            .expect("status note")
+            .contains("owner process is not running"));
     });
 }
 
@@ -400,6 +439,20 @@ fn job_ready_endpoint_preserves_background_result_events() {
 }
 
 fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {
+    sample_run_with_metadata(
+        kind,
+        component_id,
+        rig_id,
+        serde_json::json!({ "source": "http-api-test" }),
+    )
+}
+
+fn sample_run_with_metadata(
+    kind: &str,
+    component_id: &str,
+    rig_id: &str,
+    metadata_json: serde_json::Value,
+) -> NewRunRecord {
     NewRunRecord {
         kind: kind.to_string(),
         component_id: Some(component_id.to_string()),
@@ -408,6 +461,38 @@ fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {
         homeboy_version: Some("test-version".to_string()),
         git_sha: Some("abc123".to_string()),
         rig_id: Some(rig_id.to_string()),
+        metadata_json,
+    }
+}
+
+fn sample_imported_running_run(kind: &str, component_id: &str, rig_id: &str) -> RunRecord {
+    RunRecord {
+        id: format!("{kind}-dead-owner-run"),
+        kind: kind.to_string(),
+        component_id: Some(component_id.to_string()),
+        started_at: "2026-05-01T00:00:00Z".to_string(),
+        finished_at: None,
+        status: "running".to_string(),
+        command: Some(format!("homeboy {kind}")),
+        cwd: Some("/tmp/homeboy-fixture".to_string()),
+        homeboy_version: Some("test-version".to_string()),
+        git_sha: Some("abc123".to_string()),
+        rig_id: Some(rig_id.to_string()),
+        metadata_json: serde_json::json!({ "homeboy_run_owner": { "pid": u32::MAX } }),
+    }
+}
+
+fn sample_finding(run_id: &str, tool: &str, rule: &str, file: &str) -> NewFindingRecord {
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: tool.to_string(),
+        rule: Some(rule.to_string()),
+        file: Some(file.to_string()),
+        line: Some(12),
+        severity: Some("warning".to_string()),
+        fingerprint: Some(format!("{file}::{rule}")),
+        message: format!("{rule} finding"),
+        fixable: Some(false),
         metadata_json: serde_json::json!({ "source": "http-api-test" }),
     }
 }

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -178,7 +178,7 @@ fn routes_job_inspection_endpoints() {
 }
 
 #[test]
-fn handles_job_inspection_routes_against_shared_store() {
+fn test_handle_with_jobs() {
     let store = JobStore::default();
     let job = store.create("audit");
     store.start(job.id).expect("job starts");
@@ -243,7 +243,7 @@ fn handles_job_inspection_routes_against_shared_store() {
 }
 
 #[test]
-fn handles_filtered_observation_run_readers_without_starting_jobs() {
+fn test_handle() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();
         let store = ObservationStore::open_initialized().expect("store");


### PR DESCRIPTION
## Summary
- Add read-only `GET /runs/:id/findings` daemon/API routing backed by the observation-store findings reader.
- Add `status_note` to daemon run summaries by moving the CLI status-note helper into the core observation layer.
- Update daemon docs and tests for the new read-only run-history surface.

## Compare parity
- Not included in this PR. `homeboy runs compare --format=json` currently lives in the CLI command layer; a daemon compare endpoint should first expose/reuse that implementation cleanly instead of duplicating compare behavior in `http_api`.

## Testing
- `cargo test http_api_test`
- `cargo test daemon_test`
- `cargo test observation::store`
- `cargo test runs`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the daemon route/API implementation, tests, docs, and verification commands for Chris to review.