### PR TITLE
Persist daemon job state

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -11,6 +13,8 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::core::error::{Error, Result};
+
+const DEFAULT_EVENT_RETENTION_LIMIT: usize = 1000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -51,6 +55,8 @@ pub struct Job {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finished_at_ms: Option<u64>,
     pub event_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,6 +75,13 @@ pub struct JobEvent {
 pub struct JobStore {
     inner: Arc<Mutex<JobStoreInner>>,
     next_event_sequence: Arc<AtomicU64>,
+    persistence: Option<Arc<JobStorePersistence>>,
+}
+
+#[derive(Debug, Clone)]
+struct JobStorePersistence {
+    path: PathBuf,
+    event_retention_limit: usize,
 }
 
 #[derive(Debug, Default)]
@@ -76,10 +89,15 @@ struct JobStoreInner {
     jobs: HashMap<Uuid, StoredJob>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredJob {
     job: Job,
     events: Vec<JobEvent>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DurableJobStore {
+    jobs: Vec<StoredJob>,
 }
 
 #[derive(Debug)]
@@ -95,6 +113,37 @@ pub struct JobHandle {
 }
 
 impl JobStore {
+    pub(crate) fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        Self::open_with_event_retention(path, DEFAULT_EVENT_RETENTION_LIMIT)
+    }
+
+    pub(crate) fn open_with_event_retention(
+        path: impl Into<PathBuf>,
+        event_retention_limit: usize,
+    ) -> Result<Self> {
+        let path = path.into();
+        let mut durable = read_durable_store(&path)?;
+        let event_retention_limit = event_retention_limit.max(1);
+        let next_sequence = reconcile_stale_jobs(&mut durable, event_retention_limit);
+        let store = Self {
+            inner: Arc::new(Mutex::new(JobStoreInner {
+                jobs: durable
+                    .jobs
+                    .into_iter()
+                    .map(|stored| (stored.job.id, stored))
+                    .collect(),
+            })),
+            next_event_sequence: Arc::new(AtomicU64::new(next_sequence)),
+            persistence: Some(Arc::new(JobStorePersistence {
+                path,
+                event_retention_limit,
+            })),
+        };
+
+        store.persist()?;
+        Ok(store)
+    }
+
     pub(crate) fn create(&self, operation: impl Into<String>) -> Job {
         let now = timestamp_ms();
         let job = Job {
@@ -106,6 +155,7 @@ impl JobStore {
             started_at_ms: None,
             finished_at_ms: None,
             event_count: 0,
+            stale_reason: None,
         };
 
         let mut inner = self.inner.lock().expect("job store mutex poisoned");
@@ -207,8 +257,12 @@ impl JobStore {
         };
 
         stored.events.push(event.clone());
+        apply_event_retention(&mut stored.events, self.event_retention_limit());
         stored.job.event_count = stored.events.len();
         stored.job.updated_at_ms = event.timestamp_ms;
+        drop(inner);
+
+        self.persist()?;
 
         Ok(event)
     }
@@ -272,6 +326,8 @@ impl JobStore {
             }
         }
 
+        self.persist()?;
+
         self.append_status_event(job_id, next_status, message)?;
         self.get(job_id)
     }
@@ -297,6 +353,109 @@ impl JobStore {
             Some(message.into()),
             Some(serde_json::json!({ "status": status })),
         )
+    }
+
+    fn event_retention_limit(&self) -> usize {
+        self.persistence
+            .as_ref()
+            .map(|persistence| persistence.event_retention_limit)
+            .unwrap_or(usize::MAX)
+    }
+
+    fn persist(&self) -> Result<()> {
+        let Some(persistence) = &self.persistence else {
+            return Ok(());
+        };
+
+        let durable = {
+            let inner = self.inner.lock().expect("job store mutex poisoned");
+            DurableJobStore {
+                jobs: inner.jobs.values().cloned().collect(),
+            }
+        };
+
+        write_durable_store(&persistence.path, &durable)
+    }
+}
+
+fn read_durable_store(path: &Path) -> Result<DurableJobStore> {
+    if !path.exists() {
+        return Ok(DurableJobStore::default());
+    }
+
+    let content = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
+    serde_json::from_str(&content)
+        .map_err(|e| Error::config_invalid_json(path.display().to_string(), e))
+}
+
+fn write_durable_store(path: &Path, durable: &DurableJobStore) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("create {}", parent.display())))
+        })?;
+    }
+
+    let body = serde_json::to_string_pretty(durable).map_err(|e| {
+        Error::internal_json(
+            e.to_string(),
+            Some("serialize daemon job store".to_string()),
+        )
+    })?;
+    fs::write(path, body)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("write {}", path.display()))))
+}
+
+fn reconcile_stale_jobs(durable: &mut DurableJobStore, event_retention_limit: usize) -> u64 {
+    let now = timestamp_ms();
+    let mut next_sequence = durable
+        .jobs
+        .iter()
+        .flat_map(|stored| stored.events.iter().map(|event| event.sequence))
+        .max()
+        .unwrap_or(0);
+
+    for stored in &mut durable.jobs {
+        if matches!(stored.job.status, JobStatus::Queued | JobStatus::Running) {
+            let reason = "daemon restarted before the job reached a terminal status".to_string();
+            stored.job.status = JobStatus::Failed;
+            stored.job.updated_at_ms = now;
+            stored.job.finished_at_ms = Some(now);
+            stored.job.stale_reason = Some(reason.clone());
+
+            next_sequence += 1;
+            stored.events.push(JobEvent {
+                sequence: next_sequence,
+                job_id: stored.job.id,
+                kind: JobEventKind::Error,
+                timestamp_ms: now,
+                message: Some(reason.clone()),
+                data: Some(serde_json::json!({ "reason": "stale_after_daemon_restart" })),
+            });
+            next_sequence += 1;
+            stored.events.push(JobEvent {
+                sequence: next_sequence,
+                job_id: stored.job.id,
+                kind: JobEventKind::Status,
+                timestamp_ms: now,
+                message: Some("job marked failed after daemon restart".to_string()),
+                data: Some(serde_json::json!({
+                    "status": JobStatus::Failed,
+                    "reason": "stale_after_daemon_restart"
+                })),
+            });
+            apply_event_retention(&mut stored.events, event_retention_limit);
+            stored.job.event_count = stored.events.len();
+        }
+    }
+
+    next_sequence
+}
+
+fn apply_event_retention(events: &mut Vec<JobEvent>, limit: usize) {
+    if events.len() > limit {
+        let excess = events.len() - limit;
+        events.drain(0..excess);
     }
 }
 
