### PR TITLE
Drive review with quality plan

### DIFF
--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -23,6 +23,8 @@ use homeboy::code_audit::AuditCommandOutput;
 use homeboy::extension::lint::LintCommandOutput;
 use homeboy::extension::test::TestCommandOutput;
 use homeboy::git;
+use homeboy::plan::HomeboyPlan;
+use homeboy::quality::{build_quality_plan, QualityPlanOptions};
 use homeboy::ObservationOutputMetadata;
 
 use super::parse_key_val;
@@ -130,6 +132,7 @@ pub struct ReviewSummary {
 #[derive(Serialize)]
 pub struct ReviewCommandOutput {
     pub command: String,
+    pub plan: HomeboyPlan,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observation: Option<ObservationOutputMetadata>,
     pub artifact: ReviewArtifact,
@@ -171,6 +174,12 @@ struct ReviewStageDescriptor<Args, Output: Serialize> {
     finding_count: fn(&Output) -> usize,
 }
 
+enum ReviewStageRun {
+    Audit(ReviewStage<AuditCommandOutput>, i32),
+    Lint(ReviewStage<LintCommandOutput>, i32),
+    Test(ReviewStage<TestCommandOutput>, i32),
+}
+
 impl<Args, Output: Serialize> ReviewStageDescriptor<Args, Output> {
     fn execute(
         &self,
@@ -202,6 +211,63 @@ impl<Args, Output: Serialize> ReviewStageDescriptor<Args, Output> {
     }
 }
 
+fn review_stage_order(plan: &HomeboyPlan) -> Vec<String> {
+    plan.steps
+        .iter()
+        .filter(|step| step.status == homeboy::plan::PlanStepStatus::Ready)
+        .filter_map(|step| step.kind.strip_prefix("review.").map(str::to_string))
+        .collect()
+}
+
+fn execute_review_stage(
+    stage_name: &str,
+    args: &ReviewArgs,
+    global: &GlobalArgs,
+    component_label: &str,
+) -> CmdResult<ReviewStageRun> {
+    match stage_name {
+        "audit" => {
+            let descriptor = ReviewStageDescriptor {
+                name: "audit",
+                include_changed_only_scope: false,
+                build_args: build_audit_args,
+                run: audit::run,
+                finding_count: audit_finding_count,
+            };
+            descriptor
+                .execute(args, global, component_label)
+                .map(|(stage, exit_code)| (ReviewStageRun::Audit(stage, exit_code), exit_code))
+        }
+        "lint" => {
+            let descriptor = ReviewStageDescriptor {
+                name: "lint",
+                include_changed_only_scope: true,
+                build_args: build_lint_args,
+                run: lint::run,
+                finding_count: lint_finding_count,
+            };
+            descriptor
+                .execute(args, global, component_label)
+                .map(|(stage, exit_code)| (ReviewStageRun::Lint(stage, exit_code), exit_code))
+        }
+        "test" => {
+            let descriptor = ReviewStageDescriptor {
+                name: "test",
+                include_changed_only_scope: false,
+                build_args: build_test_args,
+                run: test::run,
+                finding_count: test_finding_count,
+            };
+            descriptor
+                .execute(args, global, component_label)
+                .map(|(stage, exit_code)| (ReviewStageRun::Test(stage, exit_code), exit_code))
+        }
+        other => Err(homeboy::Error::internal_unexpected(format!(
+            "review quality plan contains unsupported stage '{other}'"
+        ))),
+    }
+}
+
 pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutput> {
     // Resolve component ID (auto-discovers from CWD when omitted) and source
     // path so we can probe git for the changed-file set ourselves.
@@ -217,6 +283,8 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         "full"
     }
     .to_string();
+
+    let quality_plan = build_quality_plan(QualityPlanOptions::review(&component_label));
 
     // Probe the changed set once at the umbrella level so we can short-circuit
     // before paying for any extension setup. Each stage will re-derive its
@@ -265,6 +333,10 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
 
         let output = ReviewCommandOutput {
             command: "review".to_string(),
+            plan: build_quality_plan(QualityPlanOptions::skipped_review(
+                &component_label,
+                "no files changed",
+            )),
             observation: observation_metadata,
             artifact,
             summary: ReviewSummary {
@@ -296,51 +368,42 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
 
     let mut top_hints: Vec<String> = Vec::new();
 
-    let audit_descriptor = ReviewStageDescriptor {
-        name: "audit",
-        include_changed_only_scope: false,
-        build_args: build_audit_args,
-        run: audit::run,
-        finding_count: audit_finding_count,
-    };
-    let (audit_stage, audit_exit) = match audit_descriptor.execute(&args, global, &component_label)
-    {
-        Ok(result) => result,
-        Err(error) => {
-            observation::finish_error(review_observation, &error);
-            return Err(error);
-        }
-    };
+    let mut audit_stage = None;
+    let mut audit_exit = 0;
+    let mut lint_stage = None;
+    let mut lint_exit = 0;
+    let mut test_stage = None;
+    let mut test_exit = 0;
 
-    let lint_descriptor = ReviewStageDescriptor {
-        name: "lint",
-        include_changed_only_scope: true,
-        build_args: build_lint_args,
-        run: lint::run,
-        finding_count: lint_finding_count,
-    };
-    let (lint_stage, lint_exit) = match lint_descriptor.execute(&args, global, &component_label) {
-        Ok(result) => result,
-        Err(error) => {
-            observation::finish_error(review_observation, &error);
-            return Err(error);
-        }
-    };
+    for stage_name in review_stage_order(&quality_plan) {
+        let (stage_run, _stage_exit) =
+            match execute_review_stage(&stage_name, &args, global, &component_label) {
+                Ok(result) => result,
+                Err(error) => {
+                    observation::finish_error(review_observation, &error);
+                    return Err(error);
+                }
+            };
 
-    let test_descriptor = ReviewStageDescriptor {
-        name: "test",
-        include_changed_only_scope: false,
-        build_args: build_test_args,
-        run: test::run,
-        finding_count: test_finding_count,
-    };
-    let (test_stage, test_exit) = match test_descriptor.execute(&args, global, &component_label) {
-        Ok(result) => result,
-        Err(error) => {
-            observation::finish_error(review_observation, &error);
-            return Err(error);
+        match stage_run {
+            ReviewStageRun::Audit(stage, exit_code) => {
+                audit_stage = Some(stage);
+                audit_exit = exit_code;
+            }
+            ReviewStageRun::Lint(stage, exit_code) => {
+                lint_stage = Some(stage);
+                lint_exit = exit_code;
+            }
+            ReviewStageRun::Test(stage, exit_code) => {
+                test_stage = Some(stage);
+                test_exit = exit_code;
+            }
         }
-    };
+    }
+
+    let audit_stage = audit_stage.expect("review quality plan must include audit stage");
+    let lint_stage = lint_stage.expect("review quality plan must include lint stage");
+    let test_stage = test_stage.expect("review quality plan must include test stage");
 
     // Aggregate
     let overall_passed = audit_stage.passed && lint_stage.passed && test_stage.passed;
@@ -386,6 +449,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
 
     let output = ReviewCommandOutput {
         command: "review".to_string(),
+        plan: quality_plan,
         observation: observation_metadata,
         artifact,
         summary,

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -257,6 +257,9 @@ mod tests {
         );
         let output = ReviewCommandOutput {
             command: "review".to_string(),
+            plan: homeboy::quality::build_quality_plan(
+                homeboy::quality::QualityPlanOptions::review("homeboy"),
+            ),
             observation: None,
             artifact,
             summary: super::super::ReviewSummary {

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -344,12 +344,14 @@ mod tests {
     use homeboy::extension::lint::{LintCommandOutput, LintFinding};
     use homeboy::extension::test::{FailedTest, TestCommandOutput, TestCounts};
     use homeboy::extension::{PhaseReport, PhaseStatus, VerificationPhase};
+    use homeboy::quality::{build_quality_plan, QualityPlanOptions};
 
     // ── Builders for fixture envelopes ──────────────────────────────────
 
     fn passing_envelope() -> ReviewCommandOutput {
         ReviewCommandOutput {
             command: "review".to_string(),
+            plan: build_quality_plan(QualityPlanOptions::review("my-comp")),
             observation: None,
             artifact: super::super::build_artifact("my-comp", "", "abc123", Vec::new()),
             summary: super::super::ReviewSummary {
@@ -623,6 +625,10 @@ mod tests {
     fn renders_all_stages_skipped() {
         let env = ReviewCommandOutput {
             command: "review".to_string(),
+            plan: build_quality_plan(QualityPlanOptions::skipped_review(
+                "my-comp",
+                "no files changed",
+            )),
             observation: None,
             artifact: super::super::build_artifact("my-comp", "main", "abc123", Vec::new()),
             summary: super::super::ReviewSummary {

--- a/src/core/quality.rs
+++ b/src/core/quality.rs
@@ -8,9 +8,13 @@ pub struct QualityPlanOptions {
     pub mode: Option<String>,
     pub step_prefix: String,
     pub skip_checks: bool,
+    pub skip_reason: String,
     pub lint_needs: Vec<String>,
     pub test_needs: Vec<String>,
     pub audit_policy_available: bool,
+    pub audit_label: String,
+    pub lint_label: String,
+    pub test_label: String,
 }
 
 impl QualityPlanOptions {
@@ -20,9 +24,37 @@ impl QualityPlanOptions {
             mode: Some("release-preflight".to_string()),
             step_prefix: "preflight".to_string(),
             skip_checks,
+            skip_reason: "--skip-checks".to_string(),
             lint_needs: vec!["preflight.bump_policy".to_string()],
             test_needs: vec!["preflight.lint".to_string()],
             audit_policy_available: false,
+            audit_label: "Run release audit".to_string(),
+            lint_label: "Run release lint".to_string(),
+            test_label: "Run release tests".to_string(),
+        }
+    }
+
+    pub fn review(component_id: impl Into<String>) -> Self {
+        Self {
+            component_id: component_id.into(),
+            mode: Some("review".to_string()),
+            step_prefix: "review".to_string(),
+            skip_checks: false,
+            skip_reason: "skipped".to_string(),
+            lint_needs: vec!["review.audit".to_string()],
+            test_needs: vec!["review.lint".to_string()],
+            audit_policy_available: true,
+            audit_label: "Run review audit".to_string(),
+            lint_label: "Run review lint".to_string(),
+            test_label: "Run review tests".to_string(),
+        }
+    }
+
+    pub fn skipped_review(component_id: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            skip_checks: true,
+            skip_reason: reason.into(),
+            ..Self::review(component_id)
         }
     }
 }
@@ -55,20 +87,20 @@ pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {
             disabled_step(
                 &options.step_prefix,
                 "audit",
-                "Run release audit",
-                "--skip-checks",
+                &options.audit_label,
+                &options.skip_reason,
             ),
             disabled_step(
                 &options.step_prefix,
                 "lint",
-                "Run release lint",
-                "--skip-checks",
+                &options.lint_label,
+                &options.skip_reason,
             ),
             disabled_step(
                 &options.step_prefix,
                 "test",
-                "Run release tests",
-                "--skip-checks",
+                &options.test_label,
+                &options.skip_reason,
             ),
         ];
     }
@@ -77,14 +109,14 @@ pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {
         ready_step(
             &options.step_prefix,
             "audit",
-            "Run release audit",
+            &options.audit_label,
             Vec::new(),
         )
     } else {
         disabled_step(
             &options.step_prefix,
             "audit",
-            "Run release audit",
+            &options.audit_label,
             "no-release-audit-policy",
         )
     };
@@ -94,13 +126,13 @@ pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {
         ready_step(
             &options.step_prefix,
             "lint",
-            "Run release lint",
+            &options.lint_label,
             options.lint_needs.clone(),
         ),
         ready_step(
             &options.step_prefix,
             "test",
-            "Run release tests",
+            &options.test_label,
             options.test_needs.clone(),
         ),
     ]
@@ -159,9 +191,41 @@ mod tests {
         assert_eq!(options.component_id, "fixture");
         assert_eq!(options.mode.as_deref(), Some("release-preflight"));
         assert_eq!(options.step_prefix, "preflight");
+        assert_eq!(options.skip_reason, "--skip-checks");
         assert_eq!(options.lint_needs, vec!["preflight.bump_policy"]);
         assert_eq!(options.test_needs, vec!["preflight.lint"]);
         assert!(!options.audit_policy_available);
+    }
+
+    #[test]
+    fn test_review() {
+        let options = QualityPlanOptions::review("fixture");
+
+        assert_eq!(options.component_id, "fixture");
+        assert_eq!(options.mode.as_deref(), Some("review"));
+        assert_eq!(options.step_prefix, "review");
+        assert_eq!(options.lint_needs, vec!["review.audit"]);
+        assert_eq!(options.test_needs, vec!["review.lint"]);
+        assert!(options.audit_policy_available);
+    }
+
+    #[test]
+    fn test_skipped_review() {
+        let plan = build_quality_plan(QualityPlanOptions::skipped_review(
+            "fixture",
+            "no files changed",
+        ));
+
+        assert_eq!(plan.mode.as_deref(), Some("review"));
+        assert!(plan
+            .steps
+            .iter()
+            .all(|step| step.status == PlanStepStatus::Disabled));
+        assert!(plan.steps.iter().all(|step| step
+            .inputs
+            .get("reason")
+            .and_then(|value| value.as_str())
+            == Some("no files changed")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Route `homeboy review` through the shared `HomeboyPlan { kind: Quality }` substrate for audit, lint, and test stage ordering.
- Add review and skipped-review quality plan options so empty changed-file reviews emit an explicit disabled quality plan.
- Include the quality plan in review command output and update review fixtures accordingly.

## Verification
- `cargo fmt --check`
- `cargo test commands::review`
- `cargo test core::quality`
- `cargo test core::release`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main` (no introduced findings; 1 contextual pre-existing finding in touched scope)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the quality-plan migration and tests; Chris remains responsible for review and validation.