### PR TITLE
Support managed SSH server sessions

### DIFF
--- a/docs/commands/server.md
+++ b/docs/commands/server.md
@@ -59,6 +59,30 @@ Deletion is safety-checked:
 homeboy server list
 ```
 
+### `connect`
+
+```sh
+homeboy server connect <server_id>
+```
+
+Opens an operator-authenticated SSH control-master session for servers configured with `auth.mode = "key_plus_password_controlmaster"`. Homeboy reuses the session for later server-backed commands without storing the password.
+
+### `status`
+
+```sh
+homeboy server status <server_id>
+```
+
+Checks whether the configured control-master session is live.
+
+### `disconnect`
+
+```sh
+homeboy server disconnect <server_id>
+```
+
+Closes the configured control-master session.
+
 ### `key`
 
 ```sh
@@ -86,6 +110,7 @@ Top-level fields:
 - `updated`: list of updated field names (values are command-specific)
 - `deleted`: list of deleted IDs
 - `key`: object for key actions
+- `session`: object for managed SSH session actions
 
 Key payload (`key`):
 
@@ -94,6 +119,16 @@ Key payload (`key`):
 - `public_key` (when available)
 - `identity_file` (when set/known)
 - `imported` (original path used for import; `~` is expanded)
+
+Session payload (`session`):
+
+- `action`: `connect` | `status` | `disconnect`
+- `server_id`
+- `control_path`
+- `persist`
+- `live`
+- `stdout`
+- `stderr`
 
 ## Related
 

--- a/docs/schemas/server-schema.md
+++ b/docs/schemas/server-schema.md
@@ -12,6 +12,12 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
   "port": number,
   "user": "string",
   "identity_file": "string",
+  "kind": "string",
+  "auth": {
+    "mode": "key_plus_password_controlmaster",
+    "control_path": "string",
+    "persist": "string"
+  },
   "forward_agent": boolean
 }
 ```
@@ -29,6 +35,8 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
 
 - **`port`** (number): SSH port (default: 22)
 - **`identity_file`** (string): Path to SSH private key file for authentication
+- **`kind`** (string): Optional server classification for extensions and project-specific behavior
+- **`auth`** (object): Optional SSH authentication/session policy
 - **`forward_agent`** (boolean): Enable SSH agent forwarding (default: false)
 
 ## Example
@@ -41,9 +49,31 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
   "port": 22,
   "user": "deploy",
   "identity_file": "/Users/dev/.ssh/id_rsa",
+  "kind": "password-gated",
+  "auth": {
+    "mode": "key_plus_password_controlmaster",
+    "control_path": "~/.ssh/controlmasters/%h-%p-%r",
+    "persist": "4h"
+  },
   "forward_agent": true
 }
 ```
+
+## Managed SSH Sessions
+
+Servers that accept a key and then require an operator-entered password can opt into managed control-master reuse:
+
+```json
+{
+  "auth": {
+    "mode": "key_plus_password_controlmaster",
+    "control_path": "~/.ssh/controlmasters/%h-%p-%r",
+    "persist": "4h"
+  }
+}
+```
+
+Homeboy never stores the password. Run `homeboy server connect <server_id>` to establish the interactive session, then later `homeboy ssh`, file transfer, deploy, logs, and other server-backed commands reuse the active SSH control master.
 
 ## SSH Key Management
 

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::server::{self, Server};
+use homeboy::server::{self, Server, SshClient};
 use homeboy::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
@@ -11,6 +11,8 @@ use super::{CmdResult, DynamicSetArgs};
 pub struct ServerExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<ServerKeyOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<ServerSessionOutput>,
 }
 
 pub type ServerOutput = EntityCrudOutput<Server, ServerExtra>;
