### PR TITLE
refactor: reuse process liveness checks

### DIFF
--- a/src/core/extension/trace/attach.rs
+++ b/src/core/extension/trace/attach.rs
@@ -203,14 +203,8 @@ fn observe_pid(raw_pid: &str) -> (String, BTreeMap<String, serde_json::Value>) {
     }
 }
 
-#[cfg(unix)]
 fn process_exists(pid: u32) -> bool {
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
-
-#[cfg(not(unix))]
-fn process_exists(_pid: u32) -> bool {
-    false
+    crate::core::process::pid_is_running(pid)
 }
 
 fn observe_port(raw_port: &str) -> (String, BTreeMap<String, serde_json::Value>) {

--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -365,13 +365,8 @@ mod platform {
             })
     }
 
-    /// Cheap liveness probe — `kill(pid, 0)` returns 0 if the process exists and
-    /// we have permission to signal it. Matches what `ps` and most supervisors do.
     fn pid_alive(pid: u32) -> bool {
-        if pid == 0 {
-            return false;
-        }
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+        crate::core::process::pid_is_running(pid)
     }
 
     fn process_group_alive(pgid: u32) -> bool {

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -1493,6 +1493,8 @@ mod tests {
 
     #[cfg(unix)]
     fn pid_is_alive(pid: libc::pid_t) -> bool {
-        unsafe { libc::kill(pid, 0) == 0 }
+        u32::try_from(pid)
+            .map(crate::core::process::pid_is_running)
+            .unwrap_or(false)
     }
 }


### PR DESCRIPTION
## Summary
- Reuse `core::process::pid_is_running` for remaining simple process-alive checks in rig services, trace attachments, and server client tests.
- Leave process-group and `EPERM`-aware overlay-lock checks local because their semantics differ from the shared helper.

## Verification
- `cargo fmt && cargo fmt --check && cargo check --all-targets`
- `cargo test rig::service --lib`
- `cargo test extension::trace::attach --lib`
- `cargo test server::client --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/remaining-process-checks-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@trace-run-record-builder --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified exact liveness-check reuse sites, drafted the small refactor, and ran local verification; Chris remains responsible for review and merge.