### PR TITLE
fix(release): exclude artifacts from crate package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target/
 dist-manifest.json
 .homeboy-bin/
+/artifacts/
 
 # Dependencies
 /node_modules/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "CLI for multi-component deployment and development workflow autom
 repository = "https://github.com/Extra-Chill/homeboy"
 homepage = "https://github.com/Extra-Chill/homeboy"
 build = "build.rs"
+exclude = ["/artifacts/"]
 
 [lib]
 name = "homeboy"


### PR DESCRIPTION
## Summary
- Excludes the release job's downloaded `artifacts/` directory from the Cargo crate package.
- Ignores root `artifacts/` locally so release assets do not dirty normal worktrees.

## Why
The release pipeline now finishes at the tagged release and publishes through the rust extension. In the GitHub release job, the workflow downloads built release assets into `artifacts/` before running `cargo publish --allow-dirty`. Cargo packaged those downloaded binaries into the crate, producing a 48.4MiB compressed upload and crates.io rejected it with `413 Payload Too Large`.

Failed run: https://github.com/Extra-Chill/homeboy/actions/runs/26104920329

## Verification
- Created a synthetic 20MiB file under `artifacts/` and ran `cargo package --allow-dirty --no-verify`; Cargo still packaged 655 files, 8.2MiB total / 1.7MiB compressed.
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release pipeline failure, identified the Cargo packaging interaction with downloaded artifacts, drafted the minimal exclusion fix, and ran local verification. Chris remains responsible for review and merge.