### PR TITLE
Configure observation artifact root

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@
 ### `HomeboyConfig`
 
 - `defaults`
+- `artifact_root` — Optional directory where persisted run artifacts are copied. Override per command with `homeboy --artifact-root <dir>` or per process with `HOMEBOY_ARTIFACT_ROOT`.
 - `update_check` — Enable automatic update check on startup (default: true). Disable with `homeboy config set /update_check false` or set HOMEBOY_NO_UPDATE_CHECK=1.
 
 ### `InstallMethodsConfig`

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -124,7 +124,7 @@ homeboy config path
 
 Controls where Homeboy copies persisted run artifacts from commands such as `bench`, `trace`, and `observe`.
 
-- `artifact_root`: Optional directory path for copied artifacts. Defaults to the machine-local data directory under `artifacts/`.
+- `artifact_root`: Optional directory path for copied artifacts. Defaults to an `artifacts` subdirectory under the machine-local data directory.
 - CLI override: `homeboy --artifact-root <dir> ...`
 - Environment override: `HOMEBOY_ARTIFACT_ROOT=<dir>`
 - Config override: `homeboy config set /artifact_root '"~/Developer/.homeboy-artifacts"'`

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -36,6 +36,9 @@ homeboy config set /defaults/version_candidates/4 '{"file": "VERSION", "pattern"
 
 # Change local file permissions
 homeboy config set /defaults/permissions/local/file_mode 'g+r'
