### PR TITLE
refactor: reuse quality plan step helpers

### DIFF
--- a/src/core/quality.rs
+++ b/src/core/quality.rs
@@ -126,18 +126,19 @@ pub fn build_quality_steps(options: &QualityPlanOptions) -> Vec<PlanStep> {
 
 fn ready_step(prefix: &str, name: &str, label: &str, needs: Vec<String>) -> PlanStep {
     let id = step_id(prefix, name);
-    PlanStep::ready(id.clone(), id)
-        .label(label)
-        .needs(needs)
-        .build()
+    PlanStep::ready_labeled(
+        id.clone(),
+        id,
+        label,
+        needs,
+        std::iter::empty::<(String, serde_json::Value)>(),
+    )
 }
 
 fn disabled_step(prefix: &str, name: &str, label: &str, reason: &str) -> PlanStep {
     let id = step_id(prefix, name);
-    PlanStep::disabled(id.clone(), id)
+    PlanStep::disabled_with_reason(id.clone(), id, reason)
         .label(label)
-        .input_value("reason", serde_json::Value::String(reason.to_string()))
-        .skip_reason(reason)
         .build()
 }
 


### PR DESCRIPTION
## Summary
- Route quality plan step construction through the shared `PlanStep::ready_labeled()` and `PlanStep::disabled_with_reason()` helpers.
- Keep the existing quality plan JSON shape and step IDs unchanged while removing duplicated field assembly.

## Verification
- `cargo fmt`
- `cargo check --lib`
- `cargo test core::quality::tests --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@quality-plan-primitives --extension rust --changed-since origin/main --json-summary --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor, ran verification, and prepared the PR body; Chris directed the cleanup path.