### PR TITLE
Expose release quality plan steps

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -215,7 +215,9 @@ mod tests {
     #[test]
     fn test_release_step_is_plan_only() {
         let steps = [
-            plan_step("preflight.quality"),
+            plan_step("preflight.audit"),
+            plan_step("preflight.lint"),
+            plan_step("preflight.test"),
             plan_step("changelog.generate"),
         ];
 

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -190,11 +190,23 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     // === Stage 0.5: Remote sync check (preflight) ===
     v.capture(validate_remote_sync(&component), "remote_sync");
 
-    // === Stage 0.6: Code quality checks (lint + test) ===
+    // === Stage 0.6: Code quality checks ===
     if options.skip_checks {
         log_status!("release", "Skipping code quality checks (--skip-checks)");
     } else {
-        v.capture(validate_code_quality(&component), "code_quality");
+        let lint_ran = v
+            .capture(validate_lint_quality(&component), "lint")
+            .unwrap_or(false);
+        let tests_ran = v
+            .capture(validate_test_quality(&component), "test")
+            .unwrap_or(false);
+
+        if !lint_ran && !tests_ran {
+            log_status!(
+                "release",
+                "No linked extensions provide lint/test scripts — skipping code quality checks"
+            );
+        }
     }
 
     // === Stage 0.7: Auto-initialize changelog (first-release bootstrap) ===
@@ -625,152 +637,131 @@ pub(crate) fn validate_default_branch(component: &Component) -> Result<()> {
     ))
 }
 
-/// Run code quality checks (lint + test) via the component's extension.
+/// Run release lint via the component's extension.
 ///
