### PR TITLE
Extract shared scope model

### DIFF
--- a/docs/architecture/scope-model.md
+++ b/docs/architecture/scope-model.md
@@ -1,0 +1,48 @@
+# Scope Model
+
+Homeboy commands operate on different kinds of things. The shared scope model makes those things explicit so project/site workflows do not become the default mental model for every command.
+
+## Scopes
+
+| Scope | Meaning | Typical commands |
+| --- | --- | --- |
+| `component` | A source checkout or registered codebase. | `build`, `test`, `lint`, `audit`, `release`, `changes`, `version`, `bench` |
+| `project` | A runtime target: site, server, domain, base path, database/API context, and deploy destination. | `wp`, `db`, `logs`, `api`, `auth`, `deploy` |
+| `rig` | A reproducible local environment composed from component paths, services, symlinks, and pipelines. | `rig up`, `rig check`, `rig down`, rig-pinned `bench`/`trace` |
+| `fleet` | A group of projects/targets. | fleet status/check/exec, multi-target deploy |
+| `workspace` | Everything Homeboy can discover locally across projects, rigs, standalone components, and the current checkout. | `triage workspace`, `runs`, global reports |
+| `path` | An unregistered checkout operated on directly. | ad-hoc component/source workflows |
+
+## Command Classes
+
+Commands should describe which scope class they accept:
+
+- **Component commands** operate on source code and should work with component IDs, paths, and CWD discovery without project registration.
+- **Target commands** operate on a runtime/deploy destination and should require a project or fleet when the command writes to a site/server.
+- **Environment commands** operate on rigs or stacks and should not require project ownership.
+- **Workspace commands** aggregate evidence across scopes and should expose filters instead of silently inheriting active project state.
+
+## Design Rules
+
+- Keep `Project` as the existing config type for compatibility, but describe it as a runtime target in user-facing docs and errors.
+- Standalone components and path-based components are first-class for local/source workflows.
+- Rigs remain independent and portable; they may reference components by path without global registration.
+- Project-required errors should appear only when a command truly needs a runtime target, such as deploy, WP-CLI, database, logs, auth, or API operations.
+- Desktop and API consumers should use scope metadata to group tools by their natural operating context instead of assuming every tab belongs to the active project.
+
+## Core API
+
+The shared Rust model lives in `homeboy::scope`:
+
+```rust
+enum Scope {
+    Component(String),
+    Project(String),
+    Fleet(String),
+    Rig(String),
+    Workspace,
+    Path { path: String, component_id: Option<String> },
+}
+```
+
+Use `resolve_scope_components()` when a feature needs to turn any supported scope into component references. Triage is the first consumer; additional commands can adopt the same resolver as they clarify their accepted scopes.

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -5,6 +5,10 @@ GitHub access is read-only; each run also records a local observation in the
 Homeboy SQLite database so later runs can compare against the previous
 observation for the same target.
 
+`triage` is the reference consumer of Homeboy's shared scope model: it accepts
+component, project/target, fleet, rig, workspace, and direct path scopes, then
+normalizes each scope to component references before reading GitHub state.
+
 ## Synopsis
 
 ```sh
@@ -20,6 +24,9 @@ When no command is provided, `homeboy triage` defaults to `homeboy triage worksp
 - `fleet` — triage unique components used across a fleet
 - `rig` — triage components declared in a local rig spec
 - `workspace` — triage every configured project, rig, and registered component once per repo
+
+See [Scope model](../architecture/scope-model.md) for how these scopes relate to
+component-first, target-first, environment, and workspace commands.
 
 ## Useful filters
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Internal system architecture and internals:
 - [Keychain/secrets management](architecture/keychain-secrets.md) - Secure credential storage
 - [SSH key management](architecture/ssh-key-management.md) - SSH key handling
 - [Release pipeline system](architecture/release-pipeline.md) - Local release orchestration
+- [Scope model](architecture/scope-model.md) - Components, targets/projects, rigs, fleets, workspace, and paths
 - [Execution context](architecture/execution-context.md) - Runtime context for extensions
 - [Rig matrix axis composition](architecture/rig-matrix-axis-composition.md) - Design for derived rig variants
 - [Embedded docs](architecture/embedded-docs-topic-resolution.md) - Documentation system internals

