### PR TITLE
feat: support explicit rename variants

### DIFF
--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -91,6 +91,9 @@ enum RefactorCommand {
         /// Exclude files matching this glob (repeatable)
         #[arg(long, value_name = "GLOB")]
         exclude: Vec<String>,
+        /// Add an explicit variant mapping as FROM=TO (repeatable)
+        #[arg(long = "variant", value_name = "FROM=TO")]
+        variants: Vec<String>,
         /// Disable file/directory path renames (content edits only)
         #[arg(long)]
         no_file_renames: bool,
@@ -275,6 +278,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             literal,
             files,
             exclude,
+            variants,
             no_file_renames,
             context,
             write_mode,
@@ -286,6 +290,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             literal,
             &files,
             &exclude,
+            &variants,
             no_file_renames,
             &context,
             write_mode.write,
@@ -775,6 +780,7 @@ fn run_rename(
     literal: bool,
     include_globs: &[String],
     exclude_globs: &[String],
+    variants: &[String],
     no_file_renames: bool,
     context: &str,
     write: bool,
@@ -790,6 +796,7 @@ fn run_rename(
             literal,
             include_globs,
             exclude_globs,
+            variants,
             no_file_renames,
             context,
             write,
@@ -807,6 +814,7 @@ fn run_rename_single(
     literal: bool,
     include_globs: &[String],
     exclude_globs: &[String],
+    variants: &[String],
     no_file_renames: bool,
     context: &str,
     write: bool,
@@ -816,11 +824,13 @@ fn run_rename_single(
 
     let root = refactor::move_items::resolve_root(component_id, path)?;
 
+    let explicit_variants = parse_rename_variants(variants)?;
     let mut spec = if literal {
         RenameSpec::literal(from, to, scope.clone())
     } else {
         RenameSpec::new(from, to, scope.clone())
-    };
+    }
+    .with_explicit_variants(explicit_variants);
     spec.rename_context = rename_context;
     let targeting = RenameTargeting {
         include_globs: include_globs.to_vec(),
@@ -919,6 +929,36 @@ fn run_rename_single(
         },
         exit_code,
     ))
+}
+
+fn parse_rename_variants(values: &[String]) -> homeboy::core::Result<Vec<(String, String)>> {
+    values
+        .iter()
+        .map(|value| {
+            let (from, to) = value.split_once('=').ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "variant",
+                    format!("Invalid rename variant '{}'. Expected FROM=TO", value),
+                    Some(value.clone()),
+                    None,
+                )
+            })?;
+            let from = from.trim();
+            let to = to.trim();
+            if from.is_empty() || to.is_empty() {
+                return Err(homeboy::core::Error::validation_invalid_argument(
+                    "variant",
+                    format!(
+                        "Invalid rename variant '{}'. FROM and TO must be non-empty",
+                        value
+                    ),
+                    Some(value.clone()),
+                    None,
+                ));
+            }
+            Ok((from.to_string(), to.to_string()))
+        })
+        .collect()
 }
 
 fn run_add(

--- a/src/core/engine/codebase_scan.rs
+++ b/src/core/engine/codebase_scan.rs
@@ -26,7 +26,7 @@ pub const ALWAYS_SKIP_DIRS: &[&str] = &[
 
 /// Directories to skip only at root level (build output).
 /// At deeper levels (e.g., `scripts/build/`) they may contain source files.
-pub const ROOT_ONLY_SKIP_DIRS: &[&str] = &["build", "dist", "target", "cache", "tmp"];
+pub const ROOT_ONLY_SKIP_DIRS: &[&str] = &["artifacts", "build", "dist", "target", "cache", "tmp"];
 
 /// Common source file extensions across languages.
 pub const SOURCE_EXTENSIONS: &[&str] = &[

--- a/src/core/refactor/rename/mod.rs
+++ b/src/core/refactor/rename/mod.rs
@@ -324,11 +324,7 @@ impl RenameSpec {
             });
         }
 
-        // Deduplicate — remove variants where from matches a previous one.
-        // Sort by from length descending first so longer matches take priority.
-        variants.sort_by(|a, b| b.from.len().cmp(&a.from.len()));
-        let mut seen = std::collections::HashSet::new();
-        variants.retain(|v| seen.insert(v.from.clone()));
+        deduplicate_variants(&mut variants);
 
         RenameSpec {
             from: from.to_string(),
@@ -358,6 +354,31 @@ impl RenameSpec {
             rename_context: RenameContext::All,
         }
     }
+
+    /// Add explicit caller-provided variant mappings.
+    ///
+    /// This keeps project/domain naming conventions out of core. Callers can map
+    /// any source spelling to any target spelling, such as acronym display names
+    /// or language-specific class prefixes, without teaching the rename engine
+    /// what those conventions mean.
+    pub fn with_explicit_variants(mut self, variants: Vec<(String, String)>) -> Self {
+        for (from, to) in variants {
+            self.variants.push(CaseVariant {
+                from,
+                to,
+                label: "explicit".to_string(),
+            });
+        }
+        deduplicate_variants(&mut self.variants);
+        self
+    }
+}
+
+fn deduplicate_variants(variants: &mut Vec<CaseVariant>) {
+    // Sort by from length descending first so longer matches take priority.
+    variants.sort_by(|a, b| b.from.len().cmp(&a.from.len()));
+    let mut seen = std::collections::HashSet::new();
+    variants.retain(|variant| seen.insert(variant.from.clone()));
 }
 
 /// A single reference found in the codebase.
