### PR TITLE
fix(upgrade): verify active binary after upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.157.1"
+version = "0.158.0"
 dependencies = [
  "arboard",
  "base64",

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -152,6 +152,22 @@ mod tests {
     }
 
     #[test]
+    fn test_execute_upgrade() {
+        assert_eq!(
+            parse_cli_version_output("homeboy 0.158.0").as_deref(),
+            Some("0.158.0")
+        );
+        assert!(!upgrade_verification_result("0.157.1", Some("0.157.1")));
+    }
+
+    #[test]
+    fn test_upgrade_verification_result() {
+        assert!(upgrade_verification_result("0.157.1", Some("0.158.0")));
+        assert!(!upgrade_verification_result("0.157.1", Some("0.157.1")));
+        assert!(!upgrade_verification_result("0.157.1", None));
+    }
+
+    #[test]
     fn verification_rejects_unchanged_active_binary() {
         assert!(!upgrade_verification_result("0.157.1", Some("0.157.1")));
     }

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -2,7 +2,7 @@ use crate::defaults;
 use crate::error::{Error, Result};
 use std::process::Command;
 
-use super::helpers::fetch_latest_version;
+use super::helpers::{current_version, version_is_newer};
 use super::types::InstallMethod;
 
 pub(crate) fn execute_upgrade(method: InstallMethod) -> Result<(bool, Option<String>)> {
@@ -92,8 +92,77 @@ pub(crate) fn execute_upgrade(method: InstallMethod) -> Result<(bool, Option<Str
         ));
     }
 
-    // Try to fetch the new version
-    let new_version = fetch_latest_version(method).ok();
+    let new_version = active_binary_version().ok().flatten();
+    let success = upgrade_verification_result(current_version(), new_version.as_deref());
 
