### PR TITLE
Support proxied form API requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ regex = "1.11"
 glob-match = "0.2"
 glob = "0.3"
 zip = "0.6"
-reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls"] }
+reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls", "socks"] }
 arboard = "3"
 chrono = "0.4"
 semver = "1.0"

--- a/docs/schemas/project-schema.md
+++ b/docs/schemas/project-schema.md
@@ -48,6 +48,8 @@ Project configuration defines deployable environments stored in `projects/<id>.j
 - **`api`** (object): API client configuration
   - **`base_url`** (string): API base URL
   - **`enabled`** (boolean): Whether API client is enabled
+  - **`proxy_url`** (string): Optional HTTP/SOCKS proxy URL for API requests, e.g. `socks5://127.0.0.1:8080`
+  - API POST/PUT/PATCH calls can send form data with `homeboy api <project> post <endpoint> --form key=value`.
 - **`database`** (object): Database connection settings
   - **`host`** (string): Database host
   - **`port`** (number): Database port (default: 3306)
@@ -106,7 +108,8 @@ Project configuration defines deployable environments stored in `projects/<id>.j
   ],
   "api": {
     "base_url": "https://extrachill.com/wp-json",
-    "enabled": true
+    "enabled": true,
+    "proxy_url": "socks5://127.0.0.1:8080"
   },
   "database": {
     "host": "localhost",

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -26,6 +26,9 @@ enum ApiCommand {
         /// JSON body
         #[arg(long)]
         body: Option<String>,
+        /// Form field as key=value. May be repeated.
+        #[arg(long)]
+        form: Vec<String>,
     },
     /// Make a PUT request
     Put {
@@ -34,6 +37,9 @@ enum ApiCommand {
         /// JSON body
         #[arg(long)]
         body: Option<String>,
+        /// Form field as key=value. May be repeated.
+        #[arg(long)]
+        form: Vec<String>,
     },
     /// Make a PATCH request
     Patch {
@@ -42,6 +48,9 @@ enum ApiCommand {
         /// JSON body
         #[arg(long)]
         body: Option<String>,
+        /// Form field as key=value. May be repeated.
+        #[arg(long)]
+        form: Vec<String>,
     },
     /// Make a DELETE request
     Delete {
@@ -56,22 +65,69 @@ pub fn run(args: ApiArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<ap
 }
 
 fn build_api_json(args: &ApiArgs) -> String {
-    let (method, endpoint, body) = match &args.command {
-        ApiCommand::Get { endpoint } => ("GET", endpoint.clone(), None),
-        ApiCommand::Post { endpoint, body } => ("POST", endpoint.clone(), body.clone()),
-        ApiCommand::Put { endpoint, body } => ("PUT", endpoint.clone(), body.clone()),
-        ApiCommand::Patch { endpoint, body } => ("PATCH", endpoint.clone(), body.clone()),
-        ApiCommand::Delete { endpoint } => ("DELETE", endpoint.clone(), None),
+    let (method, endpoint, body, body_format) = match &args.command {
+        ApiCommand::Get { endpoint } => ("GET", endpoint.clone(), None, "json"),
+        ApiCommand::Post {
+            endpoint,
+            body,
+            form,
+        } => (
+            "POST",
+            endpoint.clone(),
+            build_body(body, form),
+            body_format(form),
+        ),
+        ApiCommand::Put {
+            endpoint,
+            body,
+            form,
+        } => (
+            "PUT",
+            endpoint.clone(),
+            build_body(body, form),
+            body_format(form),
+        ),
+        ApiCommand::Patch {
+            endpoint,
+            body,
+            form,
+        } => (
+            "PATCH",
+            endpoint.clone(),
+            build_body(body, form),
+            body_format(form),
+        ),
+        ApiCommand::Delete { endpoint } => ("DELETE", endpoint.clone(), None, "json"),
     };
-
-    let body_value: Option<serde_json::Value> =
-        body.as_ref().and_then(|b| serde_json::from_str(b).ok());
 
     serde_json::json!({
         "projectId": args.project_id,
         "method": method,
         "endpoint": endpoint,
-        "body": body_value,
+        "body": body,
+        "bodyFormat": body_format,
     })
     .to_string()
+}
+
+fn build_body(body: &Option<String>, form: &[String]) -> Option<serde_json::Value> {
+    if !form.is_empty() {
+        let mut pairs = Vec::new();
+        for item in form {
+            if let Some((key, value)) = item.split_once('=') {
+                pairs.push(serde_json::json!([key, value]));
+            }
+        }
+        return Some(serde_json::Value::Array(pairs));
+    }
+
+    body.as_ref().and_then(|b| serde_json::from_str(b).ok())
+}
+
+fn body_format(form: &[String]) -> &'static str {
+    if form.is_empty() {
+        "json"
+    } else {
+        "form"
+    }
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -308,6 +308,8 @@ pub struct ApiConfig {
     #[serde(default)]
     pub base_url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub auth: Option<AuthConfig>,
 }
 

--- a/src/core/server/api.rs
+++ b/src/core/server/api.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::http::ApiClient;
+use super::http::{ApiClient, BodyFormat};
 use crate::error::{Error, Result};
 use crate::project;
 
@@ -38,8 +38,17 @@ pub fn run(input: &str) -> Result<(ApiOutput, i32)> {
 
     let response = match parsed.method.to_uppercase().as_str() {
         "GET" => client.get(&parsed.endpoint)?,
+        "POST" if parsed.body_format == BodyFormat::Form => {
+            client.post_form(&parsed.endpoint, &body)?
+        }
         "POST" => client.post(&parsed.endpoint, &body)?,
+        "PUT" if parsed.body_format == BodyFormat::Form => {
+            client.put_form(&parsed.endpoint, &body)?
+        }
         "PUT" => client.put(&parsed.endpoint, &body)?,
+        "PATCH" if parsed.body_format == BodyFormat::Form => {
+            client.patch_form(&parsed.endpoint, &body)?
+        }
         "PATCH" => client.patch(&parsed.endpoint, &body)?,
         "DELETE" => client.delete(&parsed.endpoint)?,
         _ => {
@@ -72,8 +81,34 @@ pub fn run(input: &str) -> Result<(ApiOutput, i32)> {
 #[derive(Debug, Deserialize)]
 
 struct ApiInput {
+    #[serde(rename = "projectId")]
     project_id: String,
     method: String,
     endpoint: String,
     body: Option<Value>,
+    #[serde(default, rename = "bodyFormat")]
+    body_format: BodyFormat,
+}
+
+impl Default for BodyFormat {
+    fn default() -> Self {
+        Self::Json
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for BodyFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "" | "json" => Ok(Self::Json),
+            "form" => Ok(Self::Form),
+            other => Err(serde::de::Error::custom(format!(
+                "invalid bodyFormat '{}'",
+                other
+            ))),
+        }
+    }
 }

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -6,7 +6,8 @@
 use crate::error::{Error, ErrorCode, Result};
 use crate::extension::HttpMethod;
 use crate::project::{ApiConfig, AuthConfig, AuthFlowConfig, VariableSource};
-use reqwest::blocking::{Client, RequestBuilder, Response};
+use reqwest::blocking::{Client, ClientBuilder, RequestBuilder, Response};
+use reqwest::Proxy;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
@@ -57,8 +58,10 @@ impl ApiClient {
             return Err(config_error("API base URL is not configured"));
         }
 
+        let client = build_client(api_config)?;
+
         Ok(Self {
-            client: Client::new(),
+            client,
             base_url: api_config.base_url.clone(),
             project_id: project_id.to_string(),
             auth: api_config.auth.clone(),
@@ -71,6 +74,7 @@ impl ApiClient {
         method: HttpMethod,
         endpoint: &str,
         body: Option<&Value>,
+        body_format: BodyFormat,
     ) -> Result<Value> {
         let url = format!("{}{}", self.base_url, endpoint);
 
@@ -83,7 +87,10 @@ impl ApiClient {
         };
 
         let request = if let Some(body) = body {
-            request.json(body)
+            match body_format {
+                BodyFormat::Json => request.json(body),
+                BodyFormat::Form => request.form(&form_fields(body)?),
+            }
         } else {
             request
         };
@@ -101,27 +108,42 @@ impl ApiClient {
 
     /// Makes a GET request.
     pub fn get(&self, endpoint: &str) -> Result<Value> {
-        self.execute_request(HttpMethod::Get, endpoint, None)
+        self.execute_request(HttpMethod::Get, endpoint, None, BodyFormat::Json)
     }
 
     /// Makes a POST request with JSON body.
     pub fn post(&self, endpoint: &str, body: &Value) -> Result<Value> {
-        self.execute_request(HttpMethod::Post, endpoint, Some(body))
+        self.execute_request(HttpMethod::Post, endpoint, Some(body), BodyFormat::Json)
+    }
+
+    /// Makes a POST request with form fields.
+    pub fn post_form(&self, endpoint: &str, body: &Value) -> Result<Value> {
+        self.execute_request(HttpMethod::Post, endpoint, Some(body), BodyFormat::Form)
     }
 
     /// Makes a PUT request with JSON body.
     pub fn put(&self, endpoint: &str, body: &Value) -> Result<Value> {
-        self.execute_request(HttpMethod::Put, endpoint, Some(body))
+        self.execute_request(HttpMethod::Put, endpoint, Some(body), BodyFormat::Json)
+    }
+
+    /// Makes a PUT request with form fields.
+    pub fn put_form(&self, endpoint: &str, body: &Value) -> Result<Value> {
+        self.execute_request(HttpMethod::Put, endpoint, Some(body), BodyFormat::Form)
     }
 
     /// Makes a PATCH request with JSON body.
     pub fn patch(&self, endpoint: &str, body: &Value) -> Result<Value> {
-        self.execute_request(HttpMethod::Patch, endpoint, Some(body))
+        self.execute_request(HttpMethod::Patch, endpoint, Some(body), BodyFormat::Json)
+    }
+
+    /// Makes a PATCH request with form fields.
+    pub fn patch_form(&self, endpoint: &str, body: &Value) -> Result<Value> {
+        self.execute_request(HttpMethod::Patch, endpoint, Some(body), BodyFormat::Form)
     }
 
     /// Makes a DELETE request.
     pub fn delete(&self, endpoint: &str) -> Result<Value> {
-        self.execute_request(HttpMethod::Delete, endpoint, None)
+        self.execute_request(HttpMethod::Delete, endpoint, None, BodyFormat::Json)
     }
 
     /// Makes a POST request without auth (for login flows).
@@ -227,6 +249,64 @@ impl ApiClient {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyFormat {
+    Json,
+    Form,
+}
+
+fn form_fields(body: &Value) -> Result<Vec<(String, String)>> {
+    if let Some(pairs) = body.as_array() {
+        return pairs
+            .iter()
+            .map(|pair| {
+                let pair = pair.as_array().ok_or_else(|| {
+                    config_error("Form body array entries must be [key, value] pairs")
+                })?;
+                if pair.len() != 2 {
+                    return Err(config_error(
+                        "Form body array entries must be [key, value] pairs",
+                    ));
+                }
+                let key = pair[0]
+                    .as_str()
+                    .ok_or_else(|| config_error("Form field key must be a string"))?;
+                let value = pair[1]
+                    .as_str()
+                    .ok_or_else(|| config_error("Form field value must be a string"))?;
+                Ok((key.to_string(), value.to_string()))
+            })
+            .collect();
+    }
+
+    let object = body.as_object().ok_or_else(|| {
+        config_error("Form body must be a JSON object or an array of [key, value] pairs")
+    })?;
+
+    object
+        .iter()
+        .map(|(key, value)| {
+            value
+                .as_str()
+                .map(|value| (key.clone(), value.to_string()))
+                .ok_or_else(|| config_error(format!("Form field '{}' must be a string", key)))
+        })
+        .collect()
+}
+
+fn build_client(api_config: &ApiConfig) -> Result<Client> {
+    let mut builder = ClientBuilder::new();
+
+    if let Some(proxy_url) = api_config.proxy_url.as_deref() {
+        builder =
+            builder.proxy(Proxy::all(proxy_url).map_err(|e| {
+                config_error(format!("Invalid API proxy URL '{}': {}", proxy_url, e))
+            })?);
+    }
+
+    builder.build().map_err(http_error)
+}
+
 /// Resolves a variable from its source.
 fn resolve_variable(_project_id: &str, var_name: &str, source: &VariableSource) -> Result<String> {
     match source.source.as_str() {
@@ -285,4 +365,53 @@ fn parse_json_response(response: Response) -> Result<Value> {
     }
 
     serde_json::from_str(&body).map_err(|e| parse_error(format!("Invalid JSON response: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_client_with_socks_proxy() {
+        let config = ApiConfig {
+            enabled: true,
+            base_url: "https://atomic-api.wordpress.com/api/v1.0".to_string(),
+            proxy_url: Some("socks5://127.0.0.1:8080".to_string()),
+            auth: None,
+        };
+
+        build_client(&config).expect("socks proxy should be accepted");
+    }
+
+    #[test]
+    fn rejects_invalid_proxy_url() {
+        let config = ApiConfig {
+            enabled: true,
+            base_url: "https://example.com".to_string(),
+            proxy_url: Some("not a proxy".to_string()),
+            auth: None,
+        };
+
+        let err = build_client(&config).expect_err("invalid proxy should fail");
+        assert!(err.to_string().contains("Invalid API proxy URL"));
+    }
+
+    #[test]
+    fn form_fields_preserve_duplicate_keys() {
+        let fields = form_fields(&serde_json::json!([
+            ["provision[]", "base"],
+            ["provision[]", "install-wp"],
+            ["provision[]", "dereference"]
+        ]))
+        .expect("form fields");
+
+        assert_eq!(
+            fields,
+            vec![
+                ("provision[]".to_string(), "base".to_string()),
+                ("provision[]".to_string(), "install-wp".to_string()),
+                ("provision[]".to_string(), "dereference".to_string()),
+            ]
+        );
+    }
 }

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -370,6 +370,96 @@ fn parse_json_response(response: Response) -> Result<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::project::{AuthConfig, AuthFlowConfig};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn test_client(base_url: String) -> ApiClient {
+        ApiClient::new(
+            "test-project",
+            &ApiConfig {
+                enabled: true,
+                base_url,
+                proxy_url: None,
+                auth: None,
+            },
+        )
+        .expect("api client")
+    }
+
+    fn test_client_with_auth(base_url: String, auth: AuthConfig) -> ApiClient {
+        ApiClient::new(
+            "test-project",
+            &ApiConfig {
+                enabled: true,
+                base_url,
+                proxy_url: None,
+                auth: Some(auth),
+            },
+        )
+        .expect("api client")
+    }
+
+    fn with_test_server<F>(assert_request: F) -> String
+    where
+        F: FnOnce(&str) + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = Vec::new();
+            let mut temp = [0_u8; 1024];
+            loop {
+                let read = stream.read(&mut temp).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                buffer.extend_from_slice(&temp[..read]);
+
+                let request = String::from_utf8_lossy(&buffer);
+                if let Some(header_end) = request.find("\r\n\r\n") {
+                    let headers = &request[..header_end];
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.strip_prefix("Content-Length: ")
+                                .and_then(|value| value.parse::<usize>().ok())
+                        })
+                        .unwrap_or(0);
+                    let body_len = buffer.len().saturating_sub(header_end + 4);
+                    if body_len >= content_length {
+                        break;
+                    }
+                }
+            }
+
+            let request = String::from_utf8_lossy(&buffer).to_string();
+            assert_request(&request);
+            let response = concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Content-Type: application/json\r\n",
+                "Content-Length: 11\r\n",
+                "Connection: close\r\n\r\n",
+                "{\"ok\":true}"
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+
+        format!("http://{}", addr)
+    }
+
+    fn assert_method_path(request: &str, method: &str, path: &str) {
+        assert!(
+            request.starts_with(&format!("{} {} HTTP/1.1", method, path)),
+            "unexpected request: {}",
+            request
+        );
+    }
 
     #[test]
     fn builds_client_with_socks_proxy() {
@@ -413,5 +503,149 @@ mod tests {
                 ("provision[]".to_string(), "dereference".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn test_get() {
+        let base_url = with_test_server(|request| assert_method_path(request, "GET", "/items"));
+        let response = test_client(base_url).get("/items").expect("get response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_post() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "POST", "/items");
+            assert!(request.contains("content-type: application/json"));
+            assert!(request.contains("\"name\":\"soup\""));
+        });
+        let response = test_client(base_url)
+            .post("/items", &serde_json::json!({ "name": "soup" }))
+            .expect("post response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_post_form() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "POST", "/items");
+            assert!(request.contains("content-type: application/x-www-form-urlencoded"));
+            assert!(request.contains("name=soup"));
+        });
+        let response = test_client(base_url)
+            .post_form("/items", &serde_json::json!([["name", "soup"]]))
+            .expect("post form response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_post_unauthenticated() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "POST", "/login");
+            assert!(request.contains("\"username\":\"chris\""));
+        });
+        let response = test_client(base_url)
+            .post_unauthenticated("/login", &serde_json::json!({ "username": "chris" }))
+            .expect("unauthenticated post response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_put() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "PUT", "/items/1");
+            assert!(request.contains("\"name\":\"stew\""));
+        });
+        let response = test_client(base_url)
+            .put("/items/1", &serde_json::json!({ "name": "stew" }))
+            .expect("put response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_put_form() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "PUT", "/items/1");
+            assert!(request.contains("name=stew"));
+        });
+        let response = test_client(base_url)
+            .put_form("/items/1", &serde_json::json!([["name", "stew"]]))
+            .expect("put form response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_patch() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "PATCH", "/items/1");
+            assert!(request.contains("\"name\":\"bisque\""));
+        });
+        let response = test_client(base_url)
+            .patch("/items/1", &serde_json::json!({ "name": "bisque" }))
+            .expect("patch response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_patch_form() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "PATCH", "/items/1");
+            assert!(request.contains("name=bisque"));
+        });
+        let response = test_client(base_url)
+            .patch_form("/items/1", &serde_json::json!([["name", "bisque"]]))
+            .expect("patch form response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_delete() {
+        let base_url =
+            with_test_server(|request| assert_method_path(request, "DELETE", "/items/1"));
+        let response = test_client(base_url)
+            .delete("/items/1")
+            .expect("delete response");
+        assert_eq!(response["ok"], true);
+    }
+
+    #[test]
+    fn test_login() {
+        let base_url = with_test_server(|request| {
+            assert_method_path(request, "POST", "/login");
+            assert!(request.contains("\"username\":\"chris\""));
+        });
+        let client = test_client_with_auth(
+            base_url,
+            AuthConfig {
+                header: "Auth: {{token}}".to_string(),
+                variables: HashMap::new(),
+                login: Some(AuthFlowConfig {
+                    endpoint: "/login".to_string(),
+                    method: "POST".to_string(),
+                    body: HashMap::from([("username".to_string(), "{{username}}".to_string())]),
+                    store: HashMap::new(),
+                }),
+                refresh: None,
+            },
+        );
+
+        client
+            .login(&HashMap::from([(
+                "username".to_string(),
+                "chris".to_string(),
+            )]))
+            .expect("login response");
+    }
+
+    #[test]
+    fn test_logout() {
+        let client = test_client("http://127.0.0.1:1".to_string());
+        client.logout().expect("logout is a no-op");
+    }
+
+    #[test]
+    fn test_refresh_if_needed() {
+        let client = test_client("http://127.0.0.1:1".to_string());
+        assert!(!client.refresh_if_needed().expect("refresh is unsupported"));
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `api.proxy_url` so project API clients can route through HTTP/SOCKS proxies.
- Add form-encoded request support to `homeboy api` for POST/PUT/PATCH calls.
- Preserve duplicate form keys for APIs that use repeated fields.

## Testing
- `cargo fmt`
- `cargo test core::server::http`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic proxy/form API implementation, docs updates, and focused tests; Chris reviewed the direction and requested the PR.