### PR TITLE
test: guard core command boundary

### DIFF
--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -4,6 +4,81 @@ fn source_file(relative_path: &str) -> String {
 }
 
 #[test]
+fn core_source_does_not_depend_on_command_layer() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let core_root = root.join("src/core");
+    let forbidden = [
+        "use crate::commands",
+        "crate::commands::",
+        "use homeboy::commands",
+        "homeboy::commands::",
+        "use crate::cli_surface",
+        "crate::cli_surface::",
+        "use homeboy::cli_surface",
+        "homeboy::cli_surface::",
+    ];
+    let mut violations = Vec::new();
+
+    scan_core_source_for_command_layer(root, &core_root, &forbidden, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "core source must not depend on the command/CLI layer:\n{}\n\nMove command parsing/execution behind an injected adapter owned by src/commands.",
+        violations.join("\n")
+    );
+}
+
+fn scan_core_source_for_command_layer(
+    root: &std::path::Path,
+    path: &std::path::Path,
+    forbidden: &[&str],
+    violations: &mut Vec<String>,
+) {
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read core source directory") {
+            let entry = entry.expect("read core source entry");
+            scan_core_source_for_command_layer(root, &entry.path(), forbidden, violations);
+        }
+        return;
+    }
+
+    if path.extension().is_none_or(|extension| extension != "rs") {
+        return;
+    }
+
+    let content = std::fs::read_to_string(path).expect("read core source file");
+    let relative = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+    let mut skip_rest_as_test_module = false;
+
+    for (index, line) in content.lines().enumerate() {
+        if line.trim() == "#[cfg(test)]" {
+            skip_rest_as_test_module = true;
+            continue;
+        }
+        if skip_rest_as_test_module {
+            continue;
+        }
+
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+            continue;
+        }
+
+        for term in forbidden {
+            if line.contains(term) {
+                violations.push(format!("{relative}:{} contains `{term}`", index + 1));
+            }
+        }
+    }
+}
+
+#[test]
 fn validate_and_format_writes_do_not_select_ecosystem_commands() {
     let files = [
         "src/core/engine/validate_write.rs",


### PR DESCRIPTION
## Summary
- Add an architecture guard that scans production `src/core/**/*.rs` for direct command/CLI layer dependencies.
- Skip comments and test-only modules so fixture references do not create false positives.
- Point future violations toward injected adapters owned by `src/commands`.

## Verification
- `cargo fmt --check && cargo test --test architecture_core_agnostic_test`
- `homeboy audit --path "/Users/chubes/Developer/homeboy@trace-run-record-builder" --extension rust --changed-since origin/main --output "/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/guard-core-command-boundary-audit.json"`
- `homeboy lint --path "/Users/chubes/Developer/homeboy@trace-run-record-builder" --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the architecture guard test, ran focused validation, and prepared the PR summary for Chris to review.