### PR TITLE
Fix deploy verifier artifact template context

### DIFF
--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -106,6 +106,8 @@ pub(super) fn deploy_artifact(
     verification: Option<&DeployVerification>,
     remote_owner: Option<&str>,
 ) -> Result<DeployResult> {
+    let mut uploaded_artifact_path: Option<String> = None;
+
     // Step 1: Upload (directory or file)
     if local_path.is_dir() {
         let result = upload_directory(ssh_client, local_path, remote_path)?;
@@ -183,6 +185,7 @@ pub(super) fn deploy_artifact(
         if !result.success {
             return Ok(result);
         }
+        uploaded_artifact_path = Some(upload_path.clone());
 
         // Step 2: Execute extract command if configured
         if let Some(cmd_template) = extract_command {
@@ -265,6 +268,9 @@ pub(super) fn deploy_artifact(
             TemplateVars::TARGET_DIR.to_string(),
             remote_path.to_string(),
         );
+        if let Some(upload_path) = uploaded_artifact_path.as_ref() {
+            vars.insert("stagingArtifact".to_string(), upload_path.clone());
+        }
         let verify_cmd = render_map(verify_cmd_template, &vars);
 
         let verify_output = ssh_client.execute(&verify_cmd);
@@ -291,7 +297,23 @@ fn render_extract_command(template: &str, vars: &HashMap<String, String>) -> Str
 
 #[cfg(test)]
 mod tests {
-    use super::{render_extract_command, DANGEROUS_PATH_SUFFIXES};
+    use super::{deploy_artifact, render_extract_command, DANGEROUS_PATH_SUFFIXES};
+    use crate::core::extension::DeployVerification;
+    use crate::core::server::SshClient;
+    use std::collections::HashMap;
+    use std::fs;
+
+    fn local_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "test".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: HashMap::new(),
+        }
+    }
 
     #[test]
     fn test_deploy_artifact_extract_command_template_replaces_vars() {
@@ -310,5 +332,43 @@ mod tests {
     fn test_deploy_via_git_keeps_framework_safety_policy_external() {
         assert!(DANGEROUS_PATH_SUFFIXES.contains(&"/vendor"));
         assert!(!DANGEROUS_PATH_SUFFIXES.contains(&"/wp-content/plugins"));
+    }
+
+    #[test]
+    fn test_deploy_artifact_renders_staging_artifact_in_verification_error() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let artifact = temp.path().join("artifact.txt");
+        let target = temp.path().join("target");
+        fs::write(&artifact, "artifact bytes").expect("artifact");
+
+        let verification = DeployVerification {
+            path_pattern: "/target/".to_string(),
+            verify_command: Some("false".to_string()),
+            verify_error_message: Some(
+                "Deploy verification failed for {{targetDir}} against {{stagingArtifact}}"
+                    .to_string(),
+            ),
+        };
+
+        let result = deploy_artifact(
+            &local_client(),
+            &artifact,
+            target.to_str().expect("target path"),
+            None,
+            Some(&verification),
+            None,
+        )
+        .expect("deploy result");
+
+        let error = result.error.expect("verification error");
+        assert!(!result.success);
+        assert!(!error.contains("{{stagingArtifact}}"));
+        assert!(error.contains(target.to_str().expect("target path")));
+        assert!(error.contains(
+            target
+                .join("artifact.txt")
+                .to_str()
+                .expect("uploaded artifact path")
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Pass the uploaded artifact path into generic deploy verification templates as `{{stagingArtifact}}`.
- Add coverage so verification errors cannot leak an unresolved `{{stagingArtifact}}` placeholder.

Refs #2646.
Refs #2647.

## Testing
- `cargo test deploy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the deploy verification failure path, drafting the code/test changes, and running targeted verification. Chris remains responsible for review and merge.