### PR TITLE
Finish generic audit and trace plans

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -48,7 +48,9 @@ use output::{
     render_compare_markdown, render_matrix_markdown, run_compare, TraceAggregateSpanSample,
 };
 use probes::trace_probes_for_args;
-use schedule::{TraceSchedule, TraceVariantMatrixMode};
+pub(super) use schedule::{
+    plan_trace_run_order, TraceRunPlanEntry, TraceSchedule, TraceVariantMatrixMode,
+};
 
 #[cfg(test)]
 use matrix::{expand_variant_matrix, TraceVariantStackItem};
@@ -157,45 +159,6 @@ pub struct TraceArgs {
     /// Remove stale trace overlay locks even when touched files are dirty.
     #[arg(long, alias = "force-stale-lock-cleanup")]
     pub force: bool,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct TraceRunPlanEntry {
-    index: usize,
-    group: String,
-    iteration: usize,
-}
-
-fn plan_trace_run_order(
-    repeat: usize,
-    schedule: TraceSchedule,
-    groups: &[&str],
-) -> Vec<TraceRunPlanEntry> {
-    let mut entries = Vec::new();
-    let mut push_entry = |group: &str, iteration: usize| {
-        entries.push(TraceRunPlanEntry {
-            index: entries.len() + 1,
-            group: group.to_string(),
-            iteration,
-        });
-    };
-    match schedule {
-        TraceSchedule::Grouped => {
-            for group in groups {
-                for iteration in 1..=repeat {
-                    push_entry(group, iteration);
-                }
-            }
-        }
-        TraceSchedule::Interleaved => {
-            for iteration in 1..=repeat {
-                for group in groups {
-                    push_entry(group, iteration);
-                }
-            }
-        }
-    }
-    entries
 }
 
 pub fn is_markdown_mode(args: &TraceArgs) -> bool {

--- a/src/commands/trace/experiment.rs
+++ b/src/commands/trace/experiment.rs
@@ -5,11 +5,13 @@ use std::process::Command;
 
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::trace as extension_trace;
+use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 use homeboy::rig;
 
 use super::{TraceArgs, TraceRigContext};
 
 pub(super) struct TraceExperimentRunPlan<'a> {
+    plan: HomeboyPlan,
     name: String,
     spec: &'a rig::TraceExperimentSpec,
     context: &'a TraceRigContext,
@@ -59,10 +61,84 @@ pub(super) fn trace_experiment_plan_for_args<'a>(
             )
         })?;
     Ok(Some(TraceExperimentRunPlan {
+        plan: trace_experiment_plan(&context.rig_spec.id, name, experiment),
         name: name.to_string(),
         spec: experiment,
         context,
     }))
