### PR TITLE
feat: execute release deploy from plan

### DIFF
--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::component::Component;
 use crate::config;
@@ -59,7 +59,7 @@ pub struct DeployConfig {
 }
 
 /// Reason why a component was selected for deployment.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeployReason {
     /// Component was explicitly specified by ID
@@ -75,7 +75,7 @@ pub enum DeployReason {
 }
 
 /// Status indicator for component version comparison.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ComponentStatus {
     /// Local and remote versions match
@@ -92,7 +92,7 @@ pub enum ComponentStatus {
 
 /// Release state tracking for deployment decisions.
 /// Captures git state relative to the last version tag.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseState {
     /// Number of commits since the last version tag
     pub commits_since_version: u32,
@@ -159,7 +159,7 @@ pub struct ReleaseStateBuckets {
 }
 
 /// Result for a single component deployment.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 
 pub struct ComponentDeployResult {
     pub id: String,

--- a/src/core/release/deployment.rs
+++ b/src/core/release/deployment.rs
@@ -1,0 +1,221 @@
+use crate::deploy::{self, DeployConfig};
+
+use super::types::{
+    ReleaseDeploymentResult, ReleaseDeploymentSummary, ReleaseProjectDeployResult, ReleaseRun,
+    ReleaseStepResult, ReleaseStepStatus,
+};
+
+pub(super) fn plan_deployment(component_id: &str) -> ReleaseDeploymentResult {
+    let projects = release_deploy_targets(component_id);
+
+    let project_results: Vec<ReleaseProjectDeployResult> = projects
+        .iter()
+        .map(|project_id| ReleaseProjectDeployResult {
+            project_id: project_id.clone(),
+            status: "planned".to_string(),
+            error: None,
+            component_result: None,
+        })
+        .collect();
+
+    ReleaseDeploymentResult {
+        projects: project_results,
+        summary: ReleaseDeploymentSummary {
+            total_projects: projects.len() as u32,
+            ..Default::default()
+        },
+    }
+}
+
+pub(super) fn run_deployment_step(component_id: &str, local_path: &str) -> ReleaseStepResult {
+    let deployment = execute_deployment(component_id, local_path);
+    let deploy_failed = deployment.summary.failed > 0;
+
+    ReleaseStepResult {
+        id: "deploy".to_string(),
+        step_type: "deploy".to_string(),
+        status: if deploy_failed {
+            ReleaseStepStatus::Failed
+        } else {
+            ReleaseStepStatus::Success
+        },
+        missing: Vec::new(),
+        warnings: Vec::new(),
+        hints: Vec::new(),
+        data: Some(serde_json::json!({ "deployment": deployment })),
+        error: deploy_failed.then(|| "Deployment failed".to_string()),
+    }
+}
+
+pub(super) fn extract_deployment_from_run(run: &ReleaseRun) -> Option<ReleaseDeploymentResult> {
+    run.result
+        .steps
+        .iter()
+        .find(|step| step.step_type == "deploy")
+        .and_then(|step| step.data.as_ref())
+        .and_then(|data| data.get("deployment"))
+        .and_then(|deployment| serde_json::from_value(deployment.clone()).ok())
+}
+
+fn execute_deployment(component_id: &str, local_path: &str) -> ReleaseDeploymentResult {
+    let projects = release_deploy_targets(component_id);
+
+    if projects.is_empty() {
+        return ReleaseDeploymentResult {
+            projects: vec![],
+            summary: ReleaseDeploymentSummary::default(),
+        };
+    }
+
+    log_status!(
+        "release",
+        "Deploying '{}' to {} project(s)...",
+        component_id,
+        projects.len()
+    );
+
+    let config = DeployConfig {
+        component_ids: vec![component_id.to_string()],
+        all: false,
+        outdated: false,
+        behind_upstream: false,
+        dry_run: false,
+        check: false,
+        force: true,
+        skip_build: false,
+        keep_deps: false,
+        expected_version: None,
+        no_pull: true,
+        head: true,
+        tagged: true,
+    };
+
+    let deployment = match deploy::run_multi(&projects, &[component_id.to_string()], &config) {
+        Ok(result) => ReleaseDeploymentResult {
+            projects: result
+                .projects
+                .into_iter()
+                .map(|project| ReleaseProjectDeployResult {
+                    project_id: project.project_id,
+                    status: project.status,
+                    error: project.error,
+                    component_result: project
+                        .results
+                        .into_iter()
+                        .find(|result| result.id == component_id),
+                })
+                .collect(),
+            summary: ReleaseDeploymentSummary {
+                total_projects: result.summary.total_projects,
+                succeeded: result.summary.succeeded,
+                failed: result.summary.failed,
+                skipped: result.summary.skipped,
+                planned: result.summary.planned,
+            },
+        },
+        Err(error) => ReleaseDeploymentResult {
+            projects: projects
+                .iter()
+                .map(|project_id| ReleaseProjectDeployResult {
+                    project_id: project_id.clone(),
+                    status: "failed".to_string(),
+                    error: Some(error.to_string()),
+                    component_result: None,
+                })
+                .collect(),
+            summary: ReleaseDeploymentSummary {
+                total_projects: projects.len() as u32,
+                failed: projects.len() as u32,
+                ..Default::default()
+            },
+        },
+    };
+
+    cleanup_release_artifacts(local_path);
+    deployment
+}
+
+fn release_deploy_targets(component_id: &str) -> Vec<String> {
+    match deploy::resolve_shared_targets(&[component_id.to_string()]) {
+        Ok(projects) => projects,
+        Err(_) => {
+            log_status!(
+                "release",
+                "Warning: No projects use component '{}'. Nothing to deploy.",
+                component_id
+            );
+            Vec::new()
+        }
+    }
+}
+
+fn cleanup_release_artifacts(local_path: &str) {
+    let distrib_path = format!("{}/target/distrib", local_path);
+    if !std::path::Path::new(&distrib_path).exists() {
+        return;
+    }
+
+    if let Err(error) = std::fs::remove_dir_all(&distrib_path) {
+        log_status!(
+            "release",
+            "Warning: failed to clean up {}: {}",
+            distrib_path,
+            error
+        );
+    } else {
+        log_status!("release", "Cleaned up {}", distrib_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_deployment_from_run, plan_deployment};
+    use crate::release::types::{
+        ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
+    };
+
+    #[test]
+    fn test_plan_deployment() {
+        let deployment = plan_deployment("definitely-not-used-by-projects");
+
+        assert!(deployment.projects.is_empty());
+        assert_eq!(deployment.summary.total_projects, 0);
+    }
+
+    #[test]
+    fn test_run_deployment_step() {
+        let result = super::run_deployment_step("definitely-not-used-by-projects", "/tmp");
+
+        assert_eq!(result.id, "deploy");
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert!(result.error.is_none());
+        assert!(result.data.is_some());
+    }
+
+    #[test]
+    fn test_extract_deployment_from_run() {
+        let deployment = plan_deployment("definitely-not-used-by-projects");
+        let run = ReleaseRun {
+            component_id: "fixture".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![ReleaseStepResult {
+                    id: "deploy".to_string(),
+                    step_type: "deploy".to_string(),
+                    status: ReleaseStepStatus::Success,
+                    missing: vec![],
+                    warnings: vec![],
+                    hints: vec![],
+                    data: Some(serde_json::json!({ "deployment": deployment })),
+                    error: None,
+                }],
+                status: ReleaseStepStatus::Success,
+                warnings: vec![],
+                summary: None,
+            },
+        };
+
+        let extracted = extract_deployment_from_run(&run).expect("deployment result");
+        assert_eq!(extracted.summary.total_projects, 0);
+    }
+}

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -91,6 +91,10 @@ pub(super) fn execute_release_plan_step(
                     .unwrap_or_else(|err| failed_result("post_release", "post_release", err)),
             ))
         }
