### PR TITLE
refactor: add trace span record builder

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1325,15 +1325,14 @@ mod tests {
                 .start_run(sample_run("trace", "homeboy", "studio", Value::Null))
                 .expect("run");
             let span = store
-                .record_trace_span(NewTraceSpanRecord {
-                    run_id: run.id.clone(),
-                    span_id: "boot".to_string(),
-                    status: "ok".to_string(),
-                    duration_ms: Some(12.5),
-                    from_event: Some("start".to_string()),
-                    to_event: Some("ready".to_string()),
-                    metadata_json: serde_json::json!({ "phase": "cold" }),
-                })
+                .record_trace_span(
+                    NewTraceSpanRecord::builder(&run.id, "boot", "ok")
+                        .duration_ms(Some(12.5))
+                        .from_event(Some("start"))
+                        .to_event(Some("ready"))
+                        .metadata(serde_json::json!({ "phase": "cold" }))
+                        .build(),
+                )
                 .expect("span");
             let output = home.path().join("trace-bundle");
 
@@ -1366,15 +1365,12 @@ mod tests {
                     .record_artifact(&run.id, "trace_results", &artifact_path)
                     .expect("artifact record");
                 store
-                    .record_trace_span(NewTraceSpanRecord {
-                        run_id: run.id.clone(),
-                        span_id: "first".to_string(),
-                        status: "ok".to_string(),
-                        duration_ms: Some(1.0),
-                        from_event: None,
-                        to_event: Some("done".to_string()),
-                        metadata_json: serde_json::json!({}),
-                    })
+                    .record_trace_span(
+                        NewTraceSpanRecord::builder(&run.id, "first", "ok")
+                            .duration_ms(Some(1.0))
+                            .to_event(Some("done"))
+                            .build(),
+                    )
                     .expect("span");
                 store
                     .record_finding(&NewFindingRecord {

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1341,20 +1341,23 @@ fn persist_trace_workflow_result(
 
     if let Some(results) = results {
         for span in &results.span_results {
-            let _ = observation.store.record_trace_span(NewTraceSpanRecord {
-                run_id: observation.run_id.clone(),
-                span_id: span.id.clone(),
-                status: format!("{:?}", span.status).to_ascii_lowercase(),
-                duration_ms: span.duration_ms.map(|value| value as f64),
-                from_event: Some(span.from.clone()),
-                to_event: Some(span.to.clone()),
-                metadata_json: serde_json::json!({
+            let _ = observation.store.record_trace_span(
+                NewTraceSpanRecord::builder(
+                    &observation.run_id,
+                    &span.id,
+                    format!("{:?}", span.status).to_ascii_lowercase(),
+                )
+                .duration_ms(span.duration_ms.map(|value| value as f64))
+                .from_event(Some(&span.from))
+                .to_event(Some(&span.to))
+                .metadata(serde_json::json!({
                     "from_t_ms": span.from_t_ms,
                     "to_t_ms": span.to_t_ms,
                     "missing": span.missing,
                     "message": &span.message,
-                }),
-            });
+                }))
+                .build(),
+            );
         }
     }
 

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -18,9 +18,9 @@ pub use records::{
     finding_records_from_annotation_file, finding_records_from_annotations_dir,
     finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
     FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder,
-    NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTriageItemRecord,
-    RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
-    TriagePullRequestSignals,
+    NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder,
+    NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
+    TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};
 pub use timeline::{

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -8,11 +8,13 @@ use crate::extension::lint::LintFinding;
 mod run_builder;
 mod run_status;
 mod trace_run_builder;
+mod trace_span_builder;
 mod triage_items;
 
 pub use run_builder::NewRunRecordBuilder;
 pub use run_status::RunStatus;
 pub use trace_run_builder::NewTraceRunRecordBuilder;
+pub use trace_span_builder::NewTraceSpanRecordBuilder;
 pub use triage_items::{NewTriageItemRecord, TriageItemRecord, TriagePullRequestSignals};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/core/observation/records/trace_span_builder.rs
+++ b/src/core/observation/records/trace_span_builder.rs
@@ -1,0 +1,115 @@
+use super::NewTraceSpanRecord;
+
+#[derive(Debug, Clone)]
+pub struct NewTraceSpanRecordBuilder {
+    record: NewTraceSpanRecord,
+}
+
+impl NewTraceSpanRecordBuilder {
+    pub fn new(
+        run_id: impl Into<String>,
+        span_id: impl Into<String>,
+        status: impl Into<String>,
+    ) -> Self {
+        Self {
+            record: NewTraceSpanRecord {
+                run_id: run_id.into(),
+                span_id: span_id.into(),
+                status: status.into(),
+                duration_ms: None,
+                from_event: None,
+                to_event: None,
+                metadata_json: serde_json::json!({}),
+            },
+        }
+    }
+
+    pub fn duration_ms(mut self, duration_ms: Option<f64>) -> Self {
+        self.record.duration_ms = duration_ms;
+        self
+    }
+
+    pub fn from_event(mut self, from_event: Option<impl Into<String>>) -> Self {
+        self.record.from_event = from_event.map(Into::into);
+        self
+    }
+
+    pub fn to_event(mut self, to_event: Option<impl Into<String>>) -> Self {
+        self.record.to_event = to_event.map(Into::into);
+        self
+    }
+
+    pub fn metadata(mut self, metadata_json: serde_json::Value) -> Self {
+        self.record.metadata_json = metadata_json;
+        self
+    }
+
+    pub fn build(self) -> NewTraceSpanRecord {
+        self.record
+    }
+}
+
+impl NewTraceSpanRecord {
+    pub fn builder(
+        run_id: impl Into<String>,
+        span_id: impl Into<String>,
+        status: impl Into<String>,
+    ) -> NewTraceSpanRecordBuilder {
+        NewTraceSpanRecordBuilder::new(run_id, span_id, status)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let record = NewTraceSpanRecordBuilder::new("run-1", "boot", "ok").build();
+
+        assert_eq!(record.run_id, "run-1");
+        assert_eq!(record.span_id, "boot");
+        assert_eq!(record.status, "ok");
+        assert!(record.duration_ms.is_none());
+        assert!(record.from_event.is_none());
+        assert!(record.to_event.is_none());
+        assert_eq!(record.metadata_json, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_duration_ms() {
+        let record = NewTraceSpanRecordBuilder::new("run-1", "boot", "ok")
+            .duration_ms(Some(12.5))
+            .build();
+
+        assert_eq!(record.duration_ms, Some(12.5));
+    }
+
+    #[test]
+    fn test_from_event() {
+        let record = NewTraceSpanRecordBuilder::new("run-1", "boot", "ok")
+            .from_event(Some("start"))
+            .build();
+
+        assert_eq!(record.from_event.as_deref(), Some("start"));
+    }
+
+    #[test]
+    fn test_to_event() {
+        let record = NewTraceSpanRecordBuilder::new("run-1", "boot", "ok")
+            .to_event(Some("ready"))
+            .build();
+
+        assert_eq!(record.to_event.as_deref(), Some("ready"));
+    }
+
+    #[test]
+    fn test_metadata() {
+        let metadata = serde_json::json!({ "phase": "cold" });
+        let record = NewTraceSpanRecordBuilder::new("run-1", "boot", "ok")
+            .metadata(metadata.clone())
+            .build();
+
+        assert_eq!(record.metadata_json, metadata);
+    }
+}

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1611,15 +1611,14 @@ mod api_coverage_tests {
             let run = store.start_run(new_run("trace")).expect("start");
 
             let span = store
-                .record_trace_span(NewTraceSpanRecord {
-                    run_id: run.id.clone(),
-                    span_id: "boot_to_ready".to_string(),
-                    status: "ok".to_string(),
-                    duration_ms: Some(125.0),
-                    from_event: Some("runner.boot".to_string()),
-                    to_event: Some("runner.ready".to_string()),
-                    metadata_json: serde_json::json!({ "source": "test" }),
-                })
+                .record_trace_span(
+                    NewTraceSpanRecord::builder(&run.id, "boot_to_ready", "ok")
+                        .duration_ms(Some(125.0))
+                        .from_event(Some("runner.boot"))
+                        .to_event(Some("runner.ready"))
+                        .metadata(serde_json::json!({ "source": "test" }))
+                        .build(),
+                )
                 .expect("trace span");
 
             let spans = store.list_trace_spans(&run.id).expect("spans");
@@ -1635,15 +1634,14 @@ mod api_coverage_tests {
             let source = ObservationStore::open_initialized().expect("source");
             let run = source.start_run(new_run("trace")).expect("run");
             let span = source
-                .record_trace_span(NewTraceSpanRecord {
-                    run_id: run.id.clone(),
-                    span_id: "boot".to_string(),
-                    status: "ok".to_string(),
-                    duration_ms: Some(42.0),
-                    from_event: Some("start".to_string()),
-                    to_event: Some("ready".to_string()),
-                    metadata_json: serde_json::json!({ "source": "import-test" }),
-                })
+                .record_trace_span(
+                    NewTraceSpanRecord::builder(&run.id, "boot", "ok")
+                        .duration_ms(Some(42.0))
+                        .from_event(Some("start"))
+                        .to_event(Some("ready"))
+                        .metadata(serde_json::json!({ "source": "import-test" }))
+                        .build(),
+                )
                 .expect("span");
 
             let target = ObservationStore::open_initialized().expect("target");
@@ -1660,26 +1658,22 @@ mod api_coverage_tests {
             let run = store.start_run(new_run("trace")).expect("start");
 
             store
-                .record_trace_span(NewTraceSpanRecord {
-                    run_id: run.id.clone(),
-                    span_id: "first".to_string(),
-                    status: "ok".to_string(),
-                    duration_ms: Some(10.0),
-                    from_event: Some("runner.first".to_string()),
-                    to_event: Some("runner.second".to_string()),
-                    metadata_json: serde_json::json!({}),
-                })
+                .record_trace_span(
+                    NewTraceSpanRecord::builder(&run.id, "first", "ok")
+                        .duration_ms(Some(10.0))
+                        .from_event(Some("runner.first"))
+                        .to_event(Some("runner.second"))
+                        .build(),
+                )
                 .expect("first span");
             store
-                .record_trace_span(NewTraceSpanRecord {
-                    run_id: run.id.clone(),
-                    span_id: "second".to_string(),
-                    status: "skipped".to_string(),
-                    duration_ms: None,
-                    from_event: Some("runner.second".to_string()),
-                    to_event: Some("runner.third".to_string()),
-                    metadata_json: serde_json::json!({ "missing": ["runner.third"] }),
-                })
+                .record_trace_span(
+                    NewTraceSpanRecord::builder(&run.id, "second", "skipped")
+                        .from_event(Some("runner.second"))
+                        .to_event(Some("runner.third"))
+                        .metadata(serde_json::json!({ "missing": ["runner.third"] }))
+                        .build(),
+                )
                 .expect("second span");
 
             let spans = store.list_trace_spans(&run.id).expect("spans");


### PR DESCRIPTION
## Summary
- Add a `NewTraceSpanRecordBuilder` with defaults for optional trace span fields and metadata.
- Reuse the builder in trace persistence and observation store/export coverage to remove repeated literal setup.
- Keep the serialized `NewTraceSpanRecord` shape unchanged.

## Verification
- `cargo fmt && cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/trace-span-record-builder-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the builder refactor, migrated repeated trace span record construction, and ran local verification. Chris remains responsible for review and merge.