### PR TITLE
Extract release planning skip policy

### DIFF
--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -7,6 +7,7 @@ mod pipeline;
 mod pipeline_capabilities;
 mod pipeline_summary;
 mod plan_steps;
+mod planning_policy;
 mod types;
 mod utils;
 pub mod version;

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -21,10 +21,10 @@ use super::execution_plan::{
 };
 use super::pipeline_summary::{build_summary, derive_overall_status};
 use super::plan_steps::{build_preflight_steps, build_release_steps};
+use super::planning_policy::release_skip_plan;
 use super::types::{
-    ReleaseChangelogPlan, ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep,
-    ReleaseRun, ReleaseRunResult, ReleaseSemverCommit, ReleaseSemverRecommendation,
-    ReleaseStepResult,
+    ReleaseChangelogPlan, ReleaseOptions, ReleasePlan, ReleaseRun, ReleaseRunResult,
+    ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult,
 };
 
 /// Load a component with portable config fallback when path_override is set.
@@ -176,24 +176,9 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let semver_recommendation =
         build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?;
 
-    if semver_recommendation.is_none() && !options.bump_policy.force_empty_release {
-        return Ok(skipped_release_plan(
-            component_id,
-            "no-releasable-commits",
-            "No releasable commits since last tag",
-            "Use --bump to force a release when this is intentional",
-            None,
-        ));
-    }
-
-    if options.bump_policy.require_explicit_major {
-        return Ok(skipped_release_plan(
-            component_id,
-            "major-requires-flag",
-            "Breaking changes require an explicit major bump",
-            &format!("Re-run with: homeboy release {} --bump major", component_id),
-            semver_recommendation,
-        ));
+    if let Some(skip_plan) = release_skip_plan(component_id, options, semver_recommendation.clone())
+    {
+        return Ok(skip_plan);
     }
 
     // === Stage 1: Generate changelog entries from conventional commits ===
@@ -330,34 +315,6 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         warnings,
         hints,
     })
