### PR TITLE
Expose daemon artifact retrieval endpoints

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -12,6 +12,9 @@ mod query;
 mod reconcile;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 use serde::Serialize;
@@ -57,6 +60,8 @@ enum RunsCommand {
     Show { run_id: String },
     /// List artifacts recorded for one run
     Artifacts { run_id: String },
+    /// Retrieve or sync recorded run artifacts
+    Artifact(RunsArtifactArgs),
     /// List findings recorded for one run
     Findings(findings::RunsFindingsArgs),
     /// Show one recorded finding
@@ -102,6 +107,7 @@ pub enum RunsOutput {
     Compare(RunsCompareOutput),
     Show(RunsShowOutput),
     Artifacts(RunsArtifactsOutput),
+    ArtifactGet(RunsArtifactGetOutput),
     Findings(RunsFindingsOutput),
     Finding(RunsFindingOutput),
     LatestFinding(RunsLatestFindingOutput),
@@ -132,6 +138,40 @@ pub struct RunsArtifactsOutput {
     pub command: &'static str,
     pub run_id: String,
     pub artifacts: Vec<ArtifactRecord>,
+}
+
+#[derive(Args, Clone)]
+pub struct RunsArtifactArgs {
+    #[command(subcommand)]
+    command: RunsArtifactCommand,
+}
+
+#[derive(Subcommand, Clone)]
+enum RunsArtifactCommand {
+    /// Copy a recorded file artifact to a local path
+    Get(RunsArtifactGetArgs),
+}
+
+#[derive(Args, Clone)]
+pub struct RunsArtifactGetArgs {
+    /// Observation run id that owns the artifact
+    pub run_id: String,
+    /// Artifact id/path token from `homeboy runs artifacts <run-id>`
+    pub artifact_id: String,
+    /// Destination file path. Defaults to the recorded artifact filename.
+    #[arg(long, short = 'o')]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+pub struct RunsArtifactGetOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub artifact_id: String,
+    pub output_path: String,
+    pub content_type: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub sha256: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -207,6 +247,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Reconcile(args) => reconcile_runs(args),
         RunsCommand::Show { run_id } => show_run(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
+        RunsCommand::Artifact(args) => artifact_command(args),
         RunsCommand::Findings(args) => findings::findings(args),
         RunsCommand::Finding { finding_id } => findings::finding(&finding_id),
         RunsCommand::LatestFinding(args) => findings::latest_finding(args),
@@ -277,6 +318,94 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
             command: "runs.artifacts",
             run_id: run_id.to_string(),
             artifacts: store.list_artifacts(run_id)?,
+        }),
+        0,
+    ))
+}
+
+fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
+    match args.command {
+        RunsArtifactCommand::Get(args) => artifact_get(args),
+    }
+}
+
+fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    require_run(&store, &args.run_id)?;
+    let artifact = store.get_artifact(&args.artifact_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!("artifact record not found: {}", args.artifact_id),
+            Some(args.artifact_id.clone()),
+            None,
+        )
+    })?;
+
+    if artifact.run_id != args.run_id {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "artifact does not belong to requested run",
+            Some(args.artifact_id),
+            None,
+        ));
+    }
+    if artifact.artifact_type != "file" {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "artifact {} is {}, not a downloadable file",
+                artifact.id, artifact.artifact_type
+            ),
+            Some(artifact.id),
+            None,
+        ));
+    }
+
+    let source = PathBuf::from(&artifact.path);
+    let file_name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(&artifact.id)
+        .to_string();
+    let output = args.output.unwrap_or_else(|| PathBuf::from(file_name));
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("create {}", parent.display())))
+        })?;
+    }
+
+    let mut reader = File::open(&source).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("open artifact {}", source.display())),
+        )
+    })?;
+    let mut writer = File::create(&output).map_err(|e| {
+        Error::internal_io(e.to_string(), Some(format!("create {}", output.display())))
+    })?;
+    io::copy(&mut reader, &mut writer).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "copy artifact {} to {}",
+                artifact.id,
+                output.display()
+            )),
+        )
+    })?;
+
+    Ok((
+        RunsOutput::ArtifactGet(RunsArtifactGetOutput {
+            command: "runs.artifact.get",
+            run_id: artifact.run_id,
+            artifact_id: artifact.id,
+            output_path: output.display().to_string(),
+            content_type: artifact.mime,
+            size_bytes: artifact.size_bytes,
+            sha256: artifact.sha256,
         }),
         0,
     ))
