### PR TITLE
Enforce deploy path root resolution

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -9,7 +9,7 @@ use crate::project::Project;
 use crate::version;
 
 use super::execution::execute_component_deploy;
-use super::path_roots::project_with_detected_path_roots;
+use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{
     calculate_component_status, calculate_release_state, load_project_components, plan_components,
 };
@@ -71,6 +71,8 @@ pub(super) fn deploy_components(
             },
         });
     }
+
+    validate_effective_remote_paths(&components, &project, base_path)?;
 
     // Gather versions
     let local_versions: HashMap<String, String> = components
@@ -196,6 +198,18 @@ pub(super) fn deploy_components(
             skipped: 0,
         },
     })
+}
+
+fn validate_effective_remote_paths(
+    components: &[Component],
+    project: &Project,
+    base_path: &str,
+) -> Result<()> {
+    for component in components {
+        resolve_effective_remote_path(project, component, base_path)?;
+    }
+
+    Ok(())
 }
 
 /// Check mode: return component status without building or deploying.

--- a/src/core/deploy/path_roots.rs
+++ b/src/core/deploy/path_roots.rs
@@ -1,6 +1,6 @@
 use crate::component::Component;
 use crate::engine::shell;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::extension::{self, RemotePathRootRule};
 use crate::paths as base_path;
 use crate::project::Project;
@@ -82,17 +82,30 @@ fn resolve_with_project_root(
     component: &Component,
     remote_path: &str,
 ) -> Result<Option<String>> {
-    if project.path_roots.is_empty() {
-        return Ok(None);
-    }
-
     for rule in component_remote_path_root_rules(component) {
         if !path_matches_prefix(remote_path, &rule.path_prefix) {
             continue;
         }
 
         let Some(root) = project.path_roots.get(&rule.root) else {
-            continue;
+            return Err(Error::validation_invalid_argument(
+                "remotePath",
+                format!(
+                    "Component '{}' remote path '{}' matches managed path root '{}' ({}) but that root was not configured or detected",
+                    component.id, remote_path, rule.root, rule.path_prefix
+                ),
+                Some(remote_path.to_string()),
+                Some(vec![
+                    format!(
+                        "Configure project path_roots.{} to the active remote root for {}",
+                        rule.root, rule.path_prefix
+                    ),
+                    format!(
+                        "Use an explicit absolute/relative remote path if '{}' should not be root-managed",
+                        remote_path
+                    ),
+                ]),
+            ));
         };
 
         let path = if rule.strip_prefix {
@@ -302,6 +315,28 @@ mod tests {
             .expect("resolve path");
 
             assert_eq!(resolved, "/srv/site/var/log/app.log");
+        });
+    }
+
+    #[test]
+    fn matching_path_root_without_detected_root_fails_instead_of_falling_back() {
+        with_isolated_home(|_| {
+            install_extension();
+
+            let err = resolve_effective_remote_path(
+                &Project {
+                    id: "site".to_string(),
+                    base_path: Some("/srv/site".to_string()),
+                    ..Project::default()
+                },
+                &component("wp-content/plugins/foo"),
+                "/srv/site",
+            )
+            .expect_err("missing managed root should fail");
+
+            let message = err.to_string();
+            assert!(message.contains("matches managed path root"));
+            assert!(message.contains("wp_content"));
         });
     }
 }


### PR DESCRIPTION
## Summary
- Enforces extension-declared deploy `path_roots` before check/dry-run/deploy operations proceed.
- Fails fast when a component remote path matches a managed root but the active root was not configured or detected, preventing silent fallback under the project base path.
- Adds regression coverage for the missing-root fallback case.

## Tests
- `cargo fmt`
- `cargo test --release deploy::path_roots`
- `cargo test --release --test architecture_core_agnostic_test`
- `cargo test --release --test core_agnostic_test`

Closes #2520.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the deploy root validation change, adding focused regression coverage, and running verification commands. Chris reviewed the architectural constraint that Homeboy core must remain generic/agnostic.