### PR TITLE
fix: detect import references in Rust attributes

### DIFF
--- a/src/core/code_audit/import_matching.rs
+++ b/src/core/code_audit/import_matching.rs
@@ -349,7 +349,6 @@ fn content_references_name_with_context(
             || trimmed.starts_with("import ")
             || trimmed.starts_with("namespace ")
             || trimmed.starts_with("//")
-            || trimmed.starts_with("#")
             || trimmed.starts_with("/*")
             || trimmed.starts_with("*")
         {


### PR DESCRIPTION
## Summary
- Treat Rust attribute lines as code references when matching expected imports.
- Keeps string-only attribute arguments filtered by the existing attribute-string logic.
- Unblocks the release test failures in `core::code_audit::import_matching`.

## Testing
- `cargo test core::code_audit::import_matching::tests`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI failure, drafted the focused matcher fix, and ran local verification; Chris remains responsible for review and merge.