@@ -23,6 +25,17 @@ pub struct ServerKeyOutput {
     public_key: Option<String>,
     identity_file: Option<String>,
     imported: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServerSessionOutput {
+    action: String,
+    server_id: String,
+    control_path: Option<String>,
+    persist: Option<String>,
+    live: bool,
+    stdout: String,
+    stderr: String,
 }
 
 #[derive(Args)]
@@ -73,6 +86,21 @@ enum ServerCommand {
     },
     /// List all configured servers
     List,
+    /// Open a managed SSH control-master session for this server
+    Connect {
+        /// Server ID
+        server_id: String,
+    },
+    /// Check whether a managed SSH session is live
+    Status {
+        /// Server ID
+        server_id: String,
+    },
+    /// Close a managed SSH control-master session
+    Disconnect {
+        /// Server ID
+        server_id: String,
+    },
     /// Manage SSH keys
     Key(KeyArgs),
 }
@@ -163,6 +191,8 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                     user,
                     port: port.unwrap_or(22),
                     identity_file: None,
+                    kind: None,
+                    auth: None,
                     env: std::collections::HashMap::new(),
                 };
 
@@ -197,8 +227,58 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         ServerCommand::Set { args } => set(args),
         ServerCommand::Delete { server_id } => delete(&server_id),
         ServerCommand::List => list(),
+        ServerCommand::Connect { server_id } => session_connect(&server_id),
+        ServerCommand::Status { server_id } => session_status(&server_id),
+        ServerCommand::Disconnect { server_id } => session_disconnect(&server_id),
         ServerCommand::Key(key_args) => run_key(key_args),
     }
+}
+
+fn session_connect(server_id: &str) -> CmdResult<ServerOutput> {
+    run_session_action(server_id, "connect")
+}
+
+fn session_status(server_id: &str) -> CmdResult<ServerOutput> {
+    run_session_action(server_id, "status")
+}
+
+fn session_disconnect(server_id: &str) -> CmdResult<ServerOutput> {
+    run_session_action(server_id, "disconnect")
+}
+
+fn run_session_action(server_id: &str, action: &str) -> CmdResult<ServerOutput> {
+    let svr = server::load(server_id)?;
+    let client = SshClient::from_server(&svr, server_id)?;
+    let result = match action {
+        "connect" => client.connect_managed_session(),
+        "status" => client.check_managed_session(),
+        "disconnect" => client.disconnect_managed_session(),
+        _ => unreachable!(),
+    }?;
+
+    let exit_code = result.exit_code;
+
+    Ok((
+        ServerOutput {
+            command: format!("server.{}", action),
+            id: Some(server_id.to_string()),
+            entity: Some(svr),
+            extra: ServerExtra {
+                session: Some(ServerSessionOutput {
+                    action: action.to_string(),
+                    server_id: server_id.to_string(),
+                    control_path: result.control_path,
+                    persist: result.persist,
+                    live: result.live,
+                    stdout: result.stdout,
+                    stderr: result.stderr,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        exit_code,
+    ))
 }
 
 fn run_key(args: KeyArgs) -> CmdResult<ServerOutput> {
@@ -315,6 +395,7 @@ fn key_generate(server_id: &str) -> CmdResult<ServerOutput> {
                     identity_file: Some(result.identity_file),
                     imported: None,
                 }),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -337,6 +418,7 @@ fn key_show(server_id: &str) -> CmdResult<ServerOutput> {
                     identity_file: None,
                     imported: None,
                 }),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -362,6 +444,7 @@ fn key_use(server_id: &str, private_key_path: &str) -> CmdResult<ServerOutput> {
                     identity_file,
                     imported: None,
                 }),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -386,6 +469,7 @@ fn key_unset(server_id: &str) -> CmdResult<ServerOutput> {
                     identity_file: None,
                     imported: None,
                 }),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -410,6 +494,7 @@ fn key_import(server_id: &str, private_key_path: &str) -> CmdResult<ServerOutput
                     identity_file: Some(result.identity_file),
                     imported: Some(result.imported_from),
                 }),
+                ..Default::default()
             },
             ..Default::default()
         },

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::server::{self, Server, SshClient};
+use homeboy::server::{self, Server, ServerSessionConfig, SshClient};
 use homeboy::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
