### PR TITLE
fix(release): resolve HEAD version paths against git toplevel for monorepo components (#2327)

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -221,6 +221,25 @@ fn collect_head_version_mismatches(
     }
 }
 
+/// Resolve the git toplevel directory for `path`. Returns `None` if `path`
+/// is not inside a git repo or if the git invocation fails for any reason.
+/// Used to translate `component.local_path` into a stripping root for
+/// `git show HEAD:<rel>`, which always resolves `<rel>` against the
+/// repository toplevel regardless of cwd.
+fn git_toplevel(path: &str) -> Option<std::path::PathBuf> {
+    let output =
+        crate::git::execute_git_for_release(path, &["rev-parse", "--show-toplevel"]).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(trimmed))
+}
+
 /// Read a version target's content from `HEAD` (committed tree) and parse
 /// the version string out of it. Returns `None` if the file is missing at
 /// HEAD, the git command fails, or the content can't be parsed.
@@ -238,12 +257,33 @@ fn read_version_at_head(
         .or_else(|| default_pattern_for_file(&target.file))?;
 
     // Resolve the path the same way bump_component_version does, then make it
-    // repo-relative for `git show HEAD:<rel>`. `git show` requires forward
-    // slashes and rejects absolute paths.
+    // relative to the git toplevel for `git show HEAD:<rel>`. `git show`
+    // resolves `<rel>` against the repository toplevel — NOT against the
+    // current working directory — so for monorepo-scoped components whose
+    // `local_path` is a subdirectory of the toplevel (e.g. an extension at
+    // `homeboy-extensions/wordpress`) we MUST strip the toplevel, not
+    // `local_path`. Stripping `local_path` produced `HEAD:plugin.php` for a
+    // file actually at `wordpress/plugin.php`, which `git show` rejected
+    // ("path wordpress/plugin.php exists, but not plugin.php"). See #2327.
+    //
+    // For root-layout components `local_path` *is* the toplevel, so the
+    // toplevel-relative path equals the `local_path`-relative path and
+    // behavior is unchanged.
+    //
+    // We canonicalize both sides before stripping so that platform symlinks
+    // (notably macOS `/var` → `/private/var`) don't defeat the prefix match
+    // when `full_path` and the git toplevel were derived through different
+    // resolution paths.
+    //
+    // `git show` also requires forward slashes and rejects absolute paths.
     let full_path = resolve_version_file_path(&component.local_path, &target.file);
-    let local_root = std::path::Path::new(&component.local_path);
-    let rel_path = std::path::Path::new(&full_path)
-        .strip_prefix(local_root)
+    let strip_root = git_toplevel(&component.local_path)
+        .unwrap_or_else(|| std::path::PathBuf::from(&component.local_path));
+    let canonical_full =
+        std::fs::canonicalize(&full_path).unwrap_or_else(|_| std::path::PathBuf::from(&full_path));
+    let canonical_root = std::fs::canonicalize(&strip_root).unwrap_or_else(|_| strip_root.clone());
+    let rel_path = canonical_full
+        .strip_prefix(&canonical_root)
         .ok()?
         .to_string_lossy()
         .replace('\\', "/");
@@ -1350,7 +1390,10 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let toplevel = temp.path();
         run_in(toplevel, &["git", "init", "-q"]);
-        run_in(toplevel, &["git", "config", "user.email", "test@example.com"]);
+        run_in(
+            toplevel,
+            &["git", "config", "user.email", "test@example.com"],
+        );
         run_in(toplevel, &["git", "config", "user.name", "Test"]);
         run_in(toplevel, &["git", "config", "commit.gpgsign", "false"]);
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -1338,6 +1338,82 @@ mod tests {
         assert!(collect_head_version_mismatches(&component, "0.6.13").is_none());
     }
 
+    /// Fixture: a git repo whose toplevel contains a `subdir/` with the
+    /// version target file. `component.local_path` points at `<toplevel>/subdir`,
+    /// NOT the git toplevel. This mirrors the monorepo-extension layout
+    /// (`homeboy-extensions/wordpress`, `homeboy-extensions/swift`, etc.) that
+    /// triggers issue #2327.
+    fn plugin_repo_at_subdir(
+        committed_version: &str,
+        subdir: &str,
+    ) -> (tempfile::TempDir, Component) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let toplevel = temp.path();
+        run_in(toplevel, &["git", "init", "-q"]);
+        run_in(toplevel, &["git", "config", "user.email", "test@example.com"]);
+        run_in(toplevel, &["git", "config", "user.name", "Test"]);
+        run_in(toplevel, &["git", "config", "commit.gpgsign", "false"]);
+
+        let sub = toplevel.join(subdir);
+        std::fs::create_dir_all(&sub).expect("create subdir");
+
+        let plugin = format!(
+            "<?php\n/*\nPlugin Name: Fixture\nVersion: {}\n*/\n",
+            committed_version
+        );
+        std::fs::write(sub.join("plugin.php"), plugin).expect("write plugin");
+        run_in(toplevel, &["git", "add", "."]);
+        run_in(toplevel, &["git", "commit", "-q", "-m", "Initial commit"]);
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: sub.to_string_lossy().to_string(),
+            version_targets: Some(vec![VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"(?:Version|version)[:=]\s+([0-9]+\.[0-9]+\.[0-9]+)".to_string()),
+            }]),
+            ..Component::default()
+        };
+        (temp, component)
+    }
+
+    #[test]
+    fn collect_head_version_mismatches_works_in_monorepo_subdir() {
+        // Issue #2327: when the component's local_path is a subdir of the git
+        // toplevel (monorepo extension layout), `git show HEAD:<path>` must
+        // resolve `<path>` against the git toplevel, not against
+        // component.local_path. Before the fix this returns `None` because
+        // `git show HEAD:plugin.php` fails ("path subdir/plugin.php exists,
+        // but not plugin.php"), which makes the HEAD invariant treat the
+        // committed version as `<unreadable>` and either flag a spurious
+        // mismatch or silently pass when comparing `None != Some(expected)`.
+        let (_temp, component) = plugin_repo_at_subdir("0.6.13", "wordpress");
+
+        // HEAD has 0.6.13. With a correct toplevel-relative path resolution,
+        // `read_version_at_head` returns Some("0.6.13") and the mismatch
+        // collector returns None.
+        assert!(
+            collect_head_version_mismatches(&component, "0.6.13").is_none(),
+            "HEAD has the expected version; mismatch collector should return None \
+             but the bug makes git show fail and mismatches are reported with \
+             found = None"
+        );
+
+        // And when HEAD does NOT have the expected version, the collector
+        // must still surface the real committed value (0.6.13) — not None.
+        let mismatches = collect_head_version_mismatches(&component, "0.7.0")
+            .expect("HEAD does not have 0.7.0; mismatch expected");
+        assert_eq!(mismatches.len(), 1);
+        assert_eq!(mismatches[0].file, "plugin.php");
+        assert_eq!(mismatches[0].expected, "0.7.0");
+        assert_eq!(
+            mismatches[0].found.as_deref(),
+            Some("0.6.13"),
+            "found value must be the version actually committed at HEAD, \
+             not None from a failed `git show HEAD:<wrong-path>`"
+        );
+    }
+
     #[test]
     fn git_tag_step_refuses_to_tag_when_head_lacks_new_version() {
         // The orphan-tag scenario from issue #2234: the in-memory state.version


### PR DESCRIPTION
## Summary

Fix auto-release on `Extra-Chill/homeboy-extensions` for every monorepo-scoped extension (`wordpress`, `swift`, `rust`, `go`). Only `nodejs` (root-layout) currently works.

`Closes #2327`

## Root cause

`read_version_at_head` in `src/core/release/executor.rs` builds a `HEAD:<path>` spec for `git show` to read the committed version of each version target. The old code stripped `component.local_path` from the resolved file path to produce `<path>` — but `git show HEAD:<rel>` resolves `<rel>` against the **repository toplevel**, not against the cwd or against `local_path`.

For a root-layout component (e.g. `homeboy-extensions/nodejs` whose `local_path` IS the git toplevel) the two are identical and behavior was correct by accident.

For every monorepo-scoped extension whose `local_path` is a subdirectory of the toplevel (`homeboy-extensions/{wordpress,swift,rust,go}`) stripping `local_path` produced specs like `HEAD:wordpress.json`, which git rejected because the file actually lives at `wordpress/wordpress.json` relative to the toplevel. `read_version_at_head` then returned `None`, the HEAD invariant treated the committed version as `<unreadable>`, and auto-release silently broke for the entire monorepo.

## Reproducer

```
$ cd /Users/chubes/Developer/homeboy-extensions/wordpress
$ git show HEAD:wordpress.json
fatal: path 'wordpress/wordpress.json' exists, but not 'wordpress.json'
hint: Did you mean 'HEAD:wordpress/wordpress.json' aka 'HEAD:./wordpress.json'?
```

## Fix

Resolve the git toplevel for `component.local_path` via `git rev-parse --show-toplevel` and strip THAT instead of `local_path`. Both the resolved file path and the toplevel are canonicalized via `std::fs::canonicalize` before stripping so platform symlinks (notably macOS `/var` → `/private/var`) don't defeat the prefix match when `full_path` and the git toplevel were derived through different resolution paths.

If `git rev-parse --show-toplevel` fails for any reason, fall back to the previous `local_path`-relative behavior so root-layout components never regress relative to today.

This is the **only** place in the codebase that builds a `HEAD:<path>` spec from a component-relative file (verified by `grep -rn 'HEAD:' src/` — the only other match is `src/core/stack/inspect.rs:201` which formats an error message about `git rev-parse HEAD`, not a tree spec). No other call sites need to change.

The orphan-tag protection from #2234 is unchanged — only path resolution moves. No new dependencies; `git rev-parse --show-toplevel` runs through the existing `crate::git::execute_git_for_release` helper.

### Why default to toplevel resolution and not `HEAD:./<rel>`

`HEAD:./<rel>` would be cwd-relative and depends on `git show` being executed with the cwd matching `component.local_path`. The current call already passes `local_path` to `execute_git_for_release` so that would happen to work today, but it leaks an implicit cwd dependency into the spec construction. Toplevel-relative resolution is the canonical contract `git show HEAD:<path>` exposes and survives any future change to where the helper executes the command.

## Test added

`collect_head_version_mismatches_works_in_monorepo_subdir` plus the supporting `plugin_repo_at_subdir` fixture. The fixture creates a git repo whose toplevel contains a `subdir/` with the version target file, and a `Component` whose `local_path` points at `<toplevel>/subdir` (mirrors the homeboy-extensions monorepo layout).

The test asserts both directions:
- HEAD has the expected version → mismatch collector returns `None`
- HEAD has a different version → mismatch collector returns the **real committed value** (`Some("0.6.13")`), not `None` from a failed `git show`.

Before this PR the test fails on the second assertion with `found = None` (the `<unreadable>` shape). After the fix both assertions pass.

The test is committed before the fix in commit `f29a56a9` so the regression is documented in history independently of the patch.

## Validation

- `cargo test --lib release::executor` — 15/15 pass (including new test)
- `cargo test` — 2702 pass, 1 ignored, 1 pre-existing fail in `commands::runs::tests::artifacts_command_reports_paths` that fails identically on `main` and is unrelated to release path resolution
- `cargo clippy --all-targets -- -D warnings` — 67 pre-existing errors at baseline, unchanged by this PR (no new clippy issues in `executor.rs`)
- `cargo fmt --check` — clean

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the diagnosis, the test fixture, the patch (helper + canonicalization fallback), the commit messages, and this PR body. Chris reviewed each step and ran the validation suite.