### PR TITLE
Update linked extensions from default branch

### DIFF
--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -272,16 +272,8 @@ pub enum ExtensionOutput {
         source_path: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         git_root: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        old_source_revision: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        new_source_revision: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        old_branch: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        new_branch: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        update_note: Option<String>,
+        #[serde(flatten)]
+        source_update: homeboy::extension::ExtensionSourceUpdate,
         #[serde(skip_serializing_if = "Option::is_none")]
         old_version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -672,11 +664,7 @@ fn update_extension(
             git_root: result
                 .git_root
                 .map(|path| path.to_string_lossy().to_string()),
-            old_source_revision: result.old_source_revision,
-            new_source_revision: result.new_source_revision,
-            old_branch: result.old_branch,
-            new_branch: result.new_branch,
-            update_note: result.update_note,
+            source_update: result.source_update,
             old_version,
             new_version,
             repaired_source_metadata: result.repaired_source_metadata,

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -267,6 +267,21 @@ pub enum ExtensionOutput {
         extension_id: String,
         url: String,
         path: String,
+        linked: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source_path: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        git_root: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        old_source_revision: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        new_source_revision: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        old_branch: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        new_branch: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        update_note: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         old_version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -650,6 +665,18 @@ fn update_extension(
             extension_id: result.extension_id,
             url: result.url,
             path: result.path.to_string_lossy().to_string(),
+            linked: result.linked,
+            source_path: result
+                .source_path
+                .map(|path| path.to_string_lossy().to_string()),
+            git_root: result
+                .git_root
+                .map(|path| path.to_string_lossy().to_string()),
+            old_source_revision: result.old_source_revision,
+            new_source_revision: result.new_source_revision,
+            old_branch: result.old_branch,
+            new_branch: result.new_branch,
+            update_note: result.update_note,
             old_version,
             new_version,
             repaired_source_metadata: result.repaired_source_metadata,

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -34,6 +34,14 @@ pub struct UpdateResult {
     pub extension_id: String,
     pub url: String,
     pub path: PathBuf,
+    pub linked: bool,
+    pub source_path: Option<PathBuf>,
+    pub git_root: Option<PathBuf>,
+    pub old_source_revision: Option<String>,
+    pub new_source_revision: Option<String>,
+    pub old_branch: Option<String>,
+    pub new_branch: Option<String>,
+    pub update_note: Option<String>,
     pub repaired_source_metadata: Option<source_metadata::SourceMetadataRepair>,
 }
 
@@ -606,6 +614,14 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
             extension_id: extension_id.to_string(),
             url: source_url,
             path: extension_dir,
+            linked: false,
+            source_path: None,
+            git_root: None,
+            old_source_revision: None,
+            new_source_revision: None,
+            old_branch: None,
+            new_branch: None,
+            update_note: None,
             repaired_source_metadata: source_repair.take(),
         });
     }
@@ -618,6 +634,14 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
         extension_id: extension_id.to_string(),
         url: source_url,
         path: extension_dir,
+        linked: false,
+        source_path: None,
+        git_root: None,
+        old_source_revision: None,
+        new_source_revision: None,
+        old_branch: None,
+        new_branch: None,
+        update_note: None,
         repaired_source_metadata: source_repair,
     })
 }
@@ -713,6 +737,8 @@ fn update_linked_extension(
     let git_root = PathBuf::from(&git_root_str)
         .canonicalize()
         .unwrap_or_else(|_| PathBuf::from(git_root_str));
+    let old_branch = git_current_branch(&git_root);
+    let old_source_revision = get_short_head_revision(&git_root);
 
     static UPDATED_ROOTS: OnceLock<Mutex<HashMap<PathBuf, Option<String>>>> = OnceLock::new();
     let updated_roots = UPDATED_ROOTS.get_or_init(|| Mutex::new(HashMap::new()));
@@ -743,25 +769,130 @@ fn update_linked_extension(
                     ));
                 }
 
-                git::pull_repo(&git_root)?;
+                update_linked_git_root(&git_root)?;
 
                 Ok(())
             })();
             updated_roots
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
-                .insert(git_root, result.as_ref().err().map(|e| e.message.clone()));
+                .insert(
+                    git_root.clone(),
+                    result.as_ref().err().map(|e| e.message.clone()),
+                );
             result?;
         }
     };
     run_setup_if_configured(extension_id);
     let url = format!("linked:{}", source_dir.display());
