### PR TITLE
Extract release git preflight policy

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -153,7 +153,7 @@ fn run_default_branch_preflight(
     step: &ReleasePlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
-    match super::pipeline::validate_default_branch(context.component) {
+    match super::planning_git::validate_default_branch(context.component) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
             step_type: step.step_type.clone(),
@@ -191,7 +191,7 @@ fn run_remote_sync_preflight(
     step: &ReleasePlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
-    match super::pipeline::validate_remote_sync(context.component) {
+    match super::planning_git::validate_remote_sync(context.component) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
             step_type: step.step_type.clone(),

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -8,6 +8,7 @@ mod pipeline_capabilities;
 mod pipeline_summary;
 mod plan_steps;
 mod planning_changelog;
+mod planning_git;
 mod planning_policy;
 mod planning_quality;
 mod planning_semver;

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -5,7 +5,6 @@
 //! previewed steps match execution.
 
 use crate::component::{self, Component};
-use crate::engine::command;
 use crate::engine::local_files::FileSystem;
 use crate::engine::validation::ValidationCollector;
 use crate::error::{Error, Result};
@@ -279,69 +278,6 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     })
 }
 
-/// Fetch from remote and fast-forward if behind.
-///
-/// Ensures the release commit is created on top of the actual remote HEAD,
-/// preventing detached release tags when PRs merge during a CI quality gate.
-/// Returns Err if the branch has diverged and can't be fast-forwarded.
-pub(crate) fn validate_remote_sync(component: &Component) -> Result<()> {
-    let synced = git::fetch_and_fast_forward(&component.local_path)?;
-
-    if let Some(n) = synced {
-        log_status!(
-            "release",
-            "Fast-forwarded {} commit(s) from remote before release",
-            n
-        );
-    }
-
-    Ok(())
-}
-
-pub(crate) fn validate_default_branch(component: &Component) -> Result<()> {
-    let current_branch = command::run_in_optional(
-        &component.local_path,
-        "git",
-        &["symbolic-ref", "--short", "HEAD"],
-    )
-    .ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "release",
-            "Refusing to release from detached HEAD",
-            None,
-            Some(vec![
-                "Check out the default branch before releasing".to_string()
-            ]),
-        )
-    })?;
-
-    let default_branch = command::run_in_optional(
-        &component.local_path,
-        "git",
-        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-    )
-    .map(|value| value.trim().trim_start_matches("origin/").to_string())
-    .filter(|value| !value.is_empty())
-    .unwrap_or_else(|| "main".to_string());
-
-    if current_branch == default_branch {
-        return Ok(());
-    }
-
-    Err(Error::validation_invalid_argument(
-        "release",
-        format!(
-            "Refusing to release from non-default branch '{}' (default: '{}')",
-            current_branch, default_branch
-        ),
-        None,
-        Some(vec![
-            format!("Check out '{}' before releasing", default_branch),
-            "If you only want a preview, use --dry-run".to_string(),
-        ]),
-    ))
-}
-
 /// First-release bootstrap: if the component's configured `changelog_target`
 /// doesn't exist on disk (and no fallback candidate exists), create a minimal
 /// changelog scaffold so `resolve_changelog_path` + `finalize_with_generated_entries`
@@ -391,54 +327,8 @@ pub(crate) fn ensure_changelog_initialized(component: &Component) -> Result<()> 
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_changelog_initialized, validate_default_branch};
+    use super::ensure_changelog_initialized;
     use crate::component::Component;
