### PR TITLE
refactor: move raw execution into commands

### DIFF
--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -1,6 +1,36 @@
 use crate::cli_surface::{CommandRawOutputMode, Commands};
 
+use super::utils::{response as output, tty};
 use super::{changelog, docs, file, report, review, runs, trace, GlobalArgs};
+
+pub enum RawExecution {
+    Handled(i32),
+    Continue(Box<Commands>),
+}
+
+pub fn run_and_print(
+    command: Commands,
+    global: &GlobalArgs,
+    mode: CommandRawOutputMode,
+) -> RawExecution {
+    if let CommandRawOutputMode::InteractivePassthrough = mode {
+        return validate_interactive_tty(command);
+    };
+
+    let raw_result =
+        run(command, global, mode).expect("markdown and plain-text modes should return raw output");
+
+    RawExecution::Handled(match raw_result {
+        Ok((content, exit_code)) => {
+            print!("{}", content);
+            exit_code
+        }
+        Err(err) => {
+            output::print_result::<serde_json::Value>(Err(err)).ok();
+            1
+        }
+    })
+}
 
 pub fn run(
     command: Commands,
@@ -36,6 +66,21 @@ fn run_plain_text(command: Commands, global: &GlobalArgs) -> homeboy::core::Resu
         },
         _ => unsupported_output("plain text"),
     }
+}
+
+fn validate_interactive_tty(command: Commands) -> RawExecution {
+    if tty::require_tty_for_interactive() {
+        return RawExecution::Continue(Box::new(command));
+    }
+
+    let err = homeboy::core::Error::validation_invalid_argument(
+        "tty",
+        "This command requires an interactive TTY. For non-interactive usage, run: homeboy ssh <target> -- <command...>",
+        None,
+        None,
+    );
+    output::print_result::<serde_json::Value>(Err(err)).ok();
+    RawExecution::Handled(2)
 }
 
 fn unsupported_output(mode: &str) -> homeboy::core::Result<(String, i32)> {

--- a/src/commands/response.rs
+++ b/src/commands/response.rs
@@ -1,47 +1,20 @@
-use crate::cli_surface::{CommandRawOutputMode, CommandResponseMode, Commands};
+use crate::cli_surface::{CommandResponseMode, Commands};
 
-use super::utils::{response as output, tty};
+use super::utils::response as output;
 use super::GlobalArgs;
 
 pub fn run(command: Commands, global: &GlobalArgs, output_file: Option<&str>) -> i32 {
     let mode = command.response_mode(output_file.is_some());
     let output_artifact_policy = command.output_artifact_policy(output_file.is_some());
 
-    match mode {
-        CommandResponseMode::Json => {}
-        CommandResponseMode::Raw(CommandRawOutputMode::InteractivePassthrough) => {
-            if !tty::require_tty_for_interactive() {
-                let err = homeboy::core::Error::validation_invalid_argument(
-                    "tty",
-                    "This command requires an interactive TTY. For non-interactive usage, run: homeboy ssh <target> -- <command...>",
-                    None,
-                    None,
-                );
-                output::print_result::<serde_json::Value>(Err(err)).ok();
-                return 2;
-            }
+    let command = if let CommandResponseMode::Raw(raw_mode) = mode {
+        match super::raw_output::run_and_print(command, global, raw_mode) {
+            super::raw_output::RawExecution::Handled(exit_code) => return exit_code,
+            super::raw_output::RawExecution::Continue(command) => *command,
         }
-        CommandResponseMode::Raw(CommandRawOutputMode::Markdown) => {}
-        CommandResponseMode::Raw(CommandRawOutputMode::PlainText) => {}
-    }
-
-    if let CommandResponseMode::Raw(
-        raw_mode @ (CommandRawOutputMode::Markdown | CommandRawOutputMode::PlainText),
-    ) = mode
-    {
-        let raw_result = super::raw_output::run(command, global, raw_mode)
-            .expect("markdown and plain-text modes should return raw output");
-        match raw_result {
-            Ok((content, exit_code)) => {
-                print!("{}", content);
-                return exit_code;
-            }
-            Err(err) => {
-                output::print_result::<serde_json::Value>(Err(err)).ok();
-                return 1;
-            }
-        }
-    }
+    } else {
+        command
+    };
 
     let json_run = super::output_artifact::run_json(command, global, output_artifact_policy);
 


### PR DESCRIPTION
## Summary
- Move raw-mode TTY validation, raw content printing, and raw error printing from `commands::response` into `commands::raw_output`.
- Preserve interactive passthrough behavior by continuing to the existing JSON command runner after a successful TTY check.
- Keep JSON and output-artifact execution unchanged.

## Verification
- `cargo fmt --check`
- `cargo test commands::raw_output --lib`
- `cargo test commands::response --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-raw-output-execution --extension rust --changed-since origin/main --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-audit-raw-output-execution.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-raw-output-execution --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-raw-output-execution --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused raw-output execution refactor and ran local verification; Chris remains responsible for review and merge.