+        "deploy" => Ok(Some(super::deployment::run_deployment_step(
+            context.component_id,
+            &context.component.local_path,
+        ))),
         step_type if step_type.starts_with("publish.") => {
             let target = step_type.strip_prefix("publish.").unwrap_or_default();
             let result = executor::run_publish(
@@ -119,9 +123,7 @@ pub(super) fn execute_release_plan_step(
 }
 
 fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
-    step.step_type.starts_with("preflight.")
-        || step.step_type == "changelog.generate"
-        || step.step_type == "deploy"
+    step.step_type.starts_with("preflight.") || step.step_type == "changelog.generate"
 }
 
 pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
@@ -179,10 +181,10 @@ mod tests {
         let steps = [
             plan_step("preflight.quality"),
             plan_step("changelog.generate"),
-            plan_step("deploy"),
         ];
 
         assert!(steps.iter().all(release_step_is_plan_only));
+        assert!(!release_step_is_plan_only(&plan_step("deploy")));
     }
 
     #[test]

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -1,4 +1,5 @@
 pub mod changelog;
+mod deployment;
 mod execution_dispatch;
 mod executor;
 mod pipeline;

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -305,7 +305,7 @@ pub(super) fn build_release_steps(
             "deploy",
             "Deploy released component",
             deploy_needs,
-            string_config("execution", "after_release_run"),
+            string_config("execution", "release_plan"),
         ));
     }
 
