### PR TITLE
refactor: reuse observation run builder

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -152,16 +152,16 @@ fn start_audit_observation(
     let path = Path::new(source_path);
     let metadata = audit_observation_initial_metadata(source_path, args);
     let run = store
-        .start_run(NewRunRecord {
-            kind: "audit".to_string(),
-            component_id: Some(component_id.to_string()),
-            command: Some(audit_observation_command(component_id, args)),
-            cwd: Some(source_path.to_string()),
-            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            git_sha: short_head_revision_at(path),
-            rig_id: None,
-            metadata_json: metadata.clone(),
-        })
+        .start_run(
+            NewRunRecord::builder("audit")
+                .component_id(component_id)
+                .command(audit_observation_command(component_id, args))
+                .cwd_path(path)
+                .current_homeboy_version()
+                .git_sha(short_head_revision_at(path))
+                .metadata(metadata.clone())
+                .build(),
+        )
         .ok()?;
 
     Some(AuditObservation {

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -121,16 +121,16 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
         "run_dir": run_dir.path(),
     });
 
-    let run = store.start_run(NewRunRecord {
-        kind: "observe".to_string(),
-        component_id: Some(component_id.clone()),
-        command: Some(command),
-        cwd: Some(component_path.to_string_lossy().to_string()),
-        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        git_sha: short_head_revision_at(&component_path),
-        rig_id: None,
-        metadata_json: initial_metadata,
-    })?;
+    let run = store.start_run(
+        NewRunRecord::builder("observe")
+            .component_id(component_id.clone())
+            .command(command)
+            .cwd_path(&component_path)
+            .current_homeboy_version()
+            .git_sha(short_head_revision_at(&component_path))
+            .metadata(initial_metadata)
+            .build(),
+    )?;
 
     let mut status = RunStatus::Pass;
     let observe_result = collect_timeline(&args);

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -436,38 +436,38 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
         .clone()
         .unwrap_or_else(|| ctx.component.local_path.clone());
     let observation = ObservationStore::open_initialized().ok().and_then(|store| {
+        let cwd = std::env::current_dir().ok();
         store
-            .start_run(NewRunRecord {
-                kind: "trace".to_string(),
-                component_id: Some(ctx.component_id.clone()),
-                command: Some(std::env::args().collect::<Vec<_>>().join(" ")),
-                cwd: std::env::current_dir()
-                    .ok()
-                    .map(|path| path.to_string_lossy().to_string()),
-                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-                git_sha: homeboy::git::short_head_revision_at(Path::new(
-                    &component_path_for_observation,
-                )),
-                rig_id: rig_id.clone(),
-                metadata_json: serde_json::json!({
-                    "scenario_id": scenario_id,
-                    "component_path": component_path_for_observation,
-                    "requested_overlays": requested_overlays,
-                    "requested_variants": requested_variants,
-                    "span_definitions": span_definitions.clone(),
-                    "phase_preset": args.phase_preset.clone(),
-                    "phase_milestones": args.phases.clone().into_iter().map(|phase| {
-                        serde_json::json!({ "label": phase.label, "key": phase.key })
-                    }).collect::<Vec<_>>(),
-                    "baseline": {
-                        "baseline": args.baseline_args.baseline,
-                        "ignore_baseline": args.baseline_args.ignore_baseline,
-                        "ratchet": args.baseline_args.ratchet,
-                        "regression_threshold_percent": args.regression_threshold,
-                        "regression_min_delta_ms": args.regression_min_delta_ms
-                    }
-                }),
-            })
+            .start_run(
+                NewRunRecord::builder("trace")
+                    .component_id(ctx.component_id.clone())
+                    .command(std::env::args().collect::<Vec<_>>().join(" "))
+                    .optional_cwd_path(cwd.as_deref())
+                    .current_homeboy_version()
+                    .git_sha(homeboy::git::short_head_revision_at(Path::new(
+                        &component_path_for_observation,
+                    )))
+                    .optional_rig_id(rig_id.clone())
+                    .metadata(serde_json::json!({
+                        "scenario_id": scenario_id,
+                        "component_path": component_path_for_observation,
+                        "requested_overlays": requested_overlays,
+                        "requested_variants": requested_variants,
+                        "span_definitions": span_definitions.clone(),
+                        "phase_preset": args.phase_preset.clone(),
+                        "phase_milestones": args.phases.clone().into_iter().map(|phase| {
+                            serde_json::json!({ "label": phase.label, "key": phase.key })
+                        }).collect::<Vec<_>>(),
+                        "baseline": {
+                            "baseline": args.baseline_args.baseline,
+                            "ignore_baseline": args.baseline_args.ignore_baseline,
+                            "ratchet": args.baseline_args.ratchet,
+                            "regression_threshold_percent": args.regression_threshold,
+                            "regression_min_delta_ms": args.regression_min_delta_ms
+                        }
+                    }))
+                    .build(),
+            )
             .ok()
             .map(|run| ActiveTraceObservation {
                 store,

--- a/src/core/observation/records/run_builder.rs
+++ b/src/core/observation/records/run_builder.rs
@@ -38,6 +38,11 @@ impl NewRunRecordBuilder {
         self
     }
 
+    pub fn optional_cwd_path(mut self, path: Option<&Path>) -> Self {
+        self.record.cwd = path.map(|path| path.to_string_lossy().to_string());
+        self
+    }
+
     pub fn current_homeboy_version(mut self) -> Self {
         self.record.homeboy_version = Some(env!("CARGO_PKG_VERSION").to_string());
         self
@@ -102,6 +107,15 @@ mod tests {
     fn test_cwd_path() {
         let record = NewRunRecord::builder("lint")
             .cwd_path(Path::new("/tmp/homeboy"))
+            .build();
+
+        assert_eq!(record.cwd.as_deref(), Some("/tmp/homeboy"));
+    }
+
+    #[test]
+    fn test_optional_cwd_path() {
+        let record = NewRunRecord::builder("triage")
+            .optional_cwd_path(Some(Path::new("/tmp/homeboy")))
             .build();
 
         assert_eq!(record.cwd.as_deref(), Some("/tmp/homeboy"));

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -524,19 +524,17 @@ struct RigRunObserver {
 impl RigRunObserver {
     fn start(rig: &RigSpec, command: &str) -> Option<Self> {
         let store = ObservationStore::open_initialized().ok()?;
+        let cwd = std::env::current_dir().ok();
         let run = store
-            .start_run(NewRunRecord {
-                kind: "rig".to_string(),
-                component_id: None,
-                command: Some(format!("rig.{command}")),
-                cwd: std::env::current_dir()
-                    .ok()
-                    .map(|path| path.to_string_lossy().to_string()),
-                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-                git_sha: None,
-                rig_id: Some(rig.id.clone()),
-                metadata_json: rig_observation_metadata(rig, command, None, None, None),
-            })
+            .start_run(
+                NewRunRecord::builder("rig")
+                    .command(format!("rig.{command}"))
+                    .optional_cwd_path(cwd.as_deref())
+                    .current_homeboy_version()
+                    .rig_id(rig.id.clone())
+                    .metadata(rig_observation_metadata(rig, command, None, None, None))
+                    .build(),
+            )
             .ok()?;
 
         Some(Self {

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -312,40 +312,39 @@ impl TriageObservation {
             .status()
             .map(|status| status.path)
             .unwrap_or_else(|_| "<unavailable>".to_string());
+        let cwd = std::env::current_dir().ok();
         let run = store
-            .start_run(NewRunRecord {
-                kind: "triage".to_string(),
-                component_id: Some(component_id),
-                command: Some(triage_command(target)),
-                cwd: std::env::current_dir()
-                    .ok()
-                    .map(|path| path.to_string_lossy().to_string()),
-                homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-                git_sha: None,
-                rig_id: match target {
-                    TriageTarget::Rig(id) => Some(id.clone()),
-                    _ => None,
-                },
-                metadata_json: serde_json::json!({
-                    "target": {
-                        "kind": target.kind_name(),
-                        "id": target.id(),
-                    },
-                    "options": {
-                        "include_issues": options.include_issues,
-                        "include_prs": options.include_prs,
-                        "mine": options.mine,
-                        "assigned": options.assigned,
-                        "labels": options.labels,
-                        "needs_review": options.needs_review,
-                        "failing_checks": options.failing_checks,
-                        "drilldown": options.drilldown,
-                        "issue_numbers": options.issue_numbers,
-                        "stale_days": options.stale_days,
-                        "limit": options.limit,
-                    }
-                }),
-            })
+            .start_run(
+                NewRunRecord::builder("triage")
+                    .component_id(component_id)
+                    .command(triage_command(target))
+                    .optional_cwd_path(cwd.as_deref())
+                    .current_homeboy_version()
+                    .optional_rig_id(match target {
+                        TriageTarget::Rig(id) => Some(id.clone()),
+                        _ => None,
+                    })
+                    .metadata(serde_json::json!({
+                        "target": {
+                            "kind": target.kind_name(),
+                            "id": target.id(),
+                        },
+                        "options": {
+                            "include_issues": options.include_issues,
+                            "include_prs": options.include_prs,
+                            "mine": options.mine,
+                            "assigned": options.assigned,
+                            "labels": options.labels,
+                            "needs_review": options.needs_review,
+                            "failing_checks": options.failing_checks,
+                            "drilldown": options.drilldown,
+                            "issue_numbers": options.issue_numbers,
+                            "stale_days": options.stale_days,
+                            "limit": options.limit,
+                        }
+                    }))
+                    .build(),
+            )
             .ok()?;
 
         Some(Self {


### PR DESCRIPTION
## Summary
- Reuse `NewRunRecord::builder(...)` in audit, observe, trace, triage, and rig observation start paths.
- Add `optional_cwd_path(...)` for observation starts that preserve current-directory lookup as best effort.
- Leave test fixtures, imported records, and persisted `RunRecord` shapes unchanged.

## Verification
- `cargo fmt && cargo check --all-targets`
- `cargo test core::observation::records --lib`
- `cargo test commands::audit --lib`
- `cargo test commands::observe --lib`
- `cargo test commands::trace --lib`
- `cargo test core::triage --lib`
- `cargo test core::rig::runner --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@observation-run-builder-followup --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/observation-run-builder-followup-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@observation-run-builder-followup --extension rust --changed-since origin/main`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the mechanical refactor and verification pass; Chris remains responsible for review and merge.