### PR TITLE
refactor: reuse observation test run builders

### DIFF
--- a/src/core/observation/store/findings.rs
+++ b/src/core/observation/store/findings.rs
@@ -257,16 +257,12 @@ mod tests {
     }
 
     fn new_run() -> NewRunRecord {
-        NewRunRecord {
-            kind: "lint".to_string(),
-            component_id: Some("homeboy".to_string()),
-            command: Some("homeboy lint".to_string()),
-            cwd: Some("/tmp/homeboy".to_string()),
-            homeboy_version: Some("test".to_string()),
-            git_sha: None,
-            rig_id: None,
-            metadata_json: serde_json::json!({}),
-        }
+        NewRunRecord::builder("lint")
+            .component_id("homeboy")
+            .command("homeboy lint")
+            .cwd_path(std::path::Path::new("/tmp/homeboy"))
+            .homeboy_version("test")
+            .build()
     }
 
     fn new_finding(run_id: &str, rule: &str) -> NewFindingRecord {

--- a/tests/core/daemon/artifact_download_test.rs
+++ b/tests/core/daemon/artifact_download_test.rs
@@ -8,16 +8,12 @@ fn test_route() {
     let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
     let store = ObservationStore::open_initialized().expect("store");
     let run = store
-        .start_run(NewRunRecord {
-            kind: "runner-exec".to_string(),
-            component_id: None,
-            command: Some("homeboy runner exec".to_string()),
-            cwd: None,
-            homeboy_version: Some("test-version".to_string()),
-            git_sha: None,
-            rig_id: None,
-            metadata_json: json!({}),
-        })
+        .start_run(
+            NewRunRecord::builder("runner-exec")
+                .command("homeboy runner exec")
+                .homeboy_version("test-version")
+                .build(),
+        )
         .expect("run");
     let artifact_path = home_path.join("artifact.txt");
     fs::write(&artifact_path, "artifact body").expect("artifact file");

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -184,16 +184,16 @@ fn routes_registered_artifact_downloads_and_sync_manifest() {
     let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
     let store = ObservationStore::open_initialized().expect("store");
     let run = store
-        .start_run(NewRunRecord {
-            kind: "bench".to_string(),
-            component_id: Some("homeboy".to_string()),
-            command: Some("homeboy bench".to_string()),
-            cwd: Some("/tmp/homeboy-fixture".to_string()),
-            homeboy_version: Some("test-version".to_string()),
-            git_sha: Some("abc123".to_string()),
-            rig_id: Some("studio".to_string()),
-            metadata_json: serde_json::json!({}),
-        })
+        .start_run(
+            NewRunRecord::builder("bench")
+                .component_id("homeboy")
+                .command("homeboy bench")
+                .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+                .homeboy_version("test-version")
+                .git_sha(Some("abc123".to_string()))
+                .rig_id("studio")
+                .build(),
+        )
         .expect("run");
     let artifact_path = home_path.join("bench-results.json");
     std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact");

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -453,16 +453,15 @@ fn sample_run_with_metadata(
     rig_id: &str,
     metadata_json: serde_json::Value,
 ) -> NewRunRecord {
-    NewRunRecord {
-        kind: kind.to_string(),
-        component_id: Some(component_id.to_string()),
-        command: Some(format!("homeboy {kind}")),
-        cwd: Some("/tmp/homeboy-fixture".to_string()),
-        homeboy_version: Some("test-version".to_string()),
-        git_sha: Some("abc123".to_string()),
-        rig_id: Some(rig_id.to_string()),
-        metadata_json,
-    }
+    NewRunRecord::builder(kind)
+        .component_id(component_id)
+        .command(format!("homeboy {kind}"))
+        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+        .homeboy_version("test-version")
+        .git_sha(Some("abc123".to_string()))
+        .rig_id(rig_id)
+        .metadata(metadata_json)
+        .build()
 }
 
 fn sample_imported_running_run(kind: &str, component_id: &str, rig_id: &str) -> RunRecord {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -198,19 +198,18 @@ fn sample_finding(run_id: &str, rule: &str, file: &str) -> NewFindingRecord {
 }
 
 fn sample_run(kind: &str, component_id: &str) -> NewRunRecord {
-    NewRunRecord {
-        kind: kind.to_string(),
-        component_id: Some(component_id.to_string()),
-        command: Some(format!("homeboy {kind} {component_id}")),
-        cwd: Some("/tmp/homeboy-fixture".to_string()),
-        homeboy_version: Some("test-version".to_string()),
-        git_sha: Some("abc123".to_string()),
-        rig_id: Some("studio".to_string()),
-        metadata_json: serde_json::json!({
+    NewRunRecord::builder(kind)
+        .component_id(component_id)
+        .command(format!("homeboy {kind} {component_id}"))
+        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+        .homeboy_version("test-version")
+        .git_sha(Some("abc123".to_string()))
+        .rig_id("studio")
+        .metadata(serde_json::json!({
             "scenario": "fixture",
             "attempt": 1,
-        }),
-    }
+        }))
+        .build()
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace remaining test-only `NewRunRecord` fixture literals with `NewRunRecord::builder(...)`.
- Preserve fixture values for command, cwd, version, git SHA, rig ID, and metadata.
- Leave explicit `RunRecord` persisted/imported mapping fixtures untouched.

## Verification
- `cargo fmt && cargo check --all-targets`
- `cargo test core::observation::store::findings --lib`
- `cargo test http_api_test -- --test-threads=1`
- `cargo test daemon_test -- --test-threads=1`
- `cargo test artifact_download_test -- --test-threads=1`
- `homeboy audit --path /Users/chubes/Developer/homeboy@observation-test-run-builders --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/observation-test-run-builders-audit.json` (`0 introduced findings`)
- `homeboy lint --path /Users/chubes/Developer/homeboy@observation-test-run-builders --extension rust --changed-since origin/main`
- `cargo test --lib` (`3111 passed; 0 failed; 18 ignored`)

## Notes
- I initially used invalid Cargo targeted-test syntax while validating (`--test-threads` before `--`, and `--test core` for files that are not standalone integration targets), then reran the relevant filters with valid Cargo syntax and the full library suite.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the mechanical fixture-builder refactor and ran local verification; Chris remains responsible for review and merge.