### PR TITLE
Add file mkdir command

### DIFF
--- a/docs/commands/file.md
+++ b/docs/commands/file.md
@@ -11,6 +11,7 @@ homeboy file <COMMAND>
 - `list <project_id> <path>`
 - `read <project_id> <path>`
 - `write <project_id> <path>` (reads content from stdin)
+- `mkdir <project_id> <path>` (create a directory)
 - `delete <project_id> <path> [-r|--recursive]` (delete directories recursively)
 - `rename <project_id> <old_path> <new_path>`
 - `find <project_id> <path> [options]` (search for files by name)
@@ -92,11 +93,11 @@ Notes:
 
 > Note: all command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). `homeboy file` returns one of several output types as the `data` payload.
 
-### Standard operations (list, read, write, delete, rename)
+### Standard operations (list, read, write, mkdir, delete, rename)
 
 Fields:
 
-- `command`: `file.list` | `file.read` | `file.write` | `file.delete` | `file.rename`
+- `command`: `file.list` | `file.read` | `file.write` | `file.mkdir` | `file.delete` | `file.rename`
 - `project_id`
 - `base_path`: project base path if configured
 - `path` / `old_path` / `new_path`: resolved full remote paths

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -39,6 +39,13 @@ enum FileCommand {
         /// Remote file path
         path: String,
     },
+    /// Create a directory
+    Mkdir {
+        /// Project ID
+        project_id: String,
+        /// Remote directory path
+        path: String,
+    },
     /// Delete a file or directory
     Delete {
         /// Project ID
@@ -361,6 +368,10 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
             let (out, code) = write(&project_id, &path)?;
             Ok((FileCommandOutput::Standard(out), code))
         }
