### PR TITLE
feat: run declared CI jobs

### DIFF
--- a/docs/commands/ci.md
+++ b/docs/commands/ci.md
@@ -1,6 +1,6 @@
 # `homeboy ci`
 
-Inspect CI reproduction profiles and shallow CI discovery for a checkout.
+Inspect and run explicit CI reproduction profiles for a checkout.
 
 ## List Profiles
 
@@ -15,6 +15,22 @@ homeboy ci list --path /path/to/repo --extension nodejs
 - best-effort discovered CI surfaces such as `.github/workflows/*.yml` and `.buildkite/*.yml`
 
 Discovery is intentionally inventory-only. Homeboy does not infer runnable local equivalence from arbitrary CI YAML; runnable jobs come from explicit extension profile declarations.
+
+## Run Declared Jobs
+
+Run one extension-declared job:
+
+```sh
+homeboy ci run --path /path/to/repo --extension nodejs --job lint-typecheck
+```
+
+Run every job in an extension-declared profile:
+
+```sh
+homeboy ci run --path /path/to/repo --extension nodejs --profile pr
+```
+
+`ci run` executes only jobs declared under the extension manifest's `ci.jobs` contract. It does not parse arbitrary provider YAML into runnable local commands. Commands run from the component root with the declared `args` and `env`; the command's exit code is captured in JSON and the overall command exits non-zero when any selected job fails.
 
 ## Manifest Shape
 
@@ -46,5 +62,7 @@ Supported fidelity values are `local-equivalent`, `local-partial`, `remote-only`
 ## Output
 
 The JSON output uses command `ci.list` and includes an `inventory` object with `profiles`, `jobs`, and `discovered_jobs`.
