### PR TITLE
feat: add http egress probe

### DIFF
--- a/docs/architecture/trace-probes.md
+++ b/docs/architecture/trace-probes.md
@@ -29,6 +29,7 @@ Probes are declared on detailed `trace_workloads` entries:
           { "type": "file.watch", "path": "${components.app.path}/auth.json" },
           { "type": "port.snapshot", "port": 3000 },
           { "type": "http.poll", "url": "http://127.0.0.1:3000/health", "assert-status": 200 },
+          { "type": "http.egress", "host": "api.example.com", "capture": "body" },
           { "type": "cmd.run", "command": "kimaki", "args": ["send", "--thread", "123", "--prompt", "test"] }
         ]
       }
@@ -119,6 +120,27 @@ Events:
 - `http.error`: request failed.
 
 Data includes `url`, `status`, `latency_ms`, and `ok` when `assert-status` is configured.
+
+### `http.egress`
+
+Inputs:
+
+- `host`: destination host filter. Exact hosts, `*`, and `*.example.com` suffix patterns are supported.
+- `path`: optional path substring/glob-style filter.
+- `capture`: `summary`, `headers`, or `body`. Defaults to `summary`.
+- `max_body_bytes`: maximum inline request/response body bytes when `capture` is `body`. Defaults to `1048576`.
+- `redact_headers`: optional header names to redact. Defaults include `Authorization`, `Proxy-Authorization`, `x-api-key`, `Cookie`, and `Set-Cookie`.
+- `listen_port`: optional local proxy port. Defaults to an ephemeral port.
+
+Events:
+
+- `proxy.ready`: local proxy is listening; data includes `proxy_url` for `HTTP_PROXY` / `HTTPS_PROXY` injection.
+- `http.request`: proxied HTTP request matched the filters.
+- `http.response`: upstream HTTP response returned.
+- `http.connect`: HTTPS CONNECT tunnel matched the filters.
+- `http.error` / `proxy.error`: proxy or upstream failures.
+
+V1 is a portable local proxy. It captures HTTP bodies and forwards HTTPS CONNECT tunnels while recording metadata; it does not install a CA or decrypt TLS body content. Operators who need HTTPS body capture can still use the same probe envelope once a MITM/CA mechanism is added.
 
 ### `cmd.run`
 

--- a/docs/commands/observe.md
+++ b/docs/commands/observe.md
@@ -10,6 +10,7 @@ homeboy observe <component> --duration 5m --watch-process 'opencode-ai/bin/.*ser
 homeboy observe <component> --duration 5m --watch-process 'node .*serve' --watch-process-interval 1s
 homeboy observe <component> --duration 5m --tail-log /path/to/app.log --watch-process 'node .*serve'
 homeboy observe <component> --duration 30s --probe '{"type":"http.poll","url":"http://127.0.0.1:3000/health","assert-status":200}'
