### PR TITLE
Mirror runner evidence into local runs

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -11,6 +11,7 @@ mod latest;
 mod query;
 mod reconcile;
 mod remote;
+mod remote_artifact;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
@@ -343,6 +344,9 @@ fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
         ));
     }
     if artifact.artifact_type != "file" {
+        if remote_artifact::is_remote_artifact(&artifact) {
+            return remote_artifact::get(artifact, args.output);
+        }
         return Err(Error::validation_invalid_argument(
             "artifact_id",
             format!(

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+use homeboy::observation::ArtifactRecord;
+use homeboy::runner;
+
+use super::{CmdResult, RunsArtifactGetOutput, RunsOutput};
+
+pub fn is_remote_artifact(artifact: &ArtifactRecord) -> bool {
+    artifact.artifact_type == "remote_file"
+        || runner::is_remote_runner_artifact_path(&artifact.path)
+}
+
+pub fn get(artifact: ArtifactRecord, output: Option<PathBuf>) -> CmdResult<RunsOutput> {
+    let download = runner::download_remote_artifact(&artifact.path, output)?;
+    Ok((
+        RunsOutput::ArtifactGet(RunsArtifactGetOutput {
+            command: "runs.artifact.get",
+            run_id: artifact.run_id,
+            artifact_id: artifact.id,
+            output_path: download.output_path.display().to_string(),
+            content_type: download.content_type,
+            size_bytes: download.size_bytes,
+            sha256: download.sha256,
+        }),
+        0,
+    ))
+}

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -5,6 +5,7 @@
 //! command behavior. Long-running analysis endpoints enqueue daemon-owned jobs
 //! so HTTP requests can return immediately while clients poll job events.
 
+use base64::Engine;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -56,6 +57,7 @@ pub enum HttpEndpoint {
     Runs,
     Run { id: String },
     RunArtifacts { id: String },
+    RunArtifactContent { id: String, artifact_id: String },
     RunFindings { id: String },
     AuditRuns,
     BenchRuns,
@@ -116,6 +118,7 @@ impl HttpEndpoint {
             Self::Runs => "runs.list",
             Self::Run { .. } => "runs.show",
             Self::RunArtifacts { .. } => "runs.artifacts",
+            Self::RunArtifactContent { .. } => "runs.artifact.content",
             Self::RunFindings { .. } => "runs.findings",
             Self::AuditRuns => "audit.runs",
             Self::BenchRuns => "bench.runs",
@@ -164,6 +167,12 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
         (HttpMethod::Get, ["runs", id, "artifacts"]) => Ok(HttpEndpoint::RunArtifacts {
             id: (*id).to_string(),
         }),
+        (HttpMethod::Get, ["runs", id, "artifacts", artifact_id, "content"]) => {
+            Ok(HttpEndpoint::RunArtifactContent {
+                id: (*id).to_string(),
+                artifact_id: (*artifact_id).to_string(),
+            })
+        }
         (HttpMethod::Get, ["runs", id, "findings"]) => Ok(HttpEndpoint::RunFindings {
             id: (*id).to_string(),
         }),
@@ -209,6 +218,7 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "GET /runs".to_string(),
                 "GET /runs/:id".to_string(),
                 "GET /runs/:id/artifacts".to_string(),
+                "GET /runs/:id/artifacts/:artifact_id/content".to_string(),
                 "GET /runs/:id/findings".to_string(),
                 "GET /audit/runs".to_string(),
                 "GET /bench/runs".to_string(),
@@ -293,6 +303,7 @@ pub fn handle_with_jobs(request: HttpApiRequest, job_store: &JobStore) -> Result
                 "artifacts": store.list_artifacts(id)?,
             })
         }
+        HttpEndpoint::RunArtifactContent { id, artifact_id } => artifact_content(id, artifact_id)?,
         HttpEndpoint::RunFindings { id } => {
             let store = ObservationStore::open_initialized()?;
             require_run(&store, id)?;
@@ -343,6 +354,59 @@ pub fn handle_with_jobs(request: HttpApiRequest, job_store: &JobStore) -> Result
         endpoint: endpoint.name().to_string(),
         body,
     })
+}
+
+fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
+    let store = ObservationStore::open_initialized()?;
+    require_run(&store, run_id)?;
+    let artifact = store.get_artifact(artifact_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact_id",
+            format!("artifact record not found: {artifact_id}"),
+            Some(artifact_id.to_string()),
+            None,
+        )
+    })?;
+    if artifact.run_id != run_id {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "artifact does not belong to requested run",
+            Some(artifact_id.to_string()),
+            None,
+        ));
+    }
+    if artifact.artifact_type != "file" {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "artifact {} is {}, not a downloadable file",
+                artifact.id, artifact.artifact_type
+            ),
+            Some(artifact.id),
+            None,
+        ));
+    }
+    let path = std::path::PathBuf::from(&artifact.path);
+    let content = std::fs::read(&path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("read recorded artifact {}", path.display())),
+        )
+    })?;
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(&artifact.id);
+    Ok(json!({
+        "command": "api.runs.artifact.content",
+        "run_id": run_id,
+        "artifact_id": artifact.id,
+        "filename": filename,
+        "mime": artifact.mime,
+        "size_bytes": artifact.size_bytes,
+        "sha256": artifact.sha256,
+        "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
+    }))
 }
 
 fn path_segments(path: &str) -> Vec<String> {

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -1,0 +1,587 @@
+use std::fs;
+use std::path::PathBuf;
+
+use base64::Engine;
+use serde_json::{json, Value};
+
+use crate::api_jobs::{Job, JobEvent, JobStatus};
+use crate::error::{Error, Result};
+use crate::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use crate::paths;
+
+use super::execution::daemon_api_get;
+use super::Runner;
+
+pub fn is_remote_runner_artifact_path(path: &str) -> bool {
+    path.starts_with("runner-artifact://")
+}
+
+pub fn download_remote_artifact(
+    path: &str,
+    output: Option<PathBuf>,
+) -> Result<RemoteArtifactDownload> {
+    let token = RemoteArtifactToken::parse(path)?;
+    let data = daemon_api_get(
+        &token.runner_id,
+        &format!(
+            "/runs/{}/artifacts/{}/content",
+            encode_component(&token.run_id),
+            encode_component(&token.artifact_id)
+        ),
+    )?;
+    let body = data.get("body").unwrap_or(&data);
+    let content_base64 = body
+        .get("content_base64")
+        .and_then(Value::as_str)
+        .ok_or_else(|| Error::internal_unexpected("runner artifact response missing content"))?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(content_base64)
+        .map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("decode runner artifact content".to_string()),
+            )
+        })?;
+    let file_name = body
+        .get("filename")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .unwrap_or(&token.artifact_id);
+    let output_path = output.unwrap_or_else(|| {
+        paths::artifact_root()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join("runner")
+            .join(&token.runner_id)
+            .join(&token.run_id)
+            .join(file_name)
+    });
+    if let Some(parent) = output_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    fs::write(&output_path, bytes).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("write runner artifact {}", output_path.display())),
+        )
+    })?;
+    Ok(RemoteArtifactDownload {
+        output_path,
+        content_type: body.get("mime").and_then(Value::as_str).map(str::to_string),
+        size_bytes: body.get("size_bytes").and_then(Value::as_i64),
+        sha256: body
+            .get("sha256")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    })
+}
+
+#[derive(Debug)]
+pub struct RemoteArtifactDownload {
+    pub output_path: PathBuf,
+    pub content_type: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteArtifactToken {
+    runner_id: String,
+    run_id: String,
+    artifact_id: String,
+}
+
+impl RemoteArtifactToken {
+    fn parse(path: &str) -> Result<Self> {
+        let token = path.strip_prefix("runner-artifact://").ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                "artifact is not a runner artifact token",
+                Some(path.to_string()),
+                None,
+            )
+        })?;
+        let mut parts = token.split('/');
+        let runner_id = parts.next().unwrap_or_default();
+        let run_id = parts.next().unwrap_or_default();
+        let artifact_id = parts.next().unwrap_or_default();
+        if runner_id.is_empty()
+            || run_id.is_empty()
+            || artifact_id.is_empty()
+            || parts.next().is_some()
+        {
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                "runner artifact token must be runner-artifact://<runner>/<run>/<artifact>",
+                Some(path.to_string()),
+                None,
+            ));
+        }
+        Ok(Self {
+            runner_id: decode_component(runner_id),
+            run_id: decode_component(run_id),
+            artifact_id: decode_component(artifact_id),
+        })
+    }
+}
+
+pub fn mirror_daemon_evidence(
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    events: &[JobEvent],
+    result: &Value,
+) -> Result<Option<RunRecord>> {
+    let store = ObservationStore::open_initialized()?;
+    let local_job_run = mirror_job_run(&store, runner, cwd, command, job, events, result)?;
+    mirror_remote_observation_runs(&store, runner, job)?;
+    Ok(Some(local_job_run))
+}
+
+fn mirror_job_run(
+    store: &ObservationStore,
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    events: &[JobEvent],
+    result: &Value,
+) -> Result<RunRecord> {
+    let run = RunRecord {
+        id: local_job_run_id(&runner.id, &job.id.to_string()),
+        kind: "runner-exec".to_string(),
+        component_id: None,
+        started_at: ms_to_rfc3339(job.started_at_ms.unwrap_or(job.created_at_ms)),
+        finished_at: job.finished_at_ms.map(ms_to_rfc3339),
+        status: job_status_as_run_status(job.status).to_string(),
+        command: Some(command.join(" ")),
+        cwd: Some(cwd.to_string()),
+        homeboy_version: None,
+        git_sha: None,
+        rig_id: None,
+        metadata_json: json!({
+            "lab": {
+                "runner": runner_metadata(runner),
+                "remote_job": job,
+                "remote_events": events,
+                "result_summary": result_summary(result),
+                "source_snapshot": source_snapshot_from_result(result),
+            }
+        }),
+    };
+    import_run_if_absent(store, &run)?;
+    store.get_run(&run.id)?.ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "mirrored runner run {} but could not read it back",
+            run.id
+        ))
+    })
+}
+
+fn mirror_remote_observation_runs(
+    store: &ObservationStore,
+    runner: &Runner,
+    job: &Job,
+) -> Result<()> {
+    let data = daemon_api_get(&runner.id, "/runs?limit=100")?;
+    let body = data.get("body").unwrap_or(&data);
+    let Some(remote_runs) = body.get("runs").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for summary in remote_runs {
+        let Some(run_id) = summary.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        if !remote_run_matches_job_window(summary, job) {
+            continue;
+        }
+        let detail_data =
+            daemon_api_get(&runner.id, &format!("/runs/{}", encode_component(run_id)))?;
+        let detail_body = detail_data.get("body").unwrap_or(&detail_data);
+        let Some(detail) = detail_body.get("run") else {
+            continue;
+        };
+        let run = remote_detail_to_run_record(detail, runner, job)?;
+        import_run_if_absent(store, &run)?;
+        for artifact in remote_detail_artifacts(detail, runner, &run.id)? {
+            import_artifact_if_absent(store, &artifact)?;
+        }
+    }
+    Ok(())
+}
+
+fn import_run_if_absent(store: &ObservationStore, run: &RunRecord) -> Result<()> {
+    if store.get_run(&run.id)?.is_some() {
+        return Ok(());
+    }
+    store.import_run(run)
+}
+
+fn import_artifact_if_absent(store: &ObservationStore, artifact: &ArtifactRecord) -> Result<()> {
+    if store.get_artifact(&artifact.id)?.is_some() {
+        return Ok(());
+    }
+    store.import_artifact(artifact)
+}
+
+fn remote_detail_to_run_record(detail: &Value, runner: &Runner, job: &Job) -> Result<RunRecord> {
+    let id = required_str(detail, "id")?.to_string();
+    let metadata = detail.get("metadata").cloned().unwrap_or_else(|| json!({}));
+    Ok(RunRecord {
+        id,
+        kind: required_str(detail, "kind")?.to_string(),
+        component_id: detail
+            .get("component_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        started_at: required_str(detail, "started_at")?.to_string(),
+        finished_at: detail
+            .get("finished_at")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        status: required_str(detail, "status")?.to_string(),
+        command: detail
+            .get("command")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        cwd: detail
+            .get("cwd")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        homeboy_version: detail
+            .get("homeboy_version")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        git_sha: detail
+            .get("git_sha")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        rig_id: detail
+            .get("rig_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        metadata_json: merge_lab_metadata(metadata, runner, job, detail.get("artifacts").cloned()),
+    })
+}
+
+fn remote_detail_artifacts(
+    detail: &Value,
+    runner: &Runner,
+    run_id: &str,
+) -> Result<Vec<ArtifactRecord>> {
+    let Some(artifacts) = detail.get("artifacts").and_then(Value::as_array) else {
+        return Ok(Vec::new());
+    };
+    let mut imported = Vec::new();
+    for artifact in artifacts {
+        let id = required_str(artifact, "id")?.to_string();
+        let artifact_type = artifact
+            .get("type")
+            .or_else(|| artifact.get("artifact_type"))
+            .and_then(Value::as_str)
+            .unwrap_or("file");
+        let mut mirrored_type = artifact_type.to_string();
+        let path = if artifact_type == "file" {
+            mirrored_type = "remote_file".to_string();
+            runner_artifact_token(&runner.id, run_id, &id)
+        } else {
+            artifact
+                .get("url")
+                .or_else(|| artifact.get("path"))
+                .and_then(Value::as_str)
+                .unwrap_or(&id)
+                .to_string()
+        };
+        imported.push(ArtifactRecord {
+            id,
+            run_id: run_id.to_string(),
+            kind: artifact
+                .get("kind")
+                .and_then(Value::as_str)
+                .unwrap_or("artifact")
+                .to_string(),
+            artifact_type: mirrored_type,
+            path,
+            url: artifact
+                .get("url")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            sha256: artifact
+                .get("sha256")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            size_bytes: artifact.get("size_bytes").and_then(Value::as_i64),
+            mime: artifact
+                .get("mime")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            created_at: artifact
+                .get("created_at")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| chrono::Utc::now().to_rfc3339()),
+        });
+    }
+    Ok(imported)
+}
+
+fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str> {
+    value.get(field).and_then(Value::as_str).ok_or_else(|| {
+        Error::internal_json(
+            format!("remote run detail missing {field}"),
+            Some("mirror runner evidence".to_string()),
+        )
+    })
+}
+
+fn merge_lab_metadata(
+    metadata: Value,
+    runner: &Runner,
+    job: &Job,
+    artifact_manifest: Option<Value>,
+) -> Value {
+    let mut object = metadata.as_object().cloned().unwrap_or_default();
+    object.insert(
+        "lab".to_string(),
+        json!({
+            "runner": runner_metadata(runner),
+            "remote_job_id": job.id.to_string(),
+            "remote_job_status": job.status,
+            "source_snapshot": source_snapshot_from_result(&metadata),
+            "remote_artifact_manifest": artifact_manifest,
+        }),
+    );
+    Value::Object(object)
+}
+
+fn runner_metadata(runner: &Runner) -> Value {
+    json!({
+        "id": runner.id,
+        "kind": runner.kind,
+        "server_id": runner.server_id,
+        "workspace_root": runner.workspace_root,
+        "homeboy_path": runner.homeboy_path,
+        "daemon": runner.daemon,
+        "artifact_policy": runner.artifact_policy,
+    })
+}
+
+fn result_summary(result: &Value) -> Value {
+    json!({
+        "command": result.get("command").cloned(),
+        "exit_code": result.get("exit_code").cloned(),
+        "output_command": result.pointer("/output/command").cloned(),
+        "output_status": result.pointer("/output/status").cloned(),
+    })
+}
+
+fn source_snapshot_from_result(value: &Value) -> Option<Value> {
+    [
+        "/source_snapshot",
+        "/source",
+        "/metadata/source_snapshot",
+        "/metadata/source",
+        "/output/source_snapshot",
+        "/output/source",
+        "/output/metadata/source_snapshot",
+        "/output/metadata/source",
+    ]
+    .iter()
+    .find_map(|pointer| value.pointer(pointer).cloned())
+}
+
+fn remote_run_matches_job_window(summary: &Value, job: &Job) -> bool {
+    let Some(started_at) = summary.get("started_at").and_then(Value::as_str) else {
+        return false;
+    };
+    let Ok(started_at) = chrono::DateTime::parse_from_rfc3339(started_at) else {
+        return false;
+    };
+    let started_ms = started_at.timestamp_millis();
+    let job_start = i64::try_from(job.started_at_ms.unwrap_or(job.created_at_ms)).unwrap_or(0);
+    let job_finish =
+        i64::try_from(job.finished_at_ms.unwrap_or(job.updated_at_ms)).unwrap_or(i64::MAX);
+    started_ms >= job_start.saturating_sub(5_000) && started_ms <= job_finish.saturating_add(5_000)
+}
+
+fn job_status_as_run_status(status: JobStatus) -> &'static str {
+    match status {
+        JobStatus::Queued | JobStatus::Running => "running",
+        JobStatus::Succeeded => "pass",
+        JobStatus::Failed => "fail",
+        JobStatus::Cancelled => "skipped",
+    }
+}
+
+fn local_job_run_id(runner_id: &str, job_id: &str) -> String {
+    format!("runner-exec-{}-{}", sanitize_id_segment(runner_id), job_id)
+}
+
+fn runner_artifact_token(runner_id: &str, run_id: &str, artifact_id: &str) -> String {
+    format!(
+        "runner-artifact://{}/{}/{}",
+        encode_component(runner_id),
+        encode_component(run_id),
+        encode_component(artifact_id)
+    )
+}
+
+fn sanitize_id_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn ms_to_rfc3339(ms: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(i64::try_from(ms).unwrap_or(0))
+        .unwrap_or_else(chrono::Utc::now)
+        .to_rfc3339()
+}
+
+fn encode_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+fn decode_component(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let Ok(hex) = std::str::from_utf8(&bytes[index + 1..index + 3]) {
+                if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                    decoded.push(byte);
+                    index += 3;
+                    continue;
+                }
+            }
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&decoded).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::RunnerKind;
+    use uuid::Uuid;
+
+    fn ssh_runner() -> Runner {
+        Runner {
+            id: "lab".to_string(),
+            kind: RunnerKind::Ssh,
+            server_id: Some("srv".to_string()),
+            workspace_root: Some("/srv/homeboy".to_string()),
+            homeboy_path: None,
+            daemon: true,
+            concurrency_limit: None,
+            artifact_policy: None,
+            env: Default::default(),
+            resources: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_download_remote_artifact_rejects_non_runner_token() {
+        let err = download_remote_artifact("/tmp/raw-file", None).expect_err("reject raw path");
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    }
+
+    #[test]
+    fn test_runner_artifact_token_round_trips_escaped_segments() {
+        let token = runner_artifact_token("runner/a", "run b", "artifact:c");
+        assert_eq!(token, "runner-artifact://runner%2Fa/run%20b/artifact%3Ac");
+        let parsed = RemoteArtifactToken::parse(&token).expect("parse token");
+        assert_eq!(parsed.runner_id, "runner/a");
+        assert_eq!(parsed.run_id, "run b");
+        assert_eq!(parsed.artifact_id, "artifact:c");
+    }
+
+    #[test]
+    fn test_mirror_daemon_evidence_persists_runner_exec_observation() {
+        crate::test_support::with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let job_id = Uuid::new_v4();
+            let job = Job {
+                id: job_id,
+                operation: "exec".to_string(),
+                status: JobStatus::Succeeded,
+                created_at_ms: 1_700_000_000_000,
+                updated_at_ms: 1_700_000_001_000,
+                started_at_ms: Some(1_700_000_000_000),
+                finished_at_ms: Some(1_700_000_001_000),
+                event_count: 0,
+                stale_reason: None,
+            };
+            let run = mirror_job_run(
+                &store,
+                &ssh_runner(),
+                "/srv/homeboy/project",
+                &["homeboy".to_string(), "bench".to_string()],
+                &job,
+                &[],
+                &json!({"exit_code":0,"output":{"command":"bench"}}),
+            )
+            .expect("mirror job");
+            assert_eq!(run.kind, "runner-exec");
+            assert_eq!(run.status, "pass");
+            assert_eq!(run.cwd.as_deref(), Some("/srv/homeboy/project"));
+            assert_eq!(
+                run.metadata_json["lab"]["runner"]["id"].as_str(),
+                Some("lab")
+            );
+            assert_eq!(
+                run.metadata_json["lab"]["remote_job"]["id"].as_str(),
+                Some(job_id.to_string().as_str())
+            );
+        });
+    }
+
+    #[test]
+    fn test_remote_file_artifacts_are_indexed_as_runner_tokens() {
+        let detail = json!({
+            "artifacts": [{
+                "id": "artifact-1",
+                "kind": "trace",
+                "type": "file",
+                "path": "/srv/private/trace.zip",
+                "sha256": "abc",
+                "size_bytes": 12,
+                "mime": "application/zip",
+                "created_at": "2026-05-16T00:00:00Z"
+            }]
+        });
+        let artifacts =
+            remote_detail_artifacts(&detail, &ssh_runner(), "run-1").expect("artifacts");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].id, "artifact-1");
+        assert_eq!(artifacts[0].artifact_type, "remote_file");
+        assert_eq!(artifacts[0].path, "runner-artifact://lab/run-1/artifact-1");
+    }
+}

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -9,6 +9,7 @@ use crate::engine::shell;
 use crate::error::{Error, Result};
 use crate::server::{self, SshClient};
 