+    let new_branch = git_current_branch(&git_root);
+    let new_source_revision = get_short_head_revision(&git_root);
     Ok(UpdateResult {
         extension_id: extension_id.to_string(),
         url,
-        path: source_dir,
+        path: source_dir.clone(),
+        linked: true,
+        source_path: Some(source_dir.clone()),
+        git_root: Some(git_root),
+        old_source_revision,
+        new_source_revision,
+        old_branch,
+        new_branch,
+        update_note: Some(
+            "Linked extension source updated in place; clean linked repos switch to the remote default branch before pulling.".to_string(),
+        ),
         repaired_source_metadata: None,
     })
+}
+
+fn update_linked_git_root(git_root: &Path) -> Result<()> {
+    let old_branch = git_current_branch(git_root);
+    git_run(git_root, &["fetch", "origin"], "git fetch origin")?;
+    let mut detached_default_branch: Option<String> = None;
+
+    if let Some(remote_branch) = git_default_remote_branch(git_root) {
+        let local_branch = remote_branch
+            .strip_prefix("origin/")
+            .unwrap_or(&remote_branch)
+            .to_string();
+
+        if old_branch.as_deref() != Some(local_branch.as_str()) {
+            if git_run(
+                git_root,
+                &["switch", &local_branch],
+                "git switch default branch",
+            )
+            .is_err()
+            {
+                git_run(
+                    git_root,
+                    &["switch", "--detach", &remote_branch],
+                    "git switch detached default branch",
+                )?;
+                detached_default_branch = Some(local_branch);
+            }
+        }
+    }
+
+    if let Some(branch) = detached_default_branch {
+        git_run(
+            git_root,
+            &["pull", "--ff-only", "origin", &branch],
+            "git pull detached default branch --ff-only",
+        )?;
+    } else {
+        git_run(git_root, &["pull", "--ff-only"], "git pull --ff-only")?;
+    }
+    Ok(())
+}
+
+fn git_default_remote_branch(git_root: &Path) -> Option<String> {
+    git_run(
+        git_root,
+        &[
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ],
+        "git default remote branch",
+    )
+    .ok()
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+}
+
+fn git_current_branch(git_root: &Path) -> Option<String> {
+    git_run(
+        git_root,
+        &["branch", "--show-current"],
+        "git current branch",
+    )
+    .ok()
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+}
+
+fn git_run(git_root: &Path, args: &[&str], context: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(git_root)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .map_err(|e| Error::internal_io(e.to_string(), Some(context.to_string())))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(Error::git_command_failed(if detail.is_empty() {
+            context.to_string()
+        } else {
+            detail
+        }));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Uninstall a extension. Automatically detects symlinks vs cloned directories.
@@ -1404,7 +1535,7 @@ exec '{}' "$@"
     }
 
     #[test]
-    fn linked_update_pulls_current_worktree_branch_without_switching_to_default_branch() {
+    fn linked_update_switches_clean_worktree_to_default_branch_or_detached_default() {
         with_isolated_home(|home| {
             let home = home.path();
             let source = home.join("source-repo");
@@ -1450,17 +1581,30 @@ exec '{}' "$@"
             )
             .expect("install linked extension");
 
-            update("wordpress", false).expect("feature worktree update should pull current branch");
+            let result =
+                update("wordpress", false).expect("linked update should use default branch");
+            assert!(result.linked);
+            assert_eq!(
+                result.old_branch.as_deref(),
+                Some("feature-linked-extension")
+            );
 
             let branch_output = Command::new("git")
                 .args(["branch", "--show-current"])
                 .current_dir(&source)
                 .output()
                 .expect("current branch");
+            let current_branch = String::from_utf8_lossy(&branch_output.stdout)
+                .trim()
+                .to_string();
             assert_eq!(
-                String::from_utf8_lossy(&branch_output.stdout).trim(),
-                "feature-linked-extension",
-                "linked update must not checkout the default branch in the feature worktree"
+                current_branch,
+                result.new_branch.unwrap_or_default(),
+                "linked update metadata should report the resulting branch"
+            );
+            assert!(
+                current_branch == default_branch || current_branch.is_empty(),
+                "linked update should use the default branch, or detached origin/default when the branch is checked out in another worktree"
             );
         });
     }

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -11,7 +11,7 @@ use std::sync::{Mutex, OnceLock};
 
 use super::execution::run_setup;
 use super::manifest::ExtensionManifest;
