### PR TITLE
fix: preserve invocation artifacts before cleanup

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -330,7 +330,14 @@ fn rewrite_bench_results_file(results: &BenchResults, run_dir: &RunDir) {
 
 fn resolve_bench_artifact_path(path: &str, run_dir: &RunDir) -> PathBuf {
     let artifact_path = PathBuf::from(path);
-    if artifact_path.is_absolute() || artifact_path.exists() {
+    if artifact_path.exists() {
+        return artifact_path;
+    }
+    if artifact_path.is_absolute() {
+        if let Some(preserved_path) = resolve_preserved_invocation_artifact(&artifact_path, run_dir)
+        {
+            return preserved_path;
+        }
         return artifact_path;
     }
     let run_dir_path = run_dir.path().join(path);
@@ -338,6 +345,30 @@ fn resolve_bench_artifact_path(path: &str, run_dir: &RunDir) -> PathBuf {
         return run_dir_path;
     }
     artifact_path
+}
+
+fn resolve_preserved_invocation_artifact(path: &Path, run_dir: &RunDir) -> Option<PathBuf> {
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        let name = component.as_os_str().to_string_lossy();
+        let Some(short_id) = name.strip_suffix(".a") else {
+            continue;
+        };
+
+        let mut preserved = run_dir
+            .path()
+            .join("invocations")
+            .join(format!("inv-{short_id}"))
+            .join("artifacts");
+        for rest in components {
+            preserved.push(rest.as_os_str());
+        }
+        if preserved.exists() {
+            return Some(preserved);
+        }
+        return None;
+    }
+    None
 }
 
 #[cfg(test)]
@@ -617,6 +648,76 @@ mod tests {
             assert_eq!(
                 persisted_results_json["scenarios"][0]["artifacts"]["semantic"]["path"],
                 persisted_path
+            );
+        });
+    }
+
+    #[test]
+    fn bench_observation_rewrites_cleaned_short_invocation_artifact_paths() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let run_dir = RunDir::create().expect("run dir");
+            fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+            let preserved_artifact = run_dir
+                .path()
+                .join("invocations/inv-cleaned-artifacts/artifacts/semantic-fidelity.json");
+            fs::create_dir_all(preserved_artifact.parent().expect("artifact parent"))
+                .expect("mkdir");
+            fs::write(&preserved_artifact, b"{\"score\":1}").expect("artifact");
+
+            let mut results = bench_results("homeboy", "cold", 42.0);
+            let original_path = "/tmp/hb/cleaned-artifacts.a/semantic-fidelity.json".to_string();
+            results.scenarios[0].artifacts.insert(
+                "semantic".to_string(),
+                BenchArtifact {
+                    path: Some(original_path.clone()),
+                    url: None,
+                    artifact_type: None,
+                    kind: Some("json".to_string()),
+                    label: Some("Semantic fidelity".to_string()),
+                },
+            );
+            let mut workflow = BenchRunWorkflowResult {
+                status: "passed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 0,
+                iterations: 10,
+                results: Some(results),
+                gate_failures: Vec::new(),
+                baseline_comparison: None,
+                hints: None,
+                failure: None,
+                diagnostics: Vec::new(),
+            };
+
+            let args = bench_args();
+            let selected_scenarios = vec!["cold".to_string()];
+            let observation = start(BenchObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: home.path(),
+                args: &args,
+                selected_scenarios: &selected_scenarios,
+                rig_id: None,
+                rig_snapshot: None,
+                run_dir: &run_dir,
+            })
+            .expect("start observation");
+
+            finish_success(Some(observation), &mut workflow, &run_dir)
+                .expect("observation summary");
+            run_dir.cleanup();
+
+            let persisted_path = workflow.results.as_ref().unwrap().scenarios[0].artifacts
+                ["semantic"]
+                .path
+                .as_deref()
+                .expect("persisted artifact path");
+            assert_ne!(persisted_path, original_path);
+            assert!(PathBuf::from(persisted_path).is_file());
+            assert_eq!(
+                fs::read_to_string(persisted_path).expect("read persisted"),
+                "{\"score\":1}"
             );
         });
     }

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -193,6 +193,30 @@ impl InvocationGuard {
         }
         vars
     }
