### PR TITLE
Fix vacuous test detector false positives

### DIFF
--- a/src/core/code_audit/test_quality.rs
+++ b/src/core/code_audit/test_quality.rs
@@ -66,11 +66,15 @@ struct ProductImport {
 
 fn detect_vacuous_tests(file: &str, content: &str) -> Vec<Finding> {
     let file_path = file.to_string();
+    let inline_source_file = !file.starts_with("tests/") && !file.ends_with("_test.rs");
     let product_imports = collect_product_imports(content);
-    let product_symbols = product_imports
+    let mut product_symbols = product_imports
         .iter()
         .map(|import| import.symbol.clone())
         .collect::<BTreeSet<_>>();
+    if inline_source_file {
+        product_symbols.extend(collect_local_product_symbols(content));
+    }
     let tests = extract_test_functions(content);
 
     let mut findings = tests
@@ -93,11 +97,13 @@ fn detect_vacuous_tests(file: &str, content: &str) -> Vec<Finding> {
         .collect::<Vec<_>>();
 
     findings.extend(detect_duplicate_test_names(&file_path, &tests));
-    findings.extend(detect_unused_product_imports(
-        &file_path,
-        &tests,
-        &product_imports,
-    ));
+    if !inline_source_file {
+        findings.extend(detect_unused_product_imports(
+            &file_path,
+            &tests,
+            &product_imports,
+        ));
+    }
 
     findings.extend(tests.into_iter().filter_map(|test| {
         vacuous_reason(&test, &product_symbols).map(|reason| Finding {
@@ -117,6 +123,15 @@ fn detect_vacuous_tests(file: &str, content: &str) -> Vec<Finding> {
 
 fn collect_product_imports(content: &str) -> Vec<ProductImport> {
     let mut imports = BTreeSet::new();
+    let module =
+        regex::Regex::new(r"(?m)^\s*use\s+(?:homeboy|crate|super)::([A-Za-z_][A-Za-z0-9_]*)\s*;")
+            .unwrap();
+    for cap in module.captures_iter(content) {
+        imports.insert(ProductImport {
+            symbol: cap[1].to_string(),
+        });
+    }
+
     let simple = regex::Regex::new(
         r"(?m)^\s*use\s+(?:homeboy|crate|super)::[^;]*::([A-Za-z_][A-Za-z0-9_]*)\s*;",
     )
@@ -128,11 +143,19 @@ fn collect_product_imports(content: &str) -> Vec<ProductImport> {
     }
 
     let grouped =
-        regex::Regex::new(r"(?m)^\s*use\s+(?:homeboy|crate|super)::[^;]*\{([^}]+)\}\s*;").unwrap();
+        regex::Regex::new(r"(?m)^\s*use\s+(homeboy|crate|super)::([^;{]+)::\{([^}]+)\}\s*;")
+            .unwrap();
     for cap in grouped.captures_iter(content) {
-        for raw in cap[1].split(',') {
+        let root = &cap[1];
+        let prefix = cap[2].rsplit("::").next().map(str::trim).unwrap_or("");
+        for raw in cap[3].split(',') {
             let symbol = raw.trim().trim_start_matches("self::");
             let symbol = symbol.split_whitespace().next().unwrap_or("");
+            let symbol = if symbol == "self" && root == "homeboy" {
+                prefix
+            } else {
+                symbol
+            };
             if !symbol.is_empty()
                 && symbol != "self"
                 && symbol
@@ -147,6 +170,19 @@ fn collect_product_imports(content: &str) -> Vec<ProductImport> {
     }
 
     imports.into_iter().collect()
+}
+
+fn collect_local_product_symbols(content: &str) -> BTreeSet<String> {
+    let mut symbols = BTreeSet::new();
+    let product_content = content.split("#[cfg(test)]").next().unwrap_or(content);
+    let item = regex::Regex::new(
+        r"(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:fn|struct|enum|type|trait)\s+([A-Za-z_][A-Za-z0-9_]*)\b",
+    )
+    .unwrap();
+    for cap in item.captures_iter(product_content) {
+        symbols.insert(cap[1].to_string());
+    }
+    symbols
 }
 
 fn detect_duplicate_test_names(file: &str, tests: &[TestFunction]) -> Vec<Finding> {
@@ -603,6 +639,62 @@ fn test_evaluate_file_exists() {
     let rig = minimal_rig();
     let spec = CheckSpec::default();
     evaluate(&rig, &spec).expect("existing file passes");
+}
+"#,
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn keeps_module_import_product_calls() {
+        let findings = detect_vacuous_tests(
+            "tests/core/deps_test.rs",
+            r#"
+use homeboy::deps::{self, ComposerAction};
+
+#[test]
+fn status_filters_to_one_package() {
+    let status = deps::status(Some("fixture"), Some("/tmp/fixture"), Some("fixture/two")).unwrap();
+    assert_eq!(status.packages.len(), 1);
+}
+
+#[test]
+fn update_command_args_are_composer_first_and_package_scoped() {
+    assert_eq!(
+        deps::composer_command_args("fixture/package", &ComposerAction::Update),
+        vec!["update", "fixture/package"]
+    );
+}
+"#,
+        );
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn keeps_inline_super_import_tests_that_call_local_product_code() {
+        let findings = detect_vacuous_tests(
+            "src/core/extension/test/baseline.rs",
+            r#"
+pub fn load_baseline(path: &Path) -> Option<TestBaseline> { todo!() }
+pub fn compare(current: &TestCounts, baseline: &TestBaseline) -> TestBaselineComparison { todo!() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_baseline(dir.path()).is_none());
+    }
+
+    #[test]
+    fn compare_no_regression() {
+        let result = compare(&current, &baseline);
+        assert!(!result.regression);
+    }
 }
 "#,
         );

--- a/src/core/code_audit/test_vacuity.rs
+++ b/src/core/code_audit/test_vacuity.rs
@@ -175,26 +175,136 @@ fn extract_rust_function_body(content: &str, fn_name: &str) -> Option<String> {
     ))
     .ok()?;
     let mat = pattern.find(content)?;
-    let open = content[mat.end() - 1..].chars().next()?;
-    if open != '{' {
+    let open = mat.end() - 1;
+    matching_rust_brace(content, open).map(|end| content[mat.end()..end].to_string())
+}
+
+fn matching_rust_brace(content: &str, open: usize) -> Option<usize> {
+    if content.as_bytes().get(open) != Some(&b'{') {
         return None;
     }
+
     let mut depth = 0_i32;
-    let mut end = None;
-    for (idx, ch) in content[mat.end() - 1..].char_indices() {
+    let mut iter = content[open..].char_indices().peekable();
+    while let Some((idx, ch)) = iter.next() {
+        let absolute = open + idx;
         match ch {
+            '/' if iter.peek().is_some_and(|(_, next)| *next == '/') => {
+                skip_line_comment(&mut iter);
+            }
+            '/' if iter.peek().is_some_and(|(_, next)| *next == '*') => {
+                iter.next();
+                skip_block_comment(&mut iter);
+            }
+            'r' if raw_string_hashes(content, absolute).is_some() => {
+                let hashes = raw_string_hashes(content, absolute)?;
+                skip_raw_string(&mut iter, hashes);
+            }
+            '"' => skip_quoted_string(&mut iter),
+            '\'' => skip_char_literal(&mut iter),
             '{' => depth += 1,
             '}' => {
                 depth -= 1;
                 if depth == 0 {
-                    end = Some(mat.end() - 1 + idx);
-                    break;
+                    return Some(absolute);
                 }
             }
             _ => {}
         }
     }
-    end.map(|end| content[mat.end()..end].to_string())
+    None
+}
+
+fn skip_line_comment(iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>) {
+    for (_, ch) in iter.by_ref() {
+        if ch == '\n' {
+            break;
+        }
+    }
+}
+
+fn skip_block_comment(iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>) {
+    let mut previous = '\0';
+    for (_, ch) in iter.by_ref() {
+        if previous == '*' && ch == '/' {
+            break;
+        }
+        previous = ch;
+    }
+}
+
+fn raw_string_hashes(content: &str, offset: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    if bytes.get(offset) != Some(&b'r') {
+        return None;
+    }
+    let mut idx = offset + 1;
+    let mut hashes = 0;
+    while bytes.get(idx) == Some(&b'#') {
+        hashes += 1;
+        idx += 1;
+    }
+    (bytes.get(idx) == Some(&b'"')).then_some(hashes)
+}
+
+fn skip_raw_string(iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>, hashes: usize) {
+    let mut saw_opening_quote = false;
+    for (_, ch) in iter.by_ref() {
+        if ch == '"' {
+            saw_opening_quote = true;
+            break;
+        }
+    }
+    if !saw_opening_quote {
+        return;
+    }
+
+    while let Some((_, ch)) = iter.next() {
+        if ch != '"' {
+            continue;
+        }
+        if hashes == 0 {
+            break;
+        }
+
+        let mut hash_count = 0usize;
+        while iter.peek().is_some_and(|(_, next)| *next == '#') {
+            iter.next();
+            hash_count += 1;
+            if hash_count == hashes {
+                break;
+            }
+        }
+        if hash_count == hashes {
+            break;
+        }
+    }
+}
+
+fn skip_quoted_string(iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>) {
+    let mut escaped = false;
+    for (_, ch) in iter.by_ref() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if ch == '"' {
+            break;
+        }
+    }
+}
+
+fn skip_char_literal(iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>) {
+    let mut escaped = false;
+    for (_, ch) in iter.by_ref() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if ch == '\'' {
+            break;
+        }
+    }
 }
 
 fn strip_rust_comments(content: &str) -> String {
@@ -206,4 +316,42 @@ fn strip_rust_comments(content: &str) -> String {
         .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_body_with_unbalanced_braces_inside_raw_string() {
+        let content = r#"
+#[cfg(test)]
+mod tests {
+    fn build_grammar() -> Grammar {
+        Grammar {
+            regex: r"(?:::\{[^}]+\})?".to_string(),
+        }
+    }
+}
+"#;
+
+        let body = extract_rust_function_body(content, "build_grammar").expect("body");
+
+        assert!(body.contains("Grammar"));
+        assert!(body.contains("regex"));
+    }
+
+    #[test]
+    fn extracts_body_with_hash_raw_string_containing_braces() {
+        let content = r##"
+fn parse_json() {
+    let value = r#"{"name":"homeboy"}"#;
+    assert!(value.contains("homeboy"));
+}
+"##;
+
+        let body = extract_rust_function_body(content, "parse_json").expect("body");
+
+        assert!(body.contains("assert!"));
+    }
 }


### PR DESCRIPTION
## Summary
- Teach the vacuous-test detector to recognize module-style product imports like `homeboy::deps::{self, ...}`.
- Avoid unused-product-import false positives for inline source tests and recognize local product symbols used via `super::*`.
- Make Rust test body extraction skip comments and string literals so raw strings with braces do not truncate test bodies.

## Testing
- `cargo fmt --check`
- `cargo test test_topology::test_quality --lib`
- `cargo test code_audit::test_vacuity --lib`

## Related
- Fixes false-positive cases reported in https://github.com/Extra-Chill/homeboy/issues/2305

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the detector fix and regression tests; Chris reviewed/requested the change and targeted tests were run locally.