### PR TITLE
fix(test): pin version override fixture pattern

### DIFF
--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -450,7 +450,7 @@ mod tests {
             remote_path: remote_path.to_string(),
             version_targets: Some(vec![VersionTarget {
                 file: "fixture.php".to_string(),
-                pattern: None,
+                pattern: Some(r"Version:\s*(\d+\.\d+\.\d+)".to_string()),
             }]),
             ..Default::default()
         }


### PR DESCRIPTION
## Summary
- Give the deploy version override test fixture an explicit version regex instead of relying on extension-discovered defaults.
- Keeps the test stable when broader selected suites mutate or isolate extension discovery state.

## Verification
- `cargo fmt --check`
- `cargo test core::deploy::version_overrides --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-version-override-test-patterns --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-version-override-tests.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-version-override-test-patterns --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-version-override-test-patterns --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the selected-suite-only test dependency and drafted the fixture hardening; Chris remains responsible for review and merge.