### PR TITLE
refactor: reuse observation fixture builder

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -649,16 +649,15 @@ mod tests {
     }
 
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord {
-            kind: kind.to_string(),
-            component_id: Some(component_id.to_string()),
-            command: Some(format!("homeboy {kind} {component_id}")),
-            cwd: Some("/tmp/homeboy-fixture".to_string()),
-            homeboy_version: Some("test-version".to_string()),
-            git_sha: Some("abc123".to_string()),
-            rig_id: Some(rig_id.to_string()),
-            metadata_json: metadata,
-        }
+        NewRunRecord::builder(kind)
+            .component_id(component_id)
+            .command(format!("homeboy {kind} {component_id}"))
+            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+            .homeboy_version("test-version")
+            .git_sha(Some("abc123".to_string()))
+            .rig_id(rig_id)
+            .metadata(metadata)
+            .build()
     }
 
     #[test]

--- a/src/commands/runs/compare.rs
+++ b/src/commands/runs/compare.rs
@@ -293,16 +293,15 @@ mod tests {
     }
 
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord {
-            kind: kind.to_string(),
-            component_id: Some(component_id.to_string()),
-            command: Some(format!("homeboy {kind} {component_id}")),
-            cwd: Some("/tmp/homeboy-fixture".to_string()),
-            homeboy_version: Some("test-version".to_string()),
-            git_sha: Some("abc123".to_string()),
-            rig_id: Some(rig_id.to_string()),
-            metadata_json: metadata,
-        }
+        NewRunRecord::builder(kind)
+            .component_id(component_id)
+            .command(format!("homeboy {kind} {component_id}"))
+            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+            .homeboy_version("test-version")
+            .git_sha(Some("abc123".to_string()))
+            .rig_id(rig_id)
+            .metadata(metadata)
+            .build()
     }
 
     #[test]

--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -43,16 +43,11 @@ fn install_artifact(
     artifact_kind: &str,
 ) -> RunRecord {
     let run = store
-        .start_run(NewRunRecord {
-            kind: run_kind.to_string(),
-            component_id: Some(component.to_string()),
-            command: None,
-            cwd: None,
-            homeboy_version: None,
-            git_sha: None,
-            rig_id: None,
-            metadata_json: serde_json::json!({}),
-        })
+        .start_run(
+            NewRunRecord::builder(run_kind)
+                .component_id(component)
+                .build(),
+        )
         .expect("start run");
     store
         .finish_run(&run.id, RunStatus::Pass, None)

--- a/src/commands/runs/distribution.rs
+++ b/src/commands/runs/distribution.rs
@@ -235,16 +235,15 @@ mod tests {
     }
 
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord {
-            kind: kind.to_string(),
-            component_id: Some(component_id.to_string()),
-            command: Some(format!("homeboy {kind} {component_id}")),
-            cwd: Some("/tmp/homeboy-fixture".to_string()),
-            homeboy_version: Some("test-version".to_string()),
-            git_sha: Some("abc123".to_string()),
-            rig_id: Some(rig_id.to_string()),
-            metadata_json: metadata,
-        }
+        NewRunRecord::builder(kind)
+            .component_id(component_id)
+            .command(format!("homeboy {kind} {component_id}"))
+            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+            .homeboy_version("test-version")
+            .git_sha(Some("abc123".to_string()))
+            .rig_id(rig_id)
+            .metadata(metadata)
+            .build()
     }
 
     #[test]

--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -183,16 +183,15 @@ mod tests {
     }
 
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
-        NewRunRecord {
-            kind: kind.to_string(),
-            component_id: Some(component_id.to_string()),
-            command: Some(format!("homeboy {kind} {component_id}")),
-            cwd: Some("/tmp/homeboy-fixture".to_string()),
-            homeboy_version: Some("test-version".to_string()),
-            git_sha: Some("abc123".to_string()),
-            rig_id: Some(rig_id.to_string()),
-            metadata_json: metadata,
-        }
+        NewRunRecord::builder(kind)
+            .component_id(component_id)
+            .command(format!("homeboy {kind} {component_id}"))
+            .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+            .homeboy_version("test-version")
+            .git_sha(Some("abc123".to_string()))
+            .rig_id(rig_id)
+            .metadata(metadata)
+            .build()
     }
 
     #[test]

