### PR TITLE
Default triage to personal workload

### DIFF
--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -752,13 +752,17 @@ mod probes {
             return None;
         }
         let stat = unsafe { stat.assume_init() };
-        let block_size = stat.f_frsize.max(1);
-        let total_blocks = stat.f_blocks;
-        let available_blocks = stat.f_bavail;
+        let block_size = u128::from(stat.f_frsize.max(1));
+        let total_blocks = u128::from(stat.f_blocks);
+        let available_blocks = u128::from(stat.f_bavail);
         Some(DiskProbe {
             path: common::display_path(path),
-            total_mb: total_blocks.saturating_mul(block_size) / 1024 / 1024,
-            available_mb: available_blocks.saturating_mul(block_size) / 1024 / 1024,
+            total_mb: (total_blocks.saturating_mul(block_size) / 1024 / 1024)
+                .try_into()
+                .ok()?,
+            available_mb: (available_blocks.saturating_mul(block_size) / 1024 / 1024)
+                .try_into()
+                .ok()?,
         })
     }
 

--- a/src/commands/triage.rs
+++ b/src/commands/triage.rs
@@ -22,6 +22,10 @@ pub struct TriageArgs {
     #[arg(long, global = true)]
     mine: bool,
 
+    /// Show the broad repo firehose instead of the default personal workload.
+    #[arg(long, global = true, conflicts_with = "mine")]
+    all: bool,
+
     /// Restrict to issues/PRs assigned to this GitHub user.
     #[arg(long, global = true, value_name = "USER")]
     assigned: Option<String>,
@@ -93,12 +97,23 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageOut
     issue_numbers.sort_unstable();
     issue_numbers.dedup();
 
+    let target = match args.command.unwrap_or(TriageCommand::Workspace) {
+        TriageCommand::Component { component_id, path } => {
+            resolve_component_target(component_id, path)?
+        }
+        TriageCommand::Project { project_id } => TriageTarget::Project(project_id),
+        TriageCommand::Fleet { fleet_id } => TriageTarget::Fleet(fleet_id),
+        TriageCommand::Rig { rig_id } => TriageTarget::Rig(rig_id),
+        TriageCommand::Workspace => TriageTarget::Workspace,
+    };
+
     let include_issues = args.issues || !args.prs || !issue_numbers.is_empty();
     let include_prs = args.prs || !args.issues;
+    let default_to_personal_workload = matches!(target, TriageTarget::Workspace) && !args.all;
     let options = TriageOptions {
         include_issues,
         include_prs,
-        mine: args.mine,
+        mine: args.mine || default_to_personal_workload,
         assigned: args.assigned,
         labels: args.label,
         needs_review: args.needs_review,
@@ -110,16 +125,6 @@ pub fn run(args: TriageArgs, _global: &super::GlobalArgs) -> CmdResult<TriageOut
             None => None,
         },
         limit: args.limit,
-    };
-
-    let target = match args.command.unwrap_or(TriageCommand::Workspace) {
-        TriageCommand::Component { component_id, path } => {
-            resolve_component_target(component_id, path)?
-        }
-        TriageCommand::Project { project_id } => TriageTarget::Project(project_id),
-        TriageCommand::Fleet { fleet_id } => TriageTarget::Fleet(fleet_id),
-        TriageCommand::Rig { rig_id } => TriageTarget::Rig(rig_id),
-        TriageCommand::Workspace => TriageTarget::Workspace,
     };
 
     Ok((triage::run(target, options)?, 0))
@@ -194,6 +199,14 @@ mod tests {
         let cli = TestCli::parse_from(["triage", "workspace"]);
 
         assert!(matches!(cli.args.command, Some(TriageCommand::Workspace)));
+    }
+
+    #[test]
+    fn all_flag_opts_out_of_personal_workload_default() {
+        let cli = TestCli::parse_from(["triage", "--all"]);
+
+        assert!(cli.args.all);
+        assert!(!cli.args.mine);
     }
 
     #[test]

--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -266,6 +266,11 @@ pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput>
         }
     }
 
+    if options.mine {
+        components.retain(triage_component_has_items);
+        unresolved.clear();
+    }
+
     let summary = summarize(&components, &unresolved);
     let unresolved_summary = summarize_unresolved(&unresolved);
     let command = triage_command(&target);