+
+    pub fn preserve_artifacts(&self, run_dir: &RunDir) -> Result<Option<PathBuf>> {
+        if !self.env.artifact_dir.exists() {
+            return Ok(None);
+        }
+
+        let target = run_dir
+            .path()
+            .join("invocations")
+            .join(&self.env.id)
+            .join("artifacts");
+
+        if target.exists() {
+            fs::remove_dir_all(&target).map_err(|e| {
+                Error::internal_io(
+                    format!("Failed to replace preserved invocation artifacts: {e}"),
+                    Some(target.display().to_string()),
+                )
+            })?;
+        }
+
+        copy_directory(&self.env.artifact_dir, &target)?;
+        Ok(Some(target))
+    }
 }
 
 impl Drop for InvocationGuard {
@@ -470,6 +494,57 @@ fn remove_stale_index_lock(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn copy_directory(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to create directory {}: {e}", target.display()),
+            Some("invocation.artifacts.preserve".to_string()),
+        )
+    })?;
+
+    for entry in fs::read_dir(source).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read directory {}: {e}", source.display()),
+            Some("invocation.artifacts.preserve".to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to read directory entry in {}: {e}",
+                    source.display()
+                ),
+                Some("invocation.artifacts.preserve".to_string()),
+            )
+        })?;
+        let entry_source = entry.path();
+        let entry_target = target.join(entry.file_name());
+        let metadata = entry.metadata().map_err(|e| {
+            Error::internal_io(
+                format!("Failed to stat {}: {e}", entry_source.display()),
+                Some("invocation.artifacts.preserve".to_string()),
+            )
+        })?;
+
+        if metadata.is_dir() {
+            copy_directory(&entry_source, &entry_target)?;
+        } else if metadata.is_file() {
+            fs::copy(&entry_source, &entry_target).map_err(|e| {
+                Error::internal_io(
+                    format!(
+                        "Failed to copy {} to {}: {e}",
+                        entry_source.display(),
+                        entry_target.display()
+                    ),
+                    Some("invocation.artifacts.preserve".to_string()),
+                )
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[path = "../../../tests/core/engine/invocation_test.rs"]
 mod invocation_test;
@@ -492,6 +567,39 @@ mod audit_coverage_tests {
             assert!(env
                 .iter()
                 .any(|(key, _)| key == "HOMEBOY_INVOCATION_TMP_DIR"));
+        });
+    }
+
+    #[test]
+    fn preserve_artifacts_copies_before_guard_cleanup() {
+        with_isolated_home(|_| {
+            let run_dir = RunDir::create().expect("run dir");
+            let original_artifact_path;
+            let preserved_path;
+            {
+                let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+                    .expect("invocation guard");
+                original_artifact_path = guard.env.artifact_dir.join("nested/result.json");
+                fs::create_dir_all(original_artifact_path.parent().expect("artifact parent"))
+                    .expect("mkdir");
+                fs::write(&original_artifact_path, b"{\"ok\":true}").expect("artifact");
+
+                preserved_path = guard
+                    .preserve_artifacts(&run_dir)
+                    .expect("preserve artifacts")
+                    .expect("preserved path")
+                    .join("nested/result.json");
+
+                assert!(original_artifact_path.is_file());
+                assert!(preserved_path.is_file());
+            }
+
+            assert!(!original_artifact_path.exists());
+            assert_eq!(
+                fs::read_to_string(&preserved_path).expect("read preserved artifact"),
+                "{\"ok\":true}"
+            );
+            run_dir.cleanup();
         });
     }
 }

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -224,6 +224,11 @@ impl ExtensionRunner {
             let _ = resource::record_extension_child_resource(run_dir_path, child_resource);
         }
 
+        if let (Some(run_dir_path), Some(invocation)) = (&self.run_dir_path, invocation.as_ref()) {
+            let run_dir = crate::engine::run_dir::RunDir::from_existing(run_dir_path.clone())?;
+            invocation.preserve_artifacts(&run_dir)?;
+        }
+
         Ok(RunnerOutput {
             exit_code: output.exit_code,
             success: output.success,


### PR DESCRIPTION
## Summary
- Preserve invocation artifact directories into the Homeboy run dir before `InvocationGuard` cleanup removes `/tmp/hb/<id>.a`.
- Resolve cleaned short invocation artifact paths back to the preserved copy so bench observation persistence can record durable artifact-store paths.
- Add regression coverage for preserving invocation artifacts and rewriting cleaned `/tmp/hb/<id>.a/...` paths.

## Verification
- `cargo test preserve_artifacts_copies_before_guard_cleanup`
- `cargo test commands::bench::observation::tests::bench_observation`
- `homeboy bench --rig studio-agent-gpt55-ssi --scenario studio-agent-site-build --iterations 1 --warmup 0 --setting studio_site_build_prompt_variant=restaurant --output /tmp/homeboy-bench-concurrent/gpt55-after-preserve-resolver-result.json`
- `homeboy runs artifacts 737a7b66-4f15-4d1a-bc03-0a8b1a89f167`

The Studio bench rerun persisted workload artifacts under `/Users/chubes/.local/share/homeboy/artifacts/737a7b66-4f15-4d1a-bc03-0a8b1a89f167/` and rewrote the artifact entries in the persisted bench results to those durable paths.

## Related
- Follow-up to #2319, #2320, and #2322.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining invocation artifact cleanup gap, drafted the fix and regression tests, ran targeted tests, and verified with a Studio SSI bench rerun. Chris remains responsible for review and merge.