### PR TITLE
Fix source upgrade checkout resolution

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use homeboy::upgrade;
 use serde_json::Value;
+use std::path::PathBuf;
 
 use crate::commands::utils::args::HiddenJsonArgs;
 use crate::commands::{CmdResult, GlobalArgs};
@@ -26,6 +27,10 @@ pub struct UpgradeArgs {
     /// Override install method detection (homebrew|cargo|source|binary)
     #[arg(long)]
     pub method: Option<String>,
+
+    /// Homeboy source checkout to use with --method source
+    #[arg(long, value_name = "PATH")]
+    pub source_path: Option<PathBuf>,
 
     #[command(flatten)]
     _json: HiddenJsonArgs,
@@ -56,8 +61,12 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         })
         .transpose()?;
 
-    let result =
-        upgrade::run_upgrade_with_method(args.force, method_override, args.skip_extensions)?;
+    let result = upgrade::run_upgrade_with_method(
+        args.force,
+        method_override,
+        args.skip_extensions,
+        args.source_path.as_deref(),
+    )?;
     let json = serde_json::to_value(&result)
         .map_err(|e| homeboy::Error::internal_json(e.to_string(), None))?;
 

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -1,11 +1,15 @@
 use crate::defaults;
 use crate::error::{Error, Result};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::helpers::{current_version, version_is_newer};
 use super::types::InstallMethod;
 
-pub(crate) fn execute_upgrade(method: InstallMethod) -> Result<(bool, Option<String>)> {
+pub(crate) fn execute_upgrade(
+    method: InstallMethod,
+    source_path: Option<&Path>,
+) -> Result<(bool, Option<String>)> {
     let defaults = defaults::load_defaults();
 
     let output = match method {
@@ -22,33 +26,7 @@ pub(crate) fn execute_upgrade(method: InstallMethod) -> Result<(bool, Option<Str
             })?
         }
         InstallMethod::Source => {
-            // For source builds, we need to find the git root
-            let exe_path = std::env::current_exe().map_err(|e| {
-                Error::internal_io(
-                    e.to_string(),
-                    Some("get current executable path".to_string()),
-                )
-            })?;
-
-            // Navigate up from target/release/homeboy to find the workspace root
-            let mut workspace_root = exe_path.clone();
-            for _ in 0..3 {
-                workspace_root = workspace_root
-                    .parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or(workspace_root);
-            }
-
-            // Check if this looks like a git repo
-            let git_dir = workspace_root.join(".git");
-            if !git_dir.exists() {
-                return Err(Error::validation_invalid_argument(
-                    "source_path",
-                    "Could not find git repository for source build",
-                    Some(workspace_root.to_string_lossy().to_string()),
-                    None,
-                ));
-            }
+            let workspace_root = resolve_source_workspace(source_path)?;
 
             // Execute the upgrade command from defaults
             let cmd = &defaults.install_methods.source.upgrade_command;
@@ -86,16 +64,118 @@ pub(crate) fn execute_upgrade(method: InstallMethod) -> Result<(bool, Option<Str
         } else {
             format!("exit code {}", output.status.code().unwrap_or(1))
         };
-        return Err(Error::internal_io(
-            format!("{} upgrade failed: {}", method.as_str(), error_detail),
-            Some("execute upgrade".to_string()),
-        ));
+        return Err(upgrade_failure_error(method, &error_detail));
     }
 
     let new_version = active_binary_version().ok().flatten();
     let success = upgrade_verification_result(current_version(), new_version.as_deref());
 
     Ok((success, new_version))
+}
+
+fn upgrade_failure_error(method: InstallMethod, error_detail: &str) -> Error {
+    let mut error = Error::internal_io(
+        format!("{} upgrade failed: {}", method.as_str(), error_detail),
+        Some("execute upgrade".to_string()),
+    );
+
+    if method == InstallMethod::Binary && error_detail.contains("404") {
+        error = error
+            .with_hint("No release asset was found for this Homeboy version.")
+            .with_hint("Try: homeboy upgrade --method source --source-path <PATH>");
+    } else if method == InstallMethod::Cargo && error_detail.contains("cargo: not found") {
+        error = error
+            .with_hint("Cargo is not installed or is not on PATH.")
+            .with_hint(
+                "Install Rust/Cargo, or use: homeboy upgrade --method source --source-path <PATH>",
+            );
+    }
+
+    error
+}
+
+pub(crate) fn resolve_source_workspace(source_path: Option<&Path>) -> Result<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(path) = source_path {
+        candidates.push(path.to_path_buf());
+    } else {
+        if let Ok(current_dir) = std::env::current_dir() {
+            candidates.push(current_dir);
+        }
+
+        if let Ok(exe_path) = std::env::current_exe() {
+            if let Some(workspace_root) = workspace_from_exe_path(&exe_path) {
+                candidates.push(workspace_root);
+            }
+        }
+    }
+
+    for candidate in candidates {
+        if let Some(checkout) = find_homeboy_source_checkout(&candidate) {
+            return Ok(checkout);
+        }
+    }
+
+    let id = source_path
+        .map(|path| path.to_string_lossy().to_string())
+        .or_else(|| {
+            std::env::current_dir()
+                .ok()
+                .map(|path| path.to_string_lossy().to_string())
+        });
+
+    Err(Error::validation_invalid_argument(
+        "source_path",
+        "Could not find a Homeboy git checkout for source build",
+        id,
+        None,
+    )
+    .with_hint("Run from the Homeboy source checkout, or pass: homeboy upgrade --method source --source-path <PATH>"))
+}
+
+fn workspace_from_exe_path(exe_path: &Path) -> Option<PathBuf> {
+    let parent = exe_path.parent()?;
+    let build_dir = parent.file_name()?.to_string_lossy();
+    if build_dir != "release" && build_dir != "debug" {
+        return None;
+    }
+
+    let target_dir = parent.parent()?;
+    if target_dir.file_name()?.to_string_lossy() != "target" {
+        return None;
+    }
+
+    target_dir.parent().map(Path::to_path_buf)
+}
+
+fn is_homeboy_source_checkout(path: &Path) -> bool {
+    let git_dir = path.join(".git");
+    if !git_dir.exists() {
+        return false;
+    }
+
+    let manifest = path.join("homeboy.json");
+    let Ok(contents) = std::fs::read_to_string(manifest) else {
+        return false;
+    };
+
+    serde_json::from_str::<serde_json::Value>(&contents)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("id")
+                .and_then(|id| id.as_str())
+                .map(str::to_string)
+        })
+        .as_deref()
+        == Some("homeboy")
+}
+
+fn find_homeboy_source_checkout(path: &Path) -> Option<PathBuf> {
+    path.ancestors()
+        .find(|candidate| is_homeboy_source_checkout(candidate))
+        .map(Path::to_path_buf)
 }
 
 fn active_binary_version() -> Result<Option<String>> {
@@ -180,5 +260,89 @@ mod tests {
     #[test]
     fn verification_rejects_missing_active_binary_version() {
         assert!(!upgrade_verification_result("0.157.1", None));
+    }
+
+    #[test]
+    fn source_workspace_accepts_explicit_homeboy_checkout() {
+        let dir = checkout_with_package_name("homeboy");
+
+        let resolved = resolve_source_workspace(Some(dir.path())).expect("source checkout");
+
+        assert_eq!(resolved, dir.path());
+    }
+
+    #[test]
+    fn source_workspace_rejects_non_homeboy_checkout() {
+        let dir = checkout_with_package_name("other");
+
+        let err = resolve_source_workspace(Some(dir.path())).expect_err("invalid checkout");
+
+        assert!(err.message.contains("Homeboy git checkout"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("--source-path")));
+    }
+
+    #[test]
+    fn source_workspace_resolves_from_nested_checkout_path() {
+        let dir = checkout_with_package_name("homeboy");
+        let nested = dir.path().join("src/core");
+        std::fs::create_dir_all(&nested).expect("nested dir");
+
+        let resolved = resolve_source_workspace(Some(&nested)).expect("source checkout");
+
+        assert_eq!(resolved, dir.path());
+    }
+
+    #[test]
+    fn executable_workspace_only_resolves_target_build_paths() {
+        let path = Path::new("/repo/target/release/homeboy");
+        assert_eq!(
+            workspace_from_exe_path(path).as_deref(),
+            Some(Path::new("/repo"))
+        );
+
+        let installed = Path::new("/usr/local/bin/homeboy");
+        assert!(workspace_from_exe_path(installed).is_none());
+    }
+
+    #[test]
+    fn binary_404_upgrade_error_suggests_source_fallback() {
+        let err = upgrade_failure_error(
+            InstallMethod::Binary,
+            "curl: (22) The requested URL returned error: 404",
+        );
+
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("No release asset")));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("--source-path")));
+    }
+
+    #[test]
+    fn missing_cargo_upgrade_error_suggests_source_fallback() {
+        let err = upgrade_failure_error(InstallMethod::Cargo, "sh: 1: cargo: not found");
+
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("Cargo is not installed")));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("--source-path")));
+    }
+
+    fn checkout_with_package_name(package_name: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(dir.path().join(".git")).expect("git dir");
+        let manifest = serde_json::json!({ "id": package_name });
+        std::fs::write(dir.path().join("homeboy.json"), manifest.to_string()).expect("manifest");
+        dir
     }
 }

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -1,5 +1,6 @@
 use crate::defaults;
 use crate::error::{Error, Result};
