### PR TITLE
Expose release changelog contract

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -126,7 +126,9 @@ pub(super) fn execute_release_plan_step(
 
 fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
     (step.step_type.starts_with("preflight.") && step.step_type != "preflight.git_identity")
+        || step.step_type == "changelog.policy"
         || step.step_type == "changelog.generate"
+        || step.step_type == "changelog.finalize"
 }
 
 fn configure_git_identity(
@@ -218,7 +220,9 @@ mod tests {
             plan_step("preflight.audit"),
             plan_step("preflight.lint"),
             plan_step("preflight.test"),
+            plan_step("changelog.policy"),
             plan_step("changelog.generate"),
+            plan_step("changelog.finalize"),
         ];
 
         assert!(steps.iter().all(release_step_is_plan_only));

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -19,10 +19,10 @@ use super::execution_dispatch::{
     execute_release_plan_step, release_step_is_show_stopper, ReleaseExecutionContext,
 };
 use super::pipeline_summary::{build_summary, derive_overall_status};
-use super::plan_steps::{build_preflight_steps, build_release_steps, changelog_entries_to_json};
+use super::plan_steps::{build_preflight_steps, build_release_steps};
 use super::types::{
-    ReleaseOptions, ReleasePlan, ReleaseRun, ReleaseRunResult, ReleaseSemverCommit,
-    ReleaseSemverRecommendation, ReleaseState, ReleaseStepResult,
+    ReleaseChangelogPlan, ReleaseOptions, ReleasePlan, ReleaseRun, ReleaseRunResult,
+    ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseState, ReleaseStepResult,
 };
 
 /// Load a component with portable config fallback when path_override is set.
@@ -104,14 +104,14 @@ pub(crate) fn run_with_plan(
     ))
 }
 
-/// Read the auto-generated changelog entries embedded in the plan's dedicated
-/// changelog step. `plan()` computes them during validation and stashes them
-/// here so `run()` can hand them straight to [`executor::run_version`]
+/// Read the auto-generated changelog entries embedded in the plan's explicit
+/// finalization contract. `plan()` computes them during validation and stashes
+/// them here so `run()` can hand them straight to [`executor::run_version`]
 /// without recomputing.
 fn extract_pending_entries(
     plan: &ReleasePlan,
 ) -> Option<std::collections::HashMap<String, Vec<String>>> {
-    let changelog_step = plan.steps.iter().find(|s| s.id == "changelog.generate")?;
+    let changelog_step = plan.steps.iter().find(|s| s.id == "changelog.finalize")?;
     let value = changelog_step.config.get("entries")?;
     serde_json::from_value(value.clone()).ok()
 }
@@ -345,6 +345,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
 
     let mut warnings = Vec::new();
     let mut hints = Vec::new();
+    let changelog_plan = build_changelog_plan(&component, options, pending_entries)?;
 
     let mut steps = build_preflight_steps(options, semver_recommendation.as_ref());
     steps.extend(build_release_steps(
@@ -352,24 +353,12 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         &extensions,
         &version_info.version,
         &new_version,
+        &changelog_plan,
         options,
         monorepo.as_ref(),
         &mut warnings,
         &mut hints,
     )?);
-
-    if let Some(changelog_step) = steps.iter_mut().find(|s| s.id == "changelog.generate") {
-        changelog_step.config.insert(
-            "entries".to_string(),
-            changelog_entries_to_json(&pending_entries),
-        );
-        changelog_step.config.insert(
-            "entry_count".to_string(),
-            serde_json::Value::Number(serde_json::Number::from(
-                pending_entries.values().map(Vec::len).sum::<usize>() as u64,
-            )),
-        );
-    }
 
     if options.dry_run {
         hints.push("Dry run: no changes will be made".to_string());
@@ -382,6 +371,23 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         semver_recommendation,
         warnings,
         hints,
+    })
+}
+
+fn build_changelog_plan(
+    component: &Component,
+    options: &ReleaseOptions,
+    entries: std::collections::HashMap<String, Vec<String>>,
+) -> Result<ReleaseChangelogPlan> {
+    let path = changelog::resolve_changelog_path(component)?;
+    let entry_count = entries.values().map(Vec::len).sum();
+
+    Ok(ReleaseChangelogPlan {
+        policy: "generated".to_string(),
+        path: path.to_string_lossy().to_string(),
+        dry_run: options.dry_run,
+        entries,
+        entry_count,
     })
 }
 

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -5,17 +5,12 @@ use crate::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
 };
 use crate::release::types::{
-    ReleaseOptions, ReleasePlanStatus, ReleasePlanStep, ReleaseSemverRecommendation,
+    ReleaseChangelogPlan, ReleaseOptions, ReleasePlanStatus, ReleasePlanStep,
+    ReleaseSemverRecommendation,
 };
 use crate::Result;
 
 type StepConfig = std::collections::HashMap<String, serde_json::Value>;
