### PR TITLE
refactor: make server reexports explicit

### DIFF
--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -12,8 +12,8 @@ use crate::core::error::{Error, Result};
 use chrono::Utc;
 
 use super::{
-    ensure_control_path_parent, ManagedSshSession, ManagedSshSessionOutput, Server, ServerAuthMode,
-    ServerSessionConfig,
+    session::ensure_control_path_parent, ManagedSshSession, ManagedSshSessionOutput, Server,
+    ServerAuthMode, ServerSessionConfig,
 };
 use std::process::{Command, Stdio};
 

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -9,12 +9,17 @@ mod keys;
 mod session;
 pub mod transfer;
 
-pub use client::*;
-pub use connection::*;
-pub use health::*;
-pub use keys::*;
-pub use session::*;
-pub use transfer::*;
+pub(crate) use client::execute_local_command_stderr_passthrough;
+pub use client::{
+    execute_local_command, execute_local_command_in_dir, execute_local_command_interactive,
+    execute_local_command_passthrough, CommandOutput, SshClient,
+};
+pub use connection::{resolve_context, SshResolveArgs, SshResolveResult};
+pub use keys::{
+    generate_key, get_public_key, import_key, unset_key, use_key, KeyGenerateResult,
+    KeyImportResult,
+};
+pub use session::{ManagedSshSession, ManagedSshSessionOutput};
 
 use std::collections::HashMap;
 

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -89,6 +89,19 @@ fn library_root_does_not_flatten_core_surface() {
 }
 
 #[test]
+fn server_root_does_not_wildcard_reexport_private_modules() {
+    let source = source_file("src/core/server/mod.rs");
+
+    assert!(
+        !source.contains("pub use client::*")
+            && !source.contains("pub use connection::*")
+            && !source.contains("pub use keys::*")
+            && !source.contains("pub use session::*"),
+        "src/core/server/mod.rs must explicitly name the server APIs it re-exports"
+    );
+}
+
+#[test]
 fn validate_and_format_writes_do_not_select_ecosystem_commands() {
     let files = [
         "src/core/engine/validate_write.rs",


### PR DESCRIPTION
## Summary
- Replace `core::server` wildcard re-exports with explicit public exports for the current server API surface.
- Keep crate-internal stderr passthrough available as `pub(crate)` instead of exposing it publicly.
- Add an architecture guard against reintroducing wildcard server re-exports.

## Verification
- `cargo fmt --check && cargo test --test architecture_core_agnostic_test`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/core-server-explicit-reexports-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the mechanical refactor, architecture guard, and validation commands; Chris remains responsible for review and merge.