### PR TITLE
feat(git): add PR policy primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path",
+ "serde_yml",
  "sha2",
  "shellexpand",
  "tempfile",
@@ -1166,6 +1167,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -2014,6 +2025,21 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/bin/bench-audit-self.rs"
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yml = "0.0.12"
 heck = "0.5"
 uuid = { version = "1.11", features = ["v4", "v5", "serde"] }
 shellexpand = "3.1"

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -5,7 +5,8 @@ use homeboy::git::{
     self, CherryPickOptions, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput,
     IssueCloseOptions, IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions,
     IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions,
-    PrFindOptions, PrState, PushOptions, RebaseOptions,
+    PrFindOptions, PrPolicyDecision, PrPolicyMergeOptions, PrPolicyOpenOptions, PrState,
+    PushOptions, RebaseOptions,
 };
 use homeboy::BulkResult;
 
@@ -541,6 +542,108 @@ enum PrCommand {
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
     },
+    /// Evaluate PR open/merge policy.
+    Policy(PrPolicyArgs),
+}
+
+#[derive(Args)]
+pub struct PrPolicyArgs {
+    #[command(subcommand)]
+    command: PrPolicyCommand,
+}
+
+#[derive(Subcommand)]
+enum PrPolicyCommand {
+    /// Evaluate whether Homeboy may create or update a proposed PR.
+    Open {
+        /// Component ID
+        component_id: String,
+
+        /// Policy file path (YAML or JSON)
+        #[arg(long, value_name = "PATH")]
+        policy: String,
+
+        /// Change source, e.g. autofix, deps, generated, release-prep, agent.
+        #[arg(long)]
+        source: Option<String>,
+
+        /// Base branch.
+        #[arg(long)]
+        base: Option<String>,
+
+        /// Head branch.
+        #[arg(long)]
+        head: Option<String>,
+
+        /// Head repository owner/name.
+        #[arg(long = "head-repo")]
+        head_repository: Option<String>,
+
+        /// Base repository owner/name.
+        #[arg(long)]
+        repository: Option<String>,
+
+        /// Changed file path. Repeatable.
+        #[arg(long = "file", value_name = "PATH")]
+        files: Vec<String>,
+
+        /// Read changed file paths from a newline-delimited file.
+        #[arg(long, value_name = "PATH")]
+        files_file: Option<String>,
+
+        /// Read changed files from the current git working tree.
+        #[arg(long)]
+        files_from_git: bool,
+
+        /// Workspace path to discover the component from a portable homeboy.json.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Evaluate whether an existing PR is safe to merge; optionally merge it.
+    Merge {
+        /// Component ID
+        component_id: String,
+
+        /// Policy file path (YAML or JSON)
+        #[arg(long, value_name = "PATH")]
+        policy: String,
+
+        /// PR number.
+        #[arg(short, long)]
+        number: u64,
+
+        /// Author login override. Defaults to GitHub PR metadata.
+        #[arg(long)]
+        author: Option<String>,
+
+        /// Base branch override. Defaults to GitHub PR metadata.
+        #[arg(long)]
+        base: Option<String>,
+
+        /// Head branch override. Defaults to GitHub PR metadata.
+        #[arg(long)]
+        head: Option<String>,
+
+        /// Head repository owner/name override. Defaults to GitHub PR metadata.
+        #[arg(long = "head-repo")]
+        head_repository: Option<String>,
+
+        /// Base repository owner/name override. Defaults to component remote.
+        #[arg(long)]
+        repository: Option<String>,
+
+        /// Merge the PR when policy allows it.
+        #[arg(long)]
+        merge: bool,
+
+        /// Merge method: merge, squash, or rebase.
+        #[arg(long, default_value = "squash")]
+        merge_method: String,
+
+        /// Workspace path to discover the component from a portable homeboy.json.
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
 }
 
 #[derive(Serialize)]
@@ -551,6 +654,7 @@ pub enum GitCommandOutput {
     Issue(GithubIssueOutput),
     Pr(GithubPrOutput),
     Find(GithubFindOutput),
+    Policy(PrPolicyDecision),
 }
 
 pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<GitCommandOutput> {
@@ -1021,6 +1125,72 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             )?;
             Ok((GitCommandOutput::Pr(output), 0))
         }
+        PrCommand::Policy(args) => run_pr_policy(args),
+    }
+}
+
+fn run_pr_policy(args: PrPolicyArgs) -> CmdResult<GitCommandOutput> {
+    match args.command {
+        PrPolicyCommand::Open {
+            component_id,
+            policy,
+            source,
+            base,
+            head,
+            head_repository,
+            repository,
+            mut files,
+            files_file,
+            files_from_git,
+            path,
+        } => {
+            if let Some(files_file) = files_file {
+                files.extend(read_lines_file(&files_file)?);
+            }
+            let output = git::evaluate_open_policy(PrPolicyOpenOptions {
+                component_id,
+                path,
+                policy_path: policy,
+                source,
+                base,
+                head,
+                head_repository,
+                repository,
+                files,
+                files_from_git,
+            })?;
+            let exit = if output.allowed { 0 } else { 1 };
+            Ok((GitCommandOutput::Policy(output), exit))
+        }
+        PrPolicyCommand::Merge {
+            component_id,
+            policy,
+            number,
+            author,
+            base,
+            head,
+            head_repository,
+            repository,
+            merge,
+            merge_method,
+            path,
+        } => {
+            let output = git::evaluate_merge_policy(PrPolicyMergeOptions {
+                component_id,
+                path,
+                policy_path: policy,
+                number,
+                author,
+                base,
+                head,
+                head_repository,
+                repository,
+                merge,
+                merge_method: Some(merge_method),
+            })?;
+            let exit = if output.allowed { 0 } else { 1 };
+            Ok((GitCommandOutput::Policy(output), exit))
+        }
     }
 }
 