-    Ok((true, new_version))
+    Ok((success, new_version))
+}
+
+fn active_binary_version() -> Result<Option<String>> {
+    let exe_path = std::env::current_exe().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("get current executable path".to_string()),
+        )
+    })?;
+
+    let output = Command::new(exe_path)
+        .arg("--version")
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("verify active binary version".to_string()),
+            )
+        })?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    Ok(parse_cli_version_output(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+pub(crate) fn upgrade_verification_result(
+    previous_version: &str,
+    active_version: Option<&str>,
+) -> bool {
+    active_version
+        .map(|version| version_is_newer(version, previous_version))
+        .unwrap_or(false)
+}
+
+fn parse_cli_version_output(output: &str) -> Option<String> {
+    let re = regex::Regex::new(r"(\d+\.\d+\.\d+)").ok()?;
+    re.find(output).map(|m| m.as_str().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_homeboy_version_output() {
+        assert_eq!(
+            parse_cli_version_output("homeboy 0.158.0").as_deref(),
+            Some("0.158.0")
+        );
+    }
+
+    #[test]
+    fn verification_rejects_unchanged_active_binary() {
+        assert!(!upgrade_verification_result("0.157.1", Some("0.157.1")));
+    }
+
+    #[test]
+    fn verification_accepts_newer_active_binary() {
+        assert!(upgrade_verification_result("0.157.1", Some("0.158.0")));
+    }
+
+    #[test]
+    fn verification_rejects_missing_active_binary_version() {
+        assert!(!upgrade_verification_result("0.157.1", None));
+    }
 }

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -74,48 +74,53 @@ pub fn detect_install_method() -> InstallMethod {
         Err(_) => return InstallMethod::Unknown,
     };
 
+    detect_install_method_from_exe_path(&exe_path, |cmd, args| {
+        Command::new(cmd)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    })
+}
+
+pub(crate) fn detect_install_method_from_exe_path<F>(
+    exe_path: &str,
+    mut list_command_succeeds: F,
+) -> InstallMethod
+where
+    F: FnMut(&str, &[&str]) -> bool,
+{
     let defaults = defaults::load_defaults();
 
-    // Check for Homebrew installation via path patterns
+    // Prefer the active executable path over unrelated installed copies.
     for pattern in &defaults.install_methods.homebrew.path_patterns {
         if exe_path.contains(pattern) {
             return InstallMethod::Homebrew;
         }
     }
-
-    // Alternative Homebrew check: brew list (if list_command configured)
-    if let Some(list_cmd) = &defaults.install_methods.homebrew.list_command {
-        let parts: Vec<&str> = list_cmd.split_whitespace().collect();
-        if let Some((cmd, args)) = parts.split_first() {
-            if Command::new(cmd)
-                .args(args)
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false)
-            {
-                return InstallMethod::Homebrew;
-            }
-        }
-    }
-
-    // Check for Cargo installation via path patterns
     for pattern in &defaults.install_methods.cargo.path_patterns {
         if exe_path.contains(pattern) {
             return InstallMethod::Cargo;
         }
     }
-
-    // Check for source installation via path patterns
     for pattern in &defaults.install_methods.source.path_patterns {
         if exe_path.contains(pattern) {
             return InstallMethod::Source;
         }
     }
-
-    // Check for downloaded release binary via path patterns
     for pattern in &defaults.install_methods.binary.path_patterns {
         if exe_path.contains(pattern) {
             return InstallMethod::Binary;
+        }
+    }
+
+    // Fall back to Homebrew presence only when the active path is not recognized.
+    if let Some(list_cmd) = &defaults.install_methods.homebrew.list_command {
+        let parts: Vec<&str> = list_cmd.split_whitespace().collect();
+        if let Some((cmd, args)) = parts.split_first() {
+            if list_command_succeeds(cmd, args) {
+                return InstallMethod::Homebrew;
+            }
         }
     }
 
@@ -214,8 +219,13 @@ pub fn run_upgrade_with_method(
         upgraded: success,
         message: if success {
             format!("Upgraded to {}", new_version.as_deref().unwrap_or("latest"))
+        } else if let Some(version) = &new_version {
+            format!(
+                "Upgrade command completed but active binary is still {}",
+                version
+            )
         } else {
-            "Upgrade command completed but version unchanged".to_string()
+            "Upgrade command completed but active binary version could not be verified".to_string()
         },
         restart_required: success && matches!(install_method, InstallMethod::Source),
         extensions_updated,

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -58,6 +58,36 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_install_method_prefers_active_cargo_path_over_brew_list() {
+        let method = helpers::detect_install_method_from_exe_path(
+            "/Users/chubes/.cargo/bin/homeboy",
+            |cmd, args| cmd == "brew" && args == ["list", "homeboy"],
+        );
+
+        assert_eq!(method, InstallMethod::Cargo);
+    }
+
+    #[test]
+    fn test_detect_install_method_preserves_active_homebrew_path() {
+        let method = helpers::detect_install_method_from_exe_path(
+            "/opt/homebrew/bin/homeboy",
+            |_cmd, _args| false,
+        );
+
+        assert_eq!(method, InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn test_detect_install_method_uses_brew_list_only_as_fallback() {
+        let method = helpers::detect_install_method_from_exe_path(
+            "/Applications/Homeboy/homeboy",
+            |cmd, args| cmd == "brew" && args == ["list", "homeboy"],
+        );
+
+        assert_eq!(method, InstallMethod::Homebrew);
+    }
+
+    #[test]
     fn test_resolve_binary_on_path_var_finds_first_existing_binary() {
         let base = tempdir().unwrap();
         let first = base.path().join("first");


### PR DESCRIPTION
## Summary
- Prefer the active `homeboy` executable path when detecting the upgrade install method, so a cargo binary is not misclassified as Homebrew just because `brew list homeboy` succeeds.
- Verify the active binary's post-upgrade `--version` before reporting `upgraded: true` or a new version.
- Add focused tests for mixed cargo/Homebrew detection and upgrade verification reporting.

Fixes #2357.

## Tests
- `cargo test core::upgrade`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the targeted install-method detection and post-upgrade verification fix, added tests, and ran validation; Chris remains responsible for review and merge.