@@ -31,8 +31,8 @@ pub struct ServerKeyOutput {
 pub struct ServerSessionOutput {
     action: String,
     server_id: String,
-    control_path: Option<String>,
-    persist: Option<String>,
+    #[serde(flatten)]
+    session: ServerSessionConfig,
     live: bool,
     stdout: String,
     stderr: String,
@@ -267,8 +267,7 @@ fn run_session_action(server_id: &str, action: &str) -> CmdResult<ServerOutput> 
                 session: Some(ServerSessionOutput {
                     action: action.to_string(),
                     server_id: server_id.to_string(),
-                    control_path: result.control_path,
-                    persist: result.persist,
+                    session: result.session,
                     live: result.live,
                     stdout: result.stdout,
                     stderr: result.stderr,

--- a/src/core/deploy/transfer.rs
+++ b/src/core/deploy/transfer.rs
@@ -270,6 +270,7 @@ mod tests {
             user: "test".to_string(),
             port: 22,
             identity_file: None,
+            auth: None,
             is_local: true,
             env: HashMap::new(),
         }

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -11,7 +11,7 @@ use crate::engine::shell;
 use crate::error::{Error, Result};
 use chrono::Utc;
 
-use super::Server;
+use super::{Server, ServerAuthMode};
 use std::process::{Command, Stdio};
 
 #[cfg(unix)]
@@ -25,12 +25,29 @@ pub struct SshClient {
     pub user: String,
     pub port: u16,
     pub identity_file: Option<String>,
+    pub auth: Option<ManagedSshSession>,
     /// When true, all commands run locally instead of over SSH.
     /// Set automatically when the server host is localhost/127.0.0.1/::1.
     pub is_local: bool,
     /// Environment variables to inject before remote commands.
     /// Values are passed through the shell, so `$PATH`-style expansion works.
     pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedSshSession {
+    pub control_path: String,
+    pub persist: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ManagedSshSessionOutput {
+    pub control_path: Option<String>,
+    pub persist: Option<String>,
+    pub live: bool,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
 }
 
 pub struct CommandOutput {
@@ -66,11 +83,26 @@ impl SshClient {
             );
         }
 
+        let auth = match &server.auth {
+            Some(auth) if auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster => {
+                Some(ManagedSshSession {
+                    control_path: expand_control_path(
+                        auth.control_path
+                            .as_deref()
+                            .unwrap_or("~/.ssh/controlmasters/%h-%p-%r"),
+                    ),
+                    persist: auth.persist.clone().unwrap_or_else(|| "4h".to_string()),
+                })
+            }
+            _ => None,
+        };
+
         Ok(Self {
             host: server.host.clone(),
             user: server.user.clone(),
             port: server.port,
             identity_file,
+            auth,
             is_local,
             env: server.env.clone(),
         })
@@ -87,6 +119,17 @@ impl SshClient {
         if self.port != 22 {
             args.push("-p".to_string());
             args.push(self.port.to_string());
+        }
+
+        if let Some(session) = &self.auth {
+            args.extend([
+                "-o".to_string(),
+                "ControlMaster=auto".to_string(),
+                "-o".to_string(),
+                format!("ControlPath={}", session.control_path),
+                "-o".to_string(),
+                format!("ControlPersist={}", session.persist),
+            ]);
         }
 
         // For non-interactive commands, add timeout and keepalive options
@@ -111,6 +154,149 @@ impl SshClient {
         }
 
         args
+    }
+
+    fn build_session_control_args(&self, operation: &str) -> Result<Vec<String>> {
+        let session = self.auth.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "auth.mode",
+                "Server is not configured for managed SSH sessions",
+                None,
+                Some(vec![
+                    "Set auth.mode to key_plus_password_controlmaster".to_string(),
+                    "Then run: homeboy server connect <server>".to_string(),
+                ]),
+            )
+        })?;
+
+        let mut args = Vec::new();
+
+        if let Some(identity_file) = &self.identity_file {
+            args.push("-i".to_string());
+            args.push(identity_file.clone());
+        }
+
+        if self.port != 22 {
+            args.push("-p".to_string());
+            args.push(self.port.to_string());
+        }
+
+        args.extend([
+            "-S".to_string(),
+            session.control_path.clone(),
+            "-O".to_string(),
+            operation.to_string(),
+            format!("{}@{}", self.user, self.host),
+        ]);
+
+        Ok(args)
+    }
+
+    fn build_session_connect_args(&self) -> Result<Vec<String>> {
+        let session = self.auth.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "auth.mode",
+                "Server is not configured for managed SSH sessions",
+                None,
+                Some(vec![
+                    "Set auth.mode to key_plus_password_controlmaster".to_string(),
+                    "Then run: homeboy server connect <server>".to_string(),
+                ]),
+            )
+        })?;
+
+        ensure_control_path_parent(&session.control_path)?;
+
+        let mut args = Vec::new();
+
+        if let Some(identity_file) = &self.identity_file {
+            args.push("-i".to_string());
+            args.push(identity_file.clone());
+        }
+
+        if self.port != 22 {
+            args.push("-p".to_string());
+            args.push(self.port.to_string());
+        }
+
+        args.extend([
+            "-M".to_string(),
+            "-N".to_string(),
+            "-f".to_string(),
+            "-o".to_string(),
+            "ControlMaster=yes".to_string(),
+            "-o".to_string(),
+            format!("ControlPath={}", session.control_path),
+            "-o".to_string(),
+            format!("ControlPersist={}", session.persist),
+            format!("{}@{}", self.user, self.host),
+        ]);
+
+        Ok(args)
+    }
+
+    pub fn connect_managed_session(&self) -> Result<ManagedSshSessionOutput> {
+        if self.is_local {
+            return Ok(self.local_managed_session_output(true));
+        }
+
+        let args = self.build_session_connect_args()?;
+        Ok(self.run_managed_session_command(args, true))
+    }
+
+    pub fn check_managed_session(&self) -> Result<ManagedSshSessionOutput> {
+        if self.is_local {
+            return Ok(self.local_managed_session_output(true));
+        }
+
+        let args = self.build_session_control_args("check")?;
+        Ok(self.run_managed_session_command(args, true))
+    }
+
+    pub fn disconnect_managed_session(&self) -> Result<ManagedSshSessionOutput> {
+        if self.is_local {
+            return Ok(self.local_managed_session_output(false));
+        }
+
+        let args = self.build_session_control_args("exit")?;
+        Ok(self.run_managed_session_command(args, false))
+    }
+
+    fn run_managed_session_command(
+        &self,
+        args: Vec<String>,
+        expect_live_on_success: bool,
+    ) -> ManagedSshSessionOutput {
+        let output = Command::new("ssh").args(&args).output();
+        let (stdout, stderr, exit_code) = match output {
+            Ok(out) => (
+                String::from_utf8_lossy(&out.stdout).to_string(),
+                String::from_utf8_lossy(&out.stderr).to_string(),
+                out.status.code().unwrap_or(-1),
+            ),
+            Err(err) => (String::new(), format!("SSH error: {}", err), -1),
+        };
+        let success = exit_code == 0;
+
+        ManagedSshSessionOutput {
+            control_path: self.auth.as_ref().map(|auth| auth.control_path.clone()),
+            persist: self.auth.as_ref().map(|auth| auth.persist.clone()),
+            live: success && expect_live_on_success,
+            stdout,
+            stderr,
+            exit_code,
+        }
+    }
+
+    fn local_managed_session_output(&self, live: bool) -> ManagedSshSessionOutput {
+        ManagedSshSessionOutput {
+            control_path: self.auth.as_ref().map(|auth| auth.control_path.clone()),
+            persist: self.auth.as_ref().map(|auth| auth.persist.clone()),
+            live,
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+        }
     }
 
     pub fn execute(&self, command: &str) -> CommandOutput {
@@ -260,6 +446,26 @@ impl SshClient {
             Err(_) => -1,
         }
     }
