### PR TITLE
Render issue fallbacks from native outputs

### DIFF
--- a/src/core/issues/render.rs
+++ b/src/core/issues/render.rs
@@ -162,11 +162,64 @@ fn render_lint(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsI
         }
     }
 
-    if by_category.is_empty() && !data.get("passed").and_then(Value::as_bool).unwrap_or(true) {
-        by_category.insert("lint_failure".to_string(), Vec::new());
+    let mut groups = BTreeMap::new();
+    if by_category.is_empty() {
+        if let Some(items) = data
+            .pointer("/baseline_comparison/new_items")
+            .and_then(Value::as_array)
+        {
+            for item in items {
+                let category = item
+                    .get("context_label")
+                    .and_then(Value::as_str)
+                    .map(|label| {
+                        label
+                            .split_once(':')
+                            .map(|(_, category)| category)
+                            .unwrap_or(label)
+                    })
+                    .unwrap_or("lint_finding");
+                by_category
+                    .entry(category.to_string())
+                    .or_default()
+                    .push(item);
+            }
+        }
+
+        if by_category.is_empty() {
+            let delta = data
+                .pointer("/baseline_comparison/delta")
+                .and_then(Value::as_i64)
+                .unwrap_or(0);
+            if delta > 0 {
+                groups.insert(
+                    "lint_baseline_regression".to_string(),
+                    RenderedIssueGroup {
+                        count: delta as usize,
+                        label: format!("{} new findings above baseline", delta),
+                        body: render_lint_body("lint_baseline_regression", &[], data, context),
+                        confidence: None,
+                    },
+                );
+            } else if command_failed(data) {
+                let count = data
+                    .get("exit_code")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(1)
+                    .max(1) as usize;
+                groups.insert(
+                    "lint_failure".to_string(),
+                    RenderedIssueGroup {
+                        count,
+                        label: "lint failure".to_string(),
+                        body: render_lint_body("lint_failure", &[], data, context),
+                        confidence: None,
+                    },
+                );
+            }
+        }
     }
 
-    let mut groups = BTreeMap::new();
     for (category, findings) in by_category {
         let count = findings.len().max(1);
         groups.insert(
@@ -218,10 +271,15 @@ fn render_lint_body(
     }
     let _ = writeln!(out, "\n### Findings");
     for finding in findings.iter().take(20) {
-        let id = finding.get("id").and_then(Value::as_str).unwrap_or("lint");
+        let id = finding
+            .get("id")
+            .and_then(Value::as_str)
+            .or_else(|| finding.get("context_label").and_then(Value::as_str))
+            .unwrap_or("lint");
         let message = finding
             .get("message")
             .and_then(Value::as_str)
+            .or_else(|| finding.get("description").and_then(Value::as_str))
             .unwrap_or("lint finding");
         let _ = writeln!(out, "- `{}` — {}", id, message);
     }
@@ -251,11 +309,22 @@ fn render_test(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsI
     }
 
     if groups.is_empty() {
+        let summary_failures = data
+            .pointer("/summary/failures")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
         let failed = data
             .pointer("/test_counts/failed")
             .and_then(Value::as_u64)
             .unwrap_or(0) as usize;
-        if failed > 0 || !data.get("passed").and_then(Value::as_bool).unwrap_or(true) {
+        if summary_failures > 0 {
+            insert_test_group(
+                &mut groups,
+                "test_failure",
+                summary_failures,
+                render_test_fallback_body(data, context),
+            );
+        } else if failed > 0 || command_failed(data) {
             insert_test_group(
                 &mut groups,
                 "test_failure",
@@ -311,6 +380,10 @@ fn render_test_fallback_body(data: &Value, context: &IssueRenderContext) -> Stri
         .pointer("/test_counts/failed")
         .and_then(Value::as_u64)
         .unwrap_or(0);
+    let summary_failures = data
+        .pointer("/summary/failures")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
     let total = data
         .pointer("/test_counts/total")
         .and_then(Value::as_u64)
@@ -320,6 +393,8 @@ fn render_test_fallback_body(data: &Value, context: &IssueRenderContext) -> Stri
     let _ = writeln!(out);
     if failed > 0 || total > 0 {
         let _ = writeln!(out, "{} failed test(s) out of {} total.", failed, total);
+    } else if summary_failures > 0 {
+        let _ = writeln!(out, "{} test failure(s).", summary_failures);
     } else {
         let _ = writeln!(
             out,
@@ -371,6 +446,11 @@ fn insert_test_group(
 
 fn labelize(raw: &str) -> String {
     raw.replace(['_', '-'], " ")
+}
+
+fn command_failed(data: &Value) -> bool {
+    data.get("passed").and_then(Value::as_bool) == Some(false)
+        || data.get("status").and_then(Value::as_str) == Some("failed")
 }
 
 #[cfg(test)]

--- a/tests/core/issues/render_test.rs
+++ b/tests/core/issues/render_test.rs
@@ -146,10 +146,72 @@ fn renders_lint_aggregate_fallback_when_findings_are_missing() {
         build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
 
     let group = rendered.groups.get("lint_failure").unwrap();
-    assert_eq!(group.count, 1);
+    assert_eq!(group.count, 2);
     assert!(group
         .body
         .contains("Lint failed without structured findings (exit 2)."));
+}
+
+#[test]
+fn renders_lint_baseline_new_items_by_category() {
+    let output = json!({
+        "data": {
+            "status": "failed",
+            "baseline_comparison": {
+                "new_items": [
+                    {"context_label": "lint:security", "description": "escaped output missing"},
+                    {"context_label": "lint:security", "description": "nonce missing"},
+                    {"context_label": "lint:i18n", "description": "text domain missing"}
+                ]
+            }
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    assert_eq!(rendered.groups.len(), 2);
+    let security = rendered.groups.get("security").unwrap();
+    assert_eq!(security.count, 2);
+    assert!(security.body.contains("escaped output missing"));
+}
+
+#[test]
+fn renders_lint_baseline_delta_fallback() {
+    let output = json!({
+        "data": {
+            "status": "failed",
+            "baseline_comparison": {
+                "delta": 4
+            }
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("lint_baseline_regression").unwrap();
+    assert_eq!(group.count, 4);
+    assert_eq!(group.label, "4 new findings above baseline");
+}
+
+#[test]
+fn renders_lint_status_failed_without_passed_flag() {
+    let output = json!({
+        "data": {
+            "status": "failed",
+            "exit_code": 3
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("lint_failure").unwrap();
+    assert_eq!(group.count, 3);
+    assert!(group
+        .body
+        .contains("Lint failed without structured findings (exit 3)."));
 }
 
 #[test]
@@ -210,6 +272,45 @@ fn renders_test_aggregate_fallback_from_counts() {
     let group = rendered.groups.get("test_failure").unwrap();
     assert_eq!(group.count, 2);
     assert!(group.body.contains("2 failed test(s) out of 12 total."));
+}
+
+#[test]
+fn renders_test_summary_failure_fallback() {
+    let output = json!({
+        "data": {
+            "status": "failed",
+            "exit_code": 1,
+            "summary": {
+                "failures": 5
+            }
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("test", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("test_failure").unwrap();
+    assert_eq!(group.count, 5);
+    assert!(group.body.contains("5 test failure(s)."));
+}
+
+#[test]
+fn renders_test_status_failed_without_passed_flag() {
+    let output = json!({
+        "data": {
+            "status": "failed",
+            "exit_code": 2
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("test", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("test_failure").unwrap();
+    assert_eq!(group.count, 1);
+    assert!(group
+        .body
+        .contains("Test phase failed without structured counts (exit 2)."));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Extend core issue rendering for native lint output fallback shapes previously handled by homeboy-action, including baseline new-items, baseline deltas, and status-only failures.
- Extend native test output rendering for summary failure counts and status-only failure envelopes.
- Add coverage for the migrated fallback shapes so action consumers can delegate normalization safely.

## Tests
- `cargo fmt && cargo test render`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the renderer fallback migration and targeted tests; Chris remains responsible for review and validation.