### PR TITLE
refactor: plan command response execution

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -159,7 +159,24 @@ pub enum CommandOutputArtifactPolicy {
     TraceJsonSummaryArtifact,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandResponsePlan {
+    pub mode: CommandResponseMode,
+    pub output_artifact_policy: CommandOutputArtifactPolicy,
+    pub print_json: bool,
+}
+
 impl Commands {
+    pub fn response_plan(&self, has_output_file: bool) -> CommandResponsePlan {
+        let mode = self.response_mode(has_output_file);
+
+        CommandResponsePlan {
+            mode,
+            output_artifact_policy: self.output_artifact_policy(has_output_file),
+            print_json: matches!(mode, CommandResponseMode::Json),
+        }
+    }
+
     pub fn supports_lab_runner(&self) -> bool {
         match self {
             Commands::Audit(_) => true,
@@ -353,6 +370,27 @@ mod tests {
         assert_eq!(
             Commands::List.response_mode(false),
             CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
+        );
+    }
+
+    #[test]
+    fn test_response_plan() {
+        assert_eq!(
+            parsed_command(&["homeboy", "status"]).response_plan(false),
+            CommandResponsePlan {
+                mode: CommandResponseMode::Json,
+                output_artifact_policy: CommandOutputArtifactPolicy::GenericEnvelope,
+                print_json: true,
+            }
+        );
+
+        assert_eq!(
+            parsed_command(&["homeboy", "review", "--report", "pr-comment"]).response_plan(false),
+            CommandResponsePlan {
+                mode: CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
+                output_artifact_policy: CommandOutputArtifactPolicy::ReviewStableArtifact,
+                print_json: false,
+            }
         );
     }
 

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -1,4 +1,4 @@
-use crate::cli_surface::{CommandRawOutputMode, Commands};
+use crate::cli_surface::{CommandRawOutputMode, CommandResponseMode, Commands};
 
 use super::utils::{response as output, tty};
 use super::{changelog, docs, file, report, review, runs, trace, GlobalArgs};
@@ -6,6 +6,25 @@ use super::{changelog, docs, file, report, review, runs, trace, GlobalArgs};
 pub enum RawExecution {
     Handled(i32),
     Continue(Box<Commands>),
+}
+
+pub enum JsonCommandPreparation {
+    Handled(i32),
+    Continue(Box<Commands>),
+}
+
+pub fn prepare_json_command(
+    command: Commands,
+    global: &GlobalArgs,
+    mode: CommandResponseMode,
+) -> JsonCommandPreparation {
+    match mode {
+        CommandResponseMode::Json => JsonCommandPreparation::Continue(Box::new(command)),
+        CommandResponseMode::Raw(raw_mode) => match run_and_print(command, global, raw_mode) {
+            RawExecution::Handled(exit_code) => JsonCommandPreparation::Handled(exit_code),
+            RawExecution::Continue(command) => JsonCommandPreparation::Continue(command),
+        },
+    }
 }
 
 pub fn run_and_print(

--- a/src/commands/response.rs
+++ b/src/commands/response.rs
@@ -1,25 +1,20 @@
-use crate::cli_surface::{CommandResponseMode, Commands};
+use crate::cli_surface::Commands;
 
 use super::GlobalArgs;
 
 pub fn run(command: Commands, global: &GlobalArgs, output_file: Option<&str>) -> i32 {
-    let mode = command.response_mode(output_file.is_some());
-    let output_artifact_policy = command.output_artifact_policy(output_file.is_some());
+    let plan = command.response_plan(output_file.is_some());
 
-    let command = if let CommandResponseMode::Raw(raw_mode) = mode {
-        match super::raw_output::run_and_print(command, global, raw_mode) {
-            super::raw_output::RawExecution::Handled(exit_code) => return exit_code,
-            super::raw_output::RawExecution::Continue(command) => *command,
-        }
-    } else {
-        command
+    let command = match super::raw_output::prepare_json_command(command, global, plan.mode) {
+        super::raw_output::JsonCommandPreparation::Handled(exit_code) => return exit_code,
+        super::raw_output::JsonCommandPreparation::Continue(command) => *command,
     };
 
     super::output_artifact::run_and_print(
         command,
         global,
-        output_artifact_policy,
+        plan.output_artifact_policy,
         output_file,
-        matches!(mode, CommandResponseMode::Json),
+        plan.print_json,
     )
 }


### PR DESCRIPTION
## Summary
- Add `CommandResponsePlan` so command-owned response mode, artifact policy, and JSON stdout behavior are calculated together.
- Move raw-mode preparation into `raw_output::prepare_json_command`, so `response.rs` no longer matches raw continuation details directly.
- Keep `response.rs` as a thinner coordinator from response plan to JSON/artifact execution.

## Verification
- `cargo fmt --check`
- `cargo test cli_surface::tests::test_response_mode --lib`
- `cargo test cli_surface::tests::test_response_plan --lib`
- `cargo test commands::raw_output --lib`
- `cargo test commands::output_artifact --lib`
- `cargo test commands::json_output --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-response-pipeline --extension rust --changed-since origin/main --output /tmp/homeboy-response-pipeline-audit.json`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-response-pipeline --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-response-pipeline --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the response planning refactor, ran verification gates, and prepared this PR for Chris to review.