### PR TITLE
feat(triage): record comment activity observations

### DIFF
--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -1,6 +1,8 @@
 # `homeboy triage`
 
-Produce a read-only attention report for components, projects, fleets, rigs, or the full configured workspace.
+Produce an attention report for components, projects, fleets, rigs, or the full configured workspace.
+GitHub access is read-only; each run also records a local observation in the
+Homeboy SQLite database so later runs can report the previous triage time.
 
 ## Synopsis
 
@@ -27,6 +29,26 @@ When no command is provided, `homeboy triage` defaults to `homeboy triage worksp
 - `--needs-review` — restrict PRs to review-required items
 - `--failing-checks` — restrict PRs to failing-check items
 - `--drilldown` — include compact failing check names and URLs
+
+## Output Signals
+
+Surfaced issues include comment activity when GitHub returns it:
+
+- `comments_count`
+- `last_comment_at`
+
+Surfaced pull requests include the same comment activity plus review activity:
+
+- `comments_count`
+- `reviews_count`
+- `last_comment_at`
+- `last_review_at`
+
+Each successful observation adds an `observation` block to the JSON output with
+the local `run_id`, recorded `item_count`, SQLite `store_path`, and
+`previous_run_at` when the same triage target was observed before. Triage item
+snapshots are stored in the `triage_items` table and linked to the existing
+`runs` table.
 
 ## `--path` (component)
 

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -16,6 +16,6 @@ pub use records::{
     finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
     FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord,
     NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
-    TraceSpanRecord, TriageItemRecord,
+    TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -15,6 +15,7 @@ pub use records::{
     finding_records_from_annotation_file, finding_records_from_annotations_dir,
     finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
     FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord,
-    NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
+    NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
+    TraceSpanRecord, TriageItemRecord,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -99,6 +99,54 @@ pub struct NewFindingRecord {
     pub metadata_json: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct NewTriageItemRecord {
+    pub run_id: String,
+    pub provider: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub item_type: String,
+    pub number: u64,
+    pub state: String,
+    pub title: String,
+    pub url: String,
+    pub checks: Option<String>,
+    pub review_decision: Option<String>,
+    pub merge_state: Option<String>,
+    pub next_action: Option<String>,
+    pub comments_count: Option<i64>,
+    pub reviews_count: Option<i64>,
+    pub last_comment_at: Option<String>,
+    pub last_review_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub metadata_json: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TriageItemRecord {
+    pub id: String,
+    pub run_id: String,
+    pub provider: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub item_type: String,
+    pub number: u64,
+    pub state: String,
+    pub title: String,
+    pub url: String,
+    pub checks: Option<String>,
+    pub review_decision: Option<String>,
+    pub merge_state: Option<String>,
+    pub next_action: Option<String>,
+    pub comments_count: Option<i64>,
+    pub reviews_count: Option<i64>,
+    pub last_comment_at: Option<String>,
+    pub last_review_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub metadata_json: serde_json::Value,
+    pub observed_at: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FindingRecord {
     pub id: String,

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -5,6 +5,10 @@ use std::{collections::BTreeMap, path::Path};
 use crate::code_audit::{self, report::finding_kind_key};
 use crate::extension::lint::LintFinding;
 
+mod triage_items;
+
+pub use triage_items::{NewTriageItemRecord, TriageItemRecord, TriagePullRequestSignals};
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum RunStatus {
     Running,
@@ -97,54 +101,6 @@ pub struct NewFindingRecord {
     pub message: String,
     pub fixable: Option<bool>,
     pub metadata_json: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct NewTriageItemRecord {
-    pub run_id: String,
-    pub provider: String,
-    pub repo_owner: String,
-    pub repo_name: String,
-    pub item_type: String,
-    pub number: u64,
-    pub state: String,
-    pub title: String,
-    pub url: String,
-    pub checks: Option<String>,
-    pub review_decision: Option<String>,
-    pub merge_state: Option<String>,
-    pub next_action: Option<String>,
-    pub comments_count: Option<i64>,
-    pub reviews_count: Option<i64>,
-    pub last_comment_at: Option<String>,
-    pub last_review_at: Option<String>,
-    pub updated_at: Option<String>,
-    pub metadata_json: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TriageItemRecord {
-    pub id: String,
-    pub run_id: String,
-    pub provider: String,
-    pub repo_owner: String,
-    pub repo_name: String,
-    pub item_type: String,
-    pub number: u64,
-    pub state: String,
-    pub title: String,
-    pub url: String,
-    pub checks: Option<String>,
-    pub review_decision: Option<String>,
-    pub merge_state: Option<String>,
-    pub next_action: Option<String>,
-    pub comments_count: Option<i64>,
-    pub reviews_count: Option<i64>,
-    pub last_comment_at: Option<String>,
-    pub last_review_at: Option<String>,
-    pub updated_at: Option<String>,
-    pub metadata_json: serde_json::Value,
-    pub observed_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/observation/records/triage_items.rs
+++ b/src/core/observation/records/triage_items.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TriagePullRequestSignals {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checks: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_decision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comments_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reviews_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_comment_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_review_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct NewTriageItemRecord {
+    pub run_id: String,
+    pub provider: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub item_type: String,
+    pub number: u64,
+    pub state: String,
+    pub title: String,
+    pub url: String,
+    #[serde(flatten)]
+    pub signals: TriagePullRequestSignals,
+    pub updated_at: Option<String>,
+    pub metadata_json: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TriageItemRecord {
+    pub id: String,
+    pub run_id: String,
+    pub provider: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub item_type: String,
+    pub number: u64,
+    pub state: String,
+    pub title: String,
+    pub url: String,
+    #[serde(flatten)]
+    pub signals: TriagePullRequestSignals,
+    pub updated_at: Option<String>,
+    pub metadata_json: serde_json::Value,
+    pub observed_at: String,
+}

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -12,7 +12,7 @@ mod triage_items;
 use super::records::{
     ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
     NewTraceRunRecord, NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord,
-    RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
+    RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
 use crate::{paths, Error, Result};
 

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -7,15 +7,16 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 mod findings;
+mod triage_items;
 
 use super::records::{
     ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
-    NewTraceRunRecord, NewTraceSpanRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
-    TraceSpanRecord,
+    NewTraceRunRecord, NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord,
+    RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
 };
 use crate::{paths, Error, Result};
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 4;
+pub const CURRENT_SCHEMA_VERSION: i64 = 5;
 
 struct Migration {
     version: i64,
@@ -125,6 +126,40 @@ const MIGRATIONS: &[Migration] = &[
         sql: r#"
         ALTER TABLE artifacts
             ADD COLUMN artifact_type TEXT NOT NULL DEFAULT 'file';
+    "#,
+    },
+    Migration {
+        version: 5,
+        sql: r#"
+        CREATE TABLE IF NOT EXISTS triage_items (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            repo_owner TEXT NOT NULL,
+            repo_name TEXT NOT NULL,
+            item_type TEXT NOT NULL,
+            number INTEGER NOT NULL,
+            state TEXT NOT NULL,
+            title TEXT NOT NULL,
+            url TEXT NOT NULL,
+            checks TEXT,
+            review_decision TEXT,
+            merge_state TEXT,
+            next_action TEXT,
+            comments_count INTEGER,
+            reviews_count INTEGER,
+            last_comment_at TEXT,
+            last_review_at TEXT,
+            updated_at TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            observed_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_triage_items_run
+            ON triage_items(run_id);
+        CREATE INDEX IF NOT EXISTS idx_triage_items_repo_item
+            ON triage_items(provider, repo_owner, repo_name, item_type, number);
     "#,
     },
 ];

--- a/src/core/observation/store/triage_items.rs
+++ b/src/core/observation/store/triage_items.rs
@@ -1,0 +1,227 @@
+use rusqlite::{params, OptionalExtension};
+use uuid::Uuid;
+
+use super::*;
+
+impl ObservationStore {
+    pub fn record_triage_items(
+        &self,
+        items: &[NewTriageItemRecord],
+    ) -> Result<Vec<TriageItemRecord>> {
+        let mut records = Vec::with_capacity(items.len());
+        for item in items {
+            records.push(self.record_triage_item(item)?);
+        }
+        Ok(records)
+    }
+
+    pub fn record_triage_item(&self, item: &NewTriageItemRecord) -> Result<TriageItemRecord> {
+        validate_required("triage_item.run_id", &item.run_id)?;
+        validate_required("triage_item.provider", &item.provider)?;
+        validate_required("triage_item.repo_owner", &item.repo_owner)?;
+        validate_required("triage_item.repo_name", &item.repo_name)?;
+        validate_required("triage_item.item_type", &item.item_type)?;
+        validate_required("triage_item.state", &item.state)?;
+        validate_required("triage_item.title", &item.title)?;
+        validate_required("triage_item.url", &item.url)?;
+        if self.get_run(&item.run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "triage_item.run_id",
+                format!("referenced run record not found: {}", item.run_id),
+                Some(item.run_id.clone()),
+                None,
+            ));
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let observed_at = chrono::Utc::now().to_rfc3339();
+        let metadata_json = serialize_metadata(&item.metadata_json)?;
+        let number = i64::try_from(item.number).map_err(|_| {
+            Error::validation_invalid_argument(
+                "triage_item.number",
+                "number is too large to store in SQLite INTEGER",
+                Some(item.number.to_string()),
+                None,
+            )
+        })?;
+
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO triage_items(
+                    id, run_id, provider, repo_owner, repo_name, item_type, number, state,
+                    title, url, checks, review_decision, merge_state, next_action,
+                    comments_count, reviews_count, last_comment_at, last_review_at, updated_at,
+                    metadata_json, observed_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                    ?15, ?16, ?17, ?18, ?19, ?20, ?21)
+                "#,
+                params![
+                    id,
+                    item.run_id,
+                    item.provider,
+                    item.repo_owner,
+                    item.repo_name,
+                    item.item_type,
+                    number,
+                    item.state,
+                    item.title,
+                    item.url,
+                    item.checks,
+                    item.review_decision,
+                    item.merge_state,
+                    item.next_action,
+                    item.comments_count,
+                    item.reviews_count,
+                    item.last_comment_at,
+                    item.last_review_at,
+                    item.updated_at,
+                    metadata_json,
+                    observed_at,
+                ],
+            )
+            .map_err(sqlite_error("insert triage item record"))?;
+
+        self.get_triage_item(&id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Inserted triage item record {id} but could not read it back"
+            ))
+        })
+    }
+
+    pub fn get_triage_item(&self, item_id: &str) -> Result<Option<TriageItemRecord>> {
+        validate_required("triage_item_id", item_id)?;
+        self.connection
+            .query_row(
+                r#"
+                SELECT id, run_id, provider, repo_owner, repo_name, item_type, number, state,
+                       title, url, checks, review_decision, merge_state, next_action,
+                       comments_count, reviews_count, last_comment_at, last_review_at, updated_at,
+                       metadata_json, observed_at
+                FROM triage_items
+                WHERE id = ?1
+                "#,
+                [item_id],
+                row_to_triage_item_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read triage item record"))
+    }
+
+    pub fn list_triage_items_for_run(&self, run_id: &str) -> Result<Vec<TriageItemRecord>> {
+        validate_required("run_id", run_id)?;
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT id, run_id, provider, repo_owner, repo_name, item_type, number, state,
+                       title, url, checks, review_decision, merge_state, next_action,
+                       comments_count, reviews_count, last_comment_at, last_review_at, updated_at,
+                       metadata_json, observed_at
+                FROM triage_items
+                WHERE run_id = ?1
+                ORDER BY provider ASC, repo_owner ASC, repo_name ASC, item_type ASC, number ASC
+                "#,
+            )
+            .map_err(sqlite_error("prepare list run triage item records"))?;
+        let rows = statement
+            .query_map([run_id], row_to_triage_item_record)
+            .map_err(sqlite_error("list run triage item records"))?;
+
+        collect_rows(rows, "collect run triage item records")
+    }
+}
+
+fn row_to_triage_item_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<TriageItemRecord> {
+    let number: i64 = row.get(6)?;
+    Ok(TriageItemRecord {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        provider: row.get(2)?,
+        repo_owner: row.get(3)?,
+        repo_name: row.get(4)?,
+        item_type: row.get(5)?,
+        number: u64::try_from(number).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Integer,
+                Box::new(e),
+            )
+        })?,
+        state: row.get(7)?,
+        title: row.get(8)?,
+        url: row.get(9)?,
+        checks: row.get(10)?,
+        review_decision: row.get(11)?,
+        merge_state: row.get(12)?,
+        next_action: row.get(13)?,
+        comments_count: row.get(14)?,
+        reviews_count: row.get(15)?,
+        last_comment_at: row.get(16)?,
+        last_review_at: row.get(17)?,
+        updated_at: row.get(18)?,
+        metadata_json: parse_metadata(row.get(19)?)?,
+        observed_at: row.get(20)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observation::{NewRunRecord, RunStatus};
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn record_and_list_triage_items_for_run() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord {
+                    kind: "triage".to_string(),
+                    component_id: Some("workspace".to_string()),
+                    command: Some("triage.workspace".to_string()),
+                    cwd: None,
+                    homeboy_version: Some("test".to_string()),
+                    git_sha: None,
+                    rig_id: None,
+                    metadata_json: serde_json::json!({}),
+                })
+                .expect("run");
+
+            let records = store
+                .record_triage_items(&[NewTriageItemRecord {
+                    run_id: run.id.clone(),
+                    provider: "github".to_string(),
+                    repo_owner: "Extra-Chill".to_string(),
+                    repo_name: "homeboy".to_string(),
+                    item_type: "pull_request".to_string(),
+                    number: 42,
+                    state: "OPEN".to_string(),
+                    title: "Add triage observations".to_string(),
+                    url: "https://github.com/Extra-Chill/homeboy/pull/42".to_string(),
+                    checks: Some("SUCCESS".to_string()),
+                    review_decision: Some("REVIEW_REQUIRED".to_string()),
+                    merge_state: Some("CLEAN".to_string()),
+                    next_action: Some("review_required".to_string()),
+                    comments_count: Some(3),
+                    reviews_count: Some(2),
+                    last_comment_at: Some("2026-05-08T10:00:00Z".to_string()),
+                    last_review_at: Some("2026-05-08T11:00:00Z".to_string()),
+                    updated_at: Some("2026-05-08T12:00:00Z".to_string()),
+                    metadata_json: serde_json::json!({ "labels": ["enhancement"] }),
+                }])
+                .expect("triage items");
+
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].comments_count, Some(3));
+            assert_eq!(records[0].reviews_count, Some(2));
+
+            let listed = store.list_triage_items_for_run(&run.id).expect("listed");
+            assert_eq!(listed, records);
+            let finished = store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish");
+            assert_eq!(finished.status, "pass");
+        });
+    }
+}

--- a/src/core/observation/store/triage_items.rs
+++ b/src/core/observation/store/triage_items.rs
@@ -67,14 +67,14 @@ impl ObservationStore {
                     item.state,
                     item.title,
                     item.url,
-                    item.checks,
-                    item.review_decision,
-                    item.merge_state,
-                    item.next_action,
-                    item.comments_count,
-                    item.reviews_count,
-                    item.last_comment_at,
-                    item.last_review_at,
+                    item.signals.checks,
+                    item.signals.review_decision,
+                    item.signals.merge_state,
+                    item.signals.next_action,
+                    item.signals.comments_count,
+                    item.signals.reviews_count,
+                    item.signals.last_comment_at,
+                    item.signals.last_review_at,
                     item.updated_at,
                     metadata_json,
                     observed_at,
@@ -151,14 +151,16 @@ fn row_to_triage_item_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Triage
         state: row.get(7)?,
         title: row.get(8)?,
         url: row.get(9)?,
-        checks: row.get(10)?,
-        review_decision: row.get(11)?,
-        merge_state: row.get(12)?,
-        next_action: row.get(13)?,
-        comments_count: row.get(14)?,
-        reviews_count: row.get(15)?,
-        last_comment_at: row.get(16)?,
-        last_review_at: row.get(17)?,
+        signals: TriagePullRequestSignals {
+            checks: row.get(10)?,
+            review_decision: row.get(11)?,
+            merge_state: row.get(12)?,
+            next_action: row.get(13)?,
+            comments_count: row.get(14)?,
+            reviews_count: row.get(15)?,
+            last_comment_at: row.get(16)?,
+            last_review_at: row.get(17)?,
+        },
         updated_at: row.get(18)?,
         metadata_json: parse_metadata(row.get(19)?)?,
         observed_at: row.get(20)?,
@@ -199,22 +201,24 @@ mod tests {
                     state: "OPEN".to_string(),
                     title: "Add triage observations".to_string(),
                     url: "https://github.com/Extra-Chill/homeboy/pull/42".to_string(),
-                    checks: Some("SUCCESS".to_string()),
-                    review_decision: Some("REVIEW_REQUIRED".to_string()),
-                    merge_state: Some("CLEAN".to_string()),
-                    next_action: Some("review_required".to_string()),
-                    comments_count: Some(3),
-                    reviews_count: Some(2),
-                    last_comment_at: Some("2026-05-08T10:00:00Z".to_string()),
-                    last_review_at: Some("2026-05-08T11:00:00Z".to_string()),
+                    signals: TriagePullRequestSignals {
+                        checks: Some("SUCCESS".to_string()),
+                        review_decision: Some("REVIEW_REQUIRED".to_string()),
+                        merge_state: Some("CLEAN".to_string()),
+                        next_action: Some("review_required".to_string()),
+                        comments_count: Some(3),
+                        reviews_count: Some(2),
+                        last_comment_at: Some("2026-05-08T10:00:00Z".to_string()),
+                        last_review_at: Some("2026-05-08T11:00:00Z".to_string()),
+                    },
                     updated_at: Some("2026-05-08T12:00:00Z".to_string()),
                     metadata_json: serde_json::json!({ "labels": ["enhancement"] }),
                 }])
                 .expect("triage items");
 
             assert_eq!(records.len(), 1);
-            assert_eq!(records[0].comments_count, Some(3));
-            assert_eq!(records[0].reviews_count, Some(2));
+            assert_eq!(records[0].signals.comments_count, Some(3));
+            assert_eq!(records[0].signals.reviews_count, Some(2));
 
             let listed = store.list_triage_items_for_run(&run.id).expect("listed");
             assert_eq!(listed, records);

--- a/src/core/observation/store/triage_items.rs
+++ b/src/core/observation/store/triage_items.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use super::*;
 
 impl ObservationStore {
-    pub fn record_triage_items(
+    pub(crate) fn record_triage_items(
         &self,
         items: &[NewTriageItemRecord],
     ) -> Result<Vec<TriageItemRecord>> {
@@ -15,7 +15,7 @@ impl ObservationStore {
         Ok(records)
     }
 
-    pub fn record_triage_item(&self, item: &NewTriageItemRecord) -> Result<TriageItemRecord> {
+    fn record_triage_item(&self, item: &NewTriageItemRecord) -> Result<TriageItemRecord> {
         validate_required("triage_item.run_id", &item.run_id)?;
         validate_required("triage_item.provider", &item.provider)?;
         validate_required("triage_item.repo_owner", &item.repo_owner)?;
@@ -89,7 +89,7 @@ impl ObservationStore {
         })
     }
 
-    pub fn get_triage_item(&self, item_id: &str) -> Result<Option<TriageItemRecord>> {
+    fn get_triage_item(&self, item_id: &str) -> Result<Option<TriageItemRecord>> {
         validate_required("triage_item_id", item_id)?;
         self.connection
             .query_row(
@@ -106,29 +106,6 @@ impl ObservationStore {
             )
             .optional()
             .map_err(sqlite_error("read triage item record"))
-    }
-
-    pub fn list_triage_items_for_run(&self, run_id: &str) -> Result<Vec<TriageItemRecord>> {
-        validate_required("run_id", run_id)?;
-        let mut statement = self
-            .connection
-            .prepare(
-                r#"
-                SELECT id, run_id, provider, repo_owner, repo_name, item_type, number, state,
-                       title, url, checks, review_decision, merge_state, next_action,
-                       comments_count, reviews_count, last_comment_at, last_review_at, updated_at,
-                       metadata_json, observed_at
-                FROM triage_items
-                WHERE run_id = ?1
-                ORDER BY provider ASC, repo_owner ASC, repo_name ASC, item_type ASC, number ASC
-                "#,
-            )
-            .map_err(sqlite_error("prepare list run triage item records"))?;
-        let rows = statement
-            .query_map([run_id], row_to_triage_item_record)
-            .map_err(sqlite_error("list run triage item records"))?;
-
-        collect_rows(rows, "collect run triage item records")
     }
 }
 
@@ -170,62 +147,77 @@ fn row_to_triage_item_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Triage
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::observation::{NewRunRecord, RunStatus};
+    use crate::observation::NewRunRecord;
     use crate::test_support::with_isolated_home;
 
     #[test]
-    fn record_and_list_triage_items_for_run() {
+    fn test_record_triage_item() {
         with_isolated_home(|_| {
             let store = ObservationStore::open_initialized().expect("store");
-            let run = store
-                .start_run(NewRunRecord {
-                    kind: "triage".to_string(),
-                    component_id: Some("workspace".to_string()),
-                    command: Some("triage.workspace".to_string()),
-                    cwd: None,
-                    homeboy_version: Some("test".to_string()),
-                    git_sha: None,
-                    rig_id: None,
-                    metadata_json: serde_json::json!({}),
-                })
-                .expect("run");
+            let run = start_triage_run(&store);
+            let record = store
+                .record_triage_item(&sample_triage_item(&run.id))
+                .expect("triage item");
+
+            assert_eq!(record.signals.comments_count, Some(3));
+            assert_eq!(record.signals.reviews_count, Some(2));
+        });
+    }
+
+    #[test]
+    fn test_record_triage_items() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = start_triage_run(&store);
 
             let records = store
-                .record_triage_items(&[NewTriageItemRecord {
-                    run_id: run.id.clone(),
-                    provider: "github".to_string(),
-                    repo_owner: "Extra-Chill".to_string(),
-                    repo_name: "homeboy".to_string(),
-                    item_type: "pull_request".to_string(),
-                    number: 42,
-                    state: "OPEN".to_string(),
-                    title: "Add triage observations".to_string(),
-                    url: "https://github.com/Extra-Chill/homeboy/pull/42".to_string(),
-                    signals: TriagePullRequestSignals {
-                        checks: Some("SUCCESS".to_string()),
-                        review_decision: Some("REVIEW_REQUIRED".to_string()),
-                        merge_state: Some("CLEAN".to_string()),
-                        next_action: Some("review_required".to_string()),
-                        comments_count: Some(3),
-                        reviews_count: Some(2),
-                        last_comment_at: Some("2026-05-08T10:00:00Z".to_string()),
-                        last_review_at: Some("2026-05-08T11:00:00Z".to_string()),
-                    },
-                    updated_at: Some("2026-05-08T12:00:00Z".to_string()),
-                    metadata_json: serde_json::json!({ "labels": ["enhancement"] }),
-                }])
+                .record_triage_items(&[sample_triage_item(&run.id)])
                 .expect("triage items");
 
             assert_eq!(records.len(), 1);
             assert_eq!(records[0].signals.comments_count, Some(3));
             assert_eq!(records[0].signals.reviews_count, Some(2));
-
-            let listed = store.list_triage_items_for_run(&run.id).expect("listed");
-            assert_eq!(listed, records);
-            let finished = store
-                .finish_run(&run.id, RunStatus::Pass, None)
-                .expect("finish");
-            assert_eq!(finished.status, "pass");
         });
+    }
+
+    fn start_triage_run(store: &ObservationStore) -> RunRecord {
+        store
+            .start_run(NewRunRecord {
+                kind: "triage".to_string(),
+                component_id: Some("workspace".to_string()),
+                command: Some("triage.workspace".to_string()),
+                cwd: None,
+                homeboy_version: Some("test".to_string()),
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({}),
+            })
+            .expect("run")
+    }
+
+    fn sample_triage_item(run_id: &str) -> NewTriageItemRecord {
+        NewTriageItemRecord {
+            run_id: run_id.to_string(),
+            provider: "github".to_string(),
+            repo_owner: "Extra-Chill".to_string(),
+            repo_name: "homeboy".to_string(),
+            item_type: "pull_request".to_string(),
+            number: 42,
+            state: "OPEN".to_string(),
+            title: "Add triage observations".to_string(),
+            url: "https://github.com/Extra-Chill/homeboy/pull/42".to_string(),
+            signals: TriagePullRequestSignals {
+                checks: Some("SUCCESS".to_string()),
+                review_decision: Some("REVIEW_REQUIRED".to_string()),
+                merge_state: Some("CLEAN".to_string()),
+                next_action: Some("review_required".to_string()),
+                comments_count: Some(3),
+                reviews_count: Some(2),
+                last_comment_at: Some("2026-05-08T10:00:00Z".to_string()),
+                last_review_at: Some("2026-05-08T11:00:00Z".to_string()),
+            },
+            updated_at: Some("2026-05-08T12:00:00Z".to_string()),
+            metadata_json: serde_json::json!({ "labels": ["enhancement"] }),
+        }
     }
 }

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -18,6 +18,7 @@ use crate::error::{Error, Result};
 use crate::git::gh_probe_succeeds;
 use crate::observation::{
     NewRunRecord, NewTriageItemRecord, ObservationStore, RunListFilter, RunStatus,
+    TriagePullRequestSignals,
 };
 use crate::{defaults, fleet, project, rig};
 
@@ -220,14 +221,10 @@ pub struct TriagePrItem {
     pub url: String,
     pub state: String,
     pub draft: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub review_decision: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub checks: Option<String>,
+    #[serde(flatten)]
+    pub signals: TriagePullRequestSignals,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub check_failures: Vec<TriageCheckFailure>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub merge_state: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -236,18 +233,8 @@ pub struct TriagePrItem {
     pub author: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub comments_count: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reviews_count: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_comment_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_review_at: Option<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stale: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_action: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -483,18 +470,16 @@ fn triage_observation_items(run_id: &str, output: &TriageOutput) -> Vec<NewTriag
                     state: issue.state.clone(),
                     title: issue.title.clone(),
                     url: issue.url.clone(),
-                    checks: None,
-                    review_decision: None,
-                    merge_state: None,
-                    next_action: if issue.stale {
-                        Some("stale_issue".to_string())
-                    } else {
-                        None
+                    signals: TriagePullRequestSignals {
+                        comments_count: issue.comments_count.and_then(usize_to_i64),
+                        last_comment_at: issue.last_comment_at.clone(),
+                        next_action: if issue.stale {
+                            Some("stale_issue".to_string())
+                        } else {
+                            None
+                        },
+                        ..TriagePullRequestSignals::default()
                     },
-                    comments_count: issue.comments_count.and_then(usize_to_i64),
-                    reviews_count: None,
-                    last_comment_at: issue.last_comment_at.clone(),
-                    last_review_at: None,
                     updated_at: issue.updated_at.clone(),
                     metadata_json: serde_json::json!({
                         "component_id": component.component_id,
@@ -517,14 +502,7 @@ fn triage_observation_items(run_id: &str, output: &TriageOutput) -> Vec<NewTriag
                     state: pr.state.clone(),
                     title: pr.title.clone(),
                     url: pr.url.clone(),
-                    checks: pr.checks.clone(),
-                    review_decision: pr.review_decision.clone(),
-                    merge_state: pr.merge_state.clone(),
-                    next_action: pr.next_action.clone(),
-                    comments_count: pr.comments_count.and_then(usize_to_i64),
-                    reviews_count: pr.reviews_count.and_then(usize_to_i64),
-                    last_comment_at: pr.last_comment_at.clone(),
-                    last_review_at: pr.last_review_at.clone(),
+                    signals: pr.signals.clone(),
                     updated_at: pr.updated_at.clone(),
                     metadata_json: serde_json::json!({
                         "component_id": component.component_id,
@@ -1044,10 +1022,10 @@ fn fetch_prs(
     let raw = run_gh(&args)?;
     let mut items = parse_prs(&raw, stale_cutoff, options.drilldown)?;
     if options.needs_review {
-        items.retain(|item| item.review_decision.as_deref() == Some("REVIEW_REQUIRED"));
+        items.retain(|item| item.signals.review_decision.as_deref() == Some("REVIEW_REQUIRED"));
     }
     if options.failing_checks {
-        items.retain(|item| item.checks.as_deref() == Some("FAILURE"));
+        items.retain(|item| item.signals.checks.as_deref() == Some("FAILURE"));
     }
     if let Some(assigned) = &options.assigned {
         items.retain(|item| item.assignees.iter().any(|a| a == assigned));
@@ -1248,26 +1226,28 @@ fn parse_prs(
                 url: item.url,
                 state: item.state,
                 draft: item.is_draft,
-                review_decision: non_empty(item.review_decision),
-                checks: summarize_checks(&item.status_check_rollup),
+                signals: TriagePullRequestSignals {
+                    checks: summarize_checks(&item.status_check_rollup),
+                    review_decision: non_empty(item.review_decision),
+                    merge_state: non_empty(item.merge_state_status),
+                    comments_count: usize_to_i64(item.comments.len()),
+                    reviews_count: usize_to_i64(item.reviews.len()),
+                    last_comment_at: latest_comment_at(&item.comments),
+                    last_review_at: latest_review_at(&item.reviews),
+                    ..TriagePullRequestSignals::default()
+                },
                 check_failures: if include_drilldown {
                     summarize_check_failures(&item.status_check_rollup)
                 } else {
                     Vec::new()
                 },
-                merge_state: non_empty(item.merge_state_status),
                 labels: item.labels.into_iter().filter_map(|l| l.name).collect(),
                 assignees: item.assignees.into_iter().filter_map(|a| a.login).collect(),
                 author: item.author.and_then(|a| a.login),
-                comments_count: Some(item.comments.len()),
-                reviews_count: Some(item.reviews.len()),
-                last_comment_at: latest_comment_at(&item.comments),
-                last_review_at: latest_review_at(&item.reviews),
                 updated_at: item.updated_at,
                 stale,
-                next_action: None,
             };
-            pr.next_action = derive_pr_next_action(&pr);
+            pr.signals.next_action = derive_pr_next_action(&pr);
             pr
         })
         .collect())
@@ -1290,9 +1270,9 @@ fn latest_review_at(reviews: &[RawReview]) -> Option<String> {
 }
 
 fn derive_pr_next_action(pr: &TriagePrItem) -> Option<String> {
-    let checks = pr.checks.as_deref();
-    let review = pr.review_decision.as_deref();
-    let merge = pr.merge_state.as_deref();
+    let checks = pr.signals.checks.as_deref();
+    let review = pr.signals.review_decision.as_deref();
+    let merge = pr.signals.merge_state.as_deref();
 
     if pr.draft && checks == Some("FAILURE") {
         return Some("draft_with_failing_checks".to_string());
@@ -1412,7 +1392,7 @@ fn build_actions(
     if let Some(prs) = pull_requests {
         let mut action_counts = BTreeMap::<String, usize>::new();
         for pr in &prs.items {
-            if let Some(next_action) = &pr.next_action {
+            if let Some(next_action) = &pr.signals.next_action {
                 *action_counts.entry(next_action.clone()).or_default() += 1;
             }
         }
@@ -1568,12 +1548,12 @@ fn summarize(
             summary.needs_review += prs
                 .items
                 .iter()
-                .filter(|item| item.review_decision.as_deref() == Some("REVIEW_REQUIRED"))
+                .filter(|item| item.signals.review_decision.as_deref() == Some("REVIEW_REQUIRED"))
                 .count();
             summary.failing_checks += prs
                 .items
                 .iter()
-                .filter(|item| item.checks.as_deref() == Some("FAILURE"))
+                .filter(|item| item.signals.checks.as_deref() == Some("FAILURE"))
                 .count();
             summary.stale += prs.items.iter().filter(|item| item.stale).count();
         }
@@ -1928,18 +1908,18 @@ mod tests {
         let items = parse_prs(raw, None, false).unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].author.as_deref(), Some("chubes4"));
-        assert!(items[0].review_decision.is_none());
-        assert!(items[0].merge_state.is_none());
+        assert!(items[0].signals.review_decision.is_none());
+        assert!(items[0].signals.merge_state.is_none());
         assert!(items[0].check_failures.is_empty());
-        assert!(items[0].next_action.is_none());
-        assert_eq!(items[0].comments_count, Some(1));
-        assert_eq!(items[0].reviews_count, Some(1));
+        assert!(items[0].signals.next_action.is_none());
+        assert_eq!(items[0].signals.comments_count, Some(1));
+        assert_eq!(items[0].signals.reviews_count, Some(1));
         assert_eq!(
-            items[0].last_comment_at.as_deref(),
+            items[0].signals.last_comment_at.as_deref(),
             Some("2026-04-27T00:00:00Z")
         );
         assert_eq!(
-            items[0].last_review_at.as_deref(),
+            items[0].signals.last_review_at.as_deref(),
             Some("2026-04-28T00:00:00Z")
         );
     }
@@ -1987,7 +1967,10 @@ mod tests {
         ]"#;
 
         let without_drilldown = parse_prs(raw, None, false).unwrap();
-        assert_eq!(without_drilldown[0].checks.as_deref(), Some("FAILURE"));
+        assert_eq!(
+            without_drilldown[0].signals.checks.as_deref(),
+            Some("FAILURE")
+        );
         assert!(without_drilldown[0].check_failures.is_empty());
 
         let with_drilldown = parse_prs(raw, None, true).unwrap();
@@ -2083,7 +2066,7 @@ mod tests {
         let items = parse_prs(raw, None, false).unwrap();
         let actions: Vec<_> = items
             .iter()
-            .map(|item| item.next_action.as_deref().unwrap())
+            .map(|item| item.signals.next_action.as_deref().unwrap())
             .collect();
         assert_eq!(
             actions,
@@ -2145,9 +2128,15 @@ mod tests {
         ]"#;
 
         let items = parse_prs(raw, None, false).unwrap();
-        assert_eq!(items[0].next_action.as_deref(), Some("needs_rebase"));
-        assert_eq!(items[1].next_action.as_deref(), Some("needs_rebase"));
-        assert!(items[2].next_action.is_none());
+        assert_eq!(
+            items[0].signals.next_action.as_deref(),
+            Some("needs_rebase")
+        );
+        assert_eq!(
+            items[1].signals.next_action.as_deref(),
+            Some("needs_rebase")
+        );
+        assert!(items[2].signals.next_action.is_none());
 
         let actions = build_actions(
             None,
@@ -2344,20 +2333,18 @@ mod tests {
                     url: "https://github.com/o/r/pull/2".to_string(),
                     state: "OPEN".to_string(),
                     draft: false,
-                    review_decision: Some("REVIEW_REQUIRED".to_string()),
-                    checks: Some("FAILURE".to_string()),
+                    signals: TriagePullRequestSignals {
+                        checks: Some("FAILURE".to_string()),
+                        review_decision: Some("REVIEW_REQUIRED".to_string()),
+                        next_action: Some("checks_failed".to_string()),
+                        ..TriagePullRequestSignals::default()
+                    },
                     check_failures: Vec::new(),
-                    merge_state: None,
                     labels: vec![],
                     assignees: vec![],
                     author: None,
                     updated_at: None,
-                    comments_count: None,
-                    reviews_count: None,
-                    last_comment_at: None,
-                    last_review_at: None,
                     stale: false,
-                    next_action: Some("checks_failed".to_string()),
                 }],
             }),
             actions: vec![TriageAction {
@@ -2384,20 +2371,16 @@ mod tests {
             url: "https://github.com/o/r/pull/1".to_string(),
             state: "OPEN".to_string(),
             draft: false,
-            review_decision: None,
-            checks: None,
+            signals: TriagePullRequestSignals {
+                next_action: Some(action.to_string()),
+                ..TriagePullRequestSignals::default()
+            },
             check_failures: Vec::new(),
-            merge_state: None,
             labels: vec![],
             assignees: vec![],
             author: None,
             updated_at: None,
-            comments_count: None,
-            reviews_count: None,
-            last_comment_at: None,
-            last_review_at: None,
             stale: false,
-            next_action: Some(action.to_string()),
         }
     }
 

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -16,6 +16,9 @@ use crate::component;
 use crate::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
 use crate::error::{Error, Result};
 use crate::git::gh_probe_succeeds;
+use crate::observation::{
+    NewRunRecord, NewTriageItemRecord, ObservationStore, RunListFilter, RunStatus,
+};
 use crate::{defaults, fleet, project, rig};
 
 #[derive(Debug, Clone)]
@@ -92,10 +95,21 @@ pub struct TriageOptions {
 pub struct TriageOutput {
     pub command: &'static str,
     pub target: TriageTargetOutput,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observation: Option<TriageObservationOutput>,
     pub summary: TriageSummary,
     pub components: Vec<TriageComponentReport>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub unresolved: Vec<TriageUnresolved>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriageObservationOutput {
+    pub run_id: String,
+    pub item_count: usize,
+    pub store_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_run_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -173,6 +187,10 @@ pub struct TriageIssueItem {
     pub assignees: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comments_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_comment_at: Option<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stale: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -218,6 +236,14 @@ pub struct TriagePrItem {
     pub author: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comments_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reviews_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_comment_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_review_at: Option<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stale: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -293,6 +319,7 @@ impl ComponentRef {
 }
 
 pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput> {
+    let observation = TriageObservation::start(&target, &options);
     let refs = resolve_target_components(&target)?;
     let global_priority_labels = defaults::load_config().triage.priority_labels;
     let mut components = Vec::new();
@@ -316,16 +343,206 @@ pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput>
     }
 
     let summary = summarize(&components, &unresolved);
-    Ok(TriageOutput {
+    let mut output = TriageOutput {
         command: target.command(),
         target: TriageTargetOutput {
             kind: target.kind(),
             id: target.id().to_string(),
         },
+        observation: None,
         summary,
         components,
         unresolved,
-    })
+    };
+
+    if let Some(observation) = observation {
+        output.observation = observation.finish(&output);
+    }
+
+    Ok(output)
+}
+
+struct TriageObservation {
+    store: ObservationStore,
+    run_id: String,
+    store_path: String,
+    previous_run_at: Option<String>,
+}
+
+impl TriageObservation {
+    fn start(target: &TriageTarget, options: &TriageOptions) -> Option<Self> {
+        let store = ObservationStore::open_initialized().ok()?;
+        let component_id = triage_observation_component_id(target);
+        let previous_run_at = store
+            .latest_run(RunListFilter {
+                kind: Some("triage".to_string()),
+                component_id: Some(component_id.clone()),
+                status: None,
+                rig_id: None,
+                limit: Some(1),
+            })
+            .ok()
+            .flatten()
+            .map(|run| run.started_at);
+        let store_path = store
+            .status()
+            .map(|status| status.path)
+            .unwrap_or_else(|_| "<unavailable>".to_string());
+        let run = store
+            .start_run(NewRunRecord {
+                kind: "triage".to_string(),
+                component_id: Some(component_id),
+                command: Some(target.command().to_string()),
+                cwd: std::env::current_dir()
+                    .ok()
+                    .map(|path| path.to_string_lossy().to_string()),
+                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                git_sha: None,
+                rig_id: match target {
+                    TriageTarget::Rig(id) => Some(id.clone()),
+                    _ => None,
+                },
+                metadata_json: serde_json::json!({
+                    "target": {
+                        "kind": target.kind(),
+                        "id": target.id(),
+                    },
+                    "options": {
+                        "include_issues": options.include_issues,
+                        "include_prs": options.include_prs,
+                        "mine": options.mine,
+                        "assigned": options.assigned,
+                        "labels": options.labels,
+                        "needs_review": options.needs_review,
+                        "failing_checks": options.failing_checks,
+                        "drilldown": options.drilldown,
+                        "issue_numbers": options.issue_numbers,
+                        "stale_days": options.stale_days,
+                        "limit": options.limit,
+                    }
+                }),
+            })
+            .ok()?;
+
+        Some(Self {
+            store,
+            run_id: run.id,
+            store_path,
+            previous_run_at,
+        })
+    }
+
+    fn finish(self, output: &TriageOutput) -> Option<TriageObservationOutput> {
+        let items = triage_observation_items(&self.run_id, output);
+        let item_count = items.len();
+        let record_result = self.store.record_triage_items(&items);
+        let status = if record_result.is_ok() {
+            RunStatus::Pass
+        } else {
+            RunStatus::Error
+        };
+        let _ = self.store.finish_run(
+            &self.run_id,
+            status,
+            Some(serde_json::json!({
+                "summary": output.summary,
+                "item_count": item_count,
+                "recorded": record_result.is_ok(),
+            })),
+        );
+
+        if record_result.is_err() {
+            return None;
+        }
+
+        Some(TriageObservationOutput {
+            run_id: self.run_id,
+            item_count,
+            store_path: self.store_path,
+            previous_run_at: self.previous_run_at,
+        })
+    }
+}
+
+fn triage_observation_component_id(target: &TriageTarget) -> String {
+    format!("{}:{}", target.kind(), target.id())
+}
+
+fn triage_observation_items(run_id: &str, output: &TriageOutput) -> Vec<NewTriageItemRecord> {
+    let mut records = Vec::new();
+    for component in &output.components {
+        if let Some(issues) = &component.issues {
+            for issue in &issues.items {
+                records.push(NewTriageItemRecord {
+                    run_id: run_id.to_string(),
+                    provider: component.repo.provider.to_string(),
+                    repo_owner: component.repo.owner.clone(),
+                    repo_name: component.repo.name.clone(),
+                    item_type: "issue".to_string(),
+                    number: issue.number,
+                    state: issue.state.clone(),
+                    title: issue.title.clone(),
+                    url: issue.url.clone(),
+                    checks: None,
+                    review_decision: None,
+                    merge_state: None,
+                    next_action: if issue.stale {
+                        Some("stale_issue".to_string())
+                    } else {
+                        None
+                    },
+                    comments_count: issue.comments_count.and_then(usize_to_i64),
+                    reviews_count: None,
+                    last_comment_at: issue.last_comment_at.clone(),
+                    last_review_at: None,
+                    updated_at: issue.updated_at.clone(),
+                    metadata_json: serde_json::json!({
+                        "component_id": component.component_id,
+                        "labels": issue.labels,
+                        "assignees": issue.assignees,
+                        "linked_prs": issue.linked_prs,
+                    }),
+                });
+            }
+        }
+        if let Some(prs) = &component.pull_requests {
+            for pr in &prs.items {
+                records.push(NewTriageItemRecord {
+                    run_id: run_id.to_string(),
+                    provider: component.repo.provider.to_string(),
+                    repo_owner: component.repo.owner.clone(),
+                    repo_name: component.repo.name.clone(),
+                    item_type: "pull_request".to_string(),
+                    number: pr.number,
+                    state: pr.state.clone(),
+                    title: pr.title.clone(),
+                    url: pr.url.clone(),
+                    checks: pr.checks.clone(),
+                    review_decision: pr.review_decision.clone(),
+                    merge_state: pr.merge_state.clone(),
+                    next_action: pr.next_action.clone(),
+                    comments_count: pr.comments_count.and_then(usize_to_i64),
+                    reviews_count: pr.reviews_count.and_then(usize_to_i64),
+                    last_comment_at: pr.last_comment_at.clone(),
+                    last_review_at: pr.last_review_at.clone(),
+                    updated_at: pr.updated_at.clone(),
+                    metadata_json: serde_json::json!({
+                        "component_id": component.component_id,
+                        "draft": pr.draft,
+                        "labels": pr.labels,
+                        "assignees": pr.assignees,
+                        "author": pr.author,
+                        "check_failures": pr.check_failures,
+                    }),
+                });
+            }
+        }
+    }
+    records
+}
+
+fn usize_to_i64(value: usize) -> Option<i64> {
+    i64::try_from(value).ok()
 }
 
 fn resolve_target_components(target: &TriageTarget) -> Result<Vec<ComponentRef>> {
@@ -754,7 +971,7 @@ fn fetch_issues(
         "--limit".to_string(),
         effective_limit(options).to_string(),
         "--json".to_string(),
-        "number,title,url,state,labels,assignees,updatedAt".to_string(),
+        "number,title,url,state,labels,assignees,comments,updatedAt".to_string(),
     ];
     if options.mine {
         args.push("--assignee".to_string());
@@ -787,7 +1004,7 @@ fn fetch_targeted_issues(
             "-R".to_string(),
             format!("{}/{}", repo.owner, repo.repo),
             "--json".to_string(),
-            "number,title,url,state,labels,assignees,updatedAt".to_string(),
+            "number,title,url,state,labels,assignees,comments,updatedAt".to_string(),
         ];
         let raw = run_gh(&args)?;
         let mut issue = parse_issue(&raw, stale_cutoff)?;
@@ -813,7 +1030,7 @@ fn fetch_prs(
         "--limit".to_string(),
         effective_limit(options).to_string(),
         "--json".to_string(),
-        "number,title,url,state,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,labels,assignees,author,updatedAt".to_string(),
+        "number,title,url,state,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,labels,assignees,author,comments,reviews,updatedAt".to_string(),
     ];
     if options.mine {
         args.push("--author".to_string());
@@ -885,8 +1102,24 @@ struct RawIssue {
     labels: Vec<RawNamedNode>,
     #[serde(default)]
     assignees: Vec<RawNamedNode>,
+    #[serde(default)]
+    comments: Vec<RawComment>,
     #[serde(default, rename = "updatedAt")]
     updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawComment {
+    #[serde(default, rename = "createdAt")]
+    created_at: Option<String>,
+    #[serde(default, rename = "updatedAt")]
+    updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawReview {
+    #[serde(default, rename = "submittedAt")]
+    submitted_at: Option<String>,
 }
 
 fn parse_issues(
@@ -917,6 +1150,8 @@ fn raw_issue_to_item(item: RawIssue, stale_cutoff: Option<DateTime<Utc>>) -> Tri
         state: item.state,
         labels: item.labels.into_iter().filter_map(|l| l.name).collect(),
         assignees: item.assignees.into_iter().filter_map(|a| a.login).collect(),
+        comments_count: Some(item.comments.len()),
+        last_comment_at: latest_comment_at(&item.comments),
         updated_at: item.updated_at,
         stale,
         linked_prs: Vec::new(),
@@ -989,6 +1224,10 @@ struct RawPr {
     assignees: Vec<RawNamedNode>,
     #[serde(default)]
     author: Option<RawNamedNode>,
+    #[serde(default)]
+    comments: Vec<RawComment>,
+    #[serde(default)]
+    reviews: Vec<RawReview>,
     #[serde(default, rename = "updatedAt")]
     updated_at: Option<String>,
 }
@@ -1020,6 +1259,10 @@ fn parse_prs(
                 labels: item.labels.into_iter().filter_map(|l| l.name).collect(),
                 assignees: item.assignees.into_iter().filter_map(|a| a.login).collect(),
                 author: item.author.and_then(|a| a.login),
+                comments_count: Some(item.comments.len()),
+                reviews_count: Some(item.reviews.len()),
+                last_comment_at: latest_comment_at(&item.comments),
+                last_review_at: latest_review_at(&item.reviews),
                 updated_at: item.updated_at,
                 stale,
                 next_action: None,
@@ -1028,6 +1271,22 @@ fn parse_prs(
             pr
         })
         .collect())
+}
+
+fn latest_comment_at(comments: &[RawComment]) -> Option<String> {
+    comments
+        .iter()
+        .filter_map(|comment| comment.updated_at.as_ref().or(comment.created_at.as_ref()))
+        .max()
+        .cloned()
+}
+
+fn latest_review_at(reviews: &[RawReview]) -> Option<String> {
+    reviews
+        .iter()
+        .filter_map(|review| review.submitted_at.as_ref())
+        .max()
+        .cloned()
 }
 
 fn derive_pr_next_action(pr: &TriagePrItem) -> Option<String> {
@@ -1507,16 +1766,25 @@ mod tests {
           "number": 8,
           "title": "Closed bug",
           "url": "https://github.com/o/r/issues/8",
-          "state": "CLOSED",
-          "labels": [],
-          "assignees": [],
-          "updatedAt": "2026-04-01T00:00:00Z"
+              "state": "CLOSED",
+              "labels": [],
+              "assignees": [],
+              "comments": [
+                {"createdAt":"2026-04-02T00:00:00Z","updatedAt":"2026-04-03T00:00:00Z"},
+                {"createdAt":"2026-04-04T00:00:00Z","updatedAt":null}
+              ],
+              "updatedAt": "2026-04-01T00:00:00Z"
         }"#;
 
         let item = parse_issue(raw, None).unwrap();
 
         assert_eq!(item.number, 8);
         assert_eq!(item.state, "CLOSED");
+        assert_eq!(item.comments_count, Some(2));
+        assert_eq!(
+            item.last_comment_at.as_deref(),
+            Some("2026-04-04T00:00:00Z")
+        );
         assert!(item.linked_prs.is_empty());
     }
 
@@ -1531,6 +1799,8 @@ mod tests {
                 labels: vec![],
                 assignees: vec![],
                 updated_at: None,
+                comments_count: None,
+                last_comment_at: None,
                 stale: false,
                 linked_prs: Vec::new(),
             },
@@ -1542,6 +1812,8 @@ mod tests {
                 labels: vec![],
                 assignees: vec![],
                 updated_at: None,
+                comments_count: None,
+                last_comment_at: None,
                 stale: false,
                 linked_prs: Vec::new(),
             },
@@ -1563,6 +1835,8 @@ mod tests {
                 labels: vec!["P1".to_string()],
                 assignees: vec![],
                 updated_at: None,
+                comments_count: None,
+                last_comment_at: None,
                 stale: true,
                 linked_prs: Vec::new(),
             }],
@@ -1646,6 +1920,8 @@ mod tests {
               "labels": [],
               "assignees": [],
               "author": {"login":"chubes4"},
+              "comments": [{"createdAt":"2026-04-27T00:00:00Z","updatedAt":null}],
+              "reviews": [{"submittedAt":"2026-04-28T00:00:00Z"}],
               "updatedAt": "2026-04-26T00:00:00Z"
             }
         ]"#;
@@ -1656,6 +1932,16 @@ mod tests {
         assert!(items[0].merge_state.is_none());
         assert!(items[0].check_failures.is_empty());
         assert!(items[0].next_action.is_none());
+        assert_eq!(items[0].comments_count, Some(1));
+        assert_eq!(items[0].reviews_count, Some(1));
+        assert_eq!(
+            items[0].last_comment_at.as_deref(),
+            Some("2026-04-27T00:00:00Z")
+        );
+        assert_eq!(
+            items[0].last_review_at.as_deref(),
+            Some("2026-04-28T00:00:00Z")
+        );
     }
 
     #[test]
@@ -2030,6 +2316,8 @@ mod tests {
                         labels: vec!["P1".to_string()],
                         assignees: vec![],
                         updated_at: None,
+                        comments_count: None,
+                        last_comment_at: None,
                         stale: false,
                         linked_prs: Vec::new(),
                     },
@@ -2041,6 +2329,8 @@ mod tests {
                         labels: vec![],
                         assignees: vec![],
                         updated_at: None,
+                        comments_count: None,
+                        last_comment_at: None,
                         stale: false,
                         linked_prs: Vec::new(),
                     },
@@ -2062,6 +2352,10 @@ mod tests {
                     assignees: vec![],
                     author: None,
                     updated_at: None,
+                    comments_count: None,
+                    reviews_count: None,
+                    last_comment_at: None,
+                    last_review_at: None,
                     stale: false,
                     next_action: Some("checks_failed".to_string()),
                 }],
@@ -2098,6 +2392,10 @@ mod tests {
             assignees: vec![],
             author: None,
             updated_at: None,
+            comments_count: None,
+            reviews_count: None,
+            last_comment_at: None,
+            last_review_at: None,
             stale: false,
             next_action: Some(action.to_string()),
         }
@@ -2124,6 +2422,8 @@ mod tests {
                     labels: labels.into_iter().map(str::to_string).collect(),
                     assignees: vec![],
                     updated_at: None,
+                    comments_count: None,
+                    last_comment_at: None,
                     stale: false,
                     linked_prs: Vec::new(),
                 })


### PR DESCRIPTION
## Summary
- Add issue and pull request comment activity fields to `homeboy triage` output.
- Persist triage runs and surfaced issue/PR snapshots in the existing observation SQLite database.
- Report the previous triage timestamp for the same target when available.

## Validation
- `cargo test --lib triage`
- `cargo test --lib record_and_list_triage_items_for_run`
- `cargo check`
- `cargo run --quiet --bin homeboy -- triage component homeboy --prs --limit 1`

## Notes
- `cargo clippy --all-targets --all-features -- -D warnings` currently fails on existing repo-wide clippy findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the triage output, observation storage, tests, and docs; Chris directed the enhancement and remains responsible for review.