### PR TITLE
feat(release): attach state.artifacts to github.release output

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -901,23 +901,102 @@ pub(crate) fn run_github_release(
         ));
     }
 
+    // Collect artifact paths from state. Populated by release.package
+    // (or any other extension action that emits artifact metadata into
+    // ReleaseState::artifacts). Passing these to `gh release create` or
+    // `gh release upload --clobber` attaches them to the Release in a
+    // single API call — keeping the github.release step responsible for
+    // the full Release lifecycle (entry + assets) instead of requiring a
+    // separate publish.<target> step.
+    let artifact_paths: Vec<String> = state
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.path.clone())
+        .collect();
+    let has_artifacts = !artifact_paths.is_empty();
+
     let repo_flag = format!("{}/{}", github.owner, github.repo);
     if gh_release_exists(&tag, &repo_flag) {
+        // Release entry already exists (idempotent retry, or release
+        // created out of band). When the release has no artifacts to
+        // attach, skip — there is nothing to update. When artifacts are
+        // present, upload them with --clobber so retries keep the latest
+        // build attached without duplicating the GitHub Release entry.
+        if !has_artifacts {
+            log_status!(
+                "release",
+                "GitHub Release {} already exists for {} — skipping (idempotent)",
+                tag,
+                repo_flag
+            );
+            return Ok(step_success(
+                "github.release",
+                "github.release",
+                Some(serde_json::json!({
+                    "skipped": true,
+                    "reason": "release-already-exists",
+                    "tag": tag,
+                    "owner": github.owner,
+                    "repo": github.repo,
+                })),
+                Vec::new(),
+            ));
+        }
+
         log_status!(
             "release",
-            "GitHub Release {} already exists for {} — skipping (idempotent)",
+            "GitHub Release {} already exists for {} — uploading {} artifact(s) with --clobber",
             tag,
-            repo_flag
+            repo_flag,
+            artifact_paths.len()
         );
+
+        let mut upload_args: Vec<&str> = vec!["release", "upload", &tag];
+        for path in &artifact_paths {
+            upload_args.push(path);
+        }
+        upload_args.extend_from_slice(&["--clobber", "-R", &repo_flag]);
+
+        let upload_output = std::process::Command::new("gh")
+            .args(&upload_args)
+            .output()
+            .map_err(|e| {
+                Error::internal_io(
+                    format!("Failed to invoke gh: {}", e),
+                    Some("gh release upload".to_string()),
+                )
+            })?;
+
+        if !upload_output.status.success() {
+            let stderr = String::from_utf8_lossy(&upload_output.stderr).to_string();
+            let stdout = String::from_utf8_lossy(&upload_output.stdout).to_string();
+            log_status!("release", "⚠ `gh release upload` failed: {}", stderr.trim());
+            return Ok(step_success(
+                "github.release",
+                "github.release",
+                Some(serde_json::json!({
+                    "skipped": true,
+                    "reason": "gh-upload-failed",
+                    "tag": tag,
+                    "owner": github.owner,
+                    "repo": github.repo,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "artifact_count": artifact_paths.len(),
+                })),
+                Vec::new(),
+            ));
+        }
+
         return Ok(step_success(
             "github.release",
             "github.release",
             Some(serde_json::json!({
-                "skipped": true,
-                "reason": "release-already-exists",
+                "action": "github.release.upload",
                 "tag": tag,
                 "owner": github.owner,
                 "repo": github.repo,
+                "artifact_count": artifact_paths.len(),
             })),
             Vec::new(),
         ));
@@ -938,29 +1017,38 @@ pub(crate) fn run_github_release(
         )
     })?;
 
+    let notes_path_str = notes_path.to_str().ok_or_else(|| {
+        Error::internal_unexpected("github.release: notes-file path is not valid UTF-8".to_string())
+    })?;
+
     log_status!(
         "release",
-        "Creating GitHub Release {} on {}...",
+        "Creating GitHub Release {} on {} with {} artifact(s)...",
         tag,
-        repo_flag
+        repo_flag,
+        artifact_paths.len()
     );
 
+    // Build args dynamically so we can append artifact paths as positional
+    // arguments — `gh release create <tag> [files...]` attaches each file
+    // as a Release asset in the same API call.
+    let mut create_args: Vec<&str> = vec![
+        "release",
+        "create",
+        &tag,
+        "--title",
+        &tag,
+        "--notes-file",
+        notes_path_str,
+        "-R",
+        &repo_flag,
+    ];
+    for path in &artifact_paths {
+        create_args.push(path);
+    }
+
     let output = std::process::Command::new("gh")
