### PR TITLE
Refactor release worktree preflight policy

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -172,7 +172,7 @@ fn run_working_tree_preflight(
     step: &ReleasePlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
-    match super::pipeline::validate_working_tree_fail_fast(context.component) {
+    match super::planning_worktree::validate_working_tree_fail_fast(context.component) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
             step_type: step.step_type.clone(),

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -24,7 +24,7 @@ use super::plan_steps::{build_preflight_steps, build_release_steps};
 use super::planning_changelog::{build_changelog_plan, generate_changelog_entries};
 use super::planning_policy::release_skip_plan;
 use super::planning_semver::{build_semver_recommendation, validate_release_version_floor};
-use super::planning_worktree::{filter_homeboy_managed, validate_release_worktree};
+use super::planning_worktree::validate_release_worktree;
 use super::types::{ReleaseOptions, ReleasePlan, ReleaseRun, ReleaseRunResult, ReleaseStepResult};
 
 /// Load a component with portable config fallback when path_override is set.
@@ -497,54 +497,6 @@ fn is_runner_infrastructure_failure(output: &extension::RunnerOutput) -> bool {
     ]
     .iter()
     .any(|needle| combined.contains(needle))
-}
-
-/// Stage 0 fail-fast: refuse to run any release work when the working tree
-/// has unexplained dirty files.
-///
-/// At this stage we don't yet know the resolved changelog path or version-target
-/// paths (Stage 3 does the precise allow-list comparison), so we conservatively
-/// allow only homeboy-managed scratch space. If anything else is dirty we bail
-/// before lint/test/build can dump tens of thousands of lines and drown out
-/// the real error.
-pub(crate) fn validate_working_tree_fail_fast(component: &Component) -> Result<()> {
-    let uncommitted = crate::git::get_uncommitted_changes(&component.local_path)?;
-    if !uncommitted.has_changes {
-        return Ok(());
-    }
-
-    let all_files: Vec<String> = uncommitted
-        .staged
-        .iter()
-        .chain(uncommitted.unstaged.iter())
-        .chain(uncommitted.untracked.iter())
-        .cloned()
-        .collect();
-
-    let unexpected = filter_homeboy_managed(all_files);
-    if unexpected.is_empty() {
-        return Ok(());
-    }
-
-    Err(Error::validation_invalid_argument(
-        "working_tree",
-        "Uncommitted changes detected — refusing to release",
-        None,
-        Some(vec![
-            "Commit, stash, or discard changes before releasing".to_string(),
-            format!(
-                "Unexpected dirty files ({}): {}{}",
-                unexpected.len(),
-                unexpected
-                    .iter()
-                    .take(10)
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                if unexpected.len() > 10 { ", …" } else { "" }
-            ),
-        ]),
-    ))
 }
 
 /// First-release bootstrap: if the component's configured `changelog_target`

--- a/src/core/release/planning_worktree.rs
+++ b/src/core/release/planning_worktree.rs
@@ -1,5 +1,5 @@
 use crate::component::Component;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::git::UncommittedChanges;
 use crate::release::changelog;
 use crate::release::version::ComponentVersionInfo;
@@ -61,6 +61,48 @@ pub(super) fn validate_release_worktree(
     }
 
     Ok(None)
+}
+
+/// Stage 0 fail-fast: refuse to run release work when the working tree has
+/// unexplained dirty files before lint/test/build can drown out the real error.
+pub(super) fn validate_working_tree_fail_fast(component: &Component) -> Result<()> {
+    let uncommitted = crate::git::get_uncommitted_changes(&component.local_path)?;
+    if !uncommitted.has_changes {
+        return Ok(());
+    }
+
+    let all_files: Vec<String> = uncommitted
+        .staged
+        .iter()
+        .chain(uncommitted.unstaged.iter())
+        .chain(uncommitted.untracked.iter())
+        .cloned()
+        .collect();
+
+    let unexpected = filter_homeboy_managed(all_files);
+    if unexpected.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "working_tree",
+        "Uncommitted changes detected — refusing to release",
+        None,
+        Some(vec![
+            "Commit, stash, or discard changes before releasing".to_string(),
+            format!(
+                "Unexpected dirty files ({}): {}{}",
+                unexpected.len(),
+                unexpected
+                    .iter()
+                    .take(10)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                if unexpected.len() > 10 { ", …" } else { "" }
+            ),
+        ]),
+    ))
 }
 
 const HOMEBOY_MANAGED_PREFIXES: &[&str] = &[
@@ -128,7 +170,7 @@ fn get_unexpected_uncommitted_files(
 mod tests {
     use super::{
         filter_homeboy_managed, get_release_allowed_files, get_unexpected_uncommitted_files,
-        is_homeboy_managed_path, validate_release_worktree,
+        is_homeboy_managed_path, validate_release_worktree, validate_working_tree_fail_fast,
     };
     use crate::component::Component;
     use crate::git::UncommittedChanges;
@@ -214,6 +256,23 @@ mod tests {
             .and_then(|value| value.as_array())
             .expect("details should include dirty files");
         assert_eq!(files[0].as_str(), Some("src.rs"));
+    }
+
+    #[test]
+    fn test_validate_working_tree_fail_fast() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::write(dir.join("README.md"), "initial\n").unwrap();
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+        std::fs::write(dir.join("src.rs"), "unexpected\n").unwrap();
+
+        let err = validate_working_tree_fail_fast(&git_component(dir))
+            .expect_err("unexpected user file should fail fast");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("Uncommitted changes detected"));
+        assert!(err.details.to_string().contains("src.rs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move the executable release working-tree fail-fast preflight into `planning_worktree.rs` alongside the existing worktree planning policy.
- Keep `pipeline.rs` focused on release orchestration while the execution dispatcher calls the focused policy module directly.
- Add coverage for dirty working-tree fail-fast behavior in the planning worktree tests.

## Verification
- `cargo fmt --check`
- `cargo test core::release::planning_worktree`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the release policy extraction and PR description; Chris remains responsible for review and merge.