### PR TITLE
Plan release command preflights

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -1,6 +1,7 @@
 use crate::component::Component;
 use crate::error::{Error, Result};
 use crate::extension::ExtensionManifest;
+use crate::git;
 use crate::release::executor;
 use crate::release::types::{
     ReleaseOptions, ReleasePlanStatus, ReleasePlanStep, ReleaseState, ReleaseStepResult,
@@ -26,6 +27,7 @@ pub(super) fn execute_release_plan_step(
     }
 
     match step.step_type.as_str() {
+        "preflight.git_identity" => configure_git_identity(step, context).map(Some),
         "version" => executor::run_version(
             context.component,
             &mut context.state,
@@ -123,7 +125,41 @@ pub(super) fn execute_release_plan_step(
 }
 
 fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
-    step.step_type.starts_with("preflight.") || step.step_type == "changelog.generate"
+    (step.step_type.starts_with("preflight.") && step.step_type != "preflight.git_identity")
+        || step.step_type == "changelog.generate"
+}
+
+fn configure_git_identity(
+    step: &ReleasePlanStep,
+    context: &ReleaseExecutionContext,
+) -> Result<ReleaseStepResult> {
+    let identity_value = step
+        .config
+        .get("identity")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| Error::internal_unexpected("release git identity step missing identity"))?;
+    let identity = git::parse_git_identity(Some(identity_value));
+    git::configure_identity(&context.component.local_path, &identity)?;
+    log_status!(
+        "release",
+        "Git identity: {} <{}>",
+        identity.name,
+        identity.email
+    );
+
+    Ok(ReleaseStepResult {
+        id: step.id.clone(),
+        step_type: step.step_type.clone(),
+        status: ReleaseStepStatus::Success,
+        missing: Vec::new(),
+        warnings: Vec::new(),
+        hints: Vec::new(),
+        data: Some(serde_json::json!({
+            "name": identity.name,
+            "email": identity.email,
+        })),
+        error: None,
+    })
 }
 
 pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
@@ -184,6 +220,9 @@ mod tests {
         ];
 
         assert!(steps.iter().all(release_step_is_plan_only));
+        assert!(!release_step_is_plan_only(&plan_step(
+            "preflight.git_identity"
+        )));
         assert!(!release_step_is_plan_only(&plan_step("deploy")));
     }
 

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -5,6 +5,7 @@
 //! previewed steps match execution.
 
 use crate::component::{self, Component};
+use crate::engine::command;
 use crate::engine::local_files::FileSystem;
 use crate::engine::run_dir::{self, RunDir};
 use crate::engine::validation::ValidationCollector;
@@ -162,6 +163,14 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let extensions = resolve_extensions(&component)?;
 
     let mut v = ValidationCollector::new();
+
+    // === Stage -0.5: Default branch guard ===
+    // Real releases must happen from the default branch. Dry-runs are allowed
+    // from feature branches so operators can preview a release before merging.
+    if !options.dry_run {
+        v.capture(validate_default_branch(&component), "default_branch");
+        v.finish_if_errors()?;
+    }
 
     // === Stage 0: Working-tree check (fail-fast) ===
     //
@@ -570,6 +579,50 @@ fn validate_remote_sync(component: &Component) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub(crate) fn validate_default_branch(component: &Component) -> Result<()> {
+    let current_branch = command::run_in_optional(
+        &component.local_path,
+        "git",
+        &["symbolic-ref", "--short", "HEAD"],
+    )
+    .ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "release",
+            "Refusing to release from detached HEAD",
+            None,
+            Some(vec![
+                "Check out the default branch before releasing".to_string()
+            ]),
+        )
+    })?;
+
+    let default_branch = command::run_in_optional(
+        &component.local_path,
+        "git",
+        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+    )
+    .map(|value| value.trim().trim_start_matches("origin/").to_string())
+    .filter(|value| !value.is_empty())
+    .unwrap_or_else(|| "main".to_string());
+
+    if current_branch == default_branch {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "release",
+        format!(
+            "Refusing to release from non-default branch '{}' (default: '{}')",
+            current_branch, default_branch
+        ),
+        None,
+        Some(vec![
+            format!("Check out '{}' before releasing", default_branch),
+            "If you only want a preview, use --dry-run".to_string(),
+        ]),
+    ))
 }
 
 /// Run code quality checks (lint + test) via the component's extension.
