### PR TITLE
fix(audit): dedupe derived literal sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.168.0"
+version = "0.169.0"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homeboy"
-version = "0.168.0"
+version = "0.169.0"
 edition = "2021"
 license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]

--- a/docs/audit/dead-guard.md
+++ b/docs/audit/dead-guard.md
@@ -33,6 +33,15 @@ if ( function_exists( 'as_schedule_single_action' ) ) { … }  // flagged when A
 
 Dead-guard findings participate in baseline comparisons like any other audit finding.
 
+## Context comments
+
+Extensions can configure `audit.detector_rules.dead_guard_context_comment_patterns` with regexes that
+mark a specific guard as intentionally dual-context. Core only matches the configured regexes against
+comments near the guard; extensions own the wording and domain conventions.
+
+The comment context is the guard line plus the guarded `if` arm when it has braces, optionally prefixed
+by the immediately preceding comment block. Non-comment code and string literals are not matched.
+
 ## Extending the symbol table
 
 The WP-core symbol table lives in `src/core/code_audit/requirements.rs`. Add new rows as

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,20 @@ All notable changes to Homeboy CLI are documented in this file.
 
 (This file is embedded into the CLI binary and is also viewable via `homeboy changelog`.)
 
+## [0.169.0] - 2026-05-12
+
+### Added
+- support requested detector context exclusions
+- support dead guard comment exemptions
+- include major release gate plans
+- include no-releasable release plans
+
+### Fixed
+- discount corpus-common call scaffolding
+- exclude generic helper suffixes from leaf naming
+- skip typeless files for typed conventions
+- limit vacuous mapping checks to comments
+
 ## [0.168.0] - 2026-05-12
 
 ### Added

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -335,6 +335,11 @@ pub fn discover_conventions_with_config(
 
     let total = fingerprints.len();
     let threshold = (total as f32 * 0.6).ceil() as usize;
+    let typed_count = fingerprints
+        .iter()
+        .filter(|fp| declares_type_subject(fp))
+        .count();
+    let typed_subject_convention = typed_count >= threshold;
 
     // Count method frequency
     let mut method_counts: HashMap<String, usize> = HashMap::new();
@@ -437,6 +442,10 @@ pub fn discover_conventions_with_config(
     let mut outliers = Vec::new();
 
     for fp in fingerprints {
+        if typed_subject_convention && !declares_type_subject(fp) {
+            continue;
+        }
+
         // A file is "helper-like" only if NONE of its types match the convention suffix.
         // This prevents false positives where the primary type_name doesn't match but
         // the file contains another type that does (e.g., VersionOutput + VersionArgs).
@@ -617,6 +626,10 @@ fn declared_trait_name(fp: &FileFingerprint) -> Option<String> {
     re.captures(&fp.content)
         .and_then(|cap| cap.get(1))
         .map(|m| m.as_str().to_string())
+}
+
+fn declares_type_subject(fp: &FileFingerprint) -> bool {
+    fp.type_name.is_some() || !fp.type_names.is_empty()
 }
 
 fn is_utility_like_file(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
@@ -1177,6 +1190,64 @@ mod tests {
                 .all(|d| d.kind != AuditFinding::MissingRegistration
                     && d.kind != AuditFinding::MissingMethod),
             "utility classes should not be treated as runtime endpoint registrants"
+        );
+    }
+
+    #[test]
+    fn typeless_files_do_not_need_type_subject_methods_or_registration() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "abilities/CreateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                registrations: vec!["runtime_dispatch".to_string()],
+                type_name: Some("CreateAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/UpdateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                registrations: vec!["runtime_dispatch".to_string()],
+                type_name: Some("UpdateAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/DeleteAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                registrations: vec!["runtime_dispatch".to_string()],
+                type_name: Some("DeleteAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/bootstrap.php".to_string(),
+                language: Language::Php,
+                methods: vec![],
+                type_name: None,
+                type_names: vec![],
+                ..Default::default()
+            },
+        ];
+
+        let convention = discover_conventions_with_config(
+            "Abilities",
+            "abilities/*.php",
+            &fingerprints,
+            &AuditConfig::default(),
+        )
+        .unwrap();
+
+        assert!(
+            convention.outliers.is_empty(),
+            "typeless composition files should not inherit type-subject conventions: {:?}",
+            convention.outliers
+        );
+        assert!(
+            !convention
+                .conforming
+                .contains(&"abilities/bootstrap.php".to_string()),
+            "typeless composition files are skipped rather than counted as convention members"
         );
     }
 

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -13,6 +13,16 @@ use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
 use crate::component::AuditConfig;
 
+const GENERIC_UTILITY_SUFFIXES: &[&str] = &[
+    "Base",
+    "Handler",
+    "Handlers",
+    "Helper",
+    "Helpers",
+    "Projector",
+    "Projectors",
+];
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
@@ -641,10 +651,13 @@ fn is_utility_like_file(fp: &FileFingerprint, audit_config: &AuditConfig) -> boo
 
     declared_trait_name(fp).is_some()
         || names_to_check.iter().any(|name| {
-            audit_config
-                .utility_suffixes
+            GENERIC_UTILITY_SUFFIXES
                 .iter()
                 .any(|suffix| name.ends_with(suffix))
+                || audit_config
+                    .utility_suffixes
+                    .iter()
+                    .any(|suffix| name.ends_with(suffix))
         })
 }
 
@@ -1021,6 +1034,66 @@ mod tests {
             "recognized helper files are intentional utilities, got: {:?}",
             convention.outliers
         );
+    }
+
+    #[test]
+    fn generic_scaffolding_suffixes_are_not_promoted_to_naming_mismatch() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "abilities/CreateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("CreateAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/UpdateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("UpdateAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/DeleteAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("DeleteAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/WikiAbilityBase.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("WikiAbilityBase".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/WikiActionHandlers.php".to_string(),
+                language: Language::Php,
+                methods: vec!["register".to_string()],
+                type_name: Some("WikiActionHandlers".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let convention =
+            discover_conventions("Abilities", "abilities/*.php", &fingerprints).unwrap();
+
+        assert!(
+            convention.outliers.is_empty(),
+            "generic scaffolding suffixes are utility-like, got: {:?}",
+            convention.outliers
+        );
+
+        let projector = FileFingerprint {
+            relative_path: "handlers/McpPacketProjector.php".to_string(),
+            language: Language::Php,
+            methods: vec!["project".to_string()],
+            type_name: Some("McpPacketProjector".to_string()),
+            ..Default::default()
+        };
+
+        assert!(is_utility_like_file(&projector, &AuditConfig::default()));
     }
 
     #[test]

--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -72,6 +72,7 @@ struct Guard {
     kind: GuardKind,
     symbol: String,
     line: usize,
+    offset: usize,
 }
 
 pub(super) fn run_with_config(
@@ -121,9 +122,121 @@ pub(super) fn run_with_config(
 
 fn guard_is_contextual(fp: &FileFingerprint, guard: &Guard, audit_config: &AuditConfig) -> bool {
     is_lifecycle_or_test_path(&fp.relative_path, audit_config)
+        || guard_has_context_comment(&fp.content, guard, audit_config)
         || guard_is_inside_registered_lifecycle_callback(&fp.content, guard)
         || guard_defines_stub(&fp.content, guard)
         || guard_loads_symbol_provider(&fp.content, guard)
+}
+
+fn guard_has_context_comment(content: &str, guard: &Guard, audit_config: &AuditConfig) -> bool {
+    if audit_config.dead_guard_context_comment_patterns.is_empty() {
+        return false;
+    }
+    let Some(comment_context) = guard_comment_context(content, guard) else {
+        return false;
+    };
+    audit_config
+        .dead_guard_context_comment_patterns
+        .iter()
+        .filter_map(|pattern| Regex::new(pattern).ok())
+        .any(|pattern| pattern.is_match(&comment_context))
+}
+
+fn guard_comment_context(content: &str, guard: &Guard) -> Option<String> {
+    let start = preceding_comment_block_start_offset(content, guard.line)
+        .unwrap_or_else(|| line_start_offset(content, guard.line));
+    let end = guard_if_arm_end_offset(content, guard)
+        .unwrap_or_else(|| line_end_offset(content, guard.line));
+    let comments = extract_comments(&content[start..end.min(content.len())]);
+    if comments.trim().is_empty() {
+        None
+    } else {
+        Some(comments)
+    }
+}
+
+fn preceding_comment_block_start_offset(content: &str, guard_line: usize) -> Option<usize> {
+    let mut line = guard_line.checked_sub(1)?;
+    let trimmed = line_text(content, line)?.trim();
+    if trimmed.starts_with("*/") {
+        loop {
+            let current = line_text(content, line)?.trim();
+            if current.contains("/*") || line == 1 {
+                return Some(line_start_offset(content, line));
+            }
+            line -= 1;
+        }
+    }
+    if !is_line_comment_like(trimmed) {
+        return None;
+    }
+    while line > 1 {
+        let Some(previous) = line_text(content, line - 1) else {
+            break;
+        };
+        if !is_line_comment_like(previous.trim()) {
+            break;
+        }
+        line -= 1;
+    }
+    Some(line_start_offset(content, line))
+}
+
+fn is_line_comment_like(trimmed: &str) -> bool {
+    trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("*/")
+}
+
+fn guard_if_arm_end_offset(content: &str, guard: &Guard) -> Option<usize> {
+    let remainder = content.get(guard.offset..)?;
+    let brace_offset = remainder.find('{')? + guard.offset;
+    let semicolon_offset = remainder.find(';').map(|offset| offset + guard.offset);
+    if semicolon_offset.is_some_and(|semicolon| semicolon < brace_offset) {
+        return None;
+    }
+    matching_brace_offset(content, brace_offset).map(|offset| offset + 1)
+}
+
+fn extract_comments(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let mut comments = String::new();
+    let mut idx = 0usize;
+    while idx < bytes.len() {
+        if bytes[idx] == b'/' && bytes.get(idx + 1) == Some(&b'/') {
+            let start = idx + 2;
+            let end = content[start..]
+                .find('\n')
+                .map(|offset| start + offset)
+                .unwrap_or(content.len());
+            comments.push_str(&content[start..end]);
+            comments.push('\n');
+            idx = end;
+        } else if bytes[idx] == b'#' {
+            let start = idx + 1;
+            let end = content[start..]
+                .find('\n')
+                .map(|offset| start + offset)
+                .unwrap_or(content.len());
+            comments.push_str(&content[start..end]);
+            comments.push('\n');
+            idx = end;
+        } else if bytes[idx] == b'/' && bytes.get(idx + 1) == Some(&b'*') {
+            let start = idx + 2;
+            let end = content[start..]
+                .find("*/")
+                .map(|offset| start + offset)
+                .unwrap_or(content.len());
+            comments.push_str(&content[start..end]);
+            comments.push('\n');
+            idx = end.saturating_add(2);
+        } else {
+            idx += 1;
+        }
+    }
+    comments
 }
 
 fn is_lifecycle_or_test_path(path: &str, audit_config: &AuditConfig) -> bool {
@@ -304,8 +417,14 @@ fn extract_guards(content: &str) -> Vec<Guard> {
             "defined" => GuardKind::Constant,
             _ => continue,
         };
-        let line = line_of_offset(content, cap.get(0).map(|m| m.start()).unwrap_or(0));
-        out.push(Guard { kind, symbol, line });
+        let offset = cap.get(0).map(|m| m.start()).unwrap_or(0);
+        let line = line_of_offset(content, offset);
+        out.push(Guard {
+            kind,
+            symbol,
+            line,
+            offset,
+        });
     }
     out
 }
@@ -332,6 +451,26 @@ fn line_start_offset(content: &str, line: usize) -> usize {
         }
     }
     content.len()
+}
+
+fn line_end_offset(content: &str, line: usize) -> usize {
+    let start = line_start_offset(content, line);
+    content[start..]
+        .find('\n')
+        .map(|offset| start + offset)
+        .unwrap_or(content.len())
+}
+
+fn line_text(content: &str, line: usize) -> Option<&str> {
+    if line == 0 {
+        return None;
+    }
+    let start = line_start_offset(content, line);
+    if start >= content.len() {
+        return None;
+    }
+    let end = line_end_offset(content, line);
+    Some(&content[start..end])
 }
 
 #[cfg(test)]
@@ -641,6 +780,95 @@ function runtime_normal_request() {
         let findings = run(&[&fp], tmp.path());
         assert_eq!(findings.len(), 1);
         assert!(findings[0].description.contains("runtime_unschedule_all"));
+    }
+
+    #[test]
+    fn configured_comment_context_suppresses_dead_guard() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.0"), "");
+        let fp = make_fp(
+            "inc/DualContext.php",
+            r#"<?php
+// Fallback when runtime is not loaded by the smoke harness.
+if ( function_exists('runtime_unschedule_all') ) {
+    runtime_unschedule_all('demo');
+}
+"#,
+        );
+        let config = AuditConfig {
+            dead_guard_context_comment_patterns: vec![
+                "(?i)runtime is not loaded by the smoke harness".to_string(),
+            ],
+            known_symbols: test_config().known_symbols,
+            ..Default::default()
+        };
+
+        let findings = run_with_config(&[&fp], tmp.path(), &config);
+        assert!(findings.is_empty(), "matched comment context is exempt");
+    }
+
+    #[test]
+    fn configured_comment_context_can_match_guard_arm_comments() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.0"), "");
+        let fp = make_fp(
+            "inc/DualContext.php",
+            r#"<?php
+if ( function_exists('runtime_unschedule_all') ) {
+    // Dual-context fallback path for the standalone runner.
+    runtime_unschedule_all('demo');
+}
+"#,
+        );
+        let config = AuditConfig {
+            dead_guard_context_comment_patterns: vec!["standalone runner".to_string()],
+            known_symbols: test_config().known_symbols,
+            ..Default::default()
+        };
+
+        let findings = run_with_config(&[&fp], tmp.path(), &config);
+        assert!(findings.is_empty(), "guard-arm comment context is exempt");
+    }
+
+    #[test]
+    fn unconfigured_comment_context_still_reports_dead_guard() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.0"), "");
+        let fp = make_fp(
+            "inc/DualContext.php",
+            r#"<?php
+// Fallback when runtime is not loaded by the smoke harness.
+if ( function_exists('runtime_unschedule_all') ) {
+    runtime_unschedule_all('demo');
+}
+"#,
+        );
+
+        let findings = run(&[&fp], tmp.path());
+        assert_eq!(findings.len(), 1, "comments are not magic without config");
+    }
+
+    #[test]
+    fn configured_comment_context_ignores_non_comment_text() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_plugin_main(tmp.path(), Some("6.0"), "");
+        let fp = make_fp(
+            "inc/DualContext.php",
+            r#"<?php
+$message = 'standalone runner';
+if ( function_exists('runtime_unschedule_all') ) {
+    runtime_unschedule_all('demo');
+}
+"#,
+        );
+        let config = AuditConfig {
+            dead_guard_context_comment_patterns: vec!["standalone runner".to_string()],
+            known_symbols: test_config().known_symbols,
+            ..Default::default()
+        };
+
+        let findings = run_with_config(&[&fp], tmp.path(), &config);
+        assert_eq!(findings.len(), 1, "only comment context is matched");
     }
 
     #[test]

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -967,6 +967,14 @@ const MIN_LCS_RATIO: f64 = 0.5;
 /// from methods that share only 1-2 trivial calls like `to_string`.
 const MIN_SHARED_CALLS: usize = 3;
 
