### PR TITLE
refactor: add plan values builder

### DIFF
--- a/src/commands/trace/experiment.rs
+++ b/src/commands/trace/experiment.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 use homeboy::engine::run_dir::RunDir;
 use homeboy::extension::trace as extension_trace;
-use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep};
+use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use homeboy::rig;
 
 use super::{TraceArgs, TraceRigContext};
@@ -75,8 +75,11 @@ fn trace_experiment_plan(
 ) -> HomeboyPlan {
     HomeboyPlan::builder_for_description(PlanKind::Trace, format!("{rig_id} {name}"))
         .mode("experiment")
-        .input_value("rig_id", serde_json::Value::String(rig_id.to_string()))
-        .input_value("experiment", serde_json::Value::String(name.to_string()))
+        .inputs(
+            PlanValues::new()
+                .string("rig_id", rig_id)
+                .string("experiment", name),
+        )
         .steps(trace_experiment_steps(name, experiment))
         .summarize()
         .build()
@@ -105,9 +108,12 @@ fn trace_experiment_step(phase: &str, name: &str, index: usize, command: &str) -
     )
     .label(format!("{phase} trace experiment {name}"))
     .scope(vec![name.to_string()])
-    .input_value("experiment", serde_json::Value::String(name.to_string()))
-    .input_value("phase", serde_json::Value::String(phase.to_string()))
-    .input_value("command", serde_json::Value::String(command.to_string()))
+    .inputs(
+        PlanValues::new()
+            .string("experiment", name)
+            .string("phase", phase)
+            .string("command", command),
+    )
     .build()
 }
 

--- a/src/commands/trace/schedule.rs
+++ b/src/commands/trace/schedule.rs
@@ -1,5 +1,5 @@
 use clap::ValueEnum;
-use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep};
+use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use serde::Serialize;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -59,16 +59,9 @@ pub(crate) fn plan_trace_run_order(
 }
 
 fn trace_run_entry_plan(index: usize, group: &str, iteration: usize) -> HomeboyPlan {
-    let inputs = vec![
-        (
-            "group".to_string(),
-            serde_json::Value::String(group.to_string()),
-        ),
-        (
-            "iteration".to_string(),
-            serde_json::Value::Number(serde_json::Number::from(iteration)),
-        ),
-    ];
+    let inputs = PlanValues::new()
+        .string("group", group)
+        .number("iteration", iteration as u64);
 
     HomeboyPlan::builder_for_description(PlanKind::Trace, format!("{group} {iteration}"))
         .mode("run_order")

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -1,5 +1,5 @@
 use crate::component::{self, Component, DependencyStackEdge};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use crate::{Error, Result};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -232,23 +232,17 @@ fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
         step.package, step.downstream, step.upstream
     ))
     .scope(vec![step.downstream.clone()])
-    .input_value(
-        "declaring_component_id",
-        serde_json::Value::String(step.declaring_component_id.clone()),
-    )
-    .input_value("upstream", serde_json::Value::String(step.upstream.clone()))
-    .input_value(
-        "downstream",
-        serde_json::Value::String(step.downstream.clone()),
-    )
-    .input_value(
-        "downstream_path",
-        serde_json::Value::String(step.downstream_path.clone()),
-    )
-    .input_value("package", serde_json::Value::String(step.package.clone()))
-    .input_value(
-        "update_command",
-        serde_json::Value::String(step.update_command.clone()),
+    .inputs(
+        PlanValues::new()
+            .string(
+                "declaring_component_id",
+                step.declaring_component_id.clone(),
+            )
+            .string("upstream", step.upstream.clone())
+            .string("downstream", step.downstream.clone())
+            .string("downstream_path", step.downstream_path.clone())
+            .string("package", step.package.clone())
+            .string("update_command", step.update_command.clone()),
     )
     .build()
 }

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::code_audit::FindingConfidence;
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 
 /// One row of incoming findings: "command produced N findings of category X
 /// for component Y." This is the input grain reconcile reasons over.
@@ -227,10 +227,7 @@ fn action_step((index, action): (usize, &ReconcileAction)) -> PlanStep {
     )
     .label(action_label(action))
     .blocking(!matches!(action, ReconcileAction::Skip { .. }))
