### PR TITLE
Add release prepare extension step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.160.0"
+version = "0.160.1"
 dependencies = [
  "arboard",
  "base64",

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -22,6 +22,9 @@ use crate::{changelog, version};
 use super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use super::utils::{extract_latest_notes, parse_release_artifacts};
 
+mod prepare;
+pub(crate) use prepare::run_prepare;
+
 /// Build a successful step result with optional data and hints.
 pub(crate) fn step_success(
     id: &str,
@@ -538,51 +541,6 @@ pub(crate) fn run_git_push(component: &Component, component_id: &str) -> Result<
     Ok(step_success("git.push", "git.push", Some(data), Vec::new()))
 }
 
-/// Invoke every `release.prepare` action provided by the component's extensions.
-pub(crate) fn run_prepare(
-    extensions: &[ExtensionManifest],
-    state: &ReleaseState,
-    component_id: &str,
-    component_local_path: &str,
-) -> Result<ReleaseStepResult> {
-    let providers: Vec<&ExtensionManifest> = extensions
-        .iter()
-        .filter(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
-        .collect();
-
-    if providers.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "release.prepare",
-            "No extension provides release.prepare action",
-            None,
-            Some(vec![
-                "Add an extension with a release.prepare action to the component".to_string(),
-            ]),
-        ));
-    }
-
-    let payload = build_release_payload(state, component_id, component_local_path, None);
-    let mut responses = Vec::new();
-
-    for extension in providers {
-        let response = extension::execute_action(
-            &extension.id,
-            "release.prepare",
-            None,
-            None,
-            Some(&payload),
-        )?;
-        responses.push(serde_json::json!({
-            "extension": extension.id,
-            "action": "release.prepare",
-            "response": response,
-        }));
-    }
-
-    let data = serde_json::json!({ "responses": responses });
-    Ok(prepare_step_result(Some(data)))
-}
-
 /// Invoke the `release.package` action on whichever extension provides it,
 /// parse the emitted artifacts, and stash them in [`ReleaseState::artifacts`]
 /// for downstream publish targets and for the GitHub Release step.
@@ -712,69 +670,6 @@ fn publish_step_result(
         Some(publish_failure_message(target, response)),
         Vec::new(),
     )
-}
-
-fn prepare_step_result(data: Option<serde_json::Value>) -> ReleaseStepResult {
-    let failing_response = data
-        .as_ref()
-        .and_then(|data| data.get("responses"))
-        .and_then(serde_json::Value::as_array)
-        .and_then(|responses| {
-            responses.iter().find(|entry| {
-                entry
-                    .get("response")
-                    .and_then(|response| response.get("success"))
-                    .and_then(serde_json::Value::as_bool)
-                    == Some(false)
-            })
-        });
-
-    if let Some(entry) = failing_response {
-        let extension = entry
-            .get("extension")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("extension");
-        let response = entry.get("response").unwrap_or(&serde_json::Value::Null);
-        let error = extension_action_failure_message("release.prepare", extension, response);
-        return step_failed(
-            "release.prepare",
-            "release.prepare",
-            data,
-            Some(error),
-            Vec::new(),
-        );
-    }
-
-    step_success("release.prepare", "release.prepare", data, Vec::new())
-}
-
-fn extension_action_failure_message(
-    action_id: &str,
-    extension_id: &str,
-    response: &serde_json::Value,
-) -> String {
-    let exit_code = response
-        .get("exit_code")
-        .or_else(|| response.get("exitCode"))
-        .and_then(|v| v.as_i64());
-    let output = publish_response_output(response);
-    let detail = output.trim();
-
-    match (exit_code, detail.is_empty()) {
-        (Some(code), false) => format!(
-            "Action {} from {} failed (exit {}): {}",
-            action_id, extension_id, code, detail
-        ),
-        (Some(code), true) => format!(
-            "Action {} from {} failed (exit {})",
-            action_id, extension_id, code
-        ),
-        (None, false) => format!(
-            "Action {} from {} failed: {}",
-            action_id, extension_id, detail
-        ),
-        (None, true) => format!("Action {} from {} failed", action_id, extension_id),
-    }
 }
 
 fn extension_skip_reason(response: &serde_json::Value) -> Option<String> {
@@ -1268,8 +1163,8 @@ fn sanitize_tag_for_filename(tag: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        fallback_gh_command, prepare_step_result, publish_step_result, run_git_push,
-        sanitize_tag_for_filename, store_artifacts_from_output,
+        fallback_gh_command, publish_step_result, run_git_push, sanitize_tag_for_filename,
+        store_artifacts_from_output,
     };
     use crate::component::Component;
     use crate::release::ReleaseStepStatus;
@@ -1379,31 +1274,6 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
         assert!(result.error.unwrap().contains("500 server error"));
-    }
-
-    #[test]
-    fn prepare_step_fails_when_extension_command_fails() {
-        let data = serde_json::json!({
-            "responses": [
-                {
-                    "extension": "fixture",
-                    "action": "release.prepare",
-                    "response": {
-                        "success": false,
-                        "exitCode": 1,
-                        "stderr": "generated file is out of sync"
-                    }
-                }
-            ]
-        });
-
-        let result = prepare_step_result(Some(data));
-
-        assert_eq!(result.status, ReleaseStepStatus::Failed);
-        let error = result.error.expect("prepare failure message");
-        assert!(error.contains("release.prepare"));
-        assert!(error.contains("fixture"));
-        assert!(error.contains("generated file is out of sync"));
     }
 
     #[test]

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -538,6 +538,51 @@ pub(crate) fn run_git_push(component: &Component, component_id: &str) -> Result<
     Ok(step_success("git.push", "git.push", Some(data), Vec::new()))
 }
 