+        FileCommand::Mkdir { project_id, path } => {
+            let (out, code) = mkdir(&project_id, &path)?;
+            Ok((FileCommandOutput::Standard(out), code))
+        }
         FileCommand::Delete {
             project_id,
             path,
@@ -527,6 +538,30 @@ fn write(project_id: &str, path: &str) -> CmdResult<FileOutput> {
             entries: None,
             content: None,
             bytes_written: Some(result.bytes_written),
+            stdout: None,
+            stderr: None,
+            exit_code: 0,
+            success: true,
+        },
+        0,
+    ))
+}
+
+fn mkdir(project_id: &str, path: &str) -> CmdResult<FileOutput> {
+    let result = files::mkdir(project_id, path)?;
+
+    Ok((
+        FileOutput {
+            command: "file.mkdir".to_string(),
+            project_id: project_id.to_string(),
+            base_path: result.base_path,
+            path: Some(result.path),
+            old_path: None,
+            new_path: None,
+            recursive: None,
+            entries: None,
+            content: None,
+            bytes_written: None,
             stdout: None,
             stderr: None,
             exit_code: 0,

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -1,8 +1,11 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
+use homeboy::context::require_project_base_path;
+use homeboy::engine::{command, executor, shell};
 use homeboy::project::files::{self, FileEntry, GrepMatch, LineChange};
 use homeboy::server::transfer::{self, TransferConfig, TransferOutput};
+use homeboy::{join_remote_path, project};
 
 use super::CmdResult;
 
@@ -369,8 +372,34 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Mkdir { project_id, path } => {
-            let (out, code) = mkdir(&project_id, &path)?;
-            Ok((FileCommandOutput::Standard(out), code))
+            let project = project::load(&project_id)?;
+            let project_base_path = require_project_base_path(&project_id, &project)?;
+            let full_path = join_remote_path(Some(&project_base_path), &path)?;
+            let output = executor::execute_for_project(
+                &project,
+                &format!("mkdir {}", shell::quote_path(&full_path)),
+            )?;
+            command::require_success(output.success, &output.stderr, "MKDIR")?;
+
+            Ok((
+                FileCommandOutput::Standard(FileOutput {
+                    command: "file.mkdir".to_string(),
+                    project_id,
+                    base_path: Some(project_base_path),
+                    path: Some(full_path),
+                    old_path: None,
+                    new_path: None,
+                    recursive: None,
+                    entries: None,
+                    content: None,
+                    bytes_written: None,
+                    stdout: None,
+                    stderr: None,
+                    exit_code: 0,
+                    success: true,
+                }),
+                0,
+            ))
         }
         FileCommand::Delete {
             project_id,
@@ -538,30 +567,6 @@ fn write(project_id: &str, path: &str) -> CmdResult<FileOutput> {
             entries: None,
             content: None,
             bytes_written: Some(result.bytes_written),
-            stdout: None,
-            stderr: None,
-            exit_code: 0,
-            success: true,
-        },
-        0,
-    ))
-}
-
-fn mkdir(project_id: &str, path: &str) -> CmdResult<FileOutput> {
-    let result = files::mkdir(project_id, path)?;
-
-    Ok((
-        FileOutput {
-            command: "file.mkdir".to_string(),
-            project_id: project_id.to_string(),
-            base_path: result.base_path,
-            path: Some(result.path),
-            old_path: None,
-            new_path: None,
-            recursive: None,
-            entries: None,
-            content: None,
-            bytes_written: None,
             stdout: None,
             stderr: None,
             exit_code: 0,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -67,3 +67,8 @@ pub use output::{
 pub fn set_artifact_root_override(path: Option<std::path::PathBuf>) {
     paths::set_artifact_root_override(path);
 }
+
+/// Resolve a remote path against an optional project base path.
+pub fn join_remote_path(base_path: Option<&str>, path: &str) -> Result<String> {
+    paths::join_remote_path(base_path, path)
+}

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -54,13 +54,6 @@ pub struct WriteResult {
 
 #[derive(Debug, Clone, Serialize)]
 
-pub struct MkdirResult {
-    pub base_path: Option<String>,
-    pub path: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-
 pub struct DeleteResult {
     pub base_path: Option<String>,
     pub path: String,
@@ -193,21 +186,6 @@ pub fn write(project_id: &str, path: &str, content: &str) -> Result<WriteResult>
         base_path: Some(project_base_path),
         path: full_path,
         bytes_written: content.len(),
-    })
-}
-
-/// Create a directory.
-pub fn mkdir(project_id: &str, path: &str) -> Result<MkdirResult> {
-    let project = project::load(project_id)?;
-    let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
-    let command = format!("mkdir {}", shell::quote_path(&full_path));
-    let output = execute_for_project(&project, &command)?;
-    command::require_success(output.success, &output.stderr, "MKDIR")?;
-
-    Ok(MkdirResult {
-        base_path: Some(project_base_path),
-        path: full_path,
     })
 }
 
@@ -986,49 +964,5 @@ pub fn download(
             exit_code: 1,
             error: Some(err.to_string()),
         }),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::project::{self, Project};
-    use crate::test_support::with_isolated_home;
-
-    #[test]
-    fn mkdir_creates_directory_under_project_base_path() {
-        with_isolated_home(|home| {
-            let base = home.path().join("site root");
-            std::fs::create_dir_all(&base).expect("create project base");
-            project::save(&Project {
-                id: "site".to_string(),
-                base_path: Some(base.to_string_lossy().to_string()),
-                ..Project::default()
-            })
-            .expect("save project");
-
-            let result = mkdir("site", "uploads").expect("mkdir succeeds");
-
-            let expected = base.join("uploads");
-            assert!(expected.is_dir());
-            assert_eq!(result.base_path, Some(base.to_string_lossy().to_string()));
-            assert_eq!(result.path, expected.to_string_lossy().to_string());
-        });
-    }
-
-    #[test]
-    fn mkdir_uses_existing_path_validation() {
-        with_isolated_home(|home| {
-            let base = home.path().join("site");
-            std::fs::create_dir_all(&base).expect("create project base");
-            project::save(&Project {
-                id: "site".to_string(),
-                base_path: Some(base.to_string_lossy().to_string()),
-                ..Project::default()
-            })
-            .expect("save project");
-
-            assert!(mkdir("site", "   ").is_err());
-        });
     }
 }

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -54,6 +54,13 @@ pub struct WriteResult {
 
 #[derive(Debug, Clone, Serialize)]
 
+pub struct MkdirResult {
+    pub base_path: Option<String>,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+
 pub struct DeleteResult {
     pub base_path: Option<String>,
     pub path: String,
@@ -186,6 +193,21 @@ pub fn write(project_id: &str, path: &str, content: &str) -> Result<WriteResult>
         base_path: Some(project_base_path),
         path: full_path,
         bytes_written: content.len(),
+    })
+}
+
+/// Create a directory.
+pub fn mkdir(project_id: &str, path: &str) -> Result<MkdirResult> {
+    let project = project::load(project_id)?;
+    let project_base_path = require_project_base_path(project_id, &project)?;
+    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let command = format!("mkdir {}", shell::quote_path(&full_path));
+    let output = execute_for_project(&project, &command)?;
+    command::require_success(output.success, &output.stderr, "MKDIR")?;
+
+    Ok(MkdirResult {
+        base_path: Some(project_base_path),
+        path: full_path,
     })
 }
 
@@ -964,5 +986,49 @@ pub fn download(
             exit_code: 1,
             error: Some(err.to_string()),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::{self, Project};
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn mkdir_creates_directory_under_project_base_path() {
+        with_isolated_home(|home| {
+            let base = home.path().join("site root");
+            std::fs::create_dir_all(&base).expect("create project base");
+            project::save(&Project {
+                id: "site".to_string(),
+                base_path: Some(base.to_string_lossy().to_string()),
+                ..Project::default()
+            })
+            .expect("save project");
+
+            let result = mkdir("site", "uploads").expect("mkdir succeeds");
+
+            let expected = base.join("uploads");
+            assert!(expected.is_dir());
+            assert_eq!(result.base_path, Some(base.to_string_lossy().to_string()));
+            assert_eq!(result.path, expected.to_string_lossy().to_string());
+        });
+    }
+
+    #[test]
+    fn mkdir_uses_existing_path_validation() {
+        with_isolated_home(|home| {
+            let base = home.path().join("site");
+            std::fs::create_dir_all(&base).expect("create project base");
+            project::save(&Project {
+                id: "site".to_string(),
+                base_path: Some(base.to_string_lossy().to_string()),
+                ..Project::default()
+            })
+            .expect("save project");
+
+            assert!(mkdir("site", "   ").is_err());
+        });
     }
 }

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -32,6 +32,7 @@ fn includes_first_level_subcommands() {
     assert!(surface.contains_path(&["stack", "inspect"]));
     assert!(surface.contains_path(&["report", "failure-digest"]));
     assert!(surface.contains_path(&["file", "download"]));
+    assert!(surface.contains_path(&["file", "mkdir"]));
     assert!(surface.contains_path(&["file", "upload"]));
     assert!(surface.contains_path(&["file", "copy"]));
     assert!(surface.contains_path(&["file", "sync"]));


### PR DESCRIPTION
## Summary
- Add `homeboy file mkdir <project_id> <path>` with JSON output matching the standard `file.*` command payload shape.
- Route directory creation through the existing project execution path so local and SSH-backed projects use the same command dispatch and path resolution as other mutating file commands.
- Document the new command and add focused tests for local directory creation and inherited path validation.

Closes #2506.

## Tests
- `cargo fmt`
- `cargo test core::project::files::tests::mkdir`
- `cargo test core::paths::tests::join_remote_path`
- `cargo test`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-file-mkdir-command --extension rust`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI/core command wiring, tests, docs, and local verification; Chris remains responsible for review and merge.