@@ -716,6 +845,50 @@ mod tests {
                 output.artifacts[0].url.as_deref(),
                 Some("https://example.test/")
             );
+        });
+    }
+
+    #[test]
+    fn artifact_get_copies_registered_file_without_raw_path_lookup() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let artifact_path = home.path().join("bench-results.json");
+            std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact");
+            let artifact = store
+                .record_artifact(&run.id, "bench_results", &artifact_path)
+                .expect("record artifact");
+            let output_path = home.path().join("downloaded.json");
+
+            let (output, _) = artifact_get(RunsArtifactGetArgs {
+                run_id: run.id.clone(),
+                artifact_id: artifact.id.clone(),
+                output: Some(output_path.clone()),
+            })
+            .expect("get artifact");
+
+            let RunsOutput::ArtifactGet(output) = output else {
+                panic!("expected artifact get output");
+            };
+            assert_eq!(output.command, "runs.artifact.get");
+            assert_eq!(output.artifact_id, artifact.id);
+            assert_eq!(
+                std::fs::read(&output_path).expect("downloaded"),
+                br#"{"ok":true}"#
+            );
+
+            let err = match artifact_get(RunsArtifactGetArgs {
+                run_id: run.id,
+                artifact_id: artifact_path.display().to_string(),
+                output: Some(home.path().join("bad.json")),
+            }) {
+                Ok(_) => panic!("raw paths are not accepted as artifact ids"),
+                Err(err) => err,
+            };
+            assert!(err.to_string().contains("artifact record not found"));
         });
     }
 

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::fs::{self, File};
+use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
@@ -9,8 +9,10 @@ use std::sync::OnceLock;
 use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
 use crate::http_api::{self, HttpMethod};
-use crate::observation::{ArtifactRecord, ObservationStore};
 use crate::paths;
+
+mod artifact_download;
+pub use artifact_download::ArtifactDownload;
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
 
@@ -51,15 +53,6 @@ pub struct HttpResponse {
     pub status_code: u16,
     pub body: serde_json::Value,
     pub artifact: Option<ArtifactDownload>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ArtifactDownload {
-    pub record: ArtifactRecord,
-    pub path: PathBuf,
-    pub content_type: String,
-    pub size_bytes: u64,
-    pub filename: String,
 }
 
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
@@ -243,7 +236,7 @@ fn route_read_only_api(
     };
 
     if matches!(method, HttpMethod::Get) {
-        if let Some(response) = route_artifact_download(path) {
+        if let Some(response) = artifact_download::route(path) {
             return response;
         }
     }
@@ -277,170 +270,6 @@ fn error_response(status_code: u16, err: Error) -> HttpResponse {
         }),
         artifact: None,
     }
