### PR TITLE
refactor: move raw output routing into commands

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -355,6 +355,7 @@ pub mod logs;
 pub mod observe;
 pub mod output_artifact;
 pub mod project;
+pub mod raw_output;
 pub mod refactor;
 pub mod release;
 pub mod report;
@@ -374,46 +375,6 @@ pub mod undo;
 pub mod upgrade;
 pub mod utils;
 pub mod version;
-
-pub fn run_markdown(
-    command: crate::cli_surface::Commands,
-    global: &GlobalArgs,
-) -> homeboy::core::Result<(String, i32)> {
-    match command {
-        crate::cli_surface::Commands::Docs(args) => docs::run_markdown(args),
-        crate::cli_surface::Commands::Changelog(args) => changelog::run_markdown(args),
-        crate::cli_surface::Commands::Review(args) => review::run_markdown(args, global),
-        crate::cli_surface::Commands::Trace(args) => trace::run_markdown(args, global),
-        crate::cli_surface::Commands::Runs(args) => runs::run_markdown(args, global),
-        crate::cli_surface::Commands::Report(args) => report::run_markdown(args),
-        _ => Err(homeboy::core::Error::validation_invalid_argument(
-            "output_mode",
-            "Command does not support markdown output",
-            None,
-            None,
-        )),
-    }
-}
-
-pub fn run_plain_text(
-    command: crate::cli_surface::Commands,
-    global: &GlobalArgs,
-) -> homeboy::core::Result<(String, i32)> {
-    match command {
-        crate::cli_surface::Commands::File(args) => match file::run(args, global)? {
-            (file::FileCommandOutput::Raw(content), exit_code) => Ok((content, exit_code)),
-            _ => Err(homeboy::core::Error::internal_unexpected(
-                "Unexpected output type for raw mode",
-            )),
-        },
-        _ => Err(homeboy::core::Error::validation_invalid_argument(
-            "output_mode",
-            "Command does not support plain text output",
-            None,
-            None,
-        )),
-    }
-}
 
 /// Dispatch a command to its handler and map result to JSON.
 macro_rules! dispatch {

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -1,0 +1,78 @@
+use crate::cli_surface::{CommandRawOutputMode, Commands};
+
+use super::{changelog, docs, file, report, review, runs, trace, GlobalArgs};
+
+pub fn run(
+    command: Commands,
+    global: &GlobalArgs,
+    mode: CommandRawOutputMode,
+) -> Option<homeboy::core::Result<(String, i32)>> {
+    match mode {
+        CommandRawOutputMode::InteractivePassthrough => None,
+        CommandRawOutputMode::Markdown => Some(run_markdown(command, global)),
+        CommandRawOutputMode::PlainText => Some(run_plain_text(command, global)),
+    }
+}
+
+fn run_markdown(command: Commands, global: &GlobalArgs) -> homeboy::core::Result<(String, i32)> {
+    match command {
+        Commands::Docs(args) => docs::run_markdown(args),
+        Commands::Changelog(args) => changelog::run_markdown(args),
+        Commands::Review(args) => review::run_markdown(args, global),
+        Commands::Trace(args) => trace::run_markdown(args, global),
+        Commands::Runs(args) => runs::run_markdown(args, global),
+        Commands::Report(args) => report::run_markdown(args),
+        _ => Err(homeboy::core::Error::validation_invalid_argument(
+            "output_mode",
+            "Command does not support markdown output",
+            None,
+            None,
+        )),
+    }
+}
+
+fn run_plain_text(command: Commands, global: &GlobalArgs) -> homeboy::core::Result<(String, i32)> {
+    match command {
+        Commands::File(args) => match file::run(args, global)? {
+            (file::FileCommandOutput::Raw(content), exit_code) => Ok((content, exit_code)),
+            _ => Err(homeboy::core::Error::internal_unexpected(
+                "Unexpected output type for raw mode",
+            )),
+        },
+        _ => Err(homeboy::core::Error::validation_invalid_argument(
+            "output_mode",
+            "Command does not support plain text output",
+            None,
+            None,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interactive_passthrough_has_no_raw_text_result() {
+        let result = run(
+            Commands::List,
+            &GlobalArgs {},
+            CommandRawOutputMode::InteractivePassthrough,
+        );
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn unsupported_plain_text_command_returns_output_mode_error() {
+        let result = run(
+            Commands::List,
+            &GlobalArgs {},
+            CommandRawOutputMode::PlainText,
+        )
+        .expect("plain text mode should return a result")
+        .expect_err("list does not support plain text output");
+
+        assert!(result.to_string().contains("plain text output"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,23 +266,13 @@ fn main() -> std::process::ExitCode {
         }
     }
 
-    if let CommandResponseMode::Raw(CommandRawOutputMode::Markdown) = mode {
-        let markdown_result = commands::run_markdown(cli.command, &global);
-
-        match markdown_result {
-            Ok((content, exit_code)) => {
-                print!("{}", content);
-                return std::process::ExitCode::from(exit_code_to_u8(exit_code));
-            }
-            Err(err) => {
-                output::print_result::<serde_json::Value>(Err(err)).ok();
-                return std::process::ExitCode::from(exit_code_to_u8(1));
-            }
-        }
-    }
-
-    if let CommandResponseMode::Raw(CommandRawOutputMode::PlainText) = mode {
-        match commands::run_plain_text(cli.command, &global) {
+    if let CommandResponseMode::Raw(
+        raw_mode @ (CommandRawOutputMode::Markdown | CommandRawOutputMode::PlainText),
+    ) = mode
+    {
+        let raw_result = commands::raw_output::run(cli.command, &global, raw_mode)
+            .expect("markdown and plain-text modes should return raw output");
+        match raw_result {
             Ok((content, exit_code)) => {
                 print!("{}", content);
                 return std::process::ExitCode::from(exit_code_to_u8(exit_code));


### PR DESCRIPTION
## Summary
- Move markdown/plain-text command dispatch into `commands::raw_output` so `main.rs` no longer owns raw text routing tables.
- Keep interactive passthrough as the only raw mode that falls through to the existing JSON command execution path.
- Add unit coverage for raw output mode routing behavior.

Refs #2249.

## Testing
- `cargo fmt --check`
- `cargo test commands::raw_output --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-raw-output-routing --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-raw-output-routing.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-raw-output-routing --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-raw-output-routing --changed-since origin/main`

## Notes
- `homeboy test --changed-since origin/main` selected no impacted tests; targeted Rust tests cover the moved routing behavior.
- This is the second slice of #2249 after #2633. A later slice can tackle JSON dispatch metadata.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused command-layer raw output routing refactor, added routing tests, and ran local verification; Chris remains responsible for review and merge.