-}
-
-fn skipped_release_plan(
-    component_id: &str,
-    reason: &str,
-    label: &str,
-    hint: &str,
-    semver_recommendation: Option<ReleaseSemverRecommendation>,
-) -> ReleasePlan {
-    ReleasePlan {
-        component_id: component_id.to_string(),
-        enabled: false,
-        steps: vec![ReleasePlanStep {
-            id: "release.skip".to_string(),
-            step_type: "release.skip".to_string(),
-            label: Some(label.to_string()),
-            needs: vec![],
-            config: std::collections::HashMap::from([(
-                "reason".to_string(),
-                serde_json::Value::String(reason.to_string()),
-            )]),
-            status: ReleasePlanStatus::Disabled,
-            missing: vec![],
-        }],
-        semver_recommendation,
-        warnings: vec![],
-        hints: vec![hint.to_string()],
-    }
 }
 
 fn build_changelog_plan(
@@ -1151,13 +1108,12 @@ mod tests {
     use super::{
         code_quality_failure_message, ensure_changelog_initialized, filter_homeboy_managed,
         get_release_allowed_files, get_unexpected_uncommitted_files, is_homeboy_managed_path,
-        is_runner_infrastructure_failure, read_changelog_for_release, skipped_release_plan,
-        strip_pr_reference, validate_default_branch, validate_release_version_floor,
+        is_runner_infrastructure_failure, read_changelog_for_release, strip_pr_reference,
+        validate_default_branch, validate_release_version_floor,
     };
     use crate::component::Component;
     use crate::extension::RunnerOutput;
     use crate::git::{CommitCategory, CommitInfo, UncommittedChanges};
-    use crate::release::types::ReleasePlanStatus;
 
     fn commit(subject: &str, category: CommitCategory) -> CommitInfo {
         CommitInfo {
@@ -1227,32 +1183,6 @@ mod tests {
         assert_eq!(
             strip_pr_reference("has parens (not a pr ref)"),
             "has parens (not a pr ref)"
-        );
-    }
-
-    #[test]
-    fn skipped_release_plan_records_disabled_reason() {
-        let plan = skipped_release_plan(
-            "demo",
-            "no-releasable-commits",
-            "No releasable commits since last tag",
-            "Use --bump to force a release when this is intentional",
-            None,
-        );
-
-        assert!(!plan.enabled);
-        assert_eq!(plan.component_id, "demo");
-        assert_eq!(plan.steps.len(), 1);
-        assert_eq!(plan.steps[0].id, "release.skip");
-        assert_eq!(plan.steps[0].step_type, "release.skip");
-        assert_eq!(plan.steps[0].status, ReleasePlanStatus::Disabled);
-        assert_eq!(
-            plan.steps[0].config.get("reason").and_then(|v| v.as_str()),
-            Some("no-releasable-commits")
-        );
-        assert_eq!(
-            plan.hints,
-            vec!["Use --bump to force a release when this is intentional"]
         );
     }
 

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -1,0 +1,139 @@
+use super::types::{
+    ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep, ReleaseSemverRecommendation,
+};
+
+pub(super) fn release_skip_plan(
+    component_id: &str,
+    options: &ReleaseOptions,
+    semver_recommendation: Option<ReleaseSemverRecommendation>,
+) -> Option<ReleasePlan> {
+    if semver_recommendation.is_none() && !options.bump_policy.force_empty_release {
+        return Some(skipped_release_plan(
+            component_id,
+            "no-releasable-commits",
+            "No releasable commits since last tag",
+            "Use --bump to force a release when this is intentional",
+            None,
+        ));
+    }
+
+    if options.bump_policy.require_explicit_major {
+        return Some(skipped_release_plan(
+            component_id,
+            "major-requires-flag",
+            "Breaking changes require an explicit major bump",
+            &format!("Re-run with: homeboy release {} --bump major", component_id),
+            semver_recommendation,
+        ));
+    }
+
+    None
+}
+
+fn skipped_release_plan(
+    component_id: &str,
+    reason: &str,
+    label: &str,
+    hint: &str,
+    semver_recommendation: Option<ReleaseSemverRecommendation>,
+) -> ReleasePlan {
+    ReleasePlan {
+        component_id: component_id.to_string(),
+        enabled: false,
+        steps: vec![ReleasePlanStep {
+            id: "release.skip".to_string(),
+            step_type: "release.skip".to_string(),
+            label: Some(label.to_string()),
+            needs: vec![],
+            config: std::collections::HashMap::from([(
+                "reason".to_string(),
+                serde_json::Value::String(reason.to_string()),
+            )]),
+            status: ReleasePlanStatus::Disabled,
+            missing: vec![],
+        }],
+        semver_recommendation,
+        warnings: vec![],
+        hints: vec![hint.to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::release_skip_plan;
+    use crate::release::types::{
+        ReleaseBumpPolicyOptions, ReleaseOptions, ReleasePlanStatus, ReleaseSemverRecommendation,
+    };
+
+    #[test]
+    fn test_release_skip_plan() {
+        let plan = release_skip_plan("demo", &ReleaseOptions::default(), None)
+            .expect("no releasable commits should skip");
+
+        assert!(!plan.enabled);
+        assert_eq!(plan.component_id, "demo");
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].id, "release.skip");
+        assert_eq!(plan.steps[0].step_type, "release.skip");
+        assert_eq!(plan.steps[0].status, ReleasePlanStatus::Disabled);
+        assert_eq!(
+            plan.steps[0].config.get("reason").and_then(|v| v.as_str()),
+            Some("no-releasable-commits")
+        );
+        assert_eq!(
+            plan.hints,
+            vec!["Use --bump to force a release when this is intentional"]
+        );
+    }
+
+    #[test]
+    fn skip_plan_allows_forced_empty_release() {
+        let options = ReleaseOptions {
+            bump_policy: ReleaseBumpPolicyOptions {
+                force_empty_release: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(release_skip_plan("demo", &options, None).is_none());
+    }
+
+    #[test]
+    fn skip_plan_records_major_requires_flag_reason() {
+        let options = ReleaseOptions {
+            bump_policy: ReleaseBumpPolicyOptions {
+                require_explicit_major: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let recommendation = semver_recommendation("major", "major");
+
+        let plan = release_skip_plan("demo", &options, Some(recommendation))
+            .expect("implicit major should skip");
+
+        assert!(!plan.enabled);
+        assert!(plan.semver_recommendation.is_some());
+        assert_eq!(
+            plan.steps[0].config.get("reason").and_then(|v| v.as_str()),
+            Some("major-requires-flag")
+        );
+        assert_eq!(
+            plan.hints,
+            vec!["Re-run with: homeboy release demo --bump major"]
+        );
+    }
+
+    fn semver_recommendation(recommended: &str, requested: &str) -> ReleaseSemverRecommendation {
+        ReleaseSemverRecommendation {
+            latest_tag: Some("v1.0.0".to_string()),
+            range: "v1.0.0..HEAD".to_string(),
+            commits: vec![],
+            recommended_bump: Some(recommended.to_string()),
+            requested_bump: requested.to_string(),
+            is_underbump: false,
+            reasons: vec![],
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move release skip decision construction out of `pipeline.rs` into a focused planning policy module.
- Keep `pipeline::plan()` responsible for orchestration while preserving the existing no-releasable-commits and explicit-major skip behavior.
- Add targeted policy tests for empty-release skipping, forced empty releases, and explicit-major skip hints.

## Tests
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the release planning policy extraction under Chris's direction.