### PR TITLE
docs: align release plan comments with execution

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -3,8 +3,8 @@
 //! Each step is a free function that takes the component, the mutable
 //! [`ReleaseState`] threaded through the release, and whatever step-specific
 //! inputs it needs, then returns a [`ReleaseStepResult`]. The caller
-//! ([`super::pipeline::execute`]) runs them in order and handles skip-on-failure
-//! logic for subsequent steps.
+//! ([`super::pipeline::run`], via the release plan dispatcher) runs them in
+//! order and handles skip-on-failure logic for subsequent steps.
 //!
 //! This used to be a trait-object-dispatched `PipelineStepExecutor` driving a
 //! generic DAG (`engine::pipeline`). In practice every release runs the same

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -99,7 +99,7 @@ pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
 
 /// Read the auto-generated changelog entries embedded in the plan's dedicated
 /// changelog step. `plan()` computes them during validation and stashes them
-/// here so `execute()` can hand them straight to [`executor::run_version`]
+/// here so `run()` can hand them straight to [`executor::run_version`]
 /// without recomputing.
 fn extract_pending_entries(
     plan: &ReleasePlan,

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -3,12 +3,10 @@ use std::collections::HashMap;
 
 use crate::is_zero_u32;
 
-/// Dry-run description of a release step.
+/// Ordered release plan shared by dry-run output and release execution.
 ///
-/// `ReleasePlan` is a *preview* shape — it exists to render human-readable
-/// step lists in `--dry-run` mode and in `--json` output. It does NOT drive
-/// execution. The actual release runs through a straight-line function in
-/// `pipeline::execute()` that calls each step directly.
+/// `ReleasePlan` is rendered in `--dry-run` and `--json` output, then walked by
+/// `pipeline::run()` for real releases so the previewed steps match execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleasePlan {
     pub component_id: String,
@@ -113,7 +111,7 @@ pub struct ReleaseArtifact {
     pub platform: Option<String>,
 }
 
-/// Mutable state threaded through the straight-line release execution.
+/// Mutable state threaded through sequential release execution.
 ///
 /// Every step that produces a downstream value (the new version, the tag name,
 /// the release notes, the built artifacts) stores it here and the next step


### PR DESCRIPTION
## Summary
- Update release docs/comments now that `ReleasePlan` drives release execution instead of only previewing dry runs.
- Replace stale `pipeline::execute()` references with the current `pipeline::run()` / plan dispatcher path.

## Testing
- `cargo test core::release`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Identified and updated stale release-plan comments after the execution-dispatch refactor; Chris remains responsible for review.