### PR TITLE
Resolve deploy paths through project roots

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -6,9 +6,9 @@ use crate::context::RemoteProjectContext;
 use crate::error::Result;
 use crate::extension::build::resolve_artifact_path_from_root;
 use crate::git;
-use crate::paths as base_path;
 use crate::project::Project;
 
+use super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::planning::{calculate_directory_size, format_bytes};
 use super::policy::{owner_hint_for_path, protected_path_suffixes, validate_deploy_target};
 use super::release_download;
@@ -65,16 +65,14 @@ pub(super) fn execute_component_deploy(
     // Auto-resolve remote_path from linked extension deploy policy when not explicitly set.
     // This is a deploy-time safety net; the primary resolution happens in
     // resolve_project_component (#812).
-    let effective_remote_path = if component.remote_path.trim().is_empty() {
-        if let Some(resolved) = component.auto_resolve_remote_path() {
-            log_status!("deploy", "Auto-resolved remote path: {}", resolved);
-            resolved
-        } else {
-            component.remote_path.clone()
-        }
-    } else {
-        component.remote_path.clone()
-    };
+    let effective_remote_path = component_remote_path(component);
+    if component.remote_path.trim().is_empty() && !effective_remote_path.trim().is_empty() {
+        log_status!(
+            "deploy",
+            "Auto-resolved remote path: {}",
+            effective_remote_path
+        );
+    }
 
     if component.remote_owner.is_none() {
         if let Some(suggested_owner) = owner_hint_for_path(component, &effective_remote_path) {
@@ -92,8 +90,8 @@ pub(super) fn execute_component_deploy(
     }
 
     // Resolve and validate install directory before any destructive operation.
-    let install_dir = match base_path::join_remote_path(Some(base_path), &effective_remote_path)
-        .and_then(|install_dir| {
+    let install_dir =
+        match resolve_effective_remote_path(project, component, base_path).and_then(|install_dir| {
             validate_deploy_target(
                 &install_dir,
                 base_path,
@@ -102,18 +100,18 @@ pub(super) fn execute_component_deploy(
             )?;
             Ok(install_dir)
         }) {
-        Ok(install_dir) => install_dir,
-        Err(err) => {
-            return failed_component_deploy_result(
-                component,
-                base_path,
-                local_version,
-                remote_version,
-                build_exit_code,
-                err.to_string(),
-            );
-        }
-    };
+            Ok(install_dir) => install_dir,
+            Err(err) => {
+                return failed_component_deploy_result(
+                    component,
+                    base_path,
+                    local_version,
+                    remote_version,
+                    build_exit_code,
+                    err.to_string(),
+                );
+            }
+        };
 
     // Dispatch by deploy strategy
     let strategy = component.deploy_strategy.as_deref().unwrap_or("rsync");

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -1,5 +1,6 @@
 mod execution;
 mod orchestration;
+mod path_roots;
 pub(crate) mod permissions;
 mod planning;
 mod policy;

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -9,13 +9,14 @@ use crate::project::Project;
 use crate::version;
 
 use super::execution::execute_component_deploy;
+use super::path_roots::project_with_detected_path_roots;
 use super::planning::{
     calculate_component_status, calculate_release_state, load_project_components, plan_components,
 };
 use super::types::{
     ComponentDeployResult, ComponentStatus, DeployConfig, DeployOrchestrationResult, DeploySummary,
 };
-use super::version_overrides::fetch_remote_versions;
+use super::version_overrides::fetch_remote_versions_for_project;
 
 /// Main deploy orchestration entry point.
 /// Handles component selection, building, and deployment.
@@ -47,10 +48,14 @@ pub(super) fn deploy_components(
         ));
     }
 
+    let project =
+        project_with_detected_path_roots(project, &loaded.deployable, base_path, &ctx.client);
+
     let components = plan_components(
         config,
         &loaded.deployable,
         &loaded.skipped,
+        &project,
         base_path,
         &ctx.client,
     )?;
@@ -74,7 +79,7 @@ pub(super) fn deploy_components(
         .collect();
     let remote_versions =
         if config.outdated || config.behind_upstream || config.dry_run || config.check {
-            fetch_remote_versions(&components, base_path, &ctx.client)
+            fetch_remote_versions_for_project(&components, Some(&project), base_path, &ctx.client)
         } else {
             HashMap::new()
         };
@@ -85,6 +90,7 @@ pub(super) fn deploy_components(
             &components,
             &local_versions,
             &remote_versions,
+            &project,
             base_path,
         ));
     }
@@ -93,6 +99,7 @@ pub(super) fn deploy_components(
             &components,
             &local_versions,
             &remote_versions,
+            &project,
             base_path,
             config,
         ));
@@ -136,7 +143,7 @@ pub(super) fn deploy_components(
 
     for component in &components {
         // Apply per-project overrides (e.g. different extract_command or remote_owner)
-        let component = crate::project::apply_component_overrides(component, project);
+        let component = crate::project::apply_component_overrides(component, &project);
 
         let effective_config = clone_config(config);
 
@@ -145,7 +152,7 @@ pub(super) fn deploy_components(
             &effective_config,
             ctx,
             base_path,
-            project,
+            &project,
             local_versions.get(&component.id).cloned(),
             remote_versions.get(&component.id).cloned(),
         );
@@ -196,6 +203,7 @@ fn run_check_mode(
     components: &[Component],
     local_versions: &HashMap<String, String>,
     remote_versions: &HashMap<String, String>,
+    project: &Project,
     base_path: &str,
 ) -> DeployOrchestrationResult {
     let results: Vec<ComponentDeployResult> = components
@@ -203,7 +211,7 @@ fn run_check_mode(
         .map(|c| {
             let status = calculate_component_status(c, remote_versions);
             let release_state = calculate_release_state(c);
-            let mut result = ComponentDeployResult::new(c, base_path)
+            let mut result = ComponentDeployResult::new_for_project(c, project, base_path)
                 .with_status("checked")
                 .with_versions(
                     local_versions.get(&c.id).cloned(),
@@ -234,6 +242,7 @@ fn run_dry_run_mode(
     components: &[Component],
     local_versions: &HashMap<String, String>,
     remote_versions: &HashMap<String, String>,
+    project: &Project,
     base_path: &str,
     config: &DeployConfig,
 ) -> DeployOrchestrationResult {
@@ -245,7 +254,7 @@ fn run_dry_run_mode(
             } else {
                 ComponentStatus::Unknown
             };
-            let mut result = ComponentDeployResult::new(c, base_path)
+            let mut result = ComponentDeployResult::new_for_project(c, project, base_path)
                 .with_status("planned")
                 .with_versions(
                     local_versions.get(&c.id).cloned(),

--- a/src/core/deploy/path_roots.rs
+++ b/src/core/deploy/path_roots.rs
@@ -145,6 +145,7 @@ mod tests {
     use super::*;
     use crate::component::{Component, ScopedExtensionConfig};
     use crate::extension::{DeployCapability, ExtensionManifest};
+    use crate::server::SshClient;
     use crate::test_support::with_isolated_home;
     use std::collections::HashMap;
 
@@ -175,6 +176,10 @@ mod tests {
     }
 
     fn install_extension() {
+        install_extension_with_detect_command(None);
+    }
+
+    fn install_extension_with_detect_command(detect_command: Option<&str>) {
         crate::extension::save_manifest(&ExtensionManifest {
             id: "wordpress".to_string(),
             name: "WordPress".to_string(),
@@ -187,7 +192,7 @@ mod tests {
                     path_prefix: "wp-content".to_string(),
                     root: "wp_content".to_string(),
                     strip_prefix: true,
-                    detect_command: None,
+                    detect_command: detect_command.map(str::to_string),
                 }],
                 version_patterns: Vec::new(),
                 since_tag: None,
@@ -201,8 +206,36 @@ mod tests {
         .expect("save extension");
     }
 
+    fn local_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "local".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: HashMap::new(),
+        }
+    }
+
     #[test]
-    fn resolves_matching_remote_path_under_project_root() {
+    fn test_component_remote_path() {
+        assert_eq!(
+            component_remote_path(&component("explicit/path")),
+            "explicit/path"
+        );
+
+        with_isolated_home(|_| {
+            install_extension();
+            let mut auto = component("");
+            auto.local_path = std::env::temp_dir().to_string_lossy().to_string();
+
+            assert_eq!(component_remote_path(&auto), "");
+        });
+    }
+
+    #[test]
+    fn test_resolve_effective_remote_path() {
         with_isolated_home(|_| {
             install_extension();
 
@@ -214,6 +247,29 @@ mod tests {
             .expect("resolve path");
 
             assert_eq!(resolved, "/htdocs/wp-content/plugins/foo");
+        });
+    }
+
+    #[test]
+    fn test_project_with_detected_path_roots() {
+        with_isolated_home(|_| {
+            install_extension_with_detect_command(Some("printf /detected/wp-content"));
+            let project = Project {
+                id: "site".to_string(),
+                ..Project::default()
+            };
+
+            let detected = project_with_detected_path_roots(
+                &project,
+                &[component("wp-content/plugins/foo")],
+                "/tmp",
+                &local_client(),
+            );
+
+            assert_eq!(
+                detected.path_roots.get("wp_content").map(String::as_str),
+                Some("/detected/wp-content")
+            );
         });
     }
 

--- a/src/core/deploy/path_roots.rs
+++ b/src/core/deploy/path_roots.rs
@@ -1,0 +1,251 @@
+use crate::component::Component;
+use crate::engine::shell;
+use crate::error::Result;
+use crate::extension::{self, RemotePathRootRule};
+use crate::paths as base_path;
+use crate::project::Project;
+use crate::server::SshClient;
+use std::collections::HashSet;
+
+pub(super) fn component_remote_path(component: &Component) -> String {
+    if component.remote_path.trim().is_empty() {
+        component
+            .auto_resolve_remote_path()
+            .unwrap_or_else(|| component.remote_path.clone())
+    } else {
+        component.remote_path.clone()
+    }
+}
+
+pub(super) fn resolve_effective_remote_path(
+    project: &Project,
+    component: &Component,
+    fallback_base_path: &str,
+) -> Result<String> {
+    let remote_path = component_remote_path(component);
+
+    if remote_path.trim_start().starts_with('/') {
+        return base_path::join_remote_path(Some(fallback_base_path), &remote_path);
+    }
+
+    if let Some(resolved) = resolve_with_project_root(project, component, &remote_path)? {
+        return Ok(resolved);
+    }
+
+    base_path::join_remote_path(Some(fallback_base_path), &remote_path)
+}
+
+pub(super) fn project_with_detected_path_roots(
+    project: &Project,
+    components: &[Component],
+    base_path: &str,
+    client: &SshClient,
+) -> Project {
+    let mut resolved = project.clone();
+    let mut checked = HashSet::new();
+
+    for rule in components.iter().flat_map(component_remote_path_root_rules) {
+        if resolved.path_roots.contains_key(&rule.root) || !checked.insert(rule.root.clone()) {
+            continue;
+        }
+
+        let Some(command) = rule.detect_command.as_deref() else {
+            continue;
+        };
+
+        let command = command.replace("{{basePath}}", base_path);
+        let output = client.execute(&format!(
+            "cd {} && {}",
+            shell::quote_path(base_path),
+            command
+        ));
+
+        let root = output.stdout.trim().trim_end_matches('/');
+        if output.success && !root.is_empty() {
+            log_status!(
+                "deploy",
+                "Detected project path root {}={}",
+                rule.root,
+                root
+            );
+            resolved
+                .path_roots
+                .insert(rule.root.clone(), root.to_string());
+        }
+    }
+
+    resolved
+}
+
+fn resolve_with_project_root(
+    project: &Project,
+    component: &Component,
+    remote_path: &str,
+) -> Result<Option<String>> {
+    if project.path_roots.is_empty() {
+        return Ok(None);
+    }
+
+    for rule in component_remote_path_root_rules(component) {
+        if !path_matches_prefix(remote_path, &rule.path_prefix) {
+            continue;
+        }
+
+        let Some(root) = project.path_roots.get(&rule.root) else {
+            continue;
+        };
+
+        let path = if rule.strip_prefix {
+            strip_path_prefix(remote_path, &rule.path_prefix)
+        } else {
+            remote_path
+        };
+
+        if path.is_empty() {
+            return base_path::join_remote_path(None, root).map(Some);
+        }
+
+        return base_path::join_remote_path(Some(root), path).map(Some);
+    }
+
+    Ok(None)
+}
+
+fn component_remote_path_root_rules(component: &Component) -> Vec<RemotePathRootRule> {
+    let Some(extensions) = &component.extensions else {
+        return Vec::new();
+    };
+
+    extensions
+        .keys()
+        .filter_map(|id| extension::load_extension(id).ok())
+        .filter_map(|manifest| manifest.deploy)
+        .flat_map(|deploy| deploy.path_roots)
+        .collect()
+}
+
+fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    let path = path.trim_matches('/');
+    let prefix = prefix.trim_matches('/');
+
+    !prefix.is_empty() && (path == prefix || path.starts_with(&format!("{}/", prefix)))
+}
+
+fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> &'a str {
+    let path = path.trim_start_matches('/');
+    let prefix = prefix.trim_matches('/');
+
+    path.strip_prefix(prefix)
+        .map(|remaining| remaining.trim_start_matches('/'))
+        .unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::{Component, ScopedExtensionConfig};
+    use crate::extension::{DeployCapability, ExtensionManifest};
+    use crate::test_support::with_isolated_home;
+    use std::collections::HashMap;
+
+    fn component(remote_path: &str) -> Component {
+        let mut component = Component::new(
+            "fixture".to_string(),
+            "/tmp/fixture".to_string(),
+            remote_path.to_string(),
+            None,
+        );
+        component.extensions = Some(HashMap::from([(
+            "wordpress".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+        component
+    }
+
+    fn project_with_root() -> Project {
+        Project {
+            id: "site".to_string(),
+            base_path: Some("/srv/site".to_string()),
+            path_roots: HashMap::from([(
+                "wp_content".to_string(),
+                "/htdocs/wp-content".to_string(),
+            )]),
+            ..Project::default()
+        }
+    }
+
+    fn install_extension() {
+        crate::extension::save_manifest(&ExtensionManifest {
+            id: "wordpress".to_string(),
+            name: "WordPress".to_string(),
+            version: "1.0.0".to_string(),
+            deploy: Some(DeployCapability {
+                verifications: Vec::new(),
+                overrides: Vec::new(),
+                remote_path_inference: Vec::new(),
+                path_roots: vec![RemotePathRootRule {
+                    path_prefix: "wp-content".to_string(),
+                    root: "wp_content".to_string(),
+                    strip_prefix: true,
+                    detect_command: None,
+                }],
+                version_patterns: Vec::new(),
+                since_tag: None,
+            }),
+            ..serde_json::from_value(serde_json::json!({
+                "name": "WordPress",
+                "version": "1.0.0"
+            }))
+            .expect("manifest")
+        })
+        .expect("save extension");
+    }
+
+    #[test]
+    fn resolves_matching_remote_path_under_project_root() {
+        with_isolated_home(|_| {
+            install_extension();
+
+            let resolved = resolve_effective_remote_path(
+                &project_with_root(),
+                &component("wp-content/plugins/foo"),
+                "/srv/site",
+            )
+            .expect("resolve path");
+
+            assert_eq!(resolved, "/htdocs/wp-content/plugins/foo");
+        });
+    }
+
+    #[test]
+    fn applies_content_root_to_theme_paths() {
+        with_isolated_home(|_| {
+            install_extension();
+
+            let resolved = resolve_effective_remote_path(
+                &project_with_root(),
+                &component("wp-content/themes/theme"),
+                "/srv/site",
+            )
+            .expect("resolve path");
+
+            assert_eq!(resolved, "/htdocs/wp-content/themes/theme");
+        });
+    }
+
+    #[test]
+    fn falls_back_to_base_path_when_rule_does_not_match() {
+        with_isolated_home(|_| {
+            install_extension();
+
+            let resolved = resolve_effective_remote_path(
+                &project_with_root(),
+                &component("var/log/app.log"),
+                "/srv/site",
+            )
+            .expect("resolve path");
+
+            assert_eq!(resolved, "/srv/site/var/log/app.log");
+        });
+    }
+}

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -12,7 +12,7 @@ use crate::version;
 use super::types::{
     ComponentStatus, DeployConfig, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
 };
-use super::version_overrides::fetch_remote_versions;
+use super::version_overrides::fetch_remote_versions_for_project;
 
 pub(super) fn calculate_directory_size(path: &Path) -> std::io::Result<u64> {
     let mut total_size = 0;
@@ -62,6 +62,7 @@ pub(super) fn plan_components(
     config: &DeployConfig,
     all_components: &[Component],
     skipped_component_ids: &[String],
+    project: &Project,
     base_path: &str,
     client: &SshClient,
 ) -> Result<Vec<Component>> {
@@ -130,7 +131,8 @@ pub(super) fn plan_components(
     }
 
     if config.outdated {
-        let remote_versions = fetch_remote_versions(all_components, base_path, client);
+        let remote_versions =
+            fetch_remote_versions_for_project(all_components, Some(project), base_path, client);
 
         let selected: Vec<Component> = all_components
             .iter()

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -5,6 +5,9 @@ use crate::config;
 use crate::error::Result;
 use crate::is_zero_u32;
 use crate::paths as base_path;
+use crate::project::Project;
+
+use super::path_roots::resolve_effective_remote_path;
 
 /// Parse bulk component IDs from a JSON spec.
 pub fn parse_bulk_component_ids(json_spec: &str) -> Result<Vec<String>> {
@@ -201,6 +204,16 @@ impl ComponentDeployResult {
         }
     }
 
+    pub(super) fn new_for_project(
+        component: &Component,
+        project: &Project,
+        base_path: &str,
+    ) -> Self {
+        let mut result = Self::new(component, base_path);
+        result.remote_path = resolve_effective_remote_path(project, component, base_path).ok();
+        result
+    }
+
     /// Shorthand for the common failure pattern: status="failed" + versions + error.
     pub(super) fn failed(
         component: &Component,
@@ -268,7 +281,11 @@ mod tests {
         parse_bulk_component_ids, ComponentDeployResult, ComponentStatus, DeployResult,
         ReleaseState, ReleaseStateStatus,
     };
-    use crate::component::Component;
+    use crate::component::{Component, ScopedExtensionConfig};
+    use crate::extension::{DeployCapability, ExtensionManifest, RemotePathRootRule};
+    use crate::project::Project;
+    use crate::test_support::with_isolated_home;
+    use std::collections::HashMap;
 
     fn component() -> Component {
         Component::new(
@@ -277,6 +294,42 @@ mod tests {
             "wp-content/plugins/fixture".to_string(),
             None,
         )
+    }
+
+    fn component_with_extension() -> Component {
+        let mut component = component();
+        component.extensions = Some(HashMap::from([(
+            "wordpress".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+        component
+    }
+
+    fn install_wordpress_extension() {
+        crate::extension::save_manifest(&ExtensionManifest {
+            id: "wordpress".to_string(),
+            name: "WordPress".to_string(),
+            version: "1.0.0".to_string(),
+            deploy: Some(DeployCapability {
+                verifications: Vec::new(),
+                overrides: Vec::new(),
+                remote_path_inference: Vec::new(),
+                path_roots: vec![RemotePathRootRule {
+                    path_prefix: "wp-content".to_string(),
+                    root: "wp_content".to_string(),
+                    strip_prefix: true,
+                    detect_command: None,
+                }],
+                version_patterns: Vec::new(),
+                since_tag: None,
+            }),
+            ..serde_json::from_value(serde_json::json!({
+                "name": "WordPress",
+                "version": "1.0.0"
+            }))
+            .expect("manifest")
+        })
+        .expect("save extension");
     }
 
     fn deploy_result() -> ComponentDeployResult {
@@ -390,6 +443,32 @@ mod tests {
             result.remote_path.as_deref(),
             Some("/srv/wp-content/plugins/fixture")
         );
+    }
+
+    #[test]
+    fn new_for_project_reports_effective_remote_path() {
+        with_isolated_home(|_| {
+            install_wordpress_extension();
+            let project = Project {
+                id: "site".to_string(),
+                path_roots: HashMap::from([(
+                    "wp_content".to_string(),
+                    "/htdocs/wp-content".to_string(),
+                )]),
+                ..Project::default()
+            };
+
+            let result = ComponentDeployResult::new_for_project(
+                &component_with_extension(),
+                &project,
+                "/srv/site",
+            );
+
+            assert_eq!(
+                result.remote_path.as_deref(),
+                Some("/htdocs/wp-content/plugins/fixture")
+            );
+        });
     }
 
     #[test]

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -11,9 +11,11 @@ use crate::extension::{
     load_all_extensions, DeployOverride, DeployVerification, ExtensionManifest,
 };
 use crate::paths as base_path;
+use crate::project::Project;
 use crate::server::SshClient;
 use crate::version;
 
+use super::path_roots::resolve_effective_remote_path;
 use super::transfer::scp_file;
 use super::types::DeployResult;
 
@@ -78,11 +80,20 @@ pub fn fetch_remote_versions(
     base_path: &str,
     client: &SshClient,
 ) -> HashMap<String, String> {
+    fetch_remote_versions_for_project(components, None, base_path, client)
+}
+
+pub(super) fn fetch_remote_versions_for_project(
+    components: &[Component],
+    project: Option<&Project>,
+    base_path: &str,
+    client: &SshClient,
+) -> HashMap<String, String> {
     let mut versions = HashMap::new();
 
     for component in components {
         // Try standard version-file approach first
-        if let Some(ver) = fetch_version_from_file(component, base_path, client) {
+        if let Some(ver) = fetch_version_from_file(component, project, base_path, client) {
             versions.insert(component.id.clone(), ver);
             continue;
         }
@@ -100,6 +111,7 @@ pub fn fetch_remote_versions(
 /// Try to fetch version by reading a version file on the remote server.
 fn fetch_version_from_file(
     component: &Component,
+    project: Option<&Project>,
     base_path: &str,
     client: &SshClient,
 ) -> Option<String> {
@@ -109,8 +121,11 @@ fn fetch_version_from_file(
         .and_then(|targets| targets.first())
         .map(|t| t.file.as_str())?;
 
-    let remote_path =
-        base_path::join_remote_child(Some(base_path), &component.remote_path, version_file).ok()?;
+    let remote_dir = match project {
+        Some(project) => resolve_effective_remote_path(project, component, base_path).ok()?,
+        None => base_path::join_remote_path(Some(base_path), &component.remote_path).ok()?,
+    };
+    let remote_path = base_path::join_remote_child(None, &remote_dir, version_file).ok()?;
 
     let output = client.execute(&format!("cat '{}' 2>/dev/null", remote_path));
 

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -53,6 +53,8 @@ pub struct DeployCapability {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub remote_path_inference: Vec<RemotePathInferenceRule>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_roots: Vec<RemotePathRootRule>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub version_patterns: Vec<VersionPatternConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub since_tag: Option<SinceTagConfig>,
@@ -855,6 +857,16 @@ pub struct DeployOverride {
 pub struct RemotePathInferenceRule {
     pub when_file_contains: FileContainsCondition,
     pub remote_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemotePathRootRule {
+    pub path_prefix: String,
+    pub root: String,
+    #[serde(default)]
+    pub strip_prefix: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detect_command: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -37,9 +37,10 @@ pub use manifest::{
     DiscoveryConfig, DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionManifest,
     FeatureContextRule, FileContainsCondition, HttpMethod, InputConfig, LintChangedFileRoute,
     LintConfig, OutputConfig, OutputSchema, PlatformCapability, ProvidesConfig,
-    RemotePathInferenceRule, RequirementsConfig, RuntimeConfig, RuntimeRequirementsConfig,
-    ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig, StructuredSidecarDeclaration,
-    TestConfig, TestDriftConfig, TestMappingConfig, TraceConfig, VersionPatternConfig,
+    RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig, RuntimeConfig,
+    RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
+    StructuredSidecarDeclaration, TestConfig, TestDriftConfig, TestMappingConfig, TraceConfig,
+    VersionPatternConfig,
 };
 
 // Re-export version types

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -88,6 +88,8 @@ pub struct Project {
     pub server_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_path: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub path_roots: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub table_prefix: Option<String>,
 


### PR DESCRIPTION
## Summary
- Adds project-level deploy path roots with extension-provided path root rules.
- Resolves deploy execution, deploy checks, dry runs, and remote version reads through effective deploy paths.
- Detects missing deploy roots from extension commands so split WordPress root/content layouts can keep portable component metadata.

Fixes https://github.com/Extra-Chill/homeboy/issues/2507

## Testing
- `cargo fmt`
- `cargo test deploy::`
- `cargo test --test core_agnostic_test`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the deploy path-root implementation; Chris retains responsibility for review and merge.