### PR TITLE
Move workflow plans onto generic plan substrate

### DIFF
--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -127,7 +127,7 @@ pub struct ReconcileOutput {
     pub command: String,
     pub applied: bool,
     /// Always populated — same shape regardless of dry-run vs apply.
-    pub plan_summary: PlanSummary,
+    pub plan_summary: ReconcileOutputSummary,
     /// Only populated when `applied = true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<ReconcileResult>,
@@ -136,7 +136,7 @@ pub struct ReconcileOutput {
 }
 
 #[derive(Serialize, Default)]
-pub struct PlanSummary {
+pub struct ReconcileOutputSummary {
     pub total_actions: usize,
     pub file_new: usize,
     pub update: usize,
@@ -484,9 +484,9 @@ fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
         .collect()
 }
 
-fn summarize_plan(plan: &ReconcilePlan) -> PlanSummary {
+fn summarize_plan(plan: &ReconcilePlan) -> ReconcileOutputSummary {
     let counts = plan.counts();
-    PlanSummary {
+    ReconcileOutputSummary {
         total_actions: plan.actions.len(),
         file_new: counts.file_new,
         update: counts.update,

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -1,4 +1,5 @@
 use crate::component::{self, Component, DependencyStackEdge};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 use crate::{Error, Result};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -21,8 +22,10 @@ pub struct DependencyStackEdgeStatus {
     pub test: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct DependencyStackPlan {
+    #[serde(flatten)]
+    pub plan: HomeboyPlan,
     pub upstream: String,
     pub step_count: usize,
     pub steps: Vec<DependencyStackPlanStep>,
@@ -199,11 +202,75 @@ pub fn stack_plan_from_components(
         }
     }
 
-    Ok(DependencyStackPlan {
-        upstream: upstream.to_string(),
-        step_count: steps.len(),
-        steps,
-    })
+    Ok(DependencyStackPlan::new(upstream, steps))
+}
+
+impl DependencyStackPlan {
+    pub fn new(upstream: impl Into<String>, steps: Vec<DependencyStackPlanStep>) -> Self {
+        let upstream = upstream.into();
+        let mut plan = HomeboyPlan::for_component(PlanKind::DependencyStack, upstream.clone());
+        plan.steps = steps.iter().map(stack_step).collect();
+        plan.summary = Some(PlanSummary {
+            total_steps: plan.steps.len(),
+            ready: plan.steps.len(),
+            blocked: 0,
+            skipped: 0,
+            next_actions: Vec::new(),
+        });
+
+        Self {
+            plan,
+            upstream,
+            step_count: steps.len(),
+            steps,
+        }
+    }
+}
+
+fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
+    let mut inputs = std::collections::HashMap::new();
+    inputs.insert(
+        "declaring_component_id".to_string(),
+        serde_json::Value::String(step.declaring_component_id.clone()),
+    );
+    inputs.insert(
+        "upstream".to_string(),
+        serde_json::Value::String(step.upstream.clone()),
+    );
+    inputs.insert(
+        "downstream".to_string(),
+        serde_json::Value::String(step.downstream.clone()),
+    );
+    inputs.insert(
+        "downstream_path".to_string(),
+        serde_json::Value::String(step.downstream_path.clone()),
+    );
+    inputs.insert(
+        "package".to_string(),
+        serde_json::Value::String(step.package.clone()),
+    );
+    inputs.insert(
+        "update_command".to_string(),
+        serde_json::Value::String(step.update_command.clone()),
+    );
+
+    PlanStep {
+        id: format!("deps.stack.{:03}.{}", step.sequence, step.downstream),
+        kind: "deps.stack.update_downstream".to_string(),
+        label: Some(format!(
+            "Update {} in {} from {}",
+            step.package, step.downstream, step.upstream
+        )),
+        blocking: true,
+        scope: vec![step.downstream.clone()],
+        needs: Vec::new(),
+        status: PlanStepStatus::Ready,
+        inputs,
+        outputs: std::collections::HashMap::new(),
+        skip_reason: None,
+        policy: std::collections::HashMap::new(),
+        missing: Vec::new(),
+    }
 }
 
 fn edge_status(component: &Component, edge: &DependencyStackEdge) -> DependencyStackEdgeStatus {

--- a/src/core/issues/apply.rs
+++ b/src/core/issues/apply.rs
@@ -258,9 +258,7 @@ mod tests {
 
     #[test]
     fn applies_file_new_via_tracker() {
-        let plan = ReconcilePlan {
-            actions: vec![file_new("x")],
-        };
+        let plan = ReconcilePlan::new("c", vec![file_new("x")]);
         let tracker = MockTracker::new();
         let result = apply_plan(plan, &tracker).unwrap();
 
@@ -275,8 +273,9 @@ mod tests {
 
     #[test]
     fn applies_update_close_dedupe_in_order() {
-        let plan = ReconcilePlan {
-            actions: vec![
+        let plan = ReconcilePlan::new(
+            "c",
+            vec![
                 ReconcileAction::Update {
                     number: 100,
                     title: "audit: x in c (3)".into(),
@@ -296,7 +295,7 @@ mod tests {
                     comment: "dupe of #100".into(),
                 },
             ],
-        };
+        );
         let tracker = MockTracker::new();
         let result = apply_plan(plan, &tracker).unwrap();
 
@@ -325,8 +324,9 @@ mod tests {
 
     #[test]
     fn skip_actions_make_no_tracker_calls() {
-        let plan = ReconcilePlan {
-            actions: vec![
+        let plan = ReconcilePlan::new(
+            "c",
+            vec![
                 ReconcileAction::Skip {
                     category: "x".into(),
                     component_id: "c".into(),
@@ -338,7 +338,7 @@ mod tests {
                     reason: ReconcileSkipReason::ClosedNotPlannedNoRefresh,
                 },
             ],
-        };
+        );
         let tracker = MockTracker::new();
         let result = apply_plan(plan, &tracker).unwrap();
 
@@ -356,8 +356,9 @@ mod tests {
 
     #[test]
     fn failed_actions_recorded_but_run_continues() {
-        let plan = ReconcilePlan {
-            actions: vec![
+        let plan = ReconcilePlan::new(
+            "c",
+            vec![
                 file_new("a"),
                 ReconcileAction::Close {
                     number: 1,
@@ -366,7 +367,7 @@ mod tests {
                 },
                 file_new("c"),
             ],
-        };
+        );
         let mut tracker = MockTracker::new();
         tracker.fail_close = true;
 
@@ -393,14 +394,15 @@ mod tests {
         // UpdateClosed should refresh body only — the title carrying
         // an outdated count is fine because the issue is closed and the
         // body holds the latest count + run link.
-        let plan = ReconcilePlan {
-            actions: vec![ReconcileAction::UpdateClosed {
+        let plan = ReconcilePlan::new(
+            "c",
+            vec![ReconcileAction::UpdateClosed {
                 number: 50,
                 body: "fresh".into(),
                 category: "x".into(),
                 count: 99,
             }],
-        };
+        );
         let tracker = MockTracker::new();
         apply_plan(plan, &tracker).unwrap();
         assert_eq!(tracker.calls.borrow()[0], "update:#50:-");

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -7,6 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::code_audit::FindingConfidence;
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 
 /// One row of incoming findings: "command produced N findings of category X
 /// for component Y." This is the input grain reconcile reasons over.
@@ -169,12 +170,41 @@ pub enum ReconcileSkipReason {
 }
 
 /// The full reconciliation plan: every action, in execution order.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ReconcilePlan {
+    #[serde(flatten)]
+    pub plan: HomeboyPlan,
     pub actions: Vec<ReconcileAction>,
 }
 
 impl ReconcilePlan {
+    pub fn new(component_id: impl Into<String>, actions: Vec<ReconcileAction>) -> Self {
+        let component_id = component_id.into();
+        let mut plan = HomeboyPlan::for_component(PlanKind::IssueReconcile, component_id);
+        plan.steps = actions.iter().enumerate().map(action_step).collect();
+        plan.summary = Some(PlanSummary {
+            total_steps: plan.steps.len(),
+            ready: plan
+                .steps
+                .iter()
+                .filter(|step| step.status == PlanStepStatus::Ready)
+                .count(),
+            blocked: plan
+                .steps
+                .iter()
+                .filter(|step| step.status == PlanStepStatus::Missing)
+                .count(),
+            skipped: plan
+                .steps
+                .iter()
+                .filter(|step| step.status == PlanStepStatus::Skipped)
+                .count(),
+            next_actions: Vec::new(),
+        });
+
+        Self { plan, actions }
+    }
+
     /// Count actions by variant (file_new, update, etc.). Used by the CLI
     /// to render a one-line summary.
     pub fn counts(&self) -> ReconcilePlanCounts {
@@ -196,6 +226,86 @@ impl ReconcilePlan {
         self.actions
             .iter()
             .all(|a| matches!(a, ReconcileAction::Skip { .. }))
+    }
+}
+
+fn action_step((index, action): (usize, &ReconcileAction)) -> PlanStep {
+    let action_kind = action_kind(action);
+    let mut inputs = std::collections::HashMap::new();
+    inputs.insert(
+        "action".to_string(),
+        serde_json::to_value(action).unwrap_or(serde_json::Value::Null),
+    );
+
+    PlanStep {
+        id: format!("issues.reconcile.{:03}.{}", index + 1, action_kind),
+        kind: format!("issues.reconcile.{action_kind}"),
+        label: Some(action_label(action)),
+        blocking: !matches!(action, ReconcileAction::Skip { .. }),
+        scope: Vec::new(),
+        needs: Vec::new(),
+        status: if matches!(action, ReconcileAction::Skip { .. }) {
+            PlanStepStatus::Skipped
+        } else {
+            PlanStepStatus::Ready
+        },
+        inputs,
+        outputs: std::collections::HashMap::new(),
+        skip_reason: match action {
+            ReconcileAction::Skip { reason, .. } => Some(format!("{:?}", reason)),
+            _ => None,
+        },
+        policy: std::collections::HashMap::new(),
+        missing: Vec::new(),
+    }
+}
+
+fn action_kind(action: &ReconcileAction) -> &'static str {
+    match action {
+        ReconcileAction::FileNew { .. } => "file_new",
+        ReconcileAction::Update { .. } => "update",
+        ReconcileAction::UpdateClosed { .. } => "update_closed",
+        ReconcileAction::Close { .. } => "close",
+        ReconcileAction::CloseDuplicate { .. } => "close_duplicate",
+        ReconcileAction::Skip { .. } => "skip",
+    }
+}
+
+fn action_label(action: &ReconcileAction) -> String {
+    match action {
+        ReconcileAction::FileNew {
+            command,
+            component_id,
+            category,
+            count,
+            ..
+        } => format!("File new {command} issue for {category} in {component_id} ({count})"),
+        ReconcileAction::Update {
+            number,
+            category,
+            count,
+            ..
+        } => format!("Update {category} issue #{number} ({count})"),
+        ReconcileAction::UpdateClosed {
+            number,
+            category,
+            count,
+            ..
+        } => format!("Refresh closed {category} issue #{number} ({count})"),
+        ReconcileAction::Close {
+            number, category, ..
+        } => {
+            format!("Close resolved {category} issue #{number}")
+        }
+        ReconcileAction::CloseDuplicate {
+            number,
+            keep,
+            category,
+            ..
+        } => format!("Close duplicate {category} issue #{number}, keeping #{keep}"),
+        ReconcileAction::Skip {
+            category, reason, ..
+        } => format!("Skip {category} ({:?})", reason),
     }
 }
 

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -230,7 +230,19 @@ fn reconcile_with_scope(
         );
     }
 
-    ReconcilePlan { actions }
+    let component_id = scope
+        .map(|(_, component_id)| component_id.to_string())
+        .or_else(|| groups.first().map(|group| group.component_id.clone()))
+        .or_else(|| {
+            existing.iter().find_map(|issue| {
+                parse_issue_key(&issue.body)
+                    .or_else(|| parse_category_key(&issue.title))
+                    .map(|(_, component_id, _)| component_id)
+            })
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    ReconcilePlan::new(component_id, actions)
 }
 
 fn close_absent_open_issues(
@@ -1086,8 +1098,9 @@ mod tests {
 
     #[test]
     fn plan_counts_aggregate_correctly() {
-        let plan = ReconcilePlan {
-            actions: vec![
+        let plan = ReconcilePlan::new(
+            "c",
+            vec![
                 ReconcileAction::FileNew {
                     command: "a".into(),
                     component_id: "c".into(),
@@ -1117,7 +1130,7 @@ mod tests {
                     reason: ReconcileSkipReason::NoFindingsNoIssue,
                 },
             ],
-        };
+        );
         let c = plan.counts();
         assert_eq!(c.file_new, 1);
         assert_eq!(c.update, 2);

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -53,6 +53,32 @@ impl HomeboyPlan {
             hints: Vec::new(),
         }
     }
+
+    pub fn for_description(kind: PlanKind, description: impl Into<String>) -> Self {
+        let description = description.into();
+        Self {
+            id: format!("{}.{}", kind.slug(), slug_fragment(&description)),
+            kind,
+            subject: PlanSubject {
+                description: Some(description),
+                ..PlanSubject::default()
+            },
+            mode: None,
+            inputs: HashMap::new(),
+            policy: HashMap::new(),
+            steps: Vec::new(),
+            artifacts: Vec::new(),
+            summary: None,
+            warnings: Vec::new(),
+            hints: Vec::new(),
+        }
+    }
+}
+
+impl Default for HomeboyPlan {
+    fn default() -> Self {
+        Self::for_description(PlanKind::Custom, "unspecified")
+    }
 }
 
 /// High-level plan family. `Custom` gives extensions and future command
@@ -64,9 +90,13 @@ pub enum PlanKind {
     Build,
     Release,
     Deploy,
+    DependencyStack,
+    IssueReconcile,
     PullRequest,
     Ci,
     Refactor,
+    StackSync,
+    Trace,
     Review,
     Custom,
 }
@@ -78,9 +108,13 @@ impl PlanKind {
             Self::Build => "build",
             Self::Release => "release",
             Self::Deploy => "deploy",
+            Self::DependencyStack => "dependency_stack",
+            Self::IssueReconcile => "issue_reconcile",
             Self::PullRequest => "pull_request",
             Self::Ci => "ci",
             Self::Refactor => "refactor",
+            Self::StackSync => "stack_sync",
+            Self::Trace => "trace",
             Self::Review => "review",
             Self::Custom => "custom",
         }
@@ -163,6 +197,29 @@ fn default_blocking() -> bool {
     true
 }
 
+fn slug_fragment(value: &str) -> String {
+    let slug = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+
+    if slug.is_empty() {
+        "unspecified".to_string()
+    } else {
+        slug
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
@@ -202,6 +259,16 @@ mod tests {
         assert!(plan.steps.is_empty());
         assert!(plan.warnings.is_empty());
         assert!(plan.hints.is_empty());
+    }
+
+    #[test]
+    fn test_for_description() {
+        let plan = HomeboyPlan::for_description(PlanKind::Trace, "Variant A/B");
+
+        assert_eq!(plan.id, "trace.variant-a-b");
+        assert_eq!(plan.kind, PlanKind::Trace);
+        assert_eq!(plan.subject.description.as_deref(), Some("Variant A/B"));
+        assert!(plan.steps.is_empty());
     }
 
     #[test]

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -4,12 +4,15 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::extension::{self, grammar, grammar_items, ParsedItem};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 use crate::Result;
 
 use super::move_items::{MoveOptions, MoveResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DecomposePlan {
+    #[serde(flatten, default)]
+    pub plan: HomeboyPlan,
     pub file: String,
     pub strategy: String,
     pub total_items: usize,
@@ -80,6 +83,7 @@ pub fn build_plan(file: &str, root: &Path, strategy: &str) -> Result<DecomposePl
     ];
 
     Ok(DecomposePlan {
+        plan: decompose_homeboy_plan(file, strategy, items.len(), &groups, &warnings),
         file: file.to_string(),
         strategy: strategy.to_string(),
         total_items: items.len(),
@@ -88,6 +92,74 @@ pub fn build_plan(file: &str, root: &Path, strategy: &str) -> Result<DecomposePl
         checklist,
         warnings,
     })
+}
+
+fn decompose_homeboy_plan(
+    file: &str,
+    strategy: &str,
+    total_items: usize,
+    groups: &[DecomposeGroup],
+    warnings: &[String],
+) -> HomeboyPlan {
+    let mut plan = HomeboyPlan::for_description(PlanKind::Refactor, file.to_string());
+    plan.mode = Some("decompose".to_string());
+    plan.inputs.insert(
+        "file".to_string(),
+        serde_json::Value::String(file.to_string()),
+    );
+    plan.inputs.insert(
+        "strategy".to_string(),
+        serde_json::Value::String(strategy.to_string()),
+    );
+    plan.inputs.insert(
+        "total_items".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(total_items)),
+    );
+    plan.steps = groups.iter().map(decompose_group_step).collect();
+    plan.summary = Some(PlanSummary {
+        total_steps: plan.steps.len(),
+        ready: plan.steps.len(),
+        blocked: 0,
+        skipped: 0,
+        next_actions: Vec::new(),
+    });
+    plan.warnings = warnings.to_vec();
+    plan
+}
+
+fn decompose_group_step(group: &DecomposeGroup) -> PlanStep {
+    let mut inputs = std::collections::HashMap::new();
+    inputs.insert(
+        "group".to_string(),
+        serde_json::Value::String(group.name.clone()),
+    );
+    inputs.insert(
+        "suggested_target".to_string(),
+        serde_json::Value::String(group.suggested_target.clone()),
+    );
+    inputs.insert(
+        "item_names".to_string(),
+        serde_json::to_value(&group.item_names).unwrap_or(serde_json::Value::Null),
+    );
+
+    PlanStep {
+        id: format!("refactor.decompose.{}", group.name),
+        kind: "refactor.decompose.extract_group".to_string(),
+        label: Some(format!(
+            "Extract {} item(s) to {}",
+            group.item_names.len(),
+            group.suggested_target
+        )),
+        blocking: true,
+        scope: group.item_names.clone(),
+        needs: Vec::new(),
+        status: PlanStepStatus::Ready,
+        inputs,
+        outputs: std::collections::HashMap::new(),
+        skip_reason: None,
+        policy: std::collections::HashMap::new(),
+        missing: Vec::new(),
+    }
 }
 
 pub fn apply_plan(plan: &DecomposePlan, root: &Path, write: bool) -> Result<Vec<MoveResult>> {

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -32,6 +32,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 
 use crate::error::{Error, Result};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 
 use super::apply::{
     checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, AppliedPr,
@@ -62,6 +63,8 @@ pub struct SyncOutput {
 /// into `stack sync` output.
 #[derive(Debug, Clone, Serialize)]
 pub struct SyncPreview {
+    #[serde(flatten)]
+    pub plan: HomeboyPlan,
     pub stack_id: String,
     pub component_path: String,
     pub branch: String,
@@ -257,8 +260,19 @@ pub(crate) fn plan_sync(spec: &StackSpec) -> Result<SyncPlan> {
         replayed_count,
     );
 
+    let plan = sync_homeboy_plan(
+        spec,
+        &dropped,
+        &replayed,
+        &uncertain,
+        target_exists,
+        would_mutate,
+        blocked,
+    );
+
     Ok(SyncPlan {
         preview: SyncPreview {
+            plan,
             stack_id: spec.id.clone(),
             component_path: path,
             branch: spec.target.branch.clone(),
@@ -280,6 +294,117 @@ pub(crate) fn plan_sync(spec: &StackSpec) -> Result<SyncPlan> {
         kept_entries,
         kept_metas,
     })
+}
+
+fn sync_homeboy_plan(
+    spec: &StackSpec,
+    dropped: &[DroppedPr],
+    replayed: &[ReplayedPr],
+    uncertain: &[UncertainPr],
+    target_exists: bool,
+    would_mutate: bool,
+    blocked: bool,
+) -> HomeboyPlan {
+    let mut plan = HomeboyPlan::for_description(PlanKind::StackSync, spec.id.clone());
+    plan.inputs.insert(
+        "stack_id".to_string(),
+        serde_json::Value::String(spec.id.clone()),
+    );
+    plan.inputs.insert(
+        "target_exists".to_string(),
+        serde_json::Value::Bool(target_exists),
+    );
+    plan.policy.insert(
+        "would_mutate".to_string(),
+        serde_json::Value::Bool(would_mutate),
+    );
+    plan.policy
+        .insert("blocked".to_string(), serde_json::Value::Bool(blocked));
+
+    let mut steps = Vec::new();
+    for pr in dropped {
+        steps.push(sync_pr_step(
+            "drop",
+            &pr.repo,
+            pr.number,
+            PlanStepStatus::Skipped,
+            &pr.reason,
+        ));
+    }
+    for pr in replayed {
+        steps.push(sync_pr_step(
+            "replay",
+            &pr.repo,
+            pr.number,
+            PlanStepStatus::Ready,
+            &pr.reason,
+        ));
+    }
+    for pr in uncertain {
+        steps.push(sync_pr_step(
+            "uncertain",
+            &pr.repo,
+            pr.number,
+            PlanStepStatus::Missing,
+            &pr.error,
+        ));
+    }
+
+    plan.summary = Some(PlanSummary {
+        total_steps: steps.len(),
+        ready: steps
+            .iter()
+            .filter(|step| step.status == PlanStepStatus::Ready)
+            .count(),
+        blocked: steps
+            .iter()
+            .filter(|step| step.status == PlanStepStatus::Missing)
+            .count(),
+        skipped: steps
+            .iter()
+            .filter(|step| step.status == PlanStepStatus::Skipped)
+            .count(),
+        next_actions: Vec::new(),
+    });
+    plan.steps = steps;
+    plan
+}
+
+fn sync_pr_step(
+    action: &str,
+    repo: &str,
+    number: u64,
+    status: PlanStepStatus,
+    reason: &str,
+) -> PlanStep {
+    let mut inputs = std::collections::HashMap::new();
+    inputs.insert(
+        "repo".to_string(),
+        serde_json::Value::String(repo.to_string()),
+    );
+    inputs.insert(
+        "number".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(number)),
+    );
+    inputs.insert(
+        "reason".to_string(),
+        serde_json::Value::String(reason.to_string()),
+    );
+
+    PlanStep {
+        id: format!("stack.sync.{action}.{repo}#{number}"),
+        kind: format!("stack.sync.{action}"),
+        label: Some(format!("{action} {repo}#{number}")),
+        blocking: status == PlanStepStatus::Missing,
+        scope: vec![format!("{repo}#{number}")],
+        needs: Vec::new(),
+        status,
+        inputs,
+        outputs: std::collections::HashMap::new(),
+        skip_reason: None,
+        policy: std::collections::HashMap::new(),
+        missing: Vec::new(),
+    }
 }
 
 /// Read-only preview for `homeboy stack diff`.

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use crate::error::Error;
+use crate::plan::{HomeboyPlan, PlanKind};
 use crate::rig::spec::{ComponentSpec, RigSpec};
 use crate::stack::{GitRef, StackPrEntry, StackSpec, SyncOutput, SyncPreview};
 
@@ -43,6 +44,7 @@ fn rig_with_components(components: HashMap<String, ComponentSpec>) -> RigSpec {
 fn sync_output(stack_id: &str, picked: usize, skipped: usize, dropped: usize) -> SyncOutput {
     SyncOutput {
         preview: SyncPreview {
+            plan: HomeboyPlan::for_description(PlanKind::StackSync, stack_id),
             stack_id: stack_id.to_string(),
             component_path: "/tmp/component".to_string(),
             branch: "dev/combined-fixes".to_string(),
@@ -193,6 +195,7 @@ fn test_sync_entry_serializes_counts_and_refs() {
     let report = run_sync_with(&rig, false, |_component_id, stack_id, _dry_run| {
         Ok(SyncOutput {
             preview: SyncPreview {
+                plan: HomeboyPlan::for_description(PlanKind::StackSync, stack_id),
                 stack_id: stack_id.to_string(),
                 component_path: "/tmp/component".to_string(),
                 branch: "dev/combined-fixes".to_string(),


### PR DESCRIPTION
## Summary
- Extend `HomeboyPlan` with description-scoped construction plus plan kinds for dependency stacks, issue reconciliation, stack sync, and trace-oriented workflows.
- Embed generic plan metadata/steps into issue reconciliation, dependency stack, stack sync, and refactor decompose plans while preserving their existing domain fields.
- Keep execution paths driven by the domain contracts, but expose shared `HomeboyPlan` shape for preview, summary, and step metadata.

## Verification
- `cargo test`
- `cargo test commands::issues`
- `cargo test core::issues`
- `cargo test --test deps_test`
- `cargo test core::stack`
- `cargo test core::plan`
- `cargo fmt --check`
- `homeboy audit --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the broad workflow-plan refactor, compatibility-preserving tests/updates, verification, and PR description for Chris to review.