### PR TITLE
Capture Lab runner fix patches

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -156,6 +156,10 @@ enum RunnerCommand {
         #[arg(long)]
         ssh: bool,
 
+        /// Capture the file delta produced by the remote command as a patch artifact
+        #[arg(long)]
+        capture_patch: bool,
+
         /// Command and arguments to execute on the runner
         #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
@@ -264,8 +268,9 @@ pub fn run(
             id,
             cwd,
             ssh,
+            capture_patch,
             command,
-        } => map_execution(exec(&id, cwd, ssh, command)),
+        } => map_execution(exec(&id, cwd, ssh, capture_patch, command)),
         RunnerCommand::Workspace { command } => match command {
             RunnerWorkspaceCommand::Sync {
                 runner_id,
@@ -512,6 +517,7 @@ fn exec(
     runner_id: &str,
     cwd: Option<String>,
     allow_ssh: bool,
+    capture_patch: bool,
     command: Vec<String>,
 ) -> CmdResult<RunnerExecOutput> {
     runner::exec(
@@ -520,6 +526,8 @@ fn exec(
             cwd,
             allow_ssh,
             command,
+            capture_patch,
+            source_snapshot: None,
         },
     )
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -10,8 +11,22 @@ use std::sync::OnceLock;
 use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
 use crate::http_api::{self, HttpMethod};
+use crate::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::paths;
 use crate::source_snapshot::SourceSnapshot;
+use sha2::{Digest, Sha256};
+
+const PATCH_CAPTURE_EXCLUDES: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    "vendor",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    ".cache",
+];
 
 mod artifact_download;
 pub use artifact_download::ArtifactDownload;
@@ -64,7 +79,22 @@ struct ExecRequest {
     cwd: String,
     command: Vec<String>,
     #[serde(default)]
+    capture_patch: bool,
+    #[serde(default)]
     source_snapshot: Option<SourceSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PatchCaptureReport {
+    source_snapshot_id: Option<String>,
+    runner_id: String,
+    command: Vec<String>,
+    remote_path: String,
+    modified_files: Vec<String>,
+    patch_artifact_id: Option<String>,
+    patch_artifact_path: Option<String>,
+    dirty_snapshot: bool,
+    baseline_missing: bool,
 }
 
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
@@ -285,6 +315,7 @@ fn enqueue_exec_job(
         "runner_id": request.runner_id,
         "cwd": request.cwd,
         "command": request.command,
+        "capture_patch": request.capture_patch,
         "source_snapshot": source_snapshot,
     });
     let operation = "runner.exec".to_string();
@@ -297,9 +328,15 @@ fn enqueue_exec_job(
                 "runner_id": request.runner_id,
                 "cwd": request.cwd,
                 "command": request.command,
+                "capture_patch": request.capture_patch,
                 "job_id": job.job_id(),
                 "source_snapshot": source_snapshot,
             }))?;
+            let baseline = if request.capture_patch {
+                Some(capture_baseline(&request.cwd)?)
+            } else {
+                None
+            };
             let mut command = Command::new(&request.command[0]);
             command
                 .args(&request.command[1..])
@@ -329,6 +366,19 @@ fn enqueue_exec_job(
                 "phase": "finished",
                 "exit_code": exit_code,
             }))?;
+            let patch = if let Some(baseline) = baseline {
+                Some(capture_patch_report(
+                    job.job_id(),
+                    request.runner_id.as_deref().unwrap_or("unknown"),
+                    &request.cwd,
+                    &request.command,
+                    source_snapshot.as_ref(),
+                    &baseline,
+                    exit_code,
+                )?)
+            } else {
+                None
+            };
             Ok(json!({
                 "runner_id": request.runner_id,
                 "cwd": request.cwd,
@@ -337,6 +387,7 @@ fn enqueue_exec_job(
                 "stdout": stdout,
                 "stderr": stderr,
                 "source_snapshot": source_snapshot,
+                "patch": patch,
             }))
         },
     );
@@ -351,6 +402,300 @@ fn enqueue_exec_job(
         },
         "request": summary,
     }))
