### PR TITLE
Standardize bench budget findings

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -146,7 +146,35 @@ Supported operators are `eq`, `gte`, and `lte`:
 ```
 
 Failed gates add `gate_results`, set the scenario's `passed` field to
-`false`, and add top-level `gate_failures` to the bench output.
+`false`, and add top-level `gate_failures` plus `budget_findings` to the bench
+output.
+
+## Budget Findings
+
+Benchmark and profile workloads can emit top-level `budget_findings` for fixed
+threshold failures that should report and gate consistently across extensions.
+The common shape is:
+
+```json
+{
+  "category": "budget",
+  "code": "rest.max_response_bytes",
+  "severity": "error",
+  "file": null,
+  "context_label": "profile:wordpress-rest",
+  "message": "REST response exceeded 250 KB budget",
+  "actual": 4378195,
+  "expected": 250000,
+  "unit": "bytes",
+  "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
+  "passed": false
+}
+```
+
+`severity: "error"` or `passed: false` fails the bench run. Lower severities
+are report-only. `code` is the stable grouping key, `subject` identifies the
+endpoint/resource/phase being measured, and `actual` / `expected` / `unit` are
+rendered by `homeboy report failure-digest`.
 
 Rigs can also declare gates for scenario metrics when the workload output is
 owned elsewhere. The keys under `metric_gates` are exact scenario ids:

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -247,6 +247,7 @@ fn merge_matrix_results(
     outputs: &[BenchCommandOutput],
 ) -> Option<BenchResults> {
     let mut merged_scenarios = Vec::new();
+    let mut budget_findings = Vec::new();
     let mut component_id_seen: Option<String> = None;
     let mut iterations_seen: Option<u64> = None;
     let mut metric_policies_seen = std::collections::BTreeMap::new();
@@ -265,6 +266,7 @@ fn merge_matrix_results(
         for (key, policy) in suffixed.metric_policies {
             metric_policies_seen.entry(key).or_insert(policy);
         }
+        budget_findings.extend(suffixed.budget_findings);
         merged_scenarios.extend(suffixed.scenarios);
     }
 
@@ -282,6 +284,7 @@ fn merge_matrix_results(
                 .flat_map(|output| output.results.as_ref().map(|r| r.diagnostics.clone()))
                 .flatten()
                 .collect(),
+            budget_findings,
             scenarios: merged_scenarios,
             metric_policies: metric_policies_seen,
         })
@@ -349,6 +352,10 @@ pub(super) fn run_single_rig(
         .as_ref()
         .map(collect_artifacts)
         .unwrap_or_default();
+    let budget_findings = merged_results
+        .as_ref()
+        .map(|results| results.budget_findings.clone())
+        .unwrap_or_default();
 
     Ok((
         BenchCommandOutput {
@@ -359,6 +366,7 @@ pub(super) fn run_single_rig(
             iterations: args.iterations,
             artifacts,
             results: merged_results,
+            budget_findings,
             gate_failures: outputs
                 .iter()
                 .flat_map(|output| output.gate_failures.clone())
@@ -859,6 +867,10 @@ mod tests {
             exit_code: 0,
             iterations: 10,
             artifacts: results.as_ref().map(collect_artifacts).unwrap_or_default(),
+            budget_findings: results
+                .as_ref()
+                .map(|results| results.budget_findings.clone())
+                .unwrap_or_default(),
             results,
             gate_failures: Vec::new(),
             baseline_comparison: None,

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -5,7 +5,9 @@ use homeboy::engine::run_dir::{self, RunDir};
 use homeboy::extension::bench::report::collect_artifacts;
 use homeboy::extension::bench::{BenchResults, BenchRunWorkflowResult};
 use homeboy::git::short_head_revision_at;
-use homeboy::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
+use homeboy::observation::{
+    finding_records_from_budget, merge_metadata, ActiveObservation, NewRunRecord, RunStatus,
+};
 use homeboy::rig::RigStateSnapshot;
 
 use crate::commands::utils::resource_policy;
@@ -269,6 +271,10 @@ fn record_bench_observation_artifacts(
     let Some(results) = workflow.results.as_ref() else {
         return;
     };
+    observation.0.record_findings(&finding_records_from_budget(
+        observation.run_id(),
+        &results.budget_findings,
+    ));
     for artifact in collect_artifacts(results) {
         if let Some(url) = artifact.url.as_deref() {
             let kind = artifact.kind.as_deref().unwrap_or(&artifact.name);

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1438,6 +1438,7 @@ fn bench_output_single_serializes_without_wrapper_key() {
         iterations: 10,
         artifacts: Vec::new(),
         results: None,
+        budget_findings: Vec::new(),
         gate_failures: Vec::new(),
         baseline_comparison: None,
         hints: None,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,10 @@ use serde_json::{json, Map, Value};
 
 pub type CmdResult<T> = homeboy::Result<(T, i32)>;
 
+pub(crate) fn escape_markdown_table_cell(value: &str) -> String {
+    value.replace('|', "\\|")
+}
+
 /// Parse a `KEY=value` string into a (key, value) tuple.
 /// Used by clap `value_parser` attributes on `--setting` and `--input` flags.
 pub fn parse_key_val(s: &str) -> Result<(String, String), String> {

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -465,6 +465,7 @@ fn render_bench_section(out: &mut String, output_dir: &Path, run_url: &str) {
     }
 
     render_bench_summary(out, &data);
+    render_budget_findings(out, &data);
 
     let artifacts = collect_bench_artifacts(&data);
     if !artifacts.is_empty() {
@@ -503,6 +504,61 @@ fn render_bench_summary(out: &mut String, data: &Map<String, Value>) {
         let _ = writeln!(out, "- `{}` (`{}`): {}", scenario, metric, rows.join("; "));
     }
     out.push('\n');
+}
+
+fn render_budget_findings(out: &mut String, data: &Map<String, Value>) {
+    let mut findings = array_value(data, "budget_findings");
+    let results = object_value(data, "results");
+    if findings.is_empty() {
+        findings = array_value(&results, "budget_findings");
+    }
+    if findings.is_empty() {
+        return;
+    }
+
+    out.push_str("**Budget findings**\n");
+    out.push_str("| Code | Subject | Actual | Expected | Unit | Message |\n");
+    out.push_str("| --- | --- | ---: | ---: | --- | --- |\n");
+    for finding in findings.iter().take(10) {
+        let Some(finding) = finding.as_object() else {
+            continue;
+        };
+        let code = string_value(finding, "code").unwrap_or_else(|| "budget".to_string());
+        let subject = string_value(finding, "subject")
+            .or_else(|| string_value(finding, "context_label"))
+            .unwrap_or_else(|| "-".to_string());
+        let actual = number_value(finding, "actual")
+            .map(format_report_number)
+            .unwrap_or_else(|| "-".to_string());
+        let expected = number_value(finding, "expected")
+            .map(format_report_number)
+            .unwrap_or_else(|| "-".to_string());
+        let unit = string_value(finding, "unit").unwrap_or_else(|| "-".to_string());
+        let message = string_value(finding, "message").unwrap_or_default();
+        let _ = writeln!(
+            out,
+            "| `{}` | {} | {} | {} | {} | {} |",
+            escape_table_cell(&code),
+            escape_table_cell(&subject),
+            actual,
+            expected,
+            escape_table_cell(&unit),
+            escape_table_cell(&message)
+        );
+    }
+    out.push('\n');
+}
+
+fn format_report_number(value: f64) -> String {
+    if value.fract().abs() < f64::EPSILON {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.2}")
+    }
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', "\\|")
 }
 
 fn format_bench_summary_row(row: &Value) -> Option<String> {

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-use super::CmdResult;
+use super::{escape_markdown_table_cell, CmdResult};
 
 #[derive(Args, Debug, Clone)]
 pub struct ReportArgs {
@@ -538,12 +538,12 @@ fn render_budget_findings(out: &mut String, data: &Map<String, Value>) {
         let _ = writeln!(
             out,
             "| `{}` | {} | {} | {} | {} | {} |",
-            escape_table_cell(&code),
-            escape_table_cell(&subject),
+            escape_markdown_table_cell(&code),
+            escape_markdown_table_cell(&subject),
             actual,
             expected,
-            escape_table_cell(&unit),
-            escape_table_cell(&message)
+            escape_markdown_table_cell(&unit),
+            escape_markdown_table_cell(&message)
         );
     }
     out.push('\n');
@@ -555,10 +555,6 @@ fn format_report_number(value: f64) -> String {
     } else {
         format!("{value:.2}")
     }
-}
-
-fn escape_table_cell(value: &str) -> String {
-    value.replace('|', "\\|")
 }
 
 fn format_bench_summary_row(row: &Value) -> Option<String> {

--- a/src/commands/runs/compare.rs
+++ b/src/commands/runs/compare.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use homeboy::observation::{ObservationStore, RunListFilter};
 use homeboy::Error;
 
-use crate::commands::CmdResult;
+use crate::commands::{escape_markdown_table_cell, CmdResult};
 
 use super::{bench_numeric_metrics, run_contains_scenario, run_summary, RunSummary, RunsOutput};
 
@@ -218,7 +218,7 @@ fn render_compare_table(output: &RunsCompareOutput) -> String {
 
     out.push_str("\n| Run | Status | Started | Git SHA | Rig | Artifacts | Scenario |");
     for metric in &output.metrics {
-        out.push_str(&format!(" {} |", escape_table_cell(metric)));
+        out.push_str(&format!(" {} |", escape_markdown_table_cell(metric)));
     }
     out.push('\n');
     out.push_str("|---|---|---|---|---|---:|---|");
@@ -265,10 +265,6 @@ fn fmt_metric(value: Option<f64>) -> String {
             }
         })
         .unwrap_or_else(|| "-".to_string())
-}
-
-fn escape_table_cell(value: &str) -> String {
-    value.replace('|', "\\|")
 }
 
 #[cfg(test)]

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -1,0 +1,105 @@
+//! Shared budget/threshold finding contract.
+//!
+//! Benchmark and profile workloads can emit these findings when a measured
+//! value crosses a fixed budget. `severity = "error"` (or `passed = false`)
+//! gates the run; lower severities remain report-only.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BudgetFinding {
+    #[serde(default = "budget_category")]
+    pub category: String,
+    pub code: String,
+    #[serde(default = "error_severity")]
+    pub severity: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    pub context_label: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual: Option<f64>,
+    pub expected: f64,
+    pub unit: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[serde(default = "default_passed")]
+    pub passed: bool,
+}
+
+impl BudgetFinding {
+    pub fn failure(
+        code: impl Into<String>,
+        context_label: impl Into<String>,
+        message: impl Into<String>,
+        actual: impl Into<Option<f64>>,
+        expected: f64,
+        unit: impl Into<String>,
+        subject: Option<String>,
+    ) -> Self {
+        Self {
+            category: budget_category(),
+            code: code.into(),
+            severity: error_severity(),
+            file: None,
+            context_label: context_label.into(),
+            message: message.into(),
+            actual: actual.into(),
+            expected,
+            unit: unit.into(),
+            subject,
+            passed: false,
+        }
+    }
+
+    pub fn is_gate_failure(&self) -> bool {
+        !self.passed || self.severity == "error"
+    }
+
+    pub fn fingerprint(&self) -> String {
+        match self.subject.as_deref() {
+            Some(subject) if !subject.is_empty() => format!("{}:{}", self.code, subject),
+            _ => self.code.clone(),
+        }
+    }
+}
+
+fn budget_category() -> String {
+    "budget".to_string()
+}
+
+fn error_severity() -> String {
+    "error".to_string()
+}
+
+fn default_passed() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_uses_budget_defaults() {
+        let finding = BudgetFinding::failure(
+            "rest.max_response_bytes",
+            "profile:wordpress-rest",
+            "REST response exceeded 250 KB budget",
+            4378195.0,
+            250000.0,
+            "bytes",
+            Some("/wp-json/datamachine/v1/pipelines?per_page=100".to_string()),
+        );
+
+        assert_eq!(finding.category, "budget");
+        assert_eq!(finding.severity, "error");
+        assert_eq!(finding.actual, Some(4378195.0));
+        assert!(!finding.passed);
+        assert!(finding.is_gate_failure());
+        assert_eq!(
+            finding.fingerprint(),
+            "rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100"
+        );
+    }
+}

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -97,9 +97,34 @@ mod tests {
         assert_eq!(finding.actual, Some(4378195.0));
         assert!(!finding.passed);
         assert!(finding.is_gate_failure());
+    }
+
+    #[test]
+    fn test_fingerprint() {
+        let finding = BudgetFinding::failure(
+            "rest.max_response_bytes",
+            "profile:wordpress-rest",
+            "REST response exceeded 250 KB budget",
+            4378195.0,
+            250000.0,
+            "bytes",
+            Some("/wp-json/datamachine/v1/pipelines?per_page=100".to_string()),
+        );
+
         assert_eq!(
             finding.fingerprint(),
             "rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100"
         );
+
+        let without_subject = BudgetFinding::failure(
+            "page.ready_ms",
+            "profile:page-ready",
+            "Page ready time exceeded budget",
+            1200.0,
+            1000.0,
+            "ms",
+            None,
+        );
+        assert_eq!(without_subject.fingerprint(), "page.ready_ms");
     }
 }

--- a/src/core/extension/bench/aggregation.rs
+++ b/src/core/extension/bench/aggregation.rs
@@ -63,6 +63,10 @@ pub fn aggregate_runs(runs: &[BenchResults]) -> Result<BenchResults> {
             .iter()
             .flat_map(|result| result.diagnostics.clone())
             .collect(),
+        budget_findings: runs
+            .iter()
+            .flat_map(|result| result.budget_findings.clone())
+            .collect(),
         scenarios,
         metric_policies,
     })

--- a/src/core/extension/bench/artifact_validation.rs
+++ b/src/core/extension/bench/artifact_validation.rs
@@ -143,6 +143,7 @@ mod tests {
             iterations: 1,
             run_metadata: None,
             diagnostics: Vec::new(),
+            budget_findings: Vec::new(),
             scenarios: vec![BenchScenario {
                 id: "site_build".to_string(),
                 file: Some("bench/site-build.bench.mjs".to_string()),

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -397,6 +397,7 @@ mod tests {
             iterations: 10,
             run_metadata: None,
             diagnostics: Vec::new(),
+            budget_findings: Vec::new(),
             scenarios,
             metric_policies: BTreeMap::new(),
         }
@@ -411,6 +412,7 @@ mod tests {
             iterations: 10,
             run_metadata: None,
             diagnostics: Vec::new(),
+            budget_findings: Vec::new(),
             scenarios,
             metric_policies,
         }

--- a/src/core/extension/bench/diagnostic.rs
+++ b/src/core/extension/bench/diagnostic.rs
@@ -101,6 +101,7 @@ mod tests {
             iterations: 1,
             run_metadata: None,
             diagnostics: vec![run_diagnostic],
+            budget_findings: Vec::new(),
             scenarios: vec![BenchScenario {
                 id: "scenario-a".to_string(),
                 file: None,

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -341,6 +341,7 @@ mod tests {
             iterations: 10,
             run_metadata: None,
             diagnostics: Vec::new(),
+            budget_findings: Vec::new(),
             scenarios: vec![BenchScenario {
                 id: "scenario".to_string(),
                 file: None,

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -58,6 +58,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::budget::BudgetFinding;
 use crate::error::{Error, Result};
 use crate::observation::timeline::{
     reporting_timeline, summarize_spans, ObservationEvent, ObservationSpanDefinition,
@@ -87,6 +88,8 @@ pub struct BenchResults {
     pub run_metadata: Option<BenchRunMetadata>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<BenchDiagnostic>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub budget_findings: Vec<BudgetFinding>,
     pub scenarios: Vec<BenchScenario>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metric_policies: BTreeMap<String, BenchMetricPolicy>,
@@ -306,6 +309,31 @@ impl BenchGate {
     }
 }
 
+impl BenchGateResult {
+    fn budget_finding(&self, scenario_id: &str) -> Option<BudgetFinding> {
+        if self.passed {
+            return None;
+        }
+        Some(BudgetFinding::failure(
+            format!("bench.gate.{}", self.metric),
+            format!("bench:{}", scenario_id),
+            self.reason.clone().unwrap_or_else(|| {
+                format!(
+                    "scenario `{}` gate failed: {} {} {}",
+                    scenario_id,
+                    self.metric,
+                    self.op.as_str(),
+                    self.expected
+                )
+            }),
+            self.actual,
+            self.expected,
+            "value",
+            Some(self.metric.clone()),
+        ))
+    }
+}
+
 impl BenchGateOp {
     fn as_str(self) -> &'static str {
         match self {
@@ -326,6 +354,12 @@ pub fn evaluate_gates(results: &mut BenchResults) -> Vec<String> {
             .map(|gate| gate.evaluate(&scenario.id, &scenario.metrics))
             .collect();
         scenario.passed = scenario.gate_results.iter().all(|result| result.passed);
+        results.budget_findings.extend(
+            scenario
+                .gate_results
+                .iter()
+                .filter_map(|result| result.budget_finding(&scenario.id)),
+        );
         failures.extend(
             scenario
                 .gate_results
@@ -333,6 +367,15 @@ pub fn evaluate_gates(results: &mut BenchResults) -> Vec<String> {
                 .filter_map(|result| result.reason.clone()),
         );
     }
+    failures.extend(
+        results
+            .budget_findings
+            .iter()
+            .filter(|finding| finding.is_gate_failure())
+            .map(|finding| finding.message.clone()),
+    );
+    failures.sort();
+    failures.dedup();
     failures
 }
 
@@ -1109,6 +1152,45 @@ mod tests {
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("assistant_message_count gte 1"));
         assert_eq!(scenario.gate_results[0].actual, Some(0.0));
+        assert_eq!(parsed.budget_findings.len(), 1);
+        assert_eq!(parsed.budget_findings[0].category, "budget");
+        assert_eq!(
+            parsed.budget_findings[0].code,
+            "bench.gate.assistant_message_count"
+        );
+        assert!(!parsed.budget_findings[0].passed);
+    }
+
+    #[test]
+    fn emitted_budget_findings_gate_bench_runs() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 1,
+            "budget_findings": [
+                {
+                    "category": "budget",
+                    "code": "rest.max_response_bytes",
+                    "severity": "error",
+                    "context_label": "profile:wordpress-rest",
+                    "message": "REST response exceeded 250 KB budget",
+                    "actual": 4378195,
+                    "expected": 250000,
+                    "unit": "bytes",
+                    "subject": "/wp-json/datamachine/v1/pipelines?per_page=100"
+                }
+            ],
+            "scenarios": [
+                { "id": "wordpress-rest", "iterations": 1, "metrics": { "p95_ms": 50.0 } }
+            ]
+        }"#;
+
+        let mut parsed = parse_bench_results_str(raw).unwrap();
+        let failures = evaluate_gates(&mut parsed);
+
+        assert_eq!(failures, vec!["REST response exceeded 250 KB budget"]);
+        assert_eq!(parsed.budget_findings[0].actual, Some(4378195.0));
+        assert_eq!(parsed.budget_findings[0].expected, 250000.0);
+        assert_eq!(parsed.budget_findings[0].unit, "bytes");
     }
 
     #[test]

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -309,31 +309,6 @@ impl BenchGate {
     }
 }
 
-impl BenchGateResult {
-    fn budget_finding(&self, scenario_id: &str) -> Option<BudgetFinding> {
-        if self.passed {
-            return None;
-        }
-        Some(BudgetFinding::failure(
-            format!("bench.gate.{}", self.metric),
-            format!("bench:{}", scenario_id),
-            self.reason.clone().unwrap_or_else(|| {
-                format!(
-                    "scenario `{}` gate failed: {} {} {}",
-                    scenario_id,
-                    self.metric,
-                    self.op.as_str(),
-                    self.expected
-                )
-            }),
-            self.actual,
-            self.expected,
-            "value",
-            Some(self.metric.clone()),
-        ))
-    }
-}
-
 impl BenchGateOp {
     fn as_str(self) -> &'static str {
         match self {
@@ -358,7 +333,26 @@ pub fn evaluate_gates(results: &mut BenchResults) -> Vec<String> {
             scenario
                 .gate_results
                 .iter()
-                .filter_map(|result| result.budget_finding(&scenario.id)),
+                .filter(|result| !result.passed)
+                .map(|result| {
+                    BudgetFinding::failure(
+                        format!("bench.gate.{}", result.metric),
+                        format!("bench:{}", scenario.id),
+                        result.reason.clone().unwrap_or_else(|| {
+                            format!(
+                                "scenario `{}` gate failed: {} {} {}",
+                                scenario.id,
+                                result.metric,
+                                result.op.as_str(),
+                                result.expected
+                            )
+                        }),
+                        result.actual,
+                        result.expected,
+                        "value",
+                        Some(result.metric.clone()),
+                    )
+                }),
         );
         failures.extend(
             scenario
@@ -1179,9 +1173,7 @@ mod tests {
                     "subject": "/wp-json/datamachine/v1/pipelines?per_page=100"
                 }
             ],
-            "scenarios": [
-                { "id": "wordpress-rest", "iterations": 1, "metrics": { "p95_ms": 50.0 } }
-            ]
+            "scenarios": [{ "id": "wordpress-rest", "iterations": 1, "metrics": { "p95_ms": 50.0 } }]
         }"#;
 
         let mut parsed = parse_bench_results_str(raw).unwrap();

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -10,6 +10,7 @@ use super::diagnostic::BenchDiagnostic;
 use super::distribution::BenchRunDistribution;
 use super::parsing::{BenchMetricPhase, BenchResults, BenchScenario};
 use super::run::{BenchRunFailure, BenchRunWorkflowResult};
+use crate::budget::BudgetFinding;
 use crate::rig::RigStateSnapshot;
 
 #[derive(Serialize)]
@@ -23,6 +24,8 @@ pub struct BenchCommandOutput {
     pub artifacts: Vec<BenchArtifactRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub results: Option<BenchResults>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub budget_findings: Vec<BudgetFinding>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub gate_failures: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -54,6 +57,11 @@ pub fn from_main_workflow_with_rig(
     rig_state: Option<RigStateSnapshot>,
 ) -> (BenchCommandOutput, i32) {
     let exit_code = result.exit_code;
+    let budget_findings = result
+        .results
+        .as_ref()
+        .map(|results| results.budget_findings.clone())
+        .unwrap_or_default();
     (
         BenchCommandOutput {
             passed: exit_code == 0,
@@ -67,6 +75,7 @@ pub fn from_main_workflow_with_rig(
                 .map(collect_artifacts)
                 .unwrap_or_default(),
             results: result.results,
+            budget_findings,
             gate_failures: result.gate_failures,
             baseline_comparison: result.baseline_comparison,
             hints: result.hints,
@@ -1213,6 +1222,7 @@ mod tests {
             iterations: 10,
             run_metadata: None,
             diagnostics: Vec::new(),
+            budget_findings: Vec::new(),
             scenarios,
             metric_policies: BTreeMap::new(),
         }

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1134,6 +1134,7 @@ fn run_concurrent_instances(
 
     // Read & merge per-instance results files.
     let mut merged_scenarios: Vec<BenchScenario> = Vec::new();
+    let mut budget_findings = Vec::new();
     let mut component_id_seen: Option<String> = None;
     let mut iterations_seen: Option<u64> = None;
     let mut metric_policies_seen: std::collections::BTreeMap<String, parsing::BenchMetricPolicy> =
@@ -1162,6 +1163,7 @@ fn run_concurrent_instances(
         for (k, v) in parsed.metric_policies.into_iter() {
             metric_policies_seen.entry(k).or_insert(v);
         }
+        budget_findings.extend(parsed.budget_findings);
         for mut scenario in parsed.scenarios {
             scenario.id = format!("{}:i{}", scenario.id, instance_id);
             merged_scenarios.push(scenario);
@@ -1176,6 +1178,7 @@ fn run_concurrent_instances(
             iterations: iterations_seen.unwrap_or(args.iterations),
             run_metadata: None,
             diagnostics: Vec::new(),
+            budget_findings,
             scenarios: merged_scenarios,
             metric_policies: metric_policies_seen,
         })
@@ -1366,6 +1369,7 @@ mod tests {
             iterations: 7,
             run_metadata: None,
             diagnostics: Vec::new(),
+            budget_findings: Vec::new(),
             scenarios: vec![BenchScenario {
                 id: "boot".to_string(),
                 file: Some("tests/bench/boot.rs".to_string()),

--- a/src/core/extension/bench/test_support.rs
+++ b/src/core/extension/bench/test_support.rs
@@ -49,6 +49,7 @@ pub(crate) fn results_with_scenarios(
         iterations,
         run_metadata: None,
         diagnostics: Vec::new(),
+        budget_findings: Vec::new(),
         scenarios,
         metric_policies: BTreeMap::new(),
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 pub mod config;
 pub mod api_jobs;
+pub mod budget;
 pub mod code_audit;
 pub mod component;
 pub mod context;

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -1,0 +1,86 @@
+use crate::budget::BudgetFinding;
+
+use super::records::NewFindingRecord;
+
+fn finding_record_from_budget(run_id: &str, finding: &BudgetFinding) -> NewFindingRecord {
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: "budget".to_string(),
+        rule: Some(finding.code.clone()),
+        file: finding.file.clone(),
+        line: None,
+        severity: Some(finding.severity.clone()),
+        fingerprint: Some(finding.fingerprint()),
+        message: finding.message.clone(),
+        fixable: None,
+        metadata_json: serde_json::json!({
+            "category": finding.category,
+            "context_label": finding.context_label,
+            "actual": finding.actual,
+            "expected": finding.expected,
+            "unit": finding.unit,
+            "subject": finding.subject,
+            "passed": finding.passed,
+            "raw": finding,
+        }),
+    }
+}
+
+pub fn finding_records_from_budget(
+    run_id: &str,
+    findings: &[BudgetFinding],
+) -> Vec<NewFindingRecord> {
+    findings
+        .iter()
+        .map(|finding| finding_record_from_budget(run_id, finding))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_finding_record_from_budget() {
+        let finding = BudgetFinding::failure(
+            "rest.max_response_bytes",
+            "profile:wordpress-rest",
+            "REST response exceeded 250 KB budget",
+            4378195.0,
+            250000.0,
+            "bytes",
+            Some("/wp-json/datamachine/v1/pipelines?per_page=100".to_string()),
+        );
+
+        let record = finding_record_from_budget("run-1", &finding);
+
+        assert_eq!(record.tool, "budget");
+        assert_eq!(record.rule.as_deref(), Some("rest.max_response_bytes"));
+        assert_eq!(record.severity.as_deref(), Some("error"));
+        assert_eq!(record.metadata_json["actual"], 4378195.0);
+        assert_eq!(
+            record.fingerprint.as_deref(),
+            Some("rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100")
+        );
+    }
+
+    #[test]
+    fn test_finding_records_from_budget() {
+        let findings = vec![BudgetFinding::failure(
+            "page.ready_ms",
+            "profile:page-ready",
+            "Page ready time exceeded budget",
+            1200.0,
+            1000.0,
+            "ms",
+            Some("front-page".to_string()),
+        )];
+
+        let records = finding_records_from_budget("run-1", &findings);
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].tool, "budget");
+        assert_eq!(records[0].rule.as_deref(), Some("page.ready_ms"));
+        assert_eq!(records[0].metadata_json["unit"], "ms");
+    }
+}

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -12,12 +12,13 @@ pub mod timeline;
 pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveObservation};
 
 pub use records::{
-    finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
-    finding_records_from_annotation_file, finding_records_from_annotations_dir,
-    finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
-    FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord,
-    NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
-    TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
+    finding_record_from_annotation, finding_record_from_audit, finding_record_from_budget,
+    finding_record_from_lint, finding_records_from_annotation_file,
+    finding_records_from_annotations_dir, finding_records_from_audit, finding_records_from_budget,
+    finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord, FindingListFilter,
+    FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord,
+    NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
+    TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};
 pub use timeline::{

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -4,6 +4,7 @@
 //! stack specs, baselines). SQLite stores observed state from command runs and
 //! generated artifacts. This module only provides the storage substrate.
 
+mod budget_findings;
 mod lifecycle;
 pub mod records;
 pub mod store;
@@ -11,14 +12,14 @@ pub mod timeline;
 
 pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveObservation};
 
+pub use budget_findings::finding_records_from_budget;
 pub use records::{
-    finding_record_from_annotation, finding_record_from_audit, finding_record_from_budget,
-    finding_record_from_lint, finding_records_from_annotation_file,
-    finding_records_from_annotations_dir, finding_records_from_audit, finding_records_from_budget,
-    finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord, FindingListFilter,
-    FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord,
-    NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
-    TriageItemRecord, TriagePullRequestSignals,
+    finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
+    finding_records_from_annotation_file, finding_records_from_annotations_dir,
+    finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
+    FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord,
+    NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
+    TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};
 pub use timeline::{

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
-use crate::budget::BudgetFinding;
 use crate::code_audit::{self, report::finding_kind_key};
 use crate::extension::lint::LintFinding;
 
@@ -198,40 +197,6 @@ pub fn finding_records_from_audit(
     findings
         .iter()
         .map(|finding| finding_record_from_audit(run_id, finding))
-        .collect()
-}
-
-pub fn finding_record_from_budget(run_id: &str, finding: &BudgetFinding) -> NewFindingRecord {
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: "budget".to_string(),
-        rule: Some(finding.code.clone()),
-        file: finding.file.clone(),
-        line: None,
-        severity: Some(finding.severity.clone()),
-        fingerprint: Some(finding.fingerprint()),
-        message: finding.message.clone(),
-        fixable: None,
-        metadata_json: serde_json::json!({
-            "category": finding.category,
-            "context_label": finding.context_label,
-            "actual": finding.actual,
-            "expected": finding.expected,
-            "unit": finding.unit,
-            "subject": finding.subject,
-            "passed": finding.passed,
-            "raw": finding,
-        }),
-    }
-}
-
-pub fn finding_records_from_budget(
-    run_id: &str,
-    findings: &[BudgetFinding],
-) -> Vec<NewFindingRecord> {
-    findings
-        .iter()
-        .map(|finding| finding_record_from_budget(run_id, finding))
         .collect()
 }
 
@@ -513,30 +478,6 @@ mod tests {
         assert_eq!(record.metadata_json["source_sidecar"], "audit-findings");
         assert_eq!(record.metadata_json["convention"], "command modules");
         assert_eq!(record.metadata_json["kind"], "missing_method");
-    }
-
-    #[test]
-    fn test_finding_record_from_budget() {
-        let finding = BudgetFinding::failure(
-            "rest.max_response_bytes",
-            "profile:wordpress-rest",
-            "REST response exceeded 250 KB budget",
-            4378195.0,
-            250000.0,
-            "bytes",
-            Some("/wp-json/datamachine/v1/pipelines?per_page=100".to_string()),
-        );
-
-        let record = finding_record_from_budget("run-1", &finding);
-
-        assert_eq!(record.tool, "budget");
-        assert_eq!(record.rule.as_deref(), Some("rest.max_response_bytes"));
-        assert_eq!(record.severity.as_deref(), Some("error"));
-        assert_eq!(record.metadata_json["actual"], 4378195.0);
-        assert_eq!(
-            record.fingerprint.as_deref(),
-            Some("rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100")
-        );
     }
 
     #[test]

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
+use crate::budget::BudgetFinding;
 use crate::code_audit::{self, report::finding_kind_key};
 use crate::extension::lint::LintFinding;
 
@@ -197,6 +198,40 @@ pub fn finding_records_from_audit(
     findings
         .iter()
         .map(|finding| finding_record_from_audit(run_id, finding))
+        .collect()
+}
+
+pub fn finding_record_from_budget(run_id: &str, finding: &BudgetFinding) -> NewFindingRecord {
+    NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: "budget".to_string(),
+        rule: Some(finding.code.clone()),
+        file: finding.file.clone(),
+        line: None,
+        severity: Some(finding.severity.clone()),
+        fingerprint: Some(finding.fingerprint()),
+        message: finding.message.clone(),
+        fixable: None,
+        metadata_json: serde_json::json!({
+            "category": finding.category,
+            "context_label": finding.context_label,
+            "actual": finding.actual,
+            "expected": finding.expected,
+            "unit": finding.unit,
+            "subject": finding.subject,
+            "passed": finding.passed,
+            "raw": finding,
+        }),
+    }
+}
+
+pub fn finding_records_from_budget(
+    run_id: &str,
+    findings: &[BudgetFinding],
+) -> Vec<NewFindingRecord> {
+    findings
+        .iter()
+        .map(|finding| finding_record_from_budget(run_id, finding))
         .collect()
 }
 
@@ -478,6 +513,30 @@ mod tests {
         assert_eq!(record.metadata_json["source_sidecar"], "audit-findings");
         assert_eq!(record.metadata_json["convention"], "command modules");
         assert_eq!(record.metadata_json["kind"], "missing_method");
+    }
+
+    #[test]
+    fn test_finding_record_from_budget() {
+        let finding = BudgetFinding::failure(
+            "rest.max_response_bytes",
+            "profile:wordpress-rest",
+            "REST response exceeded 250 KB budget",
+            4378195.0,
+            250000.0,
+            "bytes",
+            Some("/wp-json/datamachine/v1/pipelines?per_page=100".to_string()),
+        );
+
+        let record = finding_record_from_budget("run-1", &finding);
+
+        assert_eq!(record.tool, "budget");
+        assert_eq!(record.rule.as_deref(), Some("rest.max_response_bytes"));
+        assert_eq!(record.severity.as_deref(), Some("error"));
+        assert_eq!(record.metadata_json["actual"], 4378195.0);
+        assert_eq!(
+            record.fingerprint.as_deref(),
+            Some("rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100")
+        );
     }
 
     #[test]

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -57,6 +57,7 @@ fn results_with(
         iterations: 10,
         run_metadata: None,
         diagnostics: Vec::new(),
+        budget_findings: Vec::new(),
         scenarios,
         metric_policies: policies,
     }

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -76,6 +76,20 @@ fn bench_json() -> &'static str {
             "component": "studio",
             "exit_code": 0,
             "iterations": 5,
+            "budget_findings": [
+                {
+                    "category": "budget",
+                    "code": "rest.max_response_bytes",
+                    "severity": "error",
+                    "context_label": "profile:wordpress-rest",
+                    "message": "REST response exceeded 250 KB budget",
+                    "actual": 4378195,
+                    "expected": 250000,
+                    "unit": "bytes",
+                    "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
+                    "passed": false
+                }
+            ],
             "artifacts": [
                 {
                     "scenario_id": "wp-admin-load",
@@ -281,6 +295,10 @@ fn renders_bench_status_and_artifact_paths() {
 
     assert!(markdown.contains("### Bench: studio"));
     assert!(markdown.contains("**Status:** PASSED"));
+    assert!(markdown.contains("**Budget findings**"));
+    assert!(markdown.contains(
+        "| `rest.max_response_bytes` | /wp-json/datamachine/v1/pipelines?per_page=100 | 4378195 | 250000 | bytes | REST response exceeded 250 KB budget |"
+    ));
     assert!(markdown.contains(
         "- scenario `wp-admin-load` / run 0 — Playwright trace (playwright-trace): bench-artifacts/wp-admin-load/trace.zip"
     ));


### PR DESCRIPTION
## Summary
- Adds a shared `BudgetFinding` contract for benchmark/profile threshold failures.
- Lets bench workloads emit `budget_findings` that gate runs consistently, and converts semantic gate failures into the same shape.
- Persists budget findings into observation findings and renders actual/expected/unit rows in failure digests.

## Tests
- `cargo test core::extension::bench --lib`
- `cargo test observation::records --lib`
- `cargo test --test report_failure_digest_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the budget finding contract, bench/report integration, docs, and tests for Chris to review.

Closes #2409