### PR TITLE
fix(audit): ignore namespace-only import references

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -1834,6 +1834,63 @@ mod tests {
     }
 
     #[test]
+    fn missing_import_not_flagged_when_terminal_only_appears_in_namespace() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "core/agents/AgentBundler.php".to_string(),
+                language: Language::Php,
+                methods: vec!["__construct".to_string()],
+                type_name: Some("AgentBundler".to_string()),
+                namespace: Some("DataMachine\\Core\\Agents".to_string()),
+                imports: vec!["DataMachine\\Core\\Database\\Agents\\Agents".to_string()],
+                content: "namespace DataMachine\\Core\\Agents;\nuse DataMachine\\Core\\Database\\Agents\\Agents;\nclass AgentBundler { public function __construct() { new Agents(); } }".to_string(),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "core/agents/AgentIdentityResolver.php".to_string(),
+                language: Language::Php,
+                methods: vec!["__construct".to_string()],
+                type_name: Some("AgentIdentityResolver".to_string()),
+                namespace: Some("DataMachine\\Core\\Agents".to_string()),
+                imports: vec!["DataMachine\\Core\\Database\\Agents\\Agents".to_string()],
+                content: "namespace DataMachine\\Core\\Agents;\nuse DataMachine\\Core\\Database\\Agents\\Agents;\nclass AgentIdentityResolver { public function __construct() { new Agents(); } }".to_string(),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "core/agents/AgentIdentity.php".to_string(),
+                language: Language::Php,
+                methods: vec!["__construct".to_string()],
+                type_name: Some("AgentIdentity".to_string()),
+                namespace: Some("DataMachine\\Core\\Agents".to_string()),
+                imports: vec![],
+                content: "namespace DataMachine\\Core\\Agents;\nclass AgentIdentity { public function __construct() {} }".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let convention = discover_conventions("Agents", "core/agents/*", &fingerprints).unwrap();
+
+        assert!(convention
+            .expected_imports
+            .contains(&"DataMachine\\Core\\Database\\Agents\\Agents".to_string()));
+
+        let identity_outlier = convention
+            .outliers
+            .iter()
+            .find(|o| o.file == "core/agents/AgentIdentity.php");
+
+        if let Some(outlier) = identity_outlier {
+            assert!(
+                !outlier.deviations.iter().any(|d| {
+                    d.kind == AuditFinding::MissingImport && d.description.contains("Agents")
+                }),
+                "Namespace-only terminal segment should not be flagged as missing import. Got deviations: {:?}",
+                outlier.deviations
+            );
+        }
+    }
+
+    #[test]
     fn missing_import_detected_in_convention() {
         let fingerprints = vec![
             FileFingerprint {

--- a/src/core/code_audit/import_matching.rs
+++ b/src/core/code_audit/import_matching.rs
@@ -331,8 +331,17 @@ pub(crate) fn content_references_name(content: &str, name: &str) -> bool {
 
     for line in content.lines() {
         let trimmed = line.trim();
-        // Skip import/use lines — we're looking for usage, not declarations
-        if trimmed.starts_with("use ") || trimmed.starts_with("import ") {
+        // Skip declaration/import/comment lines — we're looking for symbol
+        // usage, not namespace segments, imports, or documentation metadata
+        // that merely contain the terminal name.
+        if trimmed.starts_with("use ")
+            || trimmed.starts_with("import ")
+            || trimmed.starts_with("namespace ")
+            || trimmed.starts_with("//")
+            || trimmed.starts_with("#")
+            || trimmed.starts_with("/*")
+            || trimmed.starts_with("*")
+        {
             continue;
         }
         if !contains_word(trimmed, name) {
@@ -651,6 +660,22 @@ fn production(values: BTreeMap<String, f64>) {}
         assert!(!content_defines_name(
             "use crate::defaults::default_true;",
             "default_true"
+        ));
+    }
+
+    #[test]
+    fn content_references_name_skips_php_namespace_declarations() {
+        assert!(!content_references_name(
+            "namespace DataMachine\\Core\\Agents;\n\nclass AgentIdentity { public function __construct() {} }",
+            "Agents"
+        ));
+    }
+
+    #[test]
+    fn content_references_name_skips_comment_only_references() {
+        assert!(!content_references_name(
+            "<?php\n/**\n * @package DataMachine\\Core\\Agents\n */\nnamespace DataMachine\\Core;\nclass AgentIdentity {}",
+            "Agents"
         ));
     }
 


### PR DESCRIPTION
## Summary
- Prevent the missing-import detector from treating PHP namespace declarations, comments, and PHPDoc metadata as real symbol references.
- Add regression coverage for the Data Machine `AgentIdentity.php` value-object false positive.

Closes #2380.

## Verification
- `cargo test content_references_name_skips_comment_only_references`
- `cargo test missing_import_not_flagged_when_terminal_only_appears_in_namespace`
- `cargo run --bin homeboy -- audit --path /Users/chubes/Developer/data-machine --only missing_import --json-summary --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the false positive, drafted the detector/test changes, and ran targeted verification; Chris remains responsible for review and merge.