### PR TITLE
Extract quality plan substrate

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -26,6 +26,7 @@ pub mod observation;
 pub mod output;
 pub mod plan;
 pub mod project;
+pub mod quality;
 pub mod refactor;
 pub mod release;
 pub mod rig;

--- a/src/core/quality.rs
+++ b/src/core/quality.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSubject};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QualityPlanOptions {
+    pub component_id: String,
+    pub mode: Option<String>,
+    pub step_prefix: String,
+    pub skip_checks: bool,
+    pub lint_needs: Vec<String>,
+    pub test_needs: Vec<String>,
+    pub audit_policy_available: bool,
+}
+
+impl QualityPlanOptions {
+    pub fn release_preflight(component_id: impl Into<String>, skip_checks: bool) -> Self {
+        Self {
+            component_id: component_id.into(),
+            mode: Some("release-preflight".to_string()),
+            step_prefix: "preflight".to_string(),
+            skip_checks,
+            lint_needs: vec!["preflight.bump_policy".to_string()],
+            test_needs: vec!["preflight.lint".to_string()],
+            audit_policy_available: false,
+        }
+    }
+}
+
+pub fn build_quality_plan(options: QualityPlanOptions) -> HomeboyPlan {
+    let steps = build_quality_steps(&options);
+    let component_id = options.component_id;
+
+    HomeboyPlan {
+        id: format!("quality.{component_id}"),
+        kind: PlanKind::Quality,
+        subject: PlanSubject {
+            component_id: Some(component_id),
+            ..PlanSubject::default()
+        },
+        mode: options.mode,
+        inputs: HashMap::new(),
+        policy: HashMap::new(),
+        steps,
+        artifacts: Vec::new(),
+        summary: None,
+        warnings: Vec::new(),
+        hints: Vec::new(),
+    }
+}
+
+pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {
+    if options.skip_checks {
+        return vec![
+            disabled_step(
+                &options.step_prefix,
+                "audit",
+                "Run release audit",
+                "--skip-checks",
+            ),
+            disabled_step(
+                &options.step_prefix,
+                "lint",
+                "Run release lint",
+                "--skip-checks",
+            ),
+            disabled_step(
+                &options.step_prefix,
+                "test",
+                "Run release tests",
+                "--skip-checks",
+            ),
+        ];
+    }
+
+    let audit = if options.audit_policy_available {
+        ready_step(
+            &options.step_prefix,
+            "audit",
+            "Run release audit",
+            Vec::new(),
+        )
+    } else {
+        disabled_step(
+            &options.step_prefix,
+            "audit",
+            "Run release audit",
+            "no-release-audit-policy",
+        )
+    };
+
+    vec![
+        audit,
+        ready_step(
+            &options.step_prefix,
+            "lint",
+            "Run release lint",
+            options.lint_needs.clone(),
+        ),
+        ready_step(
+            &options.step_prefix,
+            "test",
+            "Run release tests",
+            options.test_needs.clone(),
+        ),
+    ]
+}
+
+fn ready_step(prefix: &str, name: &str, label: &str, needs: Vec<String>) -> PlanStep {
+    PlanStep {
+        id: step_id(prefix, name),
+        kind: step_id(prefix, name),
+        label: Some(label.to_string()),
+        blocking: true,
+        scope: Vec::new(),
+        needs,
+        status: PlanStepStatus::Ready,
+        inputs: HashMap::new(),
+        outputs: HashMap::new(),
+        skip_reason: None,
+        policy: HashMap::new(),
+        missing: Vec::new(),
+    }
+}
+
+fn disabled_step(prefix: &str, name: &str, label: &str, reason: &str) -> PlanStep {
+    PlanStep {
+        id: step_id(prefix, name),
+        kind: step_id(prefix, name),
+        label: Some(label.to_string()),
+        blocking: true,
+        scope: Vec::new(),
+        needs: Vec::new(),
+        status: PlanStepStatus::Disabled,
+        inputs: HashMap::from([(
+            "reason".to_string(),
+            serde_json::Value::String(reason.to_string()),
+        )]),
+        outputs: HashMap::new(),
+        skip_reason: Some(reason.to_string()),
+        policy: HashMap::new(),
+        missing: Vec::new(),
+    }
+}
+
+fn step_id(prefix: &str, name: &str) -> String {
+    format!("{prefix}.{name}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_quality_plan, build_quality_steps, QualityPlanOptions};
+    use crate::plan::{PlanKind, PlanStepStatus};
+
+    #[test]
+    fn test_release_preflight() {
+        let options = QualityPlanOptions::release_preflight("fixture", false);
+
+        assert_eq!(options.component_id, "fixture");
+        assert_eq!(options.mode.as_deref(), Some("release-preflight"));
+        assert_eq!(options.step_prefix, "preflight");
+        assert_eq!(options.lint_needs, vec!["preflight.bump_policy"]);
+        assert_eq!(options.test_needs, vec!["preflight.lint"]);
+        assert!(!options.audit_policy_available);
+    }
+
+    #[test]
+    fn test_build_quality_plan() {
+        let plan = build_quality_plan(QualityPlanOptions::release_preflight("fixture", false));
+        let ids: Vec<&str> = plan.steps.iter().map(|step| step.id.as_str()).collect();
+
+        assert_eq!(plan.kind, PlanKind::Quality);
+        assert_eq!(plan.subject.component_id.as_deref(), Some("fixture"));
+        assert_eq!(plan.mode.as_deref(), Some("release-preflight"));
+        assert_eq!(
+            ids,
+            vec!["preflight.audit", "preflight.lint", "preflight.test"]
+        );
+        assert_eq!(plan.steps[0].status, PlanStepStatus::Disabled);
+        assert_eq!(plan.steps[1].needs, vec!["preflight.bump_policy"]);
+        assert_eq!(plan.steps[2].needs, vec!["preflight.lint"]);
+    }
+
+    #[test]
+    fn test_build_quality_steps() {
+        let options = QualityPlanOptions::release_preflight("fixture", true);
+        let steps = build_quality_steps(&options);
+
+        assert!(steps
+            .iter()
+            .all(|step| step.status == PlanStepStatus::Disabled));
+        assert!(steps.iter().all(|step| step
+            .inputs
+            .get("reason")
+            .and_then(|value| value.as_str())
+            == Some("--skip-checks")));
+    }
+}

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -1,6 +1,7 @@
 use crate::component::Component;
 use crate::extension::ExtensionManifest;
 use crate::git;
+use crate::quality::{build_quality_steps as build_shared_quality_steps, QualityPlanOptions};
 use crate::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
 };