@@ -286,6 +291,17 @@ pub fn run(target: TriageTarget, options: TriageOptions) -> Result<TriageOutput>
     Ok(output)
 }
 
+fn triage_component_has_items(component: &TriageComponentReport) -> bool {
+    component
+        .issues
+        .as_ref()
+        .is_some_and(|bucket| !bucket.items.is_empty())
+        || component
+            .pull_requests
+            .as_ref()
+            .is_some_and(|bucket| !bucket.items.is_empty())
+}
+
 struct TriageObservation {
     store: ObservationStore,
     run_id: String,
@@ -298,6 +314,7 @@ impl TriageObservation {
     fn start(target: &TriageTarget, options: &TriageOptions) -> Option<Self> {
         let store = ObservationStore::open_initialized().ok()?;
         let component_id = triage_observation_component_id(target);
+        let metadata = triage_observation_metadata(target, options);
         let previous_run = store
             .latest_run(RunListFilter {
                 kind: Some("triage".to_string()),
@@ -307,7 +324,8 @@ impl TriageObservation {
                 limit: Some(1),
             })
             .ok()
-            .flatten();
+            .flatten()
+            .filter(|run| run.metadata_json == metadata);
         let store_path = store
             .status()
             .map(|status| status.path)
@@ -324,25 +342,7 @@ impl TriageObservation {
                         TriageTarget::Rig(id) => Some(id.clone()),
                         _ => None,
                     })
-                    .metadata(serde_json::json!({
-                        "target": {
-                            "kind": target.kind_name(),
-                            "id": target.id(),
-                        },
-                        "options": {
-                            "include_issues": options.include_issues,
-                            "include_prs": options.include_prs,
-                            "mine": options.mine,
-                            "assigned": options.assigned,
-                            "labels": options.labels,
-                            "needs_review": options.needs_review,
-                            "failing_checks": options.failing_checks,
-                            "drilldown": options.drilldown,
-                            "issue_numbers": options.issue_numbers,
-                            "stale_days": options.stale_days,
-                            "limit": options.limit,
-                        }
-                    }))
+                    .metadata(metadata)
                     .build(),
             )
             .ok()?;
@@ -398,6 +398,28 @@ impl TriageObservation {
             comparison,
         })
     }
+}
+
+fn triage_observation_metadata(target: &TriageTarget, options: &TriageOptions) -> Value {
+    serde_json::json!({
+        "target": {
+            "kind": target.kind_name(),
+            "id": target.id(),
+        },
+        "options": {
+            "include_issues": options.include_issues,
+            "include_prs": options.include_prs,
+            "mine": options.mine,
+            "assigned": options.assigned,
+            "labels": options.labels,
+            "needs_review": options.needs_review,
+            "failing_checks": options.failing_checks,
+            "drilldown": options.drilldown,
+            "issue_numbers": options.issue_numbers,
+            "stale_days": options.stale_days,
+            "limit": options.limit,
+        }
+    })
 }
 
 type TriageObservationItemKey = (String, String, String, String, u64);
@@ -2385,6 +2407,23 @@ mod tests {
         assert_eq!(
             comparison.changed_items[0].changed_fields,
             vec!["next_action"]
+        );
+    }
+
+    #[test]
+    fn triage_observation_metadata_distinguishes_personal_and_firehose_runs() {
+        let personal = TriageOptions {
+            mine: true,
+            ..TriageOptions::default()
+        };
+        let firehose = TriageOptions {
+            mine: false,
+            ..TriageOptions::default()
+        };
+
+        assert_ne!(
+            triage_observation_metadata(&TriageTarget::Workspace, &personal),
+            triage_observation_metadata(&TriageTarget::Workspace, &firehose)
         );
     }
 


### PR DESCRIPTION
## Summary
- Default workspace triage to the personal workload filter so bare `homeboy triage` shows actionable authored/assigned/review-requested work instead of the repo firehose.
- Add `--all` as the explicit opt-out for broad workspace triage.
- Keep triage observation comparisons scoped to matching target/options metadata and hide empty component shells in personal workload mode.

Closes #2618.

## Validation
- `cargo test triage`
- `cargo run --bin homeboy -- triage --help`
- `target/debug/homeboy triage --limit 1 --output /tmp/homeboy-triage-default-filtered.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-triage-workload-default --extension rust`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-triage-workload-default --extension rust`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the triage default behavior, drafting the Rust changes and tests, and running validation. Chris remains responsible for review and merge decisions.