### PR TITLE
refactor: require explicit core paths

### DIFF
--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use homeboy::server::api;
+use homeboy::core::server::api;
 
 use super::CmdResult;
 

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -1,12 +1,12 @@
 use clap::Args;
 use std::path::Path;
 
-use homeboy::code_audit::{
+use homeboy::core::code_audit::{
     self, report, run_main_audit_workflow, AuditCommandOutput, AuditRunWorkflowArgs,
 };
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::git::short_head_revision_at;
-use homeboy::observation::{
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::git::short_head_revision_at;
+use homeboy::core::observation::{
     finding_records_from_audit, NewRunRecord, ObservationStore, RunRecord, RunStatus,
 };
 
@@ -53,13 +53,14 @@ pub struct AuditArgs {
 fn parse_finding_kinds(
     values: &[String],
     flag: &str,
-) -> homeboy::Result<Vec<code_audit::AuditFinding>> {
+) -> homeboy::core::Result<Vec<code_audit::AuditFinding>> {
     use std::str::FromStr;
     values
         .iter()
         .map(|value| {
-            code_audit::AuditFinding::from_str(value)
-                .map_err(|msg| homeboy::Error::validation_invalid_argument(flag, msg, None, None))
+            code_audit::AuditFinding::from_str(value).map_err(|msg| {
+                homeboy::core::Error::validation_invalid_argument(flag, msg, None, None)
+            })
         })
         .collect()
 }
@@ -113,7 +114,7 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         exclude_kinds,
         only_labels: args.only,
         exclude_labels: args.exclude,
-        baseline_flags: homeboy::engine::baseline::BaselineFlags {
+        baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
             baseline: args.baseline_args.baseline,
             ignore_baseline: args.baseline_args.ignore_baseline,
             ratchet: args.baseline_args.ratchet,
@@ -199,7 +200,10 @@ fn finish_audit_observation(
         .finish_run(&observation.audit_run.id, status, Some(metadata));
 }
 
-fn finish_audit_observation_error(observation: Option<AuditObservation>, error: &homeboy::Error) {
+fn finish_audit_observation_error(
+    observation: Option<AuditObservation>,
+    error: &homeboy::core::Error,
+) {
     let Some(observation) = observation else {
         return;
     };
@@ -354,7 +358,7 @@ fn run_audit_reference_setup(component_id_or_path: &str) {
     }
 
     // Load component to find its extensions
-    let comp = match homeboy::component::load(component_id_or_path) {
+    let comp = match homeboy::core::component::load(component_id_or_path) {
         Ok(c) => c,
         Err(_) => return,
     };
@@ -365,7 +369,7 @@ fn run_audit_reference_setup(component_id_or_path: &str) {
     };
 
     for ext_id in extensions.keys() {
-        let ext_manifest = match homeboy::extension::load_extension(ext_id) {
+        let ext_manifest = match homeboy::core::extension::load_extension(ext_id) {
             Ok(m) => m,
             Err(_) => continue,
         };
@@ -376,7 +380,7 @@ fn run_audit_reference_setup(component_id_or_path: &str) {
         };
 
         // Resolve script path relative to extension directory
-        let ext_path = homeboy::extension::extension_path(ext_id);
+        let ext_path = homeboy::core::extension::extension_path(ext_id);
         if !ext_path.is_dir() {
             continue;
         }
@@ -532,7 +536,7 @@ mod tests {
 
             finish_audit_observation_error(
                 Some(observation),
-                &homeboy::Error::validation_invalid_argument(
+                &homeboy::core::Error::validation_invalid_argument(
                     "fixture",
                     "simulated audit error",
                     None,
@@ -600,10 +604,10 @@ mod tests {
 
             let store = ObservationStore::open_initialized().expect("store");
             let findings = store
-                .list_findings(homeboy::observation::FindingListFilter {
+                .list_findings(homeboy::core::observation::FindingListFilter {
                     run_id: Some(run_id),
                     tool: Some("audit".to_string()),
-                    ..homeboy::observation::FindingListFilter::default()
+                    ..homeboy::core::observation::FindingListFilter::default()
                 })
                 .expect("list findings");
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -2,10 +2,10 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::collections::HashMap;
 
-use homeboy::server::auth::{
+use homeboy::core::server::auth::{
     self, AuthStatus, GetResult, LoginResult, LogoutResult, RemoveResult, SetResult,
 };
-use homeboy::server::auth_profiles::{
+use homeboy::core::server::auth_profiles::{
     self, ProfileRemoveResult, ProfileSetResult, ProfileStatusResult,
 };
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -4,16 +4,16 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::thread;
 
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::bench as extension_bench;
-use homeboy::extension::bench::{
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::bench as extension_bench;
+use homeboy::core::extension::bench::{
     aggregate_comparison_with_axes, BenchCommandOutput, BenchComparisonOutput,
     BenchComparisonSummaryOutput, BenchDefaultBaselineExpansion, BenchListWorkflowArgs,
     BenchListWorkflowResult, RigBenchEntry, DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
-use homeboy::extension::ExtensionCapability;
-use homeboy::rig::{self, RigSpec};
+use homeboy::core::extension::ExtensionCapability;
+use homeboy::core::rig::{self, RigSpec};
 
 use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs,
@@ -366,7 +366,7 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
     // in sequence by default, or in bounded parallel batches when the user
     // explicitly opts in with --rig-concurrency.
     if run_args.baseline_args.baseline {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--baseline",
             "Cannot --baseline a cross-rig run; baselines are per-rig. \
              Run `homeboy bench --rig <id> --baseline` once per rig you \
@@ -376,7 +376,7 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
         ));
     }
     if run_args.baseline_args.ratchet {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--ratchet",
             "Cannot --ratchet a cross-rig run; baselines are per-rig. \
              Run `homeboy bench --rig <id> --ratchet` once per rig.",
@@ -447,9 +447,9 @@ struct CrossRigBenchOutput {
 }
 
 fn add_default_baseline_failure_hint(
-    error: homeboy::Error,
+    error: homeboy::core::Error,
     metadata: Option<&BenchDefaultBaselineExpansion>,
-) -> homeboy::Error {
+) -> homeboy::core::Error {
     let Some(metadata) = metadata else {
         return error;
     };
@@ -500,7 +500,7 @@ fn run_cross_rig_benches(
     run_args: &BenchRunArgs,
     passthrough_args: &[String],
     ordered_rigs: Vec<String>,
-) -> homeboy::Result<Vec<CrossRigBenchOutput>> {
+) -> homeboy::core::Result<Vec<CrossRigBenchOutput>> {
     if run_args.rig_concurrency <= 1 || ordered_rigs.len() <= 1 {
         return ordered_rigs
             .into_iter()
@@ -524,11 +524,11 @@ fn run_cross_rig_benches(
                 .into_iter()
                 .map(|handle| match handle.join() {
                     Ok(result) => result,
-                    Err(_) => Err(homeboy::Error::internal_unexpected(
+                    Err(_) => Err(homeboy::core::Error::internal_unexpected(
                         "bench rig worker panicked during parallel comparison",
                     )),
                 })
-                .collect::<homeboy::Result<Vec<_>>>()
+                .collect::<homeboy::core::Result<Vec<_>>>()
         })?;
         outputs.append(&mut chunk_outputs);
     }
@@ -540,7 +540,7 @@ fn run_cross_rig_bench(
     run_args: &BenchRunArgs,
     passthrough_args: &[String],
     rig_id: String,
-) -> homeboy::Result<CrossRigBenchOutput> {
+) -> homeboy::core::Result<CrossRigBenchOutput> {
     let axes = rig_axes(&rig_id)?;
     let (output, _exit) = matrix::run_single(run_args, passthrough_args, Some(rig_id.clone()))?;
     Ok(CrossRigBenchOutput {
@@ -550,7 +550,7 @@ fn run_cross_rig_bench(
     })
 }
 
-fn rig_axes(rig_id: &str) -> homeboy::Result<Option<BTreeMap<String, String>>> {
+fn rig_axes(rig_id: &str) -> homeboy::core::Result<Option<BTreeMap<String, String>>> {
     let spec = rig::load(rig_id)?;
     let Some(bench) = spec.bench else {
         return Ok(None);
@@ -570,12 +570,12 @@ fn ordered_rig_ids(args: &BenchRunArgs) -> Vec<String> {
     rig_ids
 }
 
-fn validate_report_selection_for_single_run(args: &BenchRunArgs) -> homeboy::Result<()> {
+fn validate_report_selection_for_single_run(args: &BenchRunArgs) -> homeboy::core::Result<()> {
     if args.report.is_empty() {
         return Ok(());
     }
 
-    Err(homeboy::Error::validation_invalid_argument(
+    Err(homeboy::core::Error::validation_invalid_argument(
         "--report",
         "Bench reports are only available for multi-rig comparisons. Pass two or more --rig values, for example: --rig baseline,candidate --report side-by-side.",
         None,
@@ -628,7 +628,7 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
         .unwrap_or_default();
 
     let run_dir = RunDir::create()?;
-    let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
+    let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
         "bench list {}",
         effective_id
     )));
@@ -657,7 +657,7 @@ struct ListRigContext {
     package_root: Option<PathBuf>,
 }
 
-fn load_list_rig(args: &BenchListArgs) -> homeboy::Result<Option<ListRigContext>> {
+fn load_list_rig(args: &BenchListArgs) -> homeboy::core::Result<Option<ListRigContext>> {
     match args.rig.as_slice() {
         [] => Ok(None),
         [rig_id] => {
@@ -666,7 +666,7 @@ fn load_list_rig(args: &BenchListArgs) -> homeboy::Result<Option<ListRigContext>
                 .map(|metadata| PathBuf::from(metadata.package_path));
             Ok(Some(ListRigContext { spec, package_root }))
         }
-        _ => Err(homeboy::Error::validation_invalid_argument(
+        _ => Err(homeboy::core::Error::validation_invalid_argument(
             "--rig",
             "bench list accepts exactly one rig id",
             None,
@@ -678,7 +678,7 @@ fn load_list_rig(args: &BenchListArgs) -> homeboy::Result<Option<ListRigContext>
 fn resolve_list_component_id(
     args: &BenchListArgs,
     rig_spec: Option<&RigSpec>,
-) -> homeboy::Result<String> {
+) -> homeboy::core::Result<String> {
     if let Some(id) = args.comp.id() {
         return Ok(id.to_string());
     }
@@ -692,7 +692,7 @@ fn resolve_list_component_id(
             return Ok(default);
         }
 
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "bench.default_component",
             format!(
                 "rig '{}' does not declare bench.default_component; pass a component id or add bench.default_component to the rig spec",
@@ -706,7 +706,10 @@ fn resolve_list_component_id(
     args.comp.resolve_id()
 }
 
-fn run_rig_workload_preflight(spec: &RigSpec, extension_id: Option<&str>) -> homeboy::Result<()> {
+fn run_rig_workload_preflight(
+    spec: &RigSpec,
+    extension_id: Option<&str>,
+) -> homeboy::core::Result<()> {
     let groups = extension_id.and_then(|id| {
         rig::check_groups_for_extension_workloads(spec, rig::RigWorkloadKind::Bench, id)
     });
@@ -715,7 +718,7 @@ fn run_rig_workload_preflight(spec: &RigSpec, extension_id: Option<&str>) -> hom
         None => rig::run_check(spec)?,
     };
     if !check.success {
-        return Err(homeboy::Error::rig_pipeline_failed(
+        return Err(homeboy::core::Error::rig_pipeline_failed(
             &spec.id,
             "check",
             "rig check failed; refusing to list bench workloads for an unhealthy rig",
@@ -769,7 +772,7 @@ fn default_baseline_notice(metadata: &BenchDefaultBaselineExpansion) -> String {
 
 fn maybe_expand_default_baseline(
     args: &BenchRunArgs,
-) -> homeboy::Result<Option<DefaultBaselineExpansion>> {
+) -> homeboy::core::Result<Option<DefaultBaselineExpansion>> {
     if args.rig.len() != 1 {
         return Ok(None);
     }
@@ -797,7 +800,7 @@ fn maybe_expand_default_baseline(
     };
 
     if baseline_rig_id == *candidate {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "bench.default_baseline_rig",
             format!(
                 "rig '{}' declares itself as its own default_baseline_rig; \

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -1,19 +1,19 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use homeboy::component::Component;
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::engine::invocation::InvocationRequirements;
-use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::bench as extension_bench;
-use homeboy::extension::bench::report::collect_artifacts;
-use homeboy::extension::bench::{
+use homeboy::core::component::Component;
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::engine::invocation::InvocationRequirements;
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::bench as extension_bench;
+use homeboy::core::extension::bench::report::collect_artifacts;
+use homeboy::core::extension::bench::{
     BenchCommandOutput, BenchGate, BenchResults, BenchRunExecution, BenchRunWorkflowArgs,
     BenchRunWorkflowResult,
 };
-use homeboy::extension::ExtensionCapability;
-use homeboy::rig::lease::ActiveRigRunLease;
-use homeboy::rig::{self, BenchSpec, RigSpec, RigStateSnapshot};
+use homeboy::core::extension::ExtensionCapability;
+use homeboy::core::rig::lease::ActiveRigRunLease;
+use homeboy::core::rig::{self, BenchSpec, RigSpec, RigStateSnapshot};
 
 use super::observation::{self, BenchObservationStart};
 use super::{BenchRunArgs, CmdResult};
@@ -26,7 +26,7 @@ struct RigBenchContext {
     _lease: Option<ActiveRigRunLease>,
 }
 
-fn prepare_rig_bench_context(rig_id: &str) -> homeboy::Result<RigBenchContext> {
+fn prepare_rig_bench_context(rig_id: &str) -> homeboy::core::Result<RigBenchContext> {
     let spec = rig::load(rig_id)?;
     let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
     let snapshot = rig::snapshot_state(&spec);
@@ -58,7 +58,7 @@ fn rig_bench_components(spec: &RigSpec) -> Vec<String> {
 pub(super) fn validate_profile_available_for_rigs(
     rig_ids: &[String],
     profile: &str,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let mut missing = Vec::new();
     let mut available_by_rig = Vec::new();
 
@@ -80,7 +80,7 @@ pub(super) fn validate_profile_available_for_rigs(
         .collect::<Vec<_>>()
         .join("; ");
 
-    Err(homeboy::Error::validation_invalid_argument(
+    Err(homeboy::core::Error::validation_invalid_argument(
         "profile",
         format!(
             "bench profile '{}' is not defined by rig(s): {}; available profiles: {}",
@@ -110,13 +110,13 @@ fn format_available_profiles(profiles: &[String]) -> String {
 fn selected_scenario_ids(
     args: &BenchRunArgs,
     rig_spec: Option<&RigSpec>,
-) -> homeboy::Result<Vec<String>> {
+) -> homeboy::core::Result<Vec<String>> {
     let Some(profile) = &args.profile else {
         return Ok(args.scenario_ids.clone());
     };
 
     let Some(spec) = rig_spec else {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "profile",
             "--profile requires --rig because profiles are declared in rig specs",
             Some(profile.clone()),
@@ -126,7 +126,7 @@ fn selected_scenario_ids(
 
     let Some(scenario_ids) = spec.bench_profiles.get(profile) else {
         let available = available_profile_names(spec);
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "profile",
             format!(
                 "unknown bench profile '{}' for rig '{}'; available profiles: {}",
@@ -452,7 +452,7 @@ fn run_component_with_rig_context(
     }
 
     let run_dir = RunDir::create()?;
-    let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
+    let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
         "bench {}",
         effective_id
     )));
@@ -487,7 +487,7 @@ fn run_component_with_rig_context(
                 runs: args.runs,
                 concurrency: args.concurrency,
             },
-            baseline_flags: homeboy::engine::baseline::BaselineFlags {
+            baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
                 baseline: args.baseline_args.baseline,
                 ignore_baseline: args.baseline_args.ignore_baseline,
                 ratchet: args.baseline_args.ratchet,
@@ -557,7 +557,10 @@ fn rig_workload_runtime_inputs(
     )
 }
 
-fn run_rig_workload_preflight(spec: &RigSpec, extension_id: Option<&str>) -> homeboy::Result<()> {
+fn run_rig_workload_preflight(
+    spec: &RigSpec,
+    extension_id: Option<&str>,
+) -> homeboy::core::Result<()> {
     let groups = extension_id.and_then(|id| {
         rig::check_groups_for_extension_workloads(spec, rig::RigWorkloadKind::Bench, id)
     });
@@ -566,7 +569,7 @@ fn run_rig_workload_preflight(spec: &RigSpec, extension_id: Option<&str>) -> hom
         None => rig::run_check(spec)?,
     };
     if !check.success {
-        return Err(homeboy::Error::rig_pipeline_failed(
+        return Err(homeboy::core::Error::rig_pipeline_failed(
             &spec.id,
             "check",
             "rig check failed; refusing to run bench against an unhealthy rig",
@@ -702,12 +705,12 @@ mod tests {
         assert_eq!(scenario_gates.len(), 2);
         assert!(scenario_gates.iter().any(|gate| {
             gate.metric == "native_block_quality_pass"
-                && gate.op == homeboy::extension::bench::BenchGateOp::Eq
+                && gate.op == homeboy::core::extension::bench::BenchGateOp::Eq
                 && gate.value == 1.0
         }));
         assert!(scenario_gates.iter().any(|gate| {
             gate.metric == "tool_error_count"
-                && gate.op == homeboy::extension::bench::BenchGateOp::Lte
+                && gate.op == homeboy::core::extension::bench::BenchGateOp::Lte
                 && gate.value == 0.0
         }));
     }

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -1,14 +1,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use homeboy::engine::run_dir::{self, RunDir};
-use homeboy::extension::bench::report::collect_artifacts;
-use homeboy::extension::bench::{BenchResults, BenchRunWorkflowResult};
-use homeboy::git::short_head_revision_at;
-use homeboy::observation::{
+use homeboy::core::engine::run_dir::{self, RunDir};
+use homeboy::core::extension::bench::report::collect_artifacts;
+use homeboy::core::extension::bench::{BenchResults, BenchRunWorkflowResult};
+use homeboy::core::git::short_head_revision_at;
+use homeboy::core::observation::{
     finding_records_from_budget, merge_metadata, ActiveObservation, NewRunRecord, RunStatus,
 };
-use homeboy::rig::RigStateSnapshot;
+use homeboy::core::rig::RigStateSnapshot;
 
 use crate::commands::utils::resource_policy;
 
@@ -110,7 +110,7 @@ pub(super) fn history_hints(summary: &BenchObservationSummary) -> Vec<String> {
 
 pub(super) fn finish_error(
     observation: Option<BenchObservation>,
-    error: &homeboy::Error,
+    error: &homeboy::core::Error,
     run_dir: &RunDir,
 ) {
     let Some(observation) = observation else {
@@ -312,7 +312,7 @@ fn persist_bench_result_artifact_paths(
 
 fn persist_bench_artifact_path(
     observation: &BenchObservation,
-    artifact: &mut homeboy::extension::bench::BenchArtifact,
+    artifact: &mut homeboy::core::extension::bench::BenchArtifact,
     run_dir: &RunDir,
 ) {
     let Some(path) = artifact.path.as_deref() else {
@@ -392,10 +392,10 @@ fn resolve_preserved_invocation_artifact(path: &Path, run_dir: &RunDir) -> Optio
 mod tests {
     use std::fs;
 
-    use homeboy::engine::run_dir::{self, RunDir};
-    use homeboy::extension::bench::artifact::BenchArtifact;
-    use homeboy::extension::bench::{BenchResults, BenchRunWorkflowResult};
-    use homeboy::observation::ObservationStore;
+    use homeboy::core::engine::run_dir::{self, RunDir};
+    use homeboy::core::extension::bench::artifact::BenchArtifact;
+    use homeboy::core::extension::bench::{BenchResults, BenchRunWorkflowResult};
+    use homeboy::core::observation::ObservationStore;
 
     use super::*;
     use crate::commands::bench::BenchRigOrder;
@@ -848,7 +848,7 @@ mod tests {
             })
             .expect("start observation");
             let run_id = observation.run_id().to_string();
-            let error = homeboy::Error::validation_invalid_argument(
+            let error = homeboy::core::Error::validation_invalid_argument(
                 "bench",
                 "synthetic bench error",
                 None,

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::test_support::with_isolated_home;
 use clap::Parser;
-use homeboy::extension::bench::aggregate_comparison;
+use homeboy::core::extension::bench::aggregate_comparison;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,9 +1,9 @@
 use clap::Args;
-use homeboy::build;
-use homeboy::component;
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::extension::ExtensionCapability;
-use homeboy::project;
+use homeboy::core::build;
+use homeboy::core::component;
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::extension::ExtensionCapability;
+use homeboy::core::project;
 
 use crate::commands::utils::resolve::resolve_project_components;
 use crate::commands::CmdResult;
@@ -53,7 +53,7 @@ pub fn run(
     }
 
     let target_id = args.target_id.as_ref().ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "input",
             "Provide component ID, project ID with --all, or JSON spec",
             None,
@@ -67,7 +67,7 @@ pub fn run(
     // --all mode: build all components in project
     if args.all {
         let proj = project::load(target_id).map_err(|e| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "project_id",
                 format!("'{}' is not a valid project ID", target_id),
                 None,
@@ -80,7 +80,7 @@ pub fn run(
         })?;
 
         if proj.components.is_empty() {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "project_id",
                 format!("Project '{}' has no components configured", target_id),
                 None,
@@ -109,7 +109,7 @@ pub fn run(
             .collect();
 
         if !invalid.is_empty() {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "component_ids",
                 format!(
                     "Components not in project '{}': {}",

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use super::CmdResult;
-use homeboy::changelog::{self, ShowOutput};
+use homeboy::core::release::changelog::{self, ShowOutput};
 
 #[derive(Args)]
 pub struct ChangelogArgs {
@@ -51,7 +51,7 @@ pub fn run_markdown(args: ChangelogArgs) -> CmdResult<String> {
             let output = changelog::show(id)?;
             Ok((output.content, 0))
         }
-        (None, false) => Err(homeboy::Error::validation_invalid_argument(
+        (None, false) => Err(homeboy::core::Error::validation_invalid_argument(
             "command",
             "No subcommand provided. Use 'show' or --self to view Homeboy's changelog",
             None,
@@ -90,7 +90,7 @@ pub fn run(
             let output = changelog::show(id)?;
             Ok((ChangelogOutput::ShowComponent(output), 0))
         }
-        (None, false) => Err(homeboy::Error::validation_invalid_argument(
+        (None, false) => Err(homeboy::core::Error::validation_invalid_argument(
             "command",
             "No subcommand provided. Use 'show' or --self to view Homeboy's changelog",
             None,

--- a/src/commands/changes.rs
+++ b/src/commands/changes.rs
@@ -1,10 +1,10 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::context;
-use homeboy::git::{self, ChangesOutput};
-use homeboy::project;
-use homeboy::BulkResult;
+use homeboy::core::context;
+use homeboy::core::git::{self, ChangesOutput};
+use homeboy::core::project;
+use homeboy::core::BulkResult;
 
 use super::utils::resolve::resolve_project_components;
 use super::CmdResult;
@@ -125,7 +125,7 @@ pub fn run(
     }
 
     // Multiple components or unmanaged: return error with helpful hints
-    let mut err = homeboy::Error::validation_invalid_argument(
+    let mut err = homeboy::core::Error::validation_invalid_argument(
         "input",
         "No component ID provided",
         None,
@@ -148,9 +148,9 @@ pub fn run(
     Err(err)
 }
 
-fn reject_path_for_bulk(path: Option<&str>, mode: &str) -> homeboy::Result<()> {
+fn reject_path_for_bulk(path: Option<&str>, mode: &str) -> homeboy::core::Result<()> {
     if path.is_some() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "path",
             format!(
                 "--path is only supported for single-component changes, not {}",

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -1,4 +1,4 @@
-use homeboy::engine::cli_tool::{self, CliToolResult};
+use homeboy::core::engine::cli_tool::{self, CliToolResult};
 use serde::Serialize;
 
 use super::CmdResult;

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -4,9 +4,9 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use homeboy::component::{self, Component};
-use homeboy::project::{self, Project};
-use homeboy::EntityCrudOutput;
+use homeboy::core::component::{self, Component};
+use homeboy::core::project::{self, Project};
+use homeboy::core::EntityCrudOutput;
 
 use super::{CmdResult, DynamicSetArgs};
 
@@ -190,7 +190,7 @@ pub fn run(
             project,
         } => {
             if json.is_some() || skip_existing {
-                return Err(homeboy::Error::validation_invalid_argument(
+                return Err(homeboy::core::Error::validation_invalid_argument(
                     "component.create",
                     "component create now initializes repo-owned homeboy.json from flags; JSON bulk create is legacy and no longer supported here",
                     None,
@@ -202,7 +202,7 @@ pub fn run(
             }
 
             let local_path = local_path.ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "local_path",
                     "Missing required argument: --local-path",
                     None,
@@ -221,10 +221,10 @@ pub fn run(
                 Component::new(id.clone(), local_path.clone(), remote_path, build_artifact);
 
             new_component.version_targets = if let Some(json_spec) = version_targets_json {
-                let raw = homeboy::config::read_json_spec_to_string(&json_spec)?;
-                serde_json::from_str::<Vec<homeboy::component::VersionTarget>>(&raw)
+                let raw = homeboy::core::config::read_json_spec_to_string(&json_spec)?;
+                serde_json::from_str::<Vec<homeboy::core::component::VersionTarget>>(&raw)
                     .map_err(|e| {
-                        homeboy::Error::validation_invalid_json(
+                        homeboy::core::Error::validation_invalid_json(
                             e,
                             Some("parse version targets JSON".to_string()),
                             Some(raw.chars().take(200).collect::<String>()),
@@ -242,7 +242,7 @@ pub fn run(
             // the actual changelog location on disk so generated homeboy.json
             // files don't ship with a path that doesn't exist. (#1128)
             new_component.changelog_target = changelog_target.or_else(|| {
-                homeboy::release::changelog::discover_changelog_relative_path(repo_path)
+                homeboy::core::release::changelog::discover_changelog_relative_path(repo_path)
             });
 
             if !extensions.is_empty() {
@@ -259,7 +259,7 @@ pub fn run(
             // discoverable by ID from any directory (#1131). This is a
             // lightweight pointer file in ~/.config/homeboy/components/<id>.json.
             if let Err(e) =
-                homeboy::component::inventory::write_standalone_registration(&new_component)
+                homeboy::core::component::inventory::write_standalone_registration(&new_component)
             {
                 eprintln!("Warning: could not write standalone registration: {}", e);
             }
@@ -365,7 +365,7 @@ fn reconcile(id: &str, apply: bool) -> CmdResult<ComponentOutput> {
             command: "component.reconcile".to_string(),
             id: Some(id.to_string()),
             entity: Some(serde_json::to_value(&report).map_err(|error| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "component.reconcile",
                     "Failed to serialize reconcile report",
                     Some(error.to_string()),
@@ -406,7 +406,10 @@ fn suggest_project_for_path(local_path: &str) -> Option<String> {
     None
 }
 
-fn derive_component_id_for_create(repo_path: &Path, local_path: &str) -> homeboy::Result<String> {
+fn derive_component_id_for_create(
+    repo_path: &Path,
+    local_path: &str,
+) -> homeboy::core::Result<String> {
     if repo_path.join("homeboy.json").exists() {
         return component::infer_portable_component_id(repo_path);
     }
@@ -415,7 +418,7 @@ fn derive_component_id_for_create(repo_path: &Path, local_path: &str) -> homeboy
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "local_path",
                 "Could not derive component ID from local path",
                 Some(local_path.to_string()),
@@ -423,7 +426,7 @@ fn derive_component_id_for_create(repo_path: &Path, local_path: &str) -> homeboy
             )
         })?;
 
-    homeboy::engine::identifier::slugify_id(dir_name, "component_id")
+    homeboy::core::engine::identifier::slugify_id(dir_name, "component_id")
 }
 
 fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
@@ -432,7 +435,7 @@ fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         (_, Some(dir)) => {
             let dir_path = std::path::Path::new(dir);
             component::resolve_effective(id, Some(dir), None).map_err(|_| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "path",
                     format!(
                         "No homeboy.json found at {} and no registered component matches",
@@ -450,12 +453,12 @@ fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         (Some(comp_id), None) => component::load(comp_id).map_err(|e| e.with_contextual_hint())?,
         // Neither: try CWD discovery
         (None, None) => component::resolve_effective(None, None, None).map_err(|_| {
-            homeboy::Error::validation_missing_argument(vec!["id or --path".to_string()])
+            homeboy::core::Error::validation_missing_argument(vec!["id or --path".to_string()])
         })?,
     };
 
     let resolved_id = component.id.clone();
-    let drift_files = homeboy::component::drift::drift_file_paths(&component);
+    let drift_files = homeboy::core::component::drift::drift_file_paths(&component);
 
     Ok((
         ComponentOutput {
@@ -463,7 +466,7 @@ fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
             id: Some(resolved_id.clone()),
             entity: Some({
                 let mut value = serde_json::to_value(&component).map_err(|error| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "component",
                         "Failed to serialize component",
                         Some(error.to_string()),
@@ -513,7 +516,7 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         (None, Some(dir)) => {
             let dir_path = Path::new(dir);
             component::portable::discover_from_portable(dir_path).ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "path",
                     format!("No homeboy.json found at {}", dir_path.display()),
                     None,
@@ -529,7 +532,7 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
             .map_err(|e| e.with_contextual_hint())?,
         // Neither: try CWD discovery
         (None, None) => component::resolve_effective(None, None, None).map_err(|_| {
-            homeboy::Error::validation_missing_argument(vec!["id or --path".to_string()])
+            homeboy::core::Error::validation_missing_argument(vec!["id or --path".to_string()])
         })?,
     };
 
@@ -552,7 +555,7 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) {
                 if let Some(ext_obj) = json.get("extensions").and_then(|e| e.get(ext_id.as_str())) {
                     if let Ok(requirements) = serde_json::from_value::<
-                        homeboy::extension::RuntimeRequirementsConfig,
+                        homeboy::core::extension::RuntimeRequirementsConfig,
                     >(ext_obj.clone())
                     {
                         apply_component_runtime_requirements(
@@ -568,7 +571,7 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
     }
 
     let extension = if let Some(ref ext_id) = extension_id {
-        homeboy::extension::load_extension(ext_id).ok()
+        homeboy::core::extension::load_extension(ext_id).ok()
     } else {
         None
     };
@@ -593,7 +596,7 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
     };
 
     let entity = serde_json::to_value(&env_output).map_err(|error| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "component",
             "Failed to serialize env output",
             Some(error.to_string()),
@@ -613,15 +616,15 @@ fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
 }
 
 fn run_component_env_detector(
-    extension: &homeboy::extension::ExtensionManifest,
+    extension: &homeboy::core::extension::ExtensionManifest,
     component_path: &Path,
-) -> homeboy::Result<Option<homeboy::extension::RuntimeRequirementsConfig>> {
+) -> homeboy::core::Result<Option<homeboy::core::extension::RuntimeRequirementsConfig>> {
     let Some(component_env) = extension.component_env.as_ref() else {
         return Ok(None);
     };
 
     let extension_path = extension.extension_path.as_ref().ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "extension",
             "Extension manifest is missing extension_path",
             Some(extension.id.clone()),
@@ -630,7 +633,7 @@ fn run_component_env_detector(
     })?;
     let script_path = Path::new(extension_path).join(&component_env.detect_script);
     if !script_path.exists() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "extension",
             format!(
                 "Extension '{}' component env detector is missing {}",
@@ -642,15 +645,15 @@ fn run_component_env_detector(
         ));
     }
 
-    let command = homeboy::engine::shell::quote_path(&script_path.to_string_lossy());
-    let output = homeboy::server::execute_local_command_in_dir(
+    let command = homeboy::core::engine::shell::quote_path(&script_path.to_string_lossy());
+    let output = homeboy::core::server::execute_local_command_in_dir(
         &command,
         Some(&component_path.to_string_lossy()),
         None,
     );
 
     if !output.success {
-        return Err(homeboy::Error::internal_io(
+        return Err(homeboy::core::Error::internal_io(
             format!(
                 "Component env detector for extension '{}' failed with exit code {}",
                 extension.id, output.exit_code
@@ -664,23 +667,24 @@ fn run_component_env_detector(
         return Ok(None);
     }
 
-    let detected = serde_json::from_str::<homeboy::extension::RuntimeRequirementsConfig>(trimmed)
-        .map_err(|error| {
-        homeboy::Error::validation_invalid_json(
-            error,
-            Some(format!(
-                "parse component env detector output for extension '{}'",
-                extension.id
-            )),
-            Some(trimmed.chars().take(200).collect()),
-        )
-    })?;
+    let detected =
+        serde_json::from_str::<homeboy::core::extension::RuntimeRequirementsConfig>(trimmed)
+            .map_err(|error| {
+                homeboy::core::Error::validation_invalid_json(
+                    error,
+                    Some(format!(
+                        "parse component env detector output for extension '{}'",
+                        extension.id
+                    )),
+                    Some(trimmed.chars().take(200).collect()),
+                )
+            })?;
 
     Ok(Some(detected))
 }
 
 fn apply_component_env_detector_output(
-    detected: homeboy::extension::RuntimeRequirementsConfig,
+    detected: homeboy::core::extension::RuntimeRequirementsConfig,
     runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
 ) {
     apply_component_runtime_requirements(detected, runtimes, "component", true);
@@ -688,7 +692,7 @@ fn apply_component_env_detector_output(
 
 fn apply_extension_runtime_requirements(
     extension_id: &str,
-    runtime: &homeboy::extension::RuntimeRequirementsConfig,
+    runtime: &homeboy::core::extension::RuntimeRequirementsConfig,
     runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
 ) {
     let source = format!("extension:{}", extension_id);
@@ -696,7 +700,7 @@ fn apply_extension_runtime_requirements(
 }
 
 fn apply_component_runtime_requirements(
-    requirements: homeboy::extension::RuntimeRequirementsConfig,
+    requirements: homeboy::core::extension::RuntimeRequirementsConfig,
     runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
     source: &str,
     overwrite: bool,
@@ -761,7 +765,7 @@ fn set(
     // Check if there's any input at all
     let has_dynamic = args.json_spec()?.is_some() || !args.effective_extra().is_empty();
     if !has_dynamic && !flags.has_any() && version_targets.is_empty() && extensions.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "spec",
             "Provide a flag (e.g., --local-path), --json spec, --base64, --key value, --version-target, or --extension",
             None,
@@ -783,7 +787,7 @@ fn set(
         if let serde_json::Value::Object(ref mut obj) = merged {
             obj.insert("version_targets".to_string(), serde_json::json!(parsed));
         } else {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "spec",
                 "Merged spec must be a JSON object",
                 None,
@@ -809,7 +813,7 @@ fn set(
     let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;
 
     match component::merge(args.id.as_deref(), &json_string, &replace_fields)? {
-        homeboy::MergeOutput::Single(result) => {
+        homeboy::core::MergeOutput::Single(result) => {
             let comp = component::load(&result.id)?;
             Ok((
                 ComponentOutput {
@@ -818,7 +822,7 @@ fn set(
                     updated_fields: result.updated_fields,
                     entity: Some({
                         let mut value = serde_json::to_value(&comp).map_err(|error| {
-                            homeboy::Error::validation_invalid_argument(
+                            homeboy::core::Error::validation_invalid_argument(
                                 "component",
                                 "Failed to serialize component",
                                 Some(error.to_string()),
@@ -835,7 +839,7 @@ fn set(
                 0,
             ))
         }
-        homeboy::MergeOutput::Bulk(summary) => {
+        homeboy::core::MergeOutput::Bulk(summary) => {
             let exit_code = summary.exit_code();
             Ok((
                 ComponentOutput {
@@ -868,10 +872,10 @@ fn add_version_target(id: &str, file: &str, pattern: &str) -> CmdResult<Componen
         }]
     });
 
-    let json_string = homeboy::config::to_json_string(&version_target)?;
+    let json_string = homeboy::core::config::to_json_string(&version_target)?;
 
     match component::merge(Some(id), &json_string, &[])? {
-        homeboy::MergeOutput::Single(result) => {
+        homeboy::core::MergeOutput::Single(result) => {
             let comp = component::load(&result.id)?;
             Ok((
                 ComponentOutput {
@@ -880,7 +884,7 @@ fn add_version_target(id: &str, file: &str, pattern: &str) -> CmdResult<Componen
                     updated_fields: result.updated_fields,
                     entity: Some({
                         let mut value = serde_json::to_value(&comp).map_err(|error| {
-                            homeboy::Error::validation_invalid_argument(
+                            homeboy::core::Error::validation_invalid_argument(
                                 "component",
                                 "Failed to serialize component",
                                 Some(error.to_string()),
@@ -897,7 +901,7 @@ fn add_version_target(id: &str, file: &str, pattern: &str) -> CmdResult<Componen
                 0,
             ))
         }
-        homeboy::MergeOutput::Bulk(_) => Err(homeboy::Error::internal_unexpected(
+        homeboy::core::MergeOutput::Bulk(_) => Err(homeboy::core::Error::internal_unexpected(
             "Unexpected bulk result for single component".to_string(),
         )),
     }
@@ -927,7 +931,7 @@ fn rename(id: &str, new_id: &str) -> CmdResult<ComponentOutput> {
             updated_fields: vec!["id".to_string()],
             entity: Some({
                 let mut value = serde_json::to_value(&component).map_err(|error| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "component",
                         "Failed to serialize component",
                         Some(error.to_string()),
@@ -950,7 +954,7 @@ fn list() -> CmdResult<ComponentOutput> {
         .into_iter()
         .map(|component| {
             let mut value = serde_json::to_value(&component).map_err(|error| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "component",
                     "Failed to serialize component",
                     Some(error.to_string()),
@@ -966,7 +970,7 @@ fn list() -> CmdResult<ComponentOutput> {
             }
             Ok(value)
         })
-        .collect::<homeboy::Result<Vec<Value>>>()?;
+        .collect::<homeboy::core::Result<Vec<Value>>>()?;
 
     Ok((
         ComponentOutput {
@@ -1128,7 +1132,7 @@ mod tests {
 
     #[test]
     fn extension_runtime_requirements_fill_missing_component_versions() {
-        let runtime: homeboy::extension::RuntimeRequirementsConfig =
+        let runtime: homeboy::core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "node": { "version": "24" },
@@ -1166,7 +1170,7 @@ mod tests {
         perms.set_mode(0o755);
         fs::set_permissions(&script, perms).expect("chmod detector");
 
-        let mut extension: homeboy::extension::ExtensionManifest =
+        let mut extension: homeboy::core::extension::ExtensionManifest =
             serde_json::from_value(serde_json::json!({
                 "name": "Demo",
                 "version": "1.0.0",
@@ -1186,7 +1190,7 @@ mod tests {
 
     #[test]
     fn runtime_requirements_accept_generic_and_legacy_shapes() {
-        let generic: homeboy::extension::RuntimeRequirementsConfig =
+        let generic: homeboy::core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "python": { "version": "3.12" },
@@ -1198,7 +1202,7 @@ mod tests {
         assert_eq!(generic.runtimes["python"].version, "3.12");
         assert_eq!(generic.runtimes["ruby"].version, "3.3");
 
-        let legacy: homeboy::extension::RuntimeRequirementsConfig =
+        let legacy: homeboy::core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({ "php": "8.2", "node": "22" }))
                 .expect("legacy requirements");
 
@@ -1208,7 +1212,7 @@ mod tests {
 
     #[test]
     fn component_env_detector_output_overrides_component_values_before_runtime_defaults() {
-        let runtime: homeboy::extension::RuntimeRequirementsConfig =
+        let runtime: homeboy::core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "node": { "version": "24" },
@@ -1250,7 +1254,7 @@ mod tests {
 
     #[test]
     fn component_versions_win_over_extension_runtime_requirements() {
-        let runtime: homeboy::extension::RuntimeRequirementsConfig =
+        let runtime: homeboy::core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "node": { "version": "24" },

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::defaults::{self, Defaults, HomeboyConfig};
+use homeboy::core::defaults::{self, Defaults, HomeboyConfig};
 
 use super::CmdResult;
 
@@ -103,7 +103,7 @@ fn show(builtin: bool) -> CmdResult<ConfigOutput> {
 fn set(pointer: &str, value_str: &str) -> CmdResult<ConfigOutput> {
     // Validate pointer format
     if !pointer.starts_with('/') {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "pointer",
             "JSON pointer must start with '/'",
             None,
@@ -113,7 +113,7 @@ fn set(pointer: &str, value_str: &str) -> CmdResult<ConfigOutput> {
 
     // Parse the value as JSON
     let value: Value = serde_json::from_str(value_str).map_err(|e| {
-        homeboy::Error::validation_invalid_json(
+        homeboy::core::Error::validation_invalid_json(
             e,
             Some("parse value".to_string()),
             Some(value_str.chars().take(200).collect::<String>()),
@@ -125,15 +125,19 @@ fn set(pointer: &str, value_str: &str) -> CmdResult<ConfigOutput> {
 
     // Convert to JSON, set the value, convert back
     let mut config_json = serde_json::to_value(&config).map_err(|e| {
-        homeboy::Error::internal_unexpected(format!("Failed to serialize config: {}", e))
+        homeboy::core::Error::internal_unexpected(format!("Failed to serialize config: {}", e))
     })?;
 
     // Navigate to the pointer location and set the value
-    homeboy::config::set_json_pointer(&mut config_json, pointer, value.clone())?;
+    homeboy::core::config::set_json_pointer(&mut config_json, pointer, value.clone())?;
 
     // Convert back to HomeboyConfig
     config = serde_json::from_value(config_json).map_err(|e| {
-        homeboy::Error::validation_invalid_json(e, Some("deserialize config".to_string()), None)
+        homeboy::core::Error::validation_invalid_json(
+            e,
+            Some("deserialize config".to_string()),
+            None,
+        )
     })?;
 
     // Save the config
@@ -157,7 +161,7 @@ fn set(pointer: &str, value_str: &str) -> CmdResult<ConfigOutput> {
 fn remove(pointer: &str) -> CmdResult<ConfigOutput> {
     // Validate pointer format
     if !pointer.starts_with('/') {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "pointer",
             "JSON pointer must start with '/'",
             None,
@@ -170,15 +174,19 @@ fn remove(pointer: &str) -> CmdResult<ConfigOutput> {
 
     // Convert to JSON
     let mut config_json = serde_json::to_value(&config).map_err(|e| {
-        homeboy::Error::internal_unexpected(format!("Failed to serialize config: {}", e))
+        homeboy::core::Error::internal_unexpected(format!("Failed to serialize config: {}", e))
     })?;
 
     // Remove the value at the pointer
-    homeboy::config::remove_json_pointer(&mut config_json, pointer)?;
+    homeboy::core::config::remove_json_pointer(&mut config_json, pointer)?;
 
     // Convert back to HomeboyConfig
     config = serde_json::from_value(config_json).map_err(|e| {
-        homeboy::Error::validation_invalid_json(e, Some("deserialize config".to_string()), None)
+        homeboy::core::Error::validation_invalid_json(
+            e,
+            Some("deserialize config".to_string()),
+            None,
+        )
     })?;
 
     // Save the config
@@ -237,4 +245,4 @@ fn path() -> CmdResult<ConfigOutput> {
 }
 
 // JSON pointer operations (set_json_pointer, remove_json_pointer) are in
-// homeboy::config — no local implementations needed.
+// homeboy::core::config — no local implementations needed.

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -4,8 +4,8 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use homeboy::daemon::{self, DaemonStartResult, DaemonStatus, DaemonStopResult};
-use homeboy::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
+use homeboy::core::daemon::{self, DaemonStartResult, DaemonStatus, DaemonStopResult};
+use homeboy::core::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
 
 use super::CmdResult;
 
@@ -70,7 +70,7 @@ fn start(addr: &str) -> CmdResult<DaemonOutput> {
     daemon::parse_bind_addr(addr)?;
 
     let exe = std::env::current_exe().map_err(|e| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             e.to_string(),
             Some("resolve current executable".to_string()),
         )
@@ -82,7 +82,7 @@ fn start(addr: &str) -> CmdResult<DaemonOutput> {
         .stderr(Stdio::null())
         .spawn()
         .map_err(|e| {
-            homeboy::Error::internal_io(e.to_string(), Some("spawn daemon".to_string()))
+            homeboy::core::Error::internal_io(e.to_string(), Some("spawn daemon".to_string()))
         })?;
     let pid = child.id();
 
@@ -103,7 +103,7 @@ fn start(addr: &str) -> CmdResult<DaemonOutput> {
         }
 
         if Instant::now() >= deadline {
-            return Err(homeboy::Error::internal_unexpected(format!(
+            return Err(homeboy::core::Error::internal_unexpected(format!(
                 "daemon process {} did not publish state before timeout",
                 pid
             )));
@@ -117,9 +117,9 @@ fn start(addr: &str) -> CmdResult<DaemonOutput> {
 struct CommandAnalysisJobRunner;
 
 impl AnalysisJobRunner for CommandAnalysisJobRunner {
-    fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::Result<AnalysisJobRunOutput> {
+    fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::core::Result<AnalysisJobRunOutput> {
         let cli = crate::cli_surface::Cli::try_parse_from(argv).map_err(|error| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "body",
                 error.to_string(),
                 None,

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -1,10 +1,10 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::db::{self, DbResult, DbTunnelResult};
-use homeboy::engine::text;
-use homeboy::observation::store::{self, ObservationDbStatus};
-use homeboy::project;
+use homeboy::core::db::{self, DbResult, DbTunnelResult};
+use homeboy::core::engine::text;
+use homeboy::core::observation::store::{self, ObservationDbStatus};
+use homeboy::core::project;
 
 use super::CmdResult;
 
@@ -151,7 +151,7 @@ fn status() -> CmdResult<DbOutput> {
 fn parse_subtarget(
     project_id: &str,
     args: &[String],
-) -> homeboy::Result<(Option<String>, Vec<String>)> {
+) -> homeboy::core::Result<(Option<String>, Vec<String>)> {
     let project = project::load(project_id)?;
 
     if project.sub_targets.is_empty() {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::deploy::{
+use homeboy::core::deploy::{
     self, ComponentDeployResult, DeployConfig, DeploySummary, MultiDeploySummary,
     ProjectDeployResult,
 };
@@ -114,7 +114,7 @@ pub fn run(
 ) -> CmdResult<DeployCommandOutput> {
     // Fleet deploy
     if let Some(ref fleet_id) = args.fleet {
-        let fl = homeboy::fleet::load(fleet_id)?;
+        let fl = homeboy::core::fleet::load(fleet_id)?;
         let (component_ids, config) = resolve_multi_args(&args)?;
         return run_multi_output(&fl.project_ids, &component_ids, &config, &args);
     }
@@ -184,13 +184,13 @@ pub fn run(
 
 // === Argument resolution helpers ===
 
-fn resolve_shared_component_ids(args: &DeployArgs) -> homeboy::Result<Vec<String>> {
+fn resolve_shared_component_ids(args: &DeployArgs) -> homeboy::core::Result<Vec<String>> {
     if let Some(ref comps) = args.component {
         Ok(comps.clone())
     } else if let Some(ref target) = args.target_id {
         Ok(vec![target.clone()])
     } else {
-        Err(homeboy::Error::validation_invalid_argument(
+        Err(homeboy::core::Error::validation_invalid_argument(
             "component",
             "At least one component ID is required when using --shared",
             None,
@@ -199,7 +199,7 @@ fn resolve_shared_component_ids(args: &DeployArgs) -> homeboy::Result<Vec<String
     }
 }
 
-fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, Vec<String>)> {
+fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::core::Result<(String, Vec<String>)> {
     match (&args.project, &args.component, &args.target_id) {
         (Some(proj), Some(comps), _) => Ok((proj.clone(), comps.clone())),
 
@@ -216,7 +216,7 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, V
                 || args.check
                 || args.json.is_some();
             if comps.is_empty() && !has_selector_flag {
-                return Err(homeboy::Error::validation_invalid_argument(
+                return Err(homeboy::core::Error::validation_invalid_argument(
                     "input",
                     "Provide component IDs with --project, or add --all/--outdated/--check",
                     None,
@@ -228,7 +228,7 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, V
         }
 
         (None, Some(comps), target) => {
-            let projects = homeboy::project::list_ids().unwrap_or_default();
+            let projects = homeboy::core::project::list_ids().unwrap_or_default();
 
             if let Some(first) = target {
                 if projects.contains(first) {
@@ -238,7 +238,7 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, V
 
             match infer_project_for_components(comps) {
                 Some(proj) => Ok((proj, comps.clone())),
-                None => Err(homeboy::Error::validation_invalid_argument(
+                None => Err(homeboy::core::Error::validation_invalid_argument(
                     "project_id",
                     "Could not infer project. Use --project flag or provide project as first argument.",
                     None,
@@ -248,7 +248,7 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, V
         }
 
         (None, None, Some(target)) => resolve_project_components(target, &args.component_ids),
-        (None, None, None) => Err(homeboy::Error::validation_invalid_argument(
+        (None, None, None) => Err(homeboy::core::Error::validation_invalid_argument(
             "input",
             "Provide component ID, project ID with --all, or use flags",
             None,
@@ -257,7 +257,7 @@ fn resolve_single_deploy_target(args: &DeployArgs) -> homeboy::Result<(String, V
     }
 }
 
-fn resolve_multi_args(args: &DeployArgs) -> homeboy::Result<(Vec<String>, DeployConfig)> {
+fn resolve_multi_args(args: &DeployArgs) -> homeboy::core::Result<(Vec<String>, DeployConfig)> {
     let mut component_ids: Vec<String> = Vec::new();
     if let Some(ref target) = args.target_id {
         component_ids.push(target.clone());

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
 
-use homeboy::deps::{
+use homeboy::core::deps::{
     self, DependencyStackApplyResult, DependencyStackPlan, DependencyStackStatus, DependencyStatus,
     DependencyUpdateResult,
 };
@@ -82,7 +82,7 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
                 deps::status(component.as_deref(), path.as_deref(), package.as_deref())?;
             Ok((
                 serde_json::to_value(output).map_err(|e| {
-                    homeboy::Error::internal_json(
+                    homeboy::core::Error::internal_json(
                         e.to_string(),
                         Some("serialize deps status".to_string()),
                     )
@@ -104,7 +104,7 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
             )?;
             Ok((
                 serde_json::to_value(output).map_err(|e| {
-                    homeboy::Error::internal_json(
+                    homeboy::core::Error::internal_json(
                         e.to_string(),
                         Some("serialize deps update".to_string()),
                     )
@@ -117,7 +117,7 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
                 let output: DependencyStackStatus = deps::stack_status()?;
                 Ok((
                     serde_json::to_value(output).map_err(|e| {
-                        homeboy::Error::internal_json(
+                        homeboy::core::Error::internal_json(
                             e.to_string(),
                             Some("serialize deps stack status".to_string()),
                         )
@@ -129,7 +129,7 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
                 let output: DependencyStackPlan = deps::stack_plan(&upstream)?;
                 Ok((
                     serde_json::to_value(output).map_err(|e| {
-                        homeboy::Error::internal_json(
+                        homeboy::core::Error::internal_json(
                             e.to_string(),
                             Some("serialize deps stack plan".to_string()),
                         )
@@ -141,7 +141,7 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
                 let output: DependencyStackApplyResult = deps::stack_apply(&upstream, dry_run)?;
                 Ok((
                     serde_json::to_value(output).map_err(|e| {
-                        homeboy::Error::internal_json(
+                        homeboy::core::Error::internal_json(
                             e.to_string(),
                             Some("serialize deps stack apply".to_string()),
                         )

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 use std::path::Path;
 
 use crate::help_topics;
-use homeboy::code_audit::codebase_map;
-use homeboy::component;
+use homeboy::core::code_audit::codebase_map;
+use homeboy::core::component;
 
 use super::CmdResult;
 
@@ -98,7 +98,7 @@ pub fn run(args: DocsArgs, _global: &super::GlobalArgs) -> CmdResult<DocsOutput>
             write,
             output_dir,
         }) => run_map(&component_id, source_dirs, include_private, write, &output_dir),
-        None => Err(homeboy::Error::validation_invalid_argument(
+        None => Err(homeboy::core::Error::validation_invalid_argument(
             "command",
             "JSON output requires the map subcommand. Use `homeboy docs <topic>` for topic display.",
             None,

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -1,11 +1,11 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::extension::{
+use homeboy::core::extension::{
     self, extension_ready_status, is_extension_linked, load_extension, run_setup, ExtensionSummary,
     UpdateEntry,
 };
-use homeboy::project::{self, Project};
+use homeboy::core::project::{self, Project};
 use std::path::Path;
 
 use crate::commands::CmdResult;
@@ -232,7 +232,7 @@ pub enum ExtensionOutput {
         #[serde(skip_serializing_if = "Option::is_none")]
         project_id: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        output: Option<homeboy::engine::command::CapturedOutput>,
+        output: Option<homeboy::core::engine::command::CapturedOutput>,
     },
     #[serde(rename = "extension.setup")]
     Setup { extension_id: String },
@@ -273,13 +273,13 @@ pub enum ExtensionOutput {
         #[serde(skip_serializing_if = "Option::is_none")]
         git_root: Option<String>,
         #[serde(flatten)]
-        source_update: homeboy::extension::ExtensionSourceUpdate,
+        source_update: homeboy::core::extension::ExtensionSourceUpdate,
         #[serde(skip_serializing_if = "Option::is_none")]
         old_version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         new_version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        repaired_source_metadata: Option<homeboy::extension::SourceMetadataRepair>,
+        repaired_source_metadata: Option<homeboy::core::extension::SourceMetadataRepair>,
     },
     #[serde(rename = "extension.update_all")]
     UpdateAll {
@@ -309,10 +309,10 @@ pub enum ExtensionOutput {
     Exec {
         extension_id: String,
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        output: Option<homeboy::engine::command::CapturedOutput>,
+        output: Option<homeboy::core::engine::command::CapturedOutput>,
     },
     #[serde(rename = "extension.set")]
-    SetBatch { batch: homeboy::BatchResult },
+    SetBatch { batch: homeboy::core::BatchResult },
 }
 
 #[derive(Serialize)]
@@ -330,7 +330,7 @@ pub struct ExtensionDetail {
     pub source_url: Option<String>,
     pub runtime: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub runtime_requirements: Option<homeboy::extension::RuntimeRequirementsConfig>,
+    pub runtime_requirements: Option<homeboy::core::extension::RuntimeRequirementsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_setup: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -349,11 +349,11 @@ pub struct ExtensionDetail {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub actions: Vec<ActionDetail>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub inputs: Vec<homeboy::extension::InputConfig>,
+    pub inputs: Vec<homeboy::core::extension::InputConfig>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub settings: Vec<homeboy::extension::SettingConfig>,
+    pub settings: Vec<homeboy::core::extension::SettingConfig>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub structured_sidecars: Vec<homeboy::extension::StructuredSidecarDeclaration>,
+    pub structured_sidecars: Vec<homeboy::core::extension::StructuredSidecarDeclaration>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequiresDetail>,
 }
@@ -381,11 +381,11 @@ pub struct ActionDetail {
     pub id: String,
     pub label: String,
     #[serde(rename = "type")]
-    pub action_type: homeboy::extension::ActionType,
+    pub action_type: homeboy::core::extension::ActionType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub method: Option<homeboy::extension::HttpMethod>,
+    pub method: Option<homeboy::core::extension::HttpMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
 }
@@ -450,7 +450,7 @@ fn show_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
         components: r.components.clone(),
     });
 
-    let source_revision = homeboy::extension::read_source_revision(&extension.id);
+    let source_revision = homeboy::core::extension::read_source_revision(&extension.id);
 
     let detail = ExtensionDetail {
         id: extension.id.clone(),
@@ -497,7 +497,7 @@ fn run_extension(
     step: Option<String>,
     skip: Option<String>,
 ) -> CmdResult<ExtensionOutput> {
-    use homeboy::extension::{ExtensionExecutionMode, ExtensionStepFilter};
+    use homeboy::core::extension::{ExtensionExecutionMode, ExtensionStepFilter};
 
     let mode = if no_stream {
         ExtensionExecutionMode::Captured
@@ -509,7 +509,7 @@ fn run_extension(
 
     let filter = ExtensionStepFilter { step, skip };
 
-    let result = homeboy::extension::run_extension(
+    let result = homeboy::core::extension::run_extension(
         extension_id,
         project.as_deref(),
         component.as_deref(),
@@ -536,8 +536,11 @@ fn install_extension(
     replace: bool,
 ) -> CmdResult<ExtensionOutput> {
     if replace {
-        let result =
-            homeboy::extension::replace_with_revision(source, id.as_deref(), revision.as_deref())?;
+        let result = homeboy::core::extension::replace_with_revision(
+            source,
+            id.as_deref(),
+            revision.as_deref(),
+        )?;
         return Ok((
             ExtensionOutput::Replace {
                 extension_id: result.extension_id,
@@ -551,8 +554,11 @@ fn install_extension(
         ));
     }
 
-    let result =
-        homeboy::extension::install_with_revision(source, id.as_deref(), revision.as_deref())?;
+    let result = homeboy::core::extension::install_with_revision(
+        source,
+        id.as_deref(),
+        revision.as_deref(),
+    )?;
     let linked = is_extension_linked(&result.extension_id);
 
     Ok((
@@ -568,7 +574,7 @@ fn install_extension(
 }
 
 fn relink_extension(extension_id: &str, source: &str) -> CmdResult<ExtensionOutput> {
-    let result = homeboy::extension::relink(extension_id, source)?;
+    let result = homeboy::core::extension::relink(extension_id, source)?;
 
     Ok((
         ExtensionOutput::Replace {
@@ -585,7 +591,7 @@ fn relink_extension(extension_id: &str, source: &str) -> CmdResult<ExtensionOutp
 
 fn install_for_component(source: &str, path: Option<&str>) -> CmdResult<ExtensionOutput> {
     let component = resolve_install_component(path)?;
-    let result = homeboy::extension::install_for_component(&component, source)?;
+    let result = homeboy::core::extension::install_for_component(&component, source)?;
 
     let installed = result
         .installed
@@ -609,19 +615,23 @@ fn install_for_component(source: &str, path: Option<&str>) -> CmdResult<Extensio
     ))
 }
 
-fn resolve_install_component(path: Option<&str>) -> homeboy::Result<homeboy::component::Component> {
+fn resolve_install_component(
+    path: Option<&str>,
+) -> homeboy::core::Result<homeboy::core::component::Component> {
     if let Some(path) = path {
-        return homeboy::component::discover_from_portable(Path::new(path)).ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
-                "path",
-                format!("No homeboy.json found at {}", path),
-                Some(path.to_string()),
-                None,
-            )
-        });
+        return homeboy::core::component::discover_from_portable(Path::new(path)).ok_or_else(
+            || {
+                homeboy::core::Error::validation_invalid_argument(
+                    "path",
+                    format!("No homeboy.json found at {}", path),
+                    Some(path.to_string()),
+                    None,
+                )
+            },
+        );
     }
 
-    homeboy::component::resolve(None)
+    homeboy::core::component::resolve(None)
 }
 
 fn update_extension(
@@ -634,7 +644,7 @@ fn update_extension(
     }
 
     let extension_id = extension_id.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "extension_id",
             "Provide a extension ID or use --all to update all extensions",
             None,
@@ -687,7 +697,7 @@ fn update_all_extensions(force: bool) -> CmdResult<ExtensionOutput> {
 
 fn uninstall_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
     let was_linked = is_extension_linked(extension_id);
-    let path = homeboy::extension::uninstall(extension_id)?;
+    let path = homeboy::core::extension::uninstall(extension_id)?;
 
     Ok((
         ExtensionOutput::Uninstall {
@@ -716,7 +726,7 @@ fn run_action(
     project_id: Option<String>,
     data: Option<String>,
 ) -> CmdResult<ExtensionOutput> {
-    let response = homeboy::extension::run_action(
+    let response = homeboy::core::extension::run_action(
         extension_id,
         action_id,
         project_id.as_deref(),
@@ -739,15 +749,15 @@ fn set_extension(
     json: &str,
     replace_fields: &[String],
 ) -> CmdResult<ExtensionOutput> {
-    match homeboy::extension::merge(extension_id, json, replace_fields)? {
-        homeboy::MergeOutput::Single(result) => Ok((
+    match homeboy::core::extension::merge(extension_id, json, replace_fields)? {
+        homeboy::core::MergeOutput::Single(result) => Ok((
             ExtensionOutput::Set {
                 extension_id: result.id,
                 updated_fields: result.updated_fields,
             },
             0,
         )),
-        homeboy::MergeOutput::Bulk(batch) => {
+        homeboy::core::MergeOutput::Bulk(batch) => {
             let exit_code = batch.exit_code();
             Ok((ExtensionOutput::SetBatch { batch }, exit_code))
         }

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -1,11 +1,11 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::context::require_project_base_path;
-use homeboy::engine::{command, executor, shell};
-use homeboy::project::files::{self, FileEntry, GrepMatch, LineChange};
-use homeboy::server::transfer::{self, TransferConfig, TransferOutput};
-use homeboy::{join_remote_path, project};
+use homeboy::core::context::require_project_base_path;
+use homeboy::core::engine::{command, executor, shell};
+use homeboy::core::project::files::{self, FileEntry, GrepMatch, LineChange};
+use homeboy::core::server::transfer::{self, TransferConfig, TransferOutput};
+use homeboy::core::{join_remote_path, project};
 
 use super::CmdResult;
 
@@ -704,7 +704,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
 
     let result = if let Some(line_num) = line_ops.replace_line {
         let content = line_ops.replace_line_content.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "content",
                 "Content required for --replace-line",
                 None,
@@ -714,7 +714,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
         files::edit_replace_line(&project_id, &file_path, line_num, &content)?
     } else if let Some(line_num) = line_ops.insert_after {
         let content = line_ops.insert_after_content.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "content",
                 "Content required for --insert-after",
                 None,
@@ -724,7 +724,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
         files::edit_insert_after_line(&project_id, &file_path, line_num, &content)?
     } else if let Some(line_num) = line_ops.insert_before {
         let content = line_ops.insert_before_content.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "content",
                 "Content required for --insert-before",
                 None,
@@ -736,7 +736,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
         files::edit_delete_line(&project_id, &file_path, line_num)?
     } else if let Some(lines) = line_ops.delete_lines {
         if lines.len() != 2 {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "delete_lines",
                 "DELETE_LINES requires exactly 2 values: START END",
                 None,
@@ -746,7 +746,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
         files::edit_delete_lines(&project_id, &file_path, lines[0], lines[1])?
     } else if let Some(pattern) = pattern_ops.replace_pattern {
         let replacement = pattern_ops.replace_pattern_content.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "content",
                 "Content required for --replace-pattern",
                 None,
@@ -756,7 +756,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
         files::edit_replace_pattern(&project_id, &file_path, &pattern, &replacement, false)?
     } else if let Some(pattern) = pattern_ops.replace_all_pattern {
         let replacement = pattern_ops.replace_all_content.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "content",
                 "Content required for --replace-all-pattern",
                 None,
@@ -771,7 +771,7 @@ fn edit(args: EditArgs) -> CmdResult<FileEditOutput> {
     } else if let Some(content) = file_mods.prepend {
         files::edit_prepend(&project_id, &file_path, &content)?
     } else {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "operation",
             "No edit operation specified. Use one of: --replace-line, --insert-after, --insert-before, --delete-line, --delete-lines, --replace-pattern, --replace-all-pattern, --delete-pattern, --append, --prepend",
             None,

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -1,9 +1,9 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::fleet::{self, Fleet, FleetComponentDrift, FleetStatusResult};
-use homeboy::project::Project;
-use homeboy::EntityCrudOutput;
+use homeboy::core::fleet::{self, Fleet, FleetComponentDrift, FleetStatusResult};
+use homeboy::core::project::Project;
+use homeboy::core::EntityCrudOutput;
 
 use super::{CmdResult, DynamicSetArgs};
 
@@ -135,13 +135,13 @@ pub struct FleetExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<FleetStatusResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub check: Option<Vec<homeboy::fleet::FleetProjectCheck>>,
+    pub check: Option<Vec<homeboy::core::fleet::FleetProjectCheck>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub summary: Option<homeboy::fleet::FleetCheckSummary>,
+    pub summary: Option<homeboy::core::fleet::FleetCheckSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exec: Option<Vec<homeboy::fleet::FleetExecProjectResult>>,
+    pub exec: Option<Vec<homeboy::core::fleet::FleetExecProjectResult>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exec_summary: Option<homeboy::fleet::FleetExecSummary>,
+    pub exec_summary: Option<homeboy::core::fleet::FleetExecSummary>,
 }
 
 pub type FleetOutput = EntityCrudOutput<Fleet, FleetExtra>;
@@ -184,18 +184,18 @@ fn create(
 ) -> CmdResult<FleetOutput> {
     // Validate projects exist
     for pid in &project_ids {
-        if !homeboy::project::exists(pid) {
-            return Err(homeboy::Error::project_not_found(pid, vec![]));
+        if !homeboy::core::project::exists(pid) {
+            return Err(homeboy::core::Error::project_not_found(pid, vec![]));
         }
     }
 
     let mut new_fleet = Fleet::new(id.to_string(), project_ids);
     new_fleet.description = description;
 
-    let json_spec = homeboy::config::to_json_string(&new_fleet)?;
+    let json_spec = homeboy::core::config::to_json_string(&new_fleet)?;
 
     match fleet::create(&json_spec, false)? {
-        homeboy::CreateOutput::Single(result) => Ok((
+        homeboy::core::CreateOutput::Single(result) => Ok((
             FleetOutput {
                 command: "fleet.create".to_string(),
                 id: Some(result.id),
@@ -204,7 +204,7 @@ fn create(
             },
             0,
         )),
-        homeboy::CreateOutput::Bulk(_) => Err(homeboy::Error::internal_unexpected(
+        homeboy::core::CreateOutput::Bulk(_) => Err(homeboy::core::Error::internal_unexpected(
             "Unexpected bulk result for single fleet".to_string(),
         )),
     }
@@ -226,7 +226,7 @@ fn show(id: &str) -> CmdResult<FleetOutput> {
 
 fn set(args: DynamicSetArgs) -> CmdResult<FleetOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "spec",
             "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
             None,
@@ -236,7 +236,7 @@ fn set(args: DynamicSetArgs) -> CmdResult<FleetOutput> {
     let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;
 
     match fleet::merge(args.id.as_deref(), &json_string, &replace_fields)? {
-        homeboy::MergeOutput::Single(result) => {
+        homeboy::core::MergeOutput::Single(result) => {
             let fl = fleet::load(&result.id)?;
             Ok((
                 FleetOutput {
@@ -249,7 +249,7 @@ fn set(args: DynamicSetArgs) -> CmdResult<FleetOutput> {
                 0,
             ))
         }
-        homeboy::MergeOutput::Bulk(_) => Err(homeboy::Error::internal_unexpected(
+        homeboy::core::MergeOutput::Bulk(_) => Err(homeboy::core::Error::internal_unexpected(
             "Unexpected bulk result for single fleet".to_string(),
         )),
     }

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -1,14 +1,14 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::git::{
+use homeboy::core::git::{
     self, CherryPickOptions, GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrOutput,
     IssueCloseOptions, IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions,
     IssueFindOptions, IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions,
     PrFindOptions, PrPolicyDecision, PrPolicyMergeOptions, PrPolicyOpenOptions, PrState,
     PushOptions, RebaseOptions,
 };
-use homeboy::BulkResult;
+use homeboy::core::BulkResult;
 
 use crate::commands::version;
 
@@ -834,7 +834,7 @@ pub fn run(args: GitArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Gi
                 None => {
                     // Need component_id to look up version
                     let id = component_id.as_ref().ok_or_else(|| {
-                        homeboy::Error::validation_invalid_argument(
+                        homeboy::core::Error::validation_invalid_argument(
                             "componentId",
                             "Missing componentId",
                             None,
@@ -939,7 +939,7 @@ fn run_issue(args: IssueArgs) -> CmdResult<GitCommandOutput> {
             path,
         } => {
             let body = resolve_body(body, body_file)?.ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "body",
                     "Comment body is required (--body or --body-file)",
                     None,
@@ -1107,7 +1107,7 @@ fn run_pr(args: PrArgs) -> CmdResult<GitCommandOutput> {
             path,
         } => {
             let body = resolve_body(body, body_file)?.ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "body",
                     "Comment body is required (--body or --body-file)",
                     None,
@@ -1227,7 +1227,10 @@ fn run_pr_policy(args: PrPolicyArgs) -> CmdResult<GitCommandOutput> {
 
 /// Resolve a body argument from either inline `--body` or a file path.
 /// Returns `Ok(None)` if neither is set. Supports `-` for stdin.
-fn resolve_body(inline: Option<String>, file: Option<String>) -> homeboy::Result<Option<String>> {
+fn resolve_body(
+    inline: Option<String>,
+    file: Option<String>,
+) -> homeboy::core::Result<Option<String>> {
     if let Some(body) = inline {
         return Ok(Some(body));
     }
@@ -1239,7 +1242,7 @@ fn resolve_body(inline: Option<String>, file: Option<String>) -> homeboy::Result
         use std::io::Read;
         let mut buf = String::new();
         std::io::stdin().read_to_string(&mut buf).map_err(|e| {
-            homeboy::Error::internal_io(
+            homeboy::core::Error::internal_io(
                 format!("Failed to read body from stdin: {}", e),
                 Some("stdin".into()),
             )
@@ -1248,7 +1251,7 @@ fn resolve_body(inline: Option<String>, file: Option<String>) -> homeboy::Result
     }
 
     let content = std::fs::read_to_string(&path).map_err(|e| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to read body file: {}", e),
             Some(path.clone()),
         )
@@ -1256,9 +1259,9 @@ fn resolve_body(inline: Option<String>, file: Option<String>) -> homeboy::Result
     Ok(Some(content))
 }
 
-fn read_lines_file(path: &str) -> homeboy::Result<Vec<String>> {
+fn read_lines_file(path: &str) -> homeboy::core::Result<Vec<String>> {
     let content = std::fs::read_to_string(path).map_err(|e| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to read lines file: {}", e),
             Some(path.to_string()),
         )
@@ -1271,12 +1274,12 @@ fn read_lines_file(path: &str) -> homeboy::Result<Vec<String>> {
         .collect())
 }
 
-fn parse_issue_state(s: &str) -> homeboy::Result<IssueState> {
+fn parse_issue_state(s: &str) -> homeboy::core::Result<IssueState> {
     match s {
         "open" => Ok(IssueState::Open),
         "closed" => Ok(IssueState::Closed),
         "all" => Ok(IssueState::All),
-        other => Err(homeboy::Error::validation_invalid_argument(
+        other => Err(homeboy::core::Error::validation_invalid_argument(
             "state",
             format!("Unknown issue state '{}'", other),
             None,
@@ -1285,13 +1288,13 @@ fn parse_issue_state(s: &str) -> homeboy::Result<IssueState> {
     }
 }
 
-fn parse_issue_close_reason(s: &str) -> homeboy::Result<IssueCloseReason> {
+fn parse_issue_close_reason(s: &str) -> homeboy::core::Result<IssueCloseReason> {
     // Accept both kebab-case (CLI ergonomic) and snake_case (matches GitHub
     // GraphQL state_reason values for symmetry with `--json stateReason`).
     match s {
         "completed" => Ok(IssueCloseReason::Completed),
         "not-planned" | "not_planned" => Ok(IssueCloseReason::NotPlanned),
-        other => Err(homeboy::Error::validation_invalid_argument(
+        other => Err(homeboy::core::Error::validation_invalid_argument(
             "reason",
             format!("Unknown close reason '{}'", other),
             None,
@@ -1300,13 +1303,13 @@ fn parse_issue_close_reason(s: &str) -> homeboy::Result<IssueCloseReason> {
     }
 }
 
-fn parse_pr_state(s: &str) -> homeboy::Result<PrState> {
+fn parse_pr_state(s: &str) -> homeboy::core::Result<PrState> {
     match s {
         "open" => Ok(PrState::Open),
         "closed" => Ok(PrState::Closed),
         "merged" => Ok(PrState::Merged),
         "all" => Ok(PrState::All),
-        other => Err(homeboy::Error::validation_invalid_argument(
+        other => Err(homeboy::core::Error::validation_invalid_argument(
             "state",
             format!("Unknown PR state '{}'", other),
             None,

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
 
-use homeboy::http_request::{self, HttpRequestInput, HttpRequestOutput};
+use homeboy::core::http_request::{self, HttpRequestInput, HttpRequestOutput};
 
 use super::{parse_key_val, CmdResult, GlobalArgs};
 

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -10,8 +10,8 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::io::Read;
 
-use homeboy::code_audit::FindingConfidence;
-use homeboy::issues::{
+use homeboy::core::code_audit::FindingConfidence;
+use homeboy::core::issues::{
     apply_plan, build_findings_from_native_output, reconcile_scoped, GithubTracker,
     IssueRenderContext, ReconcileConfig, ReconcileFindingsInput, ReconcilePlan, ReconcileResult,
     Tracker,
@@ -220,11 +220,11 @@ pub fn run(args: IssuesArgs, _global: &super::GlobalArgs) -> CmdResult<IssuesCom
 fn into_issue_groups(
     input: ReconcileFindingsInput,
     component_id: &str,
-) -> Vec<homeboy::issues::IssueGroup> {
+) -> Vec<homeboy::core::issues::IssueGroup> {
     input
         .groups
         .into_iter()
-        .map(|(category, row)| homeboy::issues::IssueGroup {
+        .map(|(category, row)| homeboy::core::issues::IssueGroup {
             command: input.command.clone(),
             component_id: component_id.to_string(),
             category,
@@ -240,17 +240,17 @@ fn read_reconcile_input(
     findings: Option<&str>,
     from_output: &[(String, String)],
     run_url: Option<String>,
-) -> homeboy::Result<ReconcileFindingsInput> {
+) -> homeboy::core::Result<ReconcileFindingsInput> {
     match (findings, from_output.is_empty()) {
         (Some(path), true) => read_findings(path),
         (None, false) => build_findings_input(from_output, run_url),
-        (Some(_), false) => Err(homeboy::Error::validation_invalid_argument(
+        (Some(_), false) => Err(homeboy::core::Error::validation_invalid_argument(
             "findings",
             "Use either --findings or --from-output, not both",
             None,
             None,
         )),
-        (None, true) => Err(homeboy::Error::validation_invalid_argument(
+        (None, true) => Err(homeboy::core::Error::validation_invalid_argument(
             "findings",
             "Missing --findings or --from-output",
             None,
@@ -265,9 +265,9 @@ fn read_reconcile_input(
 fn build_findings_input(
     from_output: &[(String, String)],
     run_url: Option<String>,
-) -> homeboy::Result<ReconcileFindingsInput> {
+) -> homeboy::core::Result<ReconcileFindingsInput> {
     if from_output.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "from-output",
             "At least one --from-output COMMAND=PATH pair is required",
             None,
@@ -281,7 +281,7 @@ fn build_findings_input(
     for (command, path) in from_output {
         if let Some(existing) = command_label {
             if existing != command {
-                return Err(homeboy::Error::validation_invalid_argument(
+                return Err(homeboy::core::Error::validation_invalid_argument(
                     "from-output",
                     "Multiple command labels in one issue reconcile input are not supported yet",
                     None,
@@ -301,16 +301,16 @@ fn build_findings_input(
     Ok(merged)
 }
 
-fn read_findings(path: &str) -> homeboy::Result<ReconcileFindingsInput> {
+fn read_findings(path: &str) -> homeboy::core::Result<ReconcileFindingsInput> {
     let value = read_json_value(path, "findings")?;
     parse_findings_value(value)
 }
 
-fn read_json_value(path: &str, label: &str) -> homeboy::Result<Value> {
+fn read_json_value(path: &str, label: &str) -> homeboy::core::Result<Value> {
     let raw = if path == "-" {
         let mut buf = String::new();
         std::io::stdin().read_to_string(&mut buf).map_err(|e| {
-            homeboy::Error::internal_io(
+            homeboy::core::Error::internal_io(
                 format!("read {} from stdin: {}", label, e),
                 Some("stdin".into()),
             )
@@ -318,7 +318,7 @@ fn read_json_value(path: &str, label: &str) -> homeboy::Result<Value> {
         buf
     } else {
         std::fs::read_to_string(path).map_err(|e| {
-            homeboy::Error::internal_io(
+            homeboy::core::Error::internal_io(
                 format!("read {} file: {}", label, e),
                 Some(path.to_string()),
             )
@@ -326,7 +326,7 @@ fn read_json_value(path: &str, label: &str) -> homeboy::Result<Value> {
     };
 
     let value: Value = serde_json::from_str(&raw).map_err(|e| {
-        homeboy::Error::validation_invalid_json(
+        homeboy::core::Error::validation_invalid_json(
             e,
             Some("parse findings JSON".to_string()),
             Some(raw.chars().take(200).collect()),
@@ -336,9 +336,9 @@ fn read_json_value(path: &str, label: &str) -> homeboy::Result<Value> {
     Ok(value)
 }
 
-fn parse_findings_value(value: Value) -> homeboy::Result<ReconcileFindingsInput> {
+fn parse_findings_value(value: Value) -> homeboy::core::Result<ReconcileFindingsInput> {
     let obj = value.as_object().ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "findings",
             "Findings JSON must be an object with a `command` and `groups` field",
             None,
@@ -350,7 +350,7 @@ fn parse_findings_value(value: Value) -> homeboy::Result<ReconcileFindingsInput>
         .get("command")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "findings.command",
                 "Missing or non-string `command` field (e.g. \"audit\")",
                 None,
@@ -359,10 +359,10 @@ fn parse_findings_value(value: Value) -> homeboy::Result<ReconcileFindingsInput>
         })?
         .to_string();
 
-    let mut groups: BTreeMap<String, homeboy::issues::RenderedIssueGroup> = BTreeMap::new();
+    let mut groups: BTreeMap<String, homeboy::core::issues::RenderedIssueGroup> = BTreeMap::new();
     if let Some(groups_value) = obj.get("groups") {
         let groups_obj = groups_value.as_object().ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "findings.groups",
                 "`groups` must be a JSON object keyed by category",
                 None,
@@ -371,7 +371,7 @@ fn parse_findings_value(value: Value) -> homeboy::Result<ReconcileFindingsInput>
         })?;
         for (category, row_value) in groups_obj {
             let row_obj = row_value.as_object().ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     format!("findings.groups.{}", category),
                     "Each group must be a JSON object with `count`, optional `label`, optional `body`, optional `confidence`",
                     None,
@@ -399,7 +399,7 @@ fn parse_findings_value(value: Value) -> homeboy::Result<ReconcileFindingsInput>
                 .and_then(parse_confidence);
             groups.insert(
                 category.clone(),
-                homeboy::issues::RenderedIssueGroup {
+                homeboy::core::issues::RenderedIssueGroup {
                     count,
                     label,
                     body,
@@ -440,7 +440,7 @@ fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
     plan.actions
         .iter()
         .map(|a| match a {
-            homeboy::issues::ReconcileAction::FileNew {
+            homeboy::core::issues::ReconcileAction::FileNew {
                 command,
                 component_id,
                 category,
@@ -450,13 +450,13 @@ fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
                 "file_new      {}: {} in {} ({})",
                 command, category, component_id, count
             ),
-            homeboy::issues::ReconcileAction::Update {
+            homeboy::core::issues::ReconcileAction::Update {
                 number,
                 category,
                 count,
                 ..
             } => format!("update        {} ({}) → #{}", category, count, number),
-            homeboy::issues::ReconcileAction::UpdateClosed {
+            homeboy::core::issues::ReconcileAction::UpdateClosed {
                 number,
                 category,
                 count,
@@ -465,10 +465,10 @@ fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
                 "update_closed {} ({}) → #{} (stays closed)",
                 category, count, number
             ),
-            homeboy::issues::ReconcileAction::Close {
+            homeboy::core::issues::ReconcileAction::Close {
                 number, category, ..
             } => format!("close         {} → #{}", category, number),
-            homeboy::issues::ReconcileAction::CloseDuplicate {
+            homeboy::core::issues::ReconcileAction::CloseDuplicate {
                 number,
                 keep,
                 category,
@@ -477,7 +477,7 @@ fn render_plan_lines(plan: &ReconcilePlan) -> Vec<String> {
                 "dedupe        {} → keep #{}, close #{}",
                 category, keep, number
             ),
-            homeboy::issues::ReconcileAction::Skip {
+            homeboy::core::issues::ReconcileAction::Skip {
                 category, reason, ..
             } => format!("skip          {} ({:?})", category, reason),
         })

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -1,15 +1,19 @@
 use clap::Args;
 
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::lint::{
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::lint::{
     report, run_main_lint_workflow, run_self_check_lint_workflow, LintCommandOutput,
     LintRunWorkflowArgs,
 };
-use homeboy::extension::ExtensionCapability;
-use homeboy::git;
-use homeboy::observation::{finding_records_from_lint, ActiveObservation, NewRunRecord, RunStatus};
-use homeboy::refactor::plan::{collect_refactor_sources, lint_refactor_request, LintSourceOptions};
+use homeboy::core::extension::ExtensionCapability;
+use homeboy::core::git;
+use homeboy::core::observation::{
+    finding_records_from_lint, ActiveObservation, NewRunRecord, RunStatus,
+};
+use homeboy::core::refactor::plan::{
+    collect_refactor_sources, lint_refactor_request, LintSourceOptions,
+};
 
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
@@ -145,7 +149,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     }
 
     let run_dir = RunDir::create()?;
-    let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
+    let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
         "lint {}",
         effective_id
     )));
@@ -172,7 +176,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             sniffs: args.sniffs.clone(),
             exclude_sniffs: args.exclude_sniffs.clone(),
             category: args.category.clone(),
-            baseline_flags: homeboy::engine::baseline::BaselineFlags {
+            baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
                 baseline: args.baseline_args.baseline,
                 ignore_baseline: args.baseline_args.ignore_baseline,
                 ratchet: args.baseline_args.ratchet,
@@ -189,8 +193,8 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
 
 fn finish_lint_workflow(
     observation: Option<LintObservation>,
-    workflow: homeboy::Result<homeboy::extension::lint::LintRunWorkflowResult>,
-) -> homeboy::Result<homeboy::extension::lint::LintRunWorkflowResult> {
+    workflow: homeboy::core::Result<homeboy::core::extension::lint::LintRunWorkflowResult>,
+) -> homeboy::core::Result<homeboy::core::extension::lint::LintRunWorkflowResult> {
     match workflow {
         Ok(workflow) => {
             if let Some(observation) = observation {
@@ -223,7 +227,7 @@ impl LintObservation {
         .map(Self)
     }
 
-    fn finish_workflow(self, workflow: &homeboy::extension::lint::LintRunWorkflowResult) {
+    fn finish_workflow(self, workflow: &homeboy::core::extension::lint::LintRunWorkflowResult) {
         if let Some(findings) = &workflow.lint_findings {
             let records = finding_records_from_lint(self.0.run_id(), findings);
             self.0.record_findings(&records);
@@ -291,7 +295,7 @@ fn lint_command_label(component_id: &str, args: &LintArgs) -> String {
 /// this path returns exit 0 unless the underlying fixer actually errored.
 fn run_fix(
     args: LintArgs,
-    ctx: &homeboy::engine::execution_context::ExecutionContext,
+    ctx: &homeboy::core::engine::execution_context::ExecutionContext,
     component_label: String,
     settings: Vec<(String, String)>,
 ) -> CmdResult<LintCommandOutput> {
@@ -335,11 +339,11 @@ fn run_fix(
 mod tests {
     use super::LintArgs;
     use clap::Parser;
-    use homeboy::component::Component;
-    use homeboy::extension::lint as extension_lint;
-    use homeboy::extension::lint::baseline::{self as lint_baseline, LintFinding};
-    use homeboy::extension::lint::report;
-    use homeboy::refactor::plan::{
+    use homeboy::core::component::Component;
+    use homeboy::core::extension::lint as extension_lint;
+    use homeboy::core::extension::lint::baseline::{self as lint_baseline, LintFinding};
+    use homeboy::core::extension::lint::report;
+    use homeboy::core::refactor::plan::{
         lint_refactor_request, LintSourceOptions, RefactorSourceRun, SourceTotals,
     };
     use std::path::Path;

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -1,7 +1,9 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::project::logs::{self, LogContent, LogEntry, LogSearchResult, PinnedLogsContent};
+use homeboy::core::project::logs::{
+    self, LogContent, LogEntry, LogSearchResult, PinnedLogsContent,
+};
 
 use crate::commands::CmdResult;
 
@@ -189,7 +191,7 @@ fn show(
 
 fn show_pinned(project_id: &str, lines: u32, follow: bool, local: bool) -> CmdResult<LogsOutput> {
     if follow {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "follow",
             "Cannot follow multiple pinned logs. Specify a log path to follow.",
             None,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,7 +2,7 @@ use base64::Engine;
 use clap::Args;
 use serde_json::{json, Map, Value};
 
-pub type CmdResult<T> = homeboy::Result<(T, i32)>;
+pub type CmdResult<T> = homeboy::core::Result<(T, i32)>;
 
 pub(crate) fn escape_markdown_table_cell(value: &str) -> String {
     value.replace('|', "\\|")
@@ -103,13 +103,13 @@ impl DynamicSetArgs {
     /// If the positional `spec` looks like a flag (starts with `--`), it was
     /// misrouted by clap after a `--` separator and is not a JSON spec.
     /// Use `effective_extra()` to recover it as a key-value flag.
-    pub fn json_spec(&self) -> Result<Option<String>, homeboy::Error> {
+    pub fn json_spec(&self) -> Result<Option<String>, homeboy::core::Error> {
         // Base64 takes priority - decode and return
         if let Some(b64) = &self.base64 {
             let decoded_bytes = base64::engine::general_purpose::STANDARD
                 .decode(b64)
                 .map_err(|e| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "base64",
                         format!("Invalid base64 encoding: {}", e),
                         None,
@@ -117,7 +117,7 @@ impl DynamicSetArgs {
                     )
                 })?;
             let decoded_str = String::from_utf8(decoded_bytes).map_err(|e| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "base64",
                     format!("Decoded base64 is not valid UTF-8: {}", e),
                     None,
@@ -162,7 +162,7 @@ fn is_dynamic_set_arg(arg: &str) -> bool {
 // ============================================================================
 
 /// Parse --key value and key=value pairs into a JSON object.
-fn parse_kv_flags(extra: &[String]) -> homeboy::Result<Value> {
+fn parse_kv_flags(extra: &[String]) -> homeboy::core::Result<Value> {
     let mut obj = Map::new();
     let mut iter = extra.iter().peekable();
 
@@ -171,7 +171,7 @@ fn parse_kv_flags(extra: &[String]) -> homeboy::Result<Value> {
             insert_path_value(&mut obj, &key, parse_value(&value));
         } else if let Some(key) = arg.strip_prefix("--") {
             let value = iter.next().ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     key,
                     format!("Missing value for flag --{}", key),
                     None,
@@ -255,9 +255,9 @@ fn parse_value(s: &str) -> Value {
 }
 
 /// Merge JSON spec with --key value flags. Flags override spec values.
-pub fn merge_json_sources(spec: Option<&str>, extra: &[String]) -> homeboy::Result<Value> {
+pub fn merge_json_sources(spec: Option<&str>, extra: &[String]) -> homeboy::core::Result<Value> {
     let mut base = if let Some(spec) = spec {
-        let raw = homeboy::config::read_json_spec_to_string(spec)?;
+        let raw = homeboy::core::config::read_json_spec_to_string(spec)?;
         serde_json::from_str(&raw).map_err(|e| {
             let hint = if raw.contains('\\') {
                 Some(
@@ -269,7 +269,7 @@ pub fn merge_json_sources(spec: Option<&str>, extra: &[String]) -> homeboy::Resu
             } else {
                 None
             };
-            homeboy::Error::validation_invalid_json(
+            homeboy::core::Error::validation_invalid_json(
                 e,
                 Some("parse JSON spec".to_string()),
                 Some(format!(
@@ -301,7 +301,7 @@ pub fn merge_json_sources(spec: Option<&str>, extra: &[String]) -> homeboy::Resu
 
 /// Merge JSON sources from `DynamicSetArgs` into a single JSON value.
 /// Returns `None` if no JSON/base64/key-value input was provided.
-pub fn merge_dynamic_args(args: &DynamicSetArgs) -> homeboy::Result<Option<Value>> {
+pub fn merge_dynamic_args(args: &DynamicSetArgs) -> homeboy::core::Result<Option<Value>> {
     let spec = args.json_spec()?;
     let extra = args.effective_extra();
     if spec.is_none() && extra.is_empty() {
@@ -315,11 +315,11 @@ pub fn merge_dynamic_args(args: &DynamicSetArgs) -> homeboy::Result<Option<Value
 pub fn finalize_set_spec(
     merged: &Value,
     explicit_replace: &[String],
-) -> homeboy::Result<(String, Vec<String>)> {
-    let json_string = homeboy::config::to_json_string(merged)?;
+) -> homeboy::core::Result<(String, Vec<String>)> {
+    let json_string = homeboy::core::config::to_json_string(merged)?;
 
     let mut replace_fields = explicit_replace.to_vec();
-    for field in homeboy::config::collect_array_fields(merged) {
+    for field in homeboy::core::config::collect_array_fields(merged) {
         if !replace_fields.contains(&field) {
             replace_fields.push(field);
         }
@@ -377,7 +377,7 @@ pub mod version;
 pub fn run_markdown(
     command: crate::cli_surface::Commands,
     global: &GlobalArgs,
-) -> homeboy::Result<(String, i32)> {
+) -> homeboy::core::Result<(String, i32)> {
     match command {
         crate::cli_surface::Commands::Docs(args) => docs::run_markdown(args),
         crate::cli_surface::Commands::Changelog(args) => changelog::run_markdown(args),
@@ -385,7 +385,7 @@ pub fn run_markdown(
         crate::cli_surface::Commands::Trace(args) => trace::run_markdown(args, global),
         crate::cli_surface::Commands::Runs(args) => runs::run_markdown(args, global),
         crate::cli_surface::Commands::Report(args) => report::run_markdown(args),
-        _ => Err(homeboy::Error::validation_invalid_argument(
+        _ => Err(homeboy::core::Error::validation_invalid_argument(
             "output_mode",
             "Command does not support markdown output",
             None,
@@ -397,15 +397,15 @@ pub fn run_markdown(
 pub fn run_plain_text(
     command: crate::cli_surface::Commands,
     global: &GlobalArgs,
-) -> homeboy::Result<(String, i32)> {
+) -> homeboy::core::Result<(String, i32)> {
     match command {
         crate::cli_surface::Commands::File(args) => match file::run(args, global)? {
             (file::FileCommandOutput::Raw(content), exit_code) => Ok((content, exit_code)),
-            _ => Err(homeboy::Error::internal_unexpected(
+            _ => Err(homeboy::core::Error::internal_unexpected(
                 "Unexpected output type for raw mode",
             )),
         },
-        _ => Err(homeboy::Error::validation_invalid_argument(
+        _ => Err(homeboy::core::Error::validation_invalid_argument(
             "output_mode",
             "Command does not support plain text output",
             None,
@@ -424,7 +424,7 @@ macro_rules! dispatch {
 pub fn run_json(
     command: crate::cli_surface::Commands,
     global: &GlobalArgs,
-) -> (homeboy::Result<serde_json::Value>, i32) {
+) -> (homeboy::core::Result<serde_json::Value>, i32) {
     crate::commands::utils::tty::status("homeboy is working...");
 
     match command {
@@ -475,7 +475,7 @@ pub fn run_json(
 
         // Special case: List uses raw output mode
         crate::cli_surface::Commands::List => {
-            let err = homeboy::Error::validation_invalid_argument(
+            let err = homeboy::core::Error::validation_invalid_argument(
                 "output_mode",
                 "List command uses raw output mode",
                 None,

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -10,14 +10,14 @@ use clap::Args;
 use regex::Regex;
 use serde::Serialize;
 
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::engine::run_dir::{self, RunDir};
-use homeboy::extension::trace::{
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::engine::run_dir::{self, RunDir};
+use homeboy::core::extension::trace::{
     ActiveTraceProbes, TraceArtifact, TraceEvent, TraceProbeConfig, TraceResults, TraceStatus,
 };
-use homeboy::git::short_head_revision_at;
-use homeboy::observation::{NewRunRecord, ObservationStore, RunStatus};
-use homeboy::Error;
+use homeboy::core::git::short_head_revision_at;
+use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use homeboy::core::Error;
 
 use super::utils::args::PositionalComponentArgs;
 use super::{CmdResult, GlobalArgs};
@@ -199,7 +199,7 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
     ))
 }
 
-fn validate_probe_selection(args: &ObserveArgs) -> homeboy::Result<()> {
+fn validate_probe_selection(args: &ObserveArgs) -> homeboy::core::Result<()> {
     if args.tail_logs.is_empty() && args.watch_processes.is_empty() && args.probes.is_empty() {
         return Err(Error::validation_invalid_argument(
             "probe",
@@ -217,7 +217,7 @@ fn validate_probe_selection(args: &ObserveArgs) -> homeboy::Result<()> {
     Ok(())
 }
 
-fn collect_timeline(args: &ObserveArgs) -> homeboy::Result<Vec<TraceEvent>> {
+fn collect_timeline(args: &ObserveArgs) -> homeboy::core::Result<Vec<TraceEvent>> {
     let start = Instant::now();
     let mut tail_logs = build_tail_log_states(args)?;
     let mut process_watches = build_process_watch_states(args)?;
@@ -247,7 +247,9 @@ fn collect_timeline(args: &ObserveArgs) -> homeboy::Result<Vec<TraceEvent>> {
     Ok(timeline)
 }
 
-fn build_standard_probe_configs(args: &ObserveArgs) -> homeboy::Result<Vec<TraceProbeConfig>> {
+fn build_standard_probe_configs(
+    args: &ObserveArgs,
+) -> homeboy::core::Result<Vec<TraceProbeConfig>> {
     args.probes
         .iter()
         .map(|raw| {
@@ -263,7 +265,7 @@ fn build_standard_probe_configs(args: &ObserveArgs) -> homeboy::Result<Vec<Trace
         .collect()
 }
 
-fn build_tail_log_states(args: &ObserveArgs) -> homeboy::Result<Vec<TailLogState>> {
+fn build_tail_log_states(args: &ObserveArgs) -> homeboy::core::Result<Vec<TailLogState>> {
     let grep = args
         .grep
         .as_deref()
@@ -286,7 +288,7 @@ fn build_tail_log_states(args: &ObserveArgs) -> homeboy::Result<Vec<TailLogState
         .collect()
 }
 
-fn build_process_watch_states(args: &ObserveArgs) -> homeboy::Result<Vec<ProcessWatchState>> {
+fn build_process_watch_states(args: &ObserveArgs) -> homeboy::core::Result<Vec<ProcessWatchState>> {
     args.watch_processes
         .iter()
         .map(|pattern| {
@@ -315,7 +317,7 @@ fn watch_process_is_due(state: &mut ProcessWatchState, start: Instant, interval:
     false
 }
 
-fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::Result<Vec<TraceEvent>> {
+fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::core::Result<Vec<TraceEvent>> {
     let mut file = match File::open(&state.path) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -375,7 +377,7 @@ fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::Result<Vec<Tra
 fn poll_process_watch(
     state: &mut ProcessWatchState,
     t_ms: u64,
-) -> homeboy::Result<Vec<TraceEvent>> {
+) -> homeboy::core::Result<Vec<TraceEvent>> {
     let output = Command::new("ps")
         .args(["-axo", "pid=,ppid=,command="])
         .output()
@@ -470,7 +472,7 @@ fn parse_process_snapshot(stdout: &str) -> Vec<(u32, ProcessInfo)> {
         .collect()
 }
 
-fn write_trace_results(path: &Path, results: &TraceResults) -> homeboy::Result<()> {
+fn write_trace_results(path: &Path, results: &TraceResults) -> homeboy::core::Result<()> {
     let content = serde_json::to_string_pretty(results).map_err(|e| {
         Error::internal_unexpected(format!("Failed to serialize observe timeline: {e}"))
     })?;

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use std::path::Path;
 
 use super::CmdResult;
-use homeboy::project::{self};
+use homeboy::core::project::{self};
 
 #[derive(Args)]
 pub struct ProjectArgs {
@@ -205,7 +205,7 @@ enum ProjectPinType {
     Log,
 }
 
-pub type ProjectOutput = homeboy::project::ProjectReportOutput;
+pub type ProjectOutput = homeboy::core::project::ProjectReportOutput;
 
 pub fn run(args: ProjectArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<ProjectOutput> {
     match args.command {
@@ -224,7 +224,7 @@ pub fn run(args: ProjectArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
                 spec
             } else {
                 let id = id.ok_or_else(|| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "id",
                         "Missing required argument: id",
                         None,
@@ -241,7 +241,7 @@ pub fn run(args: ProjectArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
                     ..Default::default()
                 };
 
-                homeboy::config::serialize_with_id(&new_project, &id)?
+                homeboy::core::config::serialize_with_id(&new_project, &id)?
             };
 
             Ok(project::build_create_output(project::create(
@@ -256,7 +256,7 @@ pub fn run(args: ProjectArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
             json,
         } => {
             let json_spec = json.or(spec).ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "spec",
                     "Provide JSON spec or use --json flag",
                     None,
@@ -290,7 +290,7 @@ fn show(project_id: &str) -> CmdResult<ProjectOutput> {
 
 fn set(args: super::DynamicSetArgs) -> CmdResult<ProjectOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "spec",
             "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
             None,
@@ -388,7 +388,7 @@ fn components_clear(project_id: &str) -> CmdResult<ProjectOutput> {
 fn write_project_components_response(
     project_id: &str,
     action: &str,
-    components: homeboy::project::ProjectComponentsOutput,
+    components: homeboy::core::project::ProjectComponentsOutput,
 ) -> (ProjectOutput, i32) {
     (
         project::build_components_output(project_id, action, components),

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
-use homeboy::code_audit::{AuditFinding, CodeAuditResult};
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::refactor::{
+use homeboy::core::code_audit::{AuditFinding, CodeAuditResult};
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::refactor::{
     self, auto, AddResult, MoveResult, RenameContext, RenameScope, RenameSpec, RenameTargeting,
 };
 use serde::Serialize;
@@ -317,7 +317,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
                 run_move_file(&file_path, &to, &target, write_mode.write)
             } else if let Some(from_path) = from {
                 if item.is_empty() {
-                    return Err(homeboy::Error::validation_invalid_argument(
+                    return Err(homeboy::core::Error::validation_invalid_argument(
                         "item",
                         "Either --item (with --from) or --file is required",
                         None,
@@ -330,7 +330,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
                 }
                 run_move(&item, &from_path, &to, &target, write_mode.write)
             } else {
-                Err(homeboy::Error::validation_invalid_argument(
+                Err(homeboy::core::Error::validation_invalid_argument(
                     "from",
                     "Either --from (with --item) or --file is required",
                     None,
@@ -377,7 +377,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
 #[serde(tag = "command")]
 pub enum RefactorOutput {
     #[serde(rename = "refactor.sources")]
-    Sources(homeboy::refactor::plan::RefactorSourceRun),
+    Sources(homeboy::core::refactor::plan::RefactorSourceRun),
 
     #[serde(rename = "refactor.rename")]
     Rename {
@@ -433,13 +433,13 @@ pub enum RefactorOutput {
     #[serde(rename = "refactor.transform")]
     Transform {
         #[serde(flatten)]
-        result: homeboy::refactor::TransformResult,
+        result: homeboy::core::refactor::TransformResult,
     },
 
     #[serde(rename = "refactor.decompose")]
     Decompose {
-        plan: homeboy::refactor::DecomposePlan,
-        move_results: Vec<homeboy::refactor::MoveResult>,
+        plan: homeboy::core::refactor::DecomposePlan,
+        move_results: Vec<homeboy::core::refactor::MoveResult>,
         dry_run: bool,
         applied: bool,
     },
@@ -504,10 +504,10 @@ pub struct RefactorBulkSummary {
 }
 
 impl RefactorTargetArgs {
-    fn resolve_targets(&self) -> homeboy::Result<Vec<RefactorTarget>> {
+    fn resolve_targets(&self) -> homeboy::core::Result<Vec<RefactorTarget>> {
         let component_ids = collect_component_ids(&self.component_ids, &self.components);
         if self.path.is_some() && !component_ids.is_empty() {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "component",
                 "--path cannot be combined with multiple component IDs",
                 None,
@@ -527,7 +527,7 @@ impl RefactorTargetArgs {
         }
 
         if component_ids.is_empty() {
-            return Err(homeboy::Error::validation_missing_argument(vec![
+            return Err(homeboy::core::Error::validation_missing_argument(vec![
                 "component".to_string(),
             ]));
         }
@@ -547,13 +547,13 @@ fn resolve_top_level_targets(
     comp: Option<&PositionalComponentArgs>,
     component_ids: &[String],
     components: &[String],
-) -> homeboy::Result<Vec<RefactorTarget>> {
+) -> homeboy::core::Result<Vec<RefactorTarget>> {
     let flagged_ids = collect_component_ids(component_ids, components);
 
     if let Some(comp) = comp {
         if let Some(ref component_id) = comp.component {
             if !flagged_ids.is_empty() {
-                return Err(homeboy::Error::validation_invalid_argument(
+                return Err(homeboy::core::Error::validation_invalid_argument(
                     "component",
                     "Use either positional component syntax or --component/--components, not both",
                     None,
@@ -572,7 +572,7 @@ fn resolve_top_level_targets(
 
     if flagged_ids.is_empty() {
         // No component specified anywhere — try CWD auto-discovery
-        let component = homeboy::component::resolution::resolve(None)?;
+        let component = homeboy::core::component::resolution::resolve(None)?;
         return Ok(vec![RefactorTarget {
             label: component.id.clone(),
             component_id: Some(component.id),
@@ -714,7 +714,7 @@ fn run_refactor_sources_single(
     git_identity: Option<&str>,
 ) -> CmdResult<RefactorOutput> {
     let component_id = component_id.ok_or_else(|| {
-        homeboy::Error::validation_missing_argument(vec!["component".to_string()])
+        homeboy::core::Error::validation_missing_argument(vec!["component".to_string()])
     })?;
     let ctx = execution_context::resolve(&ResolveOptions::source_only(
         component_id,
@@ -724,8 +724,8 @@ fn run_refactor_sources_single(
     let only_findings = parse_audit_findings(only)?;
     let exclude_findings = parse_audit_findings(exclude)?;
     let source_path = ctx.source_path.clone();
-    let sources = homeboy::refactor::plan::collect_refactor_sources(
-        homeboy::refactor::plan::RefactorSourceRequest {
+    let sources = homeboy::core::refactor::plan::collect_refactor_sources(
+        homeboy::core::refactor::plan::RefactorSourceRequest {
             component: ctx.component,
             root: ctx.source_path,
             sources: requested_sources,
@@ -733,8 +733,8 @@ fn run_refactor_sources_single(
             only: only_findings,
             exclude: exclude_findings,
             settings: settings.to_vec(),
-            lint: homeboy::refactor::plan::LintSourceOptions::default(),
-            test: homeboy::refactor::plan::TestSourceOptions::default(),
+            lint: homeboy::core::refactor::plan::LintSourceOptions::default(),
+            test: homeboy::core::refactor::plan::TestSourceOptions::default(),
             write,
             force,
         },
@@ -750,12 +750,12 @@ fn run_refactor_sources_single(
     Ok((RefactorOutput::Sources(sources), exit_code))
 }
 
-fn parse_audit_findings(values: &[String]) -> homeboy::Result<Vec<AuditFinding>> {
+fn parse_audit_findings(values: &[String]) -> homeboy::core::Result<Vec<AuditFinding>> {
     values
         .iter()
         .map(|value| {
             value.parse::<AuditFinding>().map_err(|_| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "kind",
                     format!("Unknown audit finding kind: {}", value),
                     None,
@@ -855,7 +855,7 @@ fn run_rename_single(
             .chain(result.file_renames.iter().map(|r| r.from.clone()))
             .chain(result.file_renames.iter().map(|r| r.to.clone()))
             .collect();
-        homeboy::engine::undo::UndoSnapshot::capture_and_save(
+        homeboy::core::engine::undo::UndoSnapshot::capture_and_save(
             &root,
             "refactor rename",
             &affected_files,
@@ -936,7 +936,7 @@ fn run_add(
     // Mode 2: Explicit import addition
     if let Some(import_line) = import {
         let destination = to.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "to",
                 "--to is required when using --import",
                 None,
@@ -954,7 +954,7 @@ fn run_add(
     }
 
     // Neither mode specified
-    Err(homeboy::Error::validation_invalid_argument(
+    Err(homeboy::core::Error::validation_invalid_argument(
         "add",
         "Specify either --from-audit or --import with --to",
         None,
@@ -990,7 +990,7 @@ fn run_add_from_audit(source: &str, write: bool) -> CmdResult<RefactorOutput> {
         serde_json::from_value(json_content)
     }
     .map_err(|e| {
-        homeboy::Error::validation_invalid_json(
+        homeboy::core::Error::validation_invalid_json(
             e,
             Some("parse audit result for refactor add".to_string()),
             Some(
@@ -1089,7 +1089,11 @@ fn run_move_single(
     let root = refactor::move_items::resolve_root(component_id, path)?;
 
     if write {
-        homeboy::engine::undo::UndoSnapshot::capture_and_save(&root, "refactor move", [from, to]);
+        homeboy::core::engine::undo::UndoSnapshot::capture_and_save(
+            &root,
+            "refactor move",
+            [from, to],
+        );
     }
 
     let item_refs: Vec<&str> = items.iter().map(|s| s.as_str()).collect();
@@ -1168,7 +1172,7 @@ fn run_move_file_single(
     let root = refactor::move_items::resolve_root(component_id, path)?;
 
     if write {
-        homeboy::engine::undo::UndoSnapshot::capture_and_save(
+        homeboy::core::engine::undo::UndoSnapshot::capture_and_save(
             &root,
             "refactor move --file",
             [file, to],
@@ -1243,7 +1247,7 @@ fn run_propagate_single(
         // Dry-run to discover affected files for the undo snapshot
         let preview = refactor::propagate(&config)?;
         let affected_files: Vec<&str> = preview.edits.iter().map(|e| e.file.as_str()).collect();
-        homeboy::engine::undo::UndoSnapshot::capture_and_save(
+        homeboy::core::engine::undo::UndoSnapshot::capture_and_save(
             &root,
             "refactor propagate",
             affected_files,
@@ -1344,7 +1348,7 @@ fn run_transform_single(
                 .iter()
                 .flat_map(|r| r.matches.iter().map(|m| m.file.clone()))
                 .collect();
-            homeboy::engine::undo::UndoSnapshot::capture_and_save(
+            homeboy::core::engine::undo::UndoSnapshot::capture_and_save(
                 &root,
                 "refactor transform",
                 &affected_files,
@@ -1444,7 +1448,7 @@ fn run_decompose_single(
         let affected: Vec<&str> = std::iter::once(file)
             .chain(plan.groups.iter().map(|g| g.suggested_target.as_str()))
             .collect();
-        homeboy::engine::undo::UndoSnapshot::capture_and_save(
+        homeboy::core::engine::undo::UndoSnapshot::capture_and_save(
             &root,
             "refactor decompose",
             &affected,
@@ -1514,9 +1518,9 @@ const AUTOFIX_PREFIX: &str = "chore(ci): homeboy autofix";
 /// Stage all changes and create a commit after refactor --write.
 fn autofix_commit(
     path: &str,
-    sources: &homeboy::refactor::plan::RefactorSourceRun,
+    sources: &homeboy::core::refactor::plan::RefactorSourceRun,
     git_identity: Option<&str>,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     use std::process::Command;
 
     // Stage all changes
@@ -1524,10 +1528,10 @@ fn autofix_commit(
         .args(["add", "-A"])
         .current_dir(path)
         .output()
-        .map_err(|e| homeboy::Error::git_command_failed(format!("git add: {e}")))?;
+        .map_err(|e| homeboy::core::Error::git_command_failed(format!("git add: {e}")))?;
     if !add.status.success() {
         let stderr = String::from_utf8_lossy(&add.stderr);
-        return Err(homeboy::Error::git_command_failed(format!(
+        return Err(homeboy::core::Error::git_command_failed(format!(
             "git add -A failed: {stderr}"
         )));
     }
@@ -1537,7 +1541,7 @@ fn autofix_commit(
         .args(["diff", "--cached", "--quiet"])
         .current_dir(path)
         .output()
-        .map_err(|e| homeboy::Error::git_command_failed(format!("git diff: {e}")))?;
+        .map_err(|e| homeboy::core::Error::git_command_failed(format!("git diff: {e}")))?;
     if diff_check.status.success() {
         eprintln!("[refactor] No staged changes after git add — skipping commit");
         return Ok(());
@@ -1552,10 +1556,10 @@ fn autofix_commit(
             .args(["config", key, value])
             .current_dir(path)
             .output()
-            .map_err(|e| homeboy::Error::git_command_failed(format!("git config: {e}")))?;
+            .map_err(|e| homeboy::core::Error::git_command_failed(format!("git config: {e}")))?;
         if !config.status.success() {
             let stderr = String::from_utf8_lossy(&config.stderr);
-            return Err(homeboy::Error::git_command_failed(format!(
+            return Err(homeboy::core::Error::git_command_failed(format!(
                 "git config {key} failed: {stderr}"
             )));
         }
@@ -1570,10 +1574,10 @@ fn autofix_commit(
         .args(["commit", "-m", &message, "--author", &author])
         .current_dir(path)
         .output()
-        .map_err(|e| homeboy::Error::git_command_failed(format!("git commit: {e}")))?;
+        .map_err(|e| homeboy::core::Error::git_command_failed(format!("git commit: {e}")))?;
     if !commit.status.success() {
         let stderr = String::from_utf8_lossy(&commit.stderr);
-        return Err(homeboy::Error::git_command_failed(format!(
+        return Err(homeboy::core::Error::git_command_failed(format!(
             "git commit failed: {stderr}"
         )));
     }
@@ -1618,7 +1622,9 @@ fn resolve_git_identity(identity: Option<&str>) -> (String, String) {
 /// Dead code removed: 4 fixes (2 files)
 /// ...
 /// ```
-fn build_autofix_commit_message(sources: &homeboy::refactor::plan::RefactorSourceRun) -> String {
+fn build_autofix_commit_message(
+    sources: &homeboy::core::refactor::plan::RefactorSourceRun,
+) -> String {
     let source_labels: Vec<&str> = sources.sources.iter().map(|s| s.as_str()).collect();
     let source_desc = source_labels.join(", ");
 

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -1,10 +1,10 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::component;
-use homeboy::deploy::{self, ReleaseStateStatus};
-use homeboy::project;
-use homeboy::release::{self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult};
+use homeboy::core::component;
+use homeboy::core::deploy::{self, ReleaseStateStatus};
+use homeboy::core::project;
+use homeboy::core::release::{self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult};
 
 use super::utils::args::{DryRunArgs, HiddenJsonArgs};
 use super::CmdResult;
@@ -157,7 +157,7 @@ pub fn run(
 
     // Multiple components: batch release
     if args.path.is_some() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "path",
             "--path is not supported for batch releases (multiple components)",
             None,
@@ -165,7 +165,7 @@ pub fn run(
         ));
     }
     if args.recover {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "recover",
             "--recover is not supported for batch releases — run recovery per-component",
             None,
@@ -211,13 +211,13 @@ pub fn run(
 fn resolve_component_ids(
     args: &ReleaseArgs,
     components: &[String],
-) -> homeboy::Result<Vec<String>> {
+) -> homeboy::core::Result<Vec<String>> {
     if let Some(ref project_id) = args.project {
         let proj = project::load(project_id)?;
         let components = project::resolve_project_components(&proj)?;
 
         if components.is_empty() {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "project",
                 format!("Project '{}' has no components attached", project_id),
                 Some(project_id.to_string()),
@@ -255,7 +255,7 @@ fn resolve_component_ids(
             } else {
                 "that need a release"
             };
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "project",
                 format!("No components {} in project '{}'", filter_desc, project_id),
                 Some(project_id.to_string()),
@@ -279,7 +279,7 @@ fn resolve_component_ids(
         // Try CWD-based component detection
         match component::resolve_effective(None, None, None) {
             Ok(comp) => Ok(vec![comp.id]),
-            Err(_) => Err(homeboy::Error::validation_missing_argument(vec![
+            Err(_) => Err(homeboy::core::Error::validation_missing_argument(vec![
                 "component ID(s), or --project <project-id>".to_string(),
             ])),
         }
@@ -294,7 +294,7 @@ struct PositionalReleaseArgs {
     bump: Option<String>,
 }
 
-fn resolve_positional_args(args: &ReleaseArgs) -> homeboy::Result<PositionalReleaseArgs> {
+fn resolve_positional_args(args: &ReleaseArgs) -> homeboy::core::Result<PositionalReleaseArgs> {
     let mut components = args.components.clone();
 
     if args.project.is_some() || components.len() < 2 {
@@ -313,7 +313,7 @@ fn resolve_positional_args(args: &ReleaseArgs) -> homeboy::Result<PositionalRele
     };
 
     if args.bump.is_some() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "bump",
             "Use either a positional bump type or --bump, not both",
             Some(bump),

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -95,7 +95,7 @@ pub fn run(args: ReportArgs, _global: &super::GlobalArgs) -> CmdResult<ReportOut
     }
 }
 
-pub fn render_failure_digest_from_args(args: &FailureDigestArgs) -> homeboy::Result<String> {
+pub fn render_failure_digest_from_args(args: &FailureDigestArgs) -> homeboy::core::Result<String> {
     let results = read_json_spec_value(&args.results, "results")?;
     let tooling = match args.tooling_json.as_deref() {
         Some(spec) => read_json_spec_value(spec, "tooling_json")?,
@@ -156,16 +156,16 @@ pub fn render_failure_digest(context: &FailureDigestContext) -> String {
     out
 }
 
-fn read_json_spec_value(spec: &str, context: &str) -> homeboy::Result<Value> {
+fn read_json_spec_value(spec: &str, context: &str) -> homeboy::core::Result<Value> {
     let raw = if Path::new(spec).exists() {
         std::fs::read_to_string(spec).map_err(|e| {
-            homeboy::Error::internal_unexpected(format!("Failed to read {}: {}", spec, e))
+            homeboy::core::Error::internal_unexpected(format!("Failed to read {}: {}", spec, e))
         })?
     } else {
-        homeboy::config::read_json_spec_to_string(spec)?
+        homeboy::core::config::read_json_spec_to_string(spec)?
     };
     serde_json::from_str(&raw).map_err(|e| {
-        homeboy::Error::validation_invalid_json(e, Some(context.to_string()), Some(raw))
+        homeboy::core::Error::validation_invalid_json(e, Some(context.to_string()), Some(raw))
     })
 }
 

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -19,13 +19,13 @@ use serde_json::Value;
 use std::path::Path;
 use std::process::Command;
 
-use homeboy::code_audit::AuditCommandOutput;
-use homeboy::extension::lint::LintCommandOutput;
-use homeboy::extension::test::TestCommandOutput;
-use homeboy::git;
-use homeboy::plan::HomeboyPlan;
-use homeboy::quality::{build_quality_plan, QualityPlanOptions};
-use homeboy::ObservationOutputMetadata;
+use homeboy::core::code_audit::AuditCommandOutput;
+use homeboy::core::extension::lint::LintCommandOutput;
+use homeboy::core::extension::test::TestCommandOutput;
+use homeboy::core::git;
+use homeboy::core::plan::HomeboyPlan;
+use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
+use homeboy::core::ObservationOutputMetadata;
 
 use super::parse_key_val;
 use super::utils::args::{BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs};
@@ -214,7 +214,7 @@ impl<Args, Output: Serialize> ReviewStageDescriptor<Args, Output> {
 fn review_stage_order(plan: &HomeboyPlan) -> Vec<String> {
     plan.steps
         .iter()
-        .filter(|step| step.status == homeboy::plan::PlanStepStatus::Ready)
+        .filter(|step| step.status == homeboy::core::plan::PlanStepStatus::Ready)
         .filter_map(|step| step.kind.strip_prefix("review.").map(str::to_string))
         .collect()
 }
@@ -262,7 +262,7 @@ fn execute_review_stage(
                 .execute(args, global, component_label)
                 .map(|(stage, exit_code)| (ReviewStageRun::Test(stage, exit_code), exit_code))
         }
-        other => Err(homeboy::Error::internal_unexpected(format!(
+        other => Err(homeboy::core::Error::internal_unexpected(format!(
             "review quality plan contains unsupported stage '{other}'"
         ))),
     }
@@ -484,7 +484,7 @@ pub fn run_markdown(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<String> 
 /// Falls back to the generic JSON envelope if the review command failed before
 /// producing an artifact.
 pub fn write_artifact_to_file(
-    result: &homeboy::Result<Value>,
+    result: &homeboy::core::Result<Value>,
     path: &str,
     _exit_code: i32,
 ) -> bool {

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use homeboy::git::short_head_revision_at;
-use homeboy::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
-use homeboy::ObservationOutputMetadata;
+use homeboy::core::git::short_head_revision_at;
+use homeboy::core::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
+use homeboy::core::ObservationOutputMetadata;
 
 use super::{artifact_command, ReviewArgs, ReviewCommandOutput, ReviewStage};
 
@@ -68,7 +68,7 @@ pub(super) fn finish_success(
     observation.0.finish(status, Some(metadata));
 }
 
-pub(super) fn finish_error(observation: Option<ReviewObservation>, error: &homeboy::Error) {
+pub(super) fn finish_error(observation: Option<ReviewObservation>, error: &homeboy::core::Error) {
     let Some(observation) = observation else {
         return;
     };
@@ -205,9 +205,9 @@ mod tests {
 
     #[test]
     fn finish_metadata_captures_aggregate_and_linkable_stages() {
-        use homeboy::code_audit::AuditCommandOutput;
-        use homeboy::extension::lint::LintCommandOutput;
-        use homeboy::extension::test::TestCommandOutput;
+        use homeboy::core::code_audit::AuditCommandOutput;
+        use homeboy::core::extension::lint::LintCommandOutput;
+        use homeboy::core::extension::test::TestCommandOutput;
 
         let initial = serde_json::json!({
             "schema": "homeboy/review-observation/v1",
@@ -257,8 +257,8 @@ mod tests {
         );
         let output = ReviewCommandOutput {
             command: "review".to_string(),
-            plan: homeboy::quality::build_quality_plan(
-                homeboy::quality::QualityPlanOptions::review("homeboy"),
+            plan: homeboy::core::quality::build_quality_plan(
+                homeboy::core::quality::QualityPlanOptions::review("homeboy"),
             ),
             observation: None,
             artifact,

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -17,10 +17,10 @@
 
 use std::fmt::Write as _;
 
-use homeboy::code_audit::{AuditCommandOutput, AuditFinding, Severity};
-use homeboy::extension::lint::LintCommandOutput;
-use homeboy::extension::test::{FailedTest, TestCommandOutput};
-use homeboy::top_n::top_n_by;
+use homeboy::core::code_audit::{AuditCommandOutput, AuditFinding, Severity};
+use homeboy::core::extension::lint::LintCommandOutput;
+use homeboy::core::extension::test::{FailedTest, TestCommandOutput};
+use homeboy::core::top_n::top_n_by;
 
 use super::{ReviewCommandOutput, ReviewStage};
 
@@ -338,13 +338,13 @@ fn render_failed_tests(out: &mut String, failed_tests: &[FailedTest]) {
 mod tests {
     use super::*;
 
-    use homeboy::code_audit::{
+    use homeboy::core::code_audit::{
         AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity,
     };
-    use homeboy::extension::lint::{LintCommandOutput, LintFinding};
-    use homeboy::extension::test::{FailedTest, TestCommandOutput, TestCounts};
-    use homeboy::extension::{PhaseReport, PhaseStatus, VerificationPhase};
-    use homeboy::quality::{build_quality_plan, QualityPlanOptions};
+    use homeboy::core::extension::lint::{LintCommandOutput, LintFinding};
+    use homeboy::core::extension::test::{FailedTest, TestCommandOutput, TestCounts};
+    use homeboy::core::extension::{PhaseReport, PhaseStatus, VerificationPhase};
+    use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
 
     // ── Builders for fixture envelopes ──────────────────────────────────
 
@@ -438,7 +438,7 @@ mod tests {
         let result = CodeAuditResult {
             component_id: "my-comp".to_string(),
             source_path: "/tmp/my-comp".to_string(),
-            summary: homeboy::code_audit::AuditSummary {
+            summary: homeboy::core::code_audit::AuditSummary {
                 files_scanned: 0,
                 conventions_detected: 0,
                 outliers_found: 0,

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -7,7 +7,7 @@ pub use output::RigCommandOutput;
 
 use clap::{Args, Subcommand};
 
-use homeboy::rig;
+use homeboy::core::rig;
 
 use self::output::{
     RigAppOutput, RigCheckOutput, RigDownOutput, RigInstallOutput, RigInstalledStackSummary,
@@ -191,7 +191,7 @@ fn list() -> CmdResult<RigCommandOutput> {
                 pipelines,
             })
         })
-        .collect::<homeboy::Result<Vec<_>>>()?;
+        .collect::<homeboy::core::Result<Vec<_>>>()?;
 
     Ok((
         RigCommandOutput::List(RigListOutput {
@@ -240,7 +240,7 @@ fn install(source: &str, id: Option<&str>, all: bool) -> CmdResult<RigCommandOut
 fn update(rig_id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
     let report = match (rig_id, all) {
         (Some(_), true) => {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "rig_id",
                 "Pass either a rig ID or --all, not both",
                 rig_id.map(str::to_string),
@@ -250,7 +250,7 @@ fn update(rig_id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
         (Some(id), false) => rig::update_source_for_rig(id)?,
         (None, true) => rig::update_all_sources()?,
         (None, false) => {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "rig_id",
                 "Pass a rig ID or --all",
                 None,

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -6,7 +6,7 @@
 use serde::Serialize;
 
 use crate::commands::runs::RunsOutput;
-use homeboy::rig::{self, RigResourcesSpec, RigSpec};
+use homeboy::core::rig::{self, RigResourcesSpec, RigSpec};
 
 /// Tagged union of every rig command's output. `untagged` so each variant
 /// serializes to its own shape — consumers discriminate on the `command`

--- a/src/commands/rig/sources.rs
+++ b/src/commands/rig/sources.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use homeboy::rig;
+use homeboy::core::rig;
 
 use super::output::{RigSourcesOutput, RigSourcesReport};
 use super::RigCommandOutput;

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -4,12 +4,12 @@ use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::runner::{
+use homeboy::core::runner::{
     self, Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
     RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOutput,
 };
-use homeboy::{EntityCrudOutput, MergeOutput};
+use homeboy::core::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
 
@@ -339,7 +339,7 @@ fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
         spec
     } else {
         let id = input.id.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "id",
                 "Missing required argument: id",
                 None,
@@ -366,11 +366,11 @@ fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
             resources: HashMap::<String, Value>::new(),
         };
 
-        homeboy::config::to_json_string(&new_runner)?
+        homeboy::core::config::to_json_string(&new_runner)?
     };
 
     match runner::create(&json_spec, input.skip_existing)? {
-        homeboy::CreateOutput::Single(result) => Ok((
+        homeboy::core::CreateOutput::Single(result) => Ok((
             RunnerOutput {
                 command: "runner.add".to_string(),
                 id: Some(result.id),
@@ -380,7 +380,7 @@ fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
             },
             0,
         )),
-        homeboy::CreateOutput::Bulk(summary) => {
+        homeboy::core::CreateOutput::Bulk(summary) => {
             let exit_code = summary.exit_code();
             Ok((
                 RunnerOutput {
@@ -420,7 +420,7 @@ fn show(id: &str) -> CmdResult<RunnerOutput> {
 
 fn set(args: DynamicSetArgs) -> CmdResult<RunnerOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "spec",
             "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
             None,

--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -4,8 +4,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use homeboy::runner::{self, Runner, RunnerKind};
-use homeboy::server::{self, Server, SshClient};
+use homeboy::core::runner::{self, Runner, RunnerKind};
+use homeboy::core::server::{self, Server, SshClient};
 use serde::Serialize;
 
 use crate::commands::CmdResult;
@@ -177,7 +177,7 @@ mod target {
         },
     }
 
-    pub fn resolve(runner_id: &str) -> homeboy::Result<RunnerTarget> {
+    pub fn resolve(runner_id: &str) -> homeboy::core::Result<RunnerTarget> {
         match runner::load(runner_id) {
             Ok(runner) => from_registry(runner_id, runner),
             Err(_) if is_local_runner_id(runner_id) => Ok(RunnerTarget::Local {
@@ -188,7 +188,7 @@ mod target {
         }
     }
 
-    fn from_registry(runner_id: &str, runner: Runner) -> homeboy::Result<RunnerTarget> {
+    fn from_registry(runner_id: &str, runner: Runner) -> homeboy::core::Result<RunnerTarget> {
         match runner.kind {
             RunnerKind::Local => Ok(RunnerTarget::Local {
                 id: runner_id.to_string(),
@@ -196,7 +196,7 @@ mod target {
             }),
             RunnerKind::Ssh => {
                 let server_id = runner.server_id.as_deref().ok_or_else(|| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "server_id",
                         "SSH runners require server_id",
                         None,

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -22,8 +22,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
-use homeboy::Error;
+use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::Error;
 
 use super::{CmdResult, GlobalArgs};
 use bundle::{
@@ -427,7 +427,7 @@ pub fn bench_history(
         .filter(|run| scenario_id.is_none_or(|scenario| run_contains_scenario(run, scenario)))
         .take(limit.max(1) as usize)
         .map(|run| run_detail(&store, run))
-        .collect::<homeboy::Result<Vec<_>>>()?;
+        .collect::<homeboy::core::Result<Vec<_>>>()?;
 
     Ok((
         RunsOutput::BenchHistory(BenchHistoryOutput {
@@ -498,7 +498,7 @@ pub fn bench_compare(from_run_id: &str, to_run_id: &str) -> CmdResult<RunsOutput
     ))
 }
 
-fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::Result<RunRecord> {
+fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::core::Result<RunRecord> {
     store.get_run(run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
@@ -509,7 +509,7 @@ fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::Result<RunRec
     })
 }
 
-fn require_kind(run: &RunRecord, expected: &str) -> homeboy::Result<()> {
+fn require_kind(run: &RunRecord, expected: &str) -> homeboy::core::Result<()> {
     if run.kind == expected {
         return Ok(());
     }
@@ -524,7 +524,7 @@ fn require_kind(run: &RunRecord, expected: &str) -> homeboy::Result<()> {
     ))
 }
 
-fn run_detail(store: &ObservationStore, run: RunRecord) -> homeboy::Result<RunDetail> {
+fn run_detail(store: &ObservationStore, run: RunRecord) -> homeboy::core::Result<RunDetail> {
     let artifacts = store.list_artifacts(&run.id)?;
     Ok(RunDetail {
         summary: run_summary(run.clone()),
@@ -622,7 +622,7 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    use homeboy::observation::{
+    use homeboy::core::observation::{
         FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceSpanRecord,
         RunRecord, RunStatus, TraceSpanRecord,
     };

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 use clap::Args;
 use serde::{Deserialize, Serialize};
 
-use homeboy::observation::{
+use homeboy::core::observation::{
     ArtifactRecord, FindingRecord, ObservationStore, RunRecord, TraceSpanRecord,
 };
-use homeboy::Error;
+use homeboy::core::Error;
 
 use super::common::since_threshold;
 use super::{require_run, CmdResult, RunsOutput};
@@ -216,7 +216,7 @@ fn import_via_gh_actions(args: RunsImportArgs) -> CmdResult<RunsOutput> {
     })
 }
 
-fn require_gh_arg(value: Option<String>, name: &str) -> homeboy::Result<String> {
+fn require_gh_arg(value: Option<String>, name: &str) -> homeboy::core::Result<String> {
     value
         .filter(|v| !v.trim().is_empty())
         .ok_or_else(|| Error::validation_missing_argument(vec![format!("--{name}")]))
@@ -225,7 +225,7 @@ fn require_gh_arg(value: Option<String>, name: &str) -> homeboy::Result<String> 
 fn build_bundle(
     store: &ObservationStore,
     runs: Vec<RunRecord>,
-) -> homeboy::Result<ObservationBundle> {
+) -> homeboy::core::Result<ObservationBundle> {
     let mut artifacts = Vec::new();
     let mut trace_spans = Vec::new();
     let mut findings = Vec::new();
@@ -260,7 +260,7 @@ fn build_bundle(
     })
 }
 
-fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::Result<()> {
+fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::core::Result<()> {
     if path.exists() && !path.is_dir() {
         return Err(Error::validation_invalid_argument(
             "output",
@@ -284,7 +284,7 @@ fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::Result<
     Ok(())
 }
 
-fn read_bundle_dir(path: &Path) -> homeboy::Result<ObservationBundle> {
+fn read_bundle_dir(path: &Path) -> homeboy::core::Result<ObservationBundle> {
     if !path.is_dir() {
         return Err(Error::validation_invalid_argument(
             "input",
@@ -361,7 +361,7 @@ fn is_test_failure_finding(finding: &FindingRecord) -> bool {
                 == Some("test-failures"))
 }
 
-fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::Result<()> {
+fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::core::Result<()> {
     let json = serde_json::to_string_pretty(value).map_err(|e| {
         Error::internal_json(e.to_string(), Some(format!("serialize {}", path.display())))
     })?;
@@ -373,7 +373,7 @@ fn write_json(path: PathBuf, value: &impl Serialize) -> homeboy::Result<()> {
     })
 }
 
-fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::Result<T> {
+fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::core::Result<T> {
     let raw = fs::read_to_string(&path).map_err(|e| {
         Error::internal_io(
             e.to_string(),
@@ -389,7 +389,9 @@ fn read_json<T: for<'de> Deserialize<'de>>(path: PathBuf) -> homeboy::Result<T> 
     })
 }
 
-fn read_optional_json<T: for<'de> Deserialize<'de> + Default>(path: PathBuf) -> homeboy::Result<T> {
+fn read_optional_json<T: for<'de> Deserialize<'de> + Default>(
+    path: PathBuf,
+) -> homeboy::core::Result<T> {
     if !path.exists() {
         return Ok(T::default());
     }

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -9,8 +9,8 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-use homeboy::observation::{ObservationStore, RunListFilter, RunRecord};
-use homeboy::Error;
+use homeboy::core::observation::{ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -35,7 +35,7 @@ pub struct RunSummary {
 /// Accepts the same forms as elsewhere in the runs surface (s, m, h, d).
 /// Returned timestamp is `now - duration` so the caller can compare with
 /// `started_at >= threshold` semantics.
-pub fn since_threshold(raw: &str) -> homeboy::Result<String> {
+pub fn since_threshold(raw: &str) -> homeboy::core::Result<String> {
     let duration = parse_duration(raw)?;
     let chrono_duration = chrono::Duration::from_std(duration).map_err(|e| {
         Error::validation_invalid_argument("since", e.to_string(), Some(raw.to_string()), None)
@@ -47,7 +47,7 @@ pub fn since_threshold(raw: &str) -> homeboy::Result<String> {
 ///
 /// Mirrors the parser in `bundle.rs`. Kept here so the gh-actions / query /
 /// drift commands can share the same surface without re-implementing it.
-pub fn parse_duration(raw: &str) -> homeboy::Result<Duration> {
+pub fn parse_duration(raw: &str) -> homeboy::core::Result<Duration> {
     let trimmed = raw.trim();
     let split = trimmed
         .find(|ch: char| !ch.is_ascii_digit())
@@ -97,7 +97,7 @@ pub fn parse_duration(raw: &str) -> homeboy::Result<Duration> {
 /// Compile a JSONPath expression. Returns a structured validation error on
 /// invalid syntax instead of panicking. Schema-blind: the engine doesn't know
 /// what the JSON looks like, only how to walk it.
-pub fn compile_jsonpath(expr: &str) -> homeboy::Result<serde_json_path::JsonPath> {
+pub fn compile_jsonpath(expr: &str) -> homeboy::core::Result<serde_json_path::JsonPath> {
     serde_json_path::JsonPath::parse(expr).map_err(|e| {
         Error::validation_invalid_argument(
             "jsonpath",
@@ -156,7 +156,7 @@ pub fn load_artifact_rows(
     store: &ObservationStore,
     filter: RunListFilter,
     since: Option<&str>,
-) -> homeboy::Result<Vec<ArtifactJsonRow>> {
+) -> homeboy::core::Result<Vec<ArtifactJsonRow>> {
     let runs = if let Some(raw) = since {
         let threshold = since_threshold(raw)?;
         store

--- a/src/commands/runs/compare.rs
+++ b/src/commands/runs/compare.rs
@@ -4,8 +4,8 @@ use clap::{Args, ValueEnum};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{ObservationStore, RunListFilter};
-use homeboy::Error;
+use homeboy::core::observation::{ObservationStore, RunListFilter};
+use homeboy::core::Error;
 
 use crate::commands::{escape_markdown_table_cell, CmdResult};
 
@@ -270,7 +270,7 @@ fn fmt_metric(value: Option<f64>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy::observation::{NewRunRecord, RunStatus};
+    use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
     struct XdgGuard(Option<String>);

--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -7,7 +7,7 @@
 
 #![cfg(test)]
 
-use homeboy::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
+use homeboy::core::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
 use homeboy::test_support::with_isolated_home;
 
 use super::bundle::RunsImportArgs;

--- a/src/commands/runs/distribution.rs
+++ b/src/commands/runs/distribution.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::observation::{ObservationStore, RunListFilter, RunRecord};
 
 use crate::commands::CmdResult;
 
@@ -212,7 +212,7 @@ fn scalar_metadata_label(value: &Value) -> Option<String> {
 mod tests {
     use super::*;
 
-    use homeboy::observation::{NewRunRecord, RunStatus};
+    use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
     struct XdgGuard(Option<String>);

--- a/src/commands/runs/drift.rs
+++ b/src/commands/runs/drift.rs
@@ -10,8 +10,8 @@
 use clap::{Args, ValueEnum};
 use serde::Serialize;
 
-use homeboy::observation::{ObservationStore, RunListFilter};
-use homeboy::Error;
+use homeboy::core::observation::{ObservationStore, RunListFilter};
+use homeboy::core::Error;
 
 use super::common::{
     compile_jsonpath, distribution_share, load_artifact_rows, DistributionSnapshot,

--- a/src/commands/runs/findings.rs
+++ b/src/commands/runs/findings.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::observation::{FindingListFilter, FindingRecord, ObservationStore};
-use homeboy::Error;
+use homeboy::core::observation::{FindingListFilter, FindingRecord, ObservationStore};
+use homeboy::core::Error;
 
 use crate::commands::{
     runs::{
@@ -143,7 +143,7 @@ pub fn latest_finding(args: RunsLatestFindingArgs) -> CmdResult<RunsOutput> {
     ))
 }
 
-fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::Result<()> {
+fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::core::Result<()> {
     if store.get_run(run_id)?.is_some() {
         return Ok(());
     }

--- a/src/commands/runs/gh_actions.rs
+++ b/src/commands/runs/gh_actions.rs
@@ -31,8 +31,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use homeboy::observation::{ObservationStore, RunRecord};
-use homeboy::Error;
+use homeboy::core::observation::{ObservationStore, RunRecord};
+use homeboy::core::Error;
 
 use super::{CmdResult, RunsOutput};
 
@@ -167,7 +167,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
                     persist_artifact_file(&homeboy_run_id, &artifact_id, &file_name, &json_bytes)?;
                 let sha = format!("{:x}", Sha256::digest(&json_bytes));
                 let size = i64::try_from(json_bytes.len()).ok();
-                let artifact_record = homeboy::observation::ArtifactRecord {
+                let artifact_record = homeboy::core::observation::ArtifactRecord {
                     id: artifact_id,
                     run_id: homeboy_run_id.clone(),
                     kind: artifact.name.clone(),
@@ -348,7 +348,7 @@ fn list_workflow_runs(
     repo: &str,
     workflow: &str,
     since: &str,
-) -> homeboy::Result<(Vec<GhWorkflowRun>, bool)> {
+) -> homeboy::core::Result<(Vec<GhWorkflowRun>, bool)> {
     let cache_key = list_runs_cache_key(repo, workflow);
     let etag_path = list_runs_cache_path(&cache_key, "etag")?;
     let body_path = list_runs_cache_path(&cache_key, "json")?;
@@ -488,7 +488,7 @@ fn split_headers_and_body(raw: &str) -> (Option<String>, String) {
 /// Parse one or more concatenated JSON arrays (gh `--paginate` output) into
 /// a single flat list of workflow runs. The runs payload from
 /// `actions/workflows/.../runs` is `{"total_count":N, "workflow_runs":[...]}`.
-fn parse_runs_payload(body: &[u8]) -> homeboy::Result<Vec<GhWorkflowRun>> {
+fn parse_runs_payload(body: &[u8]) -> homeboy::core::Result<Vec<GhWorkflowRun>> {
     #[derive(Deserialize)]
     struct WorkflowRunsPage {
         #[serde(default)]
@@ -515,7 +515,7 @@ fn parse_runs_payload(body: &[u8]) -> homeboy::Result<Vec<GhWorkflowRun>> {
 fn filter_runs_by_since(
     runs: Vec<GhWorkflowRun>,
     since: &str,
-) -> homeboy::Result<Vec<GhWorkflowRun>> {
+) -> homeboy::core::Result<Vec<GhWorkflowRun>> {
     let threshold = super::common::since_threshold(since)?;
     Ok(runs
         .into_iter()
@@ -533,7 +533,7 @@ fn filter_runs_by_since(
 /// `--created` uses GitHub's date filter, which is always inclusive of the
 /// boundary day. Convert our duration-style `--since` into a `YYYY-MM-DD`
 /// boundary suitable for the filter.
-fn since_iso_filter(since: &str) -> homeboy::Result<String> {
+fn since_iso_filter(since: &str) -> homeboy::core::Result<String> {
     let raw = super::common::since_threshold(since)?;
     Ok(raw[..10].to_string())
 }
@@ -563,7 +563,7 @@ struct GhArtifact {
     archive_download_url: Option<String>,
 }
 
-fn list_run_artifacts(repo: &str, gh_run_id: u64) -> homeboy::Result<Vec<GhArtifact>> {
+fn list_run_artifacts(repo: &str, gh_run_id: u64) -> homeboy::core::Result<Vec<GhArtifact>> {
     let api_path = format!("repos/{repo}/actions/runs/{gh_run_id}/artifacts?per_page=100");
     let args = vec!["api".to_string(), "--paginate".into(), api_path.clone()];
     let output = Command::new("gh")
@@ -609,7 +609,7 @@ fn list_run_artifacts(repo: &str, gh_run_id: u64) -> homeboy::Result<Vec<GhArtif
     Ok(out)
 }
 
-fn download_artifact_zip(repo: &str, artifact_id: u64) -> homeboy::Result<Vec<u8>> {
+fn download_artifact_zip(repo: &str, artifact_id: u64) -> homeboy::core::Result<Vec<u8>> {
     // `gh api repos/.../actions/artifacts/{id}/zip` follows the redirect to
     // the artifact storage URL automatically.
     let api_path = format!("repos/{repo}/actions/artifacts/{artifact_id}/zip");
@@ -633,7 +633,7 @@ fn download_artifact_zip(repo: &str, artifact_id: u64) -> homeboy::Result<Vec<u8
 /// pairs for every entry that ends in `.json`. Non-JSON entries are
 /// returned to the caller anyway when `keep_non_json` is true (currently
 /// we only return JSON — keeping the API simple).
-fn unpack_json_files_from_zip(zip_bytes: &[u8]) -> homeboy::Result<Vec<(String, Vec<u8>)>> {
+fn unpack_json_files_from_zip(zip_bytes: &[u8]) -> homeboy::core::Result<Vec<(String, Vec<u8>)>> {
     let cursor = Cursor::new(zip_bytes);
     let mut archive = zip::ZipArchive::new(cursor).map_err(|e| {
         Error::validation_invalid_argument(
@@ -674,9 +674,9 @@ fn persist_artifact_file(
     artifact_id: &str,
     file_name: &str,
     bytes: &[u8],
-) -> homeboy::Result<PathBuf> {
+) -> homeboy::core::Result<PathBuf> {
     let safe_name = sanitize_file_name(file_name);
-    let target_dir = crate::paths::homeboy_data()?
+    let target_dir = crate::core::paths::homeboy_data()?
         .join("artifacts")
         .join(homeboy_run_id);
     fs::create_dir_all(&target_dir).map_err(|e| {
@@ -705,8 +705,8 @@ fn list_runs_cache_key(repo: &str, workflow: &str) -> String {
     format!("{:x}", digest)
 }
 
-fn list_runs_cache_path(key: &str, ext: &str) -> homeboy::Result<PathBuf> {
-    let base = crate::paths::homeboy()?
+fn list_runs_cache_path(key: &str, ext: &str) -> homeboy::core::Result<PathBuf> {
+    let base = crate::core::paths::homeboy()?
         .join("cache")
         .join("gh-actions-runs");
     fs::create_dir_all(&base).map_err(|e| {
@@ -722,7 +722,7 @@ fn list_runs_cache_path(key: &str, ext: &str) -> homeboy::Result<PathBuf> {
 
 /// Compile a `--artifact-glob` value into a matcher. Uses the existing `glob`
 /// crate's `Pattern` for shell-style matching (`*`, `?`, character classes).
-fn compile_glob(raw: &str) -> homeboy::Result<glob::Pattern> {
+fn compile_glob(raw: &str) -> homeboy::core::Result<glob::Pattern> {
     glob::Pattern::new(raw).map_err(|e| {
         Error::validation_invalid_argument(
             "artifact_glob",

--- a/src/commands/runs/latest.rs
+++ b/src/commands/runs/latest.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::observation::{FindingRecord, ObservationStore, RunListFilter, RunRecord};
-use homeboy::Error;
+use homeboy::core::observation::{FindingRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::Error;
 
 use crate::commands::{
     runs::{run_summary, RunSummary, RunsOutput},
@@ -52,7 +52,7 @@ pub fn latest_run(args: RunsLatestRunArgs) -> CmdResult<RunsOutput> {
 
 pub(crate) fn latest_run_context(
     args: RunsLatestRunArgs,
-) -> homeboy::Result<(ObservationStore, RunRecord)> {
+) -> homeboy::core::Result<(ObservationStore, RunRecord)> {
     let store = ObservationStore::open_initialized()?;
     let run = require_latest_run(&store, run_filter_from_latest_args(args))?;
     Ok((store, run))
@@ -61,7 +61,7 @@ pub(crate) fn latest_run_context(
 pub(crate) fn require_latest_run(
     store: &ObservationStore,
     filter: RunListFilter,
-) -> homeboy::Result<RunRecord> {
+) -> homeboy::core::Result<RunRecord> {
     store.latest_run(filter)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "filter",

--- a/src/commands/runs/query.rs
+++ b/src/commands/runs/query.rs
@@ -13,8 +13,8 @@ use clap::{Args, ValueEnum};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{ObservationStore, RunListFilter};
-use homeboy::Error;
+use homeboy::core::observation::{ObservationStore, RunListFilter};
+use homeboy::core::Error;
 
 use super::common::{
     compile_jsonpath, distribution_share, eval_jsonpath, load_artifact_rows, ArtifactJsonRow,
@@ -121,7 +121,7 @@ pub fn runs_query(args: RunsQueryArgs) -> CmdResult<RunsOutput> {
         .select
         .iter()
         .map(|expr| compile_jsonpath(expr).map(|p| (expr.clone(), p)))
-        .collect::<homeboy::Result<Vec<_>>>()?;
+        .collect::<homeboy::core::Result<Vec<_>>>()?;
     let group_path = args
         .group_by
         .as_deref()
@@ -303,7 +303,7 @@ mod tests {
 
     fn sample_row(run_id: &str, kind: &str, json: Value) -> ArtifactJsonRow {
         ArtifactJsonRow {
-            run: homeboy::observation::RunRecord {
+            run: homeboy::core::observation::RunRecord {
                 id: run_id.into(),
                 kind: "gh-actions".into(),
                 component_id: Some("homeboy".into()),

--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -2,7 +2,9 @@ use clap::Args;
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::observation::{run_owner_pid, ObservationStore, RunListFilter, RunRecord, RunStatus};
+use homeboy::core::observation::{
+    run_owner_pid, ObservationStore, RunListFilter, RunRecord, RunStatus,
+};
 
 use crate::commands::runs::RunsOutput;
 use crate::commands::CmdResult;
@@ -64,7 +66,7 @@ pub fn reconcile_runs(args: RunsReconcileArgs) -> CmdResult<RunsOutput> {
 pub(super) fn reconcile_owned_stale_running_runs(
     store: &ObservationStore,
     limit: i64,
-) -> homeboy::Result<Vec<ReconciledRunSummary>> {
+) -> homeboy::core::Result<Vec<ReconciledRunSummary>> {
     reconcile_orphaned_running_runs(store, limit, false, pid_is_running)
 }
 
@@ -73,7 +75,7 @@ fn reconcile_orphaned_running_runs<F>(
     limit: i64,
     dry_run: bool,
     pid_is_alive: F,
-) -> homeboy::Result<Vec<ReconciledRunSummary>>
+) -> homeboy::core::Result<Vec<ReconciledRunSummary>>
 where
     F: Fn(u32) -> bool,
 {
@@ -118,7 +120,7 @@ where
 }
 
 pub fn running_status_note(run: &RunRecord) -> Option<String> {
-    homeboy::observation::running_status_note(run)
+    homeboy::core::observation::running_status_note(run)
 }
 
 fn with_reconcile_metadata(run: &RunRecord, owner_pid: u32, reason: &str) -> Value {
@@ -160,7 +162,7 @@ fn pid_is_running(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy::observation::NewRunRecord;
+    use homeboy::core::observation::NewRunRecord;
     use homeboy::test_support::with_isolated_home;
 
     struct XdgGuard(Option<String>);

--- a/src/commands/runs/remote.rs
+++ b/src/commands/runs/remote.rs
@@ -1,5 +1,5 @@
-use homeboy::runner;
-use homeboy::Error;
+use homeboy::core::runner;
+use homeboy::core::Error;
 
 use super::{CmdResult, RunsListArgs, RunsListOutput, RunsOutput};
 

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use homeboy::observation::ArtifactRecord;
-use homeboy::runner;
+use homeboy::core::observation::ArtifactRecord;
+use homeboy::core::runner;
 
 use super::{CmdResult, RunsArtifactGetOutput, RunsOutput};
 

--- a/src/commands/self_cmd.rs
+++ b/src/commands/self_cmd.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use homeboy::self_status;
+use homeboy::core::self_status;
 use serde_json::Value;
 
 use crate::commands::utils::args::HiddenJsonArgs;
@@ -28,7 +28,7 @@ pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         SelfCommand::Status(_) => {
             let status = self_status::collect_status();
             let json = serde_json::to_value(status)
-                .map_err(|e| homeboy::Error::internal_json(e.to_string(), None))?;
+                .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
             Ok((json, 0))
         }
     }

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,8 +1,8 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::server::{self, Server, ServerSessionConfig, SshClient};
-use homeboy::{EntityCrudOutput, MergeOutput};
+use homeboy::core::server::{self, Server, ServerSessionConfig, SshClient};
+use homeboy::core::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
 
@@ -158,7 +158,7 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                 spec
             } else {
                 let id = id.ok_or_else(|| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "id",
                         "Missing required argument: id",
                         None,
@@ -167,7 +167,7 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                 })?;
 
                 let host = host.ok_or_else(|| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "host",
                         "Missing required argument: --host",
                         None,
@@ -176,7 +176,7 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                 })?;
 
                 let user = user.ok_or_else(|| {
-                    homeboy::Error::validation_invalid_argument(
+                    homeboy::core::Error::validation_invalid_argument(
                         "user",
                         "Missing required argument: --user",
                         None,
@@ -196,11 +196,11 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                     env: std::collections::HashMap::new(),
                 };
 
-                homeboy::config::to_json_string(&new_server)?
+                homeboy::core::config::to_json_string(&new_server)?
             };
 
             match server::create(&json_spec, skip_existing)? {
-                homeboy::CreateOutput::Single(result) => Ok((
+                homeboy::core::CreateOutput::Single(result) => Ok((
                     ServerOutput {
                         command: "server.create".to_string(),
                         id: Some(result.id),
@@ -210,7 +210,7 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                     },
                     0,
                 )),
-                homeboy::CreateOutput::Bulk(summary) => {
+                homeboy::core::CreateOutput::Bulk(summary) => {
                     let exit_code = summary.exit_code();
                     Ok((
                         ServerOutput {
@@ -313,7 +313,7 @@ fn show(server_id: &str) -> CmdResult<ServerOutput> {
 
 fn set(args: DynamicSetArgs) -> CmdResult<ServerOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "spec",
             "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
             None,

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
-use homeboy::engine::shell;
-use homeboy::server::{self, Server};
-use homeboy::server::{resolve_context, SshClient, SshResolveArgs};
+use homeboy::core::engine::shell;
+use homeboy::core::server::{self, Server};
+use homeboy::core::server::{resolve_context, SshClient, SshResolveArgs};
 use serde::Serialize;
 
 use super::CmdResult;
@@ -120,7 +120,7 @@ pub fn run(args: SshArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Ss
             if !args.command.is_empty() {
                 // Non-interactive: capture output for JSON response
                 let cmd = effective_command.as_deref().ok_or_else(|| {
-                    homeboy::Error::internal_unexpected(
+                    homeboy::core::Error::internal_unexpected(
                         "No command resolved for non-interactive SSH execution".to_string(),
                     )
                 })?;

--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -6,7 +6,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::stack::{
+use homeboy::core::stack::{
     self, ApplyOutput, DiffOutput, GitRef, InspectOptions, InspectOutput, PushOutput, RebaseOutput,
     StackPrEntry, StackSpec, StatusOutput, SyncOutput,
 };
@@ -329,7 +329,7 @@ fn create(
     // Refuse to silently overwrite an existing stack — `add-pr`/`remove-pr`
     // are the right verbs for editing a live spec.
     if stack::exists(stack_id)? {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "stack_id",
             format!("Stack '{}' already exists", stack_id),
             None,
@@ -377,7 +377,7 @@ fn add_pr(
         .iter()
         .any(|p| p.repo == repo && p.number == number)
     {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "number",
             format!("PR {}#{} is already in stack '{}'", repo, number, stack_id),
             None,
@@ -415,7 +415,7 @@ fn remove_pr(stack_id: &str, number: u64, repo: Option<&str>) -> CmdResult<Stack
         .collect();
 
     if matches.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "number",
             format!("No PR {} in stack '{}'", number, stack_id),
             None,
@@ -426,7 +426,7 @@ fn remove_pr(stack_id: &str, number: u64, repo: Option<&str>) -> CmdResult<Stack
     }
     if matches.len() > 1 {
         let repos: Vec<String> = matches.iter().map(|i| spec.prs[*i].repo.clone()).collect();
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "number",
             format!(
                 "PR {} matches multiple entries in stack '{}' (repos: {}). Pass --repo to disambiguate.",

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,10 +1,10 @@
 use clap::Args;
-use homeboy::component;
-use homeboy::context;
-use homeboy::deploy::{self, DeployConfig, ReleaseStateStatus};
-use homeboy::git;
-use homeboy::project;
-use homeboy::version;
+use homeboy::core::component;
+use homeboy::core::context;
+use homeboy::core::deploy::{self, DeployConfig, ReleaseStateStatus};
+use homeboy::core::git;
+use homeboy::core::project;
+use homeboy::core::release::version;
 use serde::Serialize;
 
 use super::CmdResult;
@@ -148,7 +148,7 @@ pub struct ProjectDashboardSummary {
 
 pub enum StatusResult {
     Summary(StatusOutput),
-    Full(homeboy::context::report::ContextReport),
+    Full(homeboy::core::context::report::ContextReport),
     Dashboard(ProjectDashboardOutput),
 }
 
@@ -301,7 +301,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
     let components = project::resolve_project_components(&proj)?;
 
     if components.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "project",
             format!("Project '{}' has no components attached", project_id),
             Some(project_id.to_string()),
@@ -450,7 +450,11 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
 /// Returns `None` if the path is not a git repo or has no upstream configured.
 fn fetch_upstream_drift(path: &str) -> Option<UpstreamDrift> {
     // Best-effort fetch — silently proceeds if no remote or network issue.
-    let _ = homeboy::engine::command::run_in_optional(path, "git", &["fetch", "--tags", "--quiet"]);
+    let _ = homeboy::core::engine::command::run_in_optional(
+        path,
+        "git",
+        &["fetch", "--tags", "--quiet"],
+    );
 
     let snapshot = git::get_repo_snapshot(path).ok()?;
 
@@ -472,7 +476,7 @@ fn fetch_upstream_drift(path: &str) -> Option<UpstreamDrift> {
 /// Unlike `get_latest_tag()` which uses `git describe` (reachable from HEAD),
 /// this lists all tags and picks the one with the highest semver version.
 fn get_latest_tag_overall(path: &str) -> Option<String> {
-    let output = homeboy::engine::command::run_in_optional(
+    let output = homeboy::core::engine::command::run_in_optional(
         path,
         "git",
         &["tag", "-l", "--sort=-v:refname"],

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,15 +1,17 @@
 use clap::Args;
 
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::test as extension_test;
-use homeboy::extension::test::{
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::test as extension_test;
+use homeboy::core::extension::test::{
     detect_test_drift, report, run_self_check_test_workflow, TestCommandOutput, TestRunWorkflowArgs,
 };
-use homeboy::extension::test::{FailureCategory, FailureCluster, TestAnalysisInput, TestFailure};
-use homeboy::extension::ExtensionCapability;
-use homeboy::git::short_head_revision_at;
-use homeboy::observation::{
+use homeboy::core::extension::test::{
+    FailureCategory, FailureCluster, TestAnalysisInput, TestFailure,
+};
+use homeboy::core::extension::ExtensionCapability;
+use homeboy::core::git::short_head_revision_at;
+use homeboy::core::observation::{
     merge_metadata, ActiveObservation, NewFindingRecord, NewRunRecord, RunStatus,
 };
 use std::path::Path;
@@ -160,7 +162,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         "test",
         Some(&run_dir),
     );
-    let resource_run = homeboy::engine::resource::ResourceSummaryRun::start(Some(format!(
+    let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
         "test {}",
         effective_id
     )));
@@ -177,7 +179,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             coverage: args.coverage,
             coverage_min: args.coverage_min,
             analyze: args.analyze,
-            baseline_flags: homeboy::engine::baseline::BaselineFlags {
+            baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
                 baseline: args.baseline_args.baseline,
                 ignore_baseline: args.baseline_args.ignore_baseline,
                 ratchet: args.baseline_args.ratchet,
@@ -219,8 +221,8 @@ fn start_test_observation(
 
 fn finish_test_workflow_observation(
     observation: Option<TestObservation>,
-    workflow: homeboy::Result<extension_test::TestRunWorkflowResult>,
-) -> homeboy::Result<extension_test::TestRunWorkflowResult> {
+    workflow: homeboy::core::Result<extension_test::TestRunWorkflowResult>,
+) -> homeboy::core::Result<extension_test::TestRunWorkflowResult> {
     match workflow {
         Ok(workflow) => {
             finish_test_observation(observation, &workflow);
@@ -404,7 +406,10 @@ fn finish_test_drift_observation(
     observation.0.finish(status, Some(metadata));
 }
 
-fn finish_test_observation_error(observation: Option<TestObservation>, error: &homeboy::Error) {
+fn finish_test_observation_error(
+    observation: Option<TestObservation>,
+    error: &homeboy::core::Error,
+) {
     let Some(observation) = observation else {
         return;
     };
@@ -486,9 +491,9 @@ mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
     use clap::Parser;
-    use homeboy::component::Component;
-    use homeboy::observation::{FindingListFilter, ObservationStore};
-    use homeboy::refactor::plan::{build_test_refactor_request, TestSourceOptions};
+    use homeboy::core::component::Component;
+    use homeboy::core::observation::{FindingListFilter, ObservationStore};
+    use homeboy::core::refactor::plan::{build_test_refactor_request, TestSourceOptions};
     use std::fs;
     use std::path::PathBuf;
 
@@ -552,7 +557,7 @@ mod tests {
 
             finish_test_observation_error(
                 Some(observation),
-                &homeboy::Error::validation_invalid_argument(
+                &homeboy::core::Error::validation_invalid_argument(
                     "fixture",
                     "simulated test error",
                     None,

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -2,20 +2,20 @@ use clap::Args;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use homeboy::component::{Component, ScopedExtensionConfig};
-use homeboy::engine::baseline::BaselineFlags;
-use homeboy::engine::execution_context::{self, ResolveOptions};
-use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::trace as extension_trace;
-use homeboy::extension::trace::{
+use homeboy::core::component::{Component, ScopedExtensionConfig};
+use homeboy::core::engine::baseline::BaselineFlags;
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::extension::trace::{
     TraceAttachment, TraceCommandOutput, TraceListWorkflowArgs, TraceOverlayRequest,
     TraceRunWorkflowArgs, TraceRunnerInputs, TraceSpanDefinition,
 };
-use homeboy::extension::ExtensionCapability;
-use homeboy::observation::{
+use homeboy::core::extension::ExtensionCapability;
+use homeboy::core::observation::{
     NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, ObservationStore, RunStatus,
 };
-use homeboy::rig::{self, RigSpec};
+use homeboy::core::rig::{self, RigSpec};
 
 use super::utils::args::{BaselineArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs};
 use super::{CmdResult, GlobalArgs};
@@ -219,14 +219,17 @@ pub fn run_json_with_output_artifact(
     args: TraceArgs,
     _global: &GlobalArgs,
 ) -> (
-    homeboy::Result<serde_json::Value>,
+    homeboy::core::Result<serde_json::Value>,
     i32,
-    Option<homeboy::Result<serde_json::Value>>,
+    Option<homeboy::core::Result<serde_json::Value>>,
 ) {
     crate::commands::utils::tty::status("homeboy is working...");
     let output_to_json = |output: TraceCommandOutput| {
         serde_json::to_value(output).map_err(|err| {
-            homeboy::Error::internal_json(err.to_string(), Some("serialize response".to_string()))
+            homeboy::core::Error::internal_json(
+                err.to_string(),
+                Some("serialize response".to_string()),
+            )
         })
     };
     match run_outputs(args) {
@@ -265,7 +268,7 @@ fn run_outputs(args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<TraceCo
     }
 
     if args.compare_after.is_some() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "AFTER_JSON",
             "extra positional argument is only supported by `homeboy trace compare before.json after.json`",
             None,
@@ -274,7 +277,7 @@ fn run_outputs(args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<TraceCo
     }
 
     if args.repeat == 0 {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--repeat",
             "repeat must be at least 1",
             None,
@@ -316,7 +319,7 @@ fn run_overlay_locks(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         }
         Some("cleanup") => {
             if !args.stale {
-                return Err(homeboy::Error::validation_invalid_argument(
+                return Err(homeboy::core::Error::validation_invalid_argument(
                     "--stale",
                     "trace overlay lock cleanup requires --stale",
                     None,
@@ -327,13 +330,13 @@ fn run_overlay_locks(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
             let output = overlay_locks_output(result.removed);
             Ok((TraceCommandOutput::OverlayLocks(output), 0))
         }
-        Some(other) => Err(homeboy::Error::validation_invalid_argument(
+        Some(other) => Err(homeboy::core::Error::validation_invalid_argument(
             "overlay-locks",
             format!("unsupported trace overlay-locks command `{other}`"),
             None,
             Some(vec!["list".to_string(), "cleanup --stale".to_string()]),
         )),
-        None => Err(homeboy::Error::validation_missing_argument(vec![
+        None => Err(homeboy::core::Error::validation_missing_argument(vec![
             "overlay-locks command".to_string(),
         ])),
     }
@@ -364,9 +367,9 @@ fn overlay_locks_output(
     }
 }
 
-pub(super) fn required_trace_scenario(args: &TraceArgs) -> homeboy::Result<String> {
+pub(super) fn required_trace_scenario(args: &TraceArgs) -> homeboy::core::Result<String> {
     args.scenario.clone().ok_or_else(|| {
-        homeboy::Error::validation_missing_argument(vec!["trace scenario".to_string()])
+        homeboy::core::Error::validation_missing_argument(vec!["trace scenario".to_string()])
     })
 }
 
@@ -376,7 +379,7 @@ struct TraceRunExecution {
     rig_state: Option<rig::RigStateSnapshot>,
 }
 
-fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
+fn execute_trace_run(args: TraceArgs) -> homeboy::core::Result<TraceRunExecution> {
     let scenario = required_trace_scenario(&args)?;
     let rig_context = load_rig_context(args.rig.as_deref())?;
     let effective_id = resolve_component_id(&args.comp, rig_context.as_ref().map(|c| &c.rig_spec))?;
@@ -444,7 +447,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::Result<TraceRunExecution> {
                     .command(std::env::args().collect::<Vec<_>>().join(" "))
                     .optional_cwd_path(cwd.as_deref())
                     .current_homeboy_version()
-                    .git_sha(homeboy::git::short_head_revision_at(Path::new(
+                    .git_sha(homeboy::core::git::short_head_revision_at(Path::new(
                         &component_path_for_observation,
                     )))
                     .optional_rig_id(rig_id.clone())
@@ -606,7 +609,7 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
                 }
                 let artifact_path = execution
                     .run_dir
-                    .step_file(homeboy::engine::run_dir::files::TRACE_RESULTS)
+                    .step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS)
                     .to_string_lossy()
                     .to_string();
                 let mut seen_span_ids = BTreeSet::new();
@@ -756,12 +759,12 @@ fn focus_aggregate_spans(
         .collect()
 }
 
-fn trace_scenario(args: &TraceArgs) -> homeboy::Result<&str> {
+fn trace_scenario(args: &TraceArgs) -> homeboy::core::Result<&str> {
     args.scenario_arg
         .as_deref()
         .or(args.scenario.as_deref())
         .ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "scenario",
                 "trace requires a scenario positional argument or --scenario",
                 None,
@@ -772,11 +775,13 @@ fn trace_scenario(args: &TraceArgs) -> homeboy::Result<&str> {
 
 const DEFAULT_TRACE_PHASE_PRESET: &str = "default";
 
-fn cli_span_definitions_for_args(args: &TraceArgs) -> homeboy::Result<Vec<TraceSpanDefinition>> {
+fn cli_span_definitions_for_args(
+    args: &TraceArgs,
+) -> homeboy::core::Result<Vec<TraceSpanDefinition>> {
     let mut definitions = args.spans.clone();
     let phase_definitions =
         extension_trace::spans::phase_span_definitions(&args.phases).map_err(|message| {
-            homeboy::Error::validation_invalid_argument("--phase", message, None, None)
+            homeboy::core::Error::validation_invalid_argument("--phase", message, None, None)
         })?;
     definitions.extend(phase_definitions);
     Ok(definitions)
@@ -787,7 +792,7 @@ fn span_definitions_for_args(
     rig_context: Option<&TraceRigContext>,
     extension_id: Option<&str>,
     use_default_preset: bool,
-) -> homeboy::Result<Vec<TraceSpanDefinition>> {
+) -> homeboy::core::Result<Vec<TraceSpanDefinition>> {
     let mut definitions = cli_span_definitions_for_args(args)?;
     let Some(preset_name) = args.phase_preset.as_deref().or_else(|| {
         if use_default_preset {
@@ -802,7 +807,7 @@ fn span_definitions_for_args(
     let preset_phases = trace_phase_preset_for_args(args, rig_context, extension_id, preset_name)?;
     let phase_definitions = extension_trace::spans::phase_span_definitions(&preset_phases)
         .map_err(|message| {
-            homeboy::Error::validation_invalid_argument("--phase-preset", message, None, None)
+            homeboy::core::Error::validation_invalid_argument("--phase-preset", message, None, None)
         })?;
     definitions.extend(phase_definitions);
     Ok(definitions)
@@ -837,10 +842,10 @@ fn trace_phase_preset_for_args(
     rig_context: Option<&TraceRigContext>,
     extension_id: Option<&str>,
     preset_name: &str,
-) -> homeboy::Result<Vec<extension_trace::spans::TracePhaseMilestone>> {
+) -> homeboy::core::Result<Vec<extension_trace::spans::TracePhaseMilestone>> {
     let scenario = trace_scenario(args)?;
     let context = rig_context.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "--phase-preset",
             "phase presets require --rig so Homeboy can read rig/workload metadata",
             None,
@@ -848,7 +853,7 @@ fn trace_phase_preset_for_args(
         )
     })?;
     let extension_id = extension_id.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "--phase-preset",
             "phase presets require a resolved trace extension",
             None,
@@ -868,7 +873,7 @@ fn trace_phase_preset_for_args(
     let phases = workload
         .and_then(|workload| workload.trace_phase_preset(preset_name))
         .ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "--phase-preset",
                 format!(
                     "trace phase preset '{}' is not declared for scenario '{}'",
@@ -883,7 +888,12 @@ fn trace_phase_preset_for_args(
         .iter()
         .map(|phase| {
             extension_trace::spans::parse_phase_milestone(phase).map_err(|message| {
-                homeboy::Error::validation_invalid_argument("--phase-preset", message, None, None)
+                homeboy::core::Error::validation_invalid_argument(
+                    "--phase-preset",
+                    message,
+                    None,
+                    None,
+                )
             })
         })
         .collect()
@@ -973,14 +983,14 @@ struct TraceRigContext {
     rig_config_root: Option<PathBuf>,
 }
 
-fn load_rig_context(rig_id: Option<&str>) -> homeboy::Result<Option<TraceRigContext>> {
+fn load_rig_context(rig_id: Option<&str>) -> homeboy::core::Result<Option<TraceRigContext>> {
     let Some(rig_id) = rig_id else {
         return Ok(None);
     };
     let spec = rig::load(rig_id)?;
     let package_root =
         rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
-    let config_root = homeboy::paths::rig_config(&spec.id)
+    let config_root = crate::core::paths::rig_config(&spec.id)
         .ok()
         .and_then(|path| path.parent().map(Path::to_path_buf));
     Ok(Some(TraceRigContext {
@@ -996,7 +1006,7 @@ fn resolve_trace_execution_context(
     settings: Vec<(String, String)>,
     settings_json: Vec<(String, serde_json::Value)>,
     component_override: Option<Component>,
-) -> homeboy::Result<execution_context::ExecutionContext> {
+) -> homeboy::core::Result<execution_context::ExecutionContext> {
     match execution_context::resolve_with_component(
         &ResolveOptions::with_capability_and_json(
             effective_id,
@@ -1023,11 +1033,11 @@ fn trace_overlays_for_args(
     rig_context: Option<&TraceRigContext>,
     component_id: &str,
     component_path: &str,
-) -> homeboy::Result<Vec<TraceOverlayRequest>> {
+) -> homeboy::core::Result<Vec<TraceOverlayRequest>> {
     let mut overlays = Vec::new();
     if !args.variants.is_empty() {
         let context = rig_context.ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "--variant",
                 "trace variants require --rig so Homeboy can read rig/workload metadata",
                 None,
@@ -1039,7 +1049,7 @@ fn trace_overlays_for_args(
         let available = variants.keys().cloned().collect::<Vec<_>>();
         for name in &args.variants {
             let variant = variants.get(name).ok_or_else(|| {
-                homeboy::Error::validation_invalid_argument(
+                homeboy::core::Error::validation_invalid_argument(
                     "--variant",
                     format!(
                         "unknown trace variant '{}' for component '{}' and scenario '{}'",
@@ -1078,7 +1088,7 @@ fn trace_overlays_for_args(
     Ok(overlays)
 }
 
-pub(super) fn validate_trace_variants_for_args(args: &TraceArgs) -> homeboy::Result<()> {
+pub(super) fn validate_trace_variants_for_args(args: &TraceArgs) -> homeboy::core::Result<()> {
     if args.variants.is_empty() {
         return Ok(());
     }
@@ -1106,7 +1116,7 @@ fn trace_variant_overlay_requests(
     variant_name: &str,
     variant: &rig::TraceVariantSpec,
     default_component_id: &str,
-) -> homeboy::Result<Vec<TraceOverlayRequest>> {
+) -> homeboy::core::Result<Vec<TraceOverlayRequest>> {
     let mut requests = Vec::new();
     if let Some(overlay) = variant.overlay.as_deref() {
         let component_id = variant.component.as_deref().unwrap_or(default_component_id);
@@ -1133,9 +1143,9 @@ fn trace_overlay_request_for_component(
     variant_name: &str,
     component_id: &str,
     overlay: &str,
-) -> homeboy::Result<TraceOverlayRequest> {
+) -> homeboy::core::Result<TraceOverlayRequest> {
     let component_path = rig_component_path(&context.rig_spec, component_id).ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "--variant",
             format!(
                 "trace variant '{}' overlay references unknown component '{}'",
@@ -1220,7 +1230,7 @@ fn run_rig_workload_preflight(
     spec: &RigSpec,
     extension_id: Option<&str>,
     kind: rig::RigWorkloadKind,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let groups =
         extension_id.and_then(|id| rig::check_groups_for_extension_workloads(spec, kind, id));
     let check = match groups {
@@ -1228,7 +1238,7 @@ fn run_rig_workload_preflight(
         None => rig::run_check(spec)?,
     };
     if !check.success {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--rig",
             format!(
                 "rig '{}' check failed; fix the rig before running trace",
@@ -1244,7 +1254,7 @@ fn run_rig_workload_preflight(
 fn resolve_component_id(
     comp: &PositionalComponentArgs,
     rig_spec: Option<&RigSpec>,
-) -> homeboy::Result<String> {
+) -> homeboy::core::Result<String> {
     if let Some(id) = comp.id() {
         return Ok(id.to_string());
     }
@@ -1252,7 +1262,7 @@ fn resolve_component_id(
         if spec.components.len() == 1 {
             return Ok(spec.components.keys().next().unwrap().clone());
         }
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "component",
             format!(
                 "rig '{}' has multiple components; pass the component id to trace",
@@ -1267,7 +1277,10 @@ fn resolve_component_id(
 
 fn rig_component_path(spec: &RigSpec, component_id: &str) -> Option<String> {
     let component = spec.components.get(component_id)?;
-    Some(homeboy::rig::expand::expand_vars(spec, &component.path))
+    Some(homeboy::core::rig::expand::expand_vars(
+        spec,
+        &component.path,
+    ))
 }
 
 fn rig_component_for_trace(spec: &RigSpec, component_id: &str) -> Option<Component> {
@@ -1372,7 +1385,7 @@ fn persist_trace_workflow_result(
 fn persist_trace_workflow_error(
     observation: &ActiveTraceObservation,
     run_dir: &RunDir,
-    error: &homeboy::Error,
+    error: &homeboy::core::Error,
 ) {
     let error_metadata = serde_json::json!({
         "error": {

--- a/src/commands/trace/bundle.rs
+++ b/src/commands/trace/bundle.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use homeboy::extension::trace as extension_trace;
+use homeboy::core::extension::trace as extension_trace;
 
 use super::output::{
     fmt_delta_avg_ms, fmt_delta_ms, fmt_ms, render_compare_markdown, TraceAggregateInput,
@@ -71,7 +71,7 @@ struct TraceExperimentOverlayManifest {
 
 pub(super) fn write_trace_experiment_bundle(
     request: TraceExperimentBundleRequest<'_>,
-) -> homeboy::Result<PathBuf> {
+) -> homeboy::core::Result<PathBuf> {
     let experiment = sanitize_path_component(request.name);
     let bundle_root = request
         .bundle_root
@@ -79,7 +79,7 @@ pub(super) fn write_trace_experiment_bundle(
         .unwrap_or_else(|| Path::new(".homeboy").join("experiments"));
     let bundle_dir = bundle_root.join(&experiment);
     fs::create_dir_all(&bundle_dir).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!(
                 "Failed to create trace experiment bundle {}: {}",
                 bundle_dir.display(),
@@ -186,7 +186,7 @@ fn copy_overlay_manifests(
     role: &'static str,
     overlays: &[TraceOverlayInput],
     overlay_dir: &Path,
-) -> homeboy::Result<Vec<TraceExperimentOverlayManifest>> {
+) -> homeboy::core::Result<Vec<TraceExperimentOverlayManifest>> {
     overlays
         .iter()
         .enumerate()
@@ -199,7 +199,7 @@ fn overlay_manifest(
     overlay: &TraceOverlayInput,
     overlay_dir: &Path,
     index: usize,
-) -> homeboy::Result<TraceExperimentOverlayManifest> {
+) -> homeboy::core::Result<TraceExperimentOverlayManifest> {
     let source = Path::new(&overlay.path);
     let (bundle_path, sha256) = if source.is_file() {
         let target = copy_overlay_file(role, source, overlay_dir, index)?;
@@ -226,9 +226,9 @@ fn copy_overlay_file(
     source: &Path,
     overlay_dir: &Path,
     index: usize,
-) -> homeboy::Result<PathBuf> {
+) -> homeboy::core::Result<PathBuf> {
     fs::create_dir_all(overlay_dir).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!(
                 "Failed to create overlay bundle dir {}: {}",
                 overlay_dir.display(),
@@ -244,7 +244,7 @@ fn copy_overlay_file(
         .unwrap_or_else(|| format!("overlay-{}.patch", index + 1));
     let target = overlay_dir.join(format!("{}-{}", role, filename));
     let bytes = fs::read(source).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!(
                 "Failed to read trace overlay {} for bundling: {}",
                 source.display(),
@@ -254,7 +254,7 @@ fn copy_overlay_file(
         )
     })?;
     fs::write(&target, bytes).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!(
                 "Failed to write bundled trace overlay {}: {}",
                 target.display(),
@@ -437,24 +437,29 @@ fn rig_components(input: &TraceAggregateInput) -> Vec<TraceExperimentComponentMa
         .unwrap_or_default()
 }
 
-fn write_file(path: &Path, content: &str, context: &str) -> homeboy::Result<()> {
+fn write_file(path: &Path, content: &str, context: &str) -> homeboy::core::Result<()> {
     fs::write(path, content).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to write {}: {}", path.display(), err),
             Some(context.to_string()),
         )
     })
 }
 
-fn write_json_file<T: Serialize>(path: &Path, value: &T, context: &str) -> homeboy::Result<()> {
-    let content = serde_json::to_string_pretty(value)
-        .map_err(|err| homeboy::Error::internal_json(err.to_string(), Some(context.to_string())))?;
+fn write_json_file<T: Serialize>(
+    path: &Path,
+    value: &T,
+    context: &str,
+) -> homeboy::core::Result<()> {
+    let content = serde_json::to_string_pretty(value).map_err(|err| {
+        homeboy::core::Error::internal_json(err.to_string(), Some(context.to_string()))
+    })?;
     write_file(path, &(content + "\n"), context)
 }
 
-fn sha256_file(path: &Path) -> homeboy::Result<String> {
+fn sha256_file(path: &Path) -> homeboy::core::Result<String> {
     let bytes = fs::read(path).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to read {} for checksum: {}", path.display(), err),
             Some("trace.experiment.overlay.sha256".to_string()),
         )

--- a/src/commands/trace/compare_variant.rs
+++ b/src/commands/trace/compare_variant.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use homeboy::extension::trace as extension_trace;
-use homeboy::extension::trace::TraceCommandOutput;
-use homeboy::rig;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::extension::trace::TraceCommandOutput;
+use homeboy::core::rig;
 
 use super::output::{
     aggregate_span, classification_summaries, compare_trace_aggregates_with_focus,
@@ -26,10 +26,10 @@ const TRACE_COMPARE_VARIANT_SUMMARY_FILE: &str = "summary.md";
 
 pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     let output_dir = args.output_dir.clone().ok_or_else(|| {
-        homeboy::Error::validation_missing_argument(vec!["--output-dir".to_string()])
+        homeboy::core::Error::validation_missing_argument(vec!["--output-dir".to_string()])
     })?;
     if !args.variants.is_empty() && !args.overlays.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--variant",
             "mixing --variant and --overlay would make stack order ambiguous; use one ordered stack source",
             None,
@@ -37,7 +37,7 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
         ));
     }
     if args.overlays.is_empty() && args.variants.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--overlay",
             "trace compare-variant requires at least one --overlay or --variant for the variant run",
             None,
@@ -45,7 +45,7 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
         ));
     }
     if args.keep_overlay {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--keep-overlay",
             "trace compare-variant reuses the same component checkout and must revert overlays between runs",
             None,
@@ -109,7 +109,7 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
 
 fn run_compare_variant_pair(
     args: TraceArgs,
-) -> homeboy::Result<(
+) -> homeboy::core::Result<(
     extension_trace::TraceAggregateOutput,
     extension_trace::TraceAggregateOutput,
     Vec<extension_trace::TraceRunOrderEntryOutput>,
@@ -299,19 +299,21 @@ impl TraceCompareVariantAggregateBuilder {
     }
 }
 
-fn run_repeat_output(args: TraceArgs) -> homeboy::Result<extension_trace::TraceAggregateOutput> {
+fn run_repeat_output(
+    args: TraceArgs,
+) -> homeboy::core::Result<extension_trace::TraceAggregateOutput> {
     let (output, _exit_code) = run_repeat(args)?;
     match output {
         TraceCommandOutput::Aggregate(aggregate) => Ok(aggregate),
-        _ => Err(homeboy::Error::internal_unexpected(
+        _ => Err(homeboy::core::Error::internal_unexpected(
             "trace compare-variant expected aggregate output",
         )),
     }
 }
 
-fn create_trace_compare_variant_output_dir(output_dir: &Path) -> homeboy::Result<()> {
+fn create_trace_compare_variant_output_dir(output_dir: &Path) -> homeboy::core::Result<()> {
     std::fs::create_dir_all(output_dir).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!(
                 "Failed to create trace compare-variant output directory {}: {}",
                 output_dir.display(),
@@ -322,15 +324,18 @@ fn create_trace_compare_variant_output_dir(output_dir: &Path) -> homeboy::Result
     })
 }
 
-fn write_trace_compare_variant_json<T: Serialize>(path: &Path, value: &T) -> homeboy::Result<()> {
+fn write_trace_compare_variant_json<T: Serialize>(
+    path: &Path,
+    value: &T,
+) -> homeboy::core::Result<()> {
     let json = serde_json::to_string_pretty(value).map_err(|err| {
-        homeboy::Error::internal_json(
+        homeboy::core::Error::internal_json(
             err.to_string(),
             Some(format!("serialize {}", path.display())),
         )
     })?;
     std::fs::write(path, format!("{}\n", json)).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to write {}: {}", path.display(), err),
             Some("trace.compare_variant.write".to_string()),
         )
@@ -397,7 +402,7 @@ fn write_trace_compare_variant_summary(
     variant: &extension_trace::TraceAggregateOutput,
     compare: &extension_trace::TraceCompareOutput,
     run_order: &[extension_trace::TraceRunOrderEntryOutput],
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let mut out = String::new();
     out.push_str(&format!(
         "# Trace Compare Variant: `{}`\n\n",
@@ -436,7 +441,7 @@ fn write_trace_compare_variant_summary(
     push_compare_variant_span_summary(&mut out, compare);
 
     std::fs::write(path, out).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to write {}: {}", path.display(), err),
             Some("trace.compare_variant.summary".to_string()),
         )

--- a/src/commands/trace/compare_variant_tests.rs
+++ b/src/commands/trace/compare_variant_tests.rs
@@ -6,8 +6,8 @@ use crate::commands::utils::args::{
 use crate::commands::GlobalArgs;
 use crate::test_support::with_isolated_home;
 
-use homeboy::extension::trace as extension_trace;
-use homeboy::extension::trace::TraceCommandOutput;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::extension::trace::TraceCommandOutput;
 
 use super::test_fixture::{init_overlay_component, write_trace_extension};
 use super::{run, TraceArgs, TraceSchedule, TraceVariantMatrixMode};

--- a/src/commands/trace/experiment.rs
+++ b/src/commands/trace/experiment.rs
@@ -3,10 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::trace as extension_trace;
-use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
-use homeboy::rig;
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
+use homeboy::core::rig;
 
 use super::{TraceArgs, TraceRigContext};
 
@@ -20,12 +20,12 @@ pub(super) struct TraceExperimentRunPlan<'a> {
 pub(super) fn trace_experiment_plan_for_args<'a>(
     args: &TraceArgs,
     rig_context: Option<&'a TraceRigContext>,
-) -> homeboy::Result<Option<TraceExperimentRunPlan<'a>>> {
+) -> homeboy::core::Result<Option<TraceExperimentRunPlan<'a>>> {
     let Some(name) = args.experiment.as_deref() else {
         return Ok(None);
     };
     let context = rig_context.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "--experiment",
             "trace experiment plans require --rig so Homeboy can read rig metadata",
             None,
@@ -43,7 +43,7 @@ pub(super) fn trace_experiment_plan_for_args<'a>(
                 .keys()
                 .cloned()
                 .collect::<Vec<_>>();
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "--experiment",
                 format!(
                     "unknown trace experiment '{}' for rig '{}'",
@@ -119,7 +119,7 @@ fn trace_experiment_step(phase: &str, name: &str, index: usize, command: &str) -
 
 pub(super) fn trace_experiment_settings(
     plan: Option<&TraceExperimentRunPlan>,
-) -> homeboy::Result<Vec<(String, serde_json::Value)>> {
+) -> homeboy::core::Result<Vec<(String, serde_json::Value)>> {
     let Some(plan) = plan else {
         return Ok(Vec::new());
     };
@@ -142,7 +142,7 @@ pub(super) fn trace_experiment_settings(
 
 pub(super) fn trace_experiment_env(
     plan: Option<&TraceExperimentRunPlan>,
-) -> homeboy::Result<Vec<(String, String)>> {
+) -> homeboy::core::Result<Vec<(String, String)>> {
     let Some(plan) = plan else {
         return Ok(Vec::new());
     };
@@ -161,7 +161,7 @@ pub(super) fn trace_experiment_env(
 pub(super) fn run_trace_experiment_setup_for_plan(
     plan: Option<&TraceExperimentRunPlan>,
     run_dir: &RunDir,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let Some(plan) = plan else {
         return Ok(());
     };
@@ -179,7 +179,7 @@ pub(super) fn run_trace_experiment_setup_for_plan(
 pub(super) fn run_trace_experiment_teardown_for_plan(
     plan: Option<&TraceExperimentRunPlan>,
     run_dir: &RunDir,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let Some(plan) = plan else {
         return Ok(());
     };
@@ -204,7 +204,7 @@ fn validate_trace_experiment_plan_phase(
     experiment_name: &str,
     phase: &str,
     command_count: usize,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let planned_count = plan
         .steps
         .iter()
@@ -217,7 +217,7 @@ fn validate_trace_experiment_plan_phase(
         return Ok(());
     }
 
-    Err(homeboy::Error::internal_unexpected(format!(
+    Err(homeboy::core::Error::internal_unexpected(format!(
         "trace experiment '{}' {} plan has {} steps for {} commands",
         experiment_name, phase, planned_count, command_count
     )))
@@ -230,7 +230,7 @@ fn run_trace_experiment_commands(
     commands: &[rig::TraceExperimentCommandSpec],
     experiment_env: &BTreeMap<String, String>,
     run_dir: &RunDir,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     for command_spec in commands {
         let command_text = resolve_trace_experiment_string(context, &command_spec.command);
         let mut command = Command::new(trace_experiment_shell());
@@ -252,7 +252,7 @@ fn run_trace_experiment_commands(
             command.current_dir(PathBuf::from(resolve_trace_experiment_string(context, cwd)));
         }
         let status = command.status().map_err(|err| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "--experiment",
                 format!(
                     "trace experiment '{}' {} command failed to spawn: {}",
@@ -263,7 +263,7 @@ fn run_trace_experiment_commands(
             )
         })?;
         if !status.success() {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "--experiment",
                 format!(
                     "trace experiment '{}' {} command exited {}",
@@ -283,7 +283,7 @@ pub(super) fn collect_trace_experiment_artifacts_for_plan(
     plan: Option<&TraceExperimentRunPlan>,
     run_dir: &RunDir,
     workflow: &mut extension_trace::TraceRunWorkflowResult,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let Some(plan) = plan else {
         return Ok(());
     };
@@ -296,7 +296,7 @@ fn collect_trace_experiment_artifacts(
     experiment: &rig::TraceExperimentSpec,
     run_dir: &RunDir,
     workflow: &mut extension_trace::TraceRunWorkflowResult,
-) -> homeboy::Result<()> {
+) -> homeboy::core::Result<()> {
     let Some(results) = workflow.results.as_mut() else {
         return Ok(());
     };
@@ -316,7 +316,7 @@ fn collect_trace_experiment_artifacts(
         };
         let source_path = PathBuf::from(resolve_trace_experiment_string(context, source));
         if !source_path.is_file() {
-            return Err(homeboy::Error::validation_invalid_argument(
+            return Err(homeboy::core::Error::validation_invalid_argument(
                 "--experiment",
                 format!(
                     "trace experiment '{}' artifact '{}' does not exist or is not a file",
@@ -338,7 +338,7 @@ fn collect_trace_experiment_artifacts(
         let destination = run_dir.path().join(&relative);
         if let Some(parent) = destination.parent() {
             fs::create_dir_all(parent).map_err(|err| {
-                homeboy::Error::internal_io(
+                homeboy::core::Error::internal_io(
                     format!(
                         "Failed to create trace experiment artifact dir {}: {}",
                         parent.display(),
@@ -349,7 +349,7 @@ fn collect_trace_experiment_artifacts(
             })?;
         }
         fs::copy(&source_path, &destination).map_err(|err| {
-            homeboy::Error::internal_io(
+            homeboy::core::Error::internal_io(
                 format!(
                     "Failed to collect trace experiment artifact {} to {}: {}",
                     source_path.display(),

--- a/src/commands/trace/experiment_tests.rs
+++ b/src/commands/trace/experiment_tests.rs
@@ -5,7 +5,7 @@ use crate::commands::utils::args::{
 };
 use crate::test_support::with_isolated_home;
 
-use homeboy::extension::trace as extension_trace;
+use homeboy::core::extension::trace as extension_trace;
 
 use super::{execute_trace_run, TraceArgs, TraceSchedule, TraceVariantMatrixMode};
 

--- a/src/commands/trace/guardrails.rs
+++ b/src/commands/trace/guardrails.rs
@@ -1,5 +1,5 @@
-use homeboy::extension::trace as extension_trace;
-use homeboy::rig;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::rig;
 
 use super::{
     load_rig_context, required_trace_scenario, resolve_component_id, trace_variants_for_args,
@@ -8,7 +8,7 @@ use super::{
 
 pub(super) fn run_trace_guardrails_for_args(
     args: &TraceArgs,
-) -> homeboy::Result<Vec<extension_trace::TraceGuardrailOutput>> {
+) -> homeboy::core::Result<Vec<extension_trace::TraceGuardrailOutput>> {
     let Some(context) = load_rig_context(args.rig.as_deref())? else {
         return Ok(Vec::new());
     };

--- a/src/commands/trace/matrix.rs
+++ b/src/commands/trace/matrix.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use homeboy::extension::trace as extension_trace;
-use homeboy::extension::trace::TraceCommandOutput;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::extension::trace::TraceCommandOutput;
 
 use super::output::{
     compare_trace_aggregates_with_focus, render_matrix_markdown, TraceAggregateInput,
@@ -26,7 +26,7 @@ pub(super) struct TraceVariantCombination {
 
 pub(super) fn run_variant_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     if args.keep_overlay {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--keep-overlay",
             "trace compare-variant reuses the same component checkout across runs, so overlays must be reverted after each combination",
             None,
@@ -45,7 +45,7 @@ pub(super) fn run_variant_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutpu
         ))
     });
     std::fs::create_dir_all(&output_dir).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!(
                 "Failed to create trace variant output dir {}: {}",
                 output_dir.display(),
@@ -123,7 +123,7 @@ pub(super) fn run_variant_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutpu
         runs,
     };
     std::fs::write(&summary_path, render_matrix_markdown(&output)).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!(
                 "Failed to write trace variant summary {}: {}",
                 summary_path.display(),
@@ -139,7 +139,7 @@ pub(super) fn run_variant_matrix(args: TraceArgs) -> CmdResult<TraceCommandOutpu
 fn run_variant_aggregate(
     args: &TraceArgs,
     overlays: Vec<String>,
-) -> homeboy::Result<extension_trace::TraceAggregateOutput> {
+) -> homeboy::core::Result<extension_trace::TraceAggregateOutput> {
     let mut run_args = args.clone();
     apply_command_target_component(&mut run_args);
     run_args.repeat = args.repeat.max(1);
@@ -153,9 +153,9 @@ fn run_variant_aggregate(
     }
 }
 
-fn variant_stack_items(args: &TraceArgs) -> homeboy::Result<Vec<TraceVariantStackItem>> {
+fn variant_stack_items(args: &TraceArgs) -> homeboy::core::Result<Vec<TraceVariantStackItem>> {
     if !args.variants.is_empty() && !args.overlays.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--variant",
             "mixing --variant and --overlay would make stack order ambiguous; use one ordered stack source",
             None,
@@ -168,7 +168,7 @@ fn variant_stack_items(args: &TraceArgs) -> homeboy::Result<Vec<TraceVariantStac
         &args.overlays
     };
     if values.is_empty() {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "--overlay",
             "trace compare-variant requires at least one --overlay or --variant",
             None,
@@ -278,12 +278,12 @@ fn aggregate_to_compare_input(
     }
 }
 
-fn write_json_artifact<T: serde::Serialize>(path: &Path, value: &T) -> homeboy::Result<()> {
+fn write_json_artifact<T: serde::Serialize>(path: &Path, value: &T) -> homeboy::core::Result<()> {
     let content = serde_json::to_string_pretty(value).map_err(|err| {
-        homeboy::Error::internal_json(err.to_string(), Some("trace.variant.json".to_string()))
+        homeboy::core::Error::internal_json(err.to_string(), Some("trace.variant.json".to_string()))
     })?;
     std::fs::write(path, content).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to write trace artifact {}: {}", path.display(), err),
             Some("trace.variant.write".to_string()),
         )

--- a/src/commands/trace/metadata.rs
+++ b/src/commands/trace/metadata.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(super) fn trace_span_metadata_for_args(
     args: &TraceArgs,
-) -> homeboy::Result<BTreeMap<String, extension_trace::TraceSpanMetadata>> {
+) -> homeboy::core::Result<BTreeMap<String, extension_trace::TraceSpanMetadata>> {
     let Some(context) = load_rig_context(args.rig.as_deref())? else {
         return Ok(BTreeMap::new());
     };

--- a/src/commands/trace/observations.rs
+++ b/src/commands/trace/observations.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use homeboy::engine::run_dir::RunDir;
-use homeboy::extension::trace as extension_trace;
-use homeboy::observation::ObservationStore;
+use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::observation::ObservationStore;
 
 pub(super) fn record_trace_artifacts(
     store: &ObservationStore,
@@ -10,7 +10,8 @@ pub(super) fn record_trace_artifacts(
     run_dir: &RunDir,
     results: Option<&extension_trace::TraceResults>,
 ) {
-    let trace_results_path = run_dir.step_file(homeboy::engine::run_dir::files::TRACE_RESULTS);
+    let trace_results_path =
+        run_dir.step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS);
     record_artifact_if_file(store, run_id, "trace-results", &trace_results_path);
     if let Some(results) = results {
         for artifact in &results.artifacts {

--- a/src/commands/trace/output.rs
+++ b/src/commands/trace/output.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use serde_json::Value;
 
-use homeboy::extension::trace as extension_trace;
-use homeboy::extension::trace::TraceCommandOutput;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::extension::trace::TraceCommandOutput;
 
 use super::bundle::{write_trace_experiment_bundle, TraceExperimentBundleRequest};
 use super::TraceArgs;
@@ -118,9 +118,9 @@ pub(super) fn run_compare(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     Ok((TraceCommandOutput::Compare(output), exit_code))
 }
 
-fn required_compare_path_arg<T>(value: Option<T>, field: &'static str) -> homeboy::Result<T> {
+fn required_compare_path_arg<T>(value: Option<T>, field: &'static str) -> homeboy::core::Result<T> {
     value.ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             field,
             "trace compare requires before and after aggregate JSON files",
             None,
@@ -129,9 +129,9 @@ fn required_compare_path_arg<T>(value: Option<T>, field: &'static str) -> homebo
     })
 }
 
-fn read_trace_aggregate_json(path: &Path) -> homeboy::Result<String> {
+fn read_trace_aggregate_json(path: &Path) -> homeboy::core::Result<String> {
     fs::read_to_string(path).map_err(|err| {
-        homeboy::Error::internal_io(
+        homeboy::core::Error::internal_io(
             format!("Failed to read trace aggregate {}: {}", path.display(), err),
             Some("trace.compare.read".to_string()),
         )
@@ -141,9 +141,9 @@ fn read_trace_aggregate_json(path: &Path) -> homeboy::Result<String> {
 fn parse_trace_aggregate_for_path(
     content: &str,
     path: &Path,
-) -> homeboy::Result<TraceAggregateInput> {
+) -> homeboy::core::Result<TraceAggregateInput> {
     parse_trace_aggregate_input(content).map_err(|err| {
-        homeboy::Error::internal_json(
+        homeboy::core::Error::internal_json(
             err.to_string(),
             Some(format!("parse trace aggregate {}", path.display())),
         )

--- a/src/commands/trace/output_tests.rs
+++ b/src/commands/trace/output_tests.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use homeboy::extension::trace as extension_trace;
+use homeboy::core::extension::trace as extension_trace;
 
 use super::bundle::{write_trace_experiment_bundle, TraceExperimentBundleRequest};
 use super::output::{

--- a/src/commands/trace/probes.rs
+++ b/src/commands/trace/probes.rs
@@ -1,5 +1,5 @@
-use homeboy::extension::trace as extension_trace;
-use homeboy::rig;
+use homeboy::core::extension::trace as extension_trace;
+use homeboy::core::rig;
 
 use super::{trace_scenario, trace_workload_scenario_id, TraceArgs, TraceRigContext};
 
@@ -7,7 +7,7 @@ pub(super) fn trace_probes_for_args(
     args: &TraceArgs,
     rig_context: Option<&TraceRigContext>,
     extension_id: Option<&str>,
-) -> homeboy::Result<Vec<extension_trace::TraceProbeConfig>> {
+) -> homeboy::core::Result<Vec<extension_trace::TraceProbeConfig>> {
     let Some(context) = rig_context else {
         return Ok(Vec::new());
     };
@@ -38,7 +38,7 @@ pub(super) fn trace_probes_for_args(
 fn expand_trace_probe(
     context: &TraceRigContext,
     probe: &extension_trace::TraceProbeConfig,
-) -> homeboy::Result<extension_trace::TraceProbeConfig> {
+) -> homeboy::core::Result<extension_trace::TraceProbeConfig> {
     Ok(match probe {
         extension_trace::TraceProbeConfig::LogTail {
             path,

--- a/src/commands/trace/schedule.rs
+++ b/src/commands/trace/schedule.rs
@@ -1,5 +1,5 @@
 use clap::ValueEnum;
-use homeboy::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
+use homeboy::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use serde::Serialize;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -3,8 +3,8 @@ use std::fs;
 
 use crate::test_support::with_isolated_home;
 
-use homeboy::component::ScopedExtensionConfig;
-use homeboy::rig::ComponentSpec;
+use homeboy::core::component::ScopedExtensionConfig;
+use homeboy::core::rig::ComponentSpec;
 
 use super::test_fixture::{
     init_overlay_component, write_trace_extension, write_trace_rig,
@@ -348,7 +348,7 @@ fn trace_run_persists_observation_history() {
         assert_eq!(exit_code, 0);
         let store = ObservationStore::open_initialized().expect("store");
         let runs = store
-            .list_runs(homeboy::observation::RunListFilter {
+            .list_runs(homeboy::core::observation::RunListFilter {
                 kind: Some("trace".to_string()),
                 ..Default::default()
             })
@@ -1444,7 +1444,7 @@ fn failed_trace_run_persists_observation_history() {
         assert_eq!(exit_code, 3);
         let store = ObservationStore::open_initialized().expect("store");
         let runs = store
-            .list_runs(homeboy::observation::RunListFilter {
+            .list_runs(homeboy::core::observation::RunListFilter {
                 kind: Some("trace".to_string()),
                 ..Default::default()
             })

--- a/src/commands/triage.rs
+++ b/src/commands/triage.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
-use homeboy::triage::{self, TriageOptions, TriageOutput, TriageTarget};
-use homeboy::Error;
+use homeboy::core::triage::{self, TriageOptions, TriageOutput, TriageTarget};
+use homeboy::core::Error;
 use std::path::PathBuf;
 
 use super::CmdResult;
@@ -141,7 +141,7 @@ fn resolve_component_target(
             // silently picking one side. If the component is not registered, we
             // accept the explicit id as the synthetic component_id.
             if let Some(ref id) = component_id {
-                if let Ok(comp) = homeboy::component::load(id) {
+                if let Ok(comp) = homeboy::core::component::load(id) {
                     let registered = canonicalize_for_compare(&comp.local_path);
                     let supplied = canonicalize_for_compare(&path);
                     if registered != supplied {
@@ -174,7 +174,7 @@ fn canonicalize_for_compare(path: &str) -> String {
 mod tests {
     use super::{resolve_component_target, TriageArgs, TriageCommand};
     use clap::Parser;
-    use homeboy::triage::TriageTarget;
+    use homeboy::core::triage::TriageTarget;
 
     #[derive(Parser)]
     struct TestCli {

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::engine::undo;
+use homeboy::core::engine::undo;
 
 use super::CmdResult;
 

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use homeboy::upgrade;
+use homeboy::core::upgrade;
 use serde_json::Value;
 use std::path::PathBuf;
 
@@ -40,7 +40,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     if args.check {
         let result = upgrade::check_for_updates()?;
         let json = serde_json::to_value(result)
-            .map_err(|e| homeboy::Error::internal_json(e.to_string(), None))?;
+            .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
         return Ok((json, 0));
     }
 
@@ -52,7 +52,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
             "cargo" => Ok(upgrade::InstallMethod::Cargo),
             "source" => Ok(upgrade::InstallMethod::Source),
             "binary" => Ok(upgrade::InstallMethod::Binary),
-            other => Err(homeboy::Error::validation_invalid_argument(
+            other => Err(homeboy::core::Error::validation_invalid_argument(
                 "method",
                 format!("Unknown method: {}", other),
                 Some(other.to_string()),
@@ -68,7 +68,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         args.source_path.as_deref(),
     )?;
     let json = serde_json::to_value(&result)
-        .map_err(|e| homeboy::Error::internal_json(e.to_string(), None))?;
+        .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
 
     // If upgrade succeeded and restart is needed, do it
     if result.upgraded && result.restart_required && !args.no_restart {

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -10,7 +10,7 @@ use clap::{Arg, ArgAction, Args, Command, CommandFactory};
 use std::path::PathBuf;
 
 use crate::cli_surface::Cli;
-use homeboy::component::{self, Component};
+use homeboy::core::component::{self, Component};
 
 /// Normalize version command arguments.
 pub(crate) fn normalize_version_show(args: Vec<String>) -> Vec<String> {
@@ -297,11 +297,11 @@ pub struct ComponentArgs {
 
 #[allow(dead_code)]
 impl ComponentArgs {
-    pub fn resolve(&self) -> homeboy::Result<Component> {
+    pub fn resolve(&self) -> homeboy::core::Result<Component> {
         component::resolve_effective(self.component.as_deref(), self.path.as_deref(), None)
     }
 
-    pub fn resolve_root(&self) -> homeboy::Result<PathBuf> {
+    pub fn resolve_root(&self) -> homeboy::core::Result<PathBuf> {
         if let Some(ref p) = self.path {
             Ok(PathBuf::from(p))
         } else {
@@ -310,9 +310,9 @@ impl ComponentArgs {
         }
     }
 
-    pub fn load(&self) -> homeboy::Result<Component> {
+    pub fn load(&self) -> homeboy::core::Result<Component> {
         let id = self.component.as_deref().ok_or_else(|| {
-            homeboy::Error::validation_missing_argument(vec!["component".to_string()])
+            homeboy::core::Error::validation_missing_argument(vec!["component".to_string()])
         })?;
         component::resolve_effective(Some(id), self.path.as_deref(), None)
     }
@@ -345,7 +345,7 @@ pub struct ExtensionOverrideArgs {
 
 #[allow(dead_code)]
 impl PositionalComponentArgs {
-    pub fn load(&self) -> homeboy::Result<Component> {
+    pub fn load(&self) -> homeboy::core::Result<Component> {
         component::resolve_effective(self.component.as_deref(), self.path.as_deref(), None)
     }
 
@@ -355,7 +355,7 @@ impl PositionalComponentArgs {
 
     /// Resolve the component ID, falling back to CWD auto-discovery.
     /// Returns the effective component ID string for display/logging.
-    pub fn resolve_id(&self) -> homeboy::Result<String> {
+    pub fn resolve_id(&self) -> homeboy::core::Result<String> {
         if let Some(ref id) = self.component {
             return Ok(id.clone());
         }

--- a/src/commands/utils/entity_suggest.rs
+++ b/src/commands/utils/entity_suggest.rs
@@ -1,7 +1,7 @@
 //! Entity suggestion utilities for unrecognized CLI subcommands.
 
-use homeboy::engine::text::levenshtein;
-use homeboy::{component, extension, project, server};
+use homeboy::core::engine::text::levenshtein;
+use homeboy::core::{component, extension, project, server};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntityType {

--- a/src/commands/utils/resolve.rs
+++ b/src/commands/utils/resolve.rs
@@ -1,6 +1,6 @@
 //! Project/component argument resolution helpers for CLI commands.
 
-use homeboy::{component, project, Error, Result};
+use homeboy::core::{component, project, Error, Result};
 
 pub fn resolve_project_components(first: &str, rest: &[String]) -> Result<(String, Vec<String>)> {
     let projects = project::list_ids().unwrap_or_default();

--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -2,8 +2,8 @@
 //!
 //! Provides JSON envelope, printing, and exit code mapping.
 
-use homeboy::error::Hint;
-use homeboy::{Error, ErrorCode, Result};
+use homeboy::core::error::Hint;
+use homeboy::core::{Error, ErrorCode, Result};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]

--- a/src/commands/utils/tty.rs
+++ b/src/commands/utils/tty.rs
@@ -16,15 +16,15 @@ pub fn require_tty_for_interactive() -> bool {
     is_stdin_tty() && is_stdout_tty()
 }
 
-pub fn prompt(message: &str) -> homeboy::Result<String> {
+pub fn prompt(message: &str) -> homeboy::core::Result<String> {
     eprint!("{}", message);
     io::stderr().flush().ok();
 
     let stdin = io::stdin();
     let mut line = String::new();
     stdin.lock().read_line(&mut line).map_err(|e| {
-        homeboy::Error::new(
-            homeboy::ErrorCode::InternalIoError,
+        homeboy::core::Error::new(
+            homeboy::core::ErrorCode::InternalIoError,
             format!("Failed to read input: {}", e),
             serde_json::Value::Null,
         )
@@ -33,7 +33,7 @@ pub fn prompt(message: &str) -> homeboy::Result<String> {
     Ok(line.trim().to_string())
 }
 
-pub fn prompt_password(message: &str) -> homeboy::Result<String> {
+pub fn prompt_password(message: &str) -> homeboy::core::Result<String> {
     prompt(message)
 }
 

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,8 +1,8 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use homeboy::component;
-use homeboy::version::{read_component_version, read_version, VersionTargetInfo};
+use homeboy::core::component;
+use homeboy::core::release::version::{read_component_version, read_version, VersionTargetInfo};
 
 use super::CmdResult;
 

--- a/src/core/code_audit/aggregate_construction.rs
+++ b/src/core/code_audit/aggregate_construction.rs
@@ -20,8 +20,10 @@ pub(super) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
 
 fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let mut seams_by_type: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
-    let mut literals_by_type: BTreeMap<String, Vec<(&str, &crate::extension::AggregateLiteral)>> =
-        BTreeMap::new();
+    let mut literals_by_type: BTreeMap<
+        String,
+        Vec<(&str, &crate::core::extension::AggregateLiteral)>,
+    > = BTreeMap::new();
 
     for fp in fingerprints {
         if super::walker::is_test_path(&fp.relative_path) {
@@ -130,7 +132,7 @@ fn detect_direct_aggregate_construction(fingerprints: &[&FileFingerprint]) -> Ve
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::{AggregateConstructionSeam, AggregateLiteral};
+    use crate::core::extension::{AggregateConstructionSeam, AggregateLiteral};
 
     fn file(
         path: &str,

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use crate::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
+use crate::core::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
 
 use super::findings::Finding;
 use super::CodeAuditResult;
@@ -182,9 +182,9 @@ pub fn load_baseline_from_ref(source_path: &str, git_ref: &str) -> Option<AuditB
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::AuditFinding;
-    use crate::code_audit::findings::{Finding, Severity};
-    use crate::code_audit::{AuditSummary, CodeAuditResult};
+    use crate::core::code_audit::conventions::AuditFinding;
+    use crate::core::code_audit::findings::{Finding, Severity};
+    use crate::core::code_audit::{AuditSummary, CodeAuditResult};
 
     fn make_finding(convention: &str, file: &str, description: &str) -> Finding {
         Finding {

--- a/src/core/code_audit/checks.rs
+++ b/src/core/code_audit/checks.rs
@@ -62,7 +62,7 @@ pub fn check_conventions(conventions: &[Convention]) -> Vec<CheckResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::{AuditFinding, Deviation};
+    use crate::core::code_audit::conventions::{AuditFinding, Deviation};
 
     #[test]
     fn clean_convention_produces_clean_status() {

--- a/src/core/code_audit/codebase_map.rs
+++ b/src/core/code_audit/codebase_map.rs
@@ -11,9 +11,9 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use crate::code_audit::fingerprint::{self, FileFingerprint};
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::{component, extension, Error};
+use crate::core::code_audit::fingerprint::{self, FileFingerprint};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::{component, extension, Error};
 
 // ============================================================================
 // Types

--- a/src/core/code_audit/comment_blocks.rs
+++ b/src/core/code_audit/comment_blocks.rs
@@ -145,8 +145,8 @@ fn strip_block_line(line: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
-    use crate::code_audit::fingerprint::FileFingerprint;
+    use crate::core::code_audit::conventions::Language;
+    use crate::core::code_audit::fingerprint::FileFingerprint;
 
     fn make_fp(path: &str, lang: Language, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/src/core/code_audit/comment_hygiene.rs
+++ b/src/core/code_audit/comment_hygiene.rs
@@ -177,8 +177,8 @@ fn normalized_comment(comment: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
-    use crate::code_audit::fingerprint::FileFingerprint;
+    use crate::core::code_audit::conventions::Language;
+    use crate::core::code_audit::fingerprint::FileFingerprint;
 
     fn make_fp(path: &str, lang: Language, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/src/core/code_audit/compare.rs
+++ b/src/core/code_audit/compare.rs
@@ -58,7 +58,7 @@ pub fn finding_fingerprint(finding: &Finding) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::{AuditFinding, AuditSummary};
+    use crate::core::code_audit::{AuditFinding, AuditSummary};
 
     fn mk_result_with_findings(findings: Vec<Finding>) -> CodeAuditResult {
         CodeAuditResult {

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -11,7 +11,7 @@ use super::fingerprint::FileFingerprint;
 use super::import_matching::has_import_with_context;
 use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
-use crate::component::AuditConfig;
+use crate::core::component::AuditConfig;
 
 const GENERIC_UTILITY_SUFFIXES: &[&str] = &[
     "Base",

--- a/src/core/code_audit/core_boundary_leak.rs
+++ b/src/core/code_audit/core_boundary_leak.rs
@@ -2,7 +2,7 @@
 
 use regex::Regex;
 
-use crate::component::CoreBoundaryLeakConfig;
+use crate::core::component::CoreBoundaryLeakConfig;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
@@ -124,7 +124,7 @@ fn enclosing_context(content: &str, line_index: usize) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::Language;
+    use crate::core::code_audit::Language;
 
     fn rust_fp(path: &str, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -39,8 +39,8 @@ use std::path::Path;
 
 use sha2::{Digest, Sha256};
 
-use crate::extension::grammar::{self, Grammar, Symbol};
-use crate::extension::{self, DeadCodeMarker, HookRef, UnusedParam};
+use crate::core::extension::grammar::{self, Grammar, Symbol};
+use crate::core::extension::{self, DeadCodeMarker, HookRef, UnusedParam};
 
 use super::conventions::Language;
 use super::fingerprint::FileFingerprint;
@@ -1399,7 +1399,7 @@ pub fn run() {
         assert_eq!(command_fp.namespace.as_deref(), Some("crate::commands"));
 
         let nested_content = r#"
-use crate::Result;
+use crate::core::Result;
 
 pub fn undo() -> Result<()> {
     Ok(())

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -11,7 +11,7 @@ use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::walker::is_test_path;
-use crate::component::AuditConfig;
+use crate::core::component::AuditConfig;
 
 /// A cross-file caller record: which files call a function and with how many args.
 struct CallerRecord {
@@ -386,7 +386,7 @@ fn is_runtime_dispatched_type(
 /// 2. **Callers exist but none pass enough args** → `UnusedParameter` (truly dead, safe to remove)
 /// 3. **Callers pass args for this position** → `IgnoredParameter` (received but ignored, likely a bug)
 fn classify_unused_param(
-    unused: &crate::extension::UnusedParam,
+    unused: &crate::core::extension::UnusedParam,
     caller_map: &HashMap<String, CallerRecord>,
 ) -> (AuditFinding, String, String) {
     let fn_name = &unused.function;
@@ -451,8 +451,8 @@ fn classify_unused_param(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
-    use crate::extension::{DeadCodeMarker, UnusedParam};
+    use crate::core::code_audit::conventions::Language;
+    use crate::core::extension::{DeadCodeMarker, UnusedParam};
     use std::collections::HashMap;
 
     fn make_fingerprint(
@@ -513,7 +513,7 @@ mod tests {
 
         // Caller in another file passes only 2 args
         let mut caller_fp = make_fingerprint("src/bar.rs", vec![], vec![], vec!["process"], vec![]);
-        caller_fp.call_sites.push(crate::extension::CallSite {
+        caller_fp.call_sites.push(crate::core::extension::CallSite {
             target: "process".to_string(),
             line: 10,
             arg_count: 2,
@@ -541,7 +541,7 @@ mod tests {
         });
 
         let mut caller_fp = make_fingerprint("src/bar.rs", vec![], vec![], vec!["process"], vec![]);
-        caller_fp.call_sites.push(crate::extension::CallSite {
+        caller_fp.call_sites.push(crate::core::extension::CallSite {
             target: "process".to_string(),
             line: 10,
             arg_count: 3,

--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -20,7 +20,7 @@ use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::requirements::{known_available_symbols, KnownSymbols};
-use crate::component::AuditConfig;
+use crate::core::component::AuditConfig;
 
 /// Kinds of guards we detect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -476,8 +476,8 @@ fn line_text(content: &str, line: usize) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
-    use crate::code_audit::fingerprint::FileFingerprint;
+    use crate::core::code_audit::conventions::Language;
+    use crate::core::code_audit::fingerprint::FileFingerprint;
     use std::fs;
 
     fn make_fp(path: &str, content: &str) -> FileFingerprint {

--- a/src/core/code_audit/deprecation_age.rs
+++ b/src/core/code_audit/deprecation_age.rs
@@ -286,7 +286,7 @@ fn composer_json_version(root: &Path) -> Option<Version> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::CallSite;
+    use crate::core::extension::CallSite;
 
     fn make_fp(path: &str, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/src/core/code_audit/discovery.rs
+++ b/src/core/code_audit/discovery.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use super::conventions::Language;
 use super::fingerprint::{fingerprint_content, normalize_convention_tags, FileFingerprint};
 use super::walker::{is_test_path, walk_source_files_snapshot};
-use crate::component::AuditConfig;
+use crate::core::component::AuditConfig;
 
 type DiscoveryGroupKey = (String, Language, bool, Vec<String>);
 
@@ -313,7 +313,7 @@ mod tests {
             ..Default::default()
         };
         let audit_config = AuditConfig {
-            convention_tag_globs: vec![crate::component::ConventionTagGlob {
+            convention_tag_globs: vec![crate::core::component::ConventionTagGlob {
                 tag: "component:generated".to_string(),
                 globs: vec!["src/generated/*".to_string()],
             }],

--- a/src/core/code_audit/docs_audit/mod.rs
+++ b/src/core/code_audit/docs_audit/mod.rs
@@ -16,7 +16,8 @@ use std::path::Path;
 pub use claims::{Claim, ClaimConfidence, ClaimType};
 pub use verify::VerifyResult;
 
-use crate::{component, extension, is_zero};
+use crate::core::{component, extension};
+use crate::is_zero;
 
 /// A doc that needs content review due to referenced files changing.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -117,7 +118,7 @@ pub struct AuditResult {
 const DEFAULT_DOC_EXCLUDES: &[&str] = &["changelog.md"];
 
 pub(crate) fn find_doc_files(docs_path: &Path, excluded_targets: &[String]) -> Vec<String> {
-    use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+    use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
     if !docs_path.exists() {
         return Vec::new();

--- a/src/core/code_audit/docs_audit/verify.rs
+++ b/src/core/code_audit/docs_audit/verify.rs
@@ -7,7 +7,7 @@
 use std::fs;
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig, WalkEntry};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig, WalkEntry};
 
 use super::claims::{Claim, ClaimType};
 

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -19,7 +19,7 @@ use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::idiomatic::is_trivial_method;
 use super::walker::is_test_path;
-use crate::component::DuplicationDetectorConfig;
+use crate::core::component::DuplicationDetectorConfig;
 
 /// Minimum number of locations for a function to count as duplicated.
 const MIN_DUPLICATE_LOCATIONS: usize = 2;
@@ -1684,7 +1684,7 @@ pub(crate) fn detect_parallel_implementations(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
+    use crate::core::code_audit::conventions::Language;
 
     fn make_fingerprint(path: &str, methods: &[&str], hashes: &[(&str, &str)]) -> FileFingerprint {
         make_fingerprint_with_structural(path, methods, hashes, &[])

--- a/src/core/code_audit/enum_dispatch_contracts.rs
+++ b/src/core/code_audit/enum_dispatch_contracts.rs
@@ -8,7 +8,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/src/core/code_audit/field_patterns.rs
+++ b/src/core/code_audit/field_patterns.rs
@@ -29,7 +29,7 @@ mod field_patterns_data_contracts {
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -143,8 +143,8 @@ pub fn build_findings(results: &[CheckResult]) -> Vec<Finding> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::checks::CheckResult;
-    use crate::code_audit::conventions::{Deviation, Outlier};
+    use crate::core::code_audit::checks::CheckResult;
+    use crate::core::code_audit::conventions::{Deviation, Outlier};
 
     #[test]
     fn clean_result_produces_no_findings() {

--- a/src/core/code_audit/fingerprint.rs
+++ b/src/core/code_audit/fingerprint.rs
@@ -63,15 +63,15 @@ pub struct FileFingerprint {
     /// Public/protected class properties (e.g., ["string $name", "$data"]).
     pub properties: Vec<String>,
     /// Hook references: do_action() and apply_filters() calls.
-    pub hooks: Vec<crate::extension::HookRef>,
+    pub hooks: Vec<crate::core::extension::HookRef>,
     /// Function parameters that are declared but never used in the function body.
-    pub unused_parameters: Vec<crate::extension::UnusedParam>,
+    pub unused_parameters: Vec<crate::core::extension::UnusedParam>,
     /// Dead code suppression markers (e.g., `#[allow(dead_code)]`).
-    pub dead_code_markers: Vec<crate::extension::DeadCodeMarker>,
+    pub dead_code_markers: Vec<crate::core::extension::DeadCodeMarker>,
     /// Function/method names called within this file.
     pub internal_calls: Vec<String>,
     /// Call sites with argument counts (for cross-file parameter analysis).
-    pub call_sites: Vec<crate::extension::CallSite>,
+    pub call_sites: Vec<crate::core::extension::CallSite>,
     /// Public functions/methods exported from this file.
     pub public_api: Vec<String>,
     /// Functions/methods registered as hook/callback targets from WITHIN
@@ -96,9 +96,9 @@ pub struct FileFingerprint {
     /// Method names that are trait implementations (called via trait dispatch).
     pub trait_impl_methods: Vec<String>,
     /// Extension-reported direct aggregate literal construction sites.
-    pub aggregate_literals: Vec<crate::extension::AggregateLiteral>,
+    pub aggregate_literals: Vec<crate::core::extension::AggregateLiteral>,
     /// Extension-reported canonical construction seams for aggregate types.
-    pub aggregate_construction_seams: Vec<crate::extension::AggregateConstructionSeam>,
+    pub aggregate_construction_seams: Vec<crate::core::extension::AggregateConstructionSeam>,
 }
 
 /// Extract a structural fingerprint from a source file on disk.
@@ -156,7 +156,7 @@ pub(crate) fn fingerprint_extension_content(
     relative_path: &str,
     content: &str,
 ) -> Option<FileFingerprint> {
-    use crate::extension;
+    use crate::core::extension;
 
     let matched_extension = extension::find_extension_for_file_ext(ext, "fingerprint")?;
     let output = extension::run_fingerprint_script(&matched_extension, relative_path, content)?;

--- a/src/core/code_audit/global_env_guard.rs
+++ b/src/core/code_audit/global_env_guard.rs
@@ -196,7 +196,7 @@ impl Drop for HomeGuard {
         let runner = rust_fp(
             "tests/core/rig/runner_test.rs",
             r#"
-use crate::rig::test_support::with_isolated_home;
+use crate::core::rig::test_support::with_isolated_home;
 "#,
         );
 

--- a/src/core/code_audit/impact.rs
+++ b/src/core/code_audit/impact.rs
@@ -125,7 +125,7 @@ pub(crate) fn fingerprint_from_git_ref(
     // Get file content from the git ref
     let git_spec = format!("{}:{}", git_ref, relative_path);
     let content =
-        crate::engine::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
+        crate::core::engine::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
 
     let ext = Path::new(relative_path).extension()?.to_str()?;
     super::fingerprint::fingerprint_extension_content(ext, relative_path, &content)
@@ -491,7 +491,7 @@ mod tests {
             imports: imports.iter().map(|s| s.to_string()).collect(),
             hooks: hooks
                 .iter()
-                .map(|(t, n)| crate::extension::HookRef {
+                .map(|(t, n)| crate::core::extension::HookRef {
                     hook_type: t.to_string(),
                     name: n.to_string(),
                 })

--- a/src/core/code_audit/import_matching.rs
+++ b/src/core/code_audit/import_matching.rs
@@ -694,7 +694,7 @@ fn production(values: BTreeMap<String, f64>) {}
     #[test]
     fn content_defines_name_skips_use_statements() {
         assert!(!content_defines_name(
-            "use crate::defaults::default_true;",
+            "use crate::core::defaults::default_true;",
             "default_true"
         ));
     }

--- a/src/core/code_audit/layer_ownership.rs
+++ b/src/core/code_audit/layer_ownership.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use glob_match::glob_match;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -77,8 +77,10 @@ pub use report::AuditCommandOutput;
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};
 pub use walker::is_test_path;
 
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
-use crate::{component, component::AuditConfig, is_zero, Result};
+use crate::core::component::AuditConfig;
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
+use crate::core::{component, Result};
+use crate::is_zero;
 
 /// Summary counts for the audit report.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -547,7 +549,7 @@ fn read_reference_paths_from_env() -> Vec<String> {
 pub fn audit_path(path: &str) -> Result<CodeAuditResult> {
     let p = Path::new(path);
     if !p.is_dir() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "path",
             format!("Not a directory: {}", path),
             None,
@@ -642,7 +644,7 @@ fn audit_config_for(component_id: &str, root: &Path) -> AuditConfig {
     if let Some(component) = &component {
         if let Some(extensions) = &component.extensions {
             for extension_id in extensions.keys() {
-                if let Ok(manifest) = crate::extension::load_extension(extension_id) {
+                if let Ok(manifest) = crate::core::extension::load_extension(extension_id) {
                     if let Some(rules) = manifest.audit_detector_rules() {
                         audit_config.merge(rules);
                     }
@@ -922,7 +924,7 @@ fn audit_internal(
         if let Ok(comp) = component::load(component_id) {
             if let Some(extensions) = &comp.extensions {
                 for ext_id in extensions.keys() {
-                    if let Ok(ext_manifest) = crate::extension::load_extension(ext_id) {
+                    if let Ok(ext_manifest) = crate::core::extension::load_extension(ext_id) {
                         if let Some(test_mapping) = ext_manifest.test_mapping() {
                             let coverage_findings = test_coverage::analyze_test_coverage(
                                 root,
@@ -1531,9 +1533,9 @@ fn detect_doc_drift(root: &Path, component_id: &str) -> Vec<Finding> {
     };
 
     let doc_excludes = if let Ok(comp) = component::load(component_id) {
-        crate::component::scope::resolve_component_scope(
+        crate::core::component::scope::resolve_component_scope(
             &comp,
-            crate::component::scope::ScopeCommand::Audit,
+            crate::core::component::scope::ScopeCommand::Audit,
         )
         .exclude
     } else {

--- a/src/core/code_audit/parallel_runner_setup.rs
+++ b/src/core/code_audit/parallel_runner_setup.rs
@@ -226,7 +226,7 @@ fn is_control_keyword(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
+    use crate::core::code_audit::conventions::Language;
 
     fn fingerprint(path: &str, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/src/core/code_audit/repeated_literal_shape.rs
+++ b/src/core/code_audit/repeated_literal_shape.rs
@@ -611,7 +611,7 @@ fn trim_ascii(bytes: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
+    use crate::core::code_audit::conventions::Language;
 
     fn fp(path: &str, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use crate::code_audit::{
+use crate::core::code_audit::{
     baseline, AuditFinding, CodeAuditResult, ConventionReport, DirectoryConvention,
     FindingConfidence, Severity,
 };
@@ -293,14 +293,14 @@ pub fn compute_fixability(result: &CodeAuditResult) -> Option<AuditFixability> {
 
 pub(crate) fn compute_fixability_with_analysis(
     result: &CodeAuditResult,
-    analysis: &crate::code_audit::AuditAnalysisContext,
+    analysis: &crate::core::code_audit::AuditAnalysisContext,
 ) -> Option<AuditFixability> {
     compute_fixability_impl(result, Some(analysis))
 }
 
 fn compute_fixability_impl(
     result: &CodeAuditResult,
-    analysis: Option<&crate::code_audit::AuditAnalysisContext>,
+    analysis: Option<&crate::core::code_audit::AuditAnalysisContext>,
 ) -> Option<AuditFixability> {
     let source_path = Path::new(&result.source_path);
     if !source_path.is_dir() {
@@ -322,19 +322,21 @@ fn compute_fixability_impl(
     }
 
     // Generate fix plan (dry-run — never writes)
-    let fix_policy = crate::refactor::auto::FixPolicy::default();
+    let fix_policy = crate::core::refactor::auto::FixPolicy::default();
     let mut fix_result = match analysis {
         Some(analysis) if !analysis.fingerprints.is_empty() => {
-            crate::refactor::plan::generate::generate_audit_fixes_with_fingerprints(
+            crate::core::refactor::plan::generate::generate_audit_fixes_with_fingerprints(
                 result,
                 source_path,
                 &fix_policy,
                 &analysis.fingerprints,
             )
         }
-        _ => {
-            crate::refactor::plan::generate::generate_audit_fixes(result, source_path, &fix_policy)
-        }
+        _ => crate::core::refactor::plan::generate::generate_audit_fixes(
+            result,
+            source_path,
+            &fix_policy,
+        ),
     };
 
     if fix_result.fixes.is_empty() && fix_result.new_files.is_empty() {
@@ -342,12 +344,12 @@ fn compute_fixability_impl(
     }
 
     // Apply policy annotation (dry-run mode: write=false, no filtering)
-    let policy = crate::refactor::auto::FixPolicy {
+    let policy = crate::core::refactor::auto::FixPolicy {
         only: None,
         exclude: Vec::new(),
     };
     let _ = source_path;
-    crate::refactor::auto::apply_fix_policy(&mut fix_result, false, &policy);
+    crate::core::refactor::auto::apply_fix_policy(&mut fix_result, false, &policy);
 
     // Count by automation eligibility
     let mut automated_count = 0usize;

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -4,7 +4,7 @@ use regex::{Captures, Regex};
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
-use crate::component::{AuditConfig, RequestedDetectorRule, RequestedDetectorRuleBody};
+use crate::core::component::{AuditConfig, RequestedDetectorRule, RequestedDetectorRuleBody};
 
 use super::comment_blocks;
 use super::conventions::{AuditFinding, Language};

--- a/src/core/code_audit/requirements.rs
+++ b/src/core/code_audit/requirements.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::component::{
+use crate::core::component::{
     AuditConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
     KnownSymbolVersionedEntry,
 };

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -3,8 +3,8 @@
 //! Mirrors `core/extension/lint/run.rs` and `core/extension/test/run.rs` — the command
 //! layer provides CLI args, this module owns all business logic and returns structured results.
 
-use crate::code_audit::{self, baseline, AuditWithAnalysis, CodeAuditResult};
-use crate::git;
+use crate::core::code_audit::{self, baseline, AuditWithAnalysis, CodeAuditResult};
+use crate::core::git;
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -23,7 +23,7 @@ pub struct AuditRunWorkflowArgs {
     pub exclude_kinds: Vec<code_audit::AuditFinding>,
     pub only_labels: Vec<String>,
     pub exclude_labels: Vec<String>,
-    pub baseline_flags: crate::engine::baseline::BaselineFlags,
+    pub baseline_flags: crate::core::engine::baseline::BaselineFlags,
     pub changed_since: Option<String>,
     pub json_summary: bool,
     pub include_fixability: bool,
@@ -39,7 +39,7 @@ pub struct AuditRunWorkflowResult {
 /// Run the main audit workflow.
 pub fn run_main_audit_workflow(
     args: AuditRunWorkflowArgs,
-) -> crate::Result<AuditRunWorkflowResult> {
+) -> crate::core::Result<AuditRunWorkflowResult> {
     // Run audit — scoped or full
     let result = run_audit(&args)?;
 
@@ -189,7 +189,7 @@ fn scope_convention_outliers_to_findings(result: &mut CodeAuditResult) {
 }
 
 /// Run the audit scan (scoped or full). Returns None if changed-since found no files.
-fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<AuditWithAnalysis>> {
+fn run_audit(args: &AuditRunWorkflowArgs) -> crate::core::Result<Option<AuditWithAnalysis>> {
     let plan = if args.baseline_flags.baseline {
         code_audit::AuditExecutionPlan::full()
     } else {
@@ -222,7 +222,7 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> crate::Result<Option<AuditWithAnaly
 fn run_baseline_save(
     result: CodeAuditResult,
     args: &AuditRunWorkflowArgs,
-) -> crate::Result<AuditRunWorkflowResult> {
+) -> crate::core::Result<AuditRunWorkflowResult> {
     let findings = result.findings.clone();
     let saved = if let Some(ref git_ref) = args.changed_since {
         let changed = git::get_files_changed_since(&args.source_path, git_ref)?;
@@ -240,13 +240,15 @@ fn run_baseline_save(
             );
         }
         baseline::save_baseline_scoped(&result, &changed)
-            .map_err(crate::Error::internal_unexpected)?
+            .map_err(crate::core::Error::internal_unexpected)?
     } else {
-        baseline::save_baseline(&result).map_err(crate::Error::internal_unexpected)?
+        baseline::save_baseline(&result).map_err(crate::core::Error::internal_unexpected)?
     };
 
-    let baseline_data = baseline::load_baseline(Path::new(&result.source_path))
-        .ok_or_else(|| crate::Error::internal_unexpected("Failed to read back saved baseline"))?;
+    let baseline_data =
+        baseline::load_baseline(Path::new(&result.source_path)).ok_or_else(|| {
+            crate::core::Error::internal_unexpected("Failed to read back saved baseline")
+        })?;
 
     if let Some(score) = baseline_data.metadata.alignment_score {
         eprintln!(
@@ -281,7 +283,7 @@ fn run_comparison_workflow(
     result: CodeAuditResult,
     analysis: &code_audit::AuditAnalysisContext,
     args: &AuditRunWorkflowArgs,
-) -> crate::Result<AuditRunWorkflowResult> {
+) -> crate::core::Result<AuditRunWorkflowResult> {
     // Try file-based baseline
     if !args.baseline_flags.ignore_baseline {
         if let Some(existing_baseline) = baseline::load_baseline(Path::new(&result.source_path)) {
@@ -339,7 +341,7 @@ fn build_comparison_output(
     analysis: &code_audit::AuditAnalysisContext,
     existing_baseline: baseline::AuditBaseline,
     args: &AuditRunWorkflowArgs,
-) -> crate::Result<AuditRunWorkflowResult> {
+) -> crate::core::Result<AuditRunWorkflowResult> {
     let comparison = baseline::compare(&result, &existing_baseline);
     let exit_code = if comparison.drift_increased { 1 } else { 0 };
     let changed_since_summary = args

--- a/src/core/code_audit/shared_scaffolding.rs
+++ b/src/core/code_audit/shared_scaffolding.rs
@@ -252,7 +252,7 @@ fn mean_body_similarity(members: &[&ClassShape], shape: &[(String, String)]) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
+    use crate::core::code_audit::conventions::Language;
 
     fn make_class(
         path: &str,

--- a/src/core/code_audit/structural.rs
+++ b/src/core/code_audit/structural.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};

--- a/src/core/code_audit/test_coverage.rs
+++ b/src/core/code_audit/test_coverage.rs
@@ -24,7 +24,7 @@ use super::test_mapping::{
     build_source_name_index, partition_fingerprints, source_to_test_path, test_to_source_path,
 };
 use super::test_vacuity::{find_vacuous_test_methods, rust_crate_name};
-use crate::extension::TestMappingConfig;
+use crate::core::extension::TestMappingConfig;
 
 /// Analyze test coverage gaps given source fingerprints and a test mapping config.
 ///
@@ -791,7 +791,7 @@ fn is_rust_behavior_scenario_name(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
+    use crate::core::code_audit::conventions::Language;
 
     fn make_config() -> TestMappingConfig {
         TestMappingConfig {
@@ -1190,7 +1190,7 @@ fn test_chat_tools() {
             "tests/deploy_test.rs",
             vec!["test_parse_bulk_component_ids_supports_json_array"],
             r##"
-                use homeboy::deploy::parse_bulk_component_ids;
+                use homeboy::core::deploy::parse_bulk_component_ids;
 
                 #[test]
                 fn test_parse_bulk_component_ids_supports_json_array() {

--- a/src/core/code_audit/test_mapping.rs
+++ b/src/core/code_audit/test_mapping.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::fingerprint::FileFingerprint;
-use crate::extension::TestMappingConfig;
+use crate::core::extension::TestMappingConfig;
 
 /// Partition fingerprints into source files and test files based on the config.
 pub fn partition_fingerprints<'a>(
@@ -159,7 +159,7 @@ pub fn test_to_source_path(test_path: &str, config: &TestMappingConfig) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::TestMappingConfig;
+    use crate::core::extension::TestMappingConfig;
 
     fn make_config() -> TestMappingConfig {
         TestMappingConfig {

--- a/src/core/code_audit/test_quality.rs
+++ b/src/core/code_audit/test_quality.rs
@@ -7,11 +7,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
-use crate::code_audit::conventions::AuditFinding;
-use crate::code_audit::findings::{Finding, Severity};
-use crate::code_audit::walker::is_test_path;
+use crate::core::code_audit::conventions::AuditFinding;
+use crate::core::code_audit::findings::{Finding, Severity};
+use crate::core::code_audit::walker::is_test_path;
 
 pub(super) fn run(root: &Path) -> Vec<Finding> {
     let config = ScanConfig {
@@ -659,8 +659,8 @@ fn public_api_compiles() {
         let findings = detect_vacuous_tests(
             "tests/core/rig/check_test.rs",
             r#"
-use crate::rig::check::evaluate;
-use crate::rig::spec::{CheckSpec, RigSpec};
+use crate::core::rig::check::evaluate;
+use crate::core::rig::spec::{CheckSpec, RigSpec};
 
 fn minimal_rig() -> RigSpec { todo!() }
 
@@ -681,7 +681,7 @@ fn test_evaluate_file_exists() {
         let findings = detect_vacuous_tests(
             "tests/core/deps_test.rs",
             r#"
-use homeboy::deps::{self, ComposerAction};
+use homeboy::core::deps::{self, ComposerAction};
 
 #[test]
 fn status_filters_to_one_package() {
@@ -857,7 +857,7 @@ fn calls_product() {
         let findings = detect_vacuous_tests(
             "tests/core/extension/bench/runs_flag_test.rs",
             r#"
-use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+use crate::core::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
 
 fn scenario(id: &str) -> BenchScenario {
     scenario_with_iterations(id, &[("ms", 1.0)], 1)

--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::extension::{self, ExtensionManifest};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::extension::{self, ExtensionManifest};
 
 #[path = "test_quality.rs"]
 mod test_quality;
@@ -362,7 +362,7 @@ JSON
             name: "Test Extension".to_string(),
             version: "0.1.0".to_string(),
             provides: None,
-            scripts: Some(crate::extension::ScriptsConfig {
+            scripts: Some(crate::core::extension::ScriptsConfig {
                 topology: Some(script_rel.to_string()),
                 ..Default::default()
             }),

--- a/src/core/code_audit/upstream_workaround.rs
+++ b/src/core/code_audit/upstream_workaround.rs
@@ -249,8 +249,8 @@ fn truncate(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
-    use crate::code_audit::fingerprint::FileFingerprint;
+    use crate::core::code_audit::conventions::Language;
+    use crate::core::code_audit::fingerprint::FileFingerprint;
 
     fn make_fp(path: &str, lang: Language, content: &str) -> FileFingerprint {
         FileFingerprint {

--- a/src/core/code_audit/walker.rs
+++ b/src/core/code_audit/walker.rs
@@ -1,10 +1,10 @@
 //! walker — extracted from conventions.rs.
 //!
-//! File walking delegated to `crate::engine::codebase_scan` for consistency.
+//! File walking delegated to `crate::core::engine::codebase_scan` for consistency.
 
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, CodebaseSnapshot, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::{self, CodebaseSnapshot, ExtensionFilter, ScanConfig};
 
 /// Extension index/entry-point filenames that should be excluded from convention
 /// sibling detection. These files organize other files rather than being
@@ -31,7 +31,7 @@ pub(crate) fn is_index_file(path: &Path) -> bool {
 
 /// Collect all file extensions that installed extensions can handle.
 pub(crate) fn extension_provided_file_extensions() -> Vec<String> {
-    crate::extension::load_all_extensions()
+    crate::core::extension::load_all_extensions()
         .unwrap_or_default()
         .into_iter()
         .flat_map(|m| m.provided_file_extensions().to_vec())

--- a/src/core/component/drift.rs
+++ b/src/core/component/drift.rs
@@ -32,7 +32,7 @@
 //!
 //! [Extra-Chill/homeboy-action]: https://github.com/Extra-Chill/homeboy-action
 
-use crate::component::Component;
+use crate::core::component::Component;
 use std::collections::BTreeSet;
 use std::path::Path;
 
@@ -42,7 +42,7 @@ use std::path::Path;
 /// audit baseline (`homeboy.json`) is always first; remaining entries are
 /// the union of extension-declared lockfiles and component-declared extras.
 ///
-/// Extension manifests are loaded via [`crate::extension::load_extension`].
+/// Extension manifests are loaded via [`crate::core::extension::load_extension`].
 /// Extensions that fail to load are silently skipped — drift resolution is
 /// a non-essential side query and should not break callers.
 pub fn drift_file_paths(component: &Component) -> Vec<String> {
@@ -50,7 +50,7 @@ pub fn drift_file_paths(component: &Component) -> Vec<String> {
 
     if let Some(extensions) = component.extensions.as_ref() {
         for extension_id in extensions.keys() {
-            let Ok(manifest) = crate::extension::load_extension(extension_id) else {
+            let Ok(manifest) = crate::core::extension::load_extension(extension_id) else {
                 continue;
             };
             let Some(build) = manifest.build.as_ref() else {

--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -1,8 +1,8 @@
-use crate::component::{discover_from_portable, Component};
-use crate::engine::local_files::FileSystem;
-use crate::error::{Error, Result};
-use crate::extension;
-use crate::project;
+use crate::core::component::{discover_from_portable, Component};
+use crate::core::engine::local_files::FileSystem;
+use crate::core::error::{Error, Result};
+use crate::core::extension;
+use crate::core::project;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -64,7 +64,7 @@ pub fn inventory() -> Result<Vec<Component>> {
             if seen.insert(component.id.clone()) {
                 components.push(component);
             }
-        } else if let Some(git_root) = crate::component::resolution::detect_git_root(&cwd) {
+        } else if let Some(git_root) = crate::core::component::resolution::detect_git_root(&cwd) {
             if let Some(component) = discover_from_portable(&git_root) {
                 if seen.insert(component.id.clone()) {
                     components.push(component);
@@ -86,7 +86,7 @@ pub fn inventory() -> Result<Vec<Component>> {
 /// `homeboy.json`, the portable config is merged on top (portable config is
 /// the source of truth for version_targets, changelog_target, etc.).
 fn load_standalone_components() -> Result<Vec<Component>> {
-    let dir = crate::paths::components()?;
+    let dir = crate::core::paths::components()?;
     if !dir.exists() {
         return Ok(Vec::new());
     }
@@ -274,7 +274,7 @@ pub fn reconcile_standalone_registration(
     id: &str,
     apply: bool,
 ) -> Result<ComponentReconcileReport> {
-    let dir = crate::paths::components()?;
+    let dir = crate::core::paths::components()?;
     let registration_path = dir.join(format!("{}.json", id));
     let content = std::fs::read_to_string(&registration_path).map_err(|e| {
         Error::validation_invalid_argument(
@@ -329,9 +329,9 @@ pub fn reconcile_standalone_registration(
                 serde_json::Value::String(discovered.clone()),
             );
         }
-        crate::component::portable::validate_component_remote_urls(&json)?;
-        let updated = crate::config::to_string_pretty(&json)?;
-        crate::engine::local_files::write_file_atomic(
+        crate::core::component::portable::validate_component_remote_urls(&json)?;
+        let updated = crate::core::config::to_string_pretty(&json)?;
+        crate::core::engine::local_files::write_file_atomic(
             &registration_path,
             &updated,
             &format!(
@@ -397,7 +397,7 @@ fn discover_reconcile_candidate(id: &str, registered_path: &Path) -> Option<Stri
 /// it into the full inventory. Returns a minimal struct with `local_path`
 /// for error messaging when the component exists on disk but isn't loadable.
 fn read_standalone_file(id: &str) -> Option<StandaloneFileInfo> {
-    let dir = match crate::paths::components() {
+    let dir = match crate::core::paths::components() {
         Ok(d) if d.exists() => d,
         _ => return None,
     };
@@ -447,8 +447,8 @@ pub fn write_standalone_registration(component: &Component) -> Result<()> {
         ));
     }
 
-    let dir = crate::paths::components()?;
-    crate::engine::local_files::local().ensure_dir(&dir)?;
+    let dir = crate::core::paths::components()?;
+    crate::core::engine::local_files::local().ensure_dir(&dir)?;
 
     let path = dir.join(format!("{}.json", component.id));
 
@@ -478,10 +478,10 @@ pub fn write_standalone_registration(component: &Component) -> Result<()> {
         }
     }
 
-    crate::component::portable::validate_component_remote_urls(&json)?;
+    crate::core::component::portable::validate_component_remote_urls(&json)?;
 
-    let content = crate::config::to_string_pretty(&json)?;
-    crate::engine::local_files::write_file_atomic(
+    let content = crate::core::config::to_string_pretty(&json)?;
+    crate::core::engine::local_files::write_file_atomic(
         &path,
         &content,
         &format!("write standalone registration {}", path.display()),
@@ -494,8 +494,8 @@ pub fn rename_standalone_registration(old_id: &str, component: &Component) -> Re
         return write_standalone_registration(component);
     }
 
-    let dir = crate::paths::components()?;
-    crate::engine::local_files::local().ensure_dir(&dir)?;
+    let dir = crate::core::paths::components()?;
+    crate::core::engine::local_files::local().ensure_dir(&dir)?;
 
     let old_path = dir.join(format!("{}.json", old_id));
     let new_path = dir.join(format!("{}.json", component.id));

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -480,7 +480,7 @@ impl Component {
 
         let mut matches = HashSet::new();
         for extension_id in self.extensions.as_ref()?.keys() {
-            let Ok(extension) = crate::extension::load_extension(extension_id) else {
+            let Ok(extension) = crate::core::extension::load_extension(extension_id) else {
                 continue;
             };
 
@@ -504,7 +504,7 @@ impl Component {
 
     fn remote_path_inference_rule_matches(
         &self,
-        rule: &crate::extension::RemotePathInferenceRule,
+        rule: &crate::core::extension::RemotePathInferenceRule,
         local: &std::path::Path,
         dir_name: &str,
     ) -> bool {
@@ -538,31 +538,34 @@ impl Component {
 
     pub fn self_check_commands(
         &self,
-        capability: crate::extension::ExtensionCapability,
+        capability: crate::core::extension::ExtensionCapability,
     ) -> &[String] {
         let Some(checks) = self.self_checks.as_ref() else {
             return &[];
         };
 
         match capability {
-            crate::extension::ExtensionCapability::Lint => &checks.lint,
-            crate::extension::ExtensionCapability::Test => &checks.test,
+            crate::core::extension::ExtensionCapability::Lint => &checks.lint,
+            crate::core::extension::ExtensionCapability::Test => &checks.test,
             _ => &[],
         }
     }
 
-    pub fn has_self_check(&self, capability: crate::extension::ExtensionCapability) -> bool {
+    pub fn has_self_check(&self, capability: crate::core::extension::ExtensionCapability) -> bool {
         !self.self_check_commands(capability).is_empty()
     }
 
-    pub fn script_commands(&self, capability: crate::extension::ExtensionCapability) -> &[String] {
+    pub fn script_commands(
+        &self,
+        capability: crate::core::extension::ExtensionCapability,
+    ) -> &[String] {
         if let Some(scripts) = self.scripts.as_ref() {
             let commands = match capability {
-                crate::extension::ExtensionCapability::Lint => &scripts.lint,
-                crate::extension::ExtensionCapability::Test => &scripts.test,
-                crate::extension::ExtensionCapability::Build => &scripts.build,
-                crate::extension::ExtensionCapability::Bench => &scripts.bench,
-                crate::extension::ExtensionCapability::Trace => &scripts.trace,
+                crate::core::extension::ExtensionCapability::Lint => &scripts.lint,
+                crate::core::extension::ExtensionCapability::Test => &scripts.test,
+                crate::core::extension::ExtensionCapability::Build => &scripts.build,
+                crate::core::extension::ExtensionCapability::Bench => &scripts.bench,
+                crate::core::extension::ExtensionCapability::Trace => &scripts.trace,
             };
             if !commands.is_empty() {
                 return commands;
@@ -573,7 +576,7 @@ impl Component {
         self.self_check_commands(capability)
     }
 
-    pub fn has_script(&self, capability: crate::extension::ExtensionCapability) -> bool {
+    pub fn has_script(&self, capability: crate::core::extension::ExtensionCapability) -> bool {
         !self.script_commands(capability).is_empty()
     }
 

--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -1,9 +1,9 @@
-use crate::component::{
+use crate::core::component::{
     associated_projects, mutate_portable, rename_component, resolve_effective, Component,
 };
-use crate::config;
-use crate::error::{Error, Result};
-use crate::output::{MergeOutput, MergeResult};
+use crate::core::config;
+use crate::core::error::{Error, Result};
+use crate::core::output::{MergeOutput, MergeResult};
 use serde_json::Value;
 use std::path::Path;
 

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -1,5 +1,5 @@
-use crate::component::{resolve_effective, Component};
-use crate::error::{Error, Result};
+use crate::core::component::{resolve_effective, Component};
+use crate::core::error::{Error, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 
@@ -44,13 +44,13 @@ fn portable_component_id_from_value(portable: &Value, dir: &Path) -> Option<Stri
                 );
                 return None;
             }
-            return crate::engine::identifier::slugify_id(id_str, "component_id").ok();
+            return crate::core::engine::identifier::slugify_id(id_str, "component_id").ok();
         }
     }
 
     // No "id" key at all — infer from directory name (backward compat for minimal configs)
     let dir_name = dir.file_name()?.to_string_lossy();
-    crate::engine::identifier::slugify_id(&dir_name, "component_id").ok()
+    crate::core::engine::identifier::slugify_id(&dir_name, "component_id").ok()
 }
 
 pub fn infer_portable_component_id(dir: &Path) -> Result<String> {
@@ -136,8 +136,8 @@ pub fn write_portable_config(dir: &Path, component: &Component) -> Result<()> {
 
     validate_component_remote_urls(&merged)?;
 
-    let content = crate::config::to_string_pretty(&merged)?;
-    crate::engine::local_files::write_file_atomic(
+    let content = crate::core::config::to_string_pretty(&merged)?;
+    crate::core::engine::local_files::write_file_atomic(
         &path,
         &content,
         &format!("write {}", path.display()),
@@ -168,7 +168,7 @@ fn validate_github_remote_url_field(component: &Value, field: &str) -> Result<()
     if url.trim().is_empty() {
         return Ok(());
     }
-    if crate::deploy::release_download::parse_github_url(url).is_some() {
+    if crate::core::deploy::release_download::parse_github_url(url).is_some() {
         return Ok(());
     }
 
@@ -275,7 +275,7 @@ pub fn discover_from_portable(dir: &Path) -> Option<Component> {
 
         // Auto-detect remote_url from git if not already set
         if !obj.contains_key("remote_url") {
-            if let Some(url) = crate::deploy::release_download::detect_remote_url(dir) {
+            if let Some(url) = crate::core::deploy::release_download::detect_remote_url(dir) {
                 obj.insert("remote_url".to_string(), Value::String(url));
             }
         }
@@ -406,7 +406,8 @@ mod tests {
         );
 
         let patch = serde_json::json!({ "local_path": "/new/path" });
-        crate::config::merge_config(&mut component, patch, &[]).expect("merge should succeed");
+        crate::core::config::merge_config(&mut component, patch, &[])
+            .expect("merge should succeed");
 
         assert!(
             component.id.trim().is_empty(),
@@ -528,7 +529,7 @@ mod tests {
             .unwrap();
 
             let patch = r#"{"remote_url":"/Users/chubes/Developer/homeboy"}"#;
-            let result = crate::component::mutations::merge(Some("my-comp"), patch, &[]);
+            let result = crate::core::component::mutations::merge(Some("my-comp"), patch, &[]);
 
             assert!(result.is_err());
             assert_eq!(

--- a/src/core/component/relationships.rs
+++ b/src/core/component/relationships.rs
@@ -1,6 +1,6 @@
-use crate::component::Component;
-use crate::error::Result;
-use crate::project;
+use crate::core::component::Component;
+use crate::core::error::Result;
+use crate::core::project;
 
 fn update_project_references(old_id: &str, new_id: &str) -> Result<()> {
     let projects = project::list().unwrap_or_default();
@@ -60,12 +60,12 @@ pub fn shared_components() -> Result<std::collections::HashMap<String, Vec<Strin
 }
 
 pub fn rename_component(id: &str, new_id: &str) -> Result<Component> {
-    let resolved_new_id = crate::engine::identifier::slugify_id(new_id, "component_id")?;
-    let component = crate::component::mutate_portable(id, |component| {
+    let resolved_new_id = crate::core::engine::identifier::slugify_id(new_id, "component_id")?;
+    let component = crate::core::component::mutate_portable(id, |component| {
         component.id = resolved_new_id.clone();
         Ok(())
     })?;
-    crate::component::inventory::rename_standalone_registration(id, &component)?;
+    crate::core::component::inventory::rename_standalone_registration(id, &component)?;
     update_project_references(id, &resolved_new_id)?;
     Ok(component)
 }

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -1,5 +1,5 @@
-use crate::component::{discover_from_portable, inventory, load, Component};
-use crate::error::{Error, Result};
+use crate::core::component::{discover_from_portable, inventory, load, Component};
+use crate::core::error::{Error, Result};
 use std::path::{Path, PathBuf};
 
 pub fn resolve_artifact(component: &Component) -> Option<String> {
@@ -9,7 +9,7 @@ pub fn resolve_artifact(component: &Component) -> Option<String> {
 
     if let Some(ref extensions) = component.extensions {
         for extension_id in extensions.keys() {
-            if let Ok(manifest) = crate::extension::load_extension(extension_id) {
+            if let Ok(manifest) = crate::core::extension::load_extension(extension_id) {
                 if let Some(ref build) = manifest.build {
                     if let Some(ref pattern) = build.artifact_pattern {
                         let resolved = pattern
@@ -208,10 +208,10 @@ pub fn resolve(id: Option<&str>) -> Result<Component> {
 pub fn resolve_effective(
     id: Option<&str>,
     path_override: Option<&str>,
-    project: Option<&crate::project::Project>,
+    project: Option<&crate::core::project::Project>,
 ) -> Result<Component> {
     if let (Some(project), Some(id)) = (project, id) {
-        let mut component = crate::project::resolve_project_component(project, id)?;
+        let mut component = crate::core::project::resolve_project_component(project, id)?;
         if let Some(path) = path_override {
             component.local_path = path.to_string();
         }
@@ -277,7 +277,7 @@ pub fn resolve_effective(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::ScopedExtensionConfig;
+    use crate::core::component::ScopedExtensionConfig;
     use std::collections::HashMap;
     use std::fs;
     use std::sync::{Mutex, OnceLock};

--- a/src/core/component/scope.rs
+++ b/src/core/component/scope.rs
@@ -73,7 +73,7 @@ fn dedupe(items: &mut Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::{Component, ScopeConfig};
+    use crate::core::component::{Component, ScopeConfig};
 
     #[test]
     fn merges_default_and_command_specific_excludes() {

--- a/src/core/component/versioning.rs
+++ b/src/core/component/versioning.rs
@@ -1,5 +1,5 @@
-use crate::component::VersionTarget;
-use crate::error::{Error, Result};
+use crate::core::component::VersionTarget;
+use crate::core::error::{Error, Result};
 use regex::Regex;
 
 /// Check if adding a new version target would conflict with existing targets.
@@ -34,7 +34,7 @@ pub fn validate_version_pattern(pattern: &str) -> Result<()> {
         ));
     }
 
-    let re = Regex::new(&crate::engine::text::ensure_multiline(pattern)).map_err(|e| {
+    let re = Regex::new(&crate::core::engine::text::ensure_multiline(pattern)).map_err(|e| {
         Error::validation_invalid_argument(
             "version_target.pattern",
             format!("Invalid regex pattern '{}': {}", pattern, e),

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,12 +1,12 @@
-use crate::engine::identifier;
-use crate::engine::local_files::{self, FileSystem};
-use crate::engine::text::levenshtein;
-use crate::error::Error;
-use crate::output::{
+use crate::core::engine::identifier;
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::text::levenshtein;
+use crate::core::error::Error;
+use crate::core::output::{
     BatchResult, CreateOutput, CreateResult, MergeOutput, MergeResult, RemoveResult,
 };
-use crate::paths;
-use crate::Result;
+use crate::core::paths;
+use crate::core::Result;
 use heck::ToSnakeCase;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -744,11 +744,11 @@ fn entity_metadata<T: ConfigEntity>() -> ConfigEntityMetadata {
 
 fn config_entity_registry() -> [ConfigEntityMetadata; 5] {
     [
-        entity_metadata::<crate::project::Project>(),
-        entity_metadata::<crate::server::Server>(),
-        entity_metadata::<crate::runner::Runner>(),
-        entity_metadata::<crate::extension::ExtensionManifest>(),
-        entity_metadata::<crate::fleet::Fleet>(),
+        entity_metadata::<crate::core::project::Project>(),
+        entity_metadata::<crate::core::server::Server>(),
+        entity_metadata::<crate::core::runner::Runner>(),
+        entity_metadata::<crate::core::extension::ExtensionManifest>(),
+        entity_metadata::<crate::core::fleet::Fleet>(),
     ]
 }
 
@@ -1536,7 +1536,7 @@ macro_rules! entity_crud {
     // Feature: slugify_id
     (@feature $Entity:ty, slugify_id) => {
         pub fn slugify_id(name: &str) -> Result<String> {
-            crate::engine::identifier::slugify_id(name, "name")
+            crate::core::engine::identifier::slugify_id(name, "name")
         }
     };
 }

--- a/src/core/context/mod.rs
+++ b/src/core/context/mod.rs
@@ -2,12 +2,12 @@ use serde::Serialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use crate::component;
-use crate::error::{Error, Result};
-use crate::extension::{self, DiscoveryMarkerConfig, ExtensionManifest};
-use crate::project::{self, Project};
-use crate::server::SshClient;
-use crate::server::{self, Server};
+use crate::core::component;
+use crate::core::error::{Error, Result};
+use crate::core::extension::{self, DiscoveryMarkerConfig, ExtensionManifest};
+use crate::core::project::{self, Project};
+use crate::core::server::SshClient;
+use crate::core::server::{self, Server};
 
 pub mod report;
 

--- a/src/core/context/report.rs
+++ b/src/core/context/report.rs
@@ -3,14 +3,16 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::component::{self, Component};
-use crate::deploy;
-use crate::extension::{
+use crate::core::component::{self, Component};
+use crate::core::deploy;
+use crate::core::extension::{
     extension_ready_status, is_extension_compatible, is_extension_linked, load_all_extensions,
 };
-use crate::project::{self, Project};
-use crate::server::{self, Server};
-use crate::{changelog, git, is_zero, is_zero_u32, version, Result};
+use crate::core::project::{self, Project};
+use crate::core::release::{changelog, version};
+use crate::core::server::{self, Server};
+use crate::core::{git, Result};
+use crate::{is_zero, is_zero_u32};
 
 use super::{build_component_info, path_is_parent_of, ComponentGap, ContextOutput};
 
@@ -167,7 +169,7 @@ pub struct ChangelogSnapshot {
     pub items: Option<Vec<String>>,
 }
 
-pub type ComponentReleaseState = crate::deploy::ReleaseState;
+pub type ComponentReleaseState = crate::core::deploy::ReleaseState;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ComponentWithState {
@@ -408,7 +410,7 @@ fn collect_focused_components(
 
 fn compute_status(
     components: &[ComponentWithState],
-    release_buckets: &crate::deploy::ReleaseStateBuckets,
+    release_buckets: &crate::core::deploy::ReleaseStateBuckets,
 ) -> ContextReportStatus {
     let mut config_gaps = 0;
     let mut gap_details = Vec::new();
@@ -525,7 +527,7 @@ fn build_actionable_next_steps(
     components: &[ComponentWithState],
     projects: &[ProjectListItem],
     linked_extension_ids: &HashSet<String>,
-    all_extensions: &[crate::extension::ExtensionManifest],
+    all_extensions: &[crate::core::extension::ExtensionManifest],
 ) -> Vec<String> {
     let mut next_steps = Vec::new();
 
@@ -636,7 +638,7 @@ fn build_actionable_next_steps(
 
     let mut outdated_extensions = Vec::new();
     for extension in all_extensions {
-        if let Some(update) = crate::extension::check_update_available(&extension.id) {
+        if let Some(update) = crate::core::extension::check_update_available(&extension.id) {
             outdated_extensions.push(update);
         }
     }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -7,11 +7,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 
-use crate::api_jobs::JobStore;
-use crate::error::{Error, Result};
-use crate::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
-use crate::paths;
-use crate::source_snapshot::SourceSnapshot;
+use crate::core::api_jobs::JobStore;
+use crate::core::error::{Error, Result};
+use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
+use crate::core::paths;
+use crate::core::source_snapshot::SourceSnapshot;
 
 mod artifact_download;
 mod patch_capture;

--- a/src/core/daemon/artifact_download.rs
+++ b/src/core/daemon/artifact_download.rs
@@ -4,8 +4,8 @@ use std::io::Write;
 use std::net::TcpStream;
 use std::path::PathBuf;
 
-use crate::error::{Error, Result};
-use crate::observation::{ArtifactRecord, ObservationStore};
+use crate::core::error::{Error, Result};
+use crate::core::observation::{ArtifactRecord, ObservationStore};
 
 use super::{error_response, HttpResponse};
 
@@ -223,7 +223,7 @@ fn sanitize_header_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::observation::NewRunRecord;
+    use crate::core::observation::NewRunRecord;
     use crate::test_support::HomeGuard;
 
     #[test]

--- a/src/core/daemon/patch_capture.rs
+++ b/src/core/daemon/patch_capture.rs
@@ -6,10 +6,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::error::{Error, Result};
-use crate::observation::{ArtifactRecord, ObservationStore, RunRecord};
-use crate::paths;
-use crate::source_snapshot::SourceSnapshot;
+use crate::core::error::{Error, Result};
+use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use crate::core::paths;
+use crate::core::source_snapshot::SourceSnapshot;
 
 const PATCH_CAPTURE_EXCLUDES: &[&str] = &[
     ".git",

--- a/src/core/db/operations.rs
+++ b/src/core/db/operations.rs
@@ -6,13 +6,13 @@
 use serde::Serialize;
 use std::collections::HashMap;
 
-use crate::context::require_project_base_path;
-use crate::engine::executor::execute_for_project;
-use crate::engine::template::{render_map, TemplateVars};
-use crate::engine::text;
-use crate::extension::{load_all_extensions, DatabaseCliConfig};
-use crate::project::{self, Project};
-use crate::{Error, Result};
+use crate::core::context::require_project_base_path;
+use crate::core::engine::executor::execute_for_project;
+use crate::core::engine::template::{render_map, TemplateVars};
+use crate::core::engine::text;
+use crate::core::extension::{load_all_extensions, DatabaseCliConfig};
+use crate::core::project::{self, Project};
+use crate::core::{Error, Result};
 
 #[derive(Serialize, Clone)]
 pub struct DbResult {

--- a/src/core/db/tunnel.rs
+++ b/src/core/db/tunnel.rs
@@ -6,9 +6,9 @@
 use serde::Serialize;
 use std::process::{Command, Stdio};
 
-use crate::context::resolve_project_ssh;
-use crate::project;
-use crate::{Error, Result};
+use crate::core::context::resolve_project_ssh;
+use crate::core::project;
+use crate::core::{Error, Result};
 
 const DEFAULT_DATABASE_HOST: &str = "127.0.0.1";
 const DEFAULT_LOCAL_DB_PORT: u16 = 33306;

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 
-use crate::engine::local_files;
-use crate::paths;
+use crate::core::engine::local_files;
+use crate::core::paths;
 
 /// Root configuration structure for homeboy.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -354,11 +354,11 @@ pub fn load_config() -> HomeboyConfig {
 }
 
 /// Attempt to load config from homeboy.json file.
-fn load_config_from_file() -> crate::Result<HomeboyConfig> {
+fn load_config_from_file() -> crate::core::Result<HomeboyConfig> {
     let path = paths::homeboy_json()?;
 
     if !path.exists() {
-        return Err(crate::Error::internal_io(
+        return Err(crate::core::Error::internal_io(
             "homeboy.json not found",
             Some(path.display().to_string()),
         ));
@@ -367,7 +367,7 @@ fn load_config_from_file() -> crate::Result<HomeboyConfig> {
     let content = local_files::read_file(&path, &format!("read {}", path.display()))?;
 
     let config: HomeboyConfig = serde_json::from_str(&content).map_err(|e| {
-        crate::Error::validation_invalid_json(
+        crate::core::Error::validation_invalid_json(
             e,
             Some("parse homeboy.json".to_string()),
             Some(content.chars().take(200).collect::<String>()),
@@ -378,17 +378,20 @@ fn load_config_from_file() -> crate::Result<HomeboyConfig> {
 }
 
 /// Save config to homeboy.json file (creates if missing).
-pub fn save_config(config: &HomeboyConfig) -> crate::Result<()> {
+pub fn save_config(config: &HomeboyConfig) -> crate::core::Result<()> {
     let path = paths::homeboy_json()?;
 
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| {
-            crate::Error::internal_io(e.to_string(), Some(format!("create {}", parent.display())))
+            crate::core::Error::internal_io(
+                e.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
         })?;
     }
 
-    let content = crate::config::to_string_pretty(config)?;
+    let content = crate::core::config::to_string_pretty(config)?;
 
     local_files::write_file_atomic(&path, &content, &format!("write {}", path.display()))?;
 
@@ -401,12 +404,15 @@ pub fn config_exists() -> bool {
 }
 
 /// Delete homeboy.json file (reset to defaults)
-pub fn reset_config() -> crate::Result<bool> {
+pub fn reset_config() -> crate::core::Result<bool> {
     let path = paths::homeboy_json()?;
 
     if path.exists() {
         fs::remove_file(&path).map_err(|e| {
-            crate::Error::internal_io(e.to_string(), Some(format!("delete {}", path.display())))
+            crate::core::Error::internal_io(
+                e.to_string(),
+                Some(format!("delete {}", path.display())),
+            )
         })?;
         Ok(true)
     } else {
@@ -415,7 +421,7 @@ pub fn reset_config() -> crate::Result<bool> {
 }
 
 /// Get the path to homeboy.json (for display purposes)
-pub fn config_path() -> crate::Result<String> {
+pub fn config_path() -> crate::core::Result<String> {
     Ok(paths::homeboy_json()?.display().to_string())
 }
 

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
 
-use crate::build;
-use crate::component::Component;
-use crate::context::RemoteProjectContext;
-use crate::error::Result;
-use crate::extension::build::resolve_artifact_path_from_root;
-use crate::git;
-use crate::project::Project;
+use crate::core::build;
+use crate::core::component::Component;
+use crate::core::context::RemoteProjectContext;
+use crate::core::error::Result;
+use crate::core::extension::build::resolve_artifact_path_from_root;
+use crate::core::git;
+use crate::core::project::Project;
 
 use super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::planning::{calculate_directory_size, format_bytes};
@@ -282,7 +282,7 @@ fn execute_file_deploy(
 
     let mkdir_cmd = format!(
         "mkdir -p {}",
-        crate::engine::shell::quote_path(remote_parent)
+        crate::core::engine::shell::quote_path(remote_parent)
     );
     log_status!("deploy", "Ensuring remote directory: {}", remote_parent);
     let mkdir_output = ctx.client.execute(&mkdir_cmd);
@@ -316,8 +316,8 @@ fn execute_file_deploy(
             if let Some(owner) = component.remote_owner.as_deref() {
                 let chown_cmd = format!(
                     "chown {} {}",
-                    crate::engine::shell::quote_arg(owner),
-                    crate::engine::shell::quote_path(install_dir)
+                    crate::core::engine::shell::quote_arg(owner),
+                    crate::core::engine::shell::quote_path(install_dir)
                 );
                 let chown_output = ctx.client.execute(&chown_cmd);
                 if !chown_output.success {
@@ -584,7 +584,7 @@ fn cleanup_build_dependencies(
     let mut cleanup_paths = Vec::new();
     if let Some(ref extensions) = component.extensions {
         for extension_id in extensions.keys() {
-            if let Ok(manifest) = crate::extension::load_extension(extension_id) {
+            if let Ok(manifest) = crate::core::extension::load_extension(extension_id) {
                 if let Some(ref build) = manifest.build {
                     cleanup_paths.extend(build.cleanup_paths.iter().cloned());
                 }
@@ -661,7 +661,7 @@ fn cleanup_build_dependencies(
 #[cfg(test)]
 mod tests {
     use super::{failed_component_deploy_result, should_try_download_release_artifact};
-    use crate::component::Component;
+    use crate::core::component::Component;
     use crate::core::deploy::types::DeployConfig;
 
     #[test]

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -20,10 +20,10 @@ pub use types::{
 };
 pub use version_overrides::fetch_remote_versions;
 
-use crate::component;
-use crate::context::resolve_project_ssh_with_base_path;
-use crate::error::{Error, Result};
-use crate::project;
+use crate::core::component;
+use crate::core::context::resolve_project_ssh_with_base_path;
+use crate::core::error::{Error, Result};
+use crate::core::project;
 
 /// High-level deploy entry point. Resolves SSH context internally.
 ///

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::component::Component;
-use crate::context::RemoteProjectContext;
-use crate::error::{Error, Result};
-use crate::git;
-use crate::project::Project;
-use crate::version;
+use crate::core::component::Component;
+use crate::core::context::RemoteProjectContext;
+use crate::core::error::{Error, Result};
+use crate::core::git;
+use crate::core::project::Project;
+use crate::core::release::version;
 
 use super::execution::execute_component_deploy;
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
@@ -145,7 +145,7 @@ pub(super) fn deploy_components(
 
     for component in &components {
         // Apply per-project overrides (e.g. different extract_command or remote_owner)
-        let component = crate::project::apply_component_overrides(component, &project);
+        let component = crate::core::project::apply_component_overrides(component, &project);
 
         let effective_config = clone_config(config);
 
@@ -167,7 +167,7 @@ pub(super) fn deploy_components(
             result = result.with_deployed_ref(checkout.tag.clone());
         } else if config.head {
             // Deploying from HEAD — record the current branch
-            if let Some(branch) = crate::engine::command::run_in_optional(
+            if let Some(branch) = crate::core::engine::command::run_in_optional(
                 &component.local_path,
                 "git",
                 &["rev-parse", "--abbrev-ref", "HEAD"],
@@ -312,7 +312,7 @@ fn warn_non_default_branch(components: &[Component], config: &DeployConfig) -> R
         let path = &component.local_path;
 
         // Get current branch
-        let current_branch = match crate::engine::command::run_in_optional(
+        let current_branch = match crate::core::engine::command::run_in_optional(
             path,
             "git",
             &["rev-parse", "--abbrev-ref", "HEAD"],
@@ -322,7 +322,7 @@ fn warn_non_default_branch(components: &[Component], config: &DeployConfig) -> R
         };
 
         // Detect default branch from remote HEAD symref, fallback to "main"
-        let default_branch = crate::engine::command::run_in_optional(
+        let default_branch = crate::core::engine::command::run_in_optional(
             path,
             "git",
             &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
@@ -530,21 +530,22 @@ fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
         // --abbrev-ref which returns the literal "HEAD" string). If HEAD is
         // already detached, save the commit hash so we can at least restore
         // to the same commit afterward.
-        let original_ref = crate::engine::command::run_in_optional(
+        let original_ref = crate::core::engine::command::run_in_optional(
             path,
             "git",
             &["symbolic-ref", "--short", "HEAD"],
         )
         .or_else(|| {
             // Detached HEAD — save the commit hash as fallback
-            crate::engine::command::run_in_optional(path, "git", &["rev-parse", "HEAD"])
+            crate::core::engine::command::run_in_optional(path, "git", &["rev-parse", "HEAD"])
         })
         .unwrap_or_else(|| "main".to_string());
 
         // If already on this tag's commit, skip checkout
-        let tag_commit = crate::engine::command::run_in_optional(path, "git", &["rev-parse", &tag]);
+        let tag_commit =
+            crate::core::engine::command::run_in_optional(path, "git", &["rev-parse", &tag]);
         let head_commit =
-            crate::engine::command::run_in_optional(path, "git", &["rev-parse", "HEAD"]);
+            crate::core::engine::command::run_in_optional(path, "git", &["rev-parse", "HEAD"]);
         if tag_commit.is_some() && tag_commit == head_commit {
             log_status!(
                 "deploy",
@@ -568,7 +569,12 @@ fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
             component.id,
             tag
         );
-        match crate::engine::command::run_in(path, "git", &["checkout", &tag], "git checkout tag") {
+        match crate::core::engine::command::run_in(
+            path,
+            "git",
+            &["checkout", &tag],
+            "git checkout tag",
+        ) {
             Ok(_) => {
                 checkouts.push(TagCheckout {
                     component_id: component.id.clone(),
@@ -596,7 +602,7 @@ fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
 /// is inconvenient but not destructive.
 fn restore_branches(checkouts: &[TagCheckout]) {
     for checkout in checkouts {
-        let restore = crate::engine::command::run_in(
+        let restore = crate::core::engine::command::run_in(
             &checkout.local_path,
             "git",
             &["checkout", &checkout.original_ref],
@@ -630,7 +636,10 @@ fn restore_branches(checkouts: &[TagCheckout]) {
 /// When found and `--force` is not set, returns an error to prevent
 /// silently deploying stale code. Use `deploy --head` to deploy
 /// unreleased commits, or `homeboy release` to tag them first.
-fn check_unreleased_commits(components: &[Component], config: &DeployConfig) -> crate::Result<()> {
+fn check_unreleased_commits(
+    components: &[Component],
+    config: &DeployConfig,
+) -> crate::core::Result<()> {
     let mut gaps = Vec::new();
 
     for component in components {
@@ -665,7 +674,7 @@ fn check_unreleased_commits(components: &[Component], config: &DeployConfig) -> 
         .map(|(id, gap)| format!("{} ({} commits ahead of {})", id, gap.ahead, gap.tag))
         .collect();
 
-    Err(crate::Error::validation_invalid_argument(
+    Err(crate::core::Error::validation_invalid_argument(
         "deploy",
         format!(
             "Refusing to deploy: HEAD has unreleased commits for: {}",

--- a/src/core/deploy/path_roots.rs
+++ b/src/core/deploy/path_roots.rs
@@ -1,10 +1,10 @@
-use crate::component::Component;
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::extension::{self, RemotePathRootRule};
-use crate::paths as base_path;
-use crate::project::Project;
-use crate::server::SshClient;
+use crate::core::component::Component;
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::extension::{self, RemotePathRootRule};
+use crate::core::paths as base_path;
+use crate::core::project::Project;
+use crate::core::server::SshClient;
 use std::collections::HashSet;
 
 pub(super) fn component_remote_path(component: &Component) -> String {
@@ -156,9 +156,9 @@ fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> &'a str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::{Component, ScopedExtensionConfig};
-    use crate::extension::{DeployCapability, ExtensionManifest};
-    use crate::server::SshClient;
+    use crate::core::component::{Component, ScopedExtensionConfig};
+    use crate::core::extension::{DeployCapability, ExtensionManifest};
+    use crate::core::server::SshClient;
     use crate::test_support::with_isolated_home;
     use std::collections::HashMap;
 
@@ -193,7 +193,7 @@ mod tests {
     }
 
     fn install_extension_with_detect_command(detect_command: Option<&str>) {
-        crate::extension::save_manifest(&ExtensionManifest {
+        crate::core::extension::save_manifest(&ExtensionManifest {
             id: "wordpress".to_string(),
             name: "WordPress".to_string(),
             version: "1.0.0".to_string(),

--- a/src/core/deploy/permissions.rs
+++ b/src/core/deploy/permissions.rs
@@ -1,9 +1,9 @@
 use std::process::Command;
 
-use crate::defaults;
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::server::{CommandOutput, SshClient};
+use crate::core::defaults;
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::server::{CommandOutput, SshClient};
 
 /// Fix local file permissions before build.
 ///
@@ -150,12 +150,12 @@ fn ensure_remote_success(output: CommandOutput, operation: &str, remote_path: &s
     }
 
     Err(Error::remote_command_failed(
-        crate::error::RemoteCommandFailedDetails {
+        crate::core::error::RemoteCommandFailedDetails {
             command: format!("{} on {}", operation, remote_path),
             exit_code: output.exit_code,
             stdout: output.stdout,
             stderr: output.stderr,
-            target: crate::error::TargetDetails {
+            target: crate::core::error::TargetDetails {
                 project_id: None,
                 server_id: None,
                 host: None,

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::component::{self, Component};
-use crate::error::{Error, Result};
-use crate::extension;
-use crate::git;
-use crate::project::{self, Project};
-use crate::server::SshClient;
-use crate::version;
+use crate::core::component::{self, Component};
+use crate::core::error::{Error, Result};
+use crate::core::extension;
+use crate::core::git;
+use crate::core::project::{self, Project};
+use crate::core::release::version;
+use crate::core::server::SshClient;
 
 use super::types::{
     ComponentStatus, DeployConfig, ReleaseState, ReleaseStateBuckets, ReleaseStateStatus,
@@ -350,7 +350,7 @@ pub(super) fn load_project_components(
         match effective_artifact {
             Some(artifact) if !is_git_deploy && !is_file_deploy => {
                 let resolved_artifact =
-                    crate::paths::resolve_path_string(&loaded.local_path, &artifact);
+                    crate::core::paths::resolve_path_string(&loaded.local_path, &artifact);
                 loaded.build_artifact = Some(resolved_artifact);
                 deployable.push(loaded);
             }
@@ -384,7 +384,7 @@ pub(super) fn load_project_components(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::VersionTarget;
+    use crate::core::component::VersionTarget;
     use tempfile::TempDir;
 
     fn run_git(path: &Path, args: &[&str]) {

--- a/src/core/deploy/policy.rs
+++ b/src/core/deploy/policy.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use serde::Deserialize;
 
-use crate::component::Component;
-use crate::error::{Error, Result};
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
 
 /// Framework-neutral shared directory names that typically contain sibling components.
 const GENERIC_PROTECTED_PATH_SUFFIXES: &[&str] =
@@ -97,7 +97,7 @@ fn component_extension_policies(component: &Component) -> Vec<ExtensionDeployPol
 }
 
 fn extension_deploy_policy(extension_id: &str) -> Option<ExtensionDeployPolicy> {
-    let path = crate::paths::extension_manifest(extension_id).ok()?;
+    let path = crate::core::paths::extension_manifest(extension_id).ok()?;
     let raw = std::fs::read_to_string(path).ok()?;
     let manifest: serde_json::Value = serde_json::from_str(&raw).ok()?;
     serde_json::from_value(manifest.get("deploy")?.clone()).ok()
@@ -106,12 +106,14 @@ fn extension_deploy_policy(extension_id: &str) -> Option<ExtensionDeployPolicy> 
 #[cfg(test)]
 mod tests {
     use super::{owner_hint_for_path, protected_path_suffixes, validate_deploy_target};
-    use crate::component::{Component, ScopedExtensionConfig};
+    use crate::core::component::{Component, ScopedExtensionConfig};
     use crate::test_support::with_isolated_home;
     use std::collections::HashMap;
 
     fn write_extension_fixture(id: &str, deploy_json: &str) {
-        let dir = crate::paths::extensions().expect("extensions dir").join(id);
+        let dir = crate::core::paths::extensions()
+            .expect("extensions dir")
+            .join(id);
         std::fs::create_dir_all(&dir).expect("extension dir");
         std::fs::write(
             dir.join(format!("{}.json", id)),

--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -3,9 +3,9 @@
 //! Provides tag-gap detection so `build` and `deploy` can warn about
 //! unreleased commits ahead of the latest tag.
 
-use crate::component::Component;
-use crate::engine::command;
-use crate::git;
+use crate::core::component::Component;
+use crate::core::engine::command;
+use crate::core::git;
 
 /// Information about the HEAD-vs-tag gap for a component.
 #[derive(Debug, Clone)]

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -12,8 +12,8 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::component::Component;
-use crate::error::{Error, Result};
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
 
 /// Parsed GitHub owner/repo from a remote URL.
 #[derive(Debug, Clone)]
@@ -120,7 +120,7 @@ pub fn download_release_artifact(
     let url = github.release_artifact_url(tag, artifact_name);
 
     // Create temp directory for the download
-    let tmp_dir = crate::engine::temp::runtime_temp_dir("deploy-download")?;
+    let tmp_dir = crate::core::engine::temp::runtime_temp_dir("deploy-download")?;
     let dest_path = tmp_dir.join(artifact_name);
 
     log_status!("deploy", "Downloading release artifact: {}", url);

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::permissions;
-use crate::component;
-use crate::defaults;
-use crate::engine::shell;
-use crate::engine::template::{render_map, TemplateVars};
-use crate::error::{Error, Result};
-use crate::extension::DeployVerification;
-use crate::server::SshClient;
+use crate::core::component;
+use crate::core::defaults;
+use crate::core::engine::shell;
+use crate::core::engine::template::{render_map, TemplateVars};
+use crate::core::error::{Error, Result};
+use crate::core::extension::DeployVerification;
+use crate::core::server::SshClient;
 
 use super::transfer::{upload_directory, upload_file};
 use super::types::DeployResult;

--- a/src/core/deploy/transfer.rs
+++ b/src/core/deploy/transfer.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
-use crate::defaults;
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::server::SshClient;
+use crate::core::defaults;
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::server::SshClient;
 
 use super::types::DeployResult;
 
@@ -259,7 +259,7 @@ fn scp_file_atomic(
 #[cfg(test)]
 mod tests {
     use super::{process_output_result, scp_file, upload_directory, upload_file};
-    use crate::server::SshClient;
+    use crate::core::server::SshClient;
     use std::collections::HashMap;
     use std::fs;
     use std::process::Command;

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use crate::component::Component;
-use crate::config;
-use crate::error::Result;
+use crate::core::component::Component;
+use crate::core::config;
+use crate::core::error::Result;
+use crate::core::paths as base_path;
+use crate::core::project::Project;
 use crate::is_zero_u32;
-use crate::paths as base_path;
-use crate::project::Project;
 
 use super::path_roots::resolve_effective_remote_path;
 
@@ -281,9 +281,9 @@ mod tests {
         parse_bulk_component_ids, ComponentDeployResult, ComponentStatus, DeployResult,
         ReleaseState, ReleaseStateStatus,
     };
-    use crate::component::{Component, ScopedExtensionConfig};
-    use crate::extension::{DeployCapability, ExtensionManifest, RemotePathRootRule};
-    use crate::project::Project;
+    use crate::core::component::{Component, ScopedExtensionConfig};
+    use crate::core::extension::{DeployCapability, ExtensionManifest, RemotePathRootRule};
+    use crate::core::project::Project;
     use crate::test_support::with_isolated_home;
     use std::collections::HashMap;
 
@@ -306,7 +306,7 @@ mod tests {
     }
 
     fn install_wordpress_extension() {
-        crate::extension::save_manifest(&ExtensionManifest {
+        crate::core::extension::save_manifest(&ExtensionManifest {
             id: "wordpress".to_string(),
             name: "WordPress".to_string(),
             version: "1.0.0".to_string(),

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -2,18 +2,18 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use super::permissions;
-use crate::component::Component;
-use crate::engine::hooks::{self, HookFailureMode};
-use crate::engine::shell;
-use crate::engine::template::{render_map, TemplateVars};
-use crate::error::{Error, Result};
-use crate::extension::{
+use crate::core::component::Component;
+use crate::core::engine::hooks::{self, HookFailureMode};
+use crate::core::engine::shell;
+use crate::core::engine::template::{render_map, TemplateVars};
+use crate::core::error::{Error, Result};
+use crate::core::extension::{
     load_all_extensions, DeployOverride, DeployVerification, ExtensionManifest,
 };
-use crate::paths as base_path;
-use crate::project::Project;
-use crate::server::SshClient;
-use crate::version;
+use crate::core::paths as base_path;
+use crate::core::project::Project;
+use crate::core::release::version;
+use crate::core::server::SshClient;
 
 use super::path_roots::resolve_effective_remote_path;
 use super::transfer::scp_file;

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -1,5 +1,5 @@
-use crate::component::{self, Component};
-use crate::{Error, Result};
+use crate::core::component::{self, Component};
+use crate::core::{Error, Result};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -1,6 +1,6 @@
-use crate::component::{self, Component, DependencyStackEdge};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
-use crate::{Error, Result};
+use crate::core::component::{self, Component, DependencyStackEdge};
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
+use crate::core::{Error, Result};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;

--- a/src/core/engine/baseline.rs
+++ b/src/core/engine/baseline.rs
@@ -45,7 +45,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 pub trait Fingerprintable {
     fn fingerprint(&self) -> String;
@@ -401,7 +401,7 @@ pub fn load_from_git_ref<M: for<'de> Deserialize<'de> + Serialize>(
 ) -> Option<Baseline<M>> {
     let git_spec = format!("{}:{}", git_ref, HOMEBOY_JSON);
     let content =
-        crate::engine::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
+        crate::core::engine::command::run_in_optional(source_path, "git", &["show", &git_spec])?;
 
     let root: Value = serde_json::from_str(&content).ok()?;
     let value = root.get(BASELINES_KEY)?.get(key)?;

--- a/src/core/engine/cli_tool.rs
+++ b/src/core/engine/cli_tool.rs
@@ -1,18 +1,18 @@
 use serde::Serialize;
 use std::collections::HashMap;
 
-use crate::component::{self, Component};
-use crate::context::resolve_project_ssh;
-use crate::engine::executor;
-use crate::engine::shell;
-use crate::engine::template::{render_map, TemplateVars};
-use crate::engine::text;
-use crate::error::ErrorCode;
-use crate::extension::{find_extension_by_tool, CliAutoFlag, CliConfig};
-use crate::project::{self, Project};
-use crate::server;
-use crate::server::{execute_local_command, CommandOutput};
-use crate::{Error, Result};
+use crate::core::component::{self, Component};
+use crate::core::context::resolve_project_ssh;
+use crate::core::engine::executor;
+use crate::core::engine::shell;
+use crate::core::engine::template::{render_map, TemplateVars};
+use crate::core::engine::text;
+use crate::core::error::ErrorCode;
+use crate::core::extension::{find_extension_by_tool, CliAutoFlag, CliConfig};
+use crate::core::project::{self, Project};
+use crate::core::server;
+use crate::core::server::{execute_local_command, CommandOutput};
+use crate::core::{Error, Result};
 
 #[derive(Serialize, Clone)]
 
@@ -35,7 +35,7 @@ pub fn run(tool: &str, identifier: &str, args: &[String]) -> Result<CliToolResul
     let args = shell::normalize_args(args);
 
     // Parse project:subtarget syntax
-    let (project_id, embedded_subtarget) = crate::engine::text::split_identifier(identifier);
+    let (project_id, embedded_subtarget) = crate::core::engine::text::split_identifier(identifier);
 
     // Build args with embedded subtarget prepended if present
     let full_args: Vec<String> = match embedded_subtarget {
@@ -85,7 +85,7 @@ fn try_run_for_component(
 fn build_component_command(
     component: &Component,
     cli_config: &CliConfig,
-    extension: &crate::extension::ExtensionManifest,
+    extension: &crate::core::extension::ExtensionManifest,
     args: &[String],
 ) -> String {
     let mut variables = HashMap::new();
@@ -230,7 +230,7 @@ fn build_project_command(
     variables.insert(TemplateVars::CLI_PATH.to_string(), cli_path);
 
     // Add extension_path so {{extension_path}} resolves in command templates
-    let extension_dir = crate::extension::extension_path(extension_id);
+    let extension_dir = crate::core::extension::extension_path(extension_id);
     if extension_dir.exists() {
         variables.insert(
             TemplateVars::EXTENSION_PATH.to_string(),
@@ -367,7 +367,7 @@ fn resolve_subtarget(project: &Project, args: &[String]) -> Result<(String, Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::{CliAutoFlagCondition, CliHelpConfig};
+    use crate::core::extension::{CliAutoFlagCondition, CliHelpConfig};
 
     fn cli_config(auto_flags: Vec<CliAutoFlag>) -> CliConfig {
         CliConfig {

--- a/src/core/engine/command.rs
+++ b/src/core/engine/command.rs
@@ -2,7 +2,7 @@
 
 use std::process::{Command, Output};
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 use serde::Serialize;
 
 pub fn run(program: &str, args: &[&str], context: &str) -> Result<String> {

--- a/src/core/engine/edit_op.rs
+++ b/src/core/engine/edit_op.rs
@@ -25,7 +25,7 @@
 //! executes them against the filesystem. Manual refactor commands (propagate,
 //! transform) produce `EditOp` directly.
 
-use crate::code_audit::AuditFinding;
+use crate::core::code_audit::AuditFinding;
 use crate::core::refactor::auto::{Insertion, InsertionKind, RefactorPrimitive};
 
 /// Atomic file edit operation.
@@ -381,7 +381,7 @@ pub fn transform_result_to_edit_ops(
 // ============================================================================
 
 /// Translate a `FileRename` into a `TaggedEditOp`.
-pub fn file_rename_to_edit_op(rename: &crate::refactor::FileRename) -> TaggedEditOp {
+pub fn file_rename_to_edit_op(rename: &crate::core::refactor::FileRename) -> TaggedEditOp {
     TaggedEditOp {
         op: EditOp::MoveFile {
             from: rename.from.clone(),
@@ -399,7 +399,9 @@ pub fn file_rename_to_edit_op(rename: &crate::refactor::FileRename) -> TaggedEdi
 /// Only converts file/directory renames (→ `MoveFile`), not content edits.
 /// Content edits operate at whole-file granularity and are applied directly
 /// by the rename engine.
-pub fn rename_file_moves_to_edit_ops(result: &crate::refactor::RenameResult) -> Vec<TaggedEditOp> {
+pub fn rename_file_moves_to_edit_ops(
+    result: &crate::core::refactor::RenameResult,
+) -> Vec<TaggedEditOp> {
     result
         .file_renames
         .iter()
@@ -413,7 +415,7 @@ pub fn rename_file_moves_to_edit_ops(result: &crate::refactor::RenameResult) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::AuditFinding;
+    use crate::core::code_audit::AuditFinding;
     use crate::core::refactor::auto::{Fix, Insertion, InsertionKind, RefactorPrimitive};
 
     fn test_insertion(kind: InsertionKind) -> Insertion {

--- a/src/core/engine/edit_op_apply.rs
+++ b/src/core/engine/edit_op_apply.rs
@@ -9,8 +9,8 @@
 //! - `apply_edit_ops()` — filesystem entry point (read → transform → write)
 //! - `ApplyReport` / `ApplyError` — result types
 
-use crate::code_audit::conventions::Language;
-use crate::error::Result;
+use crate::core::code_audit::conventions::Language;
+use crate::core::error::Result;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -895,7 +895,7 @@ pub fn apply_edit_ops(ops: &[TaggedEditOp], root: &Path) -> Result<ApplyReport> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::Language;
+    use crate::core::code_audit::conventions::Language;
 
     #[test]
     fn resolve_anchor_at_line() {
@@ -1072,12 +1072,12 @@ mod tests {
         let op = EditOp::InsertLines {
             file: "test.rs".to_string(),
             anchor: InsertAnchor::AfterImports,
-            code: "use crate::config;".to_string(),
+            code: "use crate::core::config;".to_string(),
         };
         let result = apply_edit_ops_to_content(content, &[&op], &Language::Rust).unwrap();
-        assert!(result.contains("use crate::config;"));
+        assert!(result.contains("use crate::core::config;"));
         // The new import should appear after existing imports
-        let config_pos = result.find("use crate::config;").unwrap();
+        let config_pos = result.find("use crate::core::config;").unwrap();
         let path_pos = result.find("use std::path::Path;").unwrap();
         assert!(config_pos > path_pos);
     }
@@ -1122,12 +1122,12 @@ mod tests {
         let insert_op = EditOp::InsertLines {
             file: "test.rs".to_string(),
             anchor: InsertAnchor::AfterImports,
-            code: "use crate::config;".to_string(),
+            code: "use crate::core::config;".to_string(),
         };
         let ops: Vec<&EditOp> = vec![&replace_op, &insert_op];
         let result = apply_edit_ops_to_content(content, &ops, &Language::Rust).unwrap();
         assert!(result.contains("new_func"));
-        assert!(result.contains("use crate::config;"));
+        assert!(result.contains("use crate::core::config;"));
     }
 
     #[test]

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -11,9 +11,9 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::component::{self, Component, ScopedExtensionConfig};
-use crate::error::{Error, ErrorCode, Result};
-use crate::extension::{self, ExtensionCapability};
+use crate::core::component::{self, Component, ScopedExtensionConfig};
+use crate::core::error::{Error, ErrorCode, Result};
+use crate::core::extension::{self, ExtensionCapability};
 
 /// Unified execution context for extension-backed commands.
 ///

--- a/src/core/engine/executor.rs
+++ b/src/core/engine/executor.rs
@@ -35,12 +35,14 @@
 // execute_for_project_interactive() -> routes local/SSH with inherited stdio
 // execute_for_project_direct() -> tries direct first, falls back to shell
 
-use crate::context::resolve_project_ssh;
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::extension::CliConfig;
-use crate::project::{self, Project};
-use crate::server::{execute_local_command, execute_local_command_interactive, CommandOutput};
+use crate::core::context::resolve_project_ssh;
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::extension::CliConfig;
+use crate::core::project::{self, Project};
+use crate::core::server::{
+    execute_local_command, execute_local_command_interactive, CommandOutput,
+};
 use std::process::Command;
 
 /// Execute a command for a project - routes to local or SSH based on server_id config.
@@ -208,7 +210,7 @@ fn parse_direct_template(
     template = template.replace("{{cliPath}}", &cli_path);
 
     // Expand {{extension_path}}
-    let extension_dir = crate::extension::extension_path(extension_id);
+    let extension_dir = crate::core::extension::extension_path(extension_id);
     if extension_dir.exists() {
         template = template.replace("{{extension_path}}", &extension_dir.to_string_lossy());
     }

--- a/src/core/engine/format_write.rs
+++ b/src/core/engine/format_write.rs
@@ -14,8 +14,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::error::{Error, Result};
-use crate::extension;
+use crate::core::error::{Error, Result};
+use crate::core::extension;
 
 /// Result of a post-write format operation.
 #[derive(Debug, Clone, Serialize)]
@@ -145,7 +145,8 @@ fn resolve_format_command(_root: &Path, changed_files: &[PathBuf]) -> Option<Str
                 // Wrapping with `sh <script>` bypasses `#!/usr/bin/env bash` and runs
                 // under POSIX sh — which breaks scripts using bash-only features. See #1276.
                 return Some(
-                    crate::engine::shell::quote_path(&script_path.to_string_lossy()).to_string(),
+                    crate::core::engine::shell::quote_path(&script_path.to_string_lossy())
+                        .to_string(),
                 );
             }
         }

--- a/src/core/engine/hooks.rs
+++ b/src/core/engine/hooks.rs
@@ -7,11 +7,11 @@
 //! Event naming convention: `pre:operation` / `post:operation`
 //! Examples: `pre:version:bump`, `post:version:bump`, `post:release`, `post:deploy`
 
-use crate::component::Component;
-use crate::engine::template;
-use crate::error::{Error, Result};
-use crate::extension;
-use crate::server::{execute_local_command_in_dir, SshClient};
+use crate::core::component::Component;
+use crate::core::engine::template;
+use crate::core::error::{Error, Result};
+use crate::core::extension;
+use crate::core::server::{execute_local_command_in_dir, SshClient};
 use serde::Serialize;
 use std::collections::HashMap;
 

--- a/src/core/engine/identifier.rs
+++ b/src/core/engine/identifier.rs
@@ -1,7 +1,7 @@
 //! Shared identifier normalization and validation primitives.
 
-use crate::error::Error;
-use crate::Result;
+use crate::core::error::Error;
+use crate::core::Result;
 
 pub fn slugify_id(value: &str, field_name: &str) -> Result<String> {
     let trimmed = value.trim();

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -1,8 +1,8 @@
 //! Per-child workload invocation isolation.
 
-use crate::engine::run_dir::RunDir;
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::engine::run_dir::RunDir;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -506,7 +506,7 @@ mod invocation_test;
 #[cfg(test)]
 mod audit_coverage_tests {
     use super::*;
-    use crate::engine::run_dir::RunDir;
+    use crate::core::engine::run_dir::RunDir;
     use crate::test_support::with_isolated_home;
 
     #[test]

--- a/src/core/engine/invocation/child.rs
+++ b/src/core/engine/invocation/child.rs
@@ -1,6 +1,6 @@
-use crate::engine::resource::ChildProcessIdentity;
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::engine::resource::ChildProcessIdentity;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/core/engine/invocation/runtime.rs
+++ b/src/core/engine/invocation/runtime.rs
@@ -46,9 +46,9 @@
 //! workloads commonly nest a workload-id segment plus a socket filename
 //! (`<workload-id>/daemon/daemon.sock` ≈ 40 bytes) underneath.
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 #[cfg(windows)]
-use crate::paths;
+use crate::core::paths;
 use std::env;
 use std::path::{Path, PathBuf};
 

--- a/src/core/engine/local_files.rs
+++ b/src/core/engine/local_files.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 /// Entry returned from directory listing
 #[derive(Debug, Clone)]
@@ -128,7 +128,7 @@ pub fn local() -> LocalFs {
 
 /// Ensure all app directories exist
 pub fn ensure_app_dirs() -> Result<()> {
-    use crate::paths;
+    use crate::core::paths;
 
     let dirs = [
         paths::homeboy()?,

--- a/src/core/engine/refactor_primitive.rs
+++ b/src/core/engine/refactor_primitive.rs
@@ -1,4 +1,4 @@
-use crate::code_audit::AuditFinding;
+use crate::core::code_audit::AuditFinding;
 use crate::core::refactor::auto::{Insertion, InsertionKind, NewFile, RefactorPrimitive};
 
 pub fn insertion(

--- a/src/core/engine/resource.rs
+++ b/src/core/engine/resource.rs
@@ -1,7 +1,7 @@
 //! Best-effort run-local resource summaries.
 
-use crate::engine::run_dir::{self, RunDir};
-use crate::error::{Error, Result};
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::error::{Error, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::Path;

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -24,7 +24,7 @@
 //! point into the run dir, so extension scripts that use the old vars
 //! continue working. New scripts can use `HOMEBOY_RUN_DIR` directly.
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 use std::path::{Path, PathBuf};
 
 /// Well-known filenames for step outputs within a run directory.

--- a/src/core/engine/symbol_graph.rs
+++ b/src/core/engine/symbol_graph.rs
@@ -20,8 +20,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::extension::grammar::{self, Grammar};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::extension::grammar::{self, Grammar};
 
 // ============================================================================
 // Types
@@ -559,7 +559,7 @@ fn apply_rewrites(rewrites: &[ImportRewrite], root: &Path) {
 /// This is a shared utility — same as `core_fingerprint::load_grammar_for_ext`
 /// but accessible from the symbol_graph module without circular dependency.
 fn load_grammar_for_ext(ext: &str) -> Option<Grammar> {
-    let matched = crate::extension::find_extension_for_file_ext(ext, "fingerprint")?;
+    let matched = crate::core::extension::find_extension_for_file_ext(ext, "fingerprint")?;
     let extension_path = matched.extension_path.as_deref()?;
 
     let grammar_path = Path::new(extension_path).join("grammar.toml");
@@ -700,11 +700,11 @@ mod tests {
         if !grammar_path.exists() {
             return; // Skip if grammar not installed
         }
-        let grammar = crate::extension::grammar::load_grammar(grammar_path).unwrap();
+        let grammar = crate::core::extension::grammar::load_grammar(grammar_path).unwrap();
 
         let content = r#"use std::path::Path;
 use crate::core::fixer::{insertion, Fix};
-use crate::extension::grammar;
+use crate::core::extension::grammar;
 
 pub fn hello() {}
 "#;
@@ -723,7 +723,7 @@ pub fn hello() {}
         assert_eq!(imports[1].imported_names, vec!["insertion", "Fix"]);
 
         // Third import: module-level use
-        assert_eq!(imports[2].module_path, "crate::extension");
+        assert_eq!(imports[2].module_path, "crate::core::extension");
         assert_eq!(imports[2].imported_names, vec!["grammar"]);
     }
 

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -1,5 +1,5 @@
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/src/core/engine/text.rs
+++ b/src/core/engine/text.rs
@@ -1,6 +1,6 @@
 //! Shared text normalization and matching primitives.
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 use regex::Regex;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;

--- a/src/core/engine/undo/snapshot.rs
+++ b/src/core/engine/undo/snapshot.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 use super::entry::FileStateEntry;
-use crate::Result;
+use crate::core::Result;
 
 /// Maximum number of snapshots to keep. Oldest are expired on save.
 const MAX_SNAPSHOTS: usize = 20;
@@ -153,7 +153,7 @@ impl UndoSnapshot {
 /// Save a snapshot to a specific directory. Used internally and by tests.
 fn save_to_dir(snap: UndoSnapshot, base_dir: &Path) -> Result<String> {
     if snap.entries.is_empty() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "undo",
             "No files to snapshot",
             None,
@@ -165,7 +165,7 @@ fn save_to_dir(snap: UndoSnapshot, base_dir: &Path) -> Result<String> {
     let snapshot_dir = base_dir.join(&id);
     let files_dir = snapshot_dir.join("files");
     std::fs::create_dir_all(&files_dir).map_err(|e| {
-        crate::Error::internal_unexpected(format!("Failed to create snapshot dir: {}", e))
+        crate::core::Error::internal_unexpected(format!("Failed to create snapshot dir: {}", e))
     })?;
 
     // Write file contents
@@ -176,7 +176,7 @@ fn save_to_dir(snap: UndoSnapshot, base_dir: &Path) -> Result<String> {
             std::fs::create_dir_all(parent).ok();
         }
         std::fs::write(&dest, content).map_err(|e| {
-            crate::Error::internal_unexpected(format!(
+            crate::core::Error::internal_unexpected(format!(
                 "Failed to write snapshot file {}: {}",
                 relative_path, e
             ))
@@ -193,11 +193,11 @@ fn save_to_dir(snap: UndoSnapshot, base_dir: &Path) -> Result<String> {
     };
 
     let manifest_json = serde_json::to_string_pretty(&manifest).map_err(|e| {
-        crate::Error::internal_unexpected(format!("Failed to serialize manifest: {}", e))
+        crate::core::Error::internal_unexpected(format!("Failed to serialize manifest: {}", e))
     })?;
 
     std::fs::write(snapshot_dir.join("manifest.json"), manifest_json).map_err(|e| {
-        crate::Error::internal_unexpected(format!("Failed to write manifest: {}", e))
+        crate::core::Error::internal_unexpected(format!("Failed to write manifest: {}", e))
     })?;
 
     log_status!(
@@ -307,7 +307,7 @@ fn list_snapshots_in(base_dir: &Path) -> Result<Vec<SnapshotSummary>> {
 
     let mut entries: Vec<_> = std::fs::read_dir(base_dir)
         .map_err(|e| {
-            crate::Error::internal_unexpected(format!("Failed to read snapshots dir: {}", e))
+            crate::core::Error::internal_unexpected(format!("Failed to read snapshots dir: {}", e))
         })?
         .filter_map(|e| e.ok())
         .filter(|e| e.path().is_dir())
@@ -343,7 +343,7 @@ pub fn delete_snapshot(snapshot_id: &str) -> Result<()> {
 fn delete_snapshot_in(snapshot_id: &str, base_dir: &Path) -> Result<()> {
     let snapshot_dir = base_dir.join(snapshot_id);
     if !snapshot_dir.exists() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "snapshot_id",
             format!("Snapshot '{}' not found", snapshot_id),
             None,
@@ -352,7 +352,7 @@ fn delete_snapshot_in(snapshot_id: &str, base_dir: &Path) -> Result<()> {
     }
 
     std::fs::remove_dir_all(&snapshot_dir).map_err(|e| {
-        crate::Error::internal_unexpected(format!("Failed to delete snapshot: {}", e))
+        crate::core::Error::internal_unexpected(format!("Failed to delete snapshot: {}", e))
     })?;
 
     log_status!("undo", "Deleted snapshot {}", snapshot_id);
@@ -392,14 +392,14 @@ fn now_unix() -> u64 {
 
 fn latest_snapshot_id_in(base_dir: &Path) -> Result<String> {
     if !base_dir.exists() {
-        return Err(crate::Error::internal_unexpected(
+        return Err(crate::core::Error::internal_unexpected(
             "No undo snapshots available. Run a --write operation first.",
         ));
     }
 
     let mut entries: Vec<_> = std::fs::read_dir(base_dir)
         .map_err(|e| {
-            crate::Error::internal_unexpected(format!("Failed to read snapshots dir: {}", e))
+            crate::core::Error::internal_unexpected(format!("Failed to read snapshots dir: {}", e))
         })?
         .filter_map(|e| e.ok())
         .filter(|e| e.path().is_dir())
@@ -411,7 +411,7 @@ fn latest_snapshot_id_in(base_dir: &Path) -> Result<String> {
         .first()
         .map(|e| e.file_name().to_string_lossy().to_string())
         .ok_or_else(|| {
-            crate::Error::internal_unexpected(
+            crate::core::Error::internal_unexpected(
                 "No undo snapshots available. Run a --write operation first.",
             )
         })
@@ -420,10 +420,11 @@ fn latest_snapshot_id_in(base_dir: &Path) -> Result<String> {
 fn load_manifest(snapshot_dir: &Path) -> Result<SnapshotManifest> {
     let manifest_path = snapshot_dir.join("manifest.json");
     let content = std::fs::read_to_string(&manifest_path).map_err(|e| {
-        crate::Error::internal_unexpected(format!("Failed to read manifest: {}", e))
+        crate::core::Error::internal_unexpected(format!("Failed to read manifest: {}", e))
     })?;
-    serde_json::from_str(&content)
-        .map_err(|e| crate::Error::internal_unexpected(format!("Failed to parse manifest: {}", e)))
+    serde_json::from_str(&content).map_err(|e| {
+        crate::core::Error::internal_unexpected(format!("Failed to parse manifest: {}", e))
+    })
 }
 
 /// Convert a path like "src/core/fixer.rs" to a safe filename for snapshot storage.
@@ -517,7 +518,7 @@ mod tests {
     }
 
     /// Save a snapshot to a test-isolated snapshot directory.
-    fn save_isolated(snap: UndoSnapshot, snap_dir: &Path) -> crate::Result<String> {
+    fn save_isolated(snap: UndoSnapshot, snap_dir: &Path) -> crate::core::Result<String> {
         save_to_dir(snap, snap_dir)
     }
 

--- a/src/core/engine/validate_write.rs
+++ b/src/core/engine/validate_write.rs
@@ -17,8 +17,8 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 use super::undo::InMemoryRollback;
-use crate::error::{Error, Result};
-use crate::extension;
+use crate::core::error::{Error, Result};
+use crate::core::extension;
 
 /// Result of a post-write validation check.
 #[derive(Debug, Clone, Serialize)]
@@ -247,7 +247,8 @@ fn resolve_validate_command(_root: &Path, changed_files: &[PathBuf]) -> Option<S
                 // under POSIX sh — which breaks scripts using bash-only features like
                 // process substitution (`done < <(...)`). See #1276.
                 return Some(
-                    crate::engine::shell::quote_path(&script_path.to_string_lossy()).to_string(),
+                    crate::core::engine::shell::quote_path(&script_path.to_string_lossy())
+                        .to_string(),
                 );
             }
         }
@@ -334,7 +335,7 @@ mod tests {
         // Mimic what resolve_validate_command emits for an extension script —
         // the quoted path with no `sh ` prefix — and run it the same way
         // validate_write does.
-        let command = crate::engine::shell::quote_path(&script_path.to_string_lossy());
+        let command = crate::core::engine::shell::quote_path(&script_path.to_string_lossy());
         let output = std::process::Command::new("sh")
             .args(["-c", &command])
             .output()

--- a/src/core/engine/validation.rs
+++ b/src/core/engine/validation.rs
@@ -1,6 +1,6 @@
 //! Input validation primitives.
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 pub fn require<T>(opt: Option<T>, field: &str, message: &str) -> Result<T> {
     opt.ok_or_else(|| Error::validation_invalid_argument(field, message, None, None))
@@ -16,7 +16,7 @@ pub fn require_with_hints<T>(
 }
 
 pub struct ValidationCollector {
-    errors: Vec<crate::error::ValidationErrorItem>,
+    errors: Vec<crate::core::error::ValidationErrorItem>,
 }
 
 impl ValidationCollector {
@@ -35,7 +35,7 @@ impl ValidationCollector {
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| err.message.clone());
 
-                self.errors.push(crate::error::ValidationErrorItem {
+                self.errors.push(crate::core::error::ValidationErrorItem {
                     field: field.to_string(),
                     problem,
                     context: if err.details.as_object().is_some_and(|o| !o.is_empty()) {
@@ -50,7 +50,7 @@ impl ValidationCollector {
     }
 
     pub fn push(&mut self, field: &str, problem: &str, context: Option<serde_json::Value>) {
-        self.errors.push(crate::error::ValidationErrorItem {
+        self.errors.push(crate::core::error::ValidationErrorItem {
             field: field.to_string(),
             problem: problem.to_string(),
             context,
@@ -98,7 +98,7 @@ impl ValidationCollector {
 /// re-emit path would drop everything except `field`/`problem` — making it
 /// impossible to debug failures that bottle up via `ValidationCollector`
 /// (e.g. release working-tree checks emitting the dirty file list).
-fn single_error_to_invalid_argument(err: &crate::error::ValidationErrorItem) -> Error {
+fn single_error_to_invalid_argument(err: &crate::core::error::ValidationErrorItem) -> Error {
     let base = Error::validation_invalid_argument(&err.field, &err.problem, None, None);
     match &err.context {
         Some(context) => Error {

--- a/src/core/extension/bench/aggregation.rs
+++ b/src/core/extension/bench/aggregation.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use crate::error::{Error, Result};
-use crate::extension::bench::distribution::{distribution, percentile};
-use crate::extension::bench::parsing::{
+use crate::core::error::{Error, Result};
+use crate::core::extension::bench::distribution::{distribution, percentile};
+use crate::core::extension::bench::parsing::{
     BenchMetrics, BenchResults, BenchRunSnapshot, BenchScenario,
 };
-use crate::observation::timeline::{ObservationSpanResult, ObservationSpanStatus};
+use crate::core::observation::timeline::{ObservationSpanResult, ObservationSpanStatus};
 
 pub fn aggregate_runs(runs: &[BenchResults]) -> Result<BenchResults> {
     let first = runs

--- a/src/core/extension/bench/artifact_validation.rs
+++ b/src/core/extension/bench/artifact_validation.rs
@@ -1,6 +1,6 @@
 //! Bench artifact contract validation.
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::artifact::BenchArtifact;
 use super::parsing::{BenchResults, BenchScenario};
@@ -134,7 +134,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::extension::bench::parsing::{BenchMetrics, BenchRunSnapshot};
+    use crate::core::extension::bench::parsing::{BenchMetrics, BenchRunSnapshot};
 
     #[test]
     fn test_validate_artifact_paths() {

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::engine::baseline::{self as generic, BaselineConfig};
-use crate::error::Result;
+use crate::core::engine::baseline::{self as generic, BaselineConfig};
+use crate::core::error::Result;
 
 use super::metrics::{resolve_metric_policies, MetricDelta};
 use super::parsing::{BenchResults, BenchScenario};

--- a/src/core/extension/bench/diagnostic.rs
+++ b/src/core/extension/bench/diagnostic.rs
@@ -88,7 +88,7 @@ fn with_default_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::bench::parsing::{BenchMetrics, BenchRunSnapshot, BenchScenario};
+    use crate::core::extension::bench::parsing::{BenchMetrics, BenchRunSnapshot, BenchScenario};
 
     #[test]
     fn test_collect_diagnostics() {

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -1,6 +1,6 @@
 //! Bench runner failure diagnostic enrichment.
 
-use crate::extension::stderr_tail;
+use crate::core::extension::stderr_tail;
 
 use super::run::BenchRunWorkflowArgs;
 
@@ -85,8 +85,8 @@ fn text_after<'a>(text: &'a str, start: &str) -> Option<&'a str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::baseline::BaselineFlags;
-    use crate::extension::bench::parsing::BenchRunExecution;
+    use crate::core::engine::baseline::BaselineFlags;
+    use crate::core::extension::bench::parsing::BenchRunExecution;
 
     #[test]
     fn test_bench_failure_stderr_tail() {
@@ -145,7 +145,8 @@ mod tests {
             rig_id: Some("studio-bfb".to_string()),
             shared_state: None,
             extra_workloads: Vec::new(),
-            invocation_requirements: crate::engine::invocation::InvocationRequirements::default(),
+            invocation_requirements:
+                crate::core::engine::invocation::InvocationRequirements::default(),
         }
     }
 }

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -33,8 +33,8 @@ pub mod run;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-use crate::component::Component;
-use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
+use crate::core::component::Component;
+use crate::core::extension::{ExtensionCapability, ExtensionExecutionContext};
 
 pub use aggregation::aggregate_runs;
 pub use artifact::BenchArtifact;
@@ -63,6 +63,6 @@ pub use run::{
 
 pub fn resolve_bench_command(
     component: &Component,
-) -> crate::error::Result<ExtensionExecutionContext> {
-    crate::extension::resolve_execution_context(component, ExtensionCapability::Bench)
+) -> crate::core::error::Result<ExtensionExecutionContext> {
+    crate::core::extension::resolve_execution_context(component, ExtensionCapability::Bench)
 }

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -58,9 +58,9 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::budget::BudgetFinding;
-use crate::error::{Error, Result};
-use crate::observation::timeline::{
+use crate::core::budget::BudgetFinding;
+use crate::core::error::{Error, Result};
+use crate::core::observation::timeline::{
     reporting_timeline, summarize_spans, ObservationEvent, ObservationSpanDefinition,
     ObservationSpanResult,
 };
@@ -742,7 +742,7 @@ mod tests {
         assert_eq!(scenario.span_results.len(), 1);
         assert_eq!(
             scenario.span_results[0].status,
-            crate::observation::timeline::ObservationSpanStatus::Ok
+            crate::core::observation::timeline::ObservationSpanStatus::Ok
         );
         assert_eq!(scenario.span_results[0].duration_ms, Some(35));
     }

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -10,8 +10,8 @@ use super::diagnostic::BenchDiagnostic;
 use super::distribution::BenchRunDistribution;
 use super::parsing::{BenchMetricPhase, BenchResults, BenchScenario};
 use super::run::{BenchRunFailure, BenchRunWorkflowResult};
-use crate::budget::BudgetFinding;
-use crate::rig::RigStateSnapshot;
+use crate::core::budget::BudgetFinding;
+use crate::core::rig::RigStateSnapshot;
 
 #[derive(Serialize)]
 pub struct BenchCommandOutput {
@@ -1125,8 +1125,8 @@ fn format_diagnostic_hint_suffix(diagnostics: &[BenchDiagnostic]) -> String {
 mod tests {
     use super::super::diagnostic::BenchDiagnosticSource;
     use super::*;
-    use crate::extension::bench::artifact::BenchArtifact;
-    use crate::extension::bench::parsing::{
+    use crate::core::extension::bench::artifact::BenchArtifact;
+    use crate::core::extension::bench::parsing::{
         BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy, BenchMetrics, BenchRunSnapshot,
         BenchScenario,
     };

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -8,20 +8,20 @@ use std::thread;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
-use crate::engine::invocation::InvocationRequirements;
-use crate::engine::run_dir::{self, RunDir};
-use crate::error::{Error, Result};
-use crate::extension::bench::aggregate_runs;
-use crate::extension::bench::baseline::{self, BenchBaselineComparison};
-use crate::extension::bench::diagnostic::{self, BenchDiagnostic};
-use crate::extension::bench::failure_diagnostic::bench_failure_stderr_tail;
-use crate::extension::bench::parsing::{
+use crate::core::component::Component;
+use crate::core::engine::baseline::BaselineFlags;
+use crate::core::engine::invocation::InvocationRequirements;
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::error::{Error, Result};
+use crate::core::extension::bench::aggregate_runs;
+use crate::core::extension::bench::baseline::{self, BenchBaselineComparison};
+use crate::core::extension::bench::diagnostic::{self, BenchDiagnostic};
+use crate::core::extension::bench::failure_diagnostic::bench_failure_stderr_tail;
+use crate::core::extension::bench::parsing::{
     self, BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunnerMetadata, BenchScenario,
     BenchWorkloadMetadata,
 };
-use crate::extension::{
+use crate::core::extension::{
     build_scenario_runner, resolve_execution_context, ExtensionCapability,
     ExtensionExecutionContext, ExtensionRunner, ScenarioRunnerOptions,
 };
@@ -130,11 +130,11 @@ pub fn run_bench_list_workflow(
 ) -> Result<BenchListWorkflowResult> {
     let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
     if component.has_script(ExtensionCapability::Bench) {
-        let source_path = crate::extension::component_script::source_path(
+        let source_path = crate::core::extension::component_script::source_path(
             component,
             args.path_override.as_deref(),
         );
-        let output = crate::extension::component_script::run_component_scripts_with_run_dir(
+        let output = crate::core::extension::component_script::run_component_scripts_with_run_dir(
             component,
             ExtensionCapability::Bench,
             &source_path,
@@ -475,28 +475,29 @@ pub fn run_main_bench_workflow(
     }
 
     if component.has_script(ExtensionCapability::Bench) {
-        let script_output = crate::extension::component_script::run_component_scripts_with_run_dir(
-            component,
-            ExtensionCapability::Bench,
-            source_path,
-            run_dir,
-            true,
-            &[
-                (
-                    "HOMEBOY_BENCH_ITERATIONS".to_string(),
-                    args.iterations.to_string(),
-                ),
-                (
-                    "HOMEBOY_BENCH_WARMUP_ITERATIONS".to_string(),
-                    args.warmup_iterations.unwrap_or(0).to_string(),
-                ),
-                (
-                    "HOMEBOY_BENCH_SCENARIOS".to_string(),
-                    args.scenario_ids.join(","),
-                ),
-            ],
-            &args.passthrough_args,
-        )?;
+        let script_output =
+            crate::core::extension::component_script::run_component_scripts_with_run_dir(
+                component,
+                ExtensionCapability::Bench,
+                source_path,
+                run_dir,
+                true,
+                &[
+                    (
+                        "HOMEBOY_BENCH_ITERATIONS".to_string(),
+                        args.iterations.to_string(),
+                    ),
+                    (
+                        "HOMEBOY_BENCH_WARMUP_ITERATIONS".to_string(),
+                        args.warmup_iterations.unwrap_or(0).to_string(),
+                    ),
+                    (
+                        "HOMEBOY_BENCH_SCENARIOS".to_string(),
+                        args.scenario_ids.join(","),
+                    ),
+                ],
+                &args.passthrough_args,
+            )?;
         let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
         let mut parsed = if results_file.exists() {
             parse_execution_results_file(
@@ -880,7 +881,7 @@ fn is_secret_like_env_key(key: &str) -> bool {
 }
 
 fn source_revision_at(path: &Path) -> Option<String> {
-    crate::git::short_head_revision_at(path).or_else(|| {
+    crate::core::git::short_head_revision_at(path).or_else(|| {
         std::fs::read_to_string(path.join(".source-revision"))
             .ok()
             .map(|value| value.trim().to_string())
@@ -1099,7 +1100,7 @@ fn run_concurrent_instances(
         }));
     }
 
-    let mut per_instance: Vec<(u32, crate::extension::RunnerOutput)> =
+    let mut per_instance: Vec<(u32, crate::core::extension::RunnerOutput)> =
         Vec::with_capacity(concurrency as usize);
     for h in handles {
         match h.join() {
@@ -1190,7 +1191,7 @@ fn run_concurrent_instances(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::path_list_env_value;
+    use crate::core::extension::path_list_env_value;
     use std::collections::BTreeMap;
 
     #[test]

--- a/src/core/extension/bench/test_support.rs
+++ b/src/core/extension/bench/test_support.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
+use crate::core::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
 
 pub(crate) fn scenario_with_iterations(
     id: &str,

--- a/src/core/extension/build/artifact.rs
+++ b/src/core/extension/build/artifact.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 /// Resolve a potentially glob-patterned artifact path to an actual file.
 ///

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -1,16 +1,16 @@
 use serde::Serialize;
 use std::path::PathBuf;
 
-use crate::component::{self, Component};
-use crate::config::{is_json_input, parse_bulk_ids};
-use crate::deploy::permissions;
-use crate::engine::command::CapturedOutput;
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::extension::{self, exec_context, ExtensionCapability, ExtensionExecutionContext};
-use crate::output::{BulkResult, BulkSummary, ItemOutcome};
-use crate::paths;
-use crate::server::execute_local_command_in_dir;
+use crate::core::component::{self, Component};
+use crate::core::config::{is_json_input, parse_bulk_ids};
+use crate::core::deploy::permissions;
+use crate::core::engine::command::CapturedOutput;
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::extension::{self, exec_context, ExtensionCapability, ExtensionExecutionContext};
+use crate::core::output::{BulkResult, BulkSummary, ItemOutcome};
+use crate::core::paths;
+use crate::core::server::execute_local_command_in_dir;
 
 mod artifact;
 
@@ -382,8 +382,8 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
 
     // Warn when HEAD is ahead of the latest tag — the build will include
     // unreleased commits that won't be deployed unless using `deploy --head`.
-    if let Some(gap) = crate::deploy::provenance::detect_tag_gap(comp) {
-        crate::deploy::provenance::warn_tag_gap(&comp.id, &gap, "build");
+    if let Some(gap) = crate::core::deploy::provenance::detect_tag_gap(comp) {
+        crate::core::deploy::provenance::warn_tag_gap(&comp.id, &gap, "build");
         log_status!(
             "build",
             "Build uses current working tree. To deploy these commits: use `deploy --head` or run `homeboy release`."
@@ -420,7 +420,7 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
     // Execute via ExtensionRunner — uses the full exec context protocol (settings,
     // project info, context version) instead of the minimal env var set.
     let runner_output = if let ResolvedBuildCommand::ComponentScript { .. } = &resolved {
-        crate::extension::component_script::run_component_scripts(
+        crate::core::extension::component_script::run_component_scripts(
             comp,
             extension::ExtensionCapability::Build,
             &validated_path,

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use crate::component::Component;
-use crate::engine::invocation::{InvocationGuard, InvocationRequirements};
-use crate::engine::run_dir::RunDir;
-use crate::error::{Error, Result};
-use crate::extension::{exec_context, ExtensionCapability, RunnerOutput};
+use crate::core::component::Component;
+use crate::core::engine::invocation::{InvocationGuard, InvocationRequirements};
+use crate::core::engine::run_dir::RunDir;
+use crate::core::error::{Error, Result};
+use crate::core::extension::{exec_context, ExtensionCapability, RunnerOutput};
 
 #[derive(Debug, Clone)]
 pub struct ComponentScriptOutput {
@@ -175,7 +175,7 @@ fn command_with_args(command: &str, script_args: &[String]) -> String {
     format!(
         "{} {}",
         command,
-        crate::engine::shell::quote_args(script_args)
+        crate::core::engine::shell::quote_args(script_args)
     )
 }
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -1,13 +1,13 @@
-use crate::component::{self, Component};
-use crate::engine::command::CapturedOutput;
-use crate::engine::local_files;
-use crate::engine::shell;
-use crate::engine::{template, validation};
-use crate::error::{Error, Result};
-use crate::project::{self, Project};
-use crate::rig::toolchain;
-use crate::server::http::ApiClient;
-use crate::server::{
+use crate::core::component::{self, Component};
+use crate::core::engine::command::CapturedOutput;
+use crate::core::engine::local_files;
+use crate::core::engine::shell;
+use crate::core::engine::{template, validation};
+use crate::core::error::{Error, Result};
+use crate::core::project::{self, Project};
+use crate::core::rig::toolchain;
+use crate::core::server::http::ApiClient;
+use crate::core::server::{
     execute_local_command_in_dir, execute_local_command_interactive,
     execute_local_command_passthrough, execute_local_command_stderr_passthrough, CommandOutput,
 };
@@ -255,7 +255,7 @@ pub(crate) fn execute_action(
                 .and_then(|proj| proj.base_path.clone());
 
             let working_dir =
-                crate::engine::text::json_path_str(&payload, &["release", "local_path"]).unwrap_or(extension_path);
+                crate::core::engine::text::json_path_str(&payload, &["release", "local_path"]).unwrap_or(extension_path);
 
             let execution = execute_extension_command(
                 command_template,
@@ -451,7 +451,7 @@ pub(crate) fn build_settings_json_from_manifest(
         }
     }
 
-    crate::config::to_json_string(&settings)
+    crate::core::config::to_json_string(&settings)
 }
 
 pub(crate) fn validate_capability_script_exists(
@@ -995,7 +995,7 @@ pub fn is_extension_compatible(extension: &ExtensionManifest, project: Option<&P
     // Required components must be linked to the project (if project context exists)
     if let Some(project) = project {
         for component in &requires.components {
-            if !crate::project::has_component(project, component) {
+            if !crate::core::project::has_component(project, component) {
                 return false;
             }
         }

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -28,8 +28,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
-use crate::engine::local_files;
-use crate::error::{Error, Result};
+use crate::core::engine::local_files;
+use crate::core::error::{Error, Result};
 
 // ============================================================================
 // Grammar definition (loaded from extension TOML/JSON)
@@ -1363,13 +1363,13 @@ mod tests {
 
     #[test]
     fn extract_rust_imports() {
-        let content = "use std::path::Path;\nuse crate::error::Result;\n\nfn foo() {}\n";
+        let content = "use std::path::Path;\nuse crate::core::error::Result;\n\nfn foo() {}\n";
         let grammar = rust_grammar();
         let paths = import_paths(&extract(content, &grammar));
 
         assert_eq!(paths.len(), 2);
         assert_eq!(paths[0], "std::path::Path");
-        assert_eq!(paths[1], "crate::error::Result");
+        assert_eq!(paths[1], "crate::core::error::Result");
     }
 
     #[test]
@@ -1627,7 +1627,7 @@ mod integration_tests {
         // Test against a sample of Rust code
         let sample = r#"
 use std::path::Path;
-use crate::error::Result;
+use crate::core::error::Result;
 
 pub struct Config {
     data: String,

--- a/src/core/extension/grammar_items.rs
+++ b/src/core/extension/grammar_items.rs
@@ -591,7 +591,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    use crate::extension::grammar::{
+    use crate::core::extension::grammar::{
         BlockSyntax, CommentSyntax, ConceptPattern, FingerprintGrammar, Grammar, LanguageMeta,
         StringSyntax,
     };

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -1,9 +1,9 @@
-use crate::config::{self, from_str};
-use crate::engine::identifier;
-use crate::engine::local_files::{self, FileSystem};
-use crate::error::{Error, Result};
-use crate::git;
-use crate::paths;
+use crate::core::config::{self, from_str};
+use crate::core::engine::identifier;
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::error::{Error, Result};
+use crate::core::git;
+use crate::core::paths;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -43,8 +43,8 @@ pub struct UpdateResult {
 
 pub mod source_metadata {
     use super::{load_extension, read_source_revision, write_source_metadata};
-    use crate::error::{Error, Result};
-    use crate::paths;
+    use crate::core::error::{Error, Result};
+    use crate::core::paths;
 
     #[derive(Debug, Clone, serde::Serialize)]
     pub struct SourceMetadataRepair {
@@ -189,7 +189,7 @@ pub fn install_with_revision(
 ///
 /// Already-installed extensions are skipped so CI setup can be re-run safely.
 pub fn install_for_component(
-    component: &crate::component::Component,
+    component: &crate::core::component::Component,
     source: &str,
 ) -> Result<InstallForComponentResult> {
     let extensions = component.extensions.as_ref().ok_or_else(|| {
@@ -877,8 +877,8 @@ mod tests {
         install, install_for_component, install_with_revision, load_extension,
         read_source_revision, source_metadata, update,
     };
-    use crate::component;
-    use crate::extension::update_all;
+    use crate::core::component;
+    use crate::core::extension::update_all;
     use crate::test_support::with_isolated_home;
     use std::fs;
     use std::path::Path;
@@ -1643,7 +1643,7 @@ exec '{}' "$@"
         std::fs::write(temp.path().join("some-file.txt"), "content").expect("write file");
 
         assert!(
-            crate::git::is_workdir_clean_or_not_git(temp.path()),
+            crate::core::git::is_workdir_clean_or_not_git(temp.path()),
             "non-git directory should be treated as clean"
         );
     }
@@ -1662,7 +1662,7 @@ exec '{}' "$@"
         }
 
         assert!(
-            crate::git::is_workdir_clean_or_not_git(temp.path()),
+            crate::core::git::is_workdir_clean_or_not_git(temp.path()),
             "freshly-initialized git repo with no changes should be clean"
         );
     }
@@ -1683,7 +1683,7 @@ exec '{}' "$@"
         std::fs::write(temp.path().join("untracked.txt"), "hi").expect("write untracked file");
 
         assert!(
-            !crate::git::is_workdir_clean_or_not_git(temp.path()),
+            !crate::core::git::is_workdir_clean_or_not_git(temp.path()),
             "git repo with untracked file should be reported as dirty"
         );
     }

--- a/src/core/extension/lint/baseline.rs
+++ b/src/core/extension/lint/baseline.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 
-use crate::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
+use crate::core::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
 
 const BASELINE_KEY: &str = "lint";
 
@@ -56,13 +56,13 @@ impl Fingerprintable for LintFingerprint<'_> {
 pub type LintBaseline = generic::Baseline<LintBaselineMetadata>;
 pub type BaselineComparison = generic::Comparison;
 
-pub fn parse_findings_file(path: &Path) -> crate::error::Result<Vec<LintFinding>> {
+pub fn parse_findings_file(path: &Path) -> crate::core::error::Result<Vec<LintFinding>> {
     if !path.exists() {
         return Ok(Vec::new());
     }
 
     let content = std::fs::read_to_string(path).map_err(|e| {
-        crate::Error::internal_io(
+        crate::core::Error::internal_io(
             format!(
                 "Failed to read lint findings file {}: {}",
                 path.display(),
@@ -77,7 +77,7 @@ pub fn parse_findings_file(path: &Path) -> crate::error::Result<Vec<LintFinding>
     }
 
     let findings: Vec<LintFinding> = serde_json::from_str(&content).map_err(|e| {
-        crate::Error::internal_io(
+        crate::core::Error::internal_io(
             format!("Malformed lint findings JSON in {}: {}", path.display(), e),
             Some("lint.baseline.parse".to_string()),
         )
@@ -90,7 +90,7 @@ pub fn save_baseline(
     source_path: &Path,
     component_id: &str,
     findings: &[LintFinding],
-) -> crate::error::Result<std::path::PathBuf> {
+) -> crate::core::error::Result<std::path::PathBuf> {
     let config = BaselineConfig::new(source_path, BASELINE_KEY);
     let metadata = LintBaselineMetadata {
         findings_count: findings.len(),

--- a/src/core/extension/lint/mod.rs
+++ b/src/core/extension/lint/mod.rs
@@ -2,8 +2,8 @@ pub mod baseline;
 pub mod report;
 pub mod run;
 
-use crate::component::Component;
-use crate::extension::{ExtensionCapability, ExtensionExecutionContext, ExtensionRunner};
+use crate::core::component::Component;
+use crate::core::extension::{ExtensionCapability, ExtensionExecutionContext, ExtensionRunner};
 
 pub use baseline::{BaselineComparison, LintBaseline, LintBaselineMetadata, LintFinding};
 pub use report::LintCommandOutput;
@@ -12,12 +12,12 @@ pub use run::{
     LintRunWorkflowResult,
 };
 
-use crate::engine::run_dir::RunDir;
+use crate::core::engine::run_dir::RunDir;
 
 pub fn resolve_lint_command(
     component: &Component,
-) -> crate::error::Result<ExtensionExecutionContext> {
-    crate::extension::resolve_execution_context(component, ExtensionCapability::Lint)
+) -> crate::core::error::Result<ExtensionExecutionContext> {
+    crate::core::extension::resolve_execution_context(component, ExtensionCapability::Lint)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -34,7 +34,7 @@ pub fn build_lint_runner(
     category: Option<&str>,
     step: Option<&str>,
     run_dir: &RunDir,
-) -> crate::Result<ExtensionRunner> {
+) -> crate::core::Result<ExtensionRunner> {
     let resolved = resolve_lint_command(component)?;
 
     Ok(ExtensionRunner::for_context(resolved)

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -3,13 +3,13 @@
 //! Mirrors `core/extension/test/report.rs` — the command layer calls a single
 //! builder function to convert a workflow result into the command output tuple.
 
-use crate::extension::lint::baseline::{BaselineComparison, LintFinding};
-use crate::extension::{
+use crate::core::extension::lint::baseline::{BaselineComparison, LintFinding};
+use crate::core::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, VerificationPhase,
 };
-use crate::refactor::plan::RefactorSourceRun;
-use crate::refactor::AppliedRefactor;
+use crate::core::refactor::plan::RefactorSourceRun;
+use crate::core::refactor::AppliedRefactor;
 use serde::Serialize;
 
 use super::run::{LintRunWorkflowResult, LintSummaryOutput};

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -4,15 +4,15 @@
 //! Mirrors `core/extension/test/run.rs` — the command layer provides CLI args,
 //! this module owns all business logic and returns a structured result.
 
-use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
-use crate::engine::run_dir::{self, RunDir};
-use crate::engine::shell;
-use crate::extension::lint::baseline::{self as lint_baseline, LintFinding};
-use crate::extension::lint::build_lint_runner;
-use crate::extension::{self, ExtensionCapability, LintChangedFileRoute};
-use crate::git;
-use crate::refactor::AppliedRefactor;
+use crate::core::component::Component;
+use crate::core::engine::baseline::BaselineFlags;
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::engine::shell;
+use crate::core::extension::lint::baseline::{self as lint_baseline, LintFinding};
+use crate::core::extension::lint::build_lint_runner;
+use crate::core::extension::{self, ExtensionCapability, LintChangedFileRoute};
+use crate::core::git;
+use crate::core::refactor::AppliedRefactor;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -76,7 +76,7 @@ pub fn run_main_lint_workflow(
     source_path: &PathBuf,
     args: LintRunWorkflowArgs,
     run_dir: &RunDir,
-) -> crate::Result<LintRunWorkflowResult> {
+) -> crate::core::Result<LintRunWorkflowResult> {
     let scoped_runs = resolve_scoped_lint_runs(component, &args)?;
 
     // Early exit if changed-file mode produced no files
@@ -361,7 +361,7 @@ fn run_scoped_lint_runs(
     args: &LintRunWorkflowArgs,
     run_dir: &RunDir,
     runs: &[ScopedLintRun],
-) -> crate::Result<extension::RunnerOutput> {
+) -> crate::core::Result<extension::RunnerOutput> {
     let mut success = true;
     let mut exit_code = 0;
 
@@ -412,7 +412,7 @@ pub fn run_self_check_lint_workflow(
     source_path: &Path,
     component_label: String,
     json_summary: bool,
-) -> crate::Result<LintRunWorkflowResult> {
+) -> crate::core::Result<LintRunWorkflowResult> {
     let output = extension::self_check::run_self_checks_with_passthrough(
         component,
         ExtensionCapability::Lint,
@@ -451,7 +451,7 @@ pub fn run_self_check_lint_workflow(
 fn resolve_scoped_lint_runs(
     component: &Component,
     args: &LintRunWorkflowArgs,
-) -> crate::Result<Option<Vec<ScopedLintRun>>> {
+) -> crate::core::Result<Option<Vec<ScopedLintRun>>> {
     if args.changed_only {
         let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
         let mut changed_files: Vec<String> = Vec::new();
@@ -568,7 +568,7 @@ fn process_baseline(
     source_path: &PathBuf,
     args: &LintRunWorkflowArgs,
     lint_findings: &[LintFinding],
-) -> crate::Result<(Option<lint_baseline::BaselineComparison>, Option<i32>)> {
+) -> crate::core::Result<(Option<lint_baseline::BaselineComparison>, Option<i32>)> {
     let mut baseline_comparison = None;
     let mut baseline_exit_override = None;
 
@@ -612,8 +612,8 @@ fn process_baseline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::SelfCheckConfig;
-    use crate::engine::baseline::BaselineFlags;
+    use crate::core::component::SelfCheckConfig;
+    use crate::core::engine::baseline::BaselineFlags;
 
     fn component(root: &str) -> Component {
         Component::new(
@@ -935,7 +935,7 @@ mod tests {
 
     #[test]
     fn lint_config_deserializes_changed_file_routes() {
-        let config: crate::extension::LintConfig = serde_json::from_str(
+        let config: crate::core::extension::LintConfig = serde_json::from_str(
             r#"{
                 "extension_script": "scripts/lint.sh",
                 "changed_file_routes": [

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -1,9 +1,9 @@
-use crate::component::AuditConfig;
-use crate::config::ConfigEntity;
-use crate::engine::output_parse::ParseSpec;
-use crate::engine::run_dir;
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::component::AuditConfig;
+use crate::core::config::ConfigEntity;
+use crate::core::engine::output_parse::ParseSpec;
+use crate::core::engine::run_dir;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -669,7 +669,7 @@ impl ExtensionManifest {
     }
 
     /// Parse the version string as semver.
-    pub fn semver(&self) -> crate::error::Result<semver::Version> {
+    pub fn semver(&self) -> crate::core::error::Result<semver::Version> {
         super::version::parse_extension_version(&self.version, &self.id)
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -82,13 +82,13 @@ pub(crate) fn stderr_tail(stderr: &str) -> String {
 
 // Extension loader functions
 
-use crate::component::Component;
-use crate::config;
-use crate::engine::run_dir::RunDir;
-use crate::error::Result;
-use crate::error::{Error, ErrorCode};
-use crate::output::MergeOutput;
-use crate::paths;
+use crate::core::component::Component;
+use crate::core::config;
+use crate::core::engine::run_dir::RunDir;
+use crate::core::error::Result;
+use crate::core::error::{Error, ErrorCode};
+use crate::core::output::MergeOutput;
+use crate::core::paths;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -231,7 +231,7 @@ pub struct ScenarioRunnerOptions<'a> {
     pub artifact_env: Option<(&'a str, &'a Path)>,
     pub list_only_env: Option<(&'a str, bool)>,
     pub extra_workloads_env: Option<(&'a str, &'a [PathBuf], &'a str)>,
-    pub invocation_requirements: crate::engine::invocation::InvocationRequirements,
+    pub invocation_requirements: crate::core::engine::invocation::InvocationRequirements,
 }
 
 pub fn build_scenario_runner(options: ScenarioRunnerOptions<'_>) -> Result<ExtensionRunner> {
@@ -370,7 +370,7 @@ fn capability_ambiguous_error(
 
 fn linked_extensions(
     component: &Component,
-) -> Result<&HashMap<String, crate::component::ScopedExtensionConfig>> {
+) -> Result<&HashMap<String, crate::core::component::ScopedExtensionConfig>> {
     component
         .extensions
         .as_ref()
@@ -490,7 +490,7 @@ pub fn resolve_execution_context(
 ///   "implements": ["SomeTrait"],
 ///   "registrations": [],
 ///   "namespace": null,
-///   "imports": ["crate::error::Result"]
+///   "imports": ["crate::core::error::Result"]
 /// }
 /// ```
 pub fn run_fingerprint_script(
@@ -784,8 +784,8 @@ pub struct ParsedItem {
     pub visibility: String,
 }
 
-impl From<crate::extension::grammar_items::GrammarItem> for ParsedItem {
-    fn from(gi: crate::extension::grammar_items::GrammarItem) -> Self {
+impl From<crate::core::extension::grammar_items::GrammarItem> for ParsedItem {
+    fn from(gi: crate::core::extension::grammar_items::GrammarItem) -> Self {
         Self {
             name: gi.name,
             kind: gi.kind,
@@ -898,7 +898,7 @@ pub struct ActionSummary {
 ///
 /// Aggregates ready status, compatibility, linked status, CLI info, actions,
 /// and runtime details into a single summary per extension.
-pub fn list_summaries(project: Option<&crate::project::Project>) -> Vec<ExtensionSummary> {
+pub fn list_summaries(project: Option<&crate::core::project::Project>) -> Vec<ExtensionSummary> {
     let extensions = load_all_extensions().unwrap_or_default();
 
     extensions
@@ -1033,7 +1033,7 @@ pub fn update_all(force: bool) -> UpdateAllResult {
 /// resolves the working directory from an optional component, and runs
 /// the command interactively.
 pub fn exec_tool(extension_id: &str, component_id: Option<&str>, args: &[String]) -> Result<i32> {
-    use crate::server::execute_local_command_interactive;
+    use crate::core::server::execute_local_command_interactive;
 
     let extension = load_extension(extension_id)?;
     let ext_path = extension
@@ -1043,7 +1043,7 @@ pub fn exec_tool(extension_id: &str, component_id: Option<&str>, args: &[String]
 
     // Resolve working directory
     let working_dir = if let Some(cid) = component_id {
-        let comp = crate::component::load(cid)?;
+        let comp = crate::core::component::load(cid)?;
         comp.local_path.clone()
     } else {
         std::env::current_dir()
@@ -1091,7 +1091,7 @@ pub fn is_extension_linked(extension_id: &str) -> bool {
 /// If `component.extensions` contains keys like `{"wordpress": {}}`, those extensions
 /// are implicitly required. Returns an actionable error with install commands
 /// when any are missing.
-pub fn validate_required_extensions(component: &crate::component::Component) -> Result<()> {
+pub fn validate_required_extensions(component: &crate::core::component::Component) -> Result<()> {
     let extensions = match &component.extensions {
         Some(m) if !m.is_empty() => m,
         _ => return Ok(()),
@@ -1133,8 +1133,8 @@ pub fn validate_required_extensions(component: &crate::component::Component) -> 
         )
     };
 
-    let mut err = crate::error::Error::new(
-        crate::error::ErrorCode::ExtensionNotFound,
+    let mut err = crate::core::error::Error::new(
+        crate::core::error::ErrorCode::ExtensionNotFound,
         message,
         serde_json::json!({
             "component_id": component.id,
@@ -1158,7 +1158,9 @@ pub fn validate_required_extensions(component: &crate::component::Component) -> 
 /// and satisfy the declared version constraints.
 ///
 /// Returns an actionable error listing every unsatisfied requirement with install/update hints.
-pub fn validate_extension_requirements(component: &crate::component::Component) -> Result<()> {
+pub fn validate_extension_requirements(
+    component: &crate::core::component::Component,
+) -> Result<()> {
     let extensions = match &component.extensions {
         Some(e) if !e.is_empty() => e,
         _ => return Ok(()),
@@ -1233,8 +1235,8 @@ pub fn validate_extension_requirements(component: &crate::component::Component) 
         )
     };
 
-    let mut err = crate::error::Error::new(
-        crate::error::ErrorCode::ExtensionNotFound,
+    let mut err = crate::core::error::Error::new(
+        crate::core::error::ErrorCode::ExtensionNotFound,
         message,
         serde_json::json!({
             "component_id": component.id,
@@ -1250,7 +1252,7 @@ pub fn validate_extension_requirements(component: &crate::component::Component) 
 }
 
 /// Check if any of the component's linked extensions provide build configuration.
-pub fn extension_provides_build(component: &crate::component::Component) -> bool {
+pub fn extension_provides_build(component: &crate::core::component::Component) -> bool {
     let extensions = match &component.extensions {
         Some(m) => m,
         None => return false,
@@ -1269,7 +1271,7 @@ pub fn extension_provides_build(component: &crate::component::Component) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::{Component, ScopedExtensionConfig};
+    use crate::core::component::{Component, ScopedExtensionConfig};
     use std::collections::HashMap;
 
     #[test]
@@ -1404,7 +1406,7 @@ mod tests {
             ..Default::default()
         };
         let err = validate_required_extensions(&comp).unwrap_err();
-        assert_eq!(err.code, crate::error::ErrorCode::ExtensionNotFound);
+        assert_eq!(err.code, crate::core::error::ErrorCode::ExtensionNotFound);
         assert!(err.message.contains("nonexistent-extension-abc123"));
         assert!(err.message.contains("test-component"));
         // Should have install hint + browse hint

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -1,8 +1,8 @@
-use crate::config::{self, from_str};
-use crate::engine::local_files::{self, FileSystem};
-use crate::error::{Error, Result};
-use crate::git;
-use crate::paths;
+use crate::core::config::{self, from_str};
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::error::{Error, Result};
+use crate::core::git;
+use crate::core::paths;
 use std::path::{Path, PathBuf};
 
 use super::lifecycle::{
@@ -300,7 +300,7 @@ fn clean_replace_temp(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{relink, replace, replace_with_revision};
-    use crate::extension::{install, load_extension};
+    use crate::core::extension::{install, load_extension};
     use crate::test_support::with_isolated_home;
     use std::fs;
     use std::path::Path;

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use crate::component::Component;
-use crate::engine::invocation::{InvocationGuard, InvocationRequirements};
-use crate::engine::resource;
-use crate::error::Result;
-use crate::server::CommandOutput;
+use crate::core::component::Component;
+use crate::core::engine::invocation::{InvocationGuard, InvocationRequirements};
+use crate::core::engine::resource;
+use crate::core::error::Result;
+use crate::core::server::CommandOutput;
 
 /// Output from a extension runner script execution.
 pub struct RunnerOutput {
@@ -124,7 +124,7 @@ impl ExtensionRunner {
 
     /// Set the run directory, injecting HOMEBOY_RUN_DIR and all legacy
     /// per-file env vars so extension scripts work with either pattern.
-    pub fn with_run_dir(mut self, run_dir: &crate::engine::run_dir::RunDir) -> Self {
+    pub fn with_run_dir(mut self, run_dir: &crate::core::engine::run_dir::RunDir) -> Self {
         self.env_vars.extend(run_dir.legacy_env_vars());
         self.run_dir_path = Some(run_dir.path().to_path_buf());
         self
@@ -216,7 +216,8 @@ impl ExtensionRunner {
         }
 
         if let (Some(run_dir_path), Some(invocation)) = (&self.run_dir_path, invocation.as_ref()) {
-            let run_dir = crate::engine::run_dir::RunDir::from_existing(run_dir_path.clone())?;
+            let run_dir =
+                crate::core::engine::run_dir::RunDir::from_existing(run_dir_path.clone())?;
             invocation.preserve_artifacts(&run_dir)?;
         }
 
@@ -232,7 +233,7 @@ impl ExtensionRunner {
         let Some(path) = &self.run_dir_path else {
             return Ok(None);
         };
-        let run_dir = crate::engine::run_dir::RunDir::from_existing(path.clone())?;
+        let run_dir = crate::core::engine::run_dir::RunDir::from_existing(path.clone())?;
         InvocationGuard::acquire(&run_dir, &self.invocation_requirements).map(Some)
     }
 
@@ -277,9 +278,9 @@ impl ExtensionRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::Component;
-    use crate::engine::run_dir::RunDir;
-    use crate::extension::ExtensionCapability;
+    use crate::core::component::Component;
+    use crate::core::engine::run_dir::RunDir;
+    use crate::core::extension::ExtensionCapability;
 
     fn context() -> ExtensionExecutionContext {
         ExtensionExecutionContext {

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -1,6 +1,6 @@
-use crate::engine::local_files;
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::engine::local_files;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/src/core/extension/scope.rs
+++ b/src/core/extension/scope.rs
@@ -1,6 +1,6 @@
-use crate::component::Component;
-use crate::error::{Error, Result};
-use crate::project::Project;
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::project::Project;
 use std::collections::HashMap;
 
 use super::load_extension;
@@ -61,7 +61,7 @@ impl ExtensionScope {
 
         // Required components must be linked to the project
         for required in &requires.components {
-            if !crate::project::has_component(project, required) {
+            if !crate::core::project::has_component(project, required) {
                 return Err(Error::validation_invalid_argument(
                     "project.componentIds",
                     format!(
@@ -94,7 +94,7 @@ impl ExtensionScope {
 
         let matching_component_ids: Vec<String> = required_components
             .iter()
-            .filter(|required_id| crate::project::has_component(project, required_id))
+            .filter(|required_id| crate::core::project::has_component(project, required_id))
             .cloned()
             .collect();
 

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -1,7 +1,7 @@
-use crate::component::Component;
-use crate::error::{Error, Result};
-use crate::extension::ExtensionCapability;
-use crate::server::{
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::extension::ExtensionCapability;
+use crate::core::server::{
     execute_local_command_in_dir, execute_local_command_passthrough, CommandOutput,
 };
 use std::path::Path;
@@ -93,7 +93,7 @@ fn execute_self_check_command(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::{Component, SelfCheckConfig};
+    use crate::core::component::{Component, SelfCheckConfig};
 
     #[test]
     fn test_run_self_checks_requires_configured_commands() {

--- a/src/core/extension/test/baseline.rs
+++ b/src/core/extension/test/baseline.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::engine::baseline::{self as generic, BaselineConfig};
-use crate::error::Result;
+use crate::core::engine::baseline::{self as generic, BaselineConfig};
+use crate::core::error::Result;
 
 const BASELINE_KEY: &str = "test";
 

--- a/src/core/extension/test/drift.rs
+++ b/src/core/extension/test/drift.rs
@@ -13,10 +13,10 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::code_audit::walker::is_test_path;
-use crate::error::{Error, Result};
-use crate::extension::TestDriftConfig;
-use crate::git;
+use crate::core::code_audit::walker::is_test_path;
+use crate::core::error::{Error, Result};
+use crate::core::extension::TestDriftConfig;
+use crate::core::git;
 
 // ============================================================================
 // Models
@@ -510,7 +510,7 @@ fn matches_any_pattern(path: &str, patterns: &[String]) -> bool {
 
 /// Collect test files in the repo using extension-declared glob patterns.
 fn collect_test_files(root: &Path, test_patterns: &[String]) -> Vec<PathBuf> {
-    use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+    use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
     let config = ScanConfig {
         extensions: ExtensionFilter::All,
@@ -605,7 +605,7 @@ fn is_auto_fixable(change: &ProductionChange) -> bool {
 ///
 /// For each auto-fixable change, creates a TransformRule that replaces
 /// the old symbol with the new one in test files.
-pub fn generate_transform_rules(report: &DriftReport) -> Vec<crate::refactor::TransformRule> {
+pub fn generate_transform_rules(report: &DriftReport) -> Vec<crate::core::refactor::TransformRule> {
     let mut rules = Vec::new();
 
     for change in &report.production_changes {
@@ -677,7 +677,7 @@ pub fn generate_transform_rules(report: &DriftReport) -> Vec<crate::refactor::Tr
             _ => continue,
         };
 
-        rules.push(crate::refactor::TransformRule {
+        rules.push(crate::core::refactor::TransformRule {
             id,
             description,
             find,

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -6,10 +6,10 @@ pub mod report;
 pub mod run;
 pub mod workflow;
 
-use crate::component::Component;
-use crate::extension::test::drift::DriftOptions;
-use crate::extension::{ExtensionCapability, ExtensionExecutionContext, ExtensionRunner};
-use crate::git;
+use crate::core::component::Component;
+use crate::core::extension::test::drift::DriftOptions;
+use crate::core::extension::{ExtensionCapability, ExtensionExecutionContext, ExtensionRunner};
+use crate::core::git;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -46,8 +46,8 @@ pub use workflow::{
 
 pub fn resolve_test_command(
     component: &Component,
-) -> crate::error::Result<ExtensionExecutionContext> {
-    crate::extension::resolve_execution_context(component, ExtensionCapability::Test)
+) -> crate::core::error::Result<ExtensionExecutionContext> {
+    crate::core::extension::resolve_execution_context(component, ExtensionCapability::Test)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -59,8 +59,8 @@ pub fn build_test_runner(
     coverage_enabled: bool,
     coverage_min: Option<f64>,
     changed_test_files: Option<&[String]>,
-    run_dir: &crate::engine::run_dir::RunDir,
-) -> crate::Result<ExtensionRunner> {
+    run_dir: &crate::core::engine::run_dir::RunDir,
+) -> crate::core::Result<ExtensionRunner> {
     let resolved = resolve_test_command(component)?;
 
     let mut runner = ExtensionRunner::for_context(resolved)
@@ -95,12 +95,12 @@ fn component_source_path(component: &Component) -> PathBuf {
 pub fn resolve_drift_options(
     component: &Component,
     since: &str,
-) -> crate::error::Result<DriftOptions> {
+) -> crate::core::error::Result<DriftOptions> {
     let source_path = component_source_path(component);
 
     if let Some(extensions) = &component.extensions {
         for extension_id in extensions.keys() {
-            let manifest = crate::extension::load_extension(extension_id)?;
+            let manifest = crate::core::extension::load_extension(extension_id)?;
             if let Some(config) = manifest.test_drift() {
                 return Ok(DriftOptions::from_config(
                     &source_path,
@@ -124,7 +124,7 @@ pub fn resolve_drift_options(
 pub fn compute_changed_test_files(
     component: &Component,
     git_ref: &str,
-) -> crate::error::Result<Vec<String>> {
+) -> crate::core::error::Result<Vec<String>> {
     let source_path = component_source_path(component);
 
     let changed_files = git::get_files_changed_since(&source_path.to_string_lossy(), git_ref)?;
@@ -135,7 +135,7 @@ pub fn compute_changed_test_files(
     let mut selected: BTreeSet<String> = BTreeSet::new();
 
     for file in &changed_files {
-        if crate::code_audit::is_test_path(file) {
+        if crate::core::code_audit::is_test_path(file) {
             selected.insert(file.clone());
         }
     }
@@ -154,7 +154,7 @@ pub fn compute_changed_test_files(
 pub fn compute_changed_test_scope(
     component: &Component,
     git_ref: &str,
-) -> crate::error::Result<TestScopeOutput> {
+) -> crate::core::error::Result<TestScopeOutput> {
     let selected_files = compute_changed_test_files(component, git_ref)?;
 
     Ok(TestScopeOutput {
@@ -168,7 +168,7 @@ pub fn compute_changed_test_scope(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::TestDriftConfig;
+    use crate::core::extension::TestDriftConfig;
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;

--- a/src/core/extension/test/parsing.rs
+++ b/src/core/extension/test/parsing.rs
@@ -1,9 +1,9 @@
 use serde::Serialize;
 
-use crate::engine::local_files;
-use crate::engine::output_parse::{Aggregate, DeriveRule, ParseRule, ParseSpec};
-use crate::extension::test::analyze::{TestAnalysis, TestAnalysisInput};
-use crate::extension::test::TestCounts;
+use crate::core::engine::local_files;
+use crate::core::engine::output_parse::{Aggregate, DeriveRule, ParseRule, ParseSpec};
+use crate::core::extension::test::analyze::{TestAnalysis, TestAnalysisInput};
+use crate::core::extension::test::TestCounts;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CoverageOutput {

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -4,15 +4,15 @@
 //! produce domain-specific result types. This module provides the unified output
 //! envelope and builder functions that assemble results into command-ready output.
 
-use crate::extension::test::{
+use crate::core::extension::test::{
     CoverageOutput, DriftReport, TestAnalysis, TestBaselineComparison, TestCounts, TestScopeOutput,
     TestSummaryOutput,
 };
-use crate::extension::{
+use crate::core::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, PhaseStatus, VerificationPhase,
 };
-use crate::refactor::AppliedRefactor;
+use crate::core::refactor::AppliedRefactor;
 use serde::Serialize;
 
 use super::run::{RawTestOutput, TestRunWorkflowResult};

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -1,16 +1,16 @@
-use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
-use crate::engine::run_dir::{self, RunDir};
-use crate::extension::test::analyze::{analyze, TestAnalysis, TestAnalysisInput};
-use crate::extension::test::baseline::{self, TestBaselineComparison, TestCounts};
-use crate::extension::test::{
+use crate::core::component::Component;
+use crate::core::engine::baseline::BaselineFlags;
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::extension::test::analyze::{analyze, TestAnalysis, TestAnalysisInput};
+use crate::core::extension::test::baseline::{self, TestBaselineComparison, TestCounts};
+use crate::core::extension::test::{
     build_test_runner, build_test_summary, compute_changed_test_scope, parse_coverage_file,
     parse_failures_file, parse_test_results_file, parse_test_results_text,
     parse_test_results_text_with_spec, CoverageOutput, FailedTest, TestScopeOutput,
     TestSummaryOutput,
 };
-use crate::extension::{self, ExtensionCapability};
-use crate::refactor::AppliedRefactor;
+use crate::core::extension::{self, ExtensionCapability};
+use crate::core::refactor::AppliedRefactor;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
@@ -165,7 +165,7 @@ pub fn run_main_test_workflow(
     source_path: &PathBuf,
     args: TestRunWorkflowArgs,
     run_dir: &RunDir,
-) -> crate::Result<TestRunWorkflowResult> {
+) -> crate::core::Result<TestRunWorkflowResult> {
     let changed_scope = if let Some(ref git_ref) = args.changed_since {
         Some(compute_changed_test_scope(component, git_ref)?)
     } else {
@@ -221,9 +221,9 @@ pub fn run_main_test_workflow(
         }
     }
 
-    let result_parse = crate::extension::test::resolve_test_command(component)
+    let result_parse = crate::core::extension::test::resolve_test_command(component)
         .ok()
-        .and_then(|context| crate::extension::load_extension(&context.extension_id).ok())
+        .and_then(|context| crate::core::extension::load_extension(&context.extension_id).ok())
         .and_then(|extension| extension.test.and_then(|test| test.result_parse));
 
     let output = build_test_runner(
@@ -471,7 +471,7 @@ pub fn run_self_check_test_workflow(
     source_path: &Path,
     component_label: String,
     json_summary: bool,
-) -> crate::Result<TestRunWorkflowResult> {
+) -> crate::core::Result<TestRunWorkflowResult> {
     let output =
         extension::self_check::run_self_checks(component, ExtensionCapability::Test, source_path)?;
     let status = if output.success { "passed" } else { "failed" }.to_string();
@@ -515,8 +515,8 @@ pub fn run_self_check_test_workflow(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::SelfCheckConfig;
-    use crate::extension::test::TestFailure;
+    use crate::core::component::SelfCheckConfig;
+    use crate::core::extension::test::TestFailure;
 
     #[test]
     fn tail_lines_returns_full_text_when_under_limit() {

--- a/src/core/extension/test/workflow.rs
+++ b/src/core/extension/test/workflow.rs
@@ -1,11 +1,11 @@
-use crate::component::Component;
-use crate::extension::test::drift::{detect_drift, generate_transform_rules, DriftReport};
-use crate::extension::test::resolve_drift_options;
-use crate::extension::test::TestScopeOutput;
-use crate::extension::test::{ChangeType, TestAnalysis};
-use crate::extension::test::{TestBaselineComparison, TestCounts};
-use crate::refactor::AppliedRefactor;
-use crate::refactor::{
+use crate::core::component::Component;
+use crate::core::extension::test::drift::{detect_drift, generate_transform_rules, DriftReport};
+use crate::core::extension::test::resolve_drift_options;
+use crate::core::extension::test::TestScopeOutput;
+use crate::core::extension::test::{ChangeType, TestAnalysis};
+use crate::core::extension::test::{TestBaselineComparison, TestCounts};
+use crate::core::refactor::AppliedRefactor;
+use crate::core::refactor::{
     self,
     auto::{self, AutofixMode},
     TransformSet,
@@ -57,7 +57,7 @@ pub fn detect_test_drift(
     component_id: &str,
     component: &Component,
     since: &str,
-) -> Result<DriftWorkflowResult, crate::Error> {
+) -> Result<DriftWorkflowResult, crate::core::Error> {
     crate::log_status!(
         "drift",
         "Detecting test drift since {} in {}",
@@ -184,7 +184,7 @@ pub fn auto_fix_test_drift(
     since: &str,
     write: bool,
     include_report: bool,
-) -> Result<AutoFixDriftWorkflowResult, crate::Error> {
+) -> Result<AutoFixDriftWorkflowResult, crate::core::Error> {
     let source_path = {
         let expanded = shellexpand::tilde(&component.local_path);
         std::path::PathBuf::from(expanded.as_ref())

--- a/src/core/extension/trace/assertions.rs
+++ b/src/core/extension/trace/assertions.rs
@@ -1,6 +1,6 @@
 //! Temporal trace assertion evaluation over timeline events.
 
-use crate::extension::bench::distribution::percentile;
+use crate::core::extension::bench::distribution::percentile;
 use serde_json::json;
 
 use super::parsing::{
@@ -604,7 +604,7 @@ fn event_details(events: &[&super::parsing::TraceEvent]) -> Vec<serde_json::Valu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::trace::parsing::TraceEvent;
+    use crate::core::extension::trace::parsing::TraceEvent;
     use std::collections::BTreeMap;
 
     fn event(t_ms: u64, source: &str, event: &str) -> TraceEvent {

--- a/src/core/extension/trace/attach.rs
+++ b/src/core/extension/trace/attach.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeMap;
 use std::net::{SocketAddr, TcpStream};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
-use crate::engine::run_dir::RunDir;
-use crate::error::{Error, Result};
-use crate::http_probe;
+use crate::core::engine::run_dir::RunDir;
+use crate::core::error::{Error, Result};
+use crate::core::http_probe;
 
 use super::parsing::{TraceArtifact, TraceEvent, TraceResults};
 

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::engine::baseline::{self as generic, BaselineConfig};
-use crate::error::Result;
+use crate::core::engine::baseline::{self as generic, BaselineConfig};
+use crate::core::error::Result;
 
 use super::parsing::{TraceAssertion, TraceAssertionStatus, TraceResults};
 
@@ -367,7 +367,7 @@ impl generic::Fingerprintable for TraceBaselineItem<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::trace::parsing::{
+    use crate::core::extension::trace::parsing::{
         TraceAssertion, TraceSpanResult, TraceSpanStatus, TraceStatus,
     };
 

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -19,8 +19,8 @@ pub mod report;
 pub mod run;
 pub mod spans;
 
-use crate::component::Component;
-use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
+use crate::core::component::Component;
+use crate::core::extension::{ExtensionCapability, ExtensionExecutionContext};
 
 pub use attach::TraceAttachment;
 pub use overlay::TraceOverlayRequest;
@@ -50,6 +50,6 @@ pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult, TraceRunnerInputs};
 
 pub fn resolve_trace_command(
     component: &Component,
-) -> crate::error::Result<ExtensionExecutionContext> {
-    crate::extension::resolve_execution_context(component, ExtensionCapability::Trace)
+) -> crate::core::error::Result<ExtensionExecutionContext> {
+    crate::core::extension::resolve_execution_context(component, ExtensionCapability::Trace)
 }

--- a/src/core/extension/trace/overlay.rs
+++ b/src/core/extension/trace/overlay.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::engine::run_dir::RunDir;
-use crate::error::{Error, Result};
+use crate::core::engine::run_dir::RunDir;
+use crate::core::error::{Error, Result};
 
 use super::overlay_lock;
 
@@ -302,7 +302,7 @@ mod tests {
     use std::fs;
     use std::process::Command;
 
-    use crate::engine::run_dir::RunDir;
+    use crate::core::engine::run_dir::RunDir;
     use crate::test_support::with_isolated_home;
 
     use super::*;

--- a/src/core/extension/trace/overlay_lock.rs
+++ b/src/core/extension/trace/overlay_lock.rs
@@ -4,9 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::engine::run_dir::RunDir;
-use crate::error::{Error, ErrorCode, Result};
-use crate::paths;
+use crate::core::engine::run_dir::RunDir;
+use crate::core::error::{Error, ErrorCode, Result};
+use crate::core::paths;
 
 #[derive(Debug)]
 pub(super) struct TraceOverlayLock {

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -4,11 +4,11 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Error, Result};
-use crate::observation::timeline::{
+use crate::core::error::{Error, Result};
+use crate::core::observation::timeline::{
     ObservationEvent, ObservationSpanDefinition, ObservationSpanResult, ObservationSpanStatus,
 };
-use crate::rig::RigStateSnapshot;
+use crate::core::rig::RigStateSnapshot;
 
 pub type TraceEvent = ObservationEvent;
 pub type TraceSpanDefinition = ObservationSpanDefinition;

--- a/src/core/extension/trace/probes.rs
+++ b/src/core/extension/trace/probes.rs
@@ -11,7 +11,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::parsing::TraceEvent;
 

--- a/src/core/extension/trace/probes/port_snapshot.rs
+++ b/src/core/extension/trace/probes/port_snapshot.rs
@@ -3,7 +3,7 @@ use std::net::TcpListener;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::{event, push_event, TraceEvent};
 

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -8,7 +8,7 @@ use super::parsing::{
     TraceArtifact, TraceAssertionStatus, TraceList, TraceResults, TraceSpanStatus,
 };
 use super::run::{TraceOverlay, TraceRunWorkflowResult};
-use crate::rig::RigStateSnapshot;
+use crate::core::rig::RigStateSnapshot;
 
 #[derive(Serialize)]
 #[serde(untagged)]
@@ -527,7 +527,7 @@ pub fn from_list_workflow(component: String, list: TraceList) -> (TraceCommandOu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::trace::parsing::{TraceScenario, TraceStatus};
+    use crate::core::extension::trace::parsing::{TraceScenario, TraceStatus};
 
     #[test]
     fn test_from_list_workflow() {
@@ -622,18 +622,18 @@ mod tests {
                 summary: Some("Created a site".to_string()),
                 failure: None,
                 rig: None,
-                timeline: vec![crate::extension::trace::parsing::TraceEvent {
+                timeline: vec![crate::core::extension::trace::parsing::TraceEvent {
                     t_ms: 10,
                     source: "ui".to_string(),
                     event: "submit".to_string(),
                     data: std::collections::BTreeMap::new(),
                 }],
                 span_definitions: Vec::new(),
-                span_results: vec![crate::extension::trace::parsing::TraceSpanResult {
+                span_results: vec![crate::core::extension::trace::parsing::TraceSpanResult {
                     id: "submit_to_cli".to_string(),
                     from: "ui.submit".to_string(),
                     to: "cli.start".to_string(),
-                    status: crate::extension::trace::parsing::TraceSpanStatus::Ok,
+                    status: crate::core::extension::trace::parsing::TraceSpanStatus::Ok,
                     duration_ms: Some(42),
                     from_t_ms: Some(10),
                     to_t_ms: Some(52),
@@ -710,11 +710,11 @@ mod tests {
             rig: None,
             timeline: Vec::new(),
             span_definitions: Vec::new(),
-            span_results: vec![crate::extension::trace::parsing::TraceSpanResult {
+            span_results: vec![crate::core::extension::trace::parsing::TraceSpanResult {
                 id: "submit_to_cli".to_string(),
                 from: "ui.submit".to_string(),
                 to: "cli.start".to_string(),
-                status: crate::extension::trace::parsing::TraceSpanStatus::Ok,
+                status: crate::core::extension::trace::parsing::TraceSpanStatus::Ok,
                 duration_ms: Some(42),
                 from_t_ms: Some(10),
                 to_t_ms: Some(52),

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -5,18 +5,18 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
 
-use crate::component::Component;
-use crate::engine::baseline::BaselineFlags;
-use crate::engine::run_dir::{self, RunDir};
-use crate::error::{Error, ErrorCode, Result};
-use crate::extension::trace::baseline::TraceBaselineComparison;
-use crate::extension::RunnerOutput;
-use crate::extension::{
+use crate::core::component::Component;
+use crate::core::engine::baseline::BaselineFlags;
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::error::{Error, ErrorCode, Result};
+use crate::core::extension::trace::baseline::TraceBaselineComparison;
+use crate::core::extension::RunnerOutput;
+use crate::core::extension::{
     build_scenario_runner, path_list_env_value, resolve_execution_context, stderr_tail,
     ExtensionCapability, ExtensionExecutionContext, ScenarioRunnerOptions,
 };
-use crate::paths;
-use crate::rig::RigStateSnapshot;
+use crate::core::paths;
+use crate::core::rig::RigStateSnapshot;
 
 use super::attach::{append_attach_observations, observe_trace_attachments, TraceAttachment};
 use super::overlay::{
@@ -146,21 +146,22 @@ fn run_trace_workflow_with_component_script(
         Some(acquire_trace_overlay_locks(&args.overlays, run_dir)?)
     };
     let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
-    let script_output = crate::extension::component_script::run_component_scripts_with_run_dir(
-        component,
-        ExtensionCapability::Trace,
-        source_path,
-        run_dir,
-        true,
-        &[
-            (
-                "HOMEBOY_TRACE_SCENARIO".to_string(),
-                args.scenario_id.clone(),
-            ),
-            ("HOMEBOY_TRACE_LIST_ONLY".to_string(), "0".to_string()),
-        ],
-        &[],
-    );
+    let script_output =
+        crate::core::extension::component_script::run_component_scripts_with_run_dir(
+            component,
+            ExtensionCapability::Trace,
+            source_path,
+            run_dir,
+            true,
+            &[
+                (
+                    "HOMEBOY_TRACE_SCENARIO".to_string(),
+                    args.scenario_id.clone(),
+                ),
+                ("HOMEBOY_TRACE_LIST_ONLY".to_string(), "0".to_string()),
+            ],
+            &[],
+        );
     if !args.keep_overlay {
         cleanup_trace_overlays(&applied_overlays)?
     }
@@ -430,11 +431,11 @@ pub fn run_trace_list_workflow(
     run_dir: &RunDir,
 ) -> Result<TraceList> {
     if component.has_script(ExtensionCapability::Trace) {
-        let source_path = crate::extension::component_script::source_path(
+        let source_path = crate::core::extension::component_script::source_path(
             component,
             args.path_override.as_deref(),
         );
-        let output = crate::extension::component_script::run_component_scripts_with_run_dir(
+        let output = crate::core::extension::component_script::run_component_scripts_with_run_dir(
             component,
             ExtensionCapability::Trace,
             &source_path,
@@ -488,8 +489,8 @@ struct TraceListOutput {
     stderr: String,
 }
 
-impl From<crate::extension::component_script::ComponentScriptOutput> for TraceListOutput {
-    fn from(output: crate::extension::component_script::ComponentScriptOutput) -> Self {
+impl From<crate::core::extension::component_script::ComponentScriptOutput> for TraceListOutput {
+    fn from(output: crate::core::extension::component_script::ComponentScriptOutput) -> Self {
         Self {
             exit_code: output.exit_code,
             success: output.success,
@@ -592,7 +593,7 @@ pub(crate) fn build_trace_runner(
             &args.runner_inputs.workload_paths,
             "trace_workloads",
         )),
-        invocation_requirements: crate::engine::invocation::InvocationRequirements::default(),
+        invocation_requirements: crate::core::engine::invocation::InvocationRequirements::default(),
     })?;
 
     if let Some(rig_id) = &args.rig_id {
@@ -1050,8 +1051,8 @@ mod tests {
 
     #[test]
     fn rig_save_baseline_does_not_write_component_homeboy_json() {
-        use crate::extension::trace::baseline;
-        use crate::extension::trace::parsing::{
+        use crate::core::extension::trace::baseline;
+        use crate::core::extension::trace::parsing::{
             TraceResults, TraceSpanResult, TraceSpanStatus, TraceStatus,
         };
 

--- a/src/core/extension/trace/run_tests.inc
+++ b/src/core/extension/trace/run_tests.inc
@@ -3,8 +3,8 @@
     use std::process::Command;
     use std::sync::{Mutex, OnceLock};
 
-    use crate::component::{Component, ScopedExtensionConfig};
-    use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
+    use crate::core::component::{Component, ScopedExtensionConfig};
+    use crate::core::extension::{ExtensionCapability, ExtensionExecutionContext};
     use crate::test_support::with_isolated_home;
 
     use super::*;
@@ -95,9 +95,9 @@ JSON
                 ratchet: false,
             },
             regression_threshold_percent:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
 
         let output =
@@ -168,9 +168,9 @@ JSON
                 ratchet: false,
             },
             regression_threshold_percent:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
 
         let output = build_trace_runner(Some(&context), &component, &args, &run_dir, true).unwrap();
@@ -262,9 +262,9 @@ JSON
                 ratchet: false,
             },
             regression_threshold_percent:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
         let output = RunnerOutput {
             success: false,
@@ -347,9 +347,9 @@ JSON
                 ratchet: false,
             },
             regression_threshold_percent:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
 
         let output =
@@ -431,9 +431,9 @@ JSON
                     ratchet: false,
                 },
                 regression_threshold_percent:
-                    crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                    crate::core::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms:
-                    crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                    crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             },
             &run_dir,
             None,
@@ -562,7 +562,7 @@ JSON
                 fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
                 "base\n"
             );
-            assert!(crate::extension::trace::list_trace_overlay_locks()
+            assert!(crate::core::extension::trace::list_trace_overlay_locks()
                 .unwrap()
                 .is_empty());
             run_dir.cleanup();
@@ -623,9 +623,9 @@ JSON
                 ratchet: false,
             },
             regression_threshold_percent:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms:
-                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         };
         OverlayFixture {
             _temp: temp,

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -1,7 +1,7 @@
 //! Trace span post-processing over shared observation timeline primitives.
 
 use super::parsing::{TraceEvent, TraceResults, TraceSpanDefinition, TraceSpanResult};
-use crate::observation::timeline;
+use crate::core::observation::timeline;
 
 pub type TracePhaseMilestone = timeline::ObservationPhaseMilestone;
 
@@ -50,7 +50,7 @@ pub(crate) fn event_matches_key(event: &TraceEvent, key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::trace::parsing::{TraceAssertion, TraceSpanStatus, TraceStatus};
+    use crate::core::extension::trace::parsing::{TraceAssertion, TraceSpanStatus, TraceStatus};
 
     fn event(t_ms: u64, source: &str, event: &str) -> TraceEvent {
         TraceEvent {

--- a/src/core/extension/update_check.rs
+++ b/src/core/extension/update_check.rs
@@ -13,8 +13,8 @@
 //! [`crate::core::update_check_cache`]. The on-disk filename and JSON
 //! schema live here and are unchanged.
 
+use crate::core::extension;
 use crate::core::update_check_cache;
-use crate::extension;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -42,7 +42,7 @@ fn is_disabled_by_env() -> bool {
 }
 
 fn is_disabled_by_config() -> bool {
-    !crate::defaults::load_config().update_check
+    !crate::core::defaults::load_config().update_check
 }
 
 fn print_extension_hints(extensions_behind: &HashMap<String, usize>) {

--- a/src/core/extension/version.rs
+++ b/src/core/extension/version.rs
@@ -12,7 +12,7 @@
 //! - Less: `<1.2.3`
 //! - Wildcard: `*` — any version
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 use semver::Version;
 
 /// A parsed version constraint that can check whether a given version satisfies it.

--- a/src/core/fleet/check.rs
+++ b/src/core/fleet/check.rs
@@ -1,5 +1,5 @@
-use crate::deploy::{self, DeployConfig};
-use crate::project;
+use crate::core::deploy::{self, DeployConfig};
+use crate::core::project;
 use serde::Serialize;
 
 #[derive(Debug, Default, Clone, Serialize)]
@@ -32,7 +32,7 @@ pub struct FleetCheckSummary {
 pub fn collect_check(
     fleet_id: &str,
     only_outdated: bool,
-) -> crate::Result<(Vec<FleetProjectCheck>, FleetCheckSummary, i32)> {
+) -> crate::core::Result<(Vec<FleetProjectCheck>, FleetCheckSummary, i32)> {
     let fl = super::load(fleet_id)?;
     let mut project_checks = Vec::new();
     let mut summary = FleetCheckSummary {

--- a/src/core/fleet/exec.rs
+++ b/src/core/fleet/exec.rs
@@ -1,7 +1,7 @@
-use crate::engine::shell;
-use crate::fleet;
-use crate::project::Project;
-use crate::server::{resolve_context, SshClient, SshResolveArgs};
+use crate::core::engine::shell;
+use crate::core::fleet;
+use crate::core::project::Project;
+use crate::core::server::{resolve_context, SshClient, SshResolveArgs};
 use serde::Serialize;
 
 #[derive(Debug, Default, Clone, Serialize)]
@@ -30,10 +30,10 @@ pub fn collect_exec(
     command: Vec<String>,
     check: bool,
     user_override: Option<String>,
-) -> crate::Result<(Vec<FleetExecProjectResult>, FleetExecSummary, i32)> {
+) -> crate::core::Result<(Vec<FleetExecProjectResult>, FleetExecSummary, i32)> {
     if command.is_empty() {
         return Err(
-            crate::Error::validation_missing_argument(vec!["command".to_string()])
+            crate::core::Error::validation_missing_argument(vec!["command".to_string()])
                 .with_hint("Usage: homeboy fleet exec <fleet> -- <command>".to_string()),
         );
     }
@@ -47,7 +47,7 @@ pub fn collect_exec(
     let projects = fleet::get_projects(fleet_id)?;
 
     if projects.is_empty() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "fleet",
             "Fleet has no projects",
             Some(fleet_id.to_string()),

--- a/src/core/fleet/mod.rs
+++ b/src/core/fleet/mod.rs
@@ -1,8 +1,8 @@
-use crate::config::{self, ConfigEntity};
-use crate::error::{Error, Result};
-use crate::output::{CreateOutput, MergeOutput, RemoveResult};
-use crate::project;
-use crate::project::ProjectComponentOverrides;
+use crate::core::config::{self, ConfigEntity};
+use crate::core::error::{Error, Result};
+use crate::core::output::{CreateOutput, MergeOutput, RemoveResult};
+use crate::core::project;
+use crate::core::project::ProjectComponentOverrides;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -82,7 +82,7 @@ pub fn add_project(fleet_id: &str, project_id: &str) -> Result<Fleet> {
 
     // Validate project exists
     if !project::exists(project_id) {
-        let suggestions = config::find_similar_ids::<crate::project::Project>(project_id);
+        let suggestions = config::find_similar_ids::<crate::core::project::Project>(project_id);
         return Err(Error::project_not_found(project_id, suggestions));
     }
 
@@ -106,7 +106,7 @@ pub fn remove_project(fleet_id: &str, project_id: &str) -> Result<Fleet> {
 }
 
 /// Get all projects in a fleet with full project data
-pub fn get_projects(fleet_id: &str) -> Result<Vec<crate::project::Project>> {
+pub fn get_projects(fleet_id: &str) -> Result<Vec<crate::core::project::Project>> {
     let fleet = load(fleet_id)?;
     let mut projects = Vec::new();
 

--- a/src/core/fleet/status.rs
+++ b/src/core/fleet/status.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use crate::deploy::{self, DeployConfig, ReleaseStateStatus};
-use crate::project;
-use crate::server::health::{self, ServerHealth};
-use crate::version;
+use crate::core::deploy::{self, DeployConfig, ReleaseStateStatus};
+use crate::core::project;
+use crate::core::release::version;
+use crate::core::server::health::{self, ServerHealth};
 use serde::Serialize;
 
 // ============================================================================
@@ -112,7 +112,7 @@ pub fn collect_status(
     fleet_id: &str,
     cached: bool,
     health_only: bool,
-) -> crate::Result<FleetStatusResult> {
+) -> crate::core::Result<FleetStatusResult> {
     let fl = super::load(fleet_id)?;
 
     if cached {
@@ -211,7 +211,7 @@ pub fn collect_status(
 }
 
 /// Collect cached status (local versions only, no SSH).
-fn collect_cached_status(project_ids: &[String]) -> crate::Result<FleetStatusResult> {
+fn collect_cached_status(project_ids: &[String]) -> crate::core::Result<FleetStatusResult> {
     let mut project_statuses = Vec::new();
     let mut summary = FleetStatusSummary::default();
     summary.projects.total = project_ids.len() as u32;

--- a/src/core/git/changes.rs
+++ b/src/core/git/changes.rs
@@ -3,7 +3,7 @@ use std::path::{Component, Path};
 
 use serde::Serialize;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::execute_git;
 

--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -2,8 +2,8 @@ use regex::Regex;
 use semver::Version;
 use serde::Serialize;
 
-use crate::engine::command;
-use crate::error::Result;
+use crate::core::engine::command;
+use crate::core::error::Result;
 
 // Docs file patterns for categorizing commits
 const DOCS_FILE_EXTENSIONS: [&str; 1] = [".md"];

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -23,9 +23,9 @@ use serde::Serialize;
 use std::path::Path;
 use std::process::Command;
 
-use crate::component;
-use crate::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
-use crate::error::{Error, Result};
+use crate::core::component;
+use crate::core::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
+use crate::core::error::{Error, Result};
 
 use super::resolve_target;
 

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -14,7 +14,7 @@ pub use primitives::*;
 
 use std::process::Command;
 
-use crate::error::Error;
+use crate::core::error::Error;
 
 fn execute_git(path: &str, args: &[&str]) -> std::io::Result<std::process::Output> {
     Command::new("git").args(args).current_dir(path).output()
@@ -62,7 +62,7 @@ pub fn parse_git_identity(identity: Option<&str>) -> GitIdentity {
 }
 
 /// Configure git user.name and user.email in a repository.
-pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::Result<()> {
+pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::core::error::Result<()> {
     for (key, value) in [
         ("user.name", identity.name.as_str()),
         ("user.email", identity.email.as_str()),
@@ -90,7 +90,7 @@ pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::R
 ///    to the directory basename.
 /// 3. **`component_id` only** — look the component up in the registry,
 ///    use its configured `local_path`.
-/// 4. **Neither** — fall through to [`crate::component::resolve`], which
+/// 4. **Neither** — fall through to [`crate::core::component::resolve`], which
 ///    detects from CWD via the registry first, then portable
 ///    `homeboy.json` at CWD or git root. This is what makes
 ///    `homeboy git status` (and friends) work without arguments when
@@ -98,7 +98,7 @@ pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::R
 pub(crate) fn resolve_target(
     component_id: Option<&str>,
     path_override: Option<&str>,
-) -> crate::error::Result<(String, String)> {
+) -> crate::core::error::Result<(String, String)> {
     // Case 1 & 2: explicit path given.
     if let Some(path) = path_override {
         if let Some(id) = component_id {
@@ -106,12 +106,12 @@ pub(crate) fn resolve_target(
         }
         // Discover ID from path or its git root via portable homeboy.json.
         let dir = std::path::Path::new(path);
-        if let Some(comp) = crate::component::discover_from_portable(dir) {
+        if let Some(comp) = crate::core::component::discover_from_portable(dir) {
             return Ok((comp.id, path.to_string()));
         }
-        if let Some(git_root) = crate::component::resolution::detect_git_root(dir) {
+        if let Some(git_root) = crate::core::component::resolution::detect_git_root(dir) {
             if git_root != dir {
-                if let Some(comp) = crate::component::discover_from_portable(&git_root) {
+                if let Some(comp) = crate::core::component::discover_from_portable(&git_root) {
                     return Ok((comp.id, path.to_string()));
                 }
             }
@@ -128,12 +128,12 @@ pub(crate) fn resolve_target(
 
     // Case 3: ID without path — look it up in the registry.
     if let Some(id) = component_id {
-        let comp = crate::component::resolve_effective(Some(id), None, None)?;
+        let comp = crate::core::component::resolve_effective(Some(id), None, None)?;
         return Ok((id.to_string(), comp.local_path));
     }
 
     // Case 4: neither — CWD detection.
-    let comp = crate::component::resolve(None)?;
+    let comp = crate::core::component::resolve(None)?;
     Ok((comp.id, comp.local_path))
 }
 

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -2,11 +2,11 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::Command;
 
-use crate::config::read_json_spec_to_string;
-use crate::error::{Error, Result};
-use crate::output::{BulkResult, BulkSummary, ItemOutcome};
-use crate::project;
-use crate::release::changelog;
+use crate::core::config::read_json_spec_to_string;
+use crate::core::error::{Error, Result};
+use crate::core::output::{BulkResult, BulkSummary, ItemOutcome};
+use crate::core::project;
+use crate::core::release::changelog;
 
 use super::changes::*;
 use super::commits::*;
@@ -185,7 +185,8 @@ pub fn detect_baseline_with_version(
     // machine) are available before we resolve the baseline.  Best-effort:
     // if there is no remote or the network is unavailable we silently
     // proceed with whatever tags are already local.
-    let _ = crate::engine::command::run_in_optional(path, "git", &["fetch", "--tags", "--quiet"]);
+    let _ =
+        crate::core::engine::command::run_in_optional(path, "git", &["fetch", "--tags", "--quiet"]);
 
     // Priority 1: Check for latest tag
     if let Some(tag) = get_latest_tag(path)? {
@@ -341,7 +342,7 @@ pub fn get_repo_snapshot(path: &str) -> Result<RepoSnapshot> {
         return Err(Error::git_command_failed("Not a git repository"));
     }
 
-    let branch = crate::engine::command::run_in(
+    let branch = crate::core::engine::command::run_in(
         path,
         "git",
         &["rev-parse", "--abbrev-ref", "HEAD"],
@@ -358,13 +359,13 @@ pub fn get_repo_snapshot(path: &str) -> Result<RepoSnapshot> {
         .map(|o| o.status.success() && o.stdout.is_empty())
         .unwrap_or(false);
 
-    let (ahead, behind) = crate::engine::command::run_in_optional(
+    let (ahead, behind) = crate::core::engine::command::run_in_optional(
         path,
         "git",
         &["rev-parse", "--abbrev-ref", "@{upstream}"],
     )
     .and_then(|_| {
-        crate::engine::command::run_in_optional(
+        crate::core::engine::command::run_in_optional(
             path,
             "git",
             &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
@@ -438,7 +439,7 @@ pub(crate) fn build_untracked_hint(path: &str, untracked_count: usize) -> Option
 }
 
 fn resolve_changelog_info(
-    component: &crate::component::Component,
+    component: &crate::core::component::Component,
     _commits: &[CommitInfo],
 ) -> Option<ChangelogInfo> {
     let changelog_path = changelog::resolve_changelog_path(component).ok()?;
@@ -1130,7 +1131,7 @@ pub fn tag_at(
 
 /// Check if a tag exists on the remote.
 pub fn tag_exists_on_remote(path: &str, tag_name: &str) -> Result<bool> {
-    Ok(crate::engine::command::run_in_optional(
+    Ok(crate::core::engine::command::run_in_optional(
         path,
         "git",
         &[
@@ -1147,7 +1148,7 @@ pub fn tag_exists_on_remote(path: &str, tag_name: &str) -> Result<bool> {
 /// Check if a tag exists locally.
 pub fn tag_exists_locally(path: &str, tag_name: &str) -> Result<bool> {
     Ok(
-        crate::engine::command::run_in_optional(path, "git", &["tag", "-l", tag_name])
+        crate::core::engine::command::run_in_optional(path, "git", &["tag", "-l", tag_name])
             .map(|s| !s.is_empty())
             .unwrap_or(false),
     )
@@ -1155,7 +1156,7 @@ pub fn tag_exists_locally(path: &str, tag_name: &str) -> Result<bool> {
 
 /// Get the commit SHA a tag points to.
 pub fn get_tag_commit(path: &str, tag_name: &str) -> Result<String> {
-    crate::engine::command::run_in(
+    crate::core::engine::command::run_in(
         path,
         "git",
         &["rev-list", "-n", "1", tag_name],
@@ -1165,7 +1166,7 @@ pub fn get_tag_commit(path: &str, tag_name: &str) -> Result<String> {
 
 /// Get the current HEAD commit SHA.
 pub fn get_head_commit(path: &str) -> Result<String> {
-    crate::engine::command::run_in(path, "git", &["rev-parse", "HEAD"], "get HEAD commit")
+    crate::core::engine::command::run_in(path, "git", &["rev-parse", "HEAD"], "get HEAD commit")
 }
 
 /// Get the current HEAD short commit SHA, returning `None` outside git checkouts.
@@ -1188,10 +1189,10 @@ pub fn short_head_revision_at(path: &Path) -> Option<String> {
 /// Returns Ok(Some(n)) if behind by n commits, Ok(None) if not behind or no upstream.
 pub fn fetch_and_get_behind_count(path: &str) -> Result<Option<u32>> {
     // Run git fetch (update tracking refs)
-    crate::engine::command::run_in(path, "git", &["fetch"], "git fetch")?;
+    crate::core::engine::command::run_in(path, "git", &["fetch"], "git fetch")?;
 
     // Check if upstream exists
-    let upstream = crate::engine::command::run_in_optional(
+    let upstream = crate::core::engine::command::run_in_optional(
         path,
         "git",
         &["rev-parse", "--abbrev-ref", "@{upstream}"],
@@ -1201,7 +1202,7 @@ pub fn fetch_and_get_behind_count(path: &str) -> Result<Option<u32>> {
     }
 
     // Get ahead/behind counts
-    let counts = crate::engine::command::run_in_optional(
+    let counts = crate::core::engine::command::run_in_optional(
         path,
         "git",
         &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
@@ -1270,7 +1271,7 @@ pub fn changes_at(
     let (id, path) = resolve_target(component_id, path_override)?;
 
     // Load component for version checking and changelog info
-    let component = crate::component::resolve_effective(Some(&id), Some(&path), None).ok();
+    let component = crate::core::component::resolve_effective(Some(&id), Some(&path), None).ok();
 
     // Determine baseline with version alignment awareness
     let baseline = match since_tag {
@@ -1287,7 +1288,7 @@ pub fn changes_at(
             // Use component version for alignment checking
             let current_version = component
                 .as_ref()
-                .and_then(crate::release::version::get_component_version);
+                .and_then(crate::core::release::version::get_component_version);
             detect_baseline_with_version(&path, current_version.as_deref())?
         }
     };

--- a/src/core/git/pr_policy.rs
+++ b/src/core/git/pr_policy.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::changes::get_dirty_files;
 use super::github::{pr_files, pr_merge, pr_view, PrMergeOptions};

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 use std::process::Command;
 
-use crate::engine::command;
-use crate::error::{Error, Result};
+use crate::core::engine::command;
+use crate::core::error::{Error, Result};
 
 /// Clone a git repository to a target directory.
 pub fn clone_repo(url: &str, target_dir: &Path) -> Result<()> {

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -10,12 +10,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::api_jobs::JobStore;
-use crate::error::{Error, Result};
-use crate::observation::{
+use crate::core::api_jobs::JobStore;
+use crate::core::error::{Error, Result};
+use crate::core::observation::{
     running_status_note, FindingListFilter, ObservationStore, RunListFilter, RunRecord,
 };
-use crate::{component, git, rig, stack};
+use crate::core::{component, git, rig, stack};
 
 mod analysis_job_runner;
 
@@ -93,7 +93,7 @@ pub struct RunDetail {
     pub summary: RunSummary,
     pub homeboy_version: Option<String>,
     pub metadata: Value,
-    pub artifacts: Vec<crate::observation::ArtifactRecord>,
+    pub artifacts: Vec<crate::core::observation::ArtifactRecord>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src/core/http_api/analysis_job_runner.rs
+++ b/src/core/http_api/analysis_job_runner.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AnalysisJobRunOutput {

--- a/src/core/http_probe.rs
+++ b/src/core/http_probe.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::error::Error;
+use crate::core::error::Error;
 
 #[derive(Debug, Clone)]
 pub(crate) struct HttpProbeError {

--- a/src/core/http_request.rs
+++ b/src/core/http_request.rs
@@ -1,5 +1,5 @@
-use crate::error::{Error, Result};
-use crate::server::{auth_profiles, http};
+use crate::core::error::{Error, Result};
+use crate::core::server::{auth_profiles, http};
 use reqwest::blocking::Response;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Method;
@@ -128,7 +128,7 @@ fn response_headers(headers: &HeaderMap) -> BTreeMap<String, Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ErrorCode;
+    use crate::core::ErrorCode;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;

--- a/src/core/io/copy_tree.rs
+++ b/src/core/io/copy_tree.rs
@@ -9,7 +9,7 @@
 use std::fs;
 use std::path::Path;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 /// How [`copy_tree`] handles non-directory entries it encounters while walking
 /// the source tree, and how it formats IO error messages.

--- a/src/core/issues/apply.rs
+++ b/src/core/issues/apply.rs
@@ -6,7 +6,7 @@
 
 use serde::Serialize;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::plan::{ReconcileAction, ReconcilePlan, ReconcilePlanCounts};
 use super::tracker::{CloseReason, Tracker};

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -6,8 +6,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::code_audit::FindingConfidence;
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
+use crate::core::code_audit::FindingConfidence;
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 
 /// One row of incoming findings: "command produced N findings of category X
 /// for component Y." This is the input grain reconcile reasons over.

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -449,7 +449,7 @@ impl IssueGroup {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::FindingConfidence;
+    use crate::core::code_audit::FindingConfidence;
 
     fn group(category: &str, count: usize) -> IssueGroup {
         IssueGroup {

--- a/src/core/issues/render.rs
+++ b/src/core/issues/render.rs
@@ -10,7 +10,7 @@ use std::fmt::Write as _;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::code_audit::FindingConfidence;
+use crate::core::code_audit::FindingConfidence;
 
 /// Canonical input shape consumed by `homeboy issues reconcile`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -54,13 +54,13 @@ pub fn build_findings_from_native_output(
     command: &str,
     output: Value,
     context: &IssueRenderContext,
-) -> crate::Result<ReconcileFindingsInput> {
+) -> crate::core::Result<ReconcileFindingsInput> {
     let data = output.get("data").unwrap_or(&output);
     match command {
         "audit" => Ok(render_audit(data, context)),
         "lint" => Ok(render_lint(data, context)),
         "test" => Ok(render_test(data, context)),
-        other => Err(crate::Error::validation_invalid_argument(
+        other => Err(crate::core::Error::validation_invalid_argument(
             "command",
             format!("Unsupported native issue output command `{}`", other),
             None,

--- a/src/core/issues/tracker.rs
+++ b/src/core/issues/tracker.rs
@@ -9,8 +9,8 @@
 //! The default implementation [`GithubTracker`] wraps the existing
 //! `core/git/github.rs` primitives.
 
-use crate::error::Result;
-use crate::git::{
+use crate::core::error::Result;
+use crate::core::git::{
     issue_close, issue_create, issue_edit, issue_find, IssueCloseOptions, IssueCloseReason,
     IssueCreateOptions, IssueEditOptions, IssueFindOptions, IssueState,
 };
@@ -118,7 +118,7 @@ impl Tracker for GithubTracker {
             },
         )?;
         out.number.ok_or_else(|| {
-            crate::error::Error::internal_io(
+            crate::core::error::Error::internal_io(
                 "issue.create succeeded but returned no number".to_string(),
                 Some("gh issue create".into()),
             )
@@ -157,7 +157,7 @@ impl Tracker for GithubTracker {
 /// Translate a GitHub `GithubFindItem` into the tracker-agnostic
 /// [`TrackedIssue`] shape. Returns `None` when the issue's state shape is
 /// unrecognized — defensive against future GitHub state additions.
-fn github_to_tracked(item: crate::git::GithubFindItem) -> Option<TrackedIssue> {
+fn github_to_tracked(item: crate::core::git::GithubFindItem) -> Option<TrackedIssue> {
     let state = match item.state.to_lowercase().as_str() {
         "open" => TrackedIssueState::Open,
         "closed" => match item.state_reason.as_str() {
@@ -192,7 +192,7 @@ fn github_to_tracked(item: crate::git::GithubFindItem) -> Option<TrackedIssue> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::git::GithubFindItem;
+    use crate::core::git::GithubFindItem;
 
     fn item(state: &str, state_reason: &str) -> GithubFindItem {
         GithubFindItem {

--- a/src/core/keychain.rs
+++ b/src/core/keychain.rs
@@ -3,7 +3,7 @@
 //! Values are stored under service `homeboy` with account
 //! `<project-id>:<variable-name>`.
 
-use crate::error::{Error, ErrorCode, Result};
+use crate::core::error::{Error, ErrorCode, Result};
 use keyring::Entry;
 use serde_json::{json, Value};
 

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -1,4 +1,4 @@
-use crate::budget::BudgetFinding;
+use crate::core::budget::BudgetFinding;
 
 use super::records::NewFindingRecord;
 

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -11,7 +11,7 @@ pub struct ActiveObservation {
 }
 
 impl ActiveObservation {
-    pub fn start(record: NewRunRecord) -> crate::Result<Self> {
+    pub fn start(record: NewRunRecord) -> crate::core::Result<Self> {
         let store = ObservationStore::open_initialized()?;
         let initial_metadata = record.metadata_json.clone();
         let run = store.start_run(record)?;
@@ -140,7 +140,7 @@ fn pid_is_running(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::observation::FindingListFilter;
+    use crate::core::observation::FindingListFilter;
     use crate::test_support::with_isolated_home;
     use std::fs;
 

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
-use crate::code_audit::{self, report::finding_kind_key};
-use crate::extension::lint::LintFinding;
+use crate::core::code_audit::{self, report::finding_kind_key};
+use crate::core::extension::lint::LintFinding;
 
 mod run_builder;
 mod run_status;
@@ -211,7 +211,7 @@ fn audit_severity_key(severity: &code_audit::Severity) -> String {
 pub fn finding_records_from_annotations_dir(
     run_id: &str,
     annotations_dir: &Path,
-) -> crate::error::Result<Vec<NewFindingRecord>> {
+) -> crate::core::error::Result<Vec<NewFindingRecord>> {
     if !annotations_dir.exists() {
         return Ok(Vec::new());
     }
@@ -233,8 +233,8 @@ pub fn finding_records_from_annotations_dir(
     Ok(records)
 }
 
-fn annotation_dir_error(action: &str, path: &Path, error: std::io::Error) -> crate::Error {
-    crate::Error::internal_io(
+fn annotation_dir_error(action: &str, path: &Path, error: std::io::Error) -> crate::core::Error {
+    crate::core::Error::internal_io(
         format!(
             "Failed to {} annotations dir {}: {}",
             action,
@@ -248,13 +248,13 @@ fn annotation_dir_error(action: &str, path: &Path, error: std::io::Error) -> cra
 pub fn finding_records_from_annotation_file(
     run_id: &str,
     path: &Path,
-) -> crate::error::Result<Vec<NewFindingRecord>> {
+) -> crate::core::error::Result<Vec<NewFindingRecord>> {
     if !path.exists() {
         return Ok(Vec::new());
     }
 
     let content = std::fs::read_to_string(path).map_err(|e| {
-        crate::Error::internal_io(
+        crate::core::Error::internal_io(
             format!("Failed to read annotations file {}: {}", path.display(), e),
             Some("observation.findings.annotations".to_string()),
         )
@@ -265,7 +265,7 @@ pub fn finding_records_from_annotation_file(
 
     let annotations: Vec<AnnotationFindingRecord> =
         serde_json::from_str(&content).map_err(|e| {
-            crate::Error::internal_io(
+            crate::core::Error::internal_io(
                 format!("Malformed annotations JSON in {}: {}", path.display(), e),
                 Some("observation.findings.annotations".to_string()),
             )

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -14,7 +14,7 @@ use super::records::{
     NewTraceRunRecord, NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord,
     RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
-use crate::{paths, Error, Result};
+use crate::core::{paths, Error, Result};
 
 pub const CURRENT_SCHEMA_VERSION: i64 = 5;
 
@@ -1504,7 +1504,7 @@ mod api_coverage_tests {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
             let artifact_root = home.path().join("agent-readable-artifacts");
-            crate::set_artifact_root_override(Some(artifact_root.clone()));
+            crate::core::set_artifact_root_override(Some(artifact_root.clone()));
             let store = ObservationStore::open_initialized().expect("store");
             let run = store.start_run(new_run("bench")).expect("start");
             let path = home.path().join("artifact.json");

--- a/src/core/observation/store/triage_items.rs
+++ b/src/core/observation/store/triage_items.rs
@@ -170,7 +170,7 @@ fn row_to_triage_item_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Triage
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::observation::NewRunRecord;
+    use crate::core::observation::NewRunRecord;
     use crate::test_support::with_isolated_home;
 
     #[test]

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 use std::env;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
@@ -111,7 +111,7 @@ pub fn artifact_root() -> Result<PathBuf> {
         }
     }
 
-    if let Some(path) = crate::defaults::load_config().artifact_root {
+    if let Some(path) = crate::core::defaults::load_config().artifact_root {
         if !path.trim().is_empty() {
             return Ok(expand_path(PathBuf::from(path)));
         }
@@ -377,9 +377,9 @@ mod tests {
     fn artifact_root_uses_configured_value() {
         with_isolated_home(|home| {
             let configured = home.path().join("custom-artifacts");
-            crate::defaults::save_config(&crate::defaults::HomeboyConfig {
+            crate::core::defaults::save_config(&crate::core::defaults::HomeboyConfig {
                 artifact_root: Some(configured.to_string_lossy().to_string()),
-                ..crate::defaults::HomeboyConfig::default()
+                ..crate::core::defaults::HomeboyConfig::default()
             })
             .expect("save config");
 
@@ -392,9 +392,9 @@ mod tests {
         with_isolated_home(|home| {
             let configured = home.path().join("config-artifacts");
             let env_root = home.path().join("env-artifacts");
-            crate::defaults::save_config(&crate::defaults::HomeboyConfig {
+            crate::core::defaults::save_config(&crate::core::defaults::HomeboyConfig {
                 artifact_root: Some(configured.to_string_lossy().to_string()),
-                ..crate::defaults::HomeboyConfig::default()
+                ..crate::core::defaults::HomeboyConfig::default()
             })
             .expect("save config");
             std::env::set_var("HOMEBOY_ARTIFACT_ROOT", &env_root);

--- a/src/core/project/component/attachments.rs
+++ b/src/core/project/component/attachments.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::discovery::{discover_attached_component, infer_attached_component_id};
-use crate::project::{load, save, Project, ProjectComponentAttachment};
+use crate::core::project::{load, save, Project, ProjectComponentAttachment};
 
 fn component_ids_from_attachments(components: &[ProjectComponentAttachment]) -> Vec<String> {
     components

--- a/src/core/project/component/discovery.rs
+++ b/src/core/project/component/discovery.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use crate::component;
-use crate::error::Result;
+use crate::core::component;
+use crate::core::error::Result;
 
 pub fn infer_attached_component_id(local_path: &Path) -> Result<String> {
     component::infer_portable_component_id(local_path)

--- a/src/core/project/component/overrides.rs
+++ b/src/core/project/component/overrides.rs
@@ -1,11 +1,11 @@
-use crate::project::{Project, ProjectComponentOverrides};
+use crate::core::project::{Project, ProjectComponentOverrides};
 
 /// Apply a single layer of component overrides to a component.
 ///
 /// Fields from the overrides are applied only when present (Some), allowing
 /// each config layer to selectively override specific settings.
 fn apply_overrides_layer(
-    component: &mut crate::component::Component,
+    component: &mut crate::core::component::Component,
     overrides: &ProjectComponentOverrides,
 ) {
     if let Some(remote_path) = &overrides.remote_path {
@@ -44,17 +44,17 @@ fn apply_overrides_layer(
 ///
 /// `cli_path` has an extra fallback step: if no explicit override at any layer
 /// sets it, the project-scoped `Project::cli_path` (or Studio auto-detect) fills
-/// it in via [`crate::project::project_cli_path`]. This makes "every component
+/// it in via [`crate::core::project::project_cli_path`]. This makes "every component
 /// on this site uses `studio wp`" a one-line project config instead of a per-
 /// component repeat. Component-level `cli_path` still wins as the most-specific
 /// escape hatch.
 pub fn apply_component_overrides(
-    component: &crate::component::Component,
+    component: &crate::core::component::Component,
     project: &Project,
-) -> crate::component::Component {
+) -> crate::core::component::Component {
     let fleet_overrides = resolve_fleet_overrides(project, &component.id);
     let project_overrides = project.component_overrides.get(&component.id);
-    let project_cli_fallback = crate::project::project_cli_path(project);
+    let project_cli_fallback = crate::core::project::project_cli_path(project);
 
     if fleet_overrides.is_none() && project_overrides.is_none() && project_cli_fallback.is_none() {
         return component.clone();
@@ -94,7 +94,7 @@ fn resolve_fleet_overrides(
     project: &Project,
     component_id: &str,
 ) -> Option<ProjectComponentOverrides> {
-    let fleets = crate::fleet::list().ok()?;
+    let fleets = crate::core::fleet::list().ok()?;
 
     for fleet in &fleets {
         if fleet.project_ids.contains(&project.id) {
@@ -110,7 +110,7 @@ fn resolve_fleet_overrides(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::Component;
+    use crate::core::component::Component;
     use std::collections::HashMap;
 
     fn base_component(id: &str) -> Component {

--- a/src/core/project/component/report.rs
+++ b/src/core/project/component/report.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use crate::component::Component;
-use crate::error::{Error, Result};
-use crate::project::{load, resolve_project_components, Project, ProjectComponentAttachment};
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::project::{load, resolve_project_components, Project, ProjectComponentAttachment};
 
 use super::{
     attach_discovered_component_path, clear_component_attachments, project_component_ids,
@@ -25,7 +25,7 @@ pub fn list_components(project_id: &str) -> Result<ProjectComponentsOutput> {
 }
 
 pub fn set_components(project_id: &str, json_spec: &str) -> Result<ProjectComponentsOutput> {
-    let raw = crate::config::read_json_spec_to_string(json_spec)?;
+    let raw = crate::core::config::read_json_spec_to_string(json_spec)?;
     let attachments: Vec<ProjectComponentAttachment> = serde_json::from_str(&raw).map_err(|e| {
         Error::validation_invalid_json(
             e,

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -1,5 +1,5 @@
-use crate::error::{Error, Result};
-use crate::project::Project;
+use crate::core::error::{Error, Result};
+use crate::core::project::Project;
 
 use super::discovery::discover_attached_component;
 use super::overrides::apply_component_overrides;
@@ -7,7 +7,7 @@ use super::overrides::apply_component_overrides;
 pub fn resolve_project_component(
     project: &Project,
     component_id: &str,
-) -> Result<crate::component::Component> {
+) -> Result<crate::core::component::Component> {
     let component = if let Some(attachment) = project
         .components
         .iter()
@@ -59,7 +59,9 @@ pub fn resolve_project_component(
     Ok(resolved)
 }
 
-pub fn resolve_project_components(project: &Project) -> Result<Vec<crate::component::Component>> {
+pub fn resolve_project_components(
+    project: &Project,
+) -> Result<Vec<crate::core::component::Component>> {
     project
         .components
         .iter()

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -6,14 +6,14 @@
 use serde::Serialize;
 use std::io::{self, Read};
 
-use crate::context::{require_project_base_path, resolve_project_ssh_with_base_path};
-use crate::defaults;
-use crate::engine::executor::execute_for_project;
-use crate::engine::text;
-use crate::engine::{command, shell};
-use crate::error::{Error, Result};
-use crate::paths::{self as base_path, resolve_path_string};
-use crate::project;
+use crate::core::context::{require_project_base_path, resolve_project_ssh_with_base_path};
+use crate::core::defaults;
+use crate::core::engine::executor::execute_for_project;
+use crate::core::engine::text;
+use crate::core::engine::{command, shell};
+use crate::core::error::{Error, Result};
+use crate::core::paths::{self as base_path, resolve_path_string};
+use crate::core::project;
 
 use std::path::Path;
 use std::process::Command;

--- a/src/core/project/logs.rs
+++ b/src/core/project/logs.rs
@@ -5,12 +5,12 @@
 //! Pass `local: true` to bypass SSH and execute commands directly on the
 //! current machine (useful when homeboy runs on the target server itself).
 
-use crate::context::require_project_base_path;
-use crate::engine::executor::{execute_for_project, execute_for_project_interactive};
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::paths as base_path;
-use crate::project::{self, Project};
+use crate::core::context::require_project_base_path;
+use crate::core::engine::executor::{execute_for_project, execute_for_project_interactive};
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::paths as base_path;
+use crate::core::project::{self, Project};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -1,10 +1,10 @@
-use crate::component::ScopedExtensionConfig;
-use crate::config::{self, ConfigEntity};
-use crate::engine::local_files::{self, FileSystem};
-use crate::error::{Error, Result};
-use crate::output::{CreateOutput, MergeOutput, RemoveResult};
-use crate::paths;
-use crate::server;
+use crate::core::component::ScopedExtensionConfig;
+use crate::core::config::{self, ConfigEntity};
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::error::{Error, Result};
+use crate::core::output::{CreateOutput, MergeOutput, RemoveResult};
+use crate::core::paths;
+use crate::core::server;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -59,11 +59,11 @@ pub struct ProjectComponentOverrides {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deploy_strategy: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub git_deploy: Option<crate::component::GitDeployConfig>,
+    pub git_deploy: Option<crate::core::component::GitDeployConfig>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub hooks: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scopes: Option<crate::component::ScopeConfig>,
+    pub scopes: Option<crate::core::component::ScopeConfig>,
     /// Override the CLI path used by extension deploy install steps.
     /// For example, Studio sites need "studio wp" instead of the default "wp".
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/project/pins.rs
+++ b/src/core/project/pins.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::{load, pin, save, unpin, PinOptions, PinType, Project};
 
@@ -363,7 +363,9 @@ fn pin_type_name(pin_type: PinType) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::project::{PinnedRemoteFile, PinnedRemoteLog, RemoteFileConfig, RemoteLogConfig};
+    use crate::core::project::{
+        PinnedRemoteFile, PinnedRemoteLog, RemoteFileConfig, RemoteLogConfig,
+    };
 
     fn project() -> Project {
         Project {

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -1,4 +1,4 @@
-use crate::component;
+use crate::core::component;
 
 use super::Project;
 
@@ -12,7 +12,7 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
                 project.id
             ));
         }
-        Some(sid) if !crate::server::exists(sid) => {
+        Some(sid) if !crate::core::server::exists(sid) => {
             blockers.push(format!(
                 "Server '{}' not found - create with: homeboy server set {} '{{\"host\": \"...\", \"user\": \"...\"}}'",
                 sid, sid

--- a/src/core/project/report.rs
+++ b/src/core/project/report.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
-use crate::error::Result;
-use crate::output::{CreateOutput, EntityCrudOutput, MergeOutput, RemoveResult};
+use crate::core::error::Result;
+use crate::core::output::{CreateOutput, EntityCrudOutput, MergeOutput, RemoveResult};
 
 use super::{calculate_deploy_readiness, collect_status, list, load, Project};
 
@@ -41,7 +41,7 @@ pub struct ProjectListReport {
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectStatusReport {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub health: Option<crate::server::health::ServerHealth>,
+    pub health: Option<crate::core::server::health::ServerHealth>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_versions: Option<Vec<ProjectComponentVersion>>,
 }
@@ -51,9 +51,9 @@ pub struct ProjectReportExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub projects: Option<Vec<ProjectListItem>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub components: Option<crate::project::ProjectComponentsOutput>,
+    pub components: Option<crate::core::project::ProjectComponentsOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pin: Option<crate::project::ProjectPinOutput>,
+    pub pin: Option<crate::core::project::ProjectPinOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub removed: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -61,7 +61,7 @@ pub struct ProjectReportExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deploy_blockers: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub health: Option<crate::server::health::ServerHealth>,
+    pub health: Option<crate::core::server::health::ServerHealth>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_versions: Option<Vec<ProjectComponentVersion>>,
 }
@@ -260,7 +260,7 @@ pub fn build_delete_output(project_id: &str) -> ProjectReportOutput {
 pub fn build_components_output(
     project_id: &str,
     action: &str,
-    components: crate::project::ProjectComponentsOutput,
+    components: crate::core::project::ProjectComponentsOutput,
 ) -> ProjectReportOutput {
     ProjectReportOutput {
         command: format!("project.components.{action}"),
@@ -277,7 +277,7 @@ pub fn build_components_output(
 pub fn build_pin_output(
     command: &str,
     project_id: &str,
-    pin: crate::project::ProjectPinOutput,
+    pin: crate::core::project::ProjectPinOutput,
 ) -> ProjectReportOutput {
     ProjectReportOutput {
         command: command.to_string(),

--- a/src/core/project/status.rs
+++ b/src/core/project/status.rs
@@ -1,5 +1,5 @@
-use crate::deploy::{self, DeployConfig};
-use crate::server::health::{self, ServerHealth};
+use crate::core::deploy::{self, DeployConfig};
+use crate::core::server::health::{self, ServerHealth};
 
 #[derive(Debug, Clone)]
 pub struct ProjectComponentStatus {

--- a/src/core/quality.rs
+++ b/src/core/quality.rs
@@ -1,4 +1,4 @@
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QualityPlanOptions {
@@ -149,7 +149,7 @@ fn step_id(prefix: &str, name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{build_quality_plan, build_quality_steps, QualityPlanOptions};
-    use crate::plan::{PlanKind, PlanStepStatus};
+    use crate::core::plan::{PlanKind, PlanStepStatus};
 
     #[test]
     fn test_release_preflight() {

--- a/src/core/refactor/add.rs
+++ b/src/core/refactor/add.rs
@@ -8,10 +8,12 @@
 
 use std::path::Path;
 
-use crate::code_audit::CodeAuditResult;
-use crate::refactor::auto::{self, ChunkStatus, Fix, FixResult, Insertion, InsertionKind, NewFile};
-use crate::refactor::plan;
-use crate::Result;
+use crate::core::code_audit::CodeAuditResult;
+use crate::core::refactor::auto::{
+    self, ChunkStatus, Fix, FixResult, Insertion, InsertionKind, NewFile,
+};
+use crate::core::refactor::plan;
+use crate::core::Result;
 
 /// Result of an explicit import addition (not from audit).
 #[derive(Debug, Clone, serde::Serialize)]
@@ -36,7 +38,7 @@ pub fn fixes_from_audit(audit: &CodeAuditResult, write: bool) -> Result<FixResul
     let root = Path::new(&audit.source_path);
 
     if !root.is_dir() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "from-audit",
             format!(
                 "Audit source_path '{}' is not a directory on this machine. \
@@ -82,7 +84,7 @@ pub fn add_import(
     let matched_files = resolve_target_files(&root, target)?;
 
     if matched_files.is_empty() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "to",
             format!("No files matched pattern '{}'", target),
             None,
@@ -98,7 +100,7 @@ pub fn add_import(
     for file_path in &matched_files {
         let abs_path = root.join(file_path);
         let content = std::fs::read_to_string(&abs_path).map_err(|e| {
-            crate::Error::internal_io(e.to_string(), Some(format!("read {}", file_path)))
+            crate::core::Error::internal_io(e.to_string(), Some(format!("read {}", file_path)))
         })?;
 
         // Skip if the import already exists in the file
@@ -113,7 +115,7 @@ pub fn add_import(
             insertions: vec![Insertion {
                 primitive: None,
                 kind: InsertionKind::ImportAdd,
-                finding: crate::code_audit::AuditFinding::MissingImport,
+                finding: crate::core::code_audit::AuditFinding::MissingImport,
                 manual_only: false,
                 auto_apply: false,
                 blocked_reason: None,
@@ -167,7 +169,7 @@ fn resolve_target_files(root: &Path, target: &str) -> Result<Vec<String>> {
     let glob_pattern = root.join(target).to_string_lossy().to_string();
     let entries: Vec<String> = glob::glob(&glob_pattern)
         .map_err(|e| {
-            crate::Error::validation_invalid_argument(
+            crate::core::Error::validation_invalid_argument(
                 "to",
                 format!("Invalid glob pattern '{}': {}", target, e),
                 None,
@@ -314,7 +316,7 @@ mod tests {
         let audit = CodeAuditResult {
             component_id: "test".to_string(),
             source_path: "/nonexistent/path/that/should/not/exist".to_string(),
-            summary: crate::code_audit::AuditSummary {
+            summary: crate::core::code_audit::AuditSummary {
                 files_scanned: 0,
                 conventions_detected: 0,
                 outliers_found: 0,

--- a/src/core/refactor/auto/apply.rs
+++ b/src/core/refactor/auto/apply.rs
@@ -1,12 +1,12 @@
 use crate::core::refactor::decompose;
 use crate::core::refactor::plan::verify::rewrite_callers_after_dedup;
 
-use crate::engine::undo::InMemoryRollback;
-use crate::extension::AutofixVerifyConfig;
-use crate::refactor::auto::verify::{
+use crate::core::engine::undo::InMemoryRollback;
+use crate::core::extension::AutofixVerifyConfig;
+use crate::core::refactor::auto::verify::{
     applied_files_from_chunks, capture_pre_apply_snapshot, run_verify_gate,
 };
-use crate::refactor::auto::{ApplyChunkResult, ChunkStatus, DecomposeFixPlan, Fix, NewFile};
+use crate::core::refactor::auto::{ApplyChunkResult, ChunkStatus, DecomposeFixPlan, Fix, NewFile};
 use std::path::Path;
 
 // ============================================================================
@@ -25,8 +25,8 @@ pub fn apply_fixes_via_edit_ops(
     new_files: &mut [NewFile],
     root: &Path,
 ) -> Vec<ApplyChunkResult> {
-    use crate::engine::edit_op::{fix_to_edit_ops, new_file_to_edit_op, TaggedEditOp};
-    use crate::engine::edit_op_apply::apply_edit_ops;
+    use crate::core::engine::edit_op::{fix_to_edit_ops, new_file_to_edit_op, TaggedEditOp};
+    use crate::core::engine::edit_op_apply::apply_edit_ops;
 
     // Merge same-file insertions (same as old path)
     merge_same_file_insertions(fixes);
@@ -164,7 +164,7 @@ pub fn apply_fixes_via_edit_ops(
 
     // Format all modified/created files in one batch
     if !formatted_files.is_empty() {
-        let _ = crate::engine::format_write::format_after_write(root, &formatted_files);
+        let _ = crate::core::engine::format_write::format_after_write(root, &formatted_files);
     }
 
     // Run post-apply hooks for duplicate function fixes (caller rewriting)
@@ -363,8 +363,8 @@ pub fn apply_decompose_plans(plans: &mut [DecomposeFixPlan], root: &Path) -> Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::AuditFinding;
-    use crate::refactor::auto::{Insertion, InsertionKind};
+    use crate::core::code_audit::AuditFinding;
+    use crate::core::refactor::auto::{Insertion, InsertionKind};
 
     fn removal_insertion(start_line: usize, end_line: usize, description: &str) -> Insertion {
         Insertion {

--- a/src/core/refactor/auto/contracts.rs
+++ b/src/core/refactor/auto/contracts.rs
@@ -1,4 +1,4 @@
-use crate::code_audit::conventions::AuditFinding;
+use crate::core::code_audit::conventions::AuditFinding;
 use crate::core::refactor::decompose;
 
 /// A planned fix for a single file.

--- a/src/core/refactor/auto/policy.rs
+++ b/src/core/refactor/auto/policy.rs
@@ -1,5 +1,5 @@
-use crate::code_audit::AuditFinding;
-use crate::refactor::auto::{FixPolicy, FixResult, Insertion, NewFile, PolicySummary};
+use crate::core::code_audit::AuditFinding;
+use crate::core::refactor::auto::{FixPolicy, FixResult, Insertion, NewFile, PolicySummary};
 
 fn finding_allowed(finding: &AuditFinding, policy: &FixPolicy) -> bool {
     let included = policy
@@ -147,7 +147,7 @@ pub fn apply_fix_policy(result: &mut FixResult, write: bool, policy: &FixPolicy)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::refactor::auto::{Fix, FixResult, InsertionKind};
+    use crate::core::refactor::auto::{Fix, FixResult, InsertionKind};
 
     fn insertion(finding: AuditFinding) -> Insertion {
         Insertion {

--- a/src/core/refactor/auto/sidecar.rs
+++ b/src/core/refactor/auto/sidecar.rs
@@ -1,5 +1,5 @@
 use super::outcome::{AutofixSidecarFiles, FixApplied};
-use crate::engine::run_dir::{self, RunDir};
+use crate::core::engine::run_dir::{self, RunDir};
 use std::path::Path;
 
 impl AutofixSidecarFiles {

--- a/src/core/refactor/auto/summary.rs
+++ b/src/core/refactor/auto/summary.rs
@@ -1,5 +1,5 @@
 use super::outcome::{FixApplied, FixResultsSummary, PrimitiveFixCount, RuleFixCount};
-use crate::refactor::FixResult;
+use crate::core::refactor::FixResult;
 
 pub fn summarize_fix_results(fixes: &[FixApplied]) -> FixResultsSummary {
     use std::collections::{BTreeMap, HashSet};
@@ -109,7 +109,7 @@ pub fn summarize_audit_fix_result(fix_result: &FixResult) -> FixResultsSummary {
 /// Derive the primitive name from serde's `#[serde(tag = "type", rename_all = "snake_case")]`
 /// attribute on `RefactorPrimitive`. This eliminates manual match arms — adding a new
 /// variant to the enum automatically works for reporting.
-pub fn primitive_name(primitive: &crate::refactor::RefactorPrimitive) -> String {
+pub fn primitive_name(primitive: &crate::core::refactor::RefactorPrimitive) -> String {
     // RefactorPrimitive uses `#[serde(tag = "type", rename_all = "snake_case")]`.
     // Serializing to JSON gives `{"type": "snake_case_name", ...}`.
     // Extract the "type" field value.
@@ -122,7 +122,7 @@ pub fn primitive_name(primitive: &crate::refactor::RefactorPrimitive) -> String 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::refactor::RefactorPrimitive;
+    use crate::core::refactor::RefactorPrimitive;
 
     #[test]
     fn primitive_name_derives_from_serde() {

--- a/src/core/refactor/auto/tracking.rs
+++ b/src/core/refactor/auto/tracking.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
 #[cfg(not(test))]
-pub fn changed_file_set(local_path: &str) -> crate::Result<HashSet<String>> {
-    let uncommitted = crate::git::get_uncommitted_changes(local_path)?;
+pub fn changed_file_set(local_path: &str) -> crate::core::Result<HashSet<String>> {
+    let uncommitted = crate::core::git::get_uncommitted_changes(local_path)?;
     let mut files = HashSet::new();
     files.extend(uncommitted.staged);
     files.extend(uncommitted.unstaged);
@@ -11,12 +11,12 @@ pub fn changed_file_set(local_path: &str) -> crate::Result<HashSet<String>> {
 }
 
 #[cfg(test)]
-pub fn changed_file_set(local_path: &str) -> crate::Result<HashSet<String>> {
+pub fn changed_file_set(local_path: &str) -> crate::core::Result<HashSet<String>> {
     let path = std::path::Path::new(local_path);
     if path.exists() {
         Ok(HashSet::new())
     } else {
-        crate::git::get_uncommitted_changes(local_path).map(|changes| {
+        crate::core::git::get_uncommitted_changes(local_path).map(|changes| {
             let mut files = HashSet::new();
             files.extend(changes.staged);
             files.extend(changes.unstaged);

--- a/src/core/refactor/auto/verify.rs
+++ b/src/core/refactor/auto/verify.rs
@@ -32,9 +32,9 @@
 //!
 //! Default: gate runs when the extension provides an `autofix_verify` config.
 
-use crate::engine::undo::InMemoryRollback;
-use crate::extension::AutofixVerifyConfig;
-use crate::refactor::auto::{ApplyChunkResult, ChunkStatus};
+use crate::core::engine::undo::InMemoryRollback;
+use crate::core::extension::AutofixVerifyConfig;
+use crate::core::refactor::auto::{ApplyChunkResult, ChunkStatus};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -333,7 +333,7 @@ pub fn applied_files_from_chunks(chunks: &[ApplyChunkResult]) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::refactor::auto::{ApplyChunkResult, ChunkStatus};
+    use crate::core::refactor::auto::{ApplyChunkResult, ChunkStatus};
     use std::fs;
 
     fn chunk(name: &str, files: &[&str], status: ChunkStatus) -> ApplyChunkResult {

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::extension::{self, grammar, grammar_items, ParsedItem};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
-use crate::Result;
+use crate::core::extension::{self, grammar, grammar_items, ParsedItem};
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
+use crate::core::Result;
 
 use super::move_items::{MoveOptions, MoveResult};
 
@@ -42,7 +42,7 @@ pub struct DecomposeGroup {
 
 pub fn build_plan(file: &str, root: &Path, strategy: &str) -> Result<DecomposePlan> {
     if strategy != "grouped" {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "strategy",
             format!("Unsupported strategy '{}'. Use: grouped", strategy),
             None,
@@ -52,7 +52,7 @@ pub fn build_plan(file: &str, root: &Path, strategy: &str) -> Result<DecomposePl
 
     let source_path = root.join(file);
     if !source_path.is_file() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "file",
             format!("Source file does not exist: {}", file),
             None,
@@ -60,8 +60,9 @@ pub fn build_plan(file: &str, root: &Path, strategy: &str) -> Result<DecomposePl
         ));
     }
 
-    let content = std::fs::read_to_string(&source_path)
-        .map_err(|e| crate::Error::internal_io(e.to_string(), Some(format!("read {}", file))))?;
+    let content = std::fs::read_to_string(&source_path).map_err(|e| {
+        crate::core::Error::internal_io(e.to_string(), Some(format!("read {}", file)))
+    })?;
 
     let mut warnings = Vec::new();
     let items = parse_items(file, &content).unwrap_or_else(|| {
@@ -261,7 +262,7 @@ pub fn apply_plan_skeletons(plan: &DecomposePlan, root: &Path) -> Result<Vec<Str
 
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                crate::Error::internal_io(
+                crate::core::Error::internal_io(
                     e.to_string(),
                     Some(format!("create directory {}", parent.display())),
                 )
@@ -275,7 +276,10 @@ pub fn apply_plan_skeletons(plan: &DecomposePlan, root: &Path) -> Result<Vec<Str
         );
 
         std::fs::write(&path, header).map_err(|e| {
-            crate::Error::internal_io(e.to_string(), Some(format!("write {}", path.display())))
+            crate::core::Error::internal_io(
+                e.to_string(),
+                Some(format!("write {}", path.display())),
+            )
         })?;
         created.push(group.suggested_target.clone());
     }
@@ -1377,7 +1381,7 @@ fn split_oversized_group(name: &str, names: &[String]) -> Vec<(String, Vec<Strin
 fn validate_plan_sources(plan: &DecomposePlan, root: &Path) -> Result<()> {
     let source_path = root.join(&plan.file);
     let content = std::fs::read_to_string(&source_path).map_err(|e| {
-        crate::Error::internal_io(e.to_string(), Some("pre-write validation".to_string()))
+        crate::core::Error::internal_io(e.to_string(), Some("pre-write validation".to_string()))
     })?;
 
     let ext = Path::new(&plan.file).extension().and_then(|e| e.to_str());
@@ -1392,7 +1396,7 @@ fn validate_plan_sources(plan: &DecomposePlan, root: &Path) -> Result<()> {
         let items = grammar_items::parse_items(&content, &grammar);
         for item in &items {
             if !grammar_items::validate_brace_balance(&item.source, &grammar) {
-                return Err(crate::Error::validation_invalid_argument(
+                return Err(crate::core::Error::validation_invalid_argument(
                     "file",
                     format!(
                         "Pre-write validation failed: item '{}' (lines {}-{}) has unbalanced braces. \
@@ -1753,7 +1757,7 @@ fn public_items_for_group(plan: &DecomposePlan, group: &DecomposeGroup) -> Vec<S
 }
 
 fn parse_items_for_group_export(ext: &str, content: &str, file: &str) -> Option<Vec<ParsedItem>> {
-    let manifest = crate::extension::find_extension_for_file_ext(ext, "refactor")?;
+    let manifest = crate::core::extension::find_extension_for_file_ext(ext, "refactor")?;
     crate::core::refactor::move_items::ext_parse_items(&manifest, content, file)
         .or_else(|| crate::core::refactor::move_items::core_parse_items(&manifest, content))
 }

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -3,7 +3,7 @@
 //! Walks source files, finds all references to a term (with word-boundary matching
 //! and case-variant awareness), generates edits, and optionally applies them.
 
-use crate::refactor::auto::{AppliedAutofixCapture, FixResultsSummary};
+use crate::core::refactor::auto::{AppliedAutofixCapture, FixResultsSummary};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -17,11 +17,14 @@ mod rename;
 pub mod transform;
 
 /// Resolve the refactor root directory from an explicit path or component id.
-pub fn resolve_root(component_id: Option<&str>, path: Option<&str>) -> crate::Result<PathBuf> {
+pub fn resolve_root(
+    component_id: Option<&str>,
+    path: Option<&str>,
+) -> crate::core::Result<PathBuf> {
     if let Some(p) = path {
         let pb = PathBuf::from(p);
         if !pb.is_dir() {
-            return Err(crate::Error::validation_invalid_argument(
+            return Err(crate::core::Error::validation_invalid_argument(
                 "path",
                 format!("Not a directory: {}", p),
                 None,
@@ -30,8 +33,8 @@ pub fn resolve_root(component_id: Option<&str>, path: Option<&str>) -> crate::Re
         }
         Ok(pb)
     } else {
-        let comp = crate::component::resolve(component_id)?;
-        crate::component::validate_local_path(&comp)
+        let comp = crate::core::component::resolve(component_id)?;
+        crate::core::component::validate_local_path(&comp)
     }
 }
 

--- a/src/core/refactor/move_items.rs
+++ b/src/core/refactor/move_items.rs
@@ -26,12 +26,12 @@ pub use whole_file_move::*;
 
 use std::path::{Path, PathBuf};
 
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use crate::core::engine::symbol_graph::module_path_from_file;
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::extension::{
+use crate::core::extension::{
     self, AdjustedItem, ExtensionManifest, ParsedItem, RelatedTests, ResolvedImports,
 };
-use crate::Result;
+use crate::core::Result;
 
 impl ItemKind {
     fn from_str(s: &str) -> Self {
@@ -205,7 +205,7 @@ pub fn move_items_with_options(
         .is_some_and(|ext| ext == "inc");
 
     if !from_path.is_file() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "from",
             format!("Source file does not exist: {}", from),
             None,
@@ -213,8 +213,9 @@ pub fn move_items_with_options(
         ));
     }
 
-    let content = std::fs::read_to_string(&from_path)
-        .map_err(|e| crate::Error::internal_io(e.to_string(), Some(format!("read {}", from))))?;
+    let content = std::fs::read_to_string(&from_path).map_err(|e| {
+        crate::core::Error::internal_io(e.to_string(), Some(format!("read {}", from)))
+    })?;
 
     // Try to find a refactor-capable extension for this file type
     let ext = find_refactor_extension(from);
@@ -244,7 +245,7 @@ pub fn move_items_with_options(
 
     if all_items.is_empty() && ext.is_some() {
         // Extension returned nothing — might be a script error
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "from",
             format!("No items found in {}", from),
             None,
@@ -253,7 +254,7 @@ pub fn move_items_with_options(
             ]),
         ));
     } else if all_items.is_empty() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "from",
             format!("No refactor extension available for {} and no items could be parsed", from),
             None,
@@ -278,7 +279,7 @@ pub fn move_items_with_options(
 
     if !missing.is_empty() {
         let available: Vec<&str> = all_items.iter().map(|i| i.name.as_str()).collect();
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "item",
             format!("Item(s) not found in {}: {}", from, missing.join(", ")),
             None,
@@ -605,23 +606,27 @@ pub fn move_items_with_options(
         // Create parent directory if needed
         if let Some(parent) = to_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                crate::Error::internal_io(e.to_string(), Some(format!("create dir for {}", to)))
+                crate::core::Error::internal_io(
+                    e.to_string(),
+                    Some(format!("create dir for {}", to)),
+                )
             })?;
         }
 
         // Write destination
-        std::fs::write(&to_path, &final_dest)
-            .map_err(|e| crate::Error::internal_io(e.to_string(), Some(format!("write {}", to))))?;
+        std::fs::write(&to_path, &final_dest).map_err(|e| {
+            crate::core::Error::internal_io(e.to_string(), Some(format!("write {}", to)))
+        })?;
 
         // Write modified source
         std::fs::write(&from_path, &modified_source).map_err(|e| {
-            crate::Error::internal_io(e.to_string(), Some(format!("write {}", from)))
+            crate::core::Error::internal_io(e.to_string(), Some(format!("write {}", from)))
         })?;
 
         // Apply caller import rewrites
         for (file_path, rewrites) in &caller_rewrites {
             let file_content = std::fs::read_to_string(file_path).map_err(|e| {
-                crate::Error::internal_io(
+                crate::core::Error::internal_io(
                     e.to_string(),
                     Some(format!("read {}", file_path.display())),
                 )
@@ -643,7 +648,7 @@ pub fn move_items_with_options(
             };
 
             std::fs::write(file_path, &modified).map_err(|e| {
-                crate::Error::internal_io(
+                crate::core::Error::internal_io(
                     e.to_string(),
                     Some(format!("write {}", file_path.display())),
                 )

--- a/src/core/refactor/move_items/extension_integration.rs
+++ b/src/core/refactor/move_items/extension_integration.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::extension::{self, grammar, grammar_items, ExtensionManifest, ParsedItem};
+use crate::core::extension::{self, grammar, grammar_items, ExtensionManifest, ParsedItem};
 
 /// Find a refactor-capable extension for a file based on its extension.
 pub(crate) fn find_refactor_extension(file_path: &str) -> Option<ExtensionManifest> {

--- a/src/core/refactor/move_items/whole_file_move.rs
+++ b/src/core/refactor/move_items/whole_file_move.rs
@@ -2,9 +2,9 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use crate::core::engine::symbol_graph::module_path_from_file;
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::Result;
+use crate::core::Result;
 
 use super::{
     core_parse_items, ext_parse_items, ext_rewrite_caller_imports, find_refactor_extension,
@@ -25,7 +25,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
 
     // Validate source exists
     if !source_abs.exists() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "from",
             format!("Source file does not exist: {}", from),
             None,
@@ -35,7 +35,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
 
     // Validate destination doesn't exist
     if dest_abs.exists() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "to",
             format!("Destination already exists: {}", to),
             None,
@@ -157,7 +157,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
         // Create destination parent directory
         if let Some(parent) = dest_abs.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                crate::Error::internal_io(
+                crate::core::Error::internal_io(
                     e.to_string(),
                     Some(format!("create directory {}", parent.display())),
                 )
@@ -166,7 +166,7 @@ pub fn move_file(from: &str, to: &str, root: &Path, write: bool) -> Result<MoveF
 
         // Move the file
         std::fs::rename(&source_abs, &dest_abs).map_err(|e| {
-            crate::Error::internal_io(e.to_string(), Some(format!("move {} → {}", from, to)))
+            crate::core::Error::internal_io(e.to_string(), Some(format!("move {} → {}", from, to)))
         })?;
 
         // Update old parent mod.rs — remove mod declaration

--- a/src/core/refactor/plan/file_intent.rs
+++ b/src/core/refactor/plan/file_intent.rs
@@ -202,7 +202,7 @@ fn priority(intent: &FileIntent) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::conventions::AuditFinding;
+    use crate::core::code_audit::conventions::AuditFinding;
     use crate::core::refactor::auto::contracts::{Fix, Insertion, InsertionKind};
 
     fn make_fix(file: &str, kind: InsertionKind) -> Fix {

--- a/src/core/refactor/plan/generate/comment_fixes.rs
+++ b/src/core/refactor/plan/generate/comment_fixes.rs
@@ -20,8 +20,8 @@ use std::path::Path;
 
 use regex::Regex;
 
-use crate::code_audit::{AuditFinding, CodeAuditResult};
-use crate::refactor::auto::{Fix, SkippedFile};
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::refactor::auto::{Fix, SkippedFile};
 
 use super::{doc_line_removal, manual_blocked, range_removal};
 
@@ -555,9 +555,9 @@ fn leading_indent(line: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code_audit::test_helpers::empty_result;
-    use crate::code_audit::{Finding, Severity};
-    use crate::refactor::auto::InsertionKind;
+    use crate::core::code_audit::test_helpers::empty_result;
+    use crate::core::code_audit::{Finding, Severity};
+    use crate::core::refactor::auto::InsertionKind;
 
     // ── classify_and_bound tests ──────────────────────────────────────
 

--- a/src/core/refactor/plan/generate/compiler_warning_fixes.rs
+++ b/src/core/refactor/plan/generate/compiler_warning_fixes.rs
@@ -12,7 +12,7 @@
 use std::path::Path;
 
 use super::{tagged_line_replacement, tagged_range_removal};
-use crate::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
 use crate::core::refactor::auto::{Fix, RefactorPrimitive, SkippedFile};
 
 /// A machine-applicable fix suggestion from the compiler.
@@ -355,7 +355,7 @@ fn parse_suggestions(stdout: &str, root: &Path) -> Vec<CompilerSuggestion> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::refactor::InsertionKind;
+    use crate::core::refactor::InsertionKind;
 
     #[test]
     fn parse_suggestions_extracts_unused_import() {

--- a/src/core/refactor/plan/generate/convention_fixes.rs
+++ b/src/core/refactor/plan/generate/convention_fixes.rs
@@ -1,6 +1,6 @@
-use crate::code_audit::conventions::Language;
-use crate::code_audit::naming::{detect_naming_suffix, suffix_matches};
-use crate::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::code_audit::conventions::Language;
+use crate::core::code_audit::naming::{detect_naming_suffix, suffix_matches};
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
 use crate::core::refactor::auto::{Fix, InsertionKind, SkippedFile};
 
 use regex::Regex;

--- a/src/core/refactor/plan/generate/doc_fixes.rs
+++ b/src/core/refactor/plan/generate/doc_fixes.rs
@@ -1,4 +1,4 @@
-use crate::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
 use crate::core::refactor::auto::{Fix, RefactorPrimitive};
 use std::path::Path;
 

--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -1,5 +1,5 @@
-use crate::code_audit::conventions::Language;
-use crate::code_audit::{AuditFinding, CodeAuditResult, DuplicateGroup};
+use crate::core::code_audit::conventions::Language;
+use crate::core::code_audit::{AuditFinding, CodeAuditResult, DuplicateGroup};
 use crate::core::refactor::auto::{Fix, InsertionKind, NewFile, SkippedFile};
 
 use regex::Regex;
@@ -320,7 +320,7 @@ pub(crate) fn generate_duplicate_function_fixes(
             .unwrap_or("");
         let language = Language::from_path(&canonical_abs);
         let use_extract_shared = matches!(language, Language::Php)
-            && !crate::code_audit::is_test_path(&group.canonical_file);
+            && !crate::core::code_audit::is_test_path(&group.canonical_file);
 
         let canonical_content = match std::fs::read_to_string(&canonical_abs) {
             Ok(content) => content,
@@ -337,7 +337,7 @@ pub(crate) fn generate_duplicate_function_fixes(
         };
 
         let manifest = if use_extract_shared {
-            crate::extension::find_extension_for_file_ext(ext, "refactor")
+            crate::core::extension::find_extension_for_file_ext(ext, "refactor")
         } else {
             None
         };
@@ -387,7 +387,7 @@ pub(crate) fn generate_duplicate_function_fixes(
             "project_root": root.to_string_lossy(),
         });
 
-        let Some(result_val) = crate::extension::run_refactor_script(&manifest, &extract_cmd)
+        let Some(result_val) = crate::core::extension::run_refactor_script(&manifest, &extract_cmd)
         else {
             generate_simple_duplicate_fixes(group, root, module_surfaces, fixes, skipped);
             continue;
@@ -588,8 +588,8 @@ fn generate_simple_duplicate_fixes(
         // Integration test files (tests/) are separate compilation units —
         // they cannot import from each other via `use crate::`. Skip fixes
         // that would generate invalid cross-crate imports.
-        if crate::code_audit::walker::is_test_path(remove_file)
-            || crate::code_audit::walker::is_test_path(&group.canonical_file)
+        if crate::core::code_audit::walker::is_test_path(remove_file)
+            || crate::core::code_audit::walker::is_test_path(&group.canonical_file)
         {
             skipped.push(SkippedFile {
                 file: remove_file.clone(),
@@ -780,7 +780,7 @@ fn extract_mod_names(content: &str) -> HashSet<String> {
 }
 
 fn scan_dir_for_reference(dir: &Path, word_re: &Regex) -> bool {
-    use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+    use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 
     let config = ScanConfig {
         extensions: ExtensionFilter::Only(vec!["rs".to_string()]),

--- a/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/intra_duplicate_fixes.rs
@@ -16,9 +16,9 @@
 
 use std::path::Path;
 
-use crate::code_audit::{AuditFinding, CodeAuditResult};
-use crate::engine::local_files;
-use crate::refactor::auto::{Fix, SkippedFile};
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::engine::local_files;
+use crate::core::refactor::auto::{Fix, SkippedFile};
 
 use super::{manual_blocked, range_removal};
 

--- a/src/core/refactor/plan/generate/mod.rs
+++ b/src/core/refactor/plan/generate/mod.rs
@@ -11,7 +11,7 @@ mod orphaned_test_fixes;
 mod parameter_fixes;
 mod signatures;
 
-use crate::code_audit::{fingerprint::FileFingerprint, AuditFinding, CodeAuditResult};
+use crate::core::code_audit::{fingerprint::FileFingerprint, AuditFinding, CodeAuditResult};
 use crate::core::refactor::auto::{DecomposeFixPlan, Fix, FixPolicy, FixResult, SkippedFile};
 use crate::core::refactor::decompose;
 use crate::core::refactor::plan::file_intent::{FileIntent, FileIntentMap};
@@ -114,7 +114,7 @@ pub(crate) fn generate_fixes_impl(
         if matches!(
             finding.kind,
             AuditFinding::GodFile | AuditFinding::HighItemCount
-        ) && !crate::code_audit::walker::is_test_path(&finding.file)
+        ) && !crate::core::code_audit::walker::is_test_path(&finding.file)
         {
             intent_map.set(finding.file.clone(), FileIntent::Decompose);
         }
@@ -168,7 +168,7 @@ pub(crate) fn generate_fixes_impl(
             if decompose_seen.contains(&finding.file) {
                 continue;
             }
-            let is_test = crate::code_audit::walker::is_test_path(&finding.file);
+            let is_test = crate::core::code_audit::walker::is_test_path(&finding.file);
             if is_test {
                 continue;
             }

--- a/src/core/refactor/plan/generate/module_surface.rs
+++ b/src/core/refactor/plan/generate/module_surface.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use crate::code_audit::walker;
 use crate::core::code_audit::fingerprint::{self, FileFingerprint};
+use crate::core::code_audit::walker;
 use crate::core::engine::symbol_graph;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/core/refactor/plan/generate/near_duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/near_duplicate_fixes.rs
@@ -18,8 +18,8 @@ use std::path::Path;
 use regex::Regex;
 
 use super::{tagged_import_add, tagged_range_removal, tagged_visibility_change};
-use crate::code_audit::{AuditFinding, CodeAuditResult};
-use crate::refactor::auto::{Fix, Insertion, RefactorPrimitive, SkippedFile};
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::refactor::auto::{Fix, Insertion, RefactorPrimitive, SkippedFile};
 
 use super::{FileRole, ModuleSurfaceIndex};
 
@@ -342,7 +342,7 @@ fn build_visibility_upgrade(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::refactor::InsertionKind;
+    use crate::core::refactor::InsertionKind;
     use std::collections::{HashMap, HashSet};
 
     #[test]

--- a/src/core/refactor/plan/generate/orphaned_test_fixes.rs
+++ b/src/core/refactor/plan/generate/orphaned_test_fixes.rs
@@ -1,7 +1,7 @@
-use crate::code_audit::{AuditFinding, CodeAuditResult};
 use crate::core::code_audit::fingerprint;
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::engine::text::levenshtein;
 use crate::core::refactor::auto::{Fix, InsertionKind, RefactorPrimitive, SkippedFile};
-use crate::engine::text::levenshtein;
 use std::path::Path;
 
 use super::{insertion_with_primitive, manual_only};
@@ -129,7 +129,7 @@ fn lines_inside_string_literals(lines: &[&str]) -> Vec<bool> {
 
         // Check for raw string opening: r#"  r##"  r###" etc.
         if let Some(close_pattern) =
-            crate::extension::grammar::find_unclosed_raw_string_on_line(line)
+            crate::core::extension::grammar::find_unclosed_raw_string_on_line(line)
         {
             // Mark subsequent lines as inside the string until we find the close.
             let mut j = i + 1;
@@ -233,7 +233,7 @@ fn find_test_function_range(content: &str, fn_name: &str) -> Option<(usize, usiz
 
         // Check if this line opens a raw string that isn't closed on the same line.
         if let Some(close_pattern) =
-            crate::extension::grammar::find_unclosed_raw_string_on_line(line)
+            crate::core::extension::grammar::find_unclosed_raw_string_on_line(line)
         {
             raw_string_close = Some(close_pattern);
             // Still count braces on this line BEFORE the raw string opens.
@@ -784,9 +784,9 @@ mod tests {
 
     // ── Integration tests: source-file-deleted promotion ──────────────
 
-    use crate::code_audit::test_helpers::empty_result;
-    use crate::code_audit::{Finding, Severity};
-    use crate::refactor::auto::{Fix, SkippedFile};
+    use crate::core::code_audit::test_helpers::empty_result;
+    use crate::core::code_audit::{Finding, Severity};
+    use crate::core::refactor::auto::{Fix, SkippedFile};
 
     fn fixture_content() -> &'static str {
         r#"#[cfg(test)]

--- a/src/core/refactor/plan/generate/parameter_fixes.rs
+++ b/src/core/refactor/plan/generate/parameter_fixes.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 
 use regex::Regex;
 
-use crate::code_audit::{AuditFinding, CodeAuditResult};
-use crate::refactor::auto::{Fix, Insertion, InsertionKind, RefactorPrimitive, SkippedFile};
+use crate::core::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::refactor::auto::{Fix, Insertion, InsertionKind, RefactorPrimitive, SkippedFile};
 
 use super::insertion_with_primitive;
 
@@ -166,7 +166,7 @@ fn build_param_removal(
             old_text: old_sig.to_string(),
             new_text: new_sig,
         },
-        crate::code_audit::AuditFinding::UnusedParameter,
+        crate::core::code_audit::AuditFinding::UnusedParameter,
         String::new(),
         format!(
             "Remove unused parameter '{}' from '{}' (position {}, no callers pass it)",

--- a/src/core/refactor/plan/generate/signatures.rs
+++ b/src/core/refactor/plan/generate/signatures.rs
@@ -1,4 +1,4 @@
-use crate::code_audit::conventions::Language;
+use crate::core::code_audit::conventions::Language;
 use regex::Regex;
 
 /// Full method signature extracted from a conforming file.
@@ -86,9 +86,9 @@ fn normalize_item_name(name: &str) -> String {
 }
 
 pub(crate) fn find_parsed_item_by_name<'a>(
-    items: &'a [crate::extension::ParsedItem],
+    items: &'a [crate::core::extension::ParsedItem],
     requested_name: &str,
-) -> Option<&'a crate::extension::ParsedItem> {
+) -> Option<&'a crate::core::extension::ParsedItem> {
     if let Some(exact) = items.iter().find(|item| item.name == requested_name) {
         return Some(exact);
     }
@@ -129,20 +129,21 @@ pub(crate) fn parse_items_for_dedup(
     file_ext: &str,
     content: &str,
     file_path: &str,
-) -> Option<Vec<crate::extension::ParsedItem>> {
-    if let Some(grammar) = crate::code_audit::core_fingerprint::load_grammar_for_ext(file_ext) {
-        let items = crate::extension::grammar_items::parse_items(content, &grammar);
+) -> Option<Vec<crate::core::extension::ParsedItem>> {
+    if let Some(grammar) = crate::core::code_audit::core_fingerprint::load_grammar_for_ext(file_ext)
+    {
+        let items = crate::core::extension::grammar_items::parse_items(content, &grammar);
         if !items.is_empty() {
             return Some(
                 items
                     .into_iter()
-                    .map(crate::extension::ParsedItem::from)
+                    .map(crate::core::extension::ParsedItem::from)
                     .collect(),
             );
         }
     }
 
-    let manifest = crate::extension::find_extension_for_file_ext(file_ext, "refactor")?;
+    let manifest = crate::core::extension::find_extension_for_file_ext(file_ext, "refactor")?;
     let parse_cmd = serde_json::json!({
         "command": "parse_items",
         "file_path": file_path,
@@ -150,7 +151,7 @@ pub(crate) fn parse_items_for_dedup(
         "items": [],
     });
 
-    crate::extension::run_refactor_script(&manifest, &parse_cmd)
+    crate::core::extension::run_refactor_script(&manifest, &parse_cmd)
         .and_then(|value| value.get("items").cloned())
         .and_then(|value| serde_json::from_value(value).ok())
 }
@@ -167,11 +168,12 @@ pub(crate) fn extract_signatures_from_items(
         Language::Unknown => return Vec::new(),
     };
 
-    let Some(grammar) = crate::code_audit::core_fingerprint::load_grammar_for_ext(file_ext) else {
+    let Some(grammar) = crate::core::code_audit::core_fingerprint::load_grammar_for_ext(file_ext)
+    else {
         return Vec::new();
     };
 
-    let symbols = crate::extension::grammar::extract(content, &grammar);
+    let symbols = crate::core::extension::grammar::extract(content, &grammar);
     let lines: Vec<&str> = content.lines().collect();
 
     symbols

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -1,13 +1,13 @@
-use crate::code_audit::CodeAuditResult;
-use crate::component::Component;
-use crate::engine::run_dir::{self, RunDir};
-use crate::engine::undo::UndoSnapshot;
-use crate::extension;
-use crate::extension::test::compute_changed_test_files;
-use crate::git;
-use crate::refactor::auto as fixer;
-use crate::refactor::auto::{self, FixApplied, FixResultsSummary};
-use crate::Error;
+use crate::core::code_audit::CodeAuditResult;
+use crate::core::component::Component;
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::engine::undo::UndoSnapshot;
+use crate::core::extension;
+use crate::core::extension::test::compute_changed_test_files;
+use crate::core::git;
+use crate::core::refactor::auto as fixer;
+use crate::core::refactor::auto::{self, FixApplied, FixResultsSummary};
+use crate::core::Error;
 use serde::Serialize;
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
@@ -30,8 +30,8 @@ pub struct RefactorSourceRequest {
     pub root: PathBuf,
     pub sources: Vec<String>,
     pub changed_since: Option<String>,
-    pub only: Vec<crate::code_audit::AuditFinding>,
-    pub exclude: Vec<crate::code_audit::AuditFinding>,
+    pub only: Vec<crate::core::code_audit::AuditFinding>,
+    pub exclude: Vec<crate::core::code_audit::AuditFinding>,
     pub settings: Vec<(String, String)>,
     pub lint: LintSourceOptions,
     pub test: TestSourceOptions,
@@ -90,7 +90,7 @@ pub fn run_lint_refactor(
     settings: Vec<(String, String)>,
     options: LintSourceOptions,
     write: bool,
-) -> crate::Result<RefactorSourceRun> {
+) -> crate::core::Result<RefactorSourceRun> {
     collect_refactor_sources(lint_refactor_request(
         component, root, settings, options, write,
     ))
@@ -102,7 +102,7 @@ pub fn run_test_refactor(
     settings: Vec<(String, String)>,
     options: TestSourceOptions,
     write: bool,
-) -> crate::Result<RefactorSourceRun> {
+) -> crate::core::Result<RefactorSourceRun> {
     collect_refactor_sources(build_test_refactor_request(
         component, root, settings, options, write,
     ))
@@ -147,7 +147,7 @@ pub struct RefactorSourceRun {
     /// When set, autofix was blocked by a safety guard. The pipeline
     /// short-circuited without modifying any files.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub guard_block: Option<crate::refactor::auto::guard::GuardBlock>,
+    pub guard_block: Option<crate::core::refactor::auto::guard::GuardBlock>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -229,7 +229,7 @@ struct LintFixScopeOutcome {
 
 pub fn collect_refactor_sources(
     request: RefactorSourceRequest,
-) -> crate::Result<RefactorSourceRun> {
+) -> crate::core::Result<RefactorSourceRun> {
     let sources = normalize_sources(&request.sources)?;
     let root_str = request.root.to_string_lossy().to_string();
     let original_changes = git::get_uncommitted_changes(&root_str).ok();
@@ -241,7 +241,7 @@ pub fn collect_refactor_sources(
     if request.write && !request.force && !allows_dirty_worktree_write(&request) {
         if let Some(ref changes) = original_changes {
             if changes.has_changes {
-                return Err(crate::Error::validation_invalid_argument(
+                return Err(crate::core::Error::validation_invalid_argument(
                     "write",
                     "Working tree has uncommitted changes",
                     None,
@@ -258,10 +258,10 @@ pub fn collect_refactor_sources(
     // Guards detect reverted/force-pushed bot commits and PR labels that
     // permanently disable autofix. Outside CI, guards are no-ops.
     if request.write {
-        let guard_config = crate::refactor::auto::guard::GuardConfig::from_env();
-        match crate::refactor::auto::guard::check_guards(&root_str, &guard_config) {
-            crate::refactor::auto::guard::GuardResult::Proceed => {}
-            crate::refactor::auto::guard::GuardResult::Blocked(block) => {
+        let guard_config = crate::core::refactor::auto::guard::GuardConfig::from_env();
+        match crate::core::refactor::auto::guard::check_guards(&root_str, &guard_config) {
+            crate::core::refactor::auto::guard::GuardResult::Proceed => {}
+            crate::core::refactor::auto::guard::GuardResult::Blocked(block) => {
                 eprintln!(
                     "[refactor] autofix blocked: {} (status: {})",
                     block.message(),
@@ -397,7 +397,7 @@ pub fn collect_refactor_sources(
     if applied {
         let abs_changed: Vec<PathBuf> =
             changed_files.iter().map(|f| request.root.join(f)).collect();
-        match crate::engine::format_write::format_after_write(&request.root, &abs_changed) {
+        match crate::core::engine::format_write::format_after_write(&request.root, &abs_changed) {
             Ok(fmt) => {
                 if let Some(cmd) = &fmt.command {
                     if !fmt.success {
@@ -460,7 +460,7 @@ fn allows_dirty_worktree_write(request: &RefactorSourceRequest) -> bool {
             .is_some_and(|files| !files.is_empty())
 }
 
-pub fn normalize_sources(sources: &[String]) -> crate::Result<Vec<String>> {
+pub fn normalize_sources(sources: &[String]) -> crate::core::Result<Vec<String>> {
     let lowered: Vec<String> = sources.iter().map(|source| source.to_lowercase()).collect();
 
     if lowered.iter().any(|source| source == "all") {
@@ -518,7 +518,7 @@ fn format_changed_files(root: &Path, changed_files: &[String], warnings: &mut Ve
 
     let abs_changed: Vec<PathBuf> = changed_files.iter().map(|f| root.join(f)).collect();
 
-    match crate::engine::format_write::format_after_write(root, &abs_changed) {
+    match crate::core::engine::format_write::format_after_write(root, &abs_changed) {
         Ok(fmt) => {
             if let Some(cmd) = &fmt.command {
                 if fmt.success {
@@ -713,10 +713,10 @@ fn plan_audit_stage(
     component_id: &str,
     root: &Path,
     changed_files: Option<&[String]>,
-    only: &[crate::code_audit::AuditFinding],
-    exclude: &[crate::code_audit::AuditFinding],
+    only: &[crate::core::code_audit::AuditFinding],
+    exclude: &[crate::core::code_audit::AuditFinding],
     write: bool,
-) -> crate::Result<PlannedStage> {
+) -> crate::core::Result<PlannedStage> {
     let result = if let Some(cached) = try_load_cached_audit() {
         cached
     } else if let Some(changed) = changed_files {
@@ -724,7 +724,7 @@ fn plan_audit_stage(
             CodeAuditResult {
                 component_id: component_id.to_string(),
                 source_path: root.to_string_lossy().to_string(),
-                summary: crate::code_audit::AuditSummary {
+                summary: crate::core::code_audit::AuditSummary {
                     files_scanned: 0,
                     conventions_detected: 0,
                     outliers_found: 0,
@@ -738,7 +738,7 @@ fn plan_audit_stage(
                 duplicate_groups: vec![],
             }
         } else {
-            crate::code_audit::audit_path_scoped(
+            crate::core::code_audit::audit_path_scoped(
                 component_id,
                 &root.to_string_lossy(),
                 changed,
@@ -746,7 +746,7 @@ fn plan_audit_stage(
             )?
         }
     } else {
-        crate::code_audit::audit_path_with_id(component_id, &root.to_string_lossy())?
+        crate::core::code_audit::audit_path_with_id(component_id, &root.to_string_lossy())?
     };
 
     let policy = fixer::FixPolicy {
@@ -851,7 +851,7 @@ fn plan_audit_stage(
 fn capture_release_owned_files(
     component: &Component,
     root: &Path,
-) -> crate::Result<Vec<ReleaseOwnedFileSnapshot>> {
+) -> crate::core::Result<Vec<ReleaseOwnedFileSnapshot>> {
     release_owned_file_paths(component)
         .into_iter()
         .map(|relative| {
@@ -883,7 +883,7 @@ fn capture_release_owned_files(
 fn restore_release_owned_files(
     root: &Path,
     snapshots: &[ReleaseOwnedFileSnapshot],
-) -> crate::Result<()> {
+) -> crate::core::Result<()> {
     for snapshot in snapshots {
         let path = root.join(&snapshot.relative);
         if snapshot.existed {
@@ -918,7 +918,7 @@ fn constrain_lint_fix_changes(
     before_dirty: &[String],
     after_dirty: Vec<String>,
     release_owned: &[ReleaseOwnedFileSnapshot],
-) -> crate::Result<LintFixScopeOutcome> {
+) -> crate::core::Result<LintFixScopeOutcome> {
     let before_set: HashSet<&str> = before_dirty.iter().map(|file| file.as_str()).collect();
     let release_owned_set: HashSet<&str> = release_owned
         .iter()
@@ -1012,7 +1012,7 @@ fn run_lint_stage(
     changed_files: Option<&[String]>,
     write: bool,
     run_dir: &RunDir,
-) -> crate::Result<PlannedStage> {
+) -> crate::core::Result<PlannedStage> {
     // Check for cached lint results from the quality gate.
     let cached = try_load_cached_lint();
 
@@ -1083,7 +1083,7 @@ fn run_lint_stage(
                 let content = std::fs::read_to_string(&file).ok()?;
                 let json: serde_json::Value = serde_json::from_str(&content).ok()?;
                 let data = json.get("data")?;
-                let findings: Vec<crate::extension::lint::LintFinding> =
+                let findings: Vec<crate::core::extension::lint::LintFinding> =
                     serde_json::from_value(data.get("lint_findings")?.clone()).ok()?;
                 Some(findings)
             })
@@ -1093,7 +1093,8 @@ fn run_lint_stage(
         // No cached findings — run the diagnostic pass.
         build_lint_runner()?.run()?;
 
-        crate::extension::lint::baseline::parse_findings_file(&findings_file).unwrap_or_default()
+        crate::core::extension::lint::baseline::parse_findings_file(&findings_file)
+            .unwrap_or_default()
     };
 
     // ── Phase 2: Apply fixes (only when --write) ───────────────────────
@@ -1188,7 +1189,7 @@ fn run_test_stage(
     changed_test_files: Option<&[String]>,
     write: bool,
     run_dir: &RunDir,
-) -> crate::Result<PlannedStage> {
+) -> crate::core::Result<PlannedStage> {
     // Check for cached test results — if the quality gate already passed,
     // there's nothing to fix and we can skip re-running the test suite entirely.
     if let Some(CachedTestResult::Clean) = try_load_cached_test() {
@@ -1431,7 +1432,7 @@ pub fn summarize_source_totals(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::{Component, VersionTarget};
+    use crate::core::component::{Component, VersionTarget};
     use std::fs;
     use std::process::Command;
     use std::sync::{Mutex, OnceLock};
@@ -1797,7 +1798,7 @@ mod tests {
             root: root.clone(),
             sources: vec!["audit".to_string()],
             changed_since: None,
-            only: vec![crate::code_audit::AuditFinding::DuplicateFunction],
+            only: vec![crate::core::code_audit::AuditFinding::DuplicateFunction],
             exclude: vec![],
             settings: vec![],
             lint: LintSourceOptions::default(),
@@ -1855,7 +1856,7 @@ mod tests {
 
     #[test]
     fn test_collect_refactor_sources() {
-        let _collect: fn(RefactorSourceRequest) -> crate::Result<RefactorSourceRun> =
+        let _collect: fn(RefactorSourceRequest) -> crate::core::Result<RefactorSourceRun> =
             collect_refactor_sources;
     }
 
@@ -1867,7 +1868,7 @@ mod tests {
             Vec<(String, String)>,
             LintSourceOptions,
             bool,
-        ) -> crate::Result<RefactorSourceRun> = run_lint_refactor;
+        ) -> crate::core::Result<RefactorSourceRun> = run_lint_refactor;
     }
 
     #[test]
@@ -1878,7 +1879,7 @@ mod tests {
             Vec<(String, String)>,
             TestSourceOptions,
             bool,
-        ) -> crate::Result<RefactorSourceRun> = run_test_refactor;
+        ) -> crate::core::Result<RefactorSourceRun> = run_test_refactor;
     }
 
     #[test]
@@ -1890,7 +1891,7 @@ mod tests {
         let audit_result = CodeAuditResult {
             component_id: "test".to_string(),
             source_path: "/tmp/test".to_string(),
-            summary: crate::code_audit::AuditSummary {
+            summary: crate::core::code_audit::AuditSummary {
                 files_scanned: 10,
                 conventions_detected: 2,
                 outliers_found: 1,
@@ -1995,8 +1996,8 @@ mod tests {
     // for edits that `--write` silently declines (cascading findings, manual-only
     // fixes). Before the fix, dry-run exit 1 + write applies nothing = stuck PR.
 
-    use crate::code_audit::AuditFinding;
-    use crate::refactor::auto::{Fix, FixResult, Insertion, InsertionKind, NewFile};
+    use crate::core::code_audit::AuditFinding;
+    use crate::core::refactor::auto::{Fix, FixResult, Insertion, InsertionKind, NewFile};
 
     fn auto_insertion() -> Insertion {
         Insertion {

--- a/src/core/refactor/plan/verify.rs
+++ b/src/core/refactor/plan/verify.rs
@@ -1,10 +1,10 @@
-use crate::code_audit::CodeAuditResult;
-use crate::engine::undo::UndoSnapshot;
-use crate::refactor::auto as fixer;
+use crate::core::code_audit::CodeAuditResult;
+use crate::core::engine::undo::UndoSnapshot;
+use crate::core::refactor::auto as fixer;
 use serde::Serialize;
 use std::path::Path;
 
-pub use crate::code_audit::{
+pub use crate::core::code_audit::{
     finding_fingerprint, score_delta, weighted_finding_score_with, AuditConvergenceScoring,
 };
 
@@ -15,7 +15,7 @@ pub(crate) fn rewrite_callers_after_dedup(fix: &fixer::Fix, root: &Path) {
         if !matches!(insertion.kind, fixer::InsertionKind::FunctionRemoval { .. }) {
             continue;
         }
-        if insertion.finding != crate::code_audit::AuditFinding::DuplicateFunction {
+        if insertion.finding != crate::core::code_audit::AuditFinding::DuplicateFunction {
             continue;
         }
 
@@ -82,11 +82,11 @@ pub struct AuditRefactorOutcome {
 
 pub fn run_audit_refactor(
     initial_result: CodeAuditResult,
-    only_kinds: &[crate::code_audit::AuditFinding],
-    exclude_kinds: &[crate::code_audit::AuditFinding],
+    only_kinds: &[crate::core::code_audit::AuditFinding],
+    exclude_kinds: &[crate::core::code_audit::AuditFinding],
     scoring: AuditConvergenceScoring,
     write: bool,
-) -> crate::Result<AuditRefactorOutcome> {
+) -> crate::core::Result<AuditRefactorOutcome> {
     let current_result = initial_result;
     let final_fix_result;
     let final_policy_summary;
@@ -137,9 +137,11 @@ pub fn run_audit_refactor(
     })
 }
 
-fn resolve_verify_config(component_id: &str) -> Option<crate::extension::AutofixVerifyConfig> {
-    use crate::component;
-    use crate::extension;
+fn resolve_verify_config(
+    component_id: &str,
+) -> Option<crate::core::extension::AutofixVerifyConfig> {
+    use crate::core::component;
+    use crate::core::extension;
 
     let comp = component::load(component_id).ok()?;
     let extensions = comp.extensions.as_ref()?;
@@ -155,10 +157,10 @@ fn resolve_verify_config(component_id: &str) -> Option<crate::extension::Autofix
 
 fn run_fix_iteration(
     audit_result: &CodeAuditResult,
-    only_kinds: &[crate::code_audit::AuditFinding],
-    exclude_kinds: &[crate::code_audit::AuditFinding],
+    only_kinds: &[crate::core::code_audit::AuditFinding],
+    exclude_kinds: &[crate::core::code_audit::AuditFinding],
     scoring: AuditConvergenceScoring,
-) -> crate::Result<(
+) -> crate::core::Result<(
     fixer::FixResult,
     fixer::PolicySummary,
     AuditRefactorIterationSummary,

--- a/src/core/refactor/propagate.rs
+++ b/src/core/refactor/propagate.rs
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::extension;
-use crate::Error;
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::extension;
+use crate::core::Error;
 
 // ============================================================================
 // Types
@@ -213,8 +213,8 @@ pub fn propagate(config: &PropagateConfig) -> Result<PropagateResult, Error> {
 
     // Step 5: Apply edits if write mode — route through shared EditOp engine
     let applied = if config.write && !all_edits.is_empty() {
-        use crate::engine::edit_op::propagate_result_to_edit_ops;
-        use crate::engine::edit_op_apply::apply_edit_ops;
+        use crate::core::engine::edit_op::propagate_result_to_edit_ops;
+        use crate::core::engine::edit_op_apply::apply_edit_ops;
 
         // Build a temporary PropagateResult to convert edits
         let tmp_result = PropagateResult {

--- a/src/core/refactor/rename/mod.rs
+++ b/src/core/refactor/rename/mod.rs
@@ -6,11 +6,11 @@
 //! 3. Generates file content edits and file/directory renames
 //! 4. Applies changes to disk (or returns a dry-run preview)
 
-use crate::engine::codebase_scan::{
+use crate::core::engine::codebase_scan::{
     self, find_boundary_matches, find_case_insensitive_matches, find_literal_matches,
     ExtensionFilter, ScanConfig,
 };
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -571,11 +571,11 @@ fn join_display(words: &[String]) -> String {
         .join(" ")
 }
 
-// Boundary matching and literal matching are provided by crate::engine::codebase_scan.
+// Boundary matching and literal matching are provided by crate::core::engine::codebase_scan.
 // See: find_boundary_matches(), find_literal_matches()
 
 // ============================================================================
-// File walking — delegates to crate::engine::codebase_scan
+// File walking — delegates to crate::core::engine::codebase_scan
 // ============================================================================
 
 /// Build a ScanConfig appropriate for rename operations.
@@ -1157,8 +1157,8 @@ fn extract_field_identifier(trimmed: &str) -> Option<String> {
 /// renames are routed through `apply_edit_ops()` so they share the same
 /// execution path as the fixer pipeline and other manual commands.
 pub fn apply_renames(result: &mut RenameResult, root: &Path) -> Result<()> {
-    use crate::engine::edit_op::rename_file_moves_to_edit_ops;
-    use crate::engine::edit_op_apply::apply_edit_ops;
+    use crate::core::engine::edit_op::rename_file_moves_to_edit_ops;
+    use crate::core::engine::edit_op_apply::apply_edit_ops;
 
     // Apply content edits first (whole-file replacement — rename operates at
     // full-content granularity, not line-level, so these bypass EditOp).

--- a/src/core/refactor/transform.rs
+++ b/src/core/refactor/transform.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
-use crate::engine::local_files;
-use crate::error::{Error, Result};
+use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::local_files;
+use crate::core::error::{Error, Result};
 
 // ============================================================================
 // Rule model

--- a/src/core/release/changelog/bulk.rs
+++ b/src/core/release/changelog/bulk.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
 
-use crate::component;
-use crate::engine::local_files;
-use crate::error::Result;
+use crate::core::component;
+use crate::core::engine::local_files;
+use crate::core::error::Result;
 
 use super::io::*;
 

--- a/src/core/release/changelog/io.rs
+++ b/src/core/release/changelog/io.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use crate::component::{self, Component};
-use crate::engine::local_files;
-use crate::engine::validation;
-use crate::error::Result;
-use crate::paths::resolve_path;
+use crate::core::component::{self, Component};
+use crate::core::engine::local_files;
+use crate::core::engine::validation;
+use crate::core::error::Result;
+use crate::core::paths::resolve_path;
 
 use super::sections::*;
 use super::settings::*;

--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -8,8 +8,8 @@ pub use unreleased::*;
 
 use chrono::Local;
 
-use crate::engine::validation;
-use crate::error::{Error, Result};
+use crate::core::engine::validation;
+use crate::core::error::{Error, Result};
 
 use super::settings::*;
 

--- a/src/core/release/changelog/sections/normalize_heading_label.rs
+++ b/src/core/release/changelog/sections/normalize_heading_label.rs
@@ -1,9 +1,9 @@
 //! normalize_heading_label — extracted from sections.rs.
 
 use super::super::settings::KEEP_A_CHANGELOG_SUBSECTIONS;
+use crate::core::engine::text;
 use crate::core::release::changelog::io::FinalizedReleaseSnapshot;
 use crate::core::release::changelog::sections::types::SectionContentStatus;
-use crate::engine::text;
 
 pub(crate) fn validate_section_content(body_lines: &[&str]) -> SectionContentStatus {
     let mut has_subsection_headers = false;

--- a/src/core/release/changelog/settings.rs
+++ b/src/core/release/changelog/settings.rs
@@ -1,5 +1,5 @@
-use crate::component::{self, Component};
-use crate::project;
+use crate::core::component::{self, Component};
+use crate::core::project;
 
 pub(super) const DEFAULT_NEXT_SECTION_LABEL: &str = "Unreleased";
 pub(super) const DEFAULT_NEXT_SECTION_ALIASES: &[&str] = &["Unreleased", "Next"];

--- a/src/core/release/context.rs
+++ b/src/core/release/context.rs
@@ -1,6 +1,6 @@
-use crate::component::{self, Component};
-use crate::error::{Error, Result};
-use crate::extension::{self, ExtensionManifest};
+use crate::core::component::{self, Component};
+use crate::core::error::{Error, Result};
+use crate::core::extension::{self, ExtensionManifest};
 
 use super::types::ReleaseOptions;
 
@@ -30,8 +30,8 @@ pub(super) fn resolve_extensions(component: &Component) -> Result<Vec<ExtensionM
 #[cfg(test)]
 mod tests {
     use super::{load_component, resolve_extensions};
-    use crate::component::Component;
-    use crate::release::types::ReleaseOptions;
+    use crate::core::component::Component;
+    use crate::core::release::types::ReleaseOptions;
 
     #[test]
     fn test_load_component() {

--- a/src/core/release/deployment.rs
+++ b/src/core/release/deployment.rs
@@ -1,4 +1,4 @@
-use crate::deploy::{self, DeployConfig};
+use crate::core::deploy::{self, DeployConfig};
 
 use super::types::{
     ReleaseDeploymentResult, ReleaseDeploymentSummary, ReleaseProjectDeployResult, ReleaseRun,
@@ -170,7 +170,7 @@ fn cleanup_release_artifacts(local_path: &str) {
 #[cfg(test)]
 mod tests {
     use super::{extract_deployment_from_run, plan_deployment};
-    use crate::release::types::{
+    use crate::core::release::types::{
         ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
     };
 

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -1,10 +1,12 @@
-use crate::component::Component;
-use crate::error::{Error, Result};
-use crate::extension::ExtensionManifest;
-use crate::git;
-use crate::plan::{PlanStep, PlanStepStatus};
-use crate::release::executor;
-use crate::release::types::{ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::extension::ExtensionManifest;
+use crate::core::git;
+use crate::core::plan::{PlanStep, PlanStepStatus};
+use crate::core::release::executor;
+use crate::core::release::types::{
+    ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
+};
 
 pub(super) struct ReleaseExecutionContext<'a> {
     pub(super) component: &'a Component,
@@ -395,9 +397,9 @@ mod tests {
         execute_release_plan_step, release_step_is_plan_only, release_step_is_show_stopper,
         ReleaseExecutionContext,
     };
-    use crate::component::Component;
-    use crate::plan::PlanStep;
-    use crate::release::types::{
+    use crate::core::component::Component;
+    use crate::core::plan::PlanStep;
+    use crate::core::release::types::{
         ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
     };
 
@@ -783,7 +785,7 @@ mod tests {
 
     #[test]
     fn test_failed_result() {
-        let err = crate::error::Error::internal_unexpected("boom".to_string());
+        let err = crate::core::error::Error::internal_unexpected("boom".to_string());
 
         let result = super::failed_result("package", "package", err);
 

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
-use crate::error::Result;
-use crate::plan::PlanStep;
+use crate::core::error::Result;
+use crate::core::plan::PlanStep;
 
 use super::context::{load_component, resolve_extensions};
 use super::execution_dispatch::{
@@ -78,8 +78,8 @@ mod tests {
     use super::{
         build_initial_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
     };
-    use crate::plan::PlanStepStatus;
-    use crate::release::types::ReleaseOptions;
+    use crate::core::plan::PlanStepStatus;
+    use crate::core::release::types::ReleaseOptions;
     use std::collections::HashSet;
 
     #[test]

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -12,12 +12,12 @@
 //! steps, so the DAG scaffolding bought nothing but indirection. The logic
 //! inside each `run_*` function is unchanged; only the plumbing is different.
 
-use crate::component::Component;
-use crate::engine::local_files::FileSystem;
-use crate::engine::validation;
-use crate::error::{Error, Result};
-use crate::extension::{self, ExtensionManifest};
-use crate::{changelog as release_changelog, version};
+use crate::core::component::Component;
+use crate::core::engine::local_files::FileSystem;
+use crate::core::engine::validation;
+use crate::core::error::{Error, Result};
+use crate::core::extension::{self, ExtensionManifest};
+use crate::core::release::{changelog as release_changelog, version};
 
 use super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use super::utils::{extract_latest_notes, parse_release_artifacts};
@@ -30,7 +30,7 @@ pub(crate) fn step_success(
     id: &str,
     step_type: &str,
     data: Option<serde_json::Value>,
-    hints: Vec<crate::error::Hint>,
+    hints: Vec<crate::core::error::Hint>,
 ) -> ReleaseStepResult {
     ReleaseStepResult {
         id: id.to_string(),
@@ -50,7 +50,7 @@ fn step_failed(
     step_type: &str,
     data: Option<serde_json::Value>,
     error: Option<String>,
-    hints: Vec<crate::error::Hint>,
+    hints: Vec<crate::core::error::Hint>,
 ) -> ReleaseStepResult {
     ReleaseStepResult {
         id: id.to_string(),
@@ -136,7 +136,7 @@ pub(crate) fn run_version(
             "version",
             Some(failure_data),
             Some(error_msg),
-            vec![crate::error::Hint {
+            vec![crate::core::error::Hint {
                 message: "If a previous run partially bumped this component, run `homeboy release <component> --recover` to finish it cleanly.".to_string(),
             }],
         ));
@@ -235,7 +235,7 @@ fn collect_head_version_mismatches(
 /// repository toplevel regardless of cwd.
 fn git_toplevel(path: &str) -> Option<std::path::PathBuf> {
     let output =
-        crate::git::execute_git_for_release(path, &["rev-parse", "--show-toplevel"]).ok()?;
+        crate::core::git::execute_git_for_release(path, &["rev-parse", "--show-toplevel"]).ok()?;
     if !output.status.success() {
         return None;
     }
@@ -252,9 +252,9 @@ fn git_toplevel(path: &str) -> Option<std::path::PathBuf> {
 /// HEAD, the git command fails, or the content can't be parsed.
 fn read_version_at_head(
     component: &Component,
-    target: &crate::component::VersionTarget,
+    target: &crate::core::component::VersionTarget,
 ) -> Option<String> {
-    use crate::release::version::{
+    use crate::core::release::version::{
         default_pattern_for_file, parse_version, resolve_version_file_path,
     };
 
@@ -295,13 +295,13 @@ fn read_version_at_head(
 
     let spec = format!("HEAD:{}", rel_path);
     let output =
-        crate::git::execute_git_for_release(&component.local_path, &["show", &spec]).ok()?;
+        crate::core::git::execute_git_for_release(&component.local_path, &["show", &spec]).ok()?;
     if !output.status.success() {
         return None;
     }
 
     let content = String::from_utf8(output.stdout).ok()?;
-    let normalized_pattern = crate::component::normalize_version_pattern(&pattern);
+    let normalized_pattern = crate::core::component::normalize_version_pattern(&pattern);
     parse_version(&content, &normalized_pattern)
 }
 
@@ -313,7 +313,8 @@ pub(crate) fn run_git_commit(
     component_id: &str,
     state: &ReleaseState,
 ) -> Result<ReleaseStepResult> {
-    let status_output = crate::git::status_at(Some(component_id), Some(&component.local_path))?;
+    let status_output =
+        crate::core::git::status_at(Some(component_id), Some(&component.local_path))?;
     let is_clean = status_output.stdout.trim().is_empty();
 
     if is_clean {
@@ -336,14 +337,14 @@ pub(crate) fn run_git_commit(
         .map(|v| format!("release: v{}", v))
         .unwrap_or_else(|| "release: unknown".to_string());
 
-    let options = crate::git::CommitOptions {
+    let options = crate::core::git::CommitOptions {
         staged_only: false,
         files: None,
         exclude: None,
         amend: should_amend,
     };
 
-    let output = crate::git::commit_at(
+    let output = crate::core::git::commit_at(
         Some(component_id),
         Some(&message),
         options,
@@ -412,7 +413,7 @@ pub(crate) fn run_git_tag(
                     "mismatches": mismatches,
                 })),
                 Some(error_msg),
-                vec![crate::error::Hint {
+                vec![crate::core::error::Hint {
                     message: format!(
                         "Inspect the failed bump: `git status` then `git log -1`. To finish a partial release, run `homeboy release {} --recover`.",
                         component_id
@@ -422,9 +423,9 @@ pub(crate) fn run_git_tag(
         }
     }
 
-    if crate::git::tag_exists_locally(&component.local_path, tag_name).unwrap_or(false) {
-        let tag_commit = crate::git::get_tag_commit(&component.local_path, tag_name)?;
-        let head_commit = crate::git::get_head_commit(&component.local_path)?;
+    if crate::core::git::tag_exists_locally(&component.local_path, tag_name).unwrap_or(false) {
+        let tag_commit = crate::core::git::get_tag_commit(&component.local_path, tag_name)?;
+        let head_commit = crate::core::git::get_head_commit(&component.local_path)?;
 
         if tag_commit == head_commit {
             state.tag = Some(tag_name.to_string());
@@ -458,7 +459,7 @@ pub(crate) fn run_git_tag(
     }
 
     let message = format!("Release {}", tag_name);
-    let output = crate::git::tag_at(
+    let output = crate::core::git::tag_at(
         Some(component_id),
         Some(tag_name),
         Some(&message),
@@ -472,19 +473,21 @@ pub(crate) fn run_git_tag(
 
         if output.stderr.contains("already exists") {
             let local_exists =
-                crate::git::tag_exists_locally(&component.local_path, tag_name).unwrap_or(false);
+                crate::core::git::tag_exists_locally(&component.local_path, tag_name)
+                    .unwrap_or(false);
             let remote_exists =
-                crate::git::tag_exists_on_remote(&component.local_path, tag_name).unwrap_or(false);
+                crate::core::git::tag_exists_on_remote(&component.local_path, tag_name)
+                    .unwrap_or(false);
 
             if local_exists && !remote_exists {
-                hints.push(crate::error::Hint {
+                hints.push(crate::core::error::Hint {
                     message: format!(
                         "Tag '{}' exists locally but not on remote. Push it with: git push origin {}",
                         tag_name, tag_name
                     ),
                 });
             } else if local_exists && remote_exists {
-                hints.push(crate::error::Hint {
+                hints.push(crate::core::error::Hint {
                     message: format!(
                         "Tag '{}' already exists locally and on remote. Delete local tag first: git tag -d {}",
                         tag_name, tag_name
@@ -508,9 +511,9 @@ pub(crate) fn run_git_tag(
 
 /// Push commits (and tags) to the remote.
 pub(crate) fn run_git_push(component: &Component, component_id: &str) -> Result<ReleaseStepResult> {
-    let output = crate::git::push_at(
+    let output = crate::core::git::push_at(
         Some(component_id),
-        crate::git::PushOptions {
+        crate::core::git::PushOptions {
             tags: true,
             force_with_lease: false,
             ..Default::default()
@@ -759,11 +762,11 @@ pub(crate) fn run_post_release(
     component: &Component,
     commands: &[String],
 ) -> Result<ReleaseStepResult> {
-    let hook_result = crate::engine::hooks::run_commands(
+    let hook_result = crate::core::engine::hooks::run_commands(
         commands,
         &component.local_path,
-        crate::engine::hooks::events::POST_RELEASE,
-        crate::engine::hooks::HookFailureMode::NonFatal,
+        crate::core::engine::hooks::events::POST_RELEASE,
+        crate::core::engine::hooks::HookFailureMode::NonFatal,
     )?;
 
     if !hook_result.all_succeeded {
@@ -830,7 +833,9 @@ pub(crate) fn run_github_release(
         .remote_url
         .clone()
         .or_else(|| {
-            crate::deploy::release_download::detect_remote_url(std::path::Path::new(local_path))
+            crate::core::deploy::release_download::detect_remote_url(std::path::Path::new(
+                local_path,
+            ))
         })
         .ok_or_else(|| {
             Error::internal_unexpected(
@@ -840,7 +845,7 @@ pub(crate) fn run_github_release(
         })?;
 
     let github =
-        crate::deploy::release_download::parse_github_url(&remote_url).ok_or_else(|| {
+        crate::core::deploy::release_download::parse_github_url(&remote_url).ok_or_else(|| {
             Error::validation_invalid_argument(
                 "github.release",
                 format!("Remote URL '{}' is not a GitHub URL", remote_url),
@@ -1008,7 +1013,7 @@ pub(crate) fn run_github_release(
         notes
     };
 
-    let tmp_dir = crate::engine::temp::runtime_temp_dir("github-release")?;
+    let tmp_dir = crate::core::engine::temp::runtime_temp_dir("github-release")?;
     let notes_path = tmp_dir.join(format!("notes-{}.md", sanitize_tag_for_filename(&tag)));
     std::fs::write(&notes_path, &notes_body).map_err(|e| {
         Error::internal_io(
@@ -1104,7 +1109,7 @@ pub(crate) fn run_github_release(
 
 fn load_release_notes(component: &Component) -> Result<String> {
     let changelog_path = release_changelog::resolve_changelog_path(component)?;
-    let changelog_content = crate::engine::local_files::local().read(&changelog_path)?;
+    let changelog_content = crate::core::engine::local_files::local().read(&changelog_path)?;
     validation::require(
         extract_latest_notes(&changelog_content),
         "changelog",
@@ -1113,8 +1118,9 @@ fn load_release_notes(component: &Component) -> Result<String> {
 }
 
 fn should_amend_release_commit(local_path: &str) -> Result<bool> {
-    let log_output = crate::git::execute_git_for_release(local_path, &["log", "-1", "--format=%s"])
-        .map_err(|e| Error::internal_io(e.to_string(), Some("git log".to_string())))?;
+    let log_output =
+        crate::core::git::execute_git_for_release(local_path, &["log", "-1", "--format=%s"])
+            .map_err(|e| Error::internal_io(e.to_string(), Some("git log".to_string())))?;
     if !log_output.status.success() {
         return Ok(false);
     }
@@ -1126,8 +1132,9 @@ fn should_amend_release_commit(local_path: &str) -> Result<bool> {
         return Ok(false);
     }
 
-    let status_output = crate::git::execute_git_for_release(local_path, &["status", "-sb"])
-        .map_err(|e| Error::internal_io(e.to_string(), Some("git status".to_string())))?;
+    let status_output =
+        crate::core::git::execute_git_for_release(local_path, &["status", "-sb"])
+            .map_err(|e| Error::internal_io(e.to_string(), Some("git status".to_string())))?;
     if !status_output.status.success() {
         return Ok(false);
     }
@@ -1224,15 +1231,15 @@ fn store_artifacts_from_output(
 // ---------------------------------------------------------------------------
 
 fn gh_is_available() -> bool {
-    crate::git::gh_probe_succeeds(&["--version"])
+    crate::core::git::gh_probe_succeeds(&["--version"])
 }
 
 fn gh_is_authenticated() -> bool {
-    crate::git::gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"])
+    crate::core::git::gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"])
 }
 
 fn gh_release_exists(tag: &str, repo_flag: &str) -> bool {
-    crate::git::gh_probe_succeeds(&["release", "view", tag, "-R", repo_flag])
+    crate::core::git::gh_probe_succeeds(&["release", "view", tag, "-R", repo_flag])
 }
 
 fn fallback_gh_command(tag: &str) -> String {
@@ -1260,8 +1267,8 @@ mod tests {
         fallback_gh_command, publish_step_result, run_git_push, sanitize_tag_for_filename,
         store_artifacts_from_output,
     };
-    use crate::component::Component;
-    use crate::release::ReleaseStepStatus;
+    use crate::core::component::Component;
+    use crate::core::release::ReleaseStepStatus;
     use std::process::Command;
 
     #[test]
@@ -1378,7 +1385,7 @@ mod tests {
             "stdout": "",
             "stderr": "",
         });
-        let mut state = crate::release::types::ReleaseState::default();
+        let mut state = crate::core::release::types::ReleaseState::default();
 
         let err = store_artifacts_from_output(&mut state, &response)
             .expect_err("empty failing package output should fail");
@@ -1390,8 +1397,8 @@ mod tests {
     // ----- Orphan-tag regression coverage (issue #2234) -----
 
     use super::{collect_head_version_mismatches, collect_version_target_mismatches, run_git_tag};
-    use crate::component::VersionTarget;
-    use crate::release::types::ReleaseState;
+    use crate::core::component::VersionTarget;
+    use crate::core::release::types::ReleaseState;
 
     fn run_in(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
         let output = std::process::Command::new(args[0])
@@ -1576,7 +1583,7 @@ mod tests {
         );
         assert!(err.contains("v0.6.13"), "error should name the tag");
         assert!(
-            !crate::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(true),
+            !crate::core::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(true),
             "tag must NOT have been created when invariant fails"
         );
     }
@@ -1595,7 +1602,7 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         assert!(
-            crate::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(false),
+            crate::core::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(false),
             "tag should have been created on HEAD"
         );
     }

--- a/src/core/release/executor/changelog.rs
+++ b/src/core/release/executor/changelog.rs
@@ -1,8 +1,8 @@
-use crate::component::Component;
-use crate::error::{Error, Result};
-use crate::plan::PlanStep;
-use crate::release::types::{ReleaseState, ReleaseStepResult};
-use crate::version;
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::plan::PlanStep;
+use crate::core::release::types::{ReleaseState, ReleaseStepResult};
+use crate::core::release::version;
 
 use super::step_success;
 
@@ -52,10 +52,10 @@ pub(crate) fn run_changelog_finalize(
 #[cfg(test)]
 mod tests {
     use super::run_changelog_finalize;
-    use crate::component::{Component, VersionTarget};
-    use crate::plan::PlanStep;
-    use crate::release::types::ReleaseState;
-    use crate::release::ReleaseStepStatus;
+    use crate::core::component::{Component, VersionTarget};
+    use crate::core::plan::PlanStep;
+    use crate::core::release::types::ReleaseState;
+    use crate::core::release::ReleaseStepStatus;
 
     #[test]
     fn test_run_changelog_finalize() {

--- a/src/core/release/executor/prepare.rs
+++ b/src/core/release/executor/prepare.rs
@@ -1,8 +1,8 @@
-use crate::error::{Error, Result};
-use crate::extension::{self, ExtensionManifest};
+use crate::core::error::{Error, Result};
+use crate::core::extension::{self, ExtensionManifest};
 
 use super::{build_release_payload, publish_response_output, step_failed, step_success};
-use crate::release::types::{ReleaseState, ReleaseStepResult};
+use crate::core::release::types::{ReleaseState, ReleaseStepResult};
 
 /// Invoke every `release.prepare` action provided by the component's extensions.
 pub(crate) fn run_prepare(
@@ -115,7 +115,7 @@ fn extension_action_failure_message(
 #[cfg(test)]
 mod tests {
     use super::prepare_step_result;
-    use crate::release::ReleaseStepStatus;
+    use crate::core::release::ReleaseStepStatus;
 
     #[test]
     fn prepare_step_fails_when_extension_command_fails() {

--- a/src/core/release/orchestrator.rs
+++ b/src/core/release/orchestrator.rs
@@ -3,7 +3,7 @@
 //! The planner builds the `ReleasePlan`; this module runs that plan and wraps
 //! the accumulated step results into the public release run shape.
 
-use crate::error::Result;
+use crate::core::error::Result;
 use std::collections::HashSet;
 
 use super::execution_plan::{
@@ -81,7 +81,7 @@ fn finalize(component_id: &str, results: Vec<ReleaseStepResult>) -> ReleaseRun {
 #[cfg(test)]
 mod tests {
     use super::{run, run_with_plan};
-    use crate::release::types::ReleaseOptions;
+    use crate::core::release::types::ReleaseOptions;
 
     #[test]
     fn test_run() {

--- a/src/core/release/pipeline_capabilities.rs
+++ b/src/core/release/pipeline_capabilities.rs
@@ -1,4 +1,4 @@
-use crate::extension::ExtensionManifest;
+use crate::core::extension::ExtensionManifest;
 
 /// Derive publish targets from extensions that have `release.publish` action.
 pub(super) fn get_publish_targets(extensions: &[ExtensionManifest]) -> Vec<String> {
@@ -26,7 +26,7 @@ pub(super) fn has_prepare_capability(extensions: &[ExtensionManifest]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{get_publish_targets, has_package_capability, has_prepare_capability};
-    use crate::extension::ExtensionManifest;
+    use crate::core::extension::ExtensionManifest;
 
     fn extension(id: &str, actions: &[&str]) -> ExtensionManifest {
         let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({

--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -140,7 +140,7 @@ fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{build_summary, derive_overall_status};
-    use crate::release::types::{ReleaseStepResult, ReleaseStepStatus};
+    use crate::core::release::types::{ReleaseStepResult, ReleaseStepStatus};
 
     fn step(id: &str, status: ReleaseStepStatus) -> ReleaseStepResult {
         ReleaseStepResult {

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -1,13 +1,15 @@
-use crate::component::Component;
-use crate::extension::ExtensionManifest;
-use crate::git;
-use crate::plan::{PlanStep, PlanValues};
-use crate::quality::{build_quality_steps as build_shared_quality_steps, QualityPlanOptions};
-use crate::release::pipeline_capabilities::{
+use crate::core::component::Component;
+use crate::core::extension::ExtensionManifest;
+use crate::core::git;
+use crate::core::plan::{PlanStep, PlanValues};
+use crate::core::quality::{build_quality_steps as build_shared_quality_steps, QualityPlanOptions};
+use crate::core::release::pipeline_capabilities::{
     get_publish_targets, has_package_capability, has_prepare_capability,
 };
-use crate::release::types::{ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation};
-use crate::Result;
+use crate::core::release::types::{
+    ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation,
+};
+use crate::core::Result;
 
 type StepConfig = PlanValues;
 
@@ -19,14 +21,14 @@ type StepConfig = PlanValues;
 /// through cleanly — the step simply isn't added to the plan.
 pub(super) fn github_release_applies(component: &Component) -> bool {
     let remote_url = component.remote_url.clone().or_else(|| {
-        crate::deploy::release_download::detect_remote_url(std::path::Path::new(
+        crate::core::deploy::release_download::detect_remote_url(std::path::Path::new(
             &component.local_path,
         ))
     });
 
     remote_url
         .as_deref()
-        .and_then(crate::deploy::release_download::parse_github_url)
+        .and_then(crate::core::deploy::release_download::parse_github_url)
         .is_some()
 }
 
@@ -308,8 +310,10 @@ pub(super) fn build_release_steps(
         log_status!("release", "Skipping publish/package steps (--skip-publish)");
     }
 
-    let post_release_hooks =
-        crate::engine::hooks::resolve_hooks(component, crate::engine::hooks::events::POST_RELEASE);
+    let post_release_hooks = crate::core::engine::hooks::resolve_hooks(
+        component,
+        crate::core::engine::hooks::events::POST_RELEASE,
+    );
     if !post_release_hooks.is_empty() {
         let post_release_needs = if !options.skip_publish && !publish_targets.is_empty() {
             if options.deploy {
@@ -454,10 +458,10 @@ fn string_array_config(key: &str, values: &[String]) -> StepConfig {
 #[cfg(test)]
 mod tests {
     use super::{build_preflight_steps, build_release_steps, github_release_applies};
-    use crate::component::{Component, ScopedExtensionConfig};
-    use crate::extension::ExtensionManifest;
-    use crate::plan::PlanStepStatus;
-    use crate::release::types::{
+    use crate::core::component::{Component, ScopedExtensionConfig};
+    use crate::core::extension::ExtensionManifest;
+    use crate::core::plan::PlanStepStatus;
+    use crate::core::release::types::{
         ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation,
     };
 

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -1,9 +1,9 @@
 //! Release planning: validate inputs and build the executable release plan.
 
-use crate::engine::validation::ValidationCollector;
-use crate::error::{Error, Result};
-use crate::git;
-use crate::version;
+use crate::core::engine::validation::ValidationCollector;
+use crate::core::error::{Error, Result};
+use crate::core::git;
+use crate::core::release::version;
 
 use super::context::{load_component, resolve_extensions};
 use super::plan_steps::{build_preflight_steps, build_release_steps};
@@ -122,7 +122,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
 #[cfg(test)]
 mod tests {
     use super::plan;
-    use crate::release::types::ReleaseOptions;
+    use crate::core::release::types::ReleaseOptions;
 
     #[test]
     fn test_plan() {
@@ -148,8 +148,8 @@ mod tests {
     /// hints survive in the resulting JSON details.
     #[test]
     fn working_tree_fail_fast_error_preserves_file_hints_through_collector() {
-        use crate::engine::validation::ValidationCollector;
-        use crate::error::Error;
+        use crate::core::engine::validation::ValidationCollector;
+        use crate::core::error::Error;
 
         let original = Error::validation_invalid_argument(
             "working_tree",

--- a/src/core/release/planning_changelog.rs
+++ b/src/core/release/planning_changelog.rs
@@ -1,8 +1,8 @@
-use crate::component::Component;
-use crate::engine::local_files::FileSystem;
-use crate::error::{Error, Result};
-use crate::git;
-use crate::release::changelog;
+use crate::core::component::Component;
+use crate::core::engine::local_files::FileSystem;
+use crate::core::error::{Error, Result};
+use crate::core::git;
+use crate::core::release::changelog;
 
 use super::planning_semver::resolve_tag_and_commits;
 use super::types::{ReleaseChangelogPlan, ReleaseOptions};
@@ -109,7 +109,7 @@ fn read_changelog_for_release(
     changelog_path: &std::path::Path,
     dry_run: bool,
 ) -> Result<String> {
-    match crate::engine::local_files::local().read(changelog_path) {
+    match crate::core::engine::local_files::local().read(changelog_path) {
         Ok(content) => Ok(content),
         Err(err) if dry_run && is_file_not_found_error(&err) => {
             log_status!(
@@ -145,7 +145,7 @@ pub(super) fn ensure_changelog_initialized(component: &Component) -> Result<()> 
         return Ok(());
     };
 
-    let configured_path = crate::paths::resolve_path(&component.local_path, target);
+    let configured_path = crate::core::paths::resolve_path(&component.local_path, target);
     if configured_path.exists() {
         return Ok(());
     }
@@ -156,10 +156,10 @@ pub(super) fn ensure_changelog_initialized(component: &Component) -> Result<()> 
     }
 
     if let Some(parent) = configured_path.parent() {
-        crate::engine::local_files::local().ensure_dir(parent)?;
+        crate::core::engine::local_files::local().ensure_dir(parent)?;
     }
 
-    crate::engine::local_files::local()
+    crate::core::engine::local_files::local()
         .write(&configured_path, changelog::INITIAL_CHANGELOG_CONTENT)?;
 
     log_status!(
@@ -231,9 +231,9 @@ mod tests {
         build_changelog_plan, ensure_changelog_initialized, generate_changelog_entries,
         group_commits_for_changelog, read_changelog_for_release, strip_pr_reference,
     };
-    use crate::component::Component;
-    use crate::git::{CommitCategory, CommitInfo};
-    use crate::release::types::ReleaseOptions;
+    use crate::core::component::Component;
+    use crate::core::git::{CommitCategory, CommitInfo};
+    use crate::core::release::types::ReleaseOptions;
 
     fn commit(subject: &str, category: CommitCategory) -> CommitInfo {
         CommitInfo {

--- a/src/core/release/planning_git.rs
+++ b/src/core/release/planning_git.rs
@@ -1,7 +1,7 @@
-use crate::component::Component;
-use crate::engine::command;
-use crate::error::{Error, Result};
-use crate::git;
+use crate::core::component::Component;
+use crate::core::engine::command;
+use crate::core::error::{Error, Result};
+use crate::core::git;
 
 /// Fetch from remote and fast-forward if behind.
 ///
@@ -69,7 +69,7 @@ pub(super) fn validate_default_branch(component: &Component) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{validate_default_branch, validate_remote_sync};
-    use crate::component::Component;
+    use crate::core::component::Component;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -1,4 +1,4 @@
-use crate::plan::PlanStep;
+use crate::core::plan::PlanStep;
 
 use super::types::{ReleaseOptions, ReleasePlan, ReleaseSemverRecommendation};
 
@@ -54,8 +54,8 @@ fn skipped_release_plan(
 #[cfg(test)]
 mod tests {
     use super::release_skip_plan;
-    use crate::plan::PlanStepStatus;
-    use crate::release::types::{
+    use crate::core::plan::PlanStepStatus;
+    use crate::core::release::types::{
         ReleaseBumpPolicyOptions, ReleaseOptions, ReleaseSemverRecommendation,
     };
 

--- a/src/core/release/planning_quality.rs
+++ b/src/core/release/planning_quality.rs
@@ -1,7 +1,7 @@
-use crate::component::Component;
-use crate::engine::run_dir::{self, RunDir};
-use crate::error::{Error, Result};
-use crate::extension;
+use crate::core::component::Component;
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::error::{Error, Result};
+use crate::core::extension;
 
 /// Run release lint via the component's extension.
 ///
@@ -40,11 +40,12 @@ pub(super) fn validate_lint_quality(component: &Component) -> Result<bool> {
         true
     } else {
         let source_path = std::path::Path::new(&component.local_path);
-        let findings = crate::extension::lint::baseline::parse_findings_file(&lint_findings_file)
-            .unwrap_or_default();
+        let findings =
+            crate::core::extension::lint::baseline::parse_findings_file(&lint_findings_file)
+                .unwrap_or_default();
 
-        if let Some(baseline) = crate::extension::lint::baseline::load_baseline(source_path) {
-            let comparison = crate::extension::lint::baseline::compare(&findings, &baseline);
+        if let Some(baseline) = crate::core::extension::lint::baseline::load_baseline(source_path) {
+            let comparison = crate::core::extension::lint::baseline::compare(&findings, &baseline);
             if comparison.drift_increased {
                 log_status!(
                     "release",
@@ -165,8 +166,8 @@ mod tests {
         code_quality_failure_message, is_runner_infrastructure_failure, validate_lint_quality,
         validate_test_quality,
     };
-    use crate::component::Component;
-    use crate::extension::RunnerOutput;
+    use crate::core::component::Component;
+    use crate::core::extension::RunnerOutput;
 
     fn component_without_quality_runners() -> Component {
         Component {

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -1,6 +1,6 @@
-use crate::component::Component;
-use crate::error::{Error, Result};
-use crate::git;
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::git;
 
 use super::types::{ReleaseSemverCommit, ReleaseSemverRecommendation};
 
@@ -183,7 +183,7 @@ mod tests {
     use super::{
         build_semver_recommendation, resolve_tag_and_commits, validate_release_version_floor,
     };
-    use crate::component::Component;
+    use crate::core::component::Component;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")

--- a/src/core/release/planning_worktree.rs
+++ b/src/core/release/planning_worktree.rs
@@ -1,8 +1,8 @@
-use crate::component::Component;
-use crate::error::{Error, Result};
-use crate::git::UncommittedChanges;
-use crate::release::changelog;
-use crate::release::version::ComponentVersionInfo;
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::git::UncommittedChanges;
+use crate::core::release::changelog;
+use crate::core::release::version::ComponentVersionInfo;
 
 use super::types::ReleaseOptions;
 
@@ -13,7 +13,7 @@ pub(super) fn validate_release_worktree(
     options: &ReleaseOptions,
     version_info: &ComponentVersionInfo,
 ) -> Result<Option<serde_json::Value>> {
-    let uncommitted = crate::git::get_uncommitted_changes(&component.local_path)?;
+    let uncommitted = crate::core::git::get_uncommitted_changes(&component.local_path)?;
     if !uncommitted.has_changes {
         return Ok(None);
     }
@@ -66,7 +66,7 @@ pub(super) fn validate_release_worktree(
 /// Stage 0 fail-fast: refuse to run release work when the working tree has
 /// unexplained dirty files before lint/test/build can drown out the real error.
 pub(super) fn validate_working_tree_fail_fast(component: &Component) -> Result<()> {
-    let uncommitted = crate::git::get_uncommitted_changes(&component.local_path)?;
+    let uncommitted = crate::core::git::get_uncommitted_changes(&component.local_path)?;
     if !uncommitted.has_changes {
         return Ok(());
     }
@@ -172,10 +172,10 @@ mod tests {
         filter_homeboy_managed, get_release_allowed_files, get_unexpected_uncommitted_files,
         is_homeboy_managed_path, validate_release_worktree, validate_working_tree_fail_fast,
     };
-    use crate::component::Component;
-    use crate::git::UncommittedChanges;
-    use crate::release::types::ReleaseOptions;
-    use crate::release::version::{ComponentVersionInfo, VersionTargetInfo};
+    use crate::core::component::Component;
+    use crate::core::git::UncommittedChanges;
+    use crate::core::release::types::ReleaseOptions;
+    use crate::core::release::version::{ComponentVersionInfo, VersionTargetInfo};
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -2,8 +2,8 @@ use serde::ser::Error as SerializeError;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
 use crate::is_zero_u32;
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 /// Ordered release plan shared by dry-run output and release execution.
 ///
@@ -145,7 +145,7 @@ pub struct ReleaseStepResult {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub hints: Vec<crate::error::Hint>,
+    pub hints: Vec<crate::core::error::Hint>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -197,7 +197,7 @@ pub struct ReleaseState {
     pub tag: Option<String>,
     pub notes: Option<String>,
     pub artifacts: Vec<ReleaseArtifact>,
-    pub changelog_validation: Option<crate::version::ChangelogValidationResult>,
+    pub changelog_validation: Option<crate::core::release::version::ChangelogValidationResult>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -297,7 +297,7 @@ pub struct ReleaseProjectDeployResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub component_result: Option<crate::deploy::ComponentDeployResult>,
+    pub component_result: Option<crate::core::deploy::ComponentDeployResult>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/release/utils.rs
+++ b/src/core/release/utils.rs
@@ -1,5 +1,5 @@
-use crate::engine::validation;
-use crate::error::Result;
+use crate::core::engine::validation;
+use crate::core::error::Result;
 
 use super::types::ReleaseArtifact;
 
@@ -48,7 +48,7 @@ pub fn parse_release_artifacts(value: &serde_json::Value) -> Result<Vec<ReleaseA
         _ => Vec::new(),
     };
 
-    use crate::error::Error;
+    use crate::core::error::Error;
     for item in items {
         let artifact = match item {
             serde_json::Value::String(path) => ReleaseArtifact {

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -6,14 +6,14 @@ pub use default_pattern_for_file::*;
 pub use types::*;
 pub use version::*;
 
-use crate::component::{self, Component, VersionTarget};
-use crate::config::{from_str, set_json_pointer, to_string_pretty};
-use crate::engine::hooks::{self, HookFailureMode};
-use crate::engine::local_files::{self, FileSystem};
-use crate::engine::text;
-use crate::error::{Error, Result};
-use crate::extension::ExtensionManifest;
-use crate::release::changelog;
+use crate::core::component::{self, Component, VersionTarget};
+use crate::core::config::{from_str, set_json_pointer, to_string_pretty};
+use crate::core::engine::hooks::{self, HookFailureMode};
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::text;
+use crate::core::error::{Error, Result};
+use crate::core::extension::ExtensionManifest;
+use crate::core::release::changelog;
 use serde_json::Value;
 use std::path::Path;
 
@@ -500,7 +500,7 @@ pub(crate) fn bump_component_version_with_changelog(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::component::Component;
+    use crate::core::component::Component;
     use regex::Regex;
     use std::fs;
 

--- a/src/core/release/version/default_pattern_for_file.rs
+++ b/src/core/release/version/default_pattern_for_file.rs
@@ -1,12 +1,12 @@
 //! default_pattern_for_file — extracted from version.rs.
 
-use crate::component::{self, Component, VersionTarget};
-use crate::engine::codebase_scan;
-use crate::engine::local_files::{self, FileSystem};
-use crate::engine::text;
-use crate::error::{Error, Result};
-use crate::extension::load_all_extensions;
-use crate::paths::resolve_path_string;
+use crate::core::component::{self, Component, VersionTarget};
+use crate::core::engine::codebase_scan;
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::engine::text;
+use crate::core::error::{Error, Result};
+use crate::core::extension::load_all_extensions;
+use crate::core::paths::resolve_path_string;
 use regex::Regex;
 use std::fs;
 use std::path::Path;
@@ -72,7 +72,7 @@ pub(crate) fn build_version_parse_error(file: &str, pattern: &str, content: &str
     }
 
     if content.contains("Version:")
-        && !Regex::new(&crate::engine::text::ensure_multiline(pattern))
+        && !Regex::new(&crate::core::engine::text::ensure_multiline(pattern))
             .map(|r| r.is_match(content))
             .unwrap_or(false)
     {
@@ -192,7 +192,7 @@ pub fn read_version(component_id: Option<&str>) -> Result<ComponentVersionInfo> 
     // If no component_id, return homeboy binary's own version
     let id = match component_id {
         None => {
-            let version = crate::upgrade::current_version().to_string();
+            let version = crate::core::upgrade::current_version().to_string();
             return Ok(ComponentVersionInfo {
                 version,
                 targets: vec![],
@@ -349,7 +349,7 @@ pub(crate) fn replace_since_tag_placeholders(
     component: &Component,
     new_version: &str,
 ) -> Result<usize> {
-    use crate::extension::load_extension;
+    use crate::core::extension::load_extension;
 
     // Find the extension's since_tag config
     let since_tag = component.extensions.as_ref().and_then(|extensions| {

--- a/src/core/release/version/version.rs
+++ b/src/core/release/version/version.rs
@@ -1,7 +1,7 @@
 //! version — extracted from version.rs.
 
-use crate::component::Component;
-use crate::engine::text;
+use crate::core::component::Component;
+use crate::core::engine::text;
 
 use super::read_local_version;
 

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -1,6 +1,6 @@
-use crate::error::{Error, Result};
-use crate::git;
-use crate::plan::PlanStep;
+use crate::core::error::{Error, Result};
+use crate::core::git;
+use crate::core::plan::PlanStep;
 
 use super::context::load_component;
 use super::types::{
@@ -314,7 +314,7 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
     }
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
-    let version_info = crate::version::read_component_version(&component)?;
+    let version_info = crate::core::release::version::read_component_version(&component)?;
     let current_version = &version_info.version;
     let tag_name = format_tag(current_version, monorepo.as_ref());
 
@@ -639,8 +639,8 @@ pub fn run_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plan::{PlanStep, PlanStepStatus, PlanValues};
-    use crate::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
+    use crate::core::plan::{PlanStep, PlanStepStatus, PlanValues};
+    use crate::core::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
 
     #[test]
     fn extracts_new_version_from_plan() {

--- a/src/core/rig/app.rs
+++ b/src/core/rig/app.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 
 use super::expand::expand_vars;
 use super::spec::{AppLauncherPlatform, AppLauncherPreflight, RigSpec};
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 mod bundle;
 

--- a/src/core/rig/app/bundle.rs
+++ b/src/core/rig/app/bundle.rs
@@ -4,9 +4,9 @@ use std::fs;
 use std::path::Path;
 
 use super::ResolvedLauncher;
-use crate::error::{Error, Result};
-use crate::rig::spec::AppLauncherPreflight;
-use crate::rig::RigSpec;
+use crate::core::error::{Error, Result};
+use crate::core::rig::spec::AppLauncherPreflight;
+use crate::core::rig::RigSpec;
 
 pub(super) fn write_macos_bundle(rig: &RigSpec, launcher: &ResolvedLauncher) -> Result<()> {
     let contents = launcher.launcher_path.join("Contents");

--- a/src/core/rig/check.rs
+++ b/src/core/rig/check.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 use super::expand::expand_vars;
 use super::service::discover_newest_for_spec;
 use super::spec::{CheckSpec, NewerThanSpec, RigSpec, TimeSource};
-use crate::error::{Error, Result};
-use crate::http_probe;
+use crate::core::error::{Error, Result};
+use crate::core::http_probe;
 
 /// Run a check against the current rig state. Err on fail.
 pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {

--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -11,7 +11,7 @@
 //! command-run failure instead of a silent empty string.
 
 use super::spec::{RigResourcesSpec, RigSpec};
-use crate::expand;
+use crate::core::expand;
 use std::collections::BTreeSet;
 
 /// Expand variables + tilde in a string.

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -5,8 +5,8 @@
 //! Installed rigs stay loadable through the existing flat rig config path by
 //! linking `~/.config/homeboy/rigs/<id>.json` to the package spec.
 
-use crate::error::{Error, Result};
-use crate::{extension, git, paths, stack};
+use crate::core::error::{Error, Result};
+use crate::core::{extension, git, paths, stack};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -14,8 +14,8 @@ mod lock;
 use super::expand::expand_resources;
 use super::spec::{RigResourcesSpec, RigSpec};
 use super::state::now_rfc3339;
-use crate::error::{Error, Result, RigResourceConflictInfo};
-use crate::paths;
+use crate::core::error::{Error, Result, RigResourceConflictInfo};
+use crate::core::paths;
 use lock::LeaseIndexLock;
 
 /// On-disk lease held by one active mutating rig command.

--- a/src/core/rig/lease/lock.rs
+++ b/src/core/rig/lease/lock.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime};
 
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 
 const INDEX_LOCK_NAME: &str = ".index.lock";
 const INDEX_LOCK_STALE_AFTER: Duration = Duration::from_secs(30);

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -72,8 +72,8 @@ pub use workloads::{
     invocation_requirements_for_extension_workloads, workloads_for_extension, RigWorkloadKind,
 };
 
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 use std::fs;
 use std::path::Path;
 

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -22,8 +22,8 @@ use super::spec::{
 use super::stack as rig_stack;
 use super::state::{now_rfc3339, RigState, SharedPathState};
 use super::toolchain;
-use crate::component::Component;
-use crate::error::{Error, Result};
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
 
 /// Result of one pipeline step.
 #[derive(Debug, Clone, Serialize)]
@@ -350,11 +350,11 @@ fn resolve_rig_component(rig: &RigSpec, component_id: &str) -> Result<Component>
 
 fn run_build_step(rig: &RigSpec, component_id: &str) -> Result<()> {
     let component = resolve_rig_component(rig, component_id)?;
-    let (result, exit_code) = crate::build::run_component(&component)?;
+    let (result, exit_code) = crate::core::build::run_component(&component)?;
 
     if exit_code != 0 {
         let detail = match &result {
-            crate::build::BuildResult::Single(output) => {
+            crate::core::build::BuildResult::Single(output) => {
                 let tail = output
                     .output
                     .stderr
@@ -372,7 +372,7 @@ fn run_build_step(rig: &RigSpec, component_id: &str) -> Result<()> {
                     format!("exit {} — {}", exit_code, tail)
                 }
             }
-            crate::build::BuildResult::Bulk(_) => format!("exit {}", exit_code),
+            crate::core::build::BuildResult::Bulk(_) => format!("exit {}", exit_code),
         };
         return Err(Error::rig_pipeline_failed(
             &rig.id,
@@ -416,7 +416,7 @@ fn run_git_step(rig: &RigSpec, component_id: &str, op: GitOp, extra_args: &[Stri
     }
     let arg_refs: Vec<&str> = full_args.iter().map(String::as_str).collect();
 
-    let output = crate::git::execute_git_for_release(&path, &arg_refs).map_err(|e| {
+    let output = crate::core::git::execute_git_for_release(&path, &arg_refs).map_err(|e| {
         Error::rig_pipeline_failed(
             &rig.id,
             "git",
@@ -448,18 +448,20 @@ fn run_git_step(rig: &RigSpec, component_id: &str, op: GitOp, extra_args: &[Stri
 }
 
 fn fail_if_git_index_unmerged(rig: &RigSpec, path: &str, completed_args: &[String]) -> Result<()> {
-    let output =
-        crate::git::execute_git_for_release(path, &["diff", "--name-only", "--diff-filter=U"])
-            .map_err(|e| {
-                Error::rig_pipeline_failed(
-                    &rig.id,
-                    "git",
-                    format!(
-                        "spawn `git diff --name-only --diff-filter=U` in {}: {}",
-                        path, e
-                    ),
-                )
-            })?;
+    let output = crate::core::git::execute_git_for_release(
+        path,
+        &["diff", "--name-only", "--diff-filter=U"],
+    )
+    .map_err(|e| {
+        Error::rig_pipeline_failed(
+            &rig.id,
+            "git",
+            format!(
+                "spawn `git diff --name-only --diff-filter=U` in {}: {}",
+                path, e
+            ),
+        )
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -19,9 +19,9 @@ use super::spec::{RigSpec, ServiceKind, SymlinkSpec};
 use super::state::{
     now_rfc3339, ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot,
 };
-use crate::engine::command::run_in_optional;
-use crate::error::{Error, Result};
-use crate::observation::{NewRunRecord, ObservationStore, RunStatus};
+use crate::core::engine::command::run_in_optional;
+use crate::core::error::{Error, Result};
+use crate::core::observation::{NewRunRecord, ObservationStore, RunStatus};
 
 /// Report from `rig up`.
 #[derive(Debug, Clone, Serialize)]

--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -18,7 +18,7 @@
 //! returns `RigServiceFailed` so the crate still builds everywhere.
 
 use super::spec::{DiscoverSpec, RigSpec};
-use crate::error::Result;
+use crate::core::error::Result;
 
 /// Live status of a service as seen at probe time.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,8 +107,8 @@ mod platform {
     use super::super::spec::{RigSpec, ServiceKind, ServiceSpec};
     use super::super::state::{now_rfc3339, ServiceState};
     use super::ServiceStatus;
-    use crate::error::{Error, Result};
-    use crate::paths;
+    use crate::core::error::{Error, Result};
+    use crate::core::paths;
 
     pub fn start(rig: &RigSpec, service_id: &str) -> Result<u32> {
         let spec = rig.services.get(service_id).ok_or_else(|| {
@@ -544,7 +544,7 @@ mod platform {
     //! reason instead of a compile error.
     use super::super::spec::RigSpec;
     use super::ServiceStatus;
-    use crate::error::{Error, Result};
+    use crate::core::error::{Error, Result};
 
     const UNSUPPORTED: &str = "rig services are not supported on this platform (Unix only)";
 

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -1,8 +1,8 @@
 //! Installed rig source lifecycle.
 
-use crate::error::{Error, Result};
-use crate::git;
-use crate::paths;
+use crate::core::error::{Error, Result};
+use crate::core::git;
+use crate::core::paths;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -2,12 +2,12 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::extension::trace::TraceProbeConfig;
-use crate::extension::trace::TraceSpanMetadata;
+use crate::core::extension::trace::TraceProbeConfig;
+use crate::core::extension::trace::TraceSpanMetadata;
 use std::collections::{BTreeMap, HashMap};
 
-use crate::component::ScopedExtensionConfig;
-use crate::extension::bench::{BenchGate, BenchGateOp};
+use crate::core::component::ScopedExtensionConfig;
+use crate::core::extension::bench::{BenchGate, BenchGateOp};
 
 /// A rig: components + services + pipelines.
 ///

--- a/src/core/rig/stack.rs
+++ b/src/core/rig/stack.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 
 use super::expand::expand_vars;
 use super::spec::RigSpec;
-use crate::error::{ErrorCode, Result};
-use crate::stack::{self, StackSpec, SyncOutput};
+use crate::core::error::{ErrorCode, Result};
+use crate::core::stack::{self, StackSpec, SyncOutput};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct RigStackPlanEntry {
@@ -79,7 +79,7 @@ pub fn run_component_sync(
     dry_run: bool,
 ) -> Result<RigStackSyncEntry> {
     let component = rig.components.get(component_id).ok_or_else(|| {
-        crate::Error::rig_pipeline_failed(
+        crate::core::Error::rig_pipeline_failed(
             &rig.id,
             "stack",
             format!(
@@ -89,7 +89,7 @@ pub fn run_component_sync(
         )
     })?;
     let stack_id = component.stack.as_ref().ok_or_else(|| {
-        crate::Error::rig_pipeline_failed(
+        crate::core::Error::rig_pipeline_failed(
             &rig.id,
             "stack",
             format!("component '{}' does not declare a stack", component_id),
@@ -107,7 +107,7 @@ pub fn run_component_sync(
         return Ok(entry);
     }
 
-    Err(crate::Error::rig_pipeline_failed(
+    Err(crate::core::Error::rig_pipeline_failed(
         &rig.id,
         "stack",
         format!(
@@ -207,7 +207,7 @@ pub(crate) fn validate_component_stack_path(
     stack_spec: &StackSpec,
 ) -> Result<()> {
     let component = rig.components.get(component_id).ok_or_else(|| {
-        crate::Error::rig_pipeline_failed(
+        crate::core::Error::rig_pipeline_failed(
             &rig.id,
             "stack",
             format!(
@@ -223,7 +223,7 @@ pub(crate) fn validate_component_stack_path(
         return Ok(());
     }
 
-    Err(crate::Error::rig_pipeline_failed(
+    Err(crate::core::Error::rig_pipeline_failed(
         &rig.id,
         "stack",
         format!(

--- a/src/core/rig/state.rs
+++ b/src/core/rig/state.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 
-use crate::error::{Error, Result};
-use crate::paths;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
 
 use super::spec::RigResourcesSpec;
 

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use crate::engine::invocation::InvocationRequirements;
+use crate::core::engine::invocation::InvocationRequirements;
 
 use super::spec::RigSpec;
 

--- a/src/core/runner/apply.rs
+++ b/src/core/runner/apply.rs
@@ -6,8 +6,8 @@ use std::process::{Command, Stdio};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Error, Result};
-use crate::source_snapshot::SourceSnapshot;
+use crate::core::error::{Error, Result};
+use crate::core::source_snapshot::SourceSnapshot;
 
 #[derive(Debug, Clone)]
 pub struct RunnerWorkspaceApplyOptions {
@@ -292,7 +292,7 @@ fn safe_join(root: &Path, relative: &str) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::source_snapshot::SourceSnapshot;
+    use crate::core::source_snapshot::SourceSnapshot;
 
     #[test]
     fn test_apply_workspace_patch() {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -7,10 +7,10 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::paths;
-use crate::server::{self, Server, ServerAuthMode, SshClient};
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
+use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
 use super::{load, Runner, RunnerKind};
 
@@ -561,7 +561,7 @@ fn failed_connect(
     )
 }
 
-fn command_failure_message(prefix: &str, output: &crate::server::CommandOutput) -> String {
+fn command_failure_message(prefix: &str, output: &crate::core::server::CommandOutput) -> String {
     format!(
         "{} (exit {}): stdout={}, stderr={}",
         prefix,
@@ -656,7 +656,7 @@ mod tests {
     #[test]
     fn connect_reports_local_runner_as_unsupported() {
         test_support::with_isolated_home(|_| {
-            crate::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+            crate::core::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
                 .expect("create runner");
 
             let (report, exit_code) = connect("lab-local").expect("connect report");
@@ -675,7 +675,7 @@ mod tests {
     #[test]
     fn disconnect_removes_existing_session_file() {
         test_support::with_isolated_home(|_| {
-            crate::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
+            crate::core::runner::create(r#"{"id":"lab-local","kind":"local"}"#, false)
                 .expect("create runner");
             let session = RunnerSession {
                 runner_id: "lab-local".to_string(),

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 use base64::Engine;
 use serde_json::{json, Value};
 
-use crate::api_jobs::{Job, JobEvent, JobStatus};
-use crate::error::{Error, Result};
-use crate::observation::{ArtifactRecord, ObservationStore, RunRecord};
-use crate::paths;
+use crate::core::api_jobs::{Job, JobEvent, JobStatus};
+use crate::core::error::{Error, Result};
+use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use crate::core::paths;
 
 use super::execution::daemon_api_get;
 use super::Runner;
@@ -489,7 +489,7 @@ fn decode_component(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runner::RunnerKind;
+    use crate::core::runner::RunnerKind;
     use uuid::Uuid;
 
     fn ssh_runner() -> Runner {

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -4,11 +4,11 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::api_jobs::{Job, JobEvent, JobStatus};
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::server::{self, SshClient};
-use crate::source_snapshot::SourceSnapshot;
+use crate::core::api_jobs::{Job, JobEvent, JobStatus};
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::server::{self, SshClient};
+use crate::core::source_snapshot::SourceSnapshot;
 
 use super::evidence::mirror_daemon_evidence;
 use super::{load, status, Runner, RunnerKind};
@@ -267,7 +267,7 @@ fn result_event_data(events: &[JobEvent]) -> Option<Value> {
     events
         .iter()
         .rev()
-        .find(|event| matches!(event.kind, crate::api_jobs::JobEventKind::Result))
+        .find(|event| matches!(event.kind, crate::core::api_jobs::JobEventKind::Result))
         .and_then(|event| event.data.clone())
 }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::config::{self, ConfigEntity};
-use crate::error::{Error, Result};
-use crate::output::{CreateOutput, MergeOutput, RemoveResult};
-use crate::server;
+use crate::core::config::{self, ConfigEntity};
+use crate::core::error::{Error, Result};
+use crate::core::output::{CreateOutput, MergeOutput, RemoveResult};
+use crate::core::server;
 
 mod apply;
 mod connection;

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -6,9 +6,9 @@ use glob_match::glob_match;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::engine::shell;
-use crate::error::{Error, Result};
-use crate::server::{self, Server, SshClient};
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
+use crate::core::server::{self, Server, SshClient};
 
 use super::{load, Runner, RunnerKind};
 

--- a/src/core/scope.rs
+++ b/src/core/scope.rs
@@ -9,10 +9,10 @@ use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use crate::component;
-use crate::deploy::release_download::detect_remote_url;
-use crate::error::{Error, Result};
-use crate::{fleet, project, rig};
+use crate::core::component;
+use crate::core::deploy::release_download::detect_remote_url;
+use crate::core::error::{Error, Result};
+use crate::core::{fleet, project, rig};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Scope {

--- a/src/core/self_status.rs
+++ b/src/core/self_status.rs
@@ -1,4 +1,4 @@
-use crate::upgrade::{self, InstallMethod};
+use crate::core::upgrade::{self, InstallMethod};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/core/server/api.rs
+++ b/src/core/server/api.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::http::{ApiClient, BodyFormat};
-use crate::error::{Error, Result};
-use crate::project;
+use crate::core::error::{Error, Result};
+use crate::core::project;
 
 #[derive(Debug, Clone, Serialize)]
 

--- a/src/core/server/auth.rs
+++ b/src/core/server/auth.rs
@@ -4,9 +4,9 @@
 //! the underlying HTTP client or keychain implementation.
 
 use super::http::ApiClient;
-use crate::error::Result;
-use crate::keychain;
-use crate::project;
+use crate::core::error::Result;
+use crate::core::keychain;
+use crate::core::project;
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -194,7 +194,7 @@ fn redact(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::project::VariableSource;
+    use crate::core::project::VariableSource;
 
     #[test]
     fn test_redact() {

--- a/src/core/server/auth_profiles.rs
+++ b/src/core/server/auth_profiles.rs
@@ -1,7 +1,7 @@
 //! Reusable keychain-backed auth profiles for generic HTTP requests.
 
-use crate::error::{Error, ErrorCode, Result};
-use crate::keychain;
+use crate::core::error::{Error, ErrorCode, Result};
+use crate::core::keychain;
 use base64::Engine;
 use serde::Serialize;
 

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -5,10 +5,10 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
-use crate::engine::invocation;
-use crate::engine::resource::{ChildProcessIdentity, ExtensionChildResourceSummary};
-use crate::engine::shell;
-use crate::error::{Error, Result};
+use crate::core::engine::invocation;
+use crate::core::engine::resource::{ChildProcessIdentity, ExtensionChildResourceSummary};
+use crate::core::engine::shell;
+use crate::core::error::{Error, Result};
 use chrono::Utc;
 
 use super::{
@@ -1465,7 +1465,7 @@ mod tests {
         ));
         let command = format!(
             "sh -c 'sleep 30 >/dev/null 2>&1 < /dev/null & echo $! > {}'",
-            crate::engine::shell::quote_path(&pid_file.to_string_lossy())
+            crate::core::engine::shell::quote_path(&pid_file.to_string_lossy())
         );
 
         let output = execute_local_command_in_dir(&command, None, None);

--- a/src/core/server/connection.rs
+++ b/src/core/server/connection.rs
@@ -1,5 +1,5 @@
-use crate::error::{Error, Result};
-use crate::project::{self, Project};
+use crate::core::error::{Error, Result};
+use crate::core::project::{self, Project};
 
 use super::Server;
 

--- a/src/core/server/health.rs
+++ b/src/core/server/health.rs
@@ -4,7 +4,7 @@
 //! to collect uptime, load, disk, memory, and service health from remote servers.
 
 use super::SshClient;
-use crate::project::Project;
+use crate::core::project::Project;
 use serde::Serialize;
 
 // ============================================================================

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -3,10 +3,10 @@
 //! Makes HTTP requests with auth headers resolved from project configuration.
 //! Homeboy doesn't know about specific auth types - it just templates strings.
 
-use crate::error::{Error, ErrorCode, Result};
-use crate::extension::HttpMethod;
-use crate::keychain;
-use crate::project::{ApiConfig, AuthConfig, AuthFlowConfig, VariableSource};
+use crate::core::error::{Error, ErrorCode, Result};
+use crate::core::extension::HttpMethod;
+use crate::core::keychain;
+use crate::core::project::{ApiConfig, AuthConfig, AuthFlowConfig, VariableSource};
 use reqwest::blocking::{Client, ClientBuilder, RequestBuilder, Response};
 use reqwest::Proxy;
 use serde_json::{json, Value};
@@ -367,7 +367,7 @@ fn parse_json_response(response: Response) -> Result<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::project::{AuthConfig, AuthFlowConfig};
+    use crate::core::project::{AuthConfig, AuthFlowConfig};
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;

--- a/src/core/server/keys.rs
+++ b/src/core/server/keys.rs
@@ -1,5 +1,5 @@
-use crate::engine::local_files::{self, FileSystem};
-use crate::error::{Error, Result};
+use crate::core::engine::local_files::{self, FileSystem};
+use crate::core::error::{Error, Result};
 use serde::Serialize;
 use std::process::Command;
 

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -18,11 +18,11 @@ pub use transfer::*;
 
 use std::collections::HashMap;
 
-use crate::config::{self, ConfigEntity};
-use crate::error::{Error, Result};
-use crate::output::{CreateOutput, MergeOutput, RemoveResult};
-use crate::paths;
-use crate::project;
+use crate::core::config::{self, ConfigEntity};
+use crate::core::error::{Error, Result};
+use crate::core::output::{CreateOutput, MergeOutput, RemoveResult};
+use crate::core::paths;
+use crate::core::project;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/server/session.rs
+++ b/src/core/server/session.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::ServerAuth;
 
@@ -58,7 +58,7 @@ fn expand_control_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::server::{ServerAuthMode, ServerSessionConfig};
+    use crate::core::server::{ServerAuthMode, ServerSessionConfig};
 
     #[test]
     fn test_from_auth() {

--- a/src/core/server/transfer.rs
+++ b/src/core/server/transfer.rs
@@ -155,13 +155,13 @@ fn build_ssh_args(client: &SshClient) -> String {
 /// Execute a file transfer between local and remote paths, or between two servers.
 ///
 /// Returns `(TransferOutput, exit_code)` where exit_code is 0 on success.
-pub fn transfer(config: &TransferConfig) -> crate::Result<(TransferOutput, i32)> {
+pub fn transfer(config: &TransferConfig) -> crate::core::Result<(TransferOutput, i32)> {
     let source = parse_target(&config.source);
     let dest = parse_target(&config.destination);
 
     match (&source, &dest) {
         (TransferTarget::Local(_), TransferTarget::Local(_)) => {
-            Err(crate::Error::validation_invalid_argument(
+            Err(crate::core::Error::validation_invalid_argument(
                 "target",
                 "Both source and destination are local paths. At least one must be a remote server",
                 None,
@@ -197,7 +197,7 @@ fn run_push(
     local_path: &str,
     server_id: &str,
     remote_path: &str,
-) -> crate::Result<(TransferOutput, i32)> {
+) -> crate::core::Result<(TransferOutput, i32)> {
     let srv = super::load(server_id)?;
     let client = SshClient::from_server(&srv, server_id)?;
 
@@ -217,7 +217,7 @@ fn run_push(
     // Validate local path exists
     let local = std::path::Path::new(local_path);
     if !local.exists() {
-        return Err(crate::Error::validation_invalid_argument(
+        return Err(crate::core::Error::validation_invalid_argument(
             "source",
             format!("Local path does not exist: {}", local_path),
             None,
@@ -254,7 +254,7 @@ fn run_pull(
     server_id: &str,
     remote_path: &str,
     local_path: &str,
-) -> crate::Result<(TransferOutput, i32)> {
+) -> crate::core::Result<(TransferOutput, i32)> {
     let srv = super::load(server_id)?;
     let client = SshClient::from_server(&srv, server_id)?;
 
@@ -276,7 +276,7 @@ fn run_pull(
     if let Some(parent) = local.parent() {
         if !parent.exists() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                crate::Error::internal_io(
+                crate::core::Error::internal_io(
                     e.to_string(),
                     Some(format!("create directory {}", parent.display())),
                 )
@@ -314,7 +314,7 @@ fn run_server_to_server(
     src_path: &str,
     dst_id: &str,
     dst_path: &str,
-) -> crate::Result<(TransferOutput, i32)> {
+) -> crate::core::Result<(TransferOutput, i32)> {
     let src_server = super::load(src_id)?;
     let dst_server = super::load(dst_id)?;
 
@@ -430,7 +430,7 @@ fn run_server_to_server(
 fn execute_scp(
     scp_args: &[String],
     config: &TransferConfig,
-) -> crate::Result<(TransferOutput, i32)> {
+) -> crate::core::Result<(TransferOutput, i32)> {
     let output = Command::new("scp")
         .args(scp_args)
         .stdin(Stdio::null())
@@ -481,7 +481,7 @@ fn execute_scp(
 mod tests {
     use std::collections::HashMap;
 
-    use crate::server::{self, Server};
+    use crate::core::server::{self, Server};
     use crate::test_support::with_isolated_home;
 
     use super::{parse_target, transfer, TransferConfig, TransferTarget};

--- a/src/core/stack/apply.rs
+++ b/src/core/stack/apply.rs
@@ -25,7 +25,7 @@
 use serde::Serialize;
 use std::collections::HashSet;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::git::run_git;
 use super::pr_meta::{fetch_pr_meta, PrHead};

--- a/src/core/stack/git.rs
+++ b/src/core/stack/git.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 pub(crate) fn run_git(path: &str, args: &[&str]) -> Result<std::process::Output> {
     Command::new("git")

--- a/src/core/stack/inspect.rs
+++ b/src/core/stack/inspect.rs
@@ -18,8 +18,8 @@
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 
-use crate::error::{Error, Result};
-use crate::git::resolve_target;
+use crate::core::error::{Error, Result};
+use crate::core::git::resolve_target;
 
 /// Per-commit detail row for the inspect output.
 #[derive(Debug, Clone, Serialize)]

--- a/src/core/stack/pr_meta.rs
+++ b/src/core/stack/pr_meta.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::spec::StackPrEntry;
 
@@ -142,8 +142,8 @@ fn nested_string_field(parsed: &serde_json::Value, key: &str, child: &str) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::ErrorCode;
     use crate::test_support::home_env_guard;
-    use crate::ErrorCode;
     use std::fs;
 
     #[cfg(unix)]

--- a/src/core/stack/push.rs
+++ b/src/core/stack/push.rs
@@ -6,7 +6,7 @@
 
 use serde::Serialize;
 
-use crate::error::{Error, Result};
+use crate::core::error::{Error, Result};
 
 use super::git::run_git;
 use super::spec::{resolve_existing_component_path, StackSpec};

--- a/src/core/stack/spec.rs
+++ b/src/core/stack/spec.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
-use crate::error::{Error, Result};
-use crate::expand;
-use crate::paths;
+use crate::core::error::{Error, Result};
+use crate::core::expand;
+use crate::core::paths;
 
 /// A stack: the spec for one combined-fixes branch.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/stack/status.rs
+++ b/src/core/stack/status.rs
@@ -15,7 +15,7 @@
 
 use serde::Serialize;
 
-use crate::error::Result;
+use crate::core::error::Result;
 
 use super::git::run_git;
 use super::pr_meta::fetch_pr_meta;

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -31,8 +31,8 @@
 use serde::Serialize;
 use std::collections::HashSet;
 
-use crate::error::{Error, Result};
-use crate::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
+use crate::core::error::{Error, Result};
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 
 use super::apply::{
     checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, AppliedPr,

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -12,17 +12,17 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use crate::defaults;
-use crate::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
-use crate::error::{Error, Result};
-use crate::git::gh_probe_succeeds;
-use crate::observation::{
+use crate::core::defaults;
+use crate::core::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
+use crate::core::error::{Error, Result};
+use crate::core::git::gh_probe_succeeds;
+use crate::core::observation::{
     NewRunRecord, NewTriageItemRecord, ObservationStore, RunListFilter, RunStatus,
     TriageItemRecord, TriagePullRequestSignals,
 };
-use crate::scope::{self, Scope, ScopeComponentRef, ScopeKind, ScopeOutput};
+use crate::core::scope::{self, Scope, ScopeComponentRef, ScopeKind, ScopeOutput};
 
-pub use crate::scope::Scope as TriageTarget;
+pub use crate::core::scope::Scope as TriageTarget;
 
 #[derive(Debug, Clone, Default)]
 pub struct TriageOptions {

--- a/src/core/update_check_cache.rs
+++ b/src/core/update_check_cache.rs
@@ -10,7 +10,7 @@
 //! and JSON schemas are owned by the callers and are intentionally not
 //! changed here so existing user caches keep working.
 
-use crate::paths;
+use crate::core::paths;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::path::PathBuf;

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -1,5 +1,5 @@
-use crate::defaults;
-use crate::error::{Error, Result};
+use crate::core::defaults;
+use crate::core::error::{Error, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -1,5 +1,5 @@
-use crate::defaults;
-use crate::error::{Error, Result};
+use crate::core::defaults;
+use crate::core::error::{Error, Result};
 use std::path::Path;
 use std::process::Command;
 
@@ -239,7 +239,7 @@ pub fn run_upgrade_with_method(
 /// Migrate all flat-file projects to directory-based layout.
 /// Best-effort — failures are logged and returned in the result.
 fn migrate_all_projects() -> Vec<ProjectMigrationEntry> {
-    let results = crate::project::migrate_all_to_directories();
+    let results = crate::core::project::migrate_all_to_directories();
 
     if results.is_empty() {
         return vec![];
@@ -271,7 +271,7 @@ fn migrate_all_projects() -> Vec<ProjectMigrationEntry> {
 /// Update all installed extensions. Best-effort — failures are logged and
 /// the extension is added to the skipped list.
 fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
-    use crate::extension;
+    use crate::core::extension;
 
     let extension_ids = extension::available_extension_ids();
     if extension_ids.is_empty() {

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::extension::ExtensionSourceUpdate;
+use crate::core::extension::ExtensionSourceUpdate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/core/upgrade/update_check.rs
+++ b/src/core/upgrade/update_check.rs
@@ -14,7 +14,7 @@
 //! schema live here and are unchanged.
 
 use crate::core::update_check_cache;
-use crate::upgrade;
+use crate::core::upgrade;
 use serde::{Deserialize, Serialize};
 
 const CACHE_FILENAME: &str = "update_check.json";
@@ -49,7 +49,7 @@ fn is_disabled_by_env() -> bool {
 }
 
 pub(crate) fn is_disabled_by_config() -> bool {
-    !crate::defaults::load_config().update_check
+    !crate::core::defaults::load_config().update_check
 }
 
 fn print_hint(latest: &str, current: &str) {

--- a/src/core/upgrade/validation.rs
+++ b/src/core/upgrade/validation.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::core::error::Result;
 
 use super::helpers::{
     current_version, detect_install_method, fetch_latest_version, version_is_newer,

--- a/src/help_topics/mod.rs
+++ b/src/help_topics/mod.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::OnceLock;
 
-use homeboy::engine::text;
-use homeboy::extension::load_all_extensions;
+use homeboy::core::engine::text;
+use homeboy::core::extension::load_all_extensions;
 
 include!(concat!(env!("OUT_DIR"), "/generated_docs.rs"));
 
@@ -18,7 +18,7 @@ pub struct ResolvedDoc {
     pub content: String,
 }
 
-pub fn resolve(topic: &[String]) -> homeboy::Result<ResolvedDoc> {
+pub fn resolve(topic: &[String]) -> homeboy::core::Result<ResolvedDoc> {
     let (_, key, _) = normalize_topic(topic);
 
     // Try exact match first (existing behavior)
@@ -52,7 +52,7 @@ pub fn resolve(topic: &[String]) -> homeboy::Result<ResolvedDoc> {
         }
     }
 
-    Err(homeboy::Error::docs_topic_not_found(&key))
+    Err(homeboy::core::Error::docs_topic_not_found(&key))
 }
 
 fn load_extension_doc(topic: &str) -> Option<(String, String)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,6 @@ pub mod help_topics;
 
 #[cfg(test)]
 pub(crate) mod test_support;
-// Re-export everything from core for ergonomic library use
-// Users can write `homeboy::config` instead of `homeboy::core::config`
-pub use core::release::changelog;
-pub use core::release::version;
-pub use core::*;
 
 /// Helper for `#[serde(skip_serializing_if = "is_zero")]` on `usize` fields.
 pub fn is_zero(v: &usize) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use homeboy::commands::GlobalArgs;
 use homeboy::commands;
 use homeboy::commands::utils::{args, entity_suggest, resource_policy, response as output, tty};
 use homeboy::commands::{cli, review, trace};
-use homeboy::extension::load_all_extensions;
+use homeboy::core::extension::load_all_extensions;
 
 struct ExtensionCliCommand {
     tool: String,
@@ -146,7 +146,7 @@ fn main() -> std::process::ExitCode {
         .ok()
         .flatten()
         .cloned();
-    homeboy::set_artifact_root_override(artifact_root_override.clone());
+    homeboy::core::set_artifact_root_override(artifact_root_override.clone());
 
     if let Some(extension_cmd) = try_parse_extension_cli_command(&matches, &extension_info) {
         let cli_args = cli::CliArgs {
@@ -171,7 +171,7 @@ fn main() -> std::process::ExitCode {
 
     if let Some(runner_id) = cli.runner.as_deref() {
         if !cli.command.supports_lab_runner() {
-            let err = homeboy::Error::validation_invalid_argument(
+            let err = homeboy::core::Error::validation_invalid_argument(
                 "runner",
                 "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, and trace",
                 Some(runner_id.to_string()),
@@ -189,7 +189,7 @@ fn main() -> std::process::ExitCode {
         );
     }
 
-    homeboy::set_artifact_root_override(cli.artifact_root.clone().or(artifact_root_override));
+    homeboy::core::set_artifact_root_override(cli.artifact_root.clone().or(artifact_root_override));
 
     if matches!(&cli.command, Commands::Runs(args) if args.is_bundle_export()) {
         output_file = None;
@@ -224,8 +224,8 @@ fn main() -> std::process::ExitCode {
         &cli.command,
         Commands::Upgrade(_) | Commands::Daemon(_) | Commands::SelfCmd(_)
     ) {
-        homeboy::upgrade::update_check::run_startup_check();
-        homeboy::extension::update_check::run_startup_check();
+        homeboy::core::upgrade::update_check::run_startup_check();
+        homeboy::core::extension::update_check::run_startup_check();
     }
 
     let mode = cli.command.response_mode(output_file.is_some());
@@ -235,7 +235,7 @@ fn main() -> std::process::ExitCode {
         CommandResponseMode::Json => {}
         CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough) => {
             if !tty::require_tty_for_interactive() {
-                let err = homeboy::Error::validation_invalid_argument(
+                let err = homeboy::core::Error::validation_invalid_argument(
                     "tty",
                     "This command requires an interactive TTY. For non-interactive usage, run: homeboy ssh <target> -- <command...>",
                     None,
@@ -371,10 +371,10 @@ fn run_lab_offload_inner(
     normalized_args: &[String],
     output_file: Option<&str>,
     capture_patch: bool,
-) -> homeboy::Result<i32> {
-    let runner = homeboy::runner::load(runner_id)?;
-    if runner.kind != homeboy::runner::RunnerKind::Ssh {
-        return Err(homeboy::Error::validation_invalid_argument(
+) -> homeboy::core::Result<i32> {
+    let runner = homeboy::core::runner::load(runner_id)?;
+    if runner.kind != homeboy::core::runner::RunnerKind::Ssh {
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "runner",
             "Lab offload requires a remote SSH runner; local runners would execute on this machine",
             Some(runner.id),
@@ -385,9 +385,9 @@ fn run_lab_offload_inner(
         ));
     }
 
-    let status = homeboy::runner::status(runner_id)?;
+    let status = homeboy::core::runner::status(runner_id)?;
     if !status.connected {
-        return Err(homeboy::Error::validation_invalid_argument(
+        return Err(homeboy::core::Error::validation_invalid_argument(
             "runner",
             "Lab offload requires a connected runner daemon",
             Some(runner_id.to_string()),
@@ -398,7 +398,7 @@ fn run_lab_offload_inner(
     }
 
     let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
-        homeboy::Error::validation_invalid_argument(
+        homeboy::core::Error::validation_invalid_argument(
             "workspace_root",
             "Lab offload requires runner.workspace_root so the local checkout can be mapped remotely",
             Some(runner.id.clone()),
@@ -408,10 +408,10 @@ fn run_lab_offload_inner(
         )
     })?;
     let remote_cwd = remote_cwd_for_current_checkout(workspace_root)?;
-    let source_snapshot = homeboy::source_snapshot::SourceSnapshot::collect_local(
+    let source_snapshot = homeboy::core::source_snapshot::SourceSnapshot::collect_local(
         runner_id,
         &std::env::current_dir().map_err(|err| {
-            homeboy::Error::internal_io(err.to_string(), Some("read cwd".to_string()))
+            homeboy::core::Error::internal_io(err.to_string(), Some("read cwd".to_string()))
         })?,
         Some(&remote_cwd),
         "lab_offload",
@@ -426,9 +426,9 @@ fn run_lab_offload_inner(
         runner_id,
         remote_cwd
     );
-    let (exec_output, exit_code) = homeboy::runner::exec(
+    let (exec_output, exit_code) = homeboy::core::runner::exec(
         runner_id,
-        homeboy::runner::RunnerExecOptions {
+        homeboy::core::runner::RunnerExecOptions {
             cwd: Some(remote_cwd),
             allow_ssh: false,
             command,
@@ -442,22 +442,22 @@ fn run_lab_offload_inner(
     }
     if let Some(path) = output_file {
         std::fs::write(path, &exec_output.stdout).map_err(|err| {
-            homeboy::Error::internal_io(err.to_string(), Some(format!("write {path}")))
+            homeboy::core::Error::internal_io(err.to_string(), Some(format!("write {path}")))
         })?;
     }
     print!("{}", exec_output.stdout);
     Ok(exit_code)
 }
 
-fn remote_cwd_for_current_checkout(workspace_root: &str) -> homeboy::Result<String> {
+fn remote_cwd_for_current_checkout(workspace_root: &str) -> homeboy::core::Result<String> {
     let cwd = std::env::current_dir().map_err(|err| {
-        homeboy::Error::internal_io(err.to_string(), Some("read cwd".to_string()))
+        homeboy::core::Error::internal_io(err.to_string(), Some("read cwd".to_string()))
     })?;
     let basename = cwd
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| {
-            homeboy::Error::validation_invalid_argument(
+            homeboy::core::Error::validation_invalid_argument(
                 "cwd",
                 "current checkout path has no basename for Lab workspace mapping",
                 Some(cwd.display().to_string()),

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -39,12 +39,12 @@ impl HomeGuard {
         let prior_xdg_data_home = std::env::var("XDG_DATA_HOME").ok();
         let prior_artifact_root = std::env::var("HOMEBOY_ARTIFACT_ROOT").ok();
         let prior_invocation_runtime =
-            std::env::var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+            std::env::var(crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         let dir = TempDir::new().expect("home tempdir");
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
-        crate::set_artifact_root_override(None);
+        crate::core::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
         // and from the home tempdir (which itself can already live on a long
         // path on macOS, e.g. `/var/folders/<14>/T/.tmpXXXXXX/...`). Using
@@ -52,7 +52,7 @@ impl HomeGuard {
         // budget regardless of host configuration.
         let inv_dir = short_invocation_tempdir();
         std::env::set_var(
-            crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+            crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
             inv_dir.path(),
         );
         Self {
@@ -100,15 +100,15 @@ impl Drop for HomeGuard {
             Some(value) => std::env::set_var("HOMEBOY_ARTIFACT_ROOT", value),
             None => std::env::remove_var("HOMEBOY_ARTIFACT_ROOT"),
         }
-        crate::set_artifact_root_override(None);
+        crate::core::set_artifact_root_override(None);
         match &self.prior_invocation_runtime {
             Some(value) => std::env::set_var(
-                crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+                crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
                 value,
             ),
-            None => {
-                std::env::remove_var(crate::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV)
-            }
+            None => std::env::remove_var(
+                crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+            ),
         }
     }
 }

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -79,6 +79,16 @@ fn scan_core_source_for_command_layer(
 }
 
 #[test]
+fn library_root_does_not_flatten_core_surface() {
+    let source = source_file("src/lib.rs");
+
+    assert!(
+        !source.contains("pub use core::*"),
+        "src/lib.rs must keep core APIs behind homeboy::core instead of flattening the crate root"
+    );
+}
+
+#[test]
 fn validate_and_format_writes_do_not_select_ecosystem_commands() {
     let files = [
         "src/core/engine/validate_write.rs",

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -1,4 +1,4 @@
-use homeboy::deploy::parse_bulk_component_ids;
+use homeboy::core::deploy::parse_bulk_component_ids;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/tests/commands/refactor_test.rs
+++ b/tests/commands/refactor_test.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use homeboy::refactor;
+use homeboy::core::refactor;
 
 fn tmp_dir(name: &str) -> PathBuf {
     let nanos = SystemTime::now()

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -1,10 +1,10 @@
-use crate::code_audit::report::{
+use crate::core::code_audit::report::{
     build_audit_summary, build_changed_since_summary, compute_fixability,
     compute_fixability_with_analysis, finding_kind_key, from_main_workflow,
     AuditChangedSinceSummary, AuditCommandOutput,
 };
-use crate::code_audit::test_helpers::{empty_result, make_finding};
-use crate::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
+use crate::core::code_audit::test_helpers::{empty_result, make_finding};
+use crate::core::code_audit::{AuditFinding, Finding, FindingConfidence, Severity};
 
 #[test]
 fn test_build_audit_summary_empty_result() {
@@ -64,7 +64,7 @@ fn test_build_audit_summary_prioritizes_warnings_in_top_findings() {
         kind: AuditFinding::DuplicateFunction,
     });
 
-    let summary = crate::code_audit::report::build_audit_summary(&result, 1);
+    let summary = crate::core::code_audit::report::build_audit_summary(&result, 1);
 
     assert_eq!(summary.top_findings[0].severity, Severity::Warning);
     assert_eq!(
@@ -196,8 +196,8 @@ fn test_build_changed_since_summary_splits_introduced_from_context() {
         kind: AuditFinding::UnreferencedExport,
     });
 
-    let comparison = crate::engine::baseline::Comparison {
-        new_items: vec![crate::engine::baseline::NewItem {
+    let comparison = crate::core::engine::baseline::Comparison {
+        new_items: vec![crate::core::engine::baseline::NewItem {
             fingerprint: "dead_code::src/large.rs::UnreferencedExport".to_string(),
             description: "New unused export".to_string(),
             context_label: "dead_code".to_string(),
@@ -294,8 +294,9 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
     fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
 
     // Run a real audit
-    let result = crate::code_audit::audit_path_with_id("fixability-test", &root.to_string_lossy())
-        .expect("audit should run");
+    let result =
+        crate::core::code_audit::audit_path_with_id("fixability-test", &root.to_string_lossy())
+            .expect("audit should run");
 
     // Compute fixability
     let fixability = compute_fixability(&result);
@@ -339,10 +340,10 @@ fn test_compute_fixability_with_analysis() {
     .unwrap();
     fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
 
-    let audit = crate::code_audit::audit_path_with_id_with_plan_and_analysis(
+    let audit = crate::core::code_audit::audit_path_with_id_with_plan_and_analysis(
         "fixability-context-test",
         &root.to_string_lossy(),
-        &crate::code_audit::AuditExecutionPlan::full(),
+        &crate::core::code_audit::AuditExecutionPlan::full(),
     )
     .expect("audit should run with analysis");
 
@@ -424,11 +425,12 @@ fn test_finding_kind_key() {
 #[test]
 fn test_from_main_workflow() {
     let output = AuditCommandOutput::Summary(build_audit_summary(&empty_result(), 0));
-    let (output, exit_code) = from_main_workflow(crate::code_audit::run::AuditRunWorkflowResult {
-        output,
-        exit_code: 3,
-        findings: Vec::new(),
-    });
+    let (output, exit_code) =
+        from_main_workflow(crate::core::code_audit::run::AuditRunWorkflowResult {
+            output,
+            exit_code: 3,
+            findings: Vec::new(),
+        });
 
     assert_eq!(exit_code, 3);
     assert!(matches!(output, AuditCommandOutput::Summary(_)));

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -6,10 +6,10 @@ use super::{
     apply_finding_filters, build_comparison_output, compute_fixability_if_requested,
     scope_convention_outliers_to_findings, AuditRunWorkflowArgs,
 };
-use crate::code_audit::checks::CheckStatus;
-use crate::code_audit::conventions::{Deviation, Outlier};
-use crate::code_audit::findings::{Finding, Severity};
-use crate::code_audit::{
+use crate::core::code_audit::checks::CheckStatus;
+use crate::core::code_audit::conventions::{Deviation, Outlier};
+use crate::core::code_audit::findings::{Finding, Severity};
+use crate::core::code_audit::{
     AuditAnalysisContext, AuditExecutionPlan, AuditFinding, AuditSummary, CodeAuditResult,
     ConventionReport,
 };
@@ -90,7 +90,7 @@ fn make_args(include_fixability: bool) -> AuditRunWorkflowArgs {
         exclude_kinds: vec![],
         only_labels: vec![],
         exclude_labels: vec![],
-        baseline_flags: crate::engine::baseline::BaselineFlags {
+        baseline_flags: crate::core::engine::baseline::BaselineFlags {
             baseline: false,
             ignore_baseline: false,
             ratchet: false,
@@ -233,12 +233,12 @@ fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
     let mut result = make_result(vec![existing_finding]);
     result.findings[0].convention = "structural".to_string();
 
-    let baseline = crate::code_audit::baseline::AuditBaseline {
+    let baseline = crate::core::code_audit::baseline::AuditBaseline {
         created_at: "2026-04-28T00:00:00Z".to_string(),
         context_id: "test".to_string(),
         item_count: 1,
         known_fingerprints: vec!["structural::src/large.rs::GodFile".to_string()],
-        metadata: crate::code_audit::baseline::AuditBaselineMetadata {
+        metadata: crate::core::code_audit::baseline::AuditBaselineMetadata {
             outliers_count: 1,
             alignment_score: None,
             known_outliers: vec!["src/large.rs".to_string()],
@@ -255,7 +255,7 @@ fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
 
     assert_eq!(workflow.exit_code, 0);
     match workflow.output {
-        crate::code_audit::report::AuditCommandOutput::Compared {
+        crate::core::code_audit::report::AuditCommandOutput::Compared {
             passed,
             changed_since,
             baseline_comparison,
@@ -265,7 +265,7 @@ fn changed_since_comparison_marks_existing_touched_findings_as_contextual() {
             assert!(baseline_comparison.new_items.is_empty());
             assert_eq!(
                 changed_since,
-                Some(crate::code_audit::report::AuditChangedSinceSummary {
+                Some(crate::core::code_audit::report::AuditChangedSinceSummary {
                     introduced_findings: 0,
                     contextual_findings: 1,
                 })
@@ -283,12 +283,12 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
     introduced_finding.convention = "dead_code".to_string();
     let result = make_result(vec![existing_finding, introduced_finding]);
 
-    let baseline = crate::code_audit::baseline::AuditBaseline {
+    let baseline = crate::core::code_audit::baseline::AuditBaseline {
         created_at: "2026-04-28T00:00:00Z".to_string(),
         context_id: "test".to_string(),
         item_count: 1,
         known_fingerprints: vec!["structural::src/large.rs::GodFile".to_string()],
-        metadata: crate::code_audit::baseline::AuditBaselineMetadata {
+        metadata: crate::core::code_audit::baseline::AuditBaselineMetadata {
             outliers_count: 1,
             alignment_score: None,
             known_outliers: vec!["src/large.rs".to_string()],
@@ -305,7 +305,7 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
 
     assert_eq!(workflow.exit_code, 1);
     match workflow.output {
-        crate::code_audit::report::AuditCommandOutput::Compared {
+        crate::core::code_audit::report::AuditCommandOutput::Compared {
             passed,
             changed_since,
             baseline_comparison,
@@ -315,7 +315,7 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
             assert_eq!(baseline_comparison.new_items.len(), 1);
             assert_eq!(
                 changed_since,
-                Some(crate::code_audit::report::AuditChangedSinceSummary {
+                Some(crate::core::code_audit::report::AuditChangedSinceSummary {
                     introduced_findings: 1,
                     contextual_findings: 1,
                 })

--- a/tests/core/component/audit_test.rs
+++ b/tests/core/component/audit_test.rs
@@ -1,4 +1,4 @@
-use homeboy::component::AuditConfig;
+use homeboy::core::component::AuditConfig;
 
 #[test]
 fn is_empty_reports_only_empty_rule_sets() {

--- a/tests/core/daemon/artifact_download_test.rs
+++ b/tests/core/daemon/artifact_download_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::observation::NewRunRecord;
+use crate::core::observation::NewRunRecord;
 use crate::test_support::HomeGuard;
 
 #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::api_jobs::JobStore;
-use crate::observation::{NewRunRecord, ObservationStore};
+use crate::core::api_jobs::JobStore;
+use crate::core::observation::{NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 
 #[test]
@@ -392,15 +392,15 @@ fn exec_capture_patch_records_remote_delta_artifact() {
     assert!(patch_body.contains("+after"));
 }
 
-fn wait_for_job(store: &JobStore, job_id: &str) -> crate::api_jobs::Job {
+fn wait_for_job(store: &JobStore, job_id: &str) -> crate::core::api_jobs::Job {
     let id = uuid::Uuid::parse_str(job_id).expect("uuid");
     for _ in 0..100 {
         let job = store.get(id).expect("job");
         if matches!(
             job.status,
-            crate::api_jobs::JobStatus::Succeeded
-                | crate::api_jobs::JobStatus::Failed
-                | crate::api_jobs::JobStatus::Cancelled
+            crate::core::api_jobs::JobStatus::Succeeded
+                | crate::core::api_jobs::JobStatus::Failed
+                | crate::core::api_jobs::JobStatus::Cancelled
         ) {
             return job;
         }

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -1,5 +1,5 @@
-use homeboy::component::{Component, DependencyStackEdge};
-use homeboy::deps::{self, ComposerAction};
+use homeboy::core::component::{Component, DependencyStackEdge};
+use homeboy::core::deps::{self, ComposerAction};
 use std::fs;
 use tempfile::tempdir;
 

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::engine::run_dir::RunDir;
+use crate::core::engine::run_dir::RunDir;
 use crate::test_support::{home_env_guard, with_isolated_home};
 
 #[test]
@@ -162,7 +162,7 @@ fn write_test_child_record(invocation_id: &str, owner_pid: u32, root_pid: u32, p
         invocation_id: invocation_id.to_string(),
         owner_pid,
         owner_started_at: None,
-        child: crate::engine::resource::ChildProcessIdentity {
+        child: crate::core::engine::resource::ChildProcessIdentity {
             root_pid,
             command_label: "sleep".to_string(),
         },

--- a/tests/core/expand_test.rs
+++ b/tests/core/expand_test.rs
@@ -1,6 +1,6 @@
 //! Tests for shared token expansion helpers.
 
-use crate::expand::{expand_tokens, expand_with_tilde};
+use crate::core::expand::{expand_tokens, expand_with_tilde};
 
 #[test]
 fn test_expand_tokens() {

--- a/tests/core/extension/bench/aggregation_test.rs
+++ b/tests/core/extension/bench/aggregation_test.rs
@@ -1,5 +1,7 @@
-use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
-use crate::observation::timeline::{
+use crate::core::extension::bench::test_support::{
+    results_with_scenarios, scenario_with_iterations,
+};
+use crate::core::observation::timeline::{
     ObservationEvent, ObservationSpanDefinition, ObservationSpanResult, ObservationSpanStatus,
 };
 

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -25,12 +25,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::extension::bench::parsing::{
+use crate::core::extension::bench::parsing::{
     parse_bench_results_str, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy,
     BenchResults, BenchScenario,
 };
-use crate::extension::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
-use crate::extension::bench::test_support::scenario_with_iterations;
+use crate::core::extension::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
+use crate::core::extension::bench::test_support::scenario_with_iterations;
 
 fn policy(direction: BenchMetricDirection, phase: Option<BenchMetricPhase>) -> BenchMetricPolicy {
     BenchMetricPolicy {

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -9,10 +9,12 @@
 //! 4. Scenarios missing from some runs aggregate from the runs that emitted
 //!    them instead of failing the whole bench.
 
-use crate::extension::bench::aggregation::aggregate_runs;
-use crate::extension::bench::artifact::BenchArtifact;
-use crate::extension::bench::parsing::{BenchResults, BenchScenario};
-use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+use crate::core::extension::bench::aggregation::aggregate_runs;
+use crate::core::extension::bench::artifact::BenchArtifact;
+use crate::core::extension::bench::parsing::{BenchResults, BenchScenario};
+use crate::core::extension::bench::test_support::{
+    results_with_scenarios, scenario_with_iterations,
+};
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
     scenario_with_iterations(id, metrics, 1)

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -7,13 +7,13 @@ use crate::commands::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
 };
 use crate::commands::GlobalArgs;
-use crate::component::{Component, ComponentScriptsConfig};
-use crate::engine::run_dir::RunDir;
-use crate::extension::component_script::{
+use crate::core::component::{Component, ComponentScriptsConfig};
+use crate::core::engine::run_dir::RunDir;
+use crate::core::extension::component_script::{
     run_component_scripts, run_component_scripts_with_env, run_component_scripts_with_run_dir,
     source_path,
 };
-use crate::extension::ExtensionCapability;
+use crate::core::extension::ExtensionCapability;
 use crate::test_support::with_isolated_home;
 
 fn component_script_args(root: &Path) -> PositionalComponentArgs {
@@ -268,7 +268,7 @@ fn wordpress_phpunit_no_discovery_is_neutral_skipped() {
         assert_eq!(output.status, "skipped");
         assert_eq!(output.test_counts.expect("test counts").total, 0);
         let phase = output.phase.expect("phase report");
-        assert_eq!(phase.status, crate::extension::PhaseStatus::Skipped);
+        assert_eq!(phase.status, crate::core::extension::PhaseStatus::Skipped);
         assert_eq!(
             phase.summary,
             "activation/install passed; PHPUnit discovery found zero tests; no PHPUnit assertions ran"
@@ -331,7 +331,7 @@ fn wordpress_phpunit_no_discovery_can_be_required_as_failure() {
         let failure = output.failure.expect("failure report");
         assert_eq!(
             failure.category,
-            crate::extension::PhaseFailureCategory::Findings
+            crate::core::extension::PhaseFailureCategory::Findings
         );
     });
 }

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -1,9 +1,9 @@
-use homeboy::api_jobs::{JobEventKind, JobStatus, JobStore};
-use homeboy::http_api::{
+use homeboy::core::api_jobs::{JobEventKind, JobStatus, JobStore};
+use homeboy::core::http_api::{
     self, AnalysisJobRunOutput, AnalysisJobRunner, HttpApiRequest, HttpEndpoint, HttpMethod,
     JobReadyRunKind,
 };
-use homeboy::observation::{
+use homeboy::core::observation::{
     NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
 };
 
@@ -13,7 +13,7 @@ use crate::test_support::with_isolated_home;
 struct FakeAnalysisJobRunner;
 
 impl AnalysisJobRunner for FakeAnalysisJobRunner {
-    fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::Result<AnalysisJobRunOutput> {
+    fn run_analysis_job(&self, argv: Vec<String>) -> homeboy::core::Result<AnalysisJobRunOutput> {
         Ok(AnalysisJobRunOutput {
             exit_code: 0,
             output: serde_json::json!({ "argv": argv }),
@@ -210,7 +210,7 @@ fn test_handle_with_jobs() {
     store
         .append_event(
             job.id,
-            homeboy::api_jobs::JobEventKind::Stdout,
+            homeboy::core::api_jobs::JobEventKind::Stdout,
             Some("audit output".to_string()),
             None,
         )

--- a/tests/core/issues/render_test.rs
+++ b/tests/core/issues/render_test.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use super::{build_findings_from_native_output, IssueRenderContext};
-use crate::code_audit::FindingConfidence;
+use crate::core::code_audit::FindingConfidence;
 
 #[test]
 fn test_build_findings_from_native_output() {

--- a/tests/core/lint_baseline_test.rs
+++ b/tests/core/lint_baseline_test.rs
@@ -1,4 +1,4 @@
-use homeboy::extension::lint::baseline::{self as lint_baseline, LintFinding};
+use homeboy::core::extension::lint::baseline::{self as lint_baseline, LintFinding};
 use std::path::Path;
 
 #[test]

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -3,8 +3,8 @@
 //! These isolate `HOME` / `XDG_DATA_HOME` so the developer's real local DB is
 //! never read or written.
 
-use crate::observation::store::{self, ObservationStore, CURRENT_SCHEMA_VERSION};
-use crate::observation::{
+use crate::core::observation::store::{self, ObservationStore, CURRENT_SCHEMA_VERSION};
+use crate::core::observation::{
     FindingListFilter, NewFindingRecord, NewRunRecord, RunListFilter, RunStatus,
 };
 use crate::test_support::with_isolated_home;

--- a/tests/core/refactor/decompose_test.rs
+++ b/tests/core/refactor/decompose_test.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use homeboy::extension::ParsedItem;
-use homeboy::refactor::{self, DecomposeGroup, DecomposePlan};
+use homeboy::core::extension::ParsedItem;
+use homeboy::core::refactor::{self, DecomposeGroup, DecomposePlan};
 
 fn tmp_dir(name: &str) -> PathBuf {
     let nanos = SystemTime::now()

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -3,8 +3,10 @@
 use std::collections::HashMap;
 use std::fs;
 
-use crate::rig::app::{install_inner, uninstall_inner, AppLauncherAction, AppLauncherOptions};
-use crate::rig::spec::{
+use crate::core::rig::app::{
+    install_inner, uninstall_inner, AppLauncherAction, AppLauncherOptions,
+};
+use crate::core::rig::spec::{
     AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, ComponentSpec, RigSpec,
 };
 
@@ -149,7 +151,7 @@ fn test_uninstall_removes_generated_bundle_from_temp_dir() {
 fn test_update_reports_update_action() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
-    let report = crate::rig::app::update(&rig, AppLauncherOptions { dry_run: true })
+    let report = crate::core::rig::app::update(&rig, AppLauncherOptions { dry_run: true })
         .expect("update dry-run");
     assert_eq!(report.action, AppLauncherAction::Update);
     assert!(report.dry_run);
@@ -159,7 +161,7 @@ fn test_update_reports_update_action() {
 fn test_public_install_refuses_unsupported_platforms() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
-    let result = crate::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
+    let result = crate::core::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
     if cfg!(target_os = "macos") {
         assert!(result.is_ok(), "macOS should allow install");
     } else {
@@ -172,7 +174,7 @@ fn test_public_install_refuses_unsupported_platforms() {
 fn test_public_install_dry_run_is_cross_platform_preview() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
-    let report = crate::rig::app::install(&rig, AppLauncherOptions { dry_run: true })
+    let report = crate::core::rig::app::install(&rig, AppLauncherOptions { dry_run: true })
         .expect("dry-run preview");
     assert!(report.dry_run);
     assert!(!tmp.path().join("Studio (Dev).app").exists());

--- a/tests/core/rig/bench_default_baseline_output_test.rs
+++ b/tests/core/rig/bench_default_baseline_output_test.rs
@@ -168,7 +168,7 @@ fn default_baseline_failure_summary_marks_implicit_baseline() {
             artifacts: Vec::new(),
             results: None,
             rig_state: None,
-            failure: Some(homeboy::extension::bench::run::BenchRunFailure {
+            failure: Some(homeboy::core::extension::bench::run::BenchRunFailure {
                 component_id: "studio".to_string(),
                 component_path: None,
                 scenario_id: None,
@@ -214,7 +214,7 @@ fn default_baseline_early_error_hint_names_requested_rig() {
         execution_order: vec!["studio-agent-sdk".to_string(), "studio-bfb".to_string()],
         opt_out_flag: "--ignore-default-baseline",
     };
-    let error = homeboy::Error::rig_pipeline_failed(
+    let error = homeboy::core::Error::rig_pipeline_failed(
         "studio-agent-sdk",
         "check",
         "rig check failed; refusing to run bench against an unhealthy rig",

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -4,8 +4,8 @@
 //! the field serializes — consumers (rig spec authors, downstream
 //! tooling) read this directly off disk.
 
-use crate::extension::bench::BenchGateOp;
-use crate::rig::spec::{BenchMetricGateCondition, BenchSpec, RigSpec, WorkloadSpec};
+use crate::core::extension::bench::BenchGateOp;
+use crate::core::rig::spec::{BenchMetricGateCondition, BenchSpec, RigSpec, WorkloadSpec};
 
 /// Parses a minimal RigSpec JSON via serde and returns the embedded
 /// `BenchSpec` (or panics).

--- a/tests/core/rig/bench_resource_lease_test.rs
+++ b/tests/core/rig/bench_resource_lease_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use homeboy::error::ErrorCode;
+use homeboy::core::error::ErrorCode;
 use std::fs;
 
 fn set_rig_resources(home: &tempfile::TempDir, rig_id: &str, resources: serde_json::Value) {
@@ -36,8 +36,8 @@ fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
         set_rig_resources(home, "studio", resources.clone());
         set_rig_resources(home, "studio-bfb", resources);
 
-        let active_spec = homeboy::rig::load("studio").expect("load active rig");
-        let _lease = homeboy::rig::lease::acquire_active_run_lease(&active_spec, "bench")
+        let active_spec = homeboy::core::rig::load("studio").expect("load active rig");
+        let _lease = homeboy::core::rig::lease::acquire_active_run_lease(&active_spec, "bench")
             .expect("acquire active lease")
             .expect("resourceful rig leases");
 
@@ -71,10 +71,10 @@ fn run_single_rig_bench_without_resources_does_not_create_lease() {
         .expect("non-resourceful rig bench should run");
 
         assert_eq!(exit_code, 0);
-        assert!(homeboy::rig::lease::active_run_leases()
+        assert!(homeboy::core::rig::lease::active_run_leases()
             .expect("list active leases")
             .is_empty());
-        assert!(!homeboy::paths::rig_leases_dir()
+        assert!(!crate::core::paths::rig_leases_dir()
             .expect("lease dir path")
             .exists());
     });

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -4,8 +4,8 @@
 //! `file` and `command` probes exercise the full one-of-three logic,
 //! short-circuit on validation errors, and cover substring matching.
 
-use crate::rig::check::evaluate;
-use crate::rig::spec::{CheckSpec, RigSpec};
+use crate::core::rig::check::evaluate;
+use crate::core::rig::spec::{CheckSpec, RigSpec};
 
 fn minimal_rig() -> RigSpec {
     RigSpec {
@@ -114,7 +114,7 @@ fn test_evaluate_command_unexpected_exit() {
 
 #[test]
 fn test_evaluate_newer_than_left_newer_passes() {
-    use crate::rig::spec::{NewerThanSpec, TimeSource};
+    use crate::core::rig::spec::{NewerThanSpec, TimeSource};
     let tmp_dir = tempfile::tempdir().expect("tmpdir");
     let older = tmp_dir.path().join("older.txt");
     let newer = tmp_dir.path().join("newer.txt");
@@ -142,7 +142,7 @@ fn test_evaluate_newer_than_left_newer_passes() {
 
 #[test]
 fn test_evaluate_newer_than_left_older_fails() {
-    use crate::rig::spec::{NewerThanSpec, TimeSource};
+    use crate::core::rig::spec::{NewerThanSpec, TimeSource};
     let tmp_dir = tempfile::tempdir().expect("tmpdir");
     let older = tmp_dir.path().join("older.txt");
     let newer = tmp_dir.path().join("newer.txt");
@@ -171,7 +171,7 @@ fn test_evaluate_newer_than_left_older_fails() {
 
 #[test]
 fn test_evaluate_newer_than_missing_left_process_passes() {
-    use crate::rig::spec::{DiscoverSpec, NewerThanSpec, TimeSource};
+    use crate::core::rig::spec::{DiscoverSpec, NewerThanSpec, TimeSource};
     let tmp_dir = tempfile::tempdir().expect("tmpdir");
     let bundle = tmp_dir.path().join("bundle.js");
     std::fs::write(&bundle, "x").expect("write");
@@ -200,7 +200,7 @@ fn test_evaluate_newer_than_missing_left_process_passes() {
 
 #[test]
 fn test_evaluate_newer_than_rejects_empty_time_source() {
-    use crate::rig::spec::{NewerThanSpec, TimeSource};
+    use crate::core::rig::spec::{NewerThanSpec, TimeSource};
     let rig = minimal_rig();
     let spec = CheckSpec {
         newer_than: Some(NewerThanSpec {

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -3,8 +3,8 @@
 //! Audit convention requires a `test_expand_vars` method matching the sole
 //! public function of the module; additional cases cover edge conditions.
 
-use crate::rig::expand::{expand_resources, expand_vars};
-use crate::rig::spec::{
+use crate::core::rig::expand::{expand_resources, expand_vars};
+use crate::core::rig::spec::{
     ComponentSpec, DiscoverSpec, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec,
 };
 use crate::test_support::with_isolated_home;

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -1,6 +1,6 @@
 //! Rig install lifecycle tests. Covers `src/core/rig/install.rs`.
 
-use crate::rig::{
+use crate::core::rig::{
     declared_id, discover_rigs, install, list, list_ids, load, read_source_metadata,
     read_stack_source_metadata,
 };
@@ -139,7 +139,7 @@ fn test_read_source_metadata_after_local_install() {
     assert_eq!(result.installed.len(), 1);
     assert_eq!(result.installed[0].id, "alpha");
 
-    let installed = crate::paths::rig_config("alpha").expect("rig path");
+    let installed = crate::core::paths::rig_config("alpha").expect("rig path");
     assert!(installed.exists());
     #[cfg(unix)]
     assert_eq!(fs::read_link(&installed).expect("symlink"), source);
@@ -165,13 +165,13 @@ fn install_package_with_sibling_stacks_installs_stack_specs() {
     assert_eq!(result.installed.len(), 1);
     assert_eq!(result.installed_stacks.len(), 1);
     assert_eq!(result.installed_stacks[0].id, "studio-combined");
-    let installed = crate::paths::stack_config("studio-combined").expect("stack path");
+    let installed = crate::core::paths::stack_config("studio-combined").expect("stack path");
     assert!(installed.exists());
     #[cfg(unix)]
     assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
-    assert_eq!(crate::stack::list().expect("stack list").len(), 1);
+    assert_eq!(crate::core::stack::list().expect("stack list").len(), 1);
     assert_eq!(
-        crate::stack::load("studio-combined")
+        crate::core::stack::load("studio-combined")
             .expect("load stack")
             .component,
         "studio"
@@ -204,8 +204,8 @@ fn install_multi_rig_package_can_select_id() {
     let result = install(package.path().to_str().unwrap(), Some("beta"), false).expect("install");
     assert_eq!(result.installed.len(), 1);
     assert_eq!(result.installed[0].id, "beta");
-    assert!(crate::paths::rig_config("beta").unwrap().exists());
-    assert!(!crate::paths::rig_config("alpha").unwrap().exists());
+    assert!(crate::core::paths::rig_config("beta").unwrap().exists());
+    assert!(!crate::core::paths::rig_config("alpha").unwrap().exists());
 }
 
 #[test]
@@ -217,8 +217,8 @@ fn install_multi_rig_package_can_install_all() {
 
     let result = install(package.path().to_str().unwrap(), None, true).expect("install");
     assert_eq!(result.installed.len(), 2);
-    assert!(crate::paths::rig_config("alpha").unwrap().exists());
-    assert!(crate::paths::rig_config("beta").unwrap().exists());
+    assert!(crate::core::paths::rig_config("alpha").unwrap().exists());
+    assert!(crate::core::paths::rig_config("beta").unwrap().exists());
 }
 
 #[test]
@@ -228,9 +228,9 @@ fn install_refreshes_existing_matching_local_rig_without_metadata() {
     let refreshed = minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed");
     write_rig(package.path(), "alpha", &refreshed);
 
-    fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
+    fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
     fs::write(
-        crate::paths::rig_config("alpha").expect("alpha rig path"),
+        crate::core::paths::rig_config("alpha").expect("alpha rig path"),
         minimal_rig("alpha"),
     )
     .expect("stale installed rig");
@@ -238,8 +238,8 @@ fn install_refreshes_existing_matching_local_rig_without_metadata() {
     let result = install(package.path().to_str().unwrap(), None, false).expect("refresh");
 
     assert_eq!(result.installed.len(), 1);
-    let installed =
-        fs::read_to_string(crate::paths::rig_config("alpha").unwrap()).expect("installed rig");
+    let installed = fs::read_to_string(crate::core::paths::rig_config("alpha").unwrap())
+        .expect("installed rig");
     assert!(installed.contains("alpha rig refreshed"));
     assert_eq!(
         read_source_metadata("alpha").expect("metadata").rig_path,
@@ -253,9 +253,9 @@ fn install_rejects_existing_rig_with_different_declared_id() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
+    fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
     fs::write(
-        crate::paths::rig_config("alpha").expect("alpha rig path"),
+        crate::core::paths::rig_config("alpha").expect("alpha rig path"),
         minimal_rig("beta"),
     )
     .expect("conflicting installed rig");
@@ -271,9 +271,9 @@ fn install_refreshes_existing_matching_stack_without_metadata() {
     write_rig(package.path(), "studio", &minimal_rig("studio"));
     let stack_path = write_stack(package.path(), "studio-combined", "studio");
 
-    fs::create_dir_all(crate::paths::stacks().expect("stacks dir")).expect("stacks dir");
+    fs::create_dir_all(crate::core::paths::stacks().expect("stacks dir")).expect("stacks dir");
     fs::write(
-        crate::paths::stack_config("studio-combined").expect("stack path"),
+        crate::core::paths::stack_config("studio-combined").expect("stack path"),
         fs::read_to_string(&stack_path).expect("package stack"),
     )
     .expect("existing stack");
@@ -293,9 +293,9 @@ fn install_rejects_existing_stack_with_different_content() {
     write_rig(package.path(), "studio", &minimal_rig("studio"));
     write_stack(package.path(), "studio-combined", "studio");
 
-    fs::create_dir_all(crate::paths::stacks().expect("stacks dir")).expect("stacks dir");
+    fs::create_dir_all(crate::core::paths::stacks().expect("stacks dir")).expect("stacks dir");
     fs::write(
-        crate::paths::stack_config("studio-combined").expect("stack path"),
+        crate::core::paths::stack_config("studio-combined").expect("stack path"),
         minimal_stack("studio-combined", "other"),
     )
     .expect("conflicting stack");
@@ -307,9 +307,9 @@ fn install_rejects_existing_stack_with_different_content() {
 #[test]
 fn installed_filename_is_runtime_identity_when_declared_id_differs() {
     let _home = HomeGuard::new();
-    fs::create_dir_all(crate::paths::rigs().expect("rigs dir")).expect("rigs dir");
+    fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
     fs::write(
-        crate::paths::rig_config("replacement").expect("replacement rig path"),
+        crate::core::paths::rig_config("replacement").expect("replacement rig path"),
         minimal_rig("alpha"),
     )
     .expect("replacement rig");
@@ -395,7 +395,7 @@ fn git_url_installs_clone_package_and_config_link() {
         .parent()
         .unwrap()
         .ends_with("rig-packages"));
-    assert!(crate::paths::rig_config("alpha").unwrap().exists());
+    assert!(crate::core::paths::rig_config("alpha").unwrap().exists());
     assert_eq!(read_source_metadata("alpha").unwrap().source, source);
 }
 
@@ -423,8 +423,8 @@ fn git_url_subpath_installs_single_rig_directory() {
     assert!(result.installed[0]
         .spec_path
         .ends_with("packages/studio/rig.json"));
-    assert!(crate::paths::rig_config("studio").unwrap().exists());
-    assert!(!crate::paths::rig_config("other").unwrap().exists());
+    assert!(crate::core::paths::rig_config("studio").unwrap().exists());
+    assert!(!crate::core::paths::rig_config("other").unwrap().exists());
 
     let metadata = read_source_metadata("studio").expect("metadata");
     assert_eq!(metadata.source, root_source.to_string_lossy());
@@ -449,13 +449,13 @@ fn git_url_subpath_installs_only_stacks_under_selected_subpath() {
 
     assert_eq!(result.installed_stacks.len(), 1);
     assert_eq!(result.installed_stacks[0].id, "studio-combined");
-    assert!(crate::paths::stack_config("studio-combined")
+    assert!(crate::core::paths::stack_config("studio-combined")
         .unwrap()
         .exists());
-    assert!(!crate::paths::stack_config("root-combined")
+    assert!(!crate::core::paths::stack_config("root-combined")
         .unwrap()
         .exists());
-    let stacks = crate::stack::list().expect("stack list");
+    let stacks = crate::core::stack::list().expect("stack list");
     assert_eq!(stacks.len(), 1);
     assert_eq!(stacks[0].id, "studio-combined");
 }

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -1,9 +1,9 @@
 //! Tests for active rig run leases.
 
-use crate::error::ErrorCode;
-use crate::rig::lease::{acquire_active_run_lease, active_run_leases};
-use crate::rig::spec::{RigResourcesSpec, RigSpec};
-use crate::rig::{run_up, RigRunLease};
+use crate::core::error::ErrorCode;
+use crate::core::rig::lease::{acquire_active_run_lease, active_run_leases};
+use crate::core::rig::spec::{RigResourcesSpec, RigSpec};
+use crate::core::rig::{run_up, RigRunLease};
 use crate::test_support::with_isolated_home;
 
 fn rig(id: &str, resources: RigResourcesSpec) -> RigSpec {
@@ -126,7 +126,7 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
             started_at: "2026-04-27T00:00:00Z".to_string(),
             resources: resources(),
         };
-        let lease_dir = crate::paths::rig_leases_dir().expect("lease dir");
+        let lease_dir = crate::core::paths::rig_leases_dir().expect("lease dir");
         std::fs::create_dir_all(&lease_dir).expect("create lease dir");
         std::fs::write(
             lease_dir.join("studio.json"),

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -4,8 +4,8 @@
 //! and are covered by the manual smoke documented in #1468. Scope here is
 //! the public outcome types — shape, serialization, `is_success` contract.
 
-use crate::rig::pipeline::{run_pipeline_check_groups, PipelineOutcome, PipelineStepOutcome};
-use crate::rig::spec::RigSpec;
+use crate::core::rig::pipeline::{run_pipeline_check_groups, PipelineOutcome, PipelineStepOutcome};
+use crate::core::rig::spec::RigSpec;
 
 fn step(status: &str) -> PipelineStepOutcome {
     PipelineStepOutcome {
@@ -96,8 +96,8 @@ mod dag {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::rig::pipeline::run_pipeline;
-    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec, StackOp};
+    use crate::core::rig::pipeline::run_pipeline;
+    use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigSpec, StackOp};
 
     fn command(id: &str, depends_on: &[&str], cmd: String, cwd: Option<String>) -> PipelineStep {
         PipelineStep::Command {
@@ -365,8 +365,8 @@ mod git_steps {
     use std::fs;
     use std::process::Command;
 
-    use crate::rig::pipeline::run_pipeline;
-    use crate::rig::spec::{ComponentSpec, GitOp, PipelineStep, RigSpec};
+    use crate::core::rig::pipeline::run_pipeline;
+    use crate::core::rig::spec::{ComponentSpec, GitOp, PipelineStep, RigSpec};
 
     fn run_git(repo: &std::path::Path, args: &[&str]) -> String {
         let output = Command::new("git")
@@ -479,9 +479,9 @@ mod extension_lifecycle {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::component::ScopedExtensionConfig;
-    use crate::rig::pipeline::run_pipeline;
-    use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+    use crate::core::component::ScopedExtensionConfig;
+    use crate::core::rig::pipeline::run_pipeline;
+    use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
     use crate::test_support;
 
     fn rig_with_step(component_path: String, step: PipelineStep) -> RigSpec {
@@ -623,9 +623,9 @@ mod command_env {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::rig::pipeline::run_pipeline;
-    use crate::rig::spec::{PipelineStep, RigSpec};
-    use crate::rig::toolchain;
+    use crate::core::rig::pipeline::run_pipeline;
+    use crate::core::rig::spec::{PipelineStep, RigSpec};
+    use crate::core::rig::toolchain;
     use crate::test_support::home_env_guard;
 
     fn rig_with_command(cmd: String, env: HashMap<String, String>) -> RigSpec {
@@ -729,8 +729,8 @@ mod patch {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::rig::pipeline::run_pipeline;
-    use crate::rig::spec::{ComponentSpec, PatchOp, PipelineStep, RigSpec};
+    use crate::core::rig::pipeline::run_pipeline;
+    use crate::core::rig::spec::{ComponentSpec, PatchOp, PipelineStep, RigSpec};
 
     fn rig_with_patch(component_path: &str, step: PipelineStep) -> RigSpec {
         let mut components = HashMap::new();
@@ -947,9 +947,9 @@ mod shared_path {
     use std::collections::HashMap;
     use std::fs;
 
-    use crate::rig::pipeline::{cleanup_shared_paths, run_pipeline};
-    use crate::rig::spec::{PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
-    use crate::rig::state::RigState;
+    use crate::core::rig::pipeline::{cleanup_shared_paths, run_pipeline};
+    use crate::core::rig::spec::{PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
+    use crate::core::rig::state::RigState;
     use crate::test_support::with_isolated_home;
 
     fn rig_with_shared_path(id: &str, shared: SharedPathSpec, op: SharedPathOp) -> RigSpec {

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -3,11 +3,11 @@
 use std::collections::HashMap;
 use std::process::Command;
 
-use crate::observation::{ObservationStore, RunListFilter};
-use crate::paths;
-use crate::rig::runner::{run_check, run_up};
-use crate::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
-use crate::rig::{RigSourceMetadata, RigState};
+use crate::core::observation::{ObservationStore, RunListFilter};
+use crate::core::paths;
+use crate::core::rig::runner::{run_check, run_up};
+use crate::core::rig::spec::{ComponentSpec, PipelineStep, RigSpec};
+use crate::core::rig::{RigSourceMetadata, RigState};
 use crate::test_support::with_isolated_home;
 
 fn observation_spec(id: &str) -> RigSpec {
@@ -56,7 +56,7 @@ impl Drop for XdgDataHomeGuard {
     }
 }
 
-fn list_rig_runs(rig_id: &str) -> Vec<crate::observation::RunRecord> {
+fn list_rig_runs(rig_id: &str) -> Vec<crate::core::observation::RunRecord> {
     ObservationStore::open_initialized()
         .expect("observation store")
         .list_runs(RunListFilter {

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -15,17 +15,17 @@
 
 use std::collections::HashMap;
 
-use crate::rig::pipeline::PipelineOutcome;
-use crate::rig::runner::{
+use crate::core::rig::pipeline::PipelineOutcome;
+use crate::core::rig::runner::{
     head_sha_and_branch, run_check, run_check_groups, run_down, run_repair, run_status, run_up,
     snapshot_state, CheckReport, RigStatusReport, ServiceStatusReport, SymlinkStatusState,
     UpReport,
 };
-use crate::rig::spec::{
+use crate::core::rig::spec::{
     ComponentSpec, PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathOp,
     SharedPathSpec, SymlinkSpec,
 };
-use crate::rig::state::RigState;
+use crate::core::rig::state::RigState;
 use crate::test_support::with_isolated_home;
 
 fn empty_pipeline(name: &str) -> PipelineOutcome {
@@ -509,7 +509,7 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             app_launcher: None,
         };
 
-        let up = crate::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");
+        let up = crate::core::rig::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");
         assert!(up.is_success());
         assert!(link.is_symlink());
 

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -4,16 +4,16 @@
 //! in the end-to-end smoke described in #1468. Unit scope here covers the
 //! pure types and status-enum ergonomics that back the runner's reporting.
 
-use crate::rig::service::ServiceStatus;
+use crate::core::rig::service::ServiceStatus;
 
 #[cfg(unix)]
 mod lifecycle {
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
 
-    use crate::rig::service::{self, ServiceStatus};
-    use crate::rig::spec::{DiscoverSpec, RigSpec, ServiceKind, ServiceSpec};
-    use crate::rig::state::{RigState, ServiceState};
+    use crate::core::rig::service::{self, ServiceStatus};
+    use crate::core::rig::spec::{DiscoverSpec, RigSpec, ServiceKind, ServiceSpec};
+    use crate::core::rig::state::{RigState, ServiceState};
     use crate::test_support::with_isolated_home;
 
     fn command_rig(id: &str, command: &str, cwd: Option<String>) -> RigSpec {
@@ -350,7 +350,7 @@ fn test_service_status_stale_carries_pid() {
 
 #[test]
 fn test_parse_etime_mm_ss() {
-    use crate::rig::service::parse_etime_seconds;
+    use crate::core::rig::service::parse_etime_seconds;
     // 2 minutes 30 seconds.
     assert_eq!(parse_etime_seconds("02:30"), Some(150));
     assert_eq!(parse_etime_seconds("0:01"), Some(1));
@@ -358,14 +358,14 @@ fn test_parse_etime_mm_ss() {
 
 #[test]
 fn test_parse_etime_hh_mm_ss() {
-    use crate::rig::service::parse_etime_seconds;
+    use crate::core::rig::service::parse_etime_seconds;
     // 1h 02m 03s.
     assert_eq!(parse_etime_seconds("01:02:03"), Some(3_723));
 }
 
 #[test]
 fn test_parse_etime_dd_hh_mm_ss() {
-    use crate::rig::service::parse_etime_seconds;
+    use crate::core::rig::service::parse_etime_seconds;
     // 4 days, 9 hours, 27 minutes, 59 seconds — the format BSD `ps` emits
     // for a long-running daemon (matches what `etime` printed during dev).
     assert_eq!(parse_etime_seconds("04-09:27:59"), Some(379_679));
@@ -373,7 +373,7 @@ fn test_parse_etime_dd_hh_mm_ss() {
 
 #[test]
 fn test_parse_etime_rejects_garbage() {
-    use crate::rig::service::parse_etime_seconds;
+    use crate::core::rig::service::parse_etime_seconds;
     assert_eq!(parse_etime_seconds(""), None);
     assert_eq!(parse_etime_seconds("not-a-time"), None);
     assert_eq!(parse_etime_seconds("01"), None);

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -1,6 +1,8 @@
 //! Rig source lifecycle tests. Covers `src/core/rig/source.rs`.
 
-use crate::rig::{install, list_sources, remove_source, update_all_sources, update_source_for_rig};
+use crate::core::rig::{
+    install, list_sources, remove_source, update_all_sources, update_source_for_rig,
+};
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
@@ -139,17 +141,21 @@ fn test_remove_source() {
     write_rig(package.path(), "beta", &minimal_rig("beta"));
 
     install(package.path().to_str().unwrap(), None, true).expect("install all");
-    let manual = crate::paths::rig_config("manual").expect("manual rig path");
+    let manual = crate::core::paths::rig_config("manual").expect("manual rig path");
     fs::write(&manual, minimal_rig("manual")).expect("manual rig");
 
     let result = remove_source(&package.path().to_string_lossy()).expect("remove source");
     assert_eq!(result.removed.len(), 2);
     assert!(result.skipped.is_empty());
     assert!(result.removed_package_path.is_none());
-    assert!(!crate::paths::rig_config("alpha").unwrap().exists());
-    assert!(!crate::paths::rig_config("beta").unwrap().exists());
-    assert!(!crate::paths::rig_source_metadata("alpha").unwrap().exists());
-    assert!(!crate::paths::rig_source_metadata("beta").unwrap().exists());
+    assert!(!crate::core::paths::rig_config("alpha").unwrap().exists());
+    assert!(!crate::core::paths::rig_config("beta").unwrap().exists());
+    assert!(!crate::core::paths::rig_source_metadata("alpha")
+        .unwrap()
+        .exists());
+    assert!(!crate::core::paths::rig_source_metadata("beta")
+        .unwrap()
+        .exists());
     assert!(manual.exists());
     assert!(package.path().exists());
 }
@@ -161,7 +167,7 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
     install(package.path().to_str().unwrap(), None, false).expect("install");
-    let config = crate::paths::rig_config("alpha").expect("rig config");
+    let config = crate::core::paths::rig_config("alpha").expect("rig config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_rig("replacement")).expect("replacement rig");
 
@@ -169,7 +175,9 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
     assert!(result.removed.is_empty());
     assert_eq!(result.skipped.len(), 1);
     assert!(config.exists());
-    assert!(!crate::paths::rig_source_metadata("alpha").unwrap().exists());
+    assert!(!crate::core::paths::rig_source_metadata("alpha")
+        .unwrap()
+        .exists());
 }
 
 #[test]
@@ -179,7 +187,7 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     let source = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
     install(package.path().to_str().unwrap(), None, false).expect("install");
-    let config = crate::paths::rig_config("alpha").expect("rig config");
+    let config = crate::core::paths::rig_config("alpha").expect("rig config");
     fs::remove_file(&config).expect("remove symlink");
     fs::copy(&source, &config).expect("copy rig config");
 
@@ -190,20 +198,23 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     assert_eq!(result.removed.len(), 1);
     assert!(result.skipped.is_empty());
     assert!(!config.exists());
-    assert!(!crate::paths::rig_source_metadata("alpha").unwrap().exists());
+    assert!(!crate::core::paths::rig_source_metadata("alpha")
+        .unwrap()
+        .exists());
 }
 
 #[test]
 fn sources_list_reports_corrupt_metadata_and_missing_configs() {
     let _home = HomeGuard::new();
-    fs::create_dir_all(crate::paths::rig_sources().expect("sources dir")).expect("sources dir");
+    fs::create_dir_all(crate::core::paths::rig_sources().expect("sources dir"))
+        .expect("sources dir");
     fs::write(
-        crate::paths::rig_source_metadata("broken").expect("broken metadata"),
+        crate::core::paths::rig_source_metadata("broken").expect("broken metadata"),
         "not json",
     )
     .expect("broken metadata");
     fs::write(
-        crate::paths::rig_source_metadata("missing").expect("missing metadata"),
+        crate::core::paths::rig_source_metadata("missing").expect("missing metadata"),
         r#"{
             "source": "/tmp/package",
             "package_path": "/tmp/package",
@@ -235,7 +246,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let before = crate::rig::read_source_metadata("alpha")
+    let before = crate::core::rig::read_source_metadata("alpha")
         .expect("metadata")
         .source_revision;
 
@@ -254,11 +265,11 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     assert_eq!(result.updated[0].id, "alpha");
     assert_eq!(result.updated[0].previous_revision, before);
     assert_ne!(result.updated[0].source_revision, before);
-    let installed =
-        fs::read_to_string(crate::paths::rig_config("alpha").unwrap()).expect("installed rig");
+    let installed = fs::read_to_string(crate::core::paths::rig_config("alpha").unwrap())
+        .expect("installed rig");
     assert!(installed.contains("alpha rig updated"));
     assert_eq!(
-        crate::rig::read_source_metadata("alpha")
+        crate::core::rig::read_source_metadata("alpha")
             .expect("metadata")
             .source_revision,
         result.updated[0].source_revision
@@ -279,7 +290,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let before = crate::rig::read_stack_source_metadata("alpha-combined")
+    let before = crate::core::rig::read_stack_source_metadata("alpha-combined")
         .expect("stack metadata")
         .source_revision;
 
@@ -296,7 +307,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
     assert_eq!(result.updated_stacks.len(), 1);
     assert_eq!(result.updated_stacks[0].id, "alpha-combined");
     assert_ne!(result.updated_stacks[0].source_revision, before);
-    let installed = fs::read_to_string(crate::paths::stack_config("alpha-combined").unwrap())
+    let installed = fs::read_to_string(crate::core::paths::stack_config("alpha-combined").unwrap())
         .expect("installed stack");
     assert!(installed.contains("updated stack"));
 }
@@ -314,7 +325,8 @@ fn update_all_reports_broken_sources_and_continues() {
         .to_string_lossy()
         .to_string();
     install(&broken_source, None, false).expect("install broken source");
-    let broken_metadata = crate::rig::read_source_metadata("broken").expect("broken metadata");
+    let broken_metadata =
+        crate::core::rig::read_source_metadata("broken").expect("broken metadata");
     fs::remove_dir_all(&broken_metadata.package_path).expect("remove installed package clone");
 
     let good_package = tempfile::tempdir().expect("good package");
@@ -341,8 +353,8 @@ fn update_all_reports_broken_sources_and_continues() {
     assert!(result.failed[0].reason.contains("missing"));
     assert_eq!(result.updated.len(), 1);
     assert_eq!(result.updated[0].id, "good");
-    let installed =
-        fs::read_to_string(crate::paths::rig_config("good").unwrap()).expect("installed good rig");
+    let installed = fs::read_to_string(crate::core::paths::rig_config("good").unwrap())
+        .expect("installed good rig");
     assert!(installed.contains("good rig updated"));
 }
 
@@ -360,7 +372,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
         .to_string();
 
     install(&source, None, false).expect("install");
-    let config = crate::paths::stack_config("alpha-combined").expect("stack config");
+    let config = crate::core::paths::stack_config("alpha-combined").expect("stack config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("manual stack");
     fs::write(

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -1,7 +1,7 @@
 //! Spec parsing tests — serde round-trips, pipeline step discriminants,
 //! service-kind parsing. Covers `src/core/rig/spec.rs`.
 
-use crate::rig::{
+use crate::core::rig::{
     PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec,
     TraceVariantSpec, WorkloadEntry, WorkloadSpec,
 };
@@ -448,7 +448,7 @@ fn test_spec_pipeline_step_id_and_dependencies_parse() {
 
 #[test]
 fn test_spec_git_step_parses_with_args() {
-    use crate::rig::spec::GitOp;
+    use crate::core::rig::spec::GitOp;
     let json = r#"{
         "id": "r",
         "components": { "studio": { "path": "/tmp/studio" } },
@@ -482,7 +482,7 @@ fn test_spec_git_step_parses_with_args() {
 
 #[test]
 fn test_spec_git_op_current_branch_kebab_serializes() {
-    use crate::rig::spec::GitOp;
+    use crate::core::rig::spec::GitOp;
     let json = r#"{
         "id": "r",
         "components": { "studio": { "path": "/tmp/studio" } },
@@ -501,7 +501,7 @@ fn test_spec_git_op_current_branch_kebab_serializes() {
 
 #[test]
 fn test_spec_stack_step_parses_sync_shape() {
-    use crate::rig::spec::StackOp;
+    use crate::core::rig::spec::StackOp;
     let json = r#"{
         "id": "r",
         "components": {
@@ -560,7 +560,7 @@ fn test_spec_round_trip_preserves_shape() {
 
 #[test]
 fn test_spec_patch_step_parses_full_shape() {
-    use crate::rig::spec::PatchOp;
+    use crate::core::rig::spec::PatchOp;
     let json = r#"{
         "id": "r",
         "components": { "playground": { "path": "/tmp/pg" } },
@@ -605,7 +605,7 @@ fn test_spec_patch_step_parses_full_shape() {
 
 #[test]
 fn test_spec_patch_op_defaults_to_apply_when_omitted() {
-    use crate::rig::spec::PatchOp;
+    use crate::core::rig::spec::PatchOp;
     let json = r#"{
         "id": "r",
         "components": { "c": { "path": "/tmp/c" } },

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -2,10 +2,10 @@
 
 use std::collections::HashMap;
 
-use crate::error::Error;
-use crate::plan::{HomeboyPlan, PlanKind};
-use crate::rig::spec::{ComponentSpec, RigSpec};
-use crate::stack::{GitRef, StackPrEntry, StackSpec, SyncOutput, SyncPreview};
+use crate::core::error::Error;
+use crate::core::plan::{HomeboyPlan, PlanKind};
+use crate::core::rig::spec::{ComponentSpec, RigSpec};
+use crate::core::stack::{GitRef, StackPrEntry, StackSpec, SyncOutput, SyncPreview};
 
 use super::{plan_stack_sync, run_component_sync, run_sync_with, validate_component_stack_path};
 

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -6,8 +6,8 @@
 
 use std::collections::BTreeMap;
 
-use crate::rig::spec::RigResourcesSpec;
-use crate::rig::state::{
+use crate::core::rig::spec::RigResourcesSpec;
+use crate::core::rig::state::{
     ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, ServiceState,
     SharedPathState,
 };

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use crate::rig::spec::RigSpec;
-use crate::rig::{
+use crate::core::rig::spec::RigSpec;
+use crate::core::rig::{
     check_groups_for_extension_workloads, extension_ids_for_workloads, workloads_for_extension,
     RigWorkloadKind,
 };
@@ -61,9 +61,9 @@ fn test_invocation_requirements_for_extension_workloads() {
     )
     .expect("parse rig spec");
 
-    let requirements = crate::rig::invocation_requirements_for_extension_workloads(
+    let requirements = crate::core::rig::invocation_requirements_for_extension_workloads(
         &rig_spec,
-        crate::rig::RigWorkloadKind::Bench,
+        crate::core::rig::RigWorkloadKind::Bench,
         "nodejs",
     );
 

--- a/tests/core/stack/apply_test.rs
+++ b/tests/core/stack/apply_test.rs
@@ -9,8 +9,10 @@
 //! End-to-end correctness is verified out-of-band via the live-verify
 //! fixture spec described in the PR body.
 
-use crate::stack::apply::{checkout_force, cherry_pick, rebase, url_matches, CherryPickResult};
-use crate::stack::{save, GitRef, StackSpec};
+use crate::core::stack::apply::{
+    checkout_force, cherry_pick, rebase, url_matches, CherryPickResult,
+};
+use crate::core::stack::{save, GitRef, StackSpec};
 use crate::test_support::with_isolated_home;
 use std::fs;
 use std::process::Command;

--- a/tests/core/stack/inspect_test.rs
+++ b/tests/core/stack/inspect_test.rs
@@ -6,7 +6,7 @@
 //! intentionally not exercised end-to-end (they require a live `gh` and
 //! GitHub) — `no_pr: true` keeps tests deterministic.
 
-use crate::stack::inspect::{inspect_at, InspectOptions};
+use crate::core::stack::inspect::{inspect_at, InspectOptions};
 
 mod support;
 use support::{commit_file, git, init_repo};

--- a/tests/core/stack/push_test.rs
+++ b/tests/core/stack/push_test.rs
@@ -1,7 +1,7 @@
 //! Tests for `core::stack::push` — publishing the materialized target branch.
 
-use crate::stack::push::{local_branch_ref, push, remote_branch_ref, PushStatus};
-use crate::stack::spec::{GitRef, StackSpec};
+use crate::core::stack::push::{local_branch_ref, push, remote_branch_ref, PushStatus};
+use crate::core::stack::spec::{GitRef, StackSpec};
 use std::process::Command;
 use tempfile::TempDir;
 

--- a/tests/core/stack/spec_test.rs
+++ b/tests/core/stack/spec_test.rs
@@ -1,6 +1,6 @@
 //! Spec parsing + path expansion tests for `core::stack::spec`.
 
-use crate::stack::spec::{expand_path, parse_git_ref, GitRef, StackPrEntry, StackSpec};
+use crate::core::stack::spec::{expand_path, parse_git_ref, GitRef, StackPrEntry, StackSpec};
 
 const STUDIO_FIXTURE: &str = r#"{
     "id": "studio-combined",

--- a/tests/core/stack/status_test.rs
+++ b/tests/core/stack/status_test.rs
@@ -6,7 +6,7 @@
 //! commit reachability. End-to-end reporting is verified out-of-band via
 //! the live-verify fixture spec described in the PR body.
 
-use crate::stack::status::{commit_reachable, count_revs, git_ref_exists, patch_in_base};
+use crate::core::stack::status::{commit_reachable, count_revs, git_ref_exists, patch_in_base};
 use std::fs;
 
 mod support;

--- a/tests/core/stack/sync_test.rs
+++ b/tests/core/stack/sync_test.rs
@@ -11,7 +11,7 @@
 //! from the spec. The cherry-pick orchestration after that decision is
 //! the same machinery `apply` uses (already tested in `apply_test.rs`).
 
-use crate::stack::sync::{is_droppable, sync_would_mutate, PrMeta};
+use crate::core::stack::sync::{is_droppable, sync_would_mutate, PrMeta};
 use std::fs;
 
 mod support;

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -1,5 +1,5 @@
-use homeboy::error::{RemoteCommandFailedDetails, TargetDetails};
-use homeboy::Error;
+use homeboy::core::error::{RemoteCommandFailedDetails, TargetDetails};
+use homeboy::core::Error;
 
 #[test]
 fn remote_command_failed_creates_error_with_details() {

--- a/tests/utils/autofix_test.rs
+++ b/tests/utils/autofix_test.rs
@@ -1,4 +1,4 @@
-use homeboy::refactor::auto::{
+use homeboy::core::refactor::auto::{
     parse_fix_results_file, standard_outcome, summarize_optional_fix_results, AutofixMode,
 };
 


### PR DESCRIPTION
## Summary
- Remove the flattened `pub use core::*` library root surface so core APIs stay behind `homeboy::core`.
- Migrate internal callers, command modules, and tests to explicit `crate::core::*` / `homeboy::core::*` paths.
- Add an architecture guard to prevent reintroducing a flattened core root export.

## Why
This is a deliberate internal breaking migration to reduce the crate's implicit public footprint and make architectural boundaries explicit. Callers now have to name the layer they depend on instead of reaching through the crate root by accident.

## Verification
- `cargo check --all-targets`
- `cargo fmt --check && cargo test --test architecture_core_agnostic_test`
- `cargo test --lib` (`3126 passed`, `18 ignored`)
- `homeboy audit --path "/Users/chubes/Developer/homeboy@trace-run-record-builder" --extension rust --changed-since origin/main --output "/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/lib-public-surface-cleanup-audit.json"` (`0 introduced findings`)
- `homeboy lint --path "/Users/chubes/Developer/homeboy@trace-run-record-builder" --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Performed the mechanical path migration, added the architecture guard, ran validation, and drafted this PR description for Chris to review.