### PR TITLE
refactor: move json dispatch into commands

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -129,7 +129,7 @@ impl AnalysisJobRunner for CommandAnalysisJobRunner {
             )
         })?;
         let global = crate::commands::GlobalArgs {};
-        let (result, exit_code) = crate::commands::run_json(cli.command, &global);
+        let (result, exit_code) = crate::commands::json_output::run(cli.command, &global);
         Ok(AnalysisJobRunOutput {
             exit_code,
             output: result?,

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -1,0 +1,91 @@
+use serde_json::Value;
+
+use crate::cli_surface::Commands;
+
+use super::{
+    api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
+    deps, docs, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
+    refactor, release, report, review, rig, runner, runs, self_cmd, server, ssh, stack, status,
+    test, trace, triage, undo, upgrade, version, GlobalArgs,
+};
+
+/// Dispatch a command to its handler and map the structured result to JSON.
+pub fn run(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
+    crate::commands::utils::tty::status("homeboy is working...");
+
+    dispatch(command, global)
+}
+
+fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
+    match command {
+        Commands::Status(args) => map(status::run(args, global)),
+        Commands::Test(args) => map(test::run(args, global)),
+        Commands::Bench(args) => map(bench::run(args, global)),
+        Commands::Trace(args) => map(trace::run(args, global)),
+        Commands::Observe(args) => map(observe::run(args, global)),
+        Commands::Lint(args) => map(lint::run(args, global)),
+        Commands::Project(args) => map(project::run(args, global)),
+        Commands::Ssh(args) => map(ssh::run(args, global)),
+        Commands::Server(args) => map(server::run(args, global)),
+        Commands::Db(args) => map(db::run(args, global)),
+        Commands::Deps(args) => map(deps::run(args, global)),
+        Commands::Doctor(args) => map(doctor::run(args, global)),
+        Commands::File(args) => map(file::run(args, global)),
+        Commands::Fleet(args) => map(fleet::run(args, global)),
+        Commands::Logs(args) => map(logs::run(args, global)),
+        Commands::Triage(args) => map(triage::run(args, global)),
+        Commands::Deploy(args) => map(deploy::run(args, global)),
+        Commands::Component(args) => map(component::run(args, global)),
+        Commands::Config(args) => map(config::run(args, global)),
+        Commands::Daemon(args) => map(daemon::run(args, global)),
+        Commands::Extension(args) => map(extension::run(args, global)),
+        Commands::Docs(args) => map(docs::run(args, global)),
+        Commands::Changelog(args) => map(changelog::run(args, global)),
+        Commands::Git(args) => map(git::run(args, global)),
+        Commands::Issues(args) => map(issues::run(args, global)),
+        Commands::Version(args) => map(version::run(args, global)),
+        Commands::Build(args) => map(build::run(args, global)),
+        Commands::Changes(args) => map(changes::run(args, global)),
+        Commands::Release(args) => map(release::run(args, global)),
+        Commands::Report(args) => map(report::run(args, global)),
+        Commands::Review(args) => map(review::run(args, global)),
+        Commands::Audit(args) => map(audit::run(args, global)),
+        Commands::Refactor(args) => map(refactor::run(args, global)),
+        Commands::Rig(args) => map(rig::run(args, global)),
+        Commands::Runner(args) => map(runner::run(args, global)),
+        Commands::Runs(args) => map(runs::run(args, global)),
+        Commands::SelfCmd(args) => map(self_cmd::run(args, global)),
+        Commands::Stack(args) => map(stack::run(args, global)),
+        Commands::Undo(args) => map(undo::run(args, global)),
+        Commands::Auth(args) => map(auth::run(args, global)),
+        Commands::Api(args) => map(api::run(args, global)),
+        Commands::Http(args) => map(http::run(args, global)),
+        Commands::Upgrade(args) => map(upgrade::run(args, global)),
+        Commands::List => unsupported_raw_command("List command uses raw output mode"),
+    }
+}
+
+fn map<T: serde::Serialize>(result: super::CmdResult<T>) -> (homeboy::core::Result<Value>, i32) {
+    crate::commands::utils::response::map_cmd_result_to_json(result)
+}
+
+fn unsupported_raw_command(message: &'static str) -> (homeboy::core::Result<Value>, i32) {
+    let err = homeboy::core::Error::validation_invalid_argument("output_mode", message, None, None);
+    crate::commands::utils::response::map_cmd_result_to_json::<Value>(Err(err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_json_dispatch_reports_raw_output_mode() {
+        let (result, exit_code) = dispatch(Commands::List, &GlobalArgs {});
+
+        assert_ne!(exit_code, 0);
+        assert!(result
+            .expect_err("list should not dispatch as JSON")
+            .to_string()
+            .contains("raw output mode"));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -350,6 +350,7 @@ pub mod fleet;
 pub mod git;
 pub mod http;
 pub mod issues;
+pub mod json_output;
 pub mod lint;
 pub mod logs;
 pub mod observe;
@@ -375,78 +376,6 @@ pub mod undo;
 pub mod upgrade;
 pub mod utils;
 pub mod version;
-
-/// Dispatch a command to its handler and map result to JSON.
-macro_rules! dispatch {
-    ($args:expr, $global:expr, $extension:ident) => {
-        crate::commands::utils::response::map_cmd_result_to_json($extension::run($args, $global))
-    };
-}
-
-pub fn run_json(
-    command: crate::cli_surface::Commands,
-    global: &GlobalArgs,
-) -> (homeboy::core::Result<serde_json::Value>, i32) {
-    crate::commands::utils::tty::status("homeboy is working...");
-
-    match command {
-        // All commands use global context
-        crate::cli_surface::Commands::Status(args) => dispatch!(args, global, status),
-        crate::cli_surface::Commands::Test(args) => dispatch!(args, global, test),
-        crate::cli_surface::Commands::Bench(args) => dispatch!(args, global, bench),
-        crate::cli_surface::Commands::Trace(args) => dispatch!(args, global, trace),
-        crate::cli_surface::Commands::Observe(args) => dispatch!(args, global, observe),
-        crate::cli_surface::Commands::Lint(args) => dispatch!(args, global, lint),
-        crate::cli_surface::Commands::Project(args) => dispatch!(args, global, project),
-        crate::cli_surface::Commands::Ssh(args) => dispatch!(args, global, ssh),
-        crate::cli_surface::Commands::Server(args) => dispatch!(args, global, server),
-        crate::cli_surface::Commands::Db(args) => dispatch!(args, global, db),
-        crate::cli_surface::Commands::Deps(args) => dispatch!(args, global, deps),
-        crate::cli_surface::Commands::Doctor(args) => dispatch!(args, global, doctor),
-        crate::cli_surface::Commands::File(args) => dispatch!(args, global, file),
-        crate::cli_surface::Commands::Fleet(args) => dispatch!(args, global, fleet),
-        crate::cli_surface::Commands::Logs(args) => dispatch!(args, global, logs),
-        crate::cli_surface::Commands::Triage(args) => dispatch!(args, global, triage),
-        crate::cli_surface::Commands::Deploy(args) => dispatch!(args, global, deploy),
-        crate::cli_surface::Commands::Component(args) => dispatch!(args, global, component),
-        crate::cli_surface::Commands::Config(args) => dispatch!(args, global, config),
-        crate::cli_surface::Commands::Daemon(args) => dispatch!(args, global, daemon),
-        crate::cli_surface::Commands::Extension(args) => dispatch!(args, global, extension),
-        crate::cli_surface::Commands::Docs(args) => dispatch!(args, global, docs),
-        crate::cli_surface::Commands::Changelog(args) => dispatch!(args, global, changelog),
-        crate::cli_surface::Commands::Git(args) => dispatch!(args, global, git),
-        crate::cli_surface::Commands::Issues(args) => dispatch!(args, global, issues),
-        crate::cli_surface::Commands::Version(args) => dispatch!(args, global, version),
-        crate::cli_surface::Commands::Build(args) => dispatch!(args, global, build),
-        crate::cli_surface::Commands::Changes(args) => dispatch!(args, global, changes),
-        crate::cli_surface::Commands::Release(args) => dispatch!(args, global, release),
-        crate::cli_surface::Commands::Report(args) => dispatch!(args, global, report),
-        crate::cli_surface::Commands::Review(args) => dispatch!(args, global, review),
-        crate::cli_surface::Commands::Audit(args) => dispatch!(args, global, audit),
-        crate::cli_surface::Commands::Refactor(args) => dispatch!(args, global, refactor),
-        crate::cli_surface::Commands::Rig(args) => dispatch!(args, global, rig),
-        crate::cli_surface::Commands::Runner(args) => dispatch!(args, global, runner),
-        crate::cli_surface::Commands::Runs(args) => dispatch!(args, global, runs),
-        crate::cli_surface::Commands::SelfCmd(args) => dispatch!(args, global, self_cmd),
-        crate::cli_surface::Commands::Stack(args) => dispatch!(args, global, stack),
-        crate::cli_surface::Commands::Undo(args) => dispatch!(args, global, undo),
-        crate::cli_surface::Commands::Auth(args) => dispatch!(args, global, auth),
-        crate::cli_surface::Commands::Api(args) => dispatch!(args, global, api),
-        crate::cli_surface::Commands::Http(args) => dispatch!(args, global, http),
-        crate::cli_surface::Commands::Upgrade(args) => dispatch!(args, global, upgrade),
-
-        // Special case: List uses raw output mode
-        crate::cli_surface::Commands::List => {
-            let err = homeboy::core::Error::validation_invalid_argument(
-                "output_mode",
-                "List command uses raw output mode",
-                None,
-                None,
-            );
-            crate::commands::utils::response::map_cmd_result_to_json::<serde_json::Value>(Err(err))
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/commands/output_artifact/mod.rs
+++ b/src/commands/output_artifact/mod.rs
@@ -28,7 +28,7 @@ pub fn run_json(
             }
         }
         (_, command) => {
-            let (stdout_result, exit_code) = super::run_json(command, global);
+            let (stdout_result, exit_code) = super::json_output::run(command, global);
 
             JsonCommandRun {
                 stdout_result,


### PR DESCRIPTION
## Summary
- Move JSON command dispatch out of `commands::mod` into `commands::json_output`.
- Route output artifact and daemon JSON execution through the new command-layer router.
- Keep the existing raw-output rejection behavior for `homeboy list` in JSON mode.

## Testing
- `cargo fmt --check`
- `cargo test commands::json_output --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-json-dispatch-routing --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-json-dispatch-routing.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-json-dispatch-routing --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-json-dispatch-routing --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the command-router refactor, tests, and verification steps; Chris remains responsible for review and merge decisions.