### PR TITLE
refactor: reuse git short revision helper

### DIFF
--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -10,7 +10,6 @@ use crate::core::{extension, git, paths, stack};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DiscoveredRig {
@@ -308,7 +307,7 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
     fs::create_dir_all(paths::rig_packages()?)
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rig packages dir".into())))?;
     git::clone_repo(root_source, &package_path)?;
-    let source_revision = short_head_revision(&package_path);
+    let source_revision = git::short_head_revision(&package_path);
     let discovery_path = match subpath {
         Some(subpath) => package_path.join(subpath),
         None => package_path.clone(),
@@ -567,21 +566,6 @@ pub(crate) fn link_or_copy_file(source: &Path, target: &Path) -> Result<()> {
             .map(|_| ())
             .map_err(|e| Error::internal_io(e.to_string(), Some("copy rig spec".into())))
     }
-}
-
-fn short_head_revision(path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .current_dir(path)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!revision.is_empty()).then_some(revision)
 }
 
 #[cfg(test)]

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -6,7 +6,6 @@ use crate::core::paths;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use super::install::{
     discover_stacks, link_or_copy_file, write_source_metadata, write_stack_source_metadata,
@@ -224,9 +223,9 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
         ));
     }
 
-    let previous_revision = short_head_revision(&package_path);
+    let previous_revision = git::short_head_revision(&package_path);
     git::pull_repo(&package_path)?;
-    let source_revision = short_head_revision(&package_path);
+    let source_revision = git::short_head_revision(&package_path);
 
     let mut updated = Vec::new();
     let mut updated_stacks = Vec::new();
@@ -323,21 +322,6 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
         skipped,
         failed: Vec::new(),
     })
-}
-
-fn short_head_revision(path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .current_dir(path)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!revision.is_empty()).then_some(revision)
 }
 
 fn removed_rig_source_rig(rig: &RigSourceRig, metadata_path: &Path) -> RemovedRigSourceRig {


### PR DESCRIPTION
## Summary
- Replace duplicate rig-local `short_head_revision` helpers with the shared `core::git::short_head_revision` helper.
- Remove duplicate git subprocess code from rig install and source update paths.

## Verification
- `cargo fmt && cargo fmt --check && cargo check --all-targets && cargo test rig::install --lib && cargo test rig::source --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/rig-shared-short-head-revision-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`

## Notes
- Net diff is LOC-negative: 3 insertions, 35 deletions.
- Changed-since audit reported `introduced_findings: 0`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified duplicated git revision helpers, replaced them with the existing shared helper, and ran scoped verification for Chris to review.