@@ -1057,6 +1227,21 @@ fn resolve_body(inline: Option<String>, file: Option<String>) -> homeboy::Result
         )
     })?;
     Ok(Some(content))
+}
+
+fn read_lines_file(path: &str) -> homeboy::Result<Vec<String>> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        homeboy::Error::internal_io(
+            format!("Failed to read lines file: {}", e),
+            Some(path.to_string()),
+        )
+    })?;
+    Ok(content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect())
 }
 
 fn parse_issue_state(s: &str) -> homeboy::Result<IssueState> {

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -81,6 +81,18 @@ pub struct GithubPrOutput {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct GithubPrView {
+    pub component_id: String,
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+    pub author: Option<String>,
+    pub base: String,
+    pub head: String,
+    pub head_repository: Option<String>,
+}
+
 /// Result of a find-many operation (list of matches).
 #[derive(Debug, Clone, Serialize)]
 pub struct GithubFindOutput {
@@ -192,6 +204,15 @@ pub struct PrFindOptions {
     pub head: Option<String>,
     pub state: PrState,
     pub limit: usize,
+    /// Optional workspace path. See [`IssueCreateOptions::path`].
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PrMergeOptions {
+    pub number: u64,
+    pub method: String,
+    pub delete_branch: bool,
     /// Optional workspace path. See [`IssueCreateOptions::path`].
     pub path: Option<String>,
 }
@@ -754,6 +775,128 @@ pub fn pr_find(component_id: Option<&str>, options: PrFindOptions) -> Result<Git
         action: "pr.find".to_string(),
         success: true,
         items,
+    })
+}
+
+/// Fetch metadata for one PR.
+pub fn pr_view(
+    component_id: Option<&str>,
+    number: u64,
+    path: Option<String>,
+) -> Result<GithubPrView> {
+    let (id, repo) = resolve_component_github(component_id, path.as_deref())?;
+    ensure_gh_ready()?;
+
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+    let args: Vec<String> = vec![
+        "pr".into(),
+        "view".into(),
+        number.to_string(),
+        "-R".into(),
+        repo_flag,
+        "--json".into(),
+        "author,baseRefName,headRefName,headRepository".into(),
+    ];
+    let raw = run_gh(&args)?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+        Error::internal_json(
+            format!("Failed to parse gh pr view JSON: {}", e),
+            Some(raw.clone()),
+        )
+    })?;
+    let author = parsed
+        .pointer("/author/login")
+        .and_then(|v| v.as_str())
+        .map(|v| v.to_string());
+    let base = parsed
+        .get("baseRefName")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let head = parsed
+        .get("headRefName")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let head_repository = parsed
+        .pointer("/headRepository/nameWithOwner")
+        .or_else(|| parsed.pointer("/headRepository/name"))
+        .and_then(|v| v.as_str())
+        .map(|v| v.to_string());
+
+    Ok(GithubPrView {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        number,
+        author,
+        base,
+        head,
+        head_repository,
+    })
+}
+
+/// List changed files for one PR.
+pub fn pr_files(
+    component_id: Option<&str>,
+    number: u64,
+    path: Option<String>,
+) -> Result<Vec<String>> {
+    let (_id, repo) = resolve_component_github(component_id, path.as_deref())?;
+    ensure_gh_ready()?;
+    let args: Vec<String> = vec![
+        "api".into(),
+        "--paginate".into(),
+        format!("repos/{}/{}/pulls/{}/files", repo.owner, repo.repo, number),
+        "--jq".into(),
+        ".[].filename".into(),
+    ];
+    let raw = run_gh(&args)?;
+    Ok(raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
+/// Merge a PR with an explicit method.
+pub fn pr_merge(component_id: Option<&str>, options: PrMergeOptions) -> Result<GithubPrOutput> {
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
+    ensure_gh_ready()?;
+    let method = match options.method.as_str() {
+        "merge" | "squash" | "rebase" => options.method,
+        other => {
+            return Err(Error::validation_invalid_argument(
+                "merge_method",
+                format!("Unsupported merge method '{}'", other),
+                Some("Use merge, squash, or rebase".to_string()),
+                None,
+            ))
+        }
+    };
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+    let mut args: Vec<String> = vec![
+        "pr".into(),
+        "merge".into(),
+        options.number.to_string(),
+        "-R".into(),
+        repo_flag,
+        format!("--{}", method),
+    ];
+    if options.delete_branch {
+        args.push("--delete-branch".into());
+    }
+    run_gh(&args)?;
+    Ok(GithubPrOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: "pr.merge".to_string(),
+        success: true,
+        number: Some(options.number),
+        state: Some("merged".to_string()),
+        ..Default::default()
     })
 }
 

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -862,19 +862,9 @@ pub fn pr_files(
 
 /// Merge a PR with an explicit method.
 pub fn pr_merge(component_id: Option<&str>, options: PrMergeOptions) -> Result<GithubPrOutput> {
+    let method = validate_pr_merge_method(&options.method)?;
     let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
     ensure_gh_ready()?;
-    let method = match options.method.as_str() {
-        "merge" | "squash" | "rebase" => options.method,
-        other => {
-            return Err(Error::validation_invalid_argument(
-                "merge_method",
-                format!("Unsupported merge method '{}'", other),
-                Some("Use merge, squash, or rebase".to_string()),
-                None,
-            ))
-        }
-    };
     let repo_flag = format!("{}/{}", repo.owner, repo.repo);
     let mut args: Vec<String> = vec![
         "pr".into(),
@@ -898,6 +888,18 @@ pub fn pr_merge(component_id: Option<&str>, options: PrMergeOptions) -> Result<G
         state: Some("merged".to_string()),
         ..Default::default()
     })
+}
+
+fn validate_pr_merge_method(method: &str) -> Result<String> {
+    match method {
+        "merge" | "squash" | "rebase" => Ok(method.to_string()),
+        other => Err(Error::validation_invalid_argument(
+            "merge_method",
+            format!("Unsupported merge method '{}'", other),
+            Some("Use merge, squash, or rebase".to_string()),
+            None,
+        )),
+    }
 }
 
 /// Post a comment on a PR.
@@ -1784,6 +1786,55 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].number, 10);
         assert_eq!(items[1].state, "OPEN");
