### PR TITLE
refactor: reuse issue plan step inputs

### DIFF
--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -214,12 +214,6 @@ impl ReconcilePlan {
 
 fn action_step((index, action): (usize, &ReconcileAction)) -> PlanStep {
     let action_kind = action_kind(action);
-    let mut inputs = std::collections::HashMap::new();
-    inputs.insert(
-        "action".to_string(),
-        serde_json::to_value(action).unwrap_or(serde_json::Value::Null),
-    );
-
     let id = format!("issues.reconcile.{:03}.{}", index + 1, action_kind);
     let kind = format!("issues.reconcile.{action_kind}");
     let builder = PlanStep::builder(
@@ -233,7 +227,10 @@ fn action_step((index, action): (usize, &ReconcileAction)) -> PlanStep {
     )
     .label(action_label(action))
     .blocking(!matches!(action, ReconcileAction::Skip { .. }))
-    .inputs(inputs);
+    .input_value(
+        "action",
+        serde_json::to_value(action).unwrap_or(serde_json::Value::Null),
+    );
 
     match action {
         ReconcileAction::Skip { reason, .. } => builder.skip_reason(format!("{:?}", reason)),


### PR DESCRIPTION
## Summary
- Route issue reconcile plan step input construction through `PlanStepBuilder::input_value()`.
- Preserve existing issue reconcile step IDs, status, blocking behavior, skip reasons, and serialized `action` input shape while removing local `HashMap` assembly.

## Verification
- `cargo fmt`
- `cargo check --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@issues-plan-input-primitives --extension rust --changed-since origin/main --json-summary --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor, ran verification, and prepared the PR body; Chris directed the cleanup path.