### PR TITLE
fix: persist bench workload artifacts

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use homeboy::engine::run_dir::{self, RunDir};
@@ -239,6 +240,11 @@ fn record_bench_observation_artifacts(
     workflow: &mut BenchRunWorkflowResult,
     run_dir: &RunDir,
 ) {
+    if let Some(results) = workflow.results.as_mut() {
+        persist_bench_result_artifact_paths(observation, results, run_dir);
+        rewrite_bench_results_file(results, run_dir);
+    }
+
     record_if_exists(
         observation,
         "bench_results",
@@ -250,7 +256,7 @@ fn record_bench_observation_artifacts(
         run_dir.step_file(run_dir::files::RESOURCE_SUMMARY),
     );
 
-    let Some(results) = workflow.results.as_mut() else {
+    let Some(results) = workflow.results.as_ref() else {
         return;
     };
     for artifact in collect_artifacts(results) {
@@ -262,7 +268,6 @@ fn record_bench_observation_artifacts(
                 .record_url_artifact(observation.run_id(), kind, url);
         }
     }
-    persist_bench_result_artifact_paths(observation, results, run_dir);
 }
 
 fn record_if_exists(observation: &BenchObservation, kind: &str, path: PathBuf) {
@@ -297,17 +302,30 @@ fn persist_bench_artifact_path(
         return;
     };
     let path = resolve_bench_artifact_path(path, run_dir);
-    if !path.is_file() {
-        return;
-    }
-    if let Ok(record) =
+    let record = if path.is_file() {
         observation
             .0
             .store()
             .record_artifact(observation.run_id(), "bench_artifact", &path)
-    {
+    } else if path.is_dir() {
+        observation.0.store().record_directory_artifact(
+            observation.run_id(),
+            "bench_artifact",
+            &path,
+        )
+    } else {
+        return;
+    };
+    if let Ok(record) = record {
         artifact.path = Some(record.path);
     }
+}
+
+fn rewrite_bench_results_file(results: &BenchResults, run_dir: &RunDir) {
+    let Ok(json) = serde_json::to_vec_pretty(results) else {
+        return;
+    };
+    let _ = fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), json);
 }
 
 fn resolve_bench_artifact_path(path: &str, run_dir: &RunDir) -> PathBuf {
@@ -568,6 +586,7 @@ mod tests {
                 run_dir: &run_dir,
             })
             .expect("start observation");
+            let run_id = observation.run_id().to_string();
 
             finish_success(Some(observation), &mut workflow, &run_dir)
                 .expect("observation summary");
@@ -584,6 +603,105 @@ mod tests {
                 fs::read_to_string(persisted_path).expect("read persisted"),
                 "{\"score\":1}"
             );
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let artifacts = store.list_artifacts(&run_id).expect("artifacts");
+            let bench_results_artifact = artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "bench_results")
+                .expect("bench results artifact");
+            let persisted_results_json: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(&bench_results_artifact.path).expect("read bench results"),
+            )
+            .expect("parse persisted bench results");
+            assert_eq!(
+                persisted_results_json["scenarios"][0]["artifacts"]["semantic"]["path"],
+                persisted_path
+            );
+        });
+    }
+
+    #[test]
+    fn bench_observation_persists_workload_artifact_directories() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let run_dir = RunDir::create().expect("run dir");
+            fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+            let artifact_dir = run_dir
+                .path()
+                .join("invocations/inv-1/artifacts/visual-comparisons");
+            fs::create_dir_all(&artifact_dir).expect("mkdir");
+            fs::write(
+                artifact_dir.join("visual-comparison-skipped.json"),
+                b"{\"skip\":true}",
+            )
+            .expect("artifact");
+
+            let mut results = bench_results("homeboy", "cold", 42.0);
+            let original_path = artifact_dir.to_string_lossy().to_string();
+            results.scenarios[0].artifacts.insert(
+                "visual_comparison_dir".to_string(),
+                BenchArtifact {
+                    path: Some(original_path.clone()),
+                    url: None,
+                    artifact_type: Some("directory".to_string()),
+                    kind: Some("visual_comparison_dir".to_string()),
+                    label: Some("Visual comparisons".to_string()),
+                },
+            );
+            let mut workflow = BenchRunWorkflowResult {
+                status: "passed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 0,
+                iterations: 10,
+                results: Some(results),
+                gate_failures: Vec::new(),
+                baseline_comparison: None,
+                hints: None,
+                failure: None,
+                diagnostics: Vec::new(),
+            };
+
+            let args = bench_args();
+            let selected_scenarios = vec!["cold".to_string()];
+            let observation = start(BenchObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: home.path(),
+                args: &args,
+                selected_scenarios: &selected_scenarios,
+                rig_id: None,
+                rig_snapshot: None,
+                run_dir: &run_dir,
+            })
+            .expect("start observation");
+            let run_id = observation.run_id().to_string();
+
+            finish_success(Some(observation), &mut workflow, &run_dir)
+                .expect("observation summary");
+            run_dir.cleanup();
+
+            let persisted_path = workflow.results.as_ref().unwrap().scenarios[0].artifacts
+                ["visual_comparison_dir"]
+                .path
+                .as_deref()
+                .expect("persisted artifact path");
+            assert_ne!(persisted_path, original_path);
+            let persisted_dir = PathBuf::from(persisted_path);
+            assert!(persisted_dir.is_dir());
+            assert_eq!(
+                fs::read_to_string(persisted_dir.join("visual-comparison-skipped.json"))
+                    .expect("read persisted"),
+                "{\"skip\":true}"
+            );
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let artifacts = store.list_artifacts(&run_id).expect("artifacts");
+            assert!(artifacts
+                .iter()
+                .any(|artifact| artifact.kind == "bench_artifact"
+                    && artifact.artifact_type == "directory"
+                    && artifact.path == persisted_path));
         });
     }
 

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -497,6 +497,86 @@ impl ObservationStore {
             })
     }
 
