### PR TITLE
refactor: share raw output errors

### DIFF
--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -22,12 +22,7 @@ fn run_markdown(command: Commands, global: &GlobalArgs) -> homeboy::core::Result
         Commands::Trace(args) => trace::run_markdown(args, global),
         Commands::Runs(args) => runs::run_markdown(args, global),
         Commands::Report(args) => report::run_markdown(args),
-        _ => Err(homeboy::core::Error::validation_invalid_argument(
-            "output_mode",
-            "Command does not support markdown output",
-            None,
-            None,
-        )),
+        _ => unsupported_output("markdown"),
     }
 }
 
@@ -39,13 +34,17 @@ fn run_plain_text(command: Commands, global: &GlobalArgs) -> homeboy::core::Resu
                 "Unexpected output type for raw mode",
             )),
         },
-        _ => Err(homeboy::core::Error::validation_invalid_argument(
-            "output_mode",
-            "Command does not support plain text output",
-            None,
-            None,
-        )),
+        _ => unsupported_output("plain text"),
     }
+}
+
+fn unsupported_output(mode: &str) -> homeboy::core::Result<(String, i32)> {
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "output_mode",
+        format!("Command does not support {mode} output"),
+        None,
+        None,
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Share unsupported raw-output error construction between markdown and plain-text dispatch.
- Keep the existing raw-output command routing and error wording unchanged while reducing duplicated policy code.

## Verification
- `cargo fmt --check`
- `cargo test commands::raw_output --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-raw-output-errors --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-raw-output-errors.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-raw-output-errors --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-raw-output-errors --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused raw-output refactor and ran local verification; Chris remains responsible for review and merge.