### PR TITLE
fix(release): keep git status refresh docs ecosystem agnostic

### DIFF
--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -19,7 +19,7 @@ pub struct UncommittedChanges {
 ///
 /// Refreshes the git index (`git update-index --refresh`) before reading
 /// status so stale stat info from upstream tooling — common in CI after
-/// `git pull --ff-only`, `cargo build`, or extension setup steps that
+/// `git pull --ff-only`, build steps, or extension setup steps that
 /// touch tracked files without changing their content — does not surface
 /// as false-positive "modified" entries. The refresh never modifies file
 /// contents; it only updates the index's mtime/size cache so `git status`
@@ -269,7 +269,7 @@ mod tests {
 
     /// Regression: get_uncommitted_changes runs `git update-index --refresh`
     /// before reading status so stale stat info from upstream tooling
-    /// (cargo build, git pull, extension setup) doesn't surface as
+    /// (build steps, git pull, extension setup) doesn't surface as
     /// false-positive "modified" entries. After a touch that doesn't
     /// change content, status must report a clean tree.
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2368. The post-merge release run failed the core-agnostic architecture guard because a doc comment in `src/core/git/changes.rs` used the ecosystem-specific phrase `cargo build`.

This keeps the behavior unchanged and rewrites the comment/test prose to use generic `build steps` wording instead.

## Evidence

```
cargo test --test core_agnostic_test
running 1 test
test core_owned_source_stays_language_and_framework_agnostic ... ok
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosed the architecture-guard failure from the post-merge release log and made the minimal wording-only fix.