+    pub fn record_directory_artifact(
+        &self,
+        run_id: &str,
+        kind: &str,
+        path: impl AsRef<Path>,
+    ) -> Result<ArtifactRecord> {
+        validate_required("run_id", run_id)?;
+        validate_required("kind", kind)?;
+        if self.get_run(run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                format!("run record not found: {run_id}"),
+                Some(run_id.to_string()),
+                None,
+            ));
+        }
+
+        let path = path.as_ref();
+        let metadata = fs::metadata(path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                return Error::validation_invalid_argument(
+                    "path",
+                    format!("artifact directory not found: {}", path.display()),
+                    Some(path.to_string_lossy().to_string()),
+                    None,
+                );
+            }
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "read artifact directory metadata {}",
+                    path.display()
+                )),
+            )
+        })?;
+        if !metadata.is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                format!("artifact path is not a directory: {}", path.display()),
+                Some(path.to_string_lossy().to_string()),
+                None,
+            ));
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+        let stored_path = persisted_artifact_path(run_id, &id, path)?;
+        copy_artifact_directory(path, &stored_path)?;
+        let path_string = stored_path.to_string_lossy().to_string();
+
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO artifacts(id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                "#,
+                params![
+                    id,
+                    run_id,
+                    kind,
+                    "directory",
+                    path_string,
+                    Option::<String>::None,
+                    Option::<i64>::None,
+                    Option::<String>::None,
+                    created_at,
+                ],
+            )
+            .map_err(sqlite_error("insert directory artifact record"))?;
+
+        self.list_artifacts(run_id)?
+            .into_iter()
+            .find(|artifact| artifact.id == id)
+            .ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "Inserted directory artifact record {id} but could not read it back"
+                ))
+            })
+    }
+
     pub fn record_url_artifact(
         &self,
         run_id: &str,
@@ -1098,6 +1178,48 @@ fn copy_artifact_file(source: &Path, target: &Path) -> Result<()> {
             )),
         )
     })?;
+    Ok(())
+}
+
+fn copy_artifact_directory(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("create artifact directory {}", target.display())),
+        )
+    })?;
+    for entry in fs::read_dir(source).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read artifact directory {}", source.display())),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "read artifact directory entry {}",
+                    source.display()
+                )),
+            )
+        })?;
+        let entry_source = entry.path();
+        let entry_target = target.join(entry.file_name());
+        let entry_type = entry.file_type().map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "read artifact entry type {}",
+                    entry_source.display()
+                )),
+            )
+        })?;
+        if entry_type.is_dir() {
+            copy_artifact_directory(&entry_source, &entry_target)?;
+        } else if entry_type.is_file() {
+            copy_artifact_file(&entry_source, &entry_target)?;
+        }
+    }
     Ok(())
 }
 

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -391,6 +391,47 @@ fn test_record_artifact() {
 }
 
 #[test]
+fn test_record_directory_artifact() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+        let artifact_path = home.path().join("visual-comparisons");
+        std::fs::create_dir_all(artifact_path.join("nested")).expect("mkdir artifact");
+        std::fs::write(artifact_path.join("summary.json"), br#"{"status":"skip"}"#)
+            .expect("write artifact");
+        std::fs::write(artifact_path.join("nested/detail.txt"), "detail").expect("write nested");
+
+        let artifact = store
+            .record_directory_artifact(&run.id, "bench_artifact", &artifact_path)
+            .expect("record directory artifact");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+
+        assert_eq!(artifacts, vec![artifact.clone()]);
+        assert_eq!(artifact.run_id, run.id);
+        assert_eq!(artifact.kind, "bench_artifact");
+        assert_eq!(artifact.artifact_type, "directory");
+        assert_ne!(artifact.path, artifact_path.to_string_lossy());
+        let persisted = std::path::PathBuf::from(&artifact.path);
+        assert!(persisted.is_dir());
+        assert_eq!(
+            std::fs::read_to_string(persisted.join("summary.json")).expect("read persisted"),
+            "{\"status\":\"skip\"}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(persisted.join("nested/detail.txt")).expect("read nested"),
+            "detail"
+        );
+        assert_eq!(artifact.url, None);
+        assert_eq!(artifact.size_bytes, None);
+        assert_eq!(artifact.mime, None);
+        assert_eq!(artifact.sha256, None);
+    });
+}
+
+#[test]
 fn test_record_url_artifact() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
- Persist workload-reported bench file and directory artifacts before recording the top-level bench results artifact.
- Rewrite persisted bench results so embedded workload artifact paths point at durable observation-store copies.
- Add synthetic coverage for invocation-temp artifact files and directory artifacts.

## Verification
- `cargo test commands::bench::observation::tests::bench_observation`
- `cargo test test_record_directory_artifact`

## Related
- Fixes #2319

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining artifact persistence gap, drafted the code/test changes, ran targeted verification, and prepared this PR. Chris remains responsible for review and merge.