### PR TITLE
Use generic plan steps in release

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -2,11 +2,9 @@ use crate::component::Component;
 use crate::error::{Error, Result};
 use crate::extension::ExtensionManifest;
 use crate::git;
+use crate::plan::{PlanStep, PlanStepStatus};
 use crate::release::executor;
-use crate::release::types::{
-    ReleaseOptions, ReleasePlanStatus, ReleasePlanStep, ReleaseState, ReleaseStepResult,
-    ReleaseStepStatus,
-};
+use crate::release::types::{ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 
 pub(super) struct ReleaseExecutionContext<'a> {
     pub(super) component: &'a Component,
@@ -18,10 +16,10 @@ pub(super) struct ReleaseExecutionContext<'a> {
 }
 
 pub(super) fn execute_release_plan_step(
-    step: &ReleasePlanStep,
+    step: &PlanStep,
     context: &mut ReleaseExecutionContext,
 ) -> Result<Option<ReleaseStepResult>> {
-    if matches!(step.status, ReleasePlanStatus::Disabled) || release_step_is_plan_only(step) {
+    if matches!(step.status, PlanStepStatus::Disabled) || release_step_is_plan_only(step) {
         return Ok(None);
     }
 
@@ -135,7 +133,7 @@ pub(super) fn execute_release_plan_step(
     }
 }
 
-fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
+fn release_step_is_plan_only(step: &PlanStep) -> bool {
     (step.kind.starts_with("preflight.")
         && step.kind != "preflight.default_branch"
         && step.kind != "preflight.git_identity"
@@ -150,7 +148,7 @@ fn release_step_is_plan_only(step: &ReleasePlanStep) -> bool {
 }
 
 fn run_default_branch_preflight(
-    step: &ReleasePlanStep,
+    step: &PlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
     match super::planning_git::validate_default_branch(context.component) {
@@ -169,7 +167,7 @@ fn run_default_branch_preflight(
 }
 
 fn run_working_tree_preflight(
-    step: &ReleasePlanStep,
+    step: &PlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
     match super::planning_worktree::validate_working_tree_fail_fast(context.component) {
@@ -188,7 +186,7 @@ fn run_working_tree_preflight(
 }
 
 fn run_remote_sync_preflight(
-    step: &ReleasePlanStep,
+    step: &PlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
     match super::planning_git::validate_remote_sync(context.component) {
@@ -206,7 +204,7 @@ fn run_remote_sync_preflight(
     }
 }
 
-fn run_bump_policy_preflight(step: &ReleasePlanStep) -> ReleaseStepResult {
+fn run_bump_policy_preflight(step: &PlanStep) -> ReleaseStepResult {
     let requested = step
         .inputs
         .get("requested")
@@ -261,27 +259,21 @@ fn run_bump_policy_preflight(step: &ReleasePlanStep) -> ReleaseStepResult {
     }
 }
 
-fn run_lint_preflight(
-    step: &ReleasePlanStep,
-    context: &ReleaseExecutionContext,
-) -> ReleaseStepResult {
+fn run_lint_preflight(step: &PlanStep, context: &ReleaseExecutionContext) -> ReleaseStepResult {
     match super::planning_quality::validate_lint_quality(context.component) {
         Ok(ran) => successful_quality_result(step, ran),
         Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
-fn run_test_preflight(
-    step: &ReleasePlanStep,
-    context: &ReleaseExecutionContext,
-) -> ReleaseStepResult {
+fn run_test_preflight(step: &PlanStep, context: &ReleaseExecutionContext) -> ReleaseStepResult {
     match super::planning_quality::validate_test_quality(context.component) {
         Ok(ran) => successful_quality_result(step, ran),
         Err(err) => failed_result(&step.id, &step.kind, err),
     }
 }
 
-fn successful_quality_result(step: &ReleasePlanStep, ran: bool) -> ReleaseStepResult {
+fn successful_quality_result(step: &PlanStep, ran: bool) -> ReleaseStepResult {
     ReleaseStepResult {
         id: step.id.clone(),
         step_type: step.kind.clone(),
@@ -295,7 +287,7 @@ fn successful_quality_result(step: &ReleasePlanStep, ran: bool) -> ReleaseStepRe
 }
 
 fn run_changelog_bootstrap_preflight(
-    step: &ReleasePlanStep,
+    step: &PlanStep,
     context: &ReleaseExecutionContext,
 ) -> ReleaseStepResult {
     match super::planning_changelog::ensure_changelog_initialized(context.component) {
@@ -314,7 +306,7 @@ fn run_changelog_bootstrap_preflight(
 }
 
 fn configure_git_identity(
-    step: &ReleasePlanStep,
+    step: &PlanStep,
     context: &ReleaseExecutionContext,
 ) -> Result<ReleaseStepResult> {
     let identity_value = step
@@ -370,7 +362,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
     )
 }
 
-fn step_config_string_array(step: &ReleasePlanStep, key: &str) -> Vec<String> {
+fn step_config_string_array(step: &PlanStep, key: &str) -> Vec<String> {
     step.inputs
         .get(key)
         .and_then(|value| value.as_array())
@@ -404,9 +396,9 @@ mod tests {
         ReleaseExecutionContext,
     };
     use crate::component::Component;
+    use crate::plan::{PlanStep, PlanStepStatus};
     use crate::release::types::{
-        ReleaseOptions, ReleasePlanStatus, ReleasePlanStep, ReleaseState, ReleaseStepResult,
-        ReleaseStepStatus,
+        ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
     };
 
     #[test]
@@ -800,15 +792,15 @@ mod tests {
         assert_eq!(result.error.as_deref(), Some("boom"));
     }
 
-    fn plan_step(step_type: &str) -> ReleasePlanStep {
-        ReleasePlanStep {
+    fn plan_step(step_type: &str) -> PlanStep {
+        PlanStep {
             id: step_type.to_string(),
             kind: step_type.to_string(),
             label: None,
             blocking: true,
             scope: Vec::new(),
             needs: Vec::new(),
-            status: ReleasePlanStatus::Ready,
+            status: PlanStepStatus::Ready,
             inputs: std::collections::HashMap::new(),
             outputs: std::collections::HashMap::new(),
             skip_reason: None,

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -1,13 +1,14 @@
 use std::collections::HashSet;
 
 use crate::error::Result;
+use crate::plan::PlanStep;
 
 use super::context::{load_component, resolve_extensions};
 use super::execution_dispatch::{
     execute_release_plan_step, release_step_is_show_stopper, ReleaseExecutionContext,
 };
 use super::plan_steps::build_preflight_steps;
-use super::types::{ReleaseOptions, ReleasePlan, ReleasePlanStep, ReleaseState, ReleaseStepResult};
+use super::types::{ReleaseOptions, ReleasePlan, ReleaseState, ReleaseStepResult};
 
 pub(super) fn build_initial_preflight_plan(
     component_id: &str,
@@ -34,7 +35,7 @@ pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {
 }
 
 pub(super) fn execute_plan_steps(
-    steps: &[ReleasePlanStep],
+    steps: &[PlanStep],
     component_id: &str,
     options: &ReleaseOptions,
     results: &mut Vec<ReleaseStepResult>,
@@ -77,7 +78,8 @@ mod tests {
     use super::{
         build_initial_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
     };
-    use crate::release::types::{ReleaseOptions, ReleasePlanStatus};
+    use crate::plan::PlanStepStatus;
+    use crate::release::types::ReleaseOptions;
     use std::collections::HashSet;
 
     #[test]
@@ -96,7 +98,7 @@ mod tests {
             .steps
             .iter()
             .any(|step| step.id == "preflight.git_identity"
-                && step.status == ReleasePlanStatus::Disabled));
+                && step.status == PlanStepStatus::Disabled));
     }
 
     #[test]

--- a/src/core/release/executor/changelog.rs
+++ b/src/core/release/executor/changelog.rs
@@ -1,12 +1,13 @@
 use crate::component::Component;
 use crate::error::{Error, Result};
-use crate::release::types::{ReleasePlanStep, ReleaseState, ReleaseStepResult};
+use crate::plan::PlanStep;
+use crate::release::types::{ReleaseState, ReleaseStepResult};
 use crate::version;
 
 use super::step_success;
 
 pub(crate) fn run_changelog_finalize(
-    step: &ReleasePlanStep,
+    step: &PlanStep,
     component: &Component,
     state: &mut ReleaseState,
 ) -> Result<ReleaseStepResult> {
@@ -52,7 +53,8 @@ pub(crate) fn run_changelog_finalize(
 mod tests {
     use super::run_changelog_finalize;
     use crate::component::{Component, VersionTarget};
-    use crate::release::types::{ReleasePlanStatus, ReleasePlanStep, ReleaseState};
+    use crate::plan::{PlanStep, PlanStepStatus};
+    use crate::release::types::ReleaseState;
     use crate::release::ReleaseStepStatus;
 
     #[test]
@@ -79,14 +81,14 @@ mod tests {
             }]),
             ..Component::default()
         };
-        let mut step = ReleasePlanStep {
+        let mut step = PlanStep {
             id: "changelog.finalize".to_string(),
             kind: "changelog.finalize".to_string(),
             label: None,
             blocking: true,
             scope: Vec::new(),
             needs: Vec::new(),
-            status: ReleasePlanStatus::Ready,
+            status: PlanStepStatus::Ready,
             inputs: std::collections::HashMap::new(),
             outputs: std::collections::HashMap::new(),
             skip_reason: None,

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -26,8 +26,8 @@ pub use planner::plan;
 pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
-    ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep, ReleaseProjectDeployResult,
-    ReleaseRun, ReleaseRunResult, ReleaseRunSummary, ReleaseStepResult, ReleaseStepStatus,
+    ReleaseOptions, ReleasePlan, ReleaseProjectDeployResult, ReleaseRun, ReleaseRunResult,
+    ReleaseRunSummary, ReleaseStepResult, ReleaseStepStatus,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{run_batch, run_command};

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -1,14 +1,12 @@
 use crate::component::Component;
 use crate::extension::ExtensionManifest;
 use crate::git;
+use crate::plan::{PlanStep, PlanStepStatus};
 use crate::quality::{build_quality_steps as build_shared_quality_steps, QualityPlanOptions};
 use crate::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
 };
-use crate::release::types::{
-    ReleaseChangelogPlan, ReleaseOptions, ReleasePlanStatus, ReleasePlanStep,
-    ReleaseSemverRecommendation,
-};
+use crate::release::types::{ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation};
 use crate::Result;
 
 type StepConfig = std::collections::HashMap<String, serde_json::Value>;
@@ -38,15 +36,15 @@ fn ready_step(
     label: impl Into<String>,
     needs: Vec<String>,
     config: StepConfig,
-) -> ReleasePlanStep {
-    ReleasePlanStep {
+) -> PlanStep {
+    PlanStep {
         id: id.to_string(),
         kind: step_type.to_string(),
         label: Some(label.into()),
         blocking: true,
         scope: Vec::new(),
         needs,
-        status: ReleasePlanStatus::Ready,
+        status: PlanStepStatus::Ready,
         inputs: config,
         outputs: StepConfig::new(),
         skip_reason: None,
@@ -60,15 +58,15 @@ fn disabled_step(
     step_type: &str,
     label: impl Into<String>,
     config: StepConfig,
-) -> ReleasePlanStep {
-    ReleasePlanStep {
+) -> PlanStep {
+    PlanStep {
         id: id.to_string(),
         kind: step_type.to_string(),
         label: Some(label.into()),
         blocking: true,
         scope: Vec::new(),
         needs: Vec::new(),
-        status: ReleasePlanStatus::Disabled,
+        status: PlanStepStatus::Disabled,
         inputs: config,
         outputs: StepConfig::new(),
         skip_reason: None,
@@ -86,7 +84,7 @@ fn string_config(key: &str, value: impl Into<String>) -> StepConfig {
 pub(super) fn build_preflight_steps(
     options: &ReleaseOptions,
     semver_recommendation: Option<&ReleaseSemverRecommendation>,
-) -> Vec<ReleasePlanStep> {
+) -> Vec<PlanStep> {
     let mut steps = vec![
         ready_step(
             "preflight.default_branch",
@@ -153,7 +151,7 @@ pub(super) fn build_preflight_steps(
     steps
 }
 
-fn build_quality_steps(options: &ReleaseOptions) -> Vec<ReleasePlanStep> {
+fn build_quality_steps(options: &ReleaseOptions) -> Vec<PlanStep> {
     build_shared_quality_steps(&QualityPlanOptions::release_preflight(
         "release",
         options.skip_checks,
@@ -163,7 +161,7 @@ fn build_quality_steps(options: &ReleaseOptions) -> Vec<ReleasePlanStep> {
 fn build_bump_policy_step(
     options: &ReleaseOptions,
     semver_recommendation: Option<&ReleaseSemverRecommendation>,
-) -> ReleasePlanStep {
+) -> PlanStep {
     let Some(recommendation) = semver_recommendation else {
         return disabled_step(
             "preflight.bump_policy",
@@ -226,7 +224,7 @@ pub(super) fn build_release_steps(
     monorepo: Option<&git::MonorepoContext>,
     warnings: &mut Vec<String>,
     _hints: &mut Vec<String>,
-) -> Result<Vec<ReleasePlanStep>> {
+) -> Result<Vec<PlanStep>> {
     let mut steps = Vec::new();
     let publish_targets = get_publish_targets(extensions);
 
@@ -404,7 +402,7 @@ fn build_changelog_steps(
     changelog_plan: &ReleaseChangelogPlan,
     current_version: &str,
     new_version: &str,
-) -> Vec<ReleasePlanStep> {
+) -> Vec<PlanStep> {
     let mut policy_config = StepConfig::new();
     policy_config.insert(
         "policy".to_string(),
@@ -498,9 +496,9 @@ fn string_array_config(key: &str, values: &[String]) -> StepConfig {
 mod tests {
     use super::{build_preflight_steps, build_release_steps, github_release_applies};
     use crate::component::Component;
+    use crate::plan::PlanStepStatus;
     use crate::release::types::{
-        ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleasePlanStatus,
-        ReleaseSemverRecommendation,
+        ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation,
     };
 
     #[test]
@@ -527,8 +525,8 @@ mod tests {
                 "preflight.changelog_bootstrap"
             ]
         );
-        assert_eq!(steps[0].status, ReleasePlanStatus::Ready);
-        assert_eq!(steps[1].status, ReleasePlanStatus::Disabled);
+        assert_eq!(steps[0].status, PlanStepStatus::Ready);
+        assert_eq!(steps[1].status, PlanStepStatus::Disabled);
         assert_eq!(steps[2].needs, vec!["preflight.git_identity"]);
     }
 
@@ -546,7 +544,7 @@ mod tests {
             .find(|step| step.id == "preflight.git_identity")
             .expect("git identity step");
 
-        assert_eq!(identity.status, ReleasePlanStatus::Ready);
+        assert_eq!(identity.status, PlanStepStatus::Ready);
         assert_eq!(identity.needs, vec!["preflight.default_branch"]);
         assert_eq!(
             identity
@@ -572,7 +570,7 @@ mod tests {
                 .find(|step| step.id == step_id)
                 .expect("quality step");
 
-            assert_eq!(quality.status, ReleasePlanStatus::Disabled);
+            assert_eq!(quality.status, PlanStepStatus::Disabled);
             assert_eq!(
                 quality
                     .inputs
@@ -608,14 +606,14 @@ mod tests {
             .find(|step| step.id == "preflight.changelog_bootstrap")
             .expect("changelog bootstrap step");
 
-        assert_eq!(audit.status, ReleasePlanStatus::Disabled);
+        assert_eq!(audit.status, PlanStepStatus::Disabled);
         assert_eq!(
             audit.inputs.get("reason").and_then(|value| value.as_str()),
             Some("no-release-audit-policy")
         );
-        assert_eq!(lint.status, ReleasePlanStatus::Ready);
+        assert_eq!(lint.status, PlanStepStatus::Ready);
         assert_eq!(lint.needs, vec!["preflight.bump_policy"]);
-        assert_eq!(test.status, ReleasePlanStatus::Ready);
+        assert_eq!(test.status, PlanStepStatus::Ready);
         assert_eq!(test.needs, vec!["preflight.lint"]);
         assert_eq!(changelog_bootstrap.needs, vec!["preflight.test"]);
     }
@@ -634,7 +632,7 @@ mod tests {
             .find(|step| step.id == "preflight.bump_policy")
             .expect("bump policy step");
 
-        assert_eq!(bump_policy.status, ReleasePlanStatus::Ready);
+        assert_eq!(bump_policy.status, PlanStepStatus::Ready);
         assert_eq!(bump_policy.needs, vec!["preflight.remote_sync"]);
         assert_eq!(
             bump_policy

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -1,6 +1,6 @@
-use super::types::{
-    ReleaseOptions, ReleasePlan, ReleasePlanStatus, ReleasePlanStep, ReleaseSemverRecommendation,
-};
+use crate::plan::{PlanStep, PlanStepStatus};
+
+use super::types::{ReleaseOptions, ReleasePlan, ReleaseSemverRecommendation};
 
 pub(super) fn release_skip_plan(
     component_id: &str,
@@ -40,14 +40,14 @@ fn skipped_release_plan(
     ReleasePlan::new(
         component_id,
         false,
-        vec![ReleasePlanStep {
+        vec![PlanStep {
             id: "release.skip".to_string(),
             kind: "release.skip".to_string(),
             label: Some(label.to_string()),
             blocking: true,
             scope: Vec::new(),
             needs: Vec::new(),
-            status: ReleasePlanStatus::Disabled,
+            status: PlanStepStatus::Disabled,
             inputs: std::collections::HashMap::from([(
                 "reason".to_string(),
                 serde_json::Value::String(reason.to_string()),
@@ -66,8 +66,9 @@ fn skipped_release_plan(
 #[cfg(test)]
 mod tests {
     use super::release_skip_plan;
+    use crate::plan::PlanStepStatus;
     use crate::release::types::{
-        ReleaseBumpPolicyOptions, ReleaseOptions, ReleasePlanStatus, ReleaseSemverRecommendation,
+        ReleaseBumpPolicyOptions, ReleaseOptions, ReleaseSemverRecommendation,
     };
 
     #[test]
@@ -80,7 +81,7 @@ mod tests {
         assert_eq!(plan.steps.len(), 1);
         assert_eq!(plan.steps[0].id, "release.skip");
         assert_eq!(plan.steps[0].kind, "release.skip");
-        assert_eq!(plan.steps[0].status, ReleasePlanStatus::Disabled);
+        assert_eq!(plan.steps[0].status, PlanStepStatus::Disabled);
         assert_eq!(
             plan.steps[0].inputs.get("reason").and_then(|v| v.as_str()),
             Some("no-releasable-commits")

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use crate::is_zero_u32;
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSubject};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanSubject};
 
 /// Ordered release plan shared by dry-run output and release execution.
 ///
@@ -23,7 +23,7 @@ impl ReleasePlan {
     pub fn new(
         component_id: impl Into<String>,
         enabled: bool,
-        steps: Vec<ReleasePlanStep>,
+        steps: Vec<PlanStep>,
         semver_recommendation: Option<ReleaseSemverRecommendation>,
         warnings: Vec<String>,
         hints: Vec<String>,
@@ -187,9 +187,6 @@ pub struct ReleaseState {
     pub artifacts: Vec<ReleaseArtifact>,
     pub changelog_validation: Option<crate::version::ChangelogValidationResult>,
 }
-
-pub type ReleasePlanStep = PlanStep;
-pub type ReleasePlanStatus = PlanStepStatus;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ReleaseOptions {

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -1,11 +1,11 @@
 use crate::error::{Error, Result};
 use crate::git;
+use crate::plan::{PlanStep, PlanStepStatus};
 
 use super::context::load_component;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
-    ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleasePlanStatus,
-    ReleasePlanStep, ReleaseRun,
+    ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleaseRun,
 };
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
@@ -483,12 +483,7 @@ fn recovery_release_plan(
     )
 }
 
-fn recovery_step(
-    id: &str,
-    label: impl Into<String>,
-    needed: bool,
-    needs: Vec<String>,
-) -> ReleasePlanStep {
+fn recovery_step(id: &str, label: impl Into<String>, needed: bool, needs: Vec<String>) -> PlanStep {
     let mut config = std::collections::HashMap::new();
     if !needed {
         config.insert(
@@ -497,7 +492,7 @@ fn recovery_step(
         );
     }
 
-    ReleasePlanStep {
+    PlanStep {
         id: id.to_string(),
         kind: id.to_string(),
         label: Some(label.into()),
@@ -505,9 +500,9 @@ fn recovery_step(
         scope: Vec::new(),
         needs,
         status: if needed {
-            ReleasePlanStatus::Ready
+            PlanStepStatus::Ready
         } else {
-            ReleasePlanStatus::Disabled
+            PlanStepStatus::Disabled
         },
         inputs: config,
         outputs: std::collections::HashMap::new(),
@@ -664,6 +659,7 @@ pub fn run_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plan::{PlanStep, PlanStepStatus};
     use crate::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
     use std::collections::HashMap;
 
@@ -672,14 +668,14 @@ mod tests {
         let plan = ReleasePlan::new(
             "demo",
             true,
-            vec![crate::release::ReleasePlanStep {
+            vec![PlanStep {
                 id: "version".to_string(),
                 kind: "version".to_string(),
                 label: None,
                 blocking: true,
                 scope: Vec::new(),
                 needs: Vec::new(),
-                status: crate::release::ReleasePlanStatus::Ready,
+                status: PlanStepStatus::Ready,
                 inputs: HashMap::from([(
                     "to".to_string(),
                     serde_json::Value::String("1.2.3".to_string()),
@@ -713,20 +709,11 @@ mod tests {
         assert_eq!(plan.hints, actions);
         assert_eq!(plan.steps.len(), 3);
         assert_eq!(plan.steps[0].id, "recover.commit");
-        assert_eq!(
-            plan.steps[0].status,
-            crate::release::ReleasePlanStatus::Ready
-        );
+        assert_eq!(plan.steps[0].status, PlanStepStatus::Ready);
         assert_eq!(plan.steps[1].id, "recover.tag");
-        assert_eq!(
-            plan.steps[1].status,
-            crate::release::ReleasePlanStatus::Ready
-        );
+        assert_eq!(plan.steps[1].status, PlanStepStatus::Ready);
         assert_eq!(plan.steps[2].id, "recover.push");
-        assert_eq!(
-            plan.steps[2].status,
-            crate::release::ReleasePlanStatus::Disabled
-        );
+        assert_eq!(plan.steps[2].status, PlanStepStatus::Disabled);
         assert_eq!(
             plan.steps[2].inputs.get("reason").and_then(|v| v.as_str()),
             Some("already-complete")
@@ -750,7 +737,7 @@ mod tests {
         assert!(plan
             .steps
             .iter()
-            .all(|step| step.status == crate::release::ReleasePlanStatus::Disabled));
+            .all(|step| step.status == PlanStepStatus::Disabled));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove the release-specific `ReleasePlanStep` and `ReleasePlanStatus` aliases now that release uses the shared plan substrate.
- Update release planning, execution, recovery, and changelog code to use `PlanStep` and `PlanStepStatus` directly.
- Preserve the existing `ReleasePlan` compatibility wrapper and release JSON shape while shrinking release-local plan surface area.

## Verification
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test commands::review`
- `cargo test core::quality`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main` (no introduced findings; 2 contextual existing findings in `src/core/release/workflow.rs`)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the mechanical release alias collapse and ran targeted verification; Chris remains responsible for review and validation.