### PR TITLE
Mark missing PHPUnit discovery as skipped

### DIFF
--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -82,16 +82,21 @@ Returns JSON with test results:
 
 ```json
 {
-  "status": "passed|failed",
+  "status": "passed|failed|skipped",
   "component": "component-name",
   "output": "test output...",
   "exit_code": 0
 }
 ```
 
+For WordPress components, a successful activation/install smoke run with zero discovered PHPUnit files is reported as `status: "skipped"` with exit code `0`. The phase summary states that activation/install passed, PHPUnit discovery found zero tests, and no PHPUnit assertions ran. This preserves the smoke-script workflow while making the absence of PHPUnit assertions explicit.
+
+If a component is expected to contain PHPUnit tests, set `require_phpunit_tests=true` through the existing settings surface, for example `--setting require_phpunit_tests=true` or the component's extension settings. With that setting enabled, zero PHPUnit discovery is treated as a test failure.
+
 ## Exit Codes
 
 - `0`: Tests passed
+- `0`: PHPUnit discovery skipped because no tests were found, when not required
 - `1`: Tests failed
 - `2`: Infrastructure error (component not found, missing scripts, etc.)
 

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -10,7 +10,7 @@ use crate::extension::test::{
 };
 use crate::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
-    PhaseFailureCategory, PhaseReport, VerificationPhase,
+    PhaseFailureCategory, PhaseReport, PhaseStatus, VerificationPhase,
 };
 use crate::refactor::AppliedRefactor;
 use serde::Serialize;
