### PR TITLE
fix(release): surface dirty file list and refresh stale git index before working-tree check

### DIFF
--- a/src/core/engine/validation.rs
+++ b/src/core/engine/validation.rs
@@ -64,15 +64,7 @@ impl ValidationCollector {
     pub fn finish(self) -> Result<()> {
         match self.errors.len() {
             0 => Ok(()),
-            1 => {
-                let err = &self.errors[0];
-                Err(Error::validation_invalid_argument(
-                    &err.field,
-                    &err.problem,
-                    None,
-                    None,
-                ))
-            }
+            1 => Err(single_error_to_invalid_argument(&self.errors[0])),
             _ => Err(Error::validation_multiple_errors(self.errors)),
         }
     }
@@ -93,17 +85,27 @@ impl ValidationCollector {
         }
         let drained: Vec<_> = std::mem::take(&mut self.errors);
         match drained.len() {
-            1 => {
-                let err = &drained[0];
-                Err(Error::validation_invalid_argument(
-                    &err.field,
-                    &err.problem,
-                    None,
-                    None,
-                ))
-            }
+            1 => Err(single_error_to_invalid_argument(&drained[0])),
             _ => Err(Error::validation_multiple_errors(drained)),
         }
+    }
+}
+
+/// Convert a single collected validation error back into an [`Error`].
+///
+/// Preserves any structured `context` payload the original validator attached
+/// (file lists, hints, deeper diagnostic data). Without this, the single-error
+/// re-emit path would drop everything except `field`/`problem` — making it
+/// impossible to debug failures that bottle up via `ValidationCollector`
+/// (e.g. release working-tree checks emitting the dirty file list).
+fn single_error_to_invalid_argument(err: &crate::error::ValidationErrorItem) -> Error {
+    let base = Error::validation_invalid_argument(&err.field, &err.problem, None, None);
+    match &err.context {
+        Some(context) => Error {
+            details: context.clone(),
+            ..base
+        },
+        None => base,
     }
 }
 
@@ -183,5 +185,53 @@ mod tests {
         // Multiple errors flow through validation_multiple_errors and
         // surface as a structured payload (not a single invalid_argument).
         assert!(err.message.to_lowercase().contains("validation"));
+    }
+
+    #[test]
+    fn test_finish_if_errors_preserves_single_error_context() {
+        // Regression: the single-error re-emit path used to drop the
+        // `context` JSON entirely, making structured diagnostics
+        // (e.g. release working-tree dirty file lists) invisible to
+        // JSON consumers. Now context is preserved verbatim.
+        let mut v = ValidationCollector::new();
+        let context = serde_json::json!({
+            "files": ["target/foo.rs", "Cargo.lock"],
+            "hint": "Commit, stash, or discard changes before releasing",
+        });
+        v.push("working_tree", "Uncommitted changes detected", Some(context.clone()));
+
+        let err = v.finish_if_errors().unwrap_err();
+        assert_eq!(err.details, context);
+    }
+
+    #[test]
+    fn test_finish_preserves_single_error_context() {
+        // Same regression as above, but on the consume-self `finish` path
+        // taken by validators that don't need fail-fast semantics.
+        let mut v = ValidationCollector::new();
+        let context = serde_json::json!({"files": ["only.rs"]});
+        v.push("field", "problem", Some(context.clone()));
+
+        let err = v.finish().unwrap_err();
+        assert_eq!(err.details, context);
+    }
+
+    #[test]
+    fn test_finish_if_errors_single_error_without_context_works() {
+        // Errors collected without context still serialize cleanly — the
+        // preservation logic must not require context to be present.
+        let mut v = ValidationCollector::new();
+        v.push("field", "problem", None);
+        let err = v.finish_if_errors().unwrap_err();
+        // Without context, the base validation_invalid_argument shape
+        // (field + problem) is what we get.
+        assert_eq!(
+            err.details.get("field").and_then(|v| v.as_str()),
+            Some("field")
+        );
+        assert_eq!(
+            err.details.get("problem").and_then(|v| v.as_str()),
+            Some("problem")
+        );
     }
 }

--- a/src/core/engine/validation.rs
+++ b/src/core/engine/validation.rs
@@ -198,7 +198,11 @@ mod tests {
             "files": ["target/foo.rs", "Cargo.lock"],
             "hint": "Commit, stash, or discard changes before releasing",
         });
