### PR TITLE
Centralize component plan construction

### DIFF
--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -33,6 +33,28 @@ pub struct HomeboyPlan {
     pub hints: Vec<String>,
 }
 
+impl HomeboyPlan {
+    pub fn for_component(kind: PlanKind, component_id: impl Into<String>) -> Self {
+        let component_id = component_id.into();
+        Self {
+            id: format!("{}.{component_id}", kind.slug()),
+            kind,
+            subject: PlanSubject {
+                component_id: Some(component_id),
+                ..PlanSubject::default()
+            },
+            mode: None,
+            inputs: HashMap::new(),
+            policy: HashMap::new(),
+            steps: Vec::new(),
+            artifacts: Vec::new(),
+            summary: None,
+            warnings: Vec::new(),
+            hints: Vec::new(),
+        }
+    }
+}
+
 /// High-level plan family. `Custom` gives extensions and future command
 /// families a stable escape hatch without changing the schema shape.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -47,6 +69,22 @@ pub enum PlanKind {
     Refactor,
     Review,
     Custom,
+}
+
+impl PlanKind {
+    fn slug(&self) -> &'static str {
+        match self {
+            Self::Quality => "quality",
+            Self::Build => "build",
+            Self::Release => "release",
+            Self::Deploy => "deploy",
+            Self::PullRequest => "pull_request",
+            Self::Ci => "ci",
+            Self::Refactor => "refactor",
+            Self::Review => "review",
+            Self::Custom => "custom",
+        }
+    }
 }
 
 /// The thing a plan is about: a component, a file/symbol scope, or a prose
@@ -127,8 +165,7 @@ fn default_blocking() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSubject};
-    use std::collections::HashMap;
+    use super::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 
     #[test]
     fn serializes_plan_kind_as_snake_case() {
@@ -139,22 +176,7 @@ mod tests {
 
     #[test]
     fn serializes_minimal_component_plan() {
-        let plan = HomeboyPlan {
-            id: "release.homeboy".to_string(),
-            kind: PlanKind::Release,
-            subject: PlanSubject {
-                component_id: Some("homeboy".to_string()),
-                ..PlanSubject::default()
-            },
-            mode: None,
-            inputs: HashMap::new(),
-            policy: HashMap::new(),
-            steps: Vec::new(),
-            artifacts: Vec::new(),
-            summary: None,
-            warnings: Vec::new(),
-            hints: Vec::new(),
-        };
+        let plan = HomeboyPlan::for_component(PlanKind::Release, "homeboy");
 
         let serialized = serde_json::to_value(&plan).expect("serialize plan");
 
@@ -168,6 +190,18 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn test_for_component() {
+        let plan = HomeboyPlan::for_component(PlanKind::Quality, "fixture");
+
+        assert_eq!(plan.id, "quality.fixture");
+        assert_eq!(plan.kind, PlanKind::Quality);
+        assert_eq!(plan.subject.component_id.as_deref(), Some("fixture"));
+        assert!(plan.steps.is_empty());
+        assert!(plan.warnings.is_empty());
+        assert!(plan.hints.is_empty());
     }
 
     #[test]

--- a/src/core/quality.rs
+++ b/src/core/quality.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSubject};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QualityPlanOptions {
@@ -61,24 +61,10 @@ impl QualityPlanOptions {
 
 pub fn build_quality_plan(options: QualityPlanOptions) -> HomeboyPlan {
     let steps = build_quality_steps(&options);
-    let component_id = options.component_id;
-
-    HomeboyPlan {
-        id: format!("quality.{component_id}"),
-        kind: PlanKind::Quality,
-        subject: PlanSubject {
-            component_id: Some(component_id),
-            ..PlanSubject::default()
-        },
-        mode: options.mode,
-        inputs: HashMap::new(),
-        policy: HashMap::new(),
-        steps,
-        artifacts: Vec::new(),
-        summary: None,
-        warnings: Vec::new(),
-        hints: Vec::new(),
-    }
+    let mut plan = HomeboyPlan::for_component(PlanKind::Quality, options.component_id);
+    plan.mode = options.mode;
+    plan.steps = steps;
+    plan
 }
 
 pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::is_zero_u32;
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanSubject};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 /// Ordered release plan shared by dry-run output and release execution.
 ///
@@ -28,23 +28,13 @@ impl ReleasePlan {
         hints: Vec<String>,
     ) -> Self {
         let component_id = component_id.into();
+        let mut plan = HomeboyPlan::for_component(PlanKind::Release, component_id.clone());
+        plan.steps = steps;
+        plan.warnings = warnings;
+        plan.hints = hints;
+
         Self {
-            plan: HomeboyPlan {
-                id: format!("release.{component_id}"),
-                kind: PlanKind::Release,
-                subject: PlanSubject {
-                    component_id: Some(component_id.clone()),
-                    ..PlanSubject::default()
-                },
-                mode: None,
-                inputs: HashMap::new(),
-                policy: HashMap::new(),
-                steps,
-                artifacts: Vec::new(),
-                summary: None,
-                warnings: warnings.clone(),
-                hints: hints.clone(),
-            },
+            plan,
             component_id,
             enabled,
             semver_recommendation,


### PR DESCRIPTION
## Summary
- Add `HomeboyPlan::for_component()` so component-scoped plans are initialized from one generic substrate helper.
- Move release and quality plan builders onto the shared constructor instead of hand-building `HomeboyPlan` literals.
- Preserve existing release and quality output shapes while reducing duplicated plan initialization.

## Verification
- `cargo fmt --check`
- `cargo test core::plan`
- `cargo test core::quality`
- `cargo test core::release`
- `cargo test commands::review`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared component-plan constructor, migrated release and quality builders, and ran targeted verification; Chris remains responsible for review and validation.