### PR TITLE
fix(audit): stabilize intra-method duplicate findings

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,8 +3,8 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-05-06T20:31:56Z",
-      "item_count": 562,
+      "created_at": "2026-05-06T21:26:46Z",
+      "item_count": 561,
       "known_fingerprints": [
         "Rust test discovery::tests/commands/supports_test.rs::UnwiredNestedRustTest",
         "Rust test discovery::tests/commands/test_scope_test.rs::UnwiredNestedRustTest",
@@ -67,7 +67,6 @@
         "intra-method-duplication::src/core/db/operations.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/deploy/execution.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/engine/cli_tool.rs::IntraMethodDuplicate",
-        "intra-method-duplication::src/core/extension/grammar.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/extension/test/drift.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/fleet/exec.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/git/operations.rs::IntraMethodDuplicate",
@@ -572,9 +571,9 @@
       "metadata": {
         "alignment_score": 0.930232584476471,
         "known_outliers": [
-          "src/core/engine/undo/entry.rs",
+          "src/core/engine/undo/rollback.rs",
           "src/core/engine/undo/snapshot.rs",
-          "src/core/engine/undo/rollback.rs"
+          "src/core/engine/undo/entry.rs"
         ],
         "outliers_count": 3
       }

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -510,7 +510,11 @@ pub(crate) fn detect_intra_method_duplicates(fingerprints: &[&FileFingerprint]) 
             let mut reported = false;
             let mut suppressed_ranges: Vec<(usize, usize)> = Vec::new();
 
-            for positions in hash_positions.values() {
+            let mut duplicate_windows: Vec<&Vec<(usize, usize)>> =
+                hash_positions.values().collect();
+            duplicate_windows.sort_by_key(|positions| positions.first().copied());
+
+            for positions in duplicate_windows {
                 if reported || positions.len() < 2 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Sort intra-method duplicate windows before reporting so audit picks a deterministic duplicate per method.
- Refresh the audit baseline after deterministic output removes the previously unstable `src/core/extension/grammar.rs` finding.

## Why
The post-merge Release workflow kept failing audit because `detect_intra_method_duplicates` iterated `HashMap::values()`, allowing the selected first duplicate to vary between audit runs. A baseline refresh could drop one finding and the next audit could immediately report it again as new drift.

## Testing
- `cargo fmt --check`
- `cargo test duplication --lib`
- `cargo test --test core_agnostic_test`
- `cargo test --lib`
- `cargo run --quiet --bin homeboy -- audit homeboy --path /Users/chubes/Developer/homeboy@fix-runs-artifact-path-test --output /tmp/homeboy-audit-cargo-deterministic.json --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Diagnosed nondeterministic audit baseline drift, implemented deterministic duplicate-window ordering, refreshed the generated audit baseline, and ran validation for Chris to review.