### PR TITLE
Add invocation isolation primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.156.1"
+version = "0.156.2"
 dependencies = [
  "arboard",
  "base64",

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -170,6 +170,51 @@ Rig-declared metric gates are merged with workload-emitted `gates` before
 Homeboy evaluates scenario status. Supported rig operators are `equals`, `gte`,
 and `lte`.
 
+## Invocation Isolation
+
+Every bench child process receives generic invocation-scoped environment
+variables, independent of runner implementation:
+
+- `HOMEBOY_INVOCATION_ID`: stable identifier for this child workload invocation.
+- `HOMEBOY_INVOCATION_STATE_DIR`: private state directory for files that should
+  outlive one internal iteration but remain scoped to this invocation.
+- `HOMEBOY_INVOCATION_ARTIFACT_DIR`: private artifact directory for logs,
+  screenshots, traces, and downloaded/build artifacts.
+- `HOMEBOY_INVOCATION_TMP_DIR`: private temporary directory for project copies,
+  browser profiles, wasm caches, and other scratch state.
+
+Rig workload object entries can request optional shared-machine primitives:
+
+```json
+{
+  "bench_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/playground-server.bench.mjs",
+        "port_range_size": 8,
+        "named_leases": ["playground-browser-profile"]
+      }
+    ]
+  }
+}
+```
+
+When `port_range_size` is set, Homeboy allocates a non-overlapping local port
+range for each child invocation and exports `HOMEBOY_INVOCATION_PORT_BASE` and
+`HOMEBOY_INVOCATION_PORT_MAX`. Leases are persisted under Homeboy's local config
+directory while the child is running, guarded by a local index lock, and stale
+PID leases are pruned on the next allocation.
+
+`named_leases` are for truly shared machine-local resources that cannot be
+namespaced with dirs or ports. Conflicts fail before the workload starts and
+name the held lease and holder invocation when available.
+
+These primitives are intentionally generic enough for WordPress
+Playground-style benchmarks: one invocation can run browser/server/wasm/node
+services, consume multiple local ports, keep downloaded or built artifacts in
+the artifact dir, and use private temp project dirs without Studio-specific
+namespace code.
+
 ## Examples
 
 ```bash

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -454,6 +454,18 @@ fn run_component_with_rig_context(
             })
         })
         .unwrap_or_default();
+    let invocation_requirements = rig_spec
+        .as_ref()
+        .and_then(|spec| {
+            ctx.extension_id.as_deref().map(|id| {
+                rig::invocation_requirements_for_extension_workloads(
+                    spec,
+                    rig::RigWorkloadKind::Bench,
+                    id,
+                )
+            })
+        })
+        .unwrap_or_default();
 
     let selected_scenarios = selected_scenario_ids(args, rig_spec)?;
     let observation = observation::start(BenchObservationStart {
@@ -494,6 +506,7 @@ fn run_component_with_rig_context(
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
             extra_workloads,
+            invocation_requirements,
         },
         &run_dir,
     );

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use homeboy::component::Component;
 use homeboy::engine::execution_context::{self, ResolveOptions};
+use homeboy::engine::invocation::InvocationRequirements;
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::bench as extension_bench;
 use homeboy::extension::bench::report::collect_artifacts;
@@ -441,31 +442,8 @@ fn run_component_with_rig_context(
         effective_id
     )));
 
-    let extra_workloads = rig_spec
-        .as_ref()
-        .and_then(|spec| {
-            ctx.extension_id.as_deref().map(|id| {
-                rig::workloads_for_extension(
-                    spec,
-                    rig::RigWorkloadKind::Bench,
-                    rig_context.and_then(|context| context.package_root.as_deref()),
-                    id,
-                )
-            })
-        })
-        .unwrap_or_default();
-    let invocation_requirements = rig_spec
-        .as_ref()
-        .and_then(|spec| {
-            ctx.extension_id.as_deref().map(|id| {
-                rig::invocation_requirements_for_extension_workloads(
-                    spec,
-                    rig::RigWorkloadKind::Bench,
-                    id,
-                )
-            })
-        })
-        .unwrap_or_default();
+    let (extra_workloads, invocation_requirements) =
+        rig_workload_runtime_inputs(rig_context, rig_spec, ctx.extension_id.as_deref());
 
     let selected_scenarios = selected_scenario_ids(args, rig_spec)?;
     let observation = observation::start(BenchObservationStart {
@@ -533,6 +511,34 @@ fn run_component_with_rig_context(
         workflow,
         rig_snapshot,
     ))
+}
+
+fn rig_workload_runtime_inputs(
+    rig_context: Option<&RigBenchContext>,
+    rig_spec: Option<&RigSpec>,
+    extension_id: Option<&str>,
+) -> (Vec<PathBuf>, InvocationRequirements) {
+    let Some(spec) = rig_spec else {
+        return (Vec::new(), InvocationRequirements::default());
+    };
+    let Some(extension_id) = extension_id else {
+        return (Vec::new(), InvocationRequirements::default());
+    };
+
+    let package_root = rig_context.and_then(|context| context.package_root.as_deref());
+    (
+        rig::workloads_for_extension(
+            spec,
+            rig::RigWorkloadKind::Bench,
+            package_root,
+            extension_id,
+        ),
+        rig::invocation_requirements_for_extension_workloads(
+            spec,
+            rig::RigWorkloadKind::Bench,
+            extension_id,
+        ),
+    )
 }
 
 fn run_rig_workload_preflight(spec: &RigSpec, extension_id: Option<&str>) -> homeboy::Result<()> {

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -1,0 +1,400 @@
+//! Per-child workload invocation isolation.
+
+use crate::engine::run_dir::RunDir;
+use crate::error::{Error, Result};
+use crate::paths;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, SystemTime};
+
+const LOCK_NAME: &str = ".index.lock";
+const LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
+const LOCK_ATTEMPTS: usize = 100;
+const LOCK_SLEEP: Duration = Duration::from_millis(20);
+const PORT_POOL_START: u16 = 20_000;
+const PORT_POOL_END: u16 = 60_999;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InvocationRequirements {
+    pub port_range_size: Option<u16>,
+    pub named_leases: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvocationEnv {
+    pub id: String,
+    pub state_dir: PathBuf,
+    pub artifact_dir: PathBuf,
+    pub tmp_dir: PathBuf,
+    pub port_base: Option<u16>,
+    pub port_max: Option<u16>,
+}
+
+#[derive(Debug)]
+pub struct InvocationGuard {
+    env: InvocationEnv,
+    lease_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InvocationLease {
+    invocation_id: String,
+    pid: u32,
+    started_at: String,
+    port_base: Option<u16>,
+    port_max: Option<u16>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    named_leases: Vec<String>,
+}
+
+impl InvocationGuard {
+    pub fn acquire(run_dir: &RunDir, requirements: &InvocationRequirements) -> Result<Self> {
+        let id = format!("inv-{}", uuid::Uuid::new_v4());
+        let root = run_dir.path().join("invocations").join(&id);
+        let state_dir = root.join("state");
+        let artifact_dir = root.join("artifacts");
+        let tmp_dir = root.join("tmp");
+        for dir in [&state_dir, &artifact_dir, &tmp_dir] {
+            fs::create_dir_all(dir).map_err(|e| {
+                Error::internal_io(
+                    format!("Failed to create invocation dir {}: {}", dir.display(), e),
+                    Some("invocation.dir".to_string()),
+                )
+            })?;
+        }
+
+        let needs_lease =
+            requirements.port_range_size.is_some() || !requirements.named_leases.is_empty();
+        let mut port_base = None;
+        let mut port_max = None;
+        let mut lease_id = None;
+
+        if needs_lease {
+            let _lock = InvocationIndexLock::acquire()?;
+            fs::create_dir_all(paths::invocation_leases_dir()?).map_err(|e| {
+                Error::internal_unexpected(format!(
+                    "Failed to create invocation lease directory: {}",
+                    e
+                ))
+            })?;
+            prune_stale_leases()?;
+            validate_named_leases(&id, &requirements.named_leases)?;
+
+            if let Some(size) = requirements.port_range_size {
+                let (base, max) = allocate_port_range(size)?;
+                port_base = Some(base);
+                port_max = Some(max);
+            }
+
+            let lease = InvocationLease {
+                invocation_id: id.clone(),
+                pid: std::process::id(),
+                started_at: chrono::Utc::now().to_rfc3339(),
+                port_base,
+                port_max,
+                named_leases: requirements.named_leases.clone(),
+            };
+            write_lease(&lease)?;
+            lease_id = Some(id.clone());
+        }
+
+        Ok(Self {
+            env: InvocationEnv {
+                id,
+                state_dir,
+                artifact_dir,
+                tmp_dir,
+                port_base,
+                port_max,
+            },
+            lease_id,
+        })
+    }
+
+    pub fn env_vars(&self) -> Vec<(String, String)> {
+        let mut vars = vec![
+            ("HOMEBOY_INVOCATION_ID".to_string(), self.env.id.clone()),
+            (
+                "HOMEBOY_INVOCATION_STATE_DIR".to_string(),
+                self.env.state_dir.to_string_lossy().to_string(),
+            ),
+            (
+                "HOMEBOY_INVOCATION_ARTIFACT_DIR".to_string(),
+                self.env.artifact_dir.to_string_lossy().to_string(),
+            ),
+            (
+                "HOMEBOY_INVOCATION_TMP_DIR".to_string(),
+                self.env.tmp_dir.to_string_lossy().to_string(),
+            ),
+        ];
+        if let (Some(base), Some(max)) = (self.env.port_base, self.env.port_max) {
+            vars.push(("HOMEBOY_INVOCATION_PORT_BASE".to_string(), base.to_string()));
+            vars.push(("HOMEBOY_INVOCATION_PORT_MAX".to_string(), max.to_string()));
+        }
+        vars
+    }
+}
+
+impl Drop for InvocationGuard {
+    fn drop(&mut self) {
+        let Some(id) = &self.lease_id else {
+            return;
+        };
+        let Ok(_lock) = InvocationIndexLock::acquire() else {
+            return;
+        };
+        let Ok(path) = lease_path(id) else {
+            return;
+        };
+        let Ok(Some(lease)) = read_lease(&path) else {
+            return;
+        };
+        if lease.pid == std::process::id() {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn validate_named_leases(invocation_id: &str, wanted: &[String]) -> Result<()> {
+    if wanted.is_empty() {
+        return Ok(());
+    }
+    for lease in live_leases()? {
+        for name in wanted {
+            if lease.named_leases.contains(name) {
+                return Err(Error::validation_invalid_argument(
+                    "named_lease",
+                    format!(
+                        "Homeboy invocation lease '{}' is already held by invocation '{}' (pid {})",
+                        name, lease.invocation_id, lease.pid
+                    ),
+                    Some(invocation_id.to_string()),
+                    Some(vec![name.clone()]),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn allocate_port_range(size: u16) -> Result<(u16, u16)> {
+    if size == 0 {
+        return Err(Error::validation_invalid_argument(
+            "port_range_size",
+            "must be >= 1",
+            None,
+            None,
+        ));
+    }
+    let size = size as u32;
+    let pool_start = PORT_POOL_START as u32;
+    let pool_end = PORT_POOL_END as u32;
+    if size > pool_end - pool_start + 1 {
+        return Err(Error::validation_invalid_argument(
+            "port_range_size",
+            format!("{} exceeds Homeboy invocation port pool capacity", size),
+            None,
+            None,
+        ));
+    }
+
+    let mut ranges: Vec<(u32, u32)> = live_leases()?
+        .into_iter()
+        .filter_map(|lease| Some((lease.port_base? as u32, lease.port_max? as u32)))
+        .collect();
+    ranges.sort();
+
+    let mut candidate = pool_start;
+    for (base, max) in ranges {
+        if candidate + size - 1 < base {
+            return Ok((candidate as u16, (candidate + size - 1) as u16));
+        }
+        if candidate <= max {
+            candidate = max + 1;
+        }
+    }
+
+    if candidate + size - 1 <= pool_end {
+        return Ok((candidate as u16, (candidate + size - 1) as u16));
+    }
+
+    Err(Error::validation_invalid_argument(
+        "port_range_size",
+        "no free Homeboy invocation port range is available on this machine",
+        None,
+        None,
+    ))
+}
+
+fn prune_stale_leases() -> Result<()> {
+    for path in lease_files()? {
+        let Some(lease) = read_lease(&path)? else {
+            continue;
+        };
+        if !crate::core::daemon::pid_is_running(lease.pid) {
+            fs::remove_file(&path).map_err(|e| {
+                Error::internal_unexpected(format!(
+                    "Failed to remove stale invocation lease {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn live_leases() -> Result<Vec<InvocationLease>> {
+    let mut leases = Vec::new();
+    for path in lease_files()? {
+        if let Some(lease) = read_lease(&path)? {
+            if crate::core::daemon::pid_is_running(lease.pid) {
+                leases.push(lease);
+            }
+        }
+    }
+    Ok(leases)
+}
+
+fn lease_files() -> Result<Vec<PathBuf>> {
+    let dir = paths::invocation_leases_dir()?;
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|e| {
+        Error::internal_unexpected(format!("Failed to read invocation lease directory: {}", e))
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_unexpected(format!("Failed to read invocation lease entry: {}", e))
+        })?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "json") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn read_lease(path: &Path) -> Result<Option<InvocationLease>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(path).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to read invocation lease {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    if content.trim().is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str(&content).map(Some).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse invocation lease {}", path.display())),
+            Some(content.chars().take(200).collect()),
+        )
+    })
+}
+
+fn write_lease(lease: &InvocationLease) -> Result<()> {
+    let json = serde_json::to_string_pretty(lease).map_err(|e| {
+        Error::internal_unexpected(format!("Failed to serialize invocation lease: {}", e))
+    })?;
+    fs::write(lease_path(&lease.invocation_id)?, json).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to write invocation lease for '{}': {}",
+            lease.invocation_id, e
+        ))
+    })
+}
+
+fn lease_path(invocation_id: &str) -> Result<PathBuf> {
+    Ok(paths::invocation_leases_dir()?.join(format!("{}.json", sanitize_id(invocation_id))))
+}
+
+fn sanitize_id(id: &str) -> String {
+    id.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+struct InvocationIndexLock {
+    path: PathBuf,
+}
+
+impl InvocationIndexLock {
+    fn acquire() -> Result<Self> {
+        let dir = paths::invocation_leases_dir()?;
+        fs::create_dir_all(&dir).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to create invocation lease directory: {}",
+                e
+            ))
+        })?;
+        let path = dir.join(LOCK_NAME);
+        for _ in 0..LOCK_ATTEMPTS {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    remove_stale_index_lock(&path)?;
+                    thread::sleep(LOCK_SLEEP);
+                }
+                Err(e) => {
+                    return Err(Error::internal_unexpected(format!(
+                        "Failed to acquire invocation lease lock {}: {}",
+                        path.display(),
+                        e
+                    )))
+                }
+            }
+        }
+        Err(Error::internal_unexpected(format!(
+            "Timed out acquiring invocation lease lock {}",
+            path.display()
+        )))
+    }
+}
+
+impl Drop for InvocationIndexLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+fn remove_stale_index_lock(path: &Path) -> Result<()> {
+    let Ok(metadata) = fs::metadata(path) else {
+        return Ok(());
+    };
+    let Ok(modified) = metadata.modified() else {
+        return Ok(());
+    };
+    if SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age > LOCK_STALE_AFTER)
+    {
+        fs::remove_dir(path).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to remove stale invocation lease lock {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/engine/invocation_test.rs"]
+mod invocation_test;

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -73,17 +73,17 @@ impl InvocationGuard {
 
         if needs_lease {
             let _lock = InvocationIndexLock::acquire()?;
-            fs::create_dir_all(paths::invocation_leases_dir()?).map_err(|e| {
+            fs::create_dir_all(invocation_leases_dir()?).map_err(|e| {
                 Error::internal_unexpected(format!(
                     "Failed to create invocation lease directory: {}",
                     e
                 ))
             })?;
-            prune_stale_leases()?;
+            let live_leases = refresh_lease_index()?;
             validate_named_leases(&id, &requirements.named_leases)?;
 
             if let Some(size) = requirements.port_range_size {
-                let (base, max) = allocate_port_range(size)?;
+                let (base, max) = allocate_port_range(size, &live_leases)?;
                 port_base = Some(base);
                 port_max = Some(max);
             }
@@ -148,7 +148,7 @@ impl Drop for InvocationGuard {
         let Ok(path) = lease_path(id) else {
             return;
         };
-        let Ok(Some(lease)) = read_lease(&path) else {
+        let Ok(Some(lease)) = decode_lease_file(&path) else {
             return;
         };
         if lease.pid == std::process::id() {
@@ -161,7 +161,7 @@ fn validate_named_leases(invocation_id: &str, wanted: &[String]) -> Result<()> {
     if wanted.is_empty() {
         return Ok(());
     }
-    for lease in live_leases()? {
+    for lease in refresh_lease_index()? {
         for name in wanted {
             if lease.named_leases.contains(name) {
                 return Err(Error::validation_invalid_argument(
@@ -179,7 +179,7 @@ fn validate_named_leases(invocation_id: &str, wanted: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn allocate_port_range(size: u16) -> Result<(u16, u16)> {
+fn allocate_port_range(size: u16, live_leases: &[InvocationLease]) -> Result<(u16, u16)> {
     if size == 0 {
         return Err(Error::validation_invalid_argument(
             "port_range_size",
@@ -200,8 +200,8 @@ fn allocate_port_range(size: u16) -> Result<(u16, u16)> {
         ));
     }
 
-    let mut ranges: Vec<(u32, u32)> = live_leases()?
-        .into_iter()
+    let mut ranges: Vec<(u32, u32)> = live_leases
+        .iter()
         .filter_map(|lease| Some((lease.port_base? as u32, lease.port_max? as u32)))
         .collect();
     ranges.sort();
@@ -228,38 +228,23 @@ fn allocate_port_range(size: u16) -> Result<(u16, u16)> {
     ))
 }
 
-fn prune_stale_leases() -> Result<()> {
-    for path in lease_files()? {
-        let Some(lease) = read_lease(&path)? else {
+fn refresh_lease_index() -> Result<Vec<InvocationLease>> {
+    let mut live = Vec::new();
+    for path in invocation_lease_files()? {
+        let Some(lease) = decode_lease_file(&path)? else {
             continue;
         };
-        if !crate::core::daemon::pid_is_running(lease.pid) {
-            fs::remove_file(&path).map_err(|e| {
-                Error::internal_unexpected(format!(
-                    "Failed to remove stale invocation lease {}: {}",
-                    path.display(),
-                    e
-                ))
-            })?;
+        if crate::core::daemon::pid_is_running(lease.pid) {
+            live.push(lease);
+        } else {
+            remove_stale_invocation_lease(&path)?;
         }
     }
-    Ok(())
+    Ok(live)
 }
 
-fn live_leases() -> Result<Vec<InvocationLease>> {
-    let mut leases = Vec::new();
-    for path in lease_files()? {
-        if let Some(lease) = read_lease(&path)? {
-            if crate::core::daemon::pid_is_running(lease.pid) {
-                leases.push(lease);
-            }
-        }
-    }
-    Ok(leases)
-}
-
-fn lease_files() -> Result<Vec<PathBuf>> {
-    let dir = paths::invocation_leases_dir()?;
+fn invocation_lease_files() -> Result<Vec<PathBuf>> {
+    let dir = invocation_leases_dir()?;
     if !dir.exists() {
         return Ok(Vec::new());
     }
@@ -279,27 +264,47 @@ fn lease_files() -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-fn read_lease(path: &Path) -> Result<Option<InvocationLease>> {
+fn remove_stale_invocation_lease(path: &Path) -> Result<()> {
+    fs::remove_file(path).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to remove stale invocation lease {}: {}",
+                path.display(),
+                e
+            ),
+            Some("invocation.lease.stale".to_string()),
+        )
+    })
+}
+
+fn decode_lease_file(path: &Path) -> Result<Option<InvocationLease>> {
     if !path.exists() {
         return Ok(None);
     }
-    let content = fs::read_to_string(path).map_err(|e| {
-        Error::internal_unexpected(format!(
-            "Failed to read invocation lease {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
+    let content = fs::read_to_string(path).map_err(|e| read_lease_error(path, e))?;
     if content.trim().is_empty() {
         return Ok(None);
     }
-    serde_json::from_str(&content).map(Some).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse invocation lease {}", path.display())),
-            Some(content.chars().take(200).collect()),
-        )
-    })
+    let parsed = serde_json::from_str::<InvocationLease>(&content).map_err(|e| {
+        Error::validation_invalid_json(e, Some(parse_context(path)), Some(json_excerpt(&content)))
+    })?;
+    Ok(Some(parsed))
+}
+
+fn read_lease_error(path: &Path, error: std::io::Error) -> Error {
+    Error::internal_unexpected(format!(
+        "Failed to read invocation lease {}: {}",
+        path.display(),
+        error
+    ))
+}
+
+fn parse_context(path: &Path) -> String {
+    format!("parse invocation lease {}", path.display())
+}
+
+fn json_excerpt(content: &str) -> String {
+    content.chars().take(200).collect()
 }
 
 fn write_lease(lease: &InvocationLease) -> Result<()> {
@@ -315,7 +320,11 @@ fn write_lease(lease: &InvocationLease) -> Result<()> {
 }
 
 fn lease_path(invocation_id: &str) -> Result<PathBuf> {
-    Ok(paths::invocation_leases_dir()?.join(format!("{}.json", sanitize_id(invocation_id))))
+    Ok(invocation_leases_dir()?.join(format!("{}.json", sanitize_id(invocation_id))))
+}
+
+fn invocation_leases_dir() -> Result<PathBuf> {
+    Ok(paths::homeboy()?.join("invocation-leases"))
 }
 
 fn sanitize_id(id: &str) -> String {
@@ -336,7 +345,7 @@ struct InvocationIndexLock {
 
 impl InvocationIndexLock {
     fn acquire() -> Result<Self> {
-        let dir = paths::invocation_leases_dir()?;
+        let dir = invocation_leases_dir()?;
         fs::create_dir_all(&dir).map_err(|e| {
             Error::internal_unexpected(format!(
                 "Failed to create invocation lease directory: {}",
@@ -398,3 +407,25 @@ fn remove_stale_index_lock(path: &Path) -> Result<()> {
 #[cfg(test)]
 #[path = "../../../tests/core/engine/invocation_test.rs"]
 mod invocation_test;
+
+#[cfg(test)]
+mod audit_coverage_tests {
+    use super::*;
+    use crate::engine::run_dir::RunDir;
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn test_env_vars() {
+        with_isolated_home(|_| {
+            let run_dir = RunDir::create().expect("run dir");
+            let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+                .expect("invocation guard");
+            let env = guard.env_vars();
+
+            assert!(env.iter().any(|(key, _)| key == "HOMEBOY_INVOCATION_ID"));
+            assert!(env
+                .iter()
+                .any(|(key, _)| key == "HOMEBOY_INVOCATION_TMP_DIR"));
+        });
+    }
+}

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -13,6 +13,7 @@ pub mod executor;
 pub mod format_write;
 pub mod hooks;
 pub mod identifier;
+pub mod invocation;
 pub(crate) mod local_files;
 pub mod output_parse;
 pub mod refactor_primitive;

--- a/src/core/engine/validate_write.rs
+++ b/src/core/engine/validate_write.rs
@@ -268,6 +268,7 @@ fn find_extension_with_validate(file_ext: &str) -> Option<extension::ExtensionMa
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_isolated_home;
     use std::fs;
     use tempfile::TempDir;
 
@@ -354,28 +355,30 @@ mod tests {
 
     #[test]
     fn validate_write_without_extension_validator_is_success() {
-        let dir = TempDir::new().expect("temp dir");
-        let root = dir.path();
-        fs::create_dir_all(root.join("src")).unwrap();
-        fs::write(root.join("src/lib.rs"), "pub fn broken( {}\n").unwrap();
+        with_isolated_home(|_| {
+            let dir = TempDir::new().expect("temp dir");
+            let root = dir.path();
+            fs::create_dir_all(root.join("src")).unwrap();
+            fs::write(root.join("src/lib.rs"), "pub fn broken( {}\n").unwrap();
 
-        let mut rollback = InMemoryRollback::new();
-        let lib_path = root.join("src/lib.rs");
-        rollback.capture(&lib_path);
+            let mut rollback = InMemoryRollback::new();
+            let lib_path = root.join("src/lib.rs");
+            rollback.capture(&lib_path);
 
-        let changed = vec![lib_path.clone()];
-        let result = validate_write(root, &changed, &rollback).expect("should not error");
+            let changed = vec![lib_path.clone()];
+            let result = validate_write(root, &changed, &rollback).expect("should not error");
 
-        assert!(
-            result.success,
-            "validation should skip without extension contract"
-        );
-        assert!(
-            !result.rolled_back,
-            "skipped validation should not roll back"
-        );
-        assert!(result.command.is_none());
-        let content = fs::read_to_string(&lib_path).unwrap();
-        assert_eq!(content, "pub fn broken( {}\n");
+            assert!(
+                result.success,
+                "validation should skip without extension contract"
+            );
+            assert!(
+                !result.rolled_back,
+                "skipped validation should not roll back"
+            );
+            assert!(result.command.is_none());
+            let content = fs::read_to_string(&lib_path).unwrap();
+            assert_eq!(content, "pub fn broken( {}\n");
+        });
     }
 }

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -145,6 +145,7 @@ mod tests {
             rig_id: Some("studio-bfb".to_string()),
             shared_state: None,
             extra_workloads: Vec::new(),
+            invocation_requirements: crate::engine::invocation::InvocationRequirements::default(),
         }
     }
 }

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -10,6 +10,7 @@ use sha2::{Digest, Sha256};
 
 use crate::component::Component;
 use crate::engine::baseline::BaselineFlags;
+use crate::engine::invocation::InvocationRequirements;
 use crate::engine::run_dir::{self, RunDir};
 use crate::error::{Error, Result};
 use crate::extension::bench::aggregate_runs;
@@ -65,6 +66,10 @@ pub struct BenchRunWorkflowArgs {
     /// Rig-declared out-of-tree workloads to run alongside in-tree discovery.
     /// Exported to dispatchers as `HOMEBOY_BENCH_EXTRA_WORKLOADS`.
     pub extra_workloads: Vec<PathBuf>,
+    /// Generic Homeboy isolation requirements for each child workload
+    /// invocation. Rigs can use this for browser/server/wasm benchmarks without
+    /// runner-specific namespace logic.
+    pub invocation_requirements: InvocationRequirements,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -175,6 +180,7 @@ pub fn run_bench_list_workflow(
             rig_id: None,
             shared_state: None,
             extra_workloads: args.extra_workloads,
+            invocation_requirements: InvocationRequirements::default(),
         },
         run_dir,
         None,
@@ -1006,6 +1012,7 @@ fn build_runner(
             &args.extra_workloads,
             "bench_workloads",
         )),
+        invocation_requirements: args.invocation_requirements.clone(),
     })?
     .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
     .env("HOMEBOY_BENCH_PROGRESS", bench_progress_env_value())
@@ -1295,6 +1302,7 @@ mod tests {
                 rig_id: None,
                 shared_state: None,
                 extra_workloads: Vec::new(),
+                invocation_requirements: InvocationRequirements::default(),
             },
             &run_dir,
         )
@@ -1349,6 +1357,7 @@ mod tests {
             rig_id: Some("studio".to_string()),
             shared_state: Some(component_dir.path().join("shared")),
             extra_workloads: Vec::new(),
+            invocation_requirements: InvocationRequirements::default(),
         };
         let mut results = BenchResults {
             component_id: "homeboy".to_string(),

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::component::Component;
+use crate::engine::invocation::{InvocationGuard, InvocationRequirements};
 use crate::engine::run_dir::RunDir;
 use crate::error::{Error, Result};
 use crate::extension::{exec_context, ExtensionCapability, RunnerOutput};
@@ -130,6 +131,8 @@ pub(crate) fn run_component_scripts_with_run_dir(
     script_args: &[String],
 ) -> Result<ComponentScriptOutput> {
     let mut env = run_dir.legacy_env_vars();
+    let invocation = InvocationGuard::acquire(run_dir, &InvocationRequirements::default())?;
+    env.extend(invocation.env_vars());
     env.extend(extra_env.iter().cloned());
     run_component_scripts_with_env(
         component,

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -202,6 +202,7 @@ pub struct ScenarioRunnerOptions<'a> {
     pub artifact_env: Option<(&'a str, &'a Path)>,
     pub list_only_env: Option<(&'a str, bool)>,
     pub extra_workloads_env: Option<(&'a str, &'a [PathBuf], &'a str)>,
+    pub invocation_requirements: crate::engine::invocation::InvocationRequirements,
 }
 
 pub fn build_scenario_runner(options: ScenarioRunnerOptions<'_>) -> Result<ExtensionRunner> {
@@ -210,7 +211,8 @@ pub fn build_scenario_runner(options: ScenarioRunnerOptions<'_>) -> Result<Exten
         .path_override(options.path_override)
         .settings(options.settings)
         .settings_json(options.settings_json)
-        .with_run_dir(options.run_dir);
+        .with_run_dir(options.run_dir)
+        .invocation_requirements(options.invocation_requirements);
 
     if options.cleanup_process_group {
         runner = runner.cleanup_process_group(true);

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::component::Component;
+use crate::engine::invocation::{InvocationGuard, InvocationRequirements};
 use crate::engine::resource;
 use crate::error::Result;
 use crate::server::CommandOutput;
@@ -45,6 +46,7 @@ pub struct ExtensionRunner {
     cleanup_process_group: bool,
     /// Run directory path for recording machine-local child process evidence.
     run_dir_path: Option<PathBuf>,
+    invocation_requirements: InvocationRequirements,
 }
 
 impl ExtensionRunner {
@@ -73,6 +75,7 @@ impl ExtensionRunner {
             stderr_passthrough: false,
             cleanup_process_group: false,
             run_dir_path: None,
+            invocation_requirements: InvocationRequirements::default(),
         }
     }
 
@@ -127,6 +130,12 @@ impl ExtensionRunner {
     pub fn with_run_dir(mut self, run_dir: &crate::engine::run_dir::RunDir) -> Self {
         self.env_vars.extend(run_dir.legacy_env_vars());
         self.run_dir_path = Some(run_dir.path().to_path_buf());
+        self
+    }
+
+    /// Require invocation-scoped resources for the child workload.
+    pub fn invocation_requirements(mut self, requirements: InvocationRequirements) -> Self {
+        self.invocation_requirements = requirements;
         self
     }
 
@@ -195,11 +204,17 @@ impl ExtensionRunner {
         )?;
 
         let project_path = PathBuf::from(&prepared.execution.component.local_path);
+        let invocation = self.acquire_invocation_guard()?;
+        let mut extra_env_vars = self.env_vars.clone();
+        if let Some(invocation) = invocation.as_ref() {
+            extra_env_vars.extend(invocation.env_vars());
+        }
         let env_vars = self.prepare_env_vars(
             &prepared.execution.extension_path,
             &project_path,
             &prepared.settings_json,
             &prepared.execution.extension_id,
+            &extra_env_vars,
         );
 
         let output = self.execute_script(&prepared.execution.extension_path, &env_vars)?;
@@ -217,12 +232,21 @@ impl ExtensionRunner {
         })
     }
 
+    fn acquire_invocation_guard(&self) -> Result<Option<InvocationGuard>> {
+        let Some(path) = &self.run_dir_path else {
+            return Ok(None);
+        };
+        let run_dir = crate::engine::run_dir::RunDir::from_existing(path.clone())?;
+        InvocationGuard::acquire(&run_dir, &self.invocation_requirements).map(Some)
+    }
+
     fn prepare_env_vars(
         &self,
         extension_path: &Path,
         project_path: &Path,
         settings_json: &str,
         extension_name: &str,
+        extra_env_vars: &[(String, String)],
     ) -> Vec<(String, String)> {
         super::execution::build_capability_env(
             extension_name,
@@ -230,7 +254,7 @@ impl ExtensionRunner {
             extension_path,
             project_path,
             settings_json,
-            &self.env_vars,
+            extra_env_vars,
         )
     }
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -592,6 +592,7 @@ pub(crate) fn build_trace_runner(
             &args.runner_inputs.workload_paths,
             "trace_workloads",
         )),
+        invocation_requirements: crate::engine::invocation::InvocationRequirements::default(),
     })?;
 
     if let Some(rig_id) = &args.rig_id {

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -173,6 +173,11 @@ pub fn rig_leases_dir() -> Result<PathBuf> {
     Ok(homeboy()?.join("rig-leases"))
 }
 
+/// Active per-invocation leases (~/.config/homeboy/invocation-leases/).
+pub fn invocation_leases_dir() -> Result<PathBuf> {
+    Ok(homeboy()?.join("invocation-leases"))
+}
+
 /// Stacks directory (~/.config/homeboy/stacks/)
 pub fn stacks() -> Result<PathBuf> {
     Ok(homeboy()?.join("stacks"))

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -173,11 +173,6 @@ pub fn rig_leases_dir() -> Result<PathBuf> {
     Ok(homeboy()?.join("rig-leases"))
 }
 
-/// Active per-invocation leases (~/.config/homeboy/invocation-leases/).
-pub fn invocation_leases_dir() -> Result<PathBuf> {
-    Ok(homeboy()?.join("invocation-leases"))
-}
-
 /// Stacks directory (~/.config/homeboy/stacks/)
 pub fn stacks() -> Result<PathBuf> {
     Ok(homeboy()?.join("stacks"))

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -68,8 +68,8 @@ pub use state::{
     ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
 };
 pub use workloads::{
-    check_groups_for_extension_workloads, extension_ids_for_workloads, workloads_for_extension,
-    RigWorkloadKind,
+    check_groups_for_extension_workloads, extension_ids_for_workloads,
+    invocation_requirements_for_extension_workloads, workloads_for_extension, RigWorkloadKind,
 };
 
 use crate::error::{Error, Result};

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -659,6 +659,49 @@ mod tests {
     }
 
     #[test]
+    fn test_port_range_size() {
+        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+            path: "bench.mjs".to_string(),
+            check_groups: None,
+            port_range_size: Some(8),
+            named_leases: Vec::new(),
+            trace_phase_presets: HashMap::new(),
+            trace_span_metadata: HashMap::new(),
+            trace_default_phase_preset: None,
+            trace_variants: HashMap::new(),
+            trace_guardrails: Vec::new(),
+            trace_probes: Vec::new(),
+        });
+
+        assert_eq!(workload.port_range_size(), Some(8));
+        assert_eq!(
+            WorkloadSpec::Path("bench.mjs".to_string()).port_range_size(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_named_leases() {
+        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+            path: "bench.mjs".to_string(),
+            check_groups: None,
+            port_range_size: None,
+            named_leases: vec!["browser-profile".to_string()],
+            trace_phase_presets: HashMap::new(),
+            trace_span_metadata: HashMap::new(),
+            trace_default_phase_preset: None,
+            trace_variants: HashMap::new(),
+            trace_guardrails: Vec::new(),
+            trace_probes: Vec::new(),
+        });
+
+        assert_eq!(workload.named_leases(), &["browser-profile".to_string()]);
+        assert!(WorkloadSpec::Path("bench.mjs".to_string())
+            .named_leases()
+            .is_empty());
+    }
+
+    #[test]
     fn test_trace_guardrails_parse_at_rig_workload_and_variant_scope() {
         let spec: RigSpec = serde_json::from_str(
             r#"{

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -309,6 +309,17 @@ pub struct WorkloadEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub check_groups: Option<Vec<String>>,
 
+    /// Number of contiguous local ports this workload needs for one child
+    /// invocation. Homeboy allocates non-overlapping ranges and exposes them as
+    /// HOMEBOY_INVOCATION_PORT_BASE/MAX.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port_range_size: Option<u16>,
+
+    /// Logical machine-local resources this workload requires exclusively while
+    /// its child process is running.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub named_leases: Vec<String>,
+
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub trace_phase_presets: HashMap<String, Vec<String>>,
 
@@ -409,6 +420,20 @@ impl WorkloadSpec {
         }
     }
 
+    pub fn port_range_size(&self) -> Option<u16> {
+        match self {
+            WorkloadSpec::Path(_) => None,
+            WorkloadSpec::Detailed(entry) => entry.port_range_size,
+        }
+    }
+
+    pub fn named_leases(&self) -> &[String] {
+        match self {
+            WorkloadSpec::Path(_) => &[],
+            WorkloadSpec::Detailed(entry) => &entry.named_leases,
+        }
+    }
+
     pub fn trace_phase_preset(&self, name: &str) -> Option<&[String]> {
         match self {
             WorkloadSpec::Path(_) => None,
@@ -499,6 +524,8 @@ mod tests {
         let workload = WorkloadSpec::Detailed(WorkloadEntry {
             path: "trace.mjs".to_string(),
             check_groups: None,
+            port_range_size: None,
+            named_leases: Vec::new(),
             trace_phase_presets: HashMap::from([(
                 "startup".to_string(),
                 vec!["launch".to_string(), "ready".to_string()],
@@ -614,6 +641,8 @@ mod tests {
         let workload = WorkloadSpec::Detailed(WorkloadEntry {
             path: "trace.mjs".to_string(),
             check_groups: None,
+            port_range_size: None,
+            named_leases: Vec::new(),
             trace_phase_presets: HashMap::new(),
             trace_span_metadata: HashMap::new(),
             trace_default_phase_preset: Some("startup".to_string()),

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -3,6 +3,8 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use crate::engine::invocation::InvocationRequirements;
+
 use super::spec::RigSpec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,6 +67,40 @@ pub fn check_groups_for_extension_workloads(
     }
 
     Some(groups.into_iter().collect())
+}
+
+pub fn invocation_requirements_for_extension_workloads(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    extension_id: &str,
+) -> InvocationRequirements {
+    let workloads = match kind {
+        RigWorkloadKind::Bench => &rig_spec.bench_workloads,
+        RigWorkloadKind::Trace => &rig_spec.trace_workloads,
+    };
+    let Some(entries) = workloads.get(extension_id) else {
+        return InvocationRequirements::default();
+    };
+
+    let port_range_size = entries
+        .iter()
+        .filter_map(|entry| entry.port_range_size())
+        .max();
+    let mut named_leases = BTreeSet::new();
+    for entry in entries {
+        named_leases.extend(
+            entry
+                .named_leases()
+                .iter()
+                .filter(|name| !name.is_empty())
+                .cloned(),
+        );
+    }
+
+    InvocationRequirements {
+        port_range_size,
+        named_leases: named_leases.into_iter().collect(),
+    }
 }
 
 fn expand_workload_path(rig_spec: &RigSpec, package_root: Option<&Path>, path: &str) -> PathBuf {

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -1,0 +1,79 @@
+use super::*;
+use crate::engine::run_dir::RunDir;
+use crate::test_support::with_isolated_home;
+
+#[test]
+fn invocation_guard_exports_scoped_dirs() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+            .expect("invocation guard");
+        let env = guard.env_vars();
+
+        let id = value_for(&env, "HOMEBOY_INVOCATION_ID");
+        assert!(id.starts_with("inv-"));
+        assert!(Path::new(&value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR")).is_dir());
+        assert!(Path::new(&value_for(&env, "HOMEBOY_INVOCATION_ARTIFACT_DIR")).is_dir());
+        assert!(Path::new(&value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR")).is_dir());
+        assert!(value_for_optional(&env, "HOMEBOY_INVOCATION_PORT_BASE").is_none());
+
+        run_dir.cleanup();
+    });
+}
+
+#[test]
+fn port_ranges_do_not_overlap_while_leased() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let requirements = InvocationRequirements {
+            port_range_size: Some(4),
+            named_leases: Vec::new(),
+        };
+
+        let first = InvocationGuard::acquire(&run_dir, &requirements).expect("first lease");
+        let second = InvocationGuard::acquire(&run_dir, &requirements).expect("second lease");
+        let first_base: u16 = value_for(&first.env_vars(), "HOMEBOY_INVOCATION_PORT_BASE")
+            .parse()
+            .expect("first base");
+        let first_max: u16 = value_for(&first.env_vars(), "HOMEBOY_INVOCATION_PORT_MAX")
+            .parse()
+            .expect("first max");
+        let second_base: u16 = value_for(&second.env_vars(), "HOMEBOY_INVOCATION_PORT_BASE")
+            .parse()
+            .expect("second base");
+
+        assert!(second_base > first_max);
+        assert_eq!(first_max - first_base + 1, 4);
+
+        run_dir.cleanup();
+    });
+}
+
+#[test]
+fn named_lease_conflicts_report_holder() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let requirements = InvocationRequirements {
+            port_range_size: None,
+            named_leases: vec!["playground-browser-profile".to_string()],
+        };
+
+        let _first = InvocationGuard::acquire(&run_dir, &requirements).expect("first lease");
+        let err = InvocationGuard::acquire(&run_dir, &requirements).expect_err("lease conflict");
+        let message = err.to_string();
+
+        assert!(message.contains("playground-browser-profile"));
+        assert!(message.contains("already held"));
+
+        run_dir.cleanup();
+    });
+}
+
+fn value_for(env: &[(String, String)], key: &str) -> String {
+    value_for_optional(env, key).unwrap_or_else(|| panic!("missing {key}"))
+}
+
+fn value_for_optional(env: &[(String, String)], key: &str) -> Option<String> {
+    env.iter()
+        .find_map(|(candidate, value)| (candidate == key).then(|| value.clone()))
+}

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -3,7 +3,7 @@ use crate::engine::run_dir::RunDir;
 use crate::test_support::with_isolated_home;
 
 #[test]
-fn invocation_guard_exports_scoped_dirs() {
+fn test_env_vars() {
     with_isolated_home(|_| {
         let run_dir = RunDir::create().expect("run dir");
         let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -335,6 +335,8 @@ fn workload_with_trace_metadata() -> WorkloadSpec {
     WorkloadSpec::Detailed(WorkloadEntry {
         path: "/tmp/scoped.trace.mjs".to_string(),
         check_groups: Some(vec!["desktop-app".to_string()]),
+        port_range_size: None,
+        named_leases: Vec::new(),
         trace_phase_presets: std::collections::HashMap::from([(
             "startup".to_string(),
             vec!["boot:runner.boot".to_string()],

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -39,6 +39,42 @@ fn test_bench_workloads_for_extension_filters_and_expands_paths() {
 }
 
 #[test]
+fn invocation_requirements_for_workloads_merge_ports_and_named_leases() {
+    let rig_spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "playground-bench",
+            "bench_workloads": {
+                "nodejs": [
+                    {
+                        "path": "/tmp/playground-server.bench.mjs",
+                        "port_range_size": 8,
+                        "named_leases": ["browser-profile"]
+                    },
+                    {
+                        "path": "/tmp/playground-browser.bench.mjs",
+                        "port_range_size": 3,
+                        "named_leases": ["browser-profile", "wasm-cache"]
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse rig spec");
+
+    let requirements = crate::rig::invocation_requirements_for_extension_workloads(
+        &rig_spec,
+        crate::rig::RigWorkloadKind::Bench,
+        "nodejs",
+    );
+
+    assert_eq!(requirements.port_range_size, Some(8));
+    assert_eq!(
+        requirements.named_leases,
+        vec!["browser-profile".to_string(), "wasm-cache".to_string()]
+    );
+}
+
+#[test]
 fn test_trace_workloads_for_extension_filters_and_expands_paths() {
     std::env::set_var("HOMEBOY_TEST_TRACE_ROOT", "/tmp/private-traces");
     let rig_spec: RigSpec = serde_json::from_str(

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -39,7 +39,7 @@ fn test_bench_workloads_for_extension_filters_and_expands_paths() {
 }
 
 #[test]
-fn invocation_requirements_for_workloads_merge_ports_and_named_leases() {
+fn test_invocation_requirements_for_extension_workloads() {
     let rig_spec: RigSpec = serde_json::from_str(
         r#"{
             "id": "playground-bench",


### PR DESCRIPTION
## Summary
- Adds a core `engine::invocation` primitive that gives each child workload `HOMEBOY_INVOCATION_ID` plus scoped state, artifact, and temp dirs.
- Lets rig workload entries declare `port_range_size` and `named_leases`, then allocates non-overlapping local port ranges with stale PID lease recovery and clear named-lease conflicts.
- Wires invocation env into extension/component-script execution and documents the generic benchmark contract.

## Playground coverage
- Reviewed the existing Homeboy `studio-playground-dev` fixtures and Playground-shaped references (`wordpress-playground`, `playground-server-child.mjs`, process patterns, wasm/build references) before finalizing the API.
- The primitive is intentionally not Studio-specific: Playground-style benchmarks can compose multiple browser/server/wasm/node services with private temp project dirs, build/download artifacts, optional named leases, and port ranges via `HOMEBOY_INVOCATION_PORT_BASE`/`HOMEBOY_INVOCATION_PORT_MAX`.
- No Playground-specific code is included; the API remains generic core infrastructure.

## Follow-up gaps
- This is the first cut for #2258, not the full closure.
- Invocation-scoped process cleanup is tracked separately in #2298. Existing process-group cleanup paths remain in place, and the new invocation ID is available to child workloads, but Homeboy does not yet own a full process registry keyed by invocation ID.

Refs #2258.

## Tests
- `cargo test invocation_test`
- `cargo test workloads_test`
- `cargo test core::extension::bench::run::tests`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, documentation, and PR notes; Chris remains responsible for review and validation.