### PR TITLE
fix: allow head release from detached tags

### DIFF
--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -62,14 +62,25 @@ pub(super) fn build_preflight_steps(
     options: &ReleaseOptions,
     semver_recommendation: Option<&ReleaseSemverRecommendation>,
 ) -> Vec<PlanStep> {
-    let mut steps = vec![
+    let default_branch_step = if options.pipeline.head {
+        disabled_step(
+            "preflight.default_branch",
+            "preflight.default_branch",
+            "Validate default branch",
+            string_config("reason", "head-release"),
+        )
+    } else {
         ready_step(
             "preflight.default_branch",
             "preflight.default_branch",
             "Validate default branch",
             vec![],
             StepConfig::new(),
-        ),
+        )
+    };
+
+    let mut steps = vec![
+        default_branch_step,
         ready_step(
             "preflight.working_tree",
             "preflight.working_tree",
@@ -709,6 +720,33 @@ mod tests {
                 Some("--skip-checks")
             );
         }
+    }
+
+    #[test]
+    fn head_release_preflight_skips_default_branch_check() {
+        let options = ReleaseOptions {
+            bump_type: "head".to_string(),
+            pipeline: ReleasePipelineOptions {
+                head: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let steps = build_preflight_steps(&options, None);
+        let default_branch = steps
+            .iter()
+            .find(|step| step.id == "preflight.default_branch")
+            .expect("default branch step");
+
+        assert_eq!(default_branch.status, PlanStepStatus::Disabled);
+        assert_eq!(
+            default_branch
+                .inputs
+                .get("reason")
+                .and_then(|value| value.as_str()),
+            Some("head-release")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Disable the default-branch preflight only for `release --head` plans so cargo-dist tagged checkouts can finish from detached HEAD.
- Preserve the existing default-branch validation for normal release preparation.
- Add focused coverage for the head-release preflight behavior.

## Verification
- `cargo test head_release_preflight_skips_default_branch_check --lib`
- `cargo test head_release_plan_skips_mutation_steps_and_uses_existing_artifacts --lib`
- `cargo fmt --check`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the release workflow failure path, drafting the small release-plan change and test, and running local verification. Chris remains responsible for review and merge decisions.