-    .input_value(
-        "action",
-        serde_json::to_value(action).unwrap_or(serde_json::Value::Null),
-    );
+    .inputs(PlanValues::new().json("action", action));
 
     match action {
         ReconcileAction::Skip { reason, .. } => builder.skip_reason(format!("{:?}", reason)),

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -8,6 +8,56 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct PlanValues {
+    values: HashMap<String, serde_json::Value>,
+}
+
+impl PlanValues {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn string(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.values
+            .insert(key.into(), serde_json::Value::String(value.into()));
+        self
+    }
+
+    pub(crate) fn bool(mut self, key: impl Into<String>, value: bool) -> Self {
+        self.values
+            .insert(key.into(), serde_json::Value::Bool(value));
+        self
+    }
+
+    pub(crate) fn number(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Number>,
+    ) -> Self {
+        self.values
+            .insert(key.into(), serde_json::Value::Number(value.into()));
+        self
+    }
+
+    pub(crate) fn json<T: Serialize>(mut self, key: impl Into<String>, value: T) -> Self {
+        self.values.insert(
+            key.into(),
+            serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+        );
+        self
+    }
+}
+
+impl IntoIterator for PlanValues {
+    type Item = (String, serde_json::Value);
+    type IntoIter = std::collections::hash_map::IntoIter<String, serde_json::Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter()
+    }
+}
+
 /// A typed plan that can describe quality, build, release, deploy, PR, CI,
 /// refactor, review, or domain-specific workflows.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -244,11 +294,6 @@ impl PlanBuilder {
         self
     }
 
-    pub(crate) fn input_value(mut self, key: impl Into<String>, value: serde_json::Value) -> Self {
-        self.plan.inputs.insert(key.into(), value);
-        self
-    }
-
     pub(crate) fn inputs(
         mut self,
         inputs: impl IntoIterator<Item = (String, serde_json::Value)>,
@@ -468,7 +513,9 @@ fn slug_fragment(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{HomeboyPlan, PlanBuilder, PlanKind, PlanStep, PlanStepStatus, PlanSummary};
+    use super::{
+        HomeboyPlan, PlanBuilder, PlanKind, PlanStep, PlanStepStatus, PlanSummary, PlanValues,
+    };
 
     #[test]
     fn serializes_plan_kind_as_snake_case() {
@@ -625,18 +672,6 @@ mod tests {
     }
 
     #[test]
-    fn test_input_value() {
-        let plan = HomeboyPlan::builder_for_component(PlanKind::StackSync, "fixture")
-            .input_value("target_exists", serde_json::json!(true))
-            .build();
-
-        assert_eq!(
-            plan.inputs.get("target_exists"),
-            Some(&serde_json::json!(true))
-        );
-    }
-
-    #[test]
     fn test_plan_inputs() {
         let plan = HomeboyPlan::builder_for_component(PlanKind::Trace, "fixture")
             .inputs(vec![
@@ -650,6 +685,30 @@ mod tests {
             Some(&serde_json::json!("baseline"))
         );
         assert_eq!(plan.inputs.get("iteration"), Some(&serde_json::json!(2)));
+    }
+
+    #[test]
+    fn test_plan_values_builder() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Trace, "fixture")
+            .inputs(
+                PlanValues::new()
+                    .string("group", "baseline")
+                    .bool("dry_run", true)
+                    .number("iteration", 2_u64)
+                    .json("items", ["first", "second"]),
+            )
+            .build();
+
+        assert_eq!(
+            plan.inputs.get("group"),
+            Some(&serde_json::json!("baseline"))
+        );
+        assert_eq!(plan.inputs.get("dry_run"), Some(&serde_json::json!(true)));
+        assert_eq!(plan.inputs.get("iteration"), Some(&serde_json::json!(2)));
+        assert_eq!(
+            plan.inputs.get("items"),
+            Some(&serde_json::json!(["first", "second"]))
+        );
     }
 
     #[test]

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -688,26 +688,56 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_values_builder() {
+    fn test_string() {
         let plan = HomeboyPlan::builder_for_component(PlanKind::Trace, "fixture")
-            .inputs(
-                PlanValues::new()
-                    .string("group", "baseline")
-                    .bool("dry_run", true)
-                    .number("iteration", 2_u64)
-                    .json("items", ["first", "second"]),
-            )
+            .inputs(PlanValues::new().string("group", "baseline"))
             .build();
 
         assert_eq!(
             plan.inputs.get("group"),
             Some(&serde_json::json!("baseline"))
         );
+    }
+
+    #[test]
+    fn test_bool() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Trace, "fixture")
+            .inputs(PlanValues::new().bool("dry_run", true))
+            .build();
+
         assert_eq!(plan.inputs.get("dry_run"), Some(&serde_json::json!(true)));
+    }
+
+    #[test]
+    fn test_number() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Trace, "fixture")
+            .inputs(PlanValues::new().number("iteration", 2_u64))
+            .build();
+
         assert_eq!(plan.inputs.get("iteration"), Some(&serde_json::json!(2)));
+    }
+
+    #[test]
+    fn test_plan_values_json() {
+        let plan = HomeboyPlan::builder_for_component(PlanKind::Trace, "fixture")
+            .inputs(PlanValues::new().json("items", ["first", "second"]))
+            .build();
+
         assert_eq!(
             plan.inputs.get("items"),
             Some(&serde_json::json!(["first", "second"]))
+        );
+    }
+
+    #[test]
+    fn test_input_value() {
+        let step = PlanStep::ready("lint", "quality.lint")
+            .input_value("reason", serde_json::json!("manual"))
+            .build();
+
+        assert_eq!(
+            step.inputs.get("reason"),
+            Some(&serde_json::json!("manual"))
         );
     }
 

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::extension::{self, grammar, grammar_items, ParsedItem};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use crate::Result;
 
 use super::move_items::{MoveOptions, MoveResult};
