### PR TITLE
refactor: reuse dependency stack step inputs

### DIFF
--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -223,32 +223,6 @@ impl DependencyStackPlan {
 }
 
 fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
-    let mut inputs = std::collections::HashMap::new();
-    inputs.insert(
-        "declaring_component_id".to_string(),
-        serde_json::Value::String(step.declaring_component_id.clone()),
-    );
-    inputs.insert(
-        "upstream".to_string(),
-        serde_json::Value::String(step.upstream.clone()),
-    );
-    inputs.insert(
-        "downstream".to_string(),
-        serde_json::Value::String(step.downstream.clone()),
-    );
-    inputs.insert(
-        "downstream_path".to_string(),
-        serde_json::Value::String(step.downstream_path.clone()),
-    );
-    inputs.insert(
-        "package".to_string(),
-        serde_json::Value::String(step.package.clone()),
-    );
-    inputs.insert(
-        "update_command".to_string(),
-        serde_json::Value::String(step.update_command.clone()),
-    );
-
     PlanStep::ready(
         format!("deps.stack.{:03}.{}", step.sequence, step.downstream),
         "deps.stack.update_downstream",
@@ -258,7 +232,24 @@ fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
         step.package, step.downstream, step.upstream
     ))
     .scope(vec![step.downstream.clone()])
-    .inputs(inputs)
+    .input_value(
+        "declaring_component_id",
+        serde_json::Value::String(step.declaring_component_id.clone()),
+    )
+    .input_value("upstream", serde_json::Value::String(step.upstream.clone()))
+    .input_value(
+        "downstream",
+        serde_json::Value::String(step.downstream.clone()),
+    )
+    .input_value(
+        "downstream_path",
+        serde_json::Value::String(step.downstream_path.clone()),
+    )
+    .input_value("package", serde_json::Value::String(step.package.clone()))
+    .input_value(
+        "update_command",
+        serde_json::Value::String(step.update_command.clone()),
+    )
     .build()
 }
 


### PR DESCRIPTION
## Summary
- Route dependency stack plan step input construction through `PlanStepBuilder::input_value()`.
- Preserve existing dependency stack plan IDs, scope, status, and input JSON keys while removing local `HashMap` assembly.

## Verification
- `cargo fmt`
- `cargo check --lib`
- `cargo test --test deps_test`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@deps-stack-plan-primitives --extension rust --changed-since origin/main --json-summary --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor, corrected and ran verification, and prepared the PR body; Chris directed the cleanup path.