@@ -153,51 +154,10 @@ pub(super) fn build_preflight_steps(
 }
 
 fn build_quality_steps(options: &ReleaseOptions) -> Vec<ReleasePlanStep> {
-    if options.skip_checks {
-        return vec![
-            disabled_step(
-                "preflight.audit",
-                "preflight.audit",
-                "Run release audit",
-                string_config("reason", "--skip-checks"),
-            ),
-            disabled_step(
-                "preflight.lint",
-                "preflight.lint",
-                "Run release lint",
-                string_config("reason", "--skip-checks"),
-            ),
-            disabled_step(
-                "preflight.test",
-                "preflight.test",
-                "Run release tests",
-                string_config("reason", "--skip-checks"),
-            ),
-        ];
-    }
-
-    vec![
-        disabled_step(
-            "preflight.audit",
-            "preflight.audit",
-            "Run release audit",
-            string_config("reason", "no-release-audit-policy"),
-        ),
-        ready_step(
-            "preflight.lint",
-            "preflight.lint",
-            "Run release lint",
-            vec!["preflight.bump_policy".to_string()],
-            StepConfig::new(),
-        ),
-        ready_step(
-            "preflight.test",
-            "preflight.test",
-            "Run release tests",
-            vec!["preflight.lint".to_string()],
-            StepConfig::new(),
-        ),
-    ]
+    build_shared_quality_steps(&QualityPlanOptions::release_preflight(
+        "release",
+        options.skip_checks,
+    ))
 }
 
 fn build_bump_policy_step(


### PR DESCRIPTION
## Summary
- Add a generic `core::quality` planner that produces `HomeboyPlan { kind: Quality }` with audit, lint, and test steps.
- Add release-preflight quality plan options for the current release quality policy.
- Make release preflight planning consume the shared quality step builder instead of hand-building audit/lint/test steps inline.

## Verification
- `cargo fmt --check`
- `cargo test core::quality`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared quality plan substrate, migrated release preflight planning to it, added tests, and prepared the PR. Chris remains responsible for review and validation.