+}
+
+fn trace_experiment_plan(
+    rig_id: &str,
+    name: &str,
+    experiment: &rig::TraceExperimentSpec,
+) -> HomeboyPlan {
+    let mut plan = HomeboyPlan::for_description(PlanKind::Trace, format!("{rig_id} {name}"));
+    plan.mode = Some("experiment".to_string());
+    plan.inputs.insert(
+        "rig_id".to_string(),
+        serde_json::Value::String(rig_id.to_string()),
+    );
+    plan.inputs.insert(
+        "experiment".to_string(),
+        serde_json::Value::String(name.to_string()),
+    );
+    plan.steps = trace_experiment_steps(name, experiment);
+    plan.summary = Some(PlanSummary {
+        total_steps: plan.steps.len(),
+        ready: plan.steps.len(),
+        blocked: 0,
+        skipped: 0,
+        next_actions: Vec::new(),
+    });
+    plan
+}
+
+fn trace_experiment_steps(name: &str, experiment: &rig::TraceExperimentSpec) -> Vec<PlanStep> {
+    let setup =
+        experiment.setup.iter().enumerate().map(|(index, command)| {
+            trace_experiment_step("setup", name, index + 1, &command.command)
+        });
+    let teardown = experiment
+        .teardown
+        .iter()
+        .enumerate()
+        .map(|(index, command)| {
+            trace_experiment_step("teardown", name, index + 1, &command.command)
+        });
+
+    setup.chain(teardown).collect()
+}
+
+fn trace_experiment_step(phase: &str, name: &str, index: usize, command: &str) -> PlanStep {
+    let mut inputs = std::collections::HashMap::new();
+    inputs.insert(
+        "experiment".to_string(),
+        serde_json::Value::String(name.to_string()),
+    );
+    inputs.insert(
+        "phase".to_string(),
+        serde_json::Value::String(phase.to_string()),
+    );
+    inputs.insert(
+        "command".to_string(),
+        serde_json::Value::String(command.to_string()),
+    );
+
+    PlanStep {
+        id: format!("trace.experiment.{phase}.{index}"),
+        kind: format!("trace.experiment.{phase}"),
+        label: Some(format!("{phase} trace experiment {name}")),
+        blocking: true,
+        scope: vec![name.to_string()],
+        needs: Vec::new(),
+        status: PlanStepStatus::Ready,
+        inputs,
+        outputs: std::collections::HashMap::new(),
+        skip_reason: None,
+        policy: std::collections::HashMap::new(),
+        missing: Vec::new(),
+    }
 }
 
 pub(super) fn trace_experiment_settings(
@@ -113,6 +189,7 @@ pub(super) fn run_trace_experiment_setup_for_plan(
     let Some(plan) = plan else {
         return Ok(());
     };
+    validate_trace_experiment_plan_phase(&plan.plan, &plan.name, "setup", plan.spec.setup.len())?;
     run_trace_experiment_commands(
         plan.context,
         &plan.name,
@@ -130,6 +207,12 @@ pub(super) fn run_trace_experiment_teardown_for_plan(
     let Some(plan) = plan else {
         return Ok(());
     };
+    validate_trace_experiment_plan_phase(
+        &plan.plan,
+        &plan.name,
+        "teardown",
+        plan.spec.teardown.len(),
+    )?;
     run_trace_experiment_commands(
         plan.context,
         &plan.name,
@@ -138,6 +221,30 @@ pub(super) fn run_trace_experiment_teardown_for_plan(
         &plan.spec.env,
         run_dir,
     )
+}
+
+fn validate_trace_experiment_plan_phase(
+    plan: &HomeboyPlan,
+    experiment_name: &str,
+    phase: &str,
+    command_count: usize,
+) -> homeboy::Result<()> {
+    let planned_count = plan
+        .steps
+        .iter()
+        .filter(|step| {
+            step.kind == format!("trace.experiment.{phase}")
+                && step.inputs.get("phase").and_then(|value| value.as_str()) == Some(phase)
+        })
+        .count();
+    if planned_count == command_count {
+        return Ok(());
+    }
+
+    Err(homeboy::Error::internal_unexpected(format!(
+        "trace experiment '{}' {} plan has {} steps for {} commands",
+        experiment_name, phase, planned_count, command_count
+    )))
 }
 
 fn run_trace_experiment_commands(

--- a/src/commands/trace/schedule.rs
+++ b/src/commands/trace/schedule.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 use serde::Serialize;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -14,6 +15,82 @@ impl TraceSchedule {
             Self::Interleaved => "interleaved",
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TraceRunPlanEntry {
+    pub(super) plan: HomeboyPlan,
+    pub(super) index: usize,
+    pub(super) group: String,
+    pub(super) iteration: usize,
+}
+
+pub(crate) fn plan_trace_run_order(
+    repeat: usize,
+    schedule: TraceSchedule,
+    groups: &[&str],
+) -> Vec<TraceRunPlanEntry> {
+    let mut entries = Vec::new();
+    let mut push_entry = |group: &str, iteration: usize| {
+        entries.push(TraceRunPlanEntry {
+            plan: trace_run_entry_plan(entries.len() + 1, group, iteration),
+            index: entries.len() + 1,
+            group: group.to_string(),
+            iteration,
+        });
+    };
+    match schedule {
+        TraceSchedule::Grouped => {
+            for group in groups {
+                for iteration in 1..=repeat {
+                    push_entry(group, iteration);
+                }
+            }
+        }
+        TraceSchedule::Interleaved => {
+            for iteration in 1..=repeat {
+                for group in groups {
+                    push_entry(group, iteration);
+                }
+            }
+        }
+    }
+    entries
+}
+
+fn trace_run_entry_plan(index: usize, group: &str, iteration: usize) -> HomeboyPlan {
+    let mut plan = HomeboyPlan::for_description(PlanKind::Trace, format!("{group} {iteration}"));
+    plan.mode = Some("run_order".to_string());
+    plan.inputs.insert(
+        "group".to_string(),
+        serde_json::Value::String(group.to_string()),
+    );
+    plan.inputs.insert(
+        "iteration".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(iteration)),
+    );
+    plan.steps = vec![PlanStep {
+        id: format!("trace.run.{index}"),
+        kind: "trace.run".to_string(),
+        label: Some(format!("Run trace {group} iteration {iteration}")),
+        blocking: true,
+        scope: vec![group.to_string()],
+        needs: Vec::new(),
+        status: PlanStepStatus::Ready,
+        inputs: plan.inputs.clone(),
+        outputs: std::collections::HashMap::new(),
+        skip_reason: None,
+        policy: std::collections::HashMap::new(),
+        missing: Vec::new(),
+    }];
+    plan.summary = Some(PlanSummary {
+        total_steps: 1,
+        ready: 1,
+        blocked: 0,
+        skipped: 0,
+        next_actions: Vec::new(),
+    });
+    plan
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, ValueEnum)]

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -76,6 +76,7 @@ pub use report::AuditCommandOutput;
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};
 pub use walker::is_test_path;
 
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 use crate::{component, component::AuditConfig, is_zero, Result};
 
 /// Summary counts for the audit report.
@@ -125,8 +126,9 @@ pub(crate) struct AuditWithAnalysis {
     pub(crate) analysis: AuditAnalysisContext,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct AuditExecutionPlan {
+    pub(crate) plan: HomeboyPlan,
     pub(crate) run_conventions: bool,
     pub(crate) run_structural: bool,
     pub(crate) run_duplication: bool,
@@ -155,32 +157,36 @@ pub(crate) struct AuditExecutionPlan {
 
 impl AuditExecutionPlan {
     pub(crate) fn full() -> Self {
-        Self {
-            run_conventions: true,
-            run_structural: true,
-            run_duplication: true,
-            run_dead_code: true,
-            run_comment_hygiene: true,
-            run_test_coverage: true,
-            run_layer_ownership: true,
-            run_test_topology: true,
-            run_rust_test_wiring: true,
-            run_docs: true,
-            run_compiler_warnings: true,
-            run_wrapper_inference: true,
-            run_shadow_modules: true,
-            run_field_patterns: true,
-            run_facade_passthrough: true,
-            run_literal_shapes: true,
-            run_deprecation_age: true,
-            run_dead_guard: true,
-            run_requested_detectors: true,
-            run_core_boundary_leaks: true,
-            run_global_env_guard: true,
-            run_shared_scaffolding: true,
-            run_parallel_runner_setup: true,
-            run_enum_dispatch_contracts: true,
-        }
+        Self::with_generic_plan(
+            "full",
+            Self {
+                plan: HomeboyPlan::for_description(PlanKind::Audit, "audit"),
+                run_conventions: true,
+                run_structural: true,
+                run_duplication: true,
+                run_dead_code: true,
+                run_comment_hygiene: true,
+                run_test_coverage: true,
+                run_layer_ownership: true,
+                run_test_topology: true,
+                run_rust_test_wiring: true,
+                run_docs: true,
+                run_compiler_warnings: true,
+                run_wrapper_inference: true,
+                run_shadow_modules: true,
+                run_field_patterns: true,
+                run_facade_passthrough: true,
+                run_literal_shapes: true,
+                run_deprecation_age: true,
+                run_dead_guard: true,
+                run_requested_detectors: true,
+                run_core_boundary_leaks: true,
+                run_global_env_guard: true,
+                run_shared_scaffolding: true,
+                run_parallel_runner_setup: true,
+                run_enum_dispatch_contracts: true,
+            },
+        )
     }
 
     pub(crate) fn from_filters(only: &[AuditFinding], exclude: &[AuditFinding]) -> Self {
@@ -188,162 +194,242 @@ impl AuditExecutionPlan {
             return Self::full();
         }
 
-        Self {
-            run_conventions: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::MissingMethod,
-                    AuditFinding::ExtraMethod,
-                    AuditFinding::MissingRegistration,
-                    AuditFinding::DifferentRegistration,
-                    AuditFinding::MissingInterface,
-                    AuditFinding::NamingMismatch,
-                    AuditFinding::SignatureMismatch,
-                    AuditFinding::NamespaceMismatch,
-                    AuditFinding::MissingImport,
-                ],
-            ),
-            run_structural: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::GodFile,
-                    AuditFinding::HighItemCount,
-                    AuditFinding::DirectorySprawl,
-                ],
-            ),
-            run_duplication: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::DuplicateFunction,
-                    AuditFinding::IntraMethodDuplicate,
-                    AuditFinding::NearDuplicate,
-                    AuditFinding::ParallelImplementation,
-                ],
-            ),
-            run_dead_code: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::UnusedParameter,
-                    AuditFinding::IgnoredParameter,
-                    AuditFinding::DeadCodeMarker,
-                    AuditFinding::UnreferencedExport,
-                    AuditFinding::OrphanedInternal,
-                ],
-            ),
-            run_comment_hygiene: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::TodoMarker, AuditFinding::LegacyComment],
-            ),
-            run_test_coverage: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::MissingTestFile,
-                    AuditFinding::MissingTestMethod,
-                    AuditFinding::OrphanedTest,
-                    AuditFinding::VacuousTest,
-                ],
-            ),
-            run_layer_ownership: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::LayerOwnershipViolation],
-            ),
-            run_test_topology: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::InlineTestModule,
-                    AuditFinding::ScatteredTestFile,
-                    AuditFinding::VacuousTest,
-                ],
-            ),
-            run_rust_test_wiring: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::UnwiredNestedRustTest],
-            ),
-            run_docs: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::BrokenDocReference,
-                    AuditFinding::UndocumentedFeature,
-                    AuditFinding::StaleDocReference,
-                ],
-            ),
-            run_compiler_warnings: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::CompilerWarning],
-            ),
-            run_wrapper_inference: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::MissingWrapperDeclaration],
-            ),
-            run_shadow_modules: Self::family_enabled(only, exclude, &[AuditFinding::ShadowModule]),
-            run_field_patterns: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::RepeatedFieldPattern],
-            ),
-            run_facade_passthrough: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::FacadePassthrough],
-            ),
-            run_literal_shapes: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::RepeatedLiteralShape],
-            ),
-            run_deprecation_age: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::DeprecationAge],
-            ),
-            run_dead_guard: Self::family_enabled(only, exclude, &[AuditFinding::DeadGuard]),
-            run_requested_detectors: Self::family_enabled(
-                only,
-                exclude,
-                &[
-                    AuditFinding::JsonLikeExactMatch,
-                    AuditFinding::ConstantBackedSlugLiteral,
-                    AuditFinding::OptionScopeDrift,
-                ],
-            ),
-            run_core_boundary_leaks: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::CoreBoundaryLeak],
-            ),
-            run_global_env_guard: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::GlobalEnvMutationGuard],
-            ),
-            run_shared_scaffolding: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::SharedScaffolding],
-            ),
-            run_parallel_runner_setup: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::ParallelRunnerSetup],
-            ),
-            run_enum_dispatch_contracts: Self::family_enabled(
-                only,
-                exclude,
-                &[AuditFinding::RepeatedEnumDispatchContract],
-            ),
-        }
+        Self::with_generic_plan(
+            "filtered",
+            Self {
+                plan: HomeboyPlan::for_description(PlanKind::Audit, "audit"),
+                run_conventions: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::MissingMethod,
+                        AuditFinding::ExtraMethod,
+                        AuditFinding::MissingRegistration,
+                        AuditFinding::DifferentRegistration,
+                        AuditFinding::MissingInterface,
+                        AuditFinding::NamingMismatch,
+                        AuditFinding::SignatureMismatch,
+                        AuditFinding::NamespaceMismatch,
+                        AuditFinding::MissingImport,
+                    ],
+                ),
+                run_structural: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::GodFile,
+                        AuditFinding::HighItemCount,
+                        AuditFinding::DirectorySprawl,
+                    ],
+                ),
+                run_duplication: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::DuplicateFunction,
+                        AuditFinding::IntraMethodDuplicate,
+                        AuditFinding::NearDuplicate,
+                        AuditFinding::ParallelImplementation,
+                    ],
+                ),
+                run_dead_code: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::UnusedParameter,
+                        AuditFinding::IgnoredParameter,
+                        AuditFinding::DeadCodeMarker,
+                        AuditFinding::UnreferencedExport,
+                        AuditFinding::OrphanedInternal,
+                    ],
+                ),
+                run_comment_hygiene: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::TodoMarker, AuditFinding::LegacyComment],
+                ),
+                run_test_coverage: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::MissingTestFile,
+                        AuditFinding::MissingTestMethod,
+                        AuditFinding::OrphanedTest,
+                        AuditFinding::VacuousTest,
+                    ],
+                ),
+                run_layer_ownership: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::LayerOwnershipViolation],
+                ),
+                run_test_topology: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::InlineTestModule,
+                        AuditFinding::ScatteredTestFile,
+                        AuditFinding::VacuousTest,
+                    ],
+                ),
+                run_rust_test_wiring: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::UnwiredNestedRustTest],
+                ),
+                run_docs: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::BrokenDocReference,
+                        AuditFinding::UndocumentedFeature,
+                        AuditFinding::StaleDocReference,
+                    ],
+                ),
+                run_compiler_warnings: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::CompilerWarning],
+                ),
+                run_wrapper_inference: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::MissingWrapperDeclaration],
+                ),
+                run_shadow_modules: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::ShadowModule],
+                ),
+                run_field_patterns: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::RepeatedFieldPattern],
+                ),
+                run_facade_passthrough: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::FacadePassthrough],
+                ),
+                run_literal_shapes: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::RepeatedLiteralShape],
+                ),
+                run_deprecation_age: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::DeprecationAge],
+                ),
+                run_dead_guard: Self::family_enabled(only, exclude, &[AuditFinding::DeadGuard]),
+                run_requested_detectors: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[
+                        AuditFinding::JsonLikeExactMatch,
+                        AuditFinding::ConstantBackedSlugLiteral,
+                        AuditFinding::OptionScopeDrift,
+                    ],
+                ),
+                run_core_boundary_leaks: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::CoreBoundaryLeak],
+                ),
+                run_global_env_guard: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::GlobalEnvMutationGuard],
+                ),
+                run_shared_scaffolding: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::SharedScaffolding],
+                ),
+                run_parallel_runner_setup: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::ParallelRunnerSetup],
+                ),
+                run_enum_dispatch_contracts: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::RepeatedEnumDispatchContract],
+                ),
+            },
+        )
+    }
+
+    fn with_generic_plan(mode: &str, mut audit: Self) -> Self {
+        let mut plan = HomeboyPlan::for_description(PlanKind::Audit, "audit execution");
+        plan.mode = Some(mode.to_string());
+        plan.steps = audit.detector_steps();
+        plan.summary = Some(PlanSummary {
+            total_steps: plan.steps.len(),
+            ready: plan
+                .steps
+                .iter()
+                .filter(|step| step.status == PlanStepStatus::Ready)
+                .count(),
+            blocked: 0,
+            skipped: plan
+                .steps
+                .iter()
+                .filter(|step| step.status == PlanStepStatus::Disabled)
+                .count(),
+            next_actions: Vec::new(),
+        });
+        audit.plan = plan;
+        audit
+    }
+
+    fn detector_steps(&self) -> Vec<PlanStep> {
+        [
+            ("conventions", self.run_conventions),
+            ("structural", self.run_structural),
+            ("duplication", self.run_duplication),
+            ("dead_code", self.run_dead_code),
+            ("comment_hygiene", self.run_comment_hygiene),
+            ("test_coverage", self.run_test_coverage),
+            ("layer_ownership", self.run_layer_ownership),
+            ("test_topology", self.run_test_topology),
+            ("rust_test_wiring", self.run_rust_test_wiring),
+            ("docs", self.run_docs),
+            ("compiler_warnings", self.run_compiler_warnings),
+            ("wrapper_inference", self.run_wrapper_inference),
+            ("shadow_modules", self.run_shadow_modules),
+            ("field_patterns", self.run_field_patterns),
+            ("facade_passthrough", self.run_facade_passthrough),
+            ("literal_shapes", self.run_literal_shapes),
+            ("deprecation_age", self.run_deprecation_age),
+            ("dead_guard", self.run_dead_guard),
+            ("requested_detectors", self.run_requested_detectors),
+            ("core_boundary_leaks", self.run_core_boundary_leaks),
+            ("global_env_guard", self.run_global_env_guard),
+            ("shared_scaffolding", self.run_shared_scaffolding),
+            ("parallel_runner_setup", self.run_parallel_runner_setup),
+            ("enum_dispatch_contracts", self.run_enum_dispatch_contracts),
+        ]
+        .into_iter()
+        .map(|(name, enabled)| PlanStep {
+            id: format!("audit.{name}"),
+            kind: format!("audit.detector.{name}"),
+            label: Some(name.replace('_', " ")),
+            blocking: true,
+            scope: Vec::new(),
+            needs: Vec::new(),
+            status: if enabled {
+                PlanStepStatus::Ready
+            } else {
+                PlanStepStatus::Disabled
+            },
+            inputs: std::collections::HashMap::new(),
+            outputs: std::collections::HashMap::new(),
+            skip_reason: (!enabled).then(|| "filtered".to_string()),
+            policy: std::collections::HashMap::new(),
+            missing: Vec::new(),
+        })
+        .collect()
     }
 
     fn family_enabled(

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -86,6 +86,7 @@ impl Default for HomeboyPlan {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanKind {
+    Audit,
     Quality,
     Build,
     Release,
@@ -104,6 +105,7 @@ pub enum PlanKind {
 impl PlanKind {
     fn slug(&self) -> &'static str {
         match self {
+            Self::Audit => "audit",
             Self::Quality => "quality",
             Self::Build => "build",
             Self::Release => "release",


### PR DESCRIPTION
## Summary
- Move audit execution planning onto `HomeboyPlan` with detector-level generic plan steps and summaries.
- Carry generic trace plans through trace run-order and trace experiment lifecycle planning.
- Move trace run-order planning into the trace schedule module to avoid adding command-file structural drift.

## Verification
- `cargo fmt --check`
- `cargo test commands::trace`
- `cargo test core::code_audit`
- `cargo test core::plan`
- `cargo test`
- `homeboy audit --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the generic audit/trace plan migration; Chris remains responsible for review and merge.