### PR TITLE
fix(audit): remove deploy planning duplicate error block

### DIFF
--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -112,11 +112,9 @@ pub(super) fn plan_components(
         }
 
         if selected.is_empty() {
-            return Err(Error::validation_invalid_argument(
+            return Err(empty_selection_error(
                 "componentIds",
                 "No components selected",
-                None,
-                None,
             ));
         }
 
@@ -151,11 +149,9 @@ pub(super) fn plan_components(
             .collect();
 
         if selected.is_empty() {
-            return Err(Error::validation_invalid_argument(
+            return Err(empty_selection_error(
                 "outdated",
                 "No outdated components found",
-                None,
-                None,
             ));
         }
 
@@ -180,6 +176,10 @@ pub(super) fn plan_components(
     Err(Error::validation_missing_argument(vec![
         "component IDs, --all, --outdated, --behind-upstream, or --check".to_string(),
     ]))
+}
+
+fn empty_selection_error(field: &str, message: &str) -> Error {
+    Error::validation_invalid_argument(field, message, None, None)
 }
 
 fn select_behind_upstream_components(all_components: &[Component]) -> Vec<Component> {


### PR DESCRIPTION
## Summary

- Extracts the repeated empty-selection validation error construction in `plan_components` into a small helper.
- Clears the lone audit drift currently present on `origin/main`: `intra-method-duplication::src/core/deploy/planning.rs::IntraMethodDuplicate`.

## Why

After #2332, #2344, and #2342 landed, `origin/main` still had one audit drift item unrelated to the in-flight follow-up PRs. That drift was causing #2338 and any freshly rebased branch to inherit an audit failure from main.

## Validation

- `cargo fmt --check`
- `cargo test --lib deploy::planning`
- `homeboy audit homeboy --output /tmp/audit-deploy-planning-fix.json`

Audit result: `drift_increased: false`, `new_items: 0`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** diagnosed current main audit drift, extracted the duplicated error construction, ran targeted tests/audit, drafted commit + PR body. Chris reviewed/approved.