### PR TITLE
Enqueue analysis HTTP jobs

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -163,6 +163,19 @@ pub fn route(method: &str, path: &str) -> HttpResponse {
 }
 
 pub fn route_with_job_store(method: &str, path: &str, job_store: &JobStore) -> HttpResponse {
+    route_with_job_store_and_body(method, path, None, job_store)
+}
+
+pub fn route_with_body(method: &str, path: &str, body: Option<serde_json::Value>) -> HttpResponse {
+    route_with_job_store_and_body(method, path, body, daemon_job_store())
+}
+
+pub fn route_with_job_store_and_body(
+    method: &str,
+    path: &str,
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> HttpResponse {
     match (method, path) {
         ("GET", "/health") => HttpResponse {
             status_code: 200,
@@ -188,7 +201,7 @@ pub fn route_with_job_store(method: &str, path: &str, job_store: &JobStore) -> H
             status_code: 405,
             body: json!({ "error": "method_not_allowed" }),
         },
-        _ => route_read_only_api(method, path, job_store),
+        _ => route_read_only_api(method, path, body, job_store),
     }
 }
 
@@ -196,7 +209,12 @@ fn daemon_job_store() -> &'static JobStore {
     DAEMON_JOB_STORE.get_or_init(JobStore::default)
 }
 
