### PR TITLE
fix(ci): avoid source build during release check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
         id: release-check
         uses: Extra-Chill/homeboy-action@v2
         with:
-          source: '.'
           commands: release
           expected-commands: audit,lint,test
           release-dry-run: 'true'
@@ -642,4 +641,3 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-


### PR DESCRIPTION
## Summary
- Stop source-building Homeboy in the initial release dry-run check.
- Keep source-built Homeboy for the main release quality gates and release path.

## Why
The release decision job only needs to detect releasable commits. Building from source there can dirty the checkout before audit/lint/test run, blocking main issue filing and release gating.

## Testing
- Not run locally; workflow-only change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI regression and drafted the minimal workflow change; Chris directed the merge strategy.