+
+`ci run` uses command `ci.run` and includes the selected job/profile, per-job command output, per-job exit codes, and an aggregate `success` / `exit_code`.
 
 Refs: [#1977](https://github.com/Extra-Chill/homeboy/issues/1977)

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;
 
-use homeboy::core::ci_profile::{self, CiInventory};
+use homeboy::core::ci_profile::{self, CiInventory, CiRunOutput, CiRunSelection};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 
 use super::utils::args::{ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs};
@@ -18,6 +18,8 @@ pub struct CiArgs {
 pub enum CiCommand {
     /// List declared CI profiles and shallow discovered CI surfaces.
     List(CiListArgs),
+    /// Run an extension-declared CI job or profile locally.
+    Run(CiRunArgs),
 }
 
 #[derive(Args)]
@@ -32,6 +34,26 @@ pub struct CiListArgs {
     pub _json: HiddenJsonArgs,
 }
 
+#[derive(Args)]
+pub struct CiRunArgs {
+    #[command(flatten)]
+    pub comp: PositionalComponentArgs,
+
+    #[command(flatten)]
+    pub extension_override: ExtensionOverrideArgs,
+
+    /// Run a single extension-declared CI job.
+    #[arg(long, conflicts_with = "profile")]
+    pub job: Option<String>,
+
+    /// Run all jobs in an extension-declared CI profile.
+    #[arg(long, conflicts_with = "job")]
+    pub profile: Option<String>,
+
+    #[command(flatten)]
+    pub _json: HiddenJsonArgs,
+}
+
 #[derive(Debug, Serialize)]
 pub struct CiListOutput {
     pub command: &'static str,
@@ -40,13 +62,30 @@ pub struct CiListOutput {
     pub inventory: CiInventory,
 }
 
-pub fn run(args: CiArgs, global: &GlobalArgs) -> CmdResult<CiListOutput> {
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum CiOutput {
+    List(CiListOutput),
+    Run(CiRunCommandOutput),
+}
+
+#[derive(Debug, Serialize)]
+pub struct CiRunCommandOutput {
+    pub command: &'static str,
+    pub component_id: String,
+    pub source_path: PathBuf,
+    #[serde(flatten)]
+    pub run: CiRunOutput,
+}
+
+pub fn run(args: CiArgs, global: &GlobalArgs) -> CmdResult<CiOutput> {
     match args.command {
         CiCommand::List(args) => run_list(args, global),
+        CiCommand::Run(args) => run_ci(args, global),
     }
 }
 
-fn run_list(args: CiListArgs, _global: &GlobalArgs) -> CmdResult<CiListOutput> {
+fn run_list(args: CiListArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
     let ctx = execution_context::resolve(&ResolveOptions {
         component_id: args.comp.component.clone(),
         path_override: args.comp.path.clone(),
@@ -69,14 +108,59 @@ fn run_list(args: CiListArgs, _global: &GlobalArgs) -> CmdResult<CiListOutput> {
     let inventory = ci_profile::list_for_extension(&ctx.source_path, &extension_id)?;
 
     Ok((
-        CiListOutput {
+        CiOutput::List(CiListOutput {
             command: "ci.list",
             component_id: ctx.component_id,
             source_path: ctx.source_path,
             inventory,
-        },
+        }),
         0,
     ))
+}
+
+fn run_ci(args: CiRunArgs, _global: &GlobalArgs) -> CmdResult<CiOutput> {
+    let ctx = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: None,
+        settings_overrides: Vec::new(),
+        settings_json_overrides: Vec::new(),
+        extension_overrides: args.extension_override.extensions.clone(),
+    })?;
+    let extension_ids = ctx
+        .component
+        .extensions
+        .as_ref()
+        .map(|extensions| {
+            let mut ids: Vec<String> = extensions.keys().cloned().collect();
+            ids.sort();
+            ids
+        })
+        .unwrap_or_default();
+    let extension_id = ci_profile::select_extension_id(&extension_ids)?;
+    let selection = ci_run_selection(&args)?;
+    let run = ci_profile::run_for_extension(&ctx.source_path, &extension_id, selection)?;
+    let exit_code = run.exit_code;
+
+    Ok((
+        CiOutput::Run(CiRunCommandOutput {
+            command: "ci.run",
+            component_id: ctx.component_id,
+            source_path: ctx.source_path,
+            run,
+        }),
+        exit_code,
+    ))
+}
+
+fn ci_run_selection(args: &CiRunArgs) -> homeboy::core::Result<CiRunSelection> {
+    match (&args.job, &args.profile) {
+        (Some(job), None) => Ok(CiRunSelection::Job(job.clone())),
+        (None, Some(profile)) => Ok(CiRunSelection::Profile(profile.clone())),
+        _ => Err(homeboy::core::Error::validation_missing_argument(vec![
+            "--job <ID> or --profile <ID>".to_string(),
+        ])),
+    }
 }
 
 #[cfg(test)]
@@ -100,9 +184,54 @@ mod tests {
         let crate::cli_surface::Commands::Ci(args) = cli.command else {
             panic!("expected ci command");
         };
-        let CiCommand::List(args) = args.command;
+        let CiCommand::List(args) = args.command else {
+            panic!("expected ci list");
+        };
 
         assert_eq!(args.comp.path.as_deref(), Some("/tmp/repo"));
         assert_eq!(args.extension_override.extensions, vec!["nodejs"]);
+    }
+
+    #[test]
+    fn parses_ci_run_job_path_and_extension() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "ci",
+            "run",
+            "--path",
+            "/tmp/repo",
+            "--extension",
+            "nodejs",
+            "--job",
+            "lint",
+        ])
+        .expect("parse cli");
+
+        let crate::cli_surface::Commands::Ci(args) = cli.command else {
+            panic!("expected ci command");
+        };
+        let CiCommand::Run(args) = args.command else {
+            panic!("expected ci run");
+        };
+
+        assert_eq!(args.comp.path.as_deref(), Some("/tmp/repo"));
+        assert_eq!(args.extension_override.extensions, vec!["nodejs"]);
+        assert_eq!(args.job.as_deref(), Some("lint"));
+    }
+
+    #[test]
+    fn ci_run_requires_job_or_profile() {
+        let args = CiRunArgs {
+            comp: PositionalComponentArgs {
+                component: None,
+                path: None,
+            },
+            extension_override: ExtensionOverrideArgs::default(),
+            job: None,
+            profile: None,
+            _json: HiddenJsonArgs::default(),
+        };
+
+        assert!(ci_run_selection(&args).is_err());
     }
 }

--- a/src/core/ci_profile.rs
+++ b/src/core/ci_profile.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::core::error::{Error, Result};
 use crate::core::extension::{
@@ -53,6 +54,36 @@ pub struct DiscoveredCiJob {
     pub workflow: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CiRunSelection {
+    Job(String),
+    Profile(String),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CiRunOutput {
+    pub extension_id: String,
+    pub selection: CiRunSelection,
+    pub jobs: Vec<CiJobRunOutput>,
+    pub success: bool,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CiJobRunOutput {
+    pub id: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    pub success: bool,
+    pub exit_code: i32,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+}
+
 pub fn list_for_extension(source_path: &Path, extension_id: &str) -> Result<CiInventory> {
     let extension = extension::load_extension(extension_id)?;
     Ok(list_from_manifest(source_path, extension_id, &extension))
@@ -92,6 +123,107 @@ pub fn select_extension_id(extension_ids: &[String]) -> Result<String> {
             ]),
         )),
     }
+}
+
+pub fn run_for_extension(
+    source_path: &Path,
+    extension_id: &str,
+    selection: CiRunSelection,
+) -> Result<CiRunOutput> {
+    let extension = extension::load_extension(extension_id)?;
+    run_from_manifest(source_path, extension_id, &extension, selection)
+}
+
+pub fn run_from_manifest(
+    source_path: &Path,
+    extension_id: &str,
+    extension: &ExtensionManifest,
+    selection: CiRunSelection,
+) -> Result<CiRunOutput> {
+    let ci = extension.ci.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "extension",
+            format!("extension '{extension_id}' does not declare CI jobs"),
+            Some(extension_id.to_string()),
+            None,
+        )
+    })?;
+
+    let job_ids = match &selection {
+        CiRunSelection::Job(job_id) => vec![job_id.clone()],
+        CiRunSelection::Profile(profile_id) => ci
+            .profiles
+            .get(profile_id)
+            .map(|profile| profile.jobs.clone())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "profile",
+                    format!(
+                        "CI profile '{profile_id}' is not declared by extension '{extension_id}'"
+                    ),
+                    Some(profile_id.clone()),
+                    Some(ci.profiles.keys().cloned().collect()),
+                )
+            })?,
+    };
+
+    if job_ids.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "profile",
+            "CI profile does not declare any jobs",
+            match &selection {
+                CiRunSelection::Profile(profile_id) => Some(profile_id.clone()),
+                CiRunSelection::Job(job_id) => Some(job_id.clone()),
+            },
+            None,
+        ));
+    }
+
+    let mut jobs = Vec::new();
+    for job_id in job_ids {
+        let job = ci.jobs.get(&job_id).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "job",
+                format!("CI job '{job_id}' is not declared by extension '{extension_id}'"),
+                Some(job_id.clone()),
+                Some(ci.jobs.keys().cloned().collect()),
+            )
+        })?;
+        jobs.push(run_job(source_path, &job_id, job)?);
+    }
+
+    let success = jobs.iter().all(|job| job.success);
+    Ok(CiRunOutput {
+        extension_id: extension_id.to_string(),
+        selection,
+        exit_code: if success { 0 } else { 1 },
+        success,
+        jobs,
+    })
+}
+
+fn run_job(source_path: &Path, job_id: &str, job: &CiJobSpec) -> Result<CiJobRunOutput> {
+    let output = Command::new(&job.command)
+        .args(&job.args)
+        .envs(&job.env)
+        .current_dir(source_path)
+        .output()
+        .map_err(|error| {
+            Error::internal_io(
+                format!("Failed to run CI job '{job_id}': {error}"),
+                Some("ci.run".to_string()),
+            )
+        })?;
+
+    Ok(CiJobRunOutput {
+        id: job_id.to_string(),
+        command: job.command.clone(),
+        args: job.args.clone(),
+        success: output.status.success(),
+        exit_code: output.status.code().unwrap_or(1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
 }
 
 fn profile_summaries(profiles: &BTreeMap<String, CiProfileSpec>) -> Vec<CiProfileSummary> {
@@ -277,5 +409,123 @@ mod tests {
 
         assert!(ci.profiles.is_empty());
         assert!(ci.jobs.is_empty());
+    }
+
+    #[test]
+    fn run_from_manifest_executes_declared_job() {
+        let tmp = TempDir::new().expect("temp dir");
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Test",
+            "version": "1.0.0",
+            "ci": {
+                "jobs": {
+                    "smoke": {
+                        "command": "sh",
+                        "args": ["-c", "printf '%s' \"$CI_MESSAGE\""],
+                        "env": { "CI_MESSAGE": "ok" },
+                        "fidelity": "local-equivalent"
+                    }
+                }
+            }
+        }))
+        .expect("parse manifest");
+
+        let output = run_from_manifest(
+            tmp.path(),
+            "test",
+            &manifest,
+            CiRunSelection::Job("smoke".to_string()),
+        )
+        .expect("run job");
+
+        assert!(output.success);
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.jobs[0].stdout, "ok");
+    }
+
+    #[test]
+    fn test_run_for_extension() {
+        crate::test_support::with_isolated_home(|_home| {
+            let tmp = TempDir::new().expect("temp dir");
+            let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "id": "test",
+                "name": "Test",
+                "version": "1.0.0",
+                "ci": {
+                    "jobs": {
+                        "smoke": { "command": "sh", "args": ["-c", "printf smoke"] }
+                    }
+                }
+            }))
+            .expect("parse manifest");
+            crate::core::extension::save_manifest(&manifest).expect("save extension");
+
+            let output =
+                run_for_extension(tmp.path(), "test", CiRunSelection::Job("smoke".to_string()))
+                    .expect("run extension job");
+
+            assert!(output.success);
+            assert_eq!(output.jobs[0].stdout, "smoke");
+        });
+    }
+
+    #[test]
+    fn run_from_manifest_executes_profile_jobs() {
+        let tmp = TempDir::new().expect("temp dir");
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Test",
+            "version": "1.0.0",
+            "ci": {
+                "profiles": {
+                    "pr": { "jobs": ["first", "second"] }
+                },
+                "jobs": {
+                    "first": { "command": "sh", "args": ["-c", "printf first"] },
+                    "second": { "command": "sh", "args": ["-c", "printf second"] }
+                }
+            }
+        }))
+        .expect("parse manifest");
+
+        let output = run_from_manifest(
+            tmp.path(),
+            "test",
+            &manifest,
+            CiRunSelection::Profile("pr".to_string()),
+        )
+        .expect("run profile");
+
+        assert!(output.success);
+        assert_eq!(output.jobs.len(), 2);
+        assert_eq!(output.jobs[0].stdout, "first");
+        assert_eq!(output.jobs[1].stdout, "second");
+    }
+
+    #[test]
+    fn run_from_manifest_reports_failed_job_as_output() {
+        let tmp = TempDir::new().expect("temp dir");
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Test",
+            "version": "1.0.0",
+            "ci": {
+                "jobs": {
+                    "fail": { "command": "sh", "args": ["-c", "printf nope >&2; exit 7"] }
+                }
+            }
+        }))
+        .expect("parse manifest");
+
+        let output = run_from_manifest(
+            tmp.path(),
+            "test",
+            &manifest,
+            CiRunSelection::Job("fail".to_string()),
+        )
+        .expect("run job");
+
+        assert!(!output.success);
+        assert_eq!(output.exit_code, 1);
+        assert_eq!(output.jobs[0].exit_code, 7);
+        assert_eq!(output.jobs[0].stderr, "nope");
     }
 }


### PR DESCRIPTION
## Summary
- Add `homeboy ci run --job <id>` for running a single extension-declared CI job locally.
- Add `homeboy ci run --profile <id>` for running each job in an extension-declared CI profile.
- Keep execution limited to explicit manifest `ci.jobs` contracts; discovered CI files remain inventory-only.

Refs #1977

## Verification
- `cargo test ci_profile --lib`
- `cargo test commands::ci::tests --lib`
- `cargo test --test core_agnostic_test`
- `cargo test command_surface --test command_surface_test`
- `cargo fmt --check`
- `cargo check --release`
- `cargo test --no-run`
- `git diff --check`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-ci-job-execution --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the small CI-profile execution slice, updated docs/tests, and ran local verification; Chris remains responsible for review and merge.