### PR TITLE
refactor: unify recursive directory copy helpers

### DIFF
--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -214,7 +214,12 @@ impl InvocationGuard {
             })?;
         }
 
-        copy_directory(&self.env.artifact_dir, &target)?;
+        crate::core::io::copy_tree(
+            &self.env.artifact_dir,
+            &target,
+            "invocation.artifacts.preserve",
+            crate::core::io::EntryPolicy::CopyRegularFilesOnly,
+        )?;
         Ok(Some(target))
     }
 }
@@ -491,57 +496,6 @@ fn remove_stale_index_lock(path: &Path) -> Result<()> {
             ))
         })?;
     }
-    Ok(())
-}
-
-fn copy_directory(source: &Path, target: &Path) -> Result<()> {
-    fs::create_dir_all(target).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to create directory {}: {e}", target.display()),
-            Some("invocation.artifacts.preserve".to_string()),
-        )
-    })?;
-
-    for entry in fs::read_dir(source).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to read directory {}: {e}", source.display()),
-            Some("invocation.artifacts.preserve".to_string()),
-        )
-    })? {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(
-                format!(
-                    "Failed to read directory entry in {}: {e}",
-                    source.display()
-                ),
-                Some("invocation.artifacts.preserve".to_string()),
-            )
-        })?;
-        let entry_source = entry.path();
-        let entry_target = target.join(entry.file_name());
-        let metadata = entry.metadata().map_err(|e| {
-            Error::internal_io(
-                format!("Failed to stat {}: {e}", entry_source.display()),
-                Some("invocation.artifacts.preserve".to_string()),
-            )
-        })?;
-
-        if metadata.is_dir() {
-            copy_directory(&entry_source, &entry_target)?;
-        } else if metadata.is_file() {
-            fs::copy(&entry_source, &entry_target).map_err(|e| {
-                Error::internal_io(
-                    format!(
-                        "Failed to copy {} to {}: {e}",
-                        entry_source.display(),
-                        entry_target.display()
-                    ),
-                    Some("invocation.artifacts.preserve".to_string()),
-                )
-            })?;
-        }
-    }
-
     Ok(())
 }
 

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -447,26 +447,16 @@ pub(crate) fn rename_dir(from: &Path, to: &Path) -> Result<()> {
 }
 
 /// Recursively copy a directory tree.
+///
+/// Thin wrapper over [`crate::core::io::copy_tree`] with the legacy
+/// extension-lifecycle entry policy (copy any non-directory entry).
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-    std::fs::create_dir_all(dst)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("create target dir".into())))?;
-
-    for entry in std::fs::read_dir(src)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("read source dir".into())))?
-    {
-        let entry =
-            entry.map_err(|e| Error::internal_io(e.to_string(), Some("read dir entry".into())))?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-
-        if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
-            std::fs::copy(&src_path, &dst_path)
-                .map_err(|e| Error::internal_io(e.to_string(), Some("copy file".into())))?;
-        }
-    }
-    Ok(())
+    crate::core::io::copy_tree(
+        src,
+        dst,
+        "extension.lifecycle.copy_dir_recursive",
+        crate::core::io::EntryPolicy::CopyAnyNonDir,
+    )
 }
 
 /// Install a extension by symlinking a local directory.