-
-pub(super) fn changelog_entries_to_json(
-    entries: &std::collections::HashMap<String, Vec<String>>,
-) -> serde_json::Value {
-    serde_json::to_value(entries).unwrap_or_default()
-}
 
 /// Return true if this component should get a GitHub Release created.
 ///
@@ -254,6 +249,7 @@ pub(super) fn build_release_steps(
     extensions: &[ExtensionManifest],
     current_version: &str,
     new_version: &str,
+    changelog_plan: &ReleaseChangelogPlan,
     options: &ReleaseOptions,
     monorepo: Option<&git::MonorepoContext>,
     warnings: &mut Vec<String>,
@@ -270,13 +266,7 @@ pub(super) fn build_release_steps(
         );
     }
 
-    steps.push(ready_step(
-        "changelog.generate",
-        "changelog.generate",
-        "Generate changelog entries from commits",
-        vec!["preflight.changelog_bootstrap".to_string()],
-        string_config("policy", "generated"),
-    ));
+    steps.extend(build_changelog_steps(changelog_plan));
 
     let mut version_config = string_config("bump", options.bump_type.clone());
     version_config.insert(
@@ -294,7 +284,7 @@ pub(super) fn build_release_steps(
             "Bump version {} → {} ({})",
             current_version, new_version, options.bump_type
         ),
-        vec!["changelog.generate".to_string()],
+        vec!["changelog.finalize".to_string()],
         version_config,
     ));
 
@@ -434,6 +424,74 @@ pub(super) fn build_release_steps(
     Ok(steps)
 }
 
