### PR TITLE
fix(rig): record effective component path on bench output (#2362)

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -397,7 +397,7 @@ fn run_component_with_rig_context(
 ) -> CmdResult<BenchCommandOutput> {
     let rig_spec = rig_context.map(|context| &context.spec);
     let rig_id = rig_context.map(|context| context.id.clone());
-    let rig_snapshot = rig_context.map(|context| context.snapshot.clone());
+    let mut rig_snapshot = rig_context.map(|context| context.snapshot.clone());
     let default_component_id = rig_spec.and_then(|spec| {
         spec.bench
             .as_ref()
@@ -431,6 +431,13 @@ fn run_component_with_rig_context(
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
+
+    if let Some(snapshot) = rig_snapshot.as_mut() {
+        let effective_path = ctx.source_path.to_string_lossy().into_owned();
+        snapshot.set_effective_component_path(&ctx.component_id, &effective_path, |path| {
+            rig::head_sha_and_branch(path)
+        });
+    }
 
     if let Some(spec) = rig_spec {
         run_rig_workload_preflight(spec, ctx.extension_id.as_deref())?;

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1475,3 +1475,6 @@ mod bench_resource_lease_test;
 #[cfg(test)]
 #[path = "../../../tests/core/rig/bench_rig_concurrency_dispatch_test.rs"]
 mod bench_rig_concurrency_dispatch_test;
+#[cfg(test)]
+#[path = "../../../tests/core/rig/bench_rig_path_override_test.rs"]
+mod bench_rig_path_override_test;

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -41,8 +41,8 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, active_run_leases, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    run_check, run_check_groups, run_down, run_repair, run_status, run_up, snapshot_state,
-    CheckReport, DownReport, RepairReport, RepairResourceReport, RigStatusReport,
+    head_sha_and_branch, run_check, run_check_groups, run_down, run_repair, run_status, run_up,
+    snapshot_state, CheckReport, DownReport, RepairReport, RepairResourceReport, RigStatusReport,
     SymlinkStatusReport, SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -482,16 +482,12 @@ pub fn snapshot_state(rig: &RigSpec) -> RigStateSnapshot {
     for (id, comp) in &rig.components {
         let expanded = expand_vars(rig, &comp.path);
         let resolved = shellexpand::tilde(&expanded).into_owned();
-        let sha = run_in_optional(&resolved, "git", &["rev-parse", "HEAD"])
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
-        let branch = run_in_optional(&resolved, "git", &["rev-parse", "--abbrev-ref", "HEAD"])
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+        let (sha, branch) = head_sha_and_branch(&resolved);
         components.insert(
             id.clone(),
             ComponentSnapshot {
                 path: resolved,
+                declared_path: None,
                 sha,
                 branch,
             },
@@ -502,6 +498,21 @@ pub fn snapshot_state(rig: &RigSpec) -> RigStateSnapshot {
         captured_at: now_rfc3339(),
         components,
     }
+}
+
+/// Look up the HEAD SHA and current branch for a path on disk.
+///
+/// Returns `(None, None)` for paths that aren't git repos. Used by both rig
+/// snapshotting and effective-path overrides so persisted snapshots always
+/// describe the checkout that was actually exercised.
+pub fn head_sha_and_branch(path: &str) -> (Option<String>, Option<String>) {
+    let sha = run_in_optional(path, "git", &["rev-parse", "HEAD"])
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let branch = run_in_optional(path, "git", &["rev-parse", "--abbrev-ref", "HEAD"])
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    (sha, branch)
 }
 
 struct RigRunObserver {

--- a/src/core/rig/state.rs
+++ b/src/core/rig/state.rs
@@ -61,8 +61,21 @@ pub struct MaterializedRigState {
 /// Captured component state for one entry in a rig's components map.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ComponentSnapshot {
-    /// Resolved filesystem path after variable and tilde expansion.
+    /// Effective filesystem path used for the invocation.
+    ///
+    /// When a `--path` override (or any caller-supplied effective path) is in
+    /// effect, this is the override path — not the rig-declared one — so the
+    /// snapshot accurately reflects what the workload actually exercised. See
+    /// [`RigStateSnapshot::set_effective_component_path`].
     pub path: String,
+
+    /// Rig-declared path that `path` was overridden away from, if any.
+    ///
+    /// Absent when `path` matches the rig spec. Present when the invocation
+    /// pinned a different checkout via `--path` or another override, so
+    /// callers can still see what the rig itself configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_path: Option<String>,
 
     /// `git rev-parse HEAD` for the path's repo.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,6 +92,37 @@ pub struct RigStateSnapshot {
     pub rig_id: String,
     pub captured_at: String,
     pub components: BTreeMap<String, ComponentSnapshot>,
+}
+
+impl RigStateSnapshot {
+    /// Record the effective filesystem path used for `component_id`.
+    ///
+    /// If the snapshot already lists the component and the rig-declared `path`
+    /// differs from `effective_path`, the rig-declared path is preserved in
+    /// `declared_path` and `path` is updated to the effective one. Git SHA and
+    /// branch are re-queried against the effective path so the snapshot
+    /// reflects what was actually exercised.
+    ///
+    /// No-op when the component isn't tracked by the snapshot or the effective
+    /// path already matches `path`.
+    pub fn set_effective_component_path(
+        &mut self,
+        component_id: &str,
+        effective_path: &str,
+        git_lookup: impl FnOnce(&str) -> (Option<String>, Option<String>),
+    ) {
+        let Some(snapshot) = self.components.get_mut(component_id) else {
+            return;
+        };
+        if snapshot.path == effective_path {
+            return;
+        }
+        let declared = std::mem::replace(&mut snapshot.path, effective_path.to_string());
+        snapshot.declared_path = Some(declared);
+        let (sha, branch) = git_lookup(effective_path);
+        snapshot.sha = sha;
+        snapshot.branch = branch;
+    }
 }
 
 /// Per-service state: PID, start time, health.

--- a/tests/core/rig/bench_rig_path_override_test.rs
+++ b/tests/core/rig/bench_rig_path_override_test.rs
@@ -1,0 +1,89 @@
+//! Effective component path provenance for rig-pinned benches with
+//! `--path` overrides. See Extra-Chill/homeboy#2362.
+//!
+//! Without these tests the rig snapshot persisted on bench output would
+//! still show the rig-declared checkout even when the workload actually
+//! ran against a `--path` override. That makes diagnostics ambiguous —
+//! the workload exercised one checkout while the run envelope reported
+//! another.
+
+use super::*;
+
+#[test]
+fn rig_pinned_bench_with_path_override_records_effective_component_path() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let rig_component_dir = tempfile::TempDir::new().expect("rig component dir");
+        let override_component_dir = tempfile::TempDir::new().expect("override component dir");
+        write_rig(home, "studio-bfb", "studio", rig_component_dir.path());
+
+        let mut args = run_args(
+            None,
+            vec!["studio-bfb".to_string()],
+            vec!["rig-slow".to_string()],
+        );
+        args.run.comp.path = Some(override_component_dir.path().to_string_lossy().into_owned());
+
+        let (output, exit_code) =
+            run(args, &GlobalArgs {}).expect("rig-pinned bench with --path should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Single(result) => {
+                let rig_state = result.rig_state.expect("rig snapshot on rig-pinned output");
+                assert_eq!(rig_state.rig_id, "studio-bfb");
+                let component = rig_state
+                    .components
+                    .get("studio")
+                    .expect("studio component in snapshot");
+                assert_eq!(
+                    component.path,
+                    override_component_dir.path().to_string_lossy()
+                );
+                assert_eq!(
+                    component.declared_path.as_deref(),
+                    Some(rig_component_dir.path().to_string_lossy().as_ref()),
+                    "rig-declared path should be preserved alongside the effective override"
+                );
+            }
+            _ => panic!("expected single output"),
+        }
+    });
+}
+
+#[test]
+fn rig_pinned_bench_without_path_override_keeps_rig_declared_path() {
+    with_isolated_home(|home| {
+        write_bench_extension(home);
+        let rig_component_dir = tempfile::TempDir::new().expect("rig component dir");
+        write_rig(home, "studio-bfb", "studio", rig_component_dir.path());
+
+        let (output, exit_code) = run(
+            run_args(
+                None,
+                vec!["studio-bfb".to_string()],
+                vec!["rig-slow".to_string()],
+            ),
+            &GlobalArgs {},
+        )
+        .expect("rig-pinned bench without override should run");
+
+        assert_eq!(exit_code, 0);
+        match output {
+            BenchOutput::Single(result) => {
+                let rig_state = result.rig_state.expect("rig snapshot");
+                let component = rig_state
+                    .components
+                    .get("studio")
+                    .expect("studio component in snapshot");
+                assert_eq!(component.path, rig_component_dir.path().to_string_lossy());
+                assert!(
+                    component.declared_path.is_none(),
+                    "declared_path is only set when path was actually overridden, got {:?}",
+                    component.declared_path
+                );
+            }
+            _ => panic!("expected single output"),
+        }
+    });
+}

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -17,8 +17,9 @@ use std::collections::HashMap;
 
 use crate::rig::pipeline::PipelineOutcome;
 use crate::rig::runner::{
-    run_check, run_check_groups, run_down, run_repair, run_status, run_up, snapshot_state,
-    CheckReport, RigStatusReport, ServiceStatusReport, SymlinkStatusState, UpReport,
+    head_sha_and_branch, run_check, run_check_groups, run_down, run_repair, run_status, run_up,
+    snapshot_state, CheckReport, RigStatusReport, ServiceStatusReport, SymlinkStatusState,
+    UpReport,
 };
 use crate::rig::spec::{
     ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp,
@@ -745,4 +746,72 @@ fn test_snapshot_state() {
         assert!(entry.sha.is_none(), "non-repo path has no HEAD SHA");
         assert!(entry.branch.is_none(), "non-repo path has no branch");
     }
+}
+
+#[test]
+fn test_head_sha_and_branch_returns_none_for_non_repo_path() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let (sha, branch) = head_sha_and_branch(&temp.path().to_string_lossy());
+    assert!(sha.is_none(), "non-repo path has no HEAD SHA");
+    assert!(branch.is_none(), "non-repo path has no branch");
+}
+
+#[test]
+fn test_head_sha_and_branch_returns_sha_and_branch_for_git_repo() {
+    use std::process::Command;
+
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let path = temp.path();
+
+    // Initialize a minimal git repo with a deterministic commit so the
+    // helper has something to read. Skip the test gracefully when git is
+    // unavailable so the suite stays portable.
+    let init = Command::new("git")
+        .arg("init")
+        .arg("--quiet")
+        .arg("--initial-branch=fixture-main")
+        .current_dir(path)
+        .status();
+    let Ok(status) = init else {
+        eprintln!("git not available; skipping head_sha_and_branch repo test");
+        return;
+    };
+    if !status.success() {
+        eprintln!("git init failed; skipping head_sha_and_branch repo test");
+        return;
+    }
+
+    for (key, value) in [
+        ("user.email", "fixture@example.test"),
+        ("user.name", "Fixture"),
+        ("commit.gpgsign", "false"),
+    ] {
+        let _ = Command::new("git")
+            .args(["config", key, value])
+            .current_dir(path)
+            .status();
+    }
+
+    std::fs::write(path.join("README"), b"fixture\n").expect("write readme");
+    let _ = Command::new("git")
+        .args(["add", "README"])
+        .current_dir(path)
+        .status();
+    let commit = Command::new("git")
+        .args(["commit", "--quiet", "-m", "fixture"])
+        .current_dir(path)
+        .status();
+    if !commit.map(|s| s.success()).unwrap_or(false) {
+        eprintln!("git commit failed; skipping head_sha_and_branch repo test");
+        return;
+    }
+
+    let (sha, branch) = head_sha_and_branch(&path.to_string_lossy());
+    let sha = sha.expect("HEAD SHA on a fresh git repo");
+    assert_eq!(sha.len(), 40, "HEAD SHA is full 40-char hex: {sha}");
+    assert!(
+        sha.chars().all(|c| c.is_ascii_hexdigit()),
+        "HEAD SHA is hex: {sha}"
+    );
+    assert_eq!(branch.as_deref(), Some("fixture-main"));
 }

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -4,8 +4,13 @@
 //! touching real user state), so this module exercises serde round-tripping
 //! which is the meaningful invariant.
 
+use std::collections::BTreeMap;
+
 use crate::rig::spec::RigResourcesSpec;
-use crate::rig::state::{MaterializedRigState, RigState, ServiceState, SharedPathState};
+use crate::rig::state::{
+    ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
+    SharedPathState,
+};
 
 #[test]
 fn test_state_round_trips_empty() {
@@ -91,6 +96,121 @@ fn test_state_round_trips_with_materialized_ownership() {
     assert_eq!(
         materialized.resources.process_patterns,
         vec!["wordpress-server-child"]
+    );
+}
+
+fn snapshot_with_component(component_id: &str, path: &str) -> RigStateSnapshot {
+    let mut components = BTreeMap::new();
+    components.insert(
+        component_id.to_string(),
+        ComponentSnapshot {
+            path: path.to_string(),
+            declared_path: None,
+            sha: Some("aaaaaaaa".to_string()),
+            branch: Some("main".to_string()),
+        },
+    );
+    RigStateSnapshot {
+        rig_id: "studio".to_string(),
+        captured_at: "2026-05-04T00:00:00Z".to_string(),
+        components,
+    }
+}
+
+#[test]
+fn set_effective_component_path_records_override_and_preserves_declared() {
+    let mut snapshot = snapshot_with_component("studio", "/Users/chubes/Developer/studio");
+
+    snapshot.set_effective_component_path(
+        "studio",
+        "/Users/chubes/Developer/studio@worktree",
+        |path| {
+            assert_eq!(path, "/Users/chubes/Developer/studio@worktree");
+            (Some("bbbbbbbb".to_string()), Some("feature".to_string()))
+        },
+    );
+
+    let component = snapshot.components.get("studio").expect("component");
+    assert_eq!(component.path, "/Users/chubes/Developer/studio@worktree");
+    assert_eq!(
+        component.declared_path.as_deref(),
+        Some("/Users/chubes/Developer/studio")
+    );
+    assert_eq!(component.sha.as_deref(), Some("bbbbbbbb"));
+    assert_eq!(component.branch.as_deref(), Some("feature"));
+}
+
+#[test]
+fn set_effective_component_path_is_noop_when_path_matches() {
+    let mut snapshot = snapshot_with_component("studio", "/Users/chubes/Developer/studio");
+
+    snapshot.set_effective_component_path("studio", "/Users/chubes/Developer/studio", |_| {
+        panic!("git lookup must not run when paths already match")
+    });
+
+    let component = snapshot.components.get("studio").expect("component");
+    assert_eq!(component.path, "/Users/chubes/Developer/studio");
+    assert!(component.declared_path.is_none());
+    assert_eq!(component.sha.as_deref(), Some("aaaaaaaa"));
+    assert_eq!(component.branch.as_deref(), Some("main"));
+}
+
+#[test]
+fn set_effective_component_path_ignores_unknown_component() {
+    let mut snapshot = snapshot_with_component("studio", "/Users/chubes/Developer/studio");
+
+    snapshot.set_effective_component_path("missing", "/tmp/anywhere", |_| {
+        panic!("git lookup must not run when component is unknown");
+    });
+
+    let component = snapshot.components.get("studio").expect("component");
+    assert_eq!(component.path, "/Users/chubes/Developer/studio");
+    assert!(component.declared_path.is_none());
+    assert!(snapshot.components.get("missing").is_none());
+}
+
+#[test]
+fn set_effective_component_path_clears_stale_git_metadata_for_non_repo_path() {
+    let mut snapshot = snapshot_with_component("studio", "/Users/chubes/Developer/studio");
+
+    snapshot.set_effective_component_path("studio", "/tmp/not-a-repo", |_| (None, None));
+
+    let component = snapshot.components.get("studio").expect("component");
+    assert_eq!(component.path, "/tmp/not-a-repo");
+    assert_eq!(
+        component.declared_path.as_deref(),
+        Some("/Users/chubes/Developer/studio")
+    );
+    assert!(component.sha.is_none());
+    assert!(component.branch.is_none());
+}
+
+#[test]
+fn component_snapshot_round_trips_declared_path() {
+    let snapshot = ComponentSnapshot {
+        path: "/tmp/effective".to_string(),
+        declared_path: Some("/tmp/declared".to_string()),
+        sha: None,
+        branch: None,
+    };
+    let json = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(json.contains("\"declared_path\":\"/tmp/declared\""));
+    let parsed: ComponentSnapshot = serde_json::from_str(&json).expect("parse");
+    assert_eq!(parsed.declared_path.as_deref(), Some("/tmp/declared"));
+}
+
+#[test]
+fn component_snapshot_omits_declared_path_when_absent() {
+    let snapshot = ComponentSnapshot {
+        path: "/tmp/effective".to_string(),
+        declared_path: None,
+        sha: None,
+        branch: None,
+    };
+    let json = serde_json::to_string(&snapshot).expect("serialize");
+    assert!(
+        !json.contains("declared_path"),
+        "json should omit declared_path when None: {json}"
     );
 }
 


### PR DESCRIPTION
## Summary

- `homeboy bench --rig <id> --path <override>` now records the override path as `rig_state.components.<id>.path` in persisted bench output, so the run envelope matches the checkout the workload actually exercised.
- The rig-declared path is preserved in a new optional `rig_state.components.<id>.declared_path` field whenever an override is in effect.
- Re-queries git SHA / branch against the effective path so the snapshot is honest about which commits the numbers were measured against.

## Why

Closes #2362. Before this change, the workload received the override via `HOMEBOY_COMPONENT_PATH`, but the run envelope still showed the rig-configured checkout. That made the Studio Site Editor diagnostics run ambiguous and forced workload-level shims (`studioPath`) just to prove provenance. This is generic run provenance and belongs in Homeboy core: any rig/component invocation with a path override should make the effective checkout obvious in persisted metadata and reports.

## Implementation

- `ComponentSnapshot` gains an optional `declared_path: Option<String>` field, `#[serde(default, skip_serializing_if = "Option::is_none")]` so the legacy shape is preserved when no override is in play.
- New `RigStateSnapshot::set_effective_component_path(component_id, effective_path, git_lookup)` helper: no-op when paths match, otherwise moves the current `path` into `declared_path`, sets `path` to the effective one, and refreshes git SHA/branch from the supplied closure.
- New `rig::head_sha_and_branch(path)` helper extracted from `snapshot_state` so override application reuses the same git probing as the initial snapshot.
- `commands::bench::matrix::run_component_with_rig_context` applies the override to the local `rig_snapshot` clone after the execution context is resolved, using `ctx.source_path` (the canonical resolved path). Both the persisted bench output (`BenchCommandOutput.rig_state`) and the observation metadata see the corrected snapshot.

## Behavior

- No override: `path` stays the rig-declared one, `declared_path` is absent. Identical to today's output shape.
- With `--path /tmp/example` on a rig-pinned bench: `path` becomes `/tmp/example`, `declared_path` is the rig-configured checkout, `sha`/`branch` reflect `/tmp/example`'s git state.

## Tests

- New `tests/core/rig/bench_rig_path_override_test.rs`:
  - `rig_pinned_bench_with_path_override_records_effective_component_path` — `--path` override on a rig-pinned bench surfaces the override path with `declared_path` preserving the rig-declared one.
  - `rig_pinned_bench_without_path_override_keeps_rig_declared_path` — back-compat: no override means no `declared_path`.
- `tests/core/rig/state_test.rs`:
  - Round-trip + omission tests for the new `declared_path` field.
  - Unit tests covering `set_effective_component_path` for the override / no-op / unknown-component / non-repo-effective-path cases.

Ran:

- `cargo test --lib commands::bench::tests::bench_rig_path_override_test::` — 2 passed.
- `cargo test --lib core::rig::` — 228 passed.
- `cargo test --lib commands::bench::` — 92 passed.
- `cargo test --lib commands::trace::` — 40 passed.
- `cargo test --lib core::extension::bench` — 123 passed.
- `cargo build --bin homeboy` — clean.
- `cargo clippy --lib` — no new warnings introduced by this change.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (openai/gpt-5.5)
- **Used for:** Drafted the snapshot mutation helper, the bench dispatcher hook, and both the integration and unit tests; Chris reviewed the design choice (extra `declared_path` field vs renaming `path`), the back-compat shape, and ran the test suite.