### PR TITLE
refactor: share process liveness helper

### DIFF
--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use homeboy::core::observation::{
     run_owner_pid, ObservationStore, RunListFilter, RunRecord, RunStatus,
 };
+use homeboy::core::process::pid_is_running;
 
 use crate::commands::runs::RunsOutput;
 use crate::commands::CmdResult;
@@ -141,22 +142,6 @@ fn with_reconcile_metadata(run: &RunRecord, owner_pid: u32, reason: &str) -> Val
         "homeboy_reconciled": marker,
         "homeboy_original_metadata": metadata,
     })
-}
-
-fn pid_is_running(pid: u32) -> bool {
-    if pid > i32::MAX as u32 {
-        return false;
-    }
-
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as libc::pid_t, 0) == 0
-    }
-
-    #[cfg(not(unix))]
-    {
-        pid == std::process::id()
-    }
 }
 
 #[cfg(test)]

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -11,6 +11,7 @@ use crate::core::api_jobs::JobStore;
 use crate::core::error::{Error, Result};
 use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::core::paths;
+use crate::core::process::pid_is_running;
 use crate::core::source_snapshot::SourceSnapshot;
 
 mod artifact_download;
@@ -573,22 +574,6 @@ fn write_http_response(mut stream: TcpStream, response: HttpResponse) -> std::io
         body.len(),
         body
     )
-}
-
-pub(crate) fn pid_is_running(pid: u32) -> bool {
-    if pid > i32::MAX as u32 {
-        return false;
-    }
-
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as libc::pid_t, 0) == 0
-    }
-
-    #[cfg(not(unix))]
-    {
-        pid == std::process::id()
-    }
 }
 
 fn terminate_pid(pid: u32) -> Result<()> {

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -329,7 +329,7 @@ fn refresh_lease_index() -> Result<Vec<InvocationLease>> {
         let Some(lease) = decode_lease_file(&path)? else {
             continue;
         };
-        if crate::core::daemon::pid_is_running(lease.pid) {
+        if crate::core::process::pid_is_running(lease.pid) {
             live.push(lease);
         } else {
             remove_stale_invocation_lease(&path)?;

--- a/src/core/engine/invocation/child.rs
+++ b/src/core/engine/invocation/child.rs
@@ -236,7 +236,7 @@ impl InvocationChildRecord {
     }
 
     fn process_identity_matches(pid: u32, started_at: Option<&str>) -> bool {
-        if !crate::core::daemon::pid_is_running(pid) {
+        if !crate::core::process::pid_is_running(pid) {
             return false;
         }
         match (started_at, Self::process_started_at(pid)) {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -25,6 +25,7 @@ pub mod keychain;
 pub mod observation;
 pub mod output;
 pub mod plan;
+pub mod process;
 pub mod project;
 pub mod quality;
 pub mod refactor;

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -101,7 +101,7 @@ pub fn running_status_note(run: &RunRecord) -> Option<String> {
         );
     };
 
-    if crate::core::daemon::pid_is_running(owner_pid) {
+    if crate::core::process::pid_is_running(owner_pid) {
         None
     } else {
         Some(

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -1,0 +1,15 @@
+pub fn pid_is_running(pid: u32) -> bool {
+    if pid > i32::MAX as u32 {
+        return false;
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as libc::pid_t, 0) == 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        pid == std::process::id()
+    }
+}

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -165,7 +165,7 @@ fn prune_stale_leases() -> Result<()> {
         let Some(lease) = read_lease(&path)? else {
             continue;
         };
-        if !crate::core::daemon::pid_is_running(lease.pid) {
+        if !crate::core::process::pid_is_running(lease.pid) {
             fs::remove_file(&path).map_err(|e| {
                 Error::internal_unexpected(format!(
                     "Failed to remove stale rig lease {}: {}",
@@ -182,7 +182,7 @@ fn live_leases() -> Result<Vec<RigRunLease>> {
     let mut leases = Vec::new();
     for path in lease_files()? {
         if let Some(lease) = read_lease(&path)? {
-            if crate::core::daemon::pid_is_running(lease.pid) {
+            if crate::core::process::pid_is_running(lease.pid) {
                 leases.push(lease);
             }
         }

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -493,7 +493,7 @@ fn wait_for_tcp(port: u16, timeout: Duration) -> bool {
 
 fn session_is_live(session: &RunnerSession) -> bool {
     if let Some(pid) = session.tunnel_pid {
-        if !pid_is_running(pid) {
+        if !crate::core::process::pid_is_running(pid) {
             return false;
         }
     }
@@ -573,20 +573,6 @@ fn command_failure_message(prefix: &str, output: &crate::core::server::CommandOu
 
 fn is_loopback_host(host: &str) -> bool {
     matches!(host, "localhost" | "127.0.0.1" | "::1")
-}
-
-fn pid_is_running(pid: u32) -> bool {
-    if pid > i32::MAX as u32 {
-        return false;
-    }
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as libc::pid_t, 0) == 0
-    }
-    #[cfg(not(unix))]
-    {
-        false
-    }
 }
 
 fn terminate_pid(pid: u32) {


### PR DESCRIPTION
## Summary
- Move process liveness checks into neutral `core::process::pid_is_running`.
- Reuse it from daemon, observation, rig leases, invocation leases, runner sessions, and run reconciliation.
- Remove duplicate `pid_is_running` implementations while avoiding extra daemon coupling.

## Verification
- `cargo fmt && cargo fmt --check && cargo check --all-targets`
- `cargo test daemon --lib -- --test-threads=1`
- `cargo test observation::lifecycle --lib`
- `cargo test runner::connection --lib`
- `cargo test runs::reconcile`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/process-helper-audit-staged.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@trace-run-record-builder --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified duplicate process-liveness helpers, drafted the refactor, and ran local verification; Chris remains responsible for review and merge.