### PR TITLE
Allow project component remote path overrides

### DIFF
--- a/docs/schemas/project-schema.md
+++ b/docs/schemas/project-schema.md
@@ -24,7 +24,15 @@ Project configuration defines deployable environments stored in `projects/<id>.j
   "shared_tables": [],
   "table_groupings": [],
   "sub_targets": [],
+  "components": [
+    {
+      "id": "string",
+      "local_path": "string",
+      "remote_path": "string"
+    }
+  ],
   "component_groupings": [],
+  "component_overrides": {},
   "cli_path": "string",
   "tools": {},
   "extensions": {}
@@ -81,10 +89,12 @@ Project configuration defines deployable environments stored in `projects/<id>.j
   - **`member_ids`** (array): Explicit table IDs in this group
   - **`sort_order`** (number): Display sort order
 - **`sub_targets`** (array): Sub-target paths for multi-component sites
+- **`components`** (array): Project-attached component checkouts. Each entry requires `id` and `local_path`; optional `remote_path` overrides the repo-owned component `remote_path` for this project so the same component can deploy to projects with different filesystem layouts.
 - **`component_groupings`** (array): Groupings for organizing components
   - **`id`** (string): Unique grouping identifier
   - **`name`** (string): Grouping name
   - **`member_ids`** (array): Component IDs in this group
