### PR TITLE
Support pinned extension installs

### DIFF
--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -63,12 +63,13 @@ homeboy extension setup <extension_id>
 ### `install`
 
 ```sh
-homeboy extension install <source> [--id <extension_id>] [--replace]
+homeboy extension install <source> [--id <extension_id>] [--ref <git-ref>] [--revision <git-ref>] [--replace]
 ```
 
 Installs a extension into Homeboy's extensions directory.
 
 - If `<source>` is a git URL, Homeboy clones it and writes `sourceUrl` into the installed extension's `<extension_id>.json` manifest.
+- For git URL installs, `--ref` (alias `--revision`) checks out a branch, tag, or commit after cloning. The installed metadata still records the resolved `source_revision` SHA.
 - If `<source>` is a local path, Homeboy symlinks the directory into the extensions directory.
 - By default, install refuses to overwrite an existing extension. Use `--replace` to explicitly replace an existing install or link.
 

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -70,6 +70,9 @@ enum ExtensionCommand {
         /// Override extension id
         #[arg(long)]
         id: Option<String>,
+        /// Git ref to check out for URL installs (branch, tag, or commit)
+        #[arg(long = "ref", alias = "revision")]
+        revision: Option<String>,
         /// Replace an existing extension install/link
         #[arg(long)]
         replace: bool,
@@ -176,8 +179,9 @@ pub fn run(
         ExtensionCommand::Install {
             source,
             id,
+            revision,
             replace,
-        } => install_extension(&source, id, replace),
+        } => install_extension(&source, id, revision, replace),
         ExtensionCommand::Relink {
             extension_id,
             source,
@@ -521,10 +525,12 @@ fn run_extension(
 fn install_extension(
     source: &str,
     id: Option<String>,
+    revision: Option<String>,
     replace: bool,
 ) -> CmdResult<ExtensionOutput> {
     if replace {
-        let result = homeboy::extension::replace(source, id.as_deref())?;
+        let result =
+            homeboy::extension::replace_with_revision(source, id.as_deref(), revision.as_deref())?;
         return Ok((
             ExtensionOutput::Replace {
                 extension_id: result.extension_id,
@@ -538,7 +544,8 @@ fn install_extension(
         ));
     }
 
-    let result = homeboy::extension::install(source, id.as_deref())?;
+    let result =
+        homeboy::extension::install_with_revision(source, id.as_deref(), revision.as_deref())?;
     let linked = is_extension_linked(&result.extension_id);
 
     Ok((

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -1240,7 +1240,7 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn cloned_install_can_checkout_requested_revision() {
+    fn test_install_with_revision() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -192,8 +192,18 @@ fn manifest_path_for_extension(extension_dir: &Path, id: &str) -> PathBuf {
 /// Install a extension from a git URL or link a local directory.
 /// Automatically detects whether source is a URL (git clone) or local path (symlink).
 pub fn install(source: &str, id_override: Option<&str>) -> Result<InstallResult> {
+    install_with_revision(source, id_override, None)
+}
+
+/// Install a extension from a git URL or link a local directory.
+/// Git URL installs optionally check out a branch, tag, or commit after cloning.
+pub fn install_with_revision(
+    source: &str,
+    id_override: Option<&str>,
+    revision: Option<&str>,
+) -> Result<InstallResult> {
     if is_git_url(source) {
-        install_from_url(source, id_override)
+        install_from_url(source, id_override, revision)
     } else {
         install_from_path(source, id_override)
     }
@@ -270,7 +280,11 @@ fn install_configured_extension(source: &str, extension_id: &str) -> Result<Inst
 /// Handles both single-extension repos (manifest at repo root) and monorepos
 /// (manifest in a subdirectory matching the extension ID). For monorepos,
 /// extracts just the target subdirectory.
-fn install_from_url(url: &str, id_override: Option<&str>) -> Result<InstallResult> {
+fn install_from_url(
+    url: &str,
+    id_override: Option<&str>,
+    revision: Option<&str>,
+) -> Result<InstallResult> {
     let extension_id = match id_override {
         Some(id) => slugify_id(id)?,
         None => derive_id_from_url(url)?,
@@ -301,7 +315,7 @@ fn install_from_url(url: &str, id_override: Option<&str>) -> Result<InstallResul
         })?;
     }
 
-    git::clone_repo(url, &temp_dir)?;
+    git::clone_repo_at_ref(url, &temp_dir, revision)?;
 
     // Capture source revision before resolve_cloned_extension may discard .git
     // (monorepo installs extract only the subdirectory, losing git history).
@@ -880,8 +894,8 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        install, install_for_component, is_workdir_clean, load_extension, read_source_revision,
-        source_metadata, update,
+        install, install_for_component, install_with_revision, is_workdir_clean, load_extension,
+        read_source_revision, source_metadata, update,
     };
     use crate::component;
     use crate::extension::update_all;
@@ -972,6 +986,20 @@ mod tests {
                     message,
                 ],
             )
+    }
+
+    fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     fn prepare_git_extension_repo(repo: &Path, extension_id: &str) -> Option<TempDir> {
@@ -1207,6 +1235,82 @@ exec '{}' "$@"
                 read_source_revision("wordpress"),
                 result.source_revision,
                 "monorepo installs keep the stored source revision after .git is discarded"
+            );
+        });
+    }
+
+    #[test]
+    fn cloned_install_can_checkout_requested_revision() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let remote = match prepare_git_extension_repo(&source, "wordpress") {
+                Some(remote) => remote,
+                None => return,
+            };
+            let pinned_revision = match git_output(&source, &["rev-parse", "--short", "HEAD"]) {
+                Some(revision) => revision,
+                None => return,
+            };
+
+            write_extension_fixture_with_version(&source, "wordpress", "2.0.0");
+            assert!(commit_all(&source, "update extension"));
+            assert!(run_git(&source, &["push", "origin", "HEAD"]));
+            let remote_url = remote.path().join("extension.git");
+
+            let result = install_with_revision(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                Some(&pinned_revision),
+            )
+            .expect("install pinned revision");
+
+            let installed = load_extension("wordpress").expect("installed extension");
+            assert_eq!(installed.version, "1.0.0");
+            assert_eq!(
+                result.source_revision.as_deref(),
+                Some(pinned_revision.as_str())
+            );
+            assert_eq!(
+                read_source_revision("wordpress").as_deref(),
+                Some(pinned_revision.as_str())
+            );
+        });
+    }
+
+    #[test]
+    fn cloned_install_can_checkout_requested_branch() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let remote = match prepare_git_extension_repo(&source, "wordpress") {
+                Some(remote) => remote,
+                None => return,
+            };
+            assert!(run_git(&source, &["checkout", "-b", "next-extension"]));
+            write_extension_fixture_with_version(&source, "wordpress", "2.0.0");
+            assert!(commit_all(&source, "branch extension update"));
+            assert!(run_git(&source, &["push", "origin", "next-extension"]));
+            let branch_revision = match git_output(&source, &["rev-parse", "--short", "HEAD"]) {
+                Some(revision) => revision,
+                None => return,
+            };
+            let remote_url = remote.path().join("extension.git");
+
+            let result = install_with_revision(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                Some("next-extension"),
+            )
+            .expect("install branch revision");
+
+            let installed = load_extension("wordpress").expect("installed extension");
+            assert_eq!(installed.version, "2.0.0");
+            assert_eq!(
+                result.source_revision.as_deref(),
+                Some(branch_revision.as_str())
             );
         });
     }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -58,11 +58,11 @@ pub use scope::ExtensionScope;
 // Re-export lifecycle types and functions
 pub use lifecycle::source_metadata::SourceMetadataRepair;
 pub use lifecycle::{
-    check_update_available, derive_id_from_url, install, install_for_component, is_git_url,
-    read_source_revision, slugify_id, uninstall, update, InstallForComponentResult, InstallResult,
-    UpdateAvailable, UpdateResult,
+    check_update_available, derive_id_from_url, install, install_for_component,
+    install_with_revision, is_git_url, read_source_revision, slugify_id, uninstall, update,
+    InstallForComponentResult, InstallResult, UpdateAvailable, UpdateResult,
 };
