### PR TITLE
feat: add runner registry

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -32,6 +32,7 @@
 - [release](release.md) — local release pipeline
 - [review](review.md) — scoped audit + lint + test umbrella for PR-style changes
 - [rig](rig.md) — reproducible local dev environments ([spec](rig-spec.md))
+- [runner](runner.md) — local and SSH execution runner registry
 - [runs](runs.md) — persisted observation runs and artifacts
 - [server](server.md)
 - [self](self.md) — active binary and install-signal inspection

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -1,0 +1,94 @@
+# `homeboy runner`
+
+## Synopsis
+
+```sh
+homeboy runner <COMMAND>
+```
+
+`runner` manages durable execution backends. It records where future Homeboy workflows can run, but it does not execute remote commands.
+
+## Subcommands
+
+### `add`
+
+```sh
+homeboy runner add <id> --workspace-root <path>
+homeboy runner add <id> --server <server-id> --workspace-root <path>
+homeboy runner add --json <spec>
+```
+
+Options:
+
+- `--kind local|ssh`: explicit runner kind. Defaults to `ssh` when `--server` is set, otherwise `local`.
+- `--server <server-id>`: existing `homeboy server` record for SSH runners.
+- `--workspace-root <path>`: workspace root on the runner machine.
+- `--homeboy-path <path>`: Homeboy binary path on the runner machine.
+- `--daemon`: marks the runner as daemon-preferred for future commands.
+- `--concurrency-limit <n>`: maximum concurrent workflows this runner should accept.
+- `--artifact-policy <label>`: artifact policy label reserved for future execution commands.
+
+### `list`
+
+```sh
+homeboy runner list
+```
+
+### `show`
+
+```sh
+homeboy runner show <id>
+```
+
+### `set`
+
+```sh
+homeboy runner set <id> --json <JSON>
+homeboy runner set <id> workspace_root=/srv/homeboy
+homeboy runner set <id> -- --concurrency_limit 4
+```
+
+Updates a runner by merging a JSON object into `runners/<id>.json`.
+
+### `remove`
+
+```sh
+homeboy runner remove <id>
+```
+
+## Runner Shape
+
+Runner records are stored as JSON config entities under `~/.config/homeboy/runners/`.
+
+```json
+{
+  "id": "lab-local",
+  "kind": "local",
+  "server_id": null,
+  "workspace_root": "/Users/chubes/Developer",
+  "homeboy_path": "/usr/local/bin/homeboy",
+  "daemon": false,
+  "concurrency_limit": 2,
+  "artifact_policy": "copy",
+  "env": {},
+  "resources": {}
+}
+```
+
+Rules:
+
+- `kind` is `local` or `ssh`.
+- `ssh` runners require `server_id` to reference an existing `homeboy server` record.
+- `concurrency_limit`, when set, must be greater than zero.
+- `env` and `resources` are metadata maps for future `connect`, `doctor`, `exec`, and Desktop workflows.
+
+## JSON Output
+
+All command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). The `data` payload uses the generic entity CRUD shape:
+
+- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, or `runner.remove`
+- `id`: present for single-runner actions
+- `entity`: runner configuration for single-runner read/write actions
+- `entities`: list for `list`
+- `updated_fields`: list of updated field names for writes
+- `deleted`: list of removed runner IDs

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use crate::commands::{
     api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
     deps, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
-    refactor, release, report, review, rig, runs, self_cmd, server, ssh, stack, status, test,
-    trace, triage, undo, upgrade, version,
+    refactor, release, report, review, rig, runner, runs, self_cmd, server, ssh, stack, status,
+    test, trace, triage, undo, upgrade, version,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -110,6 +110,9 @@ pub enum Commands {
     /// Manage local dev rigs (reproducible multi-component environments)
     #[command(visible_alias = "rigs")]
     Rig(rig::RigArgs),
+    /// Manage local and SSH execution runners
+    #[command(visible_alias = "runners")]
+    Runner(runner::RunnerArgs),
     /// Inspect persisted observation runs and artifacts
     Runs(runs::RunsArgs),
     /// Inspect the active Homeboy binary and install signals

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -359,6 +359,7 @@ pub mod release;
 pub mod report;
 pub mod review;
 pub mod rig;
+pub mod runner;
 pub mod runs;
 pub mod self_cmd;
 pub mod server;
@@ -462,6 +463,7 @@ pub fn run_json(
         crate::cli_surface::Commands::Audit(args) => dispatch!(args, global, audit),
         crate::cli_surface::Commands::Refactor(args) => dispatch!(args, global, refactor),
         crate::cli_surface::Commands::Rig(args) => dispatch!(args, global, rig),
+        crate::cli_surface::Commands::Runner(args) => dispatch!(args, global, runner),
         crate::cli_surface::Commands::Runs(args) => dispatch!(args, global, runs),
         crate::cli_surface::Commands::SelfCmd(args) => dispatch!(args, global, self_cmd),
         crate::cli_surface::Commands::Stack(args) => dispatch!(args, global, stack),

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -1,0 +1,280 @@
+use std::collections::HashMap;
+
+use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+
+use homeboy::runner::{self, Runner, RunnerKind};
+use homeboy::{EntityCrudOutput, MergeOutput};
+
+use super::{CmdResult, DynamicSetArgs};
+
+#[derive(Debug, Default, Serialize)]
+pub struct RunnerExtra {}
+
+pub type RunnerOutput = EntityCrudOutput<Runner, RunnerExtra>;
+
+#[derive(Args)]
+pub struct RunnerArgs {
+    #[command(subcommand)]
+    command: RunnerCommand,
+}
+
+#[derive(Subcommand)]
+enum RunnerCommand {
+    /// Register a local or SSH execution runner
+    Add {
+        /// JSON input spec for add/update (supports single or bulk)
+        #[arg(long)]
+        json: Option<String>,
+
+        /// Skip items that already exist (JSON mode only)
+        #[arg(long)]
+        skip_existing: bool,
+
+        /// Runner ID
+        id: Option<String>,
+
+        /// Runner kind. Defaults to ssh when --server is set, otherwise local.
+        #[arg(long, value_enum)]
+        kind: Option<RunnerKindArg>,
+
+        /// Existing server ID for SSH runners
+        #[arg(long)]
+        server: Option<String>,
+
+        /// Root directory where this runner checks out or owns workspaces
+        #[arg(long)]
+        workspace_root: Option<String>,
+
+        /// Homeboy binary path on the runner machine
+        #[arg(long)]
+        homeboy_path: Option<String>,
+
+        /// Prefer daemon-backed execution for future runner commands
+        #[arg(long)]
+        daemon: bool,
+
+        /// Maximum concurrent workflows this runner should accept
+        #[arg(long)]
+        concurrency_limit: Option<usize>,
+
+        /// Artifact retention/copying policy label for future execution commands
+        #[arg(long)]
+        artifact_policy: Option<String>,
+    },
+    /// List all configured runners
+    List,
+    /// Display runner configuration
+    Show {
+        /// Runner ID
+        id: String,
+    },
+    /// Modify runner settings
+    #[command(visible_aliases = ["edit", "merge"])]
+    Set {
+        #[command(flatten)]
+        args: DynamicSetArgs,
+    },
+    /// Remove a runner configuration
+    Remove {
+        /// Runner ID
+        id: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum RunnerKindArg {
+    Local,
+    Ssh,
+}
+
+impl From<RunnerKindArg> for RunnerKind {
+    fn from(value: RunnerKindArg) -> Self {
+        match value {
+            RunnerKindArg::Local => RunnerKind::Local,
+            RunnerKindArg::Ssh => RunnerKind::Ssh,
+        }
+    }
+}
+
+pub fn run(args: RunnerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<RunnerOutput> {
+    match args.command {
+        RunnerCommand::Add {
+            json,
+            skip_existing,
+            id,
+            kind,
+            server,
+            workspace_root,
+            homeboy_path,
+            daemon,
+            concurrency_limit,
+            artifact_policy,
+        } => add(RunnerAddInput {
+            json,
+            skip_existing,
+            id,
+            kind,
+            server,
+            workspace_root,
+            homeboy_path,
+            daemon,
+            concurrency_limit,
+            artifact_policy,
+        }),
+        RunnerCommand::List => list(),
+        RunnerCommand::Show { id } => show(&id),
+        RunnerCommand::Set { args } => set(args),
+        RunnerCommand::Remove { id } => remove(&id),
+    }
+}
+
+struct RunnerAddInput {
+    json: Option<String>,
+    skip_existing: bool,
+    id: Option<String>,
+    kind: Option<RunnerKindArg>,
+    server: Option<String>,
+    workspace_root: Option<String>,
+    homeboy_path: Option<String>,
+    daemon: bool,
+    concurrency_limit: Option<usize>,
+    artifact_policy: Option<String>,
+}
+
+fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
+    let json_spec = if let Some(spec) = input.json {
+        spec
+    } else {
+        let id = input.id.ok_or_else(|| {
+            homeboy::Error::validation_invalid_argument(
+                "id",
+                "Missing required argument: id",
+                None,
+                None,
+            )
+        })?;
+        let kind = input.kind.map(RunnerKind::from).unwrap_or_else(|| {
+            if input.server.is_some() {
+                RunnerKind::Ssh
+            } else {
+                RunnerKind::Local
+            }
+        });
+        let new_runner = Runner {
+            id,
+            kind,
+            server_id: input.server,
+            workspace_root: input.workspace_root,
+            homeboy_path: input.homeboy_path,
+            daemon: input.daemon,
+            concurrency_limit: input.concurrency_limit,
+            artifact_policy: input.artifact_policy,
+            env: HashMap::new(),
+            resources: HashMap::<String, Value>::new(),
+        };
+
+        homeboy::config::to_json_string(&new_runner)?
+    };
+
+    match runner::create(&json_spec, input.skip_existing)? {
+        homeboy::CreateOutput::Single(result) => Ok((
+            RunnerOutput {
+                command: "runner.add".to_string(),
+                id: Some(result.id),
+                entity: Some(result.entity),
+                updated_fields: vec!["created".to_string()],
+                ..Default::default()
+            },
+            0,
+        )),
+        homeboy::CreateOutput::Bulk(summary) => {
+            let exit_code = summary.exit_code();
+            Ok((
+                RunnerOutput {
+                    command: "runner.add".to_string(),
+                    import: Some(summary),
+                    ..Default::default()
+                },
+                exit_code,
+            ))
+        }
+    }
+}
+
+fn list() -> CmdResult<RunnerOutput> {
+    Ok((
+        RunnerOutput {
+            command: "runner.list".to_string(),
+            entities: runner::list()?,
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
+fn show(id: &str) -> CmdResult<RunnerOutput> {
+    let runner = runner::load(id)?;
+    Ok((
+        RunnerOutput {
+            command: "runner.show".to_string(),
+            id: Some(runner.id.clone()),
+            entity: Some(runner),
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
+fn set(args: DynamicSetArgs) -> CmdResult<RunnerOutput> {
+    let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
+        homeboy::Error::validation_invalid_argument(
+            "spec",
+            "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
+            None,
+            None,
+        )
+    })?;
+    let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;
+
+    match runner::merge(args.id.as_deref(), &json_string, &replace_fields)? {
+        MergeOutput::Single(result) => {
+            let entity = runner::load(&result.id)?;
+            Ok((
+                RunnerOutput {
+                    command: "runner.set".to_string(),
+                    id: Some(result.id),
+                    entity: Some(entity),
+                    updated_fields: result.updated_fields,
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        MergeOutput::Bulk(summary) => {
+            let exit_code = summary.exit_code();
+            Ok((
+                RunnerOutput {
+                    command: "runner.set".to_string(),
+                    batch: Some(summary),
+                    ..Default::default()
+                },
+                exit_code,
+            ))
+        }
+    }
+}
+
+fn remove(id: &str) -> CmdResult<RunnerOutput> {
+    runner::delete_safe(id)?;
+    Ok((
+        RunnerOutput {
+            command: "runner.remove".to_string(),
+            id: Some(id.to_string()),
+            deleted: vec![id.to_string()],
+            ..Default::default()
+        },
+        0,
+    ))
+}

--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -132,6 +132,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
         | ErrorCode::ExtensionUnsupported
         | ErrorCode::DocsTopicNotFound
         | ErrorCode::RigNotFound
+        | ErrorCode::RunnerNotFound
         | ErrorCode::StackNotFound
         | ErrorCode::ProjectNoActive => 4,
 

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -34,6 +34,7 @@ pub enum ErrorCode {
     RigPipelineFailed,
     RigServiceFailed,
     RigResourceConflict,
+    RunnerNotFound,
     StackNotFound,
     StackApplyConflict,
 
@@ -82,6 +83,7 @@ impl ErrorCode {
             ErrorCode::RigPipelineFailed => "rig.pipeline_failed",
             ErrorCode::RigServiceFailed => "rig.service_failed",
             ErrorCode::RigResourceConflict => "rig.resource_conflict",
+            ErrorCode::RunnerNotFound => "runner.not_found",
             ErrorCode::StackNotFound => "stack.not_found",
             ErrorCode::StackApplyConflict => "stack.apply_conflict",
 
@@ -421,6 +423,10 @@ impl Error {
 
     pub fn rig_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {
         Self::entity_not_found(ErrorCode::RigNotFound, "Rig", id, suggestions)
+    }
+
+    pub fn runner_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {
+        Self::entity_not_found(ErrorCode::RunnerNotFound, "Runner", id, suggestions)
     }
 
     pub fn stack_not_found(id: impl Into<String>, suggestions: Vec<String>) -> Self {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -30,6 +30,7 @@ pub mod quality;
 pub mod refactor;
 pub mod release;
 pub mod rig;
+pub mod runner;
 pub mod scope;
 pub mod self_status;
 pub mod server;

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::config::{self, ConfigEntity};
+use crate::error::{Error, Result};
+use crate::output::{CreateOutput, MergeOutput, RemoveResult};
+use crate::server;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerKind {
+    Local,
+    Ssh,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Runner {
+    #[serde(skip_deserializing, default)]
+    pub id: String,
+    pub kind: RunnerKind,
+    #[serde(default)]
+    pub server_id: Option<String>,
+    #[serde(default)]
+    pub workspace_root: Option<String>,
+    #[serde(default)]
+    pub homeboy_path: Option<String>,
+    #[serde(default)]
+    pub daemon: bool,
+    #[serde(default)]
+    pub concurrency_limit: Option<usize>,
+    #[serde(default)]
+    pub artifact_policy: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub resources: HashMap<String, Value>,
+}
+
+impl ConfigEntity for Runner {
+    const ENTITY_TYPE: &'static str = "runner";
+    const DIR_NAME: &'static str = "runners";
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+
+    fn not_found_error(id: String, suggestions: Vec<String>) -> Error {
+        Error::runner_not_found(id, suggestions)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if matches!(self.kind, RunnerKind::Ssh) {
+            let server_id = self.server_id.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "server_id",
+                    "SSH runners require server_id",
+                    None,
+                    None,
+                )
+            })?;
+            server::load(server_id)?;
+        }
+
+        if self.concurrency_limit == Some(0) {
+            return Err(Error::validation_invalid_argument(
+                "concurrency_limit",
+                "concurrency_limit must be greater than zero",
+                None,
+                None,
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn dependents(_id: &str) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+}
+
+entity_crud!(Runner; merge);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support;
+
+    #[test]
+    fn runner_registry_persists_local_runner() {
+        test_support::with_isolated_home(|_| {
+            let spec = r#"{
+                "id": "lab-local",
+                "kind": "local",
+                "workspace_root": "/Users/chubes/Developer",
+                "homeboy_path": "/usr/local/bin/homeboy",
+                "daemon": true,
+                "concurrency_limit": 2,
+                "artifact_policy": "copy",
+                "env": {"RUST_LOG": "info"},
+                "resources": {"cpu": 8}
+            }"#;
+
+            create(spec, false).expect("create runner");
+            let runner = load("lab-local").expect("load runner");
+
+            assert_eq!(runner.id, "lab-local");
+            assert_eq!(runner.kind, RunnerKind::Local);
+            assert_eq!(runner.server_id, None);
+            assert_eq!(
+                runner.workspace_root.as_deref(),
+                Some("/Users/chubes/Developer")
+            );
+            assert_eq!(runner.concurrency_limit, Some(2));
+            assert_eq!(runner.env.get("RUST_LOG").map(String::as_str), Some("info"));
+            assert_eq!(runner.resources.get("cpu"), Some(&Value::from(8)));
+        });
+    }
+
+    #[test]
+    fn ssh_runner_requires_existing_server() {
+        test_support::with_isolated_home(|_| {
+            let spec = r#"{
+                "id": "remote-lab",
+                "kind": "ssh",
+                "server_id": "missing",
+                "workspace_root": "/srv/homeboy"
+            }"#;
+
+            let err = create(spec, false).expect_err("missing server rejects ssh runner");
+            assert_eq!(err.code.as_str(), "server.not_found");
+        });
+    }
+
+    #[test]
+    fn runner_set_updates_fields() {
+        test_support::with_isolated_home(|_| {
+            create(
+                r#"{"id":"lab-local","kind":"local","workspace_root":"/tmp/a"}"#,
+                false,
+            )
+            .expect("create runner");
+
+            let result = merge(
+                Some("lab-local"),
+                r#"{"workspace_root":"/tmp/b","concurrency_limit":3}"#,
+                &[],
+            )
+            .expect("merge runner");
+
+            match result {
+                MergeOutput::Single(result) => {
+                    assert_eq!(result.id, "lab-local");
+                    assert!(result
+                        .updated_fields
+                        .contains(&"workspace_root".to_string()));
+                    assert!(result
+                        .updated_fields
+                        .contains(&"concurrency_limit".to_string()));
+                }
+                MergeOutput::Bulk(_) => panic!("expected single merge"),
+            }
+
+            let runner = load("lab-local").expect("load runner");
+            assert_eq!(runner.workspace_root.as_deref(), Some("/tmp/b"));
+            assert_eq!(runner.concurrency_limit, Some(3));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Add a first-class `homeboy runner` registry with JSON-stable CRUD commands: `add`, `list`, `show`, `set`, and `remove`.
- Persist local and SSH runner records through the existing config entity pattern under `~/.config/homeboy/runners/`.
- Document the runner data shape for future `connect`, `doctor`, `exec`, and Desktop work without changing existing `server` behavior.

Closes #2526

## Tests
- `cargo test runner::tests`
- `cargo test command_surface`
- `cargo test cli_surface::tests`
- `cargo test`
- `./target/debug/homeboy runner add/list/show/set/remove` smoke with isolated `HOME`
- `./target/debug/homeboy server create` + `runner add --server` smoke with isolated `HOME`

## Lint
- `cargo clippy --all-targets -- -D warnings` was attempted, but it currently fails on pre-existing repository-wide clippy warnings outside this change, including `large_enum_variant`, `duplicate_mod`, `needless_update`, `unnecessary_sort_by`, and related warnings in existing modules.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner registry, docs, tests, and local verification; Chris remains responsible for review and merge decisions.