--- a/src/core/daemon/artifact_download.rs
+++ b/src/core/daemon/artifact_download.rs
@@ -232,16 +232,12 @@ mod tests {
         let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
         let store = ObservationStore::open_initialized().expect("store");
         let run = store
-            .start_run(NewRunRecord {
-                kind: "runner-exec".to_string(),
-                component_id: None,
-                command: Some("homeboy runner exec".to_string()),
-                cwd: None,
-                homeboy_version: Some("test-version".to_string()),
-                git_sha: None,
-                rig_id: None,
-                metadata_json: json!({}),
-            })
+            .start_run(
+                NewRunRecord::builder("runner-exec")
+                    .command("homeboy runner exec")
+                    .homeboy_version("test-version")
+                    .build(),
+            )
             .expect("run");
         let artifact_path = home_path.join("artifact.txt");
         fs::write(&artifact_path, "artifact body").expect("artifact file");

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -145,16 +145,15 @@ mod tests {
     use std::fs;
 
     fn run_record() -> NewRunRecord {
-        NewRunRecord {
-            kind: "test".to_string(),
-            component_id: Some("homeboy".to_string()),
-            command: Some("homeboy test homeboy".to_string()),
-            cwd: Some("/tmp/homeboy".to_string()),
-            homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            git_sha: Some("abc123".to_string()),
-            rig_id: Some("studio".to_string()),
-            metadata_json: serde_json::json!({ "status": "running" }),
-        }
+        NewRunRecord::builder("test")
+            .component_id("homeboy")
+            .command("homeboy test homeboy")
+            .cwd_path(std::path::Path::new("/tmp/homeboy"))
+            .current_homeboy_version()
+            .git_sha(Some("abc123".to_string()))
+            .rig_id("studio")
+            .metadata(serde_json::json!({ "status": "running" }))
+            .build()
     }
 
     fn active_observation() -> ActiveObservation {

--- a/src/core/observation/records/run_builder.rs
+++ b/src/core/observation/records/run_builder.rs
@@ -48,6 +48,11 @@ impl NewRunRecordBuilder {
         self
     }
 
+    pub fn homeboy_version(mut self, homeboy_version: impl Into<String>) -> Self {
+        self.record.homeboy_version = Some(homeboy_version.into());
+        self
+    }
+
     pub fn git_sha(mut self, git_sha: Option<String>) -> Self {
         self.record.git_sha = git_sha;
         self
@@ -131,6 +136,15 @@ mod tests {
             record.homeboy_version.as_deref(),
             Some(env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[test]
+    fn test_homeboy_version() {
+        let record = NewRunRecord::builder("lint")
+            .homeboy_version("test-version")
+            .build();
+
+        assert_eq!(record.homeboy_version.as_deref(), Some("test-version"));
     }
 
     #[test]

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1323,16 +1323,15 @@ mod api_coverage_tests {
     }
 
     fn new_run(kind: &str) -> NewRunRecord {
-        NewRunRecord {
-            kind: kind.to_string(),
-            component_id: Some("homeboy".to_string()),
-            command: Some(format!("homeboy {kind}")),
-            cwd: Some("/tmp/homeboy".to_string()),
-            homeboy_version: Some("test".to_string()),
-            git_sha: Some("abc123".to_string()),
-            rig_id: Some("studio".to_string()),
-            metadata_json: serde_json::json!({ "source": "inline" }),
-        }
+        NewRunRecord::builder(kind)
+            .component_id("homeboy")
+            .command(format!("homeboy {kind}"))
+            .cwd_path(std::path::Path::new("/tmp/homeboy"))
+            .homeboy_version("test")
+            .git_sha(Some("abc123".to_string()))
+            .rig_id("studio")
+            .metadata(serde_json::json!({ "source": "inline" }))
+            .build()
     }
 
     #[test]

--- a/src/core/observation/store/triage_items.rs
+++ b/src/core/observation/store/triage_items.rs
@@ -220,16 +220,13 @@ mod tests {
 
     fn start_triage_run(store: &ObservationStore) -> RunRecord {
         store
-            .start_run(NewRunRecord {
-                kind: "triage".to_string(),
-                component_id: Some("workspace".to_string()),
-                command: Some("triage.workspace".to_string()),
-                cwd: None,
-                homeboy_version: Some("test".to_string()),
-                git_sha: None,
-                rig_id: None,
-                metadata_json: serde_json::json!({}),
-            })
+            .start_run(
+                NewRunRecord::builder("triage")
+                    .component_id("workspace")
+                    .command("triage.workspace")
+                    .homeboy_version("test")
+                    .build(),
+            )
             .expect("run")
     }
 


### PR DESCRIPTION
## Summary
- Add an explicit `homeboy_version(...)` setter to `NewRunRecordBuilder` for fixture/test records.
- Replace repeated test `NewRunRecord` struct literals with the observation run builder while preserving fixture values.
- Keep persisted/imported `RunRecord` mapping paths untouched.

## Verification
- `cargo fmt && cargo check --all-targets`
- `cargo test core::observation::records --lib`
- `cargo test core::observation --lib`
- `cargo test commands::runs --lib`
- `cargo test core::daemon::artifact_download --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@observation-fixture-builders --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/observation-fixture-builders-audit.json` (`0 introduced findings`)
- `homeboy lint --path /Users/chubes/Developer/homeboy@observation-fixture-builders --extension rust --changed-since origin/main`
- `cargo test --lib` (`3111 passed; 0 failed; 18 ignored`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the mechanical fixture-builder refactor and ran local verification; Chris remains responsible for review and merge.