+/// Invoke every `release.prepare` action provided by the component's extensions.
+pub(crate) fn run_prepare(
+    extensions: &[ExtensionManifest],
+    state: &ReleaseState,
+    component_id: &str,
+    component_local_path: &str,
+) -> Result<ReleaseStepResult> {
+    let providers: Vec<&ExtensionManifest> = extensions
+        .iter()
+        .filter(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
+        .collect();
+
+    if providers.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "release.prepare",
+            "No extension provides release.prepare action",
+            None,
+            Some(vec![
+                "Add an extension with a release.prepare action to the component".to_string(),
+            ]),
+        ));
+    }
+
+    let payload = build_release_payload(state, component_id, component_local_path, None);
+    let mut responses = Vec::new();
+
+    for extension in providers {
+        let response = extension::execute_action(
+            &extension.id,
+            "release.prepare",
+            None,
+            None,
+            Some(&payload),
+        )?;
+        responses.push(serde_json::json!({
+            "extension": extension.id,
+            "action": "release.prepare",
+            "response": response,
+        }));
+    }
+
+    let data = serde_json::json!({ "responses": responses });
+    Ok(prepare_step_result(Some(data)))
+}
+
 /// Invoke the `release.package` action on whichever extension provides it,
 /// parse the emitted artifacts, and stash them in [`ReleaseState::artifacts`]
 /// for downstream publish targets and for the GitHub Release step.
@@ -667,6 +712,69 @@ fn publish_step_result(
         Some(publish_failure_message(target, response)),
         Vec::new(),
     )
