### PR TITLE
Fix audit convention grouping with opaque tags

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -1057,6 +1057,43 @@ mod tests {
     }
 
     #[test]
+    fn opaque_convention_exception_globs_suppress_group_findings() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "src/items/one.item".to_string(),
+                language: Language::Unknown,
+                methods: vec!["run".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "src/items/two.item".to_string(),
+                language: Language::Unknown,
+                methods: vec!["run".to_string()],
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "src/generated/fixture.item".to_string(),
+                language: Language::Unknown,
+                methods: vec![],
+                ..Default::default()
+            },
+        ];
+        let audit_config = AuditConfig {
+            convention_exception_globs: vec!["src/generated/*".to_string()],
+            ..Default::default()
+        };
+
+        let convention =
+            discover_conventions_with_config("Items", "src/items/*", &fingerprints, &audit_config)
+                .unwrap();
+
+        assert!(
+            convention.outliers.is_empty(),
+            "configured exception globs are opaque to core and should suppress convention deviations"
+        );
+    }
+
+    #[test]
     fn declared_traits_do_not_become_missing_interfaces() {
         let fingerprints = vec![
             FileFingerprint {

--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -248,6 +248,7 @@ pub fn fingerprint_from_grammar(
         public_api,
         hook_callbacks: Vec::new(), // Core grammar engine doesn't extract hook callbacks yet
         runtime_dispatched_types,
+        convention_tags: Vec::new(),
         trait_impl_methods,
     })
 }

--- a/src/core/code_audit/discovery.rs
+++ b/src/core/code_audit/discovery.rs
@@ -4,8 +4,11 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::conventions::Language;
-use super::fingerprint::{fingerprint_content, FileFingerprint};
+use super::fingerprint::{fingerprint_content, normalize_convention_tags, FileFingerprint};
 use super::walker::{is_test_path, walk_source_files_snapshot};
+use crate::component::AuditConfig;
+
+type DiscoveryGroupKey = (String, Language, bool, Vec<String>);
 
 /// Result of auto-discovering file groups.
 pub struct DiscoveryResult {
@@ -26,22 +29,20 @@ pub struct DiscoveryResult {
 /// exactly once. Fingerprinting goes through [`fingerprint_content`] so the
 /// snapshot's already-loaded content is reused — no second `read_to_string`.
 /// Slice 2 of #1492.
-pub(crate) fn auto_discover_groups(root: &Path) -> DiscoveryResult {
-    let mut groups: Vec<(String, String, Vec<FileFingerprint>)> = Vec::new();
-
-    // Walk directories, group files by (parent dir, language, is_test).
+pub(crate) fn auto_discover_groups(root: &Path, audit_config: &AuditConfig) -> DiscoveryResult {
+    // Walk directories, group files by (parent dir, language, is_test, opaque convention tags).
     // Test files are separated from production files so conventions from
     // production code don't get applied to test files and vice versa.
     // This prevents false positives like test files being flagged for
     // missing production methods (set_up, tear_down are optional hooks).
-    let mut dir_files: HashMap<(String, Language, bool), Vec<FileFingerprint>> = HashMap::new();
+    let mut dir_files: HashMap<DiscoveryGroupKey, Vec<FileFingerprint>> = HashMap::new();
     let mut files_walked: usize = 0;
     let mut files_fingerprinted: usize = 0;
 
     let snapshot = walk_source_files_snapshot(root);
     for (path, content) in snapshot.iter() {
         files_walked += 1;
-        if let Some(fp) = fingerprint_content(path, root, content) {
+        if let Some(mut fp) = fingerprint_content(path, root, content) {
             files_fingerprinted += 1;
             let parent = path
                 .parent()
@@ -49,12 +50,45 @@ pub(crate) fn auto_discover_groups(root: &Path) -> DiscoveryResult {
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_default();
             let file_is_test = is_test_path(&fp.relative_path);
-            let key = (parent, fp.language.clone(), file_is_test);
+            fp.convention_tags = convention_tags_for(&fp, audit_config);
+            let key = (
+                parent,
+                fp.language.clone(),
+                file_is_test,
+                fp.convention_tags.clone(),
+            );
             dir_files.entry(key).or_default().push(fp);
         }
     }
 
-    for ((dir, _lang, is_test), fingerprints) in dir_files {
+    DiscoveryResult {
+        groups: groups_from_dir_files(dir_files),
+        files_walked,
+        files_fingerprinted,
+    }
+}
+
+fn convention_tags_for(fp: &FileFingerprint, audit_config: &AuditConfig) -> Vec<String> {
+    let normalized_path = fp.relative_path.replace('\\', "/");
+    let mut tags = fp.convention_tags.clone();
+    for rule in &audit_config.convention_tag_globs {
+        if rule
+            .globs
+            .iter()
+            .any(|pattern| glob_match::glob_match(pattern, &normalized_path))
+        {
+            tags.push(rule.tag.clone());
+        }
+    }
+    normalize_convention_tags(tags)
+}
+
+fn groups_from_dir_files(
+    dir_files: HashMap<DiscoveryGroupKey, Vec<FileFingerprint>>,
+) -> Vec<(String, String, Vec<FileFingerprint>)> {
+    let mut groups: Vec<(String, String, Vec<FileFingerprint>)> = Vec::new();
+
+    for ((dir, _lang, is_test, convention_tags), fingerprints) in dir_files {
         if fingerprints.len() < 2 {
             continue;
         }
@@ -85,22 +119,21 @@ pub(crate) fn auto_discover_groups(root: &Path) -> DiscoveryResult {
                 .join(" ")
         };
 
-        let name = if is_test {
+        let mut name = if is_test {
             format!("{} (Tests)", base_name)
         } else {
             base_name
         };
+        if !convention_tags.is_empty() {
+            name = format!("{} [{}]", name, convention_tags.join(", "));
+        }
 
         groups.push((name, glob_pattern, fingerprints));
     }
 
     // Sort by group name for deterministic output
     groups.sort_by(|a, b| a.0.cmp(&b.0));
-    DiscoveryResult {
-        groups,
-        files_walked,
-        files_fingerprinted,
-    }
+    groups
 }
 
 /// Discover cross-directory conventions by analyzing sibling subdirectories.
@@ -219,6 +252,84 @@ pub(crate) fn discover_cross_directory(
 mod tests {
     use super::super::test_helpers::make_convention;
     use super::*;
+
+    fn tagged_fingerprint(path: &str, tags: &[&str]) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Unknown,
+            methods: vec!["run".to_string()],
+            convention_tags: tags.iter().map(|tag| tag.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn opaque_convention_tags_keep_directory_groups_separate() {
+        let mut dir_files: HashMap<DiscoveryGroupKey, Vec<FileFingerprint>> = HashMap::new();
+
+        let alpha = vec!["extension:alpha".to_string()];
+        let beta = vec!["extension:beta".to_string()];
+        dir_files.insert(
+            (
+                "src/items".to_string(),
+                Language::Unknown,
+                false,
+                alpha.clone(),
+            ),
+            vec![
+                tagged_fingerprint("src/items/a.one", &["extension:alpha"]),
+                tagged_fingerprint("src/items/b.one", &["extension:alpha"]),
+            ],
+        );
+        dir_files.insert(
+            (
+                "src/items".to_string(),
+                Language::Unknown,
+                false,
+                beta.clone(),
+            ),
+            vec![
+                tagged_fingerprint("src/items/a.two", &["extension:beta"]),
+                tagged_fingerprint("src/items/b.two", &["extension:beta"]),
+            ],
+        );
+
+        let groups = groups_from_dir_files(dir_files);
+
+        assert_eq!(groups.len(), 2);
+        assert!(groups
+            .iter()
+            .any(|(name, _, files)| name == "Items [extension:alpha]" && files.len() == 2));
+        assert!(groups
+            .iter()
+            .any(|(name, _, files)| name == "Items [extension:beta]" && files.len() == 2));
+    }
+
+    #[test]
+    fn component_convention_tag_globs_add_opaque_grouping_tags() {
+        let fp = FileFingerprint {
+            relative_path: "src/generated/item.fixture".to_string(),
+            convention_tags: vec!["extension:seed".to_string()],
+            ..Default::default()
+        };
+        let audit_config = AuditConfig {
+            convention_tag_globs: vec![crate::component::ConventionTagGlob {
+                tag: "component:generated".to_string(),
+                globs: vec!["src/generated/*".to_string()],
+            }],
+            ..Default::default()
+        };
+
+        let tags = convention_tags_for(&fp, &audit_config);
+
+        assert_eq!(
+            tags,
+            vec![
+                "component:generated".to_string(),
+                "extension:seed".to_string()
+            ]
+        );
+    }
 
     #[test]
     fn cross_directory_detects_shared_methods() {

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -144,6 +144,14 @@ fn fingerprint_via_extension(
     content: &str,
     relative_path: &str,
 ) -> Option<FileFingerprint> {
+    fingerprint_extension_content(ext, relative_path, content)
+}
+
+pub(crate) fn fingerprint_extension_content(
+    ext: &str,
+    relative_path: &str,
+    content: &str,
+) -> Option<FileFingerprint> {
     use crate::extension;
 
     let matched_extension = extension::find_extension_for_file_ext(ext, "fingerprint")?;
@@ -315,6 +323,29 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_normalize_convention_tags() {
+        let tags = normalize_convention_tags(vec![
+            " beta ".to_string(),
+            "alpha".to_string(),
+            "".to_string(),
+            "alpha".to_string(),
+            "  ".to_string(),
+        ]);
+
+        assert_eq!(tags, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
+    fn test_fingerprint_extension_content_returns_none_without_claimed_extension() {
+        assert!(fingerprint_extension_content(
+            "homeboy-unclaimed-extension",
+            "src/example.homeboy-unclaimed-extension",
+            "content"
+        )
+        .is_none());
     }
 
     #[test]

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -87,6 +87,12 @@ pub struct FileFingerprint {
     /// convention. Core consumes the generic metadata; extensions own the
     /// framework-specific registration parsing.
     pub runtime_dispatched_types: Vec<String>,
+    /// Opaque extension-provided tags for convention grouping.
+    ///
+    /// Core does not interpret these values. Extensions/components own the
+    /// taxonomy and core only uses the normalized tag set as part of the
+    /// convention grouping key.
+    pub convention_tags: Vec<String>,
     /// Method names that are trait implementations (called via trait dispatch).
     pub trait_impl_methods: Vec<String>,
 }
@@ -173,8 +179,20 @@ fn fingerprint_via_extension(
         public_api: output.public_api,
         hook_callbacks: output.hook_callbacks,
         runtime_dispatched_types: output.runtime_dispatched_types,
+        convention_tags: normalize_convention_tags(output.convention_tags),
         trait_impl_methods: Vec::new(), // Extension scripts don't track this
     })
+}
+
+pub(crate) fn normalize_convention_tags(tags: Vec<String>) -> Vec<String> {
+    let mut tags: Vec<String> = tags
+        .into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    tags.sort();
+    tags.dedup();
+    tags
 }
 
 // ============================================================================

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -122,52 +122,13 @@ pub(crate) fn fingerprint_from_git_ref(
     git_ref: &str,
     relative_path: &str,
 ) -> Option<FileFingerprint> {
-    use crate::extension;
-
     // Get file content from the git ref
     let git_spec = format!("{}:{}", git_ref, relative_path);
     let content =
         crate::engine::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
 
-    // Find the extension for this file type
     let ext = Path::new(relative_path).extension()?.to_str()?;
-    let matched_extension = extension::find_extension_for_file_ext(ext, "fingerprint")?;
-
-    // Run the fingerprint script on the base content
-    let output = extension::run_fingerprint_script(&matched_extension, relative_path, &content)?;
-
-    let language = super::conventions::Language::from_extension(ext);
-
-    Some(FileFingerprint {
-        relative_path: relative_path.to_string(),
-        language,
-        methods: output.methods,
-        // Extension-script fingerprinting does not structurally distinguish
-        // test methods — callers fall back to prefix filtering on `methods`.
-        test_methods: Vec::new(),
-        registrations: output.registrations,
-        type_name: output.type_name,
-        type_names: output.type_names,
-        extends: output.extends,
-        implements: output.implements,
-        namespace: output.namespace,
-        imports: output.imports,
-        content,
-        method_hashes: output.method_hashes,
-        structural_hashes: output.structural_hashes,
-        visibility: output.visibility,
-        properties: output.properties,
-        hooks: output.hooks,
-        unused_parameters: output.unused_parameters,
-        dead_code_markers: output.dead_code_markers,
-        internal_calls: output.internal_calls,
-        call_sites: output.call_sites,
-        public_api: output.public_api,
-        hook_callbacks: output.hook_callbacks,
-        runtime_dispatched_types: output.runtime_dispatched_types,
-        convention_tags: super::fingerprint::normalize_convention_tags(output.convention_tags),
-        trait_impl_methods: Vec::new(),
-    })
+    super::fingerprint::fingerprint_extension_content(ext, relative_path, &content)
 }
 
 // ============================================================================

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -165,6 +165,7 @@ pub(crate) fn fingerprint_from_git_ref(
         public_api: output.public_api,
         hook_callbacks: output.hook_callbacks,
         runtime_dispatched_types: output.runtime_dispatched_types,
+        convention_tags: super::fingerprint::normalize_convention_tags(output.convention_tags),
         trait_impl_methods: Vec::new(),
     })
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -653,7 +653,7 @@ fn audit_internal(
     }
 
     // Phase 1: Auto-discover file groups (always full codebase for convention detection)
-    let discovery = discovery::auto_discover_groups(root);
+    let discovery = discovery::auto_discover_groups(root, &audit_config);
     let files_skipped = discovery
         .files_walked
         .saturating_sub(discovery.files_fingerprinted);

--- a/src/core/code_audit/shadow_modules.rs
+++ b/src/core/code_audit/shadow_modules.rs
@@ -275,6 +275,7 @@ mod tests {
             public_api: vec![],
             hook_callbacks: vec![],
             runtime_dispatched_types: vec![],
+            convention_tags: vec![],
             trait_impl_methods: vec![],
         }
     }

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -17,6 +17,9 @@ pub struct AuditConfig {
     /// Files exempt from convention outlier checks.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub convention_exception_globs: Vec<String>,
+    /// Component-owned path rules that attach opaque tags before convention grouping.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub convention_tag_globs: Vec<ConventionTagGlob>,
     /// Symbols that are known to exist when component metadata proves a runtime
     /// floor, package, or bootstrap file is present.
     #[serde(default, skip_serializing_if = "KnownSymbolsConfig::is_empty")]
@@ -68,6 +71,15 @@ impl CoreBoundaryLeakConfig {
             &other.example_path_contains,
         );
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConventionTagGlob {
+    /// Opaque tag value. Core never interprets this string.
+    pub tag: String,
+    /// File globs that receive this tag.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub globs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -213,6 +225,7 @@ impl AuditConfig {
             && self.lifecycle_path_globs.is_empty()
             && self.utility_suffixes.is_empty()
             && self.convention_exception_globs.is_empty()
+            && self.convention_tag_globs.is_empty()
             && self.known_symbols.is_empty()
             && self.requested_detectors.is_empty()
             && self.core_boundary_leaks.is_empty()
@@ -233,6 +246,7 @@ impl AuditConfig {
             &mut self.convention_exception_globs,
             &other.convention_exception_globs,
         );
+        extend_unique(&mut self.convention_tag_globs, &other.convention_tag_globs);
         self.known_symbols.merge(&other.known_symbols);
         self.core_boundary_leaks.merge(&other.core_boundary_leaks);
         for rule in &other.requested_detectors {

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -11,8 +11,9 @@ pub mod scope;
 pub mod versioning;
 
 pub use audit::{
-    AuditConfig, CoreBoundaryLeakConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider,
-    KnownSymbolKind, KnownSymbolVersionedEntry, RequestedDetectorRule, RequestedDetectorRuleBody,
+    AuditConfig, ConventionTagGlob, CoreBoundaryLeakConfig, KnownSymbolEntry,
+    KnownSymbolHeaderVersionProvider, KnownSymbolKind, KnownSymbolVersionedEntry,
+    RequestedDetectorRule, RequestedDetectorRuleBody,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -641,6 +641,11 @@ pub struct FingerprintOutput {
     /// runtime in another file.
     #[serde(default)]
     pub runtime_dispatched_types: Vec<String>,
+    /// Opaque extension-provided tags used to keep convention inference from
+    /// mixing unlike source roles. Core never interprets tag values; it only
+    /// groups files with the same normalized tag set together.
+    #[serde(default)]
+    pub convention_tags: Vec<String>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds opaque `convention_tags` to fingerprint output so extensions can keep unrelated convention roles separate without core knowing what the tags mean.
- Adds component-owned `convention_tag_globs` so repository config can attach opaque grouping tags by path before convention inference.
- Keeps convention exception suppression generic and extends core tests around opaque tags/exceptions.

Fixes #2309.

## Tests
- `cargo fmt`
- `git diff --check`
- `cargo test core::code_audit`
- `cargo test --test core_agnostic_test --test architecture_core_agnostic_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted and tested the generic audit architecture change; Chris reviewed and remains responsible for the final patch.