@@ -73,7 +73,11 @@ pub struct TestCommandOutput {
 /// Build output from a main test workflow result.
 pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, i32) {
     let exit_code = result.exit_code;
-    let phase = Some(test_phase_report(exit_code, result.test_counts.as_ref()));
+    let phase = Some(test_phase_report(
+        &result.status,
+        exit_code,
+        result.test_counts.as_ref(),
+    ));
     let failure = if exit_code == 0 {
         None
     } else {
@@ -173,7 +177,16 @@ pub fn from_auto_fix_drift_workflow(
     )
 }
 
-fn test_phase_report(exit_code: i32, counts: Option<&TestCounts>) -> PhaseReport {
+fn test_phase_report(status: &str, exit_code: i32, counts: Option<&TestCounts>) -> PhaseReport {
+    if status == "skipped" {
+        return PhaseReport {
+            phase: VerificationPhase::Test,
+            status: PhaseStatus::Skipped,
+            exit_code: Some(exit_code),
+            summary: "activation/install passed; PHPUnit discovery found zero tests; no PHPUnit assertions ran".to_string(),
+        };
+    }
+
     PhaseReport {
         phase: VerificationPhase::Test,
         status: phase_status_from_exit_code(exit_code),
@@ -187,6 +200,8 @@ fn test_phase_report(exit_code: i32, counts: Option<&TestCounts>) -> PhaseReport
             } else {
                 "test phase passed".to_string()
             }
+        } else if counts.map(|counts| counts.total == 0).unwrap_or(false) {
+            "PHPUnit discovery found zero tests; no PHPUnit assertions ran".to_string()
         } else if exit_code >= 2 {
             format!("test harness infrastructure failure (exit {})", exit_code)
         } else if counts.map(|counts| counts.failed == 0).unwrap_or(false) {
@@ -209,7 +224,9 @@ fn test_phase_report(exit_code: i32, counts: Option<&TestCounts>) -> PhaseReport
 }
 
 fn test_phase_failure(exit_code: i32, counts: Option<&TestCounts>) -> PhaseFailure {
-    let category = if exit_code != 0 && counts.map(|counts| counts.failed == 0).unwrap_or(false) {
+    let category = if exit_code != 0 && counts.map(|counts| counts.total == 0).unwrap_or(false) {
+        PhaseFailureCategory::Findings
+    } else if exit_code != 0 && counts.map(|counts| counts.failed == 0).unwrap_or(false) {
         PhaseFailureCategory::Infrastructure
     } else {
         phase_failure_category_from_exit_code(exit_code)
@@ -218,7 +235,9 @@ fn test_phase_failure(exit_code: i32, counts: Option<&TestCounts>) -> PhaseFailu
         phase: VerificationPhase::Test,
         summary: match category {
             PhaseFailureCategory::Infrastructure => {
-                if counts.map(|counts| counts.failed == 0).unwrap_or(false) {
+                if counts.map(|counts| counts.total == 0).unwrap_or(false) {
+                    "PHPUnit discovery found zero tests; no PHPUnit assertions ran".to_string()
+                } else if counts.map(|counts| counts.failed == 0).unwrap_or(false) {
                     format!(
                         "test runner failed after reporting zero test failures (exit {})",
                         exit_code
@@ -268,6 +287,25 @@ mod tests {
             component: "homeboy".to_string(),
             exit_code,
             test_counts: Some(counts),
+            failed_tests: None,
+            failure_analysis_input: None,
+            coverage: None,
+            baseline_comparison: None,
+            analysis: None,
+            autofix: None,
+            hints: None,
+            test_scope: None,
+            summary: None,
+            raw_output: None,
+        }
+    }
+
+    fn skipped_workflow_result() -> TestRunWorkflowResult {
+        TestRunWorkflowResult {
+            status: "skipped".to_string(),
+            component: "wordpress-plugin".to_string(),
+            exit_code: 0,
+            test_counts: Some(TestCounts::new(0, 0, 0, 0)),
             failed_tests: None,
             failure_analysis_input: None,
             coverage: None,
@@ -353,6 +391,23 @@ mod tests {
         assert_eq!(json["passed"], true);
         assert_eq!(json["status"], "passed");
         assert_eq!(json["exit_code"], 0);
+        assert!(json.get("failure").is_none());
+    }
+
+    #[test]
+    fn phpunit_no_discovery_is_structured_as_skipped() {
+        let (output, exit_code) = from_main_workflow(skipped_workflow_result());
+
+        let json = serde_json::to_value(output).expect("serialize test command output");
+        assert_eq!(exit_code, 0);
+        assert_eq!(json["passed"], true);
+        assert_eq!(json["status"], "skipped");
+        assert_eq!(json["test_counts"]["total"], 0);
+        assert_eq!(json["phase"]["status"], "skipped");
+        assert_eq!(
+            json["phase"]["summary"],
+            "activation/install passed; PHPUnit discovery found zero tests; no PHPUnit assertions ran"
+        );
         assert!(json.get("failure").is_none());
     }
 }

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -70,6 +70,8 @@ pub struct RawTestOutput {
 }
 
 const RAW_OUTPUT_TAIL_LINES: usize = 80;
+const PHPUNIT_NO_DISCOVERY_MARKER: &str = "NO PHPUNIT TEST FILES DISCOVERED";
+const REQUIRE_PHPUNIT_TESTS_SETTING: &str = "require_phpunit_tests";
 
 fn failed_tests_from_analysis_input(input: &TestAnalysisInput) -> Option<Vec<FailedTest>> {
     if input.failures.is_empty() {
@@ -119,9 +121,22 @@ fn tail_lines(s: &str, max_lines: usize) -> (String, bool) {
     }
 }
 
-fn test_run_status(runner_success: bool, test_counts: Option<&TestCounts>) -> &'static str {
+fn test_run_status(
+    runner_success: bool,
+    test_counts: Option<&TestCounts>,
+    phpunit_no_discovery: bool,
+    require_phpunit_tests: bool,
+) -> &'static str {
     if !runner_success {
         return "failed";
+    }
+
+    if phpunit_no_discovery {
+        return if require_phpunit_tests {
+            "failed"
+        } else {
+            "skipped"
+        };
     }
 
     if test_counts.map(|counts| counts.failed == 0).unwrap_or(true) {
@@ -129,6 +144,20 @@ fn test_run_status(runner_success: bool, test_counts: Option<&TestCounts>) -> &'
     } else {
         "failed"
     }
+}
+
+fn phpunit_no_discovery(stdout: &str, stderr: &str) -> bool {
+    stdout.contains(PHPUNIT_NO_DISCOVERY_MARKER) || stderr.contains(PHPUNIT_NO_DISCOVERY_MARKER)
+}
+
+fn setting_truthy(settings: &[(String, String)], key: &str) -> bool {
+    settings.iter().any(|(setting_key, value)| {
+        setting_key == key
+            && matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+    })
 }
 
 pub fn run_main_test_workflow(
@@ -210,17 +239,27 @@ pub fn run_main_test_workflow(
     .script_args(&args.passthrough_args)
     .run()?;
 
-    let test_counts = parse_test_results_file(&results_file).or_else(|| {
+    let mut test_counts = parse_test_results_file(&results_file).or_else(|| {
         result_parse
             .as_ref()
             .and_then(|spec| parse_test_results_text_with_spec(&output.stdout, spec))
             .or_else(|| parse_test_results_text(&output.stdout))
     });
+    let phpunit_no_discovery = phpunit_no_discovery(&output.stdout, &output.stderr);
+    if phpunit_no_discovery && test_counts.is_none() {
+        test_counts = Some(TestCounts::new(0, 0, 0, 0));
+    }
+    let require_phpunit_tests = setting_truthy(&args.settings, REQUIRE_PHPUNIT_TESTS_SETTING);
 
     // Autofix is owned by `refactor --from test --write`; the test command is read-only.
     let test_autofix: Option<AppliedRefactor> = None;
 
-    let status = test_run_status(output.success, test_counts.as_ref());
+    let status = test_run_status(
+        output.success,
+        test_counts.as_ref(),
+        phpunit_no_discovery,
+        require_phpunit_tests,
+    );
 
     let coverage = coverage_file
         .as_ref()
@@ -248,7 +287,7 @@ pub fn run_main_test_workflow(
         None
     };
 
-    if args.baseline_flags.baseline {
+    if args.baseline_flags.baseline && !phpunit_no_discovery {
         if let Some(ref counts) = test_counts {
             let _ = baseline::save_baseline(source_path, &args.component_id, counts)?;
         }
@@ -257,7 +296,10 @@ pub fn run_main_test_workflow(
     let mut baseline_comparison = None;
     let mut baseline_exit_override = None;
 
-    if !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
+    if !args.baseline_flags.baseline
+        && !args.baseline_flags.ignore_baseline
+        && !phpunit_no_discovery
+    {
         if let Some(ref counts) = test_counts {
             let resolved_baseline = baseline::load_baseline(source_path).or_else(|| {
                 args.changed_since.as_ref().and_then(|git_ref| {
@@ -290,6 +332,20 @@ pub fn run_main_test_workflow(
         ));
     }
 
+    if phpunit_no_discovery {
+        if require_phpunit_tests {
+            hints.push(format!(
+                "PHPUnit discovery is required by {}=true, but no PHPUnit test files were found.",
+                REQUIRE_PHPUNIT_TESTS_SETTING
+            ));
+        } else {
+            hints.push(format!(
+                "Set --setting {}=true when this component is expected to contain PHPUnit tests.",
+                REQUIRE_PHPUNIT_TESTS_SETTING
+            ));
+        }
+    }
+
     if !args.skip_lint {
         hints.push(format!(
             "Auto-fix lint issues: homeboy refactor {} --from lint --write",
@@ -304,7 +360,11 @@ pub fn run_main_test_workflow(
         ));
     }
 
-    if test_counts.is_some() && !args.baseline_flags.baseline && baseline_comparison.is_none() {
+    if test_counts.is_some()
+        && !phpunit_no_discovery
+        && !args.baseline_flags.baseline
+        && baseline_comparison.is_none()
+    {
         hints.push(format!(
             "Save test baseline: homeboy test {} --baseline",
             args.component_id
@@ -332,10 +392,10 @@ pub fn run_main_test_workflow(
     hints.push("Full options: homeboy docs commands/test".to_string());
 
     let hints = if hints.is_empty() { None } else { Some(hints) };
-    let test_exit_code = if status == "passed" {
-        0
-    } else {
-        output.exit_code
+    let test_exit_code = match status {
+        "passed" | "skipped" => 0,
+        "failed" if output.exit_code == 0 => 1,
+        _ => output.exit_code,
     };
     let exit_code = baseline_exit_override.unwrap_or(test_exit_code);
     let summary = if args.json_summary {
@@ -509,19 +569,47 @@ mod tests {
     #[test]
     fn status_requires_successful_runner_even_with_zero_failures() {
         let counts = TestCounts::new(3, 3, 0, 0);
-        assert_eq!(test_run_status(false, Some(&counts)), "failed");
+        assert_eq!(
+            test_run_status(false, Some(&counts), false, false),
+            "failed"
+        );
     }
 
     #[test]
     fn status_passes_successful_runner_with_zero_failures() {
         let counts = TestCounts::new(3, 3, 0, 0);
-        assert_eq!(test_run_status(true, Some(&counts)), "passed");
+        assert_eq!(test_run_status(true, Some(&counts), false, false), "passed");
     }
 
     #[test]
     fn status_fails_successful_runner_with_parsed_failures() {
         let counts = TestCounts::new(3, 2, 1, 0);
-        assert_eq!(test_run_status(true, Some(&counts)), "failed");
+        assert_eq!(test_run_status(true, Some(&counts), false, false), "failed");
+    }
+
+    #[test]
+    fn status_skips_successful_phpunit_no_discovery_by_default() {
+        assert_eq!(test_run_status(true, None, true, false), "skipped");
+    }
+
+    #[test]
+    fn status_fails_successful_phpunit_no_discovery_when_required() {
+        assert_eq!(test_run_status(true, None, true, true), "failed");
+    }
+
+    #[test]
+    fn detects_phpunit_no_discovery_marker() {
+        assert!(phpunit_no_discovery(
+            "NO PHPUNIT TEST FILES DISCOVERED\nSkipping PHPUnit tests",
+            ""
+        ));
+        assert!(!phpunit_no_discovery("smoke scripts passed", ""));
+    }
+
+    #[test]
+    fn setting_truthy_accepts_boolean_spellings() {
+        let settings = vec![(REQUIRE_PHPUNIT_TESTS_SETTING.to_string(), "yes".to_string())];
+        assert!(setting_truthy(&settings, REQUIRE_PHPUNIT_TESTS_SETTING));
     }
 
     #[test]

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -43,6 +43,12 @@ fn test_command_args(root: &Path) -> TestArgs {
     }
 }
 
+fn test_command_args_with_setting(root: &Path, key: &str, value: &str) -> TestArgs {
+    let mut args = test_command_args(root);
+    args.setting_args.setting = vec![(key.to_string(), value.to_string())];
+    args
+}
+
 fn write_component_script(root: &Path, name: &str, body: &str) {
     let script_dir = root.join("scripts");
     fs::create_dir_all(&script_dir).expect("script dir should be created");
@@ -209,5 +215,123 @@ fn command_dispatch_falls_back_to_extension_when_component_script_is_absent() {
         assert_eq!(exit_code, 0);
         assert!(output.passed);
         assert!(dir.path().join("extension-marker").exists());
+    });
+}
+
+#[test]
+fn wordpress_phpunit_no_discovery_is_neutral_skipped() {
+    with_isolated_home(|home| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+  "id": "fixture",
+  "extensions": { "wordpress": {} }
+}"#,
+        )
+        .expect("homeboy.json should be written");
+
+        let extension_dir = home
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("extensions")
+            .join("wordpress");
+        fs::create_dir_all(&extension_dir).expect("extension dir should be created");
+        fs::write(
+            extension_dir.join("wordpress.json"),
+            r#"{
+  "name": "WordPress",
+  "version": "1.0.0",
+  "test": { "extension_script": "test.sh" }
+}"#,
+        )
+        .expect("extension manifest should be written");
+        let extension_script = extension_dir.join("test.sh");
+        fs::write(
+            &extension_script,
+            "#!/bin/sh\nprintf 'Plugin activation/install passed\\nNO PHPUNIT TEST FILES DISCOVERED\\nSkipping PHPUnit tests: no files matched the WordPress runner discovery contract.\\n'\n",
+        )
+        .expect("extension script should be written");
+        let mut perms = fs::metadata(&extension_script)
+            .expect("extension script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&extension_script, perms)
+            .expect("extension script should be executable");
+
+        let (output, exit_code) = run_test(test_command_args(dir.path()), &GlobalArgs {})
+            .expect("extension test should run");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.passed);
+        assert_eq!(output.status, "skipped");
+        assert_eq!(output.test_counts.expect("test counts").total, 0);
+        let phase = output.phase.expect("phase report");
+        assert_eq!(phase.status, crate::extension::PhaseStatus::Skipped);
+        assert_eq!(
+            phase.summary,
+            "activation/install passed; PHPUnit discovery found zero tests; no PHPUnit assertions ran"
+        );
+    });
+}
+
+#[test]
+fn wordpress_phpunit_no_discovery_can_be_required_as_failure() {
+    with_isolated_home(|home| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+  "id": "fixture",
+  "extensions": { "wordpress": {} }
+}"#,
+        )
+        .expect("homeboy.json should be written");
+
+        let extension_dir = home
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("extensions")
+            .join("wordpress");
+        fs::create_dir_all(&extension_dir).expect("extension dir should be created");
+        fs::write(
+            extension_dir.join("wordpress.json"),
+            r#"{
+  "name": "WordPress",
+  "version": "1.0.0",
+  "test": { "extension_script": "test.sh" }
+}"#,
+        )
+        .expect("extension manifest should be written");
+        let extension_script = extension_dir.join("test.sh");
+        fs::write(
+            &extension_script,
+            "#!/bin/sh\nprintf 'NO PHPUNIT TEST FILES DISCOVERED\\n'\n",
+        )
+        .expect("extension script should be written");
+        let mut perms = fs::metadata(&extension_script)
+            .expect("extension script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&extension_script, perms)
+            .expect("extension script should be executable");
+
+        let (output, exit_code) = run_test(
+            test_command_args_with_setting(dir.path(), "require_phpunit_tests", "true"),
+            &GlobalArgs {},
+        )
+        .expect("extension test should run");
+
+        assert_eq!(exit_code, 1);
+        assert!(!output.passed);
+        assert_eq!(output.status, "failed");
+        assert_eq!(output.test_counts.expect("test counts").total, 0);
+        let failure = output.failure.expect("failure report");
+        assert_eq!(
+            failure.category,
+            crate::extension::PhaseFailureCategory::Findings
+        );
     });
 }


### PR DESCRIPTION
## Summary
- Represents zero PHPUnit discovery as skipped/neutral structured output instead of plain pass.
- Updates the human summary to make clear that activation/install passed but no PHPUnit assertions ran.
- Adds an opt-in `require_phpunit_tests=true` failure path through the existing settings surface.

Fixes #2438.

## Testing
- `cargo test phpunit_no_discovery -- --nocapture`
- `cargo test core::extension::test:: -- --nocapture`
- `cargo test component_script -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and tested the PHPUnit no-discovery status change under Chris's review.