### PR TITLE
fix: exclude homeboy build artifacts from scans

### DIFF
--- a/src/core/engine/codebase_scan.rs
+++ b/src/core/engine/codebase_scan.rs
@@ -16,6 +16,9 @@ pub const ALWAYS_SKIP_DIRS: &[&str] = &[
     "node_modules",
     "vendor",
     ".git",
+    ".homeboy-build",
+    ".homeboy-bin",
+    ".homeboy",
     ".svn",
     ".hg",
     "__pycache__",
@@ -652,10 +655,16 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let _ = std::fs::create_dir_all(dir.join("node_modules"));
         let _ = std::fs::create_dir_all(dir.join("vendor"));
+        let _ = std::fs::create_dir_all(dir.join(".homeboy-build/component"));
+        let _ = std::fs::create_dir_all(dir.join(".homeboy-bin"));
+        let _ = std::fs::create_dir_all(dir.join(".homeboy/cache"));
         let _ = std::fs::create_dir_all(dir.join("src"));
 
         std::fs::write(dir.join("node_modules/lib.js"), "x").unwrap();
         std::fs::write(dir.join("vendor/lib.php"), "x").unwrap();
+        std::fs::write(dir.join(".homeboy-build/component/copied.rs"), "x").unwrap();
+        std::fs::write(dir.join(".homeboy-bin/helper.rs"), "x").unwrap();
+        std::fs::write(dir.join(".homeboy/cache/source.rs"), "x").unwrap();
         std::fs::write(dir.join("src/main.rs"), "x").unwrap();
 
         let files = walk_files(&dir, &ScanConfig::default());
@@ -667,6 +676,35 @@ mod tests {
         assert!(names.contains(&"main.rs".to_string()));
         assert!(!names.contains(&"lib.js".to_string()));
         assert!(!names.contains(&"lib.php".to_string()));
+        assert!(!names.contains(&"copied.rs".to_string()));
+        assert!(!names.contains(&"helper.rs".to_string()));
+        assert!(!names.contains(&"source.rs".to_string()));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn snapshot_skips_homeboy_build_copy_without_hidden_file_filter() {
+        let dir = std::env::temp_dir().join("homeboy_scan_build_copy_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(dir.join(".homeboy-build/component/src"));
+        let _ = std::fs::create_dir_all(dir.join("src"));
+
+        std::fs::write(dir.join(".homeboy-build/component/src/main.rs"), "copied\n").unwrap();
+        std::fs::write(dir.join("src/main.rs"), "source\n").unwrap();
+
+        let snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
+        let paths = snapshot
+            .iter()
+            .map(|(path, _)| {
+                path.strip_prefix(&dir)
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(paths, vec!["src/main.rs"]);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/core/source_snapshot.rs
+++ b/src/core/source_snapshot.rs
@@ -10,6 +10,8 @@ const DEFAULT_SYNC_EXCLUDES: &[&str] = &[
     "node_modules/",
     "target/",
     "vendor/",
+    ".homeboy-build/",
+    ".homeboy-bin/",
     ".homeboy/",
     ".datamachine/",
     ".DS_Store",
@@ -188,6 +190,7 @@ mod tests {
 
         assert!(excludes.contains(&".git/".to_string()));
         assert!(excludes.contains(&"node_modules/".to_string()));
+        assert!(excludes.contains(&".homeboy-build/".to_string()));
         assert!(excludes.contains(&".env".to_string()));
     }
 


### PR DESCRIPTION
## Summary
- Exclude Homeboy-managed `.homeboy-build`, `.homeboy-bin`, and `.homeboy` directories from shared codebase scans so audit detectors cannot report findings against generated staging copies.
- Add regression coverage for `.homeboy-build/<component>/...` being skipped even when hidden-file filtering is not enabled.
- Add `.homeboy-build/` and `.homeboy-bin/` to source snapshot sync excludes so runner snapshots do not propagate local Homeboy staging artifacts.

Fixes #2589.

## Verification
- `cargo fmt --check`
- `cargo test --lib codebase_scan::tests::`
- `cargo test --lib source_snapshot::tests::test_default_sync_excludes`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-audit-build-artifact-scope --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-audit-build-artifact-scope --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scanner/source snapshot fix and regression coverage; Chris remains responsible for review and merge.