### PR TITLE
fix: include dirty files in test drift diffs

### DIFF
--- a/src/core/extension/test/drift.rs
+++ b/src/core/extension/test/drift.rs
@@ -261,8 +261,9 @@ fn get_changed_files(root: &Path, since: &str) -> Result<Vec<String>> {
 
 /// Get diff for a specific file.
 fn get_file_diff(root: &Path, since: &str, file: &str) -> Result<String> {
+    let merge_base = merge_base(root, since)?;
     let output = Command::new("git")
-        .args(["diff", since, "HEAD", "--", file])
+        .args(["diff", &merge_base, "--", file])
         .current_dir(root)
         .output()
         .map_err(|e| {
@@ -273,6 +274,35 @@ fn get_file_diff(root: &Path, since: &str, file: &str) -> Result<String> {
         })?;
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Resolve the comparison base used for drift diffs.
+///
+/// `git diff <base> -- <file>` compares the merge base to the working tree,
+/// so drift extraction sees committed, staged, and unstaged edits. This keeps
+/// it aligned with `git::get_files_changed_since`, which already includes
+/// dirty files in changed-since scopes.
+fn merge_base(root: &Path, since: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["merge-base", since, "HEAD"])
+        .current_dir(root)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to resolve merge base for {}: {}", since, e),
+                Some("test_drift.git".to_string()),
+            )
+        })?;
+
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "git merge-base {} HEAD failed: {}",
+            since,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Get renamed files from git diff.
@@ -823,6 +853,55 @@ mod tests {
 
         let report = detect_drift("fixture", &opts).expect("drift report");
         assert!(report.production_changes.is_empty());
+    }
+
+    #[test]
+    fn detect_drift_includes_uncommitted_production_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        run_git(root, &["init", "-q", "-b", "main"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test"]);
+
+        std::fs::create_dir_all(root.join("inc")).unwrap();
+        std::fs::create_dir_all(root.join("tests")).unwrap();
+        std::fs::write(
+            root.join("inc/FlowStepConfig.php"),
+            "<?php\nclass FlowStepConfig { public function handler_config() {} }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("tests/FlowStepConfigTest.php"),
+            "<?php\n$this->assertSame([], $config->handler_config());\n",
+        )
+        .unwrap();
+        run_git(root, &["add", "inc", "tests"]);
+        run_git(root, &["commit", "-q", "-m", "initial"]);
+
+        std::fs::write(
+            root.join("inc/FlowStepConfig.php"),
+            "<?php\nclass FlowStepConfig { public function handler_configs() {} }\n",
+        )
+        .unwrap();
+
+        let opts = DriftOptions {
+            root: root.to_path_buf(),
+            since: "HEAD".to_string(),
+            source_patterns: vec!["inc/**/*.php".to_string()],
+            test_patterns: vec!["tests/**/*.php".to_string()],
+        };
+
+        let report = detect_drift("fixture", &opts).expect("drift report");
+
+        assert!(report
+            .production_changes
+            .iter()
+            .any(|change| change.old_symbol == "handler_config"));
+        assert_eq!(report.drifted_tests.len(), 1);
+        assert_eq!(
+            report.drifted_tests[0].test_file,
+            "tests/FlowStepConfigTest.php"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Resolve changed-since drift diffs from the merge base to the working tree, so staged and unstaged production edits are analyzed before commit.
- Add a regression covering an uncommitted PHP production rename selecting its dependent PHPUnit test.

## Verification
- `cargo fmt --check`
- `cargo test detect_drift_includes_uncommitted_production_changes --lib`
- `cargo test core::extension::test::drift --lib`
- `cargo test core::extension::test --lib`
- `homeboy lint --changed-since origin/main`
- Direct Rust runner smoke with Homeboy Extensions PR #661 selected `core::extension::test::drift` and ran 10 tests.

## Notes
- `homeboy test --changed-since origin/main` with the currently installed Rust extension can false-green with 0 tests. The runner fix is in Extra-Chill/homeboy-extensions#661.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the changed-since underselection root cause, drafted the implementation and regression, and ran verification; Chris remains responsible for review and merge.