+}
+
+fn expand_control_path(path: &str) -> String {
+    shellexpand::tilde(path).to_string()
+}
+
+fn ensure_control_path_parent(control_path: &str) -> Result<()> {
+    let path = std::path::Path::new(control_path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!(
+                    "create SSH control path directory {}",
+                    parent.display()
+                )),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 pub fn execute_local_command(command: &str) -> CommandOutput {
@@ -1055,6 +1261,7 @@ mod tests {
             user: "tester".to_string(),
             port: 22,
             identity_file: None,
+            auth: None,
             is_local: true,
             env: HashMap::new(),
         };
@@ -1065,6 +1272,64 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(target).expect("read target"),
             "uploaded through stdin\n"
+        );
+    }
+
+    #[test]
+    fn managed_session_config_adds_controlmaster_args() {
+        let server = Server {
+            id: "bastion".to_string(),
+            aliases: Vec::new(),
+            host: "bastion.example.test".to_string(),
+            user: "deploy".to_string(),
+            port: 2222,
+            identity_file: None,
+            kind: Some("password-gated".to_string()),
+            auth: Some(super::super::ServerAuth {
+                mode: ServerAuthMode::KeyPlusPasswordControlmaster,
+                control_path: Some("/tmp/homeboy-test-%h-%p-%r".to_string()),
+                persist: Some("4h".to_string()),
+            }),
+            env: HashMap::new(),
+        };
+
+        let client = SshClient::from_server(&server, "bastion").expect("client");
+        let args = client.build_ssh_args(Some("uptime"), false);
+
+        assert!(args.contains(&"ControlMaster=auto".to_string()));
+        assert!(args.contains(&"ControlPath=/tmp/homeboy-test-%h-%p-%r".to_string()));
+        assert!(args.contains(&"ControlPersist=4h".to_string()));
+        assert!(args.contains(&"BatchMode=yes".to_string()));
+        assert!(args.contains(&"2222".to_string()));
+        assert_eq!(args.last().map(String::as_str), Some("uptime"));
+    }
+
+    #[test]
+    fn managed_session_connect_builds_master_command() {
+        let client = SshClient {
+            host: "bastion.example.test".to_string(),
+            user: "deploy".to_string(),
+            port: 22,
+            identity_file: Some("/tmp/key".to_string()),
+            auth: Some(ManagedSshSession {
+                control_path: "/tmp/homeboy-test-control".to_string(),
+                persist: "10m".to_string(),
+            }),
+            is_local: false,
+            env: HashMap::new(),
+        };
+
+        let args = client.build_session_connect_args().expect("args");
+
+        assert!(args.contains(&"-M".to_string()));
+        assert!(args.contains(&"-N".to_string()));
+        assert!(args.contains(&"-f".to_string()));
+        assert!(args.contains(&"ControlMaster=yes".to_string()));
+        assert!(args.contains(&"ControlPath=/tmp/homeboy-test-control".to_string()));
+        assert!(args.contains(&"ControlPersist=10m".to_string()));
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("deploy@bastion.example.test")
         );
     }
 

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -11,7 +11,10 @@ use crate::engine::shell;
 use crate::error::{Error, Result};
 use chrono::Utc;
 
