### PR TITLE
Add generic HTTP auth profiles

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -20,6 +20,7 @@
 - [file](file.md) — remote file operations, downloads, uploads, copies, and syncs
 - [fleet](fleet.md)
 - [git](git.md)
+- [http](http.md) — generic proxied authenticated HTTP requests
 - [issues](issues.md) — reconcile findings against issue trackers
 - [lint](lint.md)
 - [list](list.md)

--- a/docs/commands/http.md
+++ b/docs/commands/http.md
@@ -1,0 +1,26 @@
+# http
+
+Make generic HTTP requests to full URLs.
+
+Use this when a one-off internal or external endpoint needs Homeboy's local transport affordances without creating a project API config.
+
+## Examples
+
+```sh
+homeboy auth profile set-basic matticspace --username chubes4
+homeboy http get https://logstash.a8c.com/logstash/... --proxy socks5://127.0.0.1:8080 --auth-profile matticspace
+```
+
+```sh
+homeboy http request POST https://example.com/api --json '{"ok":true}' --header 'X-Example: value'
+```
+
+## Options
+
+- `--proxy <url>` routes the request through an explicit proxy URL.
+- `--auth-profile <name>` adds an Authorization header from `homeboy auth profile` keychain storage.
+- `--header 'Name: value'` adds a request header.
+- `--json <json>` sends a JSON body.
+- `--form key=value` sends form fields.
+
+Output is structured JSON with `method`, `url`, `status`, `headers`, and `body`.

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 
 use crate::commands::{
     api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
-    deps, doctor, extension, file, fleet, git, issues, lint, logs, observe, project, refactor,
-    release, report, review, rig, runs, self_cmd, server, ssh, stack, status, test, trace, triage,
-    undo, upgrade, version,
+    deps, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
+    refactor, release, report, review, rig, runs, self_cmd, server, ssh, stack, status, test,
+    trace, triage, undo, upgrade, version,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -124,6 +124,8 @@ pub enum Commands {
     Auth(auth::AuthArgs),
     /// Make API requests to a project
     Api(api::ApiArgs),
+    /// Make generic HTTP requests
+    Http(http::HttpArgs),
     /// Upgrade Homeboy to the latest version
     Upgrade(upgrade::UpgradeArgs),
     /// List available commands (alias for --help)

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -3,7 +3,8 @@ use serde::Serialize;
 use std::collections::HashMap;
 
 use homeboy::server::auth::{
-    self, AuthStatus, GetResult, LoginResult, LogoutResult, RemoveResult, SetResult,
+    self, AuthStatus, GetResult, LoginResult, LogoutResult, ProfileRemoveResult, ProfileSetResult,
+    ProfileStatusResult, RemoveResult, SetResult,
 };
 
 use super::{CmdResult, GlobalArgs};
@@ -82,6 +83,51 @@ enum AuthCommand {
         #[arg(long)]
         project: String,
     },
+
+    /// Manage reusable auth profiles for generic HTTP requests
+    Profile {
+        #[command(subcommand)]
+        command: ProfileCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum ProfileCommand {
+    /// Store a Basic auth profile in the OS keychain
+    SetBasic {
+        /// Profile name
+        profile: String,
+
+        /// Username
+        #[arg(long)]
+        username: Option<String>,
+
+        /// Password; omit to prompt securely
+        #[arg(long)]
+        password: Option<String>,
+    },
+
+    /// Store a Bearer token auth profile in the OS keychain
+    SetBearer {
+        /// Profile name
+        profile: String,
+
+        /// Token; omit to prompt securely
+        #[arg(long)]
+        token: Option<String>,
+    },
+
+    /// Show whether an auth profile is available
+    Status {
+        /// Profile name
+        profile: String,
+    },
+
+    /// Remove an auth profile from the OS keychain
+    Remove {
+        /// Profile name
+        profile: String,
+    },
 }
 
 #[derive(Serialize)]
@@ -93,6 +139,9 @@ pub enum AuthOutput {
     Remove(RemoveResult),
     Logout(LogoutResult),
     Status(AuthStatus),
+    ProfileSet(ProfileSetResult),
+    ProfileStatus(ProfileStatusResult),
+    ProfileRemove(ProfileRemoveResult),
 }
 
 pub fn run(args: AuthArgs, _global: &GlobalArgs) -> CmdResult<AuthOutput> {
@@ -115,6 +164,48 @@ pub fn run(args: AuthArgs, _global: &GlobalArgs) -> CmdResult<AuthOutput> {
         AuthCommand::Remove { project, variable } => run_remove(&project, &variable),
         AuthCommand::Logout { project } => run_logout(&project),
         AuthCommand::Status { project } => run_status(&project),
+        AuthCommand::Profile { command } => run_profile(command),
+    }
+}
+
+fn run_profile(command: ProfileCommand) -> CmdResult<AuthOutput> {
+    match command {
+        ProfileCommand::SetBasic {
+            profile,
+            username,
+            password,
+        } => {
+            let username = match username {
+                Some(username) => username,
+                None => prompt("Username: ")?,
+            };
+            let password = match password {
+                Some(password) => password,
+                None => prompt_password("Password: ")?,
+            };
+            Ok((
+                AuthOutput::ProfileSet(auth::set_profile_basic(&profile, &username, &password)?),
+                0,
+            ))
+        }
+        ProfileCommand::SetBearer { profile, token } => {
+            let token = match token {
+                Some(token) => token,
+                None => prompt_password("Token: ")?,
+            };
+            Ok((
+                AuthOutput::ProfileSet(auth::set_profile_bearer(&profile, &token)?),
+                0,
+            ))
+        }
+        ProfileCommand::Status { profile } => Ok((
+            AuthOutput::ProfileStatus(auth::profile_status(&profile)?),
+            0,
+        )),
+        ProfileCommand::Remove { profile } => Ok((
+            AuthOutput::ProfileRemove(auth::remove_profile(&profile)?),
+            0,
+        )),
     }
 }
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -3,8 +3,10 @@ use serde::Serialize;
 use std::collections::HashMap;
 
 use homeboy::server::auth::{
-    self, AuthStatus, GetResult, LoginResult, LogoutResult, ProfileRemoveResult, ProfileSetResult,
-    ProfileStatusResult, RemoveResult, SetResult,
+    self, AuthStatus, GetResult, LoginResult, LogoutResult, RemoveResult, SetResult,
+};
+use homeboy::server::auth_profiles::{
+    self, ProfileRemoveResult, ProfileSetResult, ProfileStatusResult,
 };
 
 use super::{CmdResult, GlobalArgs};
@@ -184,7 +186,9 @@ fn run_profile(command: ProfileCommand) -> CmdResult<AuthOutput> {
                 None => prompt_password("Password: ")?,
             };
             Ok((
-                AuthOutput::ProfileSet(auth::set_profile_basic(&profile, &username, &password)?),
+                AuthOutput::ProfileSet(auth_profiles::set_profile_basic(
+                    &profile, &username, &password,
+                )?),
                 0,
             ))
         }
@@ -194,16 +198,16 @@ fn run_profile(command: ProfileCommand) -> CmdResult<AuthOutput> {
                 None => prompt_password("Token: ")?,
             };
             Ok((
-                AuthOutput::ProfileSet(auth::set_profile_bearer(&profile, &token)?),
+                AuthOutput::ProfileSet(auth_profiles::set_profile_bearer(&profile, &token)?),
                 0,
             ))
         }
         ProfileCommand::Status { profile } => Ok((
-            AuthOutput::ProfileStatus(auth::profile_status(&profile)?),
+            AuthOutput::ProfileStatus(auth_profiles::profile_status(&profile)?),
             0,
         )),
         ProfileCommand::Remove { profile } => Ok((
-            AuthOutput::ProfileRemove(auth::remove_profile(&profile)?),
+            AuthOutput::ProfileRemove(auth_profiles::remove_profile(&profile)?),
             0,
         )),
     }

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -1,0 +1,73 @@
+use clap::{Args, Subcommand};
+
+use homeboy::http_request::{self, HttpRequestInput, HttpRequestOutput};
+
+use super::{parse_key_val, CmdResult, GlobalArgs};
+
+#[derive(Args)]
+pub struct HttpArgs {
+    #[command(subcommand)]
+    command: HttpCommand,
+}
+
+#[derive(Subcommand)]
+enum HttpCommand {
+    /// Make a GET request to a full URL
+    Get(RequestArgs),
+    /// Make an arbitrary HTTP request to a full URL
+    Request {
+        /// HTTP method
+        method: String,
+
+        #[command(flatten)]
+        args: RequestArgs,
+    },
+}
+
+#[derive(Args)]
+struct RequestArgs {
+    /// Full URL to request
+    url: String,
+
+    /// Optional proxy URL, e.g. socks5://127.0.0.1:8080
+    #[arg(long)]
+    proxy: Option<String>,
+
+    /// Auth profile from `homeboy auth profile ...`
+    #[arg(long)]
+    auth_profile: Option<String>,
+
+    /// Header in `Name: value` format; repeatable
+    #[arg(long = "header")]
+    headers: Vec<String>,
+
+    /// JSON request body
+    #[arg(long)]
+    json: Option<String>,
+
+    /// Form field as key=value; repeatable
+    #[arg(long = "form", value_parser = parse_key_val)]
+    form: Vec<(String, String)>,
+}
+
+pub fn run(args: HttpArgs, _global: &GlobalArgs) -> CmdResult<HttpRequestOutput> {
+    let input = match args.command {
+        HttpCommand::Get(args) => build_input("GET", args),
+        HttpCommand::Request { method, args } => build_input(&method, args),
+    };
+
+    let output = http_request::run(input)?;
+    Ok((output, 0))
+}
+
+fn build_input(method: &str, args: RequestArgs) -> HttpRequestInput {
+    HttpRequestInput {
+        method: method.to_string(),
+        url: args.url,
+        proxy_url: args.proxy,
+        auth_profile: args.auth_profile,
+        headers: args.headers,
+        json_body: args.json,
+        form_body: args.form,
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -348,6 +348,7 @@ pub mod extension;
 pub mod file;
 pub mod fleet;
 pub mod git;
+pub mod http;
 pub mod issues;
 pub mod lint;
 pub mod logs;
@@ -467,6 +468,7 @@ pub fn run_json(
         crate::cli_surface::Commands::Undo(args) => dispatch!(args, global, undo),
         crate::cli_surface::Commands::Auth(args) => dispatch!(args, global, auth),
         crate::cli_surface::Commands::Api(args) => dispatch!(args, global, api),
+        crate::cli_surface::Commands::Http(args) => dispatch!(args, global, http),
         crate::cli_surface::Commands::Upgrade(args) => dispatch!(args, global, upgrade),
 
         // Special case: List uses raw output mode

--- a/src/core/http_request.rs
+++ b/src/core/http_request.rs
@@ -1,10 +1,10 @@
-use crate::error::{Error, ErrorCode, Result};
-use crate::server::{auth, http};
+use crate::error::{Error, Result};
+use crate::server::{auth_profiles, http};
 use reqwest::blocking::Response;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
@@ -52,7 +52,7 @@ pub fn run(input: HttpRequestInput) -> Result<HttpRequestOutput> {
         request = request.form(&input.form_body);
     }
 
-    let response = request.send().map_err(http_error)?;
+    let response = request.send().map_err(http::http_error)?;
     response_output(method.as_str(), &input.url, response)
 }
 
@@ -60,7 +60,7 @@ fn build_headers(input: &HttpRequestInput) -> Result<HeaderMap> {
     let mut headers = HeaderMap::new();
 
     if let Some(profile) = input.auth_profile.as_deref() {
-        let value = auth::profile_authorization_header(profile)?;
+        let value = auth_profiles::profile_authorization_header(profile)?;
         headers.insert(
             AUTHORIZATION,
             HeaderValue::from_str(&value).map_err(|e| {
@@ -103,7 +103,7 @@ fn parse_header(header: &str) -> Result<(HeaderName, HeaderValue)> {
 fn response_output(method: &str, url: &str, response: Response) -> Result<HttpRequestOutput> {
     let status = response.status().as_u16();
     let headers = response_headers(response.headers());
-    let text = response.text().map_err(http_error)?;
+    let text = response.text().map_err(http::http_error)?;
     let body = serde_json::from_str(&text).unwrap_or_else(|_| Value::String(text));
 
     Ok(HttpRequestOutput {
@@ -125,20 +125,18 @@ fn response_headers(headers: &HeaderMap) -> BTreeMap<String, Vec<String>> {
     out
 }
 
-fn http_error(error: reqwest::Error) -> Error {
-    Error::new(
-        ErrorCode::InternalUnexpected,
-        format!("HTTP request failed: {}", error),
-        json!({ "error": error.to_string() }),
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ErrorCode;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+
+    #[test]
+    fn test_run() {
+        get_returns_status_headers_and_json_body();
+    }
 
     #[test]
     fn get_returns_status_headers_and_json_body() {

--- a/src/core/http_request.rs
+++ b/src/core/http_request.rs
@@ -1,0 +1,187 @@
+use crate::error::{Error, ErrorCode, Result};
+use crate::server::{auth, http};
+use reqwest::blocking::Response;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub struct HttpRequestInput {
+    pub method: String,
+    pub url: String,
+    pub proxy_url: Option<String>,
+    pub auth_profile: Option<String>,
+    pub headers: Vec<String>,
+    pub json_body: Option<String>,
+    pub form_body: Vec<(String, String)>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HttpRequestOutput {
+    pub method: String,
+    pub url: String,
+    pub status: u16,
+    pub headers: BTreeMap<String, Vec<String>>,
+    pub body: Value,
+}
+
+pub fn run(input: HttpRequestInput) -> Result<HttpRequestOutput> {
+    let method = input.method.parse::<Method>().map_err(|e| {
+        Error::validation_invalid_argument(
+            "method",
+            e.to_string(),
+            Some(input.method.clone()),
+            None,
+        )
+    })?;
+    let client = http::build_client_with_proxy(input.proxy_url.as_deref())?;
+    let mut request = client.request(method.clone(), &input.url);
+
+    let headers = build_headers(&input)?;
+    if !headers.is_empty() {
+        request = request.headers(headers);
+    }
+
+    if let Some(raw_json) = input.json_body.as_deref() {
+        let value: Value = serde_json::from_str(raw_json)
+            .map_err(|e| Error::validation_invalid_argument("json", e.to_string(), None, None))?;
+        request = request.json(&value);
+    } else if !input.form_body.is_empty() {
+        request = request.form(&input.form_body);
+    }
+
+    let response = request.send().map_err(http_error)?;
+    response_output(method.as_str(), &input.url, response)
+}
+
+fn build_headers(input: &HttpRequestInput) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+
+    if let Some(profile) = input.auth_profile.as_deref() {
+        let value = auth::profile_authorization_header(profile)?;
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&value).map_err(|e| {
+                Error::validation_invalid_argument("auth-profile", e.to_string(), None, None)
+            })?,
+        );
+    }
+
+    if input.json_body.is_some() {
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+
+    for header in &input.headers {
+        let (name, value) = parse_header(header)?;
+        headers.insert(name, value);
+    }
+
+    Ok(headers)
+}
+
+fn parse_header(header: &str) -> Result<(HeaderName, HeaderValue)> {
+    let Some((name, value)) = header.split_once(':') else {
+        return Err(Error::validation_invalid_argument(
+            "header",
+            "Headers must use 'Name: value' format",
+            Some(header.to_string()),
+            None,
+        ));
+    };
+
+    let name = HeaderName::from_bytes(name.trim().as_bytes()).map_err(|e| {
+        Error::validation_invalid_argument("header", e.to_string(), Some(header.to_string()), None)
+    })?;
+    let value = HeaderValue::from_str(value.trim()).map_err(|e| {
+        Error::validation_invalid_argument("header", e.to_string(), Some(header.to_string()), None)
+    })?;
+    Ok((name, value))
+}
+
+fn response_output(method: &str, url: &str, response: Response) -> Result<HttpRequestOutput> {
+    let status = response.status().as_u16();
+    let headers = response_headers(response.headers());
+    let text = response.text().map_err(http_error)?;
+    let body = serde_json::from_str(&text).unwrap_or_else(|_| Value::String(text));
+
+    Ok(HttpRequestOutput {
+        method: method.to_string(),
+        url: url.to_string(),
+        status,
+        headers,
+        body,
+    })
+}
+
+fn response_headers(headers: &HeaderMap) -> BTreeMap<String, Vec<String>> {
+    let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (name, value) in headers {
+        out.entry(name.as_str().to_string())
+            .or_default()
+            .push(value.to_str().unwrap_or_default().to_string());
+    }
+    out
+}
+
+fn http_error(error: reqwest::Error) -> Error {
+    Error::new(
+        ErrorCode::InternalUnexpected,
+        format!("HTTP request failed: {}", error),
+        json!({ "error": error.to_string() }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    #[test]
+    fn get_returns_status_headers_and_json_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer);
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"ok\":true}";
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        let output = run(HttpRequestInput {
+            method: "GET".to_string(),
+            url: format!("http://{}", addr),
+            proxy_url: None,
+            auth_profile: None,
+            headers: Vec::new(),
+            json_body: None,
+            form_body: Vec::new(),
+        })
+        .unwrap();
+
+        assert_eq!(output.status, 200);
+        assert_eq!(output.body["ok"], true);
+        assert_eq!(output.headers["content-type"], vec!["application/json"]);
+    }
+
+    #[test]
+    fn invalid_header_is_rejected() {
+        let err = build_headers(&HttpRequestInput {
+            method: "GET".to_string(),
+            url: "https://example.com".to_string(),
+            proxy_url: None,
+            auth_profile: None,
+            headers: vec!["no-colon".to_string()],
+            json_body: None,
+            form_body: Vec::new(),
+        })
+        .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -18,6 +18,7 @@ pub mod fleet;
 pub mod git;
 pub mod http_api;
 pub(crate) mod http_probe;
+pub mod http_request;
 pub(crate) mod io;
 pub mod issues;
 pub mod keychain;

--- a/src/core/server/auth.rs
+++ b/src/core/server/auth.rs
@@ -7,8 +7,14 @@ use super::http::ApiClient;
 use crate::error::Result;
 use crate::keychain;
 use crate::project;
+use base64::Engine;
 use serde::Serialize;
 use std::collections::HashMap;
+
+const PROFILE_KIND: &str = "kind";
+const PROFILE_USERNAME: &str = "username";
+const PROFILE_PASSWORD: &str = "password";
+const PROFILE_TOKEN: &str = "token";
 
 #[derive(Debug, Serialize)]
 pub struct LoginResult {
@@ -56,6 +62,30 @@ pub struct AuthVariableStatus {
     pub name: String,
     pub source: String,
     pub available: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProfileSetResult {
+    pub profile: String,
+    pub kind: String,
+    pub stored: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProfileStatusResult {
+    pub profile: String,
+    pub kind: Option<String>,
+    pub available: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProfileRemoveResult {
+    pub profile: String,
+    pub removed: usize,
+}
+
+pub fn profile_scope(profile: &str) -> String {
+    format!("profile:{}", profile)
 }
 
 /// Authenticates with a project's API using provided credentials.
@@ -138,6 +168,107 @@ pub fn status(project_id: &str) -> Result<AuthStatus> {
         authenticated: client.is_authenticated(),
         variables: variable_statuses(project_id, &project),
     })
+}
+
+pub fn set_profile_basic(
+    profile: &str,
+    username: &str,
+    password: &str,
+) -> Result<ProfileSetResult> {
+    let scope = profile_scope(profile);
+    keychain::set(&scope, PROFILE_KIND, "basic")?;
+    keychain::set(&scope, PROFILE_USERNAME, username)?;
+    keychain::set(&scope, PROFILE_PASSWORD, password)?;
+    Ok(ProfileSetResult {
+        profile: profile.to_string(),
+        kind: "basic".to_string(),
+        stored: true,
+    })
+}
+
+pub fn set_profile_bearer(profile: &str, token: &str) -> Result<ProfileSetResult> {
+    let scope = profile_scope(profile);
+    keychain::set(&scope, PROFILE_KIND, "bearer")?;
+    keychain::set(&scope, PROFILE_TOKEN, token)?;
+    Ok(ProfileSetResult {
+        profile: profile.to_string(),
+        kind: "bearer".to_string(),
+        stored: true,
+    })
+}
+
+pub fn profile_status(profile: &str) -> Result<ProfileStatusResult> {
+    let scope = profile_scope(profile);
+    let kind = keychain::get(&scope, PROFILE_KIND)?;
+    let available = match kind.as_deref() {
+        Some("basic") => {
+            keychain::get(&scope, PROFILE_USERNAME)?.is_some()
+                && keychain::get(&scope, PROFILE_PASSWORD)?.is_some()
+        }
+        Some("bearer") => keychain::get(&scope, PROFILE_TOKEN)?.is_some(),
+        _ => false,
+    };
+
+    Ok(ProfileStatusResult {
+        profile: profile.to_string(),
+        kind,
+        available,
+    })
+}
+
+pub fn remove_profile(profile: &str) -> Result<ProfileRemoveResult> {
+    let scope = profile_scope(profile);
+    let variables = vec![
+        PROFILE_KIND.to_string(),
+        PROFILE_USERNAME.to_string(),
+        PROFILE_PASSWORD.to_string(),
+        PROFILE_TOKEN.to_string(),
+    ];
+    let removed = keychain::remove_many(&scope, &variables)?;
+    Ok(ProfileRemoveResult {
+        profile: profile.to_string(),
+        removed,
+    })
+}
+
+pub fn profile_authorization_header(profile: &str) -> Result<String> {
+    let scope = profile_scope(profile);
+    let kind =
+        keychain::get(&scope, PROFILE_KIND)?.ok_or_else(|| missing_profile_error(profile))?;
+    match kind.as_str() {
+        "basic" => {
+            let username = keychain::get(&scope, PROFILE_USERNAME)?
+                .ok_or_else(|| missing_profile_error(profile))?;
+            let password = keychain::get(&scope, PROFILE_PASSWORD)?
+                .ok_or_else(|| missing_profile_error(profile))?;
+            let encoded = base64::engine::general_purpose::STANDARD
+                .encode(format!("{}:{}", username, password));
+            Ok(format!("Basic {}", encoded))
+        }
+        "bearer" => {
+            let token = keychain::get(&scope, PROFILE_TOKEN)?
+                .ok_or_else(|| missing_profile_error(profile))?;
+            Ok(format!("Bearer {}", token))
+        }
+        other => Err(crate::error::Error::validation_invalid_argument(
+            "auth-profile",
+            format!("Unsupported auth profile kind '{}'", other),
+            Some(profile.to_string()),
+            Some(vec!["basic".to_string(), "bearer".to_string()]),
+        )),
+    }
+}
+
+fn missing_profile_error(profile: &str) -> crate::error::Error {
+    crate::error::Error::new(
+        crate::error::ErrorCode::ExtensionNotFound,
+        format!("Auth profile '{}' is not set", profile),
+        serde_json::Value::Null,
+    )
+    .with_hint(format!(
+        "Run 'homeboy auth profile set-basic {} --username <user>' or 'homeboy auth profile set-bearer {}'",
+        profile, profile
+    ))
 }
 
 fn keychain_variable_names(project: &project::Project) -> Vec<String> {

--- a/src/core/server/auth.rs
+++ b/src/core/server/auth.rs
@@ -334,6 +334,75 @@ mod tests {
     }
 
     #[test]
+    fn test_profile_scope() {
+        assert_eq!(profile_scope("matticspace"), "profile:matticspace");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_set_profile_basic() {
+        let profile = "homeboy-auth-profile-basic-test";
+        let _ = remove_profile(profile);
+
+        let result = set_profile_basic(profile, "user", "secret").expect("store basic profile");
+
+        assert!(result.stored);
+        assert_eq!(result.kind, "basic");
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_set_profile_bearer() {
+        let profile = "homeboy-auth-profile-bearer-test";
+        let _ = remove_profile(profile);
+
+        let result = set_profile_bearer(profile, "token").expect("store bearer profile");
+
+        assert!(result.stored);
+        assert_eq!(result.kind, "bearer");
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_profile_status() {
+        let profile = "homeboy-auth-profile-status-test";
+        let _ = remove_profile(profile);
+        set_profile_bearer(profile, "token").expect("store bearer profile");
+
+        let result = profile_status(profile).expect("profile status");
+
+        assert!(result.available);
+        assert_eq!(result.kind.as_deref(), Some("bearer"));
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_profile_authorization_header() {
+        let profile = "homeboy-auth-profile-header-test";
+        let _ = remove_profile(profile);
+        set_profile_basic(profile, "user", "secret").expect("store basic profile");
+
+        let header = profile_authorization_header(profile).expect("authorization header");
+
+        assert_eq!(header, "Basic dXNlcjpzZWNyZXQ=");
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_remove_profile() {
+        let profile = "homeboy-auth-profile-remove-test";
+        set_profile_bearer(profile, "token").expect("store bearer profile");
+
+        let result = remove_profile(profile).expect("remove profile");
+
+        assert!(result.removed > 0);
+    }
+
+    #[test]
     fn test_variable_available_config() {
         let source = VariableSource {
             source: "config".to_string(),

--- a/src/core/server/auth.rs
+++ b/src/core/server/auth.rs
@@ -7,14 +7,8 @@ use super::http::ApiClient;
 use crate::error::Result;
 use crate::keychain;
 use crate::project;
-use base64::Engine;
 use serde::Serialize;
 use std::collections::HashMap;
-
-const PROFILE_KIND: &str = "kind";
-const PROFILE_USERNAME: &str = "username";
-const PROFILE_PASSWORD: &str = "password";
-const PROFILE_TOKEN: &str = "token";
 
 #[derive(Debug, Serialize)]
 pub struct LoginResult {
@@ -62,30 +56,6 @@ pub struct AuthVariableStatus {
     pub name: String,
     pub source: String,
     pub available: bool,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ProfileSetResult {
-    pub profile: String,
-    pub kind: String,
-    pub stored: bool,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ProfileStatusResult {
-    pub profile: String,
-    pub kind: Option<String>,
-    pub available: bool,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ProfileRemoveResult {
-    pub profile: String,
-    pub removed: usize,
-}
-
-pub fn profile_scope(profile: &str) -> String {
-    format!("profile:{}", profile)
 }
 
 /// Authenticates with a project's API using provided credentials.
@@ -170,107 +140,6 @@ pub fn status(project_id: &str) -> Result<AuthStatus> {
     })
 }
 
-pub fn set_profile_basic(
-    profile: &str,
-    username: &str,
-    password: &str,
-) -> Result<ProfileSetResult> {
-    let scope = profile_scope(profile);
-    keychain::set(&scope, PROFILE_KIND, "basic")?;
-    keychain::set(&scope, PROFILE_USERNAME, username)?;
-    keychain::set(&scope, PROFILE_PASSWORD, password)?;
-    Ok(ProfileSetResult {
-        profile: profile.to_string(),
-        kind: "basic".to_string(),
-        stored: true,
-    })
-}
-
-pub fn set_profile_bearer(profile: &str, token: &str) -> Result<ProfileSetResult> {
-    let scope = profile_scope(profile);
-    keychain::set(&scope, PROFILE_KIND, "bearer")?;
-    keychain::set(&scope, PROFILE_TOKEN, token)?;
-    Ok(ProfileSetResult {
-        profile: profile.to_string(),
-        kind: "bearer".to_string(),
-        stored: true,
-    })
-}
-
-pub fn profile_status(profile: &str) -> Result<ProfileStatusResult> {
-    let scope = profile_scope(profile);
-    let kind = keychain::get(&scope, PROFILE_KIND)?;
-    let available = match kind.as_deref() {
-        Some("basic") => {
-            keychain::get(&scope, PROFILE_USERNAME)?.is_some()
-                && keychain::get(&scope, PROFILE_PASSWORD)?.is_some()
-        }
-        Some("bearer") => keychain::get(&scope, PROFILE_TOKEN)?.is_some(),
-        _ => false,
-    };
-
-    Ok(ProfileStatusResult {
-        profile: profile.to_string(),
-        kind,
-        available,
-    })
-}
-
-pub fn remove_profile(profile: &str) -> Result<ProfileRemoveResult> {
-    let scope = profile_scope(profile);
-    let variables = vec![
-        PROFILE_KIND.to_string(),
-        PROFILE_USERNAME.to_string(),
-        PROFILE_PASSWORD.to_string(),
-        PROFILE_TOKEN.to_string(),
-    ];
-    let removed = keychain::remove_many(&scope, &variables)?;
-    Ok(ProfileRemoveResult {
-        profile: profile.to_string(),
-        removed,
-    })
-}
-
-pub fn profile_authorization_header(profile: &str) -> Result<String> {
-    let scope = profile_scope(profile);
-    let kind =
-        keychain::get(&scope, PROFILE_KIND)?.ok_or_else(|| missing_profile_error(profile))?;
-    match kind.as_str() {
-        "basic" => {
-            let username = keychain::get(&scope, PROFILE_USERNAME)?
-                .ok_or_else(|| missing_profile_error(profile))?;
-            let password = keychain::get(&scope, PROFILE_PASSWORD)?
-                .ok_or_else(|| missing_profile_error(profile))?;
-            let encoded = base64::engine::general_purpose::STANDARD
-                .encode(format!("{}:{}", username, password));
-            Ok(format!("Basic {}", encoded))
-        }
-        "bearer" => {
-            let token = keychain::get(&scope, PROFILE_TOKEN)?
-                .ok_or_else(|| missing_profile_error(profile))?;
-            Ok(format!("Bearer {}", token))
-        }
-        other => Err(crate::error::Error::validation_invalid_argument(
-            "auth-profile",
-            format!("Unsupported auth profile kind '{}'", other),
-            Some(profile.to_string()),
-            Some(vec!["basic".to_string(), "bearer".to_string()]),
-        )),
-    }
-}
-
-fn missing_profile_error(profile: &str) -> crate::error::Error {
-    crate::error::Error::new(
-        crate::error::ErrorCode::ExtensionNotFound,
-        format!("Auth profile '{}' is not set", profile),
-        serde_json::Value::Null,
-    )
-    .with_hint(format!(
-        "Run 'homeboy auth profile set-basic {} --username <user>' or 'homeboy auth profile set-bearer {}'",
-        profile, profile
-    ))
-}
-
 fn keychain_variable_names(project: &project::Project) -> Vec<String> {
     project
         .api
@@ -331,75 +200,6 @@ mod tests {
     fn test_redact() {
         assert_eq!(redact("secret"), "********");
         assert_eq!(redact(""), "");
-    }
-
-    #[test]
-    fn test_profile_scope() {
-        assert_eq!(profile_scope("matticspace"), "profile:matticspace");
-    }
-
-    #[test]
-    #[ignore]
-    fn test_set_profile_basic() {
-        let profile = "homeboy-auth-profile-basic-test";
-        let _ = remove_profile(profile);
-
-        let result = set_profile_basic(profile, "user", "secret").expect("store basic profile");
-
-        assert!(result.stored);
-        assert_eq!(result.kind, "basic");
-        remove_profile(profile).expect("cleanup profile");
-    }
-
-    #[test]
-    #[ignore]
-    fn test_set_profile_bearer() {
-        let profile = "homeboy-auth-profile-bearer-test";
-        let _ = remove_profile(profile);
-
-        let result = set_profile_bearer(profile, "token").expect("store bearer profile");
-
-        assert!(result.stored);
-        assert_eq!(result.kind, "bearer");
-        remove_profile(profile).expect("cleanup profile");
-    }
-
-    #[test]
-    #[ignore]
-    fn test_profile_status() {
-        let profile = "homeboy-auth-profile-status-test";
-        let _ = remove_profile(profile);
-        set_profile_bearer(profile, "token").expect("store bearer profile");
-
-        let result = profile_status(profile).expect("profile status");
-
-        assert!(result.available);
-        assert_eq!(result.kind.as_deref(), Some("bearer"));
-        remove_profile(profile).expect("cleanup profile");
-    }
-
-    #[test]
-    #[ignore]
-    fn test_profile_authorization_header() {
-        let profile = "homeboy-auth-profile-header-test";
-        let _ = remove_profile(profile);
-        set_profile_basic(profile, "user", "secret").expect("store basic profile");
-
-        let header = profile_authorization_header(profile).expect("authorization header");
-
-        assert_eq!(header, "Basic dXNlcjpzZWNyZXQ=");
-        remove_profile(profile).expect("cleanup profile");
-    }
-
-    #[test]
-    #[ignore]
-    fn test_remove_profile() {
-        let profile = "homeboy-auth-profile-remove-test";
-        set_profile_bearer(profile, "token").expect("store bearer profile");
-
-        let result = remove_profile(profile).expect("remove profile");
-
-        assert!(result.removed > 0);
     }
 
     #[test]

--- a/src/core/server/auth_profiles.rs
+++ b/src/core/server/auth_profiles.rs
@@ -1,0 +1,210 @@
+//! Reusable keychain-backed auth profiles for generic HTTP requests.
+
+use crate::error::{Error, ErrorCode, Result};
+use crate::keychain;
+use base64::Engine;
+use serde::Serialize;
+
+const PROFILE_KIND: &str = "kind";
+const PROFILE_USERNAME: &str = "username";
+const PROFILE_PASSWORD: &str = "password";
+const PROFILE_TOKEN: &str = "token";
+
+#[derive(Debug, Serialize)]
+pub struct ProfileSetResult {
+    pub profile: String,
+    pub kind: String,
+    pub stored: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProfileStatusResult {
+    pub profile: String,
+    pub kind: Option<String>,
+    pub available: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProfileRemoveResult {
+    pub profile: String,
+    pub removed: usize,
+}
+
+fn profile_scope(profile: &str) -> String {
+    format!("profile:{}", profile)
+}
+
+pub fn set_profile_basic(
+    profile: &str,
+    username: &str,
+    password: &str,
+) -> Result<ProfileSetResult> {
+    let scope = profile_scope(profile);
+    keychain::set(&scope, PROFILE_KIND, "basic")?;
+    keychain::set(&scope, PROFILE_USERNAME, username)?;
+    keychain::set(&scope, PROFILE_PASSWORD, password)?;
+    Ok(ProfileSetResult {
+        profile: profile.to_string(),
+        kind: "basic".to_string(),
+        stored: true,
+    })
+}
+
+pub fn set_profile_bearer(profile: &str, token: &str) -> Result<ProfileSetResult> {
+    let scope = profile_scope(profile);
+    keychain::set(&scope, PROFILE_KIND, "bearer")?;
+    keychain::set(&scope, PROFILE_TOKEN, token)?;
+    Ok(ProfileSetResult {
+        profile: profile.to_string(),
+        kind: "bearer".to_string(),
+        stored: true,
+    })
+}
+
+pub fn profile_status(profile: &str) -> Result<ProfileStatusResult> {
+    let scope = profile_scope(profile);
+    let kind = keychain::get(&scope, PROFILE_KIND)?;
+    let available = match kind.as_deref() {
+        Some("basic") => {
+            keychain::get(&scope, PROFILE_USERNAME)?.is_some()
+                && keychain::get(&scope, PROFILE_PASSWORD)?.is_some()
+        }
+        Some("bearer") => keychain::get(&scope, PROFILE_TOKEN)?.is_some(),
+        _ => false,
+    };
+
+    Ok(ProfileStatusResult {
+        profile: profile.to_string(),
+        kind,
+        available,
+    })
+}
+
+pub fn remove_profile(profile: &str) -> Result<ProfileRemoveResult> {
+    let scope = profile_scope(profile);
+    let variables = vec![
+        PROFILE_KIND.to_string(),
+        PROFILE_USERNAME.to_string(),
+        PROFILE_PASSWORD.to_string(),
+        PROFILE_TOKEN.to_string(),
+    ];
+    let removed = keychain::remove_many(&scope, &variables)?;
+    Ok(ProfileRemoveResult {
+        profile: profile.to_string(),
+        removed,
+    })
+}
+
+pub fn profile_authorization_header(profile: &str) -> Result<String> {
+    let scope = profile_scope(profile);
+    let kind =
+        keychain::get(&scope, PROFILE_KIND)?.ok_or_else(|| missing_profile_error(profile))?;
+    match kind.as_str() {
+        "basic" => {
+            let username = keychain::get(&scope, PROFILE_USERNAME)?
+                .ok_or_else(|| missing_profile_error(profile))?;
+            let password = keychain::get(&scope, PROFILE_PASSWORD)?
+                .ok_or_else(|| missing_profile_error(profile))?;
+            let encoded = base64::engine::general_purpose::STANDARD
+                .encode(format!("{}:{}", username, password));
+            Ok(format!("Basic {}", encoded))
+        }
+        "bearer" => {
+            let token = keychain::get(&scope, PROFILE_TOKEN)?
+                .ok_or_else(|| missing_profile_error(profile))?;
+            Ok(format!("Bearer {}", token))
+        }
+        other => Err(Error::validation_invalid_argument(
+            "auth-profile",
+            format!("Unsupported auth profile kind '{}'", other),
+            Some(profile.to_string()),
+            Some(vec!["basic".to_string(), "bearer".to_string()]),
+        )),
+    }
+}
+
+fn missing_profile_error(profile: &str) -> Error {
+    Error::new(
+        ErrorCode::ExtensionNotFound,
+        format!("Auth profile '{}' is not set", profile),
+        serde_json::Value::Null,
+    )
+    .with_hint(format!(
+        "Run 'homeboy auth profile set-basic {} --username <user>' or 'homeboy auth profile set-bearer {}'",
+        profile, profile
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_profile_scope() {
+        assert_eq!(profile_scope("matticspace"), "profile:matticspace");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_set_profile_basic() {
+        let profile = "homeboy-auth-profile-basic-test";
+        let _ = remove_profile(profile);
+
+        let result = set_profile_basic(profile, "user", "secret").expect("store basic profile");
+
+        assert!(result.stored);
+        assert_eq!(result.kind, "basic");
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_set_profile_bearer() {
+        let profile = "homeboy-auth-profile-bearer-test";
+        let _ = remove_profile(profile);
+
+        let result = set_profile_bearer(profile, "token").expect("store bearer profile");
+
+        assert!(result.stored);
+        assert_eq!(result.kind, "bearer");
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_profile_status() {
+        let profile = "homeboy-auth-profile-status-test";
+        let _ = remove_profile(profile);
+        set_profile_bearer(profile, "token").expect("store bearer profile");
+
+        let result = profile_status(profile).expect("profile status");
+
+        assert!(result.available);
+        assert_eq!(result.kind.as_deref(), Some("bearer"));
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_profile_authorization_header() {
+        let profile = "homeboy-auth-profile-header-test";
+        let _ = remove_profile(profile);
+        set_profile_basic(profile, "user", "secret").expect("store basic profile");
+
+        let header = profile_authorization_header(profile).expect("authorization header");
+
+        assert_eq!(header, "Basic dXNlcjpzZWNyZXQ=");
+        remove_profile(profile).expect("cleanup profile");
+    }
+
+    #[test]
+    #[ignore]
+    fn test_remove_profile() {
+        let profile = "homeboy-auth-profile-remove-test";
+        set_profile_bearer(profile, "token").expect("store bearer profile");
+
+        let result = remove_profile(profile).expect("remove profile");
+
+        assert!(result.removed > 0);
+    }
+}

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -459,6 +459,19 @@ mod tests {
     }
 
     #[test]
+    fn test_http_error() {
+        let reqwest_error = Client::new()
+            .get("http://")
+            .send()
+            .expect_err("invalid URL should fail before network I/O");
+
+        let err = http_error(reqwest_error);
+
+        assert_eq!(err.code, ErrorCode::RemoteCommandFailed);
+        assert!(err.message.contains("HTTP request failed"));
+    }
+
+    #[test]
     fn test_build_client_with_proxy() {
         build_client_with_proxy(Some("socks5://127.0.0.1:8080"))
             .expect("socks proxy should be accepted");

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -289,10 +289,10 @@ fn form_fields(body: &Value) -> Result<Vec<(String, String)>> {
         .collect()
 }
 
-fn build_client(api_config: &ApiConfig) -> Result<Client> {
+pub(crate) fn build_client_with_proxy(proxy_url: Option<&str>) -> Result<Client> {
     let mut builder = ClientBuilder::new();
 
-    if let Some(proxy_url) = api_config.proxy_url.as_deref() {
+    if let Some(proxy_url) = proxy_url {
         builder =
             builder.proxy(Proxy::all(proxy_url).map_err(|e| {
                 config_error(format!("Invalid API proxy URL '{}': {}", proxy_url, e))
@@ -300,6 +300,10 @@ fn build_client(api_config: &ApiConfig) -> Result<Client> {
     }
 
     builder.build().map_err(http_error)
+}
+
+fn build_client(api_config: &ApiConfig) -> Result<Client> {
+    build_client_with_proxy(api_config.proxy_url.as_deref())
 }
 
 /// Resolves a variable from its source.

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -20,7 +20,7 @@ fn not_found_error(msg: impl Into<String>) -> Error {
     Error::new(ErrorCode::ExtensionNotFound, msg, Value::Null)
 }
 
-fn http_error(e: reqwest::Error) -> Error {
+pub(crate) fn http_error(e: reqwest::Error) -> Error {
     Error::new(
         ErrorCode::RemoteCommandFailed,
         format!("HTTP request failed: {}", e),

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -459,6 +459,12 @@ mod tests {
     }
 
     #[test]
+    fn test_build_client_with_proxy() {
+        build_client_with_proxy(Some("socks5://127.0.0.1:8080"))
+            .expect("socks proxy should be accepted");
+    }
+
+    #[test]
     fn builds_client_with_socks_proxy() {
         let config = ApiConfig {
             enabled: true,

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod auth;
+pub mod auth_profiles;
 mod client;
 mod connection;
 pub mod health;

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -9,6 +9,7 @@ fn includes_current_top_level_commands() {
     assert!(surface.contains_path(&["daemon"]));
     assert!(surface.contains_path(&["deps"]));
     assert!(surface.contains_path(&["git"]));
+    assert!(surface.contains_path(&["http"]));
     assert!(surface.contains_path(&["self"]));
     assert!(surface.contains_path(&["stack"]));
     assert!(surface.contains_path(&["report"]));
@@ -23,6 +24,7 @@ fn includes_first_level_subcommands() {
     let surface = current_command_surface();
 
     assert!(surface.contains_path(&["git", "status"]));
+    assert!(surface.contains_path(&["http", "get"]));
     assert!(surface.contains_path(&["deps", "status"]));
     assert!(surface.contains_path(&["deps", "update"]));
     assert!(surface.contains_path(&["daemon", "serve"]));


### PR DESCRIPTION
## Summary
- Add `homeboy http` for generic full-URL HTTP requests with headers, JSON/form bodies, optional proxying, and structured JSON output.
- Add `homeboy auth profile` commands for keychain-backed Basic and Bearer auth profiles used by generic HTTP requests.
- Document the new command and cover the command surface for the new top-level `http` entrypoint.

## Tests
- `cargo fmt --check`
- `cargo test http_request`
- `cargo test --test command_surface_test`
- `cargo run --bin homeboy -- http get https://example.com`
- Full `cargo test` not rerun for this PR; it was previously blocked by unrelated `core::extension::execution::tests::build_exec_env_includes_runtime_runner_helper_path`.

## Related issue
- Closes https://github.com/Extra-Chill/homeboy/issues/2495

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating the HTTP/auth-profile implementation, tests, docs, commit, and PR description; Chris remains responsible for review and merge.