### PR TITLE
refactor: add observation run builder

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -48,20 +48,21 @@ pub(super) fn start(start: BenchObservationStart<'_>) -> Option<BenchObservation
         start.rig_snapshot,
         start.run_dir,
     );
-    ActiveObservation::start_best_effort(NewRunRecord {
-        kind: "bench".to_string(),
-        component_id: Some(start.component_id.to_string()),
-        command: Some(bench_observation_command(
-            start.component_id,
-            start.args,
-            start.rig_id,
-        )),
-        cwd: Some(start.source_path.to_string_lossy().to_string()),
-        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        git_sha: short_head_revision_at(start.source_path),
-        rig_id: start.rig_id.map(str::to_string),
-        metadata_json: metadata.clone(),
-    })
+    ActiveObservation::start_best_effort(
+        NewRunRecord::builder("bench")
+            .component_id(start.component_id)
+            .command(bench_observation_command(
+                start.component_id,
+                start.args,
+                start.rig_id,
+            ))
+            .cwd_path(start.source_path)
+            .current_homeboy_version()
+            .git_sha(short_head_revision_at(start.source_path))
+            .optional_rig_id(start.rig_id)
+            .metadata(metadata.clone())
+            .build(),
+    )
     .map(BenchObservation)
 }
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -211,16 +211,15 @@ struct LintObservation(ActiveObservation);
 
 impl LintObservation {
     fn start(component_id: String, source_path: &std::path::Path, command: String) -> Option<Self> {
-        ActiveObservation::start_best_effort(NewRunRecord {
-            kind: "lint".to_string(),
-            component_id: Some(component_id),
-            command: Some(command),
-            cwd: Some(source_path.to_string_lossy().to_string()),
-            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            git_sha: None,
-            rig_id: None,
-            metadata_json: serde_json::json!({ "source": "homeboy lint" }),
-        })
+        ActiveObservation::start_best_effort(
+            NewRunRecord::builder("lint")
+                .component_id(component_id)
+                .command(command)
+                .cwd_path(source_path)
+                .current_homeboy_version()
+                .metadata(serde_json::json!({ "source": "homeboy lint" }))
+                .build(),
+        )
         .map(Self)
     }
 

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -30,16 +30,16 @@ pub(super) fn start(start: ReviewObservationStart<'_>) -> Option<ReviewObservati
         start.scope,
         start.changed_file_count,
     );
-    ActiveObservation::start_best_effort(NewRunRecord {
-        kind: "review".to_string(),
-        component_id: Some(start.component_id.to_string()),
-        command: Some(review_observation_command(start.component_id, start.args)),
-        cwd: Some(start.source_path.to_string_lossy().to_string()),
-        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        git_sha: short_head_revision_at(start.source_path),
-        rig_id: None,
-        metadata_json: metadata.clone(),
-    })
+    ActiveObservation::start_best_effort(
+        NewRunRecord::builder("review")
+            .component_id(start.component_id)
+            .command(review_observation_command(start.component_id, start.args))
+            .cwd_path(start.source_path)
+            .current_homeboy_version()
+            .git_sha(short_head_revision_at(start.source_path))
+            .metadata(metadata.clone())
+            .build(),
+    )
     .map(ReviewObservation)
 }
 

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -204,16 +204,16 @@ fn start_test_observation(
     run_dir: Option<&RunDir>,
 ) -> Option<TestObservation> {
     let metadata = test_observation_initial_metadata(source_path, args, mode, run_dir);
-    ActiveObservation::start_best_effort(NewRunRecord {
-        kind: "test".to_string(),
-        component_id: Some(component_id.to_string()),
-        command: Some(test_observation_command(component_id, args)),
-        cwd: Some(source_path.to_string_lossy().to_string()),
-        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        git_sha: short_head_revision_at(source_path),
-        rig_id: None,
-        metadata_json: metadata.clone(),
-    })
+    ActiveObservation::start_best_effort(
+        NewRunRecord::builder("test")
+            .component_id(component_id)
+            .command(test_observation_command(component_id, args))
+            .cwd_path(source_path)
+            .current_homeboy_version()
+            .git_sha(short_head_revision_at(source_path))
+            .metadata(metadata.clone())
+            .build(),
+    )
     .map(TestObservation)
 }
 

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -17,9 +17,9 @@ pub use records::{
     finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
     finding_records_from_annotation_file, finding_records_from_annotations_dir,
     finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
-    FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord,
-    NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord,
-    TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
+    FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder,
+    NewTraceRunRecord, NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord,
+    RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};
 pub use timeline::{

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -5,32 +5,13 @@ use std::{collections::BTreeMap, path::Path};
 use crate::code_audit::{self, report::finding_kind_key};
 use crate::extension::lint::LintFinding;
 
+mod run_builder;
+mod run_status;
 mod triage_items;
 
+pub use run_builder::NewRunRecordBuilder;
+pub use run_status::RunStatus;
 pub use triage_items::{NewTriageItemRecord, TriageItemRecord, TriagePullRequestSignals};
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-pub enum RunStatus {
-    Running,
-    Pass,
-    Fail,
-    Error,
-    Skipped,
-    Stale,
-}
-
-impl RunStatus {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Running => "running",
-            Self::Pass => "pass",
-            Self::Fail => "fail",
-            Self::Error => "error",
-            Self::Skipped => "skipped",
-            Self::Stale => "stale",
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct NewRunRecord {
@@ -42,6 +23,12 @@ pub struct NewRunRecord {
     pub git_sha: Option<String>,
     pub rig_id: Option<String>,
     pub metadata_json: serde_json::Value,
+}
+
+impl NewRunRecord {
+    pub fn builder(kind: impl Into<String>) -> NewRunRecordBuilder {
+        NewRunRecordBuilder::new(kind)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -405,13 +392,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_run_status_as_str() {
-        assert_eq!(RunStatus::Running.as_str(), "running");
-        assert_eq!(RunStatus::Pass.as_str(), "pass");
-        assert_eq!(RunStatus::Fail.as_str(), "fail");
-        assert_eq!(RunStatus::Error.as_str(), "error");
-        assert_eq!(RunStatus::Skipped.as_str(), "skipped");
-        assert_eq!(RunStatus::Stale.as_str(), "stale");
+    fn test_builder() {
+        let record = NewRunRecord::builder("lint").build();
+
+        assert_eq!(record.kind, "lint");
+        assert_eq!(record.metadata_json, serde_json::json!({}));
     }
 
     #[test]

--- a/src/core/observation/records/run_builder.rs
+++ b/src/core/observation/records/run_builder.rs
@@ -1,0 +1,174 @@
+use std::path::Path;
+
+use super::NewRunRecord;
+
+#[derive(Debug, Clone)]
+pub struct NewRunRecordBuilder {
+    record: NewRunRecord,
+}
+
+impl NewRunRecordBuilder {
+    pub fn new(kind: impl Into<String>) -> Self {
+        Self {
+            record: NewRunRecord {
+                kind: kind.into(),
+                component_id: None,
+                command: None,
+                cwd: None,
+                homeboy_version: None,
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({}),
+            },
+        }
+    }
+
+    pub fn component_id(mut self, component_id: impl Into<String>) -> Self {
+        self.record.component_id = Some(component_id.into());
+        self
+    }
+
+    pub fn command(mut self, command: impl Into<String>) -> Self {
+        self.record.command = Some(command.into());
+        self
+    }
+
+    pub fn cwd_path(mut self, path: &Path) -> Self {
+        self.record.cwd = Some(path.to_string_lossy().to_string());
+        self
+    }
+
+    pub fn current_homeboy_version(mut self) -> Self {
+        self.record.homeboy_version = Some(env!("CARGO_PKG_VERSION").to_string());
+        self
+    }
+
+    pub fn git_sha(mut self, git_sha: Option<String>) -> Self {
+        self.record.git_sha = git_sha;
+        self
+    }
+
+    pub fn rig_id(mut self, rig_id: impl Into<String>) -> Self {
+        self.record.rig_id = Some(rig_id.into());
+        self
+    }
+
+    pub fn optional_rig_id(mut self, rig_id: Option<impl Into<String>>) -> Self {
+        self.record.rig_id = rig_id.map(Into::into);
+        self
+    }
+
+    pub fn metadata(mut self, metadata_json: serde_json::Value) -> Self {
+        self.record.metadata_json = metadata_json;
+        self
+    }
+
+    pub fn build(self) -> NewRunRecord {
+        self.record
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let record = NewRunRecordBuilder::new("test").build();
+
+        assert_eq!(record.kind, "test");
+        assert!(record.component_id.is_none());
+    }
+
+    #[test]
+    fn test_component_id() {
+        let record = NewRunRecord::builder("lint")
+            .component_id("homeboy")
+            .build();
+
+        assert_eq!(record.component_id.as_deref(), Some("homeboy"));
+    }
+
+    #[test]
+    fn test_command() {
+        let record = NewRunRecord::builder("lint")
+            .command("homeboy lint homeboy")
+            .build();
+
+        assert_eq!(record.command.as_deref(), Some("homeboy lint homeboy"));
+    }
+
+    #[test]
+    fn test_cwd_path() {
+        let record = NewRunRecord::builder("lint")
+            .cwd_path(Path::new("/tmp/homeboy"))
+            .build();
+
+        assert_eq!(record.cwd.as_deref(), Some("/tmp/homeboy"));
+    }
+
+    #[test]
+    fn test_current_homeboy_version() {
+        let record = NewRunRecord::builder("lint")
+            .current_homeboy_version()
+            .build();
+
+        assert_eq!(
+            record.homeboy_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[test]
+    fn test_git_sha() {
+        let record = NewRunRecord::builder("lint")
+            .git_sha(Some("abc123".to_string()))
+            .build();
+
+        assert_eq!(record.git_sha.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn test_rig_id() {
+        let record = NewRunRecord::builder("bench").rig_id("studio").build();
+
+        assert_eq!(record.rig_id.as_deref(), Some("studio"));
+    }
+
+    #[test]
+    fn test_optional_rig_id() {
+        let record = NewRunRecord::builder("bench")
+            .optional_rig_id(Some("studio"))
+            .build();
+
+        assert_eq!(record.rig_id.as_deref(), Some("studio"));
+    }
+
+    #[test]
+    fn test_metadata() {
+        let record = NewRunRecord::builder("lint")
+            .metadata(serde_json::json!({ "source": "homeboy lint" }))
+            .build();
+
+        assert_eq!(record.metadata_json["source"], "homeboy lint");
+    }
+
+    #[test]
+    fn test_build() {
+        let record = NewRunRecord::builder("lint")
+            .component_id("homeboy")
+            .command("homeboy lint homeboy")
+            .cwd_path(Path::new("/tmp/homeboy"))
+            .current_homeboy_version()
+            .build();
+
+        assert_eq!(record.kind, "lint");
+        assert_eq!(record.component_id.as_deref(), Some("homeboy"));
+        assert_eq!(record.command.as_deref(), Some("homeboy lint homeboy"));
+        assert_eq!(record.cwd.as_deref(), Some("/tmp/homeboy"));
+        assert_eq!(
+            record.homeboy_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+}

--- a/src/core/observation/records/run_status.rs
+++ b/src/core/observation/records/run_status.rs
@@ -1,0 +1,39 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum RunStatus {
+    Running,
+    Pass,
+    Fail,
+    Error,
+    Skipped,
+    Stale,
+}
+
+impl RunStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+            Self::Error => "error",
+            Self::Skipped => "skipped",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(RunStatus::Running.as_str(), "running");
+        assert_eq!(RunStatus::Pass.as_str(), "pass");
+        assert_eq!(RunStatus::Fail.as_str(), "fail");
+        assert_eq!(RunStatus::Error.as_str(), "error");
+        assert_eq!(RunStatus::Skipped.as_str(), "skipped");
+        assert_eq!(RunStatus::Stale.as_str(), "stale");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NewRunRecord::builder(...)` for shared observation run-record construction.
- Reuse the builder in lint, test, bench, and review observation start paths.
- Split observation record helper types into focused submodules so the refactor stays audit-clean.

## Verification
- `cargo fmt && cargo check --all-targets`
- `cargo test core::observation::records --lib`
- `cargo test commands::lint --lib`
- `cargo test commands::test --lib`
- `cargo test commands::bench --lib`
- `cargo test commands::review --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@observation-run-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/observation-run-builder-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@observation-run-builder --extension rust --changed-since origin/main`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the mechanical refactor, audit cleanup, and verification commands; Chris remains responsible for review and merge.