### PR TITLE
fix: surface unresolved triage targets

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -148,6 +148,14 @@ enum ComponentCommand {
         /// Regex pattern with capture group for version
         pattern: String,
     },
+    /// Inspect and optionally repair stale standalone registry local_path data
+    Reconcile {
+        /// Component ID
+        id: String,
+        /// Apply a safe discovered repair instead of reporting only
+        #[arg(long)]
+        apply: bool,
+    },
 }
 
 /// Entity-specific fields for component commands.
@@ -327,7 +335,53 @@ pub fn run(
         ComponentCommand::AddVersionTarget { id, file, pattern } => {
             add_version_target(&id, &file, &pattern)
         }
+        ComponentCommand::Reconcile { id, apply } => reconcile(&id, apply),
     }
+}
+
+fn reconcile(id: &str, apply: bool) -> CmdResult<ComponentOutput> {
+    let report = component::reconcile_standalone_registration(id, apply)?;
+    let hint = if report.applied {
+        Some("Standalone registration repaired".to_string())
+    } else if report.repair.is_some() {
+        Some(format!(
+            "Safe repair available. Run `homeboy component reconcile {} --apply` to update the standalone registration.",
+            id
+        ))
+    } else if report.status == "ok" {
+        Some(
+            "Standalone registration local_path is present and points to a git checkout"
+                .to_string(),
+        )
+    } else {
+        Some(
+            "No safe repair path discovered; update the component registration manually"
+                .to_string(),
+        )
+    };
+
+    Ok((
+        ComponentOutput {
+            command: "component.reconcile".to_string(),
+            id: Some(id.to_string()),
+            entity: Some(serde_json::to_value(&report).map_err(|error| {
+                homeboy::Error::validation_invalid_argument(
+                    "component.reconcile",
+                    "Failed to serialize reconcile report",
+                    Some(error.to_string()),
+                    None,
+                )
+            })?),
+            hint,
+            updated_fields: if report.applied {
+                vec!["local_path".to_string()]
+            } else {
+                Vec::new()
+            },
+            ..Default::default()
+        },
+        0,
+    ))
 }
 
 /// Suggest a project for a newly created component based on sibling components.

--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -6,6 +6,19 @@ use crate::project;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct ComponentReconcileReport {
+    pub component_id: String,
+    pub registration_path: String,
+    pub registered_local_path: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovered_local_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair: Option<String>,
+    pub applied: bool,
+}
+
 /// Derive a runtime component inventory from project attachments, standalone
 /// registrations, and portable components.
 ///
