### PR TITLE
audit: detect direct aggregate construction

### DIFF
--- a/src/core/code_audit/aggregate_construction.rs
+++ b/src/core/code_audit/aggregate_construction.rs
@@ -1,0 +1,614 @@
+//! Direct aggregate construction detector.
+//!
+//! Finds repeated direct construction of aggregate values when the codebase also
+//! exposes a canonical construction seam for the same type. The detector stays
+//! project-agnostic by inferring seams from generic builder/factory/newtype
+//! naming and by reporting only repeated direct literals.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::conventions::{AuditFinding, Language};
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+
+const MIN_OCCURRENCES: usize = 3;
+const MIN_FILES: usize = 2;
+const MIN_FIELDS: usize = 2;
+
+pub(super) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    detect_direct_aggregate_construction(fingerprints)
+}
+
+#[derive(Debug, Clone)]
+struct AggregateLiteral {
+    type_name: String,
+    fields: BTreeSet<String>,
+    file: String,
+}
+
+#[derive(Debug, Clone)]
+struct ConstructionSeam {
+    type_name: String,
+    method: String,
+}
+
+fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    let mut seams_by_type: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut literals_by_type: BTreeMap<String, Vec<AggregateLiteral>> = BTreeMap::new();
+
+    for fp in fingerprints {
+        if fp.language != Language::Rust || super::walker::is_test_path(&fp.relative_path) {
+            continue;
+        }
+
+        for seam in extract_construction_seams(&fp.content) {
+            seams_by_type
+                .entry(seam.type_name)
+                .or_default()
+                .insert(seam.method);
+        }
+
+        for mut literal in extract_aggregate_literals(&fp.content) {
+            literal.file = fp.relative_path.clone();
+            literals_by_type
+                .entry(literal.type_name.clone())
+                .or_default()
+                .push(literal);
+        }
+    }
+
+    let mut findings = Vec::new();
+
+    for (type_name, literals) in literals_by_type {
+        let Some(seams) = seams_by_type.get(&type_name) else {
+            continue;
+        };
+
+        let file_count = literals
+            .iter()
+            .map(|literal| literal.file.as_str())
+            .collect::<BTreeSet<_>>()
+            .len();
+
+        if literals.len() < MIN_OCCURRENCES || file_count < MIN_FILES {
+            continue;
+        }
+
+        let mut field_counts: BTreeMap<String, usize> = BTreeMap::new();
+        let mut file_counts: BTreeMap<String, usize> = BTreeMap::new();
+        for literal in &literals {
+            *file_counts.entry(literal.file.clone()).or_insert(0) += 1;
+            for field in &literal.fields {
+                *field_counts.entry(field.clone()).or_insert(0) += 1;
+            }
+        }
+
+        let mut top_files = file_counts.into_iter().collect::<Vec<_>>();
+        top_files.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        top_files.truncate(3);
+
+        let shared_fields = field_counts
+            .iter()
+            .filter_map(|(field, count)| {
+                if *count >= MIN_OCCURRENCES {
+                    Some(field.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let seam_display = seams
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let top_files_display = top_files
+            .iter()
+            .map(|(file, count)| format!("{} ({})", file, count))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let anchor = top_files
+            .first()
+            .map(|(file, _)| file.clone())
+            .unwrap_or_else(|| "<unknown>".to_string());
+
+        findings.push(Finding {
+            convention: "direct_aggregate_construction".to_string(),
+            severity: Severity::Warning,
+            file: anchor,
+            description: format!(
+                "Direct aggregate construction: `{}` is built inline {} time(s) across {} file(s) despite canonical construction seam(s) [{}]. Repeated fields: [{}]. Top files: {}.",
+                type_name,
+                literals.len(),
+                file_count,
+                seam_display,
+                shared_fields,
+                top_files_display
+            ),
+            suggestion: format!(
+                "Route repeated `{}` construction through the existing builder/factory/helper seam instead of repeating struct literals.",
+                type_name
+            ),
+            kind: AuditFinding::DirectAggregateConstruction,
+        });
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn extract_construction_seams(content: &str) -> Vec<ConstructionSeam> {
+    let mut seams = Vec::new();
+    let bytes = content.as_bytes();
+    let mut i = 0;
+
+    while let Some(impl_pos) = find_word(bytes, i, "impl") {
+        let Some((type_name, body_start, body_end)) = parse_impl_block(bytes, impl_pos) else {
+            i = impl_pos + 4;
+            continue;
+        };
+
+        for method in extract_fn_names(&content[body_start..body_end]) {
+            if is_canonical_constructor_name(&method, &type_name) {
+                seams.push(ConstructionSeam {
+                    type_name: type_name.clone(),
+                    method,
+                });
+            }
+        }
+
+        i = body_end;
+    }
+
+    seams
+}
+
+fn extract_aggregate_literals(content: &str) -> Vec<AggregateLiteral> {
+    let bytes = content.as_bytes();
+    let mut literals = Vec::new();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if let Some(next) = skip_string_or_comment(bytes, i) {
+            i = next;
+            continue;
+        }
+
+        if !is_ident_start(bytes[i]) {
+            i += 1;
+            continue;
+        }
+
+        let start = i;
+        i += 1;
+        while i < bytes.len() && is_ident_byte(bytes[i]) {
+            i += 1;
+        }
+        let type_name = &content[start..i];
+
+        if !looks_like_type_name(type_name)
+            || is_definition_keyword_before(bytes, start)
+            || previous_non_ws(bytes, start) == Some(b'>')
+        {
+            continue;
+        }
+
+        let mut j = i;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b'{' {
+            continue;
+        }
+
+        let Some((fields, end)) = parse_struct_literal_fields(bytes, j + 1) else {
+            continue;
+        };
+        if fields.len() >= MIN_FIELDS {
+            literals.push(AggregateLiteral {
+                type_name: type_name.to_string(),
+                fields,
+                file: String::new(),
+            });
+        }
+        i = end;
+    }
+
+    literals
+}
+
+fn parse_impl_block(bytes: &[u8], impl_pos: usize) -> Option<(String, usize, usize)> {
+    let mut i = impl_pos + 4;
+    i = skip_ascii_whitespace(bytes, i);
+
+    if starts_with_word(bytes, i, "<") {
+        i = skip_angle_group(bytes, i)?;
+        i = skip_ascii_whitespace(bytes, i);
+    }
+
+    if starts_with_word(bytes, i, "dyn") {
+        return None;
+    }
+
+    let type_start = i;
+    while i < bytes.len() && is_ident_byte(bytes[i]) {
+        i += 1;
+    }
+    if type_start == i {
+        return None;
+    }
+    let type_name = std::str::from_utf8(&bytes[type_start..i]).ok()?.to_string();
+    if !looks_like_type_name(&type_name) {
+        return None;
+    }
+
+    while i < bytes.len() && bytes[i] != b'{' {
+        i += 1;
+    }
+    if i >= bytes.len() {
+        return None;
+    }
+    let body_start = i + 1;
+    let body_end = find_matching_brace(bytes, i)?;
+    Some((type_name, body_start, body_end))
+}
+
+fn extract_fn_names(content: &str) -> Vec<String> {
+    let bytes = content.as_bytes();
+    let mut names = Vec::new();
+    let mut i = 0;
+    while let Some(fn_pos) = find_word(bytes, i, "fn") {
+        let mut name_start = fn_pos + 2;
+        name_start = skip_ascii_whitespace(bytes, name_start);
+        let mut name_end = name_start;
+        while name_end < bytes.len() && is_ident_byte(bytes[name_end]) {
+            name_end += 1;
+        }
+        if name_end > name_start {
+            names.push(content[name_start..name_end].to_string());
+        }
+        i = name_end.max(fn_pos + 2);
+    }
+    names
+}
+
+fn is_canonical_constructor_name(method: &str, type_name: &str) -> bool {
+    if matches!(method, "builder" | "new" | "default") {
+        return true;
+    }
+    if method.starts_with("from_") || method.starts_with("for_") || method.starts_with("with_") {
+        return true;
+    }
+    let snake_type = to_snake_case(type_name);
+    method == format!("build_{}", snake_type) || method == format!("create_{}", snake_type)
+}
+
+fn parse_struct_literal_fields(bytes: &[u8], mut i: usize) -> Option<(BTreeSet<String>, usize)> {
+    let mut fields = BTreeSet::new();
+    let mut depth = 0usize;
+
+    while i < bytes.len() {
+        if let Some(next) = skip_string_or_comment(bytes, i) {
+            i = next;
+            continue;
+        }
+        match bytes[i] {
+            b'{' | b'(' | b'[' => {
+                depth += 1;
+                i += 1;
+            }
+            b'}' if depth == 0 => return Some((fields, i + 1)),
+            b'}' | b')' | b']' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            b'.' if depth == 0 && i + 1 < bytes.len() && bytes[i + 1] == b'.' => {
+                i += 2;
+            }
+            b if depth == 0 && is_ident_start(b) => {
+                let start = i;
+                i += 1;
+                while i < bytes.len() && is_ident_byte(bytes[i]) {
+                    i += 1;
+                }
+                let end = i;
+                let mut j = i;
+                j = skip_ascii_whitespace(bytes, j);
+                if j < bytes.len() && bytes[j] == b':' {
+                    fields.insert(std::str::from_utf8(&bytes[start..end]).ok()?.to_string());
+                }
+            }
+            _ => i += 1,
+        }
+    }
+
+    None
+}
+
+fn skip_string_or_comment(bytes: &[u8], i: usize) -> Option<usize> {
+    match bytes.get(i).copied()? {
+        b'"' => Some(skip_quoted(bytes, i, b'"')),
+        b'\'' => Some(skip_quoted(bytes, i, b'\'')),
+        b'/' if bytes.get(i + 1) == Some(&b'/') => bytes[i..]
+            .iter()
+            .position(|b| *b == b'\n')
+            .map(|offset| i + offset + 1)
+            .or(Some(bytes.len())),
+        b'/' if bytes.get(i + 1) == Some(&b'*') => bytes[i + 2..]
+            .windows(2)
+            .position(|w| w == b"*/")
+            .map(|offset| i + 2 + offset + 2)
+            .or(Some(bytes.len())),
+        _ => None,
+    }
+}
+
+fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let mut i = start + 1;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            i += 2;
+        } else if bytes[i] == quote {
+            return i + 1;
+        } else {
+            i += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn find_word(bytes: &[u8], start: usize, word: &str) -> Option<usize> {
+    let needle = word.as_bytes();
+    bytes[start..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .and_then(|offset| {
+            let pos = start + offset;
+            let before_ok = pos == 0 || !is_ident_byte(bytes[pos - 1]);
+            let after = pos + needle.len();
+            let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+            if before_ok && after_ok {
+                Some(pos)
+            } else {
+                None
+            }
+        })
+}
+
+fn starts_with_word(bytes: &[u8], start: usize, word: &str) -> bool {
+    bytes[start..].starts_with(word.as_bytes())
+}
+
+fn skip_angle_group(bytes: &[u8], mut i: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'<' => depth += 1,
+            b'>' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+fn find_matching_brace(bytes: &[u8], open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut i = open;
+    while i < bytes.len() {
+        if let Some(next) = skip_string_or_comment(bytes, i) {
+            i = next;
+            continue;
+        }
+        match bytes[i] {
+            b'{' => depth += 1,
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+fn skip_ascii_whitespace(bytes: &[u8], start: usize) -> usize {
+    bytes[start..]
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .map_or(bytes.len(), |offset| start + offset)
+}
+
+fn previous_non_ws(bytes: &[u8], start: usize) -> Option<u8> {
+    bytes[..start]
+        .iter()
+        .rev()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+}
+
+fn is_definition_keyword_before(bytes: &[u8], start: usize) -> bool {
+    let prefix = std::str::from_utf8(&bytes[..start]).unwrap_or_default();
+    let token = prefix
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .rev()
+        .find(|part| !part.is_empty());
+    matches!(
+        token,
+        Some("struct" | "enum" | "impl" | "trait" | "type" | "use")
+    )
+}
+
+fn looks_like_type_name(name: &str) -> bool {
+    name.as_bytes().first().is_some_and(u8::is_ascii_uppercase)
+}
+
+fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+fn to_snake_case(value: &str) -> String {
+    let mut out = String::new();
+    for (idx, ch) in value.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if idx > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rust_file(path: &str, content: &str) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Rust,
+            content: content.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_run() {
+        let files = [
+            rust_file(
+                "src/report.rs",
+                r#"
+                impl SummaryReport {
+                    pub fn new(status: Status, count: usize) -> Self {
+                        Self { status, count }
+                    }
+                }
+                fn local() -> SummaryReport {
+                    SummaryReport { status: Status::Ready, count: 1 }
+                }
+                "#,
+            ),
+            rust_file(
+                "src/a.rs",
+                "fn a() -> SummaryReport { SummaryReport { status: Status::Ready, count: 2 } }",
+            ),
+            rust_file(
+                "src/b.rs",
+                "fn b() -> SummaryReport { SummaryReport { status: Status::Skipped, count: 3 } }",
+            ),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert_eq!(run(&refs).len(), 1);
+    }
+
+    #[test]
+    fn flags_repeated_direct_aggregate_when_canonical_seam_exists() {
+        let files = [
+            rust_file(
+                "src/order.rs",
+                r#"
+                pub struct DispatchPlan { status: Status, steps: Vec<Step>, dry_run: bool }
+                impl DispatchPlan {
+                    pub fn builder() -> DispatchPlanBuilder { DispatchPlanBuilder::default() }
+                }
+                pub fn a() -> DispatchPlan {
+                    DispatchPlan { status: Status::Ready, steps: vec![], dry_run: false }
+                }
+                "#,
+            ),
+            rust_file(
+                "src/a.rs",
+                r#"
+                pub fn b() -> DispatchPlan {
+                    DispatchPlan { status: Status::Ready, steps: vec![], dry_run: false }
+                }
+                "#,
+            ),
+            rust_file(
+                "src/b.rs",
+                r#"
+                pub fn c() -> DispatchPlan {
+                    DispatchPlan { status: Status::Skipped, steps: vec![step()], dry_run: true }
+                }
+                "#,
+            ),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        let findings = run(&refs);
+
+        assert_eq!(findings.len(), 1, "expected one finding, got {findings:?}");
+        assert_eq!(findings[0].kind, AuditFinding::DirectAggregateConstruction);
+        assert!(findings[0].description.contains("DispatchPlan"));
+        assert!(findings[0].description.contains("builder"));
+    }
+
+    #[test]
+    fn extracts_rust_construction_seams_and_literals() {
+        let content = r#"
+        impl DispatchPlan {
+            pub fn builder() -> DispatchPlanBuilder { DispatchPlanBuilder::default() }
+        }
+        pub fn a() -> DispatchPlan {
+            DispatchPlan { status: Status::Ready, steps: vec![], dry_run: false }
+        }
+        "#;
+
+        assert_eq!(extract_construction_seams(content).len(), 1);
+        assert_eq!(extract_aggregate_literals(content).len(), 1);
+    }
+
+    #[test]
+    fn does_not_flag_repeated_aggregate_without_construction_seam() {
+        let files = [
+            rust_file("src/a.rs", "pub fn a() -> Point { Point { x: 1, y: 2 } }"),
+            rust_file("src/b.rs", "pub fn b() -> Point { Point { x: 3, y: 4 } }"),
+            rust_file("src/c.rs", "pub fn c() -> Point { Point { x: 5, y: 6 } }"),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs).is_empty());
+    }
+
+    #[test]
+    fn ignores_test_paths() {
+        let files = [
+            rust_file(
+                "src/plan.rs",
+                "impl BuildReport { pub fn new() -> Self { Self { status: Status::Ready, count: 0 } } }",
+            ),
+            rust_file(
+                "tests/a.rs",
+                "fn a() -> BuildReport { BuildReport { status: Status::Ready, count: 1 } }",
+            ),
+            rust_file(
+                "tests/b.rs",
+                "fn b() -> BuildReport { BuildReport { status: Status::Ready, count: 2 } }",
+            ),
+            rust_file(
+                "tests/c.rs",
+                "fn c() -> BuildReport { BuildReport { status: Status::Ready, count: 3 } }",
+            ),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs).is_empty());
+    }
+}

--- a/src/core/code_audit/aggregate_construction.rs
+++ b/src/core/code_audit/aggregate_construction.rs
@@ -1,59 +1,45 @@
 //! Direct aggregate construction detector.
 //!
-//! Finds repeated direct construction of aggregate values when the codebase also
-//! exposes a canonical construction seam for the same type. The detector stays
-//! project-agnostic by inferring seams from generic builder/factory/newtype
-//! naming and by reporting only repeated direct literals.
+//! Core consumes language-neutral fingerprint facts emitted by extensions. It
+//! does not parse language syntax here; the Rust/PHP/JS/etc. extension owns
+//! recognizing its own aggregate literal and construction seam syntax.
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use super::conventions::{AuditFinding, Language};
+use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 
 const MIN_OCCURRENCES: usize = 3;
 const MIN_FILES: usize = 2;
-const MIN_FIELDS: usize = 2;
+const MIN_SHARED_FIELDS: usize = 2;
 
 pub(super) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     detect_direct_aggregate_construction(fingerprints)
 }
 
-#[derive(Debug, Clone)]
-struct AggregateLiteral {
-    type_name: String,
-    fields: BTreeSet<String>,
-    file: String,
-}
-
-#[derive(Debug, Clone)]
-struct ConstructionSeam {
-    type_name: String,
-    method: String,
-}
-
 fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let mut seams_by_type: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
-    let mut literals_by_type: BTreeMap<String, Vec<AggregateLiteral>> = BTreeMap::new();
+    let mut literals_by_type: BTreeMap<String, Vec<(&str, &crate::extension::AggregateLiteral)>> =
+        BTreeMap::new();
 
     for fp in fingerprints {
-        if fp.language != Language::Rust || super::walker::is_test_path(&fp.relative_path) {
+        if super::walker::is_test_path(&fp.relative_path) {
             continue;
         }
 
-        for seam in extract_construction_seams(&fp.content) {
+        for seam in &fp.aggregate_construction_seams {
             seams_by_type
-                .entry(seam.type_name)
+                .entry(seam.type_name.clone())
                 .or_default()
-                .insert(seam.method);
+                .insert(seam.method.clone());
         }
 
-        for mut literal in extract_aggregate_literals(&fp.content) {
-            literal.file = fp.relative_path.clone();
+        for literal in &fp.aggregate_literals {
             literals_by_type
                 .entry(literal.type_name.clone())
                 .or_default()
-                .push(literal);
+                .push((&fp.relative_path, literal));
         }
     }
 
@@ -66,7 +52,7 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
 
         let file_count = literals
             .iter()
-            .map(|literal| literal.file.as_str())
+            .map(|(file, _)| *file)
             .collect::<BTreeSet<_>>()
             .len();
 
@@ -75,17 +61,13 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
         }
 
         let mut field_counts: BTreeMap<String, usize> = BTreeMap::new();
-        let mut file_counts: BTreeMap<String, usize> = BTreeMap::new();
-        for literal in &literals {
-            *file_counts.entry(literal.file.clone()).or_insert(0) += 1;
+        let mut top_file_counts: BTreeMap<String, usize> = BTreeMap::new();
+        for (file, literal) in &literals {
+            *top_file_counts.entry((*file).to_string()).or_insert(0) += 1;
             for field in &literal.fields {
                 *field_counts.entry(field.clone()).or_insert(0) += 1;
             }
         }
-
-        let mut top_files = file_counts.into_iter().collect::<Vec<_>>();
-        top_files.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-        top_files.truncate(3);
 
         let shared_fields = field_counts
             .iter()
@@ -96,8 +78,19 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
                     None
                 }
             })
-            .collect::<Vec<_>>()
-            .join(", ");
+            .collect::<Vec<_>>();
+        if shared_fields.len() < MIN_SHARED_FIELDS {
+            continue;
+        }
+
+        let mut top_files = top_file_counts.into_iter().collect::<Vec<_>>();
+        top_files.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        top_files.truncate(3);
+
+        let anchor = top_files
+            .first()
+            .map(|(file, _)| file.clone())
+            .unwrap_or_else(|| "<unknown>".to_string());
         let seam_display = seams
             .iter()
             .map(String::as_str)
@@ -108,10 +101,6 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
             .map(|(file, count)| format!("{} ({})", file, count))
             .collect::<Vec<_>>()
             .join(", ");
-        let anchor = top_files
-            .first()
-            .map(|(file, _)| file.clone())
-            .unwrap_or_else(|| "<unknown>".to_string());
 
         findings.push(Finding {
             convention: "direct_aggregate_construction".to_string(),
@@ -123,11 +112,11 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
                 literals.len(),
                 file_count,
                 seam_display,
-                shared_fields,
+                shared_fields.join(", "),
                 top_files_display
             ),
             suggestion: format!(
-                "Route repeated `{}` construction through the existing builder/factory/helper seam instead of repeating struct literals.",
+                "Route repeated `{}` construction through the existing builder/factory/helper seam instead of repeating aggregate literals.",
                 type_name
             ),
             kind: AuditFinding::DirectAggregateConstruction,
@@ -138,379 +127,57 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
     findings
 }
 
-fn extract_construction_seams(content: &str) -> Vec<ConstructionSeam> {
-    let mut seams = Vec::new();
-    let bytes = content.as_bytes();
-    let mut i = 0;
-
-    while let Some(impl_pos) = find_word(bytes, i, "impl") {
-        let Some((type_name, body_start, body_end)) = parse_impl_block(bytes, impl_pos) else {
-            i = impl_pos + 4;
-            continue;
-        };
-
-        for method in extract_fn_names(&content[body_start..body_end]) {
-            if is_canonical_constructor_name(&method, &type_name) {
-                seams.push(ConstructionSeam {
-                    type_name: type_name.clone(),
-                    method,
-                });
-            }
-        }
-
-        i = body_end;
-    }
-
-    seams
-}
-
-fn extract_aggregate_literals(content: &str) -> Vec<AggregateLiteral> {
-    let bytes = content.as_bytes();
-    let mut literals = Vec::new();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if let Some(next) = skip_string_or_comment(bytes, i) {
-            i = next;
-            continue;
-        }
-
-        if !is_ident_start(bytes[i]) {
-            i += 1;
-            continue;
-        }
-
-        let start = i;
-        i += 1;
-        while i < bytes.len() && is_ident_byte(bytes[i]) {
-            i += 1;
-        }
-        let type_name = &content[start..i];
-
-        if !looks_like_type_name(type_name)
-            || is_definition_keyword_before(bytes, start)
-            || previous_non_ws(bytes, start) == Some(b'>')
-        {
-            continue;
-        }
-
-        let mut j = i;
-        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-            j += 1;
-        }
-        if j >= bytes.len() || bytes[j] != b'{' {
-            continue;
-        }
-
-        let Some((fields, end)) = parse_struct_literal_fields(bytes, j + 1) else {
-            continue;
-        };
-        if fields.len() >= MIN_FIELDS {
-            literals.push(AggregateLiteral {
-                type_name: type_name.to_string(),
-                fields,
-                file: String::new(),
-            });
-        }
-        i = end;
-    }
-
-    literals
-}
-
-fn parse_impl_block(bytes: &[u8], impl_pos: usize) -> Option<(String, usize, usize)> {
-    let mut i = impl_pos + 4;
-    i = skip_ascii_whitespace(bytes, i);
-
-    if starts_with_word(bytes, i, "<") {
-        i = skip_angle_group(bytes, i)?;
-        i = skip_ascii_whitespace(bytes, i);
-    }
-
-    if starts_with_word(bytes, i, "dyn") {
-        return None;
-    }
-
-    let type_start = i;
-    while i < bytes.len() && is_ident_byte(bytes[i]) {
-        i += 1;
-    }
-    if type_start == i {
-        return None;
-    }
-    let type_name = std::str::from_utf8(&bytes[type_start..i]).ok()?.to_string();
-    if !looks_like_type_name(&type_name) {
-        return None;
-    }
-
-    while i < bytes.len() && bytes[i] != b'{' {
-        i += 1;
-    }
-    if i >= bytes.len() {
-        return None;
-    }
-    let body_start = i + 1;
-    let body_end = find_matching_brace(bytes, i)?;
-    Some((type_name, body_start, body_end))
-}
-
-fn extract_fn_names(content: &str) -> Vec<String> {
-    let bytes = content.as_bytes();
-    let mut names = Vec::new();
-    let mut i = 0;
-    while let Some(fn_pos) = find_word(bytes, i, "fn") {
-        let mut name_start = fn_pos + 2;
-        name_start = skip_ascii_whitespace(bytes, name_start);
-        let mut name_end = name_start;
-        while name_end < bytes.len() && is_ident_byte(bytes[name_end]) {
-            name_end += 1;
-        }
-        if name_end > name_start {
-            names.push(content[name_start..name_end].to_string());
-        }
-        i = name_end.max(fn_pos + 2);
-    }
-    names
-}
-
-fn is_canonical_constructor_name(method: &str, type_name: &str) -> bool {
-    if matches!(method, "builder" | "new" | "default") {
-        return true;
-    }
-    if method.starts_with("from_") || method.starts_with("for_") || method.starts_with("with_") {
-        return true;
-    }
-    let snake_type = to_snake_case(type_name);
-    method == format!("build_{}", snake_type) || method == format!("create_{}", snake_type)
-}
-
-fn parse_struct_literal_fields(bytes: &[u8], mut i: usize) -> Option<(BTreeSet<String>, usize)> {
-    let mut fields = BTreeSet::new();
-    let mut depth = 0usize;
-
-    while i < bytes.len() {
-        if let Some(next) = skip_string_or_comment(bytes, i) {
-            i = next;
-            continue;
-        }
-        match bytes[i] {
-            b'{' | b'(' | b'[' => {
-                depth += 1;
-                i += 1;
-            }
-            b'}' if depth == 0 => return Some((fields, i + 1)),
-            b'}' | b')' | b']' => {
-                depth = depth.saturating_sub(1);
-                i += 1;
-            }
-            b'.' if depth == 0 && i + 1 < bytes.len() && bytes[i + 1] == b'.' => {
-                i += 2;
-            }
-            b if depth == 0 && is_ident_start(b) => {
-                let start = i;
-                i += 1;
-                while i < bytes.len() && is_ident_byte(bytes[i]) {
-                    i += 1;
-                }
-                let end = i;
-                let mut j = i;
-                j = skip_ascii_whitespace(bytes, j);
-                if j < bytes.len() && bytes[j] == b':' {
-                    fields.insert(std::str::from_utf8(&bytes[start..end]).ok()?.to_string());
-                }
-            }
-            _ => i += 1,
-        }
-    }
-
-    None
-}
-
-fn skip_string_or_comment(bytes: &[u8], i: usize) -> Option<usize> {
-    match bytes.get(i).copied()? {
-        b'"' => Some(skip_quoted(bytes, i, b'"')),
-        b'\'' => Some(skip_quoted(bytes, i, b'\'')),
-        b'/' if bytes.get(i + 1) == Some(&b'/') => bytes[i..]
-            .iter()
-            .position(|b| *b == b'\n')
-            .map(|offset| i + offset + 1)
-            .or(Some(bytes.len())),
-        b'/' if bytes.get(i + 1) == Some(&b'*') => bytes[i + 2..]
-            .windows(2)
-            .position(|w| w == b"*/")
-            .map(|offset| i + 2 + offset + 2)
-            .or(Some(bytes.len())),
-        _ => None,
-    }
-}
-
-fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
-    let mut i = start + 1;
-    while i < bytes.len() {
-        if bytes[i] == b'\\' {
-            i += 2;
-        } else if bytes[i] == quote {
-            return i + 1;
-        } else {
-            i += 1;
-        }
-    }
-    bytes.len()
-}
-
-fn find_word(bytes: &[u8], start: usize, word: &str) -> Option<usize> {
-    let needle = word.as_bytes();
-    bytes[start..]
-        .windows(needle.len())
-        .position(|window| window == needle)
-        .and_then(|offset| {
-            let pos = start + offset;
-            let before_ok = pos == 0 || !is_ident_byte(bytes[pos - 1]);
-            let after = pos + needle.len();
-            let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
-            if before_ok && after_ok {
-                Some(pos)
-            } else {
-                None
-            }
-        })
-}
-
-fn starts_with_word(bytes: &[u8], start: usize, word: &str) -> bool {
-    bytes[start..].starts_with(word.as_bytes())
-}
-
-fn skip_angle_group(bytes: &[u8], mut i: usize) -> Option<usize> {
-    let mut depth = 0usize;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'<' => depth += 1,
-            b'>' => {
-                depth = depth.saturating_sub(1);
-                if depth == 0 {
-                    return Some(i + 1);
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    None
-}
-
-fn find_matching_brace(bytes: &[u8], open: usize) -> Option<usize> {
-    let mut depth = 0usize;
-    let mut i = open;
-    while i < bytes.len() {
-        if let Some(next) = skip_string_or_comment(bytes, i) {
-            i = next;
-            continue;
-        }
-        match bytes[i] {
-            b'{' => depth += 1,
-            b'}' => {
-                depth = depth.saturating_sub(1);
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    None
-}
-
-fn skip_ascii_whitespace(bytes: &[u8], start: usize) -> usize {
-    bytes[start..]
-        .iter()
-        .position(|byte| !byte.is_ascii_whitespace())
-        .map_or(bytes.len(), |offset| start + offset)
-}
-
-fn previous_non_ws(bytes: &[u8], start: usize) -> Option<u8> {
-    bytes[..start]
-        .iter()
-        .rev()
-        .copied()
-        .find(|byte| !byte.is_ascii_whitespace())
-}
-
-fn is_definition_keyword_before(bytes: &[u8], start: usize) -> bool {
-    let prefix = std::str::from_utf8(&bytes[..start]).unwrap_or_default();
-    let token = prefix
-        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
-        .rev()
-        .find(|part| !part.is_empty());
-    matches!(
-        token,
-        Some("struct" | "enum" | "impl" | "trait" | "type" | "use")
-    )
-}
-
-fn looks_like_type_name(name: &str) -> bool {
-    name.as_bytes().first().is_some_and(u8::is_ascii_uppercase)
-}
-
-fn is_ident_start(byte: u8) -> bool {
-    byte.is_ascii_alphabetic() || byte == b'_'
-}
-
-fn is_ident_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_'
-}
-
-fn to_snake_case(value: &str) -> String {
-    let mut out = String::new();
-    for (idx, ch) in value.chars().enumerate() {
-        if ch.is_ascii_uppercase() {
-            if idx > 0 {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_lowercase());
-        } else {
-            out.push(ch);
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::{AggregateConstructionSeam, AggregateLiteral};
 
-    fn rust_file(path: &str, content: &str) -> FileFingerprint {
+    fn file(
+        path: &str,
+        literals: Vec<AggregateLiteral>,
+        seams: Vec<AggregateConstructionSeam>,
+    ) -> FileFingerprint {
         FileFingerprint {
             relative_path: path.to_string(),
-            language: Language::Rust,
-            content: content.to_string(),
+            aggregate_literals: literals,
+            aggregate_construction_seams: seams,
             ..Default::default()
+        }
+    }
+
+    fn literal(type_name: &str, fields: &[&str]) -> AggregateLiteral {
+        AggregateLiteral {
+            type_name: type_name.to_string(),
+            fields: fields.iter().map(|field| field.to_string()).collect(),
+            line: 1,
+        }
+    }
+
+    fn seam(type_name: &str, method: &str) -> AggregateConstructionSeam {
+        AggregateConstructionSeam {
+            type_name: type_name.to_string(),
+            method: method.to_string(),
+            line: 1,
         }
     }
 
     #[test]
     fn test_run() {
         let files = [
-            rust_file(
+            file(
                 "src/report.rs",
-                r#"
-                impl SummaryReport {
-                    pub fn new(status: Status, count: usize) -> Self {
-                        Self { status, count }
-                    }
-                }
-                fn local() -> SummaryReport {
-                    SummaryReport { status: Status::Ready, count: 1 }
-                }
-                "#,
+                vec![literal("SummaryReport", &["status", "count"])],
+                vec![seam("SummaryReport", "new")],
             ),
-            rust_file(
+            file(
                 "src/a.rs",
-                "fn a() -> SummaryReport { SummaryReport { status: Status::Ready, count: 2 } }",
+                vec![literal("SummaryReport", &["status", "count"])],
+                vec![],
             ),
-            rust_file(
+            file(
                 "src/b.rs",
-                "fn b() -> SummaryReport { SummaryReport { status: Status::Skipped, count: 3 } }",
+                vec![literal("SummaryReport", &["status", "count"])],
+                vec![],
             ),
         ];
         let refs = files.iter().collect::<Vec<_>>();
@@ -521,33 +188,20 @@ mod tests {
     #[test]
     fn flags_repeated_direct_aggregate_when_canonical_seam_exists() {
         let files = [
-            rust_file(
+            file(
                 "src/order.rs",
-                r#"
-                pub struct DispatchPlan { status: Status, steps: Vec<Step>, dry_run: bool }
-                impl DispatchPlan {
-                    pub fn builder() -> DispatchPlanBuilder { DispatchPlanBuilder::default() }
-                }
-                pub fn a() -> DispatchPlan {
-                    DispatchPlan { status: Status::Ready, steps: vec![], dry_run: false }
-                }
-                "#,
+                vec![literal("DispatchPlan", &["status", "steps", "dry_run"])],
+                vec![seam("DispatchPlan", "builder")],
             ),
-            rust_file(
+            file(
                 "src/a.rs",
-                r#"
-                pub fn b() -> DispatchPlan {
-                    DispatchPlan { status: Status::Ready, steps: vec![], dry_run: false }
-                }
-                "#,
+                vec![literal("DispatchPlan", &["status", "steps", "dry_run"])],
+                vec![],
             ),
-            rust_file(
+            file(
                 "src/b.rs",
-                r#"
-                pub fn c() -> DispatchPlan {
-                    DispatchPlan { status: Status::Skipped, steps: vec![step()], dry_run: true }
-                }
-                "#,
+                vec![literal("DispatchPlan", &["status", "steps", "dry_run"])],
+                vec![],
             ),
         ];
         let refs = files.iter().collect::<Vec<_>>();
@@ -561,26 +215,11 @@ mod tests {
     }
 
     #[test]
-    fn extracts_rust_construction_seams_and_literals() {
-        let content = r#"
-        impl DispatchPlan {
-            pub fn builder() -> DispatchPlanBuilder { DispatchPlanBuilder::default() }
-        }
-        pub fn a() -> DispatchPlan {
-            DispatchPlan { status: Status::Ready, steps: vec![], dry_run: false }
-        }
-        "#;
-
-        assert_eq!(extract_construction_seams(content).len(), 1);
-        assert_eq!(extract_aggregate_literals(content).len(), 1);
-    }
-
-    #[test]
     fn does_not_flag_repeated_aggregate_without_construction_seam() {
         let files = [
-            rust_file("src/a.rs", "pub fn a() -> Point { Point { x: 1, y: 2 } }"),
-            rust_file("src/b.rs", "pub fn b() -> Point { Point { x: 3, y: 4 } }"),
-            rust_file("src/c.rs", "pub fn c() -> Point { Point { x: 5, y: 6 } }"),
+            file("src/a.rs", vec![literal("Point", &["x", "y"])], vec![]),
+            file("src/b.rs", vec![literal("Point", &["x", "y"])], vec![]),
+            file("src/c.rs", vec![literal("Point", &["x", "y"])], vec![]),
         ];
         let refs = files.iter().collect::<Vec<_>>();
 
@@ -590,21 +229,21 @@ mod tests {
     #[test]
     fn ignores_test_paths() {
         let files = [
-            rust_file(
-                "src/plan.rs",
-                "impl BuildReport { pub fn new() -> Self { Self { status: Status::Ready, count: 0 } } }",
-            ),
-            rust_file(
+            file("src/plan.rs", vec![], vec![seam("BuildReport", "new")]),
+            file(
                 "tests/a.rs",
-                "fn a() -> BuildReport { BuildReport { status: Status::Ready, count: 1 } }",
+                vec![literal("BuildReport", &["status", "count"])],
+                vec![],
             ),
-            rust_file(
+            file(
                 "tests/b.rs",
-                "fn b() -> BuildReport { BuildReport { status: Status::Ready, count: 2 } }",
+                vec![literal("BuildReport", &["status", "count"])],
+                vec![],
             ),
-            rust_file(
+            file(
                 "tests/c.rs",
-                "fn c() -> BuildReport { BuildReport { status: Status::Ready, count: 3 } }",
+                vec![literal("BuildReport", &["status", "count"])],
+                vec![],
             ),
         ];
         let refs = files.iter().collect::<Vec<_>>();

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -237,6 +237,9 @@ pub enum AuditFinding {
     /// Repeated exhaustive match blocks over the same enum duplicate a
     /// label/getter/policy contract that should likely live on the enum.
     RepeatedEnumDispatchContract,
+    /// Direct aggregate/struct literals are repeated even though a canonical
+    /// construction seam exists for the same type.
+    DirectAggregateConstruction,
     /// Configured ecosystem/language/framework term appears in core-owned source.
     CoreBoundaryLeak,
 }
@@ -295,6 +298,7 @@ impl AuditFinding {
             "unwired_nested_rust_test",
             "parallel_runner_setup",
             "repeated_enum_dispatch_contract",
+            "direct_aggregate_construction",
             "core_boundary_leak",
         ]
     }

--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -250,6 +250,8 @@ pub fn fingerprint_from_grammar(
         runtime_dispatched_types,
         convention_tags: Vec::new(),
         trait_impl_methods,
+        aggregate_literals: Vec::new(),
+        aggregate_construction_seams: Vec::new(),
     })
 }
 

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -95,6 +95,10 @@ pub struct FileFingerprint {
     pub convention_tags: Vec<String>,
     /// Method names that are trait implementations (called via trait dispatch).
     pub trait_impl_methods: Vec<String>,
+    /// Extension-reported direct aggregate literal construction sites.
+    pub aggregate_literals: Vec<crate::extension::AggregateLiteral>,
+    /// Extension-reported canonical construction seams for aggregate types.
+    pub aggregate_construction_seams: Vec<crate::extension::AggregateConstructionSeam>,
 }
 
 /// Extract a structural fingerprint from a source file on disk.
@@ -189,6 +193,8 @@ pub(crate) fn fingerprint_extension_content(
         runtime_dispatched_types: output.runtime_dispatched_types,
         convention_tags: normalize_convention_tags(output.convention_tags),
         trait_impl_methods: Vec::new(), // Extension scripts don't track this
+        aggregate_literals: output.aggregate_literals,
+        aggregate_construction_seams: output.aggregate_construction_seams,
     })
 }
 

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -11,6 +11,7 @@
 //! 5. Producing actionable findings for outliers
 //! 6. Analyzing structural complexity (god files, high item counts)
 
+mod aggregate_construction;
 pub mod baseline;
 mod checks;
 pub mod codebase_map;
@@ -153,6 +154,7 @@ pub(crate) struct AuditExecutionPlan {
     pub(crate) run_shared_scaffolding: bool,
     pub(crate) run_parallel_runner_setup: bool,
     pub(crate) run_enum_dispatch_contracts: bool,
+    pub(crate) run_aggregate_construction: bool,
 }
 
 impl AuditExecutionPlan {
@@ -185,6 +187,7 @@ impl AuditExecutionPlan {
                 run_shared_scaffolding: true,
                 run_parallel_runner_setup: true,
                 run_enum_dispatch_contracts: true,
+                run_aggregate_construction: true,
             },
         )
     }
@@ -356,6 +359,11 @@ impl AuditExecutionPlan {
                     exclude,
                     &[AuditFinding::RepeatedEnumDispatchContract],
                 ),
+                run_aggregate_construction: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::DirectAggregateConstruction],
+                ),
             },
         )
     }
@@ -395,6 +403,7 @@ impl AuditExecutionPlan {
             ("shared_scaffolding", self.run_shared_scaffolding),
             ("parallel_runner_setup", self.run_parallel_runner_setup),
             ("enum_dispatch_contracts", self.run_enum_dispatch_contracts),
+            ("aggregate_construction", self.run_aggregate_construction),
         ]
         .into_iter()
         .map(|(name, enabled)| {
@@ -448,6 +457,7 @@ impl AuditExecutionPlan {
             || self.run_shared_scaffolding
             || self.run_parallel_runner_setup
             || self.run_enum_dispatch_contracts
+            || self.run_aggregate_construction
     }
 }
 
@@ -1213,6 +1223,21 @@ fn audit_internal(
             enum_dispatch_findings.len()
         );
         all_findings.extend(enum_dispatch_findings);
+    }
+
+    // Phase 4x: Direct aggregate construction despite canonical construction seams.
+    let aggregate_construction_findings = if plan.run_aggregate_construction {
+        aggregate_construction::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
+    if !aggregate_construction_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Aggregate construction: {} finding(s) (direct literals bypass construction seams)",
+            aggregate_construction_findings.len()
+        );
+        all_findings.extend(aggregate_construction_findings);
     }
 
     // Phase 4p: Impact-scoped filtering — when auditing changed files only,

--- a/src/core/code_audit/shadow_modules.rs
+++ b/src/core/code_audit/shadow_modules.rs
@@ -277,6 +277,8 @@ mod tests {
             runtime_dispatched_types: vec![],
             convention_tags: vec![],
             trait_impl_methods: vec![],
+            aggregate_literals: vec![],
+            aggregate_construction_seams: vec![],
         }
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -583,6 +583,34 @@ pub struct DeadCodeMarker {
     pub marker_type: String,
 }
 
+/// Extension-reported direct aggregate literal construction site.
+///
+/// Language extensions own syntax recognition; core only groups these generic
+/// facts to detect repeated inline construction where a canonical seam exists.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct AggregateLiteral {
+    /// Aggregate type name, e.g. a struct/class/interface-backed record.
+    pub type_name: String,
+    /// Field/property names initialized at the literal site.
+    #[serde(default)]
+    pub fields: Vec<String>,
+    /// Source line where the literal starts, if available.
+    #[serde(default)]
+    pub line: usize,
+}
+
+/// Extension-reported canonical construction seam for an aggregate type.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct AggregateConstructionSeam {
+    /// Aggregate type name this seam constructs.
+    pub type_name: String,
+    /// Generic seam name, e.g. `new`, `builder`, `from_config`, `build_foo`.
+    pub method: String,
+    /// Source line where the seam is declared, if available.
+    #[serde(default)]
+    pub line: usize,
+}
+
 /// Output from a fingerprint extension script.
 /// Matches the structural data extracted from a source file.
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -672,6 +700,12 @@ pub struct FingerprintOutput {
     /// groups files with the same normalized tag set together.
     #[serde(default)]
     pub convention_tags: Vec<String>,
+    /// Direct aggregate literal construction sites reported by an extension.
+    #[serde(default)]
+    pub aggregate_literals: Vec<AggregateLiteral>,
+    /// Canonical construction seams reported by an extension.
+    #[serde(default)]
+    pub aggregate_construction_seams: Vec<AggregateConstructionSeam>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add generic aggregate construction fingerprint fields to Homeboy's extension protocol.
- Add a core detector that consumes extension-reported aggregate literals and construction seams without parsing language syntax in core.
- Wire `direct_aggregate_construction` into audit filtering, execution plans, and finding metadata.

## Extension dependency
- Rust syntax recognition lives in the Rust extension: https://github.com/Extra-Chill/homeboy-extensions/pull/656

## Verification
- `cargo check --lib`
- `cargo test aggregate_construction --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@aggregate-construction-detector --extension rust --changed-since origin/main --json-summary`

Closes #2538.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and corrected the detector implementation, extension protocol plumbing, tests, and verification workflow; Chris remains responsible for review and merge.