### PR TITLE
feat: record runner source snapshots

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::core::error::{Error, Result};
+use crate::core::source_snapshot::SourceSnapshot;
 
 const DEFAULT_EVENT_RETENTION_LIMIT: usize = 1000;
 
@@ -55,6 +56,8 @@ pub struct Job {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finished_at_ms: Option<u64>,
     pub event_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_snapshot: Option<SourceSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<String>,
 }
@@ -145,6 +148,14 @@ impl JobStore {
     }
 
     pub(crate) fn create(&self, operation: impl Into<String>) -> Job {
+        self.create_with_source_snapshot(operation, None)
+    }
+
+    pub(crate) fn create_with_source_snapshot(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+    ) -> Job {
         let now = timestamp_ms();
         let job = Job {
             id: Uuid::new_v4(),
@@ -155,6 +166,7 @@ impl JobStore {
             started_at_ms: None,
             finished_at_ms: None,
             event_count: 0,
+            source_snapshot,
             stale_reason: None,
         };
 
@@ -272,7 +284,20 @@ impl JobStore {
         T: Serialize + Send + 'static,
         F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
     {
-        let job = self.create(operation);
+        self.run_background_with_source_snapshot(operation, None, run)
+    }
+
+    pub(crate) fn run_background_with_source_snapshot<T, F>(
+        &self,
+        operation: impl Into<String>,
+        source_snapshot: Option<SourceSnapshot>,
+        run: F,
+    ) -> JobRunner
+    where
+        T: Serialize + Send + 'static,
+        F: FnOnce(JobHandle) -> Result<T> + Send + 'static,
+    {
+        let job = self.create_with_source_snapshot(operation, source_snapshot);
         let job_id = job.id;
         let handle_store = self.clone();
         let worker_store = self.clone();
@@ -535,6 +560,21 @@ mod tests {
         assert_eq!(job.operation, "audit");
         assert_eq!(job.status, JobStatus::Queued);
         assert_eq!(job.event_count, 1);
+        assert!(job.source_snapshot.is_none());
+    }
+
+    #[test]
+    fn test_create_with_source_snapshot() {
+        let store = JobStore::default();
+        let snapshot =
+            SourceSnapshot::existing_remote("lab", "/srv/homeboy/repo", Some("/srv/homeboy"));
+        let job = store.create_with_source_snapshot("runner.exec", Some(snapshot.clone()));
+
+        assert_eq!(job.source_snapshot, Some(snapshot.clone()));
+        assert_eq!(
+            store.get(job.id).expect("job").source_snapshot,
+            Some(snapshot)
+        );
     }
 
     #[test]

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -11,6 +11,7 @@ use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
 use crate::http_api::{self, HttpMethod};
 use crate::paths;
+use crate::source_snapshot::SourceSnapshot;
 
 mod artifact_download;
 pub use artifact_download::ArtifactDownload;
@@ -62,6 +63,8 @@ struct ExecRequest {
     runner_id: Option<String>,
     cwd: String,
     command: Vec<String>,
+    #[serde(default)]
+    source_snapshot: Option<SourceSnapshot>,
 }
 
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
@@ -269,52 +272,74 @@ fn enqueue_exec_job(
         ));
     }
 
+    let runner_id = request.runner_id.as_deref().unwrap_or("unknown");
+    let source_snapshot = request.source_snapshot.clone().or_else(|| {
+        Some(SourceSnapshot::existing_remote(
+            runner_id,
+            &request.cwd,
+            None,
+        ))
+    });
+
     let summary = json!({
         "runner_id": request.runner_id,
         "cwd": request.cwd,
         "command": request.command,
+        "source_snapshot": source_snapshot,
     });
     let operation = "runner.exec".to_string();
-    let runner = job_store.run_background(operation, move |job| {
-        job.progress(json!({
-            "phase": "started",
-            "runner_id": request.runner_id,
-            "cwd": request.cwd,
-            "command": request.command,
-            "job_id": job.job_id(),
-        }))?;
-        let output = Command::new(&request.command[0])
-            .args(&request.command[1..])
-            .current_dir(&request.cwd)
-            .output()
-            .map_err(|err| {
+    let runner = job_store.run_background_with_source_snapshot(
+        operation,
+        source_snapshot.clone(),
+        move |job| {
+            job.progress(json!({
+                "phase": "started",
+                "runner_id": request.runner_id,
+                "cwd": request.cwd,
+                "command": request.command,
+                "job_id": job.job_id(),
+                "source_snapshot": source_snapshot,
+            }))?;
+            let mut command = Command::new(&request.command[0]);
+            command
+                .args(&request.command[1..])
+                .current_dir(&request.cwd);
+            if let Some(snapshot) = &source_snapshot {
+                command.env(
+                    "HOMEBOY_SOURCE_SNAPSHOT_JSON",
+                    serde_json::to_string(snapshot).unwrap_or_default(),
+                );
+            }
+            let output = command.output().map_err(|err| {
                 Error::internal_io(
                     err.to_string(),
                     Some("execute daemon runner command".to_string()),
                 )
             })?;
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let exit_code = output.status.code().unwrap_or(1);
-        if !stdout.is_empty() {
-            job.stdout(stdout.clone())?;
-        }
-        if !stderr.is_empty() {
-            job.stderr(stderr.clone())?;
-        }
-        job.progress(json!({
-            "phase": "finished",
-            "exit_code": exit_code,
-        }))?;
-        Ok(json!({
-            "runner_id": request.runner_id,
-            "cwd": request.cwd,
-            "command": request.command,
-            "exit_code": exit_code,
-            "stdout": stdout,
-            "stderr": stderr,
-        }))
-    });
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            let exit_code = output.status.code().unwrap_or(1);
+            if !stdout.is_empty() {
+                job.stdout(stdout.clone())?;
+            }
+            if !stderr.is_empty() {
+                job.stderr(stderr.clone())?;
+            }
+            job.progress(json!({
+                "phase": "finished",
+                "exit_code": exit_code,
+            }))?;
+            Ok(json!({
+                "runner_id": request.runner_id,
+                "cwd": request.cwd,
+                "command": request.command,
+                "exit_code": exit_code,
+                "stdout": stdout,
+                "stderr": stderr,
+                "source_snapshot": source_snapshot,
+            }))
+        },
+    );
     let job = job_store.get(runner.job_id)?;
 
     Ok(json!({

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -33,16 +33,12 @@ pub(super) fn execute_component_deploy(
 
     // Try downloading release artifact from GitHub instead of building locally.
     // This is the preferred path when the component has remote_url set.
-    let release_artifact: Option<PathBuf> = if should_try_download_release_artifact(
-        component,
-        config,
-        is_git_deploy,
-        is_file_deploy,
-    ) {
-        try_download_release_artifact(component)
-    } else {
-        None
-    };
+    let release_artifact: Option<PathBuf> =
+        if should_try_download_release_artifact(component, config, is_git_deploy, is_file_deploy) {
+            try_download_release_artifact(component)
+        } else {
+            None
+        };
 
     // Build (git-deploy, file-deploy, skip-build, and release-download skip this step)
     let (build_exit_code, build_error) =

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -34,6 +34,7 @@ pub mod runner;
 pub mod scope;
 pub mod self_status;
 pub mod server;
+pub mod source_snapshot;
 pub mod stack;
 pub mod top_n;
 pub mod triage;

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1077,16 +1077,26 @@ fn with_run_owner_metadata(mut metadata: serde_json::Value) -> serde_json::Value
         "pid": std::process::id(),
         "recorded_at": chrono::Utc::now().to_rfc3339(),
     });
+    let source_snapshot = std::env::var("HOMEBOY_SOURCE_SNAPSHOT_JSON")
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok());
 
     if let Some(object) = metadata.as_object_mut() {
         object.insert("homeboy_run_owner".to_string(), owner);
+        if let Some(source_snapshot) = source_snapshot {
+            object.insert("source_snapshot".to_string(), source_snapshot);
+        }
         return metadata;
     }
 
-    serde_json::json!({
+    let mut wrapped = serde_json::json!({
         "homeboy_run_owner": owner,
         "homeboy_original_metadata": metadata,
-    })
+    });
+    if let (Some(object), Some(source_snapshot)) = (wrapped.as_object_mut(), source_snapshot) {
+        object.insert("source_snapshot".to_string(), source_snapshot);
+    }
+    wrapped
 }
 
 fn parse_metadata(raw: String) -> rusqlite::Result<serde_json::Value> {
@@ -1365,6 +1375,29 @@ mod api_coverage_tests {
             let run = store.start_run(new_run("bench")).expect("start");
             assert_eq!(run.status, "running");
             assert_eq!(run.kind, "bench");
+        });
+    }
+
+    #[test]
+    fn test_start_run_records_source_snapshot_from_environment() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let snapshot = serde_json::json!({
+                "runner_id": "lab",
+                "remote_path": "/srv/homeboy/repo",
+                "dirty": true,
+                "sync_mode": "snapshot",
+                "snapshot_hash": "sha256:dirty",
+                "synced_at": "2026-05-16T00:00:00Z",
+                "sync_excludes": ["node_modules/"]
+            });
+
+            std::env::set_var("HOMEBOY_SOURCE_SNAPSHOT_JSON", snapshot.to_string());
+            let run = store.start_run(new_run("test")).expect("start");
+            std::env::remove_var("HOMEBOY_SOURCE_SNAPSHOT_JSON");
+
+            assert_eq!(run.metadata_json["source_snapshot"], snapshot);
         });
     }
 

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -8,6 +8,7 @@ use crate::api_jobs::{Job, JobEvent, JobStatus};
 use crate::engine::shell;
 use crate::error::{Error, Result};
 use crate::server::{self, SshClient};