--- a/src/core/io/copy_tree.rs
+++ b/src/core/io/copy_tree.rs
@@ -1,0 +1,118 @@
+//! Recursive directory copy shared between extension lifecycle and invocation
+//! artifact preservation.
+//!
+//! Two callers have historically maintained near-identical recursive copy
+//! loops with their own error-context labels and slightly different entry
+//! filtering rules. This module unifies the loop shape; callers pass an
+//! [`EntryPolicy`] to preserve their original semantics.
+
+use std::fs;
+use std::path::Path;
+
+use crate::error::{Error, Result};
+
+/// How [`copy_tree`] handles non-directory entries it encounters while walking
+/// the source tree, and how it formats IO error messages.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum EntryPolicy {
+    /// Copy every entry that is not a directory using a cheap `Path::is_dir()`
+    /// check. Mirrors the historical `extension::lifecycle::copy_dir_recursive`
+    /// behavior; symlinks fall through to `fs::copy` (which follows them).
+    /// Error messages contain only the underlying IO error.
+    CopyAnyNonDir,
+    /// Copy only entries whose `DirEntry` metadata reports `is_file()`,
+    /// silently skipping symlinks and other non-regular files. Mirrors the
+    /// historical `engine::invocation::copy_directory` behavior used for
+    /// preserving invocation artifacts. Error messages embed the offending
+    /// source/target paths for debuggability.
+    CopyRegularFilesOnly,
+}
+
+/// Recursively copy `src` into `dst`, creating `dst` (and intermediate
+/// directories) if necessary.
+///
+/// `error_context` is attached to every IO failure so callers retain their
+/// own label (e.g. `"invocation.artifacts.preserve"`,
+/// `"extension.lifecycle.copy_dir_recursive"`). The previous
+/// `extension::lifecycle` implementation used per-step labels (`"create target
+/// dir"`, `"read dir entry"`, etc.); those were debug-only breadcrumbs not
+/// consumed by any caller, so the unified helper folds them into a single
+/// caller label for simplicity.
+pub(crate) fn copy_tree(
+    src: &Path,
+    dst: &Path,
+    error_context: &str,
+    policy: EntryPolicy,
+) -> Result<()> {
+    let ctx = || error_context.to_string();
+
+    fs::create_dir_all(dst).map_err(|e| {
+        let msg = match policy {
+            EntryPolicy::CopyAnyNonDir => e.to_string(),
+            EntryPolicy::CopyRegularFilesOnly => {
+                format!("Failed to create directory {}: {e}", dst.display())
+            }
+        };
+        Error::internal_io(msg, Some(ctx()))
+    })?;
+
+    let read_dir = fs::read_dir(src).map_err(|e| {
+        let msg = match policy {
+            EntryPolicy::CopyAnyNonDir => e.to_string(),
+            EntryPolicy::CopyRegularFilesOnly => {
+                format!("Failed to read directory {}: {e}", src.display())
+            }
+        };
+        Error::internal_io(msg, Some(ctx()))
+    })?;
+
+    for entry in read_dir {
+        let entry = entry.map_err(|e| {
+            let msg = match policy {
+                EntryPolicy::CopyAnyNonDir => e.to_string(),
+                EntryPolicy::CopyRegularFilesOnly => {
+                    format!("Failed to read directory entry in {}: {e}", src.display())
+                }
+            };
+            Error::internal_io(msg, Some(ctx()))
+        })?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        match policy {
+            EntryPolicy::CopyAnyNonDir => {
+                if src_path.is_dir() {
+                    copy_tree(&src_path, &dst_path, error_context, policy)?;
+                } else {
+                    fs::copy(&src_path, &dst_path)
+                        .map_err(|e| Error::internal_io(e.to_string(), Some(ctx())))?;
+                }
+            }
+            EntryPolicy::CopyRegularFilesOnly => {
+                let metadata = entry.metadata().map_err(|e| {
+                    Error::internal_io(
+                        format!("Failed to stat {}: {e}", src_path.display()),
+                        Some(ctx()),
+                    )
+                })?;
+                if metadata.is_dir() {
+                    copy_tree(&src_path, &dst_path, error_context, policy)?;
+                } else if metadata.is_file() {
+                    fs::copy(&src_path, &dst_path).map_err(|e| {
+                        Error::internal_io(
+                            format!(
+                                "Failed to copy {} to {}: {e}",
+                                src_path.display(),
+                                dst_path.display()
+                            ),
+                            Some(ctx()),
+                        )
+                    })?;
+                }
+                // symlinks and other non-regular entries are intentionally skipped.
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/core/io/mod.rs
+++ b/src/core/io/mod.rs
@@ -1,0 +1,11 @@
+//! Shared low-level IO helpers used across core subsystems.
+//!
+//! These helpers exist to consolidate genuinely duplicated workflows (recursive
+//! directory copy, etc.) so callers can reuse a single implementation while
+//! keeping their own error-context labels. Single-file IO (e.g. observation
+//! artifact persistence) lives with its caller — these helpers are only for
+//! workflows that recurse or loop in the same shape.
+
+pub(crate) mod copy_tree;
+
+pub(crate) use copy_tree::{copy_tree, EntryPolicy};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,6 +17,7 @@ pub mod fleet;
 pub mod git;
 pub mod http_api;
 pub(crate) mod http_probe;
+pub(crate) mod io;
 pub mod issues;
 pub mod observation;
 pub mod output;


### PR DESCRIPTION
## Summary

Extract the duplicated recursive directory-copy loop shared by `extension::lifecycle::copy_dir_recursive` and `engine::invocation::copy_directory` into a single `crate::core::io::copy_tree` helper.

Addresses #2315 (parallel implementation). Scope-guarded against the FPs tracked separately in #2333 (`cache_fallback_root` / env-path) and #2334 (`copy_artifact_file` ↔ recursive copies).

## What changed

New module `src/core/io/copy_tree.rs` exposes:

```rust
pub(crate) fn copy_tree(
    src: &Path,
    dst: &Path,
    error_context: &str,
    policy: EntryPolicy,
) -> Result<()>;

pub(crate) enum EntryPolicy {
    CopyAnyNonDir,          // lifecycle behavior
    CopyRegularFilesOnly,   // invocation behavior
}
```

Each caller keeps its own error-context label propagated through every IO failure:

- `extension::lifecycle::copy_dir_recursive` is now a thin wrapper passing `"extension.lifecycle.copy_dir_recursive"` + `EntryPolicy::CopyAnyNonDir`.
- `engine::invocation` calls `copy_tree` directly with `"invocation.artifacts.preserve"` + `EntryPolicy::CopyRegularFilesOnly`. Path-rich error messages (e.g. `"Failed to copy {src} to {dst}: {e}"`) are retained for that path.

### Why two policies, not one

The two callers diverge meaningfully:

- **Lifecycle** uses `src_path.is_dir()` (cheap, no metadata syscall) and falls through to `fs::copy` for everything else. Symlinks get followed.
- **Invocation** uses `DirEntry::metadata()` and only copies entries that report `is_file()`, **silently skipping** symlinks and other non-regular files. This is intentional for artifact preservation.

A blind merge would change behavior on either side. The enum preserves the existing semantics with a single dispatch point.

### Why a single error_context per caller, not per step

The previous lifecycle helper used distinct labels at each step (`"create target dir"`, `"read source dir"`, `"read dir entry"`, `"copy file"`). A grep across the repo confirmed nothing consumes those granular breadcrumbs — they're pure debug strings. They collapse to a single `"extension.lifecycle.copy_dir_recursive"` label, which is more informative for triage anyway. The underlying `e.to_string()` continues to disambiguate failure modes.

### Module placement

Used the existing scaffolding at `src/core/io/copy_tree.rs` (left from a prior session). The directory exists for "shared low-level IO helpers used across core subsystems"; the module documents that single-file IO (e.g. `copy_artifact_file` in observation/store.rs) intentionally lives with its caller, since this helper is only for workflows that recurse or loop in the same shape. That comment is also why the new helper does not generate a fresh FP against `copy_artifact_file`.

## JSON-decode helpers — punted

`decode_lease_file` (invocation.rs) ↔ `decode` (invocation/child.rs) was flagged at Jaccard 60% / sequence 75%, info severity, heuristic confidence. Skipped because:

- Error categories diverge: `decode_lease_file` uses `Error::internal_unexpected` for read failures; `child::decode` uses `Error::internal_io` with an `"invocation.child.read"` context label.
- The helpers `parse_context` / `json_excerpt` are duplicated separately in each module — they'd need their own consolidation pass to make the extraction clean.
- One is a method on a struct, the other a free function returning a different type — the generic helper would need `T: DeserializeOwned` plumbing for marginal benefit.

Documenting rather than papering over.

## Validation

From `/Users/chubes/Developer/homeboy@fix-2315-unify-recursive-copy-helpers`:

- `cargo check --all-targets`: clean.
- `cargo test --lib lifecycle`: **53 passed, 0 failed**.
- `cargo test --lib invocation`: **53 passed, 0 failed**.
- `cargo test --lib`: **2711 passed, 1 failed**. The one failure (`commands::runs::tests::artifacts_command_reports_paths`) reproduces on `main` with my changes stashed — pre-existing, unrelated.
- `cargo clippy --all-targets`: pre-existing baseline errors (refreshed in #2332). No new errors against my changes (`copy_tree`, `core/io`, modified callers all clean).
- `homeboy audit homeboy --output /tmp/audit-2315.json`:
  - **Resolved fingerprints (3):**
    - `parallel-implementation::src/core/extension/lifecycle.rs::ParallelImplementation`
    - `parallel-implementation::src/core/observation/store.rs::ParallelImplementation` (×2)
  - **New finding (1):** `intra-method-duplication::src/core/deploy/planning.rs::IntraMethodDuplicate` — unrelated to this change.
  - The two store.rs resolutions correspond to `copy_artifact_file` being scored against the now-unified recursive helper instead of two separate ones; the FP itself (per #2334) is unchanged in shape — `copy_artifact_file` remains a single-file copy. The `decode_lease_file` ↔ `decode` finding remains, as expected.
  - Audit baseline is **not** bumped.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafting the unified `copy_tree` module, wiring callers, and verifying the audit delta. Chris reviewed the divergence between the two helpers, the policy split, and the punt on the JSON-decode pair before merge.