### PR TITLE
feat: add plan construction helpers

### DIFF
--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -76,7 +76,7 @@ pub use report::AuditCommandOutput;
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};
 pub use walker::is_test_path;
 
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 use crate::{component, component::AuditConfig, is_zero, Result};
 
 /// Summary counts for the audit report.
@@ -361,25 +361,11 @@ impl AuditExecutionPlan {
     }
 
     fn with_generic_plan(mode: &str, mut audit: Self) -> Self {
-        let mut plan = HomeboyPlan::for_description(PlanKind::Audit, "audit execution");
-        plan.mode = Some(mode.to_string());
-        plan.steps = audit.detector_steps();
-        plan.summary = Some(PlanSummary {
-            total_steps: plan.steps.len(),
-            ready: plan
-                .steps
-                .iter()
-                .filter(|step| step.status == PlanStepStatus::Ready)
-                .count(),
-            blocked: 0,
-            skipped: plan
-                .steps
-                .iter()
-                .filter(|step| step.status == PlanStepStatus::Disabled)
-                .count(),
-            next_actions: Vec::new(),
-        });
-        audit.plan = plan;
+        audit.plan = HomeboyPlan::builder_for_description(PlanKind::Audit, "audit execution")
+            .mode(mode)
+            .steps(audit.detector_steps())
+            .summarize_disabled_as_skipped()
+            .build();
         audit
     }
 
@@ -411,23 +397,24 @@ impl AuditExecutionPlan {
             ("enum_dispatch_contracts", self.run_enum_dispatch_contracts),
         ]
         .into_iter()