@@ -255,6 +268,129 @@ pub fn load(id: &str) -> Result<Component> {
 
 pub fn exists(id: &str) -> bool {
     load(id).is_ok()
+}
+
+pub fn reconcile_standalone_registration(
+    id: &str,
+    apply: bool,
+) -> Result<ComponentReconcileReport> {
+    let dir = crate::paths::components()?;
+    let registration_path = dir.join(format!("{}.json", id));
+    let content = std::fs::read_to_string(&registration_path).map_err(|e| {
+        Error::validation_invalid_argument(
+            "component_id",
+            format!("No standalone registration found for component '{id}': {e}"),
+            Some(id.to_string()),
+            Some(vec![
+                "Run `homeboy component list` to inspect registered components".to_string(),
+                "Run `homeboy component create --local-path <path>` to register a checkout"
+                    .to_string(),
+            ]),
+        )
+    })?;
+    let mut json: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse {}", registration_path.display())),
+            Some(content.chars().take(200).collect()),
+        )
+    })?;
+    let registered_local_path = json
+        .get("local_path")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let registered_path = Path::new(&registered_local_path);
+    let status = reconcile_status(registered_path);
+    let discovered_local_path = if status == "ok" {
+        None
+    } else {
+        discover_reconcile_candidate(id, registered_path)
+    };
+    let repair = discovered_local_path
+        .as_ref()
+        .map(|path| format!("Update local_path to {path}"));
+    let mut applied = false;
+
+    if apply {
+        let discovered = discovered_local_path.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "apply",
+                "No safe repair path was discovered",
+                Some(id.to_string()),
+                Some(vec![
+                    "Run without --apply to inspect the current registry state".to_string(),
+                ]),
+            )
+        })?;
+        if let Some(obj) = json.as_object_mut() {
+            obj.insert(
+                "local_path".to_string(),
+                serde_json::Value::String(discovered.clone()),
+            );
+        }
+        crate::component::portable::validate_component_remote_urls(&json)?;
+        let updated = crate::config::to_string_pretty(&json)?;
+        crate::engine::local_files::write_file_atomic(
+            &registration_path,
+            &updated,
+            &format!(
+                "write standalone registration {}",
+                registration_path.display()
+            ),
+        )?;
+        applied = true;
+    }
+
+    Ok(ComponentReconcileReport {
+        component_id: id.to_string(),
+        registration_path: registration_path.display().to_string(),
+        registered_local_path,
+        status,
+        discovered_local_path,
+        repair,
+        applied,
+    })
+}
+
+fn reconcile_status(path: &Path) -> String {
+    if path.as_os_str().is_empty() {
+        return "missing_local_path".to_string();
+    }
+    if !path.exists() {
+        return "missing".to_string();
+    }
+    if !path.join(".git").exists() {
+        return "non_git".to_string();
+    }
+    "ok".to_string()
+}
+
+fn discover_reconcile_candidate(id: &str, registered_path: &Path) -> Option<String> {
+    let parent = registered_path.parent()?;
+    let entries = std::fs::read_dir(parent).ok()?;
+    let mut candidates = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || !path.join(".git").exists() {
+            continue;
+        }
+        let Some(component) = discover_from_portable(&path) else {
+            continue;
+        };
+        if component.id == id {
+            candidates.push(path);
+        }
+    }
+
+    if candidates.len() == 1 {
+        candidates
+            .pop()
+            .map(|path| path.to_string_lossy().to_string())
+    } else {
+        None
+    }
 }
 
 /// Read a standalone registration file for a component ID without loading