+use super::evidence::mirror_daemon_evidence;
 use super::{load, status, Runner, RunnerKind};
 
 #[derive(Debug, Clone)]
@@ -42,6 +43,8 @@ pub struct RunnerExecOutput {
     pub job_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job_events: Option<Vec<JobEvent>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirror_run_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -163,6 +166,8 @@ fn exec_via_daemon(
             }
         });
 
+    let mirror = mirror_daemon_evidence(runner, &cwd, &command, &job, &events, &result)?;
+
     Ok((
         RunnerExecOutput {
             command: "runner.exec",
@@ -176,6 +181,7 @@ fn exec_via_daemon(
             job_id: Some(job.id.to_string()),
             job: Some(job),
             job_events: Some(events),
+            mirror_run_id: mirror.map(|run| run.id),
         },
         exit_code,
     ))
@@ -332,6 +338,7 @@ fn exec_output(
             job: None,
             job_id: None,
             job_events: None,
+            mirror_run_id: None,
         },
         exit_code,
     )

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -9,11 +9,15 @@ use crate::output::{CreateOutput, MergeOutput, RemoveResult};
 use crate::server;
 
 mod connection;
+mod evidence;
 mod execution;
 
 pub use connection::{
     connect, disconnect, status, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
     RunnerSession, RunnerStatusReport,
+};
+pub use evidence::{
+    download_remote_artifact, is_remote_runner_artifact_path, RemoteArtifactDownload,
 };
 pub(crate) use execution::daemon_api_get;
 pub use execution::{exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput};


### PR DESCRIPTION
## Summary
- Mirrors daemon-backed `runner exec` jobs into local `runner-exec` observation runs.
- Imports matching remote observation runs from the Lab job window and indexes their file artifacts as `runner-artifact://<runner>/<run>/<artifact>` tokens.
- Adds a scoped daemon artifact-content endpoint plus `runs artifact get` support for downloading recorded remote artifacts into the local artifact root or `--output`.

Closes #2549.

## Testing
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-lab-evidence-mirror-2549 --extension rust`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-lab-evidence-mirror-2549 --changed-since origin/main`
- `cargo test core::runner::evidence`
- `cargo test core::runner`
- `cargo test core::http_api`
- `cargo test commands::runs`
- `RUST_TEST_THREADS=1 cargo test`

## Notes
- `cargo clippy --all-targets -- -D warnings` is currently blocked by pre-existing unrelated lints in `src/commands/issues.rs`, `src/commands/refactor.rs`, and `src/commands/release.rs`.
- `homeboy lint` passes, but it prints a pre-existing `rustfmt` preference for untouched `src/core/deploy/execution.rs`; this branch intentionally leaves that unrelated file unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner evidence mirroring changes, refactored the artifact download path, and ran local verification. Chris remains responsible for review and acceptance.