### PR TITLE
fix: guard runner doctor Unix probes

### DIFF
--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -743,6 +743,7 @@ mod probes {
         })
     }
 
+    #[cfg(unix)]
     pub fn local_disk_probe(path: &Path) -> Option<DiskProbe> {
         let c_path = std::ffi::CString::new(path.to_string_lossy().as_bytes()).ok()?;
         let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
@@ -751,14 +752,19 @@ mod probes {
             return None;
         }
         let stat = unsafe { stat.assume_init() };
-        let block_size: u64 = stat.f_frsize.max(1).into();
-        let total_blocks: u64 = stat.f_blocks.into();
-        let available_blocks: u64 = stat.f_bavail.into();
+        let block_size = stat.f_frsize.max(1);
+        let total_blocks = u64::from(stat.f_blocks);
+        let available_blocks = u64::from(stat.f_bavail);
         Some(DiskProbe {
             path: common::display_path(path),
             total_mb: total_blocks.saturating_mul(block_size) / 1024 / 1024,
             available_mb: available_blocks.saturating_mul(block_size) / 1024 / 1024,
         })
+    }
+
+    #[cfg(not(unix))]
+    pub fn local_disk_probe(_path: &Path) -> Option<DiskProbe> {
+        None
     }
 
     pub fn remote_disk_probe(client: &SshClient, path: &str) -> Option<DiskProbe> {
@@ -793,12 +799,20 @@ mod probes {
         client.execute(command).success
     }
 
+    #[cfg(unix)]
     pub fn local_path_writable(path: &Path) -> bool {
         let c_path = match std::ffi::CString::new(path.to_string_lossy().as_bytes()) {
             Ok(path) => path,
             Err(_) => return false,
         };
         unsafe { libc::access(c_path.as_ptr(), libc::W_OK) == 0 }
+    }
+
+    #[cfg(not(unix))]
+    pub fn local_path_writable(path: &Path) -> bool {
+        fs::metadata(path)
+            .map(|metadata| !metadata.permissions().readonly())
+            .unwrap_or(false)
     }
 
     pub fn local_path_or_parent_writable(path: &Path) -> bool {


### PR DESCRIPTION
## Summary
- Guard runner doctor local disk probes behind `#[cfg(unix)]` so Windows builds do not reference Unix-only `libc::statvfs` APIs.
- Add non-Unix fallbacks for local disk and writability checks to keep runner doctor diagnostics best-effort on Windows.

Fixes #2580.

## Validation
- `cargo fmt --check`
- `cargo check --lib`
- `cargo test --lib runner::doctor`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-windows-runner-doctor --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-windows-runner-doctor --extension rust --changed-since origin/main`

## Notes
- Local macOS cross-check for `x86_64-pc-windows-msvc` is blocked by missing Windows/MSVC C headers for `zstd-sys`; GitHub's Windows runner is the authoritative validation for the release-build failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Windows release-build failure, drafted the platform guards/fallbacks, and ran local validation. Chris directed the issue selection and PR creation.