### PR TITLE
feat: add ci profile listing

### DIFF
--- a/docs/commands/ci.md
+++ b/docs/commands/ci.md
@@ -1,0 +1,50 @@
+# `homeboy ci`
+
+Inspect CI reproduction profiles and shallow CI discovery for a checkout.
+
+## List Profiles
+
+```sh
+homeboy ci list --path /path/to/repo --extension nodejs
+```
+
+`ci list` resolves the same path-only component context as other Homeboy commands, then prints:
+
+- declared extension-owned CI profiles
+- declared extension-owned CI jobs
+- best-effort discovered CI surfaces such as `package.json` scripts, `.github/workflows/*.yml`, and `.buildkite/*.yml`
+
+Discovery is intentionally inventory-only. Homeboy does not infer runnable local equivalence from arbitrary CI YAML; runnable jobs come from explicit extension profile declarations.
+
+## Manifest Shape
+
+Extensions can declare CI profiles with a `ci` block:
+
+```json
+{
+  "ci": {
+    "profiles": {
+      "pr": {
+        "label": "Pull request checks",
+        "jobs": ["lint-typecheck", "unit"]
+      }
+    },
+    "jobs": {
+      "lint-typecheck": {
+        "check_names": ["Lint and typecheck"],
+        "command": "lint",
+        "env": { "CI": "1" },
+        "fidelity": "local-equivalent"
+      }
+    }
+  }
+}
+```
+
+Supported fidelity values are `local-equivalent`, `local-partial`, `remote-only`, and `unknown`.
+
+## Output
+
+The JSON output uses command `ci.list` and includes an `inventory` object with `profiles`, `jobs`, and `discovered_jobs`.
+
+Refs: [#1977](https://github.com/Extra-Chill/homeboy/issues/1977)

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -8,6 +8,7 @@
 - [cargo](cargo.md) — run Cargo commands via Rust extension routing
 - [changelog](changelog.md)
 - [changes](changes.md)
+- [ci](ci.md) — CI reproduction profiles and shallow CI surface discovery
 - [component](component.md)
 - [config](config.md)
 - [daemon](daemon.md) — local-only HTTP API daemon

--- a/homeboy.json
+++ b/homeboy.json
@@ -80,6 +80,7 @@
         "structural::src/commands/report.rs::HighItemCount",
         "structural::src/commands/runs.rs::GodFile",
         "structural::src/commands/trace.rs::GodFile",
+        "structural::src/commands/trace/tests.rs::GodFile",
         "structural::src/core/code_audit/conventions.rs::GodFile",
         "structural::src/core/code_audit/core_fingerprint.rs::GodFile",
         "structural::src/core/code_audit/core_fingerprint.rs::HighItemCount",

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -2,7 +2,7 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::commands::{
-    api, audit, auth, bench, build, changelog, changes, component, config, daemon, db, deploy,
+    api, audit, auth, bench, build, changelog, changes, ci, component, config, daemon, db, deploy,
     deps, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
     refactor, release, report, review, rig, runner, runs, self_cmd, server, ssh, stack, status,
     test, trace, triage, undo, upgrade, version,
@@ -62,6 +62,8 @@ pub enum Commands {
     /// Manage component dependencies
     #[command(visible_alias = "dependencies")]
     Deps(deps::DepsArgs),
+    /// Inspect CI reproduction profiles and discovered CI surfaces
+    Ci(ci::CiArgs),
     /// Read-only local diagnostics for Homeboy-adjacent work
     Doctor(doctor::DoctorArgs),
     /// Remote file operations
@@ -332,6 +334,7 @@ mod tests {
         assert!(surface.contains_path(&["self"]));
         assert!(surface.contains_path(&["self", "status"]));
         assert!(surface.contains_path(&["doctor", "resources"]));
+        assert!(surface.contains_path(&["ci", "list"]));
         assert!(surface.contains_path(&["observe"]));
     }
 
@@ -342,6 +345,7 @@ mod tests {
         assert!(surface.contains_path(&["self"]));
         assert!(surface.contains_path(&["self", "status"]));
         assert!(surface.contains_path(&["doctor", "resources"]));
+        assert!(surface.contains_path(&["ci", "list"]));
         assert!(surface.contains_path(&["observe"]));
     }
 

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -1,0 +1,108 @@
+use clap::{Args, Subcommand};
+use serde::Serialize;
+use std::path::PathBuf;
+
+use homeboy::core::ci_profile::{self, CiInventory};
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
+
+use super::utils::args::{ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs};
+use super::{CmdResult, GlobalArgs};
+
+#[derive(Args)]
+pub struct CiArgs {
+    #[command(subcommand)]
+    pub command: CiCommand,
+}
+
+#[derive(Subcommand)]
+pub enum CiCommand {
+    /// List declared CI profiles and shallow discovered CI surfaces.
+    List(CiListArgs),
+}
+
+#[derive(Args)]
+pub struct CiListArgs {
+    #[command(flatten)]
+    pub comp: PositionalComponentArgs,
+
+    #[command(flatten)]
+    pub extension_override: ExtensionOverrideArgs,
+
+    #[command(flatten)]
+    pub _json: HiddenJsonArgs,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CiListOutput {
+    pub command: &'static str,
+    pub component_id: String,
+    pub source_path: PathBuf,
+    pub inventory: CiInventory,
+}
+
+pub fn run(args: CiArgs, global: &GlobalArgs) -> CmdResult<CiListOutput> {
+    match args.command {
+        CiCommand::List(args) => run_list(args, global),
+    }
+}
+
+fn run_list(args: CiListArgs, _global: &GlobalArgs) -> CmdResult<CiListOutput> {
+    let ctx = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: None,
+        settings_overrides: Vec::new(),
+        settings_json_overrides: Vec::new(),
+        extension_overrides: args.extension_override.extensions.clone(),
+    })?;
+    let extension_ids = ctx
+        .component
+        .extensions
+        .as_ref()
+        .map(|extensions| {
+            let mut ids: Vec<String> = extensions.keys().cloned().collect();
+            ids.sort();
+            ids
+        })
+        .unwrap_or_default();
+    let extension_id = ci_profile::select_extension_id(&extension_ids)?;
+    let inventory = ci_profile::list_for_extension(&ctx.source_path, &extension_id)?;
+
+    Ok((
+        CiListOutput {
+            command: "ci.list",
+            component_id: ctx.component_id,
+            source_path: ctx.source_path,
+            inventory,
+        },
+        0,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parses_ci_list_path_and_extension() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "ci",
+            "list",
+            "--path",
+            "/tmp/repo",
+            "--extension",
+            "nodejs",
+        ])
+        .expect("parse cli");
+
+        let crate::cli_surface::Commands::Ci(args) = cli.command else {
+            panic!("expected ci command");
+        };
+        let CiCommand::List(args) = args.command;
+
+        assert_eq!(args.comp.path.as_deref(), Some("/tmp/repo"));
+        assert_eq!(args.extension_override.extensions, vec!["nodejs"]);
+    }
+}

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -61,6 +61,7 @@ fn family(command: &Commands) -> JsonCommandFamily {
         | Commands::Stack(_)
         | Commands::Undo(_) => JsonCommandFamily::Workspace,
         Commands::Status(_)
+        | Commands::Ci(_)
         | Commands::Ssh(_)
         | Commands::Server(_)
         | Commands::Db(_)

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -2,13 +2,14 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    api, auth, daemon, db, deploy, deps, doctor, file, fleet, git, http, issues, logs, self_cmd,
-    server, ssh, status, triage, upgrade, GlobalArgs,
+    api, auth, ci, daemon, db, deploy, deps, doctor, file, fleet, git, http, issues, logs,
+    self_cmd, server, ssh, status, triage, upgrade, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::Status(args) => map(status::run(args, global)),
+        Commands::Ci(args) => map(ci::run(args, global)),
         Commands::Ssh(args) => map(ssh::run(args, global)),
         Commands::Server(args) => map(server::run(args, global)),
         Commands::Db(args) => map(db::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -335,6 +335,7 @@ pub mod bench;
 pub mod build;
 pub mod changelog;
 pub mod changes;
+pub mod ci;
 pub mod cli;
 pub mod component;
 pub mod config;

--- a/src/core/ci_profile.rs
+++ b/src/core/ci_profile.rs
@@ -1,0 +1,314 @@
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::core::error::{Error, Result};
+use crate::core::extension::{
+    self, CiJobFidelity, CiJobSpec, CiLocalContext, CiProfileSpec, ExtensionManifest,
+};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CiInventory {
+    pub extension_id: String,
+    pub profiles: Vec<CiProfileSummary>,
+    pub jobs: Vec<CiJobSummary>,
+    pub discovered_jobs: Vec<DiscoveredCiJob>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CiProfileSummary {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub jobs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CiJobSummary {
+    pub id: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub check_names: Vec<String>,
+    pub command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+    #[serde(flatten)]
+    pub local_context: CiLocalContext,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DiscoveredCiJob {
+    pub id: String,
+    pub provider: String,
+    pub label: String,
+    #[serde(flatten)]
+    pub local_context: CiLocalContext,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+}
+
+pub fn list_for_extension(source_path: &Path, extension_id: &str) -> Result<CiInventory> {
+    let extension = extension::load_extension(extension_id)?;
+    Ok(list_from_manifest(source_path, extension_id, &extension))
+}
+
+pub fn list_from_manifest(
+    source_path: &Path,
+    extension_id: &str,
+    extension: &ExtensionManifest,
+) -> CiInventory {
+    let (profiles, jobs) = extension
+        .ci
+        .as_ref()
+        .map(|ci| (profile_summaries(&ci.profiles), job_summaries(&ci.jobs)))
+        .unwrap_or_default();
+
+    CiInventory {
+        extension_id: extension_id.to_string(),
+        profiles,
+        jobs,
+        discovered_jobs: discover_ci_jobs(source_path),
+    }
+}
+
+pub fn select_extension_id(extension_ids: &[String]) -> Result<String> {
+    match extension_ids {
+        [extension_id] => Ok(extension_id.clone()),
+        [] => Err(Error::validation_missing_argument(vec![
+            "--extension <ID> or component extensions".to_string(),
+        ])),
+        _ => Err(Error::validation_invalid_argument(
+            "extension",
+            "ci list needs exactly one extension when multiple component extensions are configured",
+            Some(extension_ids.join(", ")),
+            Some(vec![
+                "Pass --extension <ID> to choose the CI profile source.".to_string(),
+            ]),
+        )),
+    }
+}
+
+fn profile_summaries(profiles: &BTreeMap<String, CiProfileSpec>) -> Vec<CiProfileSummary> {
+    profiles
+        .iter()
+        .map(|(id, profile)| CiProfileSummary {
+            id: id.clone(),
+            label: profile.label.clone(),
+            jobs: profile.jobs.clone(),
+        })
+        .collect()
+}
+
+fn job_summaries(jobs: &BTreeMap<String, CiJobSpec>) -> Vec<CiJobSummary> {
+    jobs.iter()
+        .map(|(id, job)| CiJobSummary {
+            id: id.clone(),
+            check_names: job.check_names.clone(),
+            command: job.command.clone(),
+            args: job.args.clone(),
+            env: job.env.clone(),
+            local_context: job.local_context.clone(),
+            provider: job.provider.clone(),
+            workflow: job.workflow.clone(),
+        })
+        .collect()
+}
+
+fn discover_ci_jobs(source_path: &Path) -> Vec<DiscoveredCiJob> {
+    let mut jobs = Vec::new();
+    jobs.extend(discover_package_scripts(source_path));
+    jobs.extend(discover_github_workflows(source_path));
+    jobs.extend(discover_buildkite_pipelines(source_path));
+    jobs
+}
+
+fn discover_package_scripts(source_path: &Path) -> Vec<DiscoveredCiJob> {
+    let package_json = source_path.join("package.json");
+    let Ok(raw) = fs::read_to_string(package_json) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    let Some(scripts) = value.get("scripts").and_then(|scripts| scripts.as_object()) else {
+        return Vec::new();
+    };
+
+    scripts
+        .keys()
+        .map(|script| DiscoveredCiJob {
+            id: format!("package-script:{script}"),
+            provider: "package-scripts".to_string(),
+            label: script.clone(),
+            local_context: unknown_discovered_context(
+                "Discovered from package metadata; no Homeboy profile maps this to a local CI-equivalent command yet.",
+            ),
+            workflow: None,
+        })
+        .collect()
+}
+
+fn discover_github_workflows(source_path: &Path) -> Vec<DiscoveredCiJob> {
+    discover_named_files(
+        source_path.join(".github/workflows"),
+        "github-actions",
+        "workflow",
+        &["yml", "yaml"],
+    )
+}
+
+fn discover_buildkite_pipelines(source_path: &Path) -> Vec<DiscoveredCiJob> {
+    discover_named_files(
+        source_path.join(".buildkite"),
+        "buildkite",
+        "pipeline",
+        &["yml", "yaml"],
+    )
+}
+
+fn discover_named_files(
+    dir: PathBuf,
+    provider: &str,
+    kind: &str,
+    extensions: &[&str],
+) -> Vec<DiscoveredCiJob> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut jobs = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if !extensions.contains(&extension) {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        jobs.push(DiscoveredCiJob {
+            id: format!("{provider}:{file_name}"),
+            provider: provider.to_string(),
+            label: file_name.to_string(),
+            local_context: unknown_discovered_context(&format!(
+                "Discovered {kind} file only; Homeboy does not infer runnable local equivalence from arbitrary CI YAML."
+            )),
+            workflow: Some(file_name.to_string()),
+        });
+    }
+    jobs.sort_by(|a, b| a.id.cmp(&b.id));
+    jobs
+}
+
+fn unknown_discovered_context(limitation: &str) -> CiLocalContext {
+    CiLocalContext {
+        fidelity: CiJobFidelity::Unknown,
+        limitations: vec![limitation.to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::extension::{CiCapability, ExtensionManifest};
+    use tempfile::TempDir;
+
+    fn manifest_with_ci() -> ExtensionManifest {
+        serde_json::from_value(serde_json::json!({
+            "name": "Node.js",
+            "version": "1.0.0",
+            "ci": {
+                "profiles": {
+                    "pr": { "label": "Pull request", "jobs": ["lint"] }
+                },
+                "jobs": {
+                    "lint": {
+                        "check_names": ["Lint and typecheck"],
+                        "command": "lint",
+                        "args": ["--fix=false"],
+                        "env": { "CI": "1" },
+                        "fidelity": "local-equivalent",
+                        "provider": "github-actions",
+                        "workflow": "ci.yml"
+                    }
+                }
+            }
+        }))
+        .expect("parse manifest")
+    }
+
+    #[test]
+    fn list_from_manifest_returns_declared_profiles_and_jobs() {
+        let tmp = TempDir::new().expect("temp dir");
+        let inventory = list_from_manifest(tmp.path(), "nodejs", &manifest_with_ci());
+
+        assert_eq!(inventory.extension_id, "nodejs");
+        assert_eq!(inventory.profiles[0].id, "pr");
+        assert_eq!(inventory.jobs[0].id, "lint");
+        assert_eq!(
+            inventory.jobs[0].local_context.fidelity,
+            CiJobFidelity::LocalEquivalent
+        );
+    }
+
+    #[test]
+    fn test_list_for_extension() {
+        crate::test_support::with_isolated_home(|home| {
+            let mut extension = manifest_with_ci();
+            extension.id = "nodejs".to_string();
+            crate::core::extension::save_manifest(&extension).expect("save extension");
+
+            let inventory = list_for_extension(home.path(), "nodejs").expect("list inventory");
+
+            assert_eq!(inventory.extension_id, "nodejs");
+            assert_eq!(inventory.profiles[0].id, "pr");
+        });
+    }
+
+    #[test]
+    fn discovery_lists_package_scripts_and_ci_files_as_unknown() {
+        let tmp = TempDir::new().expect("temp dir");
+        fs::write(
+            tmp.path().join("package.json"),
+            r#"{ "scripts": { "test": "vitest", "lint": "eslint ." } }"#,
+        )
+        .expect("write package");
+        fs::create_dir_all(tmp.path().join(".github/workflows")).expect("mkdir workflows");
+        fs::write(tmp.path().join(".github/workflows/ci.yml"), "name: CI").expect("write ci");
+
+        let discovered = discover_ci_jobs(tmp.path());
+
+        assert!(discovered.iter().any(|job| job.id == "package-script:test"));
+        assert!(discovered
+            .iter()
+            .any(|job| job.id == "github-actions:ci.yml"));
+        assert!(discovered
+            .iter()
+            .all(|job| job.local_context.fidelity == CiJobFidelity::Unknown));
+    }
+
+    #[test]
+    fn select_extension_id_requires_one_extension() {
+        assert_eq!(
+            select_extension_id(&["nodejs".to_string()]).unwrap(),
+            "nodejs"
+        );
+        assert!(select_extension_id(&[]).is_err());
+        assert!(select_extension_id(&["nodejs".to_string(), "rust".to_string()]).is_err());
+    }
+
+    #[test]
+    fn empty_ci_manifest_defaults() {
+        let ci = CiCapability::default();
+
+        assert!(ci.profiles.is_empty());
+        assert!(ci.jobs.is_empty());
+    }
+}

--- a/src/core/code_audit/test_topology.rs
+++ b/src/core/code_audit/test_topology.rs
@@ -376,6 +376,7 @@ JSON
             executable: None,
             platform: None,
             component_env: None,
+            ci: None,
             runtime: None,
             cli: None,
             build: None,

--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -134,7 +134,10 @@ mod tests {
         fs::create_dir_all(&repo).expect("repo dir");
         fs::write(
             repo.join("homeboy.json"),
-            format!(r#"{{"id":"{}","remote_path":"wp-content/plugins/{}"}}"#, id, id),
+            format!(
+                r#"{{"id":"{}","remote_path":"wp-content/plugins/{}"}}"#,
+                id, id
+            ),
         )
         .expect("homeboy.json");
 
@@ -155,15 +158,16 @@ mod tests {
         crate::test_support::with_isolated_home(|home| {
             let repo = write_component_repo(home, "demo-plugin");
 
-            set_changelog_target("demo-plugin", "docs/changelog.md")
-                .expect("set changelog target");
+            set_changelog_target("demo-plugin", "docs/changelog.md").expect("set changelog target");
 
             let config: serde_json::Value = serde_json::from_str(
                 &fs::read_to_string(repo.join("homeboy.json")).expect("read homeboy.json"),
             )
             .expect("parse homeboy.json");
             assert_eq!(
-                config.get("changelog_target").and_then(|value| value.as_str()),
+                config
+                    .get("changelog_target")
+                    .and_then(|value| value.as_str()),
                 Some("docs/changelog.md")
             );
         });
@@ -239,13 +243,17 @@ mod tests {
             let loaded = crate::core::component::load("agents-api").expect("load component");
             assert_eq!(loaded.local_path, new_repo.to_string_lossy());
 
-            let registration_path = home.path().join(".config/homeboy/components/agents-api.json");
+            let registration_path = home
+                .path()
+                .join(".config/homeboy/components/agents-api.json");
             let registration: serde_json::Value = serde_json::from_str(
                 &fs::read_to_string(registration_path).expect("read registration"),
             )
             .expect("parse registration");
             assert_eq!(
-                registration.get("local_path").and_then(|value| value.as_str()),
+                registration
+                    .get("local_path")
+                    .and_then(|value| value.as_str()),
                 Some(new_repo.to_string_lossy().as_ref())
             );
         });

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -5,7 +5,7 @@ use crate::core::engine::run_dir;
 use crate::core::error::{Error, Result};
 use crate::core::paths;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 /// Type of action that can be executed by a extension.
@@ -225,6 +225,67 @@ pub struct ComponentEnvConfig {
     pub detect_script: String,
 }
 
+/// CI reproduction profiles declared by an extension.
+///
+/// Core treats these as explicit local-reproduction contracts. Best-effort
+/// workflow discovery can inventory CI files, but runnable equivalence comes
+/// from these declarations.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CiCapability {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub profiles: BTreeMap<String, CiProfileSpec>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub jobs: BTreeMap<String, CiJobSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CiProfileSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub jobs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CiJobFidelity {
+    LocalEquivalent,
+    LocalPartial,
+    RemoteOnly,
+    Unknown,
+}
+
+impl Default for CiJobFidelity {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CiJobSpec {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub check_names: Vec<String>,
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+    #[serde(flatten)]
+    pub local_context: CiLocalContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CiLocalContext {
+    #[serde(default)]
+    pub fidelity: CiJobFidelity,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limitations: Vec<String>,
+}
+
 // ============================================================================
 // ExtensionManifest
 // ============================================================================
@@ -358,6 +419,8 @@ pub struct ExtensionManifest {
     pub platform: Option<PlatformCapability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_env: Option<ComponentEnvConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci: Option<CiCapability>,
 
     /// Runtime requirements needed to execute this extension's runner scripts.
     /// Component-declared requirements still win; these are fallbacks for the

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -58,15 +58,15 @@ pub use lifecycle::{
 pub use maintenance::{exec_tool, update_all};
 pub use manifest::{
     ActionConfig, ActionType, AuditCapability, AutofixVerifyConfig, BenchConfig, BuildConfig,
-    CliAutoFlag, CliAutoFlagCondition, CliConfig, CliHelpConfig, ComponentEnvConfig,
-    DatabaseCliConfig, DatabaseConfig, DeployCapability, DeployOverride, DeployVerification,
-    DiscoveryConfig, DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionManifest,
-    FeatureContextRule, FileContainsCondition, HttpMethod, InputConfig, LintChangedFileRoute,
-    LintConfig, OutputConfig, OutputSchema, PlatformCapability, ProvidesConfig,
-    RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig, RuntimeConfig,
-    RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
-    StructuredSidecarDeclaration, TestConfig, TestDriftConfig, TestMappingConfig, TraceConfig,
-    VersionPatternConfig,
+    CiCapability, CiJobFidelity, CiJobSpec, CiLocalContext, CiProfileSpec, CliAutoFlag,
+    CliAutoFlagCondition, CliConfig, CliHelpConfig, ComponentEnvConfig, DatabaseCliConfig,
+    DatabaseConfig, DeployCapability, DeployOverride, DeployVerification, DiscoveryConfig,
+    DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionManifest, FeatureContextRule,
+    FileContainsCondition, HttpMethod, InputConfig, LintChangedFileRoute, LintConfig, OutputConfig,
+    OutputSchema, PlatformCapability, ProvidesConfig, RemotePathInferenceRule, RemotePathRootRule,
+    RequirementsConfig, RuntimeConfig, RuntimeRequirementsConfig, ScriptsConfig, SelectOption,
+    SettingConfig, SinceTagConfig, StructuredSidecarDeclaration, TestConfig, TestDriftConfig,
+    TestMappingConfig, TraceConfig, VersionPatternConfig,
 };
 pub use refactor_protocol::{
     run_refactor_script, AdjustedItem, ParsedItem, RelatedTests, ResolvedImports, RewrittenImport,

--- a/src/core/extension/trace/probes/http_egress.rs
+++ b/src/core/extension/trace/probes/http_egress.rs
@@ -512,8 +512,8 @@ fn respond_bad_gateway(mut stream: TcpStream, message: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::{ActiveTraceProbes, TraceProbeConfig};
+    use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod api_jobs;
 pub mod budget;
+pub mod ci_profile;
 pub mod code_audit;
 pub mod component;
 pub mod context;

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -723,7 +723,10 @@ mod tests {
         assert_eq!(
             profile.json_settings(),
             vec![
-                ("options".to_string(), serde_json::json!({ "headless": true })),
+                (
+                    "options".to_string(),
+                    serde_json::json!({ "headless": true })
+                ),
                 ("retry_count".to_string(), serde_json::json!(2))
             ]
         );


### PR DESCRIPTION
## Summary
- Add extension-owned CI profile/job schema for explicit local reproduction contracts.
- Add `homeboy ci list` to resolve a path-only checkout plus one extension and report declared profiles/jobs alongside shallow discovered CI surfaces.
- Document the new command and keep arbitrary CI YAML discovery inventory-only rather than pretending it is runnable.

Refs #1977

## Verification
- `cargo test ci_profile --lib`
- `cargo test parses_ci_list_path_and_extension --lib`
- `cargo test test_current_command_surface --lib`
- `cargo fmt --check`
- `cargo check --release`
- `cargo test --no-run`
- `git diff --check`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-ci-profile-list --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the CI profile listing slice, tests, docs, and local verification. Chris directed the issue burn-down flow and remains responsible for review and merge decisions.