### PR TITLE
fix: skip package during self-release prepare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,6 +352,8 @@ jobs:
           commands: release
           expected-commands: audit,lint,test
           release-dry-run: ${{ inputs.dry-run || 'false' }}
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
       - name: Use existing release tag


### PR DESCRIPTION
## Summary
- Keep the Homeboy self-release prepare step focused on version bump, tag, and push.
- Explicitly skip package/GitHub Release work in prepare so cargo-dist can build artifacts first.
- Leave the existing `release --head --from-artifacts` finish step responsible for the Homeboy release pipeline after artifacts are downloaded.

## Why
The current main release now fails in `Prepare Release` because `release.package` runs before cargo-dist is installed. The workflow already has a later artifact-backed finish step, so prepare should not try to package.

## Verification
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release workflow failure, drafted the workflow fix, and ran scoped verification. Chris remains responsible for review and merge.