+    }
+
+    #[test]
+    fn test_pr_files() {
+        let owner = "Extra-Chill";
+        let repo = "homeboy";
+        let number = 42_u64;
+        assert_eq!(
+            format!("repos/{}/{}/pulls/{}/files", owner, repo, number),
+            "repos/Extra-Chill/homeboy/pulls/42/files"
+        );
+    }
+
+    #[test]
+    fn test_pr_view() {
+        let raw = r#"{
+            "author":{"login":"homeboy-ci[bot]"},
+            "baseRefName":"main",
+            "headRefName":"ci/autofix/homeboy/main",
+            "headRepository":{"nameWithOwner":"Extra-Chill/homeboy"}
+        }"#;
+        let parsed: serde_json::Value = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            parsed.pointer("/author/login").and_then(|v| v.as_str()),
+            Some("homeboy-ci[bot]")
+        );
+        assert_eq!(
+            parsed.get("baseRefName").and_then(|v| v.as_str()),
+            Some("main")
+        );
+        assert_eq!(
+            parsed
+                .pointer("/headRepository/nameWithOwner")
+                .and_then(|v| v.as_str()),
+            Some("Extra-Chill/homeboy")
+        );
+    }
+
+    #[test]
+    fn test_pr_merge() {
+        let result = pr_merge(
+            Some("missing-component"),
+            PrMergeOptions {
+                method: "explode".into(),
+                number: 1,
+                ..Default::default()
+            },
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -2,12 +2,14 @@ mod changes;
 mod commits;
 mod github;
 mod operations;
+mod pr_policy;
 mod primitives;
 
 pub use changes::*;
 pub use commits::*;
 pub use github::*;
 pub use operations::*;
+pub use pr_policy::*;
 pub use primitives::*;
 
 use std::process::Command;

--- a/src/core/git/pr_policy.rs
+++ b/src/core/git/pr_policy.rs
@@ -1,0 +1,490 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+use crate::error::{Error, Result};
+
+use super::changes::get_dirty_files;
+use super::github::{pr_files, pr_merge, pr_view, PrMergeOptions};
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PrPolicyFile {
+    #[serde(default)]
+    pub open: PrPolicyRules,
+    #[serde(default)]
+    pub merge: PrPolicyRules,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct PrPolicyRules {
+    #[serde(default)]
+    pub allowed_sources: Vec<String>,
+    #[serde(default)]
+    pub allowed_authors: Vec<String>,
+    #[serde(default)]
+    pub allowed_base_branches: Vec<String>,
+    #[serde(default)]
+    pub allowed_head_branches: Vec<String>,
+    #[serde(default)]
+    pub allowed_head_repositories: Vec<String>,
+    #[serde(default)]
+    pub allowed_paths: Vec<String>,
+    #[serde(default)]
+    pub blocked_paths: Vec<String>,
+    #[serde(default)]
+    pub blocked_content_patterns: Vec<String>,
+    #[serde(default)]
+    pub allowed_merge_methods: Vec<String>,
+    #[serde(default)]
+    pub require_same_repository: Option<bool>,
+    pub max_changed_files: Option<usize>,
+    #[serde(default)]
+    pub delete_branch_on_merge: Option<bool>,
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PrPolicyContext {
+    pub mode: PrPolicyMode,
+    pub source: Option<String>,
+    pub author: Option<String>,
+    pub base: Option<String>,
+    pub head: Option<String>,
+    pub head_repository: Option<String>,
+    pub repository: Option<String>,
+    pub merge_method: Option<String>,
+    pub files: Vec<String>,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PrPolicyMode {
+    #[default]
+    Open,
+    Merge,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PrPolicyDecision {
+    pub mode: String,
+    pub allowed: bool,
+    pub safe: bool,
+    pub reason: String,
+    pub report: String,
+    pub changed_file_count: usize,
+    pub files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merged: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PrPolicyOpenOptions {
+    pub component_id: String,
+    pub path: Option<String>,
+    pub policy_path: String,
+    pub source: Option<String>,
+    pub base: Option<String>,
+    pub head: Option<String>,
+    pub head_repository: Option<String>,
+    pub repository: Option<String>,
+    pub files: Vec<String>,
+    pub files_from_git: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PrPolicyMergeOptions {
+    pub component_id: String,
+    pub path: Option<String>,
+    pub policy_path: String,
+    pub number: u64,
+    pub author: Option<String>,
+    pub base: Option<String>,
+    pub head: Option<String>,
+    pub head_repository: Option<String>,
+    pub repository: Option<String>,
+    pub merge: bool,
+    pub merge_method: Option<String>,
+}
+
+pub fn load_policy(path: &str) -> Result<PrPolicyFile> {
+    let raw = fs::read_to_string(path).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read PR policy file '{}': {}", path, e),
+            Some(path.to_string()),
+        )
+    })?;
+
+    let value: serde_json::Value = if path.ends_with(".json") {
+        serde_json::from_str(&raw).map_err(|e| {
+            Error::validation_invalid_argument(
+                "policy",
+                format!("PR policy JSON is invalid: {}", e),
+                Some(path.to_string()),
+                None,
+            )
+        })?
+    } else {
+        serde_yml::from_str(&raw).map_err(|e| {
+            Error::validation_invalid_argument(
+                "policy",
+                format!("PR policy YAML is invalid: {}", e),
+                Some(path.to_string()),
+                None,
+            )
+        })?
+    };
+
+    let has_scoped_sections = value.get("open").is_some() || value.get("merge").is_some();
+    if has_scoped_sections {
+        serde_json::from_value(value).map_err(|e| {
+            Error::validation_invalid_argument(
+                "policy",
+                format!("PR policy shape is invalid: {}", e),
+                Some(path.to_string()),
+                None,
+            )
+        })
+    } else {
+        // Back-compat for the original action policy file, which was a flat
+        // merge gate. Apply it to both modes so existing files keep working.
+        let mut rules: PrPolicyRules = serde_json::from_value(value).map_err(|e| {
+            Error::validation_invalid_argument(
+                "policy",
+                format!("PR policy shape is invalid: {}", e),
+                Some(path.to_string()),
+                None,
+            )
+        })?;
+        if rules.require_same_repository.is_none() {
+            rules.require_same_repository = Some(true);
+        }
+        Ok(PrPolicyFile {
+            open: PrPolicyRules::default(),
+            merge: rules,
+        })
+    }
+}
+
+pub fn evaluate_open_policy(options: PrPolicyOpenOptions) -> Result<PrPolicyDecision> {
+    let policy = load_policy(&options.policy_path)?;
+    let files = if options.files_from_git {
+        get_dirty_files(options.path.as_deref().unwrap_or("."))?
+    } else {
+        options.files
+    };
+    let context = PrPolicyContext {
+        mode: PrPolicyMode::Open,
+        source: non_empty(options.source),
+        base: non_empty(options.base),
+        head: non_empty(options.head),
+        head_repository: non_empty(options.head_repository),
+        repository: non_empty(options.repository),
+        files,
+        path: options.path,
+        ..Default::default()
+    };
+    Ok(evaluate_rules(&policy.open, context))
+}
+
+pub fn evaluate_merge_policy(options: PrPolicyMergeOptions) -> Result<PrPolicyDecision> {
+    let policy = load_policy(&options.policy_path)?;
+    let pr = pr_view(
+        Some(&options.component_id),
+        options.number,
+        options.path.clone(),
+    )?;
+    let files = pr_files(
+        Some(&options.component_id),
+        options.number,
+        options.path.clone(),
+    )?;
+    let merge_method = options.merge_method.unwrap_or_else(|| "squash".to_string());
+    let mut decision = evaluate_rules(
+        &policy.merge,
+        PrPolicyContext {
+            mode: PrPolicyMode::Merge,
+            author: non_empty(options.author).or(pr.author),
+            base: non_empty(options.base).or(Some(pr.base)),
+            head: non_empty(options.head).or(Some(pr.head)),
+            head_repository: non_empty(options.head_repository).or(pr.head_repository),
+            repository: non_empty(options.repository).or(Some(format!("{}/{}", pr.owner, pr.repo))),
+            merge_method: Some(merge_method.clone()),
+            files,
+            path: options.path.clone(),
+            ..Default::default()
+        },
+    );
+
+    if options.merge && decision.allowed {
+        pr_merge(
+            Some(&options.component_id),
+            PrMergeOptions {
+                number: options.number,
+                method: merge_method,
+                delete_branch: policy.merge.delete_branch_on_merge.unwrap_or(true),
+                path: options.path,
+            },
+        )?;
+        decision.merged = Some(true);
+        decision.report = format!("{} Merged.", decision.report);
+    } else if options.merge {
+        decision.merged = Some(false);
+    }
+
+    Ok(decision)
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+pub fn evaluate_rules(rules: &PrPolicyRules, context: PrPolicyContext) -> PrPolicyDecision {
+    let mut failures = Vec::new();
+
+    require_allowed(
+        "source",
+        context.source.as_deref(),
+        &rules.allowed_sources,
+        &mut failures,
+    );
+    require_allowed(
+        "author",
+        context.author.as_deref(),
+        &rules.allowed_authors,
+        &mut failures,
+    );
+    require_allowed(
+        "base branch",
+        context.base.as_deref(),
+        &rules.allowed_base_branches,
+        &mut failures,
+    );
+    require_allowed(
+        "head branch",
+        context.head.as_deref(),
+        &rules.allowed_head_branches,
+        &mut failures,
+    );
+    require_allowed(
+        "head repository",
+        context.head_repository.as_deref(),
+        &rules.allowed_head_repositories,
+        &mut failures,
+    );
+    require_allowed(
+        "merge method",
+        context.merge_method.as_deref(),
+        &rules.allowed_merge_methods,
+        &mut failures,
+    );
+
+    if rules.require_same_repository.unwrap_or(false) {
+        match (&context.repository, &context.head_repository) {
+            (Some(repo), Some(head_repo)) if repo == head_repo => {}
+            (Some(repo), Some(head_repo)) => failures.push(format!(
+                "head repository {} does not match {}",
+                head_repo, repo
+            )),
+            _ => failures.push("repository and head repository are required".to_string()),
+        }
+    }
+
+    if let Some(max) = rules.max_changed_files {
+        if context.files.len() > max {
+            failures.push(format!(
+                "{} changed files exceeds max_changed_files {}",
+                context.files.len(),
+                max
+            ));
+        }
+    }
+
+    let blocked_files: Vec<String> = context
+        .files
+        .iter()
+        .filter(|file| matches_any(file, &rules.blocked_paths))
+        .cloned()
+        .collect();
+    if !blocked_files.is_empty() {
+        failures.push(format!(
+            "blocked paths changed: {}",
+            blocked_files.join(", ")
+        ));
+    }
+
+    if !rules.allowed_paths.is_empty() {
+        let unallowed: Vec<String> = context
+            .files
+            .iter()
+            .filter(|file| !matches_any(file, &rules.allowed_paths))
+            .cloned()
+            .collect();
+        if !unallowed.is_empty() {
+            failures.push(format!(
+                "paths outside allowed set changed: {}",
+                unallowed.join(", ")
+            ));
+        }
+    }
+
+    if !rules.blocked_content_patterns.is_empty() {
+        let root = context.path.as_deref().unwrap_or(".");
+        let content_hits =
+            files_with_blocked_content(root, &context.files, &rules.blocked_content_patterns);
+        if !content_hits.is_empty() {
+            failures.push(format!(
+                "blocked content patterns found in: {}",
+                content_hits.join(", ")
+            ));
+        }
+    }
+
+    let mode = match context.mode {
+        PrPolicyMode::Open => "open",
+        PrPolicyMode::Merge => "merge",
+    };
+    let allowed = failures.is_empty();
+    let reason = if allowed {
+        "safe".to_string()
+    } else {
+        failures.join("; ")
+    };
+    let title = rules.title.as_deref().unwrap_or("PR policy");
+    let report = if allowed {
+        format!(
+            "## {}\n\nSafe for {}: {} changed file(s) matched policy.",
+            title,
+            mode,
+            context.files.len()
+        )
+    } else {
+        format!("## {}\n\nUnsafe for {}: {}", title, mode, reason)
+    };
+
+    PrPolicyDecision {
+        mode: mode.to_string(),
+        allowed,
+        safe: allowed,
+        reason,
+        report,
+        changed_file_count: context.files.len(),
+        files: context.files,
+        merged: None,
+    }
+}
+
+fn require_allowed(
+    label: &str,
+    value: Option<&str>,
+    patterns: &[String],
+    failures: &mut Vec<String>,
+) {
+    if patterns.is_empty() {
+        return;
+    }
+    match value {
+        Some(value) if matches_any(value, patterns) => {}
+        Some(value) => failures.push(format!("{} {} is not allowed", label, value)),
+        None => failures.push(format!("{} is required", label)),
+    }
+}
+
+fn matches_any(value: &str, patterns: &[String]) -> bool {
+    patterns
+        .iter()
+        .any(|pattern| value == pattern || glob_match::glob_match(pattern, value))
+}
+
+fn files_with_blocked_content(root: &str, files: &[String], patterns: &[String]) -> Vec<String> {
+    let regexes: Vec<regex::Regex> = patterns
+        .iter()
+        .filter_map(|pattern| regex::Regex::new(pattern).ok())
+        .collect();
+    files
+        .iter()
+        .filter(|file| {
+            let path = std::path::Path::new(root).join(file);
+            let Ok(content) = fs::read_to_string(path) else {
+                return false;
+            };
+            regexes.iter().any(|re| re.is_match(&content))
+        })
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_policy_allows_matching_source_branch_and_paths() {
+        let rules = PrPolicyRules {
+            allowed_sources: vec!["autofix".into()],
+            allowed_head_branches: vec!["chore/homeboy-*".into()],
+            allowed_paths: vec!["src/**".into(), "tests/**".into()],
+            max_changed_files: Some(2),
+            ..Default::default()
+        };
+        let decision = evaluate_rules(
+            &rules,
+            PrPolicyContext {
+                mode: PrPolicyMode::Open,
+                source: Some("autofix".into()),
+                head: Some("chore/homeboy-autofix".into()),
+                files: vec!["src/lib.rs".into(), "tests/lib.rs".into()],
+                ..Default::default()
+            },
+        );
+        assert!(decision.allowed);
+    }
+
+    #[test]
+    fn merge_policy_blocks_unallowed_files() {
+        let rules = PrPolicyRules {
+            allowed_paths: vec!["src/**".into()],
+            blocked_paths: vec!["src/unsafe/**".into()],
+            ..Default::default()
+        };
+        let decision = evaluate_rules(
+            &rules,
+            PrPolicyContext {
+                mode: PrPolicyMode::Merge,
+                files: vec![
+                    "src/lib.rs".into(),
+                    "src/unsafe/key.rs".into(),
+                    "README.md".into(),
+                ],
+                ..Default::default()
+            },
+        );
+        assert!(!decision.allowed);
+        assert!(decision.reason.contains("blocked paths changed"));
+        assert!(decision.reason.contains("paths outside allowed set"));
+    }
+
+    #[test]
+    fn require_same_repository_blocks_forks() {
+        let rules = PrPolicyRules {
+            require_same_repository: Some(true),
+            ..Default::default()
+        };
+        let decision = evaluate_rules(
+            &rules,
+            PrPolicyContext {
+                repository: Some("Extra-Chill/homeboy".into()),
+                head_repository: Some("someone/homeboy".into()),
+                ..Default::default()
+            },
+        );
+        assert!(!decision.allowed);
+        assert!(decision.reason.contains("does not match"));
+    }
+}

--- a/src/core/git/pr_policy.rs
+++ b/src/core/git/pr_policy.rs
@@ -106,7 +106,7 @@ pub struct PrPolicyMergeOptions {
     pub merge_method: Option<String>,
 }
 
-pub fn load_policy(path: &str) -> Result<PrPolicyFile> {
+fn load_policy(path: &str) -> Result<PrPolicyFile> {
     let raw = fs::read_to_string(path).map_err(|e| {
         Error::internal_io(
             format!("Failed to read PR policy file '{}': {}", path, e),
@@ -245,7 +245,7 @@ fn non_empty(value: Option<String>) -> Option<String> {
     })
 }
 
-pub fn evaluate_rules(rules: &PrPolicyRules, context: PrPolicyContext) -> PrPolicyDecision {
+fn evaluate_rules(rules: &PrPolicyRules, context: PrPolicyContext) -> PrPolicyDecision {
     let mut failures = Vec::new();
 
     require_allowed(
@@ -425,7 +425,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn open_policy_allows_matching_source_branch_and_paths() {
+    fn test_evaluate_rules() {
         let rules = PrPolicyRules {
             allowed_sources: vec!["autofix".into()],
             allowed_head_branches: vec!["chore/homeboy-*".into()],
@@ -486,5 +486,58 @@ mod tests {
         );
         assert!(!decision.allowed);
         assert!(decision.reason.contains("does not match"));
+    }
+
+    #[test]
+    fn test_load_policy_reads_scoped_yaml() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("policy.yml");
+        fs::write(
+            &path,
+            "open:\n  allowed_sources: [autofix]\nmerge:\n  allowed_authors: ['homeboy-ci[bot]']\n",
+        )
+        .expect("write policy");
+
+        let policy = load_policy(path.to_str().expect("utf8 path")).expect("policy parses");
+        assert_eq!(policy.open.allowed_sources, vec!["autofix"]);
+        assert_eq!(policy.merge.allowed_authors, vec!["homeboy-ci[bot]"]);
+    }
+
+    #[test]
+    fn test_evaluate_open_policy_reads_explicit_files() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("policy.json");
+        fs::write(
+            &path,
+            r#"{"open":{"allowed_sources":["autofix"],"allowed_paths":["src/**"]}}"#,
+        )
+        .expect("write policy");
+
+        let decision = evaluate_open_policy(PrPolicyOpenOptions {
+            component_id: "homeboy".into(),
+            policy_path: path.to_string_lossy().to_string(),
+            source: Some("autofix".into()),
+            files: vec!["src/lib.rs".into()],
+            ..Default::default()
+        })
+        .expect("policy evaluates");
+
+        assert!(decision.allowed);
+    }
+
+    #[test]
+    fn test_evaluate_merge_policy_requires_github_metadata() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let path = dir.path().join("policy.json");
+        fs::write(&path, r#"{"merge":{}}"#).expect("write policy");
+
+        let result = evaluate_merge_policy(PrPolicyMergeOptions {
+            component_id: "definitely-missing-component".into(),
+            policy_path: path.to_string_lossy().to_string(),
+            number: 1,
+            ..Default::default()
+        });
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Add `homeboy git pr policy open` and `homeboy git pr policy merge` commands backed by a shared typed policy evaluator.
- Add GitHub PR metadata, changed-file listing, and merge primitives so PR open/update and merge decisions can live in core instead of action shell scripts.
- Support scoped `open:` / `merge:` YAML or JSON policies, while keeping flat legacy policy files as merge-only policies.

## Testing
- `cargo test pr_policy`
- `cargo test command_surface`
- `cargo fmt --check`
- `cargo run --quiet --bin homeboy -- git pr policy open --help`
- `cargo run --quiet --bin homeboy -- git pr policy merge --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the core PR policy evaluator, CLI wiring, GitHub PR primitives, and targeted tests; Chris reviewed direction and requested this slice.