### PR TITLE
refactor: split JSON output dispatch

### DIFF
--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -2,12 +2,21 @@ use serde_json::Value;
 
 use crate::cli_surface::Commands;
 
-use super::{
-    api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
-    deps, docs, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
-    refactor, release, report, review, rig, runner, runs, self_cmd, server, ssh, stack, status,
-    test, trace, triage, undo, upgrade, version, GlobalArgs,
-};
+use super::GlobalArgs;
+
+mod ops;
+mod quality;
+mod workspace;
+
+type JsonRun = (homeboy::core::Result<Value>, i32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JsonCommandFamily {
+    Quality,
+    Workspace,
+    Ops,
+    RawOnly,
+}
 
 /// Dispatch a command to its handler and map the structured result to JSON.
 pub fn run(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
@@ -17,59 +26,68 @@ pub fn run(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Val
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
-    match command {
-        Commands::Status(args) => map(status::run(args, global)),
-        Commands::Test(args) => map(test::run(args, global)),
-        Commands::Bench(args) => map(bench::run(args, global)),
-        Commands::Trace(args) => map(trace::run(args, global)),
-        Commands::Observe(args) => map(observe::run(args, global)),
-        Commands::Lint(args) => map(lint::run(args, global)),
-        Commands::Project(args) => map(project::run(args, global)),
-        Commands::Ssh(args) => map(ssh::run(args, global)),
-        Commands::Server(args) => map(server::run(args, global)),
-        Commands::Db(args) => map(db::run(args, global)),
-        Commands::Deps(args) => map(deps::run(args, global)),
-        Commands::Doctor(args) => map(doctor::run(args, global)),
-        Commands::File(args) => map(file::run(args, global)),
-        Commands::Fleet(args) => map(fleet::run(args, global)),
-        Commands::Logs(args) => map(logs::run(args, global)),
-        Commands::Triage(args) => map(triage::run(args, global)),
-        Commands::Deploy(args) => map(deploy::run(args, global)),
-        Commands::Component(args) => map(component::run(args, global)),
-        Commands::Config(args) => map(config::run(args, global)),
-        Commands::Daemon(args) => map(daemon::run(args, global)),
-        Commands::Extension(args) => map(extension::run(args, global)),
-        Commands::Docs(args) => map(docs::run(args, global)),
-        Commands::Changelog(args) => map(changelog::run(args, global)),
-        Commands::Git(args) => map(git::run(args, global)),
-        Commands::Issues(args) => map(issues::run(args, global)),
-        Commands::Version(args) => map(version::run(args, global)),
-        Commands::Build(args) => map(build::run(args, global)),
-        Commands::Changes(args) => map(changes::run(args, global)),
-        Commands::Release(args) => map(release::run(args, global)),
-        Commands::Report(args) => map(report::run(args, global)),
-        Commands::Review(args) => map(review::run(args, global)),
-        Commands::Audit(args) => map(audit::run(args, global)),
-        Commands::Refactor(args) => map(refactor::run(args, global)),
-        Commands::Rig(args) => map(rig::run(args, global)),
-        Commands::Runner(args) => map(runner::run(args, global)),
-        Commands::Runs(args) => map(runs::run(args, global)),
-        Commands::SelfCmd(args) => map(self_cmd::run(args, global)),
-        Commands::Stack(args) => map(stack::run(args, global)),
-        Commands::Undo(args) => map(undo::run(args, global)),
-        Commands::Auth(args) => map(auth::run(args, global)),
-        Commands::Api(args) => map(api::run(args, global)),
-        Commands::Http(args) => map(http::run(args, global)),
-        Commands::Upgrade(args) => map(upgrade::run(args, global)),
-        Commands::List => unsupported_raw_command("List command uses raw output mode"),
+    match family(&command) {
+        JsonCommandFamily::Quality => quality::dispatch(command, global),
+        JsonCommandFamily::Workspace => workspace::dispatch(command, global),
+        JsonCommandFamily::Ops => ops::dispatch(command, global),
+        JsonCommandFamily::RawOnly => unsupported_raw_command("List command uses raw output mode"),
     }
 }
 
-fn map<T: serde::Serialize>(result: super::CmdResult<T>) -> (homeboy::core::Result<Value>, i32) {
+fn family(command: &Commands) -> JsonCommandFamily {
+    match command {
+        Commands::Test(_)
+        | Commands::Bench(_)
+        | Commands::Trace(_)
+        | Commands::Observe(_)
+        | Commands::Lint(_)
+        | Commands::Review(_)
+        | Commands::Audit(_) => JsonCommandFamily::Quality,
+        Commands::Project(_)
+        | Commands::Component(_)
+        | Commands::Config(_)
+        | Commands::Extension(_)
+        | Commands::Docs(_)
+        | Commands::Changelog(_)
+        | Commands::Version(_)
+        | Commands::Build(_)
+        | Commands::Changes(_)
+        | Commands::Release(_)
+        | Commands::Report(_)
+        | Commands::Refactor(_)
+        | Commands::Rig(_)
+        | Commands::Runner(_)
+        | Commands::Runs(_)
+        | Commands::Stack(_)
+        | Commands::Undo(_) => JsonCommandFamily::Workspace,
+        Commands::Status(_)
+        | Commands::Ssh(_)
+        | Commands::Server(_)
+        | Commands::Db(_)
+        | Commands::Deps(_)
+        | Commands::Doctor(_)
+        | Commands::File(_)
+        | Commands::Fleet(_)
+        | Commands::Logs(_)
+        | Commands::Triage(_)
+        | Commands::Deploy(_)
+        | Commands::Daemon(_)
+        | Commands::Git(_)
+        | Commands::Issues(_)
+        | Commands::SelfCmd(_)
+        | Commands::Auth(_)
+        | Commands::Api(_)
+        | Commands::Http(_)
+        | Commands::Upgrade(_) => JsonCommandFamily::Ops,
+        Commands::List => JsonCommandFamily::RawOnly,
+    }
+}
+
+fn map<T: serde::Serialize>(result: super::CmdResult<T>) -> JsonRun {
     crate::commands::utils::response::map_cmd_result_to_json(result)
 }
 
-fn unsupported_raw_command(message: &'static str) -> (homeboy::core::Result<Value>, i32) {
+fn unsupported_raw_command(message: &'static str) -> JsonRun {
     let err = homeboy::core::Error::validation_invalid_argument("output_mode", message, None, None);
     crate::commands::utils::response::map_cmd_result_to_json::<Value>(Err(err))
 }

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -1,0 +1,32 @@
+use crate::cli_surface::Commands;
+
+use super::{map, JsonRun};
+use crate::commands::{
+    api, auth, daemon, db, deploy, deps, doctor, file, fleet, git, http, issues, logs, self_cmd,
+    server, ssh, status, triage, upgrade, GlobalArgs,
+};
+
+pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
+    match command {
+        Commands::Status(args) => map(status::run(args, global)),
+        Commands::Ssh(args) => map(ssh::run(args, global)),
+        Commands::Server(args) => map(server::run(args, global)),
+        Commands::Db(args) => map(db::run(args, global)),
+        Commands::Deps(args) => map(deps::run(args, global)),
+        Commands::Doctor(args) => map(doctor::run(args, global)),
+        Commands::File(args) => map(file::run(args, global)),
+        Commands::Fleet(args) => map(fleet::run(args, global)),
+        Commands::Logs(args) => map(logs::run(args, global)),
+        Commands::Triage(args) => map(triage::run(args, global)),
+        Commands::Deploy(args) => map(deploy::run(args, global)),
+        Commands::Daemon(args) => map(daemon::run(args, global)),
+        Commands::Git(args) => map(git::run(args, global)),
+        Commands::Issues(args) => map(issues::run(args, global)),
+        Commands::SelfCmd(args) => map(self_cmd::run(args, global)),
+        Commands::Auth(args) => map(auth::run(args, global)),
+        Commands::Api(args) => map(api::run(args, global)),
+        Commands::Http(args) => map(http::run(args, global)),
+        Commands::Upgrade(args) => map(upgrade::run(args, global)),
+        _ => unreachable!("command routed to wrong JSON output family"),
+    }
+}

--- a/src/commands/json_output/quality.rs
+++ b/src/commands/json_output/quality.rs
@@ -1,0 +1,17 @@
+use crate::cli_surface::Commands;
+
+use super::{map, JsonRun};
+use crate::commands::{audit, bench, lint, observe, review, test, trace, GlobalArgs};
+
+pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
+    match command {
+        Commands::Test(args) => map(test::run(args, global)),
+        Commands::Bench(args) => map(bench::run(args, global)),
+        Commands::Trace(args) => map(trace::run(args, global)),
+        Commands::Observe(args) => map(observe::run(args, global)),
+        Commands::Lint(args) => map(lint::run(args, global)),
+        Commands::Review(args) => map(review::run(args, global)),
+        Commands::Audit(args) => map(audit::run(args, global)),
+        _ => unreachable!("command routed to wrong JSON output family"),
+    }
+}

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -1,0 +1,30 @@
+use crate::cli_surface::Commands;
+
+use super::{map, JsonRun};
+use crate::commands::{
+    build, changelog, changes, component, config, docs, extension, project, refactor, release,
+    report, rig, runner, runs, stack, undo, version, GlobalArgs,
+};
+
+pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
+    match command {
+        Commands::Project(args) => map(project::run(args, global)),
+        Commands::Component(args) => map(component::run(args, global)),
+        Commands::Config(args) => map(config::run(args, global)),
+        Commands::Extension(args) => map(extension::run(args, global)),
+        Commands::Docs(args) => map(docs::run(args, global)),
+        Commands::Changelog(args) => map(changelog::run(args, global)),
+        Commands::Version(args) => map(version::run(args, global)),
+        Commands::Build(args) => map(build::run(args, global)),
+        Commands::Changes(args) => map(changes::run(args, global)),
+        Commands::Release(args) => map(release::run(args, global)),
+        Commands::Report(args) => map(report::run(args, global)),
+        Commands::Refactor(args) => map(refactor::run(args, global)),
+        Commands::Rig(args) => map(rig::run(args, global)),
+        Commands::Runner(args) => map(runner::run(args, global)),
+        Commands::Runs(args) => map(runs::run(args, global)),
+        Commands::Stack(args) => map(stack::run(args, global)),
+        Commands::Undo(args) => map(undo::run(args, global)),
+        _ => unreachable!("command routed to wrong JSON output family"),
+    }
+}


### PR DESCRIPTION
## Summary
- Split JSON output dispatch into quality, workspace, and ops command-family modules.
- Keep the top-level JSON output module focused on routing commands to families and preserving raw-only validation.
- Reduce the central command handler import/match surface while preserving existing command behavior.

## Verification
- `cargo fmt --check`
- `cargo test commands::json_output --lib`
- `cargo check --all-targets`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-split-json-output-dispatch --extension rust --changed-since origin/main --output /tmp/homeboy-split-json-output-dispatch-audit.json` (`introduced_findings: 0`)
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-split-json-output-dispatch --extension rust --changed-since origin/main`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@refactor-split-json-output-dispatch --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the command-family module split and ran local verification; Chris reviewed direction and requested the larger slice.