### PR TITLE
refactor: reuse plan builders in trace

### DIFF
--- a/src/commands/trace/experiment.rs
+++ b/src/commands/trace/experiment.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::trace as extension_trace;
-use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep};
 use homeboy::rig;
 
 use super::{TraceArgs, TraceRigContext};
@@ -73,25 +73,13 @@ fn trace_experiment_plan(
     name: &str,
     experiment: &rig::TraceExperimentSpec,
 ) -> HomeboyPlan {
-    let mut plan = HomeboyPlan::for_description(PlanKind::Trace, format!("{rig_id} {name}"));
-    plan.mode = Some("experiment".to_string());
-    plan.inputs.insert(
-        "rig_id".to_string(),
-        serde_json::Value::String(rig_id.to_string()),
-    );
-    plan.inputs.insert(
-        "experiment".to_string(),
-        serde_json::Value::String(name.to_string()),
-    );
-    plan.steps = trace_experiment_steps(name, experiment);
-    plan.summary = Some(PlanSummary {
-        total_steps: plan.steps.len(),
-        ready: plan.steps.len(),
-        blocked: 0,
-        skipped: 0,
-        next_actions: Vec::new(),
-    });
-    plan
+    HomeboyPlan::builder_for_description(PlanKind::Trace, format!("{rig_id} {name}"))
+        .mode("experiment")
+        .input_value("rig_id", serde_json::Value::String(rig_id.to_string()))
+        .input_value("experiment", serde_json::Value::String(name.to_string()))
+        .steps(trace_experiment_steps(name, experiment))
+        .summarize()
+        .build()
 }
 
 fn trace_experiment_steps(name: &str, experiment: &rig::TraceExperimentSpec) -> Vec<PlanStep> {
@@ -111,34 +99,27 @@ fn trace_experiment_steps(name: &str, experiment: &rig::TraceExperimentSpec) -> 
 }
 
 fn trace_experiment_step(phase: &str, name: &str, index: usize, command: &str) -> PlanStep {
-    let mut inputs = std::collections::HashMap::new();
-    inputs.insert(
-        "experiment".to_string(),
-        serde_json::Value::String(name.to_string()),
-    );
-    inputs.insert(
-        "phase".to_string(),
-        serde_json::Value::String(phase.to_string()),
-    );
-    inputs.insert(
-        "command".to_string(),
-        serde_json::Value::String(command.to_string()),
-    );
-
-    PlanStep {
-        id: format!("trace.experiment.{phase}.{index}"),
-        kind: format!("trace.experiment.{phase}"),
-        label: Some(format!("{phase} trace experiment {name}")),
-        blocking: true,
-        scope: vec![name.to_string()],
-        needs: Vec::new(),
-        status: PlanStepStatus::Ready,
-        inputs,
-        outputs: std::collections::HashMap::new(),
-        skip_reason: None,
-        policy: std::collections::HashMap::new(),
-        missing: Vec::new(),
-    }
+    PlanStep::ready(
+        format!("trace.experiment.{phase}.{index}"),
+        format!("trace.experiment.{phase}"),
+    )
+    .label(format!("{phase} trace experiment {name}"))
+    .scope(vec![name.to_string()])
+    .inputs(vec![
+        (
+            "experiment".to_string(),
+            serde_json::Value::String(name.to_string()),
+        ),
+        (
+            "phase".to_string(),
+            serde_json::Value::String(phase.to_string()),
+        ),
+        (
+            "command".to_string(),
+            serde_json::Value::String(command.to_string()),
+        ),
+    ])
+    .build()
 }
 
 pub(super) fn trace_experiment_settings(

--- a/src/commands/trace/schedule.rs
+++ b/src/commands/trace/schedule.rs
@@ -1,5 +1,5 @@
 use clap::ValueEnum;
-use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep};
 use serde::Serialize;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -59,38 +59,30 @@ pub(crate) fn plan_trace_run_order(
 }
 
 fn trace_run_entry_plan(index: usize, group: &str, iteration: usize) -> HomeboyPlan {
-    let mut plan = HomeboyPlan::for_description(PlanKind::Trace, format!("{group} {iteration}"));
-    plan.mode = Some("run_order".to_string());
-    plan.inputs.insert(
-        "group".to_string(),
-        serde_json::Value::String(group.to_string()),
-    );
-    plan.inputs.insert(
-        "iteration".to_string(),
-        serde_json::Value::Number(serde_json::Number::from(iteration)),
-    );
-    plan.steps = vec![PlanStep {
-        id: format!("trace.run.{index}"),
-        kind: "trace.run".to_string(),
-        label: Some(format!("Run trace {group} iteration {iteration}")),
-        blocking: true,
-        scope: vec![group.to_string()],
-        needs: Vec::new(),
-        status: PlanStepStatus::Ready,
-        inputs: plan.inputs.clone(),
-        outputs: std::collections::HashMap::new(),
-        skip_reason: None,
-        policy: std::collections::HashMap::new(),
-        missing: Vec::new(),
-    }];
-    plan.summary = Some(PlanSummary {
-        total_steps: 1,
-        ready: 1,
-        blocked: 0,
-        skipped: 0,
-        next_actions: Vec::new(),
-    });
-    plan
+    let inputs = vec![
+        (
+            "group".to_string(),
+            serde_json::Value::String(group.to_string()),
+        ),
+        (
+            "iteration".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(iteration)),
+        ),
+    ];
+
+    HomeboyPlan::builder_for_description(PlanKind::Trace, format!("{group} {iteration}"))
+        .mode("run_order")
+        .inputs(inputs.clone())
+        .steps(vec![PlanStep::ready(
+            format!("trace.run.{index}"),
+            "trace.run",
+        )
+        .label(format!("Run trace {group} iteration {iteration}"))
+        .scope(vec![group.to_string()])
+        .inputs(inputs)
+        .build()])
+        .summarize()
+        .build()
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, ValueEnum)]

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -249,6 +249,14 @@ impl PlanBuilder {
         self
     }
 
+    pub(crate) fn inputs(
+        mut self,
+        inputs: impl IntoIterator<Item = (String, serde_json::Value)>,
+    ) -> Self {
+        self.plan.inputs.extend(inputs);
+        self
+    }
+
     pub(crate) fn policy_value(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
         self.plan.policy.insert(key.into(), value);
         self
@@ -626,6 +634,22 @@ mod tests {
             plan.inputs.get("target_exists"),
             Some(&serde_json::json!(true))
         );
+    }
+
+    #[test]
+    fn test_plan_inputs() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Trace, "fixture")
+            .inputs(vec![
+                ("group".to_string(), serde_json::json!("baseline")),
+                ("iteration".to_string(), serde_json::json!(2)),
+            ])
+            .build();
+
+        assert_eq!(
+            plan.inputs.get("group"),
+            Some(&serde_json::json!("baseline"))
+        );
+        assert_eq!(plan.inputs.get("iteration"), Some(&serde_json::json!(2)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a bulk `PlanBuilder::inputs` helper to mirror the existing step builder API.
- Move trace run-order and experiment plan construction onto `HomeboyPlan` builders.
- Replace direct trace `PlanStep` literals and manual summaries with step builders and generated summaries.

## Verification
- `cargo fmt`
- `cargo check --lib`
- `cargo test commands::trace --lib`
- `cargo test core::plan::tests --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-plan-primitives --extension rust --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the trace plan-builder migration, added the generic plan input helper, and ran verification; Chris directed the stabilization slice and reviewed the direction.