-        v.push("working_tree", "Uncommitted changes detected", Some(context.clone()));
+        v.push(
+            "working_tree",
+            "Uncommitted changes detected",
+            Some(context.clone()),
+        );
 
         let err = v.finish_if_errors().unwrap_err();
         assert_eq!(err.details, context);

--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -16,7 +16,19 @@ pub struct UncommittedChanges {
 }
 
 /// Parse git status output into structured uncommitted changes.
+///
+/// Refreshes the git index (`git update-index --refresh`) before reading
+/// status so stale stat info from upstream tooling — common in CI after
+/// `git pull --ff-only`, `cargo build`, or extension setup steps that
+/// touch tracked files without changing their content — does not surface
+/// as false-positive "modified" entries. The refresh never modifies file
+/// contents; it only updates the index's mtime/size cache so `git status`
+/// reports the true content state.
 pub fn get_uncommitted_changes(path: &str) -> Result<UncommittedChanges> {
+    // Best-effort: ignore failures (returns nonzero when files have real
+    // changes, which is exactly what `git status` is about to report anyway).
+    let _ = execute_git(path, &["update-index", "--refresh"]);
+
     let output = execute_git(
         path,
         &["status", "--porcelain=v1", "--untracked-files=normal"],
@@ -253,6 +265,73 @@ mod tests {
     fn test_get_uncommitted_changes_default_path() {
         let path = "";
         let _result = get_uncommitted_changes(path);
+    }
+
+    /// Regression: get_uncommitted_changes runs `git update-index --refresh`
+    /// before reading status so stale stat info from upstream tooling
+    /// (cargo build, git pull, extension setup) doesn't surface as
+    /// false-positive "modified" entries. After a touch that doesn't
+    /// change content, status must report a clean tree.
+    #[test]
+    fn get_uncommitted_changes_treats_stat_only_touches_as_clean() {
+        use std::fs;
+        use std::process::Command;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().unwrap();
+
+        // Init repo, commit a file, then touch it without changing content.
+        let init = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(path)
+            .output();
+        if init.is_err() || !init.unwrap().status.success() {
+            // Test environment lacks git — skip rather than fail.
+            return;
+        }
+        let _ = Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .output();
+        let _ = Command::new("git")
+            .args(["config", "user.name", "test"])
+            .current_dir(path)
+            .output();
+
+        let file = dir.path().join("hello.txt");
+        fs::write(&file, "content\n").expect("write");
+        let _ = Command::new("git")
+            .args(["add", "hello.txt"])
+            .current_dir(path)
+            .output();
+        let _ = Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(path)
+            .output();
+
+        // Rewrite the file with identical content via `touch`-then-rewrite
+        // to bump mtime/size cache state without changing the bytes. On
+        // platforms with `touch`, this is the simplest way to simulate the
+        // stale-index condition that `git pull` + prior tooling can leave
+        // behind in CI. Without the index refresh, `git status --porcelain`
+        // would report it as modified.
+        let touch = Command::new("touch")
+            .args(["-c", "-m", "-t", "203012010101"])
+            .arg(&file)
+            .output();
+        if touch.is_err() || !touch.unwrap().status.success() {
+            // No `touch` available — skip rather than fail. The Linux/macOS
+            // CI runners we care about all have it.
+            return;
+        }
+
+        let result = get_uncommitted_changes(path).expect("status read");
+        assert!(
+            !result.has_changes,
+            "stat-only touch must not surface as a real change after index refresh, got: {:?}",
+            result
+        );
     }
 
     #[test]

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -1808,6 +1808,57 @@ mod tests {
         assert_eq!(unexpected, vec!["src/lib.rs"]);
     }
 
+    /// Regression for the homeboy-action release blocker:
+    /// `validate_working_tree_fail_fast` builds an Error with a hint vec
+    /// listing the dirty files. That error flows through ValidationCollector,
+    /// which used to drop the hints on the single-error re-emit path —
+    /// leaving CI consumers with a bare `Uncommitted changes detected`
+    /// message and no way to see *which* files were dirty.
+    ///
+    /// This test pins down the round-trip: build the same shape of error
+    /// that `validate_working_tree_fail_fast` would produce, push it through
+    /// `ValidationCollector::finish_if_errors`, and assert the dirty file
+    /// hints survive in the resulting JSON details.
+    #[test]
+    fn working_tree_fail_fast_error_preserves_file_hints_through_collector() {
+        use crate::engine::validation::ValidationCollector;
+        use crate::error::Error;
+
+        let original = Error::validation_invalid_argument(
+            "working_tree",
+            "Uncommitted changes detected — refusing to release",
+            None,
+            Some(vec![
+                "Commit, stash, or discard changes before releasing".to_string(),
+                "Unexpected dirty files (2): src/lib.rs, Cargo.lock".to_string(),
+            ]),
+        );
+
+        let mut collector = ValidationCollector::new();
+        collector.capture::<()>(Err(original), "working_tree");
+        let propagated = collector.finish_if_errors().unwrap_err();
+
+        let details = &propagated.details;
+        let tried = details
+            .get("tried")
+            .and_then(|v| v.as_array())
+            .expect("tried hints must survive collector round-trip");
+        assert_eq!(tried.len(), 2, "expected both hints to survive: {details}");
+        let joined: String = tried
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            joined.contains("src/lib.rs"),
+            "dirty file list must reach the JSON envelope, got: {joined}"
+        );
+        assert!(
+            joined.contains("Cargo.lock"),
+            "dirty file list must reach the JSON envelope, got: {joined}"
+        );
+    }
+
     #[test]
     fn unexpected_files_honor_allowed_list_alongside_homeboy_filter() {
         let changes = uncommitted(


### PR DESCRIPTION
## Summary

Two related bugs combine to silently break `homeboy release` whenever new commits land on `main` while CI is running. Concrete failure: https://github.com/Extra-Chill/homeboy/actions/runs/25523389406 (PR #2362 release) — bare `Uncommitted changes detected — refusing to release` with no file list to debug from.

## Bug 1 — `ValidationCollector` drops structured context on the single-error path

`finish_if_errors` (and `finish`) reconstructed the propagated `Error` from just `field` + `problem`, discarding the `context` JSON the original validator attached. The release working-tree check passes a hint vec listing the dirty files via `validation_invalid_argument(..., Some(vec![...]))`, but by the time it reached the JSON envelope all that survived was the bare message. Multi-error path (`validation_multiple_errors`) was already structured — only the single-error case had the bug.

**Fix:** small helper `single_error_to_invalid_argument` preserves the original error's `context` when present. Three regression tests pin this down (validation.rs).

## Bug 2 — `get_uncommitted_changes` reads stale git index

`get_uncommitted_changes` ran `git status --porcelain` directly without refreshing the index first. After upstream tooling that touches tracked files (cargo build stat'ing sources, the action wrapper's `git pull --ff-only` fast-forwarding to a newer tip, extension setup steps), the index can hold stale mtime/size cache that makes git report content-unchanged files as modified. The release fail-fast then bails on a clean tree.

**Fix:** `git update-index --refresh` (best-effort, ignoring exit code — refresh returns nonzero when files have real changes, which is exactly what `git status` is about to report anyway). The refresh never modifies file contents; it only updates the index's stat cache. One regression test using `touch -m` to bump mtime without changing bytes.

## Bug 3 — round-trip safety net

New test in release pipeline tests asserts that the file-list hints attached by `validate_working_tree_fail_fast` actually survive `ValidationCollector::finish_if_errors` into the JSON envelope. Without this, the validation-collector regression could reappear silently and we'd be debug-blind on CI failures again.

## Test results

```
core::engine::validation:  10 passed (3 new)
core::git:                108 passed (1 new)
core::release::pipeline:   90 passed (1 new)
full lib test suite:    2758 passed
```

## Why this is the right layer

Per RULES.md "Fix upstream first, never paper over" — the action wrapper's `git pull --ff-only` workaround at https://github.com/Extra-Chill/homeboy-action/blob/main/scripts/release/run-release.sh#L137 was the original symptom of bug 2. Removing that workaround in the wrapper without fixing core would just shift the failure mode. With core's index refresh in place, the wrapper's redundant pull becomes safe to remove (separate PR in homeboy-action), and the action shrink-down work tracked in homeboy-action #173/#174 has a cleaner contract to collapse onto.

The companion change for the categorizer's empty-input handling (https://github.com/Extra-Chill/homeboy-action/pull/215) lives in the action because that one really is wrapper logic — it deals with what GitHub Actions step env shapes look like.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosed the failure mode from CI logs, traced the validation-collector and index-refresh bugs, drafted fixes and regression tests. Chris reviewed scope and approved the upstream-first approach.