+}
+
+struct BaselineCapture {
+    _scratch: ScratchDir,
+    path: PathBuf,
+}
+
+struct ScratchDir {
+    path: PathBuf,
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+struct PatchRunInput<'a> {
+    run_id: &'a str,
+    runner_id: &'a str,
+    cwd: &'a str,
+    command: &'a [String],
+    source_snapshot: Option<&'a SourceSnapshot>,
+    report: &'a PatchCaptureReport,
+    patch_artifact_path: Option<&'a Path>,
+    artifact_id: &'a str,
+    exit_code: i32,
+}
+
+fn capture_baseline(cwd: &str) -> Result<BaselineCapture> {
+    let cwd_path = Path::new(cwd);
+    if !cwd_path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "cwd",
+            "patch capture requires an existing directory baseline",
+            Some(cwd.to_string()),
+            None,
+        ));
+    }
+    let scratch = create_scratch_dir("baseline")?;
+    let baseline_path = scratch.path.join("baseline");
+    copy_dir_filtered(cwd_path, &baseline_path)?;
+    Ok(BaselineCapture {
+        _scratch: scratch,
+        path: baseline_path,
+    })
+}
+
+fn capture_patch_report(
+    job_id: uuid::Uuid,
+    runner_id: &str,
+    cwd: &str,
+    command: &[String],
+    source_snapshot: Option<&SourceSnapshot>,
+    baseline: &BaselineCapture,
+    exit_code: i32,
+) -> Result<PatchCaptureReport> {
+    let after_scratch = create_scratch_dir("after")?;
+    let after_path = after_scratch.path.join("after");
+    copy_dir_filtered(Path::new(cwd), &after_path)?;
+
+    let patch = normalized_no_index_diff(&baseline.path, &after_path)?;
+    let modified_files = no_index_modified_files(&baseline.path, &after_path)?;
+    let run_id = format!("runner-exec-{job_id}");
+    let artifact_id = format!("runner-fix-patch-{job_id}");
+    let patch_artifact_path = if patch.trim().is_empty() {
+        None
+    } else {
+        Some(write_patch_artifact(&run_id, &artifact_id, &patch)?)
+    };
+    let patch_artifact_path_string = patch_artifact_path
+        .as_ref()
+        .map(|path| path.display().to_string());
+    let report = PatchCaptureReport {
+        source_snapshot_id: source_snapshot.map(|snapshot| snapshot.snapshot_hash.clone()),
+        runner_id: runner_id.to_string(),
+        command: command.to_vec(),
+        remote_path: cwd.to_string(),
+        modified_files,
+        patch_artifact_id: patch_artifact_path.as_ref().map(|_| artifact_id.clone()),
+        patch_artifact_path: patch_artifact_path_string.clone(),
+        dirty_snapshot: source_snapshot
+            .map(|snapshot| snapshot.dirty)
+            .unwrap_or(false),
+        baseline_missing: false,
+    };
+    persist_patch_run(PatchRunInput {
+        run_id: &run_id,
+        runner_id,
+        cwd,
+        command,
+        source_snapshot,
+        report: &report,
+        patch_artifact_path: patch_artifact_path.as_deref(),
+        artifact_id: &artifact_id,
+        exit_code,
+    })?;
+    Ok(report)
+}
+
+fn create_scratch_dir(label: &str) -> Result<ScratchDir> {
+    let path = paths::artifact_root()?
+        .join("_scratch")
+        .join(format!("patch-{label}-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("create scratch directory {}", path.display())),
+        )
+    })?;
+    Ok(ScratchDir { path })
+}
+
+fn write_patch_artifact(run_id: &str, artifact_id: &str, patch: &str) -> Result<PathBuf> {
+    let path = paths::artifact_root()?
+        .join(run_id)
+        .join(format!("{artifact_id}.diff"));
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    fs::write(&path, patch).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("write patch artifact {}", path.display())),
+        )
+    })?;
+    Ok(path)
+}
+
+fn persist_patch_run(input: PatchRunInput<'_>) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let run = RunRecord {
+        id: input.run_id.to_string(),
+        kind: "runner-exec".to_string(),
+        component_id: None,
+        started_at: now.clone(),
+        finished_at: Some(now.clone()),
+        status: if input.exit_code == 0 { "pass" } else { "fail" }.to_string(),
+        command: Some(input.command.join(" ")),
+        cwd: Some(input.cwd.to_string()),
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_sha: input
+            .source_snapshot
+            .and_then(|snapshot| snapshot.git_sha.clone()),
+        rig_id: None,
+        metadata_json: json!({
+            "lab": {
+                "runner_id": input.runner_id,
+                "source_snapshot": input.source_snapshot,
+                "patch": input.report,
+            }
+        }),
+    };
+    if store.get_run(input.run_id)?.is_none() {
+        store.import_run(&run)?;
+    }
+    if let Some(path) = input.patch_artifact_path {
+        let bytes = fs::read(path).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        let artifact = ArtifactRecord {
+            id: input.artifact_id.to_string(),
+            run_id: input.run_id.to_string(),
+            kind: "lab_fix_patch".to_string(),
+            artifact_type: "file".to_string(),
+            path: path.display().to_string(),
+            url: None,
+            sha256: Some(format!("{:x}", Sha256::digest(&bytes))),
+            size_bytes: i64::try_from(bytes.len()).ok(),
+            mime: Some("text/x-diff".to_string()),
+            created_at: now,
+        };
+        if store.get_artifact(input.artifact_id)?.is_none() {
+            store.import_artifact(&artifact)?;
+        }
+    }
+    Ok(())
+}
+
+fn normalized_no_index_diff(baseline: &Path, after: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .args(["diff", "--no-index", "--binary", "--"])
+        .arg(baseline)
+        .arg(after)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("run git diff --no-index".to_string()))
+        })?;
+    let code = output.status.code().unwrap_or(1);
+    if code > 1 {
+        return Err(Error::internal_unexpected(format!(
+            "git diff --no-index failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok(normalize_patch_paths(
+        &String::from_utf8_lossy(&output.stdout),
+        baseline,
+        after,
+    ))
+}
+
+fn no_index_modified_files(baseline: &Path, after: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["diff", "--no-index", "--name-only", "--"])
+        .arg(baseline)
+        .arg(after)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("run git diff --name-only".to_string()),
+            )
+        })?;
+    let code = output.status.code().unwrap_or(1);
+    if code > 1 {
+        return Err(Error::internal_unexpected(format!(
+            "git diff --name-only failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let mut files = BTreeSet::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let path = Path::new(line);
+        let relative = path
+            .strip_prefix(after)
+            .or_else(|_| path.strip_prefix(baseline))
+            .unwrap_or(path)
+            .to_string_lossy()
+            .trim_start_matches('/')
+            .to_string();
+        if !relative.is_empty() {
+            files.insert(relative);
+        }
+    }
+    Ok(files.into_iter().collect())
+}
+
+fn normalize_patch_paths(patch: &str, baseline: &Path, after: &Path) -> String {
+    let baseline = baseline.to_string_lossy();
+    let after = after.to_string_lossy();
+    patch
+        .replace(&format!("a/{baseline}"), "a")
+        .replace(&format!("b/{after}"), "b")
+        .replace(baseline.as_ref(), "a")
+        .replace(after.as_ref(), "b")
+}
+
+fn copy_dir_filtered(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("create {}", target.display())),
+        )
+    })?;
+    for entry in fs::read_dir(source).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("read {}", source.display())))
+    })? {
+        let entry = entry.map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read directory entry".to_string()))
+        })?;
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if PATCH_CAPTURE_EXCLUDES.contains(&name_str) {
+            continue;
+        }
+        let source_path = entry.path();
+        let target_path = target.join(&name);
+        let metadata = entry.metadata().map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("read metadata {}", source_path.display())),
+            )
+        })?;
+        if metadata.is_dir() {
+            copy_dir_filtered(&source_path, &target_path)?;
+        } else if metadata.is_file() {
+            fs::copy(&source_path, &target_path).map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some(format!("copy {}", source_path.display())),
+                )
+            })?;
+        }
+    }
+    Ok(())
 }
 
 fn daemon_job_store() -> &'static JobStore {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::BTreeSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -11,25 +10,13 @@ use std::sync::OnceLock;
 use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
 use crate::http_api::{self, HttpMethod};
-use crate::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::paths;
 use crate::source_snapshot::SourceSnapshot;
-use sha2::{Digest, Sha256};
-
-const PATCH_CAPTURE_EXCLUDES: &[&str] = &[
-    ".git",
-    "node_modules",
-    "target",
-    "vendor",
-    "dist",
-    "build",
-    ".next",
-    ".turbo",
-    ".cache",
-];
 
 mod artifact_download;
+mod patch_capture;
 pub use artifact_download::ArtifactDownload;
+use patch_capture::{capture_baseline, capture_patch_report};
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";
 
