### PR TITLE
refactor: move response policy into commands

### DIFF
--- a/src/commands/response.rs
+++ b/src/commands/response.rs
@@ -1,17 +1,12 @@
-use crate::cli_surface::{
-    CommandOutputArtifactPolicy, CommandRawOutputMode, CommandResponseMode, Commands,
-};
+use crate::cli_surface::{CommandRawOutputMode, CommandResponseMode, Commands};
 
 use super::utils::{response as output, tty};
 use super::GlobalArgs;
 
-pub fn run(
-    command: Commands,
-    global: &GlobalArgs,
-    mode: CommandResponseMode,
-    output_artifact_policy: CommandOutputArtifactPolicy,
-    output_file: Option<&str>,
-) -> i32 {
+pub fn run(command: Commands, global: &GlobalArgs, output_file: Option<&str>) -> i32 {
+    let mode = command.response_mode(output_file.is_some());
+    let output_artifact_policy = command.output_artifact_policy(output_file.is_some());
+
     match mode {
         CommandResponseMode::Json => {}
         CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,9 +227,6 @@ fn main() -> std::process::ExitCode {
         homeboy::core::extension::update_check::run_startup_check();
     }
 
-    let mode = cli.command.response_mode(output_file.is_some());
-    let output_artifact_policy = cli.command.output_artifact_policy(output_file.is_some());
-
     if matches!(cli.command, Commands::List) {
         let mut cmd = build_augmented_command(&extension_info);
         cmd.print_help().expect("Failed to print help");
@@ -249,13 +246,7 @@ fn main() -> std::process::ExitCode {
         }
     }
 
-    let exit_code = commands::response::run(
-        cli.command,
-        &global,
-        mode,
-        output_artifact_policy,
-        output_file.as_deref(),
-    );
+    let exit_code = commands::response::run(cli.command, &global, output_file.as_deref());
 
     std::process::ExitCode::from(exit_code_to_u8(exit_code))
 }


### PR DESCRIPTION
## Summary
- Move response mode and output artifact policy calculation into `commands::response::run`.
- Leave `main.rs` responsible for top-level CLI bootstrapping and special help handling, then delegate command response execution with only the command, globals, and optional output file.
- Shrinks the command response handoff without changing CLI output behavior.

## Verification
- `cargo fmt --check`
- `cargo test commands:: --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-command-response-policy --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-response-policy.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-command-response-policy --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-command-response-policy --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor slice and ran local verification; Chris remains responsible for review and merge.