### PR TITLE
fix: select homeboy binary in release finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,7 +589,7 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
 
       - name: Finish Homeboy release pipeline at tag
-        run: cargo run --release -- release homeboy --head --from-artifacts artifacts --skip-checks
+        run: cargo run --release --bin homeboy -- release homeboy --head --from-artifacts artifacts --skip-checks
 
   publish-homebrew-formula:
     needs:


### PR DESCRIPTION
## Summary
- Selects the `homeboy` binary explicitly when finishing the release pipeline from cargo-dist artifacts.
- Fixes the self-release finish step failing in repos with multiple Cargo binaries.

## Testing
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the failed release workflow step, drafted the one-line workflow fix, and ran scoped verification.