### PR TITLE
Execute release preflights before planning

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -32,6 +32,9 @@ pub(super) fn execute_release_plan_step(
         "preflight.remote_sync" => Ok(Some(run_remote_sync_preflight(step, context))),
         "preflight.lint" => Ok(Some(run_lint_preflight(step, context))),
         "preflight.test" => Ok(Some(run_test_preflight(step, context))),
+        "preflight.changelog_bootstrap" => {
+            Ok(Some(run_changelog_bootstrap_preflight(step, context)))
+        }
         "changelog.finalize" => {
             executor::changelog::run_changelog_finalize(step, context.component, &mut context.state)
                 .map(Some)
@@ -138,7 +141,8 @@ fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
         && step.step_type != "preflight.working_tree"
         && step.step_type != "preflight.remote_sync"
         && step.step_type != "preflight.lint"
-        && step.step_type != "preflight.test")
+        && step.step_type != "preflight.test"
+        && step.step_type != "preflight.changelog_bootstrap")
         || step.step_type == "changelog.policy"
         || step.step_type == "changelog.generate"
 }
@@ -233,6 +237,25 @@ fn successful_quality_result(step: &ReleasePlanStep, ran: bool) -> ReleaseStepRe
     }
 }
 
+fn run_changelog_bootstrap_preflight(
+    step: &ReleasePlanStep,
+    context: &ReleaseExecutionContext,
+) -> ReleaseStepResult {
+    match super::pipeline::ensure_changelog_initialized(context.component) {
+        Ok(()) => ReleaseStepResult {
+            id: step.id.clone(),
+            step_type: step.step_type.clone(),
+            status: ReleaseStepStatus::Success,
+            missing: Vec::new(),
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            data: None,
+            error: None,
+        },
+        Err(err) => failed_result(&step.id, &step.step_type, err),
+    }
+}
+
 fn configure_git_identity(
     step: &ReleasePlanStep,
     context: &ReleaseExecutionContext,
@@ -279,6 +302,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
             | "preflight.remote_sync"
             | "preflight.lint"
             | "preflight.test"
+            | "preflight.changelog_bootstrap"
             | "version"
             | "release.prepare"
             | "git.commit"
@@ -350,6 +374,9 @@ mod tests {
         )));
         assert!(!release_step_is_plan_only(&plan_step("preflight.lint")));
         assert!(!release_step_is_plan_only(&plan_step("preflight.test")));
+        assert!(!release_step_is_plan_only(&plan_step(
+            "preflight.changelog_bootstrap"
+        )));
         assert!(!release_step_is_plan_only(&plan_step("changelog.finalize")));
         assert!(!release_step_is_plan_only(&plan_step("deploy")));
     }
@@ -555,6 +582,35 @@ mod tests {
     }
 
     #[test]
