### PR TITLE
refactor: make changelog reexports explicit

### DIFF
--- a/src/core/release/changelog/mod.rs
+++ b/src/core/release/changelog/mod.rs
@@ -3,7 +3,14 @@ mod io;
 mod sections;
 mod settings;
 
-pub use bulk::*;
-pub use io::*;
-pub use sections::*;
-pub use settings::*;
+pub use bulk::{show, ShowOutput};
+pub use io::{
+    discover_changelog_relative_path, read_component_snapshots, resolve_changelog_path,
+    ChangelogSnapshotData, FinalizedReleaseSnapshot, CHANGELOG_CANDIDATES,
+    INITIAL_CHANGELOG_CONTENT,
+};
+pub use sections::{
+    count_unreleased_entries, extract_last_release_snapshot, finalize_next_section,
+    finalize_with_generated_entries, get_latest_finalized_version, get_unreleased_entries,
+};
+pub use settings::{resolve_effective_settings, EffectiveChangelogSettings};

--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -2,9 +2,10 @@ mod normalize_heading_label;
 mod types;
 mod unreleased;
 
-pub use normalize_heading_label::*;
-pub(crate) use types::*;
-pub use unreleased::*;
+pub use normalize_heading_label::{extract_last_release_snapshot, get_latest_finalized_version};
+use normalize_heading_label::{is_matching_next_section_heading, validate_section_content};
+use types::SectionContentStatus;
+pub use unreleased::{count_unreleased_entries, get_unreleased_entries};
 
 use chrono::Local;
 

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -114,6 +114,27 @@ fn release_version_root_does_not_wildcard_reexport_private_modules() {
 }
 
 #[test]
+fn release_changelog_roots_do_not_wildcard_reexport_private_modules() {
+    let roots = [
+        "src/core/release/changelog/mod.rs",
+        "src/core/release/changelog/sections.rs",
+    ];
+
+    for root in roots {
+        let source = source_file(root);
+        assert!(
+            !source.contains("pub use bulk::*")
+                && !source.contains("pub use io::*")
+                && !source.contains("pub use sections::*")
+                && !source.contains("pub use settings::*")
+                && !source.contains("pub use normalize_heading_label::*")
+                && !source.contains("pub use unreleased::*"),
+            "{root} must explicitly name the changelog APIs it re-exports"
+        );
+    }
+}
+
+#[test]
 fn validate_and_format_writes_do_not_select_ecosystem_commands() {
     let files = [
         "src/core/engine/validate_write.rs",


### PR DESCRIPTION
## Summary
- Replace `core::release::changelog` wildcard re-exports with explicit public exports.
- Replace `changelog::sections` wildcard re-exports with explicit public exports and private helper imports.
- Add an architecture guard against reintroducing wildcard changelog re-exports.

## Verification
- `cargo check --all-targets`
- `cargo fmt --check && cargo test --test architecture_core_agnostic_test`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/release-changelog-explicit-reexports-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the mechanical re-export cleanup, architecture guard, and validation commands; Chris remains responsible for review and merge.