### PR TITLE
refactor: reuse daemon pid helper

### DIFF
--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -101,7 +101,7 @@ pub fn running_status_note(run: &RunRecord) -> Option<String> {
         );
     };
 
-    if pid_is_running(owner_pid) {
+    if crate::core::daemon::pid_is_running(owner_pid) {
         None
     } else {
         Some(
@@ -119,22 +119,6 @@ pub fn run_owner_pid(run: &RunRecord) -> Option<u32> {
         .or_else(|| run.metadata_json.get("process_id"))
         .and_then(|pid| pid.as_u64())
         .and_then(|pid| u32::try_from(pid).ok())
-}
-
-fn pid_is_running(pid: u32) -> bool {
-    if pid > i32::MAX as u32 {
-        return false;
-    }
-
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as libc::pid_t, 0) == 0
-    }
-
-    #[cfg(not(unix))]
-    {
-        pid == std::process::id()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Replace the duplicate observation lifecycle `pid_is_running` helper with the existing daemon helper.
- Remove duplicate platform-specific process liveness code.

## Verification
- `cargo fmt && cargo fmt --check && cargo check --all-targets && cargo test observation::lifecycle --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/observation-shared-pid-helper-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`

## Notes
- Net diff is LOC-negative: 1 insertion, 17 deletions.
- Changed-since audit reported `introduced_findings: 0` and `delta: -522`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified duplicate process liveness logic, reused the existing helper, and ran scoped verification for Chris to review.