--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -534,31 +534,23 @@ pub fn rename_standalone_registration(old_id: &str, component: &Component) -> Re
 mod tests {
     use super::*;
     use std::fs;
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
     use tempfile::TempDir;
 
     // Tests that override `HOME` to redirect `paths::components()` are
     // inherently racy when run in parallel because environment variables
     // are process-wide. Rather than `#[ignore]`-ing them (which skips
     // coverage in default `cargo test` runs), we serialize every test in
-    // this module that touches `HOME` through `HOME_LOCK`. Acquire the
-    // guard via `with_home_override()` before any `set_var("HOME", ...)`
-    // and the guard's `Drop` restores the previous value — parallel test
-    // runners block on the mutex instead of racing on the env var.
+    // every module that touches `HOME` through `test_support::home_env_guard()`.
+    // Acquire the guard via `with_home_override()` before any `set_var("HOME", ...)`
+    // and the guard's `Drop` restores the previous value; parallel test runners
+    // block on the mutex instead of racing on the env var.
     //
-    // The lock is process-local to this module because `HOME` is not
-    // consulted from any other test module in the crate today. If that
-    // changes, the lock should move somewhere more shared (or the
-    // affected code paths should accept an injected config directory so
-    // no env override is needed at all).
-
-    static HOME_LOCK: Mutex<()> = Mutex::new(());
-
     /// Serialized guard for tests that override `HOME`.
     ///
-    /// Acquires `HOME_LOCK`, snapshots the current `HOME`, and installs
-    /// the test-supplied override. When the guard is dropped the previous
-    /// `HOME` is restored and the lock is released.
+    /// Acquires the shared HOME env guard, snapshots the current `HOME`, and
+    /// installs the test-supplied override. When the guard is dropped the
+    /// previous `HOME` is restored and the lock is released.
     ///
     /// Panics on a poisoned mutex, which can only happen if a previous
     /// test panicked while holding the guard — in that case the test
@@ -579,9 +571,7 @@ mod tests {
     }
 
     fn with_home_override(new_home: &std::path::Path) -> HomeGuard {
-        let lock = HOME_LOCK
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let lock = crate::test_support::home_env_guard();
         let previous = std::env::var("HOME").ok();
         unsafe { std::env::set_var("HOME", new_home.to_string_lossy().as_ref()) };
         HomeGuard {

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -620,25 +620,9 @@ where
 mod tests {
     use super::*;
     use std::path::Path;
-    use std::sync::Mutex;
-
-    static HOME_LOCK: Mutex<()> = Mutex::new(());
 
     fn with_isolated_home<T>(f: impl FnOnce(&Path) -> T) -> T {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let old_home = std::env::var_os("HOME");
-        let home = tempfile::tempdir().expect("home tempdir");
-
-        std::env::set_var("HOME", home.path());
-        let result = f(home.path());
-
-        if let Some(value) = old_home {
-            std::env::set_var("HOME", value);
-        } else {
-            std::env::remove_var("HOME");
-        }
-
-        result
+        crate::test_support::with_isolated_home(|home| f(home.path()))
     }
 
     fn write_extension_fixture(home: &Path, id: &str, deploy_json: &str) {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,6 +27,7 @@ pub mod project;
 pub mod refactor;
 pub mod release;
 pub mod rig;
+pub mod scope;
 pub mod self_status;
 pub mod server;
 pub mod stack;

--- a/src/core/scope.rs
+++ b/src/core/scope.rs
@@ -1,0 +1,390 @@
+//! Shared Homeboy scope model.
+//!
+//! A scope is the thing a command operates on. Some commands need a runtime
+//! target, some need source code, and some aggregate multiple contexts. Keeping
+//! this vocabulary explicit prevents every workflow from pretending to be
+//! project-owned.
+
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use crate::component;
+use crate::deploy::release_download::detect_remote_url;
+use crate::error::{Error, Result};
+use crate::{fleet, project, rig};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Scope {
+    Component(String),
+    Project(String),
+    Fleet(String),
+    Rig(String),
+    Workspace,
+    /// Operate on an unregistered checkout directly.
+    Path {
+        path: String,
+        component_id: Option<String>,
+    },
+}
+
+impl Scope {
+    pub fn kind(&self) -> ScopeKind {
+        match self {
+            Scope::Component(_) => ScopeKind::Component,
+            Scope::Project(_) => ScopeKind::Project,
+            Scope::Fleet(_) => ScopeKind::Fleet,
+            Scope::Rig(_) => ScopeKind::Rig,
+            Scope::Workspace => ScopeKind::Workspace,
+            Scope::Path { .. } => ScopeKind::Path,
+        }
+    }
+
+    pub fn kind_name(&self) -> &'static str {
+        self.kind().as_str()
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            Scope::Component(id) | Scope::Project(id) | Scope::Fleet(id) | Scope::Rig(id) => id,
+            Scope::Workspace => "workspace",
+            Scope::Path { path, component_id } => component_id.as_deref().unwrap_or(path.as_str()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeKind {
+    Component,
+    Project,
+    Fleet,
+    Rig,
+    Workspace,
+    Path,
+}
+
+impl ScopeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ScopeKind::Component => "component",
+            ScopeKind::Project => "project",
+            ScopeKind::Fleet => "fleet",
+            ScopeKind::Rig => "rig",
+            ScopeKind::Workspace => "workspace",
+            ScopeKind::Path => "path",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandScopeClass {
+    Component,
+    Target,
+    Environment,
+    Workspace,
+}
+
+impl CommandScopeClass {
+    pub fn description(self) -> &'static str {
+        match self {
+            CommandScopeClass::Component => {
+                "source-code commands: component IDs, paths, or CWD discovery"
+            }
+            CommandScopeClass::Target => {
+                "runtime target commands: project/site/server context required"
+            }
+            CommandScopeClass::Environment => "local environment commands: rig or stack context",
+            CommandScopeClass::Workspace => {
+                "aggregate commands: workspace-wide filters and evidence"
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ScopeOutput {
+    pub kind: &'static str,
+    pub id: String,
+}
+
+impl From<&Scope> for ScopeOutput {
+    fn from(scope: &Scope) -> Self {
+        Self {
+            kind: scope.kind_name(),
+            id: scope.id().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ScopeComponentRef {
+    pub component_id: String,
+    pub local_path: String,
+    pub remote_url: Option<String>,
+    pub triage_remote_url: Option<String>,
+    pub priority_labels: Option<Vec<String>>,
+    pub sources: BTreeSet<String>,
+    pub usage: BTreeSet<String>,
+}
+
+impl ScopeComponentRef {
+    pub fn new(
+        component_id: String,
+        local_path: String,
+        remote_url: Option<String>,
+        triage_remote_url: Option<String>,
+        source: String,
+    ) -> Self {
+        let mut sources = BTreeSet::new();
+        sources.insert(source);
+        Self {
+            component_id,
+            local_path,
+            remote_url,
+            triage_remote_url,
+            priority_labels: None,
+            sources,
+            usage: BTreeSet::new(),
+        }
+    }
+
+    pub fn with_priority_labels(mut self, priority_labels: Option<Vec<String>>) -> Self {
+        self.priority_labels = priority_labels;
+        self
+    }
+}
+
+pub fn resolve_scope_components(scope: &Scope) -> Result<Vec<ScopeComponentRef>> {
+    match scope {
+        Scope::Component(component_id) => resolve_component_scope(component_id),
+        Scope::Project(project_id) => resolve_project_scope(project_id),
+        Scope::Fleet(fleet_id) => resolve_fleet_scope(fleet_id),
+        Scope::Rig(rig_id) => resolve_rig_scope(rig_id),
+        Scope::Workspace => resolve_workspace_scope(),
+        Scope::Path { path, component_id } => resolve_path_scope(path, component_id.as_deref()),
+    }
+}
+
+fn resolve_component_scope(component_id: &str) -> Result<Vec<ScopeComponentRef>> {
+    let comp = component::load(component_id)?;
+    let priority_labels = comp.priority_labels.clone();
+    Ok(vec![ScopeComponentRef::new(
+        comp.id,
+        comp.local_path,
+        comp.remote_url,
+        comp.triage_remote_url,
+        format!("component:{component_id}"),
+    )
+    .with_priority_labels(priority_labels)])
+}
+
+fn resolve_project_scope(project_id: &str) -> Result<Vec<ScopeComponentRef>> {
+    let proj = project::load(project_id)?;
+    Ok(proj
+        .components
+        .into_iter()
+        .map(|attachment| {
+            let comp = component::load(&attachment.id).ok();
+            let remote_url = comp.as_ref().and_then(|c| c.remote_url.clone());
+            let triage_remote_url = comp.as_ref().and_then(|c| c.triage_remote_url.clone());
+            ScopeComponentRef::new(
+                attachment.id.clone(),
+                if attachment.local_path.is_empty() {
+                    comp.as_ref()
+                        .map(|c| c.local_path.clone())
+                        .unwrap_or_default()
+                } else {
+                    attachment.local_path
+                },
+                remote_url,
+                triage_remote_url,
+                format!("project:{project_id}"),
+            )
+            .with_priority_labels(comp.and_then(|c| c.priority_labels))
+        })
+        .collect())
+}
+
+fn resolve_fleet_scope(fleet_id: &str) -> Result<Vec<ScopeComponentRef>> {
+    let fl = fleet::load(fleet_id)?;
+    let fleet_priority_labels = fl.priority_labels.clone();
+    let mut refs = BTreeMap::new();
+
+    for project_id in fl.project_ids {
+        let project_refs = resolve_project_scope(&project_id)?;
+        for mut component_ref in project_refs {
+            if component_ref.priority_labels.is_none() {
+                component_ref.priority_labels = fleet_priority_labels.clone();
+            }
+            component_ref.usage.insert(project_id.clone());
+            merge_component_ref(&mut refs, component_ref);
+        }
+    }
+
+    Ok(refs.into_values().collect())
+}
+
+fn resolve_rig_scope(rig_id: &str) -> Result<Vec<ScopeComponentRef>> {
+    let spec = rig::load(rig_id)?;
+    let mut refs = Vec::new();
+    for (component_id, component_spec) in spec.components.iter() {
+        let path = rig::expand::expand_vars(&spec, &component_spec.path);
+        let mut component_ref = ScopeComponentRef::new(
+            component_id.clone(),
+            path,
+            component_spec.remote_url.clone(),
+            component_spec.triage_remote_url.clone(),
+            format!("rig:{rig_id}"),
+        );
+        component_ref.usage.insert(rig_id.to_string());
+        refs.push(component_ref);
+    }
+    refs.sort_by(|a, b| a.component_id.cmp(&b.component_id));
+    Ok(refs)
+}
+
+fn resolve_path_scope(path: &str, component_id: Option<&str>) -> Result<Vec<ScopeComponentRef>> {
+    let checkout = Path::new(path);
+    if !checkout.exists() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "Checkout path does not exist",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    if !checkout.join(".git").exists() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "Checkout path is not a git repository (no `.git` entry)",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+
+    let canonical = checkout
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| path.to_string());
+    let synthesized_id = component_id
+        .map(|id| id.to_string())
+        .or_else(|| {
+            checkout
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.to_string())
+        })
+        .unwrap_or_else(|| "path".to_string());
+    let source = format!("path:{canonical}");
+
+    Ok(vec![ScopeComponentRef::new(
+        synthesized_id,
+        canonical.clone(),
+        detect_remote_url(Path::new(&canonical)),
+        None,
+        source,
+    )])
+}
+
+fn resolve_workspace_scope() -> Result<Vec<ScopeComponentRef>> {
+    let mut refs = BTreeMap::new();
+
+    for proj in project::list()? {
+        for mut component_ref in resolve_project_scope(&proj.id)? {
+            component_ref.usage.insert(proj.id.clone());
+            merge_component_ref(&mut refs, component_ref);
+        }
+    }
+
+    for spec in rig::list()? {
+        for mut component_ref in resolve_rig_scope(&spec.id)? {
+            component_ref.usage.insert(spec.id.clone());
+            merge_component_ref(&mut refs, component_ref);
+        }
+    }
+
+    for comp in component::list()? {
+        let source = format!("component:{}", comp.id);
+        let priority_labels = comp.priority_labels.clone();
+        merge_component_ref(
+            &mut refs,
+            ScopeComponentRef::new(
+                comp.id,
+                comp.local_path,
+                comp.remote_url,
+                comp.triage_remote_url,
+                source,
+            )
+            .with_priority_labels(priority_labels),
+        );
+    }
+
+    Ok(refs.into_values().collect())
+}
+
+fn merge_component_ref(
+    refs: &mut BTreeMap<String, ScopeComponentRef>,
+    component_ref: ScopeComponentRef,
+) {
+    let entry = refs
+        .entry(component_ref.component_id.clone())
+        .or_insert_with(|| component_ref.clone());
+    entry.sources.extend(component_ref.sources);
+    entry.usage.extend(component_ref.usage);
+    if entry.local_path.is_empty() && !component_ref.local_path.is_empty() {
+        entry.local_path = component_ref.local_path;
+    }
+    if entry.remote_url.is_none() {
+        entry.remote_url = component_ref.remote_url;
+    }
+    if entry.triage_remote_url.is_none() {
+        entry.triage_remote_url = component_ref.triage_remote_url;
+    }
+    if entry.priority_labels.is_none() {
+        entry.priority_labels = component_ref.priority_labels;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_reports_kind_and_id() {
+        let scope = Scope::Rig("studio-combined".to_string());
+
+        assert_eq!(scope.kind(), ScopeKind::Rig);
+        assert_eq!(scope.kind_name(), "rig");
+        assert_eq!(scope.id(), "studio-combined");
+    }
+
+    #[test]
+    fn path_scope_uses_component_id_when_provided() {
+        let scope = Scope::Path {
+            path: "/tmp/checkout".to_string(),
+            component_id: Some("homeboy".to_string()),
+        };
+
+        assert_eq!(scope.kind(), ScopeKind::Path);
+        assert_eq!(scope.id(), "homeboy");
+    }
+
+    #[test]
+    fn command_scope_class_descriptions_are_stable() {
+        assert!(CommandScopeClass::Component
+            .description()
+            .contains("component IDs"));
+        assert!(CommandScopeClass::Target
+            .description()
+            .contains("project/site/server"));
+        assert!(CommandScopeClass::Environment
+            .description()
+            .contains("rig or stack"));
+        assert!(CommandScopeClass::Workspace
+            .description()
+            .contains("workspace-wide"));
+    }
+}

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -1,18 +1,18 @@
 //! Read-only triage reports for component sets.
 //!
-//! The primitive resolves a target (component/project/fleet/rig) to component
+//! The primitive resolves a scope (component/project/fleet/rig/path/workspace) to component
 //! references, then overlays GitHub issue/PR state. It intentionally keeps the
 //! GitHub calls read-only so `homeboy triage ...` is safe as a dashboard verb.
 
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use crate::component;
+use crate::defaults;
 use crate::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
 use crate::error::{Error, Result};
 use crate::git::gh_probe_succeeds;
@@ -20,62 +20,9 @@ use crate::observation::{
     NewRunRecord, NewTriageItemRecord, ObservationStore, RunListFilter, RunStatus,
     TriageItemRecord, TriagePullRequestSignals,
 };
-use crate::{defaults, fleet, project, rig};
+use crate::scope::{self, Scope, ScopeComponentRef, ScopeOutput};
 
-#[derive(Debug, Clone)]
-pub enum TriageTarget {
-    Component(String),
-    Project(String),
-    Fleet(String),
-    Rig(String),
-    Workspace,
-    /// Triage an unregistered checkout directly. Skips the component registry
-    /// and resolves the GitHub remote from `git remote get-url origin`.
-    Path {
-        path: String,
-        component_id: Option<String>,
-    },
-}
-
-impl TriageTarget {
-    fn kind(&self) -> &'static str {
-        match self {
-            TriageTarget::Component(_) => "component",
-            TriageTarget::Project(_) => "project",
-            TriageTarget::Fleet(_) => "fleet",
-            TriageTarget::Rig(_) => "rig",
-            TriageTarget::Workspace => "workspace",
-            TriageTarget::Path { .. } => "path",
-        }
-    }
-
-    fn id(&self) -> &str {
-        match self {
-            TriageTarget::Component(id)
-            | TriageTarget::Project(id)
-            | TriageTarget::Fleet(id)
-            | TriageTarget::Rig(id) => id,
-            TriageTarget::Workspace => "workspace",
-            TriageTarget::Path { path, component_id } => {
-                component_id.as_deref().unwrap_or(path.as_str())
-            }
-        }
-    }
-
-    fn command(&self) -> &'static str {
-        match self {
-            TriageTarget::Component(_) => "triage.component",
-            TriageTarget::Project(_) => "triage.project",
-            TriageTarget::Fleet(_) => "triage.fleet",
-            TriageTarget::Rig(_) => "triage.rig",
-            TriageTarget::Workspace => "triage.workspace",
-            // `--path` is an escape hatch on subcommands (currently `component`); keep
-            // the same command identity so JSON consumers don't see a phantom
-            // `triage.path` verb.
-            TriageTarget::Path { .. } => "triage.component",
-        }
-    }
-}
+pub use crate::scope::Scope as TriageTarget;
 
 #[derive(Debug, Clone, Default)]
 pub struct TriageOptions {
@@ -95,7 +42,7 @@ pub struct TriageOptions {
 #[derive(Debug, Clone, Serialize)]
 pub struct TriageOutput {
     pub command: &'static str,
-    pub target: TriageTargetOutput,
+    pub target: ScopeOutput,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observation: Option<TriageObservationOutput>,
     pub summary: TriageSummary,
@@ -143,12 +90,6 @@ pub struct TriageObservationChangedItem {
     #[serde(flatten)]
     pub item: TriageObservationItemRef,
     pub changed_fields: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct TriageTargetOutput {
-    pub kind: &'static str,
-    pub id: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -299,43 +240,7 @@ pub struct TriageUnresolved {
     pub sources: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
-struct ComponentRef {
-    component_id: String,
-    local_path: String,
-    remote_url: Option<String>,
-    triage_remote_url: Option<String>,
-    priority_labels: Option<Vec<String>>,
-    sources: BTreeSet<String>,
-    usage: BTreeSet<String>,
-}
-
-impl ComponentRef {
-    fn new(
-        component_id: String,
-        local_path: String,
-        remote_url: Option<String>,
-        triage_remote_url: Option<String>,
-        source: String,
-    ) -> Self {
-        let mut sources = BTreeSet::new();
-        sources.insert(source);
-        Self {
-            component_id,
-            local_path,
-            remote_url,
-            triage_remote_url,
-            priority_labels: None,
-            sources,
-            usage: BTreeSet::new(),
-        }
-    }
-
-    fn with_priority_labels(mut self, priority_labels: Option<Vec<String>>) -> Self {
-        self.priority_labels = priority_labels;
-        self
-    }
-}
+type ComponentRef = ScopeComponentRef;
 
 pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput> {
     let observation = TriageObservation::start(&target, &options);
@@ -364,11 +269,8 @@ pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput>
     let summary = summarize(&components, &unresolved);
     let unresolved_summary = summarize_unresolved(&unresolved);
     let mut output = TriageOutput {
-        command: target.command(),
-        target: TriageTargetOutput {
-            kind: target.kind(),
-            id: target.id().to_string(),
-        },
+        command: triage_command(&target),
+        target: ScopeOutput::from(&target),
         observation: None,
         summary,
         unresolved_summary,
@@ -413,7 +315,7 @@ impl TriageObservation {
             .start_run(NewRunRecord {
                 kind: "triage".to_string(),
                 component_id: Some(component_id),
-                command: Some(target.command().to_string()),
+                command: Some(triage_command(target).to_string()),
                 cwd: std::env::current_dir()
                     .ok()
                     .map(|path| path.to_string_lossy().to_string()),
@@ -425,7 +327,7 @@ impl TriageObservation {
                 },
                 metadata_json: serde_json::json!({
                     "target": {
-                        "kind": target.kind(),
+                        "kind": target.kind_name(),
                         "id": target.id(),
                     },
                     "options": {
@@ -675,7 +577,7 @@ fn push_if_changed_unless_unknown(
 }
 
 fn triage_observation_component_id(target: &TriageTarget) -> String {
-    format!("{}:{}", target.kind(), target.id())
+    format!("{}:{}", target.kind_name(), target.id())
 }
 
 fn triage_observation_items(run_id: &str, output: &TriageOutput) -> Vec<NewTriageItemRecord> {
@@ -747,198 +649,25 @@ fn usize_to_i64(value: usize) -> Option<i64> {
 }
 
 fn resolve_target_components(target: &TriageTarget) -> Result<Vec<ComponentRef>> {
+    let refs = scope::resolve_scope_components(target)?;
+    if matches!(target, Scope::Workspace) {
+        Ok(dedupe_refs_by_repo(refs))
+    } else {
+        Ok(refs)
+    }
+}
+
+fn triage_command(target: &TriageTarget) -> &'static str {
     match target {
-        TriageTarget::Component(component_id) => {
-            let comp = component::load(component_id)?;
-            let priority_labels = comp.priority_labels.clone();
-            Ok(vec![ComponentRef::new(
-                comp.id,
-                comp.local_path,
-                comp.remote_url,
-                comp.triage_remote_url,
-                format!("component:{component_id}"),
-            )
-            .with_priority_labels(priority_labels)])
-        }
-        TriageTarget::Project(project_id) => {
-            let proj = project::load(project_id)?;
-            Ok(proj
-                .components
-                .into_iter()
-                .map(|attachment| {
-                    let comp = component::load(&attachment.id).ok();
-                    let remote_url = comp.as_ref().and_then(|c| c.remote_url.clone());
-                    let triage_remote_url = comp.as_ref().and_then(|c| c.triage_remote_url.clone());
-                    ComponentRef::new(
-                        attachment.id.clone(),
-                        if attachment.local_path.is_empty() {
-                            comp.as_ref()
-                                .map(|c| c.local_path.clone())
-                                .unwrap_or_default()
-                        } else {
-                            attachment.local_path
-                        },
-                        remote_url,
-                        triage_remote_url,
-                        format!("project:{project_id}"),
-                    )
-                    .with_priority_labels(comp.and_then(|c| c.priority_labels))
-                })
-                .collect())
-        }
-        TriageTarget::Fleet(fleet_id) => resolve_fleet_components(fleet_id),
-        TriageTarget::Rig(rig_id) => {
-            let spec = rig::load(rig_id)?;
-            let mut refs = Vec::new();
-            for (component_id, component_spec) in spec.components.iter() {
-                let path = rig::expand::expand_vars(&spec, &component_spec.path);
-                let mut component_ref = ComponentRef::new(
-                    component_id.clone(),
-                    path,
-                    component_spec.remote_url.clone(),
-                    component_spec.triage_remote_url.clone(),
-                    format!("rig:{rig_id}"),
-                );
-                component_ref.usage.insert(rig_id.to_string());
-                refs.push(component_ref);
-            }
-            refs.sort_by(|a, b| a.component_id.cmp(&b.component_id));
-            Ok(refs)
-        }
-        TriageTarget::Workspace => resolve_workspace_components(),
-        TriageTarget::Path { path, component_id } => {
-            resolve_path_component(path, component_id.as_deref())
-        }
-    }
-}
-
-fn resolve_path_component(path: &str, component_id: Option<&str>) -> Result<Vec<ComponentRef>> {
-    let checkout = Path::new(path);
-    if !checkout.exists() {
-        return Err(Error::validation_invalid_argument(
-            "path",
-            "Checkout path does not exist",
-            Some(path.to_string()),
-            None,
-        ));
-    }
-    if !checkout.join(".git").exists() {
-        return Err(Error::validation_invalid_argument(
-            "path",
-            "Checkout path is not a git repository (no `.git` entry)",
-            Some(path.to_string()),
-            None,
-        ));
-    }
-    let remote_url = detect_remote_url(checkout).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "path",
-            "Could not read `git remote get-url origin` from checkout",
-            Some(path.to_string()),
-            None,
-        )
-    })?;
-    let canonical = checkout
-        .canonicalize()
-        .ok()
-        .and_then(|p| p.to_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| path.to_string());
-    let synthesized_id = component_id
-        .map(|id| id.to_string())
-        .or_else(|| {
-            checkout
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| name.to_string())
-        })
-        .unwrap_or_else(|| "path".to_string());
-    let source = format!("path:{canonical}");
-    Ok(vec![ComponentRef::new(
-        synthesized_id,
-        canonical,
-        Some(remote_url),
-        None,
-        source,
-    )])
-}
-
-fn resolve_workspace_components() -> Result<Vec<ComponentRef>> {
-    let mut refs = BTreeMap::new();
-
-    for proj in project::list()? {
-        for attachment in proj.components {
-            let comp = component::load(&attachment.id).ok();
-            let remote_url = comp.as_ref().and_then(|c| c.remote_url.clone());
-            let triage_remote_url = comp.as_ref().and_then(|c| c.triage_remote_url.clone());
-            let mut component_ref = ComponentRef::new(
-                attachment.id.clone(),
-                if attachment.local_path.is_empty() {
-                    comp.as_ref()
-                        .map(|c| c.local_path.clone())
-                        .unwrap_or_default()
-                } else {
-                    attachment.local_path
-                },
-                remote_url,
-                triage_remote_url,
-                format!("project:{}", proj.id),
-            )
-            .with_priority_labels(comp.and_then(|c| c.priority_labels));
-            component_ref.usage.insert(proj.id.clone());
-            merge_component_ref(&mut refs, component_ref);
-        }
-    }
-
-    for spec in rig::list()? {
-        for (component_id, component_spec) in spec.components.iter() {
-            let mut component_ref = ComponentRef::new(
-                component_id.clone(),
-                rig::expand::expand_vars(&spec, &component_spec.path),
-                component_spec.remote_url.clone(),
-                component_spec.triage_remote_url.clone(),
-                format!("rig:{}", spec.id),
-            );
-            component_ref.usage.insert(spec.id.clone());
-            merge_component_ref(&mut refs, component_ref);
-        }
-    }
-
-    for comp in component::list()? {
-        let source = format!("component:{}", comp.id);
-        let priority_labels = comp.priority_labels.clone();
-        merge_component_ref(
-            &mut refs,
-            ComponentRef::new(
-                comp.id,
-                comp.local_path,
-                comp.remote_url,
-                comp.triage_remote_url,
-                source,
-            )
-            .with_priority_labels(priority_labels),
-        );
-    }
-
-    Ok(dedupe_refs_by_repo(refs.into_values().collect()))
-}
-
-fn merge_component_ref(refs: &mut BTreeMap<String, ComponentRef>, component_ref: ComponentRef) {
-    let entry = refs
-        .entry(component_ref.component_id.clone())
-        .or_insert_with(|| component_ref.clone());
-    entry.sources.extend(component_ref.sources);
-    entry.usage.extend(component_ref.usage);
-    if entry.local_path.is_empty() && !component_ref.local_path.is_empty() {
-        entry.local_path = component_ref.local_path;
-    }
-    if entry.remote_url.is_none() {
-        entry.remote_url = component_ref.remote_url;
-    }
-    if entry.triage_remote_url.is_none() {
-        entry.triage_remote_url = component_ref.triage_remote_url;
-    }
-    if entry.priority_labels.is_none() {
-        entry.priority_labels = component_ref.priority_labels;
+        Scope::Component(_) => "triage.component",
+        Scope::Project(_) => "triage.project",
+        Scope::Fleet(_) => "triage.fleet",
+        Scope::Rig(_) => "triage.rig",
+        Scope::Workspace => "triage.workspace",
+        // `--path` is an escape hatch on subcommands (currently `component`); keep
+        // the same command identity so JSON consumers don't see a phantom
+        // `triage.path` verb.
+        Scope::Path { .. } => "triage.component",
     }
 }
 
@@ -978,59 +707,6 @@ fn dedupe_refs_by_repo(component_refs: Vec<ComponentRef>) -> Vec<ComponentRef> {
     refs.extend(unresolved);
     refs.sort_by(|a, b| a.component_id.cmp(&b.component_id));
     refs
-}
-
-fn resolve_fleet_components(fleet_id: &str) -> Result<Vec<ComponentRef>> {
-    let fl = fleet::load(fleet_id)?;
-    let fleet_priority_labels = fl.priority_labels.clone();
-    let mut refs: BTreeMap<String, ComponentRef> = BTreeMap::new();
-
-    for project_id in &fl.project_ids {
-        let Ok(proj) = project::load(project_id) else {
-            continue;
-        };
-        for attachment in proj.components {
-            let comp = component::load(&attachment.id).ok();
-            let remote_url = comp.as_ref().and_then(|c| c.remote_url.clone());
-            let triage_remote_url = comp.as_ref().and_then(|c| c.triage_remote_url.clone());
-            let priority_labels = comp
-                .as_ref()
-                .and_then(|c| c.priority_labels.clone())
-                .or_else(|| fleet_priority_labels.clone());
-            let entry = refs.entry(attachment.id.clone()).or_insert_with(|| {
-                ComponentRef::new(
-                    attachment.id.clone(),
-                    if attachment.local_path.is_empty() {
-                        comp.as_ref()
-                            .map(|c| c.local_path.clone())
-                            .unwrap_or_default()
-                    } else {
-                        attachment.local_path.clone()
-                    },
-                    remote_url.clone(),
-                    triage_remote_url.clone(),
-                    format!("fleet:{fleet_id}"),
-                )
-                .with_priority_labels(priority_labels.clone())
-            });
-            entry.sources.insert(format!("project:{project_id}"));
-            entry.usage.insert(project_id.clone());
-            if entry.remote_url.is_none() {
-                entry.remote_url = remote_url;
-            }
-            if entry.triage_remote_url.is_none() {
-                entry.triage_remote_url = triage_remote_url;
-            }
-            if entry.local_path.is_empty() && !attachment.local_path.is_empty() {
-                entry.local_path = attachment.local_path;
-            }
-            if entry.priority_labels.is_none() {
-                entry.priority_labels = priority_labels;
-            }
-        }
-    }
-
-    Ok(refs.into_values().collect())
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Extract Homeboy's component/project/fleet/rig/workspace/path resolution into a shared `core::scope` module.
- Refactor `triage` to consume the shared scope model while preserving its existing command identity and output shape.
- Document the scope vocabulary and route HOME-mutating tests through the shared env guard so parallel `cargo test --lib` is stable.

Closes #2482.

## Testing
- `cargo fmt --check`
- `cargo test scope::tests --lib`
- `cargo test triage:: --lib`
- `cargo test trace_compare_variant --lib`
- `cargo test core::component --lib`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scope extraction, docs updates, and test-isolation fix; Chris remains responsible for review and validation.