+
+# Store copied run artifacts in a repo- or agent-readable directory
+homeboy config set /artifact_root '"~/Developer/.homeboy-artifacts"'
 ```
 
 ### `homeboy config remove`
@@ -73,6 +76,7 @@ homeboy config path
 
 ```json
 {
+  "artifact_root": null,
   "defaults": {
     "install_methods": {
       "homebrew": {
@@ -115,6 +119,17 @@ homeboy config path
 ```
 
 ## Configurable Behaviors
+
+### Artifact Root
+
+Controls where Homeboy copies persisted run artifacts from commands such as `bench`, `trace`, and `observe`.
+
+- `artifact_root`: Optional directory path for copied artifacts. Defaults to the machine-local data directory under `artifacts/`.
+- CLI override: `homeboy --artifact-root <dir> ...`
+- Environment override: `HOMEBOY_ARTIFACT_ROOT=<dir>`
+- Config override: `homeboy config set /artifact_root '"~/Developer/.homeboy-artifacts"'`
+
+Precedence is CLI flag, then environment variable, then global config, then the built-in default.
 
 ### Install Methods
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -24,6 +24,11 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub force_hot: bool,
 
+    /// Directory where persisted run artifacts are copied.
+    /// Overrides HOMEBOY_ARTIFACT_ROOT and global config /artifact_root.
+    #[arg(long, global = true, value_name = "DIR")]
+    pub artifact_root: Option<PathBuf>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -13,6 +13,14 @@ pub struct HomeboyConfig {
     #[serde(default)]
     pub triage: TriageConfig,
 
+    /// Directory where persisted run artifacts are copied.
+    ///
+    /// Defaults to the machine-local Homeboy data directory under
+    /// `artifacts/`. Override with `homeboy --artifact-root <path>`,
+    /// `HOMEBOY_ARTIFACT_ROOT`, or `homeboy config set /artifact_root`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_root: Option<String>,
+
     /// Enable automatic update check on startup (default: true).
     /// Disable with `homeboy config set /update_check false`
     /// or set HOMEBOY_NO_UPDATE_CHECK=1.
@@ -25,6 +33,7 @@ impl Default for HomeboyConfig {
         Self {
             defaults: Defaults::default(),
             triage: TriageConfig::default(),
+            artifact_root: None,
             update_check: true,
         }
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,8 +33,8 @@ pub mod triage;
 pub mod update_check_cache;
 pub mod upgrade;
 
-// Path resolution helpers used by the CLI and library callers.
-pub mod paths;
+// Internal path resolution helpers.
+pub(crate) mod paths;
 
 // Public extensions for CLI access
 pub mod defaults;
@@ -57,3 +57,8 @@ pub use output::{
     EntityCrudOutput, ItemOutcome, MergeOutput, MergeResult, NoExtra, ObservationOutputDetails,
     ObservationOutputMetadata, RemoveResult,
 };
+
+/// Set a process-local artifact root override for the current CLI invocation.
+pub fn set_artifact_root_override(path: Option<std::path::PathBuf>) {
+    paths::set_artifact_root_override(path);
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,8 +33,8 @@ pub mod triage;
 pub mod update_check_cache;
 pub mod upgrade;
 
-// Internal extensions - not part of public API
-pub(crate) mod paths;
+// Path resolution helpers used by the CLI and library callers.
+pub mod paths;
 
 // Public extensions for CLI access
 pub mod defaults;

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1472,7 +1472,7 @@ mod api_coverage_tests {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
             let artifact_root = home.path().join("agent-readable-artifacts");
-            crate::paths::set_artifact_root_override(Some(artifact_root.clone()));
+            crate::set_artifact_root_override(Some(artifact_root.clone()));
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.start_run(new_run("bench")).expect("start");
             let path = home.path().join("artifact.json");

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1188,10 +1188,7 @@ fn persisted_artifact_path(run_id: &str, artifact_id: &str, source: &Path) -> Re
         .filter(|name| !name.is_empty())
         .map(|name| format!("{artifact_id}-{name}"))
         .unwrap_or_else(|| artifact_id.to_string());
-    Ok(paths::homeboy_data()?
-        .join("artifacts")
-        .join(run_id)
-        .join(file_name))
+    Ok(paths::artifact_root()?.join(run_id).join(file_name))
 }
 
 fn copy_artifact_file(source: &Path, target: &Path) -> Result<()> {
@@ -1467,6 +1464,33 @@ mod api_coverage_tests {
                 .record_artifact(&run.id, "json", &path)
                 .expect("artifact");
             assert_eq!(artifact.size_bytes, Some(2));
+        });
+    }
+
+    #[test]
+    fn test_record_artifact_uses_custom_artifact_root() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let artifact_root = home.path().join("agent-readable-artifacts");
+            crate::paths::set_artifact_root_override(Some(artifact_root.clone()));
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(new_run("bench")).expect("start");
+            let path = home.path().join("artifact.json");
+            fs::write(&path, b"{}").expect("write artifact");
+
+            let artifact = store
+                .record_artifact(&run.id, "json", &path)
+                .expect("artifact");
+
+            assert!(
+                artifact
+                    .path
+                    .starts_with(&artifact_root.to_string_lossy().to_string()),
+                "artifact path {} should be under {}",
+                artifact.path,
+                artifact_root.display()
+            );
+            assert!(std::path::Path::new(&artifact.path).is_file());
         });
     }
 

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -389,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn artifact_root_prefers_process_override_over_env() {
+    fn test_set_artifact_root_override() {
         with_isolated_home(|home| {
             let env_root = home.path().join("env-artifacts");
             let override_root = home.path().join("override-artifacts");

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -1,6 +1,23 @@
 use crate::error::{Error, Result};
 use std::env;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+fn artifact_root_override() -> &'static Mutex<Option<PathBuf>> {
+    static OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+    OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+/// Set a process-local artifact root override.
+///
+/// This is intentionally process-scoped so CLI flags can outrank environment
+/// and config without mutating global config or environment variables.
+pub fn set_artifact_root_override(path: Option<PathBuf>) {
+    let mut guard = artifact_root_override()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = path;
+}
 
 /// Base homeboy config directory (universal ~/.config/homeboy/ on all platforms)
 pub fn homeboy() -> Result<PathBuf> {
@@ -70,6 +87,42 @@ pub fn homeboy_data() -> Result<PathBuf> {
 /// Local SQLite observation-store path.
 pub fn observation_db() -> Result<PathBuf> {
     Ok(homeboy_data()?.join("homeboy.sqlite"))
+}
+
+/// Root directory for copied run artifacts.
+///
+/// Precedence:
+/// 1. process-local CLI override (`homeboy --artifact-root <path>`)
+/// 2. `HOMEBOY_ARTIFACT_ROOT`
+/// 3. global config `/artifact_root`
+/// 4. historical default: `<homeboy_data>/artifacts`
+pub fn artifact_root() -> Result<PathBuf> {
+    if let Some(path) = artifact_root_override()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+    {
+        return Ok(expand_path(path));
+    }
+
+    if let Ok(path) = env::var("HOMEBOY_ARTIFACT_ROOT") {
+        if !path.trim().is_empty() {
+            return Ok(expand_path(PathBuf::from(path)));
+        }
+    }
+
+    if let Some(path) = crate::defaults::load_config().artifact_root {
+        if !path.trim().is_empty() {
+            return Ok(expand_path(PathBuf::from(path)));
+        }
+    }
+
+    Ok(homeboy_data()?.join("artifacts"))
+}
+
+fn expand_path(path: PathBuf) -> PathBuf {
+    let raw = path.to_string_lossy();
+    PathBuf::from(shellexpand::tilde(&raw).into_owned())
 }
 
 /// Projects directory
@@ -285,6 +338,7 @@ pub(crate) fn join_remote_child(base_path: Option<&str>, dir: &str, child: &str)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn join_remote_path_allows_absolute_paths_without_base() {
@@ -292,6 +346,58 @@ mod tests {
             join_remote_path(None, "/var/log/syslog").unwrap(),
             "/var/log/syslog"
         );
+    }
+
+    #[test]
+    fn artifact_root_defaults_under_homeboy_data() {
+        with_isolated_home(|home| {
+            assert_eq!(
+                artifact_root().expect("artifact root"),
+                home.path().join(".local/share/homeboy/artifacts")
+            );
+        });
+    }
+
+    #[test]
+    fn artifact_root_uses_configured_value() {
+        with_isolated_home(|home| {
+            let configured = home.path().join("custom-artifacts");
+            crate::defaults::save_config(&crate::defaults::HomeboyConfig {
+                artifact_root: Some(configured.to_string_lossy().to_string()),
+                ..crate::defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            assert_eq!(artifact_root().expect("artifact root"), configured);
+        });
+    }
+
+    #[test]
+    fn artifact_root_prefers_env_over_config() {
+        with_isolated_home(|home| {
+            let configured = home.path().join("config-artifacts");
+            let env_root = home.path().join("env-artifacts");
+            crate::defaults::save_config(&crate::defaults::HomeboyConfig {
+                artifact_root: Some(configured.to_string_lossy().to_string()),
+                ..crate::defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+            std::env::set_var("HOMEBOY_ARTIFACT_ROOT", &env_root);
+
+            assert_eq!(artifact_root().expect("artifact root"), env_root);
+        });
+    }
+
+    #[test]
+    fn artifact_root_prefers_process_override_over_env() {
+        with_isolated_home(|home| {
+            let env_root = home.path().join("env-artifacts");
+            let override_root = home.path().join("override-artifacts");
+            std::env::set_var("HOMEBOY_ARTIFACT_ROOT", &env_root);
+            set_artifact_root_override(Some(override_root.clone()));
+
+            assert_eq!(artifact_root().expect("artifact root"), override_root);
+        });
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn main() -> std::process::ExitCode {
         .ok()
         .flatten()
         .cloned();
-    homeboy::paths::set_artifact_root_override(artifact_root_override.clone());
+    homeboy::set_artifact_root_override(artifact_root_override.clone());
 
     if let Some(extension_cmd) = try_parse_extension_cli_command(&matches, &extension_info) {
         let cli_args = cli::CliArgs {
@@ -168,9 +168,7 @@ fn main() -> std::process::ExitCode {
         Err(e) => e.exit(),
     };
 
-    homeboy::paths::set_artifact_root_override(
-        cli.artifact_root.clone().or(artifact_root_override),
-    );
+    homeboy::set_artifact_root_override(cli.artifact_root.clone().or(artifact_root_override));
 
     if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
         output_file = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,13 @@ fn main() -> std::process::ExitCode {
         .flatten()
         .map(|path| path.to_string_lossy().to_string());
 
+    let artifact_root_override = matches
+        .try_get_one::<std::path::PathBuf>("artifact_root")
+        .ok()
+        .flatten()
+        .cloned();
+    homeboy::paths::set_artifact_root_override(artifact_root_override.clone());
+
     if let Some(extension_cmd) = try_parse_extension_cli_command(&matches, &extension_info) {
         let cli_args = cli::CliArgs {
             tool: extension_cmd.tool,
@@ -160,6 +167,10 @@ fn main() -> std::process::ExitCode {
         Ok(cli) => cli,
         Err(e) => e.exit(),
     };
+
+    homeboy::paths::set_artifact_root_override(
+        cli.artifact_root.clone().or(artifact_root_override),
+    );
 
     if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
         output_file = None;

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -44,7 +44,7 @@ impl HomeGuard {
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
-        crate::paths::set_artifact_root_override(None);
+        crate::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
         // and from the home tempdir (which itself can already live on a long
         // path on macOS, e.g. `/var/folders/<14>/T/.tmpXXXXXX/...`). Using
@@ -100,7 +100,7 @@ impl Drop for HomeGuard {
             Some(value) => std::env::set_var("HOMEBOY_ARTIFACT_ROOT", value),
             None => std::env::remove_var("HOMEBOY_ARTIFACT_ROOT"),
         }
-        crate::paths::set_artifact_root_override(None);
+        crate::set_artifact_root_override(None);
         match &self.prior_invocation_runtime {
             Some(value) => std::env::set_var(
                 crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 pub(crate) struct HomeGuard {
     prior: Option<String>,
     prior_xdg_data_home: Option<String>,
+    prior_artifact_root: Option<String>,
     prior_invocation_runtime: Option<String>,
     dir: TempDir,
     /// Held alongside `dir` so the short invocation runtime tempdir is
@@ -36,11 +37,14 @@ impl HomeGuard {
         let guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("HOME").ok();
         let prior_xdg_data_home = std::env::var("XDG_DATA_HOME").ok();
+        let prior_artifact_root = std::env::var("HOMEBOY_ARTIFACT_ROOT").ok();
         let prior_invocation_runtime =
             std::env::var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         let dir = TempDir::new().expect("home tempdir");
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
+        std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
+        crate::paths::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
         // and from the home tempdir (which itself can already live on a long
         // path on macOS, e.g. `/var/folders/<14>/T/.tmpXXXXXX/...`). Using
@@ -54,6 +58,7 @@ impl HomeGuard {
         Self {
             prior,
             prior_xdg_data_home,
+            prior_artifact_root,
             prior_invocation_runtime,
             dir,
             _inv_dir: Some(inv_dir),
@@ -91,6 +96,11 @@ impl Drop for HomeGuard {
             Some(value) => std::env::set_var("XDG_DATA_HOME", value),
             None => std::env::remove_var("XDG_DATA_HOME"),
         }
+        match &self.prior_artifact_root {
+            Some(value) => std::env::set_var("HOMEBOY_ARTIFACT_ROOT", value),
+            None => std::env::remove_var("HOMEBOY_ARTIFACT_ROOT"),
+        }
+        crate::paths::set_artifact_root_override(None);
         match &self.prior_invocation_runtime {
             Some(value) => std::env::set_var(
                 crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,


### PR DESCRIPTION
## Summary
- Add a global `--artifact-root <dir>` flag for choosing where copied observation artifacts are persisted.
- Add `HOMEBOY_ARTIFACT_ROOT` and `/artifact_root` global config support, keeping the existing `<homeboy_data>/artifacts` location as the default.
- Route observation artifact file/directory copies through the resolved artifact root and document the precedence.

## Verification
- `cargo test core::paths::tests::artifact_root -- --nocapture`
- `cargo test core::observation::store::api_coverage_tests::test_record_artifact_uses_custom_artifact_root -- --nocapture`
- `cargo test command_surface -- --nocapture`
- `cargo check`
- `cargo test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the artifact root resolver, CLI/config/env wiring, observation-store integration, tests, documentation, and local verification.