### PR TITLE
ci: opt into release-skip-publish and release-skip-github-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,11 @@ jobs:
           commands: release
           expected-commands: audit,lint,test
           release-dry-run: 'true'
+          # homeboy's binary cross-compile + hand-rolled `gh release create`
+          # in this same workflow handle publish and GitHub Release creation.
+          # Opt out of the homeboy-native pipeline steps for those.
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
 
       - name: Validate existing release tag
         id: recovery
@@ -352,6 +357,11 @@ jobs:
           commands: release
           expected-commands: audit,lint,test
           release-dry-run: ${{ inputs.dry-run || 'false' }}
+          # homeboy's binary cross-compile + hand-rolled `gh release create`
+          # in this same workflow handle publish and GitHub Release creation.
+          # Opt out of the homeboy-native pipeline steps for those.
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
       - name: Use existing release tag


### PR DESCRIPTION
## Summary

Companion PR to [homeboy-action#231](https://github.com/Extra-Chill/homeboy-action/pull/231). Explicitly opts homeboy's self-release back into the previous `--skip-publish` and `--no-github-release` behavior using the new `release-skip-publish` / `release-skip-github-release` inputs.

```diff
       - uses: Extra-Chill/homeboy-action@v2
         ...
         with:
           commands: release
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
```

## Why

The homeboy CLI release workflow cross-compiles binaries and creates the GitHub Release with the binaries as assets via a hand-rolled `gh release create` step later in the same workflow. The homeboy release planner adding its own `package` and `github.release` steps would collide with that.

Today this works because `homeboy-action@v2`'s `run-release.sh` hardcodes `--skip-publish --no-github-release`. The companion PR removes those hardcodes and exposes them as opt-in inputs (default `false`). Without this PR, the homeboy self-release would start producing duplicate release steps.

## Safe to land before homeboy-action#231

GitHub Actions silently ignores unknown action inputs, so these two new settings are no-ops on the currently-pinned `v2.5.4` of homeboy-action. They take effect once the v2 tag rolls forward to v2.5.5+.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Companion edit identified while preparing the action change in homeboy-action#231.