### PR TITLE
fix(test): expect persisted run artifact paths

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -663,7 +663,14 @@ mod tests {
                 panic!("expected artifacts output");
             };
             assert_eq!(output.artifacts.len(), 1);
-            assert_eq!(output.artifacts[0].path, artifact_path.to_string_lossy());
+            let reported_path = std::path::PathBuf::from(&output.artifacts[0].path);
+            let expected_file_name = format!("{}-trace-results.json", output.artifacts[0].id);
+            assert_ne!(reported_path, artifact_path);
+            assert!(reported_path.is_file());
+            assert_eq!(
+                reported_path.file_name().and_then(|name| name.to_str()),
+                Some(expected_file_name.as_str())
+            );
         });
     }
 


### PR DESCRIPTION
## Summary
- Update the run artifacts command test to assert the persisted artifact-store path returned by `record_artifact`.
- Keep the test validating that the reported artifact exists and is named with the artifact id plus source filename.

## Why
Homeboy now copies recorded file artifacts into the managed artifact store under `~/.local/share/homeboy/artifacts/<run>/...`. The release pipeline was still failing on a stale test expectation that compared the command output to the original temp source path.

## Testing
- `cargo fmt --check`
- `cargo test artifacts_command_reports_paths`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Diagnosed the release-blocking test assertion, updated the test expectation, and ran targeted plus library test validation for Chris to review.