+/// Minimum number of methods a call name must appear in before it can be
+/// treated as corpus-common scaffolding for parallel-implementation scoring.
+const MIN_COMMON_CALL_METHODS: usize = 8;
+
+/// Minimum share of methods a call name must appear in before it can be
+/// treated as corpus-common scaffolding for parallel-implementation scoring.
+const COMMON_CALL_METHOD_RATIO: f64 = 0.10;
+
 /// Raised Jaccard floor for two `StraightLine` bodies that share calls.
 ///
 /// Without a loop or recursion two functions that overlap on stdlib
@@ -1273,11 +1281,39 @@ fn extract_calls_from_body(body: &str, extra_trivial: &HashSet<&str>) -> Vec<Str
     calls
 }
 
-fn signal_calls(calls: &[String], extra_plumbing: &HashSet<&str>) -> Vec<String> {
+fn corpus_common_calls(sequences: &[MethodCallSequence]) -> HashSet<String> {
+    if sequences.len() < MIN_COMMON_CALL_METHODS {
+        return HashSet::new();
+    }
+
+    let mut method_counts: HashMap<&str, usize> = HashMap::new();
+    for sequence in sequences {
+        let unique_calls: HashSet<&str> = sequence.calls.iter().map(|call| call.as_str()).collect();
+        for call in unique_calls {
+            *method_counts.entry(call).or_insert(0) += 1;
+        }
+    }
+
+    let ratio_floor = (sequences.len() as f64 * COMMON_CALL_METHOD_RATIO).ceil() as usize;
+    let count_floor = MIN_COMMON_CALL_METHODS.max(ratio_floor);
+
+    method_counts
+        .into_iter()
+        .filter_map(|(call, count)| (count >= count_floor).then(|| call.to_string()))
+        .collect()
+}
+
+fn signal_calls(
+    calls: &[String],
+    extra_plumbing: &HashSet<&str>,
+    common_calls: &HashSet<String>,
+) -> Vec<String> {
     calls
         .iter()
         .filter(|call| {
-            !PLUMBING_CALLS.contains(&call.as_str()) && !extra_plumbing.contains(call.as_str())
+            !PLUMBING_CALLS.contains(&call.as_str())
+                && !extra_plumbing.contains(call.as_str())
+                && !common_calls.contains(call.as_str())
         })
         .cloned()
         .collect()
@@ -1479,6 +1515,7 @@ pub(crate) fn detect_parallel_implementations(
         .collect();
 
     let sequences = extract_call_sequences(fingerprints, &extra_trivial);
+    let common_calls = corpus_common_calls(&sequences);
 
     // Build sets of already-flagged pairs (exact + near duplicates) to avoid double-flagging
     let exact_groups = build_groups(fingerprints);
@@ -1534,8 +1571,8 @@ pub(crate) fn detect_parallel_implementations(
                 continue;
             }
 
-            let a_signal = signal_calls(&a.calls, &extra_plumbing);
-            let b_signal = signal_calls(&b.calls, &extra_plumbing);
+            let a_signal = signal_calls(&a.calls, &extra_plumbing, &common_calls);
+            let b_signal = signal_calls(&b.calls, &extra_plumbing, &common_calls);
 
             if a_signal.len() < MIN_CALL_COUNT || b_signal.len() < MIN_CALL_COUNT {
                 continue;
@@ -3338,6 +3375,104 @@ fn rebuild_twice(items: &[Item]) -> Result<()> {
         assert!(
             findings.is_empty(),
             "Built-in trivial floor must remain active even with extension config, got: {:?}",
+            findings.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn corpus_common_calls_filter_broad_boilerplate_signal() {
+        // Generic regression for issue #2398: if a call tuple appears across a
+        // broad slice of the scanned component, it is scaffolding for this
+        // detector. The names are intentionally framework-neutral fixtures;
+        // extensions can still provide explicit trivial/plumbing lists.
+        let mut fingerprints = Vec::new();
+
+        for idx in 0..8 {
+            let method = format!("boilerplate_holder_{idx}");
+            let content = format!(
+                "fn {method}() {{\n    scaffold_response();\n    read_request();\n    default_payload();\n    validate_presence();\n    filler_{idx}();\n}}"
+            );
+            fingerprints.push(make_fingerprint_with_content(
+                &format!("src/common_{idx}.rs"),
+                &[method.as_str()],
+                &content,
+            ));
+        }
+
+        let first = make_fingerprint_with_content(
+            "src/a.rs",
+            &["create_item"],
+            "fn create_item() {\n    scaffold_response();\n    read_request();\n    default_payload();\n    validate_presence();\n    create_specific_step();\n}",
+        );
+        let second = make_fingerprint_with_content(
+            "src/b.rs",
+            &["delete_item"],
+            "fn delete_item() {\n    scaffold_response();\n    read_request();\n    default_payload();\n    validate_presence();\n    delete_specific_step();\n}",
+        );
+        fingerprints.push(first);
+        fingerprints.push(second);
+
+        let refs = fingerprints.iter().collect::<Vec<_>>();
+        let findings = detect_parallel_implementations(
+            &refs,
+            &std::collections::HashSet::new(),
+            &DuplicationDetectorConfig::default(),
+        );
+
+        assert!(
+            findings.is_empty(),
+            "Corpus-common scaffolding calls should not produce a parallel implementation finding, got: {:?}",
+            findings.iter().map(|f| &f.description).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn corpus_common_calls_preserve_domain_specific_signal() {
+        let mut fingerprints = Vec::new();
+
+        for idx in 0..8 {
+            let method = format!("boilerplate_holder_{idx}");
+            let content = format!(
+                "fn {method}() {{\n    scaffold_response();\n    read_request();\n    default_payload();\n    validate_presence();\n    filler_{idx}();\n}}"
+            );
+            fingerprints.push(make_fingerprint_with_content(
+                &format!("src/common_{idx}.rs"),
+                &[method.as_str()],
+                &content,
+            ));
+        }
+
+        let first = make_fingerprint_with_content(
+            "src/deploy.rs",
+            &["deploy_item"],
+            "fn deploy_item() {\n    scaffold_response();\n    read_request();\n    validate_component();\n    build_artifact();\n    upload_to_host();\n    run_post_hooks();\n    verify_release();\n    deploy_specific_step();\n}",
+        );
+        let second = make_fingerprint_with_content(
+            "src/upgrade.rs",
+            &["upgrade_item"],
+            "fn upgrade_item() {\n    scaffold_response();\n    read_request();\n    validate_component();\n    build_artifact();\n    upload_to_host();\n    run_post_hooks();\n    verify_release();\n    upgrade_specific_step();\n}",
+        );
+        fingerprints.push(first);
+        fingerprints.push(second);
+
+        let refs = fingerprints.iter().collect::<Vec<_>>();
+        let findings = detect_parallel_implementations(
+            &refs,
+            &std::collections::HashSet::new(),
+            &DuplicationDetectorConfig::default(),
+        );
+
+        assert_eq!(
+            findings.len(),
+            2,
+            "Domain-specific shared workflow calls should still flag after common scaffolding is discounted"
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.description.contains("`build_artifact`")
+                    && !f.description.contains("`read_request`")),
+            "Findings should be driven by domain calls, got: {:?}",
             findings.iter().map(|f| &f.description).collect::<Vec<_>>()
         );
     }

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -358,22 +358,18 @@ fn finding_from_derived_literal_site(
     suggestion: &str,
 ) -> Finding {
     let label = site.labels.join(", ");
+    let extra = |name: &str| match name {
+        "line" => site.line.to_string(),
+        "value" => site.value.clone(),
+        "label" => label.clone(),
+        _ => String::new(),
+    };
     Finding {
         convention: rule.convention.clone(),
         severity: severity_from_config(&rule.severity),
         file: site.file.clone(),
-        description: render_template_from_values(description, &site.captures, |name| match name {
-            "line" => site.line.to_string(),
-            "value" => site.value.clone(),
-            "label" => label.clone(),
-            _ => String::new(),
-        }),
-        suggestion: render_template_from_values(suggestion, &site.captures, |name| match name {
-            "line" => site.line.to_string(),
-            "value" => site.value.clone(),
-            "label" => label.clone(),
-            _ => String::new(),
-        }),
+        description: render_template_from_values(description, &site.captures, &extra),
+        suggestion: render_template_from_values(suggestion, &site.captures, extra),
         kind: AuditFinding::from_str(&rule.kind).unwrap_or(AuditFinding::LegacyComment),
     }
 }

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -1,6 +1,7 @@
 //! Extension-owned requested detector rule-pack execution.
 
 use regex::{Captures, Regex};
+use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
 use crate::component::{AuditConfig, RequestedDetectorRule, RequestedDetectorRuleBody};
@@ -15,6 +16,15 @@ struct DerivedValue {
     value: String,
     label: String,
     file: String,
+}
+
+#[derive(Debug, Clone)]
+struct DerivedLiteralSite {
+    file: String,
+    line: usize,
+    value: String,
+    captures: HashMap<String, String>,
+    labels: Vec<String>,
 }
 
 pub(super) fn run(fingerprints: &[&FileFingerprint], audit_config: &AuditConfig) -> Vec<Finding> {
@@ -169,7 +179,7 @@ fn run_derived_literal_rule(
         return Vec::new();
     }
 
-    let mut findings = Vec::new();
+    let mut sites: BTreeMap<(String, usize, String), DerivedLiteralSite> = BTreeMap::new();
     for value in values {
         let concrete_pattern = render_template(literal_pattern, None, |name| match name {
             "value" => value.value.clone(),
@@ -184,22 +194,26 @@ fn run_derived_literal_rule(
                 continue;
             }
             for captures in literal_regex.captures_iter(&fp.content) {
-                findings.push(finding_from_captures_with_extra(
-                    rule,
-                    fp,
-                    &captures,
-                    description,
-                    suggestion,
-                    |name| match name {
-                        "value" => value.value.clone(),
-                        "label" => value.label.clone(),
-                        _ => String::new(),
-                    },
-                ));
+                let offset = captures.get(0).map(|m| m.start()).unwrap_or(0);
+                let line = line_of_offset(&fp.content, offset);
+                let key = (fp.relative_path.clone(), line, value.value.clone());
+                let site = sites.entry(key).or_insert_with(|| DerivedLiteralSite {
+                    file: fp.relative_path.clone(),
+                    line,
+                    value: value.value.clone(),
+                    captures: capture_values(&literal_regex, &captures),
+                    labels: Vec::new(),
+                });
+                if !site.labels.contains(&value.label) {
+                    site.labels.push(value.label.clone());
+                }
             }
         }
     }
-    findings
+    sites
+        .into_values()
+        .map(|site| finding_from_derived_literal_site(rule, &site, description, suggestion))
+        .collect()
 }
 
 fn collect_derived_values(
@@ -306,6 +320,70 @@ where
         suggestion: render_template(suggestion, Some(captures), extra),
         kind: AuditFinding::from_str(&rule.kind).unwrap_or(AuditFinding::LegacyComment),
     }
+}
+
+fn finding_from_derived_literal_site(
+    rule: &RequestedDetectorRule,
+    site: &DerivedLiteralSite,
+    description: &str,
+    suggestion: &str,
+) -> Finding {
+    let label = site.labels.join(", ");
+    Finding {
+        convention: rule.convention.clone(),
+        severity: severity_from_config(&rule.severity),
+        file: site.file.clone(),
+        description: render_template_from_values(description, &site.captures, |name| match name {
+            "line" => site.line.to_string(),
+            "value" => site.value.clone(),
+            "label" => label.clone(),
+            _ => String::new(),
+        }),
+        suggestion: render_template_from_values(suggestion, &site.captures, |name| match name {
+            "line" => site.line.to_string(),
+            "value" => site.value.clone(),
+            "label" => label.clone(),
+            _ => String::new(),
+        }),
+        kind: AuditFinding::from_str(&rule.kind).unwrap_or(AuditFinding::LegacyComment),
+    }
+}
+
+fn capture_values(regex: &Regex, captures: &Captures) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+    for (index, capture) in captures.iter().enumerate() {
+        if let Some(capture) = capture {
+            values.insert(index.to_string(), capture.as_str().to_string());
+        }
+    }
+    for name in regex.capture_names().flatten() {
+        if let Some(capture) = captures.name(name) {
+            values.insert(name.to_string(), capture.as_str().to_string());
+        }
+    }
+    values
+}
+
+fn render_template_from_values<F>(
+    template: &str,
+    values: &HashMap<String, String>,
+    extra: F,
+) -> String
+where
+    F: Fn(&str) -> String,
+{
+    let token =
+        Regex::new(r"\{([A-Za-z_][A-Za-z0-9_]*|[0-9]+)\}").expect("template regex compiles");
+    token
+        .replace_all(template, |caps: &Captures| {
+            let name = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+            values
+                .get(name)
+                .filter(|value| !value.is_empty())
+                .cloned()
+                .unwrap_or_else(|| extra(name))
+        })
+        .to_string()
 }
 
 fn severity_from_config(value: &str) -> Severity {
@@ -450,6 +528,52 @@ register_item( array( 'category' => 'content-item' ) );
         assert_eq!(findings[0].kind, AuditFinding::ConstantBackedSlugLiteral);
         assert_eq!(findings[0].severity, Severity::Info);
         assert!(findings[0].description.contains("Categories::CONTENT"));
+    }
+
+    #[test]
+    fn derived_literal_rules_dedupe_same_site_and_value_with_multiple_labels() {
+        let constants = php_fp(
+            "src/categories.php",
+            r#"<?php
+final class Categories {
+    public const CONTENT = 'content-item';
+}
+final class CategoryAliases {
+    public const CONTENT = 'content-item';
+}
+"#,
+        );
+        let caller = php_fp(
+            "src/caller.php",
+            r#"<?php
+register_item( array( 'category' => 'content-item' ) );
+"#,
+        );
+        let rule = RequestedDetectorRule {
+            id: "slug-constant".to_string(),
+            kind: "constant_backed_slug_literal".to_string(),
+            severity: "info".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::DerivedLiteral {
+                source_pattern: r#"(?s)\b(?:final\s+|abstract\s+)?class\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\b.*?\b(?:(?:public|protected|private)\s+)?const\s+(?P<const>[A-Z][A-Z0-9_]*)\s*=\s*['\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\"]"#.to_string(),
+                value_capture: "value".to_string(),
+                label: "{class}::{const}".to_string(),
+                literal_pattern: r#"['\"]{value}['\"]"#.to_string(),
+                description: "Raw slug literal `{value}` at line {line} duplicates constant(s) {label}".to_string(),
+                suggestion: "Use one of: {label}.".to_string(),
+            },
+        };
+
+        let findings = run(&[&constants, &caller], &config(rule));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "src/caller.php");
+        assert!(findings[0].description.contains("Categories::CONTENT"));
+        assert!(findings[0].description.contains("CategoryAliases::CONTENT"));
+        assert!(findings[0].suggestion.contains("Categories::CONTENT"));
+        assert!(findings[0].suggestion.contains("CategoryAliases::CONTENT"));
     }
 
     #[test]

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -1,6 +1,7 @@
 //! Extension-owned requested detector rule-pack execution.
 
 use regex::{Captures, Regex};
+use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
 use crate::component::{AuditConfig, RequestedDetectorRule, RequestedDetectorRuleBody};
@@ -15,6 +16,15 @@ struct DerivedValue {
     value: String,
     label: String,
     file: String,
+}
+
+#[derive(Debug, Clone)]
+struct DerivedLiteralSite {
+    file: String,
+    line: usize,
+    value: String,
+    captures: HashMap<String, String>,
+    labels: Vec<String>,
 }
 
 pub(super) fn run(fingerprints: &[&FileFingerprint], audit_config: &AuditConfig) -> Vec<Finding> {
@@ -172,7 +182,7 @@ fn run_derived_literal_rule(
         return Vec::new();
     }
 
-    let mut findings = Vec::new();
+    let mut sites: BTreeMap<(String, usize, String), DerivedLiteralSite> = BTreeMap::new();
     for value in values {
         let concrete_pattern = render_template(literal_pattern, None, |name| match name {
             "value" => value.value.clone(),
@@ -201,22 +211,26 @@ fn run_derived_literal_rule(
                 if match_context_is_excluded(&fp.content, &captures, &exclude_regexes) {
                     continue;
                 }
-                findings.push(finding_from_captures_with_extra(
-                    rule,
-                    fp,
-                    &captures,
-                    description,
-                    suggestion,
-                    |name| match name {
-                        "value" => value.value.clone(),
-                        "label" => value.label.clone(),
-                        _ => String::new(),
-                    },
-                ));
+                let offset = captures.get(0).map(|m| m.start()).unwrap_or(0);
+                let line = line_of_offset(&fp.content, offset);
+                let key = (fp.relative_path.clone(), line, value.value.clone());
+                let site = sites.entry(key).or_insert_with(|| DerivedLiteralSite {
+                    file: fp.relative_path.clone(),
+                    line,
+                    value: value.value.clone(),
+                    captures: capture_values(&literal_regex, &captures),
+                    labels: Vec::new(),
+                });
+                if !site.labels.contains(&value.label) {
+                    site.labels.push(value.label.clone());
+                }
             }
         }
     }
-    findings
+    sites
+        .into_values()
+        .map(|site| finding_from_derived_literal_site(rule, &site, description, suggestion))
+        .collect()
 }
 
 fn match_context_is_excluded(
@@ -335,6 +349,70 @@ where
         suggestion: render_template(suggestion, Some(captures), extra),
         kind: AuditFinding::from_str(&rule.kind).unwrap_or(AuditFinding::LegacyComment),
     }
+}
+
+fn finding_from_derived_literal_site(
+    rule: &RequestedDetectorRule,
+    site: &DerivedLiteralSite,
+    description: &str,
+    suggestion: &str,
+) -> Finding {
+    let label = site.labels.join(", ");
+    Finding {
+        convention: rule.convention.clone(),
+        severity: severity_from_config(&rule.severity),
+        file: site.file.clone(),
+        description: render_template_from_values(description, &site.captures, |name| match name {
+            "line" => site.line.to_string(),
+            "value" => site.value.clone(),
+            "label" => label.clone(),
+            _ => String::new(),
+        }),
+        suggestion: render_template_from_values(suggestion, &site.captures, |name| match name {
+            "line" => site.line.to_string(),
+            "value" => site.value.clone(),
+            "label" => label.clone(),
+            _ => String::new(),
+        }),
+        kind: AuditFinding::from_str(&rule.kind).unwrap_or(AuditFinding::LegacyComment),
+    }
+}
+
+fn capture_values(regex: &Regex, captures: &Captures) -> HashMap<String, String> {
+    let mut values = HashMap::new();
+    for (index, capture) in captures.iter().enumerate() {
+        if let Some(capture) = capture {
+            values.insert(index.to_string(), capture.as_str().to_string());
+        }
+    }
+    for name in regex.capture_names().flatten() {
+        if let Some(capture) = captures.name(name) {
+            values.insert(name.to_string(), capture.as_str().to_string());
+        }
+    }
+    values
+}
+
+fn render_template_from_values<F>(
+    template: &str,
+    values: &HashMap<String, String>,
+    extra: F,
+) -> String
+where
+    F: Fn(&str) -> String,
+{
+    let token =
+        Regex::new(r"\{([A-Za-z_][A-Za-z0-9_]*|[0-9]+)\}").expect("template regex compiles");
+    token
+        .replace_all(template, |caps: &Captures| {
+            let name = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+            values
+                .get(name)
+                .filter(|value| !value.is_empty())
+                .cloned()
+                .unwrap_or_else(|| extra(name))
+        })
+        .to_string()
 }
 
 fn severity_from_config(value: &str) -> Severity {
@@ -530,6 +608,53 @@ if ( $slug === 'content-item' ) { return true; }
         let findings = run(&[&constants, &caller], &config(rule));
         assert_eq!(findings.len(), 1);
         assert!(findings[0].description.contains("line 3"));
+    }
+
+    #[test]
+    fn derived_literal_rules_dedupe_same_site_and_value_with_multiple_labels() {
+        let constants = php_fp(
+            "src/categories.php",
+            r#"<?php
+final class Categories {
+    public const CONTENT = 'content-item';
+}
+final class CategoryAliases {
+    public const CONTENT = 'content-item';
+}
+"#,
+        );
+        let caller = php_fp(
+            "src/caller.php",
+            r#"<?php
+register_item( array( 'category' => 'content-item' ) );
+"#,
+        );
+        let rule = RequestedDetectorRule {
+            id: "slug-constant".to_string(),
+            kind: "constant_backed_slug_literal".to_string(),
+            severity: "info".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::DerivedLiteral {
+                source_pattern: r#"(?s)\b(?:final\s+|abstract\s+)?class\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\b.*?\b(?:(?:public|protected|private)\s+)?const\s+(?P<const>[A-Z][A-Z0-9_]*)\s*=\s*['\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\"]"#.to_string(),
+                value_capture: "value".to_string(),
+                label: "{class}::{const}".to_string(),
+                literal_pattern: r#"['\"]{value}['\"]"#.to_string(),
+                exclude_match_context_patterns: vec![],
+                description: "Raw slug literal `{value}` at line {line} duplicates constant(s) {label}".to_string(),
+                suggestion: "Use one of: {label}.".to_string(),
+            },
+        };
+
+        let findings = run(&[&constants, &caller], &config(rule));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "src/caller.php");
+        assert!(findings[0].description.contains("Categories::CONTENT"));
+        assert!(findings[0].description.contains("CategoryAliases::CONTENT"));
+        assert!(findings[0].suggestion.contains("Categories::CONTENT"));
+        assert!(findings[0].suggestion.contains("CategoryAliases::CONTENT"));
     }
 
     #[test]

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -57,6 +57,7 @@ fn run_rule(rule: &RequestedDetectorRule, fingerprints: &[&FileFingerprint]) -> 
             value_capture,
             label,
             literal_pattern,
+            exclude_match_context_patterns,
             description,
             suggestion,
         } => run_derived_literal_rule(
@@ -66,6 +67,7 @@ fn run_rule(rule: &RequestedDetectorRule, fingerprints: &[&FileFingerprint]) -> 
             value_capture,
             label,
             literal_pattern,
+            exclude_match_context_patterns,
             description,
             suggestion,
         ),
@@ -152,6 +154,7 @@ fn run_derived_literal_rule(
     value_capture: &str,
     label: &str,
     literal_pattern: &str,
+    exclude_match_context_patterns: &[String],
     description: &str,
     suggestion: &str,
 ) -> Vec<Finding> {
@@ -179,11 +182,25 @@ fn run_derived_literal_rule(
         let Ok(literal_regex) = Regex::new(&concrete_pattern) else {
             continue;
         };
+        let exclude_regexes = exclude_match_context_patterns
+            .iter()
+            .filter_map(|pattern| {
+                let concrete_pattern = render_template(pattern, None, |name| match name {
+                    "value" => value.value.clone(),
+                    "label" => value.label.clone(),
+                    _ => String::new(),
+                });
+                Regex::new(&concrete_pattern).ok()
+            })
+            .collect::<Vec<_>>();
         for fp in eligible_files(rule, fingerprints) {
             if fp.relative_path == value.file {
                 continue;
             }
             for captures in literal_regex.captures_iter(&fp.content) {
+                if match_context_is_excluded(&fp.content, &captures, &exclude_regexes) {
+                    continue;
+                }
                 findings.push(finding_from_captures_with_extra(
                     rule,
                     fp,
@@ -200,6 +217,18 @@ fn run_derived_literal_rule(
         }
     }
     findings
+}
+
+fn match_context_is_excluded(
+    content: &str,
+    captures: &Captures,
+    exclude_regexes: &[Regex],
+) -> bool {
+    let Some(match_) = captures.get(0) else {
+        return false;
+    };
+    let context = line_at_offset(content, match_.start());
+    exclude_regexes.iter().any(|regex| regex.is_match(context))
 }
 
 fn collect_derived_values(
@@ -353,6 +382,15 @@ fn line_of_offset(content: &str, offset: usize) -> usize {
         + 1
 }
 
+fn line_at_offset(content: &str, offset: usize) -> &str {
+    let offset = offset.min(content.len());
+    let start = content[..offset].rfind('\n').map_or(0, |index| index + 1);
+    let end = content[offset..]
+        .find('\n')
+        .map_or(content.len(), |index| offset + index);
+    &content[start..end]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -440,6 +478,7 @@ register_item( array( 'category' => 'content-item' ) );
                 value_capture: "value".to_string(),
                 label: "{class}::{const}".to_string(),
                 literal_pattern: r#"['\"]{value}['\"]"#.to_string(),
+                exclude_match_context_patterns: vec![],
                 description: "Raw slug literal `{value}` at line {line} duplicates constant {label}".to_string(),
                 suggestion: "Use {label} instead.".to_string(),
             },
@@ -450,6 +489,47 @@ register_item( array( 'category' => 'content-item' ) );
         assert_eq!(findings[0].kind, AuditFinding::ConstantBackedSlugLiteral);
         assert_eq!(findings[0].severity, Severity::Info);
         assert!(findings[0].description.contains("Categories::CONTENT"));
+    }
+
+    #[test]
+    fn derived_literal_rules_drop_excluded_match_contexts() {
+        let constants = php_fp(
+            "src/categories.php",
+            r#"<?php
+final class Categories {
+    public const CONTENT = 'content-item';
+}
+"#,
+        );
+        let caller = php_fp(
+            "src/caller.php",
+            r#"<?php
+$items = array( 'content-item' => true );
+if ( $slug === 'content-item' ) { return true; }
+"#,
+        );
+        let rule = RequestedDetectorRule {
+            id: "slug-constant".to_string(),
+            kind: "constant_backed_slug_literal".to_string(),
+            severity: "info".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::DerivedLiteral {
+                source_pattern: r#"(?s)\b(?:final\s+|abstract\s+)?class\s+(?P<class>[A-Za-z_][A-Za-z0-9_]*)\b.*?\b(?:(?:public|protected|private)\s+)?const\s+(?P<const>[A-Z][A-Z0-9_]*)\s*=\s*['\"](?P<value>[a-z][a-z0-9]*(?:[-_/:][a-z0-9]+)+)['\"]"#.to_string(),
+                value_capture: "value".to_string(),
+                label: "{class}::{const}".to_string(),
+                literal_pattern: r#"['\"]{value}['\"]"#.to_string(),
+                exclude_match_context_patterns: vec![r#"['\"]{value}['\"]\s*=>"#.to_string()],
+                description: "Raw slug literal `{value}` at line {line} duplicates constant {label}".to_string(),
+                suggestion: "Use {label} instead.".to_string(),
+            },
+        };
+
+        let findings = run(&[&constants, &caller], &config(rule));
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("line 3"));
     }
 
     #[test]

--- a/src/core/code_audit/test_vacuity.rs
+++ b/src/core/code_audit/test_vacuity.rs
@@ -92,7 +92,10 @@ fn classify_vacuous_rust_test(
     if compact.contains("assert!(true)") {
         return Some("it contains only placeholder assertion logic".to_string());
     }
-    if lower.contains("audit") && (lower.contains("mapping") || lower.contains("coverage")) {
+    let comment_text = collect_rust_comments(body).to_ascii_lowercase();
+    if comment_text.contains("audit")
+        && (comment_text.contains("mapping") || comment_text.contains("coverage"))
+    {
         return Some(
             "its comments describe audit coverage mapping instead of behavior".to_string(),
         );
@@ -318,6 +321,61 @@ fn strip_rust_comments(content: &str) -> String {
         .join("\n")
 }
 
+fn collect_rust_comments(content: &str) -> String {
+    let mut comments = String::new();
+    let mut iter = content.char_indices().peekable();
+    while let Some((idx, ch)) = iter.next() {
+        match ch {
+            '/' if iter.peek().is_some_and(|(_, next)| *next == '/') => {
+                iter.next();
+                collect_line_comment(&mut iter, &mut comments);
+            }
+            '/' if iter.peek().is_some_and(|(_, next)| *next == '*') => {
+                iter.next();
+                collect_block_comment(&mut iter, &mut comments);
+            }
+            'r' if raw_string_hashes(content, idx).is_some() => {
+                if let Some(hashes) = raw_string_hashes(content, idx) {
+                    skip_raw_string(&mut iter, hashes);
+                }
+            }
+            '"' => skip_quoted_string(&mut iter),
+            '\'' => skip_char_literal(&mut iter),
+            _ => {}
+        }
+    }
+    comments
+}
+
+fn collect_line_comment(
+    iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+    comments: &mut String,
+) {
+    for (_, ch) in iter.by_ref() {
+        if ch == '\n' {
+            comments.push('\n');
+            break;
+        }
+        comments.push(ch);
+    }
+}
+
+fn collect_block_comment(
+    iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+    comments: &mut String,
+) {
+    let mut previous = '\0';
+    for (_, ch) in iter.by_ref() {
+        if previous == '*' && ch == '/' {
+            comments.pop();
+            comments.push('\n');
+            break;
+        }
+        comments.push(ch);
+        previous = ch;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -353,5 +411,34 @@ fn parse_json() {
         let body = extract_rust_function_body(content, "parse_json").expect("body");
 
         assert!(body.contains("assert!"));
+    }
+
+    #[test]
+    fn vacuity_mapping_comment_heuristic_ignores_code_and_string_literals() {
+        let body = r#"
+            let finding = Finding {
+                convention: "test_coverage".to_string(),
+                kind: AuditFinding::MissingTestFile,
+            };
+            assert_eq!(finding.convention, "test_coverage");
+        "#;
+
+        assert_eq!(
+            classify_vacuous_rust_test(body, &HashSet::new(), &HashSet::new(), None),
+            None
+        );
+    }
+
+    #[test]
+    fn vacuity_mapping_comment_heuristic_flags_comment_only_mapping_tests() {
+        let body = r#"
+            // Keep this audit coverage mapping test wired.
+            assert_eq!(1, 1);
+        "#;
+
+        assert_eq!(
+            classify_vacuous_rust_test(body, &HashSet::new(), &HashSet::new(), None),
+            Some("its comments describe audit coverage mapping instead of behavior".to_string())
+        );
     }
 }

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -247,6 +247,9 @@ pub enum RequestedDetectorRuleBody {
         value_capture: String,
         label: String,
         literal_pattern: String,
+        /// Optional extension-owned regexes matched against the candidate's source line.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        exclude_match_context_patterns: Vec<String>,
         description: String,
         suggestion: String,
     },

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -11,6 +11,10 @@ pub struct AuditConfig {
     /// Paths whose guards run outside normal production runtime assumptions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub lifecycle_path_globs: Vec<String>,
+    /// Extension-owned regexes matched against nearby guard comments. Core only
+    /// applies the patterns; extensions own the contextual language.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dead_guard_context_comment_patterns: Vec<String>,
     /// Type suffixes that mark convention outliers as intentional utilities.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub utility_suffixes: Vec<String>,
@@ -261,6 +265,7 @@ impl AuditConfig {
         self.runtime_entrypoint_extends.is_empty()
             && self.runtime_entrypoint_markers.is_empty()
             && self.lifecycle_path_globs.is_empty()
+            && self.dead_guard_context_comment_patterns.is_empty()
             && self.utility_suffixes.is_empty()
             && self.convention_exception_globs.is_empty()
             && self.convention_tag_globs.is_empty()
@@ -280,6 +285,10 @@ impl AuditConfig {
             &other.runtime_entrypoint_markers,
         );
         extend_unique(&mut self.lifecycle_path_globs, &other.lifecycle_path_globs);
+        extend_unique(
+            &mut self.dead_guard_context_comment_patterns,
+            &other.dead_guard_context_comment_patterns,
+        );
         extend_unique(&mut self.utility_suffixes, &other.utility_suffixes);
         extend_unique(
             &mut self.convention_exception_globs,
@@ -328,6 +337,16 @@ mod tests {
     }
 
     #[test]
+    fn dead_guard_comment_patterns_mark_audit_config_non_empty() {
+        let config = AuditConfig {
+            dead_guard_context_comment_patterns: vec!["dual context".to_string()],
+            ..Default::default()
+        };
+
+        assert!(!config.is_empty());
+    }
+
+    #[test]
     fn merge_dedupes_core_boundary_leak_config() {
         let mut config = AuditConfig {
             core_boundary_leaks: CoreBoundaryLeakConfig {
@@ -339,6 +358,7 @@ mod tests {
         };
 
         config.merge(&AuditConfig {
+            dead_guard_context_comment_patterns: vec!["dual context".to_string()],
             core_boundary_leaks: CoreBoundaryLeakConfig {
                 terms: vec!["florpstack".to_string(), "widgetlang".to_string()],
                 scan_path_contains: vec!["src/core/".to_string(), "src/commands/".to_string()],
@@ -355,6 +375,10 @@ mod tests {
         assert_eq!(
             config.core_boundary_leaks.scan_path_contains,
             vec!["src/core/", "src/commands/"]
+        );
+        assert_eq!(
+            config.dead_guard_context_comment_patterns,
+            vec!["dual context"]
         );
         assert_eq!(
             config.core_boundary_leaks.allow_line_contains,

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -176,14 +176,22 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             );
             return Ok((
                 ReleaseCommandResult {
-                    component_id: input.component_id,
+                    component_id: input.component_id.clone(),
                     bump_type: "major".to_string(),
                     dry_run: input.dry_run,
                     releasable_commits: releasable_count,
                     new_version: None,
                     tag: None,
                     skipped_reason: Some("major-requires-flag".to_string()),
-                    plan: None,
+                    plan: Some(skipped_release_plan(
+                        &input.component_id,
+                        "major-requires-flag",
+                        "Breaking changes require an explicit major bump",
+                        &format!(
+                            "Re-run with: homeboy release {} --bump major",
+                            input.component_id
+                        ),
+                    )),
                     run: None,
                     deployment: None,
                 },


### PR DESCRIPTION
## Summary
- Deduplicate derived literal detector findings by `(file, line, value)`.
- Aggregate matching labels into the rendered finding so one literal site points to all matching constants.
- Preserve capture-template rendering for literal regex captures.

Closes #2336.

## Testing
- `cargo fmt --check`
- `cargo test core::code_audit::requested_detectors`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused dedupe implementation and regression test; Chris remains responsible for review and validation.