### PR TITLE
fix(test): isolate runtime temp env

### DIFF
--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs;
 use std::path::Path;
 
 use super::permissions;
@@ -126,16 +127,20 @@ fn fetch_version_from_file(
         None => base_path::join_remote_path(Some(base_path), &component.remote_path).ok()?,
     };
     let remote_path = base_path::join_remote_child(None, &remote_dir, version_file).ok()?;
+    let pattern = component
+        .version_targets
+        .as_ref()
+        .and_then(|targets| targets.first())
+        .and_then(|t| t.pattern.as_deref());
+
+    if client.is_local {
+        let content = fs::read_to_string(&remote_path).ok()?;
+        return parse_component_version(&content, pattern, version_file);
+    }
 
     let output = client.execute(&format!("cat '{}' 2>/dev/null", remote_path));
 
     if output.success {
-        let pattern = component
-            .version_targets
-            .as_ref()
-            .and_then(|targets| targets.first())
-            .and_then(|t| t.pattern.as_deref());
-
         parse_component_version(&output.stdout, pattern, version_file)
     } else {
         None

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -52,28 +52,19 @@ fn unique_name(prefix: &str, suffix: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
+    use crate::test_support::home_env_guard;
 
     #[test]
     fn runtime_temp_dir_honors_override() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = home_env_guard();
         let dir = tempfile::tempdir().expect("tempdir");
-        unsafe {
-            env::set_var(HOMEBOY_RUNTIME_TMPDIR_ENV, dir.path());
-        }
+        env::set_var(HOMEBOY_RUNTIME_TMPDIR_ENV, dir.path());
 
         let path = runtime_temp_dir("homeboy-test-dir").expect("temp dir path");
         assert!(path.starts_with(dir.path()));
         assert!(path.is_dir());
 
-        unsafe {
-            env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
-        }
+        env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
     }
 
     #[test]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -6,6 +6,7 @@ pub(crate) struct HomeGuard {
     prior: Option<String>,
     prior_xdg_data_home: Option<String>,
     prior_artifact_root: Option<String>,
+    prior_runtime_tmpdir: Option<String>,
     prior_invocation_runtime: Option<String>,
     dir: TempDir,
     /// Held alongside `dir` so the short invocation runtime tempdir is
@@ -38,12 +39,14 @@ impl HomeGuard {
         let prior = std::env::var("HOME").ok();
         let prior_xdg_data_home = std::env::var("XDG_DATA_HOME").ok();
         let prior_artifact_root = std::env::var("HOMEBOY_ARTIFACT_ROOT").ok();
+        let prior_runtime_tmpdir = std::env::var("HOMEBOY_RUNTIME_TMPDIR").ok();
         let prior_invocation_runtime =
             std::env::var(crate::core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         let dir = TempDir::new().expect("home tempdir");
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
+        std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
         crate::core::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
         // and from the home tempdir (which itself can already live on a long
@@ -59,6 +62,7 @@ impl HomeGuard {
             prior,
             prior_xdg_data_home,
             prior_artifact_root,
+            prior_runtime_tmpdir,
             prior_invocation_runtime,
             dir,
             _inv_dir: Some(inv_dir),
@@ -99,6 +103,10 @@ impl Drop for HomeGuard {
         match &self.prior_artifact_root {
             Some(value) => std::env::set_var("HOMEBOY_ARTIFACT_ROOT", value),
             None => std::env::remove_var("HOMEBOY_ARTIFACT_ROOT"),
+        }
+        match &self.prior_runtime_tmpdir {
+            Some(value) => std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", value),
+            None => std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR"),
         }
         crate::core::set_artifact_root_override(None);
         match &self.prior_invocation_runtime {


### PR DESCRIPTION
## Summary
- Isolate `HOMEBOY_RUNTIME_TMPDIR` in the shared test home guard so env-sensitive tests do not leak runtime temp overrides across selected suites.
- Reuse the shared home/env guard in the runtime temp override test instead of a private lock.
- Read local deploy version files directly instead of shelling through `cat`, preserving remote behavior while avoiding local path/quoting sensitivity.

## Verification
- `cargo fmt --check`
- `cargo test core::deploy::version_overrides --lib`
- `cargo test core::engine::invocation::invocation_test::named_lease_conflicts_report_holder --lib`
- `cargo test core::engine::temp --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-test-env-isolation --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-test-env-isolation.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-test-env-isolation --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-test-env-isolation --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small test-isolation fix and ran local verification; Chris remains responsible for review and merge.