### PR TITLE
refactor: decouple HTTP analysis jobs from commands

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -1,10 +1,11 @@
-use clap::{Args, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use serde::Serialize;
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use homeboy::daemon::{self, DaemonStartResult, DaemonStatus, DaemonStopResult};
+use homeboy::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
 
 use super::CmdResult;
 
@@ -54,7 +55,7 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
 
 fn serve(addr: &str) -> CmdResult<DaemonOutput> {
     let parsed = daemon::parse_bind_addr(addr)?;
-    let state = daemon::serve(parsed)?;
+    let state = daemon::serve_with_analysis_runner(parsed, CommandAnalysisJobRunner)?;
     Ok((
         DaemonOutput::Serve(DaemonStartResult {
             pid: state.pid,
@@ -109,5 +110,29 @@ fn start(addr: &str) -> CmdResult<DaemonOutput> {
         }
 
         thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandAnalysisJobRunner;
+
+impl AnalysisJobRunner for CommandAnalysisJobRunner {
+    fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::Result<AnalysisJobRunOutput> {
+        let cli = crate::cli_surface::Cli::try_parse_from(argv).map_err(|error| {
+            homeboy::Error::validation_invalid_argument(
+                "body",
+                error.to_string(),
+                None,
+                Some(vec![
+                    "Use the documented JSON request body contract for this endpoint".to_string(),
+                ]),
+            )
+        })?;
+        let global = crate::commands::GlobalArgs {};
+        let (result, exit_code) = crate::commands::run_json(cli.command, &global);
+        Ok(AnalysisJobRunOutput {
+            exit_code,
+            output: result?,
+        })
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 
 use crate::api_jobs::JobStore;
 use crate::error::{Error, Result};
-use crate::http_api::{self, HttpMethod};
+use crate::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::paths;
 use crate::source_snapshot::SourceSnapshot;
 
@@ -153,6 +153,13 @@ pub fn stop() -> Result<DaemonStopResult> {
 }
 
 pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
+    serve_with_analysis_runner(addr, UnsupportedAnalysisJobRunner)
+}
+
+pub fn serve_with_analysis_runner<R>(addr: SocketAddr, analysis_runner: R) -> Result<DaemonState>
+where
+    R: AnalysisJobRunner,
+{
     let listener = TcpListener::bind(addr)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("bind daemon to {}", addr))))?;
     let local_addr = listener.local_addr().map_err(|e| {
@@ -164,7 +171,7 @@ pub fn serve(addr: SocketAddr) -> Result<DaemonState> {
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                let _ = handle_connection(stream, &job_store);
+                let _ = handle_connection(stream, &job_store, analysis_runner.clone());
             }
             Err(err) => {
                 return Err(Error::internal_io(
@@ -192,6 +199,25 @@ fn route_with_job_store_and_body(
     body: Option<serde_json::Value>,
     job_store: &JobStore,
 ) -> HttpResponse {
+    route_with_job_store_and_body_and_runner(
+        method,
+        path,
+        body,
+        job_store,
+        UnsupportedAnalysisJobRunner,
+    )
+}
+
+fn route_with_job_store_and_body_and_runner<R>(
+    method: &str,
+    path: &str,
+    body: Option<serde_json::Value>,
+    job_store: &JobStore,
+    analysis_runner: R,
+) -> HttpResponse
+where
+    R: AnalysisJobRunner,
+{
     match (method, path) {
         ("GET", "/health") => HttpResponse {
             status_code: 200,
@@ -238,7 +264,7 @@ fn route_with_job_store_and_body(
             body: json!({ "error": "method_not_allowed" }),
             artifact: None,
         },
-        _ => route_read_only_api(method, path, body, job_store),
+        _ => route_read_only_api(method, path, body, job_store, analysis_runner),
     }
 }
 
@@ -383,6 +409,7 @@ fn route_read_only_api(
     path: &str,
     body: Option<serde_json::Value>,
     job_store: &JobStore,
+    analysis_runner: impl AnalysisJobRunner,
 ) -> HttpResponse {
     let method = match method {
         "GET" => HttpMethod::Get,
@@ -402,13 +429,14 @@ fn route_read_only_api(
         }
     }
 
-    match http_api::handle_with_jobs(
+    match http_api::handle_with_jobs_and_runner(
         http_api::HttpApiRequest {
             method,
             path: path.to_string(),
             body,
         },
         job_store,
+        analysis_runner,
     ) {
         Ok(response) => HttpResponse {
             status_code: response.status,
@@ -470,7 +498,14 @@ fn write_state(addr: SocketAddr) -> Result<DaemonState> {
     Ok(state)
 }
 
-fn handle_connection(mut stream: TcpStream, job_store: &JobStore) -> std::io::Result<()> {
+fn handle_connection<R>(
+    mut stream: TcpStream,
+    job_store: &JobStore,
+    analysis_runner: R,
+) -> std::io::Result<()>
+where
+    R: AnalysisJobRunner,
+{
     let mut buffer = [0; 64 * 1024];
     let bytes = stream.read(&mut buffer)?;
     let request = String::from_utf8_lossy(&buffer[..bytes]);
@@ -503,7 +538,13 @@ fn handle_connection(mut stream: TcpStream, job_store: &JobStore) -> std::io::Re
             }
         }
     };
-    let response = route_with_job_store_and_body(method, path, parsed_body, job_store);
+    let response = route_with_job_store_and_body_and_runner(
+        method,
+        path,
+        parsed_body,
+        job_store,
+        analysis_runner,
+    );
     write_http_response(stream, response)
 }
 

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -6,19 +6,22 @@
 //! so HTTP requests can return immediately while clients poll job events.
 
 use base64::Engine;
-use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::api_jobs::JobStore;
-use crate::cli_surface::{Cli, Commands};
-use crate::commands::{self, GlobalArgs};
 use crate::error::{Error, Result};
 use crate::observation::{
     running_status_note, FindingListFilter, ObservationStore, RunListFilter, RunRecord,
 };
 use crate::{component, git, rig, stack};
+
+mod analysis_job_runner;
+
+pub use analysis_job_runner::{
+    AnalysisJobRunOutput, AnalysisJobRunner, UnsupportedAnalysisJobRunner,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -238,6 +241,18 @@ pub fn handle(request: HttpApiRequest) -> Result<HttpApiResponse> {
 
 /// Execute a routed HTTP API request against the daemon-owned in-memory job store.
 pub fn handle_with_jobs(request: HttpApiRequest, job_store: &JobStore) -> Result<HttpApiResponse> {
+    handle_with_jobs_and_runner(request, job_store, UnsupportedAnalysisJobRunner)
+}
+
+/// Execute a routed HTTP API request with an injected analysis job runner.
+pub fn handle_with_jobs_and_runner<R>(
+    request: HttpApiRequest,
+    job_store: &JobStore,
+    analysis_runner: R,
+) -> Result<HttpApiResponse>
+where
+    R: AnalysisJobRunner,
+{
     let endpoint = route(request.method, &request.path)?;
     let body = match &endpoint {
         HttpEndpoint::Components => json!({
@@ -346,7 +361,9 @@ pub fn handle_with_jobs(request: HttpApiRequest, job_store: &JobStore) -> Result
             "command": "api.jobs.cancel",
             "job": job_store.cancel(parse_job_id(id)?, "cancel requested via HTTP API")?,
         }),
-        HttpEndpoint::JobReadyRun { kind } => enqueue_analysis_job(job_store, *kind, request.body)?,
+        HttpEndpoint::JobReadyRun { kind } => {
+            enqueue_analysis_job(job_store, *kind, request.body, analysis_runner)?
+        }
     };
 
     Ok(HttpApiResponse {
@@ -478,30 +495,29 @@ fn enqueue_analysis_job(
     job_store: &JobStore,
     kind: JobReadyRunKind,
     body: Option<Value>,
+    analysis_runner: impl AnalysisJobRunner,
 ) -> Result<Value> {
     let request = AnalysisJobRequest::from_body(kind, body)?;
     let argv = request.argv();
-    let command = parse_analysis_command(argv.clone())?;
     let operation = format!("analysis.{}", job_ready_slug(kind));
     let request_summary = request.summary();
+    let command_label = request.command_label();
     let runner = job_store.run_background(operation, move |job| {
         job.progress(json!({
             "phase": "started",
-            "command": request.command_label(),
+            "command": command_label,
             "job_id": job.job_id(),
         }))?;
 
-        let global = GlobalArgs {};
-        let (result, exit_code) = commands::run_json(command, &global);
-        let output = result?;
+        let output = analysis_runner.run_analysis_job(argv)?;
         job.progress(json!({
             "phase": "finished",
-            "exit_code": exit_code,
+            "exit_code": output.exit_code,
         }))?;
         Ok(json!({
-            "command": request.command_label(),
-            "exit_code": exit_code,
-            "output": output,
+            "command": command_label,
+            "exit_code": output.exit_code,
+            "output": output.output,
         }))
     });
     let job = job_store.get(runner.job_id)?;
@@ -515,20 +531,6 @@ fn enqueue_analysis_job(
         },
         "request": request_summary,
     }))
-}
-
-fn parse_analysis_command(argv: Vec<String>) -> Result<Commands> {
-    let cli = Cli::try_parse_from(argv).map_err(|error| {
-        Error::validation_invalid_argument(
-            "body",
-            error.to_string(),
-            None,
-            Some(vec![
-                "Use the documented JSON request body contract for this endpoint".to_string(),
-            ]),
-        )
-    })?;
-    Ok(cli.command)
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/http_api/analysis_job_runner.rs
+++ b/src/core/http_api/analysis_job_runner.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AnalysisJobRunOutput {
+    pub exit_code: i32,
+    pub output: Value,
+}
+
+pub trait AnalysisJobRunner: Clone + Send + 'static {
+    fn run_analysis_job(&self, argv: Vec<String>) -> Result<AnalysisJobRunOutput>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UnsupportedAnalysisJobRunner;
+
+impl AnalysisJobRunner for UnsupportedAnalysisJobRunner {
+    fn run_analysis_job(&self, _argv: Vec<String>) -> Result<AnalysisJobRunOutput> {
+        Err(Error::validation_invalid_argument(
+            "analysis_runner",
+            "analysis job runner is not configured for this HTTP API entrypoint",
+            None,
+            Some(vec![
+                "Run analysis job endpoints through the daemon command adapter".to_string(),
+            ]),
+        ))
+    }
+}

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -1,10 +1,35 @@
 use homeboy::api_jobs::{JobEventKind, JobStatus, JobStore};
-use homeboy::http_api::{self, HttpApiRequest, HttpEndpoint, HttpMethod, JobReadyRunKind};
+use homeboy::http_api::{
+    self, AnalysisJobRunOutput, AnalysisJobRunner, HttpApiRequest, HttpEndpoint, HttpMethod,
+    JobReadyRunKind,
+};
 use homeboy::observation::{
     NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
 };
 
 use crate::test_support::with_isolated_home;
+
+#[derive(Debug, Clone, Copy)]
+struct FakeAnalysisJobRunner;
+
+impl AnalysisJobRunner for FakeAnalysisJobRunner {
+    fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::Result<AnalysisJobRunOutput> {
+        Ok(AnalysisJobRunOutput {
+            exit_code: 0,
+            output: serde_json::json!({ "argv": argv }),
+        })
+    }
+}
+
+#[test]
+fn test_run_analysis_job() {
+    let output = FakeAnalysisJobRunner
+        .run_analysis_job(vec!["homeboy".to_string(), "lint".to_string()])
+        .expect("run analysis job");
+
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(output.output["argv"][1], "lint");
+}
 
 struct XdgGuard {
     prior: Option<String>,
@@ -402,7 +427,7 @@ fn job_ready_endpoint_rejects_unknown_body_fields() {
 #[test]
 fn job_ready_endpoint_preserves_background_result_events() {
     let store = JobStore::default();
-    let response = http_api::handle_with_jobs(
+    let response = http_api::handle_with_jobs_and_runner(
         HttpApiRequest {
             method: HttpMethod::Post,
             path: "/lint".to_string(),
@@ -413,6 +438,7 @@ fn job_ready_endpoint_preserves_background_result_events() {
             })),
         },
         &store,
+        FakeAnalysisJobRunner,
     )
     .expect("lint job enqueued");
     let job_id = response.body["job"]["id"].as_str().expect("job id");
@@ -436,6 +462,14 @@ fn job_ready_endpoint_preserves_background_result_events() {
     assert!(events
         .iter()
         .any(|event| { event.kind == JobEventKind::Result || event.kind == JobEventKind::Error }));
+    assert!(events.iter().any(|event| {
+        event.kind == JobEventKind::Result
+            && event.data.as_ref().is_some_and(|data| {
+                data["output"]["argv"]
+                    .as_array()
+                    .is_some_and(|argv| argv.iter().any(|arg| arg == "lint"))
+            })
+    }));
 }
 
 fn sample_run(kind: &str, component_id: &str, rig_id: &str) -> NewRunRecord {


### PR DESCRIPTION
## Summary
- Add an `AnalysisJobRunner` seam so `core::http_api` can enqueue analysis jobs without importing CLI command parsing/execution.
- Move the real CLI-backed analysis runner into the daemon command adapter used by `homeboy daemon serve`.
- Keep default core/daemon entrypoints non-command-aware with an unsupported runner, and cover HTTP job execution with an injected fake runner.

## Verification
- `cargo fmt && cargo check --all-targets`
- `cargo test http_api --lib -- --test-threads=1`
- `cargo test daemon --lib -- --test-threads=1`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/http-api-command-runner-seam-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the dependency seam, moved CLI-backed analysis execution to the command adapter, and ran local verification. Chris remains responsible for review and merge.