### PR TITLE
refactor: share process group liveness helper

### DIFF
--- a/src/core/engine/invocation/child.rs
+++ b/src/core/engine/invocation/child.rs
@@ -264,8 +264,8 @@ impl InvocationChildRecord {
             libc::kill(-pgid, libc::SIGTERM);
         }
         std::thread::sleep(CHILD_CLEANUP_GRACE);
-        unsafe {
-            if libc::kill(-pgid, 0) == 0 {
+        if crate::core::process::process_group_is_running(pgid) {
+            unsafe {
                 libc::kill(-pgid, libc::SIGKILL);
             }
         }

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -13,3 +13,19 @@ pub fn pid_is_running(pid: u32) -> bool {
         pid == std::process::id()
     }
 }
+
+pub fn process_group_is_running(pgid: i32) -> bool {
+    if pgid <= 0 {
+        return false;
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(-(pgid as libc::pid_t), 0) == 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}

--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -370,10 +370,9 @@ mod platform {
     }
 
     fn process_group_alive(pgid: u32) -> bool {
-        if pgid == 0 {
-            return false;
-        }
-        unsafe { libc::kill(-(pgid as libc::pid_t), 0) == 0 }
+        i32::try_from(pgid)
+            .map(crate::core::process::process_group_is_running)
+            .unwrap_or(false)
     }
 
     fn target_alive(pid: u32, process_group: bool) -> bool {

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -956,8 +956,8 @@ fn cleanup_process_group(pgid: libc::pid_t) {
         libc::kill(-pgid, libc::SIGTERM);
     }
     std::thread::sleep(Duration::from_millis(200));
-    unsafe {
-        if libc::kill(-pgid, 0) == 0 {
+    if crate::core::process::process_group_is_running(pgid) {
+        unsafe {
             libc::kill(-pgid, libc::SIGKILL);
         }
     }


### PR DESCRIPTION
## Summary
- Add a shared `core::process::process_group_is_running` helper for Unix process-group liveness checks.
- Reuse it in invocation child cleanup, server client cleanup, and rig service process-group checks.
- Preserve the existing `kill(-pgid, 0) == 0` semantics while guarding invalid group IDs in one place.

## Verification
- `cargo fmt --check`
- `cargo test rig::service --lib`
- `cargo test server::client --lib`
- `cargo test engine::invocation --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-process-group-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@trace-run-record-builder --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small refactor, ran focused verification, and prepared this PR description for Chris to review.