### PR TITLE
feat(observation): persist resource policy context with run metadata (#2363)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.158.1"
+version = "0.158.2"
 dependencies = [
  "arboard",
  "base64",

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -8,6 +8,8 @@ use homeboy::git::short_head_revision_at;
 use homeboy::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::rig::RigStateSnapshot;
 
+use crate::commands::utils::resource_policy;
+
 use super::BenchRunArgs;
 
 pub(super) struct BenchObservation(ActiveObservation);
@@ -164,6 +166,10 @@ fn bench_observation_initial_metadata(
     rig_snapshot: Option<&RigStateSnapshot>,
     run_dir: &RunDir,
 ) -> serde_json::Value {
+    let resource_policy = resource_policy::captured_context()
+        .as_ref()
+        .map(resource_policy::ResourcePolicyContext::to_json)
+        .unwrap_or(serde_json::Value::Null);
     serde_json::json!({
         "component_label": component_label,
         "iterations": args.iterations,
@@ -181,6 +187,7 @@ fn bench_observation_initial_metadata(
         "shared_state": args.shared_state.as_ref().map(|path| path.to_string_lossy().to_string()),
         "run_dir": run_dir.path().to_string_lossy().to_string(),
         "rig_state": rig_snapshot,
+        "resource_policy": resource_policy,
     })
 }
 
@@ -382,9 +389,13 @@ mod tests {
 
     use super::*;
     use crate::commands::bench::BenchRigOrder;
+    use crate::commands::doctor::resources::{
+        DoctorOutput, LoadSummary, ProcessSummary, ResourceRecommendation, RigLeaseSummary,
+    };
     use crate::commands::utils::args::{
         BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
     };
+    use crate::commands::utils::resource_policy::{self, HotCommand, ResourcePolicyContext};
     use crate::test_support::with_isolated_home;
 
     struct XdgGuard(Option<String>);
@@ -858,5 +869,205 @@ mod tests {
 
         assert!(hints.iter().any(|hint| hint
             == "List related bench runs: homeboy runs list --kind bench --component studio --rig studio-trunk"));
+    }
+
+    fn synthetic_resources(recommendation: ResourceRecommendation) -> DoctorOutput {
+        DoctorOutput {
+            command: "doctor.resources",
+            recommendation,
+            load: LoadSummary {
+                one: Some(18.2),
+                five: Some(15.0),
+                fifteen: Some(12.0),
+                cpu_count: 18,
+                recommendation,
+            },
+            memory: None,
+            processes: ProcessSummary {
+                relevant_count: 3,
+                top_cpu: Vec::new(),
+                top_rss: Vec::new(),
+                recommendation: ResourceRecommendation::Ok,
+            },
+            rig_leases: RigLeaseSummary {
+                active_count: 0,
+                leases: Vec::new(),
+                recommendation: ResourceRecommendation::Ok,
+            },
+            notes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn bench_observation_persists_resource_policy_warning_for_hot_machine() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            resource_policy::reset_captured_context_for_test();
+
+            let synthetic = synthetic_resources(ResourceRecommendation::Hot);
+            let warning = resource_policy::evaluate(HotCommand { label: "bench" }, &synthetic)
+                .expect("synthetic warning");
+            resource_policy::capture_context(ResourcePolicyContext::from_evaluation(
+                HotCommand { label: "bench" },
+                &synthetic,
+                Some(&warning),
+                false,
+            ));
+
+            let run_dir = RunDir::create().expect("run dir");
+            fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+
+            let args = bench_args();
+            let observation = start(BenchObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: home.path(),
+                args: &args,
+                selected_scenarios: &[],
+                rig_id: None,
+                rig_snapshot: None,
+                run_dir: &run_dir,
+            })
+            .expect("start observation");
+            let run_id = observation.run_id().to_string();
+
+            let mut workflow = BenchRunWorkflowResult {
+                status: "passed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 0,
+                iterations: 10,
+                results: None,
+                gate_failures: Vec::new(),
+                baseline_comparison: None,
+                hints: None,
+                failure: None,
+                diagnostics: Vec::new(),
+            };
+            finish_success(Some(observation), &mut workflow, &run_dir)
+                .expect("observation summary");
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.get_run(&run_id).expect("read run").expect("run");
+            let policy = &run.metadata_json["resource_policy"];
+            assert_eq!(policy["command"], "bench");
+            assert_eq!(policy["severity"], "hot");
+            assert_eq!(policy["force_hot"], false);
+            assert_eq!(policy["warned"], true);
+            assert!(policy["message"]
+                .as_str()
+                .expect("message string")
+                .contains("Resource policy warning"));
+            assert_eq!(policy["host"]["load_severity"], "hot");
+            assert_eq!(policy["host"]["load_one"], 18.2);
+            assert_eq!(policy["host"]["cpu_count"], 18);
+
+            resource_policy::reset_captured_context_for_test();
+        });
+    }
+
+    #[test]
+    fn bench_observation_records_force_hot_bypass() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            resource_policy::reset_captured_context_for_test();
+
+            let synthetic = synthetic_resources(ResourceRecommendation::Hot);
+            let warning = resource_policy::evaluate(HotCommand { label: "bench" }, &synthetic)
+                .expect("synthetic warning");
+            resource_policy::capture_context(ResourcePolicyContext::from_evaluation(
+                HotCommand { label: "bench" },
+                &synthetic,
+                Some(&warning),
+                true,
+            ));
+
+            let run_dir = RunDir::create().expect("run dir");
+            fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+
+            let args = bench_args();
+            let observation = start(BenchObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: home.path(),
+                args: &args,
+                selected_scenarios: &[],
+                rig_id: None,
+                rig_snapshot: None,
+                run_dir: &run_dir,
+            })
+            .expect("start observation");
+            let run_id = observation.run_id().to_string();
+
+            let mut workflow = BenchRunWorkflowResult {
+                status: "passed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 0,
+                iterations: 10,
+                results: None,
+                gate_failures: Vec::new(),
+                baseline_comparison: None,
+                hints: None,
+                failure: None,
+                diagnostics: Vec::new(),
+            };
+            finish_success(Some(observation), &mut workflow, &run_dir)
+                .expect("observation summary");
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.get_run(&run_id).expect("read run").expect("run");
+            let policy = &run.metadata_json["resource_policy"];
+            assert_eq!(policy["severity"], "hot");
+            assert_eq!(policy["force_hot"], true);
+            assert_eq!(policy["warned"], true);
+
+            resource_policy::reset_captured_context_for_test();
+        });
+    }
+
+    #[test]
+    fn bench_observation_omits_resource_policy_when_not_captured() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            resource_policy::reset_captured_context_for_test();
+
+            let run_dir = RunDir::create().expect("run dir");
+            fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+
+            let args = bench_args();
+            let observation = start(BenchObservationStart {
+                component_id: "homeboy",
+                component_label: "homeboy",
+                source_path: home.path(),
+                args: &args,
+                selected_scenarios: &[],
+                rig_id: None,
+                rig_snapshot: None,
+                run_dir: &run_dir,
+            })
+            .expect("start observation");
+            let run_id = observation.run_id().to_string();
+
+            let mut workflow = BenchRunWorkflowResult {
+                status: "passed".to_string(),
+                component: "homeboy".to_string(),
+                exit_code: 0,
+                iterations: 10,
+                results: None,
+                gate_failures: Vec::new(),
+                baseline_comparison: None,
+                hints: None,
+                failure: None,
+                diagnostics: Vec::new(),
+            };
+            finish_success(Some(observation), &mut workflow, &run_dir)
+                .expect("observation summary");
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.get_run(&run_id).expect("read run").expect("run");
+            // When no preflight context was captured (e.g. the bench was
+            // invoked from a context where main never ran), the metadata
+            // explicitly records `null` rather than fabricating a snapshot.
+            assert!(run.metadata_json["resource_policy"].is_null());
+        });
     }
 }

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -1,3 +1,7 @@
+use std::sync::RwLock;
+
+use serde::{Deserialize, Serialize};
+
 use crate::cli_surface::Commands;
 
 use crate::commands::doctor::resources::{DoctorOutput, ResourceRecommendation};
