### PR TITLE
fix: enable native macOS keychain backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
  "zeroize",
 ]
 
@@ -1284,7 +1286,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1894,6 +1896,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ regex = "1.11"
 glob-match = "0.2"
 glob = "0.3"
 zip = "0.6"
-keyring = "3.6"
+keyring = { version = "3.6", features = ["apple-native"] }
 reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls", "socks"] }
 arboard = "3"
 chrono = "0.4"


### PR DESCRIPTION
## Summary
- Enable keyring's `apple-native` backend so Homeboy API secrets persist in macOS Keychain instead of the non-persistent mock store.
- Updates `Cargo.lock` for the macOS security framework dependency pulled in by the native backend.

## Testing
- `cargo test keychain::tests::test_set -- --ignored --nocapture`
- Verified `homeboy auth status --project wpcloud-api` reports the keychain token as available after storing it.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the keyring backend mismatch, drafted the minimal dependency fix, and ran local verification. Chris reviewed and provided the real-world reproduction.