+homeboy observe <component> --duration 60s --probe '{"type":"http.egress","host":"api.example.com","capture":"body"}'
 ```
 
 ## V1 Scope
@@ -23,7 +24,9 @@ V1 supports:
 - `--grep <regex>` to filter tailed log lines
 - `--watch-process <regex>` for process command-line polling
 - `--watch-process-interval <duration>` for process polling cadence; defaults to `1s`
-- `--probe <json>` for repeatable portable trace probe configs (`log.tail`, `process.snapshot`, `file.watch`, `port.snapshot`, `http.poll`, and `cmd.run`)
+- `--probe <json>` for repeatable portable trace probe configs (`log.tail`, `process.snapshot`, `file.watch`, `port.snapshot`, `http.poll`, `http.egress`, and `cmd.run`)
+
+`http.egress` starts a local proxy and emits a `http.egress proxy.ready` event with `proxy_url`. Point a target process at that URL with `HTTP_PROXY` / `HTTPS_PROXY` to capture proxied traffic. V1 captures HTTP request/response bodies and HTTPS `CONNECT` metadata; it does not decrypt TLS tunnels.
 
 ## Output
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -79,6 +79,7 @@
         "structural::src/commands/refactor.rs::HighItemCount",
         "structural::src/commands/report.rs::HighItemCount",
         "structural::src/commands/runs.rs::GodFile",
+        "structural::src/commands/trace.rs::GodFile",
         "structural::src/core/code_audit/conventions.rs::GodFile",
         "structural::src/core/code_audit/core_fingerprint.rs::GodFile",
         "structural::src/core/code_audit/core_fingerprint.rs::HighItemCount",

--- a/src/commands/trace/probes.rs
+++ b/src/commands/trace/probes.rs
@@ -80,6 +80,23 @@ fn expand_trace_probe(
             interval_ms: *interval_ms,
             assert_status: *assert_status,
         },
+        extension_trace::TraceProbeConfig::HttpEgress {
+            host,
+            path,
+            capture,
+            max_body_bytes,
+            redact_headers,
+            listen_port,
+        } => extension_trace::TraceProbeConfig::HttpEgress {
+            host: expand_trace_probe_value(context, host),
+            path: path
+                .as_ref()
+                .map(|path| expand_trace_probe_value(context, path)),
+            capture: capture.clone(),
+            max_body_bytes: *max_body_bytes,
+            redact_headers: redact_headers.clone(),
+            listen_port: *listen_port,
+        },
         extension_trace::TraceProbeConfig::CmdRun { command, args } => {
             extension_trace::TraceProbeConfig::CmdRun {
                 command: expand_trace_probe_value(context, command),

--- a/src/core/extension/trace/probes.rs
+++ b/src/core/extension/trace/probes.rs
@@ -17,11 +17,13 @@ use super::parsing::TraceEvent;
 
 mod cmd_run;
 mod file_watch;
+mod http_egress;
 mod http_poll;
 mod port_snapshot;
 
 use cmd_run::run_cmd_run;
 use file_watch::{file_state, run_file_watch, FileState};
+use http_egress::{default_redact_headers, run_http_egress, HttpEgressConfig};
 use http_poll::run_http_poll;
 use port_snapshot::{ports_for_snapshot, run_port_snapshot};
 
@@ -81,6 +83,20 @@ pub enum TraceProbeConfig {
         )]
         assert_status: Option<u16>,
     },
+    #[serde(rename = "http.egress")]
+    HttpEgress {
+        host: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+        #[serde(default = "default_http_egress_capture")]
+        capture: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_body_bytes: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        redact_headers: Option<Vec<String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        listen_port: Option<u16>,
+    },
     #[serde(rename = "cmd.run")]
     CmdRun {
         command: String,
@@ -121,6 +137,7 @@ enum RunningTraceProbeConfig {
         interval_ms: Option<u64>,
         assert_status: Option<u16>,
     },
+    HttpEgress(HttpEgressConfig),
     CmdRun {
         command: String,
         args: Vec<String>,
@@ -212,6 +229,23 @@ fn running_probe_config(config: &TraceProbeConfig) -> RunningTraceProbeConfig {
             interval_ms: *interval_ms,
             assert_status: *assert_status,
         },
+        TraceProbeConfig::HttpEgress {
+            host,
+            path,
+            capture,
+            max_body_bytes,
+            redact_headers,
+            listen_port,
+        } => RunningTraceProbeConfig::HttpEgress(HttpEgressConfig {
+            host: host.clone(),
+            path: path.clone(),
+            capture: capture.clone(),
+            max_body_bytes: max_body_bytes.unwrap_or(1024 * 1024),
+            redact_headers: redact_headers
+                .clone()
+                .unwrap_or_else(default_redact_headers),
+            listen_port: *listen_port,
+        }),
         TraceProbeConfig::CmdRun { command, args } => RunningTraceProbeConfig::CmdRun {
             command: command.clone(),
             args: args.clone(),
@@ -271,6 +305,28 @@ fn validate_probe(config: &TraceProbeConfig) -> Result<()> {
                     None,
                 )
             })?;
+        }
+        TraceProbeConfig::HttpEgress { host, capture, .. } => {
+            if host.trim().is_empty() {
+                return Err(Error::validation_invalid_argument(
+                    "trace_probes.host",
+                    "http.egress host cannot be empty".to_string(),
+                    None,
+                    None,
+                ));
+            }
+            if !matches!(capture.as_str(), "summary" | "headers" | "body") {
+                return Err(Error::validation_invalid_argument(
+                    "trace_probes.capture",
+                    "http.egress capture must be summary, headers, or body".to_string(),
+                    None,
+                    Some(vec![
+                        "summary".to_string(),
+                        "headers".to_string(),
+                        "body".to_string(),
+                    ]),
+                ));
+            }
         }
         TraceProbeConfig::CmdRun { command, .. } => {
             if command.trim().is_empty() {
@@ -347,10 +403,17 @@ fn run_probe(
             events,
             stop,
         ),
+        RunningTraceProbeConfig::HttpEgress(config) => {
+            run_http_egress(config, started_at, events, stop)
+        }
         RunningTraceProbeConfig::CmdRun { command, args } => {
             run_cmd_run(command, args, started_at, events, stop)
         }
     }
+}
+
+fn default_http_egress_capture() -> String {
+    "summary".to_string()
 }
 
 fn run_log_tail(

--- a/src/core/extension/trace/probes/http_egress.rs
+++ b/src/core/extension/trace/probes/http_egress.rs
@@ -512,6 +512,7 @@ fn respond_bad_gateway(mut stream: TcpStream, message: &str) {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use super::super::{ActiveTraceProbes, TraceProbeConfig};
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -519,7 +520,16 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn http_egress_proxy_captures_http_request_and_response_bodies() {
+    fn test_default_redact_headers() {
+        let headers = default_redact_headers();
+
+        assert!(headers.contains(&"authorization".to_string()));
+        assert!(headers.contains(&"cookie".to_string()));
+        assert!(headers.contains(&"set-cookie".to_string()));
+    }
+
+    #[test]
+    fn test_run_http_egress() {
         let upstream = TcpListener::bind(("127.0.0.1", 0)).expect("bind upstream");
         let upstream_addr = upstream.local_addr().expect("upstream addr");
         let server = thread::spawn(move || {

--- a/src/core/extension/trace/probes/http_egress.rs
+++ b/src/core/extension/trace/probes/http_egress.rs
@@ -1,0 +1,585 @@
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::{event, push_event, TraceEvent};
+
+const DEFAULT_REDACT_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "x-api-key",
+    "cookie",
+    "set-cookie",
+];
+
+#[derive(Debug, Clone)]
+pub(super) struct HttpEgressConfig {
+    pub host: String,
+    pub path: Option<String>,
+    pub capture: String,
+    pub max_body_bytes: usize,
+    pub redact_headers: Vec<String>,
+    pub listen_port: Option<u16>,
+}
+
+pub(super) fn default_redact_headers() -> Vec<String> {
+    DEFAULT_REDACT_HEADERS
+        .iter()
+        .map(|header| header.to_string())
+        .collect()
+}
+
+pub(super) fn run_http_egress(
+    config: HttpEgressConfig,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+    stop: mpsc::Receiver<()>,
+) {
+    let listener = match TcpListener::bind(("127.0.0.1", config.listen_port.unwrap_or(0))) {
+        Ok(listener) => listener,
+        Err(error) => {
+            let mut data = BTreeMap::new();
+            data.insert("error".to_string(), serde_json::json!(error.to_string()));
+            push_event(
+                &events,
+                event(started_at, "http.egress", "proxy.error", data),
+            );
+            return;
+        }
+    };
+    let _ = listener.set_nonblocking(true);
+    let proxy_url = format!("http://{}", listener.local_addr().unwrap());
+    push_event(
+        &events,
+        event(
+            started_at,
+            "http.egress",
+            "proxy.ready",
+            BTreeMap::from([
+                ("proxy_url".to_string(), serde_json::json!(proxy_url)),
+                ("host".to_string(), serde_json::json!(config.host.clone())),
+                (
+                    "capture".to_string(),
+                    serde_json::json!(config.capture.clone()),
+                ),
+            ]),
+        ),
+    );
+
+    let mut handles = Vec::new();
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let config = config.clone();
+                let events = Arc::clone(&events);
+                handles.push(thread::spawn(move || {
+                    handle_proxy_connection(stream, config, started_at, events)
+                }));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) => {
+                let mut data = BTreeMap::new();
+                data.insert("error".to_string(), serde_json::json!(error.to_string()));
+                push_event(
+                    &events,
+                    event(started_at, "http.egress", "proxy.error", data),
+                );
+            }
+        }
+
+        if stop.recv_timeout(Duration::from_millis(25)).is_ok() {
+            break;
+        }
+    }
+
+    for handle in handles {
+        let _ = handle.join();
+    }
+}
+
+fn handle_proxy_connection(
+    mut client: TcpStream,
+    config: HttpEgressConfig,
+    started_at: Instant,
+    events: Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    let _ = client.set_read_timeout(Some(Duration::from_secs(5)));
+    let request_started = Instant::now();
+    let Ok(request) = read_http_message(&mut client) else {
+        return;
+    };
+    if request.method.eq_ignore_ascii_case("CONNECT") {
+        handle_connect_tunnel(client, request, &config, started_at, &events);
+        return;
+    }
+    if !matches_filter(&request.host, &request.path, &config) {
+        respond_bad_gateway(client, "request did not match http.egress filter");
+        return;
+    }
+
+    push_event(
+        &events,
+        event(
+            started_at,
+            "http.egress",
+            "http.request",
+            request_event_data(&request, &config),
+        ),
+    );
+
+    let target_addr = format!("{}:{}", request.host, request.port.unwrap_or(80));
+    let mut upstream = match TcpStream::connect(&target_addr) {
+        Ok(upstream) => upstream,
+        Err(error) => {
+            push_http_error(&events, started_at, &request, error.to_string());
+            respond_bad_gateway(client, "upstream connection failed");
+            return;
+        }
+    };
+    let outbound = request.to_origin_form_bytes();
+    if upstream.write_all(&outbound).is_err() {
+        push_http_error(
+            &events,
+            started_at,
+            &request,
+            "failed to write upstream request",
+        );
+        return;
+    }
+    let response = match read_http_message(&mut upstream) {
+        Ok(response) => response,
+        Err(error) => {
+            push_http_error(&events, started_at, &request, error.to_string());
+            return;
+        }
+    };
+    let _ = client.write_all(&response.raw);
+    let mut data = response_event_data(&response, &config);
+    data.insert(
+        "latency_ms".to_string(),
+        serde_json::json!(request_started.elapsed().as_millis() as u64),
+    );
+    data.insert("url".to_string(), serde_json::json!(request.url()));
+    push_event(
+        &events,
+        event(started_at, "http.egress", "http.response", data),
+    );
+}
+
+fn handle_connect_tunnel(
+    mut client: TcpStream,
+    request: HttpMessage,
+    config: &HttpEgressConfig,
+    started_at: Instant,
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+) {
+    if !matches_host(&request.host, &config.host) {
+        respond_bad_gateway(client, "CONNECT host did not match http.egress filter");
+        return;
+    }
+    push_event(
+        events,
+        event(
+            started_at,
+            "http.egress",
+            "http.connect",
+            BTreeMap::from([
+                ("host".to_string(), serde_json::json!(request.host.clone())),
+                (
+                    "port".to_string(),
+                    serde_json::json!(request.port.unwrap_or(443)),
+                ),
+                (
+                    "capture".to_string(),
+                    serde_json::json!("metadata-only: TLS tunnel not decrypted"),
+                ),
+            ]),
+        ),
+    );
+    let target_addr = format!("{}:{}", request.host, request.port.unwrap_or(443));
+    let Ok(mut upstream) = TcpStream::connect(target_addr) else {
+        respond_bad_gateway(client, "CONNECT upstream failed");
+        return;
+    };
+    let _ = client.set_read_timeout(Some(Duration::from_millis(500)));
+    let _ = upstream.set_read_timeout(Some(Duration::from_millis(500)));
+    if client
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .is_err()
+    {
+        return;
+    }
+    let Ok(mut client_to_upstream) = client.try_clone() else {
+        return;
+    };
+    let Ok(mut upstream_to_client) = upstream.try_clone() else {
+        return;
+    };
+    let a = thread::spawn(move || {
+        let _ = std::io::copy(&mut client_to_upstream, &mut upstream);
+        let _ = upstream.shutdown(Shutdown::Write);
+    });
+    let b = thread::spawn(move || {
+        let _ = std::io::copy(&mut upstream_to_client, &mut client);
+        let _ = client.shutdown(Shutdown::Write);
+    });
+    let _ = a.join();
+    let _ = b.join();
+}
+
+#[derive(Debug)]
+struct HttpMessage {
+    method: String,
+    target: String,
+    version: String,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+    raw: Vec<u8>,
+    host: String,
+    port: Option<u16>,
+    path: String,
+}
+
+impl HttpMessage {
+    fn url(&self) -> String {
+        if self.target.starts_with("http://") || self.target.starts_with("https://") {
+            return self.target.clone();
+        }
+        format!("http://{}{}", self.host, self.path)
+    }
+
+    fn to_origin_form_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(
+            format!("{} {} {}\r\n", self.method, self.path, self.version).as_bytes(),
+        );
+        for (name, value) in &self.headers {
+            if name.eq_ignore_ascii_case("proxy-connection") {
+                continue;
+            }
+            out.extend_from_slice(format!("{}: {}\r\n", name, value).as_bytes());
+        }
+        out.extend_from_slice(b"\r\n");
+        out.extend_from_slice(&self.body);
+        out
+    }
+}
+
+fn read_http_message(stream: &mut TcpStream) -> std::io::Result<HttpMessage> {
+    let mut buffer = Vec::new();
+    let header_end;
+    loop {
+        let mut chunk = [0; 1024];
+        let n = stream.read(&mut chunk)?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection closed before headers",
+            ));
+        }
+        buffer.extend_from_slice(&chunk[..n]);
+        if let Some(index) = find_header_end(&buffer) {
+            header_end = index;
+            break;
+        }
+    }
+    let header_bytes = &buffer[..header_end];
+    let header_text = String::from_utf8_lossy(header_bytes);
+    let mut lines = header_text.split("\r\n");
+    let start_line = lines.next().unwrap_or_default();
+    let mut start = start_line.split_whitespace();
+    let method = start.next().unwrap_or_default().to_string();
+    let target = start.next().unwrap_or_default().to_string();
+    let version = start.next().unwrap_or("HTTP/1.1").to_string();
+    let headers = lines
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim().to_string(), value.trim().to_string()))
+        })
+        .collect::<Vec<_>>();
+    let content_length = header_value(&headers, "content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    let mut body = buffer[header_end + 4..].to_vec();
+    while body.len() < content_length {
+        let mut chunk = vec![0; content_length - body.len()];
+        let n = stream.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        body.extend_from_slice(&chunk[..n]);
+    }
+    let (host, port, path) =
+        parse_target(&target, &headers, method.eq_ignore_ascii_case("CONNECT"));
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&buffer[..header_end + 4]);
+    raw.extend_from_slice(&body);
+    Ok(HttpMessage {
+        method,
+        target,
+        version,
+        headers,
+        body,
+        raw,
+        host,
+        port,
+        path,
+    })
+}
+
+fn parse_target(
+    target: &str,
+    headers: &[(String, String)],
+    is_connect: bool,
+) -> (String, Option<u16>, String) {
+    if is_connect {
+        let (host, port) = split_host_port(target, 443);
+        return (host, Some(port), String::new());
+    }
+    if let Some(rest) = target.strip_prefix("http://") {
+        let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+        let (host, port) = split_host_port(authority, 80);
+        return (host, Some(port), format!("/{}", path));
+    }
+    let authority = header_value(headers, "host").unwrap_or_default();
+    let (host, port) = split_host_port(&authority, 80);
+    (host, Some(port), target.to_string())
+}
+
+fn split_host_port(authority: &str, default_port: u16) -> (String, u16) {
+    let authority = authority.trim();
+    if let Some((host, port)) = authority.rsplit_once(':') {
+        if let Ok(port) = port.parse::<u16>() {
+            return (host.to_string(), port);
+        }
+    }
+    (authority.to_string(), default_port)
+}
+
+fn header_value(headers: &[(String, String)], name: &str) -> Option<String> {
+    headers
+        .iter()
+        .find(|(header, _)| header.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.clone())
+}
+
+fn find_header_end(buffer: &[u8]) -> Option<usize> {
+    buffer.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn matches_filter(host: &str, path: &str, config: &HttpEgressConfig) -> bool {
+    matches_host(host, &config.host)
+        && config
+            .path
+            .as_ref()
+            .map(|pattern| path.contains(pattern.trim_matches('*')))
+            .unwrap_or(true)
+}
+
+fn matches_host(host: &str, pattern: &str) -> bool {
+    if pattern == "*" || pattern == host {
+        return true;
+    }
+    pattern
+        .strip_prefix("*.")
+        .map(|suffix| host.ends_with(suffix))
+        .unwrap_or(false)
+}
+
+fn request_event_data(
+    message: &HttpMessage,
+    config: &HttpEgressConfig,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut data = BTreeMap::from([
+        ("method".to_string(), serde_json::json!(message.method)),
+        ("url".to_string(), serde_json::json!(message.url())),
+        ("host".to_string(), serde_json::json!(message.host)),
+        ("path".to_string(), serde_json::json!(message.path)),
+        (
+            "body_bytes".to_string(),
+            serde_json::json!(message.body.len()),
+        ),
+    ]);
+    add_capture_data(&mut data, message, config, true);
+    data
+}
+
+fn response_event_data(
+    message: &HttpMessage,
+    config: &HttpEgressConfig,
+) -> BTreeMap<String, serde_json::Value> {
+    let status = message.target.parse::<u16>().ok();
+    let mut data = BTreeMap::from([
+        ("status".to_string(), serde_json::json!(status)),
+        (
+            "body_bytes".to_string(),
+            serde_json::json!(message.body.len()),
+        ),
+    ]);
+    add_capture_data(&mut data, message, config, false);
+    data
+}
+
+fn add_capture_data(
+    data: &mut BTreeMap<String, serde_json::Value>,
+    message: &HttpMessage,
+    config: &HttpEgressConfig,
+    request: bool,
+) {
+    if matches!(config.capture.as_str(), "headers" | "body") {
+        let redacted = config
+            .redact_headers
+            .iter()
+            .map(|header| header.to_ascii_lowercase())
+            .collect::<Vec<_>>();
+        data.insert(
+            "headers".to_string(),
+            serde_json::Value::Object(
+                message
+                    .headers
+                    .iter()
+                    .map(|(name, value)| {
+                        let value = if redacted
+                            .iter()
+                            .any(|header| header == &name.to_ascii_lowercase())
+                        {
+                            serde_json::json!("<redacted>")
+                        } else {
+                            serde_json::json!(value)
+                        };
+                        (name.clone(), value)
+                    })
+                    .collect(),
+            ),
+        );
+    }
+    if config.capture == "body" {
+        let body = truncate_body(&message.body, config.max_body_bytes);
+        data.insert(
+            if request {
+                "request_body"
+            } else {
+                "response_body"
+            }
+            .to_string(),
+            serde_json::json!(body),
+        );
+        data.insert(
+            "body_truncated".to_string(),
+            serde_json::json!(message.body.len() > config.max_body_bytes),
+        );
+    }
+}
+
+fn truncate_body(body: &[u8], max: usize) -> String {
+    String::from_utf8_lossy(&body[..body.len().min(max)]).to_string()
+}
+
+fn push_http_error(
+    events: &Arc<Mutex<Vec<TraceEvent>>>,
+    started_at: Instant,
+    request: &HttpMessage,
+    error: impl Into<String>,
+) {
+    push_event(
+        events,
+        event(
+            started_at,
+            "http.egress",
+            "http.error",
+            BTreeMap::from([
+                ("url".to_string(), serde_json::json!(request.url())),
+                ("error".to_string(), serde_json::json!(error.into())),
+            ]),
+        ),
+    );
+}
+
+fn respond_bad_gateway(mut stream: TcpStream, message: &str) {
+    let body = message.as_bytes();
+    let _ = stream.write_all(
+        format!(
+            "HTTP/1.1 502 Bad Gateway\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        )
+        .as_bytes(),
+    );
+    let _ = stream.write_all(body);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{ActiveTraceProbes, TraceProbeConfig};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn http_egress_proxy_captures_http_request_and_response_bodies() {
+        let upstream = TcpListener::bind(("127.0.0.1", 0)).expect("bind upstream");
+        let upstream_addr = upstream.local_addr().expect("upstream addr");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = upstream.accept().expect("accept upstream");
+            let mut buffer = [0; 1024];
+            let n = stream.read(&mut buffer).expect("read upstream request");
+            let request = String::from_utf8_lossy(&buffer[..n]);
+            assert!(request.contains("POST /v1/messages HTTP/1.1"));
+            assert!(request.contains("hello=world"));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\nSet-Cookie: secret\r\n\r\nhello back",
+                )
+                .expect("write upstream response");
+        });
+
+        let reserved = TcpListener::bind(("127.0.0.1", 0)).expect("reserve proxy port");
+        let proxy_addr = reserved.local_addr().expect("proxy addr");
+        drop(reserved);
+        let probes = ActiveTraceProbes::start(&[TraceProbeConfig::HttpEgress {
+            host: "127.0.0.1".to_string(),
+            path: Some("/v1/messages".to_string()),
+            capture: "body".to_string(),
+            max_body_bytes: Some(1024),
+            redact_headers: None,
+            listen_port: Some(proxy_addr.port()),
+        }])
+        .expect("start egress proxy");
+        thread::sleep(Duration::from_millis(100));
+        let mut client = std::net::TcpStream::connect(proxy_addr).expect("connect proxy");
+        write!(
+            client,
+            "POST http://{}/v1/messages HTTP/1.1\r\nHost: {}\r\nAuthorization: secret\r\nContent-Length: 11\r\n\r\nhello=world",
+            upstream_addr, upstream_addr
+        )
+        .expect("write proxy request");
+        let mut response = String::new();
+        client.read_to_string(&mut response).expect("read response");
+        assert!(response.contains("hello back"));
+        drop(client);
+        let events = probes.stop();
+        let _ = server.join();
+        assert!(events.iter().any(|event| event.event == "http.request"
+            && event
+                .data
+                .get("request_body")
+                .and_then(|value| value.as_str())
+                == Some("hello=world")));
+        assert!(events.iter().any(|event| event.event == "http.response"
+            && event
+                .data
+                .get("response_body")
+                .and_then(|value| value.as_str())
+                == Some("hello back")));
+        assert!(events.iter().any(|event| event.event == "http.request"
+            && event
+                .data
+                .get("headers")
+                .and_then(|headers| headers.get("Authorization"))
+                .and_then(|value| value.as_str())
+                == Some("<redacted>")));
+    }
+}

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -641,13 +641,14 @@ mod tests {
                     { "type": "file.watch", "path": "/tmp/auth.json", "interval_ms": 100 },
                     { "type": "port.snapshot", "port": 3000 },
                     { "type": "http.poll", "url": "http://127.0.0.1:3000/health", "assert-status": 200 },
+                    { "type": "http.egress", "host": "api.example.com", "capture": "headers" },
                     { "type": "cmd.run", "command": "kimaki", "args": ["--help"] }
                 ]
             }"#,
         )
         .expect("parse detailed workload probes");
 
-        assert_eq!(workload.trace_probes().len(), 6);
+        assert_eq!(workload.trace_probes().len(), 7);
         assert!(matches!(
             &workload.trace_probes()[0],
             TraceProbeConfig::LogTail { path, grep, .. }
@@ -675,6 +676,11 @@ mod tests {
         ));
         assert!(matches!(
             &workload.trace_probes()[5],
+            TraceProbeConfig::HttpEgress { host, capture, .. }
+                if host == "api.example.com" && capture == "headers"
+        ));
+        assert!(matches!(
+            &workload.trace_probes()[6],
             TraceProbeConfig::CmdRun { command, args }
                 if command == "kimaki" && args == &vec!["--help".to_string()]
         ));

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -690,6 +690,46 @@ mod tests {
     }
 
     #[test]
+    fn test_string_settings() {
+        let profile: TraceProfileSpec = serde_json::from_str(
+            r#"{
+                "settings": {
+                    "title": "Studio",
+                    "retry_count": 2
+                }
+            }"#,
+        )
+        .expect("parse profile");
+
+        assert_eq!(
+            profile.string_settings(),
+            vec![("title".to_string(), "Studio".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_json_settings() {
+        let profile: TraceProfileSpec = serde_json::from_str(
+            r#"{
+                "settings": {
+                    "title": "Studio",
+                    "retry_count": 2,
+                    "options": { "headless": true }
+                }
+            }"#,
+        )
+        .expect("parse profile");
+
+        assert_eq!(
+            profile.json_settings(),
+            vec![
+                ("options".to_string(), serde_json::json!({ "headless": true })),
+                ("retry_count".to_string(), serde_json::json!(2))
+            ]
+        );
+    }
+
+    #[test]
     fn test_trace_default_phase_preset() {
         let workload = WorkloadSpec::Detailed(WorkloadEntry {
             path: "trace.mjs".to_string(),


### PR DESCRIPTION
## Summary
- Add `http.egress` as a portable local proxy trace/observe probe that emits `proxy.ready`, `http.request`, `http.response`, `http.connect`, and error events.
- Capture proxied HTTP request/response bodies with header redaction and host/path filtering; forward HTTPS CONNECT tunnels while recording metadata.
- Document the observe/trace probe shape and add coverage for probe serde plus proxy body capture.

Refs #2237

## Scope note
This is the portable proxy substrate for #2237, not the full HTTPS MITM layer. V1 captures HTTP bodies and HTTPS CONNECT metadata. Decrypting HTTPS bodies still needs a CA/trust mechanism layered onto this proxy before the Anthropic/opencode motivating case is fully solved.

## Tests
- `cargo test http_egress --lib`
- `cargo test test_trace_probes --lib`
- `cargo check --release`
- `cargo test --no-run`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the HTTP egress probe substrate, docs, and tests; Chris directed the work and owns review/merge decisions.