-}
-
-fn route_artifact_download(path: &str) -> Option<HttpResponse> {
-    let path_only = path.split('?').next().unwrap_or(path);
-    let segments: Vec<&str> = path_only
-        .trim_matches('/')
-        .split('/')
-        .filter(|segment| !segment.is_empty())
-        .collect();
-
-    let result = match segments.as_slice() {
-        ["artifacts", artifact_token] => resolve_artifact_download(None, artifact_token),
-        ["runs", run_id, "artifacts", "sync"] => artifact_sync_manifest(run_id),
-        ["runs", run_id, "artifacts", artifact_token] => {
-            resolve_artifact_download(Some(run_id), artifact_token)
-        }
-        _ => return None,
-    };
-
-    Some(match result {
-        Ok(ResolvedArtifactResponse::Download(artifact)) => HttpResponse {
-            status_code: 200,
-            body: artifact_metadata_body(&artifact.record, Some(&artifact)),
-            artifact: Some(*artifact),
-        },
-        Ok(ResolvedArtifactResponse::Manifest(body)) => HttpResponse {
-            status_code: 200,
-            body,
-            artifact: None,
-        },
-        Err(err) => error_response(404, err),
-    })
-}
-
-enum ResolvedArtifactResponse {
-    Download(Box<ArtifactDownload>),
-    Manifest(serde_json::Value),
-}
-
-fn resolve_artifact_download(
-    expected_run_id: Option<&str>,
-    artifact_token: &str,
-) -> Result<ResolvedArtifactResponse> {
-    let store = ObservationStore::open_initialized()?;
-    let artifact = store.get_artifact(artifact_token)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "artifact_id",
-            format!("artifact record not found: {artifact_token}"),
-            Some(artifact_token.to_string()),
-            None,
-        )
-    })?;
-
-    if let Some(run_id) = expected_run_id {
-        if artifact.run_id != run_id {
-            return Err(Error::validation_invalid_argument(
-                "artifact_id",
-                "artifact does not belong to requested run",
-                Some(artifact_token.to_string()),
-                None,
-            ));
-        }
-    }
-
-    if artifact.artifact_type != "file" {
-        return Err(Error::validation_invalid_argument(
-            "artifact_id",
-            format!(
-                "artifact {} is {}, not a downloadable file",
-                artifact.id, artifact.artifact_type
-            ),
-            Some(artifact.id.clone()),
-            None,
-        ));
-    }
-
-    let path = PathBuf::from(&artifact.path);
-    let metadata = fs::metadata(&path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("read artifact metadata {}", path.display())),
-        )
-    })?;
-    if !metadata.is_file() {
-        return Err(Error::validation_invalid_argument(
-            "artifact_id",
-            format!("registered artifact path is not a file: {}", path.display()),
-            Some(artifact.id.clone()),
-            None,
-        ));
-    }
-
-    let content_type = artifact
-        .mime
-        .clone()
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let filename = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(&artifact.id)
-        .to_string();
-
-    Ok(ResolvedArtifactResponse::Download(Box::new(
-        ArtifactDownload {
-            record: artifact,
-            path,
-            content_type,
-            size_bytes: metadata.len(),
-            filename,
-        },
-    )))
-}
-
-fn artifact_sync_manifest(run_id: &str) -> Result<ResolvedArtifactResponse> {
-    let store = ObservationStore::open_initialized()?;
-    if store.get_run(run_id)?.is_none() {
-        return Err(Error::validation_invalid_argument(
-            "run_id",
-            format!("run record not found: {run_id}"),
-            Some(run_id.to_string()),
-            None,
-        ));
-    }
-
-    let artifacts: Vec<serde_json::Value> = store
-        .list_artifacts(run_id)?
-        .into_iter()
-        .map(|artifact| {
-            json!({
-                "id": artifact.id,
-                "path_token": artifact.id,
-                "run_id": artifact.run_id,
-                "kind": artifact.kind,
-                "type": artifact.artifact_type,
-                "download_path": format!("/runs/{}/artifacts/{}", run_id, artifact.id),
-                "sha256": artifact.sha256,
-                "size_bytes": artifact.size_bytes,
-                "mime": artifact.mime,
-                "created_at": artifact.created_at,
-            })
-        })
-        .collect();
-
-    Ok(ResolvedArtifactResponse::Manifest(json!({
-        "command": "api.runs.artifacts.sync",
-        "run_id": run_id,
-        "artifacts": artifacts,
-    })))
-}
-
-fn artifact_metadata_body(
-    artifact: &ArtifactRecord,
-    download: Option<&ArtifactDownload>,
-) -> serde_json::Value {
-    json!({
-        "command": "api.runs.artifact.download",
-        "artifact": artifact,
-        "path_token": artifact.id,
-        "content_type": download.map(|download| download.content_type.clone()).or_else(|| artifact.mime.clone()),
-        "size_bytes": download
-            .and_then(|download| i64::try_from(download.size_bytes).ok())
-            .or(artifact.size_bytes),
-        "sha256": artifact.sha256,
-    })
 }
 
 fn config_paths_body() -> Result<serde_json::Value> {
@@ -518,7 +347,7 @@ fn handle_connection(mut stream: TcpStream, job_store: &JobStore) -> std::io::Re
 
 fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io::Result<()> {
     if let Some(artifact) = response.artifact {
-        return write_artifact_response(stream, response.status_code, artifact);
+        return artifact_download::write_response(stream, response.status_code, artifact);
     }
 
     let body = serde_json::to_string_pretty(&json!({
@@ -541,44 +370,6 @@ fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io
         body.len(),
         body
     )
-}
-
-fn write_artifact_response(
-    mut stream: TcpStream,
-    status_code: u16,
-    artifact: ArtifactDownload,
-) -> std::io::Result<()> {
-    let mut file = File::open(&artifact.path)?;
-    let status_text = if status_code == 200 {
-        "OK"
-    } else {
-        "Internal Server Error"
-    };
-    write!(
-        stream,
-        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nContent-Disposition: attachment; filename=\"{}\"\r\nX-Homeboy-Artifact-Id: {}\r\nX-Homeboy-Run-Id: {}\r\nX-Homeboy-Artifact-Kind: {}\r\nConnection: close\r\n",
-        status_code,
-        status_text,
-        artifact.content_type,
-        artifact.size_bytes,
-        sanitize_header_value(&artifact.filename),
-        artifact.record.id,
-        artifact.record.run_id,
-        sanitize_header_value(&artifact.record.kind),
-    )?;
-    if let Some(sha256) = &artifact.record.sha256 {
-        write!(stream, "X-Homeboy-Artifact-Sha256: {}\r\n", sha256)?;
-    }
-    write!(stream, "\r\n")?;
-    std::io::copy(&mut file, &mut stream)?;
-    Ok(())
-}
-
-fn sanitize_header_value(value: &str) -> String {
-    value
-        .chars()
-        .filter(|ch| !matches!(ch, '\r' | '\n' | '"'))
-        .collect()
 }
 
 pub(crate) fn pid_is_running(pid: u32) -> bool {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::fs;
+use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
@@ -9,6 +9,7 @@ use std::sync::OnceLock;
 use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
 use crate::http_api::{self, HttpMethod};
+use crate::observation::{ArtifactRecord, ObservationStore};
 use crate::paths;
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
@@ -49,6 +50,16 @@ pub struct DaemonStopResult {
 pub struct HttpResponse {
     pub status_code: u16,
     pub body: serde_json::Value,
+    pub artifact: Option<ArtifactDownload>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactDownload {
+    pub record: ArtifactRecord,
+    pub path: PathBuf,
+    pub content_type: String,
+    pub size_bytes: u64,
+    pub filename: String,
 }
 
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
@@ -183,23 +194,27 @@ pub fn route_with_job_store_and_body(
                 "status": "ok",
                 "version": env!("CARGO_PKG_VERSION"),
             }),
+            artifact: None,
         },
         ("GET", "/version") => HttpResponse {
             status_code: 200,
             body: json!({
                 "version": env!("CARGO_PKG_VERSION"),
             }),
+            artifact: None,
         },
         ("GET", "/config/paths") => match config_paths_body() {
             Ok(body) => HttpResponse {
                 status_code: 200,
                 body,
+                artifact: None,
             },
             Err(err) => error_response(500, err),
         },
         ("POST", "/health") | ("POST", "/version") | ("POST", "/config/paths") => HttpResponse {
             status_code: 405,
             body: json!({ "error": "method_not_allowed" }),
+            artifact: None,
         },
         _ => route_read_only_api(method, path, body, job_store),
     }
@@ -222,9 +237,16 @@ fn route_read_only_api(
             return HttpResponse {
                 status_code: 405,
                 body: json!({ "error": "method_not_allowed" }),
+                artifact: None,
             };
         }
     };
+
+    if matches!(method, HttpMethod::Get) {
+        if let Some(response) = route_artifact_download(path) {
+            return response;
+        }
+    }
 
     match http_api::handle_with_jobs(
         http_api::HttpApiRequest {
@@ -238,6 +260,7 @@ fn route_read_only_api(
             status_code: response.status,
             body: serde_json::to_value(response)
                 .unwrap_or_else(|_| json!({ "error": "internal_json" })),
+            artifact: None,
         },
         Err(err) => error_response(404, err),
     }
@@ -252,7 +275,172 @@ fn error_response(status_code: u16, err: Error) -> HttpResponse {
             "details": err.details,
             "hints": err.hints,
         }),
+        artifact: None,
     }
+}
+
+fn route_artifact_download(path: &str) -> Option<HttpResponse> {
+    let path_only = path.split('?').next().unwrap_or(path);
+    let segments: Vec<&str> = path_only
+        .trim_matches('/')
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+
+    let result = match segments.as_slice() {
+        ["artifacts", artifact_token] => resolve_artifact_download(None, artifact_token),
+        ["runs", run_id, "artifacts", "sync"] => artifact_sync_manifest(run_id),
+        ["runs", run_id, "artifacts", artifact_token] => {
+            resolve_artifact_download(Some(run_id), artifact_token)
+        }
+        _ => return None,
+    };
+
+    Some(match result {
+        Ok(ResolvedArtifactResponse::Download(artifact)) => HttpResponse {
+            status_code: 200,
+            body: artifact_metadata_body(&artifact.record, Some(&artifact)),
+            artifact: Some(*artifact),
+        },
+        Ok(ResolvedArtifactResponse::Manifest(body)) => HttpResponse {
+            status_code: 200,
+            body,
+            artifact: None,
+        },
+        Err(err) => error_response(404, err),
+    })
+}
+
+enum ResolvedArtifactResponse {
+    Download(Box<ArtifactDownload>),
+    Manifest(serde_json::Value),
+}
+
+fn resolve_artifact_download(
+    expected_run_id: Option<&str>,
+    artifact_token: &str,
+) -> Result<ResolvedArtifactResponse> {
+    let store = ObservationStore::open_initialized()?;
+    let artifact = store.get_artifact(artifact_token)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!("artifact record not found: {artifact_token}"),
+            Some(artifact_token.to_string()),
+            None,
+        )
+    })?;
+
+    if let Some(run_id) = expected_run_id {
+        if artifact.run_id != run_id {
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                "artifact does not belong to requested run",
+                Some(artifact_token.to_string()),
+                None,
+            ));
+        }
+    }
+
+    if artifact.artifact_type != "file" {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "artifact {} is {}, not a downloadable file",
+                artifact.id, artifact.artifact_type
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+
+    let path = PathBuf::from(&artifact.path);
+    let metadata = fs::metadata(&path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read artifact metadata {}", path.display())),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!("registered artifact path is not a file: {}", path.display()),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+
+    let content_type = artifact
+        .mime
+        .clone()
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(&artifact.id)
+        .to_string();
+
+    Ok(ResolvedArtifactResponse::Download(Box::new(
+        ArtifactDownload {
+            record: artifact,
+            path,
+            content_type,
+            size_bytes: metadata.len(),
+            filename,
+        },
+    )))
+}
+
+fn artifact_sync_manifest(run_id: &str) -> Result<ResolvedArtifactResponse> {
+    let store = ObservationStore::open_initialized()?;
+    if store.get_run(run_id)?.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("run record not found: {run_id}"),
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+
+    let artifacts: Vec<serde_json::Value> = store
+        .list_artifacts(run_id)?
+        .into_iter()
+        .map(|artifact| {
+            json!({
+                "id": artifact.id,
+                "path_token": artifact.id,
+                "run_id": artifact.run_id,
+                "kind": artifact.kind,
+                "type": artifact.artifact_type,
+                "download_path": format!("/runs/{}/artifacts/{}", run_id, artifact.id),
+                "sha256": artifact.sha256,
+                "size_bytes": artifact.size_bytes,
+                "mime": artifact.mime,
+                "created_at": artifact.created_at,
+            })
+        })
+        .collect();
+
+    Ok(ResolvedArtifactResponse::Manifest(json!({
+        "command": "api.runs.artifacts.sync",
+        "run_id": run_id,
+        "artifacts": artifacts,
+    })))
+}
+
+fn artifact_metadata_body(
+    artifact: &ArtifactRecord,
+    download: Option<&ArtifactDownload>,
+) -> serde_json::Value {
+    json!({
+        "command": "api.runs.artifact.download",
+        "artifact": artifact,
+        "path_token": artifact.id,
+        "content_type": download.map(|download| download.content_type.clone()).or_else(|| artifact.mime.clone()),
+        "size_bytes": download
+            .and_then(|download| i64::try_from(download.size_bytes).ok())
+            .or(artifact.size_bytes),
+        "sha256": artifact.sha256,
+    })
 }
 
 fn config_paths_body() -> Result<serde_json::Value> {
@@ -329,6 +517,10 @@ fn handle_connection(mut stream: TcpStream, job_store: &JobStore) -> std::io::Re
 }
 
 fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io::Result<()> {
+    if let Some(artifact) = response.artifact {
+        return write_artifact_response(stream, response.status_code, artifact);
+    }
+
     let body = serde_json::to_string_pretty(&json!({
         "success": (200..300).contains(&response.status_code),
         "data": response.body,
@@ -349,6 +541,44 @@ fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io
         body.len(),
         body
     )
+}
+
+fn write_artifact_response(
+    mut stream: TcpStream,
+    status_code: u16,
+    artifact: ArtifactDownload,
+) -> std::io::Result<()> {
+    let mut file = File::open(&artifact.path)?;
+    let status_text = if status_code == 200 {
+        "OK"
+    } else {
+        "Internal Server Error"
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nContent-Disposition: attachment; filename=\"{}\"\r\nX-Homeboy-Artifact-Id: {}\r\nX-Homeboy-Run-Id: {}\r\nX-Homeboy-Artifact-Kind: {}\r\nConnection: close\r\n",
+        status_code,
+        status_text,
+        artifact.content_type,
+        artifact.size_bytes,
+        sanitize_header_value(&artifact.filename),
+        artifact.record.id,
+        artifact.record.run_id,
+        sanitize_header_value(&artifact.record.kind),
+    )?;
+    if let Some(sha256) = &artifact.record.sha256 {
+        write!(stream, "X-Homeboy-Artifact-Sha256: {}\r\n", sha256)?;
+    }
+    write!(stream, "\r\n")?;
+    std::io::copy(&mut file, &mut stream)?;
+    Ok(())
+}
+
+fn sanitize_header_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| !matches!(ch, '\r' | '\n' | '"'))
+        .collect()
 }
 
 pub(crate) fn pid_is_running(pid: u32) -> bool {

--- a/src/core/daemon/artifact_download.rs
+++ b/src/core/daemon/artifact_download.rs
@@ -1,0 +1,234 @@
+use serde_json::json;
+use std::fs::{self, File};
+use std::io::Write;
+use std::net::TcpStream;
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::observation::{ArtifactRecord, ObservationStore};
+
+use super::HttpResponse;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactDownload {
+    pub record: ArtifactRecord,
+    pub path: PathBuf,
+    pub content_type: String,
+    pub size_bytes: u64,
+    pub filename: String,
+}
+
+pub(crate) fn route(path: &str) -> Option<HttpResponse> {
+    let path_only = path.split('?').next().unwrap_or(path);
+    let segments: Vec<&str> = path_only
+        .trim_matches('/')
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+
+    let result = match segments.as_slice() {
+        ["artifacts", artifact_token] => resolve_artifact_download(None, artifact_token),
+        ["runs", run_id, "artifacts", "sync"] => artifact_sync_manifest(run_id),
+        ["runs", run_id, "artifacts", artifact_token] => {
+            resolve_artifact_download(Some(run_id), artifact_token)
+        }
+        _ => return None,
+    };
+
+    Some(match result {
+        Ok(ResolvedArtifactResponse::Download(artifact)) => HttpResponse {
+            status_code: 200,
+            body: artifact_metadata_body(&artifact.record, Some(&artifact)),
+            artifact: Some(*artifact),
+        },
+        Ok(ResolvedArtifactResponse::Manifest(body)) => HttpResponse {
+            status_code: 200,
+            body,
+            artifact: None,
+        },
+        Err(err) => error_response(404, err),
+    })
+}
+
+pub(crate) fn write_response(
+    mut stream: TcpStream,
+    status_code: u16,
+    artifact: ArtifactDownload,
+) -> std::io::Result<()> {
+    let mut file = File::open(&artifact.path)?;
+    let status_text = if status_code == 200 {
+        "OK"
+    } else {
+        "Internal Server Error"
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nContent-Disposition: attachment; filename=\"{}\"\r\nX-Homeboy-Artifact-Id: {}\r\nX-Homeboy-Run-Id: {}\r\nX-Homeboy-Artifact-Kind: {}\r\nConnection: close\r\n",
+        status_code,
+        status_text,
+        artifact.content_type,
+        artifact.size_bytes,
+        sanitize_header_value(&artifact.filename),
+        artifact.record.id,
+        artifact.record.run_id,
+        sanitize_header_value(&artifact.record.kind),
+    )?;
+    if let Some(sha256) = &artifact.record.sha256 {
+        write!(stream, "X-Homeboy-Artifact-Sha256: {}\r\n", sha256)?;
+    }
+    write!(stream, "\r\n")?;
+    std::io::copy(&mut file, &mut stream)?;
+    Ok(())
+}
+
+enum ResolvedArtifactResponse {
+    Download(Box<ArtifactDownload>),
+    Manifest(serde_json::Value),
+}
+
+fn resolve_artifact_download(
+    expected_run_id: Option<&str>,
+    artifact_token: &str,
+) -> Result<ResolvedArtifactResponse> {
+    let store = ObservationStore::open_initialized()?;
+    let artifact = store.get_artifact(artifact_token)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!("artifact record not found: {artifact_token}"),
+            Some(artifact_token.to_string()),
+            None,
+        )
+    })?;
+
+    if let Some(run_id) = expected_run_id {
+        if artifact.run_id != run_id {
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                "artifact does not belong to requested run",
+                Some(artifact_token.to_string()),
+                None,
+            ));
+        }
+    }
+
+    if artifact.artifact_type != "file" {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "artifact {} is {}, not a downloadable file",
+                artifact.id, artifact.artifact_type
+            ),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+
+    let path = PathBuf::from(&artifact.path);
+    let metadata = fs::metadata(&path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read artifact metadata {}", path.display())),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!("registered artifact path is not a file: {}", path.display()),
+            Some(artifact.id.clone()),
+            None,
+        ));
+    }
+
+    let content_type = artifact
+        .mime
+        .clone()
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(&artifact.id)
+        .to_string();
+
+    Ok(ResolvedArtifactResponse::Download(Box::new(
+        ArtifactDownload {
+            record: artifact,
+            path,
+            content_type,
+            size_bytes: metadata.len(),
+            filename,
+        },
+    )))
+}
+
+fn artifact_sync_manifest(run_id: &str) -> Result<ResolvedArtifactResponse> {
+    let store = ObservationStore::open_initialized()?;
+    if store.get_run(run_id)?.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("run record not found: {run_id}"),
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+
+    let artifacts: Vec<serde_json::Value> = store
+        .list_artifacts(run_id)?
+        .into_iter()
+        .map(|artifact| {
+            json!({
+                "id": artifact.id,
+                "path_token": artifact.id,
+                "run_id": artifact.run_id,
+                "kind": artifact.kind,
+                "type": artifact.artifact_type,
+                "download_path": format!("/runs/{}/artifacts/{}", run_id, artifact.id),
+                "sha256": artifact.sha256,
+                "size_bytes": artifact.size_bytes,
+                "mime": artifact.mime,
+                "created_at": artifact.created_at,
+            })
+        })
+        .collect();
+
+    Ok(ResolvedArtifactResponse::Manifest(json!({
+        "command": "api.runs.artifacts.sync",
+        "run_id": run_id,
+        "artifacts": artifacts,
+    })))
+}
+
+fn artifact_metadata_body(
+    artifact: &ArtifactRecord,
+    download: Option<&ArtifactDownload>,
+) -> serde_json::Value {
+    json!({
+        "command": "api.runs.artifact.download",
+        "artifact": artifact,
+        "path_token": artifact.id,
+        "content_type": download.map(|download| download.content_type.clone()).or_else(|| artifact.mime.clone()),
+        "size_bytes": download
+            .and_then(|download| i64::try_from(download.size_bytes).ok())
+            .or(artifact.size_bytes),
+        "sha256": artifact.sha256,
+    })
+}
+
+fn error_response(status_code: u16, err: Error) -> HttpResponse {
+    HttpResponse {
+        status_code,
+        body: json!({
+            "error": err.code.as_str(),
+            "message": err.message,
+            "details": err.details,
+            "hints": err.hints,
+        }),
+        artifact: None,
+    }
+}
+
+fn sanitize_header_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| !matches!(ch, '\r' | '\n' | '"'))
+        .collect()
+}

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -683,7 +683,7 @@ impl ObservationStore {
         collect_rows(rows, "collect artifact records")
     }
 