@@ -103,11 +103,11 @@ fn decompose_homeboy_plan(
 ) -> HomeboyPlan {
     HomeboyPlan::builder_for_description(PlanKind::Refactor, file.to_string())
         .mode("decompose")
-        .input_value("file", serde_json::Value::String(file.to_string()))
-        .input_value("strategy", serde_json::Value::String(strategy.to_string()))
-        .input_value(
-            "total_items",
-            serde_json::Value::Number(serde_json::Number::from(total_items)),
+        .inputs(
+            PlanValues::new()
+                .string("file", file)
+                .string("strategy", strategy)
+                .number("total_items", total_items as u64),
         )
         .steps(groups.iter().map(decompose_group_step))
         .warnings(warnings.to_vec())
@@ -126,14 +126,11 @@ fn decompose_group_step(group: &DecomposeGroup) -> PlanStep {
         group.suggested_target
     ))
     .scope(group.item_names.clone())
-    .input_value("group", serde_json::Value::String(group.name.clone()))
-    .input_value(
-        "suggested_target",
-        serde_json::Value::String(group.suggested_target.clone()),
-    )
-    .input_value(
-        "item_names",
-        serde_json::to_value(&group.item_names).unwrap_or(serde_json::Value::Null),
+    .inputs(
+        PlanValues::new()
+            .string("group", group.name.clone())
+            .string("suggested_target", group.suggested_target.clone())
+            .json("item_names", &group.item_names),
     )
     .build()
 }

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -1,7 +1,7 @@
 use crate::component::Component;
 use crate::extension::ExtensionManifest;
 use crate::git;
-use crate::plan::PlanStep;
+use crate::plan::{PlanStep, PlanValues};
 use crate::quality::{build_quality_steps as build_shared_quality_steps, QualityPlanOptions};
 use crate::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
@@ -9,7 +9,7 @@ use crate::release::pipeline_capabilities::{
 use crate::release::types::{ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation};
 use crate::Result;
 
-type StepConfig = std::collections::HashMap<String, serde_json::Value>;
+type StepConfig = PlanValues;
 
 /// Return true if this component should get a GitHub Release created.
 ///
@@ -53,9 +53,7 @@ fn disabled_step(
 }
 
 fn string_config(key: &str, value: impl Into<String>) -> StepConfig {
-    let mut config = StepConfig::new();
-    config.insert(key.to_string(), serde_json::Value::String(value.into()));
-    config
+    StepConfig::new().string(key, value)
 }
 
 pub(super) fn build_preflight_steps(
@@ -112,17 +110,12 @@ pub(super) fn build_preflight_steps(
 
     steps.extend(build_quality_steps(options));
 
-    let mut changelog_config = StepConfig::new();
-    changelog_config.insert(
-        "dry_run".to_string(),
-        serde_json::Value::Bool(options.dry_run),
-    );
     steps.push(ready_step(
         "preflight.changelog_bootstrap",
         "preflight.changelog_bootstrap",
         "Ensure changelog exists",
         vec!["preflight.test".to_string()],
-        changelog_config,
+        StepConfig::new().bool("dry_run", options.dry_run),
     ));
 
     steps
@@ -148,36 +141,24 @@ fn build_bump_policy_step(
         );
     };
 
-    let mut config = StepConfig::new();
-    config.insert(
-        "requested".to_string(),
-        serde_json::Value::String(recommendation.requested_bump.clone()),
-    );
+    let mut config = StepConfig::new()
+        .string("requested", recommendation.requested_bump.clone())
+        .bool("underbump", recommendation.is_underbump)
+        .bool("force_lower_bump", options.bump_policy.force_lower_bump);
     if let Some(recommended) = recommendation.recommended_bump.as_ref() {
-        config.insert(
-            "recommended".to_string(),
-            serde_json::Value::String(recommended.clone()),
-        );
+        config = config.string("recommended", recommended.clone());
     }
-    config.insert(
-        "underbump".to_string(),
-        serde_json::Value::Bool(recommendation.is_underbump),
-    );
-    config.insert(
-        "force_lower_bump".to_string(),
-        serde_json::Value::Bool(options.bump_policy.force_lower_bump),
-    );
 
     if recommendation.is_underbump {
-        config.insert(
-            "policy".to_string(),
-            serde_json::Value::String(if options.dry_run {
+        config = config.string(
+            "policy",
+            if options.dry_run {
                 "preview-lower-bump".to_string()
             } else if options.bump_policy.force_lower_bump {
                 "forced-lower-bump".to_string()
             } else {
                 "requires-force-lower-bump".to_string()
-            }),
+            },
         );
     }
 
@@ -219,15 +200,10 @@ pub(super) fn build_release_steps(
         new_version,
     ));
 
-    let mut version_config = string_config("bump", options.bump_type.clone());
-    version_config.insert(
-        "from".to_string(),
-        serde_json::Value::String(current_version.to_string()),
-    );
-    version_config.insert(
-        "to".to_string(),
-        serde_json::Value::String(new_version.to_string()),
-    );
+    let version_config = StepConfig::new()
+        .string("bump", options.bump_type.clone())
+        .string("from", current_version)
+        .string("to", new_version);
     steps.push(ready_step(
         "version",
         "version",
@@ -285,14 +261,12 @@ pub(super) fn build_release_steps(
         string_config("name", tag_name),
     ));
 
-    let mut push_config = StepConfig::new();
-    push_config.insert("tags".to_string(), serde_json::Value::Bool(true));
     steps.push(ready_step(
         "git.push",
         "git.push",
         "Push to remote",
         vec!["git.tag".to_string()],
-        push_config,
+        StepConfig::new().bool("tags", true),
     ));
 
     if !options.skip_github_release && github_release_applies(component) {
@@ -380,55 +354,22 @@ fn build_changelog_steps(
     current_version: &str,
     new_version: &str,
 ) -> Vec<PlanStep> {
-    let mut policy_config = StepConfig::new();
-    policy_config.insert(
-        "policy".to_string(),
-        serde_json::Value::String(changelog_plan.policy.clone()),
-    );
-    policy_config.insert(
-        "path".to_string(),
-        serde_json::Value::String(changelog_plan.path.clone()),
-    );
-    policy_config.insert(
-        "dry_run".to_string(),
-        serde_json::Value::Bool(changelog_plan.dry_run),
-    );
+    let policy_config = StepConfig::new()
+        .string("policy", changelog_plan.policy.clone())
+        .string("path", changelog_plan.path.clone())
+        .bool("dry_run", changelog_plan.dry_run);
 
-    let mut generate_config = StepConfig::new();
-    generate_config.insert(
-        "source".to_string(),
-        serde_json::Value::String("commits".to_string()),
-    );
-    generate_config.insert(
-        "entry_count".to_string(),
-        serde_json::Value::Number(serde_json::Number::from(changelog_plan.entry_count as u64)),
-    );
+    let generate_config = StepConfig::new()
+        .string("source", "commits")
+        .number("entry_count", changelog_plan.entry_count as u64);
 
-    let mut finalize_config = StepConfig::new();
-    finalize_config.insert(
-        "path".to_string(),
-        serde_json::Value::String(changelog_plan.path.clone()),
-    );
-    finalize_config.insert(
-        "from".to_string(),
-        serde_json::Value::String(current_version.to_string()),
-    );
-    finalize_config.insert(
-        "to".to_string(),
-        serde_json::Value::String(new_version.to_string()),
-    );
-    finalize_config.insert(
-        "entries".to_string(),
-        serde_json::to_value(&changelog_plan.entries).unwrap_or_default(),
-    );
-    finalize_config.insert(
-        "entry_count".to_string(),
-        serde_json::Value::Number(serde_json::Number::from(changelog_plan.entry_count as u64)),
-    );
-    finalize_config.insert(
-        "mode".to_string(),
-        serde_json::Value::String("version-step".to_string()),
-    );
+    let finalize_config = StepConfig::new()
+        .string("path", changelog_plan.path.clone())
+        .string("from", current_version)
+        .string("to", new_version)
+        .json("entries", &changelog_plan.entries)
+        .number("entry_count", changelog_plan.entry_count as u64)
+        .string("mode", "version-step");
 
     vec![
         ready_step(
@@ -456,17 +397,7 @@ fn build_changelog_steps(
 }
 
 fn string_array_config(key: &str, values: &[String]) -> StepConfig {
-    let mut config = StepConfig::new();
-    config.insert(
-        key.to_string(),
-        serde_json::Value::Array(
-            values
-                .iter()
-                .map(|value| serde_json::Value::String(value.clone()))
-                .collect(),
-        ),
-    );
-    config
+    StepConfig::new().json(key, values)
 }
 
 #[cfg(test)]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -639,9 +639,8 @@ pub fn run_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plan::{PlanStep, PlanStepStatus};
+    use crate::plan::{PlanStep, PlanStepStatus, PlanValues};
     use crate::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
-    use std::collections::HashMap;
 
     #[test]
     fn extracts_new_version_from_plan() {
@@ -649,10 +648,7 @@ mod tests {
             "demo",
             true,
             vec![PlanStep::ready("version", "version")
-                .inputs(HashMap::from([(
-                    "to".to_string(),
-                    serde_json::Value::String("1.2.3".to_string()),
-                )]))
+                .inputs(PlanValues::new().string("to", "1.2.3"))
                 .build()],
             None,
             Vec::new(),

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 
 use crate::error::{Error, Result};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
+use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 
 use super::apply::{
     checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, AppliedPr,
@@ -335,8 +335,11 @@ fn sync_homeboy_plan(
     }
 
     HomeboyPlan::builder_for_description(PlanKind::StackSync, spec.id.clone())
-        .input_value("stack_id", serde_json::Value::String(spec.id.clone()))
-        .input_value("target_exists", serde_json::Value::Bool(target_exists))
+        .inputs(
+            PlanValues::new()
+                .string("stack_id", spec.id.clone())
+                .bool("target_exists", target_exists),
+        )
         .policy_value("would_mutate", serde_json::Value::Bool(would_mutate))
         .policy_value("blocked", serde_json::Value::Bool(blocked))
         .steps(steps)
@@ -359,12 +362,12 @@ fn sync_pr_step(
     .label(format!("{action} {repo}#{number}"))
     .blocking(status == PlanStepStatus::Missing)
     .scope(vec![format!("{repo}#{number}")])
-    .input_value("repo", serde_json::Value::String(repo.to_string()))
-    .input_value(
-        "number",
-        serde_json::Value::Number(serde_json::Number::from(number)),
+    .inputs(
+        PlanValues::new()
+            .string("repo", repo)
+            .number("number", number)
+            .string("reason", reason),
     )
-    .input_value("reason", serde_json::Value::String(reason.to_string()))
     .build()
 }
 


### PR DESCRIPTION
## Summary
- Add `PlanValues`, a small typed builder for `HashMap<String, serde_json::Value>` plan inputs.
- Replace ad-hoc plan input map assembly across release planning, trace planning, stack sync, dependency stacks, issue reconcile, and refactor decompose.
- Remove the now-unused plan-level `input_value()` helper so plan inputs flow through the shared iterable value builder.

## Verification
- `cargo fmt`
- `cargo check --all-targets`
- `cargo test core::plan::tests --lib`
- `cargo test core::release::plan_steps::tests --lib`
- `cargo test commands::trace::tests::trace_run_order --lib`
- `cargo test core::refactor::decompose --lib`
- `cargo test --lib`
- `homeboy lint --path /Users/chubes/Developer/homeboy@plan-values-primitive --extension rust --changed-since origin/main`
- `git diff --check`

## Audit note
- `homeboy audit --path /Users/chubes/Developer/homeboy@plan-values-primitive --extension rust --changed-since origin/main` was run with the supported options for `v0.186.5`.
- The command returned `passed=false` because this Homeboy version reported existing repository-wide missing-test-method findings, not a clean introduced-finding changed-since report.
- The changed code has targeted coverage through the tests listed above, including a new `PlanValues` builder test and existing serialized-plan contract tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the mechanical plan value builder refactor, ran local verification, and drafted this PR description. Chris remains responsible for review and merge.