@@ -688,6 +824,76 @@ mod tests {
                 .iter()
                 .any(|component| component.id == "old-plugin"),
             "stale standalone path should not re-register the old component id"
+        );
+    }
+
+    #[test]
+    fn reconcile_reports_safe_sibling_repair_without_applying() {
+        let dir = TempDir::new().unwrap();
+        let config_components = dir
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("components");
+        fs::create_dir_all(&config_components).unwrap();
+
+        let workspace = dir.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let stale_path = workspace.join("old-homeboy");
+        let checkout = workspace.join("homeboy");
+        fs::create_dir_all(checkout.join(".git")).unwrap();
+        fs::write(
+            checkout.join("homeboy.json"),
+            serde_json::to_string_pretty(&serde_json::json!({ "id": "homeboy" })).unwrap(),
+        )
+        .unwrap();
+        write_standalone_json(&config_components, "homeboy", &stale_path.to_string_lossy());
+
+        let _home = with_home_override(dir.path());
+        let report = reconcile_standalone_registration("homeboy", false).unwrap();
+
+        assert_eq!(report.status, "missing");
+        assert_eq!(
+            report.discovered_local_path.as_deref(),
+            Some(checkout.to_string_lossy().as_ref())
+        );
+        assert!(!report.applied);
+
+        let raw = fs::read_to_string(config_components.join("homeboy.json")).unwrap();
+        assert!(raw.contains(stale_path.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn reconcile_apply_updates_stale_local_path_when_candidate_is_unique() {
+        let dir = TempDir::new().unwrap();
+        let config_components = dir
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("components");
+        fs::create_dir_all(&config_components).unwrap();
+
+        let workspace = dir.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let stale_path = workspace.join("old-homeboy");
+        let checkout = workspace.join("homeboy");
+        fs::create_dir_all(checkout.join(".git")).unwrap();
+        fs::write(
+            checkout.join("homeboy.json"),
+            serde_json::to_string_pretty(&serde_json::json!({ "id": "homeboy" })).unwrap(),
+        )
+        .unwrap();
+        write_standalone_json(&config_components, "homeboy", &stale_path.to_string_lossy());
+
+        let _home = with_home_override(dir.path());
+        let report = reconcile_standalone_registration("homeboy", true).unwrap();
+
+        assert!(report.applied);
+        let raw = fs::read_to_string(config_components.join("homeboy.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            json.get("local_path").and_then(|value| value.as_str()),
+            Some(checkout.to_string_lossy().as_ref())
         );
     }
 

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -18,7 +18,7 @@ pub use audit::{
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,
-    write_standalone_registration,
+    reconcile_standalone_registration, write_standalone_registration, ComponentReconcileReport,
 };
 pub use mutations::{delete_safe, merge, rename, set_changelog_target};
 pub use portable::{

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -99,6 +99,8 @@ pub struct TriageOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observation: Option<TriageObservationOutput>,
     pub summary: TriageSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unresolved_summary: Option<String>,
     pub components: Vec<TriageComponentReport>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub unresolved: Vec<TriageUnresolved>,
@@ -360,6 +362,7 @@ pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput>
     }
 
     let summary = summarize(&components, &unresolved);
+    let unresolved_summary = summarize_unresolved(&unresolved);
     let mut output = TriageOutput {
         command: target.command(),
         target: TriageTargetOutput {
@@ -368,6 +371,7 @@ pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput>
         },
         observation: None,
         summary,
+        unresolved_summary,
         components,
         unresolved,
     };
@@ -1848,6 +1852,26 @@ fn summarize(
     summary
 }
 
+fn summarize_unresolved(unresolved: &[TriageUnresolved]) -> Option<String> {
+    if unresolved.is_empty() {
+        return None;
+    }
+
+    let mut summary = format!("{} unresolved component target(s):", unresolved.len());
+    for target in unresolved {
+        let path = if target.local_path.is_empty() {
+            "<no local_path>"
+        } else {
+            target.local_path.as_str()
+        };
+        summary.push_str(&format!(
+            " {} ({}) - {};",
+            target.component_id, path, target.reason
+        ));
+    }
+    Some(summary)
+}
+
 pub fn parse_stale_days(input: &str) -> Result<i64> {
     let trimmed = input.trim();
     let digits = trimmed.strip_suffix('d').unwrap_or(trimmed);
@@ -1998,6 +2022,21 @@ mod tests {
         assert_eq!(refs.len(), 2);
         assert!(refs.iter().any(|r| r.component_id == "data-machine"));
         assert!(refs.iter().any(|r| r.component_id == "local-only"));
+    }
+
+    #[test]
+    fn unresolved_summary_is_visible_when_targets_fail_to_resolve() {
+        let unresolved = vec![TriageUnresolved {
+            component_id: "missing".to_string(),
+            local_path: "/tmp/missing".to_string(),
+            reason: "local path does not exist".to_string(),
+            sources: vec!["workspace".to_string()],
+        }];
+
+        assert_eq!(
+            summarize_unresolved(&unresolved).as_deref(),
+            Some("1 unresolved component target(s): missing (/tmp/missing) - local path does not exist;")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds an explicit `unresolved_summary` to triage output while preserving the structured `unresolved` target details.
- Adds `homeboy component reconcile <id> [--apply]` to inspect stale standalone `local_path` registrations and apply a safe unique same-ID sibling checkout repair.
- Covers dry-run/apply reconcile behavior and unresolved-summary output with focused tests.

Fixes #2419

## Testing
- `cargo fmt`
- `cargo test core::component::inventory::tests::reconcile`
- `cargo test triage::tests::unresolved_summary_is_visible_when_targets_fail_to_resolve`
- `cargo test command_surface_test`
- `cargo test` (fails: existing `core::extension::execution::tests::build_exec_env_includes_runtime_runner_helper_path` assertion `helper.is_some()` in this checkout)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the targeted triage summary and component reconcile helper, added tests, and ran verification; Chris remains responsible for review and merge.