-    fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
+    pub fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
         validate_required("artifact_id", artifact_id)?;
         self.connection
             .query_row(

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::api_jobs::JobStore;
+use crate::observation::{NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 
 #[test]
@@ -72,6 +73,55 @@ fn routes_read_only_http_api_contract() {
     let findings = route("GET", "/runs/run-missing/findings");
     assert_eq!(findings.status_code, 404);
     assert_eq!(findings.body["error"], "validation.invalid_argument");
+}
+
+#[test]
+fn routes_registered_artifact_downloads_and_sync_manifest() {
+    let _home = HomeGuard::new();
+    let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
+    let store = ObservationStore::open_initialized().expect("store");
+    let run = store
+        .start_run(NewRunRecord {
+            kind: "bench".to_string(),
+            component_id: Some("homeboy".to_string()),
+            command: Some("homeboy bench".to_string()),
+            cwd: Some("/tmp/homeboy-fixture".to_string()),
+            homeboy_version: Some("test-version".to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: Some("studio".to_string()),
+            metadata_json: serde_json::json!({}),
+        })
+        .expect("run");
+    let artifact_path = home_path.join("bench-results.json");
+    std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact");
+    let artifact = store
+        .record_artifact(&run.id, "bench_results", &artifact_path)
+        .expect("record artifact");
+
+    let download = route(
+        "GET",
+        &format!("/runs/{}/artifacts/{}", run.id, artifact.id),
+    );
+    assert_eq!(download.status_code, 200);
+    assert!(download.artifact.is_some());
+    assert_eq!(download.body["artifact"]["id"], artifact.id);
+    assert_eq!(download.body["size_bytes"], 11);
+
+    let sync = route("GET", &format!("/runs/{}/artifacts/sync", run.id));
+    assert_eq!(sync.status_code, 200);
+    assert!(sync.artifact.is_none());
+    assert_eq!(sync.body["command"], "api.runs.artifacts.sync");
+    assert_eq!(sync.body["artifacts"][0]["id"], artifact.id);
+    assert_eq!(
+        sync.body["artifacts"][0]["download_path"],
+        format!("/runs/{}/artifacts/{}", run.id, artifact.id)
+    );
+
+    let raw_path = route(
+        "GET",
+        &format!("/runs/{}/artifacts/{}", run.id, artifact_path.display()),
+    );
+    assert_eq!(raw_path.status_code, 404);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds daemon artifact download routes that resolve only persisted artifact records/path tokens and stream file contents with metadata headers.
- Adds a run artifact sync manifest endpoint with download paths and size/type/checksum metadata for Desktop-style clients.
- Adds `homeboy runs artifact get <run-id> <artifact-id> --output <path>` for local recorded artifact retrieval without arbitrary source path reads.

Closes #2531

## Tests
- `cargo test daemon_test::routes_registered_artifact_downloads_and_sync_manifest --lib`
- `cargo test commands::runs::tests::artifact_get_copies_registered_file_without_raw_path_lookup --lib`
- `cargo test core::extension::execution::tests::build_exec_env_includes_runtime_runner_helper_path --lib`
- `cargo test --lib`
- `git diff --check`

## Notes
- `cargo clippy --lib -- -D warnings` is currently blocked by existing baseline warnings across unrelated modules; this branch fixed the new artifact resolver enum-size warning before rerunning.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the daemon artifact retrieval/sync endpoints, CLI wrapper, and regression tests; Chris remains responsible for review and validation.