### PR TITLE
Support GitHub Enterprise release remotes

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,5 +1,13 @@
 {
   "auto_cleanup": false,
+  "autofix_verify": {
+    "command": "cargo",
+    "args": [
+      "check",
+      "--release"
+    ],
+    "timeout_secs": 300
+  },
   "baselines": {
     "audit": {
       "context_id": "homeboy",

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -179,6 +179,7 @@ fn validate_github_remote_url_field(component: &Value, field: &str) -> Result<()
         Some(vec![
             "Use https://github.com/<owner>/<repo>.git".to_string(),
             "Or use git@github.com:<owner>/<repo>.git".to_string(),
+            "GitHub Enterprise hosts such as github.a8c.com are also supported".to_string(),
         ]),
     ))
 }
@@ -568,5 +569,22 @@ mod tests {
             json.get("triage_remote_url").and_then(|v| v.as_str()),
             Some("git@github.com:Extra-Chill/homeboy.git")
         );
+    }
+
+    #[test]
+    fn write_accepts_github_enterprise_remote_urls() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut component = Component::new(
+            "test-comp".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            String::new(),
+            None,
+        );
+        component.remote_url = Some("git@github.a8c.com:Automattic/intelligence.git".to_string());
+        component.triage_remote_url =
+            Some("https://github.a8c.com/Automattic/intelligence.git".to_string());
+
+        write_portable_config(dir.path(), &component)
+            .expect("GitHub Enterprise remotes should be valid");
     }
 }

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -18,6 +18,7 @@ use crate::error::{Error, Result};
 /// Parsed GitHub owner/repo from a remote URL.
 #[derive(Debug, Clone)]
 pub struct GitHubRepo {
+    pub host: String,
     pub owner: String,
     pub repo: String,
 }
@@ -26,8 +27,8 @@ impl GitHubRepo {
     /// Construct a release artifact download URL.
     pub(crate) fn release_artifact_url(&self, tag: &str, artifact_name: &str) -> String {
         format!(
-            "https://github.com/{}/{}/releases/download/{}/{}",
-            self.owner, self.repo, tag, artifact_name
+            "https://{}/{}/{}/releases/download/{}/{}",
+            self.host, self.owner, self.repo, tag, artifact_name
         )
     }
 }
