### PR TITLE
fix: allow head release artifacts in worktree

### DIFF
--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -78,16 +78,26 @@ pub(super) fn build_preflight_steps(
             StepConfig::new(),
         )
     };
-
-    let mut steps = vec![
-        default_branch_step,
+    let working_tree_step = if options.pipeline.head && options.pipeline.from_artifacts.is_some() {
+        disabled_step(
+            "preflight.working_tree",
+            "preflight.working_tree",
+            "Validate working tree",
+            string_config("reason", "head-release-artifacts"),
+        )
+    } else {
         ready_step(
             "preflight.working_tree",
             "preflight.working_tree",
             "Validate working tree",
             vec!["preflight.git_identity".to_string()],
             StepConfig::new(),
-        ),
+        )
+    };
+
+    let mut steps = vec![
+        default_branch_step,
+        working_tree_step,
         ready_step(
             "preflight.remote_sync",
             "preflight.remote_sync",
@@ -723,11 +733,12 @@ mod tests {
     }
 
     #[test]
-    fn head_release_preflight_skips_default_branch_check() {
+    fn head_release_with_artifacts_skips_branch_and_working_tree_checks() {
         let options = ReleaseOptions {
             bump_type: "head".to_string(),
             pipeline: ReleasePipelineOptions {
                 head: true,
+                from_artifacts: Some("artifacts".to_string()),
                 ..Default::default()
             },
             ..Default::default()
@@ -746,6 +757,20 @@ mod tests {
                 .get("reason")
                 .and_then(|value| value.as_str()),
             Some("head-release")
+        );
+
+        let working_tree = steps
+            .iter()
+            .find(|step| step.id == "preflight.working_tree")
+            .expect("working tree step");
+
+        assert_eq!(working_tree.status, PlanStepStatus::Disabled);
+        assert_eq!(
+            working_tree
+                .inputs
+                .get("reason")
+                .and_then(|value| value.as_str()),
+            Some("head-release-artifacts")
         );
     }
 


### PR DESCRIPTION
## Summary
- Disable the working-tree cleanliness preflight for `release --head --from-artifacts`, where CI intentionally downloads release artifacts into the checkout before finishing the Homeboy pipeline.
- Keep working-tree validation enabled for normal releases and head releases without artifact inventory input.
- Extend focused preflight coverage for the artifact-backed head-release path.

## Verification
- `cargo test head_release_with_artifacts_skips_branch_and_working_tree_checks --lib`
- `cargo test head_release_plan_skips_mutation_steps_and_uses_existing_artifacts --lib`
- `cargo fmt --check`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the failed release workflow logs, drafting the scoped release-plan fix and test update, and running local verification. Chris remains responsible for review and merge decisions.