+    fn changelog_bootstrap_preflight_initializes_missing_changelog() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let changelog_path = temp.path().join("CHANGELOG.md");
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            changelog_target: Some("CHANGELOG.md".to_string()),
+            ..Default::default()
+        };
+        let options = ReleaseOptions::default();
+        let mut context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let result =
+            execute_release_plan_step(&plan_step("preflight.changelog_bootstrap"), &mut context)
+                .expect("dispatch")
+                .expect("result");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert!(changelog_path.exists());
+    }
+
+    #[test]
     fn test_release_step_is_show_stopper() {
         let version_failure = failed_step_result("version");
         let default_branch_failure = failed_step_result("preflight.default_branch");
@@ -562,6 +618,7 @@ mod tests {
         let remote_sync_failure = failed_step_result("preflight.remote_sync");
         let lint_failure = failed_step_result("preflight.lint");
         let test_failure = failed_step_result("preflight.test");
+        let bootstrap_failure = failed_step_result("preflight.changelog_bootstrap");
         let changelog_failure = failed_step_result("changelog.finalize");
         let publish_failure = failed_step_result("publish.crates");
 
@@ -571,6 +628,7 @@ mod tests {
         assert!(release_step_is_show_stopper(&remote_sync_failure));
         assert!(release_step_is_show_stopper(&lint_failure));
         assert!(release_step_is_show_stopper(&test_failure));
+        assert!(release_step_is_show_stopper(&bootstrap_failure));
         assert!(release_step_is_show_stopper(&changelog_failure));
         assert!(!release_step_is_show_stopper(&publish_failure));
     }

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -1,0 +1,140 @@
+use std::collections::HashSet;
+
+use crate::error::Result;
+
+use super::execution_dispatch::{
+    execute_release_plan_step, release_step_is_show_stopper, ReleaseExecutionContext,
+};
+use super::plan_steps::build_preflight_steps;
+use super::types::{ReleaseOptions, ReleasePlan, ReleasePlanStep, ReleaseState, ReleaseStepResult};
+
+pub(super) fn build_initial_preflight_plan(
+    component_id: &str,
+    options: &ReleaseOptions,
+) -> ReleasePlan {
+    let steps = build_preflight_steps(options, None)
+        .into_iter()
+        .filter(|step| initial_executable_preflight_ids().contains(&step.id.as_str()))
+        .collect();
+
+    ReleasePlan {
+        component_id: component_id.to_string(),
+        enabled: true,
+        steps,
+        semver_recommendation: None,
+        warnings: Vec::new(),
+        hints: Vec::new(),
+    }
+}
+
+pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {
+    &[
+        "preflight.default_branch",
+        "preflight.git_identity",
+        "preflight.working_tree",
+        "preflight.remote_sync",
+        "preflight.lint",
+        "preflight.test",
+        "preflight.changelog_bootstrap",
+    ]
+}
+
+pub(super) fn execute_plan_steps(
+    steps: &[ReleasePlanStep],
+    component_id: &str,
+    options: &ReleaseOptions,
+    results: &mut Vec<ReleaseStepResult>,
+    skip_step_ids: &HashSet<&'static str>,
+) -> Result<bool> {
+    if steps.is_empty() {
+        return Ok(false);
+    }
+
+    let component = super::pipeline::load_component(component_id, options)?;
+    let extensions = super::pipeline::resolve_extensions(&component)?;
+    let mut context = ReleaseExecutionContext {
+        component: &component,
+        extensions: &extensions,
+        component_id,
+        options,
+        state: ReleaseState::default(),
+        publish_failed: false,
+    };
+
+    for step in steps {
+        if skip_step_ids.contains(step.id.as_str()) {
+            continue;
+        }
+
+        if let Some(result) = execute_release_plan_step(step, &mut context)? {
+            let should_stop = release_step_is_show_stopper(&result);
+            results.push(result);
+            if should_stop {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_initial_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
+    };
+    use crate::release::types::{ReleaseOptions, ReleasePlanStatus};
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_build_initial_preflight_plan() {
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+
+        let plan = build_initial_preflight_plan("fixture", &options);
+        let ids: Vec<&str> = plan.steps.iter().map(|step| step.id.as_str()).collect();
+
+        assert_eq!(ids, initial_executable_preflight_ids().to_vec());
+        assert!(plan.semver_recommendation.is_none());
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.id == "preflight.git_identity"
+                && step.status == ReleasePlanStatus::Disabled));
+    }
+
+    #[test]
+    fn test_initial_executable_preflight_ids() {
+        assert_eq!(
+            initial_executable_preflight_ids(),
+            &[
+                "preflight.default_branch",
+                "preflight.git_identity",
+                "preflight.working_tree",
+                "preflight.remote_sync",
+                "preflight.lint",
+                "preflight.test",
+                "preflight.changelog_bootstrap",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_execute_plan_steps() {
+        let mut results = Vec::new();
+
+        let stopped = execute_plan_steps(
+            &[],
+            "missing-component-is-not-loaded-for-empty-plan",
+            &ReleaseOptions::default(),
+            &mut results,
+            &HashSet::new(),
+        )
+        .expect("empty plan should be a no-op");
+
+        assert!(!stopped);
+        assert!(results.is_empty());
+    }
+}

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -1,6 +1,7 @@
 pub mod changelog;
 mod deployment;
 mod execution_dispatch;
+mod execution_plan;
 mod executor;
 mod pipeline;
 mod pipeline_capabilities;

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -14,15 +14,16 @@ use crate::extension::{self, ExtensionManifest};
 use crate::git::{self, UncommittedChanges};
 use crate::release::changelog;
 use crate::version;
+use std::collections::HashSet;
 
-use super::execution_dispatch::{
-    execute_release_plan_step, release_step_is_show_stopper, ReleaseExecutionContext,
+use super::execution_plan::{
+    build_initial_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
 };
 use super::pipeline_summary::{build_summary, derive_overall_status};
 use super::plan_steps::{build_preflight_steps, build_release_steps};
 use super::types::{
     ReleaseChangelogPlan, ReleaseOptions, ReleasePlan, ReleaseRun, ReleaseRunResult,
-    ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseState, ReleaseStepResult,
+    ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult,
 };
 
 /// Load a component with portable config fallback when path_override is set.
@@ -32,7 +33,7 @@ pub(crate) fn load_component(component_id: &str, options: &ReleaseOptions) -> Re
 }
 
 /// Resolve the component's declared extensions (for publish/package dispatch).
-fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionManifest>> {
+pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionManifest>> {
     let mut extensions = Vec::new();
     if let Some(configured) = component.extensions.as_ref() {
         let mut extension_ids: Vec<String> = configured.keys().cloned().collect();
@@ -66,35 +67,50 @@ pub(crate) fn run_with_plan(
     component_id: &str,
     options: &ReleaseOptions,
 ) -> Result<(ReleasePlan, ReleaseRun)> {
-    // plan() performs all validations + bootstraps. Its output also tells us
-    // which publish/cleanup/post_release steps should run for this component,
-    // so we don't duplicate the capability checks below.
-    let release_plan = plan(component_id, options)?;
-
-    let component = load_component(component_id, options)?;
-    let extensions = resolve_extensions(&component)?;
-    let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
-    let mut context = ReleaseExecutionContext {
-        component: &component,
-        extensions: &extensions,
-        component_id,
-        options,
-        state: ReleaseState::default(),
-        publish_failed: false,
-    };
     let mut results: Vec<ReleaseStepResult> = Vec::new();
 
-    for step in &release_plan.steps {
-        if let Some(result) = execute_release_plan_step(step, &mut context)? {
-            let should_stop = release_step_is_show_stopper(&result);
-            results.push(result);
-            if should_stop {
-                return Ok((
-                    release_plan,
-                    finalize(component_id, results, monorepo.as_ref()),
-                ));
-            }
-        }
+    let initial_plan = build_initial_preflight_plan(component_id, options);
+    let initial_stop = execute_plan_steps(
+        &initial_plan.steps,
+        component_id,
+        options,
+        &mut results,
+        &HashSet::new(),
+    )?;
+
+    if initial_stop {
+        let component = load_component(component_id, options)?;
+        let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
+        return Ok((
+            initial_plan,
+            finalize(component_id, results, monorepo.as_ref()),
+        ));
+    }
+
+    // Rebuild the full plan after executable preflights. `preflight.remote_sync`
+    // may fast-forward HEAD and `preflight.changelog_bootstrap` may create the
+    // first changelog file; changelog/version planning must observe those
+    // changes instead of stale checkout state.
+    let release_plan = plan(component_id, options)?;
+    let completed_preflights: HashSet<&'static str> =
+        initial_executable_preflight_ids().iter().copied().collect();
+
+    let full_stop = execute_plan_steps(
+        &release_plan.steps,
+        component_id,
+        options,
+        &mut results,
+        &completed_preflights,
+    )?;
+
+    let component = load_component(component_id, options)?;
+    let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
+
+    if full_stop {
+        return Ok((
+            release_plan,
+            finalize(component_id, results, monorepo.as_ref()),
+        ));
     }
 
     Ok((
@@ -150,59 +166,6 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let extensions = resolve_extensions(&component)?;
 
     let mut v = ValidationCollector::new();
-
-    // === Stage 0: Working-tree check (fail-fast) ===
-    //
-    // Run this BEFORE remote sync (which fast-forwards and mutates the tree)
-    // and BEFORE the lint/test gate (which can dump tens of thousands of lines
-    // to stdout, drowning out the real reason a release was blocked).
-    //
-    // The full file-list comparison still happens in Stage 3 once we know the
-    // resolved changelog and version-target paths — at this stage we only know
-    // there's *some* dirty file we can't account for, but that's enough to
-    // bail before doing expensive work. We filter out homeboy-managed
-    // scratch paths (.homeboy-build/, .homeboy-bin/, .homeboy/) here too so
-    // noisy build artifacts don't trigger the early exit.
-    v.capture(validate_working_tree_fail_fast(&component), "working_tree");
-    v.finish_if_errors()?;
-
-    // === Stage 0.5: Remote sync check (preflight) ===
-    v.capture(validate_remote_sync(&component), "remote_sync");
-
-    // === Stage 0.6: Code quality checks ===
-    if options.skip_checks {
-        log_status!("release", "Skipping code quality checks (--skip-checks)");
-    } else {
-        let lint_ran = v
-            .capture(validate_lint_quality(&component), "lint")
-            .unwrap_or(false);
-        let tests_ran = v
-            .capture(validate_test_quality(&component), "test")
-            .unwrap_or(false);
-
-        if !lint_ran && !tests_ran {
-            log_status!(
-                "release",
-                "No linked extensions provide lint/test scripts — skipping code quality checks"
-            );
-        }
-    }
-
-    // === Stage 0.7: Auto-initialize changelog (first-release bootstrap) ===
-    //
-    // If `changelog_target` is configured but the file doesn't exist on disk,
-    // synthesize a minimal changelog so downstream stages have something to
-    // read and finalize. Without this, three stages below all fail with
-    // "File not found" for the same root cause instead of teaching the
-    // component-owned `changelog_target` setup path. See #1172.
-    //
-    // Skipped in dry-run to avoid mutating the working tree during a preview.
-    if !options.dry_run {
-        v.capture(
-            ensure_changelog_initialized(&component),
-            "changelog_bootstrap",
-        );
-    }
 
     // Detect monorepo context for path-scoped commits and component-prefixed tags.
     let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
@@ -1053,7 +1016,7 @@ fn is_file_not_found_error(err: &Error) -> bool {
 /// - `changelog_target` is unset (resolver emits a teaching error downstream),
 /// - the configured path exists,
 /// - a fallback candidate exists (resolver's discovery covers this case).
-fn ensure_changelog_initialized(component: &Component) -> Result<()> {
+pub(crate) fn ensure_changelog_initialized(component: &Component) -> Result<()> {
     let Some(ref target) = component.changelog_target else {
         return Ok(());
     };

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -22,10 +22,6 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
     )?;
 
-    if !input.dry_run {
-        super::pipeline::validate_default_branch(&component)?;
-    }
-
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
     let (auto_bump_type, releasable_count) =
         match resolve_bump(&component.local_path, monorepo.as_ref())? {


### PR DESCRIPTION
## Summary
- Execute release preflight steps through the release dispatcher before building the full release plan.
- Rebuild the full plan after preflights so release planning observes a fast-forwarded checkout and bootstrapped changelog.
- Remove duplicated plan-time preflight execution paths from the release pipeline.

## Testing
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the release pipeline refactor and tests; Chris remains responsible for review and validation.