### PR TITLE
feat: execute commands on runners

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -6,7 +6,7 @@
 homeboy runner <COMMAND>
 ```
 
-`runner` manages durable execution backends. It records where future Homeboy workflows can run, but it does not execute remote commands.
+`runner` manages durable execution backends. It records where Homeboy workflows can run and can execute explicit commands through a connected runner daemon or an opt-in SSH diagnostic path.
 
 ## Subcommands
 
@@ -56,6 +56,23 @@ Updates a runner by merging a JSON object into `runners/<id>.json`.
 homeboy runner remove <id>
 ```
 
+### `exec`
+
+```sh
+homeboy runner exec <runner-id> -- <command...>
+homeboy runner exec <runner-id> --cwd /runner/workspace/project -- <command...>
+homeboy runner exec <runner-id> --ssh --cwd /runner/workspace/project -- <command...>
+```
+
+`exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit `--ssh`.
+
+Path rules:
+
+- SSH runners require `workspace_root` so local paths are not silently reused remotely.
+- SSH `--cwd` must be an absolute path under the configured `workspace_root`.
+- Omitting `--cwd` on an SSH runner uses the runner `workspace_root`.
+- `--ssh` is an MVP/diagnostic fallback; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
+
 ## Runner Shape
 
 Runner records are stored as JSON config entities under `~/.config/homeboy/runners/`.
@@ -86,7 +103,7 @@ Rules:
 
 All command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). The `data` payload uses the generic entity CRUD shape:
 
-- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, or `runner.remove`
+- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, or `runner.exec`
 - `id`: present for single-runner actions
 - `entity`: runner configuration for single-runner read/write actions
 - `entities`: list for `list`

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -5,7 +5,7 @@ Inspect persisted observation-store runs and artifacts.
 ## Synopsis
 
 ```bash
-homeboy runs list [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20]
+homeboy runs list [--runner <runner-id>] [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20]
 homeboy runs distribution --field <metadata.path> [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--status <status>] [--limit 20]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs show <run-id>
@@ -18,6 +18,8 @@ homeboy runs import <dir>
 ## Description
 
 `homeboy runs` is a read-only query surface over Homeboy's local observation store. Producers such as `bench`, `rig`, and `trace` write run and artifact records; this command lets humans and agents inspect that evidence without opening SQLite directly.
