### PR TITLE
Move release policy gates into the plan

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -30,6 +30,7 @@ pub(super) fn execute_release_plan_step(
         "preflight.git_identity" => configure_git_identity(step, context).map(Some),
         "preflight.working_tree" => Ok(Some(run_working_tree_preflight(step, context))),
         "preflight.remote_sync" => Ok(Some(run_remote_sync_preflight(step, context))),
+        "preflight.bump_policy" => Ok(Some(run_bump_policy_preflight(step))),
         "preflight.lint" => Ok(Some(run_lint_preflight(step, context))),
         "preflight.test" => Ok(Some(run_test_preflight(step, context))),
         "preflight.changelog_bootstrap" => {
@@ -140,6 +141,7 @@ fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
         && step.step_type != "preflight.git_identity"
         && step.step_type != "preflight.working_tree"
         && step.step_type != "preflight.remote_sync"
+        && step.step_type != "preflight.bump_policy"
         && step.step_type != "preflight.lint"
         && step.step_type != "preflight.test"
         && step.step_type != "preflight.changelog_bootstrap")
@@ -201,6 +203,61 @@ fn run_remote_sync_preflight(
             error: None,
         },
         Err(err) => failed_result(&step.id, &step.step_type, err),
+    }
+}
+
+fn run_bump_policy_preflight(step: &ReleasePlanStep) -> ReleaseStepResult {
+    let requested = step
+        .config
+        .get("requested")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown");
+    let recommended = step
+        .config
+        .get("recommended")
+        .and_then(|value| value.as_str())
+        .unwrap_or(requested);
+    let underbump = step
+        .config
+        .get("underbump")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let force_lower_bump = step
+        .config
+        .get("force_lower_bump")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+
+    if underbump && !force_lower_bump {
+        let err = Error::validation_invalid_argument(
+            "bump",
+            format!(
+                "Requested {} bump is lower than detected {} impact",
+                requested, recommended
+            ),
+            Some(requested.to_string()),
+            None,
+        )
+        .with_hint(format!("Use the detected bump: --bump {}", recommended))
+        .with_hint("If the lower release is intentional, re-run with --force-lower-bump");
+
+        return failed_result(&step.id, &step.step_type, err);
+    }
+
+    ReleaseStepResult {
+        id: step.id.clone(),
+        step_type: step.step_type.clone(),
+        status: ReleaseStepStatus::Success,
+        missing: Vec::new(),
+        warnings: Vec::new(),
+        hints: Vec::new(),
+        data: Some(serde_json::json!({
+            "requested": requested,
+            "recommended": recommended,
+            "underbump": underbump,
+            "force_lower_bump": force_lower_bump,
+        })),
+        error: None,
     }
 }
 
@@ -300,6 +357,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
             | "preflight.default_branch"
             | "preflight.working_tree"
             | "preflight.remote_sync"
+            | "preflight.bump_policy"
             | "preflight.lint"
             | "preflight.test"
             | "preflight.changelog_bootstrap"
@@ -371,6 +429,9 @@ mod tests {
         )));
         assert!(!release_step_is_plan_only(&plan_step(
             "preflight.remote_sync"
+        )));
+        assert!(!release_step_is_plan_only(&plan_step(
+            "preflight.bump_policy"
         )));
         assert!(!release_step_is_plan_only(&plan_step("preflight.lint")));
         assert!(!release_step_is_plan_only(&plan_step("preflight.test")));
@@ -582,6 +643,85 @@ mod tests {
     }
 
     #[test]