@@ -39,6 +40,7 @@ impl GitHubRepo {
 /// - `https://github.com/owner/repo.git`
 /// - `https://user:token@github.com/owner/repo.git`
 /// - `git@github.com:owner/repo.git`
+/// - GitHub Enterprise equivalents such as `git@github.a8c.com:owner/repo.git`
 pub fn parse_github_url(url: &str) -> Option<GitHubRepo> {
     // HTTPS format
     if let Some(repo) = parse_github_http_url(url) {
@@ -46,13 +48,22 @@ pub fn parse_github_url(url: &str) -> Option<GitHubRepo> {
     }
 
     // SSH format
-    if let Some(rest) = url.strip_prefix("git@github.com:") {
-        if let Some(repo) = parse_owner_repo(rest) {
-            return Some(repo);
+    if let Some(rest) = url.strip_prefix("git@") {
+        let (host, path) = rest.split_once(':')?;
+        if is_github_host(host) {
+            if let Some(repo) = parse_owner_repo(host, path) {
+                return Some(repo);
+            }
         }
     }
 
     None
+}
+
+fn is_github_host(host: &str) -> bool {
+    let host = host.rsplit('@').next().unwrap_or(host).trim();
+
+    host == "github.com" || (host.starts_with("github.") && !host.starts_with("github.com."))
 }
 
 fn parse_github_http_url(url: &str) -> Option<GitHubRepo> {
@@ -60,21 +71,23 @@ fn parse_github_http_url(url: &str) -> Option<GitHubRepo> {
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))?;
     let (host, path) = rest.split_once('/')?;
+    let host = host.rsplit('@').next()?;
 
     // GitHub HTTPS remotes may include credentials before the host, e.g.
     // https://x-access-token:TOKEN@github.com/owner/repo.git.
-    if host.rsplit('@').next()? != "github.com" {
+    if !is_github_host(host) {
         return None;
     }
 
-    parse_owner_repo(path)
+    parse_owner_repo(host, path)
 }
 
-fn parse_owner_repo(path: &str) -> Option<GitHubRepo> {
+fn parse_owner_repo(host: &str, path: &str) -> Option<GitHubRepo> {
     let path = path.trim_end_matches('/').trim_end_matches(".git");
     let parts: Vec<&str> = path.splitn(3, '/').collect();
     if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
         return Some(GitHubRepo {
+            host: host.to_string(),
             owner: parts[0].to_string(),
             repo: parts[1].to_string(),
         });
@@ -212,6 +225,7 @@ mod tests {
     #[test]
     fn parse_github_url_https() {
         let repo = parse_github_url("https://github.com/Extra-Chill/homeboy").unwrap();
+        assert_eq!(repo.host, "github.com");
         assert_eq!(repo.owner, "Extra-Chill");
         assert_eq!(repo.repo, "homeboy");
     }
@@ -251,8 +265,25 @@ mod tests {
     #[test]
     fn parse_github_url_ssh() {
         let repo = parse_github_url("git@github.com:Extra-Chill/homeboy.git").unwrap();
+        assert_eq!(repo.host, "github.com");
         assert_eq!(repo.owner, "Extra-Chill");
         assert_eq!(repo.repo, "homeboy");
+    }
+
+    #[test]
+    fn parse_github_url_enterprise_ssh() {
+        let repo = parse_github_url("git@github.a8c.com:Automattic/intelligence.git").unwrap();
+        assert_eq!(repo.host, "github.a8c.com");
+        assert_eq!(repo.owner, "Automattic");
+        assert_eq!(repo.repo, "intelligence");
+    }
+
+    #[test]
+    fn parse_github_url_enterprise_https() {
+        let repo = parse_github_url("https://github.a8c.com/Automattic/intelligence.git").unwrap();
+        assert_eq!(repo.host, "github.a8c.com");
+        assert_eq!(repo.owner, "Automattic");
+        assert_eq!(repo.repo, "intelligence");
     }
 
     #[test]
@@ -274,6 +305,7 @@ mod tests {
     #[test]
     fn release_artifact_url_format() {
         let repo = GitHubRepo {
+            host: "github.com".to_string(),
             owner: "Extra-Chill".to_string(),
             repo: "data-machine".to_string(),
         };
@@ -281,6 +313,20 @@ mod tests {
         assert_eq!(
             url,
             "https://github.com/Extra-Chill/data-machine/releases/download/v0.36.1/data-machine.zip"
+        );
+    }
+
+    #[test]
+    fn enterprise_release_artifact_url_uses_remote_host() {
+        let repo = GitHubRepo {
+            host: "github.a8c.com".to_string(),
+            owner: "Automattic".to_string(),
+            repo: "intelligence".to_string(),
+        };
+        let url = repo.release_artifact_url("v1.2.3", "intelligence.zip");
+        assert_eq!(
+            url,
+            "https://github.a8c.com/Automattic/intelligence/releases/download/v1.2.3/intelligence.zip"
         );
     }
 

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -186,6 +186,8 @@ pub(super) fn build_release_steps(
     let mut steps = Vec::new();
     let publish_targets = get_publish_targets(extensions);
 
+    add_release_extension_diagnostics(component, extensions, &publish_targets, options, warnings);
+
     if !publish_targets.is_empty() && !has_package_capability(extensions) {
         warnings.push(
             "Publish targets derived from extensions but no extension provides 'release.package'. \
@@ -349,6 +351,55 @@ pub(super) fn build_release_steps(
     Ok(steps)
 }
 
+fn add_release_extension_diagnostics(
+    component: &Component,
+    extensions: &[ExtensionManifest],
+    publish_targets: &[String],
+    options: &ReleaseOptions,
+    warnings: &mut Vec<String>,
+) {
+    if options.skip_publish || !publish_targets.is_empty() {
+        return;
+    }
+
+    let Some(configured) = component.extensions.as_ref() else {
+        return;
+    };
+    if configured.is_empty() {
+        return;
+    }
+
+    let mut configured_ids: Vec<String> = configured.keys().cloned().collect();
+    configured_ids.sort();
+    if !configured_ids.iter().any(|id| id == "wordpress") && !has_package_capability(extensions) {
+        return;
+    }
+
+    let loaded = extensions
+        .iter()
+        .map(|extension| {
+            let mut action_ids: Vec<&str> = extension
+                .actions
+                .iter()
+                .map(|action| action.id.as_str())
+                .collect();
+            action_ids.sort_unstable();
+            format!("{} [{}]", extension.id, action_ids.join(", "))
+        })
+        .collect::<Vec<_>>();
+
+    warnings.push(format!(
+        "Release publish planning found configured extensions ({}) but no extension provides \
+         'release.publish'. Loaded extension actions: {}.",
+        configured_ids.join(", "),
+        if loaded.is_empty() {
+            "none".to_string()
+        } else {
+            loaded.join("; ")
+        }
+    ));
+}
+
 fn build_changelog_steps(
     changelog_plan: &ReleaseChangelogPlan,
     current_version: &str,
@@ -403,7 +454,8 @@ fn string_array_config(key: &str, values: &[String]) -> StepConfig {
 #[cfg(test)]
 mod tests {
     use super::{build_preflight_steps, build_release_steps, github_release_applies};
-    use crate::component::Component;
+    use crate::component::{Component, ScopedExtensionConfig};
+    use crate::extension::ExtensionManifest;
     use crate::plan::PlanStepStatus;
     use crate::release::types::{
         ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation,
@@ -793,6 +845,54 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("release_plan")
         );
+    }
+
+    #[test]
+    fn release_plan_warns_when_configured_extensions_have_no_publish_action() {
+        let mut component = fixture_component();
+        component.extensions = Some(std::collections::HashMap::from([(
+            "wordpress".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+        let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "WordPress",
+            "version": "1.0.0",
+            "actions": [
+                {
+                    "id": "release.package",
+                    "label": "Package release",
+                    "type": "command",
+                    "command": "true"
+                }
+            ]
+        }))
+        .expect("extension manifest");
+        extension.id = "wordpress".to_string();
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+
+        let _steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.0",
+            "1.0.1",
+            &fixture_changelog_plan(),
+            &options,
+            None,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
+
+        assert!(warnings.iter().any(|warning| {
+            warning.contains("configured extensions (wordpress)")
+                && warning.contains("release.package")
+                && warning.contains("no extension provides 'release.publish'")
+        }));
     }
 
     #[test]

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -793,6 +793,7 @@ fn parse_github_parent_repo(raw: &str) -> std::result::Result<Option<GitHubRepo>
     let parsed: RawRepoParent = serde_json::from_str(raw.trim()).map_err(|e| e.to_string())?;
     Ok(if parsed.is_fork {
         parsed.parent.map(|parent| GitHubRepo {
+            host: "github.com".to_string(),
             owner: parent.owner.login,
             repo: parent.name,
         })
@@ -2550,6 +2551,7 @@ mod tests {
             assert_eq!(repo.owner, "chubes4");
             assert_eq!(repo.repo, "wordpress-playground");
             Ok(Some(GitHubRepo {
+                host: "github.com".to_string(),
                 owner: "WordPress".to_string(),
                 repo: "wordpress-playground".to_string(),
             }))


### PR DESCRIPTION
## Summary
- Accept GitHub Enterprise SSH/HTTPS remotes such as `github.a8c.com` in component remote validation.
- Preserve the parsed GitHub host when building release artifact URLs instead of hardcoding `github.com`.
- Add Homeboy's own `autofix_verify` gate and targeted release-plan diagnostics when package-capable WordPress extensions are missing `release.publish`.

Fixes #2562.
Helps diagnose #2572.
Addresses #1476.

## Testing
- `cargo fmt --check`
- `cargo test deploy::release_download --lib`
- `cargo test component::portable --lib`
- `cargo test release::plan_steps --lib`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-release-ghe-footguns --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-release-ghe-footguns --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the GHE remote parsing fix, safety config update, release-plan diagnostics, and verification runs; Chris remains responsible for review and merge.