### PR TITLE
fix(invocation): shorten runtime path to fit sockaddr_un budget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.156.2"
+version = "0.157.0"
 dependencies = [
  "arboard",
  "base64",

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -183,6 +183,34 @@ variables, independent of runner implementation:
 - `HOMEBOY_INVOCATION_TMP_DIR`: private temporary directory for project copies,
   browser profiles, wasm caches, and other scratch state.
 
+### Runtime path contract
+
+Invocation directories are placed under a short, platform-aware root so any
+workload can put a UNIX domain socket or other path-length-sensitive primitive
+under `HOMEBOY_INVOCATION_STATE_DIR` without bespoke defense:
+
+- macOS: `$TMPDIR/hb/<short-id>/{state,artifacts,tmp}` (typically
+  `/var/folders/<short>/T/hb/...`).
+- Linux: `$XDG_RUNTIME_DIR/hb/<short-id>/...` when set, else
+  `/tmp/hb/<short-id>/...`.
+- Fallback: `~/.cache/homeboy/inv/<short-id>/...`.
+- Override: set `HOMEBOY_INVOCATION_RUNTIME_DIR` to pin the root explicitly
+  (tests and unusual host configurations).
+
+Path components use a short opaque id (~10 hex chars) instead of a full
+UUID v4. The full UUID is retained inside the on-disk invocation lease for
+traceability, but is never embedded in path components.
+
+**Path budget contract.** Homeboy guarantees that `HOMEBOY_INVOCATION_STATE_DIR`,
+`HOMEBOY_INVOCATION_ARTIFACT_DIR`, and `HOMEBOY_INVOCATION_TMP_DIR` leave at
+least 32 bytes of headroom under the platform `sockaddr_un` `sun_path`
+capacity (104 bytes on macOS, 108 bytes on Linux). Workloads can append a
+typical socket filename like `daemon/daemon.sock` directly under any of these
+directories and bind to it without `EINVAL`. If `$HOME` or `$TMPDIR` are
+unusually long, `homeboy` fails fast at invocation acquisition with a clear
+error pointing at `HOMEBOY_INVOCATION_RUNTIME_DIR` instead of letting a
+downstream workload hit the limit at bind time.
+
 Rig workload object entries can request optional shared-machine primitives:
 
 ```json

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -17,9 +17,14 @@ const PORT_POOL_START: u16 = 20_000;
 const PORT_POOL_END: u16 = 60_999;
 
 mod child;
+mod runtime;
 pub use child::{
     cleanup_invocation_children, cleanup_stale_child_records, register_child_process,
     InvocationChildGuard, InvocationChildRecord,
+};
+pub use runtime::{
+    enforce_path_budget, invocation_runtime_root, short_invocation_id,
+    HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, SOCKET_HEADROOM_BYTES, SUN_PATH_CAPACITY,
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -42,11 +47,19 @@ pub struct InvocationEnv {
 pub struct InvocationGuard {
     env: InvocationEnv,
     lease_id: Option<String>,
+    /// Root invocation directory under [`invocation_runtime_root`]. Removed
+    /// on `Drop` so concurrent invocations do not accumulate stale state on
+    /// disk. Decoupled from any caller-provided `RunDir` cleanup.
+    invocation_root: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct InvocationLease {
     invocation_id: String,
+    /// Full UUID retained for traceability across logs and observation
+    /// records. Path components use [`short_invocation_id`] instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    invocation_uuid: Option<String>,
     pid: u32,
     started_at: String,
     port_base: Option<u16>,
@@ -56,14 +69,42 @@ struct InvocationLease {
 }
 
 impl InvocationGuard {
+    /// Acquire an isolated invocation environment.
+    ///
+    /// `run_dir` is retained for API compatibility and pipeline context,
+    /// but the invocation's state/artifact/tmp directories are placed under
+    /// a short, platform-aware root (see [`invocation_runtime_root`]) rather
+    /// than nested beneath the run dir. This keeps `HOMEBOY_INVOCATION_*`
+    /// paths within the platform `sockaddr_un` budget so downstream
+    /// workloads can place UNIX sockets under them without bespoke
+    /// path-length defense.
     pub fn acquire(run_dir: &RunDir, requirements: &InvocationRequirements) -> Result<Self> {
+        let _ = run_dir; // retained for API compatibility (see doc comment)
         cleanup_stale_child_records()?;
 
-        let id = format!("inv-{}", uuid::Uuid::new_v4());
-        let root = run_dir.path().join("invocations").join(&id);
-        let state_dir = root.join("state");
-        let artifact_dir = root.join("artifacts");
-        let tmp_dir = root.join("tmp");
+        let uuid = uuid::Uuid::new_v4();
+        let short = short_invocation_id();
+        // Public id keeps the legacy `inv-` prefix so log scrapers and
+        // existing string matchers (rigs, runners, child records) keep
+        // working. The path component does not include the prefix.
+        let id = format!("inv-{}", short);
+        let runtime_root = invocation_runtime_root()?;
+        let invocation_root = runtime_root.join(&short);
+        // Single-char subdirs keep `HOMEBOY_INVOCATION_*_DIR` paths short
+        // enough for the platform `sockaddr_un` budget on macOS where the
+        // default `$TMPDIR` is already ~50 bytes. The basenames are
+        // internal — workloads only ever read them via env var values.
+        let state_dir = invocation_root.join("s");
+        let artifact_dir = invocation_root.join("a");
+        let tmp_dir = invocation_root.join("t");
+
+        // Enforce the sockaddr_un budget before creating anything on disk
+        // so callers fail fast with a clear error instead of much later in
+        // a downstream workload's UDS bind.
+        for dir in [&state_dir, &artifact_dir, &tmp_dir] {
+            enforce_path_budget(dir)?;
+        }
+
         for dir in [&state_dir, &artifact_dir, &tmp_dir] {
             fs::create_dir_all(dir).map_err(|e| {
                 Error::internal_io(
@@ -98,6 +139,7 @@ impl InvocationGuard {
 
             let lease = InvocationLease {
                 invocation_id: id.clone(),
+                invocation_uuid: Some(uuid.to_string()),
                 pid: std::process::id(),
                 started_at: chrono::Utc::now().to_rfc3339(),
                 port_base,
@@ -118,6 +160,7 @@ impl InvocationGuard {
                 port_max,
             },
             lease_id,
+            invocation_root,
         })
     }
 
@@ -147,6 +190,12 @@ impl InvocationGuard {
 
 impl Drop for InvocationGuard {
     fn drop(&mut self) {
+        // Best-effort cleanup of the invocation root directory. Decoupled
+        // from any caller-provided `RunDir` cleanup so concurrent
+        // invocations do not accumulate stale state under the short
+        // platform runtime root.
+        let _ = fs::remove_dir_all(&self.invocation_root);
+
         let Some(id) = &self.lease_id else {
             return;
         };

--- a/src/core/engine/invocation/runtime.rs
+++ b/src/core/engine/invocation/runtime.rs
@@ -1,0 +1,262 @@
+//! Short, platform-aware invocation runtime root.
+//!
+//! Downstream workloads place UNIX domain sockets, FIFOs, and other
+//! path-length-sensitive primitives under `HOMEBOY_INVOCATION_STATE_DIR`.
+//! macOS `sockaddr_un` only accepts socket paths up to 104 bytes (108 on
+//! Linux), so the prefix that Homeboy hands out must stay short enough for
+//! a typical filename to fit underneath without any per-workload defense.
+//!
+//! ## Root selection
+//!
+//! In priority order:
+//! 1. `HOMEBOY_INVOCATION_RUNTIME_DIR` env override (tests, advanced users).
+//! 2. `$TMPDIR/hb` on macOS when set (typically `/var/folders/<short>/T/hb`).
+//! 3. `$XDG_RUNTIME_DIR/hb` on Linux when set.
+//! 4. `/tmp/hb` on Linux when no XDG runtime dir is available.
+//! 5. `~/.cache/homeboy/inv` fallback on every platform.
+//!
+//! Each invocation is one directory directly beneath the chosen root:
+//! `<root>/<short-id>/{state,artifacts,tmp}`. There is no `homeboy-run-<uuid>`
+//! / `invocations/inv-<uuid>` nesting like the legacy layout used.
+//!
+//! ## Path budget
+//!
+//! [`enforce_path_budget`] checks that the longest hand-out path leaves at
+//! least [`SOCKET_HEADROOM_BYTES`] bytes of headroom under the platform
+//! `sockaddr_un` limit, and fails fast with a clear error when an unusually
+//! long `$HOME` or `$TMPDIR` would otherwise hand out a directory that no
+//! UDS-using workload can use.
+
+use crate::error::{Error, Result};
+#[cfg(windows)]
+use crate::paths;
+use std::env;
+use std::path::{Path, PathBuf};
+
+/// Override env var that pins the invocation runtime root to a specific path.
+///
+/// Primarily for tests and unusual host configurations. When set and
+/// non-empty, it bypasses the platform detection ladder entirely.
+pub const HOMEBOY_INVOCATION_RUNTIME_DIR_ENV: &str = "HOMEBOY_INVOCATION_RUNTIME_DIR";
+
+/// Bytes of headroom reserved beneath `sockaddr_un` so workloads can append
+/// a typical socket filename (e.g. `daemon/daemon.sock`) without overflowing.
+pub const SOCKET_HEADROOM_BYTES: usize = 32;
+
+/// Platform `sockaddr_un` `sun_path` capacity in bytes (excluding NUL).
+#[cfg(target_os = "macos")]
+pub const SUN_PATH_CAPACITY: usize = 104;
+#[cfg(all(unix, not(target_os = "macos")))]
+pub const SUN_PATH_CAPACITY: usize = 108;
+#[cfg(not(unix))]
+pub const SUN_PATH_CAPACITY: usize = 108;
+
+/// Resolve the short, platform-aware root that holds invocation directories.
+///
+/// The root is *not* created on this call. Callers that allocate an
+/// invocation directory under it are responsible for `create_dir_all`.
+pub fn invocation_runtime_root() -> Result<PathBuf> {
+    if let Some(override_root) = override_root() {
+        return Ok(override_root);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(tmpdir) = non_empty_env("TMPDIR") {
+            return Ok(PathBuf::from(tmpdir).join("hb"));
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Some(xdg) = non_empty_env("XDG_RUNTIME_DIR") {
+            return Ok(PathBuf::from(xdg).join("hb"));
+        }
+        return Ok(PathBuf::from("/tmp").join("hb"));
+    }
+
+    // Generic fallback: ~/.cache/homeboy/inv (also Windows).
+    cache_fallback_root()
+}
+
+fn override_root() -> Option<PathBuf> {
+    let raw = env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok()?;
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    let raw = env::var(key).ok()?;
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn cache_fallback_root() -> Result<PathBuf> {
+    #[cfg(windows)]
+    {
+        // Reuse the existing homeboy() resolver on Windows; it lands under
+        // %APPDATA%\homeboy which is the closest analog to a per-user cache
+        // root and keeps the implementation simple.
+        return Ok(paths::homeboy()?.join("inv"));
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Some(xdg_cache) = non_empty_env("XDG_CACHE_HOME") {
+            return Ok(PathBuf::from(xdg_cache).join("homeboy").join("inv"));
+        }
+        let home = env::var("HOME").map_err(|_| {
+            Error::internal_unexpected(
+                "HOME environment variable not set on Unix-like system".to_string(),
+            )
+        })?;
+        Ok(PathBuf::from(home)
+            .join(".cache")
+            .join("homeboy")
+            .join("inv"))
+    }
+}
+
+/// Verify that handing out `path` leaves room for a downstream socket
+/// filename within the `sockaddr_un` budget.
+///
+/// Fails fast with a clear error message when the platform budget cannot
+/// accommodate at least [`SOCKET_HEADROOM_BYTES`] beyond `path`'s length.
+pub fn enforce_path_budget(path: &Path) -> Result<()> {
+    let path_str = path.to_string_lossy();
+    let path_len = path_str.len();
+    // +1 reserves the path-separator byte before the workload's filename.
+    let needed = path_len
+        .saturating_add(1)
+        .saturating_add(SOCKET_HEADROOM_BYTES);
+    if needed > SUN_PATH_CAPACITY {
+        return Err(Error::internal_unexpected(format!(
+            "Homeboy invocation runtime path is too long for the platform sockaddr_un limit: \
+             path is {path_len} bytes, need {needed} bytes (path + 1 separator + \
+             {SOCKET_HEADROOM_BYTES} bytes socket filename headroom), but sun_path capacity is \
+             {SUN_PATH_CAPACITY} bytes. Set {HOMEBOY_INVOCATION_RUNTIME_DIR_ENV} to a shorter \
+             root (path: {path_str})."
+        )));
+    }
+    Ok(())
+}
+
+/// Generate a short opaque path component (10 lowercase hex chars).
+///
+/// 40 bits of entropy ≈ 1.1e12 unique values is far beyond the number of
+/// concurrent invocations any single host will run. The lease index lock in
+/// `InvocationGuard::acquire` guarantees uniqueness against the live set.
+pub fn short_invocation_id() -> String {
+    let uuid = uuid::Uuid::new_v4().simple().to_string();
+    uuid[..10].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn override_env_takes_priority() {
+        let _guard = env_lock().lock().expect("env lock");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prior = env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+        env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, dir.path());
+
+        let root = invocation_runtime_root().expect("root resolves");
+        assert_eq!(root, dir.path());
+
+        match prior {
+            Some(value) => env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, value),
+            None => env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+        }
+    }
+
+    #[test]
+    fn override_env_blank_falls_back_to_platform() {
+        let _guard = env_lock().lock().expect("env lock");
+        let prior = env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+        env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, "   ");
+
+        let root = invocation_runtime_root().expect("root resolves");
+        assert!(root.ends_with("hb") || root.ends_with("inv"));
+
+        match prior {
+            Some(value) => env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, value),
+            None => env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+        }
+    }
+
+    #[test]
+    fn short_id_is_ten_lowercase_hex_chars() {
+        let id = short_invocation_id();
+        assert_eq!(id.len(), 10, "id={id}");
+        assert!(
+            id.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "id should be lowercase hex: {id}"
+        );
+    }
+
+    #[test]
+    fn short_ids_are_unique_across_calls() {
+        // 40 bits of entropy: collisions in 1000 calls are vanishingly rare.
+        let mut ids = std::collections::HashSet::new();
+        for _ in 0..1000 {
+            assert!(ids.insert(short_invocation_id()));
+        }
+    }
+
+    #[test]
+    fn budget_accepts_short_path() {
+        let path = PathBuf::from("/tmp/hb/abc1234567/state");
+        enforce_path_budget(&path).expect("short path fits");
+    }
+
+    #[test]
+    fn budget_reserves_socket_headroom() {
+        // Build a path that leaves <32 bytes under the platform limit.
+        let mut s = String::from("/");
+        // Aim for a path length that leaves headroom < SOCKET_HEADROOM_BYTES.
+        let target_len = SUN_PATH_CAPACITY - SOCKET_HEADROOM_BYTES;
+        while s.len() < target_len {
+            s.push('a');
+        }
+        let path = PathBuf::from(s);
+        let err = enforce_path_budget(&path).expect_err("should reject overlong path");
+        let message = err.to_string();
+        assert!(
+            message.contains("sockaddr_un"),
+            "error should mention sockaddr_un: {message}"
+        );
+        assert!(
+            message.contains(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+            "error should suggest the override env: {message}"
+        );
+    }
+
+    #[test]
+    fn budget_headroom_is_at_least_thirty_two_bytes() {
+        // For a maximum-length accepted path, the remaining bytes after
+        // appending '/' + a 32-byte socket filename must not overflow.
+        let mut s = String::from("/");
+        let max_accepted = SUN_PATH_CAPACITY - SOCKET_HEADROOM_BYTES - 1;
+        while s.len() < max_accepted {
+            s.push('b');
+        }
+        let path = PathBuf::from(&s);
+        enforce_path_budget(&path).expect("max-accepted path fits");
+
+        // Verify the headroom: appending a 32-byte filename stays under cap.
+        let appended_len = s.len() + 1 + SOCKET_HEADROOM_BYTES;
+        assert!(
+            appended_len <= SUN_PATH_CAPACITY,
+            "appended path {appended_len} should fit in {SUN_PATH_CAPACITY}"
+        );
+    }
+}

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -5,7 +5,13 @@ use tempfile::TempDir;
 pub(crate) struct HomeGuard {
     prior: Option<String>,
     prior_xdg_data_home: Option<String>,
+    prior_invocation_runtime: Option<String>,
     dir: TempDir,
+    /// Held alongside `dir` so the short invocation runtime tempdir is
+    /// dropped only after the test completes. Distinct from `dir` so the
+    /// invocation root can live on a short path (e.g. `/tmp/hb-XXXX`)
+    /// regardless of where `$TMPDIR` lands.
+    _inv_dir: Option<TempDir>,
     _guard: MutexGuard<'static, ()>,
 }
 
@@ -30,16 +36,49 @@ impl HomeGuard {
         let guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("HOME").ok();
         let prior_xdg_data_home = std::env::var("XDG_DATA_HOME").ok();
+        let prior_invocation_runtime =
+            std::env::var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         let dir = TempDir::new().expect("home tempdir");
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
+        // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
+        // and from the home tempdir (which itself can already live on a long
+        // path on macOS, e.g. `/var/folders/<14>/T/.tmpXXXXXX/...`). Using
+        // `/tmp` directly keeps tests within the platform `sockaddr_un`
+        // budget regardless of host configuration.
+        let inv_dir = short_invocation_tempdir();
+        std::env::set_var(
+            crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+            inv_dir.path(),
+        );
         Self {
             prior,
             prior_xdg_data_home,
+            prior_invocation_runtime,
             dir,
+            _inv_dir: Some(inv_dir),
             _guard: guard,
         }
     }
+}
+
+/// Return a short-path tempdir suitable for the invocation runtime root.
+///
+/// On Unix-like systems we anchor to `/tmp` so the path stays well under
+/// `sockaddr_un` even on macOS where `$TMPDIR` typically lives at
+/// `/var/folders/<14>/T/.tmpXXXXXX/`. Falls back to the default tempdir
+/// otherwise (Windows / odd hosts).
+fn short_invocation_tempdir() -> TempDir {
+    #[cfg(unix)]
+    {
+        if std::path::Path::new("/tmp").is_dir() {
+            return tempfile::Builder::new()
+                .prefix("hb-test-")
+                .tempdir_in("/tmp")
+                .expect("invocation runtime tempdir under /tmp");
+        }
+    }
+    TempDir::new().expect("invocation runtime tempdir")
 }
 
 impl Drop for HomeGuard {
@@ -51,6 +90,15 @@ impl Drop for HomeGuard {
         match &self.prior_xdg_data_home {
             Some(value) => std::env::set_var("XDG_DATA_HOME", value),
             None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+        match &self.prior_invocation_runtime {
+            Some(value) => std::env::set_var(
+                crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                value,
+            ),
+            None => {
+                std::env::remove_var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV)
+            }
         }
     }
 }

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -194,3 +194,150 @@ fn assert_child_exits(child: &mut std::process::Child) {
 fn pid_is_alive(pid: libc::pid_t) -> bool {
     unsafe { libc::kill(pid, 0) == 0 }
 }
+
+// --- issue #2311: short invocation runtime path & sockaddr_un budget -------
+
+#[test]
+fn invocation_state_dir_lives_under_runtime_root_not_run_dir() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+            .expect("invocation guard");
+        let env = guard.env_vars();
+        let state_dir = value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR");
+
+        let runtime_root = invocation_runtime_root().expect("runtime root");
+        assert!(
+            Path::new(&state_dir).starts_with(&runtime_root),
+            "state dir {} should live under runtime root {}",
+            state_dir,
+            runtime_root.display()
+        );
+        assert!(
+            !Path::new(&state_dir).starts_with(run_dir.path()),
+            "state dir {} must not be nested under run_dir {}",
+            state_dir,
+            run_dir.path().display()
+        );
+
+        run_dir.cleanup();
+    });
+}
+
+#[test]
+fn invocation_state_dir_fits_under_sockaddr_un_budget() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+            .expect("invocation guard");
+        let env = guard.env_vars();
+
+        for key in [
+            "HOMEBOY_INVOCATION_STATE_DIR",
+            "HOMEBOY_INVOCATION_ARTIFACT_DIR",
+            "HOMEBOY_INVOCATION_TMP_DIR",
+        ] {
+            let dir = value_for(&env, key);
+            // budget = path bytes + 1 separator + 32-byte filename headroom
+            let needed = dir.len() + 1 + SOCKET_HEADROOM_BYTES;
+            assert!(
+                needed <= SUN_PATH_CAPACITY,
+                "{key} = {dir} needs {needed} bytes, exceeds sockaddr_un capacity \
+                 {SUN_PATH_CAPACITY}"
+            );
+            // Headroom must be at least 32 bytes for downstream socket names.
+            let headroom = SUN_PATH_CAPACITY - dir.len() - 1;
+            assert!(
+                headroom >= SOCKET_HEADROOM_BYTES,
+                "{key} = {dir} only leaves {headroom} bytes of headroom, \
+                 less than required {SOCKET_HEADROOM_BYTES}"
+            );
+        }
+
+        run_dir.cleanup();
+    });
+}
+
+#[test]
+fn invocation_dirs_are_unique_across_concurrent_invocations() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let mut paths = std::collections::HashSet::new();
+        let mut guards = Vec::new();
+
+        for _ in 0..16 {
+            let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+                .expect("invocation guard");
+            let dir = value_for(&guard.env_vars(), "HOMEBOY_INVOCATION_STATE_DIR");
+            assert!(paths.insert(dir.clone()), "duplicate state dir: {dir}");
+            guards.push(guard);
+        }
+
+        run_dir.cleanup();
+    });
+}
+
+#[test]
+fn invocation_id_path_component_is_short() {
+    // The short id used in path components should be ~10 chars, far below
+    // the 36-char UUID we used to embed.
+    let id = short_invocation_id();
+    assert!(id.len() <= 12, "short id should be <= 12 chars: {id}");
+    assert!(id.len() >= 8, "short id should be >= 8 chars: {id}");
+}
+
+#[test]
+fn invocation_runtime_root_honors_override_env() {
+    // This test sets/restores HOMEBOY_INVOCATION_RUNTIME_DIR explicitly to
+    // verify the env-driven fallback selection.
+    let prior = std::env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, dir.path());
+
+    let root = invocation_runtime_root().expect("runtime root");
+    assert_eq!(root, dir.path());
+
+    match prior {
+        Some(value) => std::env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, value),
+        None => std::env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+    }
+}
+
+#[test]
+fn enforce_path_budget_rejects_overlong_paths() {
+    let mut s = String::from("/");
+    while s.len() < SUN_PATH_CAPACITY {
+        s.push('z');
+    }
+    let path = std::path::PathBuf::from(s);
+    let err = enforce_path_budget(&path).expect_err("overlong path should fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("sockaddr_un"),
+        "error should mention sockaddr_un: {message}"
+    );
+    assert!(
+        message.contains(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+        "error should suggest the override env: {message}"
+    );
+}
+
+#[test]
+fn invocation_drop_cleans_up_root_directory() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let state_dir = {
+            let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+                .expect("invocation guard");
+            let env = guard.env_vars();
+            std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR"))
+        };
+        assert!(
+            !state_dir.exists(),
+            "invocation state dir should be removed on Drop: {}",
+            state_dir.display()
+        );
+
+        run_dir.cleanup();
+    });
+}


### PR DESCRIPTION
## Summary

Closes #2311. The invocation runtime previously handed out

```
~/.config/homeboy/runtime/tmp/homeboy-run-<uuid>-<ts>/invocations/inv-<uuid>/state/<workload>/...
```

which already exceeded the macOS `sockaddr_un` 104-byte limit before any
workload appended a filename. Studio's daemon (and any other UDS-using
workload) hit `EINVAL` when binding `daemon/daemon.sock` under
`HOMEBOY_INVOCATION_STATE_DIR`. Pushing path-length defense into every
workload that might bind a socket is the wrong layer — the contract has
to live in core.

## What changed

- New `invocation::runtime` module with platform-aware root selection:
  - macOS: `$TMPDIR/hb/<short-id>` (typically `/var/folders/<short>/T/hb/...`)
  - Linux: `$XDG_RUNTIME_DIR/hb/<short-id>` when set, else `/tmp/hb/<short-id>`
  - Fallback: `~/.cache/homeboy/inv/<short-id>` (with `XDG_CACHE_HOME` honored)
  - Override: `HOMEBOY_INVOCATION_RUNTIME_DIR` for tests / unusual hosts
- One invocation directory per process under that root. The legacy
  `homeboy-run-<uuid>-<ts>/invocations/inv-<uuid>` nesting is gone — the
  invocation is decoupled from `RunDir`'s path entirely (the parameter is
  retained for API compatibility / pipeline context).
- Path components use a 10-char short id derived from `uuid::Uuid::new_v4()`.
  The full UUID is retained inside the on-disk invocation lease for
  traceability.
- Subdirectory basenames shortened to single chars (`s` / `a` / `t`) so the
  contract holds even on macOS where the default `$TMPDIR` is already ~50
  bytes. Workloads only see these dirs through the env vars, so the
  basename change is internal.
- New `enforce_path_budget()` runs before any directory creation and fails
  fast with a clear error pointing at `HOMEBOY_INVOCATION_RUNTIME_DIR` when
  the platform `sun_path` capacity (104 bytes macOS, 108 bytes Linux) cannot
  accommodate the path plus a 32-byte downstream filename.
- `InvocationGuard::drop` now removes the invocation root, decoupled from
  any caller-provided `RunDir::cleanup`. Lease file cleanup is unchanged.
- Test support pins the invocation runtime to a short `/tmp/hb-test-XXXX`
  tempdir so `with_isolated_home` tests stay within budget regardless of
  `$TMPDIR` and don't leak state into shared host roots.

## Compatibility

- `HOMEBOY_INVOCATION_ID` still returns a unique `inv-<short>` identifier.
- `HOMEBOY_INVOCATION_STATE_DIR` / `ARTIFACT_DIR` / `TMP_DIR` are exposed
  as before; only the path layout changed.
- `HOMEBOY_INVOCATION_PORT_BASE` / `_MAX` semantics are unchanged.
- All existing `InvocationGuard::acquire(&run_dir, ...)` call sites compile
  and behave identically to callers — only the on-disk layout under the
  hood is different.

## Tests

- `cargo check`
- `cargo fmt`
- `cargo clippy --lib` (no new warnings on changed files; pre-existing
  warnings unrelated to this PR remain)
- `cargo test --lib` — 2693 passed, 1 ignored, 0 failed
- Targeted: `cargo test --lib core::engine::invocation` — 24 passed
- Targeted: `cargo test --lib core::engine` — 214 passed
- Targeted: `cargo test --lib core::extension::runner` — 12 passed
- Targeted: `cargo test --lib core::rig::workloads` — 9 passed
- Targeted: `cargo test --lib core::extension::trace::run` — 16 passed
- Integration: `cargo test --test core_agnostic_test --test
  architecture_core_agnostic_test --test command_surface_test` — all green

New test coverage in `tests/core/engine/invocation_test.rs`:

- `invocation_state_dir_lives_under_runtime_root_not_run_dir`
- `invocation_state_dir_fits_under_sockaddr_un_budget` (verifies ≥32-byte
  headroom on every exposed dir)
- `invocation_dirs_are_unique_across_concurrent_invocations` (16 parallel
  guards, all distinct paths)
- `invocation_id_path_component_is_short` (8-12 char id contract)
- `invocation_runtime_root_honors_override_env`
- `enforce_path_budget_rejects_overlong_paths`
- `invocation_drop_cleans_up_root_directory`

Plus six unit tests in `src/core/engine/invocation/runtime.rs` covering
the platform fallback ladder, override env priority, short-id encoding,
and budget edge cases.

## Docs

`docs/commands/bench.md` — added a "Runtime path contract" subsection
under "Invocation Isolation" documenting platform roots, the short-id
contract, the `HOMEBOY_INVOCATION_RUNTIME_DIR` override, and the
≥32-byte `sockaddr_un` headroom guarantee that downstream workloads can
rely on.

## Refs

- #2296 invocation isolation primitives
- #2307 invocation child process ownership cleanup
- chubes4/homeboy-rigs#97 rig adoption that surfaced this

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime root module, the `enforce_path_budget`
  contract, the test plan, and the doc update under Chris's specification
  in #2311. Chris reviewed the design choices (single-char subdir
  basenames, `/tmp` test anchor for macOS, retaining `run_dir` parameter
  for API compatibility) and ran the targeted + broader test suites.