### PR TITLE
chore(fmt): apply cargo fmt to main

### DIFF
--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -325,12 +325,8 @@ fn run_trace_workflow_with_context(
 
     if args.baseline_flags.baseline && status == "pass" && has_baseline_items {
         if let Some(ref parsed) = results {
-            let _ = super::baseline::save_baseline(
-                &baseline_root,
-                &args.component_id,
-                parsed,
-                rig_id,
-            )?;
+            let _ =
+                super::baseline::save_baseline(&baseline_root, &args.component_id, parsed, rig_id)?;
         }
     }
     if has_baseline_items && !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
@@ -1063,8 +1059,7 @@ mod tests {
         let component_path = temp.path().to_string_lossy().to_string();
         let rig_id = format!("__hb-trace-save-test-{}", std::process::id());
 
-        let baseline_root =
-            resolve_trace_baseline_root(&component_path, Some(&rig_id)).unwrap();
+        let baseline_root = resolve_trace_baseline_root(&component_path, Some(&rig_id)).unwrap();
 
         let results = TraceResults {
             component_id: "studio".to_string(),
@@ -1091,13 +1086,8 @@ mod tests {
             artifacts: Vec::new(),
         };
 
-        let written = baseline::save_baseline(
-            &baseline_root,
-            "studio",
-            &results,
-            Some(&rig_id),
-        )
-        .expect("rig baseline saves into rig state dir");
+        let written = baseline::save_baseline(&baseline_root, "studio", &results, Some(&rig_id))
+            .expect("rig baseline saves into rig state dir");
 
         assert!(
             written.starts_with(&baseline_root),

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -396,10 +396,7 @@ mod tests {
     #[test]
     fn test_rig_baseline_root_nested_under_state_dir() {
         let path = rig_baseline_root("studio-dev").expect("rig_baseline_root resolves");
-        assert_eq!(
-            path.file_name().and_then(|s| s.to_str()),
-            Some("baselines")
-        );
+        assert_eq!(path.file_name().and_then(|s| s.to_str()), Some("baselines"));
         assert_eq!(
             path.parent()
                 .and_then(|p| p.file_name())


### PR DESCRIPTION
## Summary

Pure rustfmt-driven whitespace collapses in two files:
- `src/core/extension/trace/run.rs` — three multi-line call sites collapse to single lines
- `src/core/paths.rs` — one `assert_eq!` collapses

## Why

PR [#2331](https://github.com/Extra-Chill/homeboy/pull/2331) (`fix(trace): store rig trace baselines outside component checkouts`) landed without `cargo fmt` run on the changed files. CI's `cargo fmt --check` has been failing on every branch off `main` since then, blocking the in-flight fix PRs:

- [#2337](https://github.com/Extra-Chill/homeboy/pull/2337) — refactor(rig): extract shared files_match helper (#2301)
- [#2338](https://github.com/Extra-Chill/homeboy/pull/2338) — refactor(update-check): share cache primitives (#2302)
- [#2340](https://github.com/Extra-Chill/homeboy/pull/2340) — refactor: unify recursive directory copy helpers (#2315)
- [#2341](https://github.com/Extra-Chill/homeboy/pull/2341) — refactor(audit): move repeated enum dispatch onto impl methods (#2304)
- [#2342](https://github.com/Extra-Chill/homeboy/pull/2342) — fix(audit): body-shape gate for parallel-implementation detector (#2334)

Each of those PRs has lint failing on `cargo fmt --check` reporting the same two files this PR fixes. Their actual edits are already format-clean — the failure is inherited unformatted state from `main`.

## No semantic changes

`cargo fmt` only. Verified locally with `cargo fmt --check` clean after the change.

## Followup

Worth a separate issue to investigate why CI didn't catch the unformatted state on #2331's merge — the `cargo fmt --check` step should have blocked that PR.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** ran `cargo fmt`, inspected the diff to confirm it was pure rustfmt output, drafted commit + PR body. Chris reviewed/approved.