### PR TITLE
refactor(rig): extract shared files_match helper

### DIFF
--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -254,14 +254,7 @@ fn config_matches_source(config_path: &Path, source_path: &Path) -> bool {
 
     match (config_path.canonicalize(), source_path.canonicalize()) {
         (Ok(config), Ok(source)) if config == source => true,
-        (Ok(_), Ok(_)) => files_match(config_path, source_path),
-        _ => false,
-    }
-}
-
-fn files_match(left: &Path, right: &Path) -> bool {
-    match (fs::read(left), fs::read(right)) {
-        (Ok(left), Ok(right)) => left == right,
+        (Ok(_), Ok(_)) => super::files_match(config_path, source_path),
         _ => false,
     }
 }

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -75,6 +75,18 @@ pub use workloads::{
 use crate::error::{Error, Result};
 use crate::paths;
 use std::fs;
+use std::path::Path;
+
+/// Byte-compare the contents of two files.
+///
+/// Returns `true` only when both files are readable and have identical bytes.
+/// Any I/O error on either side yields `false`.
+pub(crate) fn files_match(left: &Path, right: &Path) -> bool {
+    match (fs::read(left), fs::read(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
 
 fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
     let path = paths::rig_config(id)?;

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -596,14 +596,7 @@ fn rig_config_matches_source(config_path: &Path, rig_path: &str) -> bool {
 
     match (config_path.canonicalize(), rig_path.canonicalize()) {
         (Ok(config), Ok(rig)) if config == rig => true,
-        (Ok(_), Ok(_)) => files_match(config_path, rig_path),
-        _ => false,
-    }
-}
-
-fn files_match(left: &Path, right: &Path) -> bool {
-    match (fs::read(left), fs::read(right)) {
-        (Ok(left), Ok(right)) => left == right,
+        (Ok(_), Ok(_)) => super::files_match(config_path, rig_path),
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

Audit finding #2301 flagged duplicate function `files_match` between `src/core/rig/install.rs` and `src/core/rig/source.rs`. Both modules had byte-equal helper bodies for "compare two files byte-by-byte after canonicalization disagrees".

This PR lifts the helper to `crate::core::rig::files_match` (in `mod.rs`) and updates both call sites to call `super::files_match`. Pure refactor — no behavior change.

## Changes

- **`src/core/rig/mod.rs`** — adds `pub(crate) fn files_match(left: &Path, right: &Path) -> bool` with rustdoc explaining the I/O-error-returns-false contract.
- **`src/core/rig/install.rs`** — drops the private `files_match`; `config_matches_source` now calls `super::files_match`.
- **`src/core/rig/source.rs`** — drops the private `files_match`; `rig_config_matches_source` now calls `super::files_match`.

## Validation

- `cargo build --lib` — clean
- `cargo test --lib core::rig::` — 222 passed, 0 failed
- `homeboy audit homeboy --output /tmp/audit-2301.json` — both `duplication::src/core/rig/install.rs::DuplicateFunction` and `duplication::src/core/rig/source.rs::DuplicateFunction` are now in `resolved_fingerprints` (gone from active findings).

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both surface pre-existing drift on `origin/main` (unrelated to this PR — `src/core/extension/trace/run.rs`, `src/core/paths.rs`, plus 68 pre-existing clippy errors in `src/core/refactor/` and `src/core/release/pipeline.rs`). Not addressed here — separate scope.

## Out of scope (documented, not folded in)

The audit also covers test-helper duplication between `tests/core/rig/install_test.rs` and `tests/core/rig/source_test.rs`:

- `write_rig`, `minimal_rig`, `write_stack`, `minimal_stack`, `run_git`, `sanitize_id`, `short_head_revision`

Lifting these requires a shared test-helper module (`tests/core/rig/common/mod.rs` or similar) and module-structure changes across two integration test crates. That is a meaningfully larger refactor with its own review surface — punted to a follow-up so this PR stays a clean, single-finding fix. Tracked separately if/when desired.

Closes #2301

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted the helper extraction across the three rig modules and the PR body. Chris reviewed the diff (14 insertions / 16 deletions) and ran the validation suite.