### PR TITLE
refactor: reuse path segment sanitizer

### DIFF
--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -415,23 +415,14 @@ fn write_lease(lease: &InvocationLease) -> Result<()> {
 }
 
 fn lease_path(invocation_id: &str) -> Result<PathBuf> {
-    Ok(invocation_leases_dir()?.join(format!("{}.json", sanitize_id(invocation_id))))
+    Ok(invocation_leases_dir()?.join(format!(
+        "{}.json",
+        paths::sanitize_path_segment(invocation_id)
+    )))
 }
 
 fn invocation_leases_dir() -> Result<PathBuf> {
     Ok(paths::homeboy()?.join("invocation-leases"))
-}
-
-fn sanitize_id(id: &str) -> String {
-    id.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
 }
 
 struct InvocationIndexLock {

--- a/src/core/engine/invocation/child.rs
+++ b/src/core/engine/invocation/child.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use super::{json_excerpt, parse_context, sanitize_id};
+use super::{json_excerpt, parse_context};
 
 const CHILD_RECORD_DIR: &str = "invocation-children";
 const CHILD_CLEANUP_GRACE: Duration = Duration::from_millis(200);
@@ -148,7 +148,7 @@ impl InvocationChildRecord {
     }
 
     pub(crate) fn children_dir(invocation_id: &str) -> Result<PathBuf> {
-        Ok(Self::root()?.join(sanitize_id(invocation_id)))
+        Ok(Self::root()?.join(paths::sanitize_path_segment(invocation_id)))
     }
 
     pub(crate) fn record_path(invocation_id: &str, root_pid: u32) -> Result<PathBuf> {

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -125,6 +125,19 @@ fn expand_path(path: PathBuf) -> PathBuf {
     PathBuf::from(shellexpand::tilde(&raw).into_owned())
 }
 
+pub(crate) fn sanitize_path_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 /// Projects directory
 pub fn projects() -> Result<PathBuf> {
     Ok(homeboy()?.join("projects"))

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -240,19 +240,7 @@ fn read_lease(path: &Path) -> Result<Option<RigRunLease>> {
 }
 
 fn lease_path(rig_id: &str) -> Result<PathBuf> {
-    Ok(paths::rig_leases_dir()?.join(format!("{}.json", sanitize_id(rig_id))))
-}
-
-fn sanitize_id(id: &str) -> String {
-    id.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+    Ok(paths::rig_leases_dir()?.join(format!("{}.json", paths::sanitize_path_segment(rig_id))))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add a shared `paths::sanitize_path_segment` helper for underscore-based path segment sanitization.
- Reuse it for rig lease paths, invocation lease paths, and invocation child record directories.
- Remove duplicate private `sanitize_id` implementations while preserving the existing character mapping.

## Verification
- `cargo fmt --check`
- `cargo test rig::lease --lib`
- `cargo test engine::invocation --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-sanitize-path-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@trace-run-record-builder --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor, ran verification, and prepared this PR description for Chris to review.