### PR TITLE
fix: install extensions before release finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,7 +589,10 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
 
       - name: Finish Homeboy release pipeline at tag
-        run: cargo run --release --bin homeboy -- release homeboy --head --from-artifacts artifacts --skip-checks
+        run: |
+          cargo build --release --bin homeboy
+          ./target/release/homeboy extension install-for-component --path . --source https://github.com/Extra-Chill/homeboy-extensions
+          ./target/release/homeboy release homeboy --head --from-artifacts artifacts --skip-checks
 
   publish-homebrew-formula:
     needs:


### PR DESCRIPTION
## Summary
- Builds the Homeboy binary once in the cargo-dist release finish step.
- Installs extensions declared by `homeboy.json` before running `release --head --from-artifacts`.
- Keeps the finish step on the repo-built binary so tagged release recovery uses the same Homeboy code as the tag.

## Testing
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the failed tagged release recovery, drafted the workflow setup fix, and ran scoped verification.