### PR TITLE
fix: fail release command on failed steps

### DIFF
--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -7,11 +7,16 @@ pub(super) fn derive_overall_status(results: &[ReleaseStepResult]) -> ReleaseSte
     let has_failed = results
         .iter()
         .any(|r| matches!(r.status, ReleaseStepStatus::Failed));
+    let has_missing = results
+        .iter()
+        .any(|r| matches!(r.status, ReleaseStepStatus::Missing));
 
-    if has_failed && has_success {
+    if (has_failed || has_missing) && has_success {
         ReleaseStepStatus::PartialSuccess
     } else if has_failed {
         ReleaseStepStatus::Failed
+    } else if has_missing {
+        ReleaseStepStatus::Missing
     } else {
         ReleaseStepStatus::Success
     }
@@ -160,6 +165,26 @@ mod tests {
         let results = vec![
             step("version", ReleaseStepStatus::Success),
             step("release.prepare", ReleaseStepStatus::Failed),
+        ];
+
+        assert_eq!(
+            derive_overall_status(&results),
+            ReleaseStepStatus::PartialSuccess
+        );
+    }
+
+    #[test]
+    fn derive_overall_status_marks_missing_steps_non_successful() {
+        let results = vec![step("package", ReleaseStepStatus::Missing)];
+
+        assert_eq!(derive_overall_status(&results), ReleaseStepStatus::Missing);
+    }
+
+    #[test]
+    fn derive_overall_status_marks_success_plus_missing_partial() {
+        let results = vec![
+            step("version", ReleaseStepStatus::Success),
+            step("package", ReleaseStepStatus::Missing),
         ];
 
         assert_eq!(

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -6,6 +6,7 @@ use super::context::load_component;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleaseRun,
+    ReleaseStepStatus,
 };
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
@@ -191,6 +192,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     let tag = new_version
         .as_ref()
         .map(|v| format_tag(v, monorepo.as_ref()));
+    let release_step_exit = release_run_failure_exit(&run_result);
     let post_release_exit = if has_post_release_warnings(&run_result) {
         3
     } else {
@@ -203,7 +205,9 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         .filter(|deployment| deployment.summary.failed > 0)
         .map(|_| 1)
         .unwrap_or(0);
-    let exit_code = if deploy_exit_code != 0 {
+    let exit_code = if release_step_exit != 0 {
+        release_step_exit
+    } else if deploy_exit_code != 0 {
         // Deploy failed after the release was already tagged and pushed.
         // The tag cannot be rolled back safely, so warn the user to retry.
         if let Some(ref t) = tag {
@@ -334,6 +338,15 @@ fn has_post_release_warnings(run: &ReleaseRun) -> bool {
                 .and_then(|v| v.as_bool())
                 == Some(false)
     })
+}
+
+fn release_run_failure_exit(run: &ReleaseRun) -> i32 {
+    match run.result.status {
+        ReleaseStepStatus::Success | ReleaseStepStatus::Skipped => 0,
+        ReleaseStepStatus::PartialSuccess
+        | ReleaseStepStatus::Failed
+        | ReleaseStepStatus::Missing => 1,
+    }
 }
 
 fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
@@ -775,6 +788,31 @@ mod tests {
         };
 
         assert!(has_post_release_warnings(&run));
+    }
+
+    #[test]
+    fn release_run_failure_exit_fails_partial_release_runs() {
+        let run = ReleaseRun {
+            component_id: "demo".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![ReleaseStepResult {
+                    id: "git.push".to_string(),
+                    step_type: "git.push".to_string(),
+                    status: ReleaseStepStatus::Failed,
+                    missing: vec![],
+                    warnings: vec![],
+                    hints: vec![],
+                    data: None,
+                    error: Some("push rejected".to_string()),
+                }],
+                status: ReleaseStepStatus::PartialSuccess,
+                warnings: vec![],
+                summary: None,
+            },
+        };
+
+        assert_eq!(release_run_failure_exit(&run), 1);
     }
 
     // ----- Recover-time orphan-tag warning (issue #2234 ask #3) -----


### PR DESCRIPTION
## Summary
- Make release run status treat missing steps as non-successful.
- Return a non-zero release command exit when release execution ends in failed, partial, or missing status.
- Cover the release-exit and missing-step status behavior with unit tests.

## Why
A main release run reported `released=true` after the release command returned success even though the release tag was not pushed. Downstream cargo-dist jobs then failed while trying to checkout a tag that did not exist. Failed release steps should stop at the release command boundary instead of handing invalid release state to later jobs.

## Verification
- `cargo fmt --check`
- `cargo test core::release --lib`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed release workflow, drafted the release status/exit fix, and ran local verification. Chris remains responsible for review and merge.