-use super::{Server, ServerAuthMode};
+use super::{
+    ensure_control_path_parent, ManagedSshSession, ManagedSshSessionOutput, Server, ServerAuthMode,
+    ServerSessionConfig,
+};
 use std::process::{Command, Stdio};
 
 #[cfg(unix)]
@@ -32,22 +35,6 @@ pub struct SshClient {
     /// Environment variables to inject before remote commands.
     /// Values are passed through the shell, so `$PATH`-style expansion works.
     pub env: HashMap<String, String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ManagedSshSession {
-    pub control_path: String,
-    pub persist: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct ManagedSshSessionOutput {
-    pub control_path: Option<String>,
-    pub persist: Option<String>,
-    pub live: bool,
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: i32,
 }
 
 pub struct CommandOutput {
@@ -85,14 +72,7 @@ impl SshClient {
 
         let auth = match &server.auth {
             Some(auth) if auth.mode == ServerAuthMode::KeyPlusPasswordControlmaster => {
-                Some(ManagedSshSession {
-                    control_path: expand_control_path(
-                        auth.control_path
-                            .as_deref()
-                            .unwrap_or("~/.ssh/controlmasters/%h-%p-%r"),
-                    ),
-                    persist: auth.persist.clone().unwrap_or_else(|| "4h".to_string()),
-                })
+                Some(ManagedSshSession::from_auth(auth))
             }
             _ => None,
         };
@@ -279,8 +259,7 @@ impl SshClient {
         let success = exit_code == 0;
 
         ManagedSshSessionOutput {
-            control_path: self.auth.as_ref().map(|auth| auth.control_path.clone()),
-            persist: self.auth.as_ref().map(|auth| auth.persist.clone()),
+            session: self.output_session_config(),
             live: success && expect_live_on_success,
             stdout,
             stderr,
@@ -290,12 +269,18 @@ impl SshClient {
 
     fn local_managed_session_output(&self, live: bool) -> ManagedSshSessionOutput {
         ManagedSshSessionOutput {
-            control_path: self.auth.as_ref().map(|auth| auth.control_path.clone()),
-            persist: self.auth.as_ref().map(|auth| auth.persist.clone()),
+            session: self.output_session_config(),
             live,
             stdout: String::new(),
             stderr: String::new(),
             exit_code: 0,
+        }
+    }
+
+    fn output_session_config(&self) -> ServerSessionConfig {
+        ServerSessionConfig {
+            control_path: self.auth.as_ref().map(|auth| auth.control_path.clone()),
+            persist: self.auth.as_ref().map(|auth| auth.persist.clone()),
         }
     }
 
@@ -446,26 +431,6 @@ impl SshClient {
             Err(_) => -1,
         }
     }
-}
-
-fn expand_control_path(path: &str) -> String {
-    shellexpand::tilde(path).to_string()
-}
-
-fn ensure_control_path_parent(control_path: &str) -> Result<()> {
-    let path = std::path::Path::new(control_path);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some(format!(
-                    "create SSH control path directory {}",
-                    parent.display()
-                )),
-            )
-        })?;
-    }
-    Ok(())
 }
 
 pub fn execute_local_command(command: &str) -> CommandOutput {
@@ -1287,8 +1252,10 @@ mod tests {
             kind: Some("password-gated".to_string()),
             auth: Some(super::super::ServerAuth {
                 mode: ServerAuthMode::KeyPlusPasswordControlmaster,
-                control_path: Some("/tmp/homeboy-test-%h-%p-%r".to_string()),
-                persist: Some("4h".to_string()),
+                session: ServerSessionConfig {
+                    control_path: Some("/tmp/homeboy-test-%h-%p-%r".to_string()),
+                    persist: Some("4h".to_string()),
+                },
             }),
             env: HashMap::new(),
         };
@@ -1331,6 +1298,115 @@ mod tests {
             args.last().map(String::as_str),
             Some("deploy@bastion.example.test")
         );
+    }
+
+    #[test]
+    fn test_from_server() {
+        let server = Server {
+            id: "local".to_string(),
+            aliases: Vec::new(),
+            host: "localhost".to_string(),
+            user: "tester".to_string(),
+            port: 22,
+            identity_file: None,
+            kind: Some("local".to_string()),
+            auth: Some(super::super::ServerAuth {
+                mode: ServerAuthMode::KeyPlusPasswordControlmaster,
+                session: ServerSessionConfig {
+                    control_path: Some("/tmp/homeboy-local-%h-%p-%r".to_string()),
+                    persist: Some("5m".to_string()),
+                },
+            }),
+            env: HashMap::new(),
+        };
+
+        let client = SshClient::from_server(&server, "local").expect("client");
+
+        assert!(client.is_local);
+        assert_eq!(client.host, "localhost");
+        assert_eq!(client.user, "tester");
+        assert_eq!(
+            client.auth.as_ref().map(|auth| auth.persist.as_str()),
+            Some("5m")
+        );
+    }
+
+    #[test]
+    fn test_connect_managed_session() {
+        let client = local_managed_session_client();
+
+        let output = client.connect_managed_session().expect("connect");
+
+        assert!(output.live);
+        assert_eq!(output.session.persist.as_deref(), Some("10m"));
+        assert_eq!(output.exit_code, 0);
+    }
+
+    #[test]
+    fn test_check_managed_session() {
+        let client = local_managed_session_client();
+
+        let output = client.check_managed_session().expect("check");
+
+        assert!(output.live);
+        assert_eq!(
+            output.session.control_path.as_deref(),
+            Some("/tmp/homeboy-local-control")
+        );
+        assert_eq!(output.exit_code, 0);
+    }
+
+    #[test]
+    fn test_disconnect_managed_session() {
+        let client = local_managed_session_client();
+
+        let output = client.disconnect_managed_session().expect("disconnect");
+
+        assert!(!output.live);
+        assert_eq!(output.exit_code, 0);
+    }
+
+    #[test]
+    fn test_execute_interactive() {
+        let client = SshClient {
+            host: "localhost".to_string(),
+            user: "tester".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: HashMap::new(),
+        };
+
+        assert_eq!(client.execute_interactive(Some("true")), 0);
+    }
+
+    #[test]
+    fn test_execute_local_command_interactive() {
+        assert_eq!(execute_local_command_interactive("true", None, None), 0);
+    }
+
+    #[test]
+    fn test_execute_local_command_passthrough() {
+        let output = execute_local_command_passthrough("printf 'passthrough\\n'", None, None);
+
+        assert!(output.success);
+        assert_eq!(output.stdout, "passthrough\n");
+    }
+
+    fn local_managed_session_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "tester".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: Some(ManagedSshSession {
+                control_path: "/tmp/homeboy-local-control".to_string(),
+                persist: "10m".to_string(),
+            }),
+            is_local: true,
+            env: HashMap::new(),
+        }
     }
 
     #[test]

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -35,10 +35,29 @@ pub struct Server {
     pub port: u16,
     #[serde(default)]
     pub identity_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<ServerAuth>,
     /// Environment variables to set before executing commands on this server.
     /// Values support `$PATH`-style expansion — the shell handles it.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerAuth {
+    pub mode: ServerAuthMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persist: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerAuthMode {
+    KeyPlusPasswordControlmaster,
 }
 
 fn default_port() -> u16 {

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -5,12 +5,14 @@ mod connection;
 pub mod health;
 pub(crate) mod http;
 mod keys;
+mod session;
 pub mod transfer;
 
 pub use client::*;
 pub use connection::*;
 pub use health::*;
 pub use keys::*;
+pub use session::*;
 pub use transfer::*;
 
 use std::collections::HashMap;
@@ -48,6 +50,12 @@ pub struct Server {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServerAuth {
     pub mode: ServerAuthMode,
+    #[serde(flatten)]
+    pub session: ServerSessionConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerSessionConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub control_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/core/server/session.rs
+++ b/src/core/server/session.rs
@@ -1,0 +1,103 @@
+use crate::error::{Error, Result};
+
+use super::ServerAuth;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedSshSession {
+    pub control_path: String,
+    pub persist: String,
+}
+
+impl ManagedSshSession {
+    pub fn from_auth(auth: &ServerAuth) -> Self {
+        Self {
+            control_path: expand_control_path(
+                auth.session
+                    .control_path
+                    .as_deref()
+                    .unwrap_or("~/.ssh/controlmasters/%h-%p-%r"),
+            ),
+            persist: auth
+                .session
+                .persist
+                .clone()
+                .unwrap_or_else(|| "4h".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ManagedSshSessionOutput {
+    pub session: super::ServerSessionConfig,
+    pub live: bool,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+pub fn ensure_control_path_parent(control_path: &str) -> Result<()> {
+    let path = std::path::Path::new(control_path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!(
+                    "create SSH control path directory {}",
+                    parent.display()
+                )),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn expand_control_path(path: &str) -> String {
+    shellexpand::tilde(path).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::{ServerAuthMode, ServerSessionConfig};
+
+    #[test]
+    fn test_from_auth() {
+        let auth = ServerAuth {
+            mode: ServerAuthMode::KeyPlusPasswordControlmaster,
+            session: ServerSessionConfig {
+                control_path: Some("/tmp/homeboy-session-%h-%p-%r".to_string()),
+                persist: Some("30m".to_string()),
+            },
+        };
+
+        let session = ManagedSshSession::from_auth(&auth);
+
+        assert_eq!(session.control_path, "/tmp/homeboy-session-%h-%p-%r");
+        assert_eq!(session.persist, "30m");
+    }
+
+    #[test]
+    fn test_from_auth_defaults() {
+        let auth = ServerAuth {
+            mode: ServerAuthMode::KeyPlusPasswordControlmaster,
+            session: ServerSessionConfig::default(),
+        };
+
+        let session = ManagedSshSession::from_auth(&auth);
+
+        assert!(session
+            .control_path
+            .ends_with("/.ssh/controlmasters/%h-%p-%r"));
+        assert_eq!(session.persist, "4h");
+    }
+
+    #[test]
+    fn test_ensure_control_path_parent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let control_path = dir.path().join("nested/control");
+
+        ensure_control_path_parent(&control_path.to_string_lossy()).expect("create parent");
+
+        assert!(control_path.parent().expect("parent").exists());
+    }
+}

--- a/src/core/server/transfer.rs
+++ b/src/core/server/transfer.rs
@@ -110,6 +110,17 @@ fn build_scp_args(client: &SshClient) -> Vec<String> {
         args.push(identity_file.clone());
     }
 
+    if let Some(session) = &client.auth {
+        args.extend([
+            "-o".to_string(),
+            "ControlMaster=auto".to_string(),
+            "-o".to_string(),
+            format!("ControlPath={}", session.control_path),
+            "-o".to_string(),
+            format!("ControlPersist={}", session.persist),
+        ]);
+    }
+
     if client.port != 22 {
         args.push("-P".to_string()); // scp uses -P (uppercase) for port
         args.push(client.port.to_string());
@@ -126,6 +137,12 @@ fn build_ssh_args(client: &SshClient) -> String {
 
     if let Some(identity_file) = &client.identity_file {
         args.push(format!("-i {}", identity_file));
+    }
+
+    if let Some(session) = &client.auth {
+        args.push("-o ControlMaster=auto".to_string());
+        args.push(format!("-o ControlPath={}", session.control_path));
+        args.push(format!("-o ControlPersist={}", session.persist));
     }
 
     if client.port != 22 {
@@ -477,6 +494,8 @@ mod tests {
             user: "deploy".to_string(),
             port: 22,
             identity_file: None,
+            kind: None,
+            auth: None,
             env: HashMap::new(),
         })
         .expect("save server");

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -665,7 +665,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 184;
+const BASELINE_OCCURRENCES: usize = 183;
 
 #[test]
 fn core_owned_source_stays_language_and_framework_agnostic() {


### PR DESCRIPTION
## Summary
- Add generic server auth/session config for key-plus-password SSH control-master reuse.
- Add `homeboy server connect`, `status`, and `disconnect` to establish, inspect, and close managed sessions without storing passwords.
- Reuse configured control-master sockets across SSH command execution and remote file transfers.

Closes #2408.

## Testing
- `cargo test --all-targets`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the managed SSH session support, docs, and tests; Chris directed scope and reviewed architectural direction during development.