### PR TITLE
refactor: make git reexports explicit

### DIFF
--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -5,12 +5,45 @@ mod operations;
 mod pr_policy;
 mod primitives;
 
-pub use changes::*;
-pub use commits::*;
-pub use github::*;
-pub use operations::*;
-pub use pr_policy::*;
-pub use primitives::*;
+pub use changes::{
+    discard_worktree_changes, get_diff, get_dirty_files, get_files_changed_since, get_range_diff,
+    get_uncommitted_changes, UncommittedChanges,
+};
+pub(crate) use commits::extract_version_from_tag;
+pub use commits::{
+    categorize_commits, find_version_commit, find_version_release_commit, get_commits_since_tag,
+    get_commits_since_tag_for_path, get_last_n_commits, get_latest_tag, get_latest_tag_with_prefix,
+    recommended_bump_from_commits, strip_conventional_prefix, CommitCategory, CommitCounts,
+    CommitInfo, MonorepoContext, SemverBump,
+};
+pub use github::{
+    gh_probe_succeeds, issue_close, issue_comment, issue_create, issue_edit, issue_find,
+    merge_section, parse_comment_sections, pr_comment, pr_create, pr_edit, pr_files, pr_find,
+    pr_merge, pr_view, render_comment, GithubFindItem, GithubFindOutput, GithubIssueOutput,
+    GithubPrOutput, GithubPrView, IssueCloseOptions, IssueCloseReason, IssueCommentOptions,
+    IssueCreateOptions, IssueEditOptions, IssueFindOptions, IssueState, PrCommentMode,
+    PrCommentOptions, PrCreateOptions, PrEditOptions, PrFindOptions, PrMergeOptions, PrState,
+};
+pub use operations::{
+    build_repo_baseline_snapshot, changes, changes_at, changes_bulk, changes_project,
+    changes_project_filtered, cherry_pick, cherry_pick_at, commit, commit_at, commit_from_json,
+    detect_baseline_with_version, execute_git_for_release, fetch_and_fast_forward,
+    fetch_and_get_behind_count, get_head_commit, get_repo_snapshot, get_tag_commit, pull, pull_at,
+    pull_bulk, push, push_at, push_bulk, rebase, rebase_at, short_head_revision_at, status,
+    status_at, status_bulk, tag, tag_at, tag_exists_locally, tag_exists_on_remote, BaselineInfo,
+    BaselineSource, ChangelogInfo, ChangesOutput, CherryPickOptions, CommitJsonOutput,
+    CommitOptions, GitOutput, PushOptions, RebaseOptions, RepoBaselineSnapshot, RepoSnapshot,
+};
+pub use pr_policy::{
+    evaluate_merge_policy, evaluate_open_policy, PrPolicyContext, PrPolicyDecision, PrPolicyFile,
+    PrPolicyMergeOptions, PrPolicyMode, PrPolicyOpenOptions, PrPolicyRules,
+};
+pub use primitives::{
+    clone_repo, clone_repo_at_ref, current_branch, get_component_path_prefix, get_git_root,
+    is_workdir_clean, is_workdir_clean_or_not_git, pull_repo, run_git, short_head_revision,
+    update_to_remote_default_branch,
+};
+pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};
 
 use std::process::Command;
 

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -135,6 +135,21 @@ fn release_changelog_roots_do_not_wildcard_reexport_private_modules() {
 }
 
 #[test]
+fn git_root_does_not_wildcard_reexport_private_modules() {
+    let source = source_file("src/core/git/mod.rs");
+
+    assert!(
+        !source.contains("pub use changes::*")
+            && !source.contains("pub use commits::*")
+            && !source.contains("pub use github::*")
+            && !source.contains("pub use operations::*")
+            && !source.contains("pub use pr_policy::*")
+            && !source.contains("pub use primitives::*"),
+        "src/core/git/mod.rs must explicitly name the git APIs it re-exports"
+    );
+}
+
+#[test]
 fn validate_and_format_writes_do_not_select_ecosystem_commands() {
     let files = [
         "src/core/engine/validate_write.rs",


### PR DESCRIPTION
## Summary
- Replace wildcard re-exports in `core::git` with explicit public and crate-visible exports.
- Add an architecture guard so the git root keeps naming the API surface it exposes.

## Verification
- `cargo fmt && cargo fmt --check && cargo test --test architecture_core_agnostic_test`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/git-explicit-reexports-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused Rust re-export cleanup, added the architecture guard, and ran scoped verification for Chris to review.