+fn build_changelog_steps(changelog_plan: &ReleaseChangelogPlan) -> Vec<ReleasePlanStep> {
+    let mut policy_config = StepConfig::new();
+    policy_config.insert(
+        "policy".to_string(),
+        serde_json::Value::String(changelog_plan.policy.clone()),
+    );
+    policy_config.insert(
+        "path".to_string(),
+        serde_json::Value::String(changelog_plan.path.clone()),
+    );
+    policy_config.insert(
+        "dry_run".to_string(),
+        serde_json::Value::Bool(changelog_plan.dry_run),
+    );
+
+    let mut generate_config = StepConfig::new();
+    generate_config.insert(
+        "source".to_string(),
+        serde_json::Value::String("commits".to_string()),
+    );
+    generate_config.insert(
+        "entry_count".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(changelog_plan.entry_count as u64)),
+    );
+
+    let mut finalize_config = StepConfig::new();
+    finalize_config.insert(
+        "path".to_string(),
+        serde_json::Value::String(changelog_plan.path.clone()),
+    );
+    finalize_config.insert(
+        "entries".to_string(),
+        serde_json::to_value(&changelog_plan.entries).unwrap_or_default(),
+    );
+    finalize_config.insert(
+        "entry_count".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(changelog_plan.entry_count as u64)),
+    );
+    finalize_config.insert(
+        "mode".to_string(),
+        serde_json::Value::String("version-step".to_string()),
+    );
+
+    vec![
+        ready_step(
+            "changelog.policy",
+            "changelog.policy",
+            "Resolve changelog policy",
+            vec!["preflight.changelog_bootstrap".to_string()],
+            policy_config,
+        ),
+        ready_step(
+            "changelog.generate",
+            "changelog.generate",
+            "Generate changelog entries from commits",
+            vec!["changelog.policy".to_string()],
+            generate_config,
+        ),
+        ready_step(
+            "changelog.finalize",
+            "changelog.finalize",
+            "Finalize changelog entries into release section",
+            vec!["changelog.generate".to_string()],
+            finalize_config,
+        ),
+    ]
+}
+
 fn string_array_config(key: &str, values: &[String]) -> StepConfig {
     let mut config = StepConfig::new();
     config.insert(
@@ -450,12 +508,11 @@ fn string_array_config(key: &str, values: &[String]) -> StepConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        build_preflight_steps, build_release_steps, changelog_entries_to_json,
-        github_release_applies,
-    };
+    use super::{build_preflight_steps, build_release_steps, github_release_applies};
     use crate::component::Component;
-    use crate::release::types::{ReleaseOptions, ReleasePlanStatus, ReleaseSemverRecommendation};
+    use crate::release::types::{
+        ReleaseChangelogPlan, ReleaseOptions, ReleasePlanStatus, ReleaseSemverRecommendation,
+    };
 
     #[test]
     fn test_build_preflight_steps() {
@@ -672,6 +729,7 @@ mod tests {
             &[extension],
             "1.0.0",
             "1.0.1",
+            &fixture_changelog_plan(),
             &options,
             None,
             &mut warnings,
@@ -680,17 +738,94 @@ mod tests {
         .expect("steps");
 
         let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+        let changelog_policy_index = step_index(&ids, "changelog.policy");
         let changelog_index = step_index(&ids, "changelog.generate");
+        let changelog_finalize_index = step_index(&ids, "changelog.finalize");
         let version_index = step_index(&ids, "version");
         let prepare_index = step_index(&ids, "release.prepare");
         let commit_index = step_index(&ids, "git.commit");
 
+        assert!(changelog_policy_index < changelog_index);
         assert!(changelog_index < version_index);
+        assert!(changelog_finalize_index < version_index);
         assert!(version_index < prepare_index);
         assert!(prepare_index < commit_index);
-        assert_eq!(steps[version_index].needs, vec!["changelog.generate"]);
+        assert_eq!(steps[changelog_index].needs, vec!["changelog.policy"]);
+        assert_eq!(
+            steps[changelog_finalize_index].needs,
+            vec!["changelog.generate"]
+        );
+        assert_eq!(steps[version_index].needs, vec!["changelog.finalize"]);
         assert_eq!(steps[prepare_index].needs, vec!["version"]);
         assert_eq!(steps[commit_index].needs, vec!["release.prepare"]);
+    }
+
+    #[test]
+    fn release_plan_records_changelog_contract() {
+        let component = fixture_component();
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+        let changelog_plan = fixture_changelog_plan();
+
+        let steps = build_release_steps(
+            &component,
+            &[],
+            "1.0.0",
+            "1.0.1",
+            &changelog_plan,
+            &options,
+            None,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
+
+        let policy = steps
+            .iter()
+            .find(|step| step.id == "changelog.policy")
+            .expect("changelog policy step");
+        let generate = steps
+            .iter()
+            .find(|step| step.id == "changelog.generate")
+            .expect("changelog generate step");
+        let finalize = steps
+            .iter()
+            .find(|step| step.id == "changelog.finalize")
+            .expect("changelog finalize step");
+
+        assert_eq!(
+            policy.config.get("policy").and_then(|value| value.as_str()),
+            Some("generated")
+        );
+        assert_eq!(
+            policy.config.get("path").and_then(|value| value.as_str()),
+            Some("CHANGELOG.md")
+        );
+        assert_eq!(
+            generate
+                .config
+                .get("entry_count")
+                .and_then(|value| value.as_u64()),
+            Some(1)
+        );
+        assert_eq!(
+            finalize.config.get("mode").and_then(|value| value.as_str()),
+            Some("version-step")
+        );
+        assert_eq!(
+            finalize
+                .config
+                .get("entries")
+                .and_then(|value| value.as_object())
+                .and_then(|entries| entries.get("Fixed"))
+                .and_then(|value| value.as_array())
+                .map(Vec::len),
+            Some(1)
+        );
     }
 
     #[test]
@@ -709,6 +844,7 @@ mod tests {
             &[],
             "1.0.0",
             "1.0.1",
+            &fixture_changelog_plan(),
             &options,
             None,
             &mut warnings,
@@ -731,18 +867,6 @@ mod tests {
     }
 
     #[test]
-    fn test_changelog_entries_to_json() {
-        let entries = std::collections::HashMap::from([(
-            "added".to_string(),
-            vec!["release plan previews".to_string()],
-        )]);
-
-        let json = changelog_entries_to_json(&entries);
-
-        assert_eq!(json["added"][0], "release plan previews");
-    }
-
-    #[test]
     fn test_github_release_applies() {
         let mut github_component = fixture_component();
         github_component.remote_url =
@@ -760,6 +884,19 @@ mod tests {
             id: "fixture".to_string(),
             local_path: "/tmp/fixture".to_string(),
             ..Default::default()
+        }
+    }
+
+    fn fixture_changelog_plan() -> ReleaseChangelogPlan {
+        ReleaseChangelogPlan {
+            policy: "generated".to_string(),
+            path: "CHANGELOG.md".to_string(),
+            dry_run: false,
+            entries: std::collections::HashMap::from([(
+                "Fixed".to_string(),
+                vec!["Correct release output".to_string()],
+            )]),
+            entry_count: 1,
         }
     }
 

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -41,6 +41,20 @@ pub struct ReleaseSemverRecommendation {
     pub reasons: Vec<String>,
 }
 
+/// Explicit changelog contract carried by the release plan.
+///
+/// Changelog entries are generated during planning so dry-run output and real
+/// release execution share one source of truth. The release executor consumes
+/// this contract when the version step finalizes the changelog on disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseChangelogPlan {
+    pub policy: String,
+    pub path: String,
+    pub dry_run: bool,
+    pub entries: HashMap<String, Vec<String>>,
+    pub entry_count: usize,
+}
+
 /// Run result for a single release. Shape is preserved from the pre-refactor
 /// `ReleaseRun { component_id, enabled, result: PipelineRunResult }` so `--json`
 /// consumers see no change.


### PR DESCRIPTION
## Summary
- Adds an explicit `ReleaseChangelogPlan` contract for generated changelog policy, path, entries, and entry count.
- Splits the release plan changelog path into `changelog.policy`, `changelog.generate`, and `changelog.finalize` steps.
- Moves pending changelog entries out of the generator step and into the finalization contract consumed by the version step.

Closes part of https://github.com/Extra-Chill/homeboy/issues/2403.

## Testing
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `cargo test` (`2890 passed; 0 failed; 1 ignored`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the changelog plan contract and release plan-step wiring; Chris owns review and final validation.