### PR TITLE
refactor: extract release context loading

### DIFF
--- a/src/core/release/context.rs
+++ b/src/core/release/context.rs
@@ -1,0 +1,73 @@
+use crate::component::{self, Component};
+use crate::error::{Error, Result};
+use crate::extension::{self, ExtensionManifest};
+
+use super::types::ReleaseOptions;
+
+/// Load a component with portable config fallback when path_override is set.
+/// In CI environments, the component may not be registered — only homeboy.json exists.
+pub(crate) fn load_component(component_id: &str, options: &ReleaseOptions) -> Result<Component> {
+    component::resolve_effective(Some(component_id), options.path_override.as_deref(), None)
+}
+
+/// Resolve the component's declared extensions for release dispatch.
+pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionManifest>> {
+    let mut extensions = Vec::new();
+    if let Some(configured) = component.extensions.as_ref() {
+        let mut extension_ids: Vec<String> = configured.keys().cloned().collect();
+        extension_ids.sort();
+        let suggestions = extension::available_extension_ids();
+        for extension_id in extension_ids {
+            let manifest = extension::load_extension(&extension_id).map_err(|_| {
+                Error::extension_not_found(extension_id.to_string(), suggestions.clone())
+            })?;
+            extensions.push(manifest);
+        }
+    }
+    Ok(extensions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load_component, resolve_extensions};
+    use crate::component::Component;
+    use crate::release::types::ReleaseOptions;
+
+    #[test]
+    fn test_load_component() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let homeboy_json = temp.path().join("homeboy.json");
+        std::fs::write(
+            homeboy_json,
+            r#"{
+                "components": {
+                    "fixture": {
+                        "type": "nodejs",
+                        "path": "."
+                    }
+                }
+            }"#,
+        )
+        .expect("write homeboy config");
+
+        let component = load_component(
+            "fixture",
+            &ReleaseOptions {
+                path_override: Some(temp.path().to_string_lossy().to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("component should load from path override");
+
+        assert_eq!(component.id, "fixture");
+    }
+
+    #[test]
+    fn test_resolve_extensions() {
+        let component = Component::default();
+
+        let extensions = resolve_extensions(&component).expect("missing extensions are optional");
+
+        assert!(extensions.is_empty());
+    }
+}

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use crate::error::Result;
 
+use super::context::{load_component, resolve_extensions};
 use super::execution_dispatch::{
     execute_release_plan_step, release_step_is_show_stopper, ReleaseExecutionContext,
 };
@@ -50,8 +51,8 @@ pub(super) fn execute_plan_steps(
         return Ok(false);
     }
 
-    let component = super::pipeline::load_component(component_id, options)?;
-    let extensions = super::pipeline::resolve_extensions(&component)?;
+    let component = load_component(component_id, options)?;
+    let extensions = resolve_extensions(&component)?;
     let mut context = ReleaseExecutionContext {
         component: &component,
         extensions: &extensions,

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -1,4 +1,5 @@
 pub mod changelog;
+mod context;
 mod deployment;
 mod execution_dispatch;
 mod execution_plan;

--- a/src/core/release/pipeline.rs
+++ b/src/core/release/pipeline.rs
@@ -4,14 +4,13 @@
 //! consumers, and `run()` walks that same plan for real releases so the
 //! previewed steps match execution.
 
-use crate::component::{self, Component};
 use crate::engine::validation::ValidationCollector;
 use crate::error::{Error, Result};
-use crate::extension::{self, ExtensionManifest};
 use crate::git;
 use crate::version;
 use std::collections::HashSet;
 
+use super::context::{load_component, resolve_extensions};
 use super::execution_plan::{
     build_initial_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
 };
@@ -22,29 +21,6 @@ use super::planning_policy::release_skip_plan;
 use super::planning_semver::{build_semver_recommendation, validate_release_version_floor};
 use super::planning_worktree::validate_release_worktree;
 use super::types::{ReleaseOptions, ReleasePlan, ReleaseRun, ReleaseRunResult, ReleaseStepResult};
-
-/// Load a component with portable config fallback when path_override is set.
-/// In CI environments, the component may not be registered — only homeboy.json exists.
-pub(crate) fn load_component(component_id: &str, options: &ReleaseOptions) -> Result<Component> {
-    component::resolve_effective(Some(component_id), options.path_override.as_deref(), None)
-}
-
-/// Resolve the component's declared extensions (for publish/package dispatch).
-pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionManifest>> {
-    let mut extensions = Vec::new();
-    if let Some(configured) = component.extensions.as_ref() {
-        let mut extension_ids: Vec<String> = configured.keys().cloned().collect();
-        extension_ids.sort();
-        let suggestions = extension::available_extension_ids();
-        for extension_id in extension_ids {
-            let manifest = extension::load_extension(&extension_id).map_err(|_| {
-                Error::extension_not_found(extension_id.to_string(), suggestions.clone())
-            })?;
-            extensions.push(manifest);
-        }
-    }
-    Ok(extensions)
-}
 
 /// Execute a release end-to-end.
 ///

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use crate::git;
 
-use super::pipeline::load_component;
+use super::context::load_component;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleasePlanStatus,


### PR DESCRIPTION
## Summary
- Move release component loading and extension resolution into a dedicated release context module.
- Update release planning, execution, and CLI glue to share the extracted helpers without changing behavior.
- Add focused tests for path-override component loading and empty extension resolution.

## Verification
- `cargo fmt --check`
- `cargo test core::release::context`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor, tests, verification, and PR description; Chris remains responsible for review and merge.