@@ -84,19 +71,6 @@ struct ExecRequest {
     source_snapshot: Option<SourceSnapshot>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-struct PatchCaptureReport {
-    source_snapshot_id: Option<String>,
-    runner_id: String,
-    command: Vec<String>,
-    remote_path: String,
-    modified_files: Vec<String>,
-    patch_artifact_id: Option<String>,
-    patch_artifact_path: Option<String>,
-    dirty_snapshot: bool,
-    baseline_missing: bool,
-}
-
 pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
     let parsed: SocketAddr = addr.parse().map_err(|e| {
         Error::validation_invalid_argument(
@@ -119,7 +93,7 @@ pub fn parse_bind_addr(addr: &str) -> Result<SocketAddr> {
     Ok(parsed)
 }
 
-pub fn state_path() -> Result<PathBuf> {
+fn state_path() -> Result<PathBuf> {
     paths::daemon_state_file()
 }
 
@@ -208,15 +182,11 @@ pub fn route(method: &str, path: &str) -> HttpResponse {
     route_with_job_store(method, path, daemon_job_store())
 }
 
-pub fn route_with_job_store(method: &str, path: &str, job_store: &JobStore) -> HttpResponse {
+fn route_with_job_store(method: &str, path: &str, job_store: &JobStore) -> HttpResponse {
     route_with_job_store_and_body(method, path, None, job_store)
 }
 
-pub fn route_with_body(method: &str, path: &str, body: Option<serde_json::Value>) -> HttpResponse {
-    route_with_job_store_and_body(method, path, body, daemon_job_store())
-}
-
-pub fn route_with_job_store_and_body(
+fn route_with_job_store_and_body(
     method: &str,
     path: &str,
     body: Option<serde_json::Value>,
@@ -404,300 +374,6 @@ fn enqueue_exec_job(
     }))
 }
 
-struct BaselineCapture {
-    _scratch: ScratchDir,
-    path: PathBuf,
-}
-
-struct ScratchDir {
-    path: PathBuf,
-}
-
-impl Drop for ScratchDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
-}
-
-struct PatchRunInput<'a> {
-    run_id: &'a str,
-    runner_id: &'a str,
-    cwd: &'a str,
-    command: &'a [String],
-    source_snapshot: Option<&'a SourceSnapshot>,
-    report: &'a PatchCaptureReport,
-    patch_artifact_path: Option<&'a Path>,
-    artifact_id: &'a str,
-    exit_code: i32,
-}
-
-fn capture_baseline(cwd: &str) -> Result<BaselineCapture> {
-    let cwd_path = Path::new(cwd);
-    if !cwd_path.is_dir() {
-        return Err(Error::validation_invalid_argument(
-            "cwd",
-            "patch capture requires an existing directory baseline",
-            Some(cwd.to_string()),
-            None,
-        ));
-    }
-    let scratch = create_scratch_dir("baseline")?;
-    let baseline_path = scratch.path.join("baseline");
-    copy_dir_filtered(cwd_path, &baseline_path)?;
-    Ok(BaselineCapture {
-        _scratch: scratch,
-        path: baseline_path,
-    })
-}
-
-fn capture_patch_report(
-    job_id: uuid::Uuid,
-    runner_id: &str,
-    cwd: &str,
-    command: &[String],
-    source_snapshot: Option<&SourceSnapshot>,
-    baseline: &BaselineCapture,
-    exit_code: i32,
-) -> Result<PatchCaptureReport> {
-    let after_scratch = create_scratch_dir("after")?;
-    let after_path = after_scratch.path.join("after");
-    copy_dir_filtered(Path::new(cwd), &after_path)?;
-
-    let patch = normalized_no_index_diff(&baseline.path, &after_path)?;
-    let modified_files = no_index_modified_files(&baseline.path, &after_path)?;
-    let run_id = format!("runner-exec-{job_id}");
-    let artifact_id = format!("runner-fix-patch-{job_id}");
-    let patch_artifact_path = if patch.trim().is_empty() {
-        None
-    } else {
-        Some(write_patch_artifact(&run_id, &artifact_id, &patch)?)
-    };
-    let patch_artifact_path_string = patch_artifact_path
-        .as_ref()
-        .map(|path| path.display().to_string());
-    let report = PatchCaptureReport {
-        source_snapshot_id: source_snapshot.map(|snapshot| snapshot.snapshot_hash.clone()),
-        runner_id: runner_id.to_string(),
-        command: command.to_vec(),
-        remote_path: cwd.to_string(),
-        modified_files,
-        patch_artifact_id: patch_artifact_path.as_ref().map(|_| artifact_id.clone()),
-        patch_artifact_path: patch_artifact_path_string.clone(),
-        dirty_snapshot: source_snapshot
-            .map(|snapshot| snapshot.dirty)
-            .unwrap_or(false),
-        baseline_missing: false,
-    };
-    persist_patch_run(PatchRunInput {
-        run_id: &run_id,
-        runner_id,
-        cwd,
-        command,
-        source_snapshot,
-        report: &report,
-        patch_artifact_path: patch_artifact_path.as_deref(),
-        artifact_id: &artifact_id,
-        exit_code,
-    })?;
-    Ok(report)
-}
-
-fn create_scratch_dir(label: &str) -> Result<ScratchDir> {
-    let path = paths::artifact_root()?
-        .join("_scratch")
-        .join(format!("patch-{label}-{}", uuid::Uuid::new_v4()));
-    fs::create_dir_all(&path).map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some(format!("create scratch directory {}", path.display())),
-        )
-    })?;
-    Ok(ScratchDir { path })
-}
-
-fn write_patch_artifact(run_id: &str, artifact_id: &str, patch: &str) -> Result<PathBuf> {
-    let path = paths::artifact_root()?
-        .join(run_id)
-        .join(format!("{artifact_id}.diff"));
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some(format!("create {}", parent.display())),
-            )
-        })?;
-    }
-    fs::write(&path, patch).map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some(format!("write patch artifact {}", path.display())),
-        )
-    })?;
-    Ok(path)
-}
-
-fn persist_patch_run(input: PatchRunInput<'_>) -> Result<()> {
-    let store = ObservationStore::open_initialized()?;
-    let now = chrono::Utc::now().to_rfc3339();
-    let run = RunRecord {
-        id: input.run_id.to_string(),
-        kind: "runner-exec".to_string(),
-        component_id: None,
-        started_at: now.clone(),
-        finished_at: Some(now.clone()),
-        status: if input.exit_code == 0 { "pass" } else { "fail" }.to_string(),
-        command: Some(input.command.join(" ")),
-        cwd: Some(input.cwd.to_string()),
-        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        git_sha: input
-            .source_snapshot
-            .and_then(|snapshot| snapshot.git_sha.clone()),
-        rig_id: None,
-        metadata_json: json!({
-            "lab": {
-                "runner_id": input.runner_id,
-                "source_snapshot": input.source_snapshot,
-                "patch": input.report,
-            }
-        }),
-    };
-    if store.get_run(input.run_id)?.is_none() {
-        store.import_run(&run)?;
-    }
-    if let Some(path) = input.patch_artifact_path {
-        let bytes = fs::read(path).map_err(|err| {
-            Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
-        })?;
-        let artifact = ArtifactRecord {
-            id: input.artifact_id.to_string(),
-            run_id: input.run_id.to_string(),
-            kind: "lab_fix_patch".to_string(),
-            artifact_type: "file".to_string(),
-            path: path.display().to_string(),
-            url: None,
-            sha256: Some(format!("{:x}", Sha256::digest(&bytes))),
-            size_bytes: i64::try_from(bytes.len()).ok(),
-            mime: Some("text/x-diff".to_string()),
-            created_at: now,
-        };
-        if store.get_artifact(input.artifact_id)?.is_none() {
-            store.import_artifact(&artifact)?;
-        }
-    }
-    Ok(())
-}
-
-fn normalized_no_index_diff(baseline: &Path, after: &Path) -> Result<String> {
-    let output = Command::new("git")
-        .args(["diff", "--no-index", "--binary", "--"])
-        .arg(baseline)
-        .arg(after)
-        .output()
-        .map_err(|err| {
-            Error::internal_io(err.to_string(), Some("run git diff --no-index".to_string()))
-        })?;
-    let code = output.status.code().unwrap_or(1);
-    if code > 1 {
-        return Err(Error::internal_unexpected(format!(
-            "git diff --no-index failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-    Ok(normalize_patch_paths(
-        &String::from_utf8_lossy(&output.stdout),
-        baseline,
-        after,
-    ))
-}
-
-fn no_index_modified_files(baseline: &Path, after: &Path) -> Result<Vec<String>> {
-    let output = Command::new("git")
-        .args(["diff", "--no-index", "--name-only", "--"])
-        .arg(baseline)
-        .arg(after)
-        .output()
-        .map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some("run git diff --name-only".to_string()),
-            )
-        })?;
-    let code = output.status.code().unwrap_or(1);
-    if code > 1 {
-        return Err(Error::internal_unexpected(format!(
-            "git diff --name-only failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-    let mut files = BTreeSet::new();
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let path = Path::new(line);
-        let relative = path
-            .strip_prefix(after)
-            .or_else(|_| path.strip_prefix(baseline))
-            .unwrap_or(path)
-            .to_string_lossy()
-            .trim_start_matches('/')
-            .to_string();
-        if !relative.is_empty() {
-            files.insert(relative);
-        }
-    }
-    Ok(files.into_iter().collect())
-}
-
-fn normalize_patch_paths(patch: &str, baseline: &Path, after: &Path) -> String {
-    let baseline = baseline.to_string_lossy();
-    let after = after.to_string_lossy();
-    patch
-        .replace(&format!("a/{baseline}"), "a")
-        .replace(&format!("b/{after}"), "b")
-        .replace(baseline.as_ref(), "a")
-        .replace(after.as_ref(), "b")
-}
-
-fn copy_dir_filtered(source: &Path, target: &Path) -> Result<()> {
-    fs::create_dir_all(target).map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some(format!("create {}", target.display())),
-        )
-    })?;
-    for entry in fs::read_dir(source).map_err(|err| {
-        Error::internal_io(err.to_string(), Some(format!("read {}", source.display())))
-    })? {
-        let entry = entry.map_err(|err| {
-            Error::internal_io(err.to_string(), Some("read directory entry".to_string()))
-        })?;
-        let name = entry.file_name();
-        let Some(name_str) = name.to_str() else {
-            continue;
-        };
-        if PATCH_CAPTURE_EXCLUDES.contains(&name_str) {
-            continue;
-        }
-        let source_path = entry.path();
-        let target_path = target.join(&name);
-        let metadata = entry.metadata().map_err(|err| {
-            Error::internal_io(
-                err.to_string(),
-                Some(format!("read metadata {}", source_path.display())),
-            )
-        })?;
-        if metadata.is_dir() {
-            copy_dir_filtered(&source_path, &target_path)?;
-        } else if metadata.is_file() {
-            fs::copy(&source_path, &target_path).map_err(|err| {
-                Error::internal_io(
-                    err.to_string(),
-                    Some(format!("copy {}", source_path.display())),
-                )
-            })?;
-        }
-    }
-    Ok(())
-}
-
 fn daemon_job_store() -> &'static JobStore {
     DAEMON_JOB_STORE.get_or_init(JobStore::default)
 }
