### PR TITLE
Add dependency stack propagation

### DIFF
--- a/docs/commands/deps.md
+++ b/docs/commands/deps.md
@@ -12,6 +12,40 @@ homeboy deps <COMMAND>
 
 - `status` — inspect dependency constraints and locked package versions
 - `update` — update one Composer package explicitly
+- `stack status` — list declared dependency stack edges
+- `stack plan <upstream>` — plan downstream updates for a merged upstream component or repo
+- `stack apply <upstream> [--dry-run]` — run declared update, post-update, and test commands in dependency order
+
+## Dependency Stacks
+
+Components can declare deterministic downstream propagation edges in `homeboy.json`:
+
+```json
+{
+  "dependency_stack": [
+    {
+      "upstream": "chubes4/html-to-blocks-converter",
+      "downstream": "block-format-bridge",
+      "package": "chubes4/html-to-blocks-converter",
+      "post_update": ["composer build"],
+      "test": ["homeboy test --path . --extension wordpress"]
+    },
+    {
+      "upstream": "block-format-bridge",
+      "downstream": "static-site-importer",
+      "package": "chubes4/block-format-bridge",
+      "update": "composer update chubes4/block-format-bridge --with-dependencies --no-interaction",
+      "test": ["homeboy test --path . --extension wordpress"]
+    }
+  ]
+}
+```
+
+When `update` is omitted, Homeboy uses:
+
+```sh
+homeboy deps update <package> --path <downstream path>
+```
 
 ## Related
 

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -1,6 +1,9 @@
 use clap::{Args, Subcommand};
 
-use homeboy::deps::{self, DependencyStatus, DependencyUpdateResult};
+use homeboy::deps::{
+    self, DependencyStackApplyResult, DependencyStackPlan, DependencyStackStatus, DependencyStatus,
+    DependencyUpdateResult,
+};
 
 use super::CmdResult;
 
@@ -40,6 +43,31 @@ enum DepsCommand {
         /// Workspace path to operate on directly.
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
+    },
+    /// Work with declared downstream dependency stacks
+    Stack {
+        #[command(subcommand)]
+        command: DepsStackCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum DepsStackCommand {
+    /// List declared dependency stack edges
+    Status,
+    /// Plan downstream updates for an upstream component/repo
+    Plan {
+        /// Upstream component or repository identifier from dependency_stack[].upstream.
+        upstream: String,
+    },
+    /// Run downstream update commands for an upstream component/repo
+    Apply {
+        /// Upstream component or repository identifier from dependency_stack[].upstream.
+        upstream: String,
+
+        /// Print the command plan without running commands.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -84,5 +112,43 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
                 0,
             ))
         }
