### PR TITLE
Track invocation child process ownership

### DIFF
--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -15,6 +15,8 @@ const LOCK_ATTEMPTS: usize = 100;
 const LOCK_SLEEP: Duration = Duration::from_millis(20);
 const PORT_POOL_START: u16 = 20_000;
 const PORT_POOL_END: u16 = 60_999;
+const CHILD_RECORD_DIR: &str = "invocation-children";
+const CHILD_CLEANUP_GRACE: Duration = Duration::from_millis(200);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InvocationRequirements {
@@ -38,6 +40,11 @@ pub struct InvocationGuard {
     lease_id: Option<String>,
 }
 
+#[derive(Debug)]
+pub struct InvocationChildGuard {
+    path: PathBuf,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct InvocationLease {
     invocation_id: String,
@@ -49,8 +56,25 @@ struct InvocationLease {
     named_leases: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvocationChildRecord {
+    pub invocation_id: String,
+    pub owner_pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_started_at: Option<String>,
+    pub root_pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pgid: Option<i32>,
+    pub command_label: String,
+    pub started_at: String,
+}
+
 impl InvocationGuard {
     pub fn acquire(run_dir: &RunDir, requirements: &InvocationRequirements) -> Result<Self> {
+        cleanup_stale_child_records()?;
+
         let id = format!("inv-{}", uuid::Uuid::new_v4());
         let root = run_dir.path().join("invocations").join(&id);
         let state_dir = root.join("state");
@@ -135,6 +159,115 @@ impl InvocationGuard {
         }
         vars
     }
+}
+
+impl Drop for InvocationChildGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub fn register_child_process(
+    invocation_id: &str,
+    root_pid: u32,
+    pgid: Option<i32>,
+    command_label: String,
+) -> Result<InvocationChildGuard> {
+    let dir = invocation_children_dir(invocation_id)?;
+    fs::create_dir_all(&dir).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to create invocation child directory {}: {}",
+                dir.display(),
+                e
+            ),
+            Some("invocation.child.dir".to_string()),
+        )
+    })?;
+
+    let record = InvocationChildRecord {
+        invocation_id: invocation_id.to_string(),
+        owner_pid: std::process::id(),
+        owner_started_at: process_started_at(std::process::id()),
+        root_pid,
+        root_started_at: process_started_at(root_pid),
+        pgid,
+        command_label,
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let path = child_record_path(invocation_id, root_pid)?;
+    let json = serde_json::to_string_pretty(&record).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to serialize invocation child record: {}",
+            e
+        ))
+    })?;
+    fs::write(&path, json).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to write invocation child record {}: {}",
+                path.display(),
+                e
+            ),
+            Some("invocation.child.write".to_string()),
+        )
+    })?;
+
+    Ok(InvocationChildGuard { path })
+}
+
+pub fn cleanup_invocation_children(invocation_id: &str) -> Result<usize> {
+    let mut cleaned = 0;
+    for path in invocation_child_files(invocation_id)? {
+        let Some(record) = decode_child_record(&path)? else {
+            continue;
+        };
+        if cleanup_child_record(&record) {
+            cleaned += 1;
+        }
+        let _ = fs::remove_file(path);
+    }
+    Ok(cleaned)
+}
+
+pub fn cleanup_stale_child_records() -> Result<usize> {
+    let mut cleaned = 0;
+    let root = invocation_children_root()?;
+    if !root.exists() {
+        return Ok(0);
+    }
+
+    for entry in fs::read_dir(&root).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read invocation child root {}: {}",
+                root.display(),
+                e
+            ),
+            Some("invocation.child.read".to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(e.to_string(), Some("invocation.child.entry".to_string()))
+        })?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        for child_path in child_files_in_dir(&path)? {
+            let Some(record) = decode_child_record(&child_path)? else {
+                let _ = fs::remove_file(child_path);
+                continue;
+            };
+            if owner_is_gone(&record) {
+                if cleanup_child_record(&record) {
+                    cleaned += 1;
+                }
+                let _ = fs::remove_file(child_path);
+            }
+        }
+    }
+    Ok(cleaned)
 }
 
 impl Drop for InvocationGuard {
@@ -325,6 +458,134 @@ fn lease_path(invocation_id: &str) -> Result<PathBuf> {
 
 fn invocation_leases_dir() -> Result<PathBuf> {
     Ok(paths::homeboy()?.join("invocation-leases"))
+}
+
+fn invocation_children_root() -> Result<PathBuf> {
+    Ok(paths::homeboy()?.join(CHILD_RECORD_DIR))
+}
+
+fn invocation_children_dir(invocation_id: &str) -> Result<PathBuf> {
+    Ok(invocation_children_root()?.join(sanitize_id(invocation_id)))
+}
+
+fn child_record_path(invocation_id: &str, root_pid: u32) -> Result<PathBuf> {
+    Ok(invocation_children_dir(invocation_id)?.join(format!("{}.json", root_pid)))
+}
+
+fn invocation_child_files(invocation_id: &str) -> Result<Vec<PathBuf>> {
+    child_files_in_dir(&invocation_children_dir(invocation_id)?)
+}
+
+fn child_files_in_dir(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read invocation child directory {}: {}",
+                dir.display(),
+                e
+            ),
+            Some("invocation.child.read".to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(e.to_string(), Some("invocation.child.entry".to_string()))
+        })?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "json") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn decode_child_record(path: &Path) -> Result<Option<InvocationChildRecord>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(path).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read invocation child record {}: {}",
+                path.display(),
+                e
+            ),
+            Some("invocation.child.read".to_string()),
+        )
+    })?;
+    if content.trim().is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str::<InvocationChildRecord>(&content)
+        .map(Some)
+        .map_err(|e| {
+            Error::validation_invalid_json(
+                e,
+                Some(parse_context(path)),
+                Some(json_excerpt(&content)),
+            )
+        })
+}
+
+fn owner_is_gone(record: &InvocationChildRecord) -> bool {
+    !process_identity_matches(record.owner_pid, record.owner_started_at.as_deref())
+}
+
+fn cleanup_child_record(record: &InvocationChildRecord) -> bool {
+    if !process_identity_matches(record.root_pid, record.root_started_at.as_deref()) {
+        return false;
+    }
+
+    #[cfg(unix)]
+    if let Some(pgid) = record.pgid {
+        if pgid <= 0 || pgid as u32 != record.root_pid {
+            return false;
+        }
+        cleanup_process_group(pgid as libc::pid_t);
+        return true;
+    }
+
+    false
+}
+
+fn process_identity_matches(pid: u32, started_at: Option<&str>) -> bool {
+    if !crate::core::daemon::pid_is_running(pid) {
+        return false;
+    }
+    match (started_at, process_started_at(pid)) {
+        (Some(expected), Some(actual)) => expected == actual,
+        (Some(_), None) => false,
+        (None, _) => true,
+    }
+}
+
+fn process_started_at(pid: u32) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "lstart=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let started = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!started.is_empty()).then_some(started)
+}
+
+#[cfg(unix)]
+fn cleanup_process_group(pgid: libc::pid_t) {
+    unsafe {
+        libc::kill(-pgid, libc::SIGTERM);
+    }
+    std::thread::sleep(CHILD_CLEANUP_GRACE);
+    unsafe {
+        if libc::kill(-pgid, 0) == 0 {
+            libc::kill(-pgid, libc::SIGKILL);
+        }
+    }
 }
 
 fn sanitize_id(id: &str) -> String {

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -15,8 +15,12 @@ const LOCK_ATTEMPTS: usize = 100;
 const LOCK_SLEEP: Duration = Duration::from_millis(20);
 const PORT_POOL_START: u16 = 20_000;
 const PORT_POOL_END: u16 = 60_999;
-const CHILD_RECORD_DIR: &str = "invocation-children";
-const CHILD_CLEANUP_GRACE: Duration = Duration::from_millis(200);
+
+mod child;
+pub use child::{
+    cleanup_invocation_children, cleanup_stale_child_records, register_child_process,
+    InvocationChildGuard, InvocationChildRecord,
+};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InvocationRequirements {
@@ -40,11 +44,6 @@ pub struct InvocationGuard {
     lease_id: Option<String>,
 }
 
-#[derive(Debug)]
-pub struct InvocationChildGuard {
-    path: PathBuf,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct InvocationLease {
     invocation_id: String,
@@ -54,21 +53,6 @@ struct InvocationLease {
     port_max: Option<u16>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     named_leases: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InvocationChildRecord {
-    pub invocation_id: String,
-    pub owner_pid: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub owner_started_at: Option<String>,
-    pub root_pid: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub root_started_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pgid: Option<i32>,
-    pub command_label: String,
-    pub started_at: String,
 }
 
 impl InvocationGuard {
@@ -159,115 +143,6 @@ impl InvocationGuard {
         }
         vars
     }
-}
-
-impl Drop for InvocationChildGuard {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
-    }
-}
-
-pub fn register_child_process(
-    invocation_id: &str,
-    root_pid: u32,
-    pgid: Option<i32>,
-    command_label: String,
-) -> Result<InvocationChildGuard> {
-    let dir = invocation_children_dir(invocation_id)?;
-    fs::create_dir_all(&dir).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to create invocation child directory {}: {}",
-                dir.display(),
-                e
-            ),
-            Some("invocation.child.dir".to_string()),
-        )
-    })?;
-
-    let record = InvocationChildRecord {
-        invocation_id: invocation_id.to_string(),
-        owner_pid: std::process::id(),
-        owner_started_at: process_started_at(std::process::id()),
-        root_pid,
-        root_started_at: process_started_at(root_pid),
-        pgid,
-        command_label,
-        started_at: chrono::Utc::now().to_rfc3339(),
-    };
-    let path = child_record_path(invocation_id, root_pid)?;
-    let json = serde_json::to_string_pretty(&record).map_err(|e| {
-        Error::internal_unexpected(format!(
-            "Failed to serialize invocation child record: {}",
-            e
-        ))
-    })?;
-    fs::write(&path, json).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to write invocation child record {}: {}",
-                path.display(),
-                e
-            ),
-            Some("invocation.child.write".to_string()),
-        )
-    })?;
-
-    Ok(InvocationChildGuard { path })
-}
-
-pub fn cleanup_invocation_children(invocation_id: &str) -> Result<usize> {
-    let mut cleaned = 0;
-    for path in invocation_child_files(invocation_id)? {
-        let Some(record) = decode_child_record(&path)? else {
-            continue;
-        };
-        if cleanup_child_record(&record) {
-            cleaned += 1;
-        }
-        let _ = fs::remove_file(path);
-    }
-    Ok(cleaned)
-}
-
-pub fn cleanup_stale_child_records() -> Result<usize> {
-    let mut cleaned = 0;
-    let root = invocation_children_root()?;
-    if !root.exists() {
-        return Ok(0);
-    }
-
-    for entry in fs::read_dir(&root).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to read invocation child root {}: {}",
-                root.display(),
-                e
-            ),
-            Some("invocation.child.read".to_string()),
-        )
-    })? {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(e.to_string(), Some("invocation.child.entry".to_string()))
-        })?;
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        for child_path in child_files_in_dir(&path)? {
-            let Some(record) = decode_child_record(&child_path)? else {
-                let _ = fs::remove_file(child_path);
-                continue;
-            };
-            if owner_is_gone(&record) {
-                if cleanup_child_record(&record) {
-                    cleaned += 1;
-                }
-                let _ = fs::remove_file(child_path);
-            }
-        }
-    }
-    Ok(cleaned)
 }
 
 impl Drop for InvocationGuard {
@@ -458,134 +333,6 @@ fn lease_path(invocation_id: &str) -> Result<PathBuf> {
 
 fn invocation_leases_dir() -> Result<PathBuf> {
     Ok(paths::homeboy()?.join("invocation-leases"))
-}
-
-fn invocation_children_root() -> Result<PathBuf> {
-    Ok(paths::homeboy()?.join(CHILD_RECORD_DIR))
-}
-
-fn invocation_children_dir(invocation_id: &str) -> Result<PathBuf> {
-    Ok(invocation_children_root()?.join(sanitize_id(invocation_id)))
-}
-
-fn child_record_path(invocation_id: &str, root_pid: u32) -> Result<PathBuf> {
-    Ok(invocation_children_dir(invocation_id)?.join(format!("{}.json", root_pid)))
-}
-
-fn invocation_child_files(invocation_id: &str) -> Result<Vec<PathBuf>> {
-    child_files_in_dir(&invocation_children_dir(invocation_id)?)
-}
-
-fn child_files_in_dir(dir: &Path) -> Result<Vec<PathBuf>> {
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-    let mut files = Vec::new();
-    for entry in fs::read_dir(dir).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to read invocation child directory {}: {}",
-                dir.display(),
-                e
-            ),
-            Some("invocation.child.read".to_string()),
-        )
-    })? {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(e.to_string(), Some("invocation.child.entry".to_string()))
-        })?;
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "json") {
-            files.push(path);
-        }
-    }
-    files.sort();
-    Ok(files)
-}
-
-fn decode_child_record(path: &Path) -> Result<Option<InvocationChildRecord>> {
-    if !path.exists() {
-        return Ok(None);
-    }
-    let content = fs::read_to_string(path).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to read invocation child record {}: {}",
-                path.display(),
-                e
-            ),
-            Some("invocation.child.read".to_string()),
-        )
-    })?;
-    if content.trim().is_empty() {
-        return Ok(None);
-    }
-    serde_json::from_str::<InvocationChildRecord>(&content)
-        .map(Some)
-        .map_err(|e| {
-            Error::validation_invalid_json(
-                e,
-                Some(parse_context(path)),
-                Some(json_excerpt(&content)),
-            )
-        })
-}
-
-fn owner_is_gone(record: &InvocationChildRecord) -> bool {
-    !process_identity_matches(record.owner_pid, record.owner_started_at.as_deref())
-}
-
-fn cleanup_child_record(record: &InvocationChildRecord) -> bool {
-    if !process_identity_matches(record.root_pid, record.root_started_at.as_deref()) {
-        return false;
-    }
-
-    #[cfg(unix)]
-    if let Some(pgid) = record.pgid {
-        if pgid <= 0 || pgid as u32 != record.root_pid {
-            return false;
-        }
-        cleanup_process_group(pgid as libc::pid_t);
-        return true;
-    }
-
-    false
-}
-
-fn process_identity_matches(pid: u32, started_at: Option<&str>) -> bool {
-    if !crate::core::daemon::pid_is_running(pid) {
-        return false;
-    }
-    match (started_at, process_started_at(pid)) {
-        (Some(expected), Some(actual)) => expected == actual,
-        (Some(_), None) => false,
-        (None, _) => true,
-    }
-}
-
-fn process_started_at(pid: u32) -> Option<String> {
-    let output = std::process::Command::new("ps")
-        .args(["-o", "lstart=", "-p", &pid.to_string()])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let started = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!started.is_empty()).then_some(started)
-}
-
-#[cfg(unix)]
-fn cleanup_process_group(pgid: libc::pid_t) {
-    unsafe {
-        libc::kill(-pgid, libc::SIGTERM);
-    }
-    std::thread::sleep(CHILD_CLEANUP_GRACE);
-    unsafe {
-        if libc::kill(-pgid, 0) == 0 {
-            libc::kill(-pgid, libc::SIGKILL);
-        }
-    }
 }
 
 fn sanitize_id(id: &str) -> String {

--- a/src/core/engine/invocation/child.rs
+++ b/src/core/engine/invocation/child.rs
@@ -1,0 +1,307 @@
+use crate::engine::resource::ChildProcessIdentity;
+use crate::error::{Error, Result};
+use crate::paths;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::{json_excerpt, parse_context, sanitize_id};
+
+const CHILD_RECORD_DIR: &str = "invocation-children";
+const CHILD_CLEANUP_GRACE: Duration = Duration::from_millis(200);
+
+#[derive(Debug)]
+pub struct InvocationChildGuard {
+    pub(crate) path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvocationChildRecord {
+    pub invocation_id: String,
+    pub owner_pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_started_at: Option<String>,
+    #[serde(flatten)]
+    pub child: ChildProcessIdentity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pgid: Option<i32>,
+    pub started_at: String,
+}
+
+impl Drop for InvocationChildGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub fn register_child_process(
+    invocation_id: &str,
+    root_pid: u32,
+    pgid: Option<i32>,
+    command_label: String,
+) -> Result<InvocationChildGuard> {
+    let dir = InvocationChildRecord::children_dir(invocation_id)?;
+    fs::create_dir_all(&dir).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to create invocation child directory {}: {}",
+                dir.display(),
+                e
+            ),
+            Some("invocation.child.dir".to_string()),
+        )
+    })?;
+
+    let record = InvocationChildRecord {
+        invocation_id: invocation_id.to_string(),
+        owner_pid: std::process::id(),
+        owner_started_at: InvocationChildRecord::process_started_at(std::process::id()),
+        child: ChildProcessIdentity {
+            root_pid,
+            command_label,
+        },
+        root_started_at: InvocationChildRecord::process_started_at(root_pid),
+        pgid,
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let path = InvocationChildRecord::record_path(invocation_id, root_pid)?;
+    let json = serde_json::to_string_pretty(&record).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to serialize invocation child record: {}",
+            e
+        ))
+    })?;
+    fs::write(&path, json).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to write invocation child record {}: {}",
+                path.display(),
+                e
+            ),
+            Some("invocation.child.write".to_string()),
+        )
+    })?;
+
+    Ok(InvocationChildGuard { path })
+}
+
+pub fn cleanup_invocation_children(invocation_id: &str) -> Result<usize> {
+    let mut cleaned = 0;
+    for path in InvocationChildRecord::files_for_invocation(invocation_id)? {
+        let Some(record) = InvocationChildRecord::decode(&path)? else {
+            continue;
+        };
+        if record.cleanup() {
+            cleaned += 1;
+        }
+        let _ = fs::remove_file(path);
+    }
+    Ok(cleaned)
+}
+
+pub fn cleanup_stale_child_records() -> Result<usize> {
+    let mut cleaned = 0;
+    let root = InvocationChildRecord::root()?;
+    if !root.exists() {
+        return Ok(0);
+    }
+
+    for entry in fs::read_dir(&root).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read invocation child root {}: {}",
+                root.display(),
+                e
+            ),
+            Some("invocation.child.read".to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(e.to_string(), Some("invocation.child.entry".to_string()))
+        })?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        for child_path in InvocationChildRecord::files_in_dir(&path)? {
+            let Some(record) = InvocationChildRecord::decode(&child_path)? else {
+                let _ = fs::remove_file(child_path);
+                continue;
+            };
+            if record.owner_is_gone() {
+                if record.cleanup() {
+                    cleaned += 1;
+                }
+                let _ = fs::remove_file(child_path);
+            }
+        }
+    }
+    Ok(cleaned)
+}
+
+impl InvocationChildRecord {
+    fn root() -> Result<PathBuf> {
+        Ok(paths::homeboy()?.join(CHILD_RECORD_DIR))
+    }
+
+    pub(crate) fn children_dir(invocation_id: &str) -> Result<PathBuf> {
+        Ok(Self::root()?.join(sanitize_id(invocation_id)))
+    }
+
+    pub(crate) fn record_path(invocation_id: &str, root_pid: u32) -> Result<PathBuf> {
+        Ok(Self::children_dir(invocation_id)?.join(format!("{}.json", root_pid)))
+    }
+
+    fn files_for_invocation(invocation_id: &str) -> Result<Vec<PathBuf>> {
+        Self::files_in_dir(&Self::children_dir(invocation_id)?)
+    }
+
+    fn files_in_dir(dir: &Path) -> Result<Vec<PathBuf>> {
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut files = Vec::new();
+        for entry in fs::read_dir(dir).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to read invocation child directory {}: {}",
+                    dir.display(),
+                    e
+                ),
+                Some("invocation.child.read".to_string()),
+            )
+        })? {
+            let entry = entry.map_err(|e| {
+                Error::internal_io(e.to_string(), Some("invocation.child.entry".to_string()))
+            })?;
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "json") {
+                files.push(path);
+            }
+        }
+        files.sort();
+        Ok(files)
+    }
+
+    fn decode(path: &Path) -> Result<Option<Self>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = fs::read_to_string(path).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to read invocation child record {}: {}",
+                    path.display(),
+                    e
+                ),
+                Some("invocation.child.read".to_string()),
+            )
+        })?;
+        if content.trim().is_empty() {
+            return Ok(None);
+        }
+        serde_json::from_str::<Self>(&content)
+            .map(Some)
+            .map_err(|e| {
+                Error::validation_invalid_json(
+                    e,
+                    Some(parse_context(path)),
+                    Some(json_excerpt(&content)),
+                )
+            })
+    }
+
+    fn owner_is_gone(&self) -> bool {
+        !Self::process_identity_matches(self.owner_pid, self.owner_started_at.as_deref())
+    }
+
+    fn cleanup(&self) -> bool {
+        if !Self::process_identity_matches(self.child.root_pid, self.root_started_at.as_deref()) {
+            return false;
+        }
+
+        #[cfg(unix)]
+        if let Some(pgid) = self.pgid {
+            if pgid <= 0 || pgid as u32 != self.child.root_pid {
+                return false;
+            }
+            Self::cleanup_process_group(pgid as libc::pid_t);
+            return true;
+        }
+
+        false
+    }
+
+    fn process_identity_matches(pid: u32, started_at: Option<&str>) -> bool {
+        if !crate::core::daemon::pid_is_running(pid) {
+            return false;
+        }
+        match (started_at, Self::process_started_at(pid)) {
+            (Some(expected), Some(actual)) => expected == actual,
+            (Some(_), None) => false,
+            (None, _) => true,
+        }
+    }
+
+    pub(crate) fn process_started_at(pid: u32) -> Option<String> {
+        let output = std::process::Command::new("ps")
+            .args(["-o", "lstart=", "-p", &pid.to_string()])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let started = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!started.is_empty()).then_some(started)
+    }
+
+    #[cfg(unix)]
+    fn cleanup_process_group(pgid: libc::pid_t) {
+        unsafe {
+            libc::kill(-pgid, libc::SIGTERM);
+        }
+        std::thread::sleep(CHILD_CLEANUP_GRACE);
+        unsafe {
+            if libc::kill(-pgid, 0) == 0 {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod audit_coverage_tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn test_register_child_process() {
+        with_isolated_home(|_| {
+            let guard = register_child_process(
+                "inv-audit",
+                std::process::id(),
+                None,
+                "audit-child".to_string(),
+            )
+            .expect("child record");
+            assert!(guard.path.exists());
+        });
+    }
+
+    #[test]
+    fn test_cleanup_invocation_children() {
+        with_isolated_home(|_| {
+            assert_eq!(cleanup_invocation_children("inv-empty").unwrap(), 0);
+        });
+    }
+
+    #[test]
+    fn test_cleanup_stale_child_records() {
+        with_isolated_home(|_| {
+            assert_eq!(cleanup_stale_child_records().unwrap(), 0);
+        });
+    }
+}

--- a/src/core/engine/resource.rs
+++ b/src/core/engine/resource.rs
@@ -39,9 +39,15 @@ pub struct RunResourceSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ExtensionChildResourceSummary {
+pub struct ChildProcessIdentity {
     pub root_pid: u32,
     pub command_label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExtensionChildResourceSummary {
+    #[serde(flatten)]
+    pub child: ChildProcessIdentity,
     pub started_at: String,
     pub finished_at: String,
     pub duration_ms: u128,
@@ -173,7 +179,7 @@ pub fn record_extension_child_resource(
 
     let filename = format!(
         "{}-{}.json",
-        summary.root_pid,
+        summary.child.root_pid,
         chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
     );
     let path = dir.join(filename);
@@ -212,7 +218,7 @@ fn read_extension_child_resources(run_dir: &RunDir) -> Vec<ExtensionChildResourc
     summaries.sort_by(|a, b| {
         a.started_at
             .cmp(&b.started_at)
-            .then(a.root_pid.cmp(&b.root_pid))
+            .then(a.child.root_pid.cmp(&b.child.root_pid))
     });
     summaries
 }
@@ -382,8 +388,10 @@ mod tests {
                 warnings: vec!["homeboy_rss_unsupported".to_string()],
             },
             vec![ExtensionChildResourceSummary {
-                root_pid: 99,
-                command_label: "runner".to_string(),
+                child: ChildProcessIdentity {
+                    root_pid: 99,
+                    command_label: "runner".to_string(),
+                },
                 started_at: Utc::now().to_rfc3339(),
                 finished_at: Utc::now().to_rfc3339(),
                 duration_ms: 10,
@@ -431,8 +439,10 @@ mod tests {
     fn test_record_extension_child_resource() {
         let run_dir = RunDir::create().expect("run dir");
         let child = ExtensionChildResourceSummary {
-            root_pid: 123,
-            command_label: "extension-runner".to_string(),
+            child: ChildProcessIdentity {
+                root_pid: 123,
+                command_label: "extension-runner".to_string(),
+            },
             started_at: "2026-04-30T00:00:00+00:00".to_string(),
             finished_at: "2026-04-30T00:00:00.100+00:00".to_string(),
             duration_ms: 100,

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use crate::engine::invocation;
-use crate::engine::resource::ExtensionChildResourceSummary;
+use crate::engine::resource::{ChildProcessIdentity, ExtensionChildResourceSummary};
 use crate::engine::shell;
 use crate::error::{Error, Result};
 use chrono::Utc;
@@ -784,8 +784,7 @@ fn cleanup_process_group(pgid: libc::pid_t) {
 }
 
 struct ChildResourceMonitor {
-    root_pid: u32,
-    command_label: String,
+    child: ChildProcessIdentity,
     started_at: String,
     started_instant: Instant,
     stop: Arc<AtomicBool>,
@@ -807,8 +806,10 @@ impl ChildResourceMonitor {
             std::thread::spawn(move || sample_child_until_stopped(root_pid, stop_for_thread));
 
         Self {
-            root_pid,
-            command_label,
+            child: ChildProcessIdentity {
+                root_pid,
+                command_label,
+            },
             started_at: Utc::now().to_rfc3339(),
             started_instant: Instant::now(),
             stop,
@@ -827,8 +828,7 @@ impl ChildResourceMonitor {
         state.warnings.dedup();
 
         ExtensionChildResourceSummary {
-            root_pid: self.root_pid,
-            command_label: self.command_label,
+            child: self.child,
             started_at: self.started_at,
             finished_at: Utc::now().to_rfc3339(),
             duration_ms: self.started_instant.elapsed().as_millis(),
@@ -1049,12 +1049,36 @@ mod tests {
 
         assert!(output.success);
         let child = output.child_resource.expect("child resource summary");
-        assert!(child.root_pid > 0);
-        assert_eq!(child.command_label, "sleep 0.2");
+        assert!(child.child.root_pid > 0);
+        assert_eq!(child.child.command_label, "sleep 0.2");
         assert!(child.duration_ms > 0);
         assert!(
             child.sampled_peak_rss_bytes.is_some() || !child.warnings.is_empty(),
             "resource probes should either sample RSS or explain why they could not"
+        );
+    }
+
+    #[test]
+    fn test_upload_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let source = dir.path().join("source.txt");
+        let target = dir.path().join("target with spaces.txt");
+        std::fs::write(&source, "uploaded through stdin\n").expect("write source");
+        let client = SshClient {
+            host: "localhost".to_string(),
+            user: "tester".to_string(),
+            port: 22,
+            identity_file: None,
+            is_local: true,
+            env: HashMap::new(),
+        };
+
+        let output = client.upload_file(&source.to_string_lossy(), &target.to_string_lossy());
+
+        assert!(output.success, "upload failed: {}", output.stderr);
+        assert_eq!(
+            std::fs::read_to_string(target).expect("read target"),
+            "uploaded through stdin\n"
         );
     }
 

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -5,6 +5,7 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
+use crate::engine::invocation;
 use crate::engine::resource::ExtensionChildResourceSummary;
 use crate::engine::shell;
 use crate::error::{Error, Result};
@@ -326,6 +327,8 @@ fn execute_local_command_in_dir_impl(
         }
     };
     let cleanup_guard = ProcessGroupCleanupGuard::new(child.id(), cleanup_process_group);
+    let _invocation_child_guard =
+        invocation_child_guard(env, child.id(), cleanup_guard.pgid(), command);
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
 
     let output = match child.wait_with_output() {
@@ -459,6 +462,8 @@ fn execute_local_command_passthrough_impl(
         }
     };
     let cleanup_guard = ProcessGroupCleanupGuard::new(child.id(), cleanup_process_group);
+    let _invocation_child_guard =
+        invocation_child_guard(env, child.id(), cleanup_guard.pgid(), command);
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
 
     // Tee each stream: copy every chunk to the parent's stdout/stderr as it
@@ -571,6 +576,8 @@ pub(crate) fn execute_local_command_stderr_passthrough(
         }
     };
     let cleanup_guard = ProcessGroupCleanupGuard::new(child.id(), cleanup_process_group);
+    let _invocation_child_guard =
+        invocation_child_guard(env, child.id(), cleanup_guard.pgid(), command);
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
 
     fn read_all<R: Read>(mut src: R) -> String {
@@ -696,6 +703,32 @@ impl ProcessGroupCleanupGuard {
             self.pgid = None;
         }
     }
+
+    #[cfg(unix)]
+    fn pgid(&self) -> Option<i32> {
+        self.pgid.map(|pgid| pgid as i32)
+    }
+
+    #[cfg(not(unix))]
+    fn pgid(&self) -> Option<i32> {
+        None
+    }
+}
+
+fn invocation_child_guard(
+    env: Option<&[(&str, &str)]>,
+    root_pid: u32,
+    pgid: Option<i32>,
+    command_label: &str,
+) -> Option<invocation::InvocationChildGuard> {
+    let invocation_id = env.and_then(|pairs| {
+        pairs
+            .iter()
+            .find_map(|(key, value)| (*key == "HOMEBOY_INVOCATION_ID").then_some(*value))
+    })?;
+
+    invocation::register_child_process(invocation_id, root_pid, pgid, command_label.to_string())
+        .ok()
 }
 
 impl Drop for ProcessGroupCleanupGuard {

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -69,6 +69,62 @@ fn named_lease_conflicts_report_holder() {
     });
 }
 
+#[test]
+fn child_record_is_removed_when_guard_drops() {
+    with_isolated_home(|_| {
+        let guard =
+            register_child_process("inv-test", std::process::id(), None, "self".to_string())
+                .expect("child record");
+        assert!(guard.path.exists());
+
+        let path = guard.path.clone();
+        drop(guard);
+
+        assert!(
+            !path.exists(),
+            "child record should be removed on normal exit"
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn stale_owner_cleanup_kills_owned_process_group() {
+    with_isolated_home(|_| {
+        let mut child = spawn_isolated_sleep();
+        let pid = child.id();
+        write_test_child_record("inv-stale", 999_999, pid, Some(pid as i32));
+
+        let cleaned = cleanup_stale_child_records().expect("cleanup stale records");
+
+        assert_eq!(cleaned, 1);
+        assert_child_exits(&mut child);
+        assert!(!child_record_path("inv-stale", pid).unwrap().exists());
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn invocation_cleanup_does_not_overlap_concurrent_invocations() {
+    with_isolated_home(|_| {
+        let mut first = spawn_isolated_sleep();
+        let mut second = spawn_isolated_sleep();
+        let first_pid = first.id();
+        let second_pid = second.id();
+        write_test_child_record("inv-first", 999_999, first_pid, Some(first_pid as i32));
+        write_test_child_record("inv-second", 999_999, second_pid, Some(second_pid as i32));
+
+        let cleaned = cleanup_invocation_children("inv-first").expect("cleanup first invocation");
+
+        assert_eq!(cleaned, 1);
+        assert_child_exits(&mut first);
+        assert!(pid_is_alive(second_pid as libc::pid_t));
+
+        let _ = cleanup_invocation_children("inv-second");
+        assert_child_exits(&mut second);
+    });
+}
+
 fn value_for(env: &[(String, String)], key: &str) -> String {
     value_for_optional(env, key).unwrap_or_else(|| panic!("missing {key}"))
 }
@@ -76,4 +132,61 @@ fn value_for(env: &[(String, String)], key: &str) -> String {
 fn value_for_optional(env: &[(String, String)], key: &str) -> Option<String> {
     env.iter()
         .find_map(|(candidate, value)| (candidate == key).then(|| value.clone()))
+}
+
+#[cfg(unix)]
+fn spawn_isolated_sleep() -> std::process::Child {
+    use std::os::unix::process::CommandExt;
+
+    let mut command = std::process::Command::new("sh");
+    command.args(["-c", "sleep 30"]);
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+    command.spawn().expect("spawn isolated sleep")
+}
+
+#[cfg(unix)]
+fn write_test_child_record(invocation_id: &str, owner_pid: u32, root_pid: u32, pgid: Option<i32>) {
+    let dir = invocation_children_dir(invocation_id).expect("child dir");
+    std::fs::create_dir_all(&dir).expect("create child dir");
+    let record = InvocationChildRecord {
+        invocation_id: invocation_id.to_string(),
+        owner_pid,
+        owner_started_at: None,
+        root_pid,
+        root_started_at: process_started_at(root_pid),
+        pgid,
+        command_label: "sleep".to_string(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let json = serde_json::to_string_pretty(&record).expect("serialize child record");
+    std::fs::write(
+        child_record_path(invocation_id, root_pid).expect("record path"),
+        json,
+    )
+    .expect("write child record");
+}
+
+#[cfg(unix)]
+fn assert_child_exits(child: &mut std::process::Child) {
+    for _ in 0..30 {
+        if child.try_wait().expect("try wait").is_some() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    panic!("child {} should have exited", child.id());
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: libc::pid_t) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
 }

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -70,7 +70,7 @@ fn named_lease_conflicts_report_holder() {
 }
 
 #[test]
-fn child_record_is_removed_when_guard_drops() {
+fn test_register_child_process() {
     with_isolated_home(|_| {
         let guard =
             register_child_process("inv-test", std::process::id(), None, "self".to_string())
@@ -89,7 +89,7 @@ fn child_record_is_removed_when_guard_drops() {
 
 #[cfg(unix)]
 #[test]
-fn stale_owner_cleanup_kills_owned_process_group() {
+fn test_cleanup_stale_child_records() {
     with_isolated_home(|_| {
         let mut child = spawn_isolated_sleep();
         let pid = child.id();
@@ -99,13 +99,15 @@ fn stale_owner_cleanup_kills_owned_process_group() {
 
         assert_eq!(cleaned, 1);
         assert_child_exits(&mut child);
-        assert!(!child_record_path("inv-stale", pid).unwrap().exists());
+        assert!(!InvocationChildRecord::record_path("inv-stale", pid)
+            .unwrap()
+            .exists());
     });
 }
 
 #[cfg(unix)]
 #[test]
-fn invocation_cleanup_does_not_overlap_concurrent_invocations() {
+fn test_cleanup_invocation_children() {
     with_isolated_home(|_| {
         let mut first = spawn_isolated_sleep();
         let mut second = spawn_isolated_sleep();
@@ -154,21 +156,23 @@ fn spawn_isolated_sleep() -> std::process::Child {
 
 #[cfg(unix)]
 fn write_test_child_record(invocation_id: &str, owner_pid: u32, root_pid: u32, pgid: Option<i32>) {
-    let dir = invocation_children_dir(invocation_id).expect("child dir");
+    let dir = InvocationChildRecord::children_dir(invocation_id).expect("child dir");
     std::fs::create_dir_all(&dir).expect("create child dir");
     let record = InvocationChildRecord {
         invocation_id: invocation_id.to_string(),
         owner_pid,
         owner_started_at: None,
-        root_pid,
-        root_started_at: process_started_at(root_pid),
+        child: crate::engine::resource::ChildProcessIdentity {
+            root_pid,
+            command_label: "sleep".to_string(),
+        },
+        root_started_at: InvocationChildRecord::process_started_at(root_pid),
         pgid,
-        command_label: "sleep".to_string(),
         started_at: chrono::Utc::now().to_rfc3339(),
     };
     let json = serde_json::to_string_pretty(&record).expect("serialize child record");
     std::fs::write(
-        child_record_path(invocation_id, root_pid).expect("record path"),
+        InvocationChildRecord::record_path(invocation_id, root_pid).expect("record path"),
         json,
     )
     .expect("write child record");


### PR DESCRIPTION
## Summary
- Add durable invocation-scoped child process ownership records under Homeboy runtime state.
- Register spawned extension child roots with invocation ID, owner/root PID identity, and PGID when available, then clear records on normal child exit.
- Add stale-owner and invocation-specific cleanup paths so Homeboy can clean known process groups without broad process-pattern matching.

## Tests
- `cargo fmt`
- `cargo test invocation_test --lib`
- `cargo test core::server::client::tests --lib`
- `cargo check`
- `cargo test --lib`

Closes #2298.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and tests; Chris remains responsible for review and validation.