### PR TITLE
Reduce audit false-positive noise

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -653,7 +653,11 @@ fn is_convention_exception(fp: &FileFingerprint, audit_config: &AuditConfig) -> 
 /// position-by-position. Positions where tokens vary across files are treated
 /// as "type parameters" (expected to differ). Only structural differences
 /// (different token count, different constant tokens) are flagged.
-pub fn check_signature_consistency(conventions: &mut [Convention], root: &Path) {
+pub fn check_signature_consistency(
+    conventions: &mut [Convention],
+    root: &Path,
+    audit_config: &AuditConfig,
+) {
     for conv in conventions.iter_mut() {
         if conv.expected_methods.is_empty() {
             continue;
@@ -680,6 +684,12 @@ pub fn check_signature_consistency(conventions: &mut [Convention], root: &Path) 
             .conforming
             .iter()
             .chain(conv.outliers.iter().map(|o| &o.file))
+            .filter(|file| {
+                !audit_config
+                    .convention_exception_globs
+                    .iter()
+                    .any(|pattern| glob_match::glob_match(pattern, file))
+            })
             .cloned()
             .collect();
 
@@ -1345,7 +1355,7 @@ mod tests {
         }];
 
         for _ in 0..5 {
-            check_signature_consistency(&mut conventions, &dir);
+            check_signature_consistency(&mut conventions, &dir, &AuditConfig::default());
             if conventions[0]
                 .outliers
                 .iter()
@@ -1419,7 +1429,7 @@ mod tests {
         }];
 
         for _ in 0..5 {
-            check_signature_consistency(&mut conventions, &dir);
+            check_signature_consistency(&mut conventions, &dir, &AuditConfig::default());
             if conventions[0].outliers[0]
                 .deviations
                 .iter()
@@ -1480,12 +1490,65 @@ mod tests {
             confidence: 1.0,
         }];
 
-        check_signature_consistency(&mut conventions, &dir);
+        check_signature_consistency(&mut conventions, &dir, &AuditConfig::default());
 
         let conv = &conventions[0];
         assert_eq!(conv.conforming.len(), 2);
         assert!(conv.outliers.is_empty());
         assert!((conv.confidence - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn signature_check_skips_convention_exception_files() {
+        let _audit_guard = crate::test_support::AuditGuard::new();
+        require_rust_grammar!("signature_check_skips_convention_exception_files");
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        std::fs::create_dir_all(dir.join("handlers")).unwrap();
+
+        std::fs::write(
+            dir.join("handlers/a.rs"),
+            "pub fn execute(config: &Config) -> Vec<Item> { vec![] }\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            dir.join("handlers/b.rs"),
+            "pub fn execute(config: &Config) -> Vec<Item> { vec![] }\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            dir.join("handlers/register.rs"),
+            "pub fn execute(config: &Config, context: &Context) -> Vec<Item> { vec![] }\n",
+        )
+        .unwrap();
+
+        let mut conventions = vec![Convention {
+            name: "Handlers".to_string(),
+            glob: "handlers/*".to_string(),
+            expected_methods: vec!["execute".to_string()],
+            expected_registrations: vec![],
+            expected_interfaces: vec![],
+            expected_namespace: None,
+            expected_imports: vec![],
+            conforming: vec![
+                "handlers/a.rs".to_string(),
+                "handlers/b.rs".to_string(),
+                "handlers/register.rs".to_string(),
+            ],
+            outliers: vec![],
+            total_files: 3,
+            confidence: 1.0,
+        }];
+        let audit_config = AuditConfig {
+            convention_exception_globs: vec!["**/register.rs".to_string()],
+            ..Default::default()
+        };
+
+        check_signature_consistency(&mut conventions, &dir, &audit_config);
+
+        assert!(conventions[0].outliers.is_empty());
     }
 
     #[test]
@@ -1511,7 +1574,7 @@ mod tests {
             confidence: 1.0,
         }];
 
-        check_signature_consistency(&mut conventions, &dir);
+        check_signature_consistency(&mut conventions, &dir, &AuditConfig::default());
 
         // Should not change anything for unknown language
         assert_eq!(conventions[0].conforming.len(), 2);
@@ -1564,7 +1627,7 @@ mod tests {
             confidence: 1.0,
         }];
 
-        check_signature_consistency(&mut conventions, &dir);
+        check_signature_consistency(&mut conventions, &dir, &AuditConfig::default());
 
         let conv = &conventions[0];
         assert_eq!(conv.conforming.len(), 2);
@@ -1607,7 +1670,7 @@ mod tests {
             confidence: 1.0,
         }];
 
-        check_signature_consistency(&mut conventions, &dir);
+        check_signature_consistency(&mut conventions, &dir, &AuditConfig::default());
 
         let conv = &conventions[0];
         assert_eq!(conv.conforming.len(), 2);
@@ -1648,7 +1711,7 @@ mod tests {
             confidence: 1.0,
         }];
 
-        check_signature_consistency(&mut conventions, &dir);
+        check_signature_consistency(&mut conventions, &dir, &AuditConfig::default());
 
         let conv = &conventions[0];
         // Both files should remain conforming — return type is not structural

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -18,6 +18,7 @@ use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::idiomatic::is_trivial_method;
+use super::walker::is_test_path;
 use crate::component::DuplicationDetectorConfig;
 
 /// Minimum number of locations for a function to count as duplicated.
@@ -135,12 +136,26 @@ pub(crate) fn detect_duplicates(
             continue;
         }
 
-        let suggestion = format!(
-            "Function `{}` has identical body in {} files. \
+        let test_only_duplicate = locations.iter().all(|file| is_test_path(file));
+        let severity = if test_only_duplicate {
+            Severity::Info
+        } else {
+            Severity::Warning
+        };
+        let suggestion = if test_only_duplicate {
+            format!(
+                "Function `{}` has identical body in {} test files. Consider a shared test helper if the duplication grows or starts obscuring test intent.",
+                method_name,
+                locations.len()
+            )
+        } else {
+            format!(
+                "Function `{}` has identical body in {} files. \
              Extract to a shared module and import it.",
-            method_name,
-            locations.len()
-        );
+                method_name,
+                locations.len()
+            )
+        };
 
         // Emit one finding per file that has the duplicate
         for file in locations {
@@ -151,7 +166,7 @@ pub(crate) fn detect_duplicates(
 
             findings.push(Finding {
                 convention: "duplication".to_string(),
-                severity: Severity::Warning,
+                severity: severity.clone(),
                 file: file.clone(),
                 description: format!("Duplicate function `{}` — also in {}", method_name, also_in),
                 suggestion: suggestion.clone(),
@@ -1678,6 +1693,30 @@ mod tests {
         assert!(findings.iter().any(|f| f.file == "src/utils/io.rs"));
         assert!(findings.iter().any(|f| f.file == "src/utils/validation.rs"));
         assert!(findings[0].description.contains("is_zero"));
+    }
+
+    #[test]
+    fn duplicate_functions_under_tests_are_info_findings() {
+        let fp1 = make_fingerprint(
+            "tests/import/ability-smoke.php",
+            &["imp_assert"],
+            &[("imp_assert", "abc123")],
+        );
+        let fp2 = make_fingerprint(
+            "tests/import/adapter-smoke.php",
+            &["imp_assert"],
+            &[("imp_assert", "abc123")],
+        );
+
+        let findings = detect_duplicates(&[&fp1, &fp2], &std::collections::HashSet::new());
+
+        assert_eq!(findings.len(), 2);
+        assert!(findings
+            .iter()
+            .all(|finding| finding.severity == Severity::Info));
+        assert!(findings
+            .iter()
+            .all(|finding| finding.suggestion.contains("shared test helper")));
     }
 
     #[test]

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -677,7 +677,7 @@ fn audit_internal(
     }
 
     // Phase 2b: Check signature consistency within conventions
-    conventions::check_signature_consistency(&mut discovered_conventions, root);
+    conventions::check_signature_consistency(&mut discovered_conventions, root, &audit_config);
 
     // Phase 3: Check all conventions
     let check_results = checks::check_conventions(&discovered_conventions);

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -173,9 +173,17 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
         .filter(|f| matches!(f.severity, Severity::Info))
         .count();
 
-    let top_findings = result
-        .findings
-        .iter()
+    let mut top_finding_refs: Vec<_> = result.findings.iter().collect();
+    top_finding_refs.sort_by(|a, b| {
+        severity_rank(&a.severity)
+            .cmp(&severity_rank(&b.severity))
+            .then_with(|| finding_kind_key(&a.kind).cmp(&finding_kind_key(&b.kind)))
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.description.cmp(&b.description))
+    });
+
+    let top_findings = top_finding_refs
+        .into_iter()
         .take(20)
         .map(|f| AuditSummaryFinding {
             file: f.file.clone(),
@@ -199,6 +207,13 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
         fixability: None,
         changed_since: None,
         exit_code,
+    }
+}
+
+fn severity_rank(severity: &Severity) -> u8 {
+    match severity {
+        Severity::Warning => 0,
+        Severity::Info => 1,
     }
 }
 

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -45,6 +45,35 @@ fn test_build_audit_summary_counts_severities() {
 }
 
 #[test]
+fn test_build_audit_summary_prioritizes_warnings_in_top_findings() {
+    let mut result = empty_result();
+    result.findings.push(Finding {
+        convention: "test_coverage".to_string(),
+        severity: Severity::Info,
+        file: "src/missing-test.rs".to_string(),
+        description: "No test file found".to_string(),
+        suggestion: "Create test file".to_string(),
+        kind: AuditFinding::MissingTestFile,
+    });
+    result.findings.push(Finding {
+        convention: "duplication".to_string(),
+        severity: Severity::Warning,
+        file: "src/duplicate.rs".to_string(),
+        description: "Duplicate function".to_string(),
+        suggestion: "Extract shared helper".to_string(),
+        kind: AuditFinding::DuplicateFunction,
+    });
+
+    let summary = build_audit_summary(&result, 1);
+
+    assert_eq!(summary.top_findings[0].severity, Severity::Warning);
+    assert_eq!(
+        summary.top_findings[0].kind,
+        AuditFinding::DuplicateFunction
+    );
+}
+
+#[test]
 fn test_build_audit_summary_groups_findings_for_drilldown() {
     let mut result = empty_result();
     result.component_id = "homeboy".to_string();


### PR DESCRIPTION
## Summary
- Prioritize warning findings ahead of info findings in audit summary `top_findings` so coverage inventory does not hide architectural drift.
- Downgrade duplicate functions found only under test paths to info-level findings with test-helper-specific guidance.
- Honor `convention_exception_globs` during signature-consistency checks so exception files do not re-enter convention drift analysis.
- Keep the changes generic in Homeboy core; ecosystem-specific audit tuning remains extension-owned.

## Issues
- Addresses Extra-Chill/homeboy#2395.
- Addresses Extra-Chill/homeboy#2397.
- Addresses Extra-Chill/homeboy#2399.

## Testing
- `cargo fmt`
- `cargo test signature_check_skips_convention_exception_files`
- `cargo test test_build_audit_summary_prioritizes_warnings_in_top_findings`
- `cargo test duplicate_functions_under_tests_are_info_findings`
- `cargo test --test architecture_core_agnostic_test`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-audit-intelligence-false-positives --extension rust --changed-since main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the audit summary, duplicate severity, and signature exception changes; added targeted tests; and ran validation. Chris directed the false-positive triage and core-vs-extension boundary.