### PR TITLE
refactor: reuse rig test support helpers

### DIFF
--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -12,39 +12,7 @@ use std::process::Command;
 #[path = "support.rs"]
 mod support;
 
-use support::minimal_stack;
-
-fn write_rig(package: &Path, id: &str, body: &str) -> std::path::PathBuf {
-    let rig_dir = package.join("rigs").join(id);
-    fs::create_dir_all(&rig_dir).expect("rig dir");
-    let rig_path = rig_dir.join("rig.json");
-    fs::write(&rig_path, body).expect("rig json");
-    rig_path
-}
-
-fn minimal_rig(id: &str) -> String {
-    format!(
-        r#"{{
-            "id": "{}",
-            "description": "{} rig",
-            "components": {{
-                "app": {{ "path": "${{env.DEV_ROOT}}/{}" }}
-            }},
-            "pipeline": {{
-                "check": [{{ "kind": "check", "label": "app exists", "file": "${{components.app.path}}" }}]
-            }}
-        }}"#,
-        id, id, id
-    )
-}
-
-fn write_stack(package: &Path, id: &str, component: &str) -> std::path::PathBuf {
-    let stacks_dir = package.join("stacks");
-    fs::create_dir_all(&stacks_dir).expect("stacks dir");
-    let stack_path = stacks_dir.join(format!("{}.json", id));
-    fs::write(&stack_path, minimal_stack(id, component)).expect("stack json");
-    stack_path
-}
+use support::{minimal_rig, minimal_stack, run_git, write_rig, write_stack};
 
 fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
     fs::create_dir_all(dir).expect("single rig dir");
@@ -52,21 +20,6 @@ fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
     fs::write(&rig_path, body).expect("rig json");
     assert!(body.contains(id));
     rig_path
-}
-
-fn run_git(dir: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .expect("git command");
-    assert!(
-        output.status.success(),
-        "git {:?} failed: {}{}",
-        args,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
 }
 
 fn commit_package(package: &Path) {

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -11,54 +11,7 @@ use std::process::Command;
 #[path = "support.rs"]
 mod support;
 
-use support::minimal_stack;
-
-fn write_rig(package: &Path, id: &str, body: &str) -> std::path::PathBuf {
-    let rig_dir = package.join("rigs").join(id);
-    fs::create_dir_all(&rig_dir).expect("rig dir");
-    let rig_path = rig_dir.join("rig.json");
-    fs::write(&rig_path, body).expect("rig json");
-    rig_path
-}
-
-fn minimal_rig(id: &str) -> String {
-    format!(
-        r#"{{
-            "id": "{}",
-            "description": "{} rig",
-            "components": {{
-                "app": {{ "path": "${{env.DEV_ROOT}}/{}" }}
-            }},
-            "pipeline": {{
-                "check": [{{ "kind": "check", "label": "app exists", "file": "${{components.app.path}}" }}]
-            }}
-        }}"#,
-        id, id, id
-    )
-}
-
-fn write_stack(package: &Path, id: &str, component: &str) -> std::path::PathBuf {
-    let stacks_dir = package.join("stacks");
-    fs::create_dir_all(&stacks_dir).expect("stacks dir");
-    let stack_path = stacks_dir.join(format!("{}.json", id));
-    fs::write(&stack_path, minimal_stack(id, component)).expect("stack json");
-    stack_path
-}
-
-fn run_git(dir: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .expect("git command");
-    assert!(
-        output.status.success(),
-        "git {:?} failed: {}{}",
-        args,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+use support::{minimal_rig, minimal_stack, run_git, write_rig, write_stack};
 
 fn commit_package(package: &Path, message: &str) {
     run_git(package, &["add", "."]);

--- a/tests/core/rig/support.rs
+++ b/tests/core/rig/support.rs
@@ -1,3 +1,31 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) fn write_rig(package: &Path, id: &str, body: &str) -> PathBuf {
+    let rig_dir = package.join("rigs").join(id);
+    fs::create_dir_all(&rig_dir).expect("rig dir");
+    let rig_path = rig_dir.join("rig.json");
+    fs::write(&rig_path, body).expect("rig json");
+    rig_path
+}
+
+pub(crate) fn minimal_rig(id: &str) -> String {
+    format!(
+        r#"{{
+            "id": "{}",
+            "description": "{} rig",
+            "components": {{
+                "app": {{ "path": "${{env.DEV_ROOT}}/{}" }}
+            }},
+            "pipeline": {{
+                "check": [{{ "kind": "check", "label": "app exists", "file": "${{components.app.path}}" }}]
+            }}
+        }}"#,
+        id, id, id
+    )
+}
+
 pub(crate) fn minimal_stack(id: &str, component: &str) -> String {
     format!(
         r#"{{
@@ -11,4 +39,27 @@ pub(crate) fn minimal_stack(id: &str, component: &str) -> String {
         }}"#,
         id, id, component, component
     )
+}
+
+pub(crate) fn write_stack(package: &Path, id: &str, component: &str) -> PathBuf {
+    let stacks_dir = package.join("stacks");
+    fs::create_dir_all(&stacks_dir).expect("stacks dir");
+    let stack_path = stacks_dir.join(format!("{}.json", id));
+    fs::write(&stack_path, minimal_stack(id, component)).expect("stack json");
+    stack_path
+}
+
+pub(crate) fn run_git(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git command");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }


### PR DESCRIPTION
## Summary
- Move duplicated rig install/source test helpers into shared `tests/core/rig/support.rs`.
- Keep the test fixtures and git helper behavior unchanged while removing duplicate local definitions.

## Verification
- `cargo fmt --check`
- `cargo test rig::install --lib`
- `cargo test rig::source --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-rig-test-support-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@trace-run-record-builder --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the test helper consolidation and ran local verification; Chris remains responsible for review and merge.