@@ -2090,6 +2111,58 @@ mod tests {
             "Should rename plural kebab: {}",
             content
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn explicit_variants_handle_project_specific_acronyms() {
+        let dir = std::env::temp_dir().join("homeboy_explicit_variant_acronym_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(
+            dir.join("plugin.php"),
+            concat!(
+                "// Display: Old API Client\n",
+                "final class Old_API_Client {}\n"
+            ),
+        )
+        .unwrap();
+
+        let spec = RenameSpec::new("old-client", "new-client", RenameScope::All)
+            .with_explicit_variants(vec![
+                ("Old API Client".to_string(), "New API Client".to_string()),
+                ("Old_API_Client".to_string(), "New_API_Client".to_string()),
+            ]);
+
+        let result = generate_renames(&spec, &dir);
+        assert_eq!(result.edits.len(), 1);
+        let content = &result.edits[0].new_content;
+
+        assert!(content.contains("New API Client"), "{}", content);
+        assert!(content.contains("New_API_Client"), "{}", content);
+        assert!(!content.contains("Old API Client"), "{}", content);
+        assert!(!content.contains("Old_API_Client"), "{}", content);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn root_artifacts_directory_is_skipped_by_default() {
+        let dir = std::env::temp_dir().join("homeboy_refactor_artifacts_skip_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+
+        std::fs::write(dir.join("src/lib.rs"), "fn old_client() {}\n").unwrap();
+        std::fs::write(dir.join("artifacts/output.rs"), "fn old_client() {}\n").unwrap();
+
+        let spec = RenameSpec::new("old-client", "new-client", RenameScope::All);
+        let result = generate_renames(&spec, &dir);
+
+        assert_eq!(result.edits.len(), 1);
+        assert_eq!(result.edits[0].file, "src/lib.rs");
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary
- Add repeatable `homeboy refactor rename --variant FROM=TO` mappings for project-specific rename spellings.
- Keep acronym/display/class-prefix conventions out of Homeboy core by making callers provide explicit variant pairs.
- Skip root-level `artifacts/` during generic codebase scans so generated runtime output is not rewritten by default.

## Verification
- `cargo fmt`
- `cargo check --release`
- `cargo test --release refactor::rename::tests::explicit_variants_handle_project_specific_acronyms`
- `cargo test --release refactor::rename::tests::root_artifacts_directory_is_skipped_by_default`
- `git diff --check`

Fixes #2603

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigation, patch drafting, focused tests, and verification command execution. Chris remains responsible for review and merge.