+}
+
+fn prepare_step_result(data: Option<serde_json::Value>) -> ReleaseStepResult {
+    let failing_response = data
+        .as_ref()
+        .and_then(|data| data.get("responses"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|responses| {
+            responses.iter().find(|entry| {
+                entry
+                    .get("response")
+                    .and_then(|response| response.get("success"))
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(false)
+            })
+        });
+
+    if let Some(entry) = failing_response {
+        let extension = entry
+            .get("extension")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("extension");
+        let response = entry.get("response").unwrap_or(&serde_json::Value::Null);
+        let error = extension_action_failure_message("release.prepare", extension, response);
+        return step_failed(
+            "release.prepare",
+            "release.prepare",
+            data,
+            Some(error),
+            Vec::new(),
+        );
+    }
+
+    step_success("release.prepare", "release.prepare", data, Vec::new())
+}
+
+fn extension_action_failure_message(
+    action_id: &str,
+    extension_id: &str,
+    response: &serde_json::Value,
+) -> String {
+    let exit_code = response
+        .get("exit_code")
+        .or_else(|| response.get("exitCode"))
+        .and_then(|v| v.as_i64());
+    let output = publish_response_output(response);
+    let detail = output.trim();
+
+    match (exit_code, detail.is_empty()) {
+        (Some(code), false) => format!(
+            "Action {} from {} failed (exit {}): {}",
+            action_id, extension_id, code, detail
+        ),
+        (Some(code), true) => format!(
+            "Action {} from {} failed (exit {})",
+            action_id, extension_id, code
+        ),
+        (None, false) => format!(
+            "Action {} from {} failed: {}",
+            action_id, extension_id, detail
+        ),
+        (None, true) => format!("Action {} from {} failed", action_id, extension_id),
+    }
 }
 
 fn extension_skip_reason(response: &serde_json::Value) -> Option<String> {
@@ -1160,8 +1268,8 @@ fn sanitize_tag_for_filename(tag: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        fallback_gh_command, publish_step_result, run_git_push, sanitize_tag_for_filename,
-        store_artifacts_from_output,
+        fallback_gh_command, prepare_step_result, publish_step_result, run_git_push,
+        sanitize_tag_for_filename, store_artifacts_from_output,
     };
     use crate::component::Component;
     use crate::release::ReleaseStepStatus;
@@ -1271,6 +1379,31 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
         assert!(result.error.unwrap().contains("500 server error"));
+    }
+
+    #[test]
+    fn prepare_step_fails_when_extension_command_fails() {
+        let data = serde_json::json!({
+            "responses": [
+                {
+                    "extension": "fixture",
+                    "action": "release.prepare",
+                    "response": {
+                        "success": false,
+                        "exitCode": 1,
+                        "stderr": "generated file is out of sync"
+                    }
+                }
+            ]
+        });
+
+        let result = prepare_step_result(Some(data));
+
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        let error = result.error.expect("prepare failure message");
+        assert!(error.contains("release.prepare"));
+        assert!(error.contains("fixture"));
+        assert!(error.contains("generated file is out of sync"));
     }
 
     #[test]

--- a/src/core/release/executor/prepare.rs
+++ b/src/core/release/executor/prepare.rs
@@ -1,0 +1,144 @@
+use crate::error::{Error, Result};
+use crate::extension::{self, ExtensionManifest};
+
+use super::{build_release_payload, publish_response_output, step_failed, step_success};
+use crate::release::types::{ReleaseState, ReleaseStepResult};
+
+/// Invoke every `release.prepare` action provided by the component's extensions.
+pub(crate) fn run_prepare(
+    extensions: &[ExtensionManifest],
+    state: &ReleaseState,
+    component_id: &str,
+    component_local_path: &str,
+) -> Result<ReleaseStepResult> {
+    let providers: Vec<&ExtensionManifest> = extensions
+        .iter()
+        .filter(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
+        .collect();
+
+    if providers.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "release.prepare",
+            "No extension provides release.prepare action",
+            None,
+            Some(vec![
+                "Add an extension with a release.prepare action to the component".to_string(),
+            ]),
+        ));
+    }
+
+    let payload = build_release_payload(state, component_id, component_local_path, None);
+    let mut responses = Vec::new();
+
+    for extension in providers {
+        let response = extension::execute_action(
+            &extension.id,
+            "release.prepare",
+            None,
+            None,
+            Some(&payload),
+        )?;
+        responses.push(serde_json::json!({
+            "extension": extension.id,
+            "action": "release.prepare",
+            "response": response,
+        }));
+    }
+
+    let data = serde_json::json!({ "responses": responses });
+    Ok(prepare_step_result(Some(data)))
+}
+
+fn prepare_step_result(data: Option<serde_json::Value>) -> ReleaseStepResult {
+    let failing_response = data
+        .as_ref()
+        .and_then(|data| data.get("responses"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|responses| {
+            responses.iter().find(|entry| {
+                entry
+                    .get("response")
+                    .and_then(|response| response.get("success"))
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(false)
+            })
+        });
+
+    if let Some(entry) = failing_response {
+        let extension = entry
+            .get("extension")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("extension");
+        let response = entry.get("response").unwrap_or(&serde_json::Value::Null);
+        let error = extension_action_failure_message("release.prepare", extension, response);
+        return step_failed(
+            "release.prepare",
+            "release.prepare",
+            data,
+            Some(error),
+            Vec::new(),
+        );
+    }
+
+    step_success("release.prepare", "release.prepare", data, Vec::new())
+}
+
+fn extension_action_failure_message(
+    action_id: &str,
+    extension_id: &str,
+    response: &serde_json::Value,
+) -> String {
+    let exit_code = response
+        .get("exit_code")
+        .or_else(|| response.get("exitCode"))
+        .and_then(|v| v.as_i64());
+    let output = publish_response_output(response);
+    let detail = output.trim();
+
+    match (exit_code, detail.is_empty()) {
+        (Some(code), false) => format!(
+            "Action {} from {} failed (exit {}): {}",
+            action_id, extension_id, code, detail
+        ),
+        (Some(code), true) => format!(
+            "Action {} from {} failed (exit {})",
+            action_id, extension_id, code
+        ),
+        (None, false) => format!(
+            "Action {} from {} failed: {}",
+            action_id, extension_id, detail
+        ),
+        (None, true) => format!("Action {} from {} failed", action_id, extension_id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prepare_step_result;
+    use crate::release::ReleaseStepStatus;
+
+    #[test]
+    fn prepare_step_fails_when_extension_command_fails() {
+        let data = serde_json::json!({
+            "responses": [
+                {
+                    "extension": "fixture",
+                    "action": "release.prepare",
+                    "response": {
+                        "success": false,
+                        "exitCode": 1,
+                        "stderr": "generated file is out of sync"
+                    }
+                }
+            ]
+        });
+
+        let result = prepare_step_result(Some(data));
+
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        let error = result.error.expect("prepare failure message");
+        assert!(error.contains("release.prepare"));
+        assert!(error.contains("fixture"));
+        assert!(error.contains("generated file is out of sync"));
+    }
+}

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -1,6 +1,8 @@
 pub mod changelog;
 mod executor;
 mod pipeline;
+mod pipeline_capabilities;
+mod pipeline_summary;
 mod types;
 mod utils;
 pub mod version;

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -23,10 +23,14 @@ use crate::release::changelog;
 use crate::version;
 
 use super::executor;
+use super::pipeline_capabilities::{
+    get_publish_targets, has_package_capability, has_prepare_capability,
+};
+use super::pipeline_summary::{build_summary, derive_overall_status};
 use super::types::{
     ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep, ReleaseRun, ReleaseRunResult,
-    ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseState,
-    ReleaseStepResult, ReleaseStepStatus,
+    ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseState, ReleaseStepResult,
+    ReleaseStepStatus,
 };
 
 /// Load a component with portable config fallback when path_override is set.
@@ -243,140 +247,6 @@ fn finalize(
             warnings: Vec::new(),
             summary: Some(summary),
         },
-    }
-}
-
-fn derive_overall_status(results: &[ReleaseStepResult]) -> ReleaseStepStatus {
-    let has_success = results
-        .iter()
-        .any(|r| matches!(r.status, ReleaseStepStatus::Success));
-    let has_failed = results
-        .iter()
-        .any(|r| matches!(r.status, ReleaseStepStatus::Failed));
-
-    if has_failed && has_success {
-        ReleaseStepStatus::PartialSuccess
-    } else if has_failed {
-        ReleaseStepStatus::Failed
-    } else {
-        ReleaseStepStatus::Success
-    }
-}
-
-fn build_summary(results: &[ReleaseStepResult], status: &ReleaseStepStatus) -> ReleaseRunSummary {
-    let succeeded = results
-        .iter()
-        .filter(|r| matches!(r.status, ReleaseStepStatus::Success))
-        .count();
-    let failed = results
-        .iter()
-        .filter(|r| matches!(r.status, ReleaseStepStatus::Failed))
-        .count();
-    let skipped = results
-        .iter()
-        .filter(|r| matches!(r.status, ReleaseStepStatus::Skipped))
-        .count();
-    let missing = results
-        .iter()
-        .filter(|r| matches!(r.status, ReleaseStepStatus::Missing))
-        .count();
-
-    let next_actions = match status {
-        ReleaseStepStatus::PartialSuccess | ReleaseStepStatus::Failed => vec![
-            "Fix the issue and re-run (idempotent - completed steps will succeed again)"
-                .to_string(),
-        ],
-        ReleaseStepStatus::Missing => {
-            vec!["Install missing extensions or actions to resolve missing steps".to_string()]
-        }
-        _ => Vec::new(),
-    };
-
-    let success_summary = if matches!(status, ReleaseStepStatus::Success) {
-        results.iter().filter_map(build_step_summary_line).collect()
-    } else {
-        Vec::new()
-    };
-
-    ReleaseRunSummary {
-        total_steps: results.len(),
-        succeeded,
-        failed,
-        skipped,
-        missing,
-        next_actions,
-        success_summary,
-    }
-}
-
-fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
-    if !matches!(result.status, ReleaseStepStatus::Success) {
-        return None;
-    }
-
-    let data = result.data.as_ref();
-
-    match result.step_type.as_str() {
-        "version" => data
-            .and_then(|d| d.get("new_version"))
-            .and_then(|v| v.as_str())
-            .map(|ver| format!("Version bumped to {}", ver)),
-        "git.commit" => {
-            let skipped = data
-                .and_then(|d| d.get("skipped"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            if skipped {
-                Some("Working tree was clean".to_string())
-            } else {
-                Some("Committed release changes".to_string())
-            }
-        }
-        "git.tag" => {
-            let tag = data.and_then(|d| d.get("tag")).and_then(|v| v.as_str());
-            let skipped = data
-                .and_then(|d| d.get("skipped"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            match (tag, skipped) {
-                (Some(t), true) => Some(format!("Tag {} already exists", t)),
-                (Some(t), false) => Some(format!("Tagged {}", t)),
-                (None, _) => Some("Tagged release".to_string()),
-            }
-        }
-        "git.push" => Some("Pushed to origin (with tags)".to_string()),
-        "release.prepare" => Some("Prepared release files".to_string()),
-        "package" => Some("Created release artifacts".to_string()),
-        "cleanup" => None,
-        "github.release" => {
-            let skipped = data
-                .and_then(|d| d.get("skipped"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            if skipped {
-                None
-            } else {
-                data.and_then(|d| d.get("url"))
-                    .and_then(|v| v.as_str())
-                    .map(|url| format!("Created GitHub Release: {}", url))
-            }
-        }
-        "post_release" => {
-            let all_succeeded = data
-                .and_then(|d| d.get("all_succeeded"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
-            if all_succeeded {
-                Some("Post-release commands completed".to_string())
-            } else {
-                Some("Post-release commands completed (with warnings)".to_string())
-            }
-        }
-        step if step.starts_with("publish.") => {
-            let target = step.strip_prefix("publish.").unwrap_or("registry");
-            Some(format!("Published to {}", target))
-        }
-        _ => None,
     }
 }
 
@@ -1160,29 +1030,6 @@ fn github_release_applies(component: &Component) -> bool {
         .as_deref()
         .and_then(crate::deploy::release_download::parse_github_url)
         .is_some()
-}
-
-/// Derive publish targets from extensions that have `release.publish` action.
-fn get_publish_targets(extensions: &[ExtensionManifest]) -> Vec<String> {
-    extensions
-        .iter()
-        .filter(|m| m.actions.iter().any(|a| a.id == "release.publish"))
-        .map(|m| m.id.clone())
-        .collect()
-}
-
-/// Check if any extension provides the `release.package` action.
-fn has_package_capability(extensions: &[ExtensionManifest]) -> bool {
-    extensions
-        .iter()
-        .any(|m| m.actions.iter().any(|a| a.id == "release.package"))
-}
-
-/// Check if any extension provides the `release.prepare` action.
-fn has_prepare_capability(extensions: &[ExtensionManifest]) -> bool {
-    extensions
-        .iter()
-        .any(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
 }
 
 /// Build all release steps: core steps (non-configurable) + publish steps (extension-derived).

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -98,11 +98,21 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
     )?);
     bail_on_failure!();
 
-    // 2. Git commit
+    // 2. Optional release preparation. Extension-owned ecosystems can sync
+    //    generated release files after the version bump and before the commit.
+    if has_prepare_capability(&extensions) {
+        match executor::run_prepare(&extensions, &state, component_id, &component.local_path) {
+            Ok(result) => results.push(result),
+            Err(err) => results.push(failed_result("release.prepare", "release.prepare", err)),
+        }
+        bail_on_failure!();
+    }
+
+    // 3. Git commit
     results.push(executor::run_git_commit(&component, component_id, &state)?);
     bail_on_failure!();
 
-    // 3. Optional packaging (runs BEFORE tag so build failures don't leave
+    // 4. Optional packaging (runs BEFORE tag so build failures don't leave
     //    orphan tags on the remote).
     let has_publish_targets = !get_publish_targets(&extensions).is_empty();
     let want_publish = !options.skip_publish && has_publish_targets;
@@ -114,7 +124,7 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
         bail_on_failure!();
     }
 
-    // 4. Git tag
+    // 5. Git tag
     let tag_name = match monorepo.as_ref() {
         Some(ctx) => ctx.format_tag(state.version.as_deref().unwrap_or("")),
         None => format!("v{}", state.version.as_deref().unwrap_or("")),
@@ -127,11 +137,11 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
     )?);
     bail_on_failure!();
 
-    // 5. Git push (commits + tags)
+    // 6. Git push (commits + tags)
     results.push(executor::run_git_push(&component, component_id)?);
     bail_on_failure!();
 
-    // 6. GitHub Release (soft-fails on gh issues; skipped for non-GitHub remotes).
+    // 7. GitHub Release (soft-fails on gh issues; skipped for non-GitHub remotes).
     if !options.skip_github_release && github_release_applies(&component) {
         match executor::run_github_release(&component, &state) {
             Ok(result) => results.push(result),
@@ -139,7 +149,7 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
         }
     }
 
-    // 7. Publish to each configured target. Failures here mark the step failed
+    // 8. Publish to each configured target. Failures here mark the step failed
     //    but don't halt — other targets may still succeed.
     let mut publish_failed = false;
     if want_publish {
@@ -166,7 +176,7 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
         }
     }
 
-    // 8. Cleanup staging dir. Skipped when --deploy is set (deploy needs the
+    // 9. Cleanup staging dir. Skipped when --deploy is set (deploy needs the
     //    build artifact) and when publishing was skipped entirely.
     if want_publish && !options.deploy && !publish_failed {
         match executor::run_cleanup(&component) {
@@ -335,6 +345,7 @@ fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
             }
         }
         "git.push" => Some("Pushed to origin (with tags)".to_string()),
+        "release.prepare" => Some("Prepared release files".to_string()),
         "package" => Some("Created release artifacts".to_string()),
         "cleanup" => None,
         "github.release" => {
@@ -383,6 +394,7 @@ fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
 /// 4. Git push (commits AND tags)
 ///
 /// Extension-derived steps, added when applicable:
+/// - `release.prepare` — component has an extension with `release.prepare` action
 /// - `package` — component has an extension with `release.package` action
 /// - `publish.<target>` — one per extension with `release.publish` action
 /// - `cleanup` — after publish (skipped with `--deploy`)
@@ -1166,6 +1178,13 @@ fn has_package_capability(extensions: &[ExtensionManifest]) -> bool {
         .any(|m| m.actions.iter().any(|a| a.id == "release.package"))
 }
 
+/// Check if any extension provides the `release.prepare` action.
+fn has_prepare_capability(extensions: &[ExtensionManifest]) -> bool {
+    extensions
+        .iter()
+        .any(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
+}
+
 /// Build all release steps: core steps (non-configurable) + publish steps (extension-derived).
 fn build_release_steps(
     component: &Component,
@@ -1220,12 +1239,27 @@ fn build_release_steps(
         missing: vec![],
     });
 
+    let commit_needs = if has_prepare_capability(extensions) {
+        steps.push(ReleasePlanStep {
+            id: "release.prepare".to_string(),
+            step_type: "release.prepare".to_string(),
+            label: Some("Prepare release files".to_string()),
+            needs: vec!["version".to_string()],
+            config: std::collections::HashMap::new(),
+            status: ReleasePlanStatus::Ready,
+            missing: vec![],
+        });
+        vec!["release.prepare".to_string()]
+    } else {
+        vec!["version".to_string()]
+    };
+
     // 2. Git commit
     steps.push(ReleasePlanStep {
         id: "git.commit".to_string(),
         step_type: "git.commit".to_string(),
         label: Some(format!("Commit release: v{}", new_version)),
-        needs: vec!["version".to_string()],
+        needs: commit_needs,
         config: std::collections::HashMap::new(),
         status: ReleasePlanStatus::Ready,
         missing: vec![],
@@ -1607,14 +1641,15 @@ fn get_unexpected_uncommitted_files(
 #[cfg(test)]
 mod tests {
     use super::{
-        code_quality_failure_message, ensure_changelog_initialized, filter_homeboy_managed,
-        get_release_allowed_files, get_unexpected_uncommitted_files, is_homeboy_managed_path,
-        is_runner_infrastructure_failure, read_changelog_for_release, strip_pr_reference,
-        validate_release_version_floor,
+        build_release_steps, code_quality_failure_message, ensure_changelog_initialized,
+        filter_homeboy_managed, get_release_allowed_files, get_unexpected_uncommitted_files,
+        is_homeboy_managed_path, is_runner_infrastructure_failure, read_changelog_for_release,
+        strip_pr_reference, validate_release_version_floor,
     };
     use crate::component::Component;
     use crate::extension::RunnerOutput;
     use crate::git::{CommitCategory, CommitInfo, UncommittedChanges};
+    use crate::release::types::ReleaseOptions;
 
     fn commit(subject: &str, category: CommitCategory) -> CommitInfo {
         CommitInfo {
@@ -1909,6 +1944,53 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn release_prepare_runs_after_version_before_commit_when_extension_declares_action() {
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: "/tmp/fixture".to_string(),
+            ..Default::default()
+        };
+        let extension = serde_json::from_value(serde_json::json!({
+            "name": "Fixture",
+            "version": "1.0.0",
+            "actions": [
+                {
+                    "id": "release.prepare",
+                    "label": "Prepare release",
+                    "type": "command",
+                    "command": "true"
+                }
+            ]
+        }))
+        .expect("extension manifest");
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+
+        let steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.0",
+            "1.0.1",
+            &options,
+            None,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
+
+        let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+        assert_eq!(ids[0], "version");
+        assert_eq!(ids[1], "release.prepare");
+        assert_eq!(ids[2], "git.commit");
+        assert_eq!(steps[1].needs, vec!["version"]);
+        assert_eq!(steps[2].needs, vec!["release.prepare"]);
     }
 
     fn component_with_changelog_target(

--- a/src/core/release/pipeline_capabilities.rs
+++ b/src/core/release/pipeline_capabilities.rs
@@ -1,0 +1,24 @@
+use crate::extension::ExtensionManifest;
+
+/// Derive publish targets from extensions that have `release.publish` action.
+pub(super) fn get_publish_targets(extensions: &[ExtensionManifest]) -> Vec<String> {
+    extensions
+        .iter()
+        .filter(|m| m.actions.iter().any(|a| a.id == "release.publish"))
+        .map(|m| m.id.clone())
+        .collect()
+}
+
+/// Check if any extension provides the `release.package` action.
+pub(super) fn has_package_capability(extensions: &[ExtensionManifest]) -> bool {
+    extensions
+        .iter()
+        .any(|m| m.actions.iter().any(|a| a.id == "release.package"))
+}
+
+/// Check if any extension provides the `release.prepare` action.
+pub(super) fn has_prepare_capability(extensions: &[ExtensionManifest]) -> bool {
+    extensions
+        .iter()
+        .any(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
+}

--- a/src/core/release/pipeline_capabilities.rs
+++ b/src/core/release/pipeline_capabilities.rs
@@ -22,3 +22,37 @@ pub(super) fn has_prepare_capability(extensions: &[ExtensionManifest]) -> bool {
         .iter()
         .any(|m| m.actions.iter().any(|a| a.id == "release.prepare"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{get_publish_targets, has_package_capability, has_prepare_capability};
+    use crate::extension::ExtensionManifest;
+
+    fn extension(id: &str, actions: &[&str]) -> ExtensionManifest {
+        let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": id,
+            "version": "1.0.0",
+            "actions": actions.iter().map(|action| serde_json::json!({
+                "id": action,
+                "label": action,
+                "type": "command",
+                "command": "true"
+            })).collect::<Vec<_>>()
+        }))
+        .expect("extension manifest");
+        manifest.id = id.to_string();
+        manifest
+    }
+
+    #[test]
+    fn release_capabilities_detect_prepare_package_and_publish_actions() {
+        let extensions = vec![
+            extension("rust", &["release.prepare", "release.publish"]),
+            extension("dist", &["release.package"]),
+        ];
+
+        assert!(has_prepare_capability(&extensions));
+        assert!(has_package_capability(&extensions));
+        assert_eq!(get_publish_targets(&extensions), vec!["rust"]);
+    }
+}

--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -1,0 +1,138 @@
+use super::types::{ReleaseRunSummary, ReleaseStepResult, ReleaseStepStatus};
+
+pub(super) fn derive_overall_status(results: &[ReleaseStepResult]) -> ReleaseStepStatus {
+    let has_success = results
+        .iter()
+        .any(|r| matches!(r.status, ReleaseStepStatus::Success));
+    let has_failed = results
+        .iter()
+        .any(|r| matches!(r.status, ReleaseStepStatus::Failed));
+
+    if has_failed && has_success {
+        ReleaseStepStatus::PartialSuccess
+    } else if has_failed {
+        ReleaseStepStatus::Failed
+    } else {
+        ReleaseStepStatus::Success
+    }
+}
+
+pub(super) fn build_summary(
+    results: &[ReleaseStepResult],
+    status: &ReleaseStepStatus,
+) -> ReleaseRunSummary {
+    let succeeded = results
+        .iter()
+        .filter(|r| matches!(r.status, ReleaseStepStatus::Success))
+        .count();
+    let failed = results
+        .iter()
+        .filter(|r| matches!(r.status, ReleaseStepStatus::Failed))
+        .count();
+    let skipped = results
+        .iter()
+        .filter(|r| matches!(r.status, ReleaseStepStatus::Skipped))
+        .count();
+    let missing = results
+        .iter()
+        .filter(|r| matches!(r.status, ReleaseStepStatus::Missing))
+        .count();
+
+    let next_actions = match status {
+        ReleaseStepStatus::PartialSuccess | ReleaseStepStatus::Failed => vec![
+            "Fix the issue and re-run (idempotent - completed steps will succeed again)"
+                .to_string(),
+        ],
+        ReleaseStepStatus::Missing => {
+            vec!["Install missing extensions or actions to resolve missing steps".to_string()]
+        }
+        _ => Vec::new(),
+    };
+
+    let success_summary = if matches!(status, ReleaseStepStatus::Success) {
+        results.iter().filter_map(build_step_summary_line).collect()
+    } else {
+        Vec::new()
+    };
+
+    ReleaseRunSummary {
+        total_steps: results.len(),
+        succeeded,
+        failed,
+        skipped,
+        missing,
+        next_actions,
+        success_summary,
+    }
+}
+
+fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
+    if !matches!(result.status, ReleaseStepStatus::Success) {
+        return None;
+    }
+
+    let data = result.data.as_ref();
+
+    match result.step_type.as_str() {
+        "version" => data
+            .and_then(|d| d.get("new_version"))
+            .and_then(|v| v.as_str())
+            .map(|ver| format!("Version bumped to {}", ver)),
+        "git.commit" => {
+            let skipped = data
+                .and_then(|d| d.get("skipped"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if skipped {
+                Some("Working tree was clean".to_string())
+            } else {
+                Some("Committed release changes".to_string())
+            }
+        }
+        "git.tag" => {
+            let tag = data.and_then(|d| d.get("tag")).and_then(|v| v.as_str());
+            let skipped = data
+                .and_then(|d| d.get("skipped"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            match (tag, skipped) {
+                (Some(t), true) => Some(format!("Tag {} already exists", t)),
+                (Some(t), false) => Some(format!("Tagged {}", t)),
+                (None, _) => Some("Tagged release".to_string()),
+            }
+        }
+        "git.push" => Some("Pushed to origin (with tags)".to_string()),
+        "release.prepare" => Some("Prepared release files".to_string()),
+        "package" => Some("Created release artifacts".to_string()),
+        "cleanup" => None,
+        "github.release" => {
+            let skipped = data
+                .and_then(|d| d.get("skipped"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if skipped {
+                None
+            } else {
+                data.and_then(|d| d.get("url"))
+                    .and_then(|v| v.as_str())
+                    .map(|url| format!("Created GitHub Release: {}", url))
+            }
+        }
+        "post_release" => {
+            let all_succeeded = data
+                .and_then(|d| d.get("all_succeeded"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            if all_succeeded {
+                Some("Post-release commands completed".to_string())
+            } else {
+                Some("Post-release commands completed (with warnings)".to_string())
+            }
+        }
+        step if step.starts_with("publish.") => {
+            let target = step.strip_prefix("publish.").unwrap_or("registry");
+            Some(format!("Published to {}", target))
+        }
+        _ => None,
+    }
+}

--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -156,7 +156,20 @@ mod tests {
     }
 
     #[test]
-    fn release_summary_counts_steps_and_partial_failures() {
+    fn test_derive_overall_status() {
+        let results = vec![
+            step("version", ReleaseStepStatus::Success),
+            step("release.prepare", ReleaseStepStatus::Failed),
+        ];
+
+        assert_eq!(
+            derive_overall_status(&results),
+            ReleaseStepStatus::PartialSuccess
+        );
+    }
+
+    #[test]
+    fn test_build_summary() {
         let results = vec![
             step("version", ReleaseStepStatus::Success),
             step("release.prepare", ReleaseStepStatus::Failed),
@@ -166,7 +179,6 @@ mod tests {
         let status = derive_overall_status(&results);
         let summary = build_summary(&results, &status);
 
-        assert_eq!(status, ReleaseStepStatus::PartialSuccess);
         assert_eq!(summary.total_steps, 3);
         assert_eq!(summary.succeeded, 1);
         assert_eq!(summary.failed, 1);

--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -136,3 +136,41 @@ fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{build_summary, derive_overall_status};
+    use crate::release::types::{ReleaseStepResult, ReleaseStepStatus};
+
+    fn step(id: &str, status: ReleaseStepStatus) -> ReleaseStepResult {
+        ReleaseStepResult {
+            id: id.to_string(),
+            step_type: id.to_string(),
+            status,
+            missing: Vec::new(),
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            data: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn release_summary_counts_steps_and_partial_failures() {
+        let results = vec![
+            step("version", ReleaseStepStatus::Success),
+            step("release.prepare", ReleaseStepStatus::Failed),
+            step("cleanup", ReleaseStepStatus::Skipped),
+        ];
+
+        let status = derive_overall_status(&results);
+        let summary = build_summary(&results, &status);
+
+        assert_eq!(status, ReleaseStepStatus::PartialSuccess);
+        assert_eq!(summary.total_steps, 3);
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(summary.next_actions.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a generic `release.prepare` extension step between version bump and release commit.
- Surface prepare failures in release results before tagging/publishing can proceed.
- Refresh the current `Cargo.lock` package entry so the existing `v0.160.1` source version is internally consistent.

## Testing
- `cargo fmt --check`
- `cargo test --lib core::release`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the release pipeline/executor changes and focused tests; Chris reviewed via this PR workflow.