-use super::{is_extension_linked, load_extension};
+use super::{is_extension_linked, load_extension, ExtensionSourceUpdate};
 
 #[derive(Debug, Clone)]
 pub struct InstallResult {
@@ -37,11 +37,7 @@ pub struct UpdateResult {
     pub linked: bool,
     pub source_path: Option<PathBuf>,
     pub git_root: Option<PathBuf>,
-    pub old_source_revision: Option<String>,
-    pub new_source_revision: Option<String>,
-    pub old_branch: Option<String>,
-    pub new_branch: Option<String>,
-    pub update_note: Option<String>,
+    pub source_update: ExtensionSourceUpdate,
     pub repaired_source_metadata: Option<source_metadata::SourceMetadataRepair>,
 }
 
@@ -162,34 +158,6 @@ pub fn is_git_url(source: &str) -> bool {
         || source.starts_with("git@")
         || source.starts_with("ssh://")
         || source.ends_with(".git")
-}
-
-fn is_workdir_clean(path: &Path) -> bool {
-    // If the directory is not a git working tree, there is nothing that can
-    // be "uncommitted". Short-circuit to clean before running `git status`.
-    let inside_tree = Command::new("git")
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(path)
-        .output();
-
-    match inside_tree {
-        Ok(output) if output.status.success() => {
-            // Fall through: this is a git working tree; check for changes.
-        }
-        _ => return true,
-    }
-
-    let status = Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(path)
-        .output();
-
-    match status {
-        Ok(output) => output.status.success() && output.stdout.is_empty(),
-        // If `status` unexpectedly fails after `rev-parse` succeeded, err on
-        // the side of blocking an overwrite so the user can investigate.
-        Err(_) => false,
-    }
 }
 
 /// Returns the path to a extension's manifest file: {extension_dir}/{id}.json
@@ -327,7 +295,7 @@ fn install_from_url(
 
     // Capture source revision before resolve_cloned_extension may discard .git
     // (monorepo installs extract only the subdirectory, losing git history).
-    let source_revision = get_short_head_revision(&temp_dir);
+    let source_revision = git::short_head_revision(&temp_dir);
 
     // Determine what was cloned and install accordingly.
     let result = resolve_cloned_extension(&temp_dir, &extension_id, &extension_dir, url);
@@ -561,7 +529,7 @@ fn install_from_path(source_path: &str, id_override: Option<&str>) -> Result<Ins
         .map_err(|e| Error::internal_io(e.to_string(), Some("create symlink".to_string())))?;
 
     // For linked (local) extensions, read revision from the source dir if it's a git repo
-    let source_revision = get_short_head_revision(&source);
+    let source_revision = git::short_head_revision(&source);
 
     Ok(InstallResult {
         extension_id,
@@ -585,7 +553,7 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
         return update_linked_extension(extension_id, &extension_dir, force);
     }
 
-    if !force && !is_workdir_clean(&extension_dir) {
+    if !force && !git::is_workdir_clean_or_not_git(&extension_dir) {
         return Err(Error::validation_invalid_argument(
             "extension_id",
             "Extension has uncommitted changes; update may overwrite them. Use --force to proceed.",
@@ -605,7 +573,7 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
         write_source_metadata(
             &extension_dir,
             &source_url,
-            get_short_head_revision(&extension_dir),
+            git::short_head_revision(&extension_dir),
         );
 
         run_setup_if_configured(extension_id);
@@ -617,11 +585,7 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
             linked: false,
             source_path: None,
             git_root: None,
-            old_source_revision: None,
-            new_source_revision: None,
-            old_branch: None,
-            new_branch: None,
-            update_note: None,
+            source_update: ExtensionSourceUpdate::default(),
             repaired_source_metadata: source_repair.take(),
         });
     }
@@ -637,11 +601,7 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
         linked: false,
         source_path: None,
         git_root: None,
-        old_source_revision: None,
-        new_source_revision: None,
-        old_branch: None,
-        new_branch: None,
-        update_note: None,
+        source_update: ExtensionSourceUpdate::default(),
         repaired_source_metadata: source_repair,
     })
 }
@@ -668,7 +628,7 @@ fn update_extracted_extension(
     }
 
     git::clone_repo(source_url, &clone_dir)?;
-    let source_revision = get_short_head_revision(&clone_dir);
+    let source_revision = git::short_head_revision(&clone_dir);
 
     let result = resolve_cloned_extension(&clone_dir, extension_id, &staged_dir, source_url);
     if clone_dir.exists() {
@@ -737,8 +697,8 @@ fn update_linked_extension(
     let git_root = PathBuf::from(&git_root_str)
         .canonicalize()
         .unwrap_or_else(|_| PathBuf::from(git_root_str));
-    let old_branch = git_current_branch(&git_root);
-    let old_source_revision = get_short_head_revision(&git_root);
+    let old_branch = git::current_branch(&git_root);
+    let old_source_revision = git::short_head_revision(&git_root);
 
     static UPDATED_ROOTS: OnceLock<Mutex<HashMap<PathBuf, Option<String>>>> = OnceLock::new();
     let updated_roots = UPDATED_ROOTS.get_or_init(|| Mutex::new(HashMap::new()));
@@ -757,7 +717,7 @@ fn update_linked_extension(
         )),
         None => {
             let result = (|| {
-                if !force && !is_workdir_clean(&git_root) {
+                if !force && !git::is_workdir_clean_or_not_git(&git_root) {
                     return Err(Error::validation_invalid_argument(
                         "extension_id",
                         format!(
@@ -769,7 +729,7 @@ fn update_linked_extension(
                     ));
                 }
 
-                update_linked_git_root(&git_root)?;
+                git::update_to_remote_default_branch(&git_root)?;
 
                 Ok(())
             })();
@@ -785,8 +745,8 @@ fn update_linked_extension(
     };
     run_setup_if_configured(extension_id);
     let url = format!("linked:{}", source_dir.display());
-    let new_branch = git_current_branch(&git_root);
-    let new_source_revision = get_short_head_revision(&git_root);
+    let new_branch = git::current_branch(&git_root);
+    let new_source_revision = git::short_head_revision(&git_root);
     Ok(UpdateResult {
         extension_id: extension_id.to_string(),
         url,
@@ -794,105 +754,17 @@ fn update_linked_extension(
         linked: true,
         source_path: Some(source_dir.clone()),
         git_root: Some(git_root),
-        old_source_revision,
-        new_source_revision,
-        old_branch,
-        new_branch,
-        update_note: Some(
-            "Linked extension source updated in place; clean linked repos switch to the remote default branch before pulling.".to_string(),
-        ),
+        source_update: ExtensionSourceUpdate {
+            old_source_revision,
+            new_source_revision,
+            old_branch,
+            new_branch,
+            update_note: Some(
+                "Linked extension source updated in place; clean linked repos switch to the remote default branch before pulling.".to_string(),
+            ),
+        },
         repaired_source_metadata: None,
     })
-}
-
-fn update_linked_git_root(git_root: &Path) -> Result<()> {
-    let old_branch = git_current_branch(git_root);
-    git_run(git_root, &["fetch", "origin"], "git fetch origin")?;
-    let mut detached_default_branch: Option<String> = None;
-
-    if let Some(remote_branch) = git_default_remote_branch(git_root) {
-        let local_branch = remote_branch
-            .strip_prefix("origin/")
-            .unwrap_or(&remote_branch)
-            .to_string();
-
-        if old_branch.as_deref() != Some(local_branch.as_str()) {
-            if git_run(
-                git_root,
-                &["switch", &local_branch],
-                "git switch default branch",
-            )
-            .is_err()
-            {
-                git_run(
-                    git_root,
-                    &["switch", "--detach", &remote_branch],
-                    "git switch detached default branch",
-                )?;
-                detached_default_branch = Some(local_branch);
-            }
-        }
-    }
-
-    if let Some(branch) = detached_default_branch {
-        git_run(
-            git_root,
-            &["pull", "--ff-only", "origin", &branch],
-            "git pull detached default branch --ff-only",
-        )?;
-    } else {
-        git_run(git_root, &["pull", "--ff-only"], "git pull --ff-only")?;
-    }
-    Ok(())
-}
-
-fn git_default_remote_branch(git_root: &Path) -> Option<String> {
-    git_run(
-        git_root,
-        &[
-            "symbolic-ref",
-            "--quiet",
-            "--short",
-            "refs/remotes/origin/HEAD",
-        ],
-        "git default remote branch",
-    )
-    .ok()
-    .map(|value| value.trim().to_string())
-    .filter(|value| !value.is_empty())
-}
-
-fn git_current_branch(git_root: &Path) -> Option<String> {
-    git_run(
-        git_root,
-        &["branch", "--show-current"],
-        "git current branch",
-    )
-    .ok()
-    .map(|value| value.trim().to_string())
-    .filter(|value| !value.is_empty())
-}
-
-fn git_run(git_root: &Path, args: &[&str], context: &str) -> Result<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(git_root)
-        .stdin(std::process::Stdio::null())
-        .output()
-        .map_err(|e| Error::internal_io(e.to_string(), Some(context.to_string())))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if stderr.is_empty() { stdout } else { stderr };
-        return Err(Error::git_command_failed(if detail.is_empty() {
-            context.to_string()
-        } else {
-            detail
-        }));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Uninstall a extension. Automatically detects symlinks vs cloned directories.
@@ -978,29 +850,6 @@ pub struct UpdateAvailable {
     pub behind_count: usize,
 }
 
-/// Get the short HEAD revision from a git directory.
-/// Returns None if the directory is not a git repo or the command fails.
-pub(crate) fn get_short_head_revision(dir: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .current_dir(dir)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let rev = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if rev.is_empty() {
-        None
-    } else {
-        Some(rev)
-    }
-}
-
 /// Read the source revision for an installed extension.
 /// Checks (in order): .git directory (git rev-parse), then .source-revision file.
 pub fn read_source_revision(extension_id: &str) -> Option<String> {
@@ -1010,7 +859,7 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
     }
 
     // Try .git first (single-extension repos and linked extensions)
-    if let Some(rev) = get_short_head_revision(&extension_dir) {
+    if let Some(rev) = git::short_head_revision(&extension_dir) {
         return Some(rev);
     }
 
@@ -1025,7 +874,7 @@ pub fn read_source_revision(extension_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        install, install_for_component, install_with_revision, is_workdir_clean, load_extension,
+        install, install_for_component, install_with_revision, load_extension,
         read_source_revision, source_metadata, update,
     };
     use crate::component;
@@ -1585,7 +1434,7 @@ exec '{}' "$@"
                 update("wordpress", false).expect("linked update should use default branch");
             assert!(result.linked);
             assert_eq!(
-                result.old_branch.as_deref(),
+                result.source_update.old_branch.as_deref(),
                 Some("feature-linked-extension")
             );
 
@@ -1599,7 +1448,7 @@ exec '{}' "$@"
                 .to_string();
             assert_eq!(
                 current_branch,
-                result.new_branch.unwrap_or_default(),
+                result.source_update.new_branch.unwrap_or_default(),
                 "linked update metadata should report the resulting branch"
             );
             assert!(
@@ -1794,7 +1643,7 @@ exec '{}' "$@"
         std::fs::write(temp.path().join("some-file.txt"), "content").expect("write file");
 
         assert!(
-            is_workdir_clean(temp.path()),
+            crate::git::is_workdir_clean_or_not_git(temp.path()),
             "non-git directory should be treated as clean"
         );
     }
@@ -1813,7 +1662,7 @@ exec '{}' "$@"
         }
 
         assert!(
-            is_workdir_clean(temp.path()),
+            crate::git::is_workdir_clean_or_not_git(temp.path()),
             "freshly-initialized git repo with no changes should be clean"
         );
     }
@@ -1834,7 +1683,7 @@ exec '{}' "$@"
         std::fs::write(temp.path().join("untracked.txt"), "hi").expect("write untracked file");
 
         assert!(
-            !is_workdir_clean(temp.path()),
+            !crate::git::is_workdir_clean_or_not_git(temp.path()),
             "git repo with untracked file should be reported as dirty"
         );
     }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -16,6 +16,7 @@ pub mod self_check;
 pub mod test;
 pub mod trace;
 pub mod update_check;
+mod update_output;
 pub mod version;
 
 pub mod exec_context;
@@ -63,6 +64,10 @@ pub use lifecycle::{
     InstallForComponentResult, InstallResult, UpdateAvailable, UpdateResult,
 };
 pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
+pub use update_output::{
+    ExtensionSourceUpdate, SourceMetadataRepairEntry, UpdateAllResult, UpdateEntry,
+    UpdateSkippedEntry,
+};
 
 pub(crate) fn stderr_tail(stderr: &str) -> String {
     const MAX_LINES: usize = 20;
@@ -72,7 +77,7 @@ pub(crate) fn stderr_tail(stderr: &str) -> String {
 }
 
 // Re-export aggregate query types
-// (ActionSummary, ExtensionSummary, UpdateAllResult, UpdateEntry defined below in this file)
+// (ActionSummary, ExtensionSummary, and update output types are re-exported from sibling modules.)
 
 // Extension loader functions
 
@@ -927,57 +932,6 @@ pub fn list_summaries(project: Option<&crate::project::Project>) -> Vec<Extensio
         .collect()
 }
 
-/// Result of updating all extensions.
-#[derive(Debug, Clone, Serialize)]
-pub struct UpdateAllResult {
-    pub updated: Vec<UpdateEntry>,
-    pub skipped: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub skipped_details: Vec<UpdateSkippedEntry>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub repaired_source_metadata: Vec<SourceMetadataRepairEntry>,
-}
-
-/// A single extension update entry with before/after versions.
-#[derive(Debug, Clone, Serialize)]
-pub struct UpdateEntry {
-    pub extension_id: String,
-    pub old_version: String,
-    pub new_version: String,
-    pub linked: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub git_root: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub old_source_revision: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_source_revision: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub old_branch: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_branch: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub update_note: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub repaired_source_metadata: Option<SourceMetadataRepair>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct SourceMetadataRepairEntry {
-    pub extension_id: String,
-    #[serde(flatten)]
-    pub repair: SourceMetadataRepair,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct UpdateSkippedEntry {
-    pub extension_id: String,
-    pub reason: String,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub hints: Vec<String>,
-}
-
 /// Update all installed extensions through the same path used by single-extension updates.
 pub fn update_all(force: bool) -> UpdateAllResult {
     let extension_ids = available_extension_ids();
@@ -1015,11 +969,7 @@ pub fn update_all(force: bool) -> UpdateAllResult {
                     git_root: result
                         .git_root
                         .map(|path| path.to_string_lossy().to_string()),
-                    old_source_revision: result.old_source_revision,
-                    new_source_revision: result.new_source_revision,
-                    old_branch: result.old_branch,
-                    new_branch: result.new_branch,
-                    update_note: result.update_note,
+                    source_update: result.source_update,
                     repaired_source_metadata: repaired,
                 });
             }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -944,6 +944,21 @@ pub struct UpdateEntry {
     pub extension_id: String,
     pub old_version: String,
     pub new_version: String,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_note: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repaired_source_metadata: Option<SourceMetadataRepair>,
 }
@@ -993,6 +1008,18 @@ pub fn update_all(force: bool) -> UpdateAllResult {
                     extension_id: id.clone(),
                     old_version: old_version.unwrap_or_default(),
                     new_version,
+                    linked: result.linked,
+                    source_path: result
+                        .source_path
+                        .map(|path| path.to_string_lossy().to_string()),
+                    git_root: result
+                        .git_root
+                        .map(|path| path.to_string_lossy().to_string()),
+                    old_source_revision: result.old_source_revision,
+                    new_source_revision: result.new_source_revision,
+                    old_branch: result.old_branch,
+                    new_branch: result.new_branch,
+                    update_note: result.update_note,
                     repaired_source_metadata: repaired,
                 });
             }

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -6,8 +6,8 @@ use crate::paths;
 use std::path::{Path, PathBuf};
 
 use super::lifecycle::{
-    derive_id_from_url, get_short_head_revision, is_git_url, rename_dir, resolve_cloned_extension,
-    run_setup_if_configured, slugify_id, write_source_metadata,
+    derive_id_from_url, is_git_url, rename_dir, resolve_cloned_extension, run_setup_if_configured,
+    slugify_id, write_source_metadata,
 };
 use super::manifest::ExtensionManifest;
 
@@ -69,7 +69,7 @@ fn replace_from_url(
     clean_replace_temp(&backup_dir)?;
 
     git::clone_repo_at_ref(url, &clone_dir, revision)?;
-    let source_revision = get_short_head_revision(&clone_dir);
+    let source_revision = git::short_head_revision(&clone_dir);
 
     let result = resolve_cloned_extension(&clone_dir, &extension_id, &staged_dir, url);
     if clone_dir.exists() {
@@ -128,7 +128,7 @@ fn replace_from_path(
     local_files::ensure_app_dirs()?;
 
     let old_path = installed_source_path(&extension_dir);
-    let source_revision = get_short_head_revision(&source);
+    let source_revision = git::short_head_revision(&source);
     let staged_link = extension_dir.with_file_name(format!(".replace-link-tmp-{}", extension_id));
     clean_replace_temp(&staged_link)?;
 

--- a/src/core/extension/update_output.rs
+++ b/src/core/extension/update_output.rs
@@ -1,0 +1,93 @@
+use serde::Serialize;
+
+use super::SourceMetadataRepair;
+
+/// Result of updating all extensions.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateAllResult {
+    pub updated: Vec<UpdateEntry>,
+    pub skipped: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skipped_details: Vec<UpdateSkippedEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub repaired_source_metadata: Vec<SourceMetadataRepairEntry>,
+}
+
+/// A single extension update entry with before/after versions.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateEntry {
+    pub extension_id: String,
+    pub old_version: String,
+    pub new_version: String,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_root: Option<String>,
+    #[serde(flatten)]
+    pub source_update: ExtensionSourceUpdate,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repaired_source_metadata: Option<SourceMetadataRepair>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, serde::Deserialize)]
+pub struct ExtensionSourceUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceMetadataRepairEntry {
+    pub extension_id: String,
+    #[serde(flatten)]
+    pub repair: SourceMetadataRepair,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateSkippedEntry {
+    pub extension_id: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_source_update_flattens_legacy_json_fields() {
+        let entry = UpdateEntry {
+            extension_id: "wordpress".to_string(),
+            old_version: "1.0.0".to_string(),
+            new_version: "1.0.1".to_string(),
+            linked: true,
+            source_path: Some("/tmp/homeboy-extensions/wordpress".to_string()),
+            git_root: Some("/tmp/homeboy-extensions".to_string()),
+            source_update: ExtensionSourceUpdate {
+                old_source_revision: Some("abc1234".to_string()),
+                new_source_revision: Some("def5678".to_string()),
+                old_branch: Some("feature".to_string()),
+                new_branch: Some("main".to_string()),
+                update_note: Some("updated linked source".to_string()),
+            },
+            repaired_source_metadata: None,
+        };
+
+        let value = serde_json::to_value(entry).expect("serialize update entry");
+
+        assert_eq!(value["old_source_revision"], "abc1234");
+        assert_eq!(value["new_source_revision"], "def5678");
+        assert_eq!(value["old_branch"], "feature");
+        assert_eq!(value["new_branch"], "main");
+        assert!(value.get("source_update").is_none());
+    }
+}

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -56,6 +56,133 @@ pub fn is_workdir_clean(path: &Path) -> bool {
     }
 }
 
+/// Check if a path is either not a git worktree or is a clean git worktree.
+pub fn is_workdir_clean_or_not_git(path: &Path) -> bool {
+    let inside_tree = Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(path)
+        .output();
+
+    match inside_tree {
+        Ok(output) if output.status.success() => is_workdir_clean(path),
+        _ => true,
+    }
+}
+
+/// Run a git command in a repository and return stdout.
+pub fn run_git(git_root: &Path, args: &[&str], context: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(git_root)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .map_err(|e| Error::internal_io(e.to_string(), Some(context.to_string())))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(Error::git_command_failed(if detail.is_empty() {
+            context.to_string()
+        } else {
+            detail
+        }));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub fn current_branch(git_root: &Path) -> Option<String> {
+    run_git(
+        git_root,
+        &["branch", "--show-current"],
+        "git current branch",
+    )
+    .ok()
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+}
+
+fn default_remote_branch(git_root: &Path) -> Option<String> {
+    run_git(
+        git_root,
+        &[
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ],
+        "git default remote branch",
+    )
+    .ok()
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty())
+}
+
+/// Update a clean linked repo to the latest remote default-branch revision.
+pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
+    let old_branch = current_branch(git_root);
+    run_git(git_root, &["fetch", "origin"], "git fetch origin")?;
+    let mut detached_default_branch: Option<String> = None;
+
+    if let Some(remote_branch) = default_remote_branch(git_root) {
+        let local_branch = remote_branch
+            .strip_prefix("origin/")
+            .unwrap_or(&remote_branch)
+            .to_string();
+
+        if old_branch.as_deref() != Some(local_branch.as_str())
+            && run_git(
+                git_root,
+                &["switch", &local_branch],
+                "git switch default branch",
+            )
+            .is_err()
+        {
+            run_git(
+                git_root,
+                &["switch", "--detach", &remote_branch],
+                "git switch detached default branch",
+            )?;
+            detached_default_branch = Some(local_branch);
+        }
+    }
+
+    if let Some(branch) = detached_default_branch {
+        run_git(
+            git_root,
+            &["pull", "--ff-only", "origin", &branch],
+            "git pull detached default branch --ff-only",
+        )?;
+    } else {
+        run_git(git_root, &["pull", "--ff-only"], "git pull --ff-only")?;
+    }
+
+    Ok(())
+}
+
+/// Get the short HEAD revision from a git directory.
+pub fn short_head_revision(dir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(dir)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let rev = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if rev.is_empty() {
+        None
+    } else {
+        Some(rev)
+    }
+}
+
 /// List all git-tracked markdown files in a directory.
 /// Uses `git ls-files` to respect .gitignore and only include tracked/staged files.
 /// Returns relative paths from the repository root.

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -301,7 +301,10 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
                     .unwrap_or_default();
 
                 if result.linked {
-                    let branch_detail = match (&result.old_branch, &result.new_branch) {
+                    let branch_detail = match (
+                        &result.source_update.old_branch,
+                        &result.source_update.new_branch,
+                    ) {
                         (Some(old), Some(new)) if old != new => format!(" ({} → {})", old, new),
                         (Some(branch), _) => format!(" ({})", branch),
                         _ => String::new(),
@@ -331,11 +334,7 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
                     git_root: result
                         .git_root
                         .map(|path| path.to_string_lossy().to_string()),
-                    old_source_revision: result.old_source_revision,
-                    new_source_revision: result.new_source_revision,
-                    old_branch: result.old_branch,
-                    new_branch: result.new_branch,
-                    update_note: result.update_note,
+                    source_update: result.source_update,
                 });
             }
             Err(e) => {

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -294,13 +294,27 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
             .unwrap_or_default();
 
         match extension::update(id, false) {
-            Ok(_) => {
+            Ok(result) => {
                 let new_version = extension::load_extension(id)
                     .ok()
                     .map(|m| m.version.clone())
                     .unwrap_or_default();
 
-                if old_version != new_version {
+                if result.linked {
+                    let branch_detail = match (&result.old_branch, &result.new_branch) {
+                        (Some(old), Some(new)) if old != new => format!(" ({} → {})", old, new),
+                        (Some(branch), _) => format!(" ({})", branch),
+                        _ => String::new(),
+                    };
+                    log_status!(
+                        "upgrade",
+                        "  {} {} → {} linked source updated{}",
+                        id,
+                        old_version,
+                        new_version,
+                        branch_detail
+                    );
+                } else if old_version != new_version {
                     log_status!("upgrade", "  {} {} → {}", id, old_version, new_version);
                 } else {
                     log_status!("upgrade", "  {} {} (up to date)", id, new_version);
@@ -310,6 +324,18 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
                     extension_id: id.clone(),
                     old_version,
                     new_version,
+                    linked: result.linked,
+                    source_path: result
+                        .source_path
+                        .map(|path| path.to_string_lossy().to_string()),
+                    git_root: result
+                        .git_root
+                        .map(|path| path.to_string_lossy().to_string()),
+                    old_source_revision: result.old_source_revision,
+                    new_source_revision: result.new_source_revision,
+                    old_branch: result.old_branch,
+                    new_branch: result.new_branch,
+                    update_note: result.update_note,
                 });
             }
             Err(e) => {

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::extension::ExtensionSourceUpdate;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InstallMethod {
@@ -49,16 +51,8 @@ pub struct ExtensionUpgradeEntry {
     pub source_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_root: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub old_source_revision: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_source_revision: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub old_branch: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_branch: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub update_note: Option<String>,
+    #[serde(flatten)]
+    pub source_update: ExtensionSourceUpdate,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -44,6 +44,21 @@ pub struct ExtensionUpgradeEntry {
     pub extension_id: String,
     pub old_version: String,
     pub new_version: String,
+    pub linked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_note: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Update linked extension sources from the remote default branch instead of only pulling the currently checked-out worktree branch.
- Add linked-extension update metadata to `extension update`, `extension update --all`, and `homeboy upgrade` JSON output.
- Surface branch/revision movement and source paths so linked extension behavior is clear instead of silently looking up to date.

## Verification
- `cargo test linked_update_switches_clean_worktree_to_default_branch_or_detached_default`
- `cargo test update_all_updates_linked_extensions_through_single_update_path`

## Notes
- `cargo test extension` was also attempted and still has an unrelated existing failure in `build_exec_env_includes_runtime_runner_helper_path`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented linked extension update behavior and output metadata, then ran targeted regression tests.