### PR TITLE
fix: keep release diagnostics extension agnostic

### DIFF
--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -375,7 +375,9 @@ fn add_release_extension_diagnostics(
 
     let mut configured_ids: Vec<String> = configured.keys().cloned().collect();
     configured_ids.sort();
-    if !configured_ids.iter().any(|id| id == "wordpress") && !has_package_capability(extensions) {
+    if !configured_extension_has_release_actions(&configured_ids, extensions)
+        && !has_package_capability(extensions)
+    {
         return;
     }
 
@@ -402,6 +404,19 @@ fn add_release_extension_diagnostics(
             loaded.join("; ")
         }
     ));
+}
+
+fn configured_extension_has_release_actions(
+    configured_ids: &[String],
+    extensions: &[ExtensionManifest],
+) -> bool {
+    extensions.iter().any(|extension| {
+        configured_ids.iter().any(|id| id == &extension.id)
+            && extension
+                .actions
+                .iter()
+                .any(|action| action.id.starts_with("release."))
+    })
 }
 
 fn build_changelog_steps(


### PR DESCRIPTION
## Summary
- Remove the ecosystem-specific extension ID check from release planning diagnostics.
- Trigger the missing `release.publish` warning from loaded release capabilities instead, keeping core release planning extension-agnostic.

Fixes #2586.

## Validation
- `cargo fmt --check`
- `cargo test --test core_agnostic_test core_owned_source_stays_language_and_framework_agnostic`
- `cargo test --lib release::plan_steps`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-release-diagnostic-agnostic --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-release-diagnostic-agnostic --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the failing core-agnostic architecture test, drafted the generic release-capability diagnostic, and ran local validation. Chris directed the issue selection and PR creation.