### PR TITLE
refactor: move output artifact handling into commands

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -353,6 +353,7 @@ pub mod issues;
 pub mod lint;
 pub mod logs;
 pub mod observe;
+pub mod output_artifact;
 pub mod project;
 pub mod refactor;
 pub mod release;

--- a/src/commands/output_artifact/mod.rs
+++ b/src/commands/output_artifact/mod.rs
@@ -1,0 +1,122 @@
+use serde_json::Value;
+
+use crate::cli_surface::{CommandOutputArtifactPolicy, Commands};
+
+use super::utils::response as output;
+use super::{review, trace, GlobalArgs};
+
+pub struct JsonCommandRun {
+    pub stdout_result: homeboy::core::Result<Value>,
+    pub exit_code: i32,
+    pub output_file_result: Option<homeboy::core::Result<Value>>,
+}
+
+pub fn run_json(
+    command: Commands,
+    global: &GlobalArgs,
+    policy: CommandOutputArtifactPolicy,
+) -> JsonCommandRun {
+    match (policy, command) {
+        (CommandOutputArtifactPolicy::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
+            let (stdout_result, exit_code, output_file_result) =
+                trace::run_json_with_output_artifact(args, global);
+
+            JsonCommandRun {
+                stdout_result,
+                exit_code,
+                output_file_result,
+            }
+        }
+        (_, command) => {
+            let (stdout_result, exit_code) = super::run_json(command, global);
+
+            JsonCommandRun {
+                stdout_result,
+                exit_code,
+                output_file_result: None,
+            }
+        }
+    }
+}
+
+pub fn write_to_file(run: &JsonCommandRun, policy: CommandOutputArtifactPolicy, path: &str) {
+    match policy {
+        CommandOutputArtifactPolicy::ReviewStableArtifact => {
+            if !review::write_artifact_to_file(&run.stdout_result, path, run.exit_code) {
+                output::write_json_to_file(&run.stdout_result, path, run.exit_code);
+            }
+        }
+        CommandOutputArtifactPolicy::TraceJsonSummaryArtifact => {
+            output::write_json_to_file(select_output_file_result(run, policy), path, run.exit_code);
+        }
+        CommandOutputArtifactPolicy::GenericEnvelope => {
+            output::write_json_to_file(&run.stdout_result, path, run.exit_code);
+        }
+    }
+}
+
+fn select_output_file_result(
+    run: &JsonCommandRun,
+    policy: CommandOutputArtifactPolicy,
+) -> &homeboy::core::Result<Value> {
+    match policy {
+        CommandOutputArtifactPolicy::TraceJsonSummaryArtifact => run
+            .output_file_result
+            .as_ref()
+            .unwrap_or(&run.stdout_result),
+        CommandOutputArtifactPolicy::ReviewStableArtifact
+        | CommandOutputArtifactPolicy::GenericEnvelope => &run.stdout_result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn run_with_output_file_result(
+        output_file_result: Option<homeboy::core::Result<Value>>,
+    ) -> JsonCommandRun {
+        JsonCommandRun {
+            stdout_result: Ok(json!({ "kind": "stdout" })),
+            exit_code: 0,
+            output_file_result,
+        }
+    }
+
+    #[test]
+    fn trace_output_file_prefers_summary_artifact_result() {
+        let run = run_with_output_file_result(Some(Ok(json!({ "kind": "summary" }))));
+
+        assert_eq!(
+            select_output_file_result(&run, CommandOutputArtifactPolicy::TraceJsonSummaryArtifact)
+                .as_ref()
+                .unwrap(),
+            &json!({ "kind": "summary" })
+        );
+    }
+
+    #[test]
+    fn trace_output_file_falls_back_to_stdout_result() {
+        let run = run_with_output_file_result(None);
+
+        assert_eq!(
+            select_output_file_result(&run, CommandOutputArtifactPolicy::TraceJsonSummaryArtifact)
+                .as_ref()
+                .unwrap(),
+            &json!({ "kind": "stdout" })
+        );
+    }
+
+    #[test]
+    fn generic_output_file_uses_stdout_result() {
+        let run = run_with_output_file_result(Some(Ok(json!({ "kind": "summary" }))));
+
+        assert_eq!(
+            select_output_file_result(&run, CommandOutputArtifactPolicy::GenericEnvelope)
+                .as_ref()
+                .unwrap(),
+            &json!({ "kind": "stdout" })
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,12 @@
 use clap::{ArgMatches, Command, CommandFactory, FromArgMatches};
 use std::path::Path;
 
-use homeboy::cli_surface::{
-    Cli, CommandOutputArtifactPolicy, CommandRawOutputMode, CommandResponseMode, Commands,
-};
+use homeboy::cli_surface::{Cli, CommandRawOutputMode, CommandResponseMode, Commands};
 use homeboy::commands::GlobalArgs;
 
 use homeboy::commands;
+use homeboy::commands::cli;
 use homeboy::commands::utils::{args, entity_suggest, resource_policy, response as output, tty};
-use homeboy::commands::{cli, review, trace};
 use homeboy::core::extension::load_all_extensions;
 
 struct ExtensionCliCommand {
@@ -296,49 +294,24 @@ fn main() -> std::process::ExitCode {
         }
     }
 
-    let (json_result, exit_code, output_json_result) = match (output_artifact_policy, cli.command) {
-        (CommandOutputArtifactPolicy::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
-            let (json_result, exit_code, output_json_result) =
-                trace::run_json_with_output_artifact(args, &global);
-            (json_result, exit_code, output_json_result)
-        }
-        (_, command) => {
-            let (json_result, exit_code) = commands::run_json(command, &global);
-            (json_result, exit_code, None)
-        }
-    };
+    let json_run =
+        commands::output_artifact::run_json(cli.command, &global, output_artifact_policy);
 
     // Write JSON to --output file if specified (before printing to stdout).
     if let Some(ref path) = output_file {
-        match output_artifact_policy {
-            CommandOutputArtifactPolicy::ReviewStableArtifact => {
-                if !review::write_artifact_to_file(&json_result, path, exit_code) {
-                    output::write_json_to_file(&json_result, path, exit_code);
-                }
-            }
-            CommandOutputArtifactPolicy::TraceJsonSummaryArtifact => {
-                output::write_json_to_file(
-                    output_json_result.as_ref().unwrap_or(&json_result),
-                    path,
-                    exit_code,
-                );
-            }
-            CommandOutputArtifactPolicy::GenericEnvelope => {
-                output::write_json_to_file(&json_result, path, exit_code);
-            }
-        }
+        commands::output_artifact::write_to_file(&json_run, output_artifact_policy, path);
     }
 
     match mode {
         CommandResponseMode::Json => {
-            output::print_json_result(json_result, exit_code).ok();
+            output::print_json_result(json_run.stdout_result, json_run.exit_code).ok();
         }
         CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough) => {}
         CommandResponseMode::Raw(CommandRawOutputMode::Markdown) => {}
         CommandResponseMode::Raw(CommandRawOutputMode::PlainText) => {}
     }
 
-    std::process::ExitCode::from(exit_code_to_u8(exit_code))
+    std::process::ExitCode::from(exit_code_to_u8(json_run.exit_code))
 }
 
 fn exit_code_to_u8(code: i32) -> u8 {


### PR DESCRIPTION
## Summary
- Move JSON execution/output-file artifact routing into `commands::output_artifact` so `main.rs` no longer knows about review/trace artifact exceptions.
- Preserve the existing command-owned `CommandOutputArtifactPolicy` behavior while making top-level orchestration more generic.
- Add unit coverage for trace summary artifact selection and generic output fallback behavior.

Refs #2249.

## Testing
- `cargo fmt --check`
- `cargo test commands::output_artifact --lib`
- `cargo test write_artifact_to_file --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-output-artifact-policy --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-output-artifact-policy.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-output-artifact-policy --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-output-artifact-policy --changed-since origin/main`

## Notes
- `homeboy test --changed-since origin/main` selected no impacted tests; targeted Rust tests cover the moved policy behavior.
- This is the first slice of #2249. The next slice can move raw markdown/plain-text routing out of `main.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused command-layer artifact routing refactor, added regression tests, and ran local verification; Chris remains responsible for review and merge.