@@ -463,7 +463,7 @@ mod tests {
                 .config
                 .get("execution")
                 .and_then(|value| value.as_str()),
-            Some("after_release_run")
+            Some("release_plan")
         );
     }
 

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -203,7 +203,8 @@ pub struct ReleaseCommandInput {
     pub git_identity: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct ReleaseDeploymentSummary {
     pub total_projects: u32,
     pub succeeded: u32,
@@ -214,7 +215,7 @@ pub struct ReleaseDeploymentSummary {
     pub planned: u32,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseProjectDeployResult {
     pub project_id: String,
     pub status: String,
@@ -224,7 +225,7 @@ pub struct ReleaseProjectDeployResult {
     pub component_result: Option<crate::deploy::ComponentDeployResult>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseDeploymentResult {
     pub projects: Vec<ReleaseProjectDeployResult>,
     pub summary: ReleaseDeploymentSummary,

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -1,5 +1,3 @@
-use crate::component;
-use crate::deploy::{self, DeployConfig};
 use crate::engine::command;
 use crate::error::{Error, Result};
 use crate::git;
@@ -8,8 +6,7 @@ use std::io::{self, BufRead, IsTerminal, Write};
 use super::pipeline::load_component;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseCommandInput,
-    ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary, ReleaseOptions,
-    ReleasePlan, ReleaseProjectDeployResult, ReleaseRun,
+    ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleaseRun,
 };
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
@@ -215,7 +212,9 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         let tag = new_version
             .as_ref()
             .map(|v| format_tag(v, monorepo.as_ref()));
-        let deployment = input.deploy.then(|| plan_deployment(&input.component_id));
+        let deployment = input
+            .deploy
+            .then(|| super::deployment::plan_deployment(&input.component_id));
 
         return Ok((
             ReleaseCommandResult {
@@ -246,11 +245,12 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     } else {
         0
     };
-    let (deployment, deploy_exit_code) = if input.deploy {
-        execute_deployment(&input.component_id, &component.local_path)
-    } else {
-        (None, 0)
-    };
+    let deployment = super::deployment::extract_deployment_from_run(&run_result);
+    let deploy_exit_code = deployment
+        .as_ref()
+        .filter(|deployment| deployment.summary.failed > 0)
+        .map(|_| 1)
+        .unwrap_or(0);
     let exit_code = if deploy_exit_code != 0 {
         // Deploy failed after the release was already tagged and pushed.
         // The tag cannot be rolled back safely, so warn the user to retry.
@@ -401,174 +401,6 @@ fn has_post_release_warnings(run: &ReleaseRun) -> bool {
                 .and_then(|v| v.as_bool())
                 == Some(false)
     })
-}
-
-fn empty_deployment_summary(total_projects: u32) -> ReleaseDeploymentSummary {
-    ReleaseDeploymentSummary {
-        total_projects,
-        succeeded: 0,
-        failed: 0,
-        skipped: 0,
-        planned: 0,
-    }
-}
-
-fn plan_deployment(component_id: &str) -> ReleaseDeploymentResult {
-    let projects = component::projects_using(component_id).unwrap_or_default();
-
-    if projects.is_empty() {
-        log_status!(
-            "release",
-            "Warning: No projects use component '{}'. Nothing to deploy.",
-            component_id
-        );
-    }
-
-    let project_results: Vec<ReleaseProjectDeployResult> = projects
-        .iter()
-        .map(|project_id| ReleaseProjectDeployResult {
-            project_id: project_id.clone(),
-            status: "planned".to_string(),
-            error: None,
-            component_result: None,
-        })
-        .collect();
-
-    ReleaseDeploymentResult {
-        projects: project_results,
-        summary: empty_deployment_summary(projects.len() as u32),
-    }
-}
-
-fn execute_deployment(
-    component_id: &str,
-    local_path: &str,
-) -> (Option<ReleaseDeploymentResult>, i32) {
-    let projects = component::projects_using(component_id).unwrap_or_default();
-
-    if projects.is_empty() {
-        log_status!(
-            "release",
-            "Warning: No projects use component '{}'. Nothing to deploy.",
-            component_id
-        );
-        return (
-            Some(ReleaseDeploymentResult {
-                projects: vec![],
-                summary: empty_deployment_summary(0),
-            }),
-            0,
-        );
-    }
-
-    log_status!(
-        "release",
-        "Deploying '{}' to {} project(s)...",
-        component_id,
-        projects.len()
-    );
-
-    let mut project_results = Vec::new();
-    let mut succeeded: u32 = 0;
-    let mut failed: u32 = 0;
-
-    for project_id in &projects {
-        log_status!("release", "Deploying to project '{}'...", project_id);
-
-        let config = DeployConfig {
-            component_ids: vec![component_id.to_string()],
-            all: false,
-            outdated: false,
-            behind_upstream: false,
-            dry_run: false,
-            check: false,
-            // Force: the release pipeline just committed and tagged, so the
-            // workspace is clean by definition. Skipping the uncommitted changes
-            // check avoids false positives that silently block deployment.
-            force: true,
-            // Always rebuild to guarantee the artifact matches the just-tagged
-            // commit. Reusing a stale artifact is a silent production bug (#991).
-            skip_build: false,
-            keep_deps: false,
-            expected_version: None,
-            no_pull: true,
-            head: true,
-            tagged: true,
-        };
-
-        match deploy::run(project_id, &config) {
-            Ok(result) => {
-                let component_result = result.results.into_iter().next();
-                let deploy_failed = result.summary.failed > 0;
-
-                if deploy_failed {
-                    let error_msg = component_result
-                        .as_ref()
-                        .and_then(|r| r.error.clone())
-                        .unwrap_or_else(|| "Deployment failed".to_string());
-
-                    project_results.push(ReleaseProjectDeployResult {
-                        project_id: project_id.clone(),
-                        status: "failed".to_string(),
-                        error: Some(error_msg),
-                        component_result,
-                    });
-                    failed += 1;
-                } else {
-                    project_results.push(ReleaseProjectDeployResult {
-                        project_id: project_id.clone(),
-                        status: "deployed".to_string(),
-                        error: None,
-                        component_result,
-                    });
-                    succeeded += 1;
-                }
-            }
-            Err(e) => {
-                project_results.push(ReleaseProjectDeployResult {
-                    project_id: project_id.clone(),
-                    status: "failed".to_string(),
-                    error: Some(e.to_string()),
-                    component_result: None,
-                });
-                failed += 1;
-            }
-        }
-    }
-
-    let total = project_results.len() as u32;
-    let exit_code = if failed > 0 { 1 } else { 0 };
-
-    // Clean up build artifacts now that deployment is complete.
-    // The release pipeline skipped cleanup when --deploy was set so the
-    // deploy step could find the ZIP artifact.
-    let distrib_path = format!("{}/target/distrib", local_path);
-    if std::path::Path::new(&distrib_path).exists() {
-        if let Err(e) = std::fs::remove_dir_all(&distrib_path) {
-            log_status!(
-                "release",
-                "Warning: failed to clean up {}: {}",
-                distrib_path,
-                e
-            );
-        } else {
-            log_status!("release", "Cleaned up {}", distrib_path);
-        }
-    }
-
-    (
-        Some(ReleaseDeploymentResult {
-            projects: project_results,
-            summary: ReleaseDeploymentSummary {
-                total_projects: total,
-                succeeded,
-                failed,
-                skipped: 0,
-                planned: 0,
-            },
-        }),
-        exit_code,
-    )
 }
 
 fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {


### PR DESCRIPTION
## Summary
- Make the release `deploy` plan step executable instead of running deployment as a separate post-release path in `workflow.rs`.
- Move release deployment result handling into `release/deployment.rs` and have it delegate multi-project orchestration to `deploy::run_multi()`.
- Keep the top-level release command response populated by extracting the deployment result from the executed deploy step.

## Testing
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test core::deploy`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Refactored release deploy execution into the plan-driven path and updated tests; Chris remains responsible for review and validation.