### PR TITLE
fix(engine): honor project CLI path for CLI tools

### DIFF
--- a/src/core/engine/cli_tool.rs
+++ b/src/core/engine/cli_tool.rs
@@ -212,10 +212,12 @@ fn build_project_command(
         ]));
     }
 
-    let cli_path = cli_config
-        .default_cli_path
-        .clone()
-        .unwrap_or_else(|| cli_config.tool.clone());
+    let cli_path = project::project_cli_path(project).unwrap_or_else(|| {
+        cli_config
+            .default_cli_path
+            .clone()
+            .unwrap_or_else(|| cli_config.tool.clone())
+    });
 
     let mut variables = HashMap::new();
     variables.insert(TemplateVars::PROJECT_ID.to_string(), project.id.clone());
@@ -451,5 +453,38 @@ mod tests {
             Some("root")
         );
         assert_eq!(config.auto_flags[0].flag, "--allow-root");
+    }
+
+    #[test]
+    fn project_cli_path_overrides_manifest_default() {
+        let mut project = Project {
+            id: "sandbox".to_string(),
+            domain: Some("example.com".to_string()),
+            base_path: Some("/home/wpdev/public_html".to_string()),
+            cli_path: Some("/home/wpdev/public_html/bin/wp".to_string()),
+            ..Default::default()
+        };
+
+        let config = cli_config(Vec::new());
+        let (_, command) = build_project_command(
+            &project,
+            &config,
+            "wordpress",
+            &["core".into(), "version".into()],
+        )
+        .expect("build command");
+
+        assert!(command.starts_with("/home/wpdev/public_html/bin/wp core version"));
+
+        project.cli_path = None;
+        let (_, command) = build_project_command(
+            &project,
+            &config,
+            "wordpress",
+            &["core".into(), "version".into()],
+        )
+        .expect("build command");
+
+        assert!(command.starts_with("wp core version"));
     }
 }

--- a/src/core/engine/executor.rs
+++ b/src/core/engine/executor.rs
@@ -39,7 +39,7 @@ use crate::context::resolve_project_ssh;
 use crate::engine::shell;
 use crate::error::{Error, Result};
 use crate::extension::CliConfig;
-use crate::project::Project;
+use crate::project::{self, Project};
 use crate::server::{execute_local_command, execute_local_command_interactive, CommandOutput};
 use std::process::Command;
 
@@ -110,7 +110,7 @@ pub fn execute_for_project_direct(
     }
 
     // Fallback to shell execution
-    let command = build_shell_command(&base_path, cli_config, args, target_domain)?;
+    let command = build_shell_command(&base_path, cli_config, project, args, target_domain)?;
     execute_for_project(project, &command)
 }
 
@@ -199,10 +199,12 @@ fn parse_direct_template(
     let mut template = cli_config.command_template.clone();
 
     // Expand {{cliPath}}
-    let cli_path = cli_config
-        .default_cli_path
-        .clone()
-        .unwrap_or_else(|| cli_config.tool.clone());
+    let cli_path = project::project_cli_path(project).unwrap_or_else(|| {
+        cli_config
+            .default_cli_path
+            .clone()
+            .unwrap_or_else(|| cli_config.tool.clone())
+    });
     template = template.replace("{{cliPath}}", &cli_path);
 
     // Expand {{extension_path}}
@@ -279,16 +281,19 @@ fn parse_direct_template(
 fn build_shell_command(
     base_path: &str,
     cli_config: &CliConfig,
+    project: &Project,
     args: &[String],
     target_domain: &str,
 ) -> Result<String> {
     let mut template = cli_config.command_template.clone();
 
     // Expand {{cliPath}}
-    let cli_path = cli_config
-        .default_cli_path
-        .clone()
-        .unwrap_or_else(|| cli_config.tool.clone());
+    let cli_path = project::project_cli_path(project).unwrap_or_else(|| {
+        cli_config
+            .default_cli_path
+            .clone()
+            .unwrap_or_else(|| cli_config.tool.clone())
+    });
     template = template.replace("{{cliPath}}", &cli_path);
 
     // Expand {{sitePath}}


### PR DESCRIPTION
## Summary
- Honor project-scoped `cli_path` when rendering CLI tool command templates.
- Apply the same `cli_path` cascade to direct and shell fallback execution paths.
- Add regression coverage showing project `cli_path` overrides the manifest default while preserving the default fallback.

## Testing
- `cargo check --release --lib`
- `cargo test --release project_cli_path`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the sandbox WP-CLI path regression, drafted the code/test changes, and ran targeted verification for Chris to review.