@@ -12,6 +16,160 @@ pub struct ResourcePolicyWarning {
     pub command: &'static str,
     pub recommendation: ResourceRecommendation,
     pub message: String,
+}
+
+/// Persisted, host-pressure context captured at preflight time for any
+/// observation run that originates from a "hot" command (`bench`, `rig up`,
+/// `lint`, `test`, `audit`, etc.).
+///
+/// Generic across components and rigs. Persisted into observation run
+/// `metadata_json` under the `resource_policy` key so later readers can
+/// distinguish noisy timings caused by host pressure from regressions in the
+/// system under test.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourcePolicyContext {
+    /// Hot command label (e.g. `bench`, `lint`).
+    pub command: String,
+    /// Overall severity: `ok`, `warm`, or `hot`.
+    pub severity: String,
+    /// Whether the user passed `--force-hot` to intentionally bypass the
+    /// warning. When true and severity is non-ok, the warning was suppressed
+    /// from stderr but still recorded here.
+    pub force_hot: bool,
+    /// Whether a warning was emitted (or would have been) for this run.
+    pub warned: bool,
+    /// Human-readable warning message produced by the policy, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Structured host snapshot used to derive the severity.
+    pub host: ResourcePolicyHostSnapshot,
+}
+
+/// Subset of the doctor resource report that explains why the resource policy
+/// fired. Stored as plain numbers/strings so it round-trips cleanly through
+/// JSON without depending on internal `DoctorOutput` types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourcePolicyHostSnapshot {
+    /// Severity of the load average alone.
+    pub load_severity: String,
+    /// 1-minute load average if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_one: Option<f64>,
+    /// 5-minute load average if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_five: Option<f64>,
+    /// 15-minute load average if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_fifteen: Option<f64>,
+    /// CPU count reported by the host.
+    pub cpu_count: usize,
+    /// Memory severity if memory data was collected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_severity: Option<String>,
+    /// Memory used percent if memory data was collected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_used_percent: Option<f64>,
+    /// Memory available in MB if memory data was collected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_available_mb: Option<u64>,
+    /// Number of Homeboy-adjacent processes already active.
+    pub relevant_process_count: usize,
+    /// Severity classification of the active process set.
+    pub process_severity: String,
+    /// Number of active rig run leases.
+    pub active_rig_lease_count: usize,
+    /// Severity classification of the active rig lease set.
+    pub rig_lease_severity: String,
+}
+
+impl ResourcePolicyContext {
+    /// Build a structured context from a `DoctorOutput`, the matched hot
+    /// command, an optional warning, and whether `--force-hot` was passed.
+    pub fn from_evaluation(
+        command: HotCommand,
+        resources: &DoctorOutput,
+        warning: Option<&ResourcePolicyWarning>,
+        force_hot: bool,
+    ) -> Self {
+        Self {
+            command: command.label.to_string(),
+            severity: severity_str(resources.recommendation).to_string(),
+            force_hot,
+            warned: warning.is_some(),
+            message: warning.map(|warning| warning.message.clone()),
+            host: ResourcePolicyHostSnapshot {
+                load_severity: severity_str(resources.load.recommendation).to_string(),
+                load_one: resources.load.one,
+                load_five: resources.load.five,
+                load_fifteen: resources.load.fifteen,
+                cpu_count: resources.load.cpu_count,
+                memory_severity: resources
+                    .memory
+                    .as_ref()
+                    .map(|memory| severity_str(memory.recommendation).to_string()),
+                memory_used_percent: resources.memory.as_ref().map(|memory| memory.used_percent),
+                memory_available_mb: resources.memory.as_ref().map(|memory| memory.available_mb),
+                relevant_process_count: resources.processes.relevant_count,
+                process_severity: severity_str(resources.processes.recommendation).to_string(),
+                active_rig_lease_count: resources.rig_leases.active_count,
+                rig_lease_severity: severity_str(resources.rig_leases.recommendation).to_string(),
+            },
+        }
+    }
+
+    /// Serialize as the JSON value that lands inside observation
+    /// `metadata_json["resource_policy"]`.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+fn severity_str(recommendation: ResourceRecommendation) -> &'static str {
+    match recommendation {
+        ResourceRecommendation::Ok => "ok",
+        ResourceRecommendation::Warm => "warm",
+        ResourceRecommendation::Hot => "hot",
+    }
+}
+
+/// Process-wide capture of the preflight resource policy decision so that
+/// observation runs started later in the command can include it in their
+/// metadata without re-querying the host (which would re-introduce flakiness
+/// and double-count Homeboy as a relevant process).
+fn captured_storage() -> &'static RwLock<Option<ResourcePolicyContext>> {
+    static STORAGE: std::sync::OnceLock<RwLock<Option<ResourcePolicyContext>>> =
+        std::sync::OnceLock::new();
+    STORAGE.get_or_init(|| RwLock::new(None))
+}
+
+/// Capture the resource policy context for the current process. Idempotent
+/// against later overwrites in production: once a context is recorded, repeat
+/// captures are dropped so the preflight decision wins. Tests can override
+/// this by calling [`reset_captured_context_for_test`] first.
+pub fn capture_context(context: ResourcePolicyContext) {
+    let mut slot = match captured_storage().write() {
+        Ok(slot) => slot,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if slot.is_none() {
+        *slot = Some(context);
+    }
+}
+
+/// Return a clone of the resource policy context captured at preflight time,
+/// if any.
+pub fn captured_context() -> Option<ResourcePolicyContext> {
+    captured_storage().read().ok().and_then(|slot| slot.clone())
+}
+
+/// Clear the captured context. Test-only: production code never resets the
+/// preflight decision so that the persisted observation matches the warning
+/// the user actually saw on stderr.
+#[cfg(test)]
+pub fn reset_captured_context_for_test() {
+    if let Ok(mut slot) = captured_storage().write() {
+        *slot = None;
+    }
 }
 
 pub fn hot_command(command: &Commands) -> Option<HotCommand> {
@@ -48,11 +206,7 @@ fn warning_message(
     recommendation: ResourceRecommendation,
     resources: &DoctorOutput,
 ) -> String {
-    let severity = match recommendation {
-        ResourceRecommendation::Ok => "ok",
-        ResourceRecommendation::Warm => "warm",
-        ResourceRecommendation::Hot => "hot",
-    };
+    let severity = severity_str(recommendation);
     let reason = primary_reason(resources);
     format!(
         "Resource policy warning: machine is {severity}; starting `{command}` may skew results or add pressure. {reason} Use --force-hot to run without this warning."
@@ -107,7 +261,9 @@ fn primary_reason(resources: &DoctorOutput) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::doctor::resources::{LoadSummary, ProcessSummary, RigLeaseSummary};
+    use crate::commands::doctor::resources::{
+        LoadSummary, MemorySummary, ProcessSummary, RigLeaseSummary,
+    };
 
     fn resources(recommendation: ResourceRecommendation) -> DoctorOutput {
         DoctorOutput {
@@ -162,5 +318,111 @@ mod tests {
             &resources(ResourceRecommendation::Ok)
         )
         .is_none());
+    }
+
+    #[test]
+    fn context_records_severity_warning_and_host_snapshot_when_hot() {
+        let resources = resources(ResourceRecommendation::Hot);
+        let warning = evaluate(HotCommand { label: "bench" }, &resources).expect("warning");
+        let context = ResourcePolicyContext::from_evaluation(
+            HotCommand { label: "bench" },
+            &resources,
+            Some(&warning),
+            false,
+        );
+
+        assert_eq!(context.command, "bench");
+        assert_eq!(context.severity, "hot");
+        assert!(!context.force_hot);
+        assert!(context.warned);
+        assert!(context
+            .message
+            .as_deref()
+            .expect("message")
+            .contains("Resource policy warning"));
+        assert_eq!(context.host.load_severity, "hot");
+        assert_eq!(context.host.load_one, Some(9.0));
+        assert_eq!(context.host.cpu_count, 4);
+        assert_eq!(context.host.memory_severity, None);
+        assert_eq!(context.host.relevant_process_count, 0);
+        assert_eq!(context.host.process_severity, "ok");
+        assert_eq!(context.host.active_rig_lease_count, 0);
+        assert_eq!(context.host.rig_lease_severity, "ok");
+    }
+
+    #[test]
+    fn context_records_force_hot_bypass_for_hot_machine() {
+        let resources = resources(ResourceRecommendation::Hot);
+        let warning = evaluate(HotCommand { label: "bench" }, &resources).expect("warning");
+        let context = ResourcePolicyContext::from_evaluation(
+            HotCommand { label: "bench" },
+            &resources,
+            Some(&warning),
+            true,
+        );
+
+        assert!(context.force_hot);
+        assert!(context.warned);
+        assert_eq!(context.severity, "hot");
+        assert!(context.message.is_some());
+    }
+
+    #[test]
+    fn context_records_ok_machine_with_no_warning() {
+        let resources = resources(ResourceRecommendation::Ok);
+        assert!(evaluate(HotCommand { label: "bench" }, &resources).is_none());
+        let context = ResourcePolicyContext::from_evaluation(
+            HotCommand { label: "bench" },
+            &resources,
+            None,
+            false,
+        );
+
+        assert_eq!(context.severity, "ok");
+        assert!(!context.warned);
+        assert!(context.message.is_none());
+        assert!(!context.force_hot);
+    }
+
+    #[test]
+    fn context_includes_memory_snapshot_when_available() {
+        let mut resources = resources(ResourceRecommendation::Warm);
+        resources.memory = Some(MemorySummary {
+            total_mb: 32_000,
+            available_mb: 1_500,
+            used_percent: 95.3,
+            recommendation: ResourceRecommendation::Warm,
+        });
+        let context = ResourcePolicyContext::from_evaluation(
+            HotCommand { label: "bench" },
+            &resources,
+            None,
+            false,
+        );
+
+        assert_eq!(context.host.memory_severity.as_deref(), Some("warm"));
+        assert_eq!(context.host.memory_used_percent, Some(95.3));
+        assert_eq!(context.host.memory_available_mb, Some(1_500));
+    }
+
+    #[test]
+    fn context_serializes_to_json_with_expected_keys() {
+        let resources = resources(ResourceRecommendation::Hot);
+        let warning = evaluate(HotCommand { label: "bench" }, &resources).expect("warning");
+        let context = ResourcePolicyContext::from_evaluation(
+            HotCommand { label: "bench" },
+            &resources,
+            Some(&warning),
+            false,
+        );
+        let value = context.to_json();
+
+        assert_eq!(value["command"], "bench");
+        assert_eq!(value["severity"], "hot");
+        assert_eq!(value["force_hot"], false);
+        assert_eq!(value["warned"], true);
+        assert!(value["message"].is_string());
+        assert_eq!(value["host"]["load_severity"], "hot");
+        assert_eq!(value["host"]["cpu_count"], 4);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,15 +165,27 @@ fn main() -> std::process::ExitCode {
         output_file = None;
     }
 
-    if !cli.force_hot {
-        if let Some(hot_command) = resource_policy::hot_command(&cli.command) {
-            if let Ok((resources, _)) = homeboy::commands::doctor::resources::run(
-                homeboy::commands::doctor::resources::ResourcesArgs {},
-            ) {
-                if let Some(warning) = resource_policy::evaluate(hot_command, &resources) {
+    if let Some(hot_command) = resource_policy::hot_command(&cli.command) {
+        if let Ok((resources, _)) = homeboy::commands::doctor::resources::run(
+            homeboy::commands::doctor::resources::ResourcesArgs {},
+        ) {
+            let warning = resource_policy::evaluate(hot_command, &resources);
+            if let Some(warning) = warning.as_ref() {
+                if !cli.force_hot {
                     eprintln!("{}", warning.message);
                 }
             }
+            // Persist the preflight resource policy decision so observation
+            // runs (bench, lint, test, etc.) can record it in their metadata
+            // for later interpretation. This stays generic to Homeboy core.
+            resource_policy::capture_context(
+                resource_policy::ResourcePolicyContext::from_evaluation(
+                    hot_command,
+                    &resources,
+                    warning.as_ref(),
+                    cli.force_hot,
+                ),
+            );
         }
     }
 


### PR DESCRIPTION
Closes #2363.

## Summary

Hot commands (`bench`, `lint`, `test`, `audit`, `rig up`, `fleet exec`) already emit a stderr resource policy warning when the host is warm or hot. That warning was ephemeral — once a benchmark finished, later readers of the persisted run could not tell whether noisy timings came from the system under test or from host pressure at preflight.

This PR threads the preflight decision through to the observation run so it lands in `metadata.resource_policy` and surfaces naturally in `homeboy runs show <id>` and JSON output.

## What changed

- Added `ResourcePolicyContext` and `ResourcePolicyHostSnapshot` (serializable) in `commands::utils::resource_policy`. Captures `command`, `severity` (`ok`/`warm`/`hot`), `force_hot`, `warned`, the human warning `message`, and a structured host snapshot: load 1/5/15, CPU count, memory severity / used percent / available MB (when available), relevant process count, active rig lease count, and per-signal severities.
- `main` now evaluates the resource policy even when `--force-hot` is passed, so the bypass is recorded as `force_hot: true, warned: true`. The stderr warning is still suppressed under `--force-hot`, matching prior UX.
- Captured context is stored in a process-wide slot (`RwLock<Option<...>>`, first-write-wins) and read by `bench/observation::bench_observation_initial_metadata`. The persisted run now carries `metadata.resource_policy`.
- `homeboy runs show` already flattens `metadata` as a JSON value, so no `runs` plumbing changes were needed — the new section appears in both human and JSON output for free.

## Tests

- New unit tests in `resource_policy.rs` for context construction across `ok` / `warm` / `hot` / memory-pressure / `--force-hot` cases and for JSON serialization.
- New bench observation tests that inject a synthetic `DoctorOutput` (load average 18.2, 18 CPUs — same shape the issue cited from the Studio diagnostics run) and assert the persisted run includes the structured `resource_policy` block, including a `force_hot` bypass case and the negative case where no preflight context is captured.
- All assertions are against synthetic data; no test depends on actual host load.

Test runs (in the worktree):

```
cargo test --lib
# 2739 passed; 0 failed; 1 ignored

cargo test --lib bench::observation
# 9 passed (3 new + 6 existing)

cargo test --lib resource_policy
# 9 passed (4 new + 3 existing context tests + 2 existing warning tests)

cargo test --test command_surface_test
# 5 passed

cargo fmt --check  # clean after `cargo fmt`
cargo clippy --lib --bin homeboy  # no new warnings on touched files
```

## Generic to Homeboy core

No WordPress, Studio, or extension-specific logic. Bench is the only observation start site wired in this PR (it is the one cited in the issue), but `resource_policy::captured_context()` is a public helper any other hot-command observation entry point (`test`, `trace`, `rig`, `lint`) can adopt the same way without further changes to the captured shape.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (openai/gpt-5.5)
- **Used for:** Drafted the `ResourcePolicyContext` struct, the process-wide capture wiring in `main`, the bench observation metadata hookup, and the synthetic-resource tests. Chris reviewed and ran the full lib test suite locally before merge.