### PR TITLE
refactor: reuse plan step builders

### DIFF
--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -188,8 +188,33 @@ impl PlanStep {
         PlanStepBuilder::new(id, kind, PlanStepStatus::Ready)
     }
 
+    pub(crate) fn ready_labeled(
+        id: impl Into<String>,
+        kind: impl Into<String>,
+        label: impl Into<String>,
+        needs: impl IntoIterator<Item = String>,
+        inputs: impl IntoIterator<Item = (String, serde_json::Value)>,
+    ) -> Self {
+        Self::ready(id, kind)
+            .label(label)
+            .needs(needs)
+            .inputs(inputs)
+            .build()
+    }
+
     pub(crate) fn disabled(id: impl Into<String>, kind: impl Into<String>) -> PlanStepBuilder {
         PlanStepBuilder::new(id, kind, PlanStepStatus::Disabled)
+    }
+
+    pub(crate) fn disabled_with_reason(
+        id: impl Into<String>,
+        kind: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> PlanStepBuilder {
+        let reason = reason.into();
+        Self::disabled(id, kind)
+            .input_value("reason", serde_json::Value::String(reason.clone()))
+            .skip_reason(reason)
     }
 }
 
@@ -665,6 +690,22 @@ mod tests {
     }
 
     #[test]
+    fn test_ready_labeled() {
+        let step = PlanStep::ready_labeled(
+            "test",
+            "quality.test",
+            "Run tests",
+            vec!["lint".to_string()],
+            vec![("profile".to_string(), serde_json::json!("ci"))],
+        );
+
+        assert_eq!(step.status, PlanStepStatus::Ready);
+        assert_eq!(step.label.as_deref(), Some("Run tests"));
+        assert_eq!(step.needs, vec!["lint"]);
+        assert_eq!(step.inputs.get("profile"), Some(&serde_json::json!("ci")));
+    }
+
+    #[test]
     fn test_disabled() {
         let step = PlanStep::disabled("audit", "quality.audit").build();
 
@@ -717,6 +758,20 @@ mod tests {
             .build();
 
         assert_eq!(step.skip_reason.as_deref(), Some("filtered"));
+    }
+
+    #[test]
+    fn test_disabled_with_reason() {
+        let step = PlanStep::disabled_with_reason("release.skip", "release.skip", "no-commits")
+            .label("No releasable commits")
+            .build();
+
+        assert_eq!(step.status, PlanStepStatus::Disabled);
+        assert_eq!(step.skip_reason.as_deref(), Some("no-commits"));
+        assert_eq!(
+            step.inputs.get("reason").and_then(|value| value.as_str()),
+            Some("no-commits")
+        );
     }
 
     #[test]

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -396,7 +396,7 @@ mod tests {
         ReleaseExecutionContext,
     };
     use crate::component::Component;
-    use crate::plan::{PlanStep, PlanStepStatus};
+    use crate::plan::PlanStep;
     use crate::release::types::{
         ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
     };
@@ -793,20 +793,7 @@ mod tests {
     }
 
     fn plan_step(step_type: &str) -> PlanStep {
-        PlanStep {
-            id: step_type.to_string(),
-            kind: step_type.to_string(),
-            label: None,
-            blocking: true,
-            scope: Vec::new(),
-            needs: Vec::new(),
-            status: PlanStepStatus::Ready,
-            inputs: std::collections::HashMap::new(),
-            outputs: std::collections::HashMap::new(),
-            skip_reason: None,
-            policy: std::collections::HashMap::new(),
-            missing: Vec::new(),
-        }
+        PlanStep::ready(step_type, step_type).build()
     }
 
     fn failed_step_result(step_type: &str) -> ReleaseStepResult {

--- a/src/core/release/executor/changelog.rs
+++ b/src/core/release/executor/changelog.rs
@@ -53,7 +53,7 @@ pub(crate) fn run_changelog_finalize(
 mod tests {
     use super::run_changelog_finalize;
     use crate::component::{Component, VersionTarget};
-    use crate::plan::{PlanStep, PlanStepStatus};
+    use crate::plan::PlanStep;
     use crate::release::types::ReleaseState;
     use crate::release::ReleaseStepStatus;
 
@@ -81,20 +81,7 @@ mod tests {
             }]),
             ..Component::default()
         };
-        let mut step = PlanStep {
-            id: "changelog.finalize".to_string(),
-            kind: "changelog.finalize".to_string(),
-            label: None,
-            blocking: true,
-            scope: Vec::new(),
-            needs: Vec::new(),
-            status: PlanStepStatus::Ready,
-            inputs: std::collections::HashMap::new(),
-            outputs: std::collections::HashMap::new(),
-            skip_reason: None,
-            policy: std::collections::HashMap::new(),
-            missing: Vec::new(),
-        };
+        let mut step = PlanStep::ready("changelog.finalize", "changelog.finalize").build();
         step.inputs
             .insert("from".to_string(), serde_json::json!("0.6.12"));
         step.inputs

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -1,7 +1,7 @@
 use crate::component::Component;
 use crate::extension::ExtensionManifest;
 use crate::git;
-use crate::plan::{PlanStep, PlanStepStatus};
+use crate::plan::PlanStep;
 use crate::quality::{build_quality_steps as build_shared_quality_steps, QualityPlanOptions};
 use crate::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
@@ -37,20 +37,7 @@ fn ready_step(
     needs: Vec<String>,
     config: StepConfig,
 ) -> PlanStep {
-    PlanStep {
-        id: id.to_string(),
-        kind: step_type.to_string(),
-        label: Some(label.into()),
-        blocking: true,
-        scope: Vec::new(),
-        needs,
-        status: PlanStepStatus::Ready,
-        inputs: config,
-        outputs: StepConfig::new(),
-        skip_reason: None,
-        policy: StepConfig::new(),
-        missing: Vec::new(),
-    }
+    PlanStep::ready_labeled(id, step_type, label, needs, config)
 }
 
 fn disabled_step(
@@ -59,20 +46,10 @@ fn disabled_step(
     label: impl Into<String>,
     config: StepConfig,
 ) -> PlanStep {
-    PlanStep {
-        id: id.to_string(),
-        kind: step_type.to_string(),
-        label: Some(label.into()),
-        blocking: true,
-        scope: Vec::new(),
-        needs: Vec::new(),
-        status: PlanStepStatus::Disabled,
-        inputs: config,
-        outputs: StepConfig::new(),
-        skip_reason: None,
-        policy: StepConfig::new(),
-        missing: Vec::new(),
-    }
+    PlanStep::disabled(id, step_type)
+        .label(label)
+        .inputs(config)
+        .build()
 }
 
 fn string_config(key: &str, value: impl Into<String>) -> StepConfig {

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -1,4 +1,4 @@
-use crate::plan::{PlanStep, PlanStepStatus};
+use crate::plan::PlanStep;
 
 use super::types::{ReleaseOptions, ReleasePlan, ReleaseSemverRecommendation};
 
@@ -40,23 +40,11 @@ fn skipped_release_plan(
     ReleasePlan::new(
         component_id,
         false,
-        vec![PlanStep {
-            id: "release.skip".to_string(),
-            kind: "release.skip".to_string(),
-            label: Some(label.to_string()),
-            blocking: true,
-            scope: Vec::new(),
-            needs: Vec::new(),
-            status: PlanStepStatus::Disabled,
-            inputs: std::collections::HashMap::from([(
-                "reason".to_string(),
-                serde_json::Value::String(reason.to_string()),
-            )]),
-            outputs: std::collections::HashMap::new(),
-            skip_reason: Some(reason.to_string()),
-            policy: std::collections::HashMap::new(),
-            missing: Vec::new(),
-        }],
+        vec![
+            PlanStep::disabled_with_reason("release.skip", "release.skip", reason)
+                .label(label)
+                .build(),
+        ],
         semver_recommendation,
         Vec::new(),
         vec![hint.to_string()],

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use crate::git;
-use crate::plan::{PlanStep, PlanStepStatus};
+use crate::plan::PlanStep;
 
 use super::context::load_component;
 use super::types::{
@@ -486,35 +486,13 @@ fn recovery_release_plan(
 }
 
 fn recovery_step(id: &str, label: impl Into<String>, needed: bool, needs: Vec<String>) -> PlanStep {
-    let mut config = std::collections::HashMap::new();
-    if !needed {
-        config.insert(
-            "reason".to_string(),
-            serde_json::Value::String("already-complete".to_string()),
-        );
-    }
-
-    PlanStep {
-        id: id.to_string(),
-        kind: id.to_string(),
-        label: Some(label.into()),
-        blocking: true,
-        scope: Vec::new(),
-        needs,
-        status: if needed {
-            PlanStepStatus::Ready
-        } else {
-            PlanStepStatus::Disabled
-        },
-        inputs: config,
-        outputs: std::collections::HashMap::new(),
-        skip_reason: if needed {
-            None
-        } else {
-            Some("already-complete".to_string())
-        },
-        policy: std::collections::HashMap::new(),
-        missing: Vec::new(),
+    if needed {
+        PlanStep::ready_labeled(id, id, label, needs, std::collections::HashMap::new())
+    } else {
+        PlanStep::disabled_with_reason(id, id, "already-complete")
+            .label(label)
+            .needs(needs)
+            .build()
     }
 }
 
@@ -670,23 +648,12 @@ mod tests {
         let plan = ReleasePlan::new(
             "demo",
             true,
-            vec![PlanStep {
-                id: "version".to_string(),
-                kind: "version".to_string(),
-                label: None,
-                blocking: true,
-                scope: Vec::new(),
-                needs: Vec::new(),
-                status: PlanStepStatus::Ready,
-                inputs: HashMap::from([(
+            vec![PlanStep::ready("version", "version")
+                .inputs(HashMap::from([(
                     "to".to_string(),
                     serde_json::Value::String("1.2.3".to_string()),
-                )]),
-                outputs: HashMap::new(),
-                skip_reason: None,
-                policy: HashMap::new(),
-                missing: Vec::new(),
-            }],
+                )]))
+                .build()],
             None,
             Vec::new(),
             Vec::new(),

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -537,6 +537,7 @@ mod tests {
                 started_at_ms: Some(1_700_000_000_000),
                 finished_at_ms: Some(1_700_000_001_000),
                 event_count: 0,
+                source_snapshot: None,
                 stale_reason: None,
             };
             let run = mirror_job_run(


### PR DESCRIPTION
## Summary
- Add shared `PlanStep` helpers for labeled ready steps and disabled steps with reasons.
- Reuse those helpers across release planning and release workflow test fixtures to remove direct aggregate construction.
- Keep the runner evidence fixture aligned with the current `Job` shape.

## Verification
- `cargo fmt`
- `cargo check --lib`
- `cargo test release:: --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@plan-step-helper-cleanup --extension rust --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the helper refactor, updated release-plan call sites, and ran verification; Chris reviewed direction and approved committing/opening the PR.