### PR TITLE
refactor: share code audit line lookup

### DIFF
--- a/src/core/code_audit/dead_guard.rs
+++ b/src/core/code_audit/dead_guard.rs
@@ -20,6 +20,7 @@ use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
 use super::requirements::{known_available_symbols, KnownSymbols};
+use super::source_locations::line_of_offset;
 use crate::core::component::AuditConfig;
 
 /// Kinds of guards we detect.
@@ -427,14 +428,6 @@ fn extract_guards(content: &str) -> Vec<Guard> {
         });
     }
     out
-}
-
-fn line_of_offset(content: &str, offset: usize) -> usize {
-    content[..offset.min(content.len())]
-        .bytes()
-        .filter(|b| *b == b'\n')
-        .count()
-        + 1
 }
 
 fn line_start_offset(content: &str, line: usize) -> usize {

--- a/src/core/code_audit/global_env_guard.rs
+++ b/src/core/code_audit/global_env_guard.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
+use super::source_locations::line_of_offset;
 
 static ENV_MUTATION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"std::env::(?:set_var|remove_var)\s*\(\s*\"([A-Z_][A-Z0-9_]*)\""#)
@@ -109,14 +110,6 @@ fn is_canonical_env_guard_file(path: &str) -> bool {
         || normalized.contains("/support/")
         || normalized.ends_with("/test_helpers.rs")
         || normalized.ends_with("/test_support.rs")
-}
-
-fn line_of_offset(content: &str, offset: usize) -> usize {
-    content[..offset.min(content.len())]
-        .bytes()
-        .filter(|b| *b == b'\n')
-        .count()
-        + 1
 }
 
 #[cfg(test)]

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -49,6 +49,7 @@ mod rust_test_wiring;
 mod shadow_modules;
 mod shared_scaffolding;
 mod signatures;
+mod source_locations;
 mod structural;
 mod test_coverage;
 pub(crate) mod test_mapping;

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -10,6 +10,7 @@ use super::comment_blocks;
 use super::conventions::{AuditFinding, Language};
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
+use super::source_locations::line_of_offset;
 
 #[derive(Debug, Clone)]
 struct DerivedValue {
@@ -446,14 +447,6 @@ where
                 .unwrap_or_else(|| extra(name))
         })
         .to_string()
-}
-
-fn line_of_offset(content: &str, offset: usize) -> usize {
-    content[..offset.min(content.len())]
-        .bytes()
-        .filter(|b| *b == b'\n')
-        .count()
-        + 1
 }
 
 fn line_at_offset(content: &str, offset: usize) -> &str {

--- a/src/core/code_audit/source_locations.rs
+++ b/src/core/code_audit/source_locations.rs
@@ -1,0 +1,19 @@
+pub(super) fn line_of_offset(content: &str, offset: usize) -> usize {
+    content[..offset.min(content.len())]
+        .bytes()
+        .filter(|b| *b == b'\n')
+        .count()
+        + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_line_of_offset() {
+        assert_eq!(line_of_offset("one\ntwo\nthree", 0), 1);
+        assert_eq!(line_of_offset("one\ntwo\nthree", 4), 2);
+        assert_eq!(line_of_offset("one\ntwo\nthree", usize::MAX), 3);
+    }
+}


### PR DESCRIPTION
## Summary
- Move the repeated code-audit `line_of_offset` helper into a private `source_locations` module.
- Reuse it from dead guard, global env guard, and requested detector logic while preserving existing line-number behavior.

## Verification
- `cargo fmt --check`
- `cargo test code_audit::source_locations --lib`
- `cargo test code_audit --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-line-offset-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@trace-run-record-builder --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@trace-run-record-builder --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper extraction and ran local verification; Chris remains responsible for review and merge.