### PR TITLE
Add atomic project pin update commands

### DIFF
--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -414,10 +414,10 @@ fn pin(command: ProjectPinCommand) -> CmdResult<ProjectOutput> {
         ProjectPinCommand::Update {
             project_id,
             path,
-            r#type,
+            r#type: update_type,
             label,
             tail,
-        } => pin_update(&project_id, &path, r#type, label, tail),
+        } => pin_update(&project_id, &path, update_type, label, tail),
         ProjectPinCommand::Rename {
             project_id,
             old_path,

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -169,6 +169,34 @@ enum ProjectPinCommand {
         #[arg(long, value_enum)]
         r#type: ProjectPinType,
     },
+    /// Update an existing pinned file or log
+    Update {
+        /// Project ID
+        project_id: String,
+        /// Path to update
+        path: String,
+        /// Item type: file or log
+        #[arg(long, value_enum)]
+        r#type: ProjectPinType,
+        /// Optional display label
+        #[arg(long)]
+        label: Option<String>,
+        /// Number of lines to tail (logs only)
+        #[arg(long)]
+        tail: Option<u32>,
+    },
+    /// Rename the path for an existing pinned file or log
+    Rename {
+        /// Project ID
+        project_id: String,
+        /// Current pinned path
+        old_path: String,
+        /// New pinned path
+        new_path: String,
+        /// Item type: file or log
+        #[arg(long, value_enum)]
+        r#type: ProjectPinType,
+    },
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -383,6 +411,19 @@ fn pin(command: ProjectPinCommand) -> CmdResult<ProjectOutput> {
             path,
             r#type,
         } => pin_remove(&project_id, &path, r#type),
+        ProjectPinCommand::Update {
+            project_id,
+            path,
+            r#type,
+            label,
+            tail,
+        } => pin_update(&project_id, &path, r#type, label, tail),
+        ProjectPinCommand::Rename {
+            project_id,
+            old_path,
+            new_path,
+            r#type,
+        } => pin_rename(&project_id, &old_path, &new_path, r#type),
     }
 }
 
@@ -425,6 +466,43 @@ fn pin_remove(project_id: &str, path: &str, pin_type: ProjectPinType) -> CmdResu
 
     Ok((
         project::build_pin_output("project.pin.remove", project_id, pin),
+        0,
+    ))
+}
+
+fn pin_update(
+    project_id: &str,
+    path: &str,
+    pin_type: ProjectPinType,
+    label: Option<String>,
+    tail: Option<u32>,
+) -> CmdResult<ProjectOutput> {
+    let pin = project::update_pin(
+        project_id,
+        map_pin_type(pin_type),
+        path,
+        project::PinUpdateOptions {
+            label,
+            tail_lines: tail,
+        },
+    )?;
+
+    Ok((
+        project::build_pin_output("project.pin.update", project_id, pin),
+        0,
+    ))
+}
+
+fn pin_rename(
+    project_id: &str,
+    old_path: &str,
+    new_path: &str,
+    pin_type: ProjectPinType,
+) -> CmdResult<ProjectOutput> {
+    let pin = project::rename_pin(project_id, map_pin_type(pin_type), old_path, new_path)?;
+
+    Ok((
+        project::build_pin_output("project.pin.rename", project_id, pin),
         0,
     ))
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -27,7 +27,8 @@ pub use component::{
 pub use files::{FileEntry, GrepMatch, LineChange};
 pub use logs::{LogContent, LogEntry, LogSearchResult, PinnedLogsContent};
 pub use pins::{
-    add_pin, list_pins, remove_pin, ProjectPinChange, ProjectPinListItem, ProjectPinOutput,
+    add_pin, list_pins, remove_pin, rename_pin, update_pin, PinUpdateOptions, ProjectPinChange,
+    ProjectPinListItem, ProjectPinOutput,
 };
 pub use readiness::calculate_deploy_readiness;
 pub use report::{

--- a/src/core/project/pins.rs
+++ b/src/core/project/pins.rs
@@ -43,6 +43,24 @@ pub struct ProjectPinOutput {
 pub fn list_pins(project_id: &str, pin_type: PinType) -> Result<ProjectPinOutput> {
     let project = load(project_id)?;
 
+    Ok(list_pins_output(project_id, pin_type, &project))
+}
+
+fn list_pins_output(project_id: &str, pin_type: PinType, project: &Project) -> ProjectPinOutput {
+    let (items, type_string) = list_pin_items(pin_type, project);
+
+    ProjectPinOutput {
+        action: "list".to_string(),
+        project_id: project_id.to_string(),
+        r#type: type_string.to_string(),
+        items: Some(items),
+        added: None,
+        removed: None,
+        updated: None,
+    }
+}
+
+fn list_pin_items(pin_type: PinType, project: &Project) -> (Vec<ProjectPinListItem>, &'static str) {
     let (items, type_string) = match pin_type {
         PinType::File => (
             project
@@ -74,15 +92,7 @@ pub fn list_pins(project_id: &str, pin_type: PinType) -> Result<ProjectPinOutput
         ),
     };
 
-    Ok(ProjectPinOutput {
-        action: "list".to_string(),
-        project_id: project_id.to_string(),
-        r#type: type_string.to_string(),
-        items: Some(items),
-        added: None,
-        removed: None,
-        updated: None,
-    })
+    (items, type_string)
 }
 
 pub fn add_pin(
@@ -94,36 +104,44 @@ pub fn add_pin(
     let type_string = pin_type_name(pin_type).to_string();
     pin(project_id, pin_type, path, options)?;
 
-    Ok(ProjectPinOutput {
-        action: "add".to_string(),
+    Ok(change_pin_output("add", project_id, &type_string, path))
+}
+
+fn change_pin_output(
+    action: &str,
+    project_id: &str,
+    type_string: &str,
+    path: &str,
+) -> ProjectPinOutput {
+    let change = ProjectPinChange {
+        path: path.to_string(),
+        r#type: type_string.to_string(),
+    };
+
+    ProjectPinOutput {
+        action: action.to_string(),
         project_id: project_id.to_string(),
-        r#type: type_string.clone(),
+        r#type: type_string.to_string(),
         items: None,
-        added: Some(ProjectPinChange {
-            path: path.to_string(),
-            r#type: type_string,
-        }),
-        removed: None,
+        added: if action == "add" {
+            Some(change.clone())
+        } else {
+            None
+        },
+        removed: if action == "remove" {
+            Some(change)
+        } else {
+            None
+        },
         updated: None,
-    })
+    }
 }
 
 pub fn remove_pin(project_id: &str, pin_type: PinType, path: &str) -> Result<ProjectPinOutput> {
     let type_string = pin_type_name(pin_type).to_string();
     unpin(project_id, pin_type, path)?;
 
-    Ok(ProjectPinOutput {
-        action: "remove".to_string(),
-        project_id: project_id.to_string(),
-        r#type: type_string.clone(),
-        items: None,
-        added: None,
-        removed: Some(ProjectPinChange {
-            path: path.to_string(),
-            r#type: type_string,
-        }),
-        updated: None,
-    })
+    Ok(change_pin_output("remove", project_id, &type_string, path))
 }
 
 pub fn update_pin(
@@ -375,7 +393,40 @@ mod tests {
     }
 
     #[test]
-    fn update_log_pin_changes_tail_lines() {
+    fn test_list_pins() {
+        let output = list_pins_output("site", PinType::Log, &project());
+
+        assert_eq!(output.action, "list");
+        assert_eq!(output.project_id, "site");
+        assert_eq!(output.r#type, "log");
+        let items = output.items.expect("list items");
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].path, "logs/php.log");
+        assert_eq!(items[0].tail_lines, Some(100));
+    }
+
+    #[test]
+    fn test_add_pin() {
+        let output = change_pin_output("add", "site", "file", "wp-config.php");
+
+        assert_eq!(output.action, "add");
+        assert_eq!(output.r#type, "file");
+        assert_eq!(output.added.expect("added pin").path, "wp-config.php");
+        assert!(output.removed.is_none());
+    }
+
+    #[test]
+    fn test_remove_pin() {
+        let output = change_pin_output("remove", "site", "log", "logs/php.log");
+
+        assert_eq!(output.action, "remove");
+        assert_eq!(output.r#type, "log");
+        assert_eq!(output.removed.expect("removed pin").path, "logs/php.log");
+        assert!(output.added.is_none());
+    }
+
+    #[test]
+    fn test_update_pin() {
         let mut project = project();
 
         let updated = update_pin_in_project(
@@ -415,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn rename_file_pin_changes_path() {
+    fn test_rename_pin() {
         let mut project = project();
 
         let updated = rename_pin_in_project(

--- a/src/core/project/pins.rs
+++ b/src/core/project/pins.rs
@@ -1,8 +1,13 @@
 use serde::Serialize;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
-use super::{load, pin, unpin, PinOptions, PinType};
+use super::{load, pin, save, unpin, PinOptions, PinType, Project};
+
+pub struct PinUpdateOptions {
+    pub label: Option<String>,
+    pub tail_lines: Option<u32>,
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectPinListItem {
@@ -31,6 +36,8 @@ pub struct ProjectPinOutput {
     pub added: Option<ProjectPinChange>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub removed: Option<ProjectPinChange>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated: Option<ProjectPinListItem>,
 }
 
 pub fn list_pins(project_id: &str, pin_type: PinType) -> Result<ProjectPinOutput> {
@@ -74,6 +81,7 @@ pub fn list_pins(project_id: &str, pin_type: PinType) -> Result<ProjectPinOutput
         items: Some(items),
         added: None,
         removed: None,
+        updated: None,
     })
 }
 
@@ -96,6 +104,7 @@ pub fn add_pin(
             r#type: type_string,
         }),
         removed: None,
+        updated: None,
     })
 }
 
@@ -113,12 +122,357 @@ pub fn remove_pin(project_id: &str, pin_type: PinType, path: &str) -> Result<Pro
             path: path.to_string(),
             r#type: type_string,
         }),
+        updated: None,
     })
+}
+
+pub fn update_pin(
+    project_id: &str,
+    pin_type: PinType,
+    path: &str,
+    options: PinUpdateOptions,
+) -> Result<ProjectPinOutput> {
+    let type_string = pin_type_name(pin_type).to_string();
+    let mut project = load(project_id)?;
+    let updated = update_pin_in_project(&mut project, pin_type, path, options)?;
+    save(&project)?;
+
+    Ok(ProjectPinOutput {
+        action: "update".to_string(),
+        project_id: project_id.to_string(),
+        r#type: type_string,
+        items: None,
+        added: None,
+        removed: None,
+        updated: Some(updated),
+    })
+}
+
+pub fn rename_pin(
+    project_id: &str,
+    pin_type: PinType,
+    old_path: &str,
+    new_path: &str,
+) -> Result<ProjectPinOutput> {
+    let type_string = pin_type_name(pin_type).to_string();
+    let mut project = load(project_id)?;
+    let updated = rename_pin_in_project(&mut project, pin_type, old_path, new_path)?;
+    save(&project)?;
+
+    Ok(ProjectPinOutput {
+        action: "rename".to_string(),
+        project_id: project_id.to_string(),
+        r#type: type_string.clone(),
+        items: None,
+        added: Some(ProjectPinChange {
+            path: new_path.to_string(),
+            r#type: type_string.clone(),
+        }),
+        removed: Some(ProjectPinChange {
+            path: old_path.to_string(),
+            r#type: type_string,
+        }),
+        updated: Some(updated),
+    })
+}
+
+fn update_pin_in_project(
+    project: &mut Project,
+    pin_type: PinType,
+    path: &str,
+    options: PinUpdateOptions,
+) -> Result<ProjectPinListItem> {
+    if options.label.is_none() && options.tail_lines.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "options",
+            "Provide --label or --tail to update a pin",
+            Some(project.id.clone()),
+            Some(vec![path.to_string()]),
+        ));
+    }
+
+    match pin_type {
+        PinType::File => {
+            if options.tail_lines.is_some() {
+                return Err(Error::validation_invalid_argument(
+                    "tail",
+                    "Tail lines can only be updated for log pins",
+                    Some(project.id.clone()),
+                    Some(vec![path.to_string()]),
+                ));
+            }
+
+            let index = project
+                .remote_files
+                .pinned_files
+                .iter()
+                .position(|file| file.path == path)
+                .ok_or_else(|| pin_not_found(project, pin_type, path))?;
+            let file = &mut project.remote_files.pinned_files[index];
+
+            if let Some(label) = options.label {
+                file.label = Some(label);
+            }
+            Ok(ProjectPinListItem {
+                path: file.path.clone(),
+                label: file.label.clone(),
+                display_name: file.display_name().to_string(),
+                tail_lines: None,
+            })
+        }
+        PinType::Log => {
+            let index = project
+                .remote_logs
+                .pinned_logs
+                .iter()
+                .position(|log| log.path == path)
+                .ok_or_else(|| pin_not_found(project, pin_type, path))?;
+            let log = &mut project.remote_logs.pinned_logs[index];
+
+            if let Some(label) = options.label {
+                log.label = Some(label);
+            }
+            if let Some(tail_lines) = options.tail_lines {
+                log.tail_lines = tail_lines;
+            }
+            Ok(ProjectPinListItem {
+                path: log.path.clone(),
+                label: log.label.clone(),
+                display_name: log.display_name().to_string(),
+                tail_lines: Some(log.tail_lines),
+            })
+        }
+    }
+}
+
+fn rename_pin_in_project(
+    project: &mut Project,
+    pin_type: PinType,
+    old_path: &str,
+    new_path: &str,
+) -> Result<ProjectPinListItem> {
+    if old_path == new_path {
+        return Err(Error::validation_invalid_argument(
+            "new_path",
+            "New pin path must differ from the current path",
+            Some(project.id.clone()),
+            Some(vec![old_path.to_string()]),
+        ));
+    }
+
+    match pin_type {
+        PinType::File => {
+            if project
+                .remote_files
+                .pinned_files
+                .iter()
+                .any(|file| file.path == new_path)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "new_path",
+                    "File is already pinned",
+                    Some(project.id.clone()),
+                    Some(vec![new_path.to_string()]),
+                ));
+            }
+
+            let index = project
+                .remote_files
+                .pinned_files
+                .iter()
+                .position(|file| file.path == old_path)
+                .ok_or_else(|| pin_not_found(project, pin_type, old_path))?;
+            project.remote_files.pinned_files[index].path = new_path.to_string();
+            let file = &project.remote_files.pinned_files[index];
+
+            Ok(ProjectPinListItem {
+                path: file.path.clone(),
+                label: file.label.clone(),
+                display_name: file.display_name().to_string(),
+                tail_lines: None,
+            })
+        }
+        PinType::Log => {
+            if project
+                .remote_logs
+                .pinned_logs
+                .iter()
+                .any(|log| log.path == new_path)
+            {
+                return Err(Error::validation_invalid_argument(
+                    "new_path",
+                    "Log is already pinned",
+                    Some(project.id.clone()),
+                    Some(vec![new_path.to_string()]),
+                ));
+            }
+
+            let index = project
+                .remote_logs
+                .pinned_logs
+                .iter()
+                .position(|log| log.path == old_path)
+                .ok_or_else(|| pin_not_found(project, pin_type, old_path))?;
+            project.remote_logs.pinned_logs[index].path = new_path.to_string();
+            let log = &project.remote_logs.pinned_logs[index];
+
+            Ok(ProjectPinListItem {
+                path: log.path.clone(),
+                label: log.label.clone(),
+                display_name: log.display_name().to_string(),
+                tail_lines: Some(log.tail_lines),
+            })
+        }
+    }
+}
+
+fn pin_not_found(project: &Project, pin_type: PinType, path: &str) -> Error {
+    Error::validation_invalid_argument(
+        "path",
+        format!("{} is not pinned", pin_type_name(pin_type)),
+        Some(project.id.clone()),
+        Some(vec![path.to_string()]),
+    )
 }
 
 fn pin_type_name(pin_type: PinType) -> &'static str {
     match pin_type {
         PinType::File => "file",
         PinType::Log => "log",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::{PinnedRemoteFile, PinnedRemoteLog, RemoteFileConfig, RemoteLogConfig};
+
+    fn project() -> Project {
+        Project {
+            id: "site".to_string(),
+            remote_files: RemoteFileConfig {
+                pinned_files: vec![PinnedRemoteFile {
+                    path: "wp-config.php".to_string(),
+                    label: Some("Config".to_string()),
+                }],
+            },
+            remote_logs: RemoteLogConfig {
+                pinned_logs: vec![
+                    PinnedRemoteLog {
+                        path: "logs/php.log".to_string(),
+                        label: Some("PHP".to_string()),
+                        tail_lines: 100,
+                    },
+                    PinnedRemoteLog {
+                        path: "logs/nginx.log".to_string(),
+                        label: Some("Nginx".to_string()),
+                        tail_lines: 50,
+                    },
+                ],
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn update_log_pin_changes_tail_lines() {
+        let mut project = project();
+
+        let updated = update_pin_in_project(
+            &mut project,
+            PinType::Log,
+            "logs/php.log",
+            PinUpdateOptions {
+                label: Some("PHP error log".to_string()),
+                tail_lines: Some(250),
+            },
+        )
+        .expect("update log pin");
+
+        assert_eq!(updated.path, "logs/php.log");
+        assert_eq!(updated.label.as_deref(), Some("PHP error log"));
+        assert_eq!(updated.tail_lines, Some(250));
+        assert_eq!(project.remote_logs.pinned_logs[0].tail_lines, 250);
+    }
+
+    #[test]
+    fn tail_only_log_update_preserves_label() {
+        let mut project = project();
+
+        let updated = update_pin_in_project(
+            &mut project,
+            PinType::Log,
+            "logs/php.log",
+            PinUpdateOptions {
+                label: None,
+                tail_lines: Some(25),
+            },
+        )
+        .expect("update log tail");
+
+        assert_eq!(updated.label.as_deref(), Some("PHP"));
+        assert_eq!(updated.tail_lines, Some(25));
+    }
+
+    #[test]
+    fn rename_file_pin_changes_path() {
+        let mut project = project();
+
+        let updated = rename_pin_in_project(
+            &mut project,
+            PinType::File,
+            "wp-config.php",
+            "wp-config-local.php",
+        )
+        .expect("rename file pin");
+
+        assert_eq!(updated.path, "wp-config-local.php");
+        assert_eq!(updated.label.as_deref(), Some("Config"));
+        assert_eq!(
+            project.remote_files.pinned_files[0].path,
+            "wp-config-local.php"
+        );
+    }
+
+    #[test]
+    fn failed_log_update_leaves_previous_state_intact() {
+        let mut project = project();
+        let before = project.clone();
+
+        let err = update_pin_in_project(
+            &mut project,
+            PinType::Log,
+            "logs/missing.log",
+            PinUpdateOptions {
+                label: Some("Missing".to_string()),
+                tail_lines: Some(500),
+            },
+        )
+        .expect_err("missing log update should fail");
+
+        assert!(err.message.contains("log is not pinned"));
+        assert_eq!(
+            project.remote_logs.pinned_logs,
+            before.remote_logs.pinned_logs
+        );
+    }
+
+    #[test]
+    fn failed_file_rename_leaves_previous_state_intact() {
+        let mut project = project();
+        project.remote_files.pinned_files.push(PinnedRemoteFile {
+            path: "index.php".to_string(),
+            label: None,
+        });
+        let before = project.clone();
+
+        let err = rename_pin_in_project(&mut project, PinType::File, "wp-config.php", "index.php")
+            .expect_err("duplicate rename should fail");
+
+        assert!(err.message.contains("File is already pinned"));
+        assert_eq!(
+            project.remote_files.pinned_files,
+            before.remote_files.pinned_files
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `homeboy project pin update` for in-place pinned log/file metadata updates, including log tail-line changes without client-side remove/add sequencing.
- Add `homeboy project pin rename` for pinned path renames while preserving existing label/tail metadata.
- Validate update/rename operations before mutating project config so failed updates leave the previous pin state intact.

## Tests
- `cargo test project::pins`
- `cargo test`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-project-pin-update-commands --extension rust`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI/core changes and drafted tests; Chris remains responsible for review and merge.

Fixes #2505