### PR TITLE
Apply Lab fix patches safely to local worktrees

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -95,6 +95,60 @@ Safety rules:
 - Output includes `local_path`, `remote_path`, `sync_mode`, `snapshot_identity`, and snapshot `files` / `bytes` when available.
 - The runner workspace is execution-only; this command does not push branches, commit, or make the runner authoritative for source changes.
 
+### `workspace apply`
+
+```sh
+homeboy runner workspace apply <lab-apply.json>
+homeboy runner workspace apply <lab-apply.json> --force
+```
+
+`workspace apply` brings a Lab-generated fix artifact back to the local source worktree recorded in the artifact's `source_snapshot.local_path`. It is local-only: it does not commit, push, or make the Lab runner canonical. Reviewability stays in normal local Git via `git status` and `git diff`.
+
+Safety rules:
+
+- The artifact must identify the local source worktree through `source_snapshot.local_path`.
+- Homeboy recalculates the current local `source_snapshot.snapshot_hash` before applying.
+- If the local source worktree drifted since the Lab snapshot, apply is refused unless `--force` is explicit.
+- Unified diffs are checked with `git apply --check` before mutation, so conflicts do not partially apply.
+- Delta paths must be relative and stay inside the source worktree.
+- Output includes `apply_status`, `modified_files`, `expected_snapshot_hash`, and `current_snapshot_hash`.
+
+Temporary Wave 4 adapter contract, until the Lab fix-capture contract settles:
+
+```json
+{
+  "source_snapshot": {
+    "runner_id": "lab-a",
+    "local_path": "/Users/chubes/Developer/project@branch",
+    "remote_path": "/srv/homeboy/_lab_workspaces/project-abc123",
+    "git_sha": "...",
+    "dirty": false,
+    "sync_mode": "snapshot",
+    "snapshot_hash": "sha256:...",
+    "synced_at": "2026-05-16T00:00:00Z",
+    "sync_excludes": [".git/", "node_modules/"]
+  },
+  "patch": {
+    "format": "unified_diff",
+    "content": "diff --git a/file.txt b/file.txt\n..."
+  }
+}
+```
+
+Delta form is also accepted for explicit file replacement/deletion:
+
+```json
+{
+  "source_snapshot": { "...": "..." },
+  "delta": {
+    "files": [
+      { "path": "src/file.txt", "content_base64": "Li4u" },
+      { "path": "obsolete.txt", "delete": true }
+    ]
+  }
+}
+```
+
 ## Runner Shape
 
 Runner records are stored as JSON config entities under `~/.config/homeboy/runners/`.
@@ -125,7 +179,7 @@ Rules:
 
 All command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). The `data` payload uses the generic entity CRUD shape:
 
-- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.exec`, or `runner.workspace.sync`
+- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.exec`, `runner.workspace.sync`, or `runner.workspace.apply`
 - `id`: present for single-runner actions
 - `entity`: runner configuration for single-runner read/write actions
 - `entities`: list for `list`

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -6,7 +6,8 @@ use serde_json::Value;
 
 use homeboy::runner::{
     self, Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
-    RunnerStatusReport, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOutput,
+    RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
+    RunnerWorkspaceSyncOutput,
 };
 use homeboy::{EntityCrudOutput, MergeOutput};
 
@@ -38,6 +39,7 @@ pub enum RunnerExecutionOutput {
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum RunnerWorkspaceOutput {
     Sync(RunnerWorkspaceSyncOutput),
+    Apply(RunnerWorkspaceApplyOutput),
 }
 
 pub type RunnerOutput = EntityCrudOutput<Runner, RunnerExtra>;
@@ -180,6 +182,15 @@ enum RunnerWorkspaceCommand {
         #[arg(long, value_enum, default_value_t = RunnerWorkspaceSyncModeArg::Snapshot)]
         mode: RunnerWorkspaceSyncModeArg,
     },
+    /// Apply a Lab-generated patch/delta back to its local source worktree
+    Apply {
+        /// Lab apply JSON artifact path
+        input: String,
+
+        /// Apply even when the local worktree snapshot no longer matches the Lab source snapshot
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -261,6 +272,9 @@ pub fn run(
                 path,
                 mode,
             } => map_workspace(workspace_sync(&runner_id, path, mode)),
+            RunnerWorkspaceCommand::Apply { input, force } => map_workspace_apply(
+                runner::apply_workspace_patch(runner::RunnerWorkspaceApplyOptions { input, force }),
+            ),
         },
     }
 }
@@ -286,6 +300,17 @@ fn map_workspace(result: CmdResult<RunnerWorkspaceSyncOutput>) -> CmdResult<Runn
     result.map(|(output, exit_code)| {
         (
             RunnerCommandOutput::Workspace(RunnerWorkspaceOutput::Sync(output)),
+            exit_code,
+        )
+    })
+}
+
+fn map_workspace_apply(
+    result: CmdResult<RunnerWorkspaceApplyOutput>,
+) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| {
+        (
+            RunnerCommandOutput::Workspace(RunnerWorkspaceOutput::Apply(output)),
             exit_code,
         )
     })

