### PR TITLE
feat(release): finish pipeline from tagged head

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,22 +586,8 @@ jobs:
         run: |
           rm -f artifacts/*-dist-manifest.json
 
-      - name: Create GitHub Release
-        env:
-          PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
-        run: |
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
-          TAG="${{ needs.prepare.outputs.release-tag }}"
-          RELEASE_COMMIT="$(git rev-list -n 1 "$TAG")"
-          if gh release view "$TAG" > /dev/null 2>&1; then
-            echo "Release $TAG already exists. Uploading assets..."
-            gh release upload "$TAG" artifacts/* --clobber
-          else
-            echo "Creating release $TAG..."
-            gh release create "$TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
-          fi
+      - name: Finish Homeboy release pipeline at tag
+        run: cargo run --release -- release homeboy --head --from-artifacts artifacts --skip-checks
 
   publish-homebrew-formula:
     needs:

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -18,6 +18,8 @@ Legacy positional bump syntax is still accepted for compatibility: `homeboy rele
 - `--path <PATH>`: Override local path for a single-component release
 - `--deploy`: Deploy this component to all projects that use it after release
 - `--recover`: Recover from an interrupted release
+- `--head`: Finish the release pipeline for the version commit and tag already checked out at HEAD
+- `--from-artifacts <DIR>`: With `--head`, attach/publish existing artifacts from a directory instead of running `release.package`
 - `--skip-checks`: Skip pre-release lint/test checks
 - `--bump <BUMP>`: Force `major`, `minor`, `patch`, or an explicit version like `2.0.0`
 - `--force-lower-bump`: Allow a forced bump lower than the commit-derived recommendation
@@ -28,6 +30,8 @@ Legacy positional bump syntax is still accepted for compatibility: `homeboy rele
 ## Description
 
 `homeboy release` executes component releases: detects or applies a version bump, finalizes generated changelog entries, commits, tags, pushes, and optionally publishes release artifacts. Use `--dry-run` to preview the release plan without making changes.
+
+`--head` is for CI jobs where another step already created the release commit and tag, but Homeboy should still own the rest of the release lifecycle. It keeps the safe preflight checks, skips changelog/version/git mutation steps, populates release state from the version and tag at HEAD, then runs `release.package` (unless `--from-artifacts` is provided), `github.release`, `release.publish`, cleanup, and post-release hooks through the normal pipeline.
 
 When `--bump` requests a lower keyword bump than Homeboy detects from releasable commits, release execution requires confirmation in an interactive terminal. Non-interactive runs must pass `--force-lower-bump`; otherwise Homeboy refuses before creating release artifacts, commits, tags, or pushes. Dry-run still returns the plan and semver recommendation for review.
 
@@ -42,6 +46,14 @@ homeboy release <component_id> --dry-run
 
 # 3. Execute the release
 homeboy release <component_id>
+```
+
+### Finish an already-tagged release
+
+```sh
+# Build/package artifacts somewhere else, then let Homeboy create/update the
+# GitHub Release and run publish hooks without re-tagging.
+homeboy release <component_id> --head --from-artifacts ./artifacts --skip-checks
 ```
 
 ## Release Pipeline

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -40,6 +40,17 @@ pub struct ReleaseArgs {
     #[arg(long)]
     recover: bool,
 
+    /// Finish the release pipeline for an already-versioned, already-tagged HEAD.
+    /// Skips changelog/version/git mutation steps and runs package, GitHub Release,
+    /// publish, cleanup, and post-release hooks against the tag pointing at HEAD.
+    #[arg(long)]
+    head: bool,
+
+    /// Use existing release artifacts from this directory instead of running release.package.
+    /// Requires --head.
+    #[arg(long, value_name = "DIR")]
+    from_artifacts: Option<String>,
+
     /// Skip pre-release lint and test checks
     #[arg(long)]
     skip_checks: bool,
@@ -100,6 +111,8 @@ impl ReleaseArgs {
         dry_run: bool,
         deploy: bool,
         recover: bool,
+        head: bool,
+        from_artifacts: Option<String>,
         skip_checks: bool,
         skip_publish: bool,
         bump: Option<String>,
@@ -113,6 +126,8 @@ impl ReleaseArgs {
             _json: HiddenJsonArgs::default(),
             deploy,
             recover,
+            head,
+            from_artifacts,
             skip_checks,
             bump,
             force_lower_bump: false,
@@ -141,6 +156,8 @@ pub fn run(
             dry_run: args.dry_run_args.dry_run,
             deploy: args.deploy,
             recover: args.recover,
+            head: args.head,
+            from_artifacts: args.from_artifacts.clone(),
             skip_checks: args.skip_checks,
             bump_override: bump_override.clone(),
             force_lower_bump: args.force_lower_bump,
@@ -172,6 +189,22 @@ pub fn run(
             None,
         ));
     }
+    if args.head {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "head",
+            "--head is not supported for batch releases — finish one component release at a time",
+            None,
+            None,
+        ));
+    }
+    if args.from_artifacts.is_some() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "from-artifacts",
+            "--from-artifacts requires --head and is not supported for batch releases",
+            args.from_artifacts.clone(),
+            None,
+        ));
+    }
 
     let input_template = ReleaseCommandInput {
         component_id: String::new(), // overridden per component
@@ -179,6 +212,8 @@ pub fn run(
         dry_run: args.dry_run_args.dry_run,
         deploy: args.deploy,
         recover: false,
+        head: false,
+        from_artifacts: None,
         skip_checks: args.skip_checks,
         bump_override,
         force_lower_bump: args.force_lower_bump,
@@ -355,6 +390,8 @@ mod tests {
             true,
             false,
             false,
+            false,
+            None,
             false,
             false,
             None,

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -4,7 +4,9 @@ use serde::Serialize;
 use homeboy::core::component;
 use homeboy::core::deploy::{self, ReleaseStateStatus};
 use homeboy::core::project;
-use homeboy::core::release::{self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult};
+use homeboy::core::release::{
+    self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult, ReleasePipelineOptions,
+};
 
 use super::utils::args::{DryRunArgs, HiddenJsonArgs};
 use super::CmdResult;
@@ -100,6 +102,17 @@ pub enum ReleaseCommandOutput {
     Batch(BatchReleaseOutput),
 }
 
+impl ReleaseArgs {
+    fn pipeline_options(&self) -> ReleasePipelineOptions {
+        ReleasePipelineOptions {
+            deploy: self.deploy,
+            skip_publish: self.skip_publish,
+            head: self.head,
+            from_artifacts: self.from_artifacts.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 impl ReleaseArgs {
     /// Construct ReleaseArgs programmatically for tests and internal callers.
@@ -154,14 +167,11 @@ pub fn run(
             component_id: component_id.clone(),
             path_override: args.path.clone(),
             dry_run: args.dry_run_args.dry_run,
-            deploy: args.deploy,
             recover: args.recover,
-            head: args.head,
-            from_artifacts: args.from_artifacts.clone(),
             skip_checks: args.skip_checks,
             bump_override: bump_override.clone(),
             force_lower_bump: args.force_lower_bump,
-            skip_publish: args.skip_publish,
+            pipeline: args.pipeline_options(),
             skip_github_release: args.no_github_release,
             git_identity: args.git_identity.clone(),
         })?;
@@ -210,14 +220,16 @@ pub fn run(
         component_id: String::new(), // overridden per component
         path_override: None,
         dry_run: args.dry_run_args.dry_run,
-        deploy: args.deploy,
         recover: false,
-        head: false,
-        from_artifacts: None,
         skip_checks: args.skip_checks,
         bump_override,
         force_lower_bump: args.force_lower_bump,
-        skip_publish: args.skip_publish,
+        pipeline: ReleasePipelineOptions {
+            deploy: args.deploy,
+            skip_publish: args.skip_publish,
+            head: false,
+            from_artifacts: None,
+        },
         skip_github_release: args.no_github_release,
         git_identity: args.git_identity.clone(),
     };

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -75,9 +75,10 @@ pub(super) fn execute_release_plan_step(
                 .and_then(|value| value.as_str())
                 .unwrap_or_default();
             Ok(Some(
-                executor::run_artifact_inventory(&mut context.state, dir).unwrap_or_else(|err| {
-                    failed_result("artifacts.inventory", "artifacts.inventory", err)
-                }),
+                executor::artifacts::run_artifact_inventory(&mut context.state, dir)
+                    .unwrap_or_else(|err| {
+                        failed_result("artifacts.inventory", "artifacts.inventory", err)
+                    }),
             ))
         }
         "git.tag" => {

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -68,6 +68,18 @@ pub(super) fn execute_release_plan_step(
             )
             .unwrap_or_else(|err| failed_result("package", "package", err)),
         )),
+        "artifacts.inventory" => {
+            let dir = step
+                .inputs
+                .get("dir")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default();
+            Ok(Some(
+                executor::run_artifact_inventory(&mut context.state, dir).unwrap_or_else(|err| {
+                    failed_result("artifacts.inventory", "artifacts.inventory", err)
+                }),
+            ))
+        }
         "git.tag" => {
             let tag_name = step
                 .inputs

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -81,7 +81,7 @@ fn initial_release_state(
     component_id: &str,
     options: &ReleaseOptions,
 ) -> Result<ReleaseState> {
-    if !options.head {
+    if !options.pipeline.head {
         return Ok(ReleaseState::default());
     }
 

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
+use std::path::Path;
 
-use crate::core::error::Result;
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::git;
 use crate::core::plan::PlanStep;
 
 use super::context::{load_component, resolve_extensions};
@@ -52,7 +55,7 @@ pub(super) fn execute_plan_steps(
         extensions: &extensions,
         component_id,
         options,
-        state: ReleaseState::default(),
+        state: initial_release_state(&component, component_id, options)?,
         publish_failed: false,
     };
 
@@ -71,6 +74,92 @@ pub(super) fn execute_plan_steps(
     }
 
     Ok(false)
+}
+
+fn initial_release_state(
+    component: &Component,
+    component_id: &str,
+    options: &ReleaseOptions,
+) -> Result<ReleaseState> {
+    if !options.head {
+        return Ok(ReleaseState::default());
+    }
+
+    let version_info = super::version::read_component_version(component)?;
+    let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
+    let expected_tag = match monorepo.as_ref() {
+        Some(ctx) => ctx.format_tag(&version_info.version),
+        None => format!("v{}", version_info.version),
+    };
+
+    let tag = resolve_head_tag(&component.local_path, &expected_tag)?;
+    let notes = read_current_release_notes(component)?;
+
+    Ok(ReleaseState {
+        version: Some(version_info.version),
+        tag: Some(tag),
+        notes,
+        artifacts: Vec::new(),
+        changelog_validation: None,
+    })
+}
+
+fn resolve_head_tag(local_path: &str, expected_tag: &str) -> Result<String> {
+    let output = git::execute_git_for_release(local_path, &["tag", "--points-at", "HEAD"])
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to inspect tags pointing at HEAD: {}", e),
+                Some("git tag --points-at HEAD".to_string()),
+            )
+        })?;
+
+    let tags: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect();
+
+    if tags.iter().any(|tag| tag == expected_tag) {
+        return Ok(expected_tag.to_string());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "head",
+        format!(
+            "--head requires tag '{}' to point at HEAD; found: {}",
+            expected_tag,
+            if tags.is_empty() {
+                "none".to_string()
+            } else {
+                tags.join(", ")
+            }
+        ),
+        Some(expected_tag.to_string()),
+        Some(vec![
+            "Check out the release tag or push the expected tag before running `homeboy release --head`.".to_string(),
+        ]),
+    ))
+}
+
+fn read_current_release_notes(component: &Component) -> Result<Option<String>> {
+    let changelog = component
+        .changelog_target
+        .as_deref()
+        .unwrap_or("CHANGELOG.md");
+    let path = Path::new(&component.local_path).join(changelog);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&path).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read changelog release notes: {}", e),
+            Some(path.display().to_string()),
+        )
+    })?;
+
+    Ok(super::utils::extract_latest_notes(&content))
 }
 
 #[cfg(test)]

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -22,6 +22,7 @@ use crate::core::release::{changelog as release_changelog, version};
 use super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use super::utils::{extract_latest_notes, parse_release_artifacts};
 
+pub(crate) mod artifacts;
 pub(crate) mod changelog;
 pub(crate) mod prepare;
 
@@ -585,86 +586,6 @@ pub(crate) fn run_package(
     });
 
     Ok(step_success("package", "package", Some(data), Vec::new()))
-}
-
-/// Inventory artifacts that were already built by an external release build.
-/// This lets `homeboy release --head --from-artifacts <dir>` reuse the normal
-/// github.release and publish steps without re-running release.package.
-pub(crate) fn run_artifact_inventory(
-    state: &mut ReleaseState,
-    artifact_dir: &str,
-) -> Result<ReleaseStepResult> {
-    let dir = std::path::Path::new(artifact_dir);
-    if !dir.is_dir() {
-        return Err(Error::validation_invalid_argument(
-            "from-artifacts",
-            format!("Artifact directory '{}' does not exist", artifact_dir),
-            Some(artifact_dir.to_string()),
-            None,
-        ));
-    }
-
-    let mut artifacts = Vec::new();
-    for entry in std::fs::read_dir(dir).map_err(|e| {
-        Error::internal_io(
-            format!(
-                "Failed to read artifact directory '{}': {}",
-                artifact_dir, e
-            ),
-            Some(artifact_dir.to_string()),
-        )
-    })? {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(
-                format!("Failed to read artifact directory entry: {}", e),
-                Some(artifact_dir.to_string()),
-            )
-        })?;
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        let canonical = std::fs::canonicalize(&path).map_err(|e| {
-            Error::internal_io(
-                format!(
-                    "Failed to resolve artifact path '{}': {}",
-                    path.display(),
-                    e
-                ),
-                Some(path.display().to_string()),
-            )
-        })?;
-        artifacts.push(ReleaseArtifact {
-            path: canonical.display().to_string(),
-            artifact_type: None,
-            platform: None,
-        });
-    }
-
-    artifacts.sort_by(|a, b| a.path.cmp(&b.path));
-    if artifacts.is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "from-artifacts",
-            format!("Artifact directory '{}' contains no files", artifact_dir),
-            Some(artifact_dir.to_string()),
-            None,
-        ));
-    }
-
-    let artifact_count = artifacts.len();
-    state.artifacts.extend(artifacts.clone());
-    let data = serde_json::json!({
-        "dir": artifact_dir,
-        "artifact_count": artifact_count,
-        "artifacts": artifacts,
-    });
-
-    Ok(step_success(
-        "artifacts.inventory",
-        "artifacts.inventory",
-        Some(data),
-        Vec::new(),
-    ))
 }
 
 /// Invoke the `release.publish` action on the named extension.
@@ -1344,8 +1265,8 @@ fn sanitize_tag_for_filename(tag: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        fallback_gh_command, publish_step_result, run_artifact_inventory, run_git_push,
-        sanitize_tag_for_filename, store_artifacts_from_output,
+        fallback_gh_command, publish_step_result, run_git_push, sanitize_tag_for_filename,
+        store_artifacts_from_output,
     };
     use crate::core::component::Component;
     use crate::core::release::ReleaseStepStatus;
@@ -1399,28 +1320,6 @@ mod tests {
                 .data
                 .and_then(|data| data.get("success").and_then(serde_json::Value::as_bool)),
             Some(false)
-        );
-    }
-
-    #[test]
-    fn artifact_inventory_loads_existing_files_into_release_state() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let artifact_path = temp.path().join("homeboy.tar.gz");
-        std::fs::write(&artifact_path, "artifact").expect("write artifact");
-        std::fs::create_dir(temp.path().join("nested")).expect("nested dir");
-
-        let mut state = crate::core::release::types::ReleaseState::default();
-        let result = run_artifact_inventory(&mut state, &temp.path().to_string_lossy())
-            .expect("inventory should succeed");
-
-        assert_eq!(result.status, ReleaseStepStatus::Success);
-        assert_eq!(state.artifacts.len(), 1);
-        assert_eq!(
-            state.artifacts[0].path,
-            std::fs::canonicalize(&artifact_path)
-                .expect("canonical artifact")
-                .display()
-                .to_string()
         );
     }
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -587,6 +587,86 @@ pub(crate) fn run_package(
     Ok(step_success("package", "package", Some(data), Vec::new()))
 }
 
+/// Inventory artifacts that were already built by an external release build.
+/// This lets `homeboy release --head --from-artifacts <dir>` reuse the normal
+/// github.release and publish steps without re-running release.package.
+pub(crate) fn run_artifact_inventory(
+    state: &mut ReleaseState,
+    artifact_dir: &str,
+) -> Result<ReleaseStepResult> {
+    let dir = std::path::Path::new(artifact_dir);
+    if !dir.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!("Artifact directory '{}' does not exist", artifact_dir),
+            Some(artifact_dir.to_string()),
+            None,
+        ));
+    }
+
+    let mut artifacts = Vec::new();
+    for entry in std::fs::read_dir(dir).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read artifact directory '{}': {}",
+                artifact_dir, e
+            ),
+            Some(artifact_dir.to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                format!("Failed to read artifact directory entry: {}", e),
+                Some(artifact_dir.to_string()),
+            )
+        })?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let canonical = std::fs::canonicalize(&path).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to resolve artifact path '{}': {}",
+                    path.display(),
+                    e
+                ),
+                Some(path.display().to_string()),
+            )
+        })?;
+        artifacts.push(ReleaseArtifact {
+            path: canonical.display().to_string(),
+            artifact_type: None,
+            platform: None,
+        });
+    }
+
+    artifacts.sort_by(|a, b| a.path.cmp(&b.path));
+    if artifacts.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!("Artifact directory '{}' contains no files", artifact_dir),
+            Some(artifact_dir.to_string()),
+            None,
+        ));
+    }
+
+    let artifact_count = artifacts.len();
+    state.artifacts.extend(artifacts.clone());
+    let data = serde_json::json!({
+        "dir": artifact_dir,
+        "artifact_count": artifact_count,
+        "artifacts": artifacts,
+    });
+
+    Ok(step_success(
+        "artifacts.inventory",
+        "artifacts.inventory",
+        Some(data),
+        Vec::new(),
+    ))
+}
+
 /// Invoke the `release.publish` action on the named extension.
 pub(crate) fn run_publish(
     extensions: &[ExtensionManifest],
@@ -1264,8 +1344,8 @@ fn sanitize_tag_for_filename(tag: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        fallback_gh_command, publish_step_result, run_git_push, sanitize_tag_for_filename,
-        store_artifacts_from_output,
+        fallback_gh_command, publish_step_result, run_artifact_inventory, run_git_push,
+        sanitize_tag_for_filename, store_artifacts_from_output,
     };
     use crate::core::component::Component;
     use crate::core::release::ReleaseStepStatus;
@@ -1319,6 +1399,28 @@ mod tests {
                 .data
                 .and_then(|data| data.get("success").and_then(serde_json::Value::as_bool)),
             Some(false)
+        );
+    }
+
+    #[test]
+    fn artifact_inventory_loads_existing_files_into_release_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact_path = temp.path().join("homeboy.tar.gz");
+        std::fs::write(&artifact_path, "artifact").expect("write artifact");
+        std::fs::create_dir(temp.path().join("nested")).expect("nested dir");
+
+        let mut state = crate::core::release::types::ReleaseState::default();
+        let result = run_artifact_inventory(&mut state, &temp.path().to_string_lossy())
+            .expect("inventory should succeed");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert_eq!(state.artifacts.len(), 1);
+        assert_eq!(
+            state.artifacts[0].path,
+            std::fs::canonicalize(&artifact_path)
+                .expect("canonical artifact")
+                .display()
+                .to_string()
         );
     }
 

--- a/src/core/release/executor/artifacts.rs
+++ b/src/core/release/executor/artifacts.rs
@@ -1,0 +1,112 @@
+use crate::core::error::{Error, Result};
+
+use super::{step_success, ReleaseArtifact, ReleaseState, ReleaseStepResult};
+
+/// Inventory artifacts that were already built by an external release build.
+/// This lets `homeboy release --head --from-artifacts <dir>` reuse the normal
+/// github.release and publish steps without re-running release.package.
+pub(crate) fn run_artifact_inventory(
+    state: &mut ReleaseState,
+    artifact_dir: &str,
+) -> Result<ReleaseStepResult> {
+    let dir = std::path::Path::new(artifact_dir);
+    if !dir.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!("Artifact directory '{}' does not exist", artifact_dir),
+            Some(artifact_dir.to_string()),
+            None,
+        ));
+    }
+
+    let mut artifacts = Vec::new();
+    for entry in std::fs::read_dir(dir).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to read artifact directory '{}': {}",
+                artifact_dir, e
+            ),
+            Some(artifact_dir.to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                format!("Failed to read artifact directory entry: {}", e),
+                Some(artifact_dir.to_string()),
+            )
+        })?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let canonical = std::fs::canonicalize(&path).map_err(|e| {
+            Error::internal_io(
+                format!(
+                    "Failed to resolve artifact path '{}': {}",
+                    path.display(),
+                    e
+                ),
+                Some(path.display().to_string()),
+            )
+        })?;
+        artifacts.push(ReleaseArtifact {
+            path: canonical.display().to_string(),
+            artifact_type: None,
+            platform: None,
+        });
+    }
+
+    artifacts.sort_by(|a, b| a.path.cmp(&b.path));
+    if artifacts.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            format!("Artifact directory '{}' contains no files", artifact_dir),
+            Some(artifact_dir.to_string()),
+            None,
+        ));
+    }
+
+    let artifact_count = artifacts.len();
+    state.artifacts.extend(artifacts.clone());
+    let data = serde_json::json!({
+        "dir": artifact_dir,
+        "artifact_count": artifact_count,
+        "artifacts": artifacts,
+    });
+
+    Ok(step_success(
+        "artifacts.inventory",
+        "artifacts.inventory",
+        Some(data),
+        Vec::new(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_artifact_inventory;
+    use crate::core::release::types::ReleaseState;
+    use crate::core::release::ReleaseStepStatus;
+
+    #[test]
+    fn test_run_artifact_inventory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact_path = temp.path().join("homeboy.tar.gz");
+        std::fs::write(&artifact_path, "artifact").expect("write artifact");
+        std::fs::create_dir(temp.path().join("nested")).expect("nested dir");
+
+        let mut state = ReleaseState::default();
+        let result = run_artifact_inventory(&mut state, &temp.path().to_string_lossy())
+            .expect("inventory should succeed");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert_eq!(state.artifacts.len(), 1);
+        assert_eq!(
+            state.artifacts[0].path,
+            std::fs::canonicalize(&artifact_path)
+                .expect("canonical artifact")
+                .display()
+                .to_string()
+        );
+    }
+}

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -26,8 +26,8 @@ pub use planner::plan;
 pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
-    ReleaseOptions, ReleasePlan, ReleaseProjectDeployResult, ReleaseRun, ReleaseRunResult,
-    ReleaseRunSummary, ReleaseStepResult, ReleaseStepStatus,
+    ReleaseOptions, ReleasePipelineOptions, ReleasePlan, ReleaseProjectDeployResult, ReleaseRun,
+    ReleaseRunResult, ReleaseRunSummary, ReleaseStepResult, ReleaseStepStatus,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{run_batch, run_command};

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -112,7 +112,7 @@ pub(super) fn build_preflight_steps(
 
     steps.extend(build_quality_steps(options));
 
-    if !options.head {
+    if !options.pipeline.head {
         steps.push(ready_step(
             "preflight.changelog_bootstrap",
             "preflight.changelog_bootstrap",
@@ -192,7 +192,7 @@ pub(super) fn build_release_steps(
 
     add_release_extension_diagnostics(component, extensions, &publish_targets, options, warnings);
 
-    if options.head {
+    if options.pipeline.head {
         return Ok(build_head_release_steps(
             component,
             extensions,
@@ -254,7 +254,7 @@ pub(super) fn build_release_steps(
         StepConfig::new(),
     ));
 
-    let tag_needs = if !publish_targets.is_empty() && !options.skip_publish {
+    let tag_needs = if !publish_targets.is_empty() && !options.pipeline.skip_publish {
         steps.push(ready_step(
             "package",
             "package",
@@ -298,7 +298,7 @@ pub(super) fn build_release_steps(
     }
 
     let mut publish_step_ids: Vec<String> = Vec::new();
-    if !publish_targets.is_empty() && !options.skip_publish {
+    if !publish_targets.is_empty() && !options.pipeline.skip_publish {
         for target in &publish_targets {
             let step_id = format!("publish.{}", target);
             publish_step_ids.push(step_id.clone());
@@ -311,7 +311,7 @@ pub(super) fn build_release_steps(
             ));
         }
 
-        if !options.deploy {
+        if !options.pipeline.deploy {
             steps.push(ready_step(
                 "cleanup",
                 "cleanup",
@@ -320,7 +320,7 @@ pub(super) fn build_release_steps(
                 StepConfig::new(),
             ));
         }
-    } else if options.skip_publish && !publish_targets.is_empty() {
+    } else if options.pipeline.skip_publish && !publish_targets.is_empty() {
         log_status!("release", "Skipping publish/package steps (--skip-publish)");
     }
 
@@ -329,8 +329,8 @@ pub(super) fn build_release_steps(
         crate::core::engine::hooks::events::POST_RELEASE,
     );
     if !post_release_hooks.is_empty() {
-        let post_release_needs = if !options.skip_publish && !publish_targets.is_empty() {
-            if options.deploy {
+        let post_release_needs = if !options.pipeline.skip_publish && !publish_targets.is_empty() {
+            if options.pipeline.deploy {
                 publish_step_ids.clone()
             } else {
                 vec!["cleanup".to_string()]
@@ -348,10 +348,10 @@ pub(super) fn build_release_steps(
         ));
     }
 
-    if options.deploy {
+    if options.pipeline.deploy {
         let deploy_needs = if !post_release_hooks.is_empty() {
             vec!["post_release".to_string()]
-        } else if !options.skip_publish && !publish_step_ids.is_empty() {
+        } else if !options.pipeline.skip_publish && !publish_step_ids.is_empty() {
             publish_step_ids
         } else {
             vec!["git.push".to_string()]
@@ -382,8 +382,8 @@ fn build_head_release_steps(
     let mut artifact_need = "preflight.remote_sync".to_string();
 
     if !publish_targets.is_empty()
-        && !options.skip_publish
-        && options.from_artifacts.is_none()
+        && !options.pipeline.skip_publish
+        && options.pipeline.from_artifacts.is_none()
         && !has_package_capability(extensions)
     {
         warnings.push(
@@ -393,8 +393,8 @@ fn build_head_release_steps(
         );
     }
 
-    if !options.skip_publish {
-        if let Some(dir) = options.from_artifacts.as_ref() {
+    if !options.pipeline.skip_publish {
+        if let Some(dir) = options.pipeline.from_artifacts.as_ref() {
             steps.push(ready_step(
                 "artifacts.inventory",
                 "artifacts.inventory",
@@ -413,7 +413,7 @@ fn build_head_release_steps(
             ));
             artifact_need = "package".to_string();
         }
-    } else if options.skip_publish && !publish_targets.is_empty() {
+    } else if options.pipeline.skip_publish && !publish_targets.is_empty() {
         log_status!("release", "Skipping publish/package steps (--skip-publish)");
     }
 
@@ -432,7 +432,7 @@ fn build_head_release_steps(
     }
 
     let mut publish_step_ids: Vec<String> = Vec::new();
-    if !publish_targets.is_empty() && !options.skip_publish {
+    if !publish_targets.is_empty() && !options.pipeline.skip_publish {
         for target in publish_targets {
             let step_id = format!("publish.{}", target);
             publish_step_ids.push(step_id.clone());
@@ -445,7 +445,7 @@ fn build_head_release_steps(
             ));
         }
 
-        if !options.deploy {
+        if !options.pipeline.deploy {
             steps.push(ready_step(
                 "cleanup",
                 "cleanup",
@@ -461,8 +461,8 @@ fn build_head_release_steps(
         crate::core::engine::hooks::events::POST_RELEASE,
     );
     if !post_release_hooks.is_empty() {
-        let post_release_needs = if !options.skip_publish && !publish_targets.is_empty() {
-            if options.deploy {
+        let post_release_needs = if !options.pipeline.skip_publish && !publish_targets.is_empty() {
+            if options.pipeline.deploy {
                 publish_step_ids.clone()
             } else {
                 vec!["cleanup".to_string()]
@@ -482,10 +482,10 @@ fn build_head_release_steps(
         ));
     }
 
-    if options.deploy {
+    if options.pipeline.deploy {
         let deploy_needs = if !post_release_hooks.is_empty() {
             vec!["post_release".to_string()]
-        } else if !options.skip_publish && !publish_step_ids.is_empty() {
+        } else if !options.pipeline.skip_publish && !publish_step_ids.is_empty() {
             publish_step_ids
         } else if !options.skip_github_release && github_release_applies(component) {
             vec!["github.release".to_string()]
@@ -512,7 +512,7 @@ fn add_release_extension_diagnostics(
     options: &ReleaseOptions,
     warnings: &mut Vec<String>,
 ) {
-    if options.skip_publish || !publish_targets.is_empty() {
+    if options.pipeline.skip_publish || !publish_targets.is_empty() {
         return;
     }
 
@@ -612,7 +612,8 @@ mod tests {
     use crate::core::extension::ExtensionManifest;
     use crate::core::plan::PlanStepStatus;
     use crate::core::release::types::{
-        ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleaseSemverRecommendation,
+        ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleasePipelineOptions,
+        ReleaseSemverRecommendation,
     };
 
     #[test]
@@ -970,7 +971,10 @@ mod tests {
         let mut hints = Vec::new();
         let options = ReleaseOptions {
             bump_type: "patch".to_string(),
-            deploy: true,
+            pipeline: ReleasePipelineOptions {
+                deploy: true,
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -1023,8 +1027,11 @@ mod tests {
         let mut hints = Vec::new();
         let options = ReleaseOptions {
             bump_type: "head".to_string(),
-            head: true,
-            from_artifacts: Some("artifacts".to_string()),
+            pipeline: ReleasePipelineOptions {
+                head: true,
+                from_artifacts: Some("artifacts".to_string()),
+                ..Default::default()
+            },
             ..Default::default()
         };
 

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -112,13 +112,15 @@ pub(super) fn build_preflight_steps(
 
     steps.extend(build_quality_steps(options));
 
-    steps.push(ready_step(
-        "preflight.changelog_bootstrap",
-        "preflight.changelog_bootstrap",
-        "Ensure changelog exists",
-        vec!["preflight.test".to_string()],
-        StepConfig::new().bool("dry_run", options.dry_run),
-    ));
+    if !options.head {
+        steps.push(ready_step(
+            "preflight.changelog_bootstrap",
+            "preflight.changelog_bootstrap",
+            "Ensure changelog exists",
+            vec!["preflight.test".to_string()],
+            StepConfig::new().bool("dry_run", options.dry_run),
+        ));
+    }
 
     steps
 }
@@ -189,6 +191,18 @@ pub(super) fn build_release_steps(
     let publish_targets = get_publish_targets(extensions);
 
     add_release_extension_diagnostics(component, extensions, &publish_targets, options, warnings);
+
+    if options.head {
+        return Ok(build_head_release_steps(
+            component,
+            extensions,
+            new_version,
+            options,
+            monorepo,
+            &publish_targets,
+            warnings,
+        ));
+    }
 
     if !publish_targets.is_empty() && !has_package_capability(extensions) {
         warnings.push(
@@ -353,6 +367,142 @@ pub(super) fn build_release_steps(
     }
 
     Ok(steps)
+}
+
+fn build_head_release_steps(
+    component: &Component,
+    extensions: &[ExtensionManifest],
+    version: &str,
+    options: &ReleaseOptions,
+    monorepo: Option<&git::MonorepoContext>,
+    publish_targets: &[String],
+    warnings: &mut Vec<String>,
+) -> Vec<PlanStep> {
+    let mut steps = Vec::new();
+    let mut artifact_need = "preflight.remote_sync".to_string();
+
+    if !publish_targets.is_empty()
+        && !options.skip_publish
+        && options.from_artifacts.is_none()
+        && !has_package_capability(extensions)
+    {
+        warnings.push(
+            "Publish targets derived from extensions but no extension provides 'release.package'. \
+             Add an extension that provides packaging or use --from-artifacts."
+                .to_string(),
+        );
+    }
+
+    if !options.skip_publish {
+        if let Some(dir) = options.from_artifacts.as_ref() {
+            steps.push(ready_step(
+                "artifacts.inventory",
+                "artifacts.inventory",
+                "Inventory existing release artifacts",
+                vec![artifact_need.clone()],
+                string_config("dir", dir),
+            ));
+            artifact_need = "artifacts.inventory".to_string();
+        } else if has_package_capability(extensions) {
+            steps.push(ready_step(
+                "package",
+                "package",
+                "Package release artifacts",
+                vec![artifact_need.clone()],
+                StepConfig::new(),
+            ));
+            artifact_need = "package".to_string();
+        }
+    } else if options.skip_publish && !publish_targets.is_empty() {
+        log_status!("release", "Skipping publish/package steps (--skip-publish)");
+    }
+
+    if !options.skip_github_release && github_release_applies(component) {
+        let tag_name = match monorepo {
+            Some(ctx) => ctx.format_tag(version),
+            None => format!("v{}", version),
+        };
+        steps.push(ready_step(
+            "github.release",
+            "github.release",
+            "Create GitHub Release",
+            vec![artifact_need.clone()],
+            string_config("tag", tag_name),
+        ));
+    }
+
+    let mut publish_step_ids: Vec<String> = Vec::new();
+    if !publish_targets.is_empty() && !options.skip_publish {
+        for target in publish_targets {
+            let step_id = format!("publish.{}", target);
+            publish_step_ids.push(step_id.clone());
+            steps.push(ready_step(
+                &step_id,
+                &step_id,
+                format!("Publish to {}", target),
+                vec![artifact_need.clone()],
+                StepConfig::new(),
+            ));
+        }
+
+        if !options.deploy {
+            steps.push(ready_step(
+                "cleanup",
+                "cleanup",
+                "Clean up release artifacts",
+                publish_step_ids.clone(),
+                StepConfig::new(),
+            ));
+        }
+    }
+
+    let post_release_hooks = crate::core::engine::hooks::resolve_hooks(
+        component,
+        crate::core::engine::hooks::events::POST_RELEASE,
+    );
+    if !post_release_hooks.is_empty() {
+        let post_release_needs = if !options.skip_publish && !publish_targets.is_empty() {
+            if options.deploy {
+                publish_step_ids.clone()
+            } else {
+                vec!["cleanup".to_string()]
+            }
+        } else if !options.skip_github_release && github_release_applies(component) {
+            vec!["github.release".to_string()]
+        } else {
+            vec![artifact_need.clone()]
+        };
+
+        steps.push(ready_step(
+            "post_release",
+            "post_release",
+            "Run post-release hooks",
+            post_release_needs,
+            string_array_config("commands", &post_release_hooks),
+        ));
+    }
+
+    if options.deploy {
+        let deploy_needs = if !post_release_hooks.is_empty() {
+            vec!["post_release".to_string()]
+        } else if !options.skip_publish && !publish_step_ids.is_empty() {
+            publish_step_ids
+        } else if !options.skip_github_release && github_release_applies(component) {
+            vec!["github.release".to_string()]
+        } else {
+            vec![artifact_need]
+        };
+
+        steps.push(ready_step(
+            "deploy",
+            "deploy",
+            "Deploy released component",
+            deploy_needs,
+            string_config("execution", "release_plan"),
+        ));
+    }
+
+    steps
 }
 
 fn add_release_extension_diagnostics(
@@ -849,6 +999,69 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("release_plan")
         );
+    }
+
+    #[test]
+    fn head_release_plan_skips_mutation_steps_and_uses_existing_artifacts() {
+        let mut component = fixture_component();
+        component.remote_url = Some("https://github.com/Extra-Chill/homeboy.git".to_string());
+        let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "WordPress",
+            "version": "1.0.0",
+            "actions": [
+                {
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": "true"
+                }
+            ]
+        }))
+        .expect("extension manifest");
+        extension.id = "wordpress".to_string();
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let options = ReleaseOptions {
+            bump_type: "head".to_string(),
+            head: true,
+            from_artifacts: Some("artifacts".to_string()),
+            ..Default::default()
+        };
+
+        let steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.1",
+            "1.0.1",
+            &fixture_changelog_plan(),
+            &options,
+            None,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
+
+        let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+        assert!(!ids.contains(&"changelog.finalize"));
+        assert!(!ids.contains(&"version"));
+        assert!(!ids.contains(&"git.commit"));
+        assert!(!ids.contains(&"git.tag"));
+        assert!(!ids.contains(&"git.push"));
+        assert_eq!(
+            ids,
+            vec![
+                "artifacts.inventory",
+                "github.release",
+                "publish.wordpress",
+                "cleanup"
+            ]
+        );
+        assert_eq!(
+            steps[0].inputs.get("dir").and_then(|value| value.as_str()),
+            Some("artifacts")
+        );
+        assert_eq!(steps[1].needs, vec!["artifacts.inventory"]);
+        assert_eq!(steps[2].needs, vec!["artifacts.inventory"]);
     }
 
     #[test]

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -25,13 +25,13 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let mut v = ValidationCollector::new();
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
-    let semver_recommendation = if options.head {
+    let semver_recommendation = if options.pipeline.head {
         None
     } else {
         build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?
     };
 
-    if !options.head {
+    if !options.pipeline.head {
         if let Some(skip_plan) =
             release_skip_plan(component_id, options, semver_recommendation.clone())
         {
@@ -39,7 +39,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         }
     }
 
-    let pending_entries = if options.head {
+    let pending_entries = if options.pipeline.head {
         Default::default()
     } else {
         v.capture(
@@ -51,7 +51,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
 
     let version_info = v.capture(version::read_component_version(&component), "version");
     let new_version = if let Some(ref info) = version_info {
-        if options.head {
+        if options.pipeline.head {
             Some(info.version.clone())
         } else {
             match version::increment_version(&info.version, &options.bump_type) {

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -25,32 +25,45 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let mut v = ValidationCollector::new();
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
-    let semver_recommendation =
-        build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?;
+    let semver_recommendation = if options.head {
+        None
+    } else {
+        build_semver_recommendation(&component, &options.bump_type, monorepo.as_ref())?
+    };
 
-    if let Some(skip_plan) = release_skip_plan(component_id, options, semver_recommendation.clone())
-    {
-        return Ok(skip_plan);
+    if !options.head {
+        if let Some(skip_plan) =
+            release_skip_plan(component_id, options, semver_recommendation.clone())
+        {
+            return Ok(skip_plan);
+        }
     }
 
-    let pending_entries = v
-        .capture(
+    let pending_entries = if options.head {
+        Default::default()
+    } else {
+        v.capture(
             generate_changelog_entries(&component, component_id, options, monorepo.as_ref()),
             "commits",
         )
-        .unwrap_or_default();
+        .unwrap_or_default()
+    };
 
     let version_info = v.capture(version::read_component_version(&component), "version");
     let new_version = if let Some(ref info) = version_info {
-        match version::increment_version(&info.version, &options.bump_type) {
-            Some(ver) => Some(ver),
-            None => {
-                v.push(
-                    "version",
-                    &format!("Invalid version format: {}", info.version),
-                    None,
-                );
-                None
+        if options.head {
+            Some(info.version.clone())
+        } else {
+            match version::increment_version(&info.version, &options.bump_type) {
+                Some(ver) => Some(ver),
+                None => {
+                    v.push(
+                        "version",
+                        &format!("Invalid version format: {}", info.version),
+                        None,
+                    );
+                    None
+                }
             }
         }
     } else {

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -201,15 +201,7 @@ pub struct ReleaseState {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ReleaseOptions {
-    pub bump_type: String,
-    pub dry_run: bool,
-    /// Override the component's `local_path` for this release.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub path_override: Option<String>,
-    /// Skip lint/test code quality checks before release.
-    #[serde(default)]
-    pub skip_checks: bool,
+pub struct ReleasePipelineOptions {
     /// Skip publish/package steps (version bump + tag + push only).
     /// Use when CI handles publishing after the tag is pushed.
     #[serde(default)]
@@ -223,6 +215,20 @@ pub struct ReleaseOptions {
     /// Deploy after release — defers artifact cleanup until after deployment.
     #[serde(default)]
     pub deploy: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReleaseOptions {
+    pub bump_type: String,
+    pub dry_run: bool,
+    /// Override the component's `local_path` for this release.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_override: Option<String>,
+    /// Skip lint/test code quality checks before release.
+    #[serde(default)]
+    pub skip_checks: bool,
+    #[serde(default, flatten)]
+    pub pipeline: ReleasePipelineOptions,
     /// Skip the GitHub Release creation step (tag + notes on github.com).
     /// Use when another pipeline (CI, semantic-release, etc.) already owns that step.
     #[serde(default)]
@@ -262,13 +268,7 @@ pub struct ReleaseCommandInput {
     #[serde(default)]
     pub dry_run: bool,
     #[serde(default)]
-    pub deploy: bool,
-    #[serde(default)]
     pub recover: bool,
-    #[serde(default)]
-    pub head: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub from_artifacts: Option<String>,
     #[serde(default)]
     pub skip_checks: bool,
     /// Explicit bump override: "major", "minor", "patch", or a version string like "2.0.0".
@@ -278,8 +278,8 @@ pub struct ReleaseCommandInput {
     /// Permit a keyword bump lower than the commit-derived recommendation.
     #[serde(default)]
     pub force_lower_bump: bool,
-    #[serde(default)]
-    pub skip_publish: bool,
+    #[serde(default, flatten)]
+    pub pipeline: ReleasePipelineOptions,
     /// Skip the GitHub Release creation step (tag + notes on github.com).
     #[serde(default)]
     pub skip_github_release: bool,

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -214,6 +214,12 @@ pub struct ReleaseOptions {
     /// Use when CI handles publishing after the tag is pushed.
     #[serde(default)]
     pub skip_publish: bool,
+    /// Finish a release whose version commit and tag already exist at HEAD.
+    #[serde(default)]
+    pub head: bool,
+    /// Existing release artifacts to inventory instead of running release.package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_artifacts: Option<String>,
     /// Deploy after release — defers artifact cleanup until after deployment.
     #[serde(default)]
     pub deploy: bool,
@@ -259,6 +265,10 @@ pub struct ReleaseCommandInput {
     pub deploy: bool,
     #[serde(default)]
     pub recover: bool,
+    #[serde(default)]
+    pub head: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_artifacts: Option<String>,
     #[serde(default)]
     pub skip_checks: bool,
     /// Explicit bump override: "major", "minor", "patch", or a version string like "2.0.0".

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -13,16 +13,16 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         return run_recover(&input);
     }
 
-    if input.from_artifacts.is_some() && !input.head {
+    if input.pipeline.from_artifacts.is_some() && !input.pipeline.head {
         return Err(Error::validation_invalid_argument(
             "from-artifacts",
             "--from-artifacts requires --head",
-            input.from_artifacts.clone(),
+            input.pipeline.from_artifacts.clone(),
             None,
         ));
     }
 
-    if input.head && input.bump_override.is_some() {
+    if input.pipeline.head && input.bump_override.is_some() {
         return Err(Error::validation_invalid_argument(
             "bump",
             "--head uses the version already present at HEAD and cannot be combined with --bump",
@@ -40,7 +40,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     )?;
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
-    let resolved_bump = if input.head {
+    let resolved_bump = if input.pipeline.head {
         None
     } else {
         resolve_bump(&component.local_path, monorepo.as_ref())?
@@ -52,7 +52,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     let has_breaking_commits = auto_bump_type == "major";
 
     // Resolve the effective bump type: --bump overrides auto-detection.
-    let bump_type = if input.head {
+    let bump_type = if input.pipeline.head {
         "head".to_string()
     } else if let Some(ref override_value) = input.bump_override {
         // Check if it's an explicit version string (e.g. "2.0.0")
@@ -138,10 +138,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         dry_run: input.dry_run,
         path_override: input.path_override,
         skip_checks: input.skip_checks,
-        skip_publish: input.skip_publish,
-        head: input.head,
-        from_artifacts: input.from_artifacts.clone(),
-        deploy: input.deploy,
+        pipeline: input.pipeline.clone(),
         skip_github_release: input.skip_github_release,
         git_identity: input.git_identity.clone(),
         bump_policy: ReleaseBumpPolicyOptions {
@@ -153,7 +150,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
 
     if options.dry_run {
         let plan = super::plan(&input.component_id, &options)?;
-        let new_version = if input.head {
+        let new_version = if input.pipeline.head {
             current_component_version(&component)?
         } else {
             extract_new_version_from_plan(&plan)
@@ -162,6 +159,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             .as_ref()
             .map(|v| format_tag(v, monorepo.as_ref()));
         let deployment = input
+            .pipeline
             .deploy
             .then(|| super::deployment::plan_deployment(&input.component_id));
 
@@ -185,7 +183,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     let (plan, run_result) = super::pipeline::run_with_plan(&input.component_id, &options)?;
     display_release_summary(&run_result);
 
-    let new_version = if input.head {
+    let new_version = if input.pipeline.head {
         current_component_version(&component)?
     } else {
         extract_new_version_from_run(&run_result)
@@ -609,14 +607,11 @@ pub fn run_batch(
             component_id: component_id.clone(),
             path_override: None,
             dry_run: input_template.dry_run,
-            deploy: input_template.deploy,
             recover: input_template.recover,
-            head: input_template.head,
-            from_artifacts: input_template.from_artifacts.clone(),
             skip_checks: input_template.skip_checks,
             bump_override: input_template.bump_override.clone(),
             force_lower_bump: input_template.force_lower_bump,
-            skip_publish: input_template.skip_publish,
+            pipeline: input_template.pipeline.clone(),
             skip_github_release: input_template.skip_github_release,
             git_identity: input_template.git_identity.clone(),
         };

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -13,6 +13,24 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         return run_recover(&input);
     }
 
+    if input.from_artifacts.is_some() && !input.head {
+        return Err(Error::validation_invalid_argument(
+            "from-artifacts",
+            "--from-artifacts requires --head",
+            input.from_artifacts.clone(),
+            None,
+        ));
+    }
+
+    if input.head && input.bump_override.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "bump",
+            "--head uses the version already present at HEAD and cannot be combined with --bump",
+            input.bump_override.clone(),
+            None,
+        ));
+    }
+
     let component = load_component(
         &input.component_id,
         &ReleaseOptions {
@@ -22,7 +40,11 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     )?;
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, &input.component_id);
-    let resolved_bump = resolve_bump(&component.local_path, monorepo.as_ref())?;
+    let resolved_bump = if input.head {
+        None
+    } else {
+        resolve_bump(&component.local_path, monorepo.as_ref())?
+    };
     let (auto_bump_type, releasable_count) = resolved_bump
         .clone()
         .unwrap_or_else(|| ("none".to_string(), 0));
@@ -30,7 +52,9 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     let has_breaking_commits = auto_bump_type == "major";
 
     // Resolve the effective bump type: --bump overrides auto-detection.
-    let bump_type = if let Some(ref override_value) = input.bump_override {
+    let bump_type = if input.head {
+        "head".to_string()
+    } else if let Some(ref override_value) = input.bump_override {
         // Check if it's an explicit version string (e.g. "2.0.0")
         let is_explicit_version = override_value.contains('.');
 
@@ -115,6 +139,8 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         path_override: input.path_override,
         skip_checks: input.skip_checks,
         skip_publish: input.skip_publish,
+        head: input.head,
+        from_artifacts: input.from_artifacts.clone(),
         deploy: input.deploy,
         skip_github_release: input.skip_github_release,
         git_identity: input.git_identity.clone(),
@@ -127,7 +153,11 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
 
     if options.dry_run {
         let plan = super::plan(&input.component_id, &options)?;
-        let new_version = extract_new_version_from_plan(&plan);
+        let new_version = if input.head {
+            current_component_version(&component)?
+        } else {
+            extract_new_version_from_plan(&plan)
+        };
         let tag = new_version
             .as_ref()
             .map(|v| format_tag(v, monorepo.as_ref()));
@@ -155,7 +185,11 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     let (plan, run_result) = super::pipeline::run_with_plan(&input.component_id, &options)?;
     display_release_summary(&run_result);
 
-    let new_version = extract_new_version_from_run(&run_result);
+    let new_version = if input.head {
+        current_component_version(&component)?
+    } else {
+        extract_new_version_from_run(&run_result)
+    };
     let tag = new_version
         .as_ref()
         .map(|v| format_tag(v, monorepo.as_ref()));
@@ -207,6 +241,12 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
         exit_code,
     ))
+}
+
+fn current_component_version(
+    component: &crate::core::component::Component,
+) -> Result<Option<String>> {
+    super::version::read_component_version(component).map(|info| Some(info.version))
 }
 
 fn resolve_bump(
@@ -571,6 +611,8 @@ pub fn run_batch(
             dry_run: input_template.dry_run,
             deploy: input_template.deploy,
             recover: input_template.recover,
+            head: input_template.head,
+            from_artifacts: input_template.from_artifacts.clone(),
             skip_checks: input_template.skip_checks,
             bump_override: input_template.bump_override.clone(),
             force_lower_bump: input_template.force_lower_bump,


### PR DESCRIPTION
## Summary
- Adds `homeboy release --head` for release jobs where the version commit and tag already exist at HEAD.
- Adds `--from-artifacts <dir>` so externally built artifacts can be inventoried into `ReleaseState` and then attached/published through the normal `github.release` and `release.publish` pipeline.
- Refactors Homeboy's own release workflow to delete the hand-rolled `gh release create/upload` block and dogfood `homeboy release homeboy --head --from-artifacts artifacts --skip-checks`.

## Why
This fixes the architectural release gap tracked in #2581: downstream users like WordPress plugins should not need workaround workflows or tag-triggered asset jobs. Homeboy core should own the complete release lifecycle: package/artifact inventory, GitHub Release assets, publish targets, cleanup, and post-release hooks.

## Testing
- `cargo check`
- `cargo test core::release --lib`
- `cargo test head_release_plan_skips_mutation_steps_and_uses_existing_artifacts --lib`
- `cargo test artifact_inventory_loads_existing_files_into_release_state --lib`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `cargo run --bin homeboy -- release homeboy --head --from-artifacts /tmp --skip-checks --dry-run --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-head-dry-run.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause tracing, implementation of the `--head` release path, workflow refactor, tests, and local verification. Chris remains responsible for review and merge.