-
-    fn run_git(dir: &std::path::Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {:?} failed: stdout={} stderr={}",
-            args,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn git_component(dir: &std::path::Path) -> Component {
-        Component {
-            id: "fixture".to_string(),
-            local_path: dir.to_string_lossy().to_string(),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_validate_default_branch_allows_default_branch() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let dir = temp.path();
-        run_git(dir, &["init", "-q"]);
-        run_git(dir, &["symbolic-ref", "HEAD", "refs/heads/main"]);
-
-        validate_default_branch(&git_component(dir)).expect("main should be allowed");
-    }
-
-    #[test]
-    fn test_validate_default_branch_blocks_non_default_branch() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let dir = temp.path();
-        run_git(dir, &["init", "-q"]);
-        run_git(dir, &["symbolic-ref", "HEAD", "refs/heads/feature"]);
-
-        let err = validate_default_branch(&git_component(dir)).expect_err("feature should fail");
-
-        assert_eq!(err.code.as_str(), "validation.invalid_argument");
-        assert!(err.message.contains("non-default branch 'feature'"));
-    }
 
     /// Regression for the homeboy-action release blocker:
     /// `validate_working_tree_fail_fast` builds an Error with a hint vec

--- a/src/core/release/planning_git.rs
+++ b/src/core/release/planning_git.rs
@@ -1,0 +1,169 @@
+use crate::component::Component;
+use crate::engine::command;
+use crate::error::{Error, Result};
+use crate::git;
+
+/// Fetch from remote and fast-forward if behind.
+///
+/// Ensures the release commit is created on top of the actual remote HEAD,
+/// preventing detached release tags when PRs merge during a CI quality gate.
+/// Returns Err if the branch has diverged and can't be fast-forwarded.
+pub(super) fn validate_remote_sync(component: &Component) -> Result<()> {
+    let synced = git::fetch_and_fast_forward(&component.local_path)?;
+
+    if let Some(n) = synced {
+        log_status!(
+            "release",
+            "Fast-forwarded {} commit(s) from remote before release",
+            n
+        );
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_default_branch(component: &Component) -> Result<()> {
+    let current_branch = command::run_in_optional(
+        &component.local_path,
+        "git",
+        &["symbolic-ref", "--short", "HEAD"],
+    )
+    .ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "release",
+            "Refusing to release from detached HEAD",
+            None,
+            Some(vec![
+                "Check out the default branch before releasing".to_string()
+            ]),
+        )
+    })?;
+
+    let default_branch = command::run_in_optional(
+        &component.local_path,
+        "git",
+        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+    )
+    .map(|value| value.trim().trim_start_matches("origin/").to_string())
+    .filter(|value| !value.is_empty())
+    .unwrap_or_else(|| "main".to_string());
+
+    if current_branch == default_branch {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "release",
+        format!(
+            "Refusing to release from non-default branch '{}' (default: '{}')",
+            current_branch, default_branch
+        ),
+        None,
+        Some(vec![
+            format!("Check out '{}' before releasing", default_branch),
+            "If you only want a preview, use --dry-run".to_string(),
+        ]),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_default_branch, validate_remote_sync};
+    use crate::component::Component;
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_component(dir: &std::path::Path) -> Component {
+        Component {
+            id: "fixture".to_string(),
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn configure_git_user(dir: &std::path::Path) {
+        run_git(dir, &["config", "user.email", "test@example.com"]);
+        run_git(dir, &["config", "user.name", "Test"]);
+    }
+
+    #[test]
+    fn test_validate_default_branch_allows_default_branch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q"]);
+        run_git(dir, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+        validate_default_branch(&git_component(dir)).expect("main should be allowed");
+    }
+
+    #[test]
+    fn test_validate_default_branch_blocks_non_default_branch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q"]);
+        run_git(dir, &["symbolic-ref", "HEAD", "refs/heads/feature"]);
+
+        let err = validate_default_branch(&git_component(dir)).expect_err("feature should fail");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("non-default branch 'feature'"));
+    }
+
+    #[test]
+    fn test_validate_remote_sync() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote = temp.path().join("remote.git");
+        let seed = temp.path().join("seed");
+        let checkout = temp.path().join("checkout");
+        let remote_str = remote.to_string_lossy().to_string();
+
+        run_git(
+            temp.path(),
+            &["init", "--bare", "--initial-branch", "main", &remote_str],
+        );
+        run_git(temp.path(), &["clone", &remote_str, "seed"]);
+        configure_git_user(&seed);
+        std::fs::write(seed.join("README.md"), "fixture\n").expect("write fixture");
+        run_git(&seed, &["add", "."]);
+        run_git(&seed, &["commit", "-q", "-m", "Initial commit"]);
+        run_git(&seed, &["push", "-q", "origin", "main"]);
+
+        run_git(temp.path(), &["clone", &remote_str, "checkout"]);
+        configure_git_user(&checkout);
+
+        std::fs::write(seed.join("README.md"), "fixture\nsecond\n").expect("write update");
+        run_git(&seed, &["add", "."]);
+        run_git(&seed, &["commit", "-q", "-m", "Second commit"]);
+        run_git(&seed, &["push", "-q", "origin", "main"]);
+
+        validate_remote_sync(&git_component(&checkout)).expect("checkout should fast-forward");
+
+        assert_eq!(
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&checkout)
+                .output()
+                .expect("read HEAD")
+                .stdout,
+            std::process::Command::new("git")
+                .args(["rev-parse", "origin/main"])
+                .current_dir(&checkout)
+                .output()
+                .expect("read origin/main")
+                .stdout
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Move executable release git preflight policy out of `pipeline.rs` into `planning_git.rs`.
- Update release execution dispatch to call the focused git preflight module for default-branch and remote-sync checks.
- Move default-branch tests with the policy and add direct remote-sync coverage for the fast-forward path.

## Verification
- `cargo fmt --check`
- `cargo test core::release::planning_git`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the release git preflight extraction and PR description; Chris remains responsible for review and merge.