### PR TITLE
test(observation): update schema count expectations

### DIFF
--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -82,8 +82,8 @@ fn test_open_initialized() {
 
         assert!(status.exists);
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 4);
-        assert_eq!(status.table_count, 6);
+        assert_eq!(status.migration_count, 5);
+        assert_eq!(status.table_count, 7);
     });
 }
 
@@ -97,8 +97,8 @@ fn initialization_is_idempotent() {
         let status = second.status().expect("status");
 
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
-        assert_eq!(status.migration_count, 4);
-        assert_eq!(status.table_count, 6);
+        assert_eq!(status.migration_count, 5);
+        assert_eq!(status.table_count, 7);
     });
 }
 


### PR DESCRIPTION
## Summary
- Update observation store initialization tests for schema migration 5.
- Account for the new `triage_items` table added by the triage observation storage change.

## Validation
- `cargo test --lib core::observation::store::store_test`
- `cargo fmt --check`
- `homeboy audit homeboy --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the post-merge release test failure, updated the failing test expectations, and ran targeted validation; Chris reviewed and requested the follow-up PR.