### PR TITLE
Persist component local path updates

### DIFF
--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -129,6 +129,76 @@ mod tests {
     use super::*;
     use std::fs;
 
+    fn write_component_repo(home: &tempfile::TempDir, id: &str) -> std::path::PathBuf {
+        let repo = home.path().join(id);
+        fs::create_dir_all(&repo).expect("repo dir");
+        fs::write(
+            repo.join("homeboy.json"),
+            format!(r#"{{"id":"{}","remote_path":"wp-content/plugins/{}"}}"#, id, id),
+        )
+        .expect("homeboy.json");
+
+        let component = Component::new(
+            id.to_string(),
+            repo.to_string_lossy().to_string(),
+            format!("wp-content/plugins/{}", id),
+            None,
+        );
+        inventory::write_standalone_registration(&component)
+            .expect("write standalone registration");
+
+        repo
+    }
+
+    #[test]
+    fn test_set_changelog_target() {
+        crate::test_support::with_isolated_home(|home| {
+            let repo = write_component_repo(home, "demo-plugin");
+
+            set_changelog_target("demo-plugin", "docs/changelog.md")
+                .expect("set changelog target");
+
+            let config: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(repo.join("homeboy.json")).expect("read homeboy.json"),
+            )
+            .expect("parse homeboy.json");
+            assert_eq!(
+                config.get("changelog_target").and_then(|value| value.as_str()),
+                Some("docs/changelog.md")
+            );
+        });
+    }
+
+    #[test]
+    fn test_delete_safe() {
+        crate::test_support::with_isolated_home(|home| {
+            let repo = write_component_repo(home, "demo-plugin");
+
+            delete_safe("demo-plugin").expect("delete component config");
+
+            assert!(!repo.join("homeboy.json").exists());
+        });
+    }
+
+    #[test]
+    fn test_rename() {
+        crate::test_support::with_isolated_home(|home| {
+            let repo = write_component_repo(home, "demo-plugin");
+
+            let renamed = rename("demo-plugin", "renamed-plugin").expect("rename component");
+
+            assert_eq!(renamed.id, "renamed-plugin");
+            let config: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(repo.join("homeboy.json")).expect("read homeboy.json"),
+            )
+            .expect("parse homeboy.json");
+            assert_eq!(
+                config.get("id").and_then(|value| value.as_str()),
+                Some("renamed-plugin")
+            );
+        });
+    }
+
     #[test]
     fn merge_local_path_updates_standalone_registration() {
         crate::test_support::with_isolated_home(|home| {

--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -1,5 +1,5 @@
 use crate::core::component::{
-    associated_projects, mutate_portable, rename_component, resolve_effective, Component,
+    associated_projects, inventory, mutate_portable, rename_component, resolve_effective, Component,
 };
 use crate::core::config;
 use crate::core::error::{Error, Result};
@@ -52,6 +52,11 @@ pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Re
         map.remove("id");
     }
 
+    let updates_standalone_registration = patch
+        .as_object()
+        .map(|obj| obj.contains_key("local_path") || obj.contains_key("remote_path"))
+        .unwrap_or(false);
+
     let component = mutate_portable(id, |component| {
         let fields = config::merge_config(component, patch.clone(), replace_fields)?;
         if fields.updated_fields.is_empty() {
@@ -64,6 +69,10 @@ pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Re
         }
         Ok(())
     })?;
+
+    if updates_standalone_registration {
+        inventory::write_standalone_registration(&component)?;
+    }
 
     let updated_fields = match patch {
         Value::Object(obj) => obj.keys().cloned().collect(),
@@ -113,4 +122,62 @@ pub fn delete_safe(id: &str) -> Result<()> {
 
 pub fn rename(id: &str, new_id: &str) -> Result<Component> {
     rename_component(id, new_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn merge_local_path_updates_standalone_registration() {
+        crate::test_support::with_isolated_home(|home| {
+            let old_repo = home.path().join("agents-api");
+            let new_repo = home.path().join("agents-api-current");
+            fs::create_dir_all(&old_repo).expect("old repo dir");
+            fs::create_dir_all(&new_repo).expect("new repo dir");
+            fs::write(
+                old_repo.join("homeboy.json"),
+                r#"{"id":"agents-api","remote_path":"wp-content/plugins/agents-api"}"#,
+            )
+            .expect("old homeboy.json");
+            fs::write(
+                new_repo.join("homeboy.json"),
+                r#"{"id":"agents-api","remote_path":"wp-content/plugins/agents-api"}"#,
+            )
+            .expect("new homeboy.json");
+
+            let component = Component::new(
+                "agents-api".to_string(),
+                old_repo.to_string_lossy().to_string(),
+                "wp-content/plugins/agents-api".to_string(),
+                None,
+            );
+            inventory::write_standalone_registration(&component)
+                .expect("write initial standalone registration");
+
+            let patch = serde_json::json!({
+                "local_path": new_repo.to_string_lossy()
+            })
+            .to_string();
+            let result = merge(Some("agents-api"), &patch, &[]).expect("component merge");
+            let MergeOutput::Single(result) = result else {
+                panic!("expected single merge result");
+            };
+            assert_eq!(result.updated_fields, vec!["local_path".to_string()]);
+
+            let loaded = crate::core::component::load("agents-api").expect("load component");
+            assert_eq!(loaded.local_path, new_repo.to_string_lossy());
+
+            let registration_path = home.path().join(".config/homeboy/components/agents-api.json");
+            let registration: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(registration_path).expect("read registration"),
+            )
+            .expect("parse registration");
+            assert_eq!(
+                registration.get("local_path").and_then(|value| value.as_str()),
+                Some(new_repo.to_string_lossy().as_ref())
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Persist standalone component registration when `homeboy component set` changes machine-local fields like `local_path` or `remote_path`.
- Add a regression test proving `component set` updates the registry pointer instead of only reporting the field as updated.

## Verification
- `cargo test core::component::mutations::tests::merge_local_path_updates_standalone_registration`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the component-set persistence gap, drafted the fix and regression test, and ran targeted verification.