### PR TITLE
fix(invocation): meet sockaddr_un budget with /tmp anchor and STATE_DIR leaf

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -187,29 +187,54 @@ variables, independent of runner implementation:
 
 Invocation directories are placed under a short, platform-aware root so any
 workload can put a UNIX domain socket or other path-length-sensitive primitive
-under `HOMEBOY_INVOCATION_STATE_DIR` without bespoke defense:
+under `HOMEBOY_INVOCATION_STATE_DIR` without bespoke defense.
 
-- macOS: `$TMPDIR/hb/<short-id>/{state,artifacts,tmp}` (typically
-  `/var/folders/<short>/T/hb/...`).
-- Linux: `$XDG_RUNTIME_DIR/hb/<short-id>/...` when set, else
-  `/tmp/hb/<short-id>/...`.
-- Fallback: `~/.cache/homeboy/inv/<short-id>/...`.
-- Override: set `HOMEBOY_INVOCATION_RUNTIME_DIR` to pin the root explicitly
-  (tests and unusual host configurations).
+**Layout.** The invocation owns three sibling directories under the runtime
+root:
+
+- `<root>/<short-id>`     → `HOMEBOY_INVOCATION_STATE_DIR` (the leaf the
+  workload owns; downstream sockets bind directly here).
+- `<root>/<short-id>.a`   → `HOMEBOY_INVOCATION_ARTIFACT_DIR`
+- `<root>/<short-id>.t`   → `HOMEBOY_INVOCATION_TMP_DIR`
+
+There is no `s/a/t` subdir layer underneath the short id. The invocation is
+1:1 with a single workload run, so an extra workload-id segment under
+STATE_DIR would burn `sockaddr_un` budget for no isolation gain. Workloads
+that need internal subdirs under STATE_DIR can still create them, but they
+own the path-length budget at that point.
+
+**Root selection.** In priority order:
+
+- `HOMEBOY_INVOCATION_RUNTIME_DIR` env override (tests and unusual host
+  configurations).
+- `/tmp/hb` on every Unix host when `/tmp` is a writable directory. macOS
+  apps that respect `$TMPDIR` get per-user isolation under
+  `/var/folders/<14>/T/...` (~50 bytes), which leaves no realistic
+  `sockaddr_un` budget. Anchoring to `/tmp` saves ~35 bytes of headroom and
+  is writable on every standard macOS / Linux configuration.
+- Linux fallback: `$XDG_RUNTIME_DIR/hb` when set and `/tmp` is unusable.
+- macOS fallback: `$TMPDIR/hb` when `/tmp` is unusable.
+- Generic fallback: `~/.cache/homeboy/inv` (or `$XDG_CACHE_HOME/homeboy/inv`).
 
 Path components use a short opaque id (~10 hex chars) instead of a full
 UUID v4. The full UUID is retained inside the on-disk invocation lease for
 traceability, but is never embedded in path components.
 
