### PR TITLE
refactor: make version reexports explicit

### DIFF
--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -2,9 +2,23 @@ mod default_pattern_for_file;
 mod types;
 mod version;
 
-pub use default_pattern_for_file::*;
-pub use types::*;
-pub use version::*;
+pub(crate) use default_pattern_for_file::{
+    build_init_warnings, read_component_snapshot, resolve_version_file_path,
+};
+use default_pattern_for_file::{
+    build_version_parse_error, parse_versions, replace_since_tag_placeholders,
+    resolve_target_pattern,
+};
+pub use default_pattern_for_file::{
+    default_pattern_for_file, read_component_version, read_version,
+};
+#[cfg(test)]
+use types::DEFAULT_SINCE_PLACEHOLDER;
+pub use types::{
+    BumpResult, ChangelogValidationResult, ComponentVersionInfo, ComponentVersionSnapshot,
+    UnconfiguredPattern, VersionTargetInfo,
+};
+pub use version::{get_component_version, increment_version, parse_version};
 
 use crate::core::component::{self, Component, VersionTarget};
 use crate::core::config::{from_str, set_json_pointer, to_string_pretty};

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -102,6 +102,18 @@ fn server_root_does_not_wildcard_reexport_private_modules() {
 }
 
 #[test]
+fn release_version_root_does_not_wildcard_reexport_private_modules() {
+    let source = source_file("src/core/release/version.rs");
+
+    assert!(
+        !source.contains("pub use default_pattern_for_file::*")
+            && !source.contains("pub use types::*")
+            && !source.contains("pub use version::*"),
+        "src/core/release/version.rs must explicitly name the version APIs it re-exports"
+    );
+}
+
+#[test]
 fn validate_and_format_writes_do_not_select_ecosystem_commands() {
     let files = [
         "src/core/engine/validate_write.rs",


### PR DESCRIPTION
## Summary
- Replace `core::release::version` wildcard child-module re-exports with an explicit public API list.
- Keep crate-internal version helpers available with `pub(crate)` or private imports instead of exposing every child-module item through wildcard imports.
- Add an architecture guard against reintroducing wildcard re-exports in the version root module.

## Verification
- `cargo fmt --check && cargo test --test architecture_core_agnostic_test`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/release-version-explicit-reexports-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the mechanical re-export cleanup, architecture guard, and validation commands; Chris remains responsible for review and merge.