@@ -672,5 +831,93 @@ mod tests {
             events.last().unwrap().data,
             Some(json!({ "status": "failed" }))
         );
+    }
+
+    #[test]
+    fn durable_store_persists_completed_jobs_and_events() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("durable store opens");
+        let job = store.create("bench");
+
+        store.start(job.id).expect("job starts");
+        store
+            .append_event(job.id, JobEventKind::Stdout, Some("done".to_string()), None)
+            .expect("stdout event appends");
+        store
+            .complete(job.id, Some(json!({ "ok": true })))
+            .expect("job completes");
+
+        let reopened = JobStore::open(&path).expect("durable store reopens");
+        let persisted = reopened.get(job.id).expect("job persists");
+        assert_eq!(persisted.status, JobStatus::Succeeded);
+        assert!(persisted.finished_at_ms.is_some());
+
+        let events = reopened.events(job.id).expect("events persist");
+        assert!(events
+            .iter()
+            .any(|event| event.kind == JobEventKind::Stdout));
+        assert!(events
+            .iter()
+            .any(|event| event.kind == JobEventKind::Result));
+    }
+
+    #[test]
+    fn durable_store_reconciles_running_jobs_as_stale_after_restart() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("durable store opens");
+        let job = store.create("audit");
+        store.start(job.id).expect("job starts");
+
+        let reopened = JobStore::open(&path).expect("durable store reopens");
+        let stale = reopened.get(job.id).expect("job persists");
+        assert_eq!(stale.status, JobStatus::Failed);
+        assert_eq!(
+            stale.stale_reason.as_deref(),
+            Some("daemon restarted before the job reached a terminal status")
+        );
+        assert!(stale.finished_at_ms.is_some());
+
+        let events = reopened.events(job.id).expect("events persist");
+        assert!(events.iter().any(|event| {
+            event.kind == JobEventKind::Error
+                && event
+                    .data
+                    .as_ref()
+                    .is_some_and(|data| data["reason"] == json!("stale_after_daemon_restart"))
+        }));
+    }
+
+    #[test]
+    fn durable_store_bounds_retained_event_history() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open_with_event_retention(&path, 3).expect("durable store opens");
+        let job = store.create("test");
+        store.start(job.id).expect("job starts");
+
+        for index in 0..5 {
+            store
+                .append_event(
+                    job.id,
+                    JobEventKind::Progress,
+                    None,
+                    Some(json!({ "index": index })),
+                )
+                .expect("progress event appends");
+        }
+
+        let events = store.events(job.id).expect("events are readable");
+        assert_eq!(events.len(), 3);
+        assert_eq!(store.get(job.id).expect("job persists").event_count, 3);
+
+        let reopened =
+            JobStore::open_with_event_retention(&path, 3).expect("durable store reopens");
+        let reopened_events = reopened.events(job.id).expect("events persist");
+        assert_eq!(reopened_events.len(), 3);
+        assert!(reopened_events
+            .windows(2)
+            .all(|pair| pair[0].sequence < pair[1].sequence));
     }
 }