-        .args([
-            "release",
-            "create",
-            &tag,
-            "--title",
-            &tag,
-            "--notes-file",
-            notes_path.to_str().ok_or_else(|| {
-                Error::internal_unexpected(
-                    "github.release: notes-file path is not valid UTF-8".to_string(),
-                )
-            })?,
-            "-R",
-            &repo_flag,
-        ])
+        .args(&create_args)
         .output()
         .map_err(|e| {
             Error::internal_io(
@@ -1004,6 +1092,7 @@ pub(crate) fn run_github_release(
             "owner": github.owner,
             "repo": github.repo,
             "url": url,
+            "artifact_count": artifact_paths.len(),
         })),
         Vec::new(),
     ))


### PR DESCRIPTION
## Summary

Extend the built-in `github.release` step in `core::release::executor::run_github_release` to read `ReleaseState::artifacts` and pass each artifact path as a positional argument to `gh release create`. The `gh` CLI accepts `<tag> [files...]` for asset attachment, so a single call now creates the Release entry AND attaches every artifact the `release.package` step produced.

For idempotent retries where the Release entry already exists, the step now uploads artifacts via `gh release upload --clobber` instead of skipping. Without artifacts the old skip behavior is preserved so retries on already-complete releases stay cheap.

```diff
 // In run_github_release, after extension capability/auth checks:
+let artifact_paths: Vec<String> = state.artifacts.iter().map(|a| a.path.clone()).collect();
+let has_artifacts = !artifact_paths.is_empty();
+
 // ... existing gh_release_exists check ...
+ if has_artifacts {
+   // Upload via `gh release upload <tag> [files...] --clobber`
+ } else {
+   // Skip (existing behavior)
+ }
+
 // ... new release path:
-.args(["release", "create", &tag, "--title", &tag, "--notes-file", ..., "-R", &repo_flag])
+.args(&create_args)  // dynamic vec including <tag> [files...]
```

## Why now

This is the architectural seam needed to **dogfood homeboy's own release pipeline**. Today, homeboy's release workflow (`Extra-Chill/homeboy/.github/workflows/release.yml`, 698 lines) hand-rolls a cargo-dist cross-compile matrix that ends with `gh release create $TAG --title ... --notes-file ... artifacts/*` — because the homeboy planner's `github.release` step couldn't attach files. After this change, the cargo-dist matrix can still produce artifacts in a separate workflow job, but the final job invokes `homeboy release` and lets the planner's `github.release` step attach them — keeping a single canonical pipeline for the full Release lifecycle (entry + assets) instead of two parallel codepaths.

Downstream consequence: components like Extra-Chill/data-machine (which adopted the homeboy-native release pattern via the wordpress extension) can stop relying on a hand-rolled `release-asset.yml` triggered by `release.published`. The wordpress extension's `release.package` already populates `state.artifacts` with the built ZIP; this PR makes that ZIP automatically attach to the GitHub Release without a separate `publish.<target>` step.

## What this does NOT do

- **No extension contract changes.** The `release.publish` action shape stays the same. Extensions can still provide `release.publish` for registry-style uploads (crates.io, npm) without conflict with this built-in asset-attachment behavior.
- **No homeboy-action changes.** The wrapper's `--skip-publish` and `--no-github-release` flags continue to behave as before. Whether or not to invoke the github.release step is still a separate concern from what that step does.
- **No homeboy/.github/workflows/release.yml refactor.** The cargo-dist hand-rolled block is still there. The next PR (homeboy release workflow refactor) will delete the hand-rolled `gh release create artifacts/*` block and let the homeboy pipeline do the work — but that depends on this change landing first.

## Validation

- `cargo check --release` passes
- `cargo test --lib --release -- core::release` passes (145/145 tests)
- `cargo fmt --check` clean
- `cargo clippy --lib --release` clean on the changed file (`src/core/release/executor.rs`); pre-existing clippy warnings in other files are not touched by this PR

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Identified the architectural gap during a multi-PR debugging session about why Extra-Chill/data-machine's homeboy-native releases produced no assets. Traced through the planner, executor, and homeboy-action wrapper. Chris steered away from a band-aid `--skip-publish` opt-in change and toward the proper dogfooding refactor (this PR is phase 1 of 4).