### PR TITLE
refactor: reuse remaining plan step inputs

### DIFF
--- a/src/commands/trace/experiment.rs
+++ b/src/commands/trace/experiment.rs
@@ -105,20 +105,9 @@ fn trace_experiment_step(phase: &str, name: &str, index: usize, command: &str) -
     )
     .label(format!("{phase} trace experiment {name}"))
     .scope(vec![name.to_string()])
-    .inputs(vec![
-        (
-            "experiment".to_string(),
-            serde_json::Value::String(name.to_string()),
-        ),
-        (
-            "phase".to_string(),
-            serde_json::Value::String(phase.to_string()),
-        ),
-        (
-            "command".to_string(),
-            serde_json::Value::String(command.to_string()),
-        ),
-    ])
+    .input_value("experiment", serde_json::Value::String(name.to_string()))
+    .input_value("phase", serde_json::Value::String(phase.to_string()))
+    .input_value("command", serde_json::Value::String(command.to_string()))
     .build()
 }
 

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -487,7 +487,7 @@ fn recovery_release_plan(
 
 fn recovery_step(id: &str, label: impl Into<String>, needed: bool, needs: Vec<String>) -> PlanStep {
     if needed {
-        PlanStep::ready_labeled(id, id, label, needs, std::collections::HashMap::new())
+        PlanStep::ready_labeled(id, id, label, needs, std::iter::empty())
     } else {
         PlanStep::disabled_with_reason(id, id, "already-complete")
             .label(label)


### PR DESCRIPTION
## Summary
- Reuse `PlanStepBuilder::input_value()` for trace experiment step inputs instead of constructing the input vector inline.
- Pass an empty iterator into `PlanStep::ready_labeled()` for release recovery steps instead of allocating an empty `HashMap`.

## Verification
- `cargo fmt`
- `cargo check --lib`
- `cargo test commands::trace::experiment --lib`
- `cargo test core::release::workflow::tests --lib`
- `cargo test --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@plan-input-final-primitives --extension rust --changed-since origin/main --report json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the mechanical cleanup, ran local verification, and prepared this PR description. Chris remains responsible for review and merge.