-pub use repair::{relink, replace, ReplaceResult};
+pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
 
 pub(crate) fn stderr_tail(stderr: &str) -> String {
     const MAX_LINES: usize = 20;

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -299,7 +299,7 @@ fn clean_replace_temp(path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{relink, replace};
+    use super::{relink, replace, replace_with_revision};
     use crate::extension::{install, load_extension};
     use crate::test_support::with_isolated_home;
     use std::fs;
@@ -350,6 +350,20 @@ mod tests {
                     message,
                 ],
             )
+    }
+
+    fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     fn prepare_git_extension_repo(repo: &Path, extension_id: &str) -> Option<TempDir> {
@@ -458,6 +472,45 @@ mod tests {
 
             let extension = load_extension("swift").expect("load replaced extension");
             assert_eq!(extension.version, "2.0.0");
+        });
+    }
+
+    #[test]
+    fn test_replace_with_revision() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            let remote = match prepare_git_extension_repo(&source, "swift") {
+                Some(remote) => remote,
+                None => return,
+            };
+            let pinned_revision = match git_output(&source, &["rev-parse", "--short", "HEAD"]) {
+                Some(revision) => revision,
+                None => return,
+            };
+            let remote_url = remote.path().join("extension.git");
+
+            install(&remote_url.to_string_lossy(), Some("swift"))
+                .expect("install copied extension");
+
+            write_extension_fixture_with_version(&source, "swift", "2.0.0");
+            assert!(commit_all(&source, "update extension"));
+            assert!(run_git(&source, &["push", "origin", "HEAD"]));
+
+            let result = replace_with_revision(
+                &remote_url.to_string_lossy(),
+                Some("swift"),
+                Some(&pinned_revision),
+            )
+            .expect("replace copied extension at pinned revision");
+
+            let extension = load_extension("swift").expect("load replaced extension");
+            assert_eq!(extension.version, "1.0.0");
+            assert_eq!(
+                result.source_revision.as_deref(),
+                Some(pinned_revision.as_str())
+            );
         });
     }
 }

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -22,8 +22,16 @@ pub struct ReplaceResult {
 }
 
 pub fn replace(source: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
+    replace_with_revision(source, id_override, None)
+}
+
+pub fn replace_with_revision(
+    source: &str,
+    id_override: Option<&str>,
+    revision: Option<&str>,
+) -> Result<ReplaceResult> {
     if is_git_url(source) {
-        replace_from_url(source, id_override)
+        replace_from_url(source, id_override, revision)
     } else {
         replace_from_path(source, id_override, false)
     }
@@ -33,7 +41,11 @@ pub fn relink(extension_id: &str, source: &str) -> Result<ReplaceResult> {
     replace_from_path(source, Some(extension_id), true)
 }
 
-fn replace_from_url(url: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
+fn replace_from_url(
+    url: &str,
+    id_override: Option<&str>,
+    revision: Option<&str>,
+) -> Result<ReplaceResult> {
     let extension_id = match id_override {
         Some(id) => slugify_id(id)?,
         None => derive_id_from_url(url)?,
@@ -56,7 +68,7 @@ fn replace_from_url(url: &str, id_override: Option<&str>) -> Result<ReplaceResul
     clean_replace_temp(&staged_dir)?;
     clean_replace_temp(&backup_dir)?;
 
-    git::clone_repo(url, &clone_dir)?;
+    git::clone_repo_at_ref(url, &clone_dir, revision)?;
     let source_revision = get_short_head_revision(&clone_dir);
 
     let result = resolve_cloned_extension(&clone_dir, &extension_id, &staged_dir, url);

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -15,6 +15,23 @@ pub fn clone_repo(url: &str, target_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Clone a git repository to a target directory and check out a requested ref.
+pub fn clone_repo_at_ref(url: &str, target_dir: &Path, revision: Option<&str>) -> Result<()> {
+    clone_repo(url, target_dir)?;
+
+    if let Some(revision) = revision {
+        command::run_in(
+            &target_dir.to_string_lossy(),
+            "git",
+            &["checkout", "--quiet", revision],
+            "git checkout",
+        )
+        .map_err(|e| Error::git_command_failed(e.to_string()))?;
+    }
+
+    Ok(())
+}
+
 /// Pull latest changes in a git repository.
 pub fn pull_repo(repo_dir: &Path) -> Result<()> {
     command::run_in(&repo_dir.to_string_lossy(), "git", &["pull"], "git pull")


### PR DESCRIPTION
## Summary
- Add `--ref` / `--revision` to `homeboy extension install` for git URL installs.
- Check out the requested branch, tag, or commit after cloning while preserving `source_revision` as the resolved SHA.
- Cover pinned commit and branch installs with focused lifecycle tests.

Fixes #2343

## Testing
- `cargo test cloned_install_can_checkout`
- `cargo test cloned_monorepo_install_preserves_source_revision_marker`
- `cargo test --test command_surface_test`
- `cargo run --bin homeboy -- extension install --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI/core install-path changes, added focused tests, and ran verification; Chris remains responsible for review and merge.