+
+`homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
 

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -5,7 +5,8 @@ use serde::Serialize;
 use serde_json::Value;
 
 use homeboy::runner::{
-    self, Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerKind, RunnerStatusReport,
+    self, Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
+    RunnerStatusReport,
 };
 use homeboy::{EntityCrudOutput, MergeOutput};
 
@@ -27,6 +28,12 @@ pub enum RunnerConnectionOutput {
     Disconnect(RunnerDisconnectReport),
 }
 
+#[derive(Debug, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum RunnerExecutionOutput {
+    Exec(RunnerExecOutput),
+}
+
 pub type RunnerOutput = EntityCrudOutput<Runner, RunnerExtra>;
 
 #[derive(Debug, Serialize)]
@@ -34,6 +41,7 @@ pub type RunnerOutput = EntityCrudOutput<Runner, RunnerExtra>;
 pub enum RunnerCommandOutput {
     Registry(RunnerOutput),
     Doctor(doctor::RunnerDoctorOutput),
+    Execution(RunnerExecutionOutput),
 }
 
 #[derive(Args)]
@@ -124,6 +132,25 @@ enum RunnerCommand {
         /// Runner ID
         id: String,
     },
+    /// Execute a command on a configured runner
+    Exec {
+        /// Runner ID
+        id: String,
+
+        /// Remote/current working directory. SSH runners require this to be
+        /// inside the runner workspace root unless the runner has a default
+        /// workspace_root.
+        #[arg(long)]
+        cwd: Option<String>,
+
+        /// Allow explicit SSH command execution when no daemon session is connected
+        #[arg(long)]
+        ssh: bool,
+
+        /// Command and arguments to execute on the runner
+        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -177,6 +204,12 @@ pub fn run(
         RunnerCommand::Connect { id } => map_registry(connect(&id)),
         RunnerCommand::Status { id } => map_registry(status(&id)),
         RunnerCommand::Disconnect { id } => map_registry(disconnect(&id)),
+        RunnerCommand::Exec {
+            id,
+            cwd,
+            ssh,
+            command,
+        } => map_execution(exec(&id, cwd, ssh, command)),
     }
 }
 
@@ -186,6 +219,15 @@ fn map_registry(result: CmdResult<RunnerOutput>) -> CmdResult<RunnerCommandOutpu
 
 fn map_doctor(result: CmdResult<doctor::RunnerDoctorOutput>) -> CmdResult<RunnerCommandOutput> {
     result.map(|(output, exit_code)| (RunnerCommandOutput::Doctor(output), exit_code))
+}
+
+fn map_execution(result: CmdResult<RunnerExecOutput>) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| {
+        (
+            RunnerCommandOutput::Execution(RunnerExecutionOutput::Exec(output)),
+            exit_code,
+        )
+    })
 }
 
 struct RunnerAddInput {
@@ -378,4 +420,20 @@ fn disconnect(id: &str) -> CmdResult<RunnerOutput> {
         },
         0,
     ))
+}
+
+fn exec(
+    runner_id: &str,
+    cwd: Option<String>,
+    allow_ssh: bool,
+    command: Vec<String>,
+) -> CmdResult<RunnerExecOutput> {
+    runner::exec(
+        runner_id,
+        runner::RunnerExecOptions {
+            cwd,
+            allow_ssh,
+            command,
+        },
+    )
 }

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -10,6 +10,7 @@ mod gh_actions;
 mod latest;
 mod query;
 mod reconcile;
+mod remote;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
@@ -27,6 +28,7 @@ use super::{CmdResult, GlobalArgs};
 use bundle::{
     export_runs, import_runs, RunsExportArgs, RunsExportOutput, RunsImportArgs, RunsImportOutput,
 };
+pub use common::RunSummary;
 use compare::{compare_runs, RunsCompareArgs, RunsCompareOutput};
 pub use distribution::{runs_distribution, RunsDistributionArgs, RunsDistributionOutput};
 use drift::{runs_drift, RunsDriftArgs, RunsDriftOutput};
@@ -81,6 +83,9 @@ enum RunsCommand {
 
 #[derive(Args, Clone, Default)]
 pub struct RunsListArgs {
+    /// Query runs from a connected execution runner daemon
+    #[arg(long)]
+    pub runner: Option<String>,
     /// Run kind: bench, rig, trace, etc.
     #[arg(long)]
     pub kind: Option<String>,
@@ -194,22 +199,6 @@ pub struct BenchCompareOutput {
     pub missing: Vec<BenchMissingMetric>,
 }
 
-#[derive(Serialize, Clone)]
-pub struct RunSummary {
-    pub id: String,
-    pub kind: String,
-    pub status: String,
-    pub started_at: String,
-    pub finished_at: Option<String>,
-    pub component_id: Option<String>,
-    pub rig_id: Option<String>,
-    pub git_sha: Option<String>,
-    pub command: Option<String>,
-    pub cwd: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status_note: Option<String>,
-}
-
 #[derive(Serialize)]
 pub struct RunDetail {
     #[serde(flatten)]
@@ -281,6 +270,10 @@ pub fn run_markdown(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<String> {
 }
 
 pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOutput> {
+    if let Some(runner_id) = args.runner.clone() {
+        return remote::list_runner_runs(&runner_id, args, command);
+    }
+
     let store = ObservationStore::open_initialized()?;
     reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     let runs = store
@@ -684,6 +677,7 @@ mod tests {
 
             let (output, _) = list_runs(
                 RunsListArgs {
+                    runner: None,
                     kind: Some("bench".to_string()),
                     component_id: Some("homeboy".to_string()),
                     rig: Some("studio".to_string()),
@@ -728,6 +722,7 @@ mod tests {
 
             let (output, _) = list_runs(
                 RunsListArgs {
+                    runner: None,
                     kind: Some("bench".to_string()),
                     component_id: Some("homeboy".to_string()),
                     rig: Some("studio".to_string()),

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -11,7 +11,24 @@ use std::time::Duration;
 
 use homeboy::observation::{ObservationStore, RunListFilter, RunRecord};
 use homeboy::Error;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RunSummary {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub component_id: Option<String>,
+    pub rig_id: Option<String>,
+    pub git_sha: Option<String>,
+    pub command: Option<String>,
+    pub cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_note: Option<String>,
+}
 
 /// Convert a `--since <duration>` flag value into an RFC-3339 timestamp.
 ///

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -1,0 +1,51 @@
+use homeboy::runner;
+use homeboy::Error;
+
+use super::{CmdResult, RunsListArgs, RunsListOutput, RunsOutput};
+
+pub fn list_runner_runs(
+    runner_id: &str,
+    args: RunsListArgs,
+    command: &'static str,
+) -> CmdResult<RunsOutput> {
+    let mut query = Vec::new();
+    if let Some(kind) = args.kind {
+        query.push(("kind", kind));
+    }
+    if let Some(component_id) = args.component_id {
+        query.push(("component", component_id));
+    }
+    if let Some(status) = args.status {
+        query.push(("status", status));
+    }
+    if let Some(rig) = args.rig {
+        query.push(("rig", rig));
+    }
+    query.push(("limit", args.limit.to_string()));
+    let query = query
+        .into_iter()
+        .map(|(key, value)| format!("{}={}", key, url_encode_component(&value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    let data = runner::daemon_api_get(runner_id, &format!("/runs?{query}"))?;
+    let runs = serde_json::from_value(data["body"]["runs"].clone()).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse runner daemon runs list".to_string()),
+        )
+    })?;
+
+    Ok((RunsOutput::List(RunsListOutput { command, runs }), 0))
+}
+
+fn url_encode_component(value: &str) -> String {
+    value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                vec![byte as char]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect()
+}

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -3,7 +3,8 @@ use serde_json::json;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::OnceLock;
 
 use crate::api_jobs::JobStore;
@@ -53,6 +54,14 @@ pub struct HttpResponse {
     pub status_code: u16,
     pub body: serde_json::Value,
     pub artifact: Option<ArtifactDownload>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ExecRequest {
+    #[serde(default)]
+    runner_id: Option<String>,
+    cwd: String,
+    command: Vec<String>,
 }
 
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
@@ -209,8 +218,114 @@ pub fn route_with_job_store_and_body(
             body: json!({ "error": "method_not_allowed" }),
             artifact: None,
         },
+        ("POST", "/exec") => match enqueue_exec_job(body, job_store) {
+            Ok(body) => HttpResponse {
+                status_code: 200,
+                body: json!({
+                    "status": 200,
+                    "endpoint": "jobs.exec",
+                    "body": body,
+                }),
+                artifact: None,
+            },
+            Err(err) => error_response(400, err),
+        },
+        ("GET", "/exec") => HttpResponse {
+            status_code: 405,
+            body: json!({ "error": "method_not_allowed" }),
+            artifact: None,
+        },
         _ => route_read_only_api(method, path, body, job_store),
     }
+}
+
+fn enqueue_exec_job(
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+) -> Result<serde_json::Value> {
+    let request: ExecRequest =
+        serde_json::from_value(body.unwrap_or_else(|| json!({}))).map_err(|err| {
+            Error::validation_invalid_argument(
+                "body",
+                format!("invalid exec request body: {err}"),
+                None,
+                None,
+            )
+        })?;
+    if request.command.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "exec request requires command array",
+            None,
+            None,
+        ));
+    }
+    if request.cwd.is_empty() || !Path::new(&request.cwd).is_absolute() {
+        return Err(Error::validation_invalid_argument(
+            "cwd",
+            "exec request requires an absolute cwd",
+            Some(request.cwd),
+            None,
+        ));
+    }
+
+    let summary = json!({
+        "runner_id": request.runner_id,
+        "cwd": request.cwd,
+        "command": request.command,
+    });
+    let operation = "runner.exec".to_string();
+    let runner = job_store.run_background(operation, move |job| {
+        job.progress(json!({
+            "phase": "started",
+            "runner_id": request.runner_id,
+            "cwd": request.cwd,
+            "command": request.command,
+            "job_id": job.job_id(),
+        }))?;
+        let output = Command::new(&request.command[0])
+            .args(&request.command[1..])
+            .current_dir(&request.cwd)
+            .output()
+            .map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some("execute daemon runner command".to_string()),
+                )
+            })?;
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let exit_code = output.status.code().unwrap_or(1);
+        if !stdout.is_empty() {
+            job.stdout(stdout.clone())?;
+        }
+        if !stderr.is_empty() {
+            job.stderr(stderr.clone())?;
+        }
+        job.progress(json!({
+            "phase": "finished",
+            "exit_code": exit_code,
+        }))?;
+        Ok(json!({
+            "runner_id": request.runner_id,
+            "cwd": request.cwd,
+            "command": request.command,
+            "exit_code": exit_code,
+            "stdout": stdout,
+            "stderr": stderr,
+        }))
+    });
+    let job = job_store.get(runner.job_id)?;
+
+    Ok(json!({
+        "command": "api.runner.exec.enqueue",
+        "job": job,
+        "poll": {
+            "job": format!("/jobs/{}", runner.job_id),
+            "events": format!("/jobs/{}/events", runner.job_id),
+        },
+        "request": summary,
+    }))
 }
 
 fn daemon_job_store() -> &'static JobStore {

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -1,0 +1,480 @@
+use std::time::{Duration, Instant};
+
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::api_jobs::{Job, JobEvent, JobStatus};
+use crate::engine::shell;
+use crate::error::{Error, Result};
+use crate::server::{self, SshClient};
+
+use super::{load, status, Runner, RunnerKind};
+
+#[derive(Debug, Clone)]
+pub struct RunnerExecOptions {
+    pub cwd: Option<String>,
+    pub allow_ssh: bool,
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerExecMode {
+    Daemon,
+    Local,
+    Ssh,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerExecOutput {
+    pub command: &'static str,
+    pub runner_id: String,
+    pub mode: RunnerExecMode,
+    pub argv: Vec<String>,
+    pub remote_cwd: String,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job: Option<Job>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_events: Option<Vec<JobEvent>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaemonEnvelope {
+    success: bool,
+    data: Option<Value>,
+    error: Option<Value>,
+}
+
+pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOutput, i32)> {
+    if options.command.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "runner exec requires a command after --",
+            None,
+            None,
+        ));
+    }
+
+    let runner = load(runner_id)?;
+    let cwd = resolve_cwd(&runner, options.cwd.as_deref())?;
+    let connected = status(runner_id)?;
+
+    if connected.connected {
+        if let Some(session) = connected.session {
+            return exec_via_daemon(&runner, &session.local_url, cwd, options.command);
+        }
+    }
+
+    match runner.kind {
+        RunnerKind::Local => exec_local(&runner, cwd, options.command),
+        RunnerKind::Ssh if options.allow_ssh => exec_ssh(&runner, cwd, options.command),
+        RunnerKind::Ssh => Err(Error::validation_invalid_argument(
+            "runner",
+            "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` or pass `--ssh` for explicit SSH diagnostics",
+            Some(runner.id),
+            Some(vec![
+                "Daemon-backed execution preserves job metadata and artifact discovery.".to_string(),
+                "SSH execution is intended for MVP diagnostics and must be explicit.".to_string(),
+            ]),
+        )),
+    }
+}
+
+fn exec_via_daemon(
+    runner: &Runner,
+    local_url: &str,
+    cwd: String,
+    command: Vec<String>,
+) -> Result<(RunnerExecOutput, i32)> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
+    let response = client
+        .post(format!("{}/exec", local_url.trim_end_matches('/')))
+        .json(&json!({
+            "runner_id": runner.id,
+            "cwd": cwd,
+            "command": command,
+        }))
+        .send()
+        .map_err(|err| {
+            Error::internal_unexpected(format!("submit runner daemon exec job: {err}"))
+        })?;
+    let status_code = response.status().as_u16();
+    let envelope: DaemonEnvelope = response.json().map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse daemon exec response".to_string()),
+        )
+    })?;
+    if status_code >= 400 || !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "daemon exec request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+
+    let data = envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("daemon exec returned no data"))?;
+    let body = data.get("body").unwrap_or(&data);
+    let job_value = body
+        .get("job")
+        .ok_or_else(|| Error::internal_unexpected("daemon exec returned no job"))?;
+    let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon exec job".to_string()))
+    })?;
+
+    let deadline = Instant::now() + Duration::from_secs(60 * 60);
+    while !matches!(
+        job.status,
+        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+    ) {
+        if Instant::now() >= deadline {
+            return Err(Error::internal_unexpected(format!(
+                "runner daemon job {} did not finish before timeout",
+                job.id
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+        job = fetch_daemon_job(&client, local_url, &job.id.to_string())?;
+    }
+    let events = fetch_daemon_events(&client, local_url, &job.id.to_string())?;
+
+    let result = result_event_data(&events).unwrap_or_else(|| json!({}));
+    let stdout = string_field(&result, "stdout");
+    let stderr = string_field(&result, "stderr");
+    let exit_code = result
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok())
+        .unwrap_or_else(|| {
+            if job.status == JobStatus::Succeeded {
+                0
+            } else {
+                1
+            }
+        });
+
+    Ok((
+        RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: runner.id.clone(),
+            mode: RunnerExecMode::Daemon,
+            argv: command,
+            remote_cwd: cwd,
+            exit_code,
+            stdout,
+            stderr,
+            job_id: Some(job.id.to_string()),
+            job: Some(job),
+            job_events: Some(events),
+        },
+        exit_code,
+    ))
+}
+
+fn fetch_daemon_job(client: &Client, local_url: &str, job_id: &str) -> Result<Job> {
+    let data = daemon_get(client, local_url, &format!("/jobs/{job_id}"))?;
+    serde_json::from_value(data["body"]["job"].clone())
+        .map_err(|err| Error::internal_json(err.to_string(), Some("parse daemon job".to_string())))
+}
+
+fn fetch_daemon_events(client: &Client, local_url: &str, job_id: &str) -> Result<Vec<JobEvent>> {
+    let data = daemon_get(client, local_url, &format!("/jobs/{job_id}/events"))?;
+    serde_json::from_value(data["body"]["events"].clone()).map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon job events".to_string()))
+    })
+}
+
+fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result<Value> {
+    let response = client
+        .get(format!("{}{}", local_url.trim_end_matches('/'), path))
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("query runner daemon: {err}")))?;
+    let envelope: DaemonEnvelope = response.json().map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
+    })?;
+    if !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "daemon request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
+}
+
+pub(crate) fn daemon_api_get(runner_id: &str, path: &str) -> Result<Value> {
+    let runner = load(runner_id)?;
+    let connected = status(runner_id)?;
+    let Some(session) = connected.session.filter(|_| connected.connected) else {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` first",
+            Some(runner.id),
+            Some(vec![
+                "Read/query integrations use the connected daemon so results come from the runner machine.".to_string(),
+            ]),
+        ));
+    };
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
+    daemon_get(&client, &session.local_url, path)
+}
+
+fn result_event_data(events: &[JobEvent]) -> Option<Value> {
+    events
+        .iter()
+        .rev()
+        .find(|event| matches!(event.kind, crate::api_jobs::JobEventKind::Result))
+        .and_then(|event| event.data.clone())
+}
+
+fn exec_local(
+    runner: &Runner,
+    cwd: String,
+    command: Vec<String>,
+) -> Result<(RunnerExecOutput, i32)> {
+    let output = command_output(
+        std::process::Command::new(&command[0])
+            .args(&command[1..])
+            .current_dir(&cwd),
+    )?;
+    Ok(exec_output(
+        runner,
+        RunnerExecMode::Local,
+        cwd,
+        command,
+        output,
+    ))
+}
+
+fn exec_ssh(runner: &Runner, cwd: String, command: Vec<String>) -> Result<(RunnerExecOutput, i32)> {
+    let server_id = runner.server_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "server_id",
+            "SSH runner requires server_id",
+            Some(runner.id.clone()),
+            None,
+        )
+    })?;
+    let server = server::load(server_id)?;
+    let client = SshClient::from_server(&server, server_id)?;
+    let command_line = format!(
+        "cd {} && {}",
+        shell::quote_arg(&cwd),
+        command
+            .iter()
+            .map(|arg| shell::quote_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let output = client.execute(&command_line);
+    Ok(exec_output(
+        runner,
+        RunnerExecMode::Ssh,
+        cwd,
+        command,
+        ProcessOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code: output.exit_code,
+        },
+    ))
+}
+
+struct ProcessOutput {
+    stdout: String,
+    stderr: String,
+    exit_code: i32,
+}
+
+fn command_output(command: &mut std::process::Command) -> Result<ProcessOutput> {
+    let output = command.output().map_err(|err| {
+        Error::internal_io(err.to_string(), Some("execute runner command".to_string()))
+    })?;
+    Ok(ProcessOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        exit_code: output.status.code().unwrap_or(1),
+    })
+}
+
+fn exec_output(
+    runner: &Runner,
+    mode: RunnerExecMode,
+    cwd: String,
+    command: Vec<String>,
+    output: ProcessOutput,
+) -> (RunnerExecOutput, i32) {
+    let exit_code = output.exit_code;
+    (
+        RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: runner.id.clone(),
+            mode,
+            argv: command,
+            remote_cwd: cwd,
+            exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
+            job: None,
+            job_id: None,
+            job_events: None,
+        },
+        exit_code,
+    )
+}
+
+fn resolve_cwd(runner: &Runner, cwd: Option<&str>) -> Result<String> {
+    match runner.kind {
+        RunnerKind::Local => {
+            if let Some(cwd) = cwd {
+                return Ok(cwd.to_string());
+            }
+            if let Some(root) = &runner.workspace_root {
+                return Ok(root.clone());
+            }
+            std::env::current_dir()
+                .map(|path| path.display().to_string())
+                .map_err(|err| {
+                    Error::internal_io(err.to_string(), Some("read current directory".to_string()))
+                })
+        }
+        RunnerKind::Ssh => {
+            let Some(root) = runner.workspace_root.as_deref() else {
+                return Err(Error::validation_invalid_argument(
+                    "workspace_root",
+                    "SSH runner execution requires workspace_root so local paths are not silently reused remotely",
+                    Some(runner.id.clone()),
+                    Some(vec!["Set the runner workspace root or pass --cwd inside that root.".to_string()]),
+                ));
+            };
+            let remote_cwd = cwd.unwrap_or(root);
+            validate_remote_cwd(root, remote_cwd)?;
+            Ok(remote_cwd.to_string())
+        }
+    }
+}
+
+fn validate_remote_cwd(root: &str, cwd: &str) -> Result<()> {
+    if !root.starts_with('/') || !cwd.starts_with('/') {
+        return Err(Error::validation_invalid_argument(
+            "cwd",
+            "remote runner cwd and workspace_root must be absolute paths",
+            Some(cwd.to_string()),
+            None,
+        ));
+    }
+    let root = trim_trailing_slashes(root);
+    let cwd = trim_trailing_slashes(cwd);
+    if cwd == root || cwd.starts_with(&format!("{root}/")) {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "cwd",
+        "remote cwd must be inside the configured runner workspace_root",
+        Some(cwd),
+        Some(vec![format!("Use a path under {root}")]),
+    ))
+}
+
+fn trim_trailing_slashes(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ssh_runner() -> Runner {
+        Runner {
+            id: "lab".to_string(),
+            kind: RunnerKind::Ssh,
+            server_id: Some("srv".to_string()),
+            workspace_root: Some("/srv/homeboy".to_string()),
+            homeboy_path: None,
+            daemon: true,
+            concurrency_limit: None,
+            artifact_policy: None,
+            env: Default::default(),
+            resources: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_resolve_cwd_defaults_ssh_runner_to_workspace_root() {
+        let cwd = resolve_cwd(&ssh_runner(), None).expect("cwd");
+        assert_eq!(cwd, "/srv/homeboy");
+    }
+
+    #[test]
+    fn test_resolve_cwd_rejects_ssh_cwd_outside_workspace_root() {
+        let err = resolve_cwd(&ssh_runner(), Some("/tmp/project")).expect_err("reject cwd");
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("workspace_root"));
+    }
+
+    #[test]
+    fn test_exec_runs_local_runner_command() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+                .expect("create local runner");
+
+            let (output, exit_code) = exec(
+                "lab-local",
+                RunnerExecOptions {
+                    cwd: None,
+                    allow_ssh: false,
+                    command: vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
+                },
+            )
+            .expect("exec local runner");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(output.runner_id, "lab-local");
+            assert_eq!(output.mode, RunnerExecMode::Local);
+            assert_eq!(output.stdout, "ok");
+            assert!(output.job_id.is_none());
+        });
+    }
+
+    #[test]
+    fn test_daemon_api_get_requires_connected_runner() {
+        crate::test_support::with_isolated_home(|_| {
+            super::super::create(
+                r#"{"id":"lab-local","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create local runner");
+
+            let err = daemon_api_get("lab-local", "/runs").expect_err("requires daemon");
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("connected to a daemon"));
+        });
+    }
+}

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -9,11 +9,14 @@ use crate::output::{CreateOutput, MergeOutput, RemoveResult};
 use crate::server;
 
 mod connection;
+mod execution;
 
 pub use connection::{
     connect, disconnect, status, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
     RunnerSession, RunnerStatusReport,
 };
+pub(crate) use execution::daemon_api_get;
+pub use execution::{exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -176,6 +176,26 @@ fn routes_json_body_to_analysis_enqueue() {
 }
 
 #[test]
+fn routes_exec_body_to_daemon_job() {
+    let store = JobStore::default();
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/exec",
+        Some(serde_json::json!({
+            "runner_id": "lab-local",
+            "cwd": std::env::current_dir().expect("cwd"),
+            "command": ["sh", "-c", "printf ok"]
+        })),
+        &store,
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body["endpoint"], "jobs.exec");
+    assert_eq!(response.body["body"]["command"], "api.runner.exec.enqueue");
+    assert_eq!(store.list().len(), 1);
+}
+
+#[test]
 fn route_rejects_unknown_paths_and_methods() {
     assert_eq!(route("GET", "/missing").status_code, 404);
     assert_eq!(route("POST", "/health").status_code, 405);


### PR DESCRIPTION
## Summary
- Adds `homeboy runner exec <runner-id> -- <command...>` with connected-daemon execution first, local runner direct execution, and explicit `--ssh` fallback for SSH diagnostics.
- Adds daemon `/exec` job submission with runner/cwd/command metadata and stdout/stderr/result events.
- Adds `homeboy runs list --runner <runner-id>` to query a connected runner daemon while preserving the normal `runs.list` JSON payload.

Closes #2529.

## Verification
- `cargo test`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-runner-exec-2529 --extension rust --summary`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-runner-exec-2529 --extension rust --changed-since origin/main --json-summary`
- `cargo run --quiet --bin homeboy -- runner exec lab-local -- sh -c 'printf hi'` with isolated Homeboy config

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner execution implementation, tests, docs, and verification loop for Chris to review.