@@ -744,7 +420,7 @@ fn route_read_only_api(
     }
 }
 
-fn error_response(status_code: u16, err: Error) -> HttpResponse {
+pub(super) fn error_response(status_code: u16, err: Error) -> HttpResponse {
     HttpResponse {
         status_code,
         body: json!({

--- a/src/core/daemon/artifact_download.rs
+++ b/src/core/daemon/artifact_download.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use crate::error::{Error, Result};
 use crate::observation::{ArtifactRecord, ObservationStore};
 
-use super::HttpResponse;
+use super::{error_response, HttpResponse};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArtifactDownload {
@@ -213,22 +213,97 @@ fn artifact_metadata_body(
     })
 }
 
-fn error_response(status_code: u16, err: Error) -> HttpResponse {
-    HttpResponse {
-        status_code,
-        body: json!({
-            "error": err.code.as_str(),
-            "message": err.message,
-            "details": err.details,
-            "hints": err.hints,
-        }),
-        artifact: None,
-    }
-}
-
 fn sanitize_header_value(value: &str) -> String {
     value
         .chars()
         .filter(|ch| !matches!(ch, '\r' | '\n' | '"'))
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observation::NewRunRecord;
+    use crate::test_support::HomeGuard;
+
+    #[test]
+    fn test_route() {
+        let _home = HomeGuard::new();
+        let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(NewRunRecord {
+                kind: "runner-exec".to_string(),
+                component_id: None,
+                command: Some("homeboy runner exec".to_string()),
+                cwd: None,
+                homeboy_version: Some("test-version".to_string()),
+                git_sha: None,
+                rig_id: None,
+                metadata_json: json!({}),
+            })
+            .expect("run");
+        let artifact_path = home_path.join("artifact.txt");
+        fs::write(&artifact_path, "artifact body").expect("artifact file");
+        let artifact = store
+            .record_artifact(&run.id, "lab_fix_patch", &artifact_path)
+            .expect("artifact");
+
+        let response =
+            route(&format!("/runs/{}/artifacts/{}", run.id, artifact.id)).expect("artifact route");
+
+        assert_eq!(response.status_code, 200);
+        assert!(response.artifact.is_some());
+        assert_eq!(response.body["artifact"]["id"], artifact.id);
+    }
+
+    #[test]
+    fn test_sanitize_header_value_removes_response_splitting_chars() {
+        assert_eq!(sanitize_header_value("a\r\nb\"c"), "abc");
+    }
+
+    #[test]
+    fn test_write_response() {
+        let _home = HomeGuard::new();
+        let artifact_path = tempfile::NamedTempFile::new().expect("artifact file");
+        fs::write(artifact_path.path(), "artifact body").expect("artifact body");
+        let artifact = ArtifactDownload {
+            record: ArtifactRecord {
+                id: "artifact-1".to_string(),
+                run_id: "run-1".to_string(),
+                kind: "lab_fix_patch".to_string(),
+                artifact_type: "file".to_string(),
+                path: artifact_path.path().display().to_string(),
+                url: None,
+                sha256: Some("abc123".to_string()),
+                size_bytes: Some(13),
+                mime: Some("text/plain".to_string()),
+                created_at: chrono::Utc::now().to_rfc3339(),
+            },
+            path: artifact_path.path().to_path_buf(),
+            content_type: "text/plain".to_string(),
+            size_bytes: 13,
+            filename: "artifact.txt".to_string(),
+        };
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let addr = listener.local_addr().expect("addr");
+        let reader = std::thread::spawn(move || {
+            let mut stream = std::net::TcpStream::connect(addr).expect("connect");
+            let mut body = String::new();
+            std::io::Read::read_to_string(&mut stream, &mut body).expect("read response");
+            body
+        });
+        let (stream, _) = listener.accept().expect("accept");
+
+        write_response(stream, 200, artifact).expect("write response");
+        let response = reader.join().expect("reader");
+
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        assert!(response.contains("Content-Type: text/plain"));
+        assert!(response.ends_with("artifact body"));
+    }
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/daemon/artifact_download_test.rs"]
+mod artifact_download_test;

--- a/src/core/daemon/patch_capture.rs
+++ b/src/core/daemon/patch_capture.rs
@@ -1,0 +1,383 @@
+use serde::Serialize;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::error::{Error, Result};
+use crate::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use crate::paths;
+use crate::source_snapshot::SourceSnapshot;
+
+const PATCH_CAPTURE_EXCLUDES: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    "vendor",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    ".cache",
+];
+
+pub(super) struct BaselineCapture {
+    _scratch: ScratchDir,
+    path: PathBuf,
+}
+
+struct ScratchDir {
+    path: PathBuf,
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PatchCaptureReport {
+    source_snapshot_id: Option<String>,
+    runner_id: String,
+    command: Vec<String>,
+    remote_path: String,
+    modified_files: Vec<String>,
+    patch_artifact_id: Option<String>,
+    patch_artifact_path: Option<String>,
+    dirty_snapshot: bool,
+    baseline_missing: bool,
+}
+
+struct PatchRunInput<'a> {
+    run_id: &'a str,
+    runner_id: &'a str,
+    cwd: &'a str,
+    command: &'a [String],
+    source_snapshot: Option<&'a SourceSnapshot>,
+    report: &'a PatchCaptureReport,
+    patch_artifact_path: Option<&'a Path>,
+    artifact_id: &'a str,
+    exit_code: i32,
+}
+
+pub(super) fn capture_baseline(cwd: &str) -> Result<BaselineCapture> {
+    let cwd_path = Path::new(cwd);
+    if !cwd_path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "cwd",
+            "patch capture requires an existing directory baseline",
+            Some(cwd.to_string()),
+            None,
+        ));
+    }
+    let scratch = create_scratch_dir("baseline")?;
+    let baseline_path = scratch.path.join("baseline");
+    copy_dir_filtered(cwd_path, &baseline_path)?;
+    Ok(BaselineCapture {
+        _scratch: scratch,
+        path: baseline_path,
+    })
+}
+
+pub(super) fn capture_patch_report(
+    job_id: uuid::Uuid,
+    runner_id: &str,
+    cwd: &str,
+    command: &[String],
+    source_snapshot: Option<&SourceSnapshot>,
+    baseline: &BaselineCapture,
+    exit_code: i32,
+) -> Result<PatchCaptureReport> {
+    let after_scratch = create_scratch_dir("after")?;
+    let after_path = after_scratch.path.join("after");
+    copy_dir_filtered(Path::new(cwd), &after_path)?;
+
+    let patch = normalized_no_index_diff(&baseline.path, &after_path)?;
+    let modified_files = no_index_modified_files(&baseline.path, &after_path)?;
+    let run_id = format!("runner-exec-{job_id}");
+    let artifact_id = format!("runner-fix-patch-{job_id}");
+    let patch_artifact_path = if patch.trim().is_empty() {
+        None
+    } else {
+        Some(write_patch_artifact(&run_id, &artifact_id, &patch)?)
+    };
+    let patch_artifact_path_string = patch_artifact_path
+        .as_ref()
+        .map(|path| path.display().to_string());
+    let report = PatchCaptureReport {
+        source_snapshot_id: source_snapshot.map(|snapshot| snapshot.snapshot_hash.clone()),
+        runner_id: runner_id.to_string(),
+        command: command.to_vec(),
+        remote_path: cwd.to_string(),
+        modified_files,
+        patch_artifact_id: patch_artifact_path.as_ref().map(|_| artifact_id.clone()),
+        patch_artifact_path: patch_artifact_path_string,
+        dirty_snapshot: source_snapshot
+            .map(|snapshot| snapshot.dirty)
+            .unwrap_or(false),
+        baseline_missing: false,
+    };
+    persist_patch_run(PatchRunInput {
+        run_id: &run_id,
+        runner_id,
+        cwd,
+        command,
+        source_snapshot,
+        report: &report,
+        patch_artifact_path: patch_artifact_path.as_deref(),
+        artifact_id: &artifact_id,
+        exit_code,
+    })?;
+    Ok(report)
+}
+
+fn create_scratch_dir(label: &str) -> Result<ScratchDir> {
+    let path = paths::artifact_root()?
+        .join("_scratch")
+        .join(format!("patch-{label}-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("create scratch directory {}", path.display())),
+        )
+    })?;
+    Ok(ScratchDir { path })
+}
+
+fn write_patch_artifact(run_id: &str, artifact_id: &str, patch: &str) -> Result<PathBuf> {
+    let path = paths::artifact_root()?
+        .join(run_id)
+        .join(format!("{artifact_id}.diff"));
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    fs::write(&path, patch).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("write patch artifact {}", path.display())),
+        )
+    })?;
+    Ok(path)
+}
+
+fn persist_patch_run(input: PatchRunInput<'_>) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let run = RunRecord {
+        id: input.run_id.to_string(),
+        kind: "runner-exec".to_string(),
+        component_id: None,
+        started_at: now.clone(),
+        finished_at: Some(now.clone()),
+        status: if input.exit_code == 0 { "pass" } else { "fail" }.to_string(),
+        command: Some(input.command.join(" ")),
+        cwd: Some(input.cwd.to_string()),
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_sha: input
+            .source_snapshot
+            .and_then(|snapshot| snapshot.git_sha.clone()),
+        rig_id: None,
+        metadata_json: json!({
+            "lab": {
+                "runner_id": input.runner_id,
+                "source_snapshot": input.source_snapshot,
+                "patch": input.report,
+            }
+        }),
+    };
+    if store.get_run(input.run_id)?.is_none() {
+        store.import_run(&run)?;
+    }
+    if let Some(path) = input.patch_artifact_path {
+        let bytes = fs::read(path).map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("read {}", path.display())))
+        })?;
+        let artifact = ArtifactRecord {
+            id: input.artifact_id.to_string(),
+            run_id: input.run_id.to_string(),
+            kind: "lab_fix_patch".to_string(),
+            artifact_type: "file".to_string(),
+            path: path.display().to_string(),
+            url: None,
+            sha256: Some(format!("{:x}", Sha256::digest(&bytes))),
+            size_bytes: i64::try_from(bytes.len()).ok(),
+            mime: Some("text/x-diff".to_string()),
+            created_at: now,
+        };
+        if store.get_artifact(input.artifact_id)?.is_none() {
+            store.import_artifact(&artifact)?;
+        }
+    }
+    Ok(())
+}
+
+fn normalized_no_index_diff(baseline: &Path, after: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .args(["diff", "--no-index", "--binary", "--"])
+        .arg(baseline)
+        .arg(after)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("run git diff --no-index".to_string()))
+        })?;
+    let code = output.status.code().unwrap_or(1);
+    if code > 1 {
+        return Err(Error::internal_unexpected(format!(
+            "git diff --no-index failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    Ok(normalize_patch_paths(
+        &String::from_utf8_lossy(&output.stdout),
+        baseline,
+        after,
+    ))
+}
+
+fn no_index_modified_files(baseline: &Path, after: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["diff", "--no-index", "--name-only", "--"])
+        .arg(baseline)
+        .arg(after)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("run git diff --name-only".to_string()),
+            )
+        })?;
+    let code = output.status.code().unwrap_or(1);
+    if code > 1 {
+        return Err(Error::internal_unexpected(format!(
+            "git diff --name-only failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let mut files = BTreeSet::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let path = Path::new(line);
+        let relative = path
+            .strip_prefix(after)
+            .or_else(|_| path.strip_prefix(baseline))
+            .unwrap_or(path)
+            .to_string_lossy()
+            .trim_start_matches('/')
+            .to_string();
+        if !relative.is_empty() {
+            files.insert(relative);
+        }
+    }
+    Ok(files.into_iter().collect())
+}
+
+fn normalize_patch_paths(patch: &str, baseline: &Path, after: &Path) -> String {
+    let baseline = baseline.to_string_lossy();
+    let after = after.to_string_lossy();
+    patch
+        .replace(&format!("a/{baseline}"), "a")
+        .replace(&format!("b/{after}"), "b")
+        .replace(baseline.as_ref(), "a")
+        .replace(after.as_ref(), "b")
+}
+
+fn copy_dir_filtered(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("create {}", target.display())),
+        )
+    })?;
+    for entry in fs::read_dir(source).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("read {}", source.display())))
+    })? {
+        let entry = entry.map_err(|err| {
+            Error::internal_io(err.to_string(), Some("read directory entry".to_string()))
+        })?;
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if PATCH_CAPTURE_EXCLUDES.contains(&name_str) {
+            continue;
+        }
+        let source_path = entry.path();
+        let target_path = target.join(&name);
+        let metadata = entry.metadata().map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("read metadata {}", source_path.display())),
+            )
+        })?;
+        if metadata.is_dir() {
+            copy_dir_filtered(&source_path, &target_path)?;
+        } else if metadata.is_file() {
+            fs::copy(&source_path, &target_path).map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some(format!("copy {}", source_path.display())),
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::HomeGuard;
+
+    #[test]
+    fn capture_baseline_filters_large_generated_directories() {
+        let _home = HomeGuard::new();
+        let workspace = tempfile::tempdir().expect("workspace");
+        fs::write(workspace.path().join("file.txt"), "tracked\n").expect("file");
+        fs::create_dir(workspace.path().join("target")).expect("target dir");
+        fs::write(
+            workspace.path().join("target").join("ignored.txt"),
+            "ignored\n",
+        )
+        .expect("ignored file");
+
+        let baseline = capture_baseline(&workspace.path().display().to_string()).expect("baseline");
+
+        assert!(baseline.path.join("file.txt").exists());
+        assert!(!baseline.path.join("target").exists());
+    }
+
+    #[test]
+    fn capture_patch_report_records_diff_artifact() {
+        let _home = HomeGuard::new();
+        let workspace = tempfile::tempdir().expect("workspace");
+        fs::write(workspace.path().join("file.txt"), "before\n").expect("before");
+        let baseline = capture_baseline(&workspace.path().display().to_string()).expect("baseline");
+        fs::write(workspace.path().join("file.txt"), "after\n").expect("after");
+        let job_id = uuid::Uuid::new_v4();
+        let command = vec!["sh".to_string(), "-c".to_string(), "true".to_string()];
+
+        let report = capture_patch_report(
+            job_id,
+            "lab-local",
+            &workspace.path().display().to_string(),
+            &command,
+            None,
+            &baseline,
+            0,
+        )
+        .expect("patch report");
+
+        assert_eq!(report.modified_files, vec!["file.txt".to_string()]);
+        let artifact_path = report.patch_artifact_path.expect("artifact path");
+        let patch_body = fs::read_to_string(artifact_path).expect("patch body");
+        assert!(patch_body.contains("-before"));
+        assert!(patch_body.contains("+after"));
+    }
+}