-/// Resolves the extension for the component, then runs lint and test scripts
-/// if the extension provides them. If no extension is configured or the extension
-/// doesn't provide lint/test, those checks are silently skipped.
-///
-/// This is the pre-release quality gate — ensures code passes lint and tests
-/// before any version bump or tag is created.
-fn validate_code_quality(component: &Component) -> Result<()> {
+/// Returns whether a lint command was available and executed. Missing lint
+/// support is not a release blocker because not every extension provides it.
+fn validate_lint_quality(component: &Component) -> Result<bool> {
     let lint_context = extension::lint::resolve_lint_command(component);
+
+    let Ok(lint_context) = lint_context else {
+        return Ok(false);
+    };
+
+    log_status!("release", "Running lint ({})...", lint_context.extension_id);
+
+    let release_run_dir = RunDir::create()?;
+    let lint_findings_file = release_run_dir.step_file(run_dir::files::LINT_FINDINGS);
+
+    let output = extension::lint::build_lint_runner(
+        component,
+        None,
+        &[],
+        false,
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+        None,
+        &release_run_dir,
+    )
+    .and_then(|runner| runner.run())
+    .map_err(|e| quality_error("lint", format!("Lint runner error: {}", e)))?;
+
+    let lint_passed = if output.success {
+        true
+    } else {
+        let source_path = std::path::Path::new(&component.local_path);
+        let findings = crate::extension::lint::baseline::parse_findings_file(&lint_findings_file)
+            .unwrap_or_default();
+
+        if let Some(baseline) = crate::extension::lint::baseline::load_baseline(source_path) {
+            let comparison = crate::extension::lint::baseline::compare(&findings, &baseline);
+            if comparison.drift_increased {
+                log_status!(
+                    "release",
+                    "Lint baseline drift increased: {} new finding(s)",
+                    comparison.new_items.len()
+                );
+                false
+            } else {
+                log_status!(
+                    "release",
+                    "Lint has known findings but no new drift (baseline honored)"
+                );
+                true
+            }
+        } else {
+            false
+        }
+    };
+
+    if lint_passed {
+        log_status!("release", "Lint passed");
+        Ok(true)
+    } else {
+        Err(quality_error(
+            "lint",
+            code_quality_failure_message("Lint", &output),
+        ))
+    }
+}
+
+/// Run release tests via the component's extension.
+///
+/// Returns whether a test command was available and executed. Missing test
+/// support is not a release blocker because not every extension provides it.
+fn validate_test_quality(component: &Component) -> Result<bool> {
     let test_context = extension::test::resolve_test_command(component);
 
-    let mut checks_run = 0;
-    let mut failures = Vec::new();
+    let Ok(test_context) = test_context else {
+        return Ok(false);
+    };
 
-    if let Ok(lint_context) = lint_context {
-        log_status!("release", "Running lint ({})...", lint_context.extension_id);
+    log_status!(
+        "release",
+        "Running tests ({})...",
+        test_context.extension_id
+    );
+    let test_run_dir = RunDir::create()?;
+    let output = extension::test::build_test_runner(
+        component,
+        None,
+        &[],
+        false,
+        false,
+        None,
+        None,
+        &test_run_dir,
+    )
+    .and_then(|runner| runner.run())
+    .map_err(|e| quality_error("test", format!("Test runner error: {}", e)))?;
 
-        let release_run_dir = RunDir::create()?;
-        let lint_findings_file = release_run_dir.step_file(run_dir::files::LINT_FINDINGS);
-
-        match extension::lint::build_lint_runner(
-            component,
-            None,
-            &[],
-            false,
-            None,
-            None,
-            false,
-            None,
-            None,
-            None,
-            None,
-            &release_run_dir,
-        )
-        .and_then(|runner| runner.run())
-        {
-            Ok(output) => {
-                checks_run += 1;
-
-                // Check baseline before declaring pass/fail
-                let lint_passed = if output.success {
-                    true
-                } else {
-                    // Lint failed — but check if baseline says drift didn't increase
-                    let source_path = std::path::Path::new(&component.local_path);
-                    let findings =
-                        crate::extension::lint::baseline::parse_findings_file(&lint_findings_file)
-                            .unwrap_or_default();
-
-                    if let Some(baseline) =
-                        crate::extension::lint::baseline::load_baseline(source_path)
-                    {
-                        let comparison =
-                            crate::extension::lint::baseline::compare(&findings, &baseline);
-                        if comparison.drift_increased {
-                            log_status!(
-                                "release",
-                                "Lint baseline drift increased: {} new finding(s)",
-                                comparison.new_items.len()
-                            );
-                            false
-                        } else {
-                            log_status!(
-                                "release",
-                                "Lint has known findings but no new drift (baseline honored)"
-                            );
-                            true
-                        }
-                    } else {
-                        // No baseline — raw exit code is authoritative
-                        false
-                    }
-                };
-
-                if lint_passed {
-                    log_status!("release", "Lint passed");
-                } else {
-                    failures.push(code_quality_failure_message("Lint", &output));
-                }
-            }
-            Err(e) => {
-                failures.push(format!("Lint runner error: {}", e));
-            }
-        }
+    if output.success {
+        log_status!("release", "Tests passed");
+        Ok(true)
+    } else {
+        Err(quality_error(
+            "test",
+            code_quality_failure_message("Tests", &output),
+        ))
     }
+}
 
-    if let Ok(test_context) = test_context {
-        log_status!(
-            "release",
-            "Running tests ({})...",
-            test_context.extension_id
-        );
-        let test_run_dir = RunDir::create()?;
-        match extension::test::build_test_runner(
-            component,
-            None,
-            &[],
-            false,
-            false,
-            None,
-            None,
-            &test_run_dir,
-        )
-        .and_then(|runner| runner.run())
-        {
-            Ok(output) if output.success => {
-                log_status!("release", "Tests passed");
-                checks_run += 1;
-            }
-            Ok(output) => {
-                checks_run += 1;
-                failures.push(code_quality_failure_message("Tests", &output));
-            }
-            Err(e) => {
-                failures.push(format!("Test runner error: {}", e));
-            }
-        }
-    }
+fn quality_error(field: &str, message: String) -> Error {
+    log_status!("release", "Code quality check failed: {}", message);
 
-    if checks_run == 0 {
-        log_status!(
-            "release",
-            "No linked extensions provide lint/test scripts — skipping code quality checks"
-        );
-        return Ok(());
-    }
-
-    if failures.is_empty() {
-        return Ok(());
-    }
-
-    log_status!("release", "Code quality check summary:");
-    for failure in &failures {
-        log_status!("release", "  - {}", failure);
-    }
-
-    Err(Error::validation_invalid_argument(
-        "code_quality",
-        failures.join("; "),
+    Error::validation_invalid_argument(
+        field,
+        message,
         None,
         Some(vec![
-            "Fix the issues above before releasing".to_string(),
+            "Fix the issue above before releasing".to_string(),
             "To bypass: homeboy release <component> --skip-checks".to_string(),
         ]),
-    ))
+    )
 }
 
 fn code_quality_failure_message(check: &str, output: &extension::RunnerOutput) -> String {

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -129,22 +129,7 @@ pub(super) fn build_preflight_steps(
         );
     }
 
-    if options.skip_checks {
-        steps.push(disabled_step(
-            "preflight.quality",
-            "preflight.quality",
-            "Run release quality checks",
-            string_config("reason", "--skip-checks"),
-        ));
-    } else {
-        steps.push(ready_step(
-            "preflight.quality",
-            "preflight.quality",
-            "Run release quality checks",
-            vec!["preflight.bump_policy".to_string()],
-            StepConfig::new(),
-        ));
-    }
+    steps.extend(build_quality_steps(options));
 
     let mut changelog_config = StepConfig::new();
     changelog_config.insert(
@@ -155,11 +140,59 @@ pub(super) fn build_preflight_steps(
         "preflight.changelog_bootstrap",
         "preflight.changelog_bootstrap",
         "Ensure changelog exists",
-        vec!["preflight.quality".to_string()],
+        vec!["preflight.test".to_string()],
         changelog_config,
     ));
 
     steps
+}
+
+fn build_quality_steps(options: &ReleaseOptions) -> Vec<ReleasePlanStep> {
+    if options.skip_checks {
+        return vec![
+            disabled_step(
+                "preflight.audit",
+                "preflight.audit",
+                "Run release audit",
+                string_config("reason", "--skip-checks"),
+            ),
+            disabled_step(
+                "preflight.lint",
+                "preflight.lint",
+                "Run release lint",
+                string_config("reason", "--skip-checks"),
+            ),
+            disabled_step(
+                "preflight.test",
+                "preflight.test",
+                "Run release tests",
+                string_config("reason", "--skip-checks"),
+            ),
+        ];
+    }
+
+    vec![
+        disabled_step(
+            "preflight.audit",
+            "preflight.audit",
+            "Run release audit",
+            string_config("reason", "no-release-audit-policy"),
+        ),
+        ready_step(
+            "preflight.lint",
+            "preflight.lint",
+            "Run release lint",
+            vec!["preflight.bump_policy".to_string()],
+            StepConfig::new(),
+        ),
+        ready_step(
+            "preflight.test",
+            "preflight.test",
+            "Run release tests",
+            vec!["preflight.lint".to_string()],
+            StepConfig::new(),
+        ),
+    ]
 }
 
 fn build_bump_policy_step(
@@ -442,7 +475,9 @@ mod tests {
                 "preflight.working_tree",
                 "preflight.remote_sync",
                 "preflight.bump_policy",
-                "preflight.quality",
+                "preflight.audit",
+                "preflight.lint",
+                "preflight.test",
                 "preflight.changelog_bootstrap"
             ]
         );
@@ -477,7 +512,7 @@ mod tests {
     }
 
     #[test]
-    fn release_plan_marks_quality_preflight_disabled_when_checks_are_skipped() {
+    fn release_plan_marks_quality_preflights_disabled_when_checks_are_skipped() {
         let options = ReleaseOptions {
             bump_type: "patch".to_string(),
             skip_checks: true,
@@ -485,19 +520,58 @@ mod tests {
         };
 
         let steps = build_preflight_steps(&options, None);
-        let quality = steps
-            .iter()
-            .find(|step| step.id == "preflight.quality")
-            .expect("quality step");
+        for step_id in ["preflight.audit", "preflight.lint", "preflight.test"] {
+            let quality = steps
+                .iter()
+                .find(|step| step.id == step_id)
+                .expect("quality step");
 
-        assert_eq!(quality.status, ReleasePlanStatus::Disabled);
+            assert_eq!(quality.status, ReleasePlanStatus::Disabled);
+            assert_eq!(
+                quality
+                    .config
+                    .get("reason")
+                    .and_then(|value| value.as_str()),
+                Some("--skip-checks")
+            );
+        }
+    }
+
+    #[test]
+    fn release_plan_records_explicit_quality_preflights() {
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+
+        let steps = build_preflight_steps(&options, None);
+        let audit = steps
+            .iter()
+            .find(|step| step.id == "preflight.audit")
+            .expect("audit step");
+        let lint = steps
+            .iter()
+            .find(|step| step.id == "preflight.lint")
+            .expect("lint step");
+        let test = steps
+            .iter()
+            .find(|step| step.id == "preflight.test")
+            .expect("test step");
+        let changelog_bootstrap = steps
+            .iter()
+            .find(|step| step.id == "preflight.changelog_bootstrap")
+            .expect("changelog bootstrap step");
+
+        assert_eq!(audit.status, ReleasePlanStatus::Disabled);
         assert_eq!(
-            quality
-                .config
-                .get("reason")
-                .and_then(|value| value.as_str()),
-            Some("--skip-checks")
+            audit.config.get("reason").and_then(|value| value.as_str()),
+            Some("no-release-audit-policy")
         );
+        assert_eq!(lint.status, ReleasePlanStatus::Ready);
+        assert_eq!(lint.needs, vec!["preflight.bump_policy"]);
+        assert_eq!(test.status, ReleasePlanStatus::Ready);
+        assert_eq!(test.needs, vec!["preflight.lint"]);
+        assert_eq!(changelog_bootstrap.needs, vec!["preflight.test"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replaces the aggregate `preflight.quality` release plan step with explicit `preflight.audit`, `preflight.lint`, and `preflight.test` steps.
- Splits the release quality validation path so lint and test failures are collected under their own validation fields while preserving the existing pre-release quality gate semantics.
- Records release audit as a disabled plan step until a durable release audit policy exists, keeping the larger plan shape visible without silently adding a new release blocker.

Closes part of https://github.com/Extra-Chill/homeboy/issues/2403.

## Testing
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `cargo test` (`2890 passed; 0 failed; 1 ignored`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the release quality plan-step split and validation refactor; Chris owns review and final validation.