### PR TITLE
refactor: reuse stack sync step inputs

### DIFF
--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -351,20 +351,6 @@ fn sync_pr_step(
     status: PlanStepStatus,
     reason: &str,
 ) -> PlanStep {
-    let mut inputs = std::collections::HashMap::new();
-    inputs.insert(
-        "repo".to_string(),
-        serde_json::Value::String(repo.to_string()),
-    );
-    inputs.insert(
-        "number".to_string(),
-        serde_json::Value::Number(serde_json::Number::from(number)),
-    );
-    inputs.insert(
-        "reason".to_string(),
-        serde_json::Value::String(reason.to_string()),
-    );
-
     PlanStep::builder(
         format!("stack.sync.{action}.{repo}#{number}"),
         format!("stack.sync.{action}"),
@@ -373,7 +359,12 @@ fn sync_pr_step(
     .label(format!("{action} {repo}#{number}"))
     .blocking(status == PlanStepStatus::Missing)
     .scope(vec![format!("{repo}#{number}")])
-    .inputs(inputs)
+    .input_value("repo", serde_json::Value::String(repo.to_string()))
+    .input_value(
+        "number",
+        serde_json::Value::Number(serde_json::Number::from(number)),
+    )
+    .input_value("reason", serde_json::Value::String(reason.to_string()))
     .build()
 }
 


### PR DESCRIPTION
## Summary
- Route stack sync step input construction through the shared `PlanStepBuilder::input_value()` plumbing.
- Preserve existing stack sync plan IDs, statuses, blocking behavior, scope, and input JSON shape while removing local `HashMap` assembly.

## Verification
- `cargo fmt`
- `cargo check --lib`
- `cargo test core::stack::sync::sync_test --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@stack-sync-plan-primitives --extension rust --changed-since origin/main --json-summary --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor, ran verification, and prepared the PR body; Chris directed the cleanup path.