--- a/src/core/engine/invocation/child.rs
+++ b/src/core/engine/invocation/child.rs
@@ -292,6 +292,36 @@ mod audit_coverage_tests {
     }
 
     #[test]
+    fn test_children_dir() {
+        with_isolated_home(|_| {
+            let dir = InvocationChildRecord::children_dir("inv/../audit").expect("children dir");
+
+            assert!(dir.ends_with("inv____audit"));
+        });
+    }
+
+    #[test]
+    fn test_record_path() {
+        with_isolated_home(|_| {
+            let dir = InvocationChildRecord::children_dir("inv/../audit").expect("children dir");
+            let path =
+                InvocationChildRecord::record_path("inv/../audit", 1234).expect("record path");
+
+            assert_eq!(
+                path.file_name().and_then(|name| name.to_str()),
+                Some("1234.json")
+            );
+            assert!(path.starts_with(&dir));
+        });
+    }
+
+    #[test]
+    fn test_process_started_at_handles_current_and_missing_processes() {
+        assert!(InvocationChildRecord::process_started_at(std::process::id()).is_some());
+        assert!(InvocationChildRecord::process_started_at(u32::MAX).is_none());
+    }
+
+    #[test]
     fn test_cleanup_invocation_children() {
         with_isolated_home(|_| {
             assert_eq!(cleanup_invocation_children("inv-empty").unwrap(), 0);

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -604,6 +604,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::test_support;
 
     #[test]
     fn rejects_non_loopback_remote_daemon_address() {
@@ -650,5 +651,52 @@ mod tests {
         assert!(tunnel.success);
         assert_eq!(tunnel.pid, None);
         assert_eq!(tunnel.stderr, "");
+    }
+
+    #[test]
+    fn connect_reports_local_runner_as_unsupported() {
+        test_support::with_isolated_home(|_| {
+            crate::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+                .expect("create runner");
+
+            let (report, exit_code) = connect("lab-local").expect("connect report");
+
+            assert_eq!(exit_code, 20);
+            assert!(!report.connected);
+            assert_eq!(report.failure_kind, Some(RunnerFailureKind::SshFailure));
+            assert!(report
+                .failure_message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("only SSH runners"));
+        });
+    }
+
+    #[test]
+    fn disconnect_removes_existing_session_file() {
+        test_support::with_isolated_home(|_| {
+            crate::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+                .expect("create runner");
+            let session = RunnerSession {
+                runner_id: "lab-local".to_string(),
+                server_id: None,
+                remote_daemon_address: "127.0.0.1:49152".to_string(),
+                local_port: 49153,
+                local_url: "http://127.0.0.1:49153".to_string(),
+                tunnel_pid: None,
+                remote_daemon_pid: None,
+                homeboy_version: "test".to_string(),
+                connected_at: Utc::now().to_rfc3339(),
+            };
+            write_session(&session).expect("write session");
+            let path = session_path("lab-local").expect("session path");
+            assert!(path.exists());
+
+            let report = disconnect("lab-local").expect("disconnect");
+
+            assert!(report.disconnected);
+            assert_eq!(report.session.expect("session").runner_id, "lab-local");
+            assert!(!path.exists());
+        });
     }
 }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -18,6 +18,8 @@ pub struct RunnerExecOptions {
     pub cwd: Option<String>,
     pub allow_ssh: bool,
     pub command: Vec<String>,
+    pub capture_patch: bool,
+    pub source_snapshot: Option<SourceSnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -48,6 +50,8 @@ pub struct RunnerExecOutput {
     pub job_events: Option<Vec<JobEvent>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mirror_run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,7 +77,14 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     if connected.connected {
         if let Some(session) = connected.session {
-            return exec_via_daemon(&runner, &session.local_url, cwd, options.command);
+            return exec_via_daemon(
+                &runner,
+                &session.local_url,
+                cwd,
+                options.command,
+                options.capture_patch,
+                options.source_snapshot,
+            );
         }
     }
 
@@ -97,19 +108,23 @@ fn exec_via_daemon(
     local_url: &str,
     cwd: String,
     command: Vec<String>,
+    capture_patch: bool,
+    source_snapshot_override: Option<SourceSnapshot>,
 ) -> Result<(RunnerExecOutput, i32)> {
     let client = Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
-    let source_snapshot =
-        SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref());
+    let source_snapshot = source_snapshot_override.unwrap_or_else(|| {
+        SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref())
+    });
     let response = client
         .post(format!("{}/exec", local_url.trim_end_matches('/')))
         .json(&json!({
             "runner_id": runner.id,
             "cwd": cwd,
             "command": command,
+            "capture_patch": capture_patch,
             "source_snapshot": source_snapshot,
         }))
         .send()
@@ -160,6 +175,7 @@ fn exec_via_daemon(
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
     let stdout = string_field(&result, "stdout");
     let stderr = string_field(&result, "stderr");
+    let patch = result.get("patch").cloned();
     let exit_code = result
         .get("exit_code")
         .and_then(Value::as_i64)
@@ -189,6 +205,7 @@ fn exec_via_daemon(
             job: Some(job),
             job_events: Some(events),
             mirror_run_id: mirror.map(|run| run.id),
+            patch,
         },
         exit_code,
     ))
@@ -358,6 +375,7 @@ fn exec_output(
             job_id: None,
             job_events: None,
             mirror_run_id: None,
+            patch: None,
         },
         exit_code,
     )
@@ -477,6 +495,8 @@ mod tests {
                     cwd: None,
                     allow_ssh: false,
                     command: vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
+                    capture_patch: false,
+                    source_snapshot: None,
                 },
             )
             .expect("exec local runner");

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,22 +180,13 @@ fn main() -> std::process::ExitCode {
             output::print_result::<serde_json::Value>(Err(err)).ok();
             return std::process::ExitCode::from(exit_code_to_u8(2));
         }
-        if let Some(flag) = cli.command.lab_offload_mutation_flag() {
-            let err = homeboy::Error::validation_invalid_argument(
-                "runner",
-                format!(
-                    "Lab offload does not run commands that may write canonical workspace state ({flag})"
-                ),
-                Some(runner_id.to_string()),
-                Some(vec![
-                    "Run the command locally without --runner when you intend to write files or baselines."
-                        .to_string(),
-                ]),
-            );
-            output::print_result::<serde_json::Value>(Err(err)).ok();
-            return std::process::ExitCode::from(exit_code_to_u8(2));
-        }
-        return run_lab_offload(runner_id, &normalized, output_file.as_deref());
+        let capture_patch = cli.command.lab_offload_mutation_flag().is_some();
+        return run_lab_offload(
+            runner_id,
+            &normalized,
+            output_file.as_deref(),
+            capture_patch,
+        );
     }
 
     homeboy::set_artifact_root_override(cli.artifact_root.clone().or(artifact_root_override));
