### PR TITLE
Include major release gate plans

### DIFF
--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -176,14 +176,22 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             );
             return Ok((
                 ReleaseCommandResult {
-                    component_id: input.component_id,
+                    component_id: input.component_id.clone(),
                     bump_type: "major".to_string(),
                     dry_run: input.dry_run,
                     releasable_commits: releasable_count,
                     new_version: None,
                     tag: None,
                     skipped_reason: Some("major-requires-flag".to_string()),
-                    plan: None,
+                    plan: Some(skipped_release_plan(
+                        &input.component_id,
+                        "major-requires-flag",
+                        "Breaking changes require an explicit major bump",
+                        &format!(
+                            "Re-run with: homeboy release {} --bump major",
+                            input.component_id
+                        ),
+                    )),
                     run: None,
                     deployment: None,
                 },


### PR DESCRIPTION
## Summary
- Return an explicit disabled release plan when breaking commits require an explicit `--bump major`.
- Preserve the existing `major-requires-flag` skip reason and zero exit behavior while making the gate visible in JSON plan output.
- Reuse the existing skipped release plan shape introduced for no-releasable releases.

## Verification
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the release workflow change and verification notes; Chris remains responsible for review and merge.