+use std::path::Path;
 use std::process::Command;
 
 use super::constants::{CRATES_IO_API, GITHUB_RELEASES_API, VERSION};
@@ -151,6 +152,7 @@ pub fn run_upgrade_with_method(
     force: bool,
     method_override: Option<InstallMethod>,
     skip_extensions: bool,
+    source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
     let install_method = method_override.unwrap_or_else(detect_install_method);
     let previous_version = current_version().to_string();
@@ -195,7 +197,7 @@ pub fn run_upgrade_with_method(
     }
 
     // Execute the upgrade
-    let (success, new_version) = execute_upgrade(install_method)?;
+    let (success, new_version) = execute_upgrade(install_method, source_path)?;
 
     // Auto-update all installed extensions after a successful upgrade.
     // This prevents CI/local extension version drift that causes baseline


### PR DESCRIPTION
## Summary
- Add `homeboy upgrade --source-path <PATH>` so source upgrades can target an explicit checkout.
- Resolve source upgrades from the current working directory before falling back to executable-derived `target/{debug,release}` paths.
- Add hints for binary release 404s and missing Cargo so stock VPS failures point to a working source upgrade path.

Fixes #2377.

## Testing
- `cargo fmt --check`
- `cargo test upgrade::execution`
- `cargo test command_surface`
- `cargo check`
- `homeboy review --path /Users/chubes/Developer/homeboy@fix-upgrade-source-path --changed-only --summary` *(fails on existing full-suite/audit scope: audit baseline findings plus unrelated `core::refactor::plan::sources::tests::lint_stage_empty_selected_files_does_not_fall_back_to_broad_lint` with `create annotations dir`, os error 22; changed lint passed and upgrade tests passed)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Diagnosed the upgrade source-path failure, drafted the implementation and regression tests, relinked the local Rust Homeboy extension, and ran verification commands for Chris to review.