### PR TITLE
Drive release plans with generic substrate

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -25,7 +25,7 @@ pub(super) fn execute_release_plan_step(
         return Ok(None);
     }
 
-    match step.step_type.as_str() {
+    match step.kind.as_str() {
         "preflight.default_branch" => Ok(Some(run_default_branch_preflight(step, context))),
         "preflight.git_identity" => configure_git_identity(step, context).map(Some),
         "preflight.working_tree" => Ok(Some(run_working_tree_preflight(step, context))),
@@ -70,7 +70,7 @@ pub(super) fn execute_release_plan_step(
         )),
         "git.tag" => {
             let tag_name = step
-                .config
+                .inputs
                 .get("name")
                 .and_then(|value| value.as_str())
                 .map(str::to_string)
@@ -108,8 +108,8 @@ pub(super) fn execute_release_plan_step(
             context.component_id,
             &context.component.local_path,
         ))),
-        step_type if step_type.starts_with("publish.") => {
-            let target = step_type.strip_prefix("publish.").unwrap_or_default();
+        step_kind if step_kind.starts_with("publish.") => {
+            let target = step_kind.strip_prefix("publish.").unwrap_or_default();
             let result = executor::run_publish(
                 context.extensions,
                 &context.state,
@@ -119,7 +119,7 @@ pub(super) fn execute_release_plan_step(
             )
             .unwrap_or_else(|err| {
                 context.publish_failed = true;
-                failed_result(step_type, step_type, err)
+                failed_result(step_kind, step_kind, err)
             });
 
             if matches!(result.status, ReleaseStepStatus::Failed) {
@@ -130,23 +130,23 @@ pub(super) fn execute_release_plan_step(
         }
         _ => Err(Error::internal_unexpected(format!(
             "release plan contains unsupported executable step '{}'",
-            step.step_type
+            step.kind
         ))),
     }
 }
 
 fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
-    (step.step_type.starts_with("preflight.")
-        && step.step_type != "preflight.default_branch"
-        && step.step_type != "preflight.git_identity"
-        && step.step_type != "preflight.working_tree"
-        && step.step_type != "preflight.remote_sync"
-        && step.step_type != "preflight.bump_policy"
-        && step.step_type != "preflight.lint"
-        && step.step_type != "preflight.test"
-        && step.step_type != "preflight.changelog_bootstrap")
-        || step.step_type == "changelog.policy"
-        || step.step_type == "changelog.generate"
+    (step.kind.starts_with("preflight.")
+        && step.kind != "preflight.default_branch"
+        && step.kind != "preflight.git_identity"
+        && step.kind != "preflight.working_tree"
+        && step.kind != "preflight.remote_sync"
+        && step.kind != "preflight.bump_policy"
+        && step.kind != "preflight.lint"
+        && step.kind != "preflight.test"
+        && step.kind != "preflight.changelog_bootstrap")
+        || step.kind == "changelog.policy"
+        || step.kind == "changelog.generate"
 }
 
 fn run_default_branch_preflight(
@@ -156,7 +156,7 @@ fn run_default_branch_preflight(
     match super::planning_git::validate_default_branch(context.component) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
-            step_type: step.step_type.clone(),
+            step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
             missing: Vec::new(),
             warnings: Vec::new(),
@@ -164,7 +164,7 @@ fn run_default_branch_preflight(
             data: None,
             error: None,
         },
-        Err(err) => failed_result(&step.id, &step.step_type, err),
+        Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
@@ -175,7 +175,7 @@ fn run_working_tree_preflight(
     match super::planning_worktree::validate_working_tree_fail_fast(context.component) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
-            step_type: step.step_type.clone(),
+            step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
             missing: Vec::new(),
             warnings: Vec::new(),
@@ -183,7 +183,7 @@ fn run_working_tree_preflight(
             data: None,
             error: None,
         },
-        Err(err) => failed_result(&step.id, &step.step_type, err),
+        Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
@@ -194,7 +194,7 @@ fn run_remote_sync_preflight(
     match super::planning_git::validate_remote_sync(context.component) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
-            step_type: step.step_type.clone(),
+            step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
             missing: Vec::new(),
             warnings: Vec::new(),
@@ -202,28 +202,28 @@ fn run_remote_sync_preflight(
             data: None,
             error: None,
         },
-        Err(err) => failed_result(&step.id, &step.step_type, err),
+        Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
 fn run_bump_policy_preflight(step: &ReleasePlanStep) -> ReleaseStepResult {
     let requested = step
-        .config
+        .inputs
         .get("requested")
         .and_then(|value| value.as_str())
         .unwrap_or("unknown");
     let recommended = step
-        .config
+        .inputs
         .get("recommended")
         .and_then(|value| value.as_str())
         .unwrap_or(requested);
     let underbump = step
-        .config
+        .inputs
         .get("underbump")
         .and_then(|value| value.as_bool())
         .unwrap_or(false);
     let force_lower_bump = step
-        .config
+        .inputs
         .get("force_lower_bump")
         .and_then(|value| value.as_bool())
         .unwrap_or(false);
@@ -241,12 +241,12 @@ fn run_bump_policy_preflight(step: &ReleasePlanStep) -> ReleaseStepResult {
         .with_hint(format!("Use the detected bump: --bump {}", recommended))
         .with_hint("If the lower release is intentional, re-run with --force-lower-bump");
 
-        return failed_result(&step.id, &step.step_type, err);
+        return failed_result(&step.id, &step.kind, err);
     }
 
     ReleaseStepResult {
         id: step.id.clone(),
-        step_type: step.step_type.clone(),
+        step_type: step.kind.clone(),
         status: ReleaseStepStatus::Success,
         missing: Vec::new(),
         warnings: Vec::new(),
@@ -267,7 +267,7 @@ fn run_lint_preflight(
 ) -> ReleaseStepResult {
     match super::planning_quality::validate_lint_quality(context.component) {
         Ok(ran) => successful_quality_result(step, ran),
-        Err(err) => failed_result(&step.id, &step.step_type, err),
+        Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
@@ -277,14 +277,14 @@ fn run_test_preflight(
 ) -> ReleaseStepResult {
     match super::planning_quality::validate_test_quality(context.component) {
         Ok(ran) => successful_quality_result(step, ran),
-        Err(err) => failed_result(&step.id, &step.step_type, err),
+        Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
 fn successful_quality_result(step: &ReleasePlanStep, ran: bool) -> ReleaseStepResult {
     ReleaseStepResult {
         id: step.id.clone(),
-        step_type: step.step_type.clone(),
+        step_type: step.kind.clone(),
         status: ReleaseStepStatus::Success,
         missing: Vec::new(),
         warnings: Vec::new(),
@@ -301,7 +301,7 @@ fn run_changelog_bootstrap_preflight(
     match super::planning_changelog::ensure_changelog_initialized(context.component) {
         Ok(()) => ReleaseStepResult {
             id: step.id.clone(),
-            step_type: step.step_type.clone(),
+            step_type: step.kind.clone(),
             status: ReleaseStepStatus::Success,
             missing: Vec::new(),
             warnings: Vec::new(),
@@ -309,7 +309,7 @@ fn run_changelog_bootstrap_preflight(
             data: None,
             error: None,
         },
-        Err(err) => failed_result(&step.id, &step.step_type, err),
+        Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
@@ -318,7 +318,7 @@ fn configure_git_identity(
     context: &ReleaseExecutionContext,
 ) -> Result<ReleaseStepResult> {
     let identity_value = step
-        .config
+        .inputs
         .get("identity")
         .and_then(|value| value.as_str())
         .ok_or_else(|| Error::internal_unexpected("release git identity step missing identity"))?;
@@ -333,7 +333,7 @@ fn configure_git_identity(
 
     Ok(ReleaseStepResult {
         id: step.id.clone(),
-        step_type: step.step_type.clone(),
+        step_type: step.kind.clone(),
         status: ReleaseStepStatus::Success,
         missing: Vec::new(),
         warnings: Vec::new(),
@@ -371,7 +371,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
 }
 
 fn step_config_string_array(step: &ReleasePlanStep, key: &str) -> Vec<String> {
-    step.config
+    step.inputs
         .get(key)
         .and_then(|value| value.as_array())
         .map(|items| {
@@ -645,13 +645,13 @@ mod tests {
     #[test]
     fn bump_policy_preflight_blocks_unforced_underbump() {
         let mut step = plan_step("preflight.bump_policy");
-        step.config
+        step.inputs
             .insert("requested".to_string(), serde_json::json!("patch"));
-        step.config
+        step.inputs
             .insert("recommended".to_string(), serde_json::json!("minor"));
-        step.config
+        step.inputs
             .insert("underbump".to_string(), serde_json::json!(true));
-        step.config
+        step.inputs
             .insert("force_lower_bump".to_string(), serde_json::json!(false));
 
         let component = Component::default();
@@ -685,13 +685,13 @@ mod tests {
     #[test]
     fn bump_policy_preflight_allows_forced_underbump() {
         let mut step = plan_step("preflight.bump_policy");
-        step.config
+        step.inputs
             .insert("requested".to_string(), serde_json::json!("patch"));
-        step.config
+        step.inputs
             .insert("recommended".to_string(), serde_json::json!("minor"));
-        step.config
+        step.inputs
             .insert("underbump".to_string(), serde_json::json!(true));
-        step.config
+        step.inputs
             .insert("force_lower_bump".to_string(), serde_json::json!(true));
 
         let component = Component::default();
@@ -778,7 +778,7 @@ mod tests {
     #[test]
     fn test_step_config_string_array() {
         let mut step = plan_step("post_release");
-        step.config.insert(
+        step.inputs.insert(
             "commands".to_string(),
             serde_json::json!(["git tag -f stable", 123, "git push"]),
         );
@@ -803,12 +803,17 @@ mod tests {
     fn plan_step(step_type: &str) -> ReleasePlanStep {
         ReleasePlanStep {
             id: step_type.to_string(),
-            step_type: step_type.to_string(),
+            kind: step_type.to_string(),
             label: None,
-            needs: vec![],
-            config: std::collections::HashMap::new(),
+            blocking: true,
+            scope: Vec::new(),
+            needs: Vec::new(),
             status: ReleasePlanStatus::Ready,
-            missing: vec![],
+            inputs: std::collections::HashMap::new(),
+            outputs: std::collections::HashMap::new(),
+            skip_reason: None,
+            policy: std::collections::HashMap::new(),
+            missing: Vec::new(),
         }
     }
 

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -18,14 +18,7 @@ pub(super) fn build_initial_preflight_plan(
         .filter(|step| initial_executable_preflight_ids().contains(&step.id.as_str()))
         .collect();
 
-    ReleasePlan {
-        component_id: component_id.to_string(),
-        enabled: true,
-        steps,
-        semver_recommendation: None,
-        warnings: Vec::new(),
-        hints: Vec::new(),
-    }
+    ReleasePlan::new(component_id, true, steps, None, Vec::new(), Vec::new())
 }
 
 pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {

--- a/src/core/release/executor/changelog.rs
+++ b/src/core/release/executor/changelog.rs
@@ -11,17 +11,17 @@ pub(crate) fn run_changelog_finalize(
     state: &mut ReleaseState,
 ) -> Result<ReleaseStepResult> {
     let current_version = step
-        .config
+        .inputs
         .get("from")
         .and_then(|value| value.as_str())
         .ok_or_else(|| Error::internal_unexpected("changelog.finalize step missing from"))?;
     let new_version = step
-        .config
+        .inputs
         .get("to")
         .and_then(|value| value.as_str())
         .ok_or_else(|| Error::internal_unexpected("changelog.finalize step missing to"))?;
     let entries = step
-        .config
+        .inputs
         .get("entries")
         .cloned()
         .map(serde_json::from_value)
@@ -81,18 +81,23 @@ mod tests {
         };
         let mut step = ReleasePlanStep {
             id: "changelog.finalize".to_string(),
-            step_type: "changelog.finalize".to_string(),
+            kind: "changelog.finalize".to_string(),
             label: None,
-            needs: vec![],
-            config: std::collections::HashMap::new(),
+            blocking: true,
+            scope: Vec::new(),
+            needs: Vec::new(),
             status: ReleasePlanStatus::Ready,
-            missing: vec![],
+            inputs: std::collections::HashMap::new(),
+            outputs: std::collections::HashMap::new(),
+            skip_reason: None,
+            policy: std::collections::HashMap::new(),
+            missing: Vec::new(),
         };
-        step.config
+        step.inputs
             .insert("from".to_string(), serde_json::json!("0.6.12"));
-        step.config
+        step.inputs
             .insert("to".to_string(), serde_json::json!("0.6.13"));
-        step.config.insert(
+        step.inputs.insert(
             "entries".to_string(),
             serde_json::json!({ "Fixed": ["Close release plan gap"] }),
         );

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -40,12 +40,17 @@ fn ready_step(
 ) -> ReleasePlanStep {
     ReleasePlanStep {
         id: id.to_string(),
-        step_type: step_type.to_string(),
+        kind: step_type.to_string(),
         label: Some(label.into()),
+        blocking: true,
+        scope: Vec::new(),
         needs,
-        config,
         status: ReleasePlanStatus::Ready,
-        missing: vec![],
+        inputs: config,
+        outputs: StepConfig::new(),
+        skip_reason: None,
+        policy: StepConfig::new(),
+        missing: Vec::new(),
     }
 }
 
@@ -57,12 +62,17 @@ fn disabled_step(
 ) -> ReleasePlanStep {
     ReleasePlanStep {
         id: id.to_string(),
-        step_type: step_type.to_string(),
+        kind: step_type.to_string(),
         label: Some(label.into()),
-        needs: vec![],
-        config,
+        blocking: true,
+        scope: Vec::new(),
+        needs: Vec::new(),
         status: ReleasePlanStatus::Disabled,
-        missing: vec![],
+        inputs: config,
+        outputs: StepConfig::new(),
+        skip_reason: None,
+        policy: StepConfig::new(),
+        missing: Vec::new(),
     }
 }
 
@@ -580,7 +590,7 @@ mod tests {
         assert_eq!(identity.needs, vec!["preflight.default_branch"]);
         assert_eq!(
             identity
-                .config
+                .inputs
                 .get("identity")
                 .and_then(|value| value.as_str()),
             Some("Release Bot <bot@example.com>")
@@ -605,7 +615,7 @@ mod tests {
             assert_eq!(quality.status, ReleasePlanStatus::Disabled);
             assert_eq!(
                 quality
-                    .config
+                    .inputs
                     .get("reason")
                     .and_then(|value| value.as_str()),
                 Some("--skip-checks")
@@ -640,7 +650,7 @@ mod tests {
 
         assert_eq!(audit.status, ReleasePlanStatus::Disabled);
         assert_eq!(
-            audit.config.get("reason").and_then(|value| value.as_str()),
+            audit.inputs.get("reason").and_then(|value| value.as_str()),
             Some("no-release-audit-policy")
         );
         assert_eq!(lint.status, ReleasePlanStatus::Ready);
@@ -668,28 +678,28 @@ mod tests {
         assert_eq!(bump_policy.needs, vec!["preflight.remote_sync"]);
         assert_eq!(
             bump_policy
-                .config
+                .inputs
                 .get("recommended")
                 .and_then(|value| value.as_str()),
             Some("minor")
         );
         assert_eq!(
             bump_policy
-                .config
+                .inputs
                 .get("requested")
                 .and_then(|value| value.as_str()),
             Some("patch")
         );
         assert_eq!(
             bump_policy
-                .config
+                .inputs
                 .get("policy")
                 .and_then(|value| value.as_str()),
             Some("requires-force-lower-bump")
         );
         assert_eq!(
             bump_policy
-                .config
+                .inputs
                 .get("force_lower_bump")
                 .and_then(|value| value.as_bool()),
             Some(false)
@@ -716,14 +726,14 @@ mod tests {
 
         assert_eq!(
             bump_policy
-                .config
+                .inputs
                 .get("policy")
                 .and_then(|value| value.as_str()),
             Some("forced-lower-bump")
         );
         assert_eq!(
             bump_policy
-                .config
+                .inputs
                 .get("force_lower_bump")
                 .and_then(|value| value.as_bool()),
             Some(true)
@@ -747,7 +757,7 @@ mod tests {
 
         assert_eq!(
             bump_policy
-                .config
+                .inputs
                 .get("policy")
                 .and_then(|value| value.as_str()),
             Some("preview-lower-bump")
@@ -851,27 +861,27 @@ mod tests {
             .expect("changelog finalize step");
 
         assert_eq!(
-            policy.config.get("policy").and_then(|value| value.as_str()),
+            policy.inputs.get("policy").and_then(|value| value.as_str()),
             Some("generated")
         );
         assert_eq!(
-            policy.config.get("path").and_then(|value| value.as_str()),
+            policy.inputs.get("path").and_then(|value| value.as_str()),
             Some("CHANGELOG.md")
         );
         assert_eq!(
             generate
-                .config
+                .inputs
                 .get("entry_count")
                 .and_then(|value| value.as_u64()),
             Some(1)
         );
         assert_eq!(
-            finalize.config.get("mode").and_then(|value| value.as_str()),
+            finalize.inputs.get("mode").and_then(|value| value.as_str()),
             Some("version-step")
         );
         assert_eq!(
             finalize
-                .config
+                .inputs
                 .get("entries")
                 .and_then(|value| value.as_object())
                 .and_then(|entries| entries.get("Fixed"))
@@ -912,7 +922,7 @@ mod tests {
         assert_eq!(deploy.needs, vec!["git.push"]);
         assert_eq!(
             deploy
-                .config
+                .inputs
                 .get("execution")
                 .and_then(|value| value.as_str()),
             Some("release_plan")

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -109,14 +109,14 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         hints.push("Dry run: no changes will be made".to_string());
     }
 
-    Ok(ReleasePlan {
-        component_id: component_id.to_string(),
-        enabled: true,
+    Ok(ReleasePlan::new(
+        component_id,
+        true,
         steps,
         semver_recommendation,
         warnings,
         hints,
-    })
+    ))
 }
 
 #[cfg(test)]

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -37,25 +37,30 @@ fn skipped_release_plan(
     hint: &str,
     semver_recommendation: Option<ReleaseSemverRecommendation>,
 ) -> ReleasePlan {
-    ReleasePlan {
-        component_id: component_id.to_string(),
-        enabled: false,
-        steps: vec![ReleasePlanStep {
+    ReleasePlan::new(
+        component_id,
+        false,
+        vec![ReleasePlanStep {
             id: "release.skip".to_string(),
-            step_type: "release.skip".to_string(),
+            kind: "release.skip".to_string(),
             label: Some(label.to_string()),
-            needs: vec![],
-            config: std::collections::HashMap::from([(
+            blocking: true,
+            scope: Vec::new(),
+            needs: Vec::new(),
+            status: ReleasePlanStatus::Disabled,
+            inputs: std::collections::HashMap::from([(
                 "reason".to_string(),
                 serde_json::Value::String(reason.to_string()),
             )]),
-            status: ReleasePlanStatus::Disabled,
-            missing: vec![],
+            outputs: std::collections::HashMap::new(),
+            skip_reason: Some(reason.to_string()),
+            policy: std::collections::HashMap::new(),
+            missing: Vec::new(),
         }],
         semver_recommendation,
-        warnings: vec![],
-        hints: vec![hint.to_string()],
-    }
+        Vec::new(),
+        vec![hint.to_string()],
+    )
 }
 
 #[cfg(test)]
@@ -74,10 +79,10 @@ mod tests {
         assert_eq!(plan.component_id, "demo");
         assert_eq!(plan.steps.len(), 1);
         assert_eq!(plan.steps[0].id, "release.skip");
-        assert_eq!(plan.steps[0].step_type, "release.skip");
+        assert_eq!(plan.steps[0].kind, "release.skip");
         assert_eq!(plan.steps[0].status, ReleasePlanStatus::Disabled);
         assert_eq!(
-            plan.steps[0].config.get("reason").and_then(|v| v.as_str()),
+            plan.steps[0].inputs.get("reason").and_then(|v| v.as_str()),
             Some("no-releasable-commits")
         );
         assert_eq!(
@@ -116,7 +121,7 @@ mod tests {
         assert!(!plan.enabled);
         assert!(plan.semver_recommendation.is_some());
         assert_eq!(
-            plan.steps[0].config.get("reason").and_then(|v| v.as_str()),
+            plan.steps[0].inputs.get("reason").and_then(|v| v.as_str()),
             Some("major-requires-flag")
         );
         assert_eq!(

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 
 use crate::is_zero_u32;
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSubject};
 
 /// Ordered release plan shared by dry-run output and release execution.
 ///
@@ -9,15 +11,60 @@ use crate::is_zero_u32;
 /// `pipeline::run()` for real releases so the previewed steps match execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleasePlan {
+    #[serde(flatten)]
+    pub plan: HomeboyPlan,
     pub component_id: String,
     pub enabled: bool,
-    pub steps: Vec<ReleasePlanStep>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semver_recommendation: Option<ReleaseSemverRecommendation>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub warnings: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub hints: Vec<String>,
+}
+
+impl ReleasePlan {
+    pub fn new(
+        component_id: impl Into<String>,
+        enabled: bool,
+        steps: Vec<ReleasePlanStep>,
+        semver_recommendation: Option<ReleaseSemverRecommendation>,
+        warnings: Vec<String>,
+        hints: Vec<String>,
+    ) -> Self {
+        let component_id = component_id.into();
+        Self {
+            plan: HomeboyPlan {
+                id: format!("release.{component_id}"),
+                kind: PlanKind::Release,
+                subject: PlanSubject {
+                    component_id: Some(component_id.clone()),
+                    ..PlanSubject::default()
+                },
+                mode: None,
+                inputs: HashMap::new(),
+                policy: HashMap::new(),
+                steps,
+                artifacts: Vec::new(),
+                summary: None,
+                warnings: warnings.clone(),
+                hints: hints.clone(),
+            },
+            component_id,
+            enabled,
+            semver_recommendation,
+        }
+    }
+}
+
+impl Deref for ReleasePlan {
+    type Target = HomeboyPlan;
+
+    fn deref(&self) -> &Self::Target {
+        &self.plan
+    }
+}
+
+impl DerefMut for ReleasePlan {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.plan
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,29 +188,8 @@ pub struct ReleaseState {
     pub changelog_validation: Option<crate::version::ChangelogValidationResult>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReleasePlanStep {
-    pub id: String,
-    #[serde(rename = "type")]
-    pub step_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub needs: Vec<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub config: HashMap<String, serde_json::Value>,
-    pub status: ReleasePlanStatus,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub missing: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ReleasePlanStatus {
-    Ready,
-    Missing,
-    Disabled,
-}
+pub type ReleasePlanStep = PlanStep;
+pub type ReleasePlanStatus = PlanStepStatus;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ReleaseOptions {

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -243,8 +243,8 @@ fn format_tag(version: &str, monorepo: Option<&git::MonorepoContext>) -> String 
 fn extract_new_version_from_plan(plan: &ReleasePlan) -> Option<String> {
     plan.steps
         .iter()
-        .find(|s| s.step_type == "version")
-        .and_then(|s| s.config.get("to"))
+        .find(|s| s.kind == "version")
+        .and_then(|s| s.inputs.get("to"))
         .and_then(|v| v.as_str())
         .map(String::from)
 }
@@ -257,7 +257,7 @@ fn skipped_reason_from_plan(plan: &ReleasePlan) -> Option<String> {
     plan.steps
         .iter()
         .find(|step| step.id == "release.skip")
-        .and_then(|step| step.config.get("reason"))
+        .and_then(|step| step.inputs.get("reason"))
         .and_then(|value| value.as_str())
         .map(str::to_string)
 }
@@ -463,24 +463,24 @@ fn recovery_release_plan(
     ));
 
     for step in &mut steps {
-        step.config.insert(
+        step.inputs.insert(
             "version".to_string(),
             serde_json::Value::String(version.to_string()),
         );
-        step.config.insert(
+        step.inputs.insert(
             "tag".to_string(),
             serde_json::Value::String(tag_name.to_string()),
         );
     }
 
-    ReleasePlan {
-        component_id: component_id.to_string(),
-        enabled: !actions.is_empty(),
+    ReleasePlan::new(
+        component_id,
+        !actions.is_empty(),
         steps,
-        semver_recommendation: None,
-        warnings: vec![],
-        hints: actions.to_vec(),
-    }
+        None,
+        Vec::new(),
+        actions.to_vec(),
+    )
 }
 
 fn recovery_step(
@@ -499,16 +499,25 @@ fn recovery_step(
 
     ReleasePlanStep {
         id: id.to_string(),
-        step_type: id.to_string(),
+        kind: id.to_string(),
         label: Some(label.into()),
+        blocking: true,
+        scope: Vec::new(),
         needs,
-        config,
         status: if needed {
             ReleasePlanStatus::Ready
         } else {
             ReleasePlanStatus::Disabled
         },
-        missing: vec![],
+        inputs: config,
+        outputs: std::collections::HashMap::new(),
+        skip_reason: if needed {
+            None
+        } else {
+            Some("already-complete".to_string())
+        },
+        policy: std::collections::HashMap::new(),
+        missing: Vec::new(),
     }
 }
 
@@ -660,25 +669,30 @@ mod tests {
 
     #[test]
     fn extracts_new_version_from_plan() {
-        let plan = ReleasePlan {
-            component_id: "demo".to_string(),
-            enabled: true,
-            steps: vec![crate::release::ReleasePlanStep {
+        let plan = ReleasePlan::new(
+            "demo",
+            true,
+            vec![crate::release::ReleasePlanStep {
                 id: "version".to_string(),
-                step_type: "version".to_string(),
+                kind: "version".to_string(),
                 label: None,
-                needs: vec![],
-                config: HashMap::from([(
+                blocking: true,
+                scope: Vec::new(),
+                needs: Vec::new(),
+                status: crate::release::ReleasePlanStatus::Ready,
+                inputs: HashMap::from([(
                     "to".to_string(),
                     serde_json::Value::String("1.2.3".to_string()),
                 )]),
-                status: crate::release::ReleasePlanStatus::Ready,
-                missing: vec![],
+                outputs: HashMap::new(),
+                skip_reason: None,
+                policy: HashMap::new(),
+                missing: Vec::new(),
             }],
-            semver_recommendation: None,
-            warnings: vec![],
-            hints: vec![],
-        };
+            None,
+            Vec::new(),
+            Vec::new(),
+        );
 
         assert_eq!(
             extract_new_version_from_plan(&plan).as_deref(),
@@ -714,15 +728,15 @@ mod tests {
             crate::release::ReleasePlanStatus::Disabled
         );
         assert_eq!(
-            plan.steps[2].config.get("reason").and_then(|v| v.as_str()),
+            plan.steps[2].inputs.get("reason").and_then(|v| v.as_str()),
             Some("already-complete")
         );
         assert_eq!(
-            plan.steps[0].config.get("version").and_then(|v| v.as_str()),
+            plan.steps[0].inputs.get("version").and_then(|v| v.as_str()),
             Some("1.2.3")
         );
         assert_eq!(
-            plan.steps[0].config.get("tag").and_then(|v| v.as_str()),
+            plan.steps[0].inputs.get("tag").and_then(|v| v.as_str()),
             Some("v1.2.3")
         );
     }


### PR DESCRIPTION
## Summary
- Make `ReleasePlan` wrap a flattened generic `HomeboyPlan` while keeping release metadata such as component enablement and semver recommendation.
- Replace release-specific plan step/status structs with aliases to the shared `PlanStep` and `PlanStepStatus` substrate.
- Update release planning, recovery planning, changelog execution, and dispatch to use generic step `kind` and `inputs` fields.

## Verification
- `cargo fmt --check`
- `cargo test core::plan`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## Notes
- Audit reported no introduced findings. It still shows 2 contextual `workflow.rs` test-coverage notes already known in the touched scope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the release plan substrate migration, updated tests/callers, and prepared the PR. Chris remains responsible for review and validation.