--- a/src/core/runner/apply.rs
+++ b/src/core/runner/apply.rs
@@ -1,0 +1,468 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::source_snapshot::SourceSnapshot;
+
+#[derive(Debug, Clone)]
+pub struct RunnerWorkspaceApplyOptions {
+    pub input: String,
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerWorkspaceApplyStatus {
+    Applied,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerWorkspaceApplyOutput {
+    pub command: &'static str,
+    pub local_path: String,
+    pub apply_status: RunnerWorkspaceApplyStatus,
+    pub force: bool,
+    pub expected_snapshot_hash: String,
+    pub current_snapshot_hash: String,
+    pub modified_files: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabPatchApplyInput {
+    source_snapshot: SourceSnapshot,
+    #[serde(default)]
+    patch: Option<LabPatch>,
+    #[serde(default)]
+    delta: Option<LabDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabPatch {
+    #[serde(default)]
+    format: Option<String>,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabDelta {
+    files: Vec<LabDeltaFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabDeltaFile {
+    path: String,
+    #[serde(default)]
+    content_base64: Option<String>,
+    #[serde(default)]
+    delete: bool,
+}
+
+pub fn apply_workspace_patch(
+    options: RunnerWorkspaceApplyOptions,
+) -> Result<(RunnerWorkspaceApplyOutput, i32)> {
+    let input = read_apply_input(&options.input)?;
+    let local_path = local_source_path(&input.source_snapshot)?;
+    let current = SourceSnapshot::collect_local(
+        &input.source_snapshot.runner_id,
+        &local_path,
+        input.source_snapshot.remote_path.as_deref(),
+        &input.source_snapshot.sync_mode,
+    );
+
+    if current.snapshot_hash != input.source_snapshot.snapshot_hash && !options.force {
+        return Err(Error::validation_invalid_argument(
+            "source_snapshot",
+            "local source worktree has drifted since the Lab snapshot; rerun the Lab job from a fresh snapshot or pass --force to apply explicitly",
+            Some(local_path.display().to_string()),
+            Some(vec![format!(
+                "expected {}, current {}",
+                input.source_snapshot.snapshot_hash, current.snapshot_hash
+            )]),
+        ));
+    }
+
+    let modified_files = match (input.patch, input.delta) {
+        (Some(patch), None) => apply_unified_patch(&local_path, patch)?,
+        (None, Some(delta)) => apply_delta(&local_path, delta)?,
+        (Some(_), Some(_)) => {
+            return Err(Error::validation_invalid_argument(
+                "input",
+                "Lab apply input must contain either patch or delta, not both",
+                None,
+                None,
+            ));
+        }
+        (None, None) => {
+            return Err(Error::validation_invalid_argument(
+                "input",
+                "Lab apply input must contain patch or delta",
+                None,
+                None,
+            ));
+        }
+    };
+
+    Ok((
+        RunnerWorkspaceApplyOutput {
+            command: "runner.workspace.apply",
+            local_path: local_path.display().to_string(),
+            apply_status: RunnerWorkspaceApplyStatus::Applied,
+            force: options.force,
+            expected_snapshot_hash: input.source_snapshot.snapshot_hash,
+            current_snapshot_hash: current.snapshot_hash,
+            modified_files,
+        },
+        0,
+    ))
+}
+
+fn read_apply_input(path: &str) -> Result<LabPatchApplyInput> {
+    let contents = fs::read_to_string(path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(format!("read {path}"))))?;
+    serde_json::from_str(&contents).map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse Lab apply input".to_string()))
+    })
+}
+
+fn local_source_path(snapshot: &SourceSnapshot) -> Result<PathBuf> {
+    let path = snapshot.local_path.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "source_snapshot.local_path",
+            "Lab apply requires the local source worktree from the source snapshot",
+            Some(snapshot.snapshot_hash.clone()),
+            None,
+        )
+    })?;
+    let path = shellexpand::tilde(path).to_string();
+    let path = Path::new(&path);
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "source_snapshot.local_path",
+            "local source worktree does not exist",
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    path.canonicalize().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("canonicalize source snapshot path".to_string()),
+        )
+    })
+}
+
+fn apply_unified_patch(local_path: &Path, patch: LabPatch) -> Result<Vec<String>> {
+    let format = patch.format.as_deref().unwrap_or("unified_diff");
+    if format != "unified_diff" {
+        return Err(Error::validation_invalid_argument(
+            "patch.format",
+            "only unified_diff Lab patches are supported",
+            Some(format.to_string()),
+            None,
+        ));
+    }
+    let modified_files = git_apply_numstat(local_path, &patch.content)?;
+    run_git_with_stdin(local_path, &["apply", "--check", "-"], &patch.content)?;
+    run_git_with_stdin(local_path, &["apply", "-"], &patch.content)?;
+    Ok(modified_files)
+}
+
+fn git_apply_numstat(local_path: &Path, patch: &str) -> Result<Vec<String>> {
+    let output = run_git_with_stdin(local_path, &["apply", "--numstat", "-"], patch)?;
+    let mut files = output
+        .lines()
+        .filter_map(|line| line.rsplit('\t').next())
+        .filter(|path| !path.is_empty())
+        .map(|path| path.to_string())
+        .collect::<Vec<_>>();
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn run_git_with_stdin(local_path: &Path, args: &[&str], stdin: &str) -> Result<String> {
+    let mut child = Command::new("git")
+        .args(args)
+        .current_dir(local_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| Error::internal_io(err.to_string(), Some("run git".to_string())))?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| Error::internal_unexpected("git stdin unavailable"))?
+        .write_all(stdin.as_bytes())
+        .map_err(|err| Error::internal_io(err.to_string(), Some("write git stdin".to_string())))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|err| Error::internal_io(err.to_string(), Some("wait for git".to_string())))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+    }
+    Err(Error::git_command_failed(format!(
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    )))
+}
+
+fn apply_delta(local_path: &Path, delta: LabDelta) -> Result<Vec<String>> {
+    if delta.files.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "delta.files",
+            "delta must include at least one file",
+            None,
+            None,
+        ));
+    }
+    let mut modified = Vec::new();
+    for file in delta.files {
+        let target = safe_join(local_path, &file.path)?;
+        if file.delete {
+            match fs::remove_file(&target) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(Error::internal_io(
+                        err.to_string(),
+                        Some(format!("delete {}", target.display())),
+                    ));
+                }
+            }
+        } else {
+            let encoded = file.content_base64.as_deref().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "delta.files.content_base64",
+                    "delta file writes require content_base64 unless delete is true",
+                    Some(file.path.clone()),
+                    None,
+                )
+            })?;
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|err| {
+                    Error::internal_json(err.to_string(), Some("decode delta file".to_string()))
+                })?;
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent).map_err(|err| {
+                    Error::internal_io(
+                        err.to_string(),
+                        Some(format!("create {}", parent.display())),
+                    )
+                })?;
+            }
+            fs::write(&target, bytes).map_err(|err| {
+                Error::internal_io(err.to_string(), Some(format!("write {}", target.display())))
+            })?;
+        }
+        modified.push(file.path);
+    }
+    modified.sort();
+    modified.dedup();
+    Ok(modified)
+}
+
+fn safe_join(root: &Path, relative: &str) -> Result<PathBuf> {
+    let path = Path::new(relative);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(Error::validation_invalid_argument(
+            "delta.files.path",
+            "delta paths must be relative and stay inside the source worktree",
+            Some(relative.to_string()),
+            None,
+        ));
+    }
+    Ok(root.join(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source_snapshot::SourceSnapshot;
+
+    #[test]
+    fn test_apply_workspace_patch() {
+        let repo = git_repo();
+        let snapshot =
+            SourceSnapshot::collect_local("lab", repo.path(), Some("/lab/repo"), "snapshot");
+        let input_dir = tempfile::tempdir().expect("input tempdir");
+        let input = input_dir.path().join("lab-patch.json");
+        fs::write(
+            &input,
+            serde_json::json!({
+                "source_snapshot": snapshot,
+                "patch": {
+                    "format": "unified_diff",
+                    "content": "diff --git a/file.txt b/file.txt\nindex 5626abf..f719efd 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-before\n+after\n"
+                }
+            })
+            .to_string(),
+        )
+        .expect("write input");
+
+        let (output, exit_code) = apply_workspace_patch(RunnerWorkspaceApplyOptions {
+            input: input.display().to_string(),
+            force: false,
+        })
+        .expect("apply patch");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.apply_status, RunnerWorkspaceApplyStatus::Applied);
+        assert_eq!(output.modified_files, vec!["file.txt".to_string()]);
+        assert_eq!(
+            fs::read_to_string(repo.path().join("file.txt")).unwrap(),
+            "after\n"
+        );
+    }
+
+    #[test]
+    fn rejects_local_drift_without_force() {
+        let repo = git_repo();
+        let snapshot =
+            SourceSnapshot::collect_local("lab", repo.path(), Some("/lab/repo"), "snapshot");
+        fs::write(repo.path().join("other.txt"), "local drift\n").expect("drift");
+        let input_dir = tempfile::tempdir().expect("input tempdir");
+        let input = input_dir.path().join("lab-patch.json");
+        fs::write(
+            &input,
+            serde_json::json!({
+                "source_snapshot": snapshot,
+                "patch": {
+                    "format": "unified_diff",
+                    "content": "diff --git a/file.txt b/file.txt\nindex 5626abf..f719efd 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-before\n+after\n"
+                }
+            })
+            .to_string(),
+        )
+        .expect("write input");
+
+        let err = apply_workspace_patch(RunnerWorkspaceApplyOptions {
+            input: input.display().to_string(),
+            force: false,
+        })
+        .expect_err("drift rejects");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("drifted"));
+        assert_eq!(
+            fs::read_to_string(repo.path().join("file.txt")).unwrap(),
+            "before\n"
+        );
+    }
+
+    #[test]
+    fn applies_delta_with_force_after_explicit_drift_acknowledgement() {
+        let repo = git_repo();
+        let snapshot =
+            SourceSnapshot::collect_local("lab", repo.path(), Some("/lab/repo"), "snapshot");
+        fs::write(repo.path().join("other.txt"), "local drift\n").expect("drift");
+        let input_dir = tempfile::tempdir().expect("input tempdir");
+        let input = input_dir.path().join("lab-delta.json");
+        fs::write(
+            &input,
+            serde_json::json!({
+                "source_snapshot": snapshot,
+                "delta": {
+                    "files": [{
+                        "path": "nested/file.txt",
+                        "content_base64": "ZGVsdGEK"
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .expect("write input");
+
+        let (output, _) = apply_workspace_patch(RunnerWorkspaceApplyOptions {
+            input: input.display().to_string(),
+            force: true,
+        })
+        .expect("force delta");
+
+        assert!(output.force);
+        assert_eq!(output.modified_files, vec!["nested/file.txt".to_string()]);
+        assert_eq!(
+            fs::read_to_string(repo.path().join("nested/file.txt")).unwrap(),
+            "delta\n"
+        );
+        assert_eq!(
+            fs::read_to_string(repo.path().join("other.txt")).unwrap(),
+            "local drift\n"
+        );
+    }
+
+    #[test]
+    fn rejects_delta_path_traversal() {
+        let repo = git_repo();
+        let snapshot =
+            SourceSnapshot::collect_local("lab", repo.path(), Some("/lab/repo"), "snapshot");
+        let input_dir = tempfile::tempdir().expect("input tempdir");
+        let input = input_dir.path().join("lab-delta.json");
+        fs::write(
+            &input,
+            serde_json::json!({
+                "source_snapshot": snapshot,
+                "delta": { "files": [{ "path": "../outside", "content_base64": "eA==" }] }
+            })
+            .to_string(),
+        )
+        .expect("write input");
+
+        let err = apply_workspace_patch(RunnerWorkspaceApplyOptions {
+            input: input.display().to_string(),
+            force: false,
+        })
+        .expect_err("path traversal rejects");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("delta paths"));
+    }
+
+    fn git_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        git(repo.path(), &["init"]);
+        fs::write(repo.path().join("file.txt"), "before\n").expect("seed file");
+        git(repo.path(), &["add", "file.txt"]);
+        git(
+            repo.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Tests",
+                "-c",
+                "user.email=homeboy@example.com",
+                "commit",
+                "-m",
+                "seed",
+            ],
+        );
+        repo
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -537,6 +537,7 @@ mod tests {
                 started_at_ms: Some(1_700_000_000_000),
                 finished_at_ms: Some(1_700_000_001_000),
                 event_count: 0,
+                source_snapshot: None,
                 stale_reason: None,
             };
             let run = mirror_job_run(

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -8,11 +8,16 @@ use crate::error::{Error, Result};
 use crate::output::{CreateOutput, MergeOutput, RemoveResult};
 use crate::server;
 
+mod apply;
 mod connection;
 mod evidence;
 mod execution;
 mod workspace;
 
+pub use apply::{
+    apply_workspace_patch, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
+    RunnerWorkspaceApplyStatus,
+};
 pub use connection::{
     connect, disconnect, status, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
     RunnerSession, RunnerStatusReport,


### PR DESCRIPTION
## Summary
- Adds `homeboy runner workspace apply <lab-apply.json>` for applying Lab-generated unified diffs or file deltas back to the source snapshot's local worktree.
- Refuses local apply when the source worktree snapshot hash has drifted unless `--force` is explicit, and keeps canonical edits local/reviewable through normal `git status`.
- Documents the temporary Wave 4 patch/delta adapter contract until the Lab fix-capture contract lands.

Fixes #2550

## Testing
- `cargo test runner::apply`
- `cargo test --test command_surface_test`
- `cargo test --lib core::runner`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-lab-local-apply-safety-2550 --extension rust`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-lab-local-apply-safety-2550 --extension rust`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-lab-local-apply-safety-2550 --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the local Lab patch apply path, tests, and documentation under Chris's requested issue scope.