+use crate::source_snapshot::SourceSnapshot;
 
 use super::{load, status, Runner, RunnerKind};
 
@@ -36,6 +37,8 @@ pub struct RunnerExecOutput {
     pub exit_code: i32,
     pub stdout: String,
     pub stderr: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_snapshot: Option<SourceSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job: Option<Job>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -96,12 +99,15 @@ fn exec_via_daemon(
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
+    let source_snapshot =
+        SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref());
     let response = client
         .post(format!("{}/exec", local_url.trim_end_matches('/')))
         .json(&json!({
             "runner_id": runner.id,
             "cwd": cwd,
             "command": command,
+            "source_snapshot": source_snapshot,
         }))
         .send()
         .map_err(|err| {
@@ -173,6 +179,7 @@ fn exec_via_daemon(
             exit_code,
             stdout,
             stderr,
+            source_snapshot: Some(source_snapshot),
             job_id: Some(job.id.to_string()),
             job: Some(job),
             job_events: Some(events),
@@ -251,12 +258,19 @@ fn exec_local(
             .args(&command[1..])
             .current_dir(&cwd),
     )?;
+    let source_snapshot = SourceSnapshot::collect_local(
+        &runner.id,
+        std::path::Path::new(&cwd),
+        Some(&cwd),
+        "existing_remote",
+    );
     Ok(exec_output(
         runner,
         RunnerExecMode::Local,
         cwd,
         command,
         output,
+        Some(source_snapshot),
     ))
 }
 
@@ -281,6 +295,8 @@ fn exec_ssh(runner: &Runner, cwd: String, command: Vec<String>) -> Result<(Runne
             .join(" ")
     );
     let output = client.execute(&command_line);
+    let source_snapshot =
+        SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref());
     Ok(exec_output(
         runner,
         RunnerExecMode::Ssh,
@@ -291,6 +307,7 @@ fn exec_ssh(runner: &Runner, cwd: String, command: Vec<String>) -> Result<(Runne
             stderr: output.stderr,
             exit_code: output.exit_code,
         },
+        Some(source_snapshot),
     ))
 }
 
@@ -317,6 +334,7 @@ fn exec_output(
     cwd: String,
     command: Vec<String>,
     output: ProcessOutput,
+    source_snapshot: Option<SourceSnapshot>,
 ) -> (RunnerExecOutput, i32) {
     let exit_code = output.exit_code;
     (
@@ -329,6 +347,7 @@ fn exec_output(
             exit_code,
             stdout: output.stdout,
             stderr: output.stderr,
+            source_snapshot,
             job: None,
             job_id: None,
             job_events: None,
@@ -459,6 +478,10 @@ mod tests {
             assert_eq!(output.runner_id, "lab-local");
             assert_eq!(output.mode, RunnerExecMode::Local);
             assert_eq!(output.stdout, "ok");
+            let source_snapshot = output.source_snapshot.expect("source snapshot");
+            assert_eq!(source_snapshot.runner_id, "lab-local");
+            assert_eq!(source_snapshot.sync_mode, "existing_remote");
+            assert!(source_snapshot.snapshot_hash.starts_with("sha256:"));
             assert!(output.job_id.is_none());
         });
     }

--- a/src/core/source_snapshot.rs
+++ b/src/core/source_snapshot.rs
@@ -1,0 +1,225 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const DEFAULT_SYNC_EXCLUDES: &[&str] = &[
+    ".git/",
+    "node_modules/",
+    "target/",
+    "vendor/",
+    ".homeboy/",
+    ".datamachine/",
+    ".DS_Store",
+    ".env",
+    ".env.*",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceSnapshot {
+    pub runner_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+    pub dirty: bool,
+    pub sync_mode: String,
+    pub snapshot_hash: String,
+    pub synced_at: String,
+    pub sync_excludes: Vec<String>,
+}
+
+impl SourceSnapshot {
+    pub fn collect_local(
+        runner_id: &str,
+        path: &Path,
+        remote_path: Option<&str>,
+        sync_mode: &str,
+    ) -> Self {
+        let local_path = path.display().to_string();
+        let git_root = git_output(path, &["rev-parse", "--show-toplevel"]);
+        let git_branch = git_output(path, &["branch", "--show-current"])
+            .filter(|branch| !branch.is_empty())
+            .or_else(|| git_output(path, &["rev-parse", "--abbrev-ref", "HEAD"]));
+        let git_sha = git_output(path, &["rev-parse", "HEAD"]);
+        let status =
+            git_output_bytes(path, &["status", "--porcelain=v1", "-z"]).unwrap_or_default();
+        let dirty = !status.is_empty();
+        let snapshot_hash = if git_sha.is_some() {
+            git_snapshot_hash(path, git_sha.as_deref(), &status)
+        } else {
+            generic_snapshot_hash(&local_path)
+        };
+
+        Self {
+            runner_id: runner_id.to_string(),
+            local_path: Some(local_path),
+            remote_path: remote_path.map(str::to_string),
+            workspace_root: git_root,
+            git_branch,
+            git_sha,
+            dirty,
+            sync_mode: sync_mode.to_string(),
+            snapshot_hash,
+            synced_at: chrono::Utc::now().to_rfc3339(),
+            sync_excludes: default_sync_excludes(),
+        }
+    }
+
+    pub fn existing_remote(
+        runner_id: &str,
+        remote_path: &str,
+        workspace_root: Option<&str>,
+    ) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(b"existing_remote\0");
+        hasher.update(runner_id.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(remote_path.as_bytes());
+        if let Some(workspace_root) = workspace_root {
+            hasher.update(b"\0");
+            hasher.update(workspace_root.as_bytes());
+        }
+
+        Self {
+            runner_id: runner_id.to_string(),
+            local_path: None,
+            remote_path: Some(remote_path.to_string()),
+            workspace_root: workspace_root.map(str::to_string),
+            git_branch: None,
+            git_sha: None,
+            dirty: false,
+            sync_mode: "existing_remote".to_string(),
+            snapshot_hash: format!("sha256:{:x}", hasher.finalize()),
+            synced_at: chrono::Utc::now().to_rfc3339(),
+            sync_excludes: default_sync_excludes(),
+        }
+    }
+}
+
+pub fn default_sync_excludes() -> Vec<String> {
+    DEFAULT_SYNC_EXCLUDES
+        .iter()
+        .map(|value| value.to_string())
+        .collect()
+}
+
+fn git_snapshot_hash(path: &Path, git_sha: Option<&str>, status: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"homeboy-source-snapshot-v1\0");
+    if let Some(git_sha) = git_sha {
+        hasher.update(git_sha.as_bytes());
+    }
+    hasher.update(b"\0status\0");
+    hasher.update(status);
+
+    if status.is_empty() {
+        if let Some(tree) = git_output(path, &["rev-parse", "HEAD^{tree}"]) {
+            hasher.update(b"\0tree\0");
+            hasher.update(tree.as_bytes());
+        }
+    } else {
+        if let Some(diff) = git_output_bytes(path, &["diff", "--binary", "HEAD"]) {
+            hasher.update(b"\0diff\0");
+            hasher.update(diff);
+        }
+        if let Some(untracked) =
+            git_output_bytes(path, &["ls-files", "--others", "--exclude-standard", "-z"])
+        {
+            hasher.update(b"\0untracked\0");
+            for relative in untracked
+                .split(|byte| *byte == 0)
+                .filter(|entry| !entry.is_empty())
+            {
+                hasher.update(relative);
+                hasher.update(b"\0");
+                if let Ok(relative) = std::str::from_utf8(relative) {
+                    let file = PathBuf::from(path).join(relative);
+                    if let Ok(bytes) = fs::read(&file) {
+                        hasher.update(bytes);
+                    }
+                }
+            }
+        }
+    }
+
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn generic_snapshot_hash(identity: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"non_git_path\0");
+    hasher.update(identity.as_bytes());
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn git_output(path: &Path, args: &[&str]) -> Option<String> {
+    let output = git_output_bytes(path, args)?;
+    let value = String::from_utf8_lossy(&output).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn git_output_bytes(path: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    output.status.success().then_some(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_sync_excludes() {
+        let excludes = default_sync_excludes();
+
+        assert!(excludes.contains(&".git/".to_string()));
+        assert!(excludes.contains(&"node_modules/".to_string()));
+        assert!(excludes.contains(&".env".to_string()));
+    }
+
+    #[test]
+    fn test_collect_local() {
+        let snapshot = SourceSnapshot::collect_local(
+            "lab-local",
+            Path::new(env!("CARGO_MANIFEST_DIR")),
+            Some("/srv/homeboy/repo"),
+            "snapshot",
+        );
+
+        assert_eq!(snapshot.runner_id, "lab-local");
+        assert_eq!(snapshot.remote_path.as_deref(), Some("/srv/homeboy/repo"));
+        assert_eq!(snapshot.sync_mode, "snapshot");
+        assert!(snapshot.local_path.is_some());
+        assert!(snapshot.workspace_root.is_some());
+        assert!(snapshot.git_sha.is_some());
+        assert!(snapshot.snapshot_hash.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn existing_remote_snapshot_is_explicit() {
+        let snapshot =
+            SourceSnapshot::existing_remote("lab", "/srv/homeboy/repo", Some("/srv/homeboy"));
+
+        assert_eq!(snapshot.runner_id, "lab");
+        assert_eq!(snapshot.remote_path.as_deref(), Some("/srv/homeboy/repo"));
+        assert_eq!(snapshot.workspace_root.as_deref(), Some("/srv/homeboy"));
+        assert_eq!(snapshot.sync_mode, "existing_remote");
+        assert!(!snapshot.dirty);
+        assert!(snapshot.snapshot_hash.starts_with("sha256:"));
+        assert!(snapshot.sync_excludes.contains(&".git/".to_string()));
+    }
+}

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -192,7 +192,30 @@ fn routes_exec_body_to_daemon_job() {
     assert_eq!(response.status_code, 200);
     assert_eq!(response.body["endpoint"], "jobs.exec");
     assert_eq!(response.body["body"]["command"], "api.runner.exec.enqueue");
+    assert_eq!(
+        response.body["body"]["job"]["source_snapshot"]["runner_id"],
+        "lab-local"
+    );
+    assert_eq!(
+        response.body["body"]["job"]["source_snapshot"]["remote_path"],
+        std::env::current_dir()
+            .expect("cwd")
+            .to_string_lossy()
+            .to_string()
+    );
+    assert_eq!(
+        response.body["body"]["job"]["source_snapshot"]["sync_mode"],
+        "existing_remote"
+    );
     assert_eq!(store.list().len(), 1);
+    assert_eq!(
+        store.list()[0]
+            .source_snapshot
+            .as_ref()
+            .expect("stored source snapshot")
+            .runner_id,
+        "lab-local"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds structured `source_snapshot` provenance to durable daemon jobs and runner exec JSON output.
- Records dirty snapshot identity explicitly with `dirty`, `sync_mode`, `snapshot_hash`, paths, git branch/SHA, sync timestamp, and sync excludes.
- Propagates daemon runner snapshots into child Homeboy observation run metadata through `HOMEBOY_SOURCE_SNAPSHOT_JSON` so persisted runs/artifacts retain evidence provenance.

Closes #2547.

## Testing
- `cargo test source_snapshot`
- `cargo test routes_exec_body_to_daemon_job`
- `cargo test test_exec_runs_local_runner_command`
- `cargo test test_start_run_records_source_snapshot_from_environment`
- `homeboy lint --path /Users/chubes/Developer/homeboy@source-snapshot-provenance-2547 --extension rust`
- `homeboy test --path /Users/chubes/Developer/homeboy@source-snapshot-provenance-2547 --extension rust`
- `homeboy audit --path /Users/chubes/Developer/homeboy@source-snapshot-provenance-2547 --extension rust --changed-since origin/main`

## Notes
- `cargo fmt` also normalized an existing rustfmt hunk in `src/core/deploy/execution.rs`; without it, the Homeboy test gate stopped at `cargo fmt --check` before running tests.
- Field names are aligned with #2546's proposed metadata: `runner_id`, `local_path`, `remote_path`, `workspace_root`, `git_branch`, `git_sha`, `dirty`, `sync_mode`, `snapshot_hash`, `synced_at`, and `sync_excludes`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the runner source snapshot provenance plumbing, tests, and PR description; Chris remains responsible for review and merge.