### PR TITLE
fix: let Homeboy own release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,8 +567,8 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host --tag=${{ needs.prepare.outputs.release-tag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
-          echo "artifacts uploaded and released successfully"
+          dist host --tag=${{ needs.prepare.outputs.release-tag }} --steps=upload --output-format=json > dist-manifest.json
+          echo "artifacts uploaded successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Stop running cargo-dist's `release` host step in Homeboy's release workflow.
- Keep cargo-dist responsible for uploading built artifacts, then let `homeboy release --head --from-artifacts` create/update the GitHub Release through the Homeboy pipeline.

## Verification
- `git diff --check`
- `homeboy release homeboy --dry-run --skip-checks`
- Confirmed `.github/workflows/release.yml` no longer contains `gh release create` or `--steps=release`.

Fixes #2581

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Issue triage, workflow patch drafting, and local verification. Chris remains responsible for review and merge.