### PR TITLE
Derive release plan metadata from generic plan

### DIFF
--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -98,7 +98,7 @@ mod tests {
             .collect();
 
         assert_eq!(ids, initial_executable_preflight_ids().to_vec());
-        assert!(plan.semver_recommendation.is_none());
+        assert!(plan.semver_recommendation().is_none());
         assert!(plan
             .plan
             .steps

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -76,8 +76,8 @@ mod tests {
         let plan = release_skip_plan("demo", &ReleaseOptions::default(), None)
             .expect("no releasable commits should skip");
 
-        assert!(!plan.enabled);
-        assert_eq!(plan.component_id, "demo");
+        assert!(!plan.enabled());
+        assert_eq!(plan.component_id(), Some("demo"));
         assert_eq!(plan.plan.steps.len(), 1);
         assert_eq!(plan.plan.steps[0].id, "release.skip");
         assert_eq!(plan.plan.steps[0].kind, "release.skip");
@@ -122,8 +122,8 @@ mod tests {
         let plan = release_skip_plan("demo", &options, Some(recommendation))
             .expect("implicit major should skip");
 
-        assert!(!plan.enabled);
-        assert!(plan.semver_recommendation.is_some());
+        assert!(!plan.enabled());
+        assert!(plan.semver_recommendation().is_some());
         assert_eq!(
             plan.plan.steps[0]
                 .inputs

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::ser::Error as SerializeError;
+use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 
 use crate::is_zero_u32;
@@ -8,14 +9,11 @@ use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
 ///
 /// `ReleasePlan` is rendered in `--dry-run` and `--json` output, then walked by
 /// `pipeline::run()` for real releases so the previewed steps match execution.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ReleasePlan {
-    #[serde(flatten)]
     pub plan: HomeboyPlan,
-    pub component_id: String,
-    pub enabled: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub semver_recommendation: Option<ReleaseSemverRecommendation>,
+    enabled: bool,
+    semver_recommendation: Option<ReleaseSemverRecommendation>,
 }
 
 impl ReleasePlan {
@@ -35,10 +33,49 @@ impl ReleasePlan {
 
         Self {
             plan,
-            component_id,
             enabled,
             semver_recommendation,
         }
+    }
+
+    pub fn component_id(&self) -> Option<&str> {
+        self.plan.subject.component_id.as_deref()
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn semver_recommendation(&self) -> Option<&ReleaseSemverRecommendation> {
+        self.semver_recommendation.as_ref()
+    }
+}
+
+impl Serialize for ReleasePlan {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = serde_json::to_value(&self.plan).map_err(S::Error::custom)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| S::Error::custom("release plan did not serialize to a JSON object"))?;
+
+        if let Some(component_id) = self.component_id() {
+            object.insert(
+                "component_id".to_string(),
+                serde_json::Value::String(component_id.to_string()),
+            );
+        }
+        object.insert("enabled".to_string(), serde_json::Value::Bool(self.enabled));
+        if let Some(semver_recommendation) = self.semver_recommendation.as_ref() {
+            object.insert(
+                "semver_recommendation".to_string(),
+                serde_json::to_value(semver_recommendation).map_err(S::Error::custom)?,
+            );
+        }
+
+        value.serialize(serializer)
     }
 }
 
@@ -319,6 +356,63 @@ pub struct BatchReleaseSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_component_id() {
+        let plan = ReleasePlan::new("demo", true, Vec::new(), None, Vec::new(), Vec::new());
+
+        assert_eq!(plan.component_id(), Some("demo"));
+    }
+
+    #[test]
+    fn test_enabled() {
+        let enabled = ReleasePlan::new("demo", true, Vec::new(), None, Vec::new(), Vec::new());
+        let disabled = ReleasePlan::new("demo", false, Vec::new(), None, Vec::new(), Vec::new());
+
+        assert!(enabled.enabled());
+        assert!(!disabled.enabled());
+    }
+
+    #[test]
+    fn test_semver_recommendation() {
+        let recommendation = ReleaseSemverRecommendation {
+            latest_tag: Some("v1.0.0".to_string()),
+            range: "v1.0.0..HEAD".to_string(),
+            commits: Vec::new(),
+            recommended_bump: Some("minor".to_string()),
+            requested_bump: "minor".to_string(),
+            is_underbump: false,
+            reasons: Vec::new(),
+        };
+        let plan = ReleasePlan::new(
+            "demo",
+            true,
+            Vec::new(),
+            Some(recommendation),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert_eq!(
+            plan.semver_recommendation()
+                .and_then(|recommendation| recommendation.recommended_bump.as_deref()),
+            Some("minor")
+        );
+    }
+
+    #[test]
+    fn release_plan_serializes_legacy_component_fields_from_generic_plan() {
+        let plan = ReleasePlan::new("demo", true, Vec::new(), None, Vec::new(), Vec::new());
+
+        let serialized = serde_json::to_value(&plan).expect("serialize release plan");
+
+        assert_eq!(serialized["id"], "release.demo");
+        assert_eq!(serialized["kind"], "release");
+        assert_eq!(serialized["subject"]["component_id"], "demo");
+        assert_eq!(serialized["component_id"], "demo");
+        assert_eq!(serialized["enabled"], true);
+        assert!(serialized.get("semver_recommendation").is_none());
+    }
 
     #[test]
     fn release_command_input_defaults_do_not_force_lower_bumps() {

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -251,7 +251,7 @@ fn extract_new_version_from_plan(plan: &ReleasePlan) -> Option<String> {
 }
 
 fn skipped_reason_from_plan(plan: &ReleasePlan) -> Option<String> {
-    if plan.enabled {
+    if plan.enabled() {
         return None;
     }
 
@@ -706,8 +706,8 @@ mod tests {
         ];
         let plan = recovery_release_plan("demo", "1.2.3", "v1.2.3", true, true, false, &actions);
 
-        assert!(plan.enabled);
-        assert_eq!(plan.component_id, "demo");
+        assert!(plan.enabled());
+        assert_eq!(plan.component_id(), Some("demo"));
         assert_eq!(plan.plan.hints, actions);
         assert_eq!(plan.plan.steps.len(), 3);
         assert_eq!(plan.plan.steps[0].id, "recover.commit");
@@ -743,7 +743,7 @@ mod tests {
     fn recovery_release_plan_is_disabled_when_nothing_needed() {
         let plan = recovery_release_plan("demo", "1.2.3", "v1.2.3", false, false, false, &[]);
 
-        assert!(!plan.enabled);
+        assert!(!plan.enabled());
         assert!(plan.plan.hints.is_empty());
         assert!(plan
             .plan


### PR DESCRIPTION
## Summary
- Remove duplicated release plan `component_id` storage by deriving it from the embedded generic `HomeboyPlan` subject.
- Keep release-only metadata private behind accessors while preserving the existing top-level JSON fields through custom serialization.
- Add regression coverage for accessor behavior and legacy release-plan JSON shape.

## Verification
- `cargo fmt --check`
- `cargo test core::release`
- `cargo test core::plan`
- `cargo test core::quality`
- `cargo test commands::review`
- `cargo test --test core_agnostic_test`
- `homeboy audit --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the release plan refactor, tests, verification, and PR description for Chris to review.