@@ -1111,7 +1164,7 @@ mod tests {
         code_quality_failure_message, ensure_changelog_initialized, filter_homeboy_managed,
         get_release_allowed_files, get_unexpected_uncommitted_files, is_homeboy_managed_path,
         is_runner_infrastructure_failure, read_changelog_for_release, strip_pr_reference,
-        validate_release_version_floor,
+        validate_default_branch, validate_release_version_floor,
     };
     use crate::component::Component;
     use crate::extension::RunnerOutput;
@@ -1123,6 +1176,52 @@ mod tests {
             subject: subject.to_string(),
             category,
         }
+    }
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_component(dir: &std::path::Path) -> Component {
+        Component {
+            id: "fixture".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_validate_default_branch_allows_default_branch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q"]);
+        run_git(dir, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+        validate_default_branch(&git_component(dir)).expect("main should be allowed");
+    }
+
+    #[test]
+    fn test_validate_default_branch_blocks_non_default_branch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q"]);
+        run_git(dir, &["symbolic-ref", "HEAD", "refs/heads/feature"]);
+
+        let err = validate_default_branch(&git_component(dir)).expect_err("feature should fail");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("non-default branch 'feature'"));
     }
 
     #[test]

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -78,10 +78,17 @@ fn string_config(key: &str, value: impl Into<String>) -> StepConfig {
 pub(super) fn build_preflight_steps(options: &ReleaseOptions) -> Vec<ReleasePlanStep> {
     let mut steps = vec![
         ready_step(
+            "preflight.default_branch",
+            "preflight.default_branch",
+            "Validate default branch",
+            vec![],
+            StepConfig::new(),
+        ),
+        ready_step(
             "preflight.working_tree",
             "preflight.working_tree",
             "Validate working tree",
-            vec![],
+            vec!["preflight.git_identity".to_string()],
             StepConfig::new(),
         ),
         ready_step(
@@ -92,6 +99,29 @@ pub(super) fn build_preflight_steps(options: &ReleaseOptions) -> Vec<ReleasePlan
             StepConfig::new(),
         ),
     ];
+
+    if let Some(identity) = options.git_identity.as_ref() {
+        steps.insert(
+            1,
+            ready_step(
+                "preflight.git_identity",
+                "preflight.git_identity",
+                "Configure git identity",
+                vec!["preflight.default_branch".to_string()],
+                string_config("identity", identity.as_str()),
+            ),
+        );
+    } else {
+        steps.insert(
+            1,
+            disabled_step(
+                "preflight.git_identity",
+                "preflight.git_identity",
+                "Configure git identity",
+                string_config("reason", "not-requested"),
+            ),
+        );
+    }
 
     if options.skip_checks {
         steps.push(disabled_step(
@@ -348,13 +378,42 @@ mod tests {
         assert_eq!(
             ids,
             vec![
+                "preflight.default_branch",
+                "preflight.git_identity",
                 "preflight.working_tree",
                 "preflight.remote_sync",
                 "preflight.quality",
                 "preflight.changelog_bootstrap"
             ]
         );
-        assert_eq!(steps[2].status, ReleasePlanStatus::Ready);
+        assert_eq!(steps[0].status, ReleasePlanStatus::Ready);
+        assert_eq!(steps[1].status, ReleasePlanStatus::Disabled);
+        assert_eq!(steps[2].needs, vec!["preflight.git_identity"]);
+    }
+
+    #[test]
+    fn release_plan_marks_git_identity_ready_when_requested() {
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            git_identity: Some("Release Bot <bot@example.com>".to_string()),
+            ..Default::default()
+        };
+
+        let steps = build_preflight_steps(&options);
+        let identity = steps
+            .iter()
+            .find(|step| step.id == "preflight.git_identity")
+            .expect("git identity step");
+
+        assert_eq!(identity.status, ReleasePlanStatus::Ready);
+        assert_eq!(identity.needs, vec!["preflight.default_branch"]);
+        assert_eq!(
+            identity
+                .config
+                .get("identity")
+                .and_then(|value| value.as_str()),
+            Some("Release Bot <bot@example.com>")
+        );
     }
 
     #[test]

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -171,6 +171,9 @@ pub struct ReleaseOptions {
     /// Use when another pipeline (CI, semantic-release, etc.) already owns that step.
     #[serde(default)]
     pub skip_github_release: bool,
+    /// Git identity for release commits: "bot", "Name <email>", or None (use existing config).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_identity: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -1,4 +1,3 @@
-use crate::engine::command;
 use crate::error::{Error, Result};
 use crate::git;
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -24,19 +23,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     )?;
 
     if !input.dry_run {
-        ensure_release_on_default_branch(&component.local_path)?;
-
-        // Configure git identity for release commits/tags
-        if let Some(ref identity_str) = input.git_identity {
-            let identity = git::parse_git_identity(Some(identity_str));
-            git::configure_identity(&component.local_path, &identity)?;
-            log_status!(
-                "release",
-                "Git identity: {} <{}>",
-                identity.name,
-                identity.email
-            );
-        }
+        super::pipeline::validate_default_branch(&component)?;
     }
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
@@ -218,6 +205,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         skip_publish: input.skip_publish,
         deploy: input.deploy,
         skip_github_release: input.skip_github_release,
+        git_identity: input.git_identity.clone(),
     };
 
     if options.dry_run {
@@ -331,47 +319,6 @@ fn format_tag(version: &str, monorepo: Option<&git::MonorepoContext>) -> String 
         Some(ctx) => ctx.format_tag(version),
         None => format!("v{}", version),
     }
-}
-
-fn ensure_release_on_default_branch(local_path: &str) -> Result<()> {
-    let current_branch =
-        command::run_in_optional(local_path, "git", &["symbolic-ref", "--short", "HEAD"])
-            .ok_or_else(|| {
-                Error::validation_invalid_argument(
-                    "release",
-                    "Refusing to release from detached HEAD",
-                    None,
-                    Some(vec![
-                        "Check out the default branch before releasing".to_string()
-                    ]),
-                )
-            })?;
-
-    let default_branch = command::run_in_optional(
-        local_path,
-        "git",
-        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-    )
-    .map(|value| value.trim().trim_start_matches("origin/").to_string())
-    .filter(|value| !value.is_empty())
-    .unwrap_or_else(|| "main".to_string());
-
-    if current_branch == default_branch {
-        return Ok(());
-    }
-
-    Err(Error::validation_invalid_argument(
-        "release",
-        format!(
-            "Refusing to release from non-default branch '{}' (default: '{}')",
-            current_branch, default_branch
-        ),
-        None,
-        Some(vec![
-            format!("Check out '{}' before releasing", default_branch),
-            "If you only want a preview, use --dry-run".to_string(),
-        ]),
-    ))
 }
 
 fn extract_new_version_from_plan(plan: &ReleasePlan) -> Option<String> {


### PR DESCRIPTION
## Summary
- Move the default-branch release guard into the release planning layer and expose it as `preflight.default_branch`.
- Carry `--git-identity` through `ReleaseOptions` and execute it as `preflight.git_identity` before release mutations.
- Keep the existing early non-default-branch refusal before bump/no-releasable handling while making the same guard visible in release plans.

## Testing
- `cargo fmt`
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `cargo test` (`2877 passed, 0 failed, 1 ignored`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the release preflight planning changes and test coverage; Chris remains responsible for review and validation.