### PR TITLE
fix(audit): move framework command scopes into extension config

### DIFF
--- a/src/core/code_audit/command_output_policy.rs
+++ b/src/core/code_audit/command_output_policy.rs
@@ -3,6 +3,13 @@
 //! The audit is intentionally source-shape based: command modules should not
 //! independently own response modes, artifact emission, or success/error
 //! wrapping policy. The canonical output layer should own those contracts.
+//!
+//! The detector is shaped for binaries with central dispatch. Consumers built
+//! on a framework that owns dispatch per-subcommand declare a
+//! `framework_command_recognizers` rule via their extension manifest so this
+//! detector skips files where "duplication" is the framework contract rather
+//! than a refactor target. Core never names a specific framework — the
+//! recognizer rules are extension-owned. See Extra-Chill/homeboy#2335.
 
 use std::collections::{BTreeSet, HashMap};
 
@@ -11,6 +18,7 @@ use regex::Regex;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
+use crate::component::FrameworkCommandRecognizer;
 
 const MIN_FILES: usize = 2;
 
@@ -20,7 +28,10 @@ struct PolicySite {
     functions: Vec<String>,
 }
 
-pub(super) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+pub(super) fn run(
+    fingerprints: &[&FileFingerprint],
+    framework_recognizers: &[FrameworkCommandRecognizer],
+) -> Vec<Finding> {
     let mut groups: HashMap<String, Vec<PolicySite>> = HashMap::new();
 
     for fp in fingerprints {
@@ -30,14 +41,12 @@ pub(super) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
         if is_intentionally_command_specific(&fp.content) {
             continue;
         }
-        if is_wp_cli_command_module(&fp.content) {
-            // WP-CLI consumers register subcommands with `WP_CLI::add_command` and
-            // emit output through the framework contract (`WP_CLI::success`,
-            // `WP_CLI::error`, `WP_CLI::log`, `WP_CLI::print_value`). The
-            // "duplication" the detector sees on these modules is the framework
-            // contract itself, not a refactor target — there is no canonical
-            // command output layer to extract to without inventing one.
-            // See Extra-Chill/homeboy#2335.
+        if matches_framework_recognizer(&fp.content, framework_recognizers) {
+            // The file matched an extension-declared framework recognizer.
+            // "Duplication" inside framework-owned per-subcommand surfaces
+            // is the contract, not a refactor target. Core never names a
+            // specific framework — each ecosystem extension declares its
+            // own recognizer rule.
             continue;
         }
 
@@ -120,54 +129,17 @@ fn is_excluded_path(path: &str) -> bool {
         || lower.ends_with(".md")
 }
 
-/// Returns true when the file is a WP-CLI subcommand module.
+/// Returns true when any extension-declared recognizer matches the file.
 ///
-/// WP-CLI plugins register each subcommand with `WP_CLI::add_command` (or by
-/// extending `\WP_CLI_Command`) and emit output through the framework's
-/// per-command API: `WP_CLI::success`, `WP_CLI::error`, `WP_CLI::log`,
-/// `WP_CLI::print_value`, and `WP_CLI\Utils\format_items`. That is the
-/// framework contract — every subcommand calling `WP_CLI::success` is correct,
-/// not a smell. The `command_output_policy` detector is shaped for binaries
-/// with central dispatch (cf. homeboy's own #2249 refactor); it does not
-/// transfer to WP-CLI consumers because the framework owns dispatch
-/// per-subcommand. Skip these files entirely.
-///
-/// Recognition strategy (substring-based — cheap, no PHP parser):
-///
-/// 1. **Direct registration:** the file calls `WP_CLI::add_command` itself
-///    (top-level `Bootstrap.php`-style files inside a command directory).
-/// 2. **Direct framework subclass:** the file extends `\WP_CLI_Command`.
-/// 3. **Indirect framework subclass:** the file imports `WP_CLI` (via
-///    `use WP_CLI;` or fully qualified `\WP_CLI`) AND calls one of the
-///    framework's per-command output methods (`WP_CLI::success`,
-///    `WP_CLI::error`, `WP_CLI::log`, `WP_CLI::warning`, `WP_CLI::print_value`,
-///    `WP_CLI\Utils\format_items`). This catches plugins that put a thin
-///    `BaseCommand extends \WP_CLI_Command` shim between every command and
-///    the framework — the dominant idiomatic shape for non-trivial WP-CLI
-///    plugins (e.g. `data-machine`'s `inc/Cli/BaseCommand.php`). Without
-///    this, the scope guard misses the very files the issue reports.
-fn is_wp_cli_command_module(content: &str) -> bool {
-    if content.contains("WP_CLI::add_command")
-        || content.contains("extends WP_CLI_Command")
-        || content.contains("extends \\WP_CLI_Command")
-    {
-        return true;
-    }
-
-    let imports_wp_cli = content.contains("use WP_CLI;")
-        || content.contains("use \\WP_CLI;")
-        || content.contains("use WP_CLI ")
-        || content.contains("use \\WP_CLI ");
-    if !imports_wp_cli {
-        return false;
-    }
-
-    content.contains("WP_CLI::success")
-        || content.contains("WP_CLI::error")
-        || content.contains("WP_CLI::log")
-        || content.contains("WP_CLI::warning")
-        || content.contains("WP_CLI::print_value")
-        || content.contains("WP_CLI\\Utils\\format_items")
+/// Each [`FrameworkCommandRecognizer`] encodes the structural shape of a
+/// framework subcommand for one ecosystem (for example, framework-owned CLI
+/// commands, etc.). Core stays framework-agnostic; the rules live in
+/// extension manifests. Substring matching is intentional — cheap,
+/// language-agnostic, and avoids any per-framework parser dependency.
+fn matches_framework_recognizer(content: &str, recognizers: &[FrameworkCommandRecognizer]) -> bool {
+    recognizers
+        .iter()
+        .any(|recognizer| recognizer.matches(content))
 }
 
 fn is_intentionally_command_specific(content: &str) -> bool {
@@ -352,7 +324,7 @@ function execute_beta(ctx) {
 "#,
         );
 
-        let findings = run(&[&one, &two]);
+        let findings = run(&[&one, &two], &[]);
 
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, AuditFinding::CommandOutputPolicy);
@@ -385,7 +357,7 @@ function run_beta(ctx) {
 "#,
         );
 
-        assert!(run(&[&one, &two]).is_empty());
+        assert!(run(&[&one, &two], &[]).is_empty());
     }
 
     #[test]
@@ -410,7 +382,7 @@ function run_alpha(ctx) {
 "#,
         );
 
-        assert!(run(&[&helper, &command]).is_empty());
+        assert!(run(&[&helper, &command], &[]).is_empty());
     }
 
     #[test]
@@ -436,139 +408,67 @@ function canonical(ctx) {
 "#,
         );
 
-        assert!(run(&[&test_module, &response_helper]).is_empty());
+        assert!(run(&[&test_module, &response_helper], &[]).is_empty());
+    }
+
+    /// Synthetic, framework-agnostic recognizer used purely to exercise the
+    /// extension hook from inside core tests. Real recognizer values come
+    /// from extension manifests; core never names a specific framework.
+    fn synthetic_recognizer() -> FrameworkCommandRecognizer {
+        FrameworkCommandRecognizer {
+            id: "synthetic-test-framework".to_string(),
+            requires_all: vec!["FRAMEWORK_REGISTER(".to_string()],
+            requires_any: vec![
+                "framework_emit_success".to_string(),
+                "framework_emit_error".to_string(),
+            ],
+            requires_any_groups: Vec::new(),
+        }
     }
 
     #[test]
-    fn skips_wp_cli_command_modules_using_framework_contract() {
-        // Negative case: idiomatic WP-CLI subcommands. Each module registers a
-        // command via `WP_CLI::add_command` (or extends `\WP_CLI_Command`) and
-        // calls the framework's per-command output API. The detector must NOT
-        // flag these even though every module ends up "duplicating" the
-        // success/error contract — that is the framework, not a smell.
-        // Regression coverage for Extra-Chill/homeboy#2335.
+    fn skips_files_matching_framework_recognizer() {
+        // Negative case: extension declares a recognizer for its framework's
+        // per-subcommand shape. Files emitting through the framework contract
+        // are skipped even though they otherwise look like duplication. Core
+        // stays framework-agnostic — the recognizer values come from an
+        // extension manifest, not from core.
         let alpha = fp(
-            "inc/Cli/Commands/AlphaCommand.php",
+            "src/commands/alpha.ext",
             r#"
-<?php
-WP_CLI::add_command('alpha do', AlphaCommand::class);
-
-class AlphaCommand extends \WP_CLI_Command {
-    public function do($args, $assoc_args) {
-        $format = $assoc_args['format'] ?? 'text';
-        if ($format === 'json') {
-            WP_CLI::print_value(['success' => true, 'message' => 'ok'], ['format' => 'json']);
-            return;
-        }
-        if (empty($args)) {
-            WP_CLI::error('missing arg');
-        }
-        WP_CLI::success('done');
-    }
+FRAMEWORK_REGISTER('alpha do', AlphaCommand);
+function run_alpha(ctx) {
+  if (ctx.output_format == "json") framework_emit_success({ value: ctx.value });
+  if (ctx.output_format == "markdown") framework_emit_success(renderMarkdown(ctx.value));
+  if (ctx.artifact_path) writeArtifact(ctx.artifact_path, ctx.value);
 }
 "#,
         );
         let beta = fp(
-            "inc/Cli/Commands/BetaCommand.php",
+            "src/commands/beta.ext",
             r#"
-<?php
-WP_CLI::add_command('beta run', BetaCommand::class);
-
-class BetaCommand extends \WP_CLI_Command {
-    public function run($args, $assoc_args) {
-        $format = $assoc_args['format'] ?? 'table';
-        if ($format === 'json') {
-            WP_CLI::print_value(['success' => false, 'error' => 'nope'], ['format' => 'json']);
-            return;
-        }
-        if (!isset($args[0])) {
-            WP_CLI::error('boom');
-        }
-        WP_CLI::log('working');
-        WP_CLI::success('finished');
-    }
+FRAMEWORK_REGISTER('beta run', BetaCommand);
+function run_beta(ctx) {
+  if (ctx.output_format == "json") framework_emit_error({ err: ctx.err });
+  if (ctx.output_format == "markdown") framework_emit_error(formatMarkdown(ctx.err));
+  if (ctx.artifact_path) saveArtifact(ctx.artifact_path, ctx.err);
 }
 "#,
         );
 
+        let recognizers = vec![synthetic_recognizer()];
         assert!(
-            run(&[&alpha, &beta]).is_empty(),
-            "WP-CLI command modules using framework contract must not be flagged"
+            run(&[&alpha, &beta], &recognizers).is_empty(),
+            "files matching a framework recognizer must not be flagged"
         );
     }
 
     #[test]
-    fn skips_wp_cli_command_modules_via_intermediate_base_class() {
-        // Real-world shape from data-machine (and many other non-trivial
-        // WP-CLI plugins): commands extend an in-tree `BaseCommand` that
-        // itself extends `\WP_CLI_Command`. Registration happens centrally in
-        // a `Bootstrap.php`. Each command file imports `WP_CLI` and emits
-        // output through the framework contract — that's the WP-CLI shape,
-        // not a refactor target. Regression coverage for
-        // Extra-Chill/homeboy#2335.
-        let alpha = fp(
-            "inc/Cli/Commands/AlphaCommand.php",
-            r#"
-<?php
-namespace Plugin\Cli\Commands;
-
-use Plugin\Cli\BaseCommand;
-use WP_CLI;
-
-class AlphaCommand extends BaseCommand {
-    public function list_things($args, $assoc_args) {
-        $format = $assoc_args['format'] ?? 'table';
-        if ($format === 'json') {
-            WP_CLI::print_value($items, ['format' => 'json']);
-            return;
-        }
-        if (empty($items)) {
-            WP_CLI::error('no items');
-        }
-        WP_CLI::success(sprintf('listed %d', count($items)));
-    }
-}
-"#,
-        );
-        let beta = fp(
-            "inc/Cli/Commands/BetaCommand.php",
-            r#"
-<?php
-namespace Plugin\Cli\Commands;
-
-use Plugin\Cli\BaseCommand;
-use WP_CLI;
-
-class BetaCommand extends BaseCommand {
-    public function run($args, $assoc_args) {
-        $format = $assoc_args['format'] ?? 'text';
-        if ($format === 'json') {
-            WP_CLI::print_value($result, ['format' => 'json']);
-            return;
-        }
-        if (!isset($args[0])) {
-            WP_CLI::error('missing arg');
-        }
-        WP_CLI::log('working');
-        WP_CLI::success('done');
-    }
-}
-"#,
-        );
-
-        assert!(
-            run(&[&alpha, &beta]).is_empty(),
-            "WP-CLI command modules using an intermediate BaseCommand must not be flagged"
-        );
-    }
-
-    #[test]
-    fn fires_on_non_wp_cli_command_duplication() {
-        // Positive case: parallel-shape command modules with custom response
-        // mode branching, success/error envelopes, and artifact emission —
-        // none of them WP-CLI consumers. The detector must still fire so
-        // homeboy's own #2249 surface (and similar non-framework duplication)
-        // remains covered.
+    fn fires_when_recognizer_does_not_match() {
+        // Positive case: parallel-shape command modules with response-mode
+        // branching, success/error envelopes, and artifact emission. No
+        // recognizer matches, so the detector still fires — covering homeboy's
+        // own #2249 surface and any non-framework duplication.
         let one = fp(
             "src/commands/alpha.rs",
             r#"
@@ -593,9 +493,41 @@ fn run_beta(ctx: Context) {
 "#,
         );
 
-        let findings = run(&[&one, &two]);
-        assert_eq!(findings.len(), 1, "non-WP-CLI duplication must still fire");
+        let findings = run(&[&one, &two], &[synthetic_recognizer()]);
+        assert_eq!(
+            findings.len(),
+            1,
+            "duplication outside any recognized framework must still fire"
+        );
         assert_eq!(findings[0].kind, AuditFinding::CommandOutputPolicy);
+    }
+
+    #[test]
+    fn empty_recognizers_match_nothing() {
+        // Sanity: when no extension declares a recognizer, the detector
+        // behaves exactly as it did before the extension hook was added.
+        let one = fp(
+            "src/commands/alpha.rs",
+            r#"
+fn run_alpha(ctx: Context) {
+    if ctx.output_format == "json" { return json!({ "success": true, "message": ctx.value }); }
+    if ctx.output_format == "markdown" { return render_markdown(ctx.value); }
+    if let Some(path) = ctx.artifact_path { write_artifact(path, ctx.value); }
+}
+"#,
+        );
+        let two = fp(
+            "src/commands/beta.rs",
+            r#"
+fn run_beta(ctx: Context) {
+    if ctx.output_format == "json" { return json!({ "success": false, "error": ctx.err }); }
+    if ctx.output_format == "markdown" { return format_markdown(ctx.err); }
+    if let Some(path) = ctx.artifact_path { save_artifact(path, ctx.err); }
+}
+"#,
+        );
+
+        assert_eq!(run(&[&one, &two], &[]).len(), 1);
     }
 
     #[test]
@@ -635,6 +567,6 @@ mod tests {
 "#,
         );
 
-        assert!(run(&[&one, &two]).is_empty());
+        assert!(run(&[&one, &two], &[]).is_empty());
     }
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -1225,7 +1225,10 @@ fn audit_internal(
 
     // Phase 4x: Scattered command response/output policy ownership.
     let command_output_findings = if plan.run_command_output_policy {
-        command_output_policy::run(&all_fingerprints)
+        command_output_policy::run(
+            &all_fingerprints,
+            &audit_config.framework_command_recognizers,
+        )
     } else {
         Vec::new()
     };

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -36,6 +36,14 @@ pub struct AuditConfig {
     /// are merged with the built-in generic floor lists.
     #[serde(default, skip_serializing_if = "DuplicationDetectorConfig::is_empty")]
     pub duplication_detector: DuplicationDetectorConfig,
+    /// Extension-owned recognizers that mark a file as a framework subcommand.
+    ///
+    /// Used by `command_output_policy` to scope itself out of files where
+    /// "duplication" is the framework contract rather than a refactor target.
+    /// Core never names a specific framework — extensions declare which
+    /// substring patterns identify their framework's per-subcommand surface.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub framework_command_recognizers: Vec<FrameworkCommandRecognizer>,
 }
 
 /// Extension-supplied call-name lists for the parallel-implementation /
@@ -248,6 +256,71 @@ pub enum RequestedDetectorRuleBody {
     },
 }
 
+/// Recognizer rule that flags a file as a framework subcommand.
+///
+/// A file matches the rule when:
+///
+/// 1. It contains every substring in `requires_all` (zero entries = trivially
+///    satisfied), AND
+/// 2. Either `requires_any` is empty, or it contains at least one substring
+///    in `requires_any`, AND
+/// 3. Every `requires_any_groups` group contains at least one matching
+///    substring.
+///
+/// `requires_any_groups` lets an extension express shapes like:
+///
+/// ```text
+/// (any framework import marker) AND (any framework output marker)
+/// ```
+///
+/// Multiple recognizers in the same `AuditConfig` are OR'd together: a file
+/// matches if any recognizer matches. Substring matching is intentional —
+/// cheap, language-agnostic, and avoids per-framework parser dependencies.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FrameworkCommandRecognizer {
+    /// Human-readable rule label. Core never interprets this string; it is
+    /// surfaced in debug logging and helps extension authors trace which
+    /// rule fired for a given file.
+    pub id: String,
+    /// All substrings that must be present in the file content.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requires_all: Vec<String>,
+    /// At least one of these substrings must be present in the file content.
+    /// An empty list disables this constraint (acts as wildcard).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requires_any: Vec<String>,
+    /// Every nested group must have at least one substring present in the file
+    /// content. Empty nested groups are ignored.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requires_any_groups: Vec<Vec<String>>,
+}
+
+impl FrameworkCommandRecognizer {
+    /// Returns true when `content` matches this recognizer.
+    pub fn matches(&self, content: &str) -> bool {
+        if !self
+            .requires_all
+            .iter()
+            .all(|needle| content.contains(needle))
+        {
+            return false;
+        }
+
+        if self.requires_any.is_empty() {
+            return self.requires_any_groups.iter().all(|group| {
+                group.is_empty() || group.iter().any(|needle| content.contains(needle))
+            });
+        }
+
+        self.requires_any
+            .iter()
+            .any(|needle| content.contains(needle))
+            && self.requires_any_groups.iter().all(|group| {
+                group.is_empty() || group.iter().any(|needle| content.contains(needle))
+            })
+    }
+}
+
 fn default_requested_detector_severity() -> String {
     "warning".to_string()
 }
@@ -268,6 +341,7 @@ impl AuditConfig {
             && self.requested_detectors.is_empty()
             && self.core_boundary_leaks.is_empty()
             && self.duplication_detector.is_empty()
+            && self.framework_command_recognizers.is_empty()
     }
 
     pub fn merge(&mut self, other: &AuditConfig) {
@@ -296,6 +370,15 @@ impl AuditConfig {
                 .any(|existing| existing.id == rule.id)
             {
                 self.requested_detectors.push(rule.clone());
+            }
+        }
+        for recognizer in &other.framework_command_recognizers {
+            if !self
+                .framework_command_recognizers
+                .iter()
+                .any(|existing| existing.id == recognizer.id)
+            {
+                self.framework_command_recognizers.push(recognizer.clone());
             }
         }
     }
@@ -360,5 +443,26 @@ mod tests {
             config.core_boundary_leaks.allow_line_contains,
             vec!["allow-core-boundary-example"]
         );
+    }
+
+    #[test]
+    fn framework_command_recognizer_requires_each_any_group() {
+        let recognizer = FrameworkCommandRecognizer {
+            id: "test-framework".to_string(),
+            requires_all: vec!["command module".to_string()],
+            requires_any: Vec::new(),
+            requires_any_groups: vec![
+                vec!["import Framework".to_string(), "use Framework".to_string()],
+                vec![
+                    "Framework.success".to_string(),
+                    "Framework.error".to_string(),
+                ],
+            ],
+        };
+
+        assert!(recognizer.matches("command module\nuse Framework\nFramework.success('done')"));
+        assert!(!recognizer.matches("command module\nuse Framework"));
+        assert!(!recognizer.matches("command module\nFramework.success('done')"));
+        assert!(!recognizer.matches("use Framework\nFramework.success('done')"));
     }
 }

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn framework_command_recognizer_requires_each_any_group() {
+    fn test_matches() {
         let recognizer = FrameworkCommandRecognizer {
             id: "test-framework".to_string(),
             requires_all: vec!["command module".to_string()],

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -13,8 +13,8 @@ pub mod versioning;
 
 pub use audit::{
     AuditConfig, ConventionTagGlob, CoreBoundaryLeakConfig, DuplicationDetectorConfig,
-    KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind, KnownSymbolVersionedEntry,
-    RequestedDetectorRule, RequestedDetectorRuleBody,
+    FrameworkCommandRecognizer, KnownSymbolEntry, KnownSymbolHeaderVersionProvider,
+    KnownSymbolKind, KnownSymbolVersionedEntry, RequestedDetectorRule, RequestedDetectorRuleBody,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,


### PR DESCRIPTION
## Summary

Follow-up to #2339. That PR fixed the `command_output_policy` false positives but put WP-CLI symbol recognition directly in homeboy core. This PR removes that framework-specific logic from core and replaces it with a generic extension-owned recognizer contract.

Core now exposes `audit.detector_rules.framework_command_recognizers`, consumed only by `command_output_policy`. A recognizer is an opaque substring rule with:

- `id`
- `requires_all`
- `requires_any`
- `requires_any_groups`

`requires_any_groups` is the important bit: it lets an extension express shapes like `(any framework import marker) AND (any framework output marker)` without hardcoding framework symbols in core.

## What changed

- Removed `is_wp_cli_command_module` and all WP-CLI fixtures from `src/core/code_audit/command_output_policy.rs`.
- Added `FrameworkCommandRecognizer` to `AuditConfig`.
- Plumbed `audit_config.framework_command_recognizers` into `command_output_policy`.
- Replaced WP-CLI-specific detector tests with synthetic framework fixtures.
- Added recognizer matching tests for grouped `any` requirements.

## Companion extension PR

The WordPress/WP-CLI-specific recognizers now live where they belong: `homeboy-extensions`.

Companion PR: https://github.com/Extra-Chill/homeboy-extensions/pull/436

## Validation

Core:

- `cargo fmt --all -- --check` passed.
- `cargo build` passed.
- `cargo build --release` passed.
- `cargo test --lib code_audit::command_output_policy` passed: 8/8.
- `cargo test --lib component::audit` passed: 3/3.

End-to-end with the companion WordPress extension manifest copied into a temporary `HOME`:

- `/Users/chubes/Developer/data-machine`: `command_output_policy` findings = **0**.
- `/Users/chubes/Developer/homeboy`: `command_output_policy` findings = **5** (legitimate #2249 findings preserved).

Without the extension recognizer, data-machine goes back to 3 findings, which confirms the WordPress-specific scope lives in the extension rather than core.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic extension-owned recognizer contract, removed the WP-CLI hardcoding from core, wrote the generic tests, and ran targeted build/test/audit validation. Chris identified the architectural issue and directed that the WP-CLI logic belongs in `homeboy-extensions`.