+- **`component_overrides`** (object): Per-component project overrides keyed by component ID. These remain the most-specific deploy overrides and take precedence over `components[].remote_path`.
 - **`cli_path`** (string): Project-scoped CLI path used by extension deploy install steps. On any given site the WP-CLI entrypoint is fixed (`wp`, `studio wp`, a Lando wrapper, etc.) and shared by every component deployed there, so this lives at the project layer instead of being repeated per component. Component-level `component_overrides[id].cli_path` still wins as the most-specific escape hatch. If unset, the deploy resolver auto-detects Studio sites (projects whose `base_path` is under `~/Studio/`) and defaults them to `"studio wp"`.
 - **`tools`** (object): Project-specific tool configurations
   - Keys are tool identifiers (e.g., `"newsletter"`, `"bandcamp_scraper"`)

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -108,7 +108,7 @@ enum ProjectComponentsCommand {
     Set {
         /// Project ID
         project_id: String,
-        /// JSON array of attachments: [{"id":"foo","local_path":"/repo"}]
+        /// JSON array of attachments: [{"id":"foo","local_path":"/repo","remote_path":"wp-content/plugins/foo"}]
         #[arg(long)]
         json: String,
     },

--- a/src/core/project/component/attachments.rs
+++ b/src/core/project/component/attachments.rs
@@ -119,6 +119,7 @@ pub fn attach_component_path(project_id: &str, component_id: &str, local_path: &
         project.components.push(ProjectComponentAttachment {
             id: component_id.to_string(),
             local_path: local_path.to_string(),
+            remote_path: None,
         });
     }
 
@@ -250,6 +251,7 @@ mod tests {
             project.components.push(ProjectComponentAttachment {
                 id: id.to_string(),
                 local_path: format!("/workspace/{}", id),
+                remote_path: None,
             });
         }
         project

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -8,24 +8,27 @@ pub fn resolve_project_component(
     project: &Project,
     component_id: &str,
 ) -> Result<crate::core::component::Component> {
-    let component = if let Some(attachment) = project
+    let (mut component, attachment_remote_path) = if let Some(attachment) = project
         .components
         .iter()
         .find(|component| component.id == component_id)
     {
-        discover_attached_component(std::path::Path::new(&attachment.local_path)).ok_or_else(
-            || {
-                Error::validation_invalid_argument(
-                    "components.local_path",
-                    format!(
-                        "Project component '{}' points to '{}' but no homeboy.json was found",
-                        component_id, attachment.local_path
-                    ),
-                    Some(project.id.clone()),
-                    None,
-                )
-            },
-        )?
+        (
+            discover_attached_component(std::path::Path::new(&attachment.local_path)).ok_or_else(
+                || {
+                    Error::validation_invalid_argument(
+                        "components.local_path",
+                        format!(
+                            "Project component '{}' points to '{}' but no homeboy.json was found",
+                            component_id, attachment.local_path
+                        ),
+                        Some(project.id.clone()),
+                        None,
+                    )
+                },
+            )?,
+            attachment.remote_path.clone(),
+        )
     } else {
         return Err(Error::validation_invalid_argument(
             "components",
@@ -37,6 +40,12 @@ pub fn resolve_project_component(
             None,
         ));
     };
+
+    if let Some(remote_path) = attachment_remote_path {
+        if !remote_path.trim().is_empty() {
+            component.remote_path = remote_path;
+        }
+    }
 
     let mut resolved = apply_component_overrides(&component, project);
 
@@ -67,4 +76,71 @@ pub fn resolve_project_components(
         .iter()
         .map(|component| resolve_project_component(project, &component.id))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::project::{ProjectComponentAttachment, ProjectComponentOverrides};
+    use tempfile::TempDir;
+
+    fn repo_with_portable_remote_path(remote_path: &str) -> TempDir {
+        let dir = TempDir::new().expect("temp dir");
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            serde_json::json!({
+                "id": "fixture",
+                "remote_path": remote_path,
+                "build_artifact": "dist/fixture.zip"
+            })
+            .to_string(),
+        )
+        .expect("write homeboy.json");
+        dir
+    }
+
+    fn project_with_attachment(remote_path: Option<&str>, local_path: String) -> Project {
+        Project {
+            id: "site".to_string(),
+            components: vec![ProjectComponentAttachment {
+                id: "fixture".to_string(),
+                local_path,
+                remote_path: remote_path.map(str::to_string),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn attachment_remote_path_overrides_portable_remote_path() {
+        let repo = repo_with_portable_remote_path("../wp-content/plugins/fixture");
+        let project = project_with_attachment(
+            Some("wp-content/plugins/fixture"),
+            repo.path().to_string_lossy().to_string(),
+        );
+
+        let component = resolve_project_component(&project, "fixture").expect("component");
+
+        assert_eq!(component.remote_path, "wp-content/plugins/fixture");
+    }
+
+    #[test]
+    fn component_overrides_still_win_over_attachment_remote_path() {
+        let repo = repo_with_portable_remote_path("portable/plugins/fixture");
+        let mut project = project_with_attachment(
+            Some("attachment/plugins/fixture"),
+            repo.path().to_string_lossy().to_string(),
+        );
+        project.component_overrides.insert(
+            "fixture".to_string(),
+            ProjectComponentOverrides {
+                remote_path: Some("override/plugins/fixture".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let component = resolve_project_component(&project, "fixture").expect("component");
+
+        assert_eq!(component.remote_path, "override/plugins/fixture");
+    }
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -44,6 +44,14 @@ pub use status::{collect_status, ProjectComponentStatus, ProjectStatusSnapshot};
 pub struct ProjectComponentAttachment {
     pub id: String,
     pub local_path: String,
+    /// Project-specific deploy target for this attached component.
+    ///
+    /// Repo-owned `homeboy.json` is portable component metadata, while the
+    /// install path can vary by project layout. Keeping this optional field on
+    /// the attachment lets one component deploy to multiple projects without
+    /// rewriting the repo-tracked `remote_path` for each environment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary
- Add optional `components[].remote_path` so project attachments can override repo-owned component deploy paths per environment.
- Preserve existing precedence by letting `component_overrides[id].remote_path` win over attachment-level paths.
- Document the project schema and add regression tests for portable-vs-project path resolution.

Fixes #2539.

## Verification
- `cargo fmt --check`
- `cargo test core::project::component`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-project-remote-path-overrides --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-project-remote-path-overrides --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, regression tests, docs update, and local verification; Chris remains responsible for review and merge.