@@ -364,8 +355,9 @@ fn run_lab_offload(
     runner_id: &str,
     normalized_args: &[String],
     output_file: Option<&str>,
+    capture_patch: bool,
 ) -> std::process::ExitCode {
-    match run_lab_offload_inner(runner_id, normalized_args, output_file) {
+    match run_lab_offload_inner(runner_id, normalized_args, output_file, capture_patch) {
         Ok(exit_code) => std::process::ExitCode::from(exit_code_to_u8(exit_code)),
         Err(err) => {
             output::print_result::<serde_json::Value>(Err(err)).ok();
@@ -378,6 +370,7 @@ fn run_lab_offload_inner(
     runner_id: &str,
     normalized_args: &[String],
     output_file: Option<&str>,
+    capture_patch: bool,
 ) -> homeboy::Result<i32> {
     let runner = homeboy::runner::load(runner_id)?;
     if runner.kind != homeboy::runner::RunnerKind::Ssh {
@@ -415,6 +408,14 @@ fn run_lab_offload_inner(
         )
     })?;
     let remote_cwd = remote_cwd_for_current_checkout(workspace_root)?;
+    let source_snapshot = homeboy::source_snapshot::SourceSnapshot::collect_local(
+        runner_id,
+        &std::env::current_dir().map_err(|err| {
+            homeboy::Error::internal_io(err.to_string(), Some("read cwd".to_string()))
+        })?,
+        Some(&remote_cwd),
+        "lab_offload",
+    );
     let homeboy_path = runner.homeboy_path.as_deref().unwrap_or("homeboy");
     let mut command = vec![homeboy_path.to_string()];
     command.extend(strip_runner_flag(normalized_args).into_iter().skip(1));
@@ -431,6 +432,8 @@ fn run_lab_offload_inner(
             cwd: Some(remote_cwd),
             allow_ssh: false,
             command,
+            capture_patch,
+            source_snapshot: Some(source_snapshot),
         },
     )?;
 

--- a/tests/core/daemon/artifact_download_test.rs
+++ b/tests/core/daemon/artifact_download_test.rs
@@ -1,0 +1,34 @@
+use super::*;
+use crate::observation::NewRunRecord;
+use crate::test_support::HomeGuard;
+
+#[test]
+fn test_route() {
+    let _home = HomeGuard::new();
+    let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
+    let store = ObservationStore::open_initialized().expect("store");
+    let run = store
+        .start_run(NewRunRecord {
+            kind: "runner-exec".to_string(),
+            component_id: None,
+            command: Some("homeboy runner exec".to_string()),
+            cwd: None,
+            homeboy_version: Some("test-version".to_string()),
+            git_sha: None,
+            rig_id: None,
+            metadata_json: json!({}),
+        })
+        .expect("run");
+    let artifact_path = home_path.join("artifact.txt");
+    fs::write(&artifact_path, "artifact body").expect("artifact file");
+    let artifact = store
+        .record_artifact(&run.id, "lab_fix_patch", &artifact_path)
+        .expect("artifact");
+
+    let response =
+        route(&format!("/runs/{}/artifacts/{}", run.id, artifact.id)).expect("artifact route");
+
+    assert_eq!(response.status_code, 200);
+    assert!(response.artifact.is_some());
+    assert_eq!(response.body["artifact"]["id"], artifact.id);
+}

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -19,6 +19,105 @@ fn parse_bind_addr_rejects_public_bind() {
 }
 
 #[test]
+fn state_path_uses_daemon_state_location() {
+    let _home = HomeGuard::new();
+
+    let path = state_path().expect("state path");
+
+    assert!(path.ends_with("daemon/state.json"));
+}
+
+#[test]
+fn test_pid_is_running_rejects_impossible_pid_and_drives_status() {
+    let _home = HomeGuard::new();
+    let path = state_path().expect("state path");
+    std::fs::create_dir_all(path.parent().expect("state parent")).expect("state dir");
+    std::fs::write(
+        &path,
+        serde_json::json!({
+            "address": "127.0.0.1:49152",
+            "pid": u32::MAX,
+            "state_path": path.display().to_string(),
+        })
+        .to_string(),
+    )
+    .expect("write state");
+
+    assert!(pid_is_running(std::process::id()));
+    assert!(!pid_is_running(u32::MAX));
+    assert!(!read_status().expect("status").running);
+}
+
+#[test]
+fn read_status_reports_stale_state_as_not_running() {
+    let _home = HomeGuard::new();
+    let path = state_path().expect("state path");
+    std::fs::create_dir_all(path.parent().expect("state parent")).expect("state dir");
+    std::fs::write(
+        &path,
+        serde_json::json!({
+            "address": "127.0.0.1:49152",
+            "pid": u32::MAX,
+            "state_path": path.display().to_string(),
+        })
+        .to_string(),
+    )
+    .expect("write state");
+
+    let status = read_status().expect("status");
+
+    assert!(!status.running);
+    assert_eq!(status.state.expect("state").pid, u32::MAX);
+}
+
+#[test]
+fn stop_without_state_reports_noop() {
+    let _home = HomeGuard::new();
+
+    let result = stop().expect("stop");
+
+    assert!(!result.stopped);
+    assert_eq!(result.pid, None);
+    assert!(result.state_path.ends_with("daemon/state.json"));
+}
+
+#[test]
+fn test_serve_writes_state_and_routes_health_requests() {
+    let _home = HomeGuard::new();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener);
+
+    std::thread::spawn(move || {
+        let _ = serve(addr);
+    });
+
+    let mut stream = None;
+    for _ in 0..100 {
+        match std::net::TcpStream::connect(addr) {
+            Ok(candidate) => {
+                stream = Some(candidate);
+                break;
+            }
+            Err(_) => std::thread::sleep(std::time::Duration::from_millis(10)),
+        }
+    }
+    let mut stream = stream.expect("daemon connection");
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .expect("write request");
+    let mut response = String::new();
+    stream.read_to_string(&mut response).expect("read response");
+
+    let status = read_status().expect("status");
+
+    assert!(response.contains("200 OK"));
+    assert!(response.contains("\"status\": \"ok\""));
+    assert!(status.running);
+    assert_eq!(status.state.expect("state").address, addr.to_string());
+}
+
+#[test]
 fn routes_health_version_and_config_paths() {
     let _home = HomeGuard::new();
 
@@ -173,6 +272,23 @@ fn routes_json_body_to_analysis_enqueue() {
     assert_eq!(response.body["endpoint"], "jobs.required");
     assert_eq!(response.body["body"]["command"], "api.lint.enqueue");
     assert_eq!(store.list().len(), 1);
+}
+
+#[test]
+fn route_with_body_validates_exec_requests() {
+    let _home = HomeGuard::new();
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/exec",
+        Some(serde_json::json!({
+            "cwd": "relative",
+            "command": []
+        })),
+        daemon_job_store(),
+    );
+
+    assert_eq!(response.status_code, 400);
+    assert_eq!(response.body["error"], "validation.invalid_argument");
 }
 
 #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -219,6 +219,81 @@ fn routes_exec_body_to_daemon_job() {
 }
 
 #[test]
+fn exec_capture_patch_records_remote_delta_artifact() {
+    let _home = HomeGuard::new();
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::write(workspace.path().join("file.txt"), "before\n").expect("seed file");
+    let source_snapshot = SourceSnapshot::existing_remote(
+        "lab-local",
+        &workspace.path().display().to_string(),
+        Some(workspace.path().display().to_string().as_str()),
+    );
+    let store = JobStore::default();
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/exec",
+        Some(serde_json::json!({
+            "runner_id": "lab-local",
+            "cwd": workspace.path(),
+            "command": ["sh", "-c", "printf 'after\n' > file.txt"],
+            "capture_patch": true,
+            "source_snapshot": source_snapshot,
+        })),
+        &store,
+    );
+
+    assert_eq!(response.status_code, 200);
+    let job_id = response.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job id")
+        .to_string();
+    let job = wait_for_job(&store, &job_id);
+    assert_eq!(format!("{:?}", job.status), "Succeeded");
+
+    let events = store.events(job.id).expect("events");
+    let result = events
+        .iter()
+        .rev()
+        .filter_map(|event| event.data.as_ref())
+        .find(|data| data.get("patch").is_some())
+        .expect("patch result");
+    let patch = &result["patch"];
+    assert_eq!(patch["runner_id"], "lab-local");
+    assert_eq!(patch["remote_path"], workspace.path().display().to_string());
+    assert_eq!(patch["modified_files"], serde_json::json!(["file.txt"]));
+    assert_eq!(patch["dirty_snapshot"], false);
+    assert_eq!(patch["baseline_missing"], false);
+    assert!(patch["patch_artifact_id"].as_str().is_some());
+
+    let observation_store = ObservationStore::open_initialized().expect("observation store");
+    let run_id = format!("runner-exec-{job_id}");
+    let artifacts = observation_store
+        .list_artifacts(&run_id)
+        .expect("patch artifacts");
+    assert_eq!(artifacts.len(), 1);
+    let patch_body = std::fs::read_to_string(&artifacts[0].path).expect("patch file");
+    assert!(patch_body.contains("-before"));
+    assert!(patch_body.contains("+after"));
+}
+
+fn wait_for_job(store: &JobStore, job_id: &str) -> crate::api_jobs::Job {
+    let id = uuid::Uuid::parse_str(job_id).expect("uuid");
+    for _ in 0..100 {
+        let job = store.get(id).expect("job");
+        if matches!(
+            job.status,
+            crate::api_jobs::JobStatus::Succeeded
+                | crate::api_jobs::JobStatus::Failed
+                | crate::api_jobs::JobStatus::Cancelled
+        ) {
+            return job;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    store.get(id).expect("job")
+}
+
+#[test]
 fn route_rejects_unknown_paths_and_methods() {
     assert_eq!(route("GET", "/missing").status_code, 404);
     assert_eq!(route("POST", "/health").status_code, 405);


### PR DESCRIPTION
## Summary
- Enables Lab offload for fix-capable hot commands by requesting daemon-side patch capture instead of refusing mutating flags.
- Adds runner exec `--capture-patch` support and persists generated remote file deltas as structured runner-exec evidence plus downloadable patch artifacts.
- Records patch metadata including source snapshot id, runner id, command, remote path, modified files, patch artifact id/path, and dirty snapshot state.

Fixes #2550.

## Verification
- `cargo test` passed: 3069 lib tests, bin/integration tests, and doctests.
- `cargo test core::daemon --lib` passed: 11 tests.
- `cargo test exec_capture_patch_records_remote_delta_artifact --lib` passed.
- `homeboy lint --path /Users/chubes/Developer/homeboy@lab-fix-patch-capture-2550 --extension rust` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` failed on existing repository-wide clippy debt unrelated to this patch.
- `homeboy audit --path /Users/chubes/Developer/homeboy@lab-fix-patch-capture-2550 --extension rust` reported existing broad audit/coverage findings.
- `homeboy test --path /Users/chubes/Developer/homeboy@lab-fix-patch-capture-2550 --extension rust` hit one infrastructure-style runtime tmp error in `lint_stage_empty_selected_files_does_not_fall_back_to_broad_lint`; plain `cargo test` passed the same suite.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Lab runner patch-capture flow, added daemon coverage, and ran verification; Chris remains responsible for review and merge.