### PR TITLE
fix: add runner artifact cleanup

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -10,6 +10,7 @@ homeboy runs distribution --field <metadata.path> [--kind bench] [--component <i
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs show <run-id>
 homeboy runs artifacts <run-id>
+homeboy runs artifact cleanup-downloads [--runner <runner-id>] [--run-id <run-id>] [--apply]
 homeboy runs export --run <run-id> --output <dir>
 homeboy runs export --since <duration> --output <dir>
 homeboy runs import <dir>
@@ -22,6 +23,8 @@ homeboy runs import <dir>
 `homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
+
+`homeboy runs artifact cleanup-downloads` plans cleanup for local runner artifact downloads under Homeboy's artifact root (`<artifact-root>/runner`). By default it is a dry run; pass `--apply` to remove the planned cache subtree. Use `--runner` and `--run-id` to narrow cleanup to a specific runner or run cache.
 
 `homeboy runs distribution` aggregates categorical values from dot-separated JSON metadata paths. Scalar string, number, and boolean values are counted directly; arrays are flattened and counted by scalar element. The output reports inspected runs, matched/missing runs per field, total and unique value counts, value percentages, and repeated values.
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -114,6 +114,7 @@ pub enum RunsOutput {
     Show(RunsShowOutput),
     Artifacts(RunsArtifactsOutput),
     ArtifactGet(RunsArtifactGetOutput),
+    ArtifactCleanupDownloads(RunsArtifactCleanupDownloadsOutput),
     Findings(RunsFindingsOutput),
     Finding(RunsFindingOutput),
     LatestFinding(RunsLatestFindingOutput),
@@ -156,6 +157,8 @@ pub struct RunsArtifactArgs {
 enum RunsArtifactCommand {
     /// Copy a recorded file artifact to a local path
     Get(RunsArtifactGetArgs),
+    /// Plan or delete locally cached runner artifact downloads
+    CleanupDownloads(RunsArtifactCleanupDownloadsArgs),
 }
 
 #[derive(Args, Clone)]
@@ -178,6 +181,31 @@ pub struct RunsArtifactGetOutput {
     pub content_type: Option<String>,
     pub size_bytes: Option<i64>,
     pub sha256: Option<String>,
+}
+
+#[derive(Args, Clone, Default)]
+pub struct RunsArtifactCleanupDownloadsArgs {
+    /// Delete the planned cached downloads. Without this flag, only reports the plan.
+    #[arg(long)]
+    pub apply: bool,
+    /// Limit cleanup to one runner id under the local runner artifact cache.
+    #[arg(long)]
+    pub runner: Option<String>,
+    /// Limit cleanup to one run id. Requires --runner.
+    #[arg(long)]
+    pub run_id: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RunsArtifactCleanupDownloadsOutput {
+    pub command: &'static str,
+    pub dry_run: bool,
+    pub root: String,
+    pub removed: bool,
+    pub file_count: usize,
+    pub directory_count: usize,
+    pub size_bytes: u64,
+    pub paths: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -320,6 +348,7 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
 fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
     match args.command {
         RunsArtifactCommand::Get(args) => artifact_get(args),
+        RunsArtifactCommand::CleanupDownloads(args) => remote_artifact::cleanup_downloads(args),
     }
 }
 

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -1,9 +1,13 @@
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use homeboy::core::observation::ArtifactRecord;
 use homeboy::core::runner;
 
-use super::{CmdResult, RunsArtifactGetOutput, RunsOutput};
+use super::{
+    CmdResult, RunsArtifactCleanupDownloadsArgs, RunsArtifactCleanupDownloadsOutput,
+    RunsArtifactGetOutput, RunsOutput,
+};
 
 pub fn is_remote_artifact(artifact: &ArtifactRecord) -> bool {
     artifact.artifact_type == "remote_file"
@@ -24,4 +28,277 @@ pub fn get(artifact: ArtifactRecord, output: Option<PathBuf>) -> CmdResult<RunsO
         }),
         0,
     ))
+}
+
+pub fn cleanup_downloads(args: RunsArtifactCleanupDownloadsArgs) -> CmdResult<RunsOutput> {
+    if args.run_id.is_some() && args.runner.is_none() {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "run_id",
+            "--run-id requires --runner so cleanup stays inside one runner cache",
+            args.run_id,
+            None,
+        ));
+    }
+
+    let root = runner_download_root(args.runner.as_deref(), args.run_id.as_deref())?;
+    let plan = plan_runner_download_cleanup(&root)?;
+    if args.apply && root.exists() {
+        remove_runner_download_root(&root)?;
+    }
+
+    Ok((
+        RunsOutput::ArtifactCleanupDownloads(RunsArtifactCleanupDownloadsOutput {
+            command: "runs.artifact.cleanup-downloads",
+            dry_run: !args.apply,
+            root: root.display().to_string(),
+            removed: args.apply && !root.exists(),
+            file_count: plan.file_count,
+            directory_count: plan.directory_count,
+            size_bytes: plan.size_bytes,
+            paths: plan.paths,
+        }),
+        0,
+    ))
+}
+
+#[derive(Debug, Default)]
+struct RunnerDownloadCleanupPlan {
+    file_count: usize,
+    directory_count: usize,
+    size_bytes: u64,
+    paths: Vec<String>,
+}
+
+fn runner_download_root(
+    runner: Option<&str>,
+    run_id: Option<&str>,
+) -> crate::core::Result<PathBuf> {
+    let mut root = homeboy::core::artifact_root()?.join("runner");
+    if let Some(runner) = cleanup_path_component("runner", runner)? {
+        root = root.join(runner);
+    }
+    if let Some(run_id) = cleanup_path_component("run_id", run_id)? {
+        root = root.join(run_id);
+    }
+    Ok(root)
+}
+
+fn cleanup_path_component(name: &str, value: Option<&str>) -> crate::core::Result<Option<String>> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let path = Path::new(value);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(crate::core::Error::validation_invalid_argument(
+            name,
+            format!("{name} must be a single path component"),
+            Some(value.to_string()),
+            None,
+        ));
+    }
+    Ok(Some(value.to_string()))
+}
+
+fn plan_runner_download_cleanup(root: &Path) -> crate::core::Result<RunnerDownloadCleanupPlan> {
+    let mut plan = RunnerDownloadCleanupPlan::default();
+    if !root.exists() {
+        return Ok(plan);
+    }
+
+    let metadata = fs::symlink_metadata(root).map_err(|err| {
+        crate::core::Error::internal_io(
+            err.to_string(),
+            Some(format!("read runner artifact cache {}", root.display())),
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "artifact_root",
+            format!(
+                "runner artifact cache root must be a real directory: {}",
+                root.display()
+            ),
+            Some(root.display().to_string()),
+            None,
+        ));
+    }
+
+    collect_runner_download_cleanup(root, root, &mut plan)?;
+    plan.paths.sort();
+    Ok(plan)
+}
+
+fn collect_runner_download_cleanup(
+    root: &Path,
+    path: &Path,
+    plan: &mut RunnerDownloadCleanupPlan,
+) -> crate::core::Result<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|err| {
+        crate::core::Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "read runner artifact cache entry {}",
+                path.display()
+            )),
+        )
+    })?;
+
+    if path != root {
+        plan.paths.push(relative_cleanup_path(root, path));
+    }
+
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        plan.directory_count += usize::from(path != root);
+        for entry in fs::read_dir(path).map_err(|err| {
+            crate::core::Error::internal_io(
+                err.to_string(),
+                Some(format!(
+                    "read runner artifact cache directory {}",
+                    path.display()
+                )),
+            )
+        })? {
+            let entry = entry.map_err(|err| {
+                crate::core::Error::internal_io(
+                    err.to_string(),
+                    Some(format!(
+                        "read runner artifact cache directory {}",
+                        path.display()
+                    )),
+                )
+            })?;
+            collect_runner_download_cleanup(root, &entry.path(), plan)?;
+        }
+    } else {
+        plan.file_count += 1;
+        plan.size_bytes += metadata.len();
+    }
+
+    Ok(())
+}
+
+fn remove_runner_download_root(root: &Path) -> crate::core::Result<()> {
+    let metadata = fs::symlink_metadata(root).map_err(|err| {
+        crate::core::Error::internal_io(
+            err.to_string(),
+            Some(format!("read runner artifact cache {}", root.display())),
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "artifact_root",
+            format!(
+                "runner artifact cache root must be a real directory: {}",
+                root.display()
+            ),
+            Some(root.display().to_string()),
+            None,
+        ));
+    }
+    fs::remove_dir_all(root).map_err(|err| {
+        crate::core::Error::internal_io(
+            err.to_string(),
+            Some(format!("remove runner artifact cache {}", root.display())),
+        )
+    })
+}
+
+fn relative_cleanup_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn cleanup_downloads_plans_and_removes_runner_cache() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact_root = temp.path().join("artifacts");
+        homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
+
+        let run_dir = artifact_root.join("runner").join("local").join("run-1");
+        fs::create_dir_all(&run_dir).expect("run dir");
+        fs::write(run_dir.join("trace.zip"), b"trace").expect("trace");
+        fs::write(run_dir.join("report.json"), b"{}").expect("report");
+
+        let dry = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
+            apply: false,
+            runner: Some("local".to_string()),
+            run_id: Some("run-1".to_string()),
+        })
+        .expect("dry-run")
+        .0;
+        let RunsOutput::ArtifactCleanupDownloads(dry) = dry else {
+            panic!("unexpected output");
+        };
+        assert!(dry.dry_run);
+        assert!(!dry.removed);
+        assert_eq!(dry.file_count, 2);
+        assert_eq!(dry.directory_count, 0);
+        assert_eq!(dry.size_bytes, 7);
+        assert!(run_dir.exists());
+
+        let applied = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
+            apply: true,
+            runner: Some("local".to_string()),
+            run_id: Some("run-1".to_string()),
+        })
+        .expect("apply")
+        .0;
+        let RunsOutput::ArtifactCleanupDownloads(applied) = applied else {
+            panic!("unexpected output");
+        };
+        assert!(!applied.dry_run);
+        assert!(applied.removed);
+        assert_eq!(applied.file_count, 2);
+        assert_eq!(applied.size_bytes, 7);
+        assert!(!run_dir.exists());
+
+        homeboy::core::set_artifact_root_override(None);
+    }
+
+    #[test]
+    fn cleanup_downloads_requires_runner_for_run_filter() {
+        let result = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
+            apply: false,
+            runner: None,
+            run_id: Some("run-1".to_string()),
+        });
+        let Err(err) = result else {
+            panic!("missing runner should fail");
+        };
+
+        assert!(err.to_string().contains("--run-id requires --runner"));
+    }
+
+    #[test]
+    fn cleanup_downloads_rejects_path_traversal_filters() {
+        for (runner, run_id) in [
+            (Some("../outside".to_string()), None),
+            (Some("local".to_string()), Some("../outside".to_string())),
+            (Some("/tmp/outside".to_string()), None),
+        ] {
+            let result = cleanup_downloads(RunsArtifactCleanupDownloadsArgs {
+                apply: false,
+                runner,
+                run_id,
+            });
+            let Err(err) = result else {
+                panic!("path traversal should fail");
+            };
+
+            assert!(err.to_string().contains("single path component"));
+        }
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -71,6 +71,11 @@ pub fn set_artifact_root_override(path: Option<std::path::PathBuf>) {
     paths::set_artifact_root_override(path);
 }
 
+/// Resolve the artifact root used for copied/downloaded run artifacts.
+pub fn artifact_root() -> Result<std::path::PathBuf> {
+    paths::artifact_root()
+}
+
 /// Resolve a remote path against an optional project base path.
 pub fn join_remote_path(base_path: Option<&str>, path: &str) -> Result<String> {
     paths::join_remote_path(base_path, path)


### PR DESCRIPTION
## Summary
- Adds `homeboy runs artifact cleanup-downloads` to dry-run or apply cleanup of local runner artifact download caches.
- Supports narrowing cleanup by runner and run id, with path-component validation to keep deletion inside the runner cache.
- Documents the command and adds unit coverage for dry-run/apply, missing runner validation, and traversal rejection.

Closes #2607.

## Testing
- `cargo fmt --check`
- `cargo test cleanup_downloads`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the cleanup command implementation, safety validation, tests, docs, and verification commands for Chris to review.