### PR TITLE
Make release plan access explicit

### DIFF
--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -397,6 +397,7 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
                     recursive: None,
                     entries: None,
                     content: None,
+                    size: None,
                     bytes_written: None,
                     stdout: None,
                     stderr: None,

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -90,11 +90,17 @@ mod tests {
         };
 
         let plan = build_initial_preflight_plan("fixture", &options);
-        let ids: Vec<&str> = plan.steps.iter().map(|step| step.id.as_str()).collect();
+        let ids: Vec<&str> = plan
+            .plan
+            .steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect();
 
         assert_eq!(ids, initial_executable_preflight_ids().to_vec());
         assert!(plan.semver_recommendation.is_none());
         assert!(plan
+            .plan
             .steps
             .iter()
             .any(|step| step.id == "preflight.git_identity"

--- a/src/core/release/orchestrator.rs
+++ b/src/core/release/orchestrator.rs
@@ -30,7 +30,7 @@ pub(crate) fn run_with_plan(
 
     let initial_plan = build_initial_preflight_plan(component_id, options);
     let initial_stop = execute_plan_steps(
-        &initial_plan.steps,
+        &initial_plan.plan.steps,
         component_id,
         options,
         &mut results,
@@ -50,7 +50,7 @@ pub(crate) fn run_with_plan(
         initial_executable_preflight_ids().iter().copied().collect();
 
     execute_plan_steps(
-        &release_plan.steps,
+        &release_plan.plan.steps,
         component_id,
         options,
         &mut results,

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -78,16 +78,19 @@ mod tests {
 
         assert!(!plan.enabled);
         assert_eq!(plan.component_id, "demo");
-        assert_eq!(plan.steps.len(), 1);
-        assert_eq!(plan.steps[0].id, "release.skip");
-        assert_eq!(plan.steps[0].kind, "release.skip");
-        assert_eq!(plan.steps[0].status, PlanStepStatus::Disabled);
+        assert_eq!(plan.plan.steps.len(), 1);
+        assert_eq!(plan.plan.steps[0].id, "release.skip");
+        assert_eq!(plan.plan.steps[0].kind, "release.skip");
+        assert_eq!(plan.plan.steps[0].status, PlanStepStatus::Disabled);
         assert_eq!(
-            plan.steps[0].inputs.get("reason").and_then(|v| v.as_str()),
+            plan.plan.steps[0]
+                .inputs
+                .get("reason")
+                .and_then(|v| v.as_str()),
             Some("no-releasable-commits")
         );
         assert_eq!(
-            plan.hints,
+            plan.plan.hints,
             vec!["Use --bump to force a release when this is intentional"]
         );
     }
@@ -122,11 +125,14 @@ mod tests {
         assert!(!plan.enabled);
         assert!(plan.semver_recommendation.is_some());
         assert_eq!(
-            plan.steps[0].inputs.get("reason").and_then(|v| v.as_str()),
+            plan.plan.steps[0]
+                .inputs
+                .get("reason")
+                .and_then(|v| v.as_str()),
             Some("major-requires-flag")
         );
         assert_eq!(
-            plan.hints,
+            plan.plan.hints,
             vec!["Re-run with: homeboy release demo --bump major"]
         );
     }

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
 use crate::is_zero_u32;
 use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanSubject};
@@ -50,20 +49,6 @@ impl ReleasePlan {
             enabled,
             semver_recommendation,
         }
-    }
-}
-
-impl Deref for ReleasePlan {
-    type Target = HomeboyPlan;
-
-    fn deref(&self) -> &Self::Target {
-        &self.plan
-    }
-}
-
-impl DerefMut for ReleasePlan {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.plan
     }
 }
 

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -241,7 +241,8 @@ fn format_tag(version: &str, monorepo: Option<&git::MonorepoContext>) -> String 
 }
 
 fn extract_new_version_from_plan(plan: &ReleasePlan) -> Option<String> {
-    plan.steps
+    plan.plan
+        .steps
         .iter()
         .find(|s| s.kind == "version")
         .and_then(|s| s.inputs.get("to"))
@@ -254,7 +255,8 @@ fn skipped_reason_from_plan(plan: &ReleasePlan) -> Option<String> {
         return None;
     }
 
-    plan.steps
+    plan.plan
+        .steps
         .iter()
         .find(|step| step.id == "release.skip")
         .and_then(|step| step.inputs.get("reason"))
@@ -706,24 +708,33 @@ mod tests {
 
         assert!(plan.enabled);
         assert_eq!(plan.component_id, "demo");
-        assert_eq!(plan.hints, actions);
-        assert_eq!(plan.steps.len(), 3);
-        assert_eq!(plan.steps[0].id, "recover.commit");
-        assert_eq!(plan.steps[0].status, PlanStepStatus::Ready);
-        assert_eq!(plan.steps[1].id, "recover.tag");
-        assert_eq!(plan.steps[1].status, PlanStepStatus::Ready);
-        assert_eq!(plan.steps[2].id, "recover.push");
-        assert_eq!(plan.steps[2].status, PlanStepStatus::Disabled);
+        assert_eq!(plan.plan.hints, actions);
+        assert_eq!(plan.plan.steps.len(), 3);
+        assert_eq!(plan.plan.steps[0].id, "recover.commit");
+        assert_eq!(plan.plan.steps[0].status, PlanStepStatus::Ready);
+        assert_eq!(plan.plan.steps[1].id, "recover.tag");
+        assert_eq!(plan.plan.steps[1].status, PlanStepStatus::Ready);
+        assert_eq!(plan.plan.steps[2].id, "recover.push");
+        assert_eq!(plan.plan.steps[2].status, PlanStepStatus::Disabled);
         assert_eq!(
-            plan.steps[2].inputs.get("reason").and_then(|v| v.as_str()),
+            plan.plan.steps[2]
+                .inputs
+                .get("reason")
+                .and_then(|v| v.as_str()),
             Some("already-complete")
         );
         assert_eq!(
-            plan.steps[0].inputs.get("version").and_then(|v| v.as_str()),
+            plan.plan.steps[0]
+                .inputs
+                .get("version")
+                .and_then(|v| v.as_str()),
             Some("1.2.3")
         );
         assert_eq!(
-            plan.steps[0].inputs.get("tag").and_then(|v| v.as_str()),
+            plan.plan.steps[0]
+                .inputs
+                .get("tag")
+                .and_then(|v| v.as_str()),
             Some("v1.2.3")
         );
     }
@@ -733,8 +744,9 @@ mod tests {
         let plan = recovery_release_plan("demo", "1.2.3", "v1.2.3", false, false, false, &[]);
 
         assert!(!plan.enabled);
-        assert!(plan.hints.is_empty());
+        assert!(plan.plan.hints.is_empty());
         assert!(plan
+            .plan
             .steps
             .iter()
             .all(|step| step.status == PlanStepStatus::Disabled));


### PR DESCRIPTION
## Summary
- Remove `Deref` / `DerefMut` from `ReleasePlan` so access to the embedded generic `HomeboyPlan` is explicit.
- Update release orchestration, recovery, and planning-policy tests to use `release_plan.plan.steps` / `release_plan.plan.hints` where they consume generic plan fields.
- Add the missing `size: None` field to `file mkdir` output so the current base compiles after the `FileOutput` shape change.

## Verification
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test commands::review`
- `cargo test core::quality`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main` (no introduced findings; 2 contextual existing findings in `src/core/release/workflow.rs`)
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the explicit release-plan access refactor, fixed the compile blocker found during verification, and ran targeted checks; Chris remains responsible for review and validation.