+        DepsCommand::Stack { command } => match command {
+            DepsStackCommand::Status => {
+                let output: DependencyStackStatus = deps::stack_status()?;
+                Ok((
+                    serde_json::to_value(output).map_err(|e| {
+                        homeboy::Error::internal_json(
+                            e.to_string(),
+                            Some("serialize deps stack status".to_string()),
+                        )
+                    })?,
+                    0,
+                ))
+            }
+            DepsStackCommand::Plan { upstream } => {
+                let output: DependencyStackPlan = deps::stack_plan(&upstream)?;
+                Ok((
+                    serde_json::to_value(output).map_err(|e| {
+                        homeboy::Error::internal_json(
+                            e.to_string(),
+                            Some("serialize deps stack plan".to_string()),
+                        )
+                    })?,
+                    0,
+                ))
+            }
+            DepsStackCommand::Apply { upstream, dry_run } => {
+                let output: DependencyStackApplyResult = deps::stack_apply(&upstream, dry_run)?;
+                Ok((
+                    serde_json::to_value(output).map_err(|e| {
+                        homeboy::Error::internal_json(
+                            e.to_string(),
+                            Some("serialize deps stack apply".to_string()),
+                        )
+                    })?,
+                    0,
+                ))
+            }
+        },
     }
 }

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -143,6 +143,19 @@ pub struct ComponentScriptsConfig {
     pub trace: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct DependencyStackEdge {
+    pub upstream: String,
+    pub downstream: String,
+    pub package: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_update: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub test: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(from = "RawComponent", into = "RawComponent")]
 pub struct Component {
@@ -185,6 +198,8 @@ pub struct Component {
     pub scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit: Option<AuditConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependency_stack: Vec<DependencyStackEdge>,
     /// Override the CLI path used by extension deploy install steps.
     /// For example, Studio sites need "studio wp" instead of the default "wp".
     pub cli_path: Option<String>,
@@ -266,6 +281,8 @@ struct RawComponent {
     scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     audit: Option<AuditConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    dependency_stack: Vec<DependencyStackEdge>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cli_path: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -320,6 +337,7 @@ impl From<RawComponent> for Component {
             self_checks: raw.self_checks,
             scripts: raw.scripts,
             audit: raw.audit,
+            dependency_stack: raw.dependency_stack,
             cli_path: raw.cli_path,
             extra_drift_files: raw.extra_drift_files,
         }
@@ -357,6 +375,7 @@ impl From<Component> for RawComponent {
             self_checks: c.self_checks,
             scripts: c.scripts,
             audit: c.audit,
+            dependency_stack: c.dependency_stack,
             cli_path: c.cli_path,
             extra_drift_files: c.extra_drift_files,
         }
@@ -431,6 +450,7 @@ impl Component {
             self_checks: None,
             scripts: None,
             audit: None,
+            dependency_stack: Vec::new(),
             cli_path: None,
             extra_drift_files: Vec::new(),
         }

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -1,4 +1,4 @@
-use crate::component::{self, Component, DependencyStackEdge};
+use crate::component::{self, Component};
 use crate::{Error, Result};
 use serde::Serialize;
 use serde_json::Value;
@@ -6,6 +6,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+mod stack;
+
+pub use stack::{
+    stack_apply, stack_plan, stack_plan_from_components, stack_status, DependencyStackApplyResult,
+    DependencyStackApplyStep, DependencyStackCommandResult, DependencyStackEdgeStatus,
+    DependencyStackPlan, DependencyStackPlanStep, DependencyStackStatus,
+};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DependencyPackage {
@@ -41,69 +49,6 @@ pub struct DependencyUpdateResult {
     pub before: Option<DependencyPackage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<DependencyPackage>,
-    pub stdout: String,
-    pub stderr: String,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DependencyStackStatus {
-    pub edge_count: usize,
-    pub edges: Vec<DependencyStackEdgeStatus>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DependencyStackEdgeStatus {
-    pub declaring_component_id: String,
-    pub upstream: String,
-    pub downstream: String,
-    pub package: String,
-    pub update_command: String,
-    pub post_update: Vec<String>,
-    pub test: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DependencyStackPlan {
-    pub upstream: String,
-    pub step_count: usize,
-    pub steps: Vec<DependencyStackPlanStep>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DependencyStackPlanStep {
-    pub sequence: usize,
-    pub declaring_component_id: String,
-    pub upstream: String,
-    pub downstream: String,
-    pub downstream_path: String,
-    pub package: String,
-    pub update_command: String,
-    pub post_update: Vec<String>,
-    pub test: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DependencyStackApplyResult {
-    pub upstream: String,
-    pub dry_run: bool,
-    pub step_count: usize,
-    pub steps: Vec<DependencyStackApplyStep>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DependencyStackApplyStep {
-    pub sequence: usize,
-    pub downstream: String,
-    pub command_results: Vec<DependencyStackCommandResult>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DependencyStackCommandResult {
-    pub phase: String,
-    pub command: String,
-    pub skipped: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<i32>,
     pub stdout: String,
     pub stderr: String,
 }
@@ -201,226 +146,6 @@ pub fn update(
         stdout,
         stderr,
     })
-}
-
-pub fn stack_status() -> Result<DependencyStackStatus> {
-    let mut edges = Vec::new();
-    for component in component::list()? {
-        for edge in &component.dependency_stack {
-            edges.push(edge_status(&component, edge));
-        }
-    }
-
-    edges.sort_by(|a, b| {
-        a.upstream
-            .cmp(&b.upstream)
-            .then_with(|| a.downstream.cmp(&b.downstream))
-            .then_with(|| a.package.cmp(&b.package))
-    });
-
-    Ok(DependencyStackStatus {
-        edge_count: edges.len(),
-        edges,
-    })
-}
-
-pub fn stack_plan(upstream: &str) -> Result<DependencyStackPlan> {
-    let components = component::list()?;
-    stack_plan_from_components(upstream, &components)
-}
-
-pub fn stack_apply(upstream: &str, dry_run: bool) -> Result<DependencyStackApplyResult> {
-    let plan = stack_plan(upstream)?;
-    let mut steps = Vec::new();
-
-    for step in &plan.steps {
-        let mut command_results = Vec::new();
-        command_results.push(run_stack_command(
-            "update",
-            &step.update_command,
-            &step.downstream_path,
-            dry_run,
-        )?);
-        for command in &step.post_update {
-            command_results.push(run_stack_command(
-                "post_update",
-                command,
-                &step.downstream_path,
-                dry_run,
-            )?);
-        }
-        for command in &step.test {
-            command_results.push(run_stack_command(
-                "test",
-                command,
-                &step.downstream_path,
-                dry_run,
-            )?);
-        }
-        steps.push(DependencyStackApplyStep {
-            sequence: step.sequence,
-            downstream: step.downstream.clone(),
-            command_results,
-        });
-    }
-
-    Ok(DependencyStackApplyResult {
-        upstream: plan.upstream,
-        dry_run,
-        step_count: steps.len(),
-        steps,
-    })
-}
-
-pub fn stack_plan_from_components(
-    upstream: &str,
-    components: &[Component],
-) -> Result<DependencyStackPlan> {
-    let mut steps = Vec::new();
-    let mut queue = vec![upstream.to_string()];
-    let mut visited_edges = BTreeSet::new();
-    let component_paths: BTreeMap<String, String> = components
-        .iter()
-        .map(|component| (component.id.clone(), component.local_path.clone()))
-        .collect();
-
-    while let Some(current_upstream) = queue.pop() {
-        let mut matching_edges = Vec::new();
-        for component in components {
-            for edge in &component.dependency_stack {
-                if edge.upstream == current_upstream {
-                    matching_edges.push((component, edge));
-                }
-            }
-        }
-        matching_edges.sort_by(|(a_component, a_edge), (b_component, b_edge)| {
-            a_edge
-                .downstream
-                .cmp(&b_edge.downstream)
-                .then_with(|| a_edge.package.cmp(&b_edge.package))
-                .then_with(|| a_component.id.cmp(&b_component.id))
-        });
-
-        for (component, edge) in matching_edges {
-            let key = format!("{}>{}:{}", edge.upstream, edge.downstream, edge.package);
-            if !visited_edges.insert(key) {
-                continue;
-            }
-            let Some(downstream_path) = component_paths.get(&edge.downstream) else {
-                return Err(Error::validation_invalid_argument(
-                    "dependency_stack.downstream",
-                    format!(
-                        "Dependency stack edge {} -> {} references an unknown downstream component",
-                        edge.upstream, edge.downstream
-                    ),
-                    Some(edge.downstream.clone()),
-                    Some(vec![
-                        "Add the downstream component to Homeboy inventory".to_string(),
-                        "Or fix dependency_stack[].downstream in homeboy.json".to_string(),
-                    ]),
-                ));
-            };
-            steps.push(DependencyStackPlanStep {
-                sequence: steps.len() + 1,
-                declaring_component_id: component.id.clone(),
-                upstream: edge.upstream.clone(),
-                downstream: edge.downstream.clone(),
-                downstream_path: downstream_path.clone(),
-                package: edge.package.clone(),
-                update_command: update_command(edge, downstream_path),
-                post_update: edge.post_update.clone(),
-                test: edge.test.clone(),
-            });
-            queue.push(edge.downstream.clone());
-        }
-    }
-
-    Ok(DependencyStackPlan {
-        upstream: upstream.to_string(),
-        step_count: steps.len(),
-        steps,
-    })
-}
-
-fn edge_status(component: &Component, edge: &DependencyStackEdge) -> DependencyStackEdgeStatus {
-    DependencyStackEdgeStatus {
-        declaring_component_id: component.id.clone(),
-        upstream: edge.upstream.clone(),
-        downstream: edge.downstream.clone(),
-        package: edge.package.clone(),
-        update_command: update_command(edge, &component.local_path),
-        post_update: edge.post_update.clone(),
-        test: edge.test.clone(),
-    }
-}
-
-fn update_command(edge: &DependencyStackEdge, downstream_path: &str) -> String {
-    edge.update.clone().unwrap_or_else(|| {
-        format!(
-            "homeboy deps update {} --path {}",
-            shell_word(&edge.package),
-            shell_word(downstream_path)
-        )
-    })
-}
-
-fn run_stack_command(
-    phase: &str,
-    command: &str,
-    cwd: &str,
-    dry_run: bool,
-) -> Result<DependencyStackCommandResult> {
-    if dry_run {
-        return Ok(DependencyStackCommandResult {
-            phase: phase.to_string(),
-            command: command.to_string(),
-            skipped: true,
-            status: None,
-            stdout: String::new(),
-            stderr: String::new(),
-        });
-    }
-
-    let output = Command::new("sh")
-        .args(["-c", command])
-        .current_dir(cwd)
-        .output()
-        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("run {phase} command"))))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
-            "dependency_stack.command",
-            format!(
-                "Dependency stack {phase} command failed with status {}: {}",
-                output.status,
-                first_non_empty_line(&stderr)
-                    .or_else(|| first_non_empty_line(&stdout))
-                    .unwrap_or("no output")
-            ),
-            Some(command.to_string()),
-            Some(vec![format!("Run manually in {cwd}: {command}")]),
-        ));
-    }
-
-    Ok(DependencyStackCommandResult {
-        phase: phase.to_string(),
-        command: command.to_string(),
-        skipped: false,
-        status: output.status.code(),
-        stdout,
-        stderr,
-    })
-}
-
-fn shell_word(value: &str) -> String {
-    if value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '@'))
-    {
-        return value.to_string();
-    }
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn resolve_component_path(

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -1,4 +1,4 @@
-use crate::component::{self, Component};
+use crate::component::{self, Component, DependencyStackEdge};
 use crate::{Error, Result};
 use serde::Serialize;
 use serde_json::Value;
@@ -41,6 +41,69 @@ pub struct DependencyUpdateResult {
     pub before: Option<DependencyPackage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<DependencyPackage>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackStatus {
+    pub edge_count: usize,
+    pub edges: Vec<DependencyStackEdgeStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackEdgeStatus {
+    pub declaring_component_id: String,
+    pub upstream: String,
+    pub downstream: String,
+    pub package: String,
+    pub update_command: String,
+    pub post_update: Vec<String>,
+    pub test: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackPlan {
+    pub upstream: String,
+    pub step_count: usize,
+    pub steps: Vec<DependencyStackPlanStep>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackPlanStep {
+    pub sequence: usize,
+    pub declaring_component_id: String,
+    pub upstream: String,
+    pub downstream: String,
+    pub downstream_path: String,
+    pub package: String,
+    pub update_command: String,
+    pub post_update: Vec<String>,
+    pub test: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackApplyResult {
+    pub upstream: String,
+    pub dry_run: bool,
+    pub step_count: usize,
+    pub steps: Vec<DependencyStackApplyStep>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackApplyStep {
+    pub sequence: usize,
+    pub downstream: String,
+    pub command_results: Vec<DependencyStackCommandResult>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackCommandResult {
+    pub phase: String,
+    pub command: String,
+    pub skipped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
     pub stdout: String,
     pub stderr: String,
 }
@@ -138,6 +201,226 @@ pub fn update(
         stdout,
         stderr,
     })
+}
+
+pub fn stack_status() -> Result<DependencyStackStatus> {
+    let mut edges = Vec::new();
+    for component in component::list()? {
+        for edge in &component.dependency_stack {
+            edges.push(edge_status(&component, edge));
+        }
+    }
+
+    edges.sort_by(|a, b| {
+        a.upstream
+            .cmp(&b.upstream)
+            .then_with(|| a.downstream.cmp(&b.downstream))
+            .then_with(|| a.package.cmp(&b.package))
+    });
+
+    Ok(DependencyStackStatus {
+        edge_count: edges.len(),
+        edges,
+    })
+}
+
+pub fn stack_plan(upstream: &str) -> Result<DependencyStackPlan> {
+    let components = component::list()?;
+    stack_plan_from_components(upstream, &components)
+}
+
+pub fn stack_apply(upstream: &str, dry_run: bool) -> Result<DependencyStackApplyResult> {
+    let plan = stack_plan(upstream)?;
+    let mut steps = Vec::new();
+
+    for step in &plan.steps {
+        let mut command_results = Vec::new();
+        command_results.push(run_stack_command(
+            "update",
+            &step.update_command,
+            &step.downstream_path,
+            dry_run,
+        )?);
+        for command in &step.post_update {
+            command_results.push(run_stack_command(
+                "post_update",
+                command,
+                &step.downstream_path,
+                dry_run,
+            )?);
+        }
+        for command in &step.test {
+            command_results.push(run_stack_command(
+                "test",
+                command,
+                &step.downstream_path,
+                dry_run,
+            )?);
+        }
+        steps.push(DependencyStackApplyStep {
+            sequence: step.sequence,
+            downstream: step.downstream.clone(),
+            command_results,
+        });
+    }
+
+    Ok(DependencyStackApplyResult {
+        upstream: plan.upstream,
+        dry_run,
+        step_count: steps.len(),
+        steps,
+    })
+}
+
+pub fn stack_plan_from_components(
+    upstream: &str,
+    components: &[Component],
+) -> Result<DependencyStackPlan> {
+    let mut steps = Vec::new();
+    let mut queue = vec![upstream.to_string()];
+    let mut visited_edges = BTreeSet::new();
+    let component_paths: BTreeMap<String, String> = components
+        .iter()
+        .map(|component| (component.id.clone(), component.local_path.clone()))
+        .collect();
+
+    while let Some(current_upstream) = queue.pop() {
+        let mut matching_edges = Vec::new();
+        for component in components {
+            for edge in &component.dependency_stack {
+                if edge.upstream == current_upstream {
+                    matching_edges.push((component, edge));
+                }
+            }
+        }
+        matching_edges.sort_by(|(a_component, a_edge), (b_component, b_edge)| {
+            a_edge
+                .downstream
+                .cmp(&b_edge.downstream)
+                .then_with(|| a_edge.package.cmp(&b_edge.package))
+                .then_with(|| a_component.id.cmp(&b_component.id))
+        });
+
+        for (component, edge) in matching_edges {
+            let key = format!("{}>{}:{}", edge.upstream, edge.downstream, edge.package);
+            if !visited_edges.insert(key) {
+                continue;
+            }
+            let Some(downstream_path) = component_paths.get(&edge.downstream) else {
+                return Err(Error::validation_invalid_argument(
+                    "dependency_stack.downstream",
+                    format!(
+                        "Dependency stack edge {} -> {} references an unknown downstream component",
+                        edge.upstream, edge.downstream
+                    ),
+                    Some(edge.downstream.clone()),
+                    Some(vec![
+                        "Add the downstream component to Homeboy inventory".to_string(),
+                        "Or fix dependency_stack[].downstream in homeboy.json".to_string(),
+                    ]),
+                ));
+            };
+            steps.push(DependencyStackPlanStep {
+                sequence: steps.len() + 1,
+                declaring_component_id: component.id.clone(),
+                upstream: edge.upstream.clone(),
+                downstream: edge.downstream.clone(),
+                downstream_path: downstream_path.clone(),
+                package: edge.package.clone(),
+                update_command: update_command(edge, downstream_path),
+                post_update: edge.post_update.clone(),
+                test: edge.test.clone(),
+            });
+            queue.push(edge.downstream.clone());
+        }
+    }
+
+    Ok(DependencyStackPlan {
+        upstream: upstream.to_string(),
+        step_count: steps.len(),
+        steps,
+    })
+}
+
+fn edge_status(component: &Component, edge: &DependencyStackEdge) -> DependencyStackEdgeStatus {
+    DependencyStackEdgeStatus {
+        declaring_component_id: component.id.clone(),
+        upstream: edge.upstream.clone(),
+        downstream: edge.downstream.clone(),
+        package: edge.package.clone(),
+        update_command: update_command(edge, &component.local_path),
+        post_update: edge.post_update.clone(),
+        test: edge.test.clone(),
+    }
+}
+
+fn update_command(edge: &DependencyStackEdge, downstream_path: &str) -> String {
+    edge.update.clone().unwrap_or_else(|| {
+        format!(
+            "homeboy deps update {} --path {}",
+            shell_word(&edge.package),
+            shell_word(downstream_path)
+        )
+    })
+}
+
+fn run_stack_command(
+    phase: &str,
+    command: &str,
+    cwd: &str,
+    dry_run: bool,
+) -> Result<DependencyStackCommandResult> {
+    if dry_run {
+        return Ok(DependencyStackCommandResult {
+            phase: phase.to_string(),
+            command: command.to_string(),
+            skipped: true,
+            status: None,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+    }
+
+    let output = Command::new("sh")
+        .args(["-c", command])
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("run {phase} command"))))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "dependency_stack.command",
+            format!(
+                "Dependency stack {phase} command failed with status {}: {}",
+                output.status,
+                first_non_empty_line(&stderr)
+                    .or_else(|| first_non_empty_line(&stdout))
+                    .unwrap_or("no output")
+            ),
+            Some(command.to_string()),
+            Some(vec![format!("Run manually in {cwd}: {command}")]),
+        ));
+    }
+
+    Ok(DependencyStackCommandResult {
+        phase: phase.to_string(),
+        command: command.to_string(),
+        skipped: false,
+        status: output.status.code(),
+        stdout,
+        stderr,
+    })
+}
+
+fn shell_word(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '@'))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn resolve_component_path(

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -1,0 +1,292 @@
+use crate::component::{self, Component, DependencyStackEdge};
+use crate::{Error, Result};
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackStatus {
+    pub edge_count: usize,
+    pub edges: Vec<DependencyStackEdgeStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackEdgeStatus {
+    pub declaring_component_id: String,
+    pub upstream: String,
+    pub downstream: String,
+    pub package: String,
+    pub update_command: String,
+    pub post_update: Vec<String>,
+    pub test: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackPlan {
+    pub upstream: String,
+    pub step_count: usize,
+    pub steps: Vec<DependencyStackPlanStep>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackPlanStep {
+    pub sequence: usize,
+    pub declaring_component_id: String,
+    pub upstream: String,
+    pub downstream: String,
+    pub downstream_path: String,
+    pub package: String,
+    pub update_command: String,
+    pub post_update: Vec<String>,
+    pub test: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackApplyResult {
+    pub upstream: String,
+    pub dry_run: bool,
+    pub step_count: usize,
+    pub steps: Vec<DependencyStackApplyStep>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackApplyStep {
+    pub sequence: usize,
+    pub downstream: String,
+    pub command_results: Vec<DependencyStackCommandResult>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DependencyStackCommandResult {
+    pub phase: String,
+    pub command: String,
+    pub skipped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub fn stack_status() -> Result<DependencyStackStatus> {
+    let mut edges = Vec::new();
+    for component in component::list()? {
+        for edge in &component.dependency_stack {
+            edges.push(edge_status(&component, edge));
+        }
+    }
+
+    edges.sort_by(|a, b| {
+        a.upstream
+            .cmp(&b.upstream)
+            .then_with(|| a.downstream.cmp(&b.downstream))
+            .then_with(|| a.package.cmp(&b.package))
+    });
+
+    Ok(DependencyStackStatus {
+        edge_count: edges.len(),
+        edges,
+    })
+}
+
+pub fn stack_plan(upstream: &str) -> Result<DependencyStackPlan> {
+    let components = component::list()?;
+    stack_plan_from_components(upstream, &components)
+}
+
+pub fn stack_apply(upstream: &str, dry_run: bool) -> Result<DependencyStackApplyResult> {
+    let plan = stack_plan(upstream)?;
+    let mut steps = Vec::new();
+
+    for step in &plan.steps {
+        let mut command_results = Vec::new();
+        command_results.push(run_stack_command(
+            "update",
+            &step.update_command,
+            &step.downstream_path,
+            dry_run,
+        )?);
+        for command in &step.post_update {
+            command_results.push(run_stack_command(
+                "post_update",
+                command,
+                &step.downstream_path,
+                dry_run,
+            )?);
+        }
+        for command in &step.test {
+            command_results.push(run_stack_command(
+                "test",
+                command,
+                &step.downstream_path,
+                dry_run,
+            )?);
+        }
+        steps.push(DependencyStackApplyStep {
+            sequence: step.sequence,
+            downstream: step.downstream.clone(),
+            command_results,
+        });
+    }
+
+    Ok(DependencyStackApplyResult {
+        upstream: plan.upstream,
+        dry_run,
+        step_count: steps.len(),
+        steps,
+    })
+}
+
+pub fn stack_plan_from_components(
+    upstream: &str,
+    components: &[Component],
+) -> Result<DependencyStackPlan> {
+    let mut steps = Vec::new();
+    let mut queue = vec![upstream.to_string()];
+    let mut visited_edges = BTreeSet::new();
+    let component_paths: BTreeMap<String, String> = components
+        .iter()
+        .map(|component| (component.id.clone(), component.local_path.clone()))
+        .collect();
+
+    while let Some(current_upstream) = queue.pop() {
+        let mut matching_edges = Vec::new();
+        for component in components {
+            for edge in &component.dependency_stack {
+                if edge.upstream == current_upstream {
+                    matching_edges.push((component, edge));
+                }
+            }
+        }
+        matching_edges.sort_by(|(a_component, a_edge), (b_component, b_edge)| {
+            a_edge
+                .downstream
+                .cmp(&b_edge.downstream)
+                .then_with(|| a_edge.package.cmp(&b_edge.package))
+                .then_with(|| a_component.id.cmp(&b_component.id))
+        });
+
+        for (component, edge) in matching_edges {
+            let key = format!("{}>{}:{}", edge.upstream, edge.downstream, edge.package);
+            if !visited_edges.insert(key) {
+                continue;
+            }
+            let Some(downstream_path) = component_paths.get(&edge.downstream) else {
+                return Err(Error::validation_invalid_argument(
+                    "dependency_stack.downstream",
+                    format!(
+                        "Dependency stack edge {} -> {} references an unknown downstream component",
+                        edge.upstream, edge.downstream
+                    ),
+                    Some(edge.downstream.clone()),
+                    Some(vec![
+                        "Add the downstream component to Homeboy inventory".to_string(),
+                        "Or fix dependency_stack[].downstream in homeboy.json".to_string(),
+                    ]),
+                ));
+            };
+            steps.push(DependencyStackPlanStep {
+                sequence: steps.len() + 1,
+                declaring_component_id: component.id.clone(),
+                upstream: edge.upstream.clone(),
+                downstream: edge.downstream.clone(),
+                downstream_path: downstream_path.clone(),
+                package: edge.package.clone(),
+                update_command: update_command(edge, downstream_path),
+                post_update: edge.post_update.clone(),
+                test: edge.test.clone(),
+            });
+            queue.push(edge.downstream.clone());
+        }
+    }
+
+    Ok(DependencyStackPlan {
+        upstream: upstream.to_string(),
+        step_count: steps.len(),
+        steps,
+    })
+}
+
+fn edge_status(component: &Component, edge: &DependencyStackEdge) -> DependencyStackEdgeStatus {
+    DependencyStackEdgeStatus {
+        declaring_component_id: component.id.clone(),
+        upstream: edge.upstream.clone(),
+        downstream: edge.downstream.clone(),
+        package: edge.package.clone(),
+        update_command: update_command(edge, &component.local_path),
+        post_update: edge.post_update.clone(),
+        test: edge.test.clone(),
+    }
+}
+
+fn update_command(edge: &DependencyStackEdge, downstream_path: &str) -> String {
+    edge.update.clone().unwrap_or_else(|| {
+        format!(
+            "homeboy deps update {} --path {}",
+            shell_word(&edge.package),
+            shell_word(downstream_path)
+        )
+    })
+}
+
+fn run_stack_command(
+    phase: &str,
+    command: &str,
+    cwd: &str,
+    dry_run: bool,
+) -> Result<DependencyStackCommandResult> {
+    if dry_run {
+        return Ok(DependencyStackCommandResult {
+            phase: phase.to_string(),
+            command: command.to_string(),
+            skipped: true,
+            status: None,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+    }
+
+    let output = Command::new("sh")
+        .args(["-c", command])
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("run {phase} command"))))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "dependency_stack.command",
+            format!(
+                "Dependency stack {phase} command failed with status {}: {}",
+                output.status,
+                first_non_empty_line(&stderr)
+                    .or_else(|| first_non_empty_line(&stdout))
+                    .unwrap_or("no output")
+            ),
+            Some(command.to_string()),
+            Some(vec![format!("Run manually in {cwd}: {command}")]),
+        ));
+    }
+
+    Ok(DependencyStackCommandResult {
+        phase: phase.to_string(),
+        command: command.to_string(),
+        skipped: false,
+        status: output.status.code(),
+        stdout,
+        stderr,
+    })
+}
+
+fn shell_word(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '@'))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn first_non_empty_line(output: &str) -> Option<&str> {
+    output.lines().find(|line| !line.trim().is_empty())
+}

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -122,7 +122,7 @@ fn status_filters_to_one_package() {
 }
 
 #[test]
-fn update_command_args_are_composer_first_and_package_scoped() {
+fn test_composer_command_args() {
     assert_eq!(
         deps::composer_command_args(
             "fixture/package",

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -1,3 +1,4 @@
+use homeboy::component::{Component, DependencyStackEdge};
 use homeboy::deps::{self, ComposerAction};
 use std::fs;
 use tempfile::tempdir;
@@ -8,6 +9,12 @@ fn write_file(path: &std::path::Path, contents: &str) {
 
 fn fixture_component(path: &std::path::Path) -> (&'static str, String) {
     ("fixture", path.display().to_string())
+}
+
+fn stack_component(id: &str, path: &str, edges: Vec<DependencyStackEdge>) -> Component {
+    let mut component = Component::new(id.to_string(), path.to_string(), String::new(), None);
+    component.dependency_stack = edges;
+    component
 }
 
 #[test]
@@ -140,6 +147,88 @@ fn update_command_args_are_composer_first_and_package_scoped() {
             "--no-interaction",
         ]
     );
+}
+
+#[test]
+fn stack_plan_walks_declared_downstream_edges_in_order() {
+    let components = vec![
+        stack_component(
+            "block-format-bridge",
+            "/repo/block-format-bridge",
+            vec![DependencyStackEdge {
+                upstream: "chubes4/html-to-blocks-converter".to_string(),
+                downstream: "block-format-bridge".to_string(),
+                package: "chubes4/html-to-blocks-converter".to_string(),
+                update: None,
+                post_update: vec!["composer build".to_string()],
+                test: vec!["homeboy test --path . --extension wordpress".to_string()],
+            }],
+        ),
+        stack_component(
+            "static-site-importer",
+            "/repo/static-site-importer",
+            vec![DependencyStackEdge {
+                upstream: "block-format-bridge".to_string(),
+                downstream: "static-site-importer".to_string(),
+                package: "chubes4/block-format-bridge".to_string(),
+                update: Some("composer update chubes4/block-format-bridge".to_string()),
+                post_update: Vec::new(),
+                test: vec!["homeboy test --path . --extension wordpress".to_string()],
+            }],
+        ),
+    ];
+
+    let plan = deps::stack_plan_from_components("chubes4/html-to-blocks-converter", &components).unwrap();
+
+    assert_eq!(plan.step_count, 2);
+    assert_eq!(plan.steps[0].downstream, "block-format-bridge");
+    assert_eq!(plan.steps[0].package, "chubes4/html-to-blocks-converter");
+    assert_eq!(
+        plan.steps[0].update_command,
+        "homeboy deps update chubes4/html-to-blocks-converter --path /repo/block-format-bridge"
+    );
+    assert_eq!(plan.steps[0].post_update, vec!["composer build"]);
+    assert_eq!(plan.steps[1].downstream, "static-site-importer");
+    assert_eq!(
+        plan.steps[1].update_command,
+        "composer update chubes4/block-format-bridge"
+    );
+}
+
+#[test]
+fn stack_plan_dedupes_cycles_by_edge_identity() {
+    let components = vec![
+        stack_component(
+            "a",
+            "/repo/a",
+            vec![DependencyStackEdge {
+                upstream: "a".to_string(),
+                downstream: "b".to_string(),
+                package: "fixture/b".to_string(),
+                update: None,
+                post_update: Vec::new(),
+                test: Vec::new(),
+            }],
+        ),
+        stack_component(
+            "b",
+            "/repo/b",
+            vec![DependencyStackEdge {
+                upstream: "b".to_string(),
+                downstream: "a".to_string(),
+                package: "fixture/a".to_string(),
+                update: None,
+                post_update: Vec::new(),
+                test: Vec::new(),
+            }],
+        ),
+    ];
+
+    let plan = deps::stack_plan_from_components("a", &components).unwrap();
+
+    assert_eq!(plan.step_count, 2);
+    assert_eq!(plan.steps[0].downstream, "b");
+    assert_eq!(plan.steps[1].downstream, "a");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `dependency_stack` edges to component config for declaring deterministic downstream dependency propagation.
- Add `homeboy deps stack status|plan|apply` to list stack edges, build downstream propagation plans, and run declared update/post-update/test commands.
- Document the stack config shape and default update command behavior.

## Testing
- `cargo test --test deps_test`
- `cargo test --test command_surface_test`
- `cargo run --bin homeboy -- deps stack --help`
- `cargo run --bin homeboy -- deps stack status`

## Related
- Closes #2481

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the dependency stack propagation primitive, tests, docs, and local verification.