-fn route_read_only_api(method: &str, path: &str, job_store: &JobStore) -> HttpResponse {
+fn route_read_only_api(
+    method: &str,
+    path: &str,
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> HttpResponse {
     let method = match method {
         "GET" => HttpMethod::Get,
         "POST" => HttpMethod::Post,
@@ -212,7 +230,7 @@ fn route_read_only_api(method: &str, path: &str, job_store: &JobStore) -> HttpRe
         http_api::HttpApiRequest {
             method,
             path: path.to_string(),
-            body: None,
+            body,
         },
         job_store,
     ) {
@@ -274,17 +292,43 @@ fn write_state(addr: SocketAddr) -> Result<DaemonState> {
 }
 
 fn handle_connection(mut stream: TcpStream, job_store: &JobStore) -> std::io::Result<()> {
-    let mut buffer = [0; 2048];
+    let mut buffer = [0; 64 * 1024];
     let bytes = stream.read(&mut buffer)?;
     let request = String::from_utf8_lossy(&buffer[..bytes]);
-    let mut parts = request
+    let mut headers_and_body = request.splitn(2, "\r\n\r\n");
+    let headers = headers_and_body.next().unwrap_or_default();
+    let body = headers_and_body.next().unwrap_or_default();
+    let mut parts = headers
         .lines()
         .next()
         .unwrap_or_default()
         .split_whitespace();
     let method = parts.next().unwrap_or_default();
     let path = parts.next().unwrap_or_default();
-    let response = route_with_job_store(method, path, job_store);
+    let parsed_body = if body.trim().is_empty() {
+        None
+    } else {
+        match serde_json::from_str::<serde_json::Value>(body.trim()) {
+            Ok(value) => Some(value),
+            Err(error) => {
+                let response = error_response(
+                    400,
+                    Error::validation_invalid_argument(
+                        "body",
+                        format!("invalid JSON request body: {error}"),
+                        None,
+                        None,
+                    ),
+                );
+                return write_http_response(stream, response);
+            }
+        }
+    };
+    let response = route_with_job_store_and_body(method, path, parsed_body, job_store);
+    write_http_response(stream, response)
+}
+
+fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io::Result<()> {
     let body = serde_json::to_string_pretty(&json!({
         "success": (200..300).contains(&response.status_code),
         "data": response.body,
@@ -292,6 +336,7 @@ fn handle_connection(mut stream: TcpStream, job_store: &JobStore) -> std::io::Re
     .unwrap_or_else(|_| "{\"success\":false}".to_string());
     let status_text = match response.status_code {
         200 => "OK",
+        400 => "Bad Request",
         404 => "Not Found",
         405 => "Method Not Allowed",
         _ => "Internal Server Error",

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -2,14 +2,17 @@
 //!
 //! This module is intentionally transport-free: the daemon can hand it a
 //! method/path pair and serialize the returned JSON without duplicating Homeboy
-//! command behavior. Long-running analysis endpoints are routed here, but they
-//! wait for daemon HTTP job routing before execution.
+//! command behavior. Long-running analysis endpoints enqueue daemon-owned jobs
+//! so HTTP requests can return immediately while clients poll job events.
 
+use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::api_jobs::JobStore;
+use crate::cli_surface::{Cli, Commands};
+use crate::commands::{self, GlobalArgs};
 use crate::error::{Error, Result};
 use crate::observation::{ObservationStore, RunListFilter, RunRecord};
 use crate::{component, git, rig, stack};
@@ -305,20 +308,7 @@ pub fn handle_with_jobs(request: HttpApiRequest, job_store: &JobStore) -> Result
             "command": "api.jobs.cancel",
             "job": job_store.cancel(parse_job_id(id)?, "cancel requested via HTTP API")?,
         }),
-        HttpEndpoint::JobReadyRun { kind } => {
-            return Err(Error::validation_invalid_argument(
-                "endpoint",
-                format!(
-                    "POST /{} requires daemon HTTP analysis enqueue wiring through src/core/api_jobs.rs before it can run safely",
-                    job_ready_slug(*kind)
-                ),
-                Some(job_ready_slug(*kind).to_string()),
-                Some(vec![
-                    "Wire this endpoint to enqueue a long-running analysis job through the existing daemon job model"
-                        .to_string(),
-                ]),
-            ));
-        }
+        HttpEndpoint::JobReadyRun { kind } => enqueue_analysis_job(job_store, *kind, request.body)?,
     };
 
     Ok(HttpApiResponse {
@@ -391,6 +381,375 @@ fn parse_job_id(job_id: &str) -> Result<Uuid> {
             None,
         )
     })
+}
+
+fn enqueue_analysis_job(
+    job_store: &JobStore,
+    kind: JobReadyRunKind,
+    body: Option<Value>,
+) -> Result<Value> {
+    let request = AnalysisJobRequest::from_body(kind, body)?;
+    let argv = request.argv();
+    let command = parse_analysis_command(argv.clone())?;
+    let operation = format!("analysis.{}", job_ready_slug(kind));
+    let request_summary = request.summary();
+    let runner = job_store.run_background(operation, move |job| {
+        job.progress(json!({
+            "phase": "started",
+            "command": request.command_label(),
+            "job_id": job.job_id(),
+        }))?;
+
+        let global = GlobalArgs {};
+        let (result, exit_code) = commands::run_json(command, &global);
+        let output = result?;
+        job.progress(json!({
+            "phase": "finished",
+            "exit_code": exit_code,
+        }))?;
+        Ok(json!({
+            "command": request.command_label(),
+            "exit_code": exit_code,
+            "output": output,
+        }))
+    });
+    let job = job_store.get(runner.job_id)?;
+
+    Ok(json!({
+        "command": format!("api.{}.enqueue", job_ready_slug(kind)),
+        "job": job,
+        "poll": {
+            "job": format!("/jobs/{}", runner.job_id),
+            "events": format!("/jobs/{}/events", runner.job_id),
+        },
+        "request": request_summary,
+    }))
+}
+
+fn parse_analysis_command(argv: Vec<String>) -> Result<Commands> {
+    let cli = Cli::try_parse_from(argv).map_err(|error| {
+        Error::validation_invalid_argument(
+            "body",
+            error.to_string(),
+            None,
+            Some(vec![
+                "Use the documented JSON request body contract for this endpoint".to_string(),
+            ]),
+        )
+    })?;
+    Ok(cli.command)
+}
+
+#[derive(Debug, Clone)]
+struct AnalysisJobRequest {
+    kind: JobReadyRunKind,
+    args: Vec<String>,
+    summary: Value,
+}
+
+impl AnalysisJobRequest {
+    fn from_body(kind: JobReadyRunKind, body: Option<Value>) -> Result<Self> {
+        let mut parser = AnalysisBodyParser::new(body)?;
+        let mut args = vec![job_ready_slug(kind).to_string()];
+
+        parser.push_optional_string("component", &mut args)?;
+        parser.push_optional_flag_value("path", "--path", &mut args)?;
+        parser.push_bool_flag("json_summary", "--json-summary", &mut args)?;
+
+        match kind {
+            JobReadyRunKind::Audit => {
+                parser.push_bool_flag("conventions", "--conventions", &mut args)?;
+                parser.push_string_array("only", "--only", &mut args)?;
+                parser.push_string_array("exclude", "--exclude", &mut args)?;
+                parser.push_optional_flag_value("changed_since", "--changed-since", &mut args)?;
+                parser.push_bool_flag("fixability", "--fixability", &mut args)?;
+            }
+            JobReadyRunKind::Lint => {
+                parser.push_bool_flag("summary", "--summary", &mut args)?;
+                parser.push_optional_flag_value("file", "--file", &mut args)?;
+                parser.push_optional_flag_value("glob", "--glob", &mut args)?;
+                parser.push_bool_flag("changed_only", "--changed-only", &mut args)?;
+                parser.push_optional_flag_value("changed_since", "--changed-since", &mut args)?;
+                parser.push_bool_flag("errors_only", "--errors-only", &mut args)?;
+                parser.push_optional_flag_value("sniffs", "--sniffs", &mut args)?;
+                parser.push_optional_flag_value("exclude_sniffs", "--exclude-sniffs", &mut args)?;
+                parser.push_optional_flag_value("category", "--category", &mut args)?;
+                parser.reject_present("fix", "POST /lint jobs do not expose mutating --fix")?;
+            }
+            JobReadyRunKind::Test => {
+                parser.push_bool_flag("skip_lint", "--skip-lint", &mut args)?;
+                parser.push_bool_flag("coverage", "--coverage", &mut args)?;
+                parser.push_optional_number("coverage_min", "--coverage-min", &mut args)?;
+                parser.push_bool_flag("analyze", "--analyze", &mut args)?;
+                parser.push_bool_flag("drift", "--drift", &mut args)?;
+                parser.push_optional_flag_value("since", "--since", &mut args)?;
+                parser.push_optional_flag_value("changed_since", "--changed-since", &mut args)?;
+                parser.push_passthrough_args(&mut args)?;
+                parser.reject_present("write", "POST /test jobs do not expose mutating --write")?;
+            }
+            JobReadyRunKind::Bench => {
+                parser.push_optional_u64("iterations", "--iterations", &mut args)?;
+                parser.push_optional_u64("warmup", "--warmup", &mut args)?;
+                parser.push_optional_u64("runs", "--runs", &mut args)?;
+                parser.push_optional_u32("concurrency", "--concurrency", &mut args)?;
+                parser.push_string_array("rig", "--rig", &mut args)?;
+                parser.push_string_array("scenario", "--scenario", &mut args)?;
+                parser.push_optional_flag_value("profile", "--profile", &mut args)?;
+                parser.push_optional_number(
+                    "regression_threshold",
+                    "--regression-threshold",
+                    &mut args,
+                )?;
+                parser.push_bool_flag(
+                    "ignore_default_baseline",
+                    "--ignore-default-baseline",
+                    &mut args,
+                )?;
+                parser.push_passthrough_args(&mut args)?;
+            }
+        }
+
+        parser.reject_present(
+            "baseline",
+            "analysis jobs do not expose mutating --baseline",
+        )?;
+        parser.reject_present("ratchet", "analysis jobs do not expose mutating --ratchet")?;
+        parser.reject_present(
+            "shared_state",
+            "POST /bench jobs do not expose --shared-state",
+        )?;
+        parser.reject_unknown()?;
+
+        Ok(Self {
+            kind,
+            summary: parser.summary(),
+            args,
+        })
+    }
+
+    fn argv(&self) -> Vec<String> {
+        let mut argv = vec!["homeboy".to_string()];
+        argv.extend(self.args.clone());
+        argv
+    }
+
+    fn command_label(&self) -> String {
+        format!("homeboy {}", self.args.join(" "))
+    }
+
+    fn summary(&self) -> Value {
+        json!({
+            "kind": job_ready_slug(self.kind),
+            "args": self.args,
+            "body": self.summary,
+        })
+    }
+}
+
+struct AnalysisBodyParser {
+    fields: serde_json::Map<String, Value>,
+    consumed: Vec<String>,
+}
+
+impl AnalysisBodyParser {
+    fn new(body: Option<Value>) -> Result<Self> {
+        match body.unwrap_or_else(|| json!({})) {
+            Value::Object(fields) => Ok(Self {
+                fields,
+                consumed: Vec::new(),
+            }),
+            other => Err(Error::validation_invalid_argument(
+                "body",
+                "request body must be a JSON object",
+                Some(other.to_string()),
+                None,
+            )),
+        }
+    }
+
+    fn push_optional_string(&mut self, key: &str, args: &mut Vec<String>) -> Result<()> {
+        if let Some(value) = self.take_string(key)? {
+            args.push(value);
+        }
+        Ok(())
+    }
+
+    fn push_optional_flag_value(
+        &mut self,
+        key: &str,
+        flag: &str,
+        args: &mut Vec<String>,
+    ) -> Result<()> {
+        if let Some(value) = self.take_string(key)? {
+            args.push(flag.to_string());
+            args.push(value);
+        }
+        Ok(())
+    }
+
+    fn push_bool_flag(&mut self, key: &str, flag: &str, args: &mut Vec<String>) -> Result<()> {
+        if let Some(value) = self.take(key) {
+            match value {
+                Value::Bool(true) => args.push(flag.to_string()),
+                Value::Bool(false) | Value::Null => {}
+                other => return Err(invalid_body_type(key, "boolean", &other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn push_string_array(&mut self, key: &str, flag: &str, args: &mut Vec<String>) -> Result<()> {
+        if let Some(value) = self.take(key) {
+            match value {
+                Value::Array(values) => {
+                    for value in values {
+                        let Some(value) = value.as_str() else {
+                            return Err(invalid_body_type(key, "array of strings", &value));
+                        };
+                        args.push(flag.to_string());
+                        args.push(value.to_string());
+                    }
+                }
+                Value::String(value) => {
+                    args.push(flag.to_string());
+                    args.push(value);
+                }
+                Value::Null => {}
+                other => return Err(invalid_body_type(key, "string or array of strings", &other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn push_optional_number(
+        &mut self,
+        key: &str,
+        flag: &str,
+        args: &mut Vec<String>,
+    ) -> Result<()> {
+        if let Some(value) = self.take(key) {
+            match value {
+                Value::Number(number) => {
+                    args.push(flag.to_string());
+                    args.push(number.to_string());
+                }
+                Value::Null => {}
+                other => return Err(invalid_body_type(key, "number", &other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn push_optional_u64(&mut self, key: &str, flag: &str, args: &mut Vec<String>) -> Result<()> {
+        if let Some(value) = self.take(key) {
+            match value {
+                Value::Number(number) if number.as_u64().is_some() => {
+                    args.push(flag.to_string());
+                    args.push(number.to_string());
+                }
+                Value::Null => {}
+                other => return Err(invalid_body_type(key, "unsigned integer", &other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn push_optional_u32(&mut self, key: &str, flag: &str, args: &mut Vec<String>) -> Result<()> {
+        if let Some(value) = self.take(key) {
+            match value {
+                Value::Number(number) => {
+                    let Some(parsed) = number.as_u64().and_then(|value| u32::try_from(value).ok())
+                    else {
+                        return Err(invalid_body_type(key, "u32", &Value::Number(number)));
+                    };
+                    args.push(flag.to_string());
+                    args.push(parsed.to_string());
+                }
+                Value::Null => {}
+                other => return Err(invalid_body_type(key, "u32", &other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn push_passthrough_args(&mut self, args: &mut Vec<String>) -> Result<()> {
+        if let Some(value) = self.take("args") {
+            match value {
+                Value::Array(values) if values.is_empty() => {}
+                Value::Array(values) => {
+                    args.push("--".to_string());
+                    for value in values {
+                        let Some(value) = value.as_str() else {
+                            return Err(invalid_body_type("args", "array of strings", &value));
+                        };
+                        args.push(value.to_string());
+                    }
+                }
+                Value::Null => {}
+                other => return Err(invalid_body_type("args", "array of strings", &other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn reject_present(&mut self, key: &str, message: &str) -> Result<()> {
+        if self.take(key).is_some() {
+            return Err(Error::validation_invalid_argument(
+                key,
+                message,
+                Some(key.to_string()),
+                None,
+            ));
+        }
+        Ok(())
+    }
+
+    fn reject_unknown(&self) -> Result<()> {
+        if self.fields.is_empty() {
+            return Ok(());
+        }
+        let mut unknown: Vec<String> = self.fields.keys().cloned().collect();
+        unknown.sort();
+        Err(Error::validation_invalid_argument(
+            "body",
+            format!(
+                "unsupported analysis job body field(s): {}",
+                unknown.join(", ")
+            ),
+            Some(unknown.join(",")),
+            None,
+        ))
+    }
+
+    fn summary(&self) -> Value {
+        json!({ "accepted_fields": self.consumed })
+    }
+
+    fn take_string(&mut self, key: &str) -> Result<Option<String>> {
+        let Some(value) = self.take(key) else {
+            return Ok(None);
+        };
+        match value {
+            Value::String(value) => Ok(Some(value)),
+            Value::Null => Ok(None),
+            other => Err(invalid_body_type(key, "string", &other)),
+        }
+    }
+
+    fn take(&mut self, key: &str) -> Option<Value> {
+        let value = self.fields.remove(key)?;
+        self.consumed.push(key.to_string());
+        Some(value)
+    }
+}
+
+fn invalid_body_type(key: &str, expected: &str, value: &Value) -> Error {
+    Error::validation_invalid_argument(
+        key,
+        format!("{key} must be {expected}"),
+        Some(value.to_string()),
+        None,
+    )
 }
 
 fn run_summary(run: RunRecord) -> RunSummary {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -51,12 +51,13 @@ fn routes_read_only_http_api_contract() {
     assert!(components.body["body"]["components"].is_array());
 
     let job_ready = route("POST", "/audit");
-    assert_eq!(job_ready.status_code, 404);
-    assert_eq!(job_ready.body["error"], "validation.invalid_argument");
-    assert!(job_ready.body["message"]
+    assert_eq!(job_ready.status_code, 200);
+    assert_eq!(job_ready.body["endpoint"], "jobs.required");
+    assert_eq!(job_ready.body["body"]["command"], "api.audit.enqueue");
+    assert!(job_ready.body["body"]["poll"]["job"]
         .as_str()
         .unwrap()
-        .contains("daemon HTTP analysis enqueue wiring"));
+        .starts_with("/jobs/"));
 
     let runs = route("GET", "/runs?kind=bench&limit=1");
     assert_eq!(runs.status_code, 200);
@@ -93,6 +94,27 @@ fn routes_job_inspection_against_daemon_job_store() {
     assert_eq!(cancel.status_code, 200);
     assert_eq!(cancel.body["endpoint"], "jobs.cancel");
     assert_eq!(cancel.body["body"]["job"]["status"], "cancelled");
+}
+
+#[test]
+fn routes_json_body_to_analysis_enqueue() {
+    let store = JobStore::default();
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/lint",
+        Some(serde_json::json!({
+            "component": "missing-component",
+            "path": "/tmp/homeboy-missing-component",
+            "changed_since": "origin/main",
+            "json_summary": true
+        })),
+        &store,
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body["endpoint"], "jobs.required");
+    assert_eq!(response.body["body"]["command"], "api.lint.enqueue");
+    assert_eq!(store.list().len(), 1);
 }
 
 #[test]

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -1,4 +1,4 @@
-use homeboy::api_jobs::{JobStatus, JobStore};
+use homeboy::api_jobs::{JobEventKind, JobStatus, JobStore};
 use homeboy::http_api::{self, HttpApiRequest, HttpEndpoint, HttpMethod, JobReadyRunKind};
 use homeboy::observation::{NewRunRecord, ObservationStore, RunStatus};
 
@@ -301,21 +301,102 @@ fn rejects_mutating_endpoint_shapes() {
 }
 
 #[test]
-fn job_ready_endpoint_reports_daemon_job_routing_blocker() {
-    let err = http_api::handle(HttpApiRequest {
-        method: HttpMethod::Post,
-        path: "/audit".to_string(),
-        body: None,
-    })
-    .expect_err("daemon job routing blocker");
+fn job_ready_endpoint_enqueues_daemon_job() {
+    let store = JobStore::default();
+    let response = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/audit".to_string(),
+            body: Some(serde_json::json!({
+                "component": "missing-component",
+                "path": "/tmp/homeboy-missing-component",
+                "changed_since": "origin/main",
+                "json_summary": true
+            })),
+        },
+        &store,
+    )
+    .expect("audit job enqueued");
+
+    assert_eq!(response.endpoint, "jobs.required");
+    assert_eq!(response.body["command"], "api.audit.enqueue");
+    let job_id = response.body["job"]["id"].as_str().expect("job id");
+    assert_eq!(response.body["poll"]["job"], format!("/jobs/{job_id}"));
+    assert_eq!(store.list().len(), 1);
+}
+
+#[test]
+fn job_ready_endpoint_rejects_mutating_body_fields() {
+    let err = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/lint".to_string(),
+            body: Some(serde_json::json!({ "fix": true })),
+        },
+        &JobStore::default(),
+    )
+    .expect_err("mutating lint fix is rejected");
+
+    let rendered = err.to_string();
+    assert!(rendered.contains("--fix"), "{rendered}");
+}
+
+#[test]
+fn job_ready_endpoint_rejects_unknown_body_fields() {
+    let err = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/bench".to_string(),
+            body: Some(serde_json::json!({ "deploy": true })),
+        },
+        &JobStore::default(),
+    )
+    .expect_err("unknown field is rejected");
 
     let rendered = err.to_string();
     assert!(
-        rendered.contains("daemon HTTP analysis enqueue wiring"),
+        rendered.contains("unsupported analysis job body field"),
         "{rendered}"
     );
-    assert!(rendered.contains("src/core/api_jobs.rs"), "{rendered}");
-    assert!(!rendered.contains("Extra-Chill/homeboy#"), "{rendered}");
+}
+
+#[test]
+fn job_ready_endpoint_preserves_background_result_events() {
+    let store = JobStore::default();
+    let response = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/lint".to_string(),
+            body: Some(serde_json::json!({
+                "component": "missing-component",
+                "path": "/tmp/homeboy-missing-component",
+                "json_summary": true
+            })),
+        },
+        &store,
+    )
+    .expect("lint job enqueued");
+    let job_id = response.body["job"]["id"].as_str().expect("job id");
+    let job_id = uuid::Uuid::parse_str(job_id).expect("uuid");
+
+    for _ in 0..100 {
+        let status = store.get(job_id).expect("job").status;
+        if matches!(
+            status,
+            JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+        ) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let events = store.events(job_id).expect("events");
+    assert!(events
+        .iter()
+        .any(|event| event.kind == JobEventKind::Progress));
+    assert!(events
+        .iter()
+        .any(|event| { event.kind == JobEventKind::Result || event.kind == JobEventKind::Error }));
 }
 
 fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {


### PR DESCRIPTION
## Summary
- Wire `POST /audit`, `POST /lint`, `POST /test`, and `POST /bench` to daemon-owned background jobs instead of returning the previous blocker error.
- Add minimal JSON body parsing for the daemon HTTP path and a narrow analysis request contract for component/path/scope options.
- Preserve command JSON envelopes in job result events while keeping deploy/release/git/rig mutation routes unexposed.

## Request contract
- Common fields: `component`, `path`, `json_summary`.
- Audit fields: `conventions`, `only`, `exclude`, `changed_since`, `fixability`.
- Lint fields: `summary`, `file`, `glob`, `changed_only`, `changed_since`, `errors_only`, `sniffs`, `exclude_sniffs`, `category`.
- Test fields: `skip_lint`, `coverage`, `coverage_min`, `analyze`, `drift`, `since`, `changed_since`, `args`.
- Bench fields: `iterations`, `warmup`, `runs`, `concurrency`, `rig`, `scenario`, `profile`, `regression_threshold`, `ignore_default_baseline`, `args`.
- Rejected mutation fields include `fix`, `write`, `baseline`, `ratchet`, and `shared_state`.

## Tests
- `cargo test api_jobs --lib`
- `cargo test http_api_test --lib`
- `cargo test daemon_test --lib`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the daemon analysis job enqueue implementation, tests, and PR description; Chris remains responsible for review and validation.