--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -834,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn durable_store_persists_completed_jobs_and_events() {
+    fn test_open() {
         let temp = tempfile::tempdir().expect("temp dir");
         let path = temp.path().join("jobs.json");
         let store = JobStore::open(&path).expect("durable store opens");
@@ -890,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn durable_store_bounds_retained_event_history() {
+    fn test_open_with_event_retention() {
         let temp = tempfile::tempdir().expect("temp dir");
         let path = temp.path().join("jobs.json");
         let store = JobStore::open_with_event_retention(&path, 3).expect("durable store opens");

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -143,7 +143,7 @@ pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
         Error::internal_io(e.to_string(), Some("read daemon local address".to_string()))
     })?;
     let state = write_state(local_addr)?;
-    let job_store = JobStore::default();
+    let job_store = JobStore::open(paths::daemon_jobs_file()?)?;
 
     for stream in listener.incoming() {
         match stream {
@@ -283,6 +283,7 @@ fn config_paths_body() -> Result<serde_json::Value> {
         "rigs": paths::rigs()?.display().to_string(),
         "stacks": paths::stacks()?.display().to_string(),
         "daemon_state": paths::daemon_state_file()?.display().to_string(),
+        "daemon_jobs": paths::daemon_jobs_file()?.display().to_string(),
     }))
 }
 

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -250,6 +250,11 @@ pub fn daemon_state_file() -> Result<PathBuf> {
     Ok(daemon_state_dir()?.join("state.json"))
 }
 
+/// Daemon durable job state file (~/.config/homeboy/daemon/jobs.json).
+pub fn daemon_jobs_file() -> Result<PathBuf> {
+    Ok(daemon_state_dir()?.join("jobs.json"))
+}
+
 /// Stack config file path (~/.config/homeboy/stacks/{id}.json)
 pub fn stack_config(id: &str) -> Result<PathBuf> {
     Ok(stacks()?.join(format!("{}.json", id)))

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -40,6 +40,10 @@ fn routes_health_version_and_config_paths() {
         .as_str()
         .unwrap()
         .ends_with("daemon/state.json"));
+    assert!(paths.body["daemon_jobs"]
+        .as_str()
+        .unwrap()
+        .ends_with("daemon/jobs.json"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Persist daemon job records/events to `daemon/jobs.json` so completed Lab runs survive daemon restarts.
- Reconcile queued/running jobs loaded after restart as failed stale jobs with a generic `stale_reason` and reconciliation events.
- Bound retained per-job event history while preserving existing `/jobs`, `/jobs/:id`, and `/jobs/:id/events` response shapes plus optional metadata.

Closes #2530

## Tests
- `cargo fmt --check`
- `cargo test daemon_test`
- `cargo test api_jobs`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-lab-durable-job-state-2530 --extension rust`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the durable daemon job store, restart reconciliation, bounded event retention, and tests for Chris to review.