### PR TITLE
refactor: decouple artifact output from response mode

### DIFF
--- a/src/commands/output_artifact/mod.rs
+++ b/src/commands/output_artifact/mod.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::cli_surface::{CommandOutputArtifactPolicy, CommandResponseMode, Commands};
+use crate::cli_surface::{CommandOutputArtifactPolicy, Commands};
 
 use super::utils::response as output;
 use super::{review, trace, GlobalArgs};
@@ -16,7 +16,7 @@ pub fn run_and_print(
     global: &GlobalArgs,
     policy: CommandOutputArtifactPolicy,
     output_file: Option<&str>,
-    mode: CommandResponseMode,
+    print_json: bool,
 ) -> i32 {
     let json_run = run_json(command, global, policy);
 
@@ -24,7 +24,7 @@ pub fn run_and_print(
         write_to_file(&json_run, policy, path);
     }
 
-    if let CommandResponseMode::Json = mode {
+    if print_json {
         output::print_json_result(json_run.stdout_result, json_run.exit_code).ok();
     }
 

--- a/src/commands/response.rs
+++ b/src/commands/response.rs
@@ -20,6 +20,6 @@ pub fn run(command: Commands, global: &GlobalArgs, output_file: Option<&str>) ->
         global,
         output_artifact_policy,
         output_file,
-        mode,
+        matches!(mode, CommandResponseMode::Json),
     )
 }


### PR DESCRIPTION
## Summary
- Pass a `print_json` flag into `output_artifact::run_and_print` instead of the full `CommandResponseMode`.
- Keep `output_artifact` focused on artifact execution and JSON printing, without knowing about raw response variants.
- Preserve existing raw passthrough and JSON stdout behavior.

## Verification
- `cargo fmt --check`
- `cargo test commands::output_artifact --lib`
- `cargo test commands::json_output --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-json-run-wrapper --extension rust --changed-since origin/main --output /tmp/homeboy-json-run-wrapper-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-json-run-wrapper --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-json-run-wrapper --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small refactor, ran verification gates, and prepared this PR for Chris to review.