### PR TITLE
fix: always pgid+cleanup local command spawns

### DIFF
--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1002,7 +1002,6 @@ fn build_runner(
         settings: &args.settings,
         settings_json: &args.settings_json,
         run_dir,
-        cleanup_process_group: false,
         results_env: None,
         scenario_env: None,
         artifact_env: None,

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -93,10 +93,6 @@ pub(crate) fn run_component_scripts_with_env(
             super::execution::CapabilityScriptOptions {
                 passthrough,
                 stderr_passthrough: false,
-                cleanup_process_group: matches!(
-                    capability,
-                    ExtensionCapability::Bench | ExtensionCapability::Trace
-                ),
             },
         )?;
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -8,10 +8,8 @@ use crate::project::{self, Project};
 use crate::rig::toolchain;
 use crate::server::http::ApiClient;
 use crate::server::{
-    execute_local_command_in_dir, execute_local_command_in_dir_with_process_cleanup,
-    execute_local_command_interactive, execute_local_command_passthrough,
-    execute_local_command_passthrough_with_process_cleanup,
-    execute_local_command_stderr_passthrough, CommandOutput,
+    execute_local_command_in_dir, execute_local_command_interactive,
+    execute_local_command_passthrough, execute_local_command_stderr_passthrough, CommandOutput,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -536,13 +534,6 @@ pub(crate) fn execute_capability_script(
     let current_dir = working_dir;
 
     if options.passthrough {
-        if options.cleanup_process_group {
-            return Ok(execute_local_command_passthrough_with_process_cleanup(
-                &command,
-                current_dir,
-                env_opt,
-            ));
-        }
         Ok(execute_local_command_passthrough(
             &command,
             current_dir,
@@ -553,16 +544,8 @@ pub(crate) fn execute_capability_script(
             &command,
             current_dir,
             env_opt,
-            options.cleanup_process_group,
         ))
     } else {
-        if options.cleanup_process_group {
-            return Ok(execute_local_command_in_dir_with_process_cleanup(
-                &command,
-                current_dir,
-                env_opt,
-            ));
-        }
         Ok(execute_local_command_in_dir(&command, current_dir, env_opt))
     }
 }
@@ -570,7 +553,6 @@ pub(crate) fn execute_capability_script(
 pub(crate) struct CapabilityScriptOptions {
     pub passthrough: bool,
     pub stderr_passthrough: bool,
-    pub cleanup_process_group: bool,
 }
 
 pub(crate) struct PreparedCapabilityRun {
@@ -1296,7 +1278,6 @@ mod tests {
             CapabilityScriptOptions {
                 passthrough: false,
                 stderr_passthrough: true,
-                cleanup_process_group: false,
             },
         )
         .expect("script should run");

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -196,7 +196,6 @@ pub struct ScenarioRunnerOptions<'a> {
     pub settings: &'a [(String, String)],
     pub settings_json: &'a [(String, serde_json::Value)],
     pub run_dir: &'a RunDir,
-    pub cleanup_process_group: bool,
     pub results_env: Option<(&'a str, PathBuf)>,
     pub scenario_env: Option<(&'a str, &'a str)>,
     pub artifact_env: Option<(&'a str, &'a Path)>,
@@ -214,9 +213,6 @@ pub fn build_scenario_runner(options: ScenarioRunnerOptions<'_>) -> Result<Exten
         .with_run_dir(options.run_dir)
         .invocation_requirements(options.invocation_requirements);
 
-    if options.cleanup_process_group {
-        runner = runner.cleanup_process_group(true);
-    }
     if let Some((key, path)) = options.results_env {
         runner = runner.env(key, &path.to_string_lossy());
     }

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -42,8 +42,6 @@ pub struct ExtensionRunner {
     passthrough: bool,
     /// Tee only runner stderr to the terminal while capturing stdout/stderr.
     stderr_passthrough: bool,
-    /// Run the child shell in a process group and clean up lingering descendants.
-    cleanup_process_group: bool,
     /// Run directory path for recording machine-local child process evidence.
     run_dir_path: Option<PathBuf>,
     invocation_requirements: InvocationRequirements,
@@ -73,7 +71,6 @@ impl ExtensionRunner {
             command_override: None,
             passthrough: true,
             stderr_passthrough: false,
-            cleanup_process_group: false,
             run_dir_path: None,
             invocation_requirements: InvocationRequirements::default(),
         }
@@ -176,12 +173,6 @@ impl ExtensionRunner {
         self
     }
 
-    /// Clean up the full process group after this runner exits or is interrupted.
-    pub(crate) fn cleanup_process_group(mut self, cleanup: bool) -> Self {
-        self.cleanup_process_group = cleanup;
-        self
-    }
-
     /// Execute the extension runner script.
     ///
     /// Performs the full orchestration:
@@ -278,7 +269,6 @@ impl ExtensionRunner {
             super::execution::CapabilityScriptOptions {
                 passthrough: self.passthrough,
                 stderr_passthrough: self.stderr_passthrough,
-                cleanup_process_group: self.cleanup_process_group,
             },
         )
     }

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -579,7 +579,6 @@ pub(crate) fn build_trace_runner(
         settings: &args.settings,
         settings_json: &args.runner_inputs.json_settings,
         run_dir,
-        cleanup_process_group: true,
         results_env: Some((
             "HOMEBOY_TRACE_RESULTS_FILE",
             run_dir.step_file(run_dir::files::TRACE_RESULTS),

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -266,27 +266,26 @@ pub fn execute_local_command(command: &str) -> CommandOutput {
     execute_local_command_in_dir(command, None, None)
 }
 
+/// Run a local command, capturing stdout/stderr.
+///
+/// All locally-spawned commands run in their own process group with
+/// guaranteed teardown of every descendant on exit, panic, or signal.
+/// There is no "leak the children" mode — verbs that genuinely want a
+/// process to outlive the command (e.g. `homeboy daemon`) build their
+/// own background spawn directly with `std::process::Command` and
+/// manage the pid themselves.
 pub fn execute_local_command_in_dir(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
 ) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, current_dir, env, false)
-}
-
-pub fn execute_local_command_in_dir_with_process_cleanup(
-    command: &str,
-    current_dir: Option<&str>,
-    env: Option<&[(&str, &str)]>,
-) -> CommandOutput {
-    execute_local_command_in_dir_impl(command, current_dir, env, true)
+    execute_local_command_in_dir_impl(command, current_dir, env)
 }
 
 fn execute_local_command_in_dir_impl(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
-    cleanup_process_group: bool,
 ) -> CommandOutput {
     #[cfg(windows)]
     let mut cmd = {
@@ -312,7 +311,7 @@ fn execute_local_command_in_dir_impl(
 
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    configure_process_group_cleanup(&mut cmd, cleanup_process_group);
+    configure_process_group_cleanup(&mut cmd);
 
     let child = match cmd.spawn() {
         Ok(child) => child,
@@ -326,7 +325,7 @@ fn execute_local_command_in_dir_impl(
             };
         }
     };
-    let cleanup_guard = ProcessGroupCleanupGuard::new(child.id(), cleanup_process_group);
+    let cleanup_guard = ProcessGroupCleanupGuard::new(child.id());
     let _invocation_child_guard =
         invocation_child_guard(env, child.id(), cleanup_guard.pgid(), command);
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
@@ -403,22 +402,13 @@ pub fn execute_local_command_passthrough(
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
 ) -> CommandOutput {
-    execute_local_command_passthrough_impl(command, current_dir, env, false)
-}
-
-pub fn execute_local_command_passthrough_with_process_cleanup(
-    command: &str,
-    current_dir: Option<&str>,
-    env: Option<&[(&str, &str)]>,
-) -> CommandOutput {
-    execute_local_command_passthrough_impl(command, current_dir, env, true)
+    execute_local_command_passthrough_impl(command, current_dir, env)
 }
 
 fn execute_local_command_passthrough_impl(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
-    cleanup_process_group: bool,
 ) -> CommandOutput {
     use std::io::{Read, Write};
     use std::thread;
@@ -447,7 +437,7 @@ fn execute_local_command_passthrough_impl(
 
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    configure_process_group_cleanup(&mut cmd, cleanup_process_group);
+    configure_process_group_cleanup(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -461,7 +451,7 @@ fn execute_local_command_passthrough_impl(
             };
         }
     };
-    let cleanup_guard = ProcessGroupCleanupGuard::new(child.id(), cleanup_process_group);
+    let cleanup_guard = ProcessGroupCleanupGuard::new(child.id());
     let _invocation_child_guard =
         invocation_child_guard(env, child.id(), cleanup_guard.pgid(), command);
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
@@ -532,7 +522,6 @@ pub(crate) fn execute_local_command_stderr_passthrough(
     command: &str,
     current_dir: Option<&str>,
     env: Option<&[(&str, &str)]>,
-    cleanup_process_group: bool,
 ) -> CommandOutput {
     use std::io::{Read, Write};
     use std::thread;
@@ -561,7 +550,7 @@ pub(crate) fn execute_local_command_stderr_passthrough(
 
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    configure_process_group_cleanup(&mut cmd, cleanup_process_group);
+    configure_process_group_cleanup(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -575,7 +564,7 @@ pub(crate) fn execute_local_command_stderr_passthrough(
             };
         }
     };
-    let cleanup_guard = ProcessGroupCleanupGuard::new(child.id(), cleanup_process_group);
+    let cleanup_guard = ProcessGroupCleanupGuard::new(child.id());
     let _invocation_child_guard =
         invocation_child_guard(env, child.id(), cleanup_guard.pgid(), command);
     let monitor = ChildResourceMonitor::start(child.id(), command.to_string());
@@ -650,10 +639,7 @@ pub(crate) fn execute_local_command_stderr_passthrough(
 }
 
 #[cfg(unix)]
-fn configure_process_group_cleanup(cmd: &mut Command, enabled: bool) {
-    if !enabled {
-        return;
-    }
+fn configure_process_group_cleanup(cmd: &mut Command) {
     install_process_cleanup_signal_handlers();
     use std::os::unix::process::CommandExt;
     unsafe {
@@ -668,7 +654,7 @@ fn configure_process_group_cleanup(cmd: &mut Command, enabled: bool) {
 }
 
 #[cfg(not(unix))]
-fn configure_process_group_cleanup(_cmd: &mut Command, _enabled: bool) {}
+fn configure_process_group_cleanup(_cmd: &mut Command) {}
 
 struct ProcessGroupCleanupGuard {
     #[cfg(unix)]
@@ -676,10 +662,10 @@ struct ProcessGroupCleanupGuard {
 }
 
 impl ProcessGroupCleanupGuard {
-    fn new(root_pid: u32, enabled: bool) -> Self {
+    fn new(root_pid: u32) -> Self {
         #[cfg(unix)]
         {
-            let pgid = enabled.then_some(root_pid as libc::pid_t);
+            let pgid = Some(root_pid as libc::pid_t);
             if let Some(pgid) = pgid {
                 ACTIVE_CLEANUP_PGID.store(pgid, Ordering::SeqCst);
             }
@@ -688,7 +674,7 @@ impl ProcessGroupCleanupGuard {
 
         #[cfg(not(unix))]
         {
-            let _ = (root_pid, enabled);
+            let _ = root_pid;
             Self {}
         }
     }
@@ -1088,21 +1074,6 @@ mod tests {
             "printf '{\"ok\":true}\n'; printf 'progress turn=1\n' >&2",
             None,
             None,
-            false,
-        );
-
-        assert!(output.success);
-        assert_eq!(output.stdout, "{\"ok\":true}\n");
-        assert_eq!(output.stderr, "progress turn=1\n");
-    }
-
-    #[test]
-    fn stderr_passthrough_with_process_cleanup_preserves_stdout() {
-        let output = execute_local_command_stderr_passthrough(
-            "printf '{\"ok\":true}\n'; printf 'progress turn=1\n' >&2",
-            None,
-            None,
-            true,
         );
 
         assert!(output.success);
@@ -1122,7 +1093,7 @@ mod tests {
             crate::engine::shell::quote_path(&pid_file.to_string_lossy())
         );
 
-        let output = execute_local_command_in_dir_with_process_cleanup(&command, None, None);
+        let output = execute_local_command_in_dir(&command, None, None);
 
         assert!(output.success, "command failed: {}", output.stderr);
         let pid: libc::pid_t = std::fs::read_to_string(&pid_file)


### PR DESCRIPTION
## Summary

Extension bench was the only path that opted out of process-group cleanup, which left Studio CLI playground daemons and process-manager nodes alive after every `homeboy bench` run. Found in the wild as **22 `playground-server-child.mjs` + 31 `process-manager-daemon.mjs` orphans** (PPID=1, ~4 GB RSS) on a dev machine after a day of `homeboy bench studio --rig=studio-agent-gpt55-ssi --iterations=1` runs.

This collapses the `cleanup_process_group` flag entirely. All `execute_local_command_*` paths now `setpgid` and tear down the full process group on exit, panic, and SIGINT/SIGTERM.

## Root cause

`src/core/extension/bench/run.rs` `build_runner` set `cleanup_process_group: false` while `trace/run.rs` set `true` and `component_script.rs` set `true` for `Bench | Trace`. The flag was a refactor scar: `_with_process_cleanup` variants got bolted on next to the original `execute_local_command_*` API, and bench never moved across. With `cleanup_process_group: false`:

- The child does not call `setpgid`, so descendants share the parent shell's pgid.
- `ProcessGroupCleanupGuard::new(_, false)` constructs with `pgid: None`, so `Drop` and `cleanup()` are no-ops.
- `install_process_cleanup_signal_handlers()` is gated behind the same `if !enabled { return; }`, so SIGINT/SIGTERM cleanup is also disabled.
- `invocation_child_guard` records the child without a pgid, so invocation-level cleanup can't kill the descendant tree by `kill(-pgid, ...)`.

Net result: every successful or failed `homeboy bench studio` run leaks one Studio process-manager-daemon plus its playground-server-child.

## Why no flag

There is no real-world case where a verb routed through these helpers wants to leak children. `homeboy daemon` does want to outlive the command, but it doesn't go through these helpers — it builds its own `Command::new(exe).spawn()` directly with `Stdio::null()` and manages the pid via `libc::kill`. Other long-running services in rigs are handled through `pipeline.up`/`pipeline.down`, `services` blocks, and `engine::resource` leases. The flag was only ever giving call sites a way to silently regress.

## Changes

- Remove `_with_process_cleanup` variants of `execute_local_command_in_dir` and `execute_local_command_passthrough`.
- Drop the `cleanup_process_group` parameter from `execute_local_command_stderr_passthrough`.
- Drop the `cleanup_process_group` field from `ExtensionRunner`, `ScenarioRunnerOptions`, and `CapabilityScriptOptions`.
- Drop the `Bench | Trace` carve-out in `component_script.rs`.
- Always install signal handlers, always `setpgid`, always run `ProcessGroupCleanupGuard` cleanup.
- Update `process_cleanup_kills_lingering_background_children` to call the consolidated `execute_local_command_in_dir` helper. Test still passes — proof that ordinary `execute_local_command_in_dir` now reaps lingering background children, which it previously did not.

Net diff: **24 inserted, 92 removed, 7 files** (`-68` lines).

## Verification

- `cargo build` — clean.
- `cargo test --lib 'extension::bench'` — 123 passed.
- `cargo test --lib 'extension::trace'` — 90 passed.
- `cargo test --lib 'extension::runner'` — 12 passed.
- `cargo test --lib 'extension::component_script'` — 6 passed.
- `cargo test --lib 'server::client'` — 6 passed, including the rebuilt `process_cleanup_kills_lingering_background_children`.
- `cargo fmt --check` — clean.
- Pre-existing `commands::runs::tests::artifacts_command_reports_paths` failure also fails on plain `main` HEAD (verified by stashing this change and running the test on `a98a47f2`); not caused by this PR.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosing the leak from process-tree evidence on a developer machine, tracing the bug to `cleanup_process_group: false` in extension bench's `build_runner`, drafting the collapse refactor across `client.rs`/`runner.rs`/`mod.rs`/`execution.rs`/`component_script.rs`/`bench/run.rs`/`trace/run.rs`, and updating the affected tests. Reviewed end-to-end and tested locally.