+    fn bump_policy_preflight_blocks_unforced_underbump() {
+        let mut step = plan_step("preflight.bump_policy");
+        step.config
+            .insert("requested".to_string(), serde_json::json!("patch"));
+        step.config
+            .insert("recommended".to_string(), serde_json::json!("minor"));
+        step.config
+            .insert("underbump".to_string(), serde_json::json!(true));
+        step.config
+            .insert("force_lower_bump".to_string(), serde_json::json!(false));
+
+        let component = Component::default();
+        let options = ReleaseOptions::default();
+        let mut context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let result = execute_release_plan_step(&step, &mut context)
+            .expect("dispatch")
+            .expect("result");
+
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        assert!(release_step_is_show_stopper(&result));
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Requested patch bump is lower"));
+        assert!(result
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("--force-lower-bump")));
+    }
+
+    #[test]
+    fn bump_policy_preflight_allows_forced_underbump() {
+        let mut step = plan_step("preflight.bump_policy");
+        step.config
+            .insert("requested".to_string(), serde_json::json!("patch"));
+        step.config
+            .insert("recommended".to_string(), serde_json::json!("minor"));
+        step.config
+            .insert("underbump".to_string(), serde_json::json!(true));
+        step.config
+            .insert("force_lower_bump".to_string(), serde_json::json!(true));
+
+        let component = Component::default();
+        let options = ReleaseOptions::default();
+        let mut context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let result = execute_release_plan_step(&step, &mut context)
+            .expect("dispatch")
+            .expect("result");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert_eq!(
+            result.data,
+            Some(serde_json::json!({
+                "requested": "patch",
+                "recommended": "minor",
+                "underbump": true,
+                "force_lower_bump": true,
+            }))
+        );
+    }
+
+    #[test]
     fn changelog_bootstrap_preflight_initializes_missing_changelog() {
         let temp = tempfile::tempdir().expect("tempdir");
         let changelog_path = temp.path().join("CHANGELOG.md");
@@ -616,6 +756,7 @@ mod tests {
         let default_branch_failure = failed_step_result("preflight.default_branch");
         let working_tree_failure = failed_step_result("preflight.working_tree");
         let remote_sync_failure = failed_step_result("preflight.remote_sync");
+        let bump_policy_failure = failed_step_result("preflight.bump_policy");
         let lint_failure = failed_step_result("preflight.lint");
         let test_failure = failed_step_result("preflight.test");
         let bootstrap_failure = failed_step_result("preflight.changelog_bootstrap");
@@ -626,6 +767,7 @@ mod tests {
         assert!(release_step_is_show_stopper(&default_branch_failure));
         assert!(release_step_is_show_stopper(&working_tree_failure));
         assert!(release_step_is_show_stopper(&remote_sync_failure));
+        assert!(release_step_is_show_stopper(&bump_policy_failure));
         assert!(release_step_is_show_stopper(&lint_failure));
         assert!(release_step_is_show_stopper(&test_failure));
         assert!(release_step_is_show_stopper(&bootstrap_failure));

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -220,16 +220,18 @@ fn build_bump_policy_step(
     );
     config.insert(
         "force_lower_bump".to_string(),
-        serde_json::Value::Bool(recommendation.is_underbump && !options.dry_run),
+        serde_json::Value::Bool(options.bump_policy.force_lower_bump),
     );
 
     if recommendation.is_underbump {
         config.insert(
             "policy".to_string(),
-            serde_json::Value::String(if !options.dry_run {
+            serde_json::Value::String(if options.dry_run {
+                "preview-lower-bump".to_string()
+            } else if options.bump_policy.force_lower_bump {
                 "forced-lower-bump".to_string()
             } else {
-                "preview-lower-bump".to_string()
+                "requires-force-lower-bump".to_string()
             }),
         );
     }
@@ -527,7 +529,8 @@ mod tests {
     use super::{build_preflight_steps, build_release_steps, github_release_applies};
     use crate::component::Component;
     use crate::release::types::{
-        ReleaseChangelogPlan, ReleaseOptions, ReleasePlanStatus, ReleaseSemverRecommendation,
+        ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleasePlanStatus,
+        ReleaseSemverRecommendation,
     };
 
     #[test]
@@ -648,7 +651,7 @@ mod tests {
     }
 
     #[test]
-    fn release_plan_records_forced_lower_bump_policy() {
+    fn release_plan_records_unforced_lower_bump_policy() {
         let options = ReleaseOptions {
             bump_type: "patch".to_string(),
             ..Default::default()
@@ -677,6 +680,39 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("patch")
         );
+        assert_eq!(
+            bump_policy
+                .config
+                .get("policy")
+                .and_then(|value| value.as_str()),
+            Some("requires-force-lower-bump")
+        );
+        assert_eq!(
+            bump_policy
+                .config
+                .get("force_lower_bump")
+                .and_then(|value| value.as_bool()),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn release_plan_records_forced_lower_bump_policy() {
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            bump_policy: ReleaseBumpPolicyOptions {
+                force_lower_bump: true,
+            },
+            ..Default::default()
+        };
+        let recommendation = semver_recommendation("minor", "patch", true);
+
+        let steps = build_preflight_steps(&options, Some(&recommendation));
+        let bump_policy = steps
+            .iter()
+            .find(|step| step.id == "preflight.bump_policy")
+            .expect("bump policy step");
+
         assert_eq!(
             bump_policy
                 .config

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -189,6 +189,22 @@ pub struct ReleaseOptions {
     /// Git identity for release commits: "bot", "Name <email>", or None (use existing config).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_identity: Option<String>,
+    /// Bump policy controls that affect release plan validation.
+    #[serde(default, skip_serializing_if = "ReleaseBumpPolicyOptions::is_default")]
+    pub bump_policy: ReleaseBumpPolicyOptions,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleaseBumpPolicyOptions {
+    /// Permit a keyword bump lower than the commit-derived recommendation.
+    #[serde(default)]
+    pub force_lower_bump: bool,
+}
+
+impl ReleaseBumpPolicyOptions {
+    fn is_default(value: &Self) -> bool {
+        value == &Self::default()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Default)]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -4,9 +4,9 @@ use std::io::{self, BufRead, IsTerminal, Write};
 
 use super::pipeline::load_component;
 use super::types::{
-    BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseCommandInput,
-    ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep,
-    ReleaseRun,
+    BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
+    ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleasePlanStatus,
+    ReleasePlanStep, ReleaseRun,
 };
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
@@ -202,6 +202,9 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         deploy: input.deploy,
         skip_github_release: input.skip_github_release,
         git_identity: input.git_identity.clone(),
+        bump_policy: ReleaseBumpPolicyOptions {
+            force_lower_bump: input.force_lower_bump,
+        },
     };
 
     if options.dry_run {


### PR DESCRIPTION
## Summary
- Execute `preflight.bump_policy` through the release plan dispatcher.
- Move no-releasable and major-requires-explicit-bump skip gates into `pipeline::plan()`.
- Delete the command-level lower-bump prompt/helpers and route lower-bump enforcement through the plan-owned bump-policy preflight.

## Testing
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the release policy gate refactor and tests; Chris remains responsible for review and validation.