### PR TITLE
Add compiler warning extension contracts

### DIFF
--- a/src/core/code_audit/compiler_warnings.rs
+++ b/src/core/code_audit/compiler_warnings.rs
@@ -1,182 +1,86 @@
 //! Surface compiler warnings (dead code, unused imports, unused variables) as audit findings.
 //!
-//! Runs the project's compiler/checker and parses structured output into audit findings.
-//! For Rust: `cargo check --message-format=json`
-//! For TypeScript: `tsc --noEmit` (future)
-//! For Go: `go vet ./...` (future)
+//! Runs extension-owned compiler/checker scripts and maps their structured output
+//! into audit findings.
 //!
 //! See: https://github.com/Extra-Chill/homeboy/issues/636
 
 use std::path::Path;
 
 use super::{AuditFinding, Finding, Severity};
+use crate::core::extension::{
+    extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
+    CompilerWarningContract, ExtensionManifest,
+};
 
-/// A parsed compiler warning.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize)]
 struct CompilerWarning {
-    /// Compiler warning code (e.g., "dead_code", "unused_imports").
     code: String,
-    /// Human-readable message.
     message: String,
-    /// Relative file path from the project root.
     file: String,
-    /// 1-indexed line number.
-    line: usize,
+    #[serde(rename = "line")]
+    _line: usize,
+    #[serde(default)]
+    suggestion: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CompilerWarningEnvelope {
+    #[serde(default)]
+    warnings: Vec<CompilerWarning>,
 }
 
 /// Run compiler checks and return findings for any warnings detected.
 pub fn run(root: &Path) -> Vec<Finding> {
-    if root.join("Cargo.toml").exists() {
-        run_cargo_check(root)
-    } else {
-        // Future: TypeScript, Go, etc.
-        Vec::new()
-    }
+    extensions_for_compiler_warning_contract(root, CompilerWarningContract::Warnings)
+        .into_iter()
+        .flat_map(|extension| run_extension_compiler_warnings(&extension, root))
+        .collect()
 }
 
-/// Run `cargo check --message-format=json` and parse warnings into findings.
-fn run_cargo_check(root: &Path) -> Vec<Finding> {
-    let output = match std::process::Command::new("cargo")
-        .args(["check", "--message-format=json"])
-        .current_dir(root)
-        .output()
-    {
-        Ok(output) => output,
-        Err(e) => {
-            crate::log_status!(
-                "audit",
-                "Could not run cargo check: {} — skipping compiler warnings",
-                e
-            );
-            return Vec::new();
-        }
+fn run_extension_compiler_warnings(extension: &ExtensionManifest, root: &Path) -> Vec<Finding> {
+    let Some(envelope) = run_compiler_warning_script(extension, root) else {
+        return Vec::new();
     };
 
-    // cargo check outputs one JSON object per line on stdout
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let warnings = parse_cargo_json_output(&stdout, root);
-
-    warnings
+    envelope
+        .warnings
         .into_iter()
-        .map(|w| Finding {
-            file: w.file.clone(),
+        .filter(|warning| !warning.file.is_empty() && !warning.file.starts_with('/'))
+        .map(|warning| Finding {
+            file: warning.file.clone(),
             kind: AuditFinding::CompilerWarning,
             severity: Severity::Warning,
             convention: "compiler".to_string(),
-            description: format!("[{}] {}", w.code, w.message),
-            suggestion: suggestion_for_code(&w.code, &w.file, w.line),
+            description: format!("[{}] {}", warning.code, warning.message),
+            suggestion: warning
+                .suggestion
+                .unwrap_or_else(|| format!("Address compiler warning: {}", warning.code)),
         })
         .collect()
 }
 
-/// Parse `cargo check --message-format=json` output into structured warnings.
-fn parse_cargo_json_output(stdout: &str, root: &Path) -> Vec<CompilerWarning> {
-    let root_str = root.to_string_lossy();
-    let mut warnings = Vec::new();
-
-    for line in stdout.lines() {
-        let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-
-        if msg.get("reason").and_then(|v| v.as_str()) != Some("compiler-message") {
-            continue;
+fn run_compiler_warning_script(
+    extension: &ExtensionManifest,
+    root: &Path,
+) -> Option<CompilerWarningEnvelope> {
+    let input = serde_json::json!({
+        "root": root,
+    });
+    let stdout = match run_compiler_warning_contract_script(
+        extension,
+        CompilerWarningContract::Warnings,
+        root,
+        &input,
+    ) {
+        Ok(Some(stdout)) => stdout,
+        Ok(None) => return None,
+        Err(error) => {
+            crate::log_status!("audit", "{}", error);
+            return None;
         }
-
-        let Some(message) = msg.get("message") else {
-            continue;
-        };
-
-        if message.get("level").and_then(|v| v.as_str()) != Some("warning") {
-            continue;
-        }
-
-        let code = message
-            .get("code")
-            .and_then(|c| c.get("code"))
-            .and_then(|c| c.as_str())
-            .unwrap_or("unknown")
-            .to_string();
-
-        let text = message
-            .get("message")
-            .and_then(|m| m.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        // Find the primary span
-        let spans = message
-            .get("spans")
-            .and_then(|s| s.as_array())
-            .cloned()
-            .unwrap_or_default();
-
-        let primary = spans
-            .iter()
-            .find(|s| s.get("is_primary").and_then(|v| v.as_bool()) == Some(true))
-            .or_else(|| spans.first());
-
-        let (file, line_num) = if let Some(span) = primary {
-            let file_name = span
-                .get("file_name")
-                .and_then(|f| f.as_str())
-                .unwrap_or("")
-                .to_string();
-            let line_start = span.get("line_start").and_then(|l| l.as_u64()).unwrap_or(0) as usize;
-
-            // Make path relative to root
-            let relative = file_name
-                .strip_prefix(&*root_str)
-                .map(|s| s.trim_start_matches('/').to_string())
-                .unwrap_or(file_name);
-
-            (relative, line_start)
-        } else {
-            (String::new(), 0)
-        };
-
-        // Skip warnings from dependencies or build scripts
-        if file.is_empty() || file.starts_with('/') || file.contains("/.cargo/") {
-            continue;
-        }
-
-        // Skip certain noise warnings that aren't actionable
-        if code == "unknown" && text.contains("generated") {
-            continue;
-        }
-
-        warnings.push(CompilerWarning {
-            code,
-            message: text,
-            file,
-            line: line_num,
-        });
-    }
-
-    // Deduplicate — cargo can emit the same warning multiple times for different targets
-    warnings.sort_by(|a, b| (&a.file, a.line, &a.code).cmp(&(&b.file, b.line, &b.code)));
-    warnings.dedup_by(|a, b| a.file == b.file && a.line == b.line && a.code == b.code);
-
-    warnings
-}
-
-/// Generate a fix suggestion based on the warning code.
-fn suggestion_for_code(code: &str, _file: &str, _line: usize) -> String {
-    match code {
-        "dead_code" => {
-            "Remove the unused item or add `#[allow(dead_code)]` if intentionally reserved"
-                .to_string()
-        }
-        "unused_imports" => "Remove the unused import".to_string(),
-        "unused_variables" => "Prefix with underscore `_` or remove the variable".to_string(),
-        "unused_assignments" => "Remove the unnecessary assignment".to_string(),
-        "unused_mut" => "Remove the `mut` qualifier".to_string(),
-        "unreachable_code" => "Remove or refactor the unreachable code path".to_string(),
-        "unused_must_use" => {
-            "Handle the return value or explicitly ignore with `let _ = ...`".to_string()
-        }
-        _ => format!("Address compiler warning: {}", code),
-    }
+    };
+    serde_json::from_str(&stdout).ok()
 }
 
 #[cfg(test)]
@@ -185,51 +89,61 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    #[test]
-    fn parse_cargo_json_output_extracts_warnings() {
-        let root = Path::new("/project");
-        let json_lines = r#"{"reason":"compiler-artifact","package_id":"foo 0.1.0","target":{"name":"foo"}}
-{"reason":"compiler-message","package_id":"foo 0.1.0","message":{"rendered":"warning: unused import","level":"warning","code":{"code":"unused_imports","explanation":null},"message":"unused import: `std::fs`","spans":[{"file_name":"src/main.rs","byte_start":0,"byte_end":10,"line_start":3,"line_end":3,"column_start":5,"column_end":15,"is_primary":true,"text":[]}]}}
-{"reason":"compiler-message","package_id":"foo 0.1.0","message":{"rendered":"warning: function `old` is never used","level":"warning","code":{"code":"dead_code","explanation":null},"message":"function `old` is never used","spans":[{"file_name":"src/lib.rs","byte_start":50,"byte_end":60,"line_start":10,"line_end":10,"column_start":8,"column_end":11,"is_primary":true,"text":[]}]}}
-{"reason":"build-finished","success":true}"#;
-
-        let warnings = parse_cargo_json_output(json_lines, root);
-        assert_eq!(warnings.len(), 2);
-        // Sorted by (file, line, code) — src/lib.rs comes before src/main.rs
-        assert_eq!(warnings[0].code, "dead_code");
-        assert_eq!(warnings[0].file, "src/lib.rs");
-        assert_eq!(warnings[0].line, 10);
-        assert_eq!(warnings[1].code, "unused_imports");
-        assert_eq!(warnings[1].file, "src/main.rs");
-        assert_eq!(warnings[1].line, 3);
+    fn write_executable(path: &Path, content: &str) {
+        fs::write(path, content).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).unwrap();
+        }
     }
 
     #[test]
-    fn run_on_rust_project_returns_findings() {
-        let dir = TempDir::new().expect("temp dir");
-        let root = dir.path();
+    fn run_uses_extension_compiler_warning_script() {
+        crate::test_support::with_isolated_home(|home| {
+            let extension_dir = home.path().join(".config/homeboy/extensions/example");
+            fs::create_dir_all(extension_dir.join("scripts")).unwrap();
+            fs::write(
+                extension_dir.join("example.json"),
+                r#"{
+                    "name": "Example",
+                    "version": "1.0.0",
+                    "scripts": { "compiler_warnings": "scripts/warnings.sh" }
+                }"#,
+            )
+            .unwrap();
+            write_executable(
+                &extension_dir.join("scripts/warnings.sh"),
+                r#"#!/usr/bin/env bash
+cat >/dev/null
+printf '{"warnings":[{"code":"unused_imports","message":"unused import","file":"src/lib.rs","line":3,"suggestion":"Remove import"}]}'
+"#,
+            );
 
-        // Create a minimal Rust project with a dead code warning
-        fs::write(
-            root.join("Cargo.toml"),
-            "[package]\nname = \"test-warn\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-        )
-        .unwrap();
-        fs::create_dir_all(root.join("src")).unwrap();
-        fs::write(
-            root.join("src/lib.rs"),
-            "fn unused_function() {}\npub fn used() {}\n",
-        )
-        .unwrap();
+            let root = TempDir::new().expect("temp dir");
+            let findings = run(root.path());
 
-        let findings = run(root);
-        // Should find at least the dead_code warning for unused_function
-        assert!(
-            findings.iter().any(|f| f.description.contains("dead_code")
-                || f.description.contains("unused")
-                || f.description.contains("never used")),
-            "expected dead_code warning, got: {:?}",
-            findings
-        );
+            assert_eq!(findings.len(), 1);
+            assert_eq!(findings[0].file, "src/lib.rs");
+            assert_eq!(findings[0].kind, AuditFinding::CompilerWarning);
+            assert_eq!(findings[0].description, "[unused_imports] unused import");
+            assert_eq!(findings[0].suggestion, "Remove import");
+        });
+    }
+
+    #[test]
+    fn run_returns_no_findings_without_extension_contract() {
+        crate::test_support::with_isolated_home(|_| {
+            let dir = TempDir::new().expect("temp dir");
+            fs::write(
+                dir.path().join("Cargo.toml"),
+                "[package]\nname = \"test-warn\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+
+            assert!(run(dir.path()).is_empty());
+        });
     }
 }

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -172,7 +172,7 @@ pub enum AuditFinding {
     /// Documentation exists but references stale paths that have moved.
     StaleDocReference,
     /// Compiler warning (dead code, unused import, unused variable, etc).
-    /// Detected by running the language compiler/checker (cargo check, tsc, etc).
+    /// Detected by running an extension-owned language compiler/checker script.
     CompilerWarning,
     /// Wrapper file is missing an explicit declaration of what it wraps.
     /// Detected by tracing calls in the wrapper to infer the implementation target.

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -1010,7 +1010,7 @@ fn audit_internal(
     }
 
     // Phase 4l: Compiler warnings (dead code, unused imports, unused variables)
-    // Runs cargo check / tsc / go vet and parses warnings into findings.
+    // Runs extension-owned warning scripts and maps their output to findings.
     let compiler_findings = if plan.run_compiler_warnings {
         compiler_warnings::run(root)
     } else {

--- a/src/core/extension/compiler_warning_contract.rs
+++ b/src/core/extension/compiler_warning_contract.rs
@@ -1,0 +1,182 @@
+use std::path::Path;
+
+use super::ExtensionManifest;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CompilerWarningContract {
+    Warnings,
+    Fixes,
+}
+
+impl CompilerWarningContract {
+    fn script_path(self, extension: &ExtensionManifest) -> Option<&str> {
+        match self {
+            Self::Warnings => extension.compiler_warnings_script(),
+            Self::Fixes => extension.compiler_warning_fixes_script(),
+        }
+    }
+}
+
+pub(crate) fn extensions_for_compiler_warning_contract(
+    root: &Path,
+    contract: CompilerWarningContract,
+) -> Vec<ExtensionManifest> {
+    let mut extensions = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    if let Some(component) = crate::core::component::discover_from_portable(root) {
+        if let Some(component_extensions) = component.extensions.as_ref() {
+            for extension_id in component_extensions.keys() {
+                let Ok(extension) = crate::core::extension::load_extension(extension_id) else {
+                    continue;
+                };
+                if contract.script_path(&extension).is_some() && seen.insert(extension.id.clone()) {
+                    extensions.push(extension);
+                }
+            }
+        }
+    }
+
+    if extensions.is_empty() {
+        extensions.extend(
+            crate::core::extension::load_all_extensions()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|extension| contract.script_path(extension).is_some()),
+        );
+    }
+
+    extensions
+}
+
+pub(crate) fn run_compiler_warning_contract_script(
+    extension: &ExtensionManifest,
+    contract: CompilerWarningContract,
+    root: &Path,
+    input: &serde_json::Value,
+) -> Result<Option<String>, String> {
+    let Some(extension_path) = extension.extension_path.as_deref() else {
+        return Ok(None);
+    };
+    let Some(script_rel) = contract.script_path(extension) else {
+        return Ok(None);
+    };
+    let script_path = Path::new(extension_path).join(script_rel);
+
+    if !script_path.exists() {
+        return Ok(None);
+    }
+
+    let Some(output) = std::process::Command::new(&script_path)
+        .current_dir(root)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .ok()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                let _ = stdin.write_all(input.to_string().as_bytes());
+            }
+            child.wait_with_output().ok()
+        })
+    else {
+        return Err(format!(
+            "Failed to run compiler warning script for extension '{}'",
+            extension.id
+        ));
+    };
+
+    if !output.status.success() {
+        return Err(format!(
+            "Compiler warning script failed for extension '{}': {}",
+            extension.id,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_executable(path: &Path, content: &str) {
+        fs::write(path, content).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_extensions_for_compiler_warning_contract_prefers_component_extensions() {
+        crate::test_support::with_isolated_home(|home| {
+            for (id, script) in [("selected", "warnings.sh"), ("fallback", "warnings.sh")] {
+                let extension_dir = home.path().join(format!(".config/homeboy/extensions/{id}"));
+                fs::create_dir_all(extension_dir.join("scripts")).unwrap();
+                fs::write(
+                    extension_dir.join(format!("{id}.json")),
+                    format!(
+                        r#"{{"name":"{id}","version":"1.0.0","scripts":{{"compiler_warnings":"scripts/{script}"}}}}"#
+                    ),
+                )
+                .unwrap();
+            }
+
+            let root = TempDir::new().expect("temp dir");
+            fs::write(
+                root.path().join("homeboy.json"),
+                r#"{"id":"example","extensions":{"selected":{}}}"#,
+            )
+            .unwrap();
+
+            let extensions = extensions_for_compiler_warning_contract(
+                root.path(),
+                CompilerWarningContract::Warnings,
+            );
+
+            assert_eq!(extensions.len(), 1);
+            assert_eq!(extensions[0].id, "selected");
+        });
+    }
+
+    #[test]
+    fn test_run_compiler_warning_contract_script_returns_stdout() {
+        let dir = TempDir::new().expect("temp dir");
+        let script_path = dir.path().join("warnings.sh");
+        write_executable(
+            &script_path,
+            "#!/usr/bin/env bash\ncat >/dev/null\nprintf 'ok'\n",
+        );
+
+        let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Example",
+            "version": "1.0.0"
+        }))
+        .unwrap();
+        extension.id = "example".to_string();
+        extension.extension_path = Some(dir.path().to_string_lossy().to_string());
+        extension.scripts = Some(crate::core::extension::ScriptsConfig {
+            compiler_warnings: Some("warnings.sh".to_string()),
+            ..Default::default()
+        });
+
+        let stdout = run_compiler_warning_contract_script(
+            &extension,
+            CompilerWarningContract::Warnings,
+            dir.path(),
+            &serde_json::json!({ "root": dir.path() }),
+        )
+        .unwrap();
+
+        assert_eq!(stdout.as_deref(), Some("ok"));
+    }
+}

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -296,6 +296,16 @@ pub struct ScriptsConfig {
     /// - PHP: `vendor/bin/phpcbf`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
+    /// Script that collects compiler warnings.
+    /// Runs from the project root and receives `{root}` JSON on stdin.
+    /// Outputs `{warnings:[...]}` JSON using Homeboy's generic warning envelope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compiler_warnings: Option<String>,
+    /// Script that converts compiler warnings into machine-applicable fixes.
+    /// Runs from the project root and receives `{root, findings}` JSON on stdin.
+    /// Outputs `{fixes:[...]}` JSON using Homeboy's generic fix envelope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compiler_warning_fixes: Option<String>,
     /// Script that extracts function contracts from source files.
     /// Receives `{file, content}` JSON on stdin, outputs `{file, contracts: [...]}` JSON on stdout.
     /// Each contract describes a function's signature, control flow branches, effects, and calls.
@@ -725,6 +735,20 @@ impl ExtensionManifest {
     /// Get the format script path (relative to extension dir), if configured.
     pub fn format_script(&self) -> Option<&str> {
         self.scripts.as_ref().and_then(|s| s.format.as_deref())
+    }
+
+    /// Get the compiler warning script path (relative to extension dir), if configured.
+    pub fn compiler_warnings_script(&self) -> Option<&str> {
+        self.scripts
+            .as_ref()
+            .and_then(|s| s.compiler_warnings.as_deref())
+    }
+
+    /// Get the compiler warning fixes script path (relative to extension dir), if configured.
+    pub fn compiler_warning_fixes_script(&self) -> Option<&str> {
+        self.scripts
+            .as_ref()
+            .and_then(|s| s.compiler_warning_fixes.as_deref())
     }
 
     /// Get the contract script path (relative to extension dir), if configured.

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -1,6 +1,7 @@
 pub mod bench;
 pub mod build;
 mod capability;
+mod compiler_warning_contract;
 pub mod component_script;
 mod execution;
 mod fingerprint;
@@ -34,6 +35,10 @@ pub use capability::{
     ExtensionExecutionContext, ScenarioRunnerOptions,
 };
 pub(crate) use capability::{extension_guidance_hints, stderr_tail};
+pub(crate) use compiler_warning_contract::{
+    extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
+    CompilerWarningContract,
+};
 pub(crate) use execution::execute_action;
 pub use execution::{
     extension_ready_status, is_extension_compatible, run_action, run_extension, run_setup,

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -7,6 +7,10 @@ fn extension_capability_owns_labels_and_scripts() {
     let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
         "name": "Example",
         "version": "0.0.0",
+        "scripts": {
+            "compiler_warnings": "compiler-warnings.sh",
+            "compiler_warning_fixes": "compiler-warning-fixes.sh"
+        },
         "runtime": { "runtimes": { "node": { "version": "24" } } },
         "lint": { "extension_script": "lint.sh" },
         "test": {
@@ -36,6 +40,14 @@ fn extension_capability_owns_labels_and_scripts() {
             .and_then(|test| test.result_parse.as_ref())
             .map(|spec| spec.rules.len()),
         Some(1)
+    );
+    assert_eq!(
+        manifest.compiler_warnings_script(),
+        Some("compiler-warnings.sh")
+    );
+    assert_eq!(
+        manifest.compiler_warning_fixes_script(),
+        Some("compiler-warning-fixes.sh")
     );
 
     for (capability, label, script, requires_script) in [

--- a/src/core/refactor/plan/generate/compiler_warning_fixes.rs
+++ b/src/core/refactor/plan/generate/compiler_warning_fixes.rs
@@ -1,25 +1,26 @@
 //! Auto-fix compiler warnings using machine-applicable suggestions from the compiler.
 //!
-//! Runs `cargo check --message-format=json` to get structured warnings with fix
-//! suggestions, then converts them to Fix objects that the refactor pipeline applies.
-//!
-//! Supported warnings:
-//! - `unused_imports`: remove the import line
-//! - `unused_mut`: remove the `mut` keyword
-//! - `unused_assignments`: remove the assignment
-//! - `dead_code`: remove the function/method (line-range removal)
+//! Runs extension-owned compiler warning fix scripts, then converts their generic
+//! fix envelopes to Fix objects that the refactor pipeline applies.
 
 use std::path::Path;
 
 use super::{tagged_line_replacement, tagged_range_removal};
 use crate::core::code_audit::{AuditFinding, CodeAuditResult};
+use crate::core::extension::{
+    extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
+    CompilerWarningContract, ExtensionManifest,
+};
 use crate::core::refactor::auto::{Fix, RefactorPrimitive, SkippedFile};
 
 /// A machine-applicable fix suggestion from the compiler.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize)]
 struct CompilerSuggestion {
     /// Warning code (e.g., "unused_imports", "dead_code").
+    #[serde(default)]
     code: String,
+    /// Generic edit kind: line_removal or line_replacement.
+    kind: String,
     /// Relative file path.
     file: String,
     /// 1-indexed start line of the span to replace.
@@ -34,7 +35,13 @@ struct CompilerSuggestion {
     message: String,
 }
 
-/// Generate fixes for compiler warnings by running `cargo check` and parsing suggestions.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CompilerFixEnvelope {
+    #[serde(default)]
+    fixes: Vec<CompilerSuggestion>,
+}
+
+/// Generate fixes for compiler warnings by running extension-owned fix scripts.
 pub(crate) fn generate_compiler_warning_fixes(
     result: &CodeAuditResult,
     root: &Path,
@@ -52,65 +59,79 @@ pub(crate) fn generate_compiler_warning_fixes(
         return;
     }
 
-    // Don't run cargo check if not a Rust project.
-    if !root.join("Cargo.toml").exists() {
-        return;
-    }
-
-    let suggestions = match run_cargo_check_for_suggestions(root) {
-        Ok(s) => s,
-        Err(e) => {
-            skipped.push(SkippedFile {
-                file: String::new(),
-                reason: format!("Failed to run cargo check for fix suggestions: {}", e),
-            });
-            return;
-        }
-    };
+    let suggestions =
+        extensions_for_compiler_warning_contract(root, CompilerWarningContract::Fixes)
+            .into_iter()
+            .flat_map(|extension| {
+                run_compiler_warning_fixes_script(&extension, root, result, skipped)
+            })
+            .collect::<Vec<_>>();
 
     for suggestion in suggestions {
-        let fix = match suggestion.code.as_str() {
-            // For unused_imports: the compiler suggests removing the full line(s).
-            // Use FunctionRemoval for line-range deletion.
-            "unused_imports" => build_line_removal_fix(&suggestion),
-
-            // For unused_mut, unused_assignments: use LineReplacement.
-            "unused_mut" | "unused_variables" | "unused_assignments" => {
-                build_line_replacement_fix(&suggestion)
-            }
-
-            // dead_code: use FunctionRemoval for the span range.
-            // Skip functions inside #[cfg(test)] modules — these are test helpers
-            // (e.g., make_fingerprint, make_rule) that may appear unused to the
-            // compiler in isolation but are called by test functions. Deleting them
-            // breaks the tests that depend on them.
-            "dead_code" => {
+        let fix = match suggestion.kind.as_str() {
+            "line_removal" => {
                 if is_inside_test_module(root, &suggestion) {
                     continue;
                 }
                 build_line_removal_fix(&suggestion)
             }
-
-            // Other warnings with suggestions: use LineReplacement if single-line.
-            _ => {
-                if suggestion.line_start == suggestion.line_end {
-                    build_line_replacement_fix(&suggestion)
-                } else {
-                    // Multi-line replacement without specific handler — skip.
-                    skipped.push(SkippedFile {
-                        file: suggestion.file.clone(),
-                        reason: format!(
-                            "No fixer for multi-line {} warning at line {}",
-                            suggestion.code, suggestion.line_start
-                        ),
-                    });
-                    continue;
-                }
+            "line_replacement" => build_line_replacement_fix(&suggestion),
+            other => {
+                skipped.push(SkippedFile {
+                    file: suggestion.file.clone(),
+                    reason: format!(
+                        "Unknown compiler warning fix kind '{}' at line {}",
+                        other, suggestion.line_start
+                    ),
+                });
+                continue;
             }
         };
 
         fixes.push(fix);
     }
+}
+
+fn run_compiler_warning_fixes_script(
+    extension: &ExtensionManifest,
+    root: &Path,
+    result: &CodeAuditResult,
+    skipped: &mut Vec<SkippedFile>,
+) -> Vec<CompilerSuggestion> {
+    let input = serde_json::json!({
+        "root": root,
+        "findings": result.findings,
+    });
+
+    let stdout = match run_compiler_warning_contract_script(
+        extension,
+        CompilerWarningContract::Fixes,
+        root,
+        &input,
+    ) {
+        Ok(Some(stdout)) => stdout,
+        Ok(None) => return Vec::new(),
+        Err(error) => {
+            skipped.push(SkippedFile {
+                file: String::new(),
+                reason: error,
+            });
+            return Vec::new();
+        }
+    };
+
+    serde_json::from_str::<CompilerFixEnvelope>(&stdout)
+        .map(|envelope| envelope.fixes)
+        .unwrap_or_else(|e| {
+            skipped.push(SkippedFile {
+                file: String::new(),
+                reason: format!(
+                    "Invalid compiler warning fix output for extension '{}': {}",
+                    extension.id, e
+                ),
+            });
+            Vec::new()
+        })
 }
 
 /// Build a Fix that removes lines (for unused imports, dead code).
@@ -207,189 +228,16 @@ fn is_inside_test_module(root: &Path, suggestion: &CompilerSuggestion) -> bool {
     false
 }
 
-/// Run `cargo check --message-format=json` and extract machine-applicable suggestions.
-fn run_cargo_check_for_suggestions(root: &Path) -> Result<Vec<CompilerSuggestion>, String> {
-    let output = std::process::Command::new("cargo")
-        .args(["check", "--message-format=json"])
-        .current_dir(root)
-        .output()
-        .map_err(|e| format!("Failed to run cargo check: {}", e))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(parse_suggestions(&stdout, root))
-}
-
-/// Parse cargo JSON output for machine-applicable suggestions.
-fn parse_suggestions(stdout: &str, root: &Path) -> Vec<CompilerSuggestion> {
-    let root_str = root.to_string_lossy();
-    let mut suggestions = Vec::new();
-
-    for line in stdout.lines() {
-        let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-
-        if msg.get("reason").and_then(|v| v.as_str()) != Some("compiler-message") {
-            continue;
-        }
-
-        let Some(message) = msg.get("message") else {
-            continue;
-        };
-
-        if message.get("level").and_then(|v| v.as_str()) != Some("warning") {
-            continue;
-        }
-
-        let code = message
-            .get("code")
-            .and_then(|c| c.get("code"))
-            .and_then(|c| c.as_str())
-            .unwrap_or("unknown")
-            .to_string();
-
-        let text = message
-            .get("message")
-            .and_then(|m| m.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        // Look for machine-applicable suggestions in children.
-        for child in message
-            .get("children")
-            .and_then(|c| c.as_array())
-            .into_iter()
-            .flatten()
-        {
-            for span in child
-                .get("spans")
-                .and_then(|s| s.as_array())
-                .into_iter()
-                .flatten()
-            {
-                let Some(replacement) = span.get("suggested_replacement").and_then(|r| r.as_str())
-                else {
-                    continue;
-                };
-
-                let file_name = span
-                    .get("file_name")
-                    .and_then(|f| f.as_str())
-                    .unwrap_or("")
-                    .to_string();
-
-                // Make path relative to root.
-                let relative = file_name
-                    .strip_prefix(&*root_str)
-                    .map(|s| s.trim_start_matches('/').to_string())
-                    .unwrap_or(file_name);
-
-                // Skip external files.
-                if relative.is_empty() || relative.starts_with('/') || relative.contains("/.cargo/")
-                {
-                    continue;
-                }
-
-                let line_start =
-                    span.get("line_start").and_then(|l| l.as_u64()).unwrap_or(1) as usize;
-                let line_end = span
-                    .get("line_end")
-                    .and_then(|l| l.as_u64())
-                    .unwrap_or(line_start as u64) as usize;
-
-                // Extract the original text from the span for LineReplacement matching.
-                let original_text = span
-                    .get("text")
-                    .and_then(|t| t.as_array())
-                    .and_then(|arr| arr.first())
-                    .and_then(|t| t.get("text"))
-                    .and_then(|t| t.as_str())
-                    .unwrap_or("")
-                    .to_string();
-
-                // For single-line replacements, extract just the portion being replaced.
-                let col_start = span
-                    .get("column_start")
-                    .and_then(|c| c.as_u64())
-                    .unwrap_or(1) as usize;
-                let col_end = span
-                    .get("column_end")
-                    .and_then(|c| c.as_u64())
-                    .unwrap_or(col_start as u64) as usize;
-
-                let old_text = if line_start == line_end && !original_text.is_empty() {
-                    // Extract just the replaced portion from the line.
-                    let start = col_start.saturating_sub(1);
-                    let end = col_end.saturating_sub(1);
-                    if start < original_text.len() && end <= original_text.len() {
-                        original_text[start..end].to_string()
-                    } else {
-                        original_text.clone()
-                    }
-                } else {
-                    original_text
-                };
-
-                suggestions.push(CompilerSuggestion {
-                    code: code.clone(),
-                    file: relative,
-                    line_start,
-                    line_end,
-                    original_text: old_text,
-                    replacement: replacement.to_string(),
-                    message: text.clone(),
-                });
-            }
-        }
-    }
-
-    // Deduplicate.
-    suggestions
-        .sort_by(|a, b| (&a.file, a.line_start, &a.code).cmp(&(&b.file, b.line_start, &b.code)));
-    suggestions
-        .dedup_by(|a, b| a.file == b.file && a.line_start == b.line_start && a.code == b.code);
-
-    suggestions
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::refactor::InsertionKind;
 
     #[test]
-    fn parse_suggestions_extracts_unused_import() {
-        let json_line = r#"{"reason":"compiler-message","package_id":"foo 0.1.0","message":{"rendered":"warning: unused import","level":"warning","code":{"code":"unused_imports","explanation":null},"message":"unused import: `std::collections::HashMap`","spans":[{"file_name":"src/lib.rs","byte_start":0,"byte_end":31,"line_start":1,"line_end":2,"column_start":1,"column_end":1,"is_primary":true,"text":[{"text":"use std::collections::HashMap;","highlight_start":1,"highlight_end":31}]}],"children":[{"message":"remove the whole `use` item","code":null,"level":"help","spans":[{"file_name":"src/lib.rs","byte_start":0,"byte_end":31,"line_start":1,"line_end":2,"column_start":1,"column_end":1,"is_primary":true,"text":[{"text":"use std::collections::HashMap;","highlight_start":1,"highlight_end":31}],"suggested_replacement":""}],"children":[],"rendered":null}]}}"#;
-
-        let root = Path::new("/project");
-        let suggestions = parse_suggestions(json_line, root);
-
-        assert_eq!(suggestions.len(), 1);
-        assert_eq!(suggestions[0].code, "unused_imports");
-        assert_eq!(suggestions[0].file, "src/lib.rs");
-        assert_eq!(suggestions[0].line_start, 1);
-        assert_eq!(suggestions[0].replacement, "");
-    }
-
-    #[test]
-    fn parse_suggestions_extracts_unused_mut() {
-        let json_line = r#"{"reason":"compiler-message","package_id":"foo 0.1.0","message":{"rendered":"warning: unused mut","level":"warning","code":{"code":"unused_mut","explanation":null},"message":"variable does not need to be mutable","spans":[{"file_name":"src/lib.rs","byte_start":90,"byte_end":94,"line_start":6,"line_end":6,"column_start":9,"column_end":13,"is_primary":true,"text":[{"text":"    let mut x = 5;","highlight_start":9,"highlight_end":13}]}],"children":[{"message":"remove this `mut`","code":null,"level":"help","spans":[{"file_name":"src/lib.rs","byte_start":90,"byte_end":94,"line_start":6,"line_end":6,"column_start":9,"column_end":13,"is_primary":true,"text":[{"text":"    let mut x = 5;","highlight_start":9,"highlight_end":13}],"suggested_replacement":""}],"children":[],"rendered":null}]}}"#;
-
-        let root = Path::new("/project");
-        let suggestions = parse_suggestions(json_line, root);
-
-        assert_eq!(suggestions.len(), 1);
-        assert_eq!(suggestions[0].code, "unused_mut");
-        assert_eq!(suggestions[0].file, "src/lib.rs");
-        assert_eq!(suggestions[0].line_start, 6);
-        assert_eq!(suggestions[0].original_text, "mut ");
-        assert_eq!(suggestions[0].replacement, "");
-    }
-
-    #[test]
     fn build_line_removal_fix_creates_function_removal() {
         let suggestion = CompilerSuggestion {
             code: "unused_imports".to_string(),
+            kind: "line_removal".to_string(),
             file: "src/lib.rs".to_string(),
             line_start: 1,
             line_end: 1,
@@ -415,6 +263,7 @@ mod tests {
     fn build_line_replacement_fix_creates_replacement() {
         let suggestion = CompilerSuggestion {
             code: "unused_mut".to_string(),
+            kind: "line_replacement".to_string(),
             file: "src/lib.rs".to_string(),
             line_start: 6,
             line_end: 6,
@@ -462,6 +311,7 @@ mod tests {
         // Line 8 is inside the test module (make_fingerprint)
         let suggestion_inside = CompilerSuggestion {
             code: "dead_code".to_string(),
+            kind: "line_removal".to_string(),
             file: "src/lib.rs".to_string(),
             line_start: 8,
             line_end: 10,
@@ -477,6 +327,7 @@ mod tests {
         // Line 2 is outside the test module (public_function)
         let suggestion_outside = CompilerSuggestion {
             code: "dead_code".to_string(),
+            kind: "line_removal".to_string(),
             file: "src/lib.rs".to_string(),
             line_start: 2,
             line_end: 2,
@@ -509,6 +360,7 @@ mod helpers {
 
         let suggestion = CompilerSuggestion {
             code: "dead_code".to_string(),
+            kind: "line_removal".to_string(),
             file: "src/lib.rs".to_string(),
             line_start: 3,
             line_end: 5,

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -137,10 +137,6 @@ const TERMS: &[Term] = &[
 const BASELINE: &[ViolationKey] = &[
     ViolationKey {
         path: "src/commands/component.rs",
-        term: "php",
-    },
-    ViolationKey {
-        path: "src/commands/component.rs",
         term: "wordpress",
     },
     ViolationKey {
@@ -184,32 +180,8 @@ const BASELINE: &[ViolationKey] = &[
         term: "php",
     },
     ViolationKey {
-        path: "src/core/code_audit/compiler_warnings.rs",
-        term: "Cargo.toml",
-    },
-    ViolationKey {
-        path: "src/core/code_audit/compiler_warnings.rs",
-        term: "cargo",
-    },
-    ViolationKey {
-        path: "src/core/code_audit/compiler_warnings.rs",
-        term: "go vet",
-    },
-    ViolationKey {
-        path: "src/core/code_audit/conventions.rs",
-        term: "cargo",
-    },
-    ViolationKey {
         path: "src/core/code_audit/conventions.rs",
         term: "php",
-    },
-    ViolationKey {
-        path: "src/core/code_audit/core_fingerprint.rs",
-        term: "php",
-    },
-    ViolationKey {
-        path: "src/core/code_audit/core_fingerprint.rs",
-        term: "rust",
     },
     ViolationKey {
         path: "src/core/code_audit/dead_code.rs",
@@ -306,34 +278,6 @@ const BASELINE: &[ViolationKey] = &[
     ViolationKey {
         path: "src/core/component/mod.rs",
         term: "npm",
-    },
-    ViolationKey {
-        path: "src/core/context/mod.rs",
-        term: "Cargo.toml",
-    },
-    ViolationKey {
-        path: "src/core/context/mod.rs",
-        term: "functions.php",
-    },
-    ViolationKey {
-        path: "src/core/context/mod.rs",
-        term: "nodejs",
-    },
-    ViolationKey {
-        path: "src/core/context/mod.rs",
-        term: "package.json",
-    },
-    ViolationKey {
-        path: "src/core/context/mod.rs",
-        term: "php",
-    },
-    ViolationKey {
-        path: "src/core/context/mod.rs",
-        term: "rust",
-    },
-    ViolationKey {
-        path: "src/core/context/mod.rs",
-        term: "style.css",
     },
     ViolationKey {
         path: "src/core/context/mod.rs",
@@ -572,14 +516,6 @@ const BASELINE: &[ViolationKey] = &[
         term: "rust",
     },
     ViolationKey {
-        path: "src/core/refactor/plan/generate/compiler_warning_fixes.rs",
-        term: "Cargo.toml",
-    },
-    ViolationKey {
-        path: "src/core/refactor/plan/generate/compiler_warning_fixes.rs",
-        term: "cargo",
-    },
-    ViolationKey {
         path: "src/core/refactor/plan/generate/duplicate_fixes.rs",
         term: "php",
     },
@@ -665,7 +601,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 182;
+const BASELINE_OCCURRENCES: usize = 161;
 
 #[test]
 fn core_owned_source_stays_language_and_framework_agnostic() {


### PR DESCRIPTION
## Summary
- Adds manifest-declared `scripts.compiler_warnings` and `scripts.compiler_warning_fixes` contracts.
- Routes compiler warning audit and refactor fix generation through extension-owned JSON scripts instead of hardcoded Cargo execution in core.
- Ratchets the core-agnostic baseline down after removing Cargo/Rust-specific compiler warning behavior from core.

Fixes #2420.

## Companion
- Rust extension implementation: Extra-Chill/homeboy-extensions#667

## Testing
- `cargo fmt --check`
- `cargo test compiler_warnings --lib`
- `cargo test compiler_warning_fixes --lib`
- `cargo test compiler_warning_contract --lib`
- `cargo test extension_capability_owns_labels_and_scripts --lib`
- `cargo test core_owned_source_stays_language_and_framework_agnostic --test core_agnostic_test`
- `homeboy audit homeboy --changed-since=origin/main --json-summary`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-compiler-warning-contracts --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-compiler-warning-contracts --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the compiler warning contract plumbing, refactor updates, tests, and local verification commands; Chris remains responsible for review and merge.