### PR TITLE
fix: scope rename duplicate identifier warnings

### DIFF
--- a/src/core/refactor/rename/mod.rs
+++ b/src/core/refactor/rename/mod.rs
@@ -1542,6 +1542,14 @@ mod tests {
     }
 
     #[test]
+    fn detect_duplicate_identifiers_scopes_sibling_object_literals() {
+        let content = "const tasks = [\n    {\n        promptFile: 'a.md',\n        graderFile: 'a.test.md',\n    },\n    {\n        promptFile: 'b.md',\n        graderFile: 'b.test.md',\n    },\n];\n";
+        let mut warnings = Vec::new();
+        detect_duplicate_identifiers("test.js", content, &mut warnings);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
     fn collision_detection_file_rename_target_exists() {
         let dir = std::env::temp_dir().join("homeboy_collision_file_test");
         let _ = std::fs::create_dir_all(&dir);


### PR DESCRIPTION
## Summary
- Scope rename duplicate-identifier collision detection to the matching brace block instead of indentation alone.
- Add a regression test for repeated object keys in sibling JavaScript task objects.

Fixes #2414

## Testing
- `cargo fmt --check`
- `cargo test detect_duplicate_identifiers`
- `cargo test core::refactor::rename`
- `cargo test`
- `cargo run --bin homeboy -- refactor rename --path /Users/chubes/Developer/wp-rl@rename-wp-gym --from wp-rl --to wp-gym --scope all`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the false-positive collision warning, implementing the scanner fix, adding regression coverage, and running verification commands. Chris remains responsible for review and merge.