-**Path budget contract.** Homeboy guarantees that `HOMEBOY_INVOCATION_STATE_DIR`,
-`HOMEBOY_INVOCATION_ARTIFACT_DIR`, and `HOMEBOY_INVOCATION_TMP_DIR` leave at
-least 32 bytes of headroom under the platform `sockaddr_un` `sun_path`
-capacity (104 bytes on macOS, 108 bytes on Linux). Workloads can append a
-typical socket filename like `daemon/daemon.sock` directly under any of these
-directories and bind to it without `EINVAL`. If `$HOME` or `$TMPDIR` are
-unusually long, `homeboy` fails fast at invocation acquisition with a clear
-error pointing at `HOMEBOY_INVOCATION_RUNTIME_DIR` instead of letting a
-downstream workload hit the limit at bind time.
+**Path budget contract.** Homeboy guarantees that
+`HOMEBOY_INVOCATION_STATE_DIR`, `HOMEBOY_INVOCATION_ARTIFACT_DIR`, and
+`HOMEBOY_INVOCATION_TMP_DIR` leave at least:
+
+- **48 bytes** of headroom under the macOS `sockaddr_un` `sun_path`
+  capacity (104 bytes), and
+- **32 bytes** of headroom under the Linux capacity (108 bytes).
+
+Workloads can append a realistic workload-relative socket name like
+`<workload-id>/daemon/daemon.sock` (≈40 bytes) directly under STATE_DIR and
+bind to it without `EINVAL`. If `$HOME` or the configured root are
+unusually long, Homeboy fails fast at invocation acquisition with a clear
+error naming `sockaddr_un`, the platform-specific limit, the available
+headroom, and the `HOMEBOY_INVOCATION_RUNTIME_DIR` override — instead of
+letting a downstream workload hit the limit at bind time.
 
 Rig workload object entries can request optional shared-machine primitives:
 

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -47,10 +47,11 @@ pub struct InvocationEnv {
 pub struct InvocationGuard {
     env: InvocationEnv,
     lease_id: Option<String>,
-    /// Root invocation directory under [`invocation_runtime_root`]. Removed
-    /// on `Drop` so concurrent invocations do not accumulate stale state on
-    /// disk. Decoupled from any caller-provided `RunDir` cleanup.
-    invocation_root: PathBuf,
+    /// Sibling invocation directories (state, artifact, tmp) under
+    /// [`invocation_runtime_root`]. All three are removed on `Drop` so
+    /// concurrent invocations do not accumulate stale state on disk.
+    /// Decoupled from any caller-provided `RunDir` cleanup.
+    cleanup_paths: [PathBuf; 3],
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,18 +90,23 @@ impl InvocationGuard {
         // working. The path component does not include the prefix.
         let id = format!("inv-{}", short);
         let runtime_root = invocation_runtime_root()?;
-        let invocation_root = runtime_root.join(&short);
-        // Single-char subdirs keep `HOMEBOY_INVOCATION_*_DIR` paths short
-        // enough for the platform `sockaddr_un` budget on macOS where the
-        // default `$TMPDIR` is already ~50 bytes. The basenames are
-        // internal — workloads only ever read them via env var values.
-        let state_dir = invocation_root.join("s");
-        let artifact_dir = invocation_root.join("a");
-        let tmp_dir = invocation_root.join("t");
+        // STATE_DIR is the leaf the workload owns: the invocation root
+        // itself. ARTIFACT_DIR and TMP_DIR are siblings with `.a` / `.t`
+        // suffixes so they cannot collide with workload-created subdirs
+        // under STATE_DIR. Removing the `s/a/t` subdir layer used in the
+        // initial PR #2312 reclaims 2 bytes of `sockaddr_un` budget per
+        // invocation and — more importantly — gives downstream workloads
+        // exclusive ownership of the leaf they bind sockets under, so
+        // no extra workload-id segment is needed under STATE_DIR.
+        let state_dir = runtime_root.join(&short);
+        let artifact_dir = runtime_root.join(format!("{short}.a"));
+        let tmp_dir = runtime_root.join(format!("{short}.t"));
 
         // Enforce the sockaddr_un budget before creating anything on disk
         // so callers fail fast with a clear error instead of much later in
-        // a downstream workload's UDS bind.
+        // a downstream workload's UDS bind. STATE_DIR is the leaf
+        // workloads will append socket names to, so its budget is the one
+        // that matters most; check all three for completeness.
         for dir in [&state_dir, &artifact_dir, &tmp_dir] {
             enforce_path_budget(dir)?;
         }
@@ -150,6 +156,7 @@ impl InvocationGuard {
             lease_id = Some(id.clone());
         }
 
+        let cleanup_paths = [state_dir.clone(), artifact_dir.clone(), tmp_dir.clone()];
         Ok(Self {
             env: InvocationEnv {
                 id,
@@ -160,7 +167,7 @@ impl InvocationGuard {
                 port_max,
             },
             lease_id,
-            invocation_root,
+            cleanup_paths,
         })
     }
 
@@ -190,11 +197,13 @@ impl InvocationGuard {
 
 impl Drop for InvocationGuard {
     fn drop(&mut self) {
-        // Best-effort cleanup of the invocation root directory. Decoupled
-        // from any caller-provided `RunDir` cleanup so concurrent
+        // Best-effort cleanup of all three sibling invocation directories.
+        // Decoupled from any caller-provided `RunDir` cleanup so concurrent
         // invocations do not accumulate stale state under the short
         // platform runtime root.
-        let _ = fs::remove_dir_all(&self.invocation_root);
+        for path in &self.cleanup_paths {
+            let _ = fs::remove_dir_all(path);
+        }
 
         let Some(id) = &self.lease_id else {
             return;

--- a/src/core/engine/invocation/runtime.rs
+++ b/src/core/engine/invocation/runtime.rs
@@ -4,20 +4,36 @@
 //! path-length-sensitive primitives under `HOMEBOY_INVOCATION_STATE_DIR`.
 //! macOS `sockaddr_un` only accepts socket paths up to 104 bytes (108 on
 //! Linux), so the prefix that Homeboy hands out must stay short enough for
-//! a typical filename to fit underneath without any per-workload defense.
+//! a realistic workload-relative socket name to fit underneath without any
+//! per-workload defense.
 //!
 //! ## Root selection
 //!
 //! In priority order:
 //! 1. `HOMEBOY_INVOCATION_RUNTIME_DIR` env override (tests, advanced users).
-//! 2. `$TMPDIR/hb` on macOS when set (typically `/var/folders/<short>/T/hb`).
-//! 3. `$XDG_RUNTIME_DIR/hb` on Linux when set.
-//! 4. `/tmp/hb` on Linux when no XDG runtime dir is available.
+//! 2. `/tmp/hb` on macOS / Linux when `/tmp` is a writable directory. macOS
+//!    apps that respect `$TMPDIR` get per-user isolation under
+//!    `/var/folders/<14>/T/...` which is already ~50 bytes — anchoring the
+//!    runtime root to `/tmp` saves ~35 bytes of `sockaddr_un` budget per
+//!    invocation, the difference between "fits" and "EINVAL on bind".
+//! 3. `$XDG_RUNTIME_DIR/hb` on Linux when set and `/tmp` is not usable.
+//! 4. `$TMPDIR/hb` on macOS as a last resort before falling back to the
+//!    user cache directory. Only reached when `/tmp` is missing, which is
+//!    not a real macOS configuration.
 //! 5. `~/.cache/homeboy/inv` fallback on every platform.
 //!
-//! Each invocation is one directory directly beneath the chosen root:
-//! `<root>/<short-id>/{state,artifacts,tmp}`. There is no `homeboy-run-<uuid>`
-//! / `invocations/inv-<uuid>` nesting like the legacy layout used.
+//! Each invocation owns one short id; the directories are siblings of that
+//! id under the chosen root:
+//!
+//! - `<root>/<short-id>`     → `HOMEBOY_INVOCATION_STATE_DIR` (the leaf the
+//!   workload owns; downstream sockets bind directly here).
+//! - `<root>/<short-id>.a`   → `HOMEBOY_INVOCATION_ARTIFACT_DIR`
+//! - `<root>/<short-id>.t`   → `HOMEBOY_INVOCATION_TMP_DIR`
+//!
+//! There is no `s/a/t` subdir layer — that would burn `sockaddr_un` budget
+//! for no isolation gain since the invocation is already 1:1 with a single
+//! workload run. Workloads that need internal subdirs under STATE_DIR can
+//! still create them, but they own the path-length budget at that point.
 //!
 //! ## Path budget
 //!
@@ -25,7 +41,10 @@
 //! least [`SOCKET_HEADROOM_BYTES`] bytes of headroom under the platform
 //! `sockaddr_un` limit, and fails fast with a clear error when an unusually
 //! long `$HOME` or `$TMPDIR` would otherwise hand out a directory that no
-//! UDS-using workload can use.
+//! UDS-using workload can use. macOS reserves more headroom (48 bytes) than
+//! Linux (32 bytes) because the macOS limit is 4 bytes shorter and
+//! workloads commonly nest a workload-id segment plus a socket filename
+//! (`<workload-id>/daemon/daemon.sock` ≈ 40 bytes) underneath.
 
 use crate::error::{Error, Result};
 #[cfg(windows)]
@@ -40,7 +59,18 @@ use std::path::{Path, PathBuf};
 pub const HOMEBOY_INVOCATION_RUNTIME_DIR_ENV: &str = "HOMEBOY_INVOCATION_RUNTIME_DIR";
 
 /// Bytes of headroom reserved beneath `sockaddr_un` so workloads can append
-/// a typical socket filename (e.g. `daemon/daemon.sock`) without overflowing.
+/// a realistic workload-relative socket name (e.g.
+/// `<workload-id>/daemon/daemon.sock`, ≈40 bytes) without overflowing.
+///
+/// macOS gets a larger reserve (48 bytes) than Linux (32 bytes) because the
+/// macOS `sockaddr_un` limit is 4 bytes shorter (104 vs 108) *and*
+/// workloads typically nest a workload-id segment under STATE_DIR. The
+/// previous 32-byte reserve was insufficient under realistic Apple
+/// `$TMPDIR` configurations and caused Studio's daemon to hit `EINVAL` on
+/// bind despite the contract.
+#[cfg(target_os = "macos")]
+pub const SOCKET_HEADROOM_BYTES: usize = 48;
+#[cfg(not(target_os = "macos"))]
 pub const SOCKET_HEADROOM_BYTES: usize = 32;
 
 /// Platform `sockaddr_un` `sun_path` capacity in bytes (excluding NUL).
@@ -60,19 +90,32 @@ pub fn invocation_runtime_root() -> Result<PathBuf> {
         return Ok(override_root);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     {
-        if let Some(tmpdir) = non_empty_env("TMPDIR") {
-            return Ok(PathBuf::from(tmpdir).join("hb"));
+        // Prefer `/tmp/hb` on every Unix host. On macOS the per-user
+        // `$TMPDIR` (`/var/folders/<14>/T/...`) is already ~50 bytes long,
+        // which leaves no realistic `sockaddr_un` budget after appending a
+        // short id and a typical workload-relative socket name. `/tmp` is
+        // ~5 bytes, gives us ~35 extra bytes of headroom, and is writable
+        // on every standard macOS / Linux configuration.
+        if Path::new("/tmp").is_dir() {
+            return Ok(PathBuf::from("/tmp/hb"));
         }
-    }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        if let Some(xdg) = non_empty_env("XDG_RUNTIME_DIR") {
-            return Ok(PathBuf::from(xdg).join("hb"));
+        // Fallbacks for unusual hosts where `/tmp` is missing or not a
+        // directory (containers with stripped layouts, etc.).
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(xdg) = non_empty_env("XDG_RUNTIME_DIR") {
+                return Ok(PathBuf::from(xdg).join("hb"));
+            }
         }
-        return Ok(PathBuf::from("/tmp").join("hb"));
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(tmpdir) = non_empty_env("TMPDIR") {
+                return Ok(PathBuf::from(tmpdir).join("hb"));
+            }
+        }
     }
 
     // Generic fallback: ~/.cache/homeboy/inv (also Windows).
@@ -85,6 +128,7 @@ fn override_root() -> Option<PathBuf> {
     (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
 }
 
+#[cfg_attr(windows, allow(dead_code))]
 fn non_empty_env(key: &str) -> Option<String> {
     let raw = env::var(key).ok()?;
     let trimmed = raw.trim();
@@ -117,11 +161,13 @@ fn cache_fallback_root() -> Result<PathBuf> {
     }
 }
 
-/// Verify that handing out `path` leaves room for a downstream socket
-/// filename within the `sockaddr_un` budget.
+/// Verify that handing out `path` leaves room for a realistic
+/// workload-relative socket name within the `sockaddr_un` budget.
 ///
-/// Fails fast with a clear error message when the platform budget cannot
-/// accommodate at least [`SOCKET_HEADROOM_BYTES`] beyond `path`'s length.
+/// Fails fast with a clear error message that names `sockaddr_un`, the
+/// platform-specific limit, the actual headroom available, and the override
+/// env var when the platform budget cannot accommodate at least
+/// [`SOCKET_HEADROOM_BYTES`] beyond `path`'s length.
 pub fn enforce_path_budget(path: &Path) -> Result<()> {
     let path_str = path.to_string_lossy();
     let path_len = path_str.len();
@@ -130,12 +176,13 @@ pub fn enforce_path_budget(path: &Path) -> Result<()> {
         .saturating_add(1)
         .saturating_add(SOCKET_HEADROOM_BYTES);
     if needed > SUN_PATH_CAPACITY {
+        let headroom = SUN_PATH_CAPACITY.saturating_sub(path_len).saturating_sub(1);
         return Err(Error::internal_unexpected(format!(
-            "Homeboy invocation runtime path is too long for the platform sockaddr_un limit: \
-             path is {path_len} bytes, need {needed} bytes (path + 1 separator + \
-             {SOCKET_HEADROOM_BYTES} bytes socket filename headroom), but sun_path capacity is \
-             {SUN_PATH_CAPACITY} bytes. Set {HOMEBOY_INVOCATION_RUNTIME_DIR_ENV} to a shorter \
-             root (path: {path_str})."
+            "Homeboy invocation runtime path exceeds the platform sockaddr_un budget: \
+             path is {path_len} bytes, leaving {headroom} bytes of headroom for a downstream \
+             socket name, but Homeboy guarantees at least {SOCKET_HEADROOM_BYTES} bytes of \
+             headroom under the {SUN_PATH_CAPACITY}-byte sun_path capacity. Set \
+             {HOMEBOY_INVOCATION_RUNTIME_DIR_ENV} to a shorter root (path: {path_str})."
         )));
     }
     Ok(())
@@ -241,9 +288,10 @@ mod tests {
     }
 
     #[test]
-    fn budget_headroom_is_at_least_thirty_two_bytes() {
+    fn budget_headroom_meets_platform_minimum() {
         // For a maximum-length accepted path, the remaining bytes after
-        // appending '/' + a 32-byte socket filename must not overflow.
+        // appending '/' + a platform-headroom socket filename must not
+        // overflow the platform sun_path capacity.
         let mut s = String::from("/");
         let max_accepted = SUN_PATH_CAPACITY - SOCKET_HEADROOM_BYTES - 1;
         while s.len() < max_accepted {
@@ -252,11 +300,30 @@ mod tests {
         let path = PathBuf::from(&s);
         enforce_path_budget(&path).expect("max-accepted path fits");
 
-        // Verify the headroom: appending a 32-byte filename stays under cap.
+        // Verify the headroom: appending a SOCKET_HEADROOM_BYTES-sized
+        // filename stays under cap.
         let appended_len = s.len() + 1 + SOCKET_HEADROOM_BYTES;
         assert!(
             appended_len <= SUN_PATH_CAPACITY,
             "appended path {appended_len} should fit in {SUN_PATH_CAPACITY}"
+        );
+    }
+
+    #[test]
+    fn macos_headroom_is_at_least_forty_eight_bytes() {
+        // The macOS sockaddr_un limit is 4 bytes shorter than Linux and
+        // workloads commonly nest a workload-id/daemon/daemon.sock segment
+        // (~40 bytes) under STATE_DIR. The contract guarantees ≥48 bytes
+        // of headroom on macOS so realistic workload paths always fit.
+        #[cfg(target_os = "macos")]
+        assert!(
+            SOCKET_HEADROOM_BYTES >= 48,
+            "macOS headroom must be at least 48 bytes; got {SOCKET_HEADROOM_BYTES}"
+        );
+        #[cfg(not(target_os = "macos"))]
+        assert!(
+            SOCKET_HEADROOM_BYTES >= 32,
+            "non-macOS headroom must be at least 32 bytes; got {SOCKET_HEADROOM_BYTES}"
         );
     }
 }

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::engine::run_dir::RunDir;
-use crate::test_support::with_isolated_home;
+use crate::test_support::{home_env_guard, with_isolated_home};
 
 #[test]
 fn test_env_vars() {
@@ -290,6 +290,7 @@ fn invocation_id_path_component_is_short() {
 fn invocation_runtime_root_honors_override_env() {
     // This test sets/restores HOMEBOY_INVOCATION_RUNTIME_DIR explicitly to
     // verify the env-driven fallback selection.
+    let _guard = home_env_guard();
     let prior = std::env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
     let dir = tempfile::tempdir().expect("tempdir");
     std::env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, dir.path());
@@ -326,18 +327,149 @@ fn enforce_path_budget_rejects_overlong_paths() {
 fn invocation_drop_cleans_up_root_directory() {
     with_isolated_home(|_| {
         let run_dir = RunDir::create().expect("run dir");
-        let state_dir = {
+        let (state_dir, artifact_dir, tmp_dir) = {
             let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
                 .expect("invocation guard");
             let env = guard.env_vars();
-            std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR"))
+            (
+                std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR")),
+                std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_ARTIFACT_DIR")),
+                std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR")),
+            )
         };
-        assert!(
-            !state_dir.exists(),
-            "invocation state dir should be removed on Drop: {}",
-            state_dir.display()
+        for path in [&state_dir, &artifact_dir, &tmp_dir] {
+            assert!(
+                !path.exists(),
+                "invocation dir should be removed on Drop: {}",
+                path.display()
+            );
+        }
+
+        run_dir.cleanup();
+    });
+}
+
+// --- followup: STATE_DIR is the leaf the workload owns ---------------------
+
+#[test]
+fn state_dir_is_the_invocation_leaf_with_artifact_and_tmp_as_siblings() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+            .expect("invocation guard");
+        let env = guard.env_vars();
+
+        let state = std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_STATE_DIR"));
+        let artifact = std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_ARTIFACT_DIR"));
+        let tmp = std::path::PathBuf::from(value_for(&env, "HOMEBOY_INVOCATION_TMP_DIR"));
+
+        // STATE_DIR is the invocation leaf — workloads bind sockets directly
+        // under it without any extra Homeboy-injected segment. ARTIFACT_DIR
+        // and TMP_DIR live alongside as siblings under the runtime root, so
+        // they cannot collide with workload-created subdirs under STATE_DIR.
+        assert_eq!(
+            state.parent(),
+            artifact.parent(),
+            "siblings under same root"
+        );
+        assert_eq!(state.parent(), tmp.parent(), "siblings under same root");
+
+        // Distinct leaves (no two env vars pointing at the same dir).
+        assert_ne!(state, artifact);
+        assert_ne!(state, tmp);
+        assert_ne!(artifact, tmp);
+
+        // No `s/a/t` subdir layer — STATE_DIR's basename is the short id
+        // (10 hex chars), not `s`.
+        let state_basename = state
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("state basename");
+        assert_eq!(
+            state_basename.len(),
+            10,
+            "STATE_DIR basename should be the 10-char short id, not a subdir: {state_basename}"
         );
 
         run_dir.cleanup();
     });
+}
+
+#[test]
+fn realistic_socket_path_fits_under_sockaddr_un_on_default_platform_root() {
+    // Regression for #2311 follow-up: on macOS the default $TMPDIR is
+    // ~/var/folders/<14>/T/ ≈ 50 bytes, so anchoring to /tmp instead is
+    // what makes the budget work. Build the longest realistic socket path
+    // the Studio site-build workload produces and assert it fits under
+    // sockaddr_un on the default platform root (no override env).
+
+    // Save and clear the runtime override so the platform detection ladder
+    // is exercised end-to-end.
+    let _guard = home_env_guard();
+    let prior = std::env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+    std::env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV);
+
+    let runtime_root = invocation_runtime_root().expect("platform runtime root");
+
+    // Worst-case STATE_DIR: runtime_root + '/' + 10-char short id.
+    let state_dir = runtime_root.join("a1b2c3d4e5");
+
+    // Realistic workload-relative socket suffix: a 32-char workload id
+    // plus the canonical `daemon/daemon.sock` filename. This is what the
+    // Studio site-build workload + similar rigs append under STATE_DIR.
+    let workload_relative = "studio-agent-site-build-restaurant/daemon/daemon.sock";
+    assert!(
+        workload_relative.len() >= 32,
+        "regression test should use a realistic 32+ byte socket suffix"
+    );
+
+    let full_socket_path = state_dir.join(workload_relative);
+    let full_len = full_socket_path.to_string_lossy().len();
+
+    assert!(
+        full_len <= SUN_PATH_CAPACITY,
+        "realistic socket path is {full_len} bytes, exceeds platform sun_path \
+         capacity {SUN_PATH_CAPACITY}: {} (runtime_root = {})",
+        full_socket_path.display(),
+        runtime_root.display()
+    );
+
+    // STATE_DIR alone must also satisfy the homeboy ≥48-byte (macOS) /
+    // ≥32-byte (Linux) headroom contract under default platform root.
+    enforce_path_budget(&state_dir).expect("default platform root meets budget contract");
+
+    match prior {
+        Some(value) => std::env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, value),
+        None => std::env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+    }
+}
+
+#[test]
+fn studio_site_build_socket_path_fits_macos_sockaddr_un() {
+    // Specific regression for the failure observed in #2311 follow-up:
+    // Studio's daemon binds to
+    //   $HOMEBOY_INVOCATION_STATE_DIR/studio-agent-site-build/daemon/daemon.sock
+    // and previously got EINVAL on macOS because the prefix was already
+    // ~64 bytes by the time the workload appended its 41-byte suffix.
+    let _guard = home_env_guard();
+    let prior = std::env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+    std::env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV);
+
+    let runtime_root = invocation_runtime_root().expect("platform runtime root");
+    let state_dir = runtime_root.join("0123456789");
+    let socket = state_dir.join("studio-agent-site-build/daemon/daemon.sock");
+    let socket_len = socket.to_string_lossy().len();
+
+    // macOS sockaddr_un sun_path = 104; Linux = 108. Test must hold on
+    // either platform's actual default root.
+    assert!(
+        socket_len <= SUN_PATH_CAPACITY,
+        "Studio site-build socket path is {socket_len} bytes, exceeds {SUN_PATH_CAPACITY}: {}",
+        socket.display()
+    );
+
+    match prior {
+        Some(value) => std::env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, value),
+        None => std::env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2312. The previous PR shortened the runtime path but the
contract still broke on macOS under default `\$TMPDIR`. Studio's
site-build daemon reproducibly hit `EINVAL` binding

```
/var/folders/<14>/T/hb/<id>/s/studio-agent-site-build/daemon/daemon.sock
```

at ~110 bytes — over the 104-byte `sockaddr_un` limit. Two changes meet
the budget for real.

## What changed

### 1. Anchor the runtime root at `/tmp/hb` on every Unix host

`\$TMPDIR` on macOS is `/var/folders/<14>/T/...` which is already ~50
bytes — there's no realistic `sockaddr_un` budget left after appending a
short id and a workload-relative socket name. `/tmp` is 4 bytes and is
writable on every standard macOS / Linux configuration. This saves ~35
bytes of headroom per invocation, which is the difference between 'fits'
and 'EINVAL'.

Fallback ladder for unusual hosts (containers with stripped layouts):

- Linux: `\$XDG_RUNTIME_DIR/hb` when `/tmp` is unusable
- macOS: `\$TMPDIR/hb` when `/tmp` is unusable
- Generic: `~/.cache/homeboy/inv` (or `\$XDG_CACHE_HOME/homeboy/inv`)
- Override: `HOMEBOY_INVOCATION_RUNTIME_DIR` always wins

### 2. Drop the `s/a/t` subdir layer — STATE_DIR is the leaf

```
<root>/<short-id>      → HOMEBOY_INVOCATION_STATE_DIR (the leaf)
<root>/<short-id>.a    → HOMEBOY_INVOCATION_ARTIFACT_DIR
<root>/<short-id>.t    → HOMEBOY_INVOCATION_TMP_DIR
```

The invocation is 1:1 with a single workload run, so an extra
workload-id segment under STATE_DIR would burn `sockaddr_un` budget for
no isolation gain. Workloads now bind sockets directly under STATE_DIR
without any extra Homeboy-injected segment. ARTIFACT_DIR and TMP_DIR
move to siblings with `.a`/`.t` suffixes so they cannot collide with
workload-created subdirs under STATE_DIR.

### 3. Bump macOS headroom contract from 32 → 48 bytes

The macOS `sockaddr_un` limit is 4 bytes shorter than Linux (104 vs
108) *and* workloads commonly nest a `<workload-id>/daemon/daemon.sock`
segment (~40 bytes) under STATE_DIR. The previous 32-byte reserve was
insufficient under realistic Apple `\$TMPDIR` configurations. Linux
stays at ≥32 bytes since the limit there is 108 and typical root
prefixes are shorter.

### 4. `enforce_path_budget` still fails fast

When the platform budget cannot be met, Homeboy aborts at invocation
acquisition with a clear error naming `sockaddr_un`, the platform-
specific limit, the available headroom, and the
`HOMEBOY_INVOCATION_RUNTIME_DIR` override — instead of letting a
downstream workload hit `EINVAL` at bind time.

## Verification

On this macOS host, Studio's previously-failing path now resolves to:

```
/tmp/hb/<id>/studio-agent-site-build/daemon/daemon.sock = 61 bytes
```

well under the 104-byte limit, with 85 bytes of STATE_DIR headroom
(contract minimum: 48 bytes).

## Compatibility

- `HOMEBOY_INVOCATION_ID` still resolves to a unique `inv-<short>` id.
- `HOMEBOY_INVOCATION_PORT_BASE` / `_MAX` semantics unchanged.
- `InvocationGuard::acquire(&run_dir, ...)` signature unchanged; all
  call sites continue to compile and behave identically to callers.
- Lifecycle ownership from #2296 / #2307 is preserved (Drop still
  cleans up all three sibling directories; lease file cleanup
  unchanged).

## Tests

- `cargo check` — clean
- `cargo fmt` — clean
- `cargo clippy --lib` — no new warnings on changed files
- `cargo test --lib` — **2697 passed**, 1 ignored, 0 failed
- `cargo test --lib core::engine::invocation` — 28 passed
- `cargo test --lib core::engine` — 218 passed
- `cargo test --lib core::extension::runner` — 12 passed
- `cargo test --lib core::rig::workloads` — 9 passed
- `cargo test --lib core::extension::trace::run` — 16 passed

New regression tests in `tests/core/engine/invocation_test.rs`:

- `studio_site_build_socket_path_fits_macos_sockaddr_un` — exact
  reproduction of the reported failure path constructed on the default
  platform root, asserts ≤ `sun_path` capacity.
- `realistic_socket_path_fits_under_sockaddr_un_on_default_platform_root`
  — generic regression with a 32-char workload-relative socket suffix
  exercising the platform detection ladder end-to-end.
- `state_dir_is_the_invocation_leaf_with_artifact_and_tmp_as_siblings`
  — asserts the new layout contract: STATE basename = short id (no
  subdir), siblings under same parent.
- `macos_headroom_is_at_least_forty_eight_bytes` (in `runtime.rs`) —
  enforces the bumped macOS budget at the constant level.

Existing `invocation_state_dir_fits_under_sockaddr_un_budget` continues
to pass with the new ≥48-byte macOS / ≥32-byte Linux thresholds.

## Docs

`docs/commands/bench.md` — rewrote the runtime path contract section to
document:

- The new sibling layout (STATE_DIR is the leaf, ARTIFACT/TMP as `.a`/`.t`)
- The `/tmp/hb` anchor decision and the rationale (macOS \$TMPDIR is
  ~50 bytes, /tmp is 4)
- The platform-specific headroom guarantees (≥48 macOS, ≥32 Linux)
- The fail-fast behavior of `enforce_path_budget` and the override env

## Refs

- #2296 invocation isolation primitives
- #2307 invocation child process ownership cleanup
- #2311 original issue
- #2312 first attempt at the fix (insufficient on macOS)
- chubes4/homeboy-rigs#97 rig adoption that surfaced the failure

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed why #2312's fix was insufficient on the
  default macOS \$TMPDIR, drafted the /tmp anchor + STATE_DIR-as-leaf
  redesign, the bumped macOS headroom contract, the regression tests,
  and the doc rewrite. Chris reviewed the design choices (specifically:
  /tmp over /tmp/hb-versus-\$XDG, sibling .a/.t suffix vs nested subdirs,
  48-byte macOS budget) and ran the targeted plus broader test suites
  on macOS.