-        .map(|(name, enabled)| PlanStep {
-            id: format!("audit.{name}"),
-            kind: format!("audit.detector.{name}"),
-            label: Some(name.replace('_', " ")),
-            blocking: true,
-            scope: Vec::new(),
-            needs: Vec::new(),
-            status: if enabled {
-                PlanStepStatus::Ready
+        .map(|(name, enabled)| {
+            let builder = PlanStep::builder(
+                format!("audit.{name}"),
+                format!("audit.detector.{name}"),
+                if enabled {
+                    PlanStepStatus::Ready
+                } else {
+                    PlanStepStatus::Disabled
+                },
+            )
+            .label(name.replace('_', " "));
+
+            if enabled {
+                builder
             } else {
-                PlanStepStatus::Disabled
-            },
-            inputs: std::collections::HashMap::new(),
-            outputs: std::collections::HashMap::new(),
-            skip_reason: (!enabled).then(|| "filtered".to_string()),
-            policy: std::collections::HashMap::new(),
-            missing: Vec::new(),
+                builder.skip_reason("filtered")
+            }
+            .build()
         })
         .collect()
     }

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -1,5 +1,5 @@
 use crate::component::{self, Component, DependencyStackEdge};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
 use crate::{Error, Result};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -208,15 +208,10 @@ pub fn stack_plan_from_components(
 impl DependencyStackPlan {
     pub fn new(upstream: impl Into<String>, steps: Vec<DependencyStackPlanStep>) -> Self {
         let upstream = upstream.into();
-        let mut plan = HomeboyPlan::for_component(PlanKind::DependencyStack, upstream.clone());
-        plan.steps = steps.iter().map(stack_step).collect();
-        plan.summary = Some(PlanSummary {
-            total_steps: plan.steps.len(),
-            ready: plan.steps.len(),
-            blocked: 0,
-            skipped: 0,
-            next_actions: Vec::new(),
-        });
+        let plan = HomeboyPlan::builder_for_component(PlanKind::DependencyStack, upstream.clone())
+            .steps(steps.iter().map(stack_step))
+            .summarize()
+            .build();
 
         Self {
             plan,
@@ -254,23 +249,17 @@ fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
         serde_json::Value::String(step.update_command.clone()),
     );
 
-    PlanStep {
-        id: format!("deps.stack.{:03}.{}", step.sequence, step.downstream),
-        kind: "deps.stack.update_downstream".to_string(),
-        label: Some(format!(
-            "Update {} in {} from {}",
-            step.package, step.downstream, step.upstream
-        )),
-        blocking: true,
-        scope: vec![step.downstream.clone()],
-        needs: Vec::new(),
-        status: PlanStepStatus::Ready,
-        inputs,
-        outputs: std::collections::HashMap::new(),
-        skip_reason: None,
-        policy: std::collections::HashMap::new(),
-        missing: Vec::new(),
-    }
+    PlanStep::ready(
+        format!("deps.stack.{:03}.{}", step.sequence, step.downstream),
+        "deps.stack.update_downstream",
+    )
+    .label(format!(
+        "Update {} in {} from {}",
+        step.package, step.downstream, step.upstream
+    ))
+    .scope(vec![step.downstream.clone()])
+    .inputs(inputs)
+    .build()
 }
 
 fn edge_status(component: &Component, edge: &DependencyStackEdge) -> DependencyStackEdgeStatus {

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::code_audit::FindingConfidence;
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 
 /// One row of incoming findings: "command produced N findings of category X
 /// for component Y." This is the input grain reconcile reasons over.
@@ -180,27 +180,10 @@ pub struct ReconcilePlan {
 impl ReconcilePlan {
     pub fn new(component_id: impl Into<String>, actions: Vec<ReconcileAction>) -> Self {
         let component_id = component_id.into();
-        let mut plan = HomeboyPlan::for_component(PlanKind::IssueReconcile, component_id);
-        plan.steps = actions.iter().enumerate().map(action_step).collect();
-        plan.summary = Some(PlanSummary {
-            total_steps: plan.steps.len(),
-            ready: plan
-                .steps
-                .iter()
-                .filter(|step| step.status == PlanStepStatus::Ready)
-                .count(),
-            blocked: plan
-                .steps
-                .iter()
-                .filter(|step| step.status == PlanStepStatus::Missing)
-                .count(),
-            skipped: plan
-                .steps
-                .iter()
-                .filter(|step| step.status == PlanStepStatus::Skipped)
-                .count(),
-            next_actions: Vec::new(),
-        });
+        let plan = HomeboyPlan::builder_for_component(PlanKind::IssueReconcile, component_id)
+            .steps(actions.iter().enumerate().map(action_step))
+            .summarize()
+            .build();
 
         Self { plan, actions }
     }
@@ -237,27 +220,26 @@ fn action_step((index, action): (usize, &ReconcileAction)) -> PlanStep {
         serde_json::to_value(action).unwrap_or(serde_json::Value::Null),
     );
 
-    PlanStep {
-        id: format!("issues.reconcile.{:03}.{}", index + 1, action_kind),
-        kind: format!("issues.reconcile.{action_kind}"),
-        label: Some(action_label(action)),
-        blocking: !matches!(action, ReconcileAction::Skip { .. }),
-        scope: Vec::new(),
-        needs: Vec::new(),
-        status: if matches!(action, ReconcileAction::Skip { .. }) {
+    let id = format!("issues.reconcile.{:03}.{}", index + 1, action_kind);
+    let kind = format!("issues.reconcile.{action_kind}");
+    let builder = PlanStep::builder(
+        id,
+        kind,
+        if matches!(action, ReconcileAction::Skip { .. }) {
             PlanStepStatus::Skipped
         } else {
             PlanStepStatus::Ready
         },
-        inputs,
-        outputs: std::collections::HashMap::new(),
-        skip_reason: match action {
-            ReconcileAction::Skip { reason, .. } => Some(format!("{:?}", reason)),
-            _ => None,
-        },
-        policy: std::collections::HashMap::new(),
-        missing: Vec::new(),
+    )
+    .label(action_label(action))
+    .blocking(!matches!(action, ReconcileAction::Skip { .. }))
+    .inputs(inputs);
+
+    match action {
+        ReconcileAction::Skip { reason, .. } => builder.skip_reason(format!("{:?}", reason)),
+        _ => builder,
     }
+    .build()
 }
 
 fn action_kind(action: &ReconcileAction) -> &'static str {

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -73,6 +73,20 @@ impl HomeboyPlan {
             hints: Vec::new(),
         }
     }
+
+    pub(crate) fn builder_for_component(
+        kind: PlanKind,
+        component_id: impl Into<String>,
+    ) -> PlanBuilder {
+        PlanBuilder::from_plan(Self::for_component(kind, component_id))
+    }
+
+    pub(crate) fn builder_for_description(
+        kind: PlanKind,
+        description: impl Into<String>,
+    ) -> PlanBuilder {
+        PlanBuilder::from_plan(Self::for_description(kind, description))
+    }
 }
 
 impl Default for HomeboyPlan {
@@ -161,6 +175,168 @@ pub struct PlanStep {
     pub missing: Vec<String>,
 }
 
+impl PlanStep {
+    pub(crate) fn builder(
+        id: impl Into<String>,
+        kind: impl Into<String>,
+        status: PlanStepStatus,
+    ) -> PlanStepBuilder {
+        PlanStepBuilder::new(id, kind, status)
+    }
+
+    pub(crate) fn ready(id: impl Into<String>, kind: impl Into<String>) -> PlanStepBuilder {
+        PlanStepBuilder::new(id, kind, PlanStepStatus::Ready)
+    }
+
+    pub(crate) fn disabled(id: impl Into<String>, kind: impl Into<String>) -> PlanStepBuilder {
+        PlanStepBuilder::new(id, kind, PlanStepStatus::Disabled)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlanBuilder {
+    plan: HomeboyPlan,
+    summary_mode: SummaryMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SummaryMode {
+    None,
+    Standard,
+    DisabledAsSkipped,
+}
+
+impl PlanBuilder {
+    pub(crate) fn from_plan(plan: HomeboyPlan) -> Self {
+        Self {
+            plan,
+            summary_mode: SummaryMode::None,
+        }
+    }
+
+    pub(crate) fn mode(mut self, mode: impl Into<String>) -> Self {
+        self.plan.mode = Some(mode.into());
+        self
+    }
+
+    pub(crate) fn input_value(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+        self.plan.inputs.insert(key.into(), value);
+        self
+    }
+
+    pub(crate) fn policy_value(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+        self.plan.policy.insert(key.into(), value);
+        self
+    }
+
+    pub(crate) fn warnings(mut self, warnings: impl IntoIterator<Item = String>) -> Self {
+        self.plan.warnings.extend(warnings);
+        self
+    }
+
+    pub(crate) fn steps(mut self, steps: impl IntoIterator<Item = PlanStep>) -> Self {
+        self.plan.steps.extend(steps);
+        self
+    }
+
+    pub(crate) fn summarize(mut self) -> Self {
+        self.summary_mode = SummaryMode::Standard;
+        self
+    }
+
+    pub(crate) fn summarize_disabled_as_skipped(mut self) -> Self {
+        self.summary_mode = SummaryMode::DisabledAsSkipped;
+        self
+    }
+
+    pub(crate) fn build(mut self) -> HomeboyPlan {
+        match self.summary_mode {
+            SummaryMode::None => {}
+            SummaryMode::Standard => {
+                self.plan.summary = Some(PlanSummary::from_steps(&self.plan.steps));
+            }
+            SummaryMode::DisabledAsSkipped => {
+                self.plan.summary = Some(PlanSummary::from_steps_counting_disabled_as_skipped(
+                    &self.plan.steps,
+                ));
+            }
+        }
+        self.plan
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlanStepBuilder {
+    step: PlanStep,
+}
+
+impl PlanStepBuilder {
+    pub(crate) fn new(
+        id: impl Into<String>,
+        kind: impl Into<String>,
+        status: PlanStepStatus,
+    ) -> Self {
+        Self {
+            step: PlanStep {
+                id: id.into(),
+                kind: kind.into(),
+                label: None,
+                blocking: true,
+                scope: Vec::new(),
+                needs: Vec::new(),
+                status,
+                inputs: HashMap::new(),
+                outputs: HashMap::new(),
+                skip_reason: None,
+                policy: HashMap::new(),
+                missing: Vec::new(),
+            },
+        }
+    }
+
+    pub(crate) fn label(mut self, label: impl Into<String>) -> Self {
+        self.step.label = Some(label.into());
+        self
+    }
+
+    pub(crate) fn blocking(mut self, blocking: bool) -> Self {
+        self.step.blocking = blocking;
+        self
+    }
+
+    pub(crate) fn scope(mut self, scope: impl IntoIterator<Item = String>) -> Self {
+        self.step.scope.extend(scope);
+        self
+    }
+
+    pub(crate) fn needs(mut self, needs: impl IntoIterator<Item = String>) -> Self {
+        self.step.needs.extend(needs);
+        self
+    }
+
+    pub(crate) fn input_value(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
+        self.step.inputs.insert(key.into(), value);
+        self
+    }
+
+    pub(crate) fn inputs(
+        mut self,
+        inputs: impl IntoIterator<Item = (String, serde_json::Value)>,
+    ) -> Self {
+        self.step.inputs.extend(inputs);
+        self
+    }
+
+    pub(crate) fn skip_reason(mut self, reason: impl Into<String>) -> Self {
+        self.step.skip_reason = Some(reason.into());
+        self
+    }
+
+    pub(crate) fn build(self) -> PlanStep {
+        self.step
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanStepStatus {
@@ -195,6 +371,41 @@ pub struct PlanSummary {
     pub next_actions: Vec<String>,
 }
 
+impl PlanSummary {
+    pub(crate) fn from_steps(steps: &[PlanStep]) -> Self {
+        Self::from_steps_with_skipped_statuses(steps, &[PlanStepStatus::Skipped])
+    }
+
+    pub(crate) fn from_steps_counting_disabled_as_skipped(steps: &[PlanStep]) -> Self {
+        Self::from_steps_with_skipped_statuses(
+            steps,
+            &[PlanStepStatus::Skipped, PlanStepStatus::Disabled],
+        )
+    }
+
+    fn from_steps_with_skipped_statuses(
+        steps: &[PlanStep],
+        skipped_statuses: &[PlanStepStatus],
+    ) -> Self {
+        Self {
+            total_steps: steps.len(),
+            ready: steps
+                .iter()
+                .filter(|step| step.status == PlanStepStatus::Ready)
+                .count(),
+            blocked: steps
+                .iter()
+                .filter(|step| step.status == PlanStepStatus::Missing)
+                .count(),
+            skipped: steps
+                .iter()
+                .filter(|step| skipped_statuses.contains(&step.status))
+                .count(),
+            next_actions: Vec::new(),
+        }
+    }
+}
+
 fn default_blocking() -> bool {
     true
 }
@@ -224,7 +435,7 @@ fn slug_fragment(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
+    use super::{HomeboyPlan, PlanBuilder, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
 
     #[test]
     fn serializes_plan_kind_as_snake_case() {
@@ -293,5 +504,240 @@ mod tests {
             serde_json::to_value(PlanStepStatus::PartialSuccess).expect("serialize step status");
 
         assert_eq!(serialized, serde_json::json!("partial_success"));
+    }
+
+    #[test]
+    fn builder_generates_summary_from_step_statuses() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Quality, "fixture")
+            .steps(vec![
+                PlanStep::ready("quality.lint", "quality.lint").build(),
+                PlanStep::builder("quality.test", "quality.test", PlanStepStatus::Missing).build(),
+                PlanStep::builder("quality.audit", "quality.audit", PlanStepStatus::Skipped)
+                    .build(),
+                PlanStep::disabled("quality.docs", "quality.docs").build(),
+            ])
+            .summarize()
+            .build();
+
+        assert_eq!(
+            plan.summary,
+            Some(PlanSummary {
+                total_steps: 4,
+                ready: 1,
+                blocked: 1,
+                skipped: 1,
+                next_actions: Vec::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn step_builder_preserves_minimal_step_json_shape() {
+        let step = PlanStep::ready("lint", "quality.lint")
+            .label("Run lint")
+            .blocking(false)
+            .needs(vec!["audit".to_string()])
+            .input_value("reason", serde_json::json!("manual"))
+            .skip_reason("manual")
+            .build();
+
+        let serialized = serde_json::to_value(&step).expect("serialize step");
+
+        assert_eq!(
+            serialized,
+            serde_json::json!({
+                "id": "lint",
+                "kind": "quality.lint",
+                "label": "Run lint",
+                "blocking": false,
+                "needs": ["audit"],
+                "status": "ready",
+                "inputs": {
+                    "reason": "manual"
+                },
+                "skip_reason": "manual"
+            })
+        );
+    }
+
+    #[test]
+    fn test_builder_for_component() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Quality, "fixture").build();
+
+        assert_eq!(plan.subject.component_id.as_deref(), Some("fixture"));
+    }
+
+    #[test]
+    fn test_builder_for_description() {
+        let plan = HomeboyPlan::builder_for_description(PlanKind::Trace, "Variant A").build();
+
+        assert_eq!(plan.subject.description.as_deref(), Some("Variant A"));
+    }
+
+    #[test]
+    fn test_from_plan() {
+        let plan =
+            PlanBuilder::from_plan(HomeboyPlan::for_component(PlanKind::Build, "fixture")).build();
+
+        assert_eq!(plan.kind, PlanKind::Build);
+    }
+
+    #[test]
+    fn test_mode() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Review, "fixture")
+            .mode("changed")
+            .build();
+
+        assert_eq!(plan.mode.as_deref(), Some("changed"));
+    }
+
+    #[test]
+    fn test_input_value() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::StackSync, "fixture")
+            .input_value("target_exists", serde_json::json!(true))
+            .build();
+
+        assert_eq!(
+            plan.inputs.get("target_exists"),
+            Some(&serde_json::json!(true))
+        );
+    }
+
+    #[test]
+    fn test_policy_value() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::StackSync, "fixture")
+            .policy_value("blocked", serde_json::json!(false))
+            .build();
+
+        assert_eq!(plan.policy.get("blocked"), Some(&serde_json::json!(false)));
+    }
+
+    #[test]
+    fn test_warnings() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Refactor, "fixture")
+            .warnings(vec!["review grouping".to_string()])
+            .build();
+
+        assert_eq!(plan.warnings, vec!["review grouping"]);
+    }
+
+    #[test]
+    fn test_steps() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Quality, "fixture")
+            .steps(vec![PlanStep::ready("lint", "quality.lint").build()])
+            .build();
+
+        assert_eq!(plan.steps.len(), 1);
+    }
+
+    #[test]
+    fn test_summarize() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Quality, "fixture")
+            .steps(vec![PlanStep::ready("lint", "quality.lint").build()])
+            .summarize()
+            .build();
+
+        assert_eq!(plan.summary.as_ref().map(|summary| summary.ready), Some(1));
+    }
+
+    #[test]
+    fn test_summarize_disabled_as_skipped() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Audit, "fixture")
+            .steps(vec![PlanStep::disabled(
+                "audit.docs",
+                "audit.detector.docs",
+            )
+            .build()])
+            .summarize_disabled_as_skipped()
+            .build();
+
+        assert_eq!(
+            plan.summary.as_ref().map(|summary| summary.skipped),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn test_ready() {
+        let step = PlanStep::ready("lint", "quality.lint").build();
+
+        assert_eq!(step.status, PlanStepStatus::Ready);
+    }
+
+    #[test]
+    fn test_disabled() {
+        let step = PlanStep::disabled("audit", "quality.audit").build();
+
+        assert_eq!(step.status, PlanStepStatus::Disabled);
+    }
+
+    #[test]
+    fn test_label() {
+        let step = PlanStep::ready("lint", "quality.lint")
+            .label("Run lint")
+            .build();
+
+        assert_eq!(step.label.as_deref(), Some("Run lint"));
+    }
+
+    #[test]
+    fn test_scope() {
+        let step = PlanStep::ready("deps", "deps.stack")
+            .scope(vec!["downstream".to_string()])
+            .build();
+
+        assert_eq!(step.scope, vec!["downstream"]);
+    }
+
+    #[test]
+    fn test_needs() {
+        let step = PlanStep::ready("test", "quality.test")
+            .needs(vec!["lint".to_string()])
+            .build();
+
+        assert_eq!(step.needs, vec!["lint"]);
+    }
+
+    #[test]
+    fn test_inputs() {
+        let step = PlanStep::ready("deps", "deps.stack")
+            .inputs(vec![("package".to_string(), serde_json::json!("homeboy"))])
+            .build();
+
+        assert_eq!(
+            step.inputs.get("package"),
+            Some(&serde_json::json!("homeboy"))
+        );
+    }
+
+    #[test]
+    fn test_skip_reason() {
+        let step = PlanStep::disabled("audit", "quality.audit")
+            .skip_reason("filtered")
+            .build();
+
+        assert_eq!(step.skip_reason.as_deref(), Some("filtered"));
+    }
+
+    #[test]
+    fn test_from_steps() {
+        let summary = PlanSummary::from_steps(&[
+            PlanStep::ready("lint", "quality.lint").build(),
+            PlanStep::builder("test", "quality.test", PlanStepStatus::Missing).build(),
+        ]);
+
+        assert_eq!(summary.ready, 1);
+        assert_eq!(summary.blocked, 1);
+    }
+
+    #[test]
+    fn test_from_steps_counting_disabled_as_skipped() {
+        let summary = PlanSummary::from_steps_counting_disabled_as_skipped(&[PlanStep::disabled(
+            "audit",
+            "audit.detector.docs",
+        )
+        .build()]);
+
+        assert_eq!(summary.skipped, 1);
     }
 }

--- a/src/core/quality.rs
+++ b/src/core/quality.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QualityPlanOptions {
@@ -61,10 +59,12 @@ impl QualityPlanOptions {
 
 pub fn build_quality_plan(options: QualityPlanOptions) -> HomeboyPlan {
     let steps = build_quality_steps(&options);
-    let mut plan = HomeboyPlan::for_component(PlanKind::Quality, options.component_id);
-    plan.mode = options.mode;
-    plan.steps = steps;
-    plan
+    let mut builder =
+        HomeboyPlan::builder_for_component(PlanKind::Quality, options.component_id).steps(steps);
+    if let Some(mode) = options.mode {
+        builder = builder.mode(mode);
+    }
+    builder.build()
 }
 
 pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {
@@ -125,40 +125,20 @@ pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {
 }
 
 fn ready_step(prefix: &str, name: &str, label: &str, needs: Vec<String>) -> PlanStep {
-    PlanStep {
-        id: step_id(prefix, name),
-        kind: step_id(prefix, name),
-        label: Some(label.to_string()),
-        blocking: true,
-        scope: Vec::new(),
-        needs,
-        status: PlanStepStatus::Ready,
-        inputs: HashMap::new(),
-        outputs: HashMap::new(),
-        skip_reason: None,
-        policy: HashMap::new(),
-        missing: Vec::new(),
-    }
+    let id = step_id(prefix, name);
+    PlanStep::ready(id.clone(), id)
+        .label(label)
+        .needs(needs)
+        .build()
 }
 
 fn disabled_step(prefix: &str, name: &str, label: &str, reason: &str) -> PlanStep {
-    PlanStep {
-        id: step_id(prefix, name),
-        kind: step_id(prefix, name),
-        label: Some(label.to_string()),
-        blocking: true,
-        scope: Vec::new(),
-        needs: Vec::new(),
-        status: PlanStepStatus::Disabled,
-        inputs: HashMap::from([(
-            "reason".to_string(),
-            serde_json::Value::String(reason.to_string()),
-        )]),
-        outputs: HashMap::new(),
-        skip_reason: Some(reason.to_string()),
-        policy: HashMap::new(),
-        missing: Vec::new(),
-    }
+    let id = step_id(prefix, name);
+    PlanStep::disabled(id.clone(), id)
+        .label(label)
+        .input_value("reason", serde_json::Value::String(reason.to_string()))
+        .skip_reason(reason)
+        .build()
 }
 
 fn step_id(prefix: &str, name: &str) -> String {

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::extension::{self, grammar, grammar_items, ParsedItem};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
 use crate::Result;
 
 use super::move_items::{MoveOptions, MoveResult};
@@ -101,30 +101,18 @@ fn decompose_homeboy_plan(
     groups: &[DecomposeGroup],
     warnings: &[String],
 ) -> HomeboyPlan {
-    let mut plan = HomeboyPlan::for_description(PlanKind::Refactor, file.to_string());
-    plan.mode = Some("decompose".to_string());
-    plan.inputs.insert(
-        "file".to_string(),
-        serde_json::Value::String(file.to_string()),
-    );
-    plan.inputs.insert(
-        "strategy".to_string(),
-        serde_json::Value::String(strategy.to_string()),
-    );
-    plan.inputs.insert(
-        "total_items".to_string(),
-        serde_json::Value::Number(serde_json::Number::from(total_items)),
-    );
-    plan.steps = groups.iter().map(decompose_group_step).collect();
-    plan.summary = Some(PlanSummary {
-        total_steps: plan.steps.len(),
-        ready: plan.steps.len(),
-        blocked: 0,
-        skipped: 0,
-        next_actions: Vec::new(),
-    });
-    plan.warnings = warnings.to_vec();
-    plan
+    HomeboyPlan::builder_for_description(PlanKind::Refactor, file.to_string())
+        .mode("decompose")
+        .input_value("file", serde_json::Value::String(file.to_string()))
+        .input_value("strategy", serde_json::Value::String(strategy.to_string()))
+        .input_value(
+            "total_items",
+            serde_json::Value::Number(serde_json::Number::from(total_items)),
+        )
+        .steps(groups.iter().map(decompose_group_step))
+        .warnings(warnings.to_vec())
+        .summarize()
+        .build()
 }
 
 fn decompose_group_step(group: &DecomposeGroup) -> PlanStep {
@@ -142,24 +130,18 @@ fn decompose_group_step(group: &DecomposeGroup) -> PlanStep {
         serde_json::to_value(&group.item_names).unwrap_or(serde_json::Value::Null),
     );
 
-    PlanStep {
-        id: format!("refactor.decompose.{}", group.name),
-        kind: "refactor.decompose.extract_group".to_string(),
-        label: Some(format!(
-            "Extract {} item(s) to {}",
-            group.item_names.len(),
-            group.suggested_target
-        )),
-        blocking: true,
-        scope: group.item_names.clone(),
-        needs: Vec::new(),
-        status: PlanStepStatus::Ready,
-        inputs,
-        outputs: std::collections::HashMap::new(),
-        skip_reason: None,
-        policy: std::collections::HashMap::new(),
-        missing: Vec::new(),
-    }
+    PlanStep::ready(
+        format!("refactor.decompose.{}", group.name),
+        "refactor.decompose.extract_group",
+    )
+    .label(format!(
+        "Extract {} item(s) to {}",
+        group.item_names.len(),
+        group.suggested_target
+    ))
+    .scope(group.item_names.clone())
+    .inputs(inputs)
+    .build()
 }
 
 pub fn apply_plan(plan: &DecomposePlan, root: &Path, write: bool) -> Result<Vec<MoveResult>> {

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 
 use crate::error::{Error, Result};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 
 use super::apply::{
     checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, AppliedPr,
@@ -305,22 +305,6 @@ fn sync_homeboy_plan(
     would_mutate: bool,
     blocked: bool,
 ) -> HomeboyPlan {
-    let mut plan = HomeboyPlan::for_description(PlanKind::StackSync, spec.id.clone());
-    plan.inputs.insert(
-        "stack_id".to_string(),
-        serde_json::Value::String(spec.id.clone()),
-    );
-    plan.inputs.insert(
-        "target_exists".to_string(),
-        serde_json::Value::Bool(target_exists),
-    );
-    plan.policy.insert(
-        "would_mutate".to_string(),
-        serde_json::Value::Bool(would_mutate),
-    );
-    plan.policy
-        .insert("blocked".to_string(), serde_json::Value::Bool(blocked));
-
     let mut steps = Vec::new();
     for pr in dropped {
         steps.push(sync_pr_step(
@@ -350,24 +334,14 @@ fn sync_homeboy_plan(
         ));
     }
 
-    plan.summary = Some(PlanSummary {
-        total_steps: steps.len(),
-        ready: steps
-            .iter()
-            .filter(|step| step.status == PlanStepStatus::Ready)
-            .count(),
-        blocked: steps
-            .iter()
-            .filter(|step| step.status == PlanStepStatus::Missing)
-            .count(),
-        skipped: steps
-            .iter()
-            .filter(|step| step.status == PlanStepStatus::Skipped)
-            .count(),
-        next_actions: Vec::new(),
-    });
-    plan.steps = steps;
-    plan
+    HomeboyPlan::builder_for_description(PlanKind::StackSync, spec.id.clone())
+        .input_value("stack_id", serde_json::Value::String(spec.id.clone()))
+        .input_value("target_exists", serde_json::Value::Bool(target_exists))
+        .policy_value("would_mutate", serde_json::Value::Bool(would_mutate))
+        .policy_value("blocked", serde_json::Value::Bool(blocked))
+        .steps(steps)
+        .summarize()
+        .build()
 }
 
 fn sync_pr_step(
@@ -391,20 +365,16 @@ fn sync_pr_step(
         serde_json::Value::String(reason.to_string()),
     );
 
-    PlanStep {
-        id: format!("stack.sync.{action}.{repo}#{number}"),
-        kind: format!("stack.sync.{action}"),
-        label: Some(format!("{action} {repo}#{number}")),
-        blocking: status == PlanStepStatus::Missing,
-        scope: vec![format!("{repo}#{number}")],
-        needs: Vec::new(),
-        status,
-        inputs,
-        outputs: std::collections::HashMap::new(),
-        skip_reason: None,
-        policy: std::collections::HashMap::new(),
-        missing: Vec::new(),
-    }
+    PlanStep::builder(
+        format!("stack.sync.{action}.{repo}#{number}"),
+        format!("stack.sync.{action}"),
+        status.clone(),
+    )
+    .label(format!("{action} {repo}#{number}"))
+    .blocking(status == PlanStepStatus::Missing)
+    .scope(vec![format!("{repo}#{number}")])
+    .inputs(inputs)
+    .build()
 }
 
 /// Read-only preview for `homeboy stack diff`.


### PR DESCRIPTION
## Summary
- Add internal `HomeboyPlan` and `PlanStep` construction helpers so planner adopters do not hand-roll step/default/summary boilerplate.
- Migrate existing generic-plan adopters in audit, quality, dependency stack, issue reconcile, refactor decompose, and stack sync to the shared helpers.
- Preserve existing JSON contracts, including the audit plan's historical disabled-as-skipped summary behavior.

Closes #2537

## Verification
- `cargo check --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@plan-construction-helpers --extension rust --changed-since origin/main --json-summary`

## Audit notes
- Changed-code audit reports no introduced findings.
- It still reports 10 contextual findings already known in touched scope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the plan construction helper API, migrated call sites, and ran verification; Chris remains responsible for review and merge.