### PR TITLE
refactor: move output artifact execution into commands

### DIFF
--- a/src/commands/output_artifact/mod.rs
+++ b/src/commands/output_artifact/mod.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::cli_surface::{CommandOutputArtifactPolicy, Commands};
+use crate::cli_surface::{CommandOutputArtifactPolicy, CommandResponseMode, Commands};
 
 use super::utils::response as output;
 use super::{review, trace, GlobalArgs};
@@ -9,6 +9,26 @@ pub struct JsonCommandRun {
     pub stdout_result: homeboy::core::Result<Value>,
     pub exit_code: i32,
     pub output_file_result: Option<homeboy::core::Result<Value>>,
+}
+
+pub fn run_and_print(
+    command: Commands,
+    global: &GlobalArgs,
+    policy: CommandOutputArtifactPolicy,
+    output_file: Option<&str>,
+    mode: CommandResponseMode,
+) -> i32 {
+    let json_run = run_json(command, global, policy);
+
+    if let Some(path) = output_file {
+        write_to_file(&json_run, policy, path);
+    }
+
+    if let CommandResponseMode::Json = mode {
+        output::print_json_result(json_run.stdout_result, json_run.exit_code).ok();
+    }
+
+    json_run.exit_code
 }
 
 pub fn run_json(

--- a/src/commands/response.rs
+++ b/src/commands/response.rs
@@ -1,6 +1,5 @@
 use crate::cli_surface::{CommandResponseMode, Commands};
 
-use super::utils::response as output;
 use super::GlobalArgs;
 
 pub fn run(command: Commands, global: &GlobalArgs, output_file: Option<&str>) -> i32 {
@@ -16,15 +15,11 @@ pub fn run(command: Commands, global: &GlobalArgs, output_file: Option<&str>) ->
         command
     };
 
-    let json_run = super::output_artifact::run_json(command, global, output_artifact_policy);
-
-    if let Some(path) = output_file {
-        super::output_artifact::write_to_file(&json_run, output_artifact_policy, path);
-    }
-
-    if let CommandResponseMode::Json = mode {
-        output::print_json_result(json_run.stdout_result, json_run.exit_code).ok();
-    }
-
-    json_run.exit_code
+    super::output_artifact::run_and_print(
+        command,
+        global,
+        output_artifact_policy,
+        output_file,
+        mode,
+    )
 }


### PR DESCRIPTION
## Summary
- Move JSON execution, output-file writing, and JSON stdout printing into `output_artifact::run_and_print`.
- Leave `response.rs` as a small coordinator between raw execution and JSON/artifact execution.
- Preserve raw interactive passthrough behavior by printing JSON only when the original response mode is JSON.

## Verification
- `cargo fmt --check`
- `cargo test commands::output_artifact --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-output-artifact-execution --extension rust --changed-since origin/main --output /tmp/homeboy-output-artifact-execution-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-output-artifact-execution --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-output-artifact-execution --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small refactor, ran verification gates, and prepared this PR for Chris to review.