### PR TITLE
feat: run CI profiles during review

### DIFF
--- a/docs/commands/review.md
+++ b/docs/commands/review.md
@@ -6,6 +6,7 @@ Run scoped audit + lint + test in a single invocation against PR-style changes.
 
 ```bash
 homeboy review [component] --changed-since=<ref>
+homeboy review [component] --changed-since=<ref> --ci-profile=<profile>
 homeboy review [component] --changed-only
 homeboy review [component]
 ```
@@ -44,6 +45,17 @@ Output is deterministic and matches each command's per-stage output.
 If neither flag is passed, all three stages run against the entire component —
 equivalent to running `audit`, `lint`, and `test` back-to-back without scope.
 
+## CI profile gate
+
+- `--ci-profile <ID>`: Run an extension-declared CI profile as an additional
+  review gate after audit, lint, and test. The profile resolves through the
+  same explicit `ci.profiles` / `ci.jobs` manifest contract used by
+  `homeboy ci run --profile <ID>`.
+
+`review --ci-profile` does not parse arbitrary provider YAML. Discovered CI
+files remain inventory-only; runnable review parity comes from extension-owned
+profile declarations.
+
 ## Component Requirements
 
 `review` delegates to `audit`, `lint`, and `test`. Lint and test stages require linked extensions that provide those capabilities; review does not run arbitrary component shell commands.
@@ -58,6 +70,7 @@ Useful remediation paths when review reports missing extensions:
 
 - `--summary`: Forward the per-stage summary flag to each command (`--summary`
   on lint, `--json-summary` on audit and test).
+- `--ci-profile <ID>`: Add the declared CI profile as a fourth review stage.
 - `--baseline` / `--ignore-baseline` / `--ratchet`: Forwarded to every stage
   that participates in the baseline engine.
 
@@ -69,6 +82,9 @@ homeboy review --changed-since=trunk
 
 # Review a specific component against a release tag
 homeboy review my-plugin --changed-since=v1.2.0
+
+# Review a branch and run the extension-declared PR CI profile
+homeboy review my-plugin --changed-since=main --ci-profile=pr
 
 # Quick local check of working-tree edits (lint only scopes)
 homeboy review --changed-only

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -19,7 +19,9 @@ use serde_json::Value;
 use std::path::Path;
 use std::process::Command;
 
+use homeboy::core::ci_profile::{self, CiRunOutput, CiRunSelection};
 use homeboy::core::code_audit::AuditCommandOutput;
+use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::extension::lint::LintCommandOutput;
 use homeboy::core::extension::test::TestCommandOutput;
 use homeboy::core::git;
@@ -57,6 +59,10 @@ pub struct ReviewArgs {
     /// Show compact summary instead of full per-stage output
     #[arg(long)]
     pub summary: bool,
+
+    /// Run an extension-declared CI profile as an additional review gate.
+    #[arg(long, value_name = "ID")]
+    pub ci_profile: Option<String>,
 
     /// Output format. Default JSON envelope; `--report=pr-comment` emits a
     /// markdown PR-comment section instead, suitable for piping to
@@ -140,6 +146,8 @@ pub struct ReviewCommandOutput {
     pub audit: ReviewStage<AuditCommandOutput>,
     pub lint: ReviewStage<LintCommandOutput>,
     pub test: ReviewStage<TestCommandOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_profile: Option<ReviewStage<CiRunOutput>>,
 }
 
 /// Stable machine-readable artifact for automated PR review consumers.
@@ -329,6 +337,14 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
                 artifact_command(&stage_skipped::<Value>("test", "no files changed")),
             ],
         };
+        if args.ci_profile.is_some() {
+            artifact
+                .commands
+                .push(artifact_command(&stage_skipped::<Value>(
+                    "ci",
+                    "no files changed",
+                )));
+        }
         artifact.observation = observation_metadata.clone();
 
         let output = ReviewCommandOutput {
@@ -352,6 +368,10 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
             audit: stage_skipped("audit", "no files changed"),
             lint: stage_skipped("lint", "no files changed"),
             test: stage_skipped("test", "no files changed"),
+            ci_profile: args
+                .ci_profile
+                .as_ref()
+                .map(|_| stage_skipped("ci", "no files changed")),
         };
         observation::finish_success(review_observation, &output, 0);
         return Ok((output, 0));
@@ -404,18 +424,77 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
     let audit_stage = audit_stage.expect("review quality plan must include audit stage");
     let lint_stage = lint_stage.expect("review quality plan must include lint stage");
     let test_stage = test_stage.expect("review quality plan must include test stage");
+    let (ci_profile_stage, ci_profile_exit) = match args.ci_profile.as_ref() {
+        Some(profile) => {
+            let ctx = execution_context::resolve(&ResolveOptions {
+                component_id: args.comp.component.clone(),
+                path_override: args.comp.path.clone(),
+                capability: None,
+                settings_overrides: Vec::new(),
+                settings_json_overrides: Vec::new(),
+                extension_overrides: args.extension_override.extensions.clone(),
+            })?;
+            let extension_ids = ctx
+                .component
+                .extensions
+                .as_ref()
+                .map(|extensions| {
+                    let mut ids: Vec<String> = extensions.keys().cloned().collect();
+                    ids.sort();
+                    ids
+                })
+                .unwrap_or_default();
+            let extension_id = ci_profile::select_extension_id(&extension_ids)?;
+            let output = ci_profile::run_for_extension(
+                &ctx.source_path,
+                &extension_id,
+                CiRunSelection::Profile(profile.clone()),
+            )?;
+            let exit_code = output.exit_code;
+            let finding_count = output.jobs.iter().filter(|job| !job.success).count();
+            let stage = ReviewStage {
+                stage: "ci".to_string(),
+                ran: true,
+                passed: exit_code == 0,
+                exit_code,
+                finding_count,
+                hint: format!(
+                    "Deep dive: homeboy ci run {} --profile {}",
+                    component_label, profile
+                ),
+                skipped_reason: None,
+                output: Some(output),
+            };
+            (Some(stage), exit_code)
+        }
+        None => (None, 0),
+    };
 
     // Aggregate
-    let overall_passed = audit_stage.passed && lint_stage.passed && test_stage.passed;
+    let overall_passed = audit_stage.passed
+        && lint_stage.passed
+        && test_stage.passed
+        && ci_profile_stage
+            .as_ref()
+            .map(|stage| stage.passed)
+            .unwrap_or(true);
     let overall_exit = if overall_passed {
         0
-    } else if [audit_exit, lint_exit, test_exit].iter().any(|&c| c >= 2) {
+    } else if [audit_exit, lint_exit, test_exit, ci_profile_exit]
+        .iter()
+        .any(|&c| c >= 2)
+    {
         2
     } else {
         1
     };
-    let total_findings =
-        audit_stage.finding_count + lint_stage.finding_count + test_stage.finding_count;
+    let total_findings = audit_stage.finding_count
+        + lint_stage.finding_count
+        + test_stage.finding_count
+        + ci_profile_stage
+            .as_ref()
+            .map(|stage| stage.finding_count)
+            .unwrap_or(0);
 
     if args.changed_only {
         top_hints.push(
@@ -434,15 +513,20 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         hints: top_hints,
     };
 
+    let mut commands = vec![
+        artifact_command(&audit_stage),
+        artifact_command(&lint_stage),
+        artifact_command(&test_stage),
+    ];
+    if let Some(ref stage) = ci_profile_stage {
+        commands.push(artifact_command(stage));
+    }
+
     let mut artifact = build_artifact(
         &component_label,
         args.changed_since.as_deref().unwrap_or(""),
         git_ref(&source_path, "HEAD").unwrap_or_default().as_str(),
-        vec![
-            artifact_command(&audit_stage),
-            artifact_command(&lint_stage),
-            artifact_command(&test_stage),
-        ],
+        commands,
     );
     let observation_metadata = review_observation.as_ref().map(|o| o.output_metadata());
     artifact.observation = observation_metadata.clone();
@@ -456,6 +540,7 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
         audit: audit_stage,
         lint: lint_stage,
         test: test_stage,
+        ci_profile: ci_profile_stage,
     };
 
     print_human_summary(&output);
@@ -731,6 +816,9 @@ fn print_human_summary(output: &ReviewCommandOutput) {
     print_stage_line(&output.audit);
     print_stage_line(&output.lint);
     print_stage_line(&output.test);
+    if let Some(ref stage) = output.ci_profile {
+        print_stage_line(stage);
+    }
     for hint in &output.summary.hints {
         eprintln!("[review] hint: {}", hint);
     }
@@ -875,6 +963,14 @@ mod tests {
         .expect("should parse");
         assert!(cli.review.summary);
         assert!(cli.review.baseline_args.ignore_baseline);
+    }
+
+    #[test]
+    fn parses_ci_profile() {
+        let cli = TestCli::try_parse_from(["test", "my-comp", "--ci-profile", "pr"])
+            .expect("should parse ci profile");
+
+        assert_eq!(cli.review.ci_profile.as_deref(), Some("pr"));
     }
 
     #[test]
@@ -1069,6 +1165,7 @@ mod tests {
             changed_since: Some("trunk".to_string()),
             changed_only: false,
             summary: false,
+            ci_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
@@ -1088,6 +1185,7 @@ mod tests {
             changed_since: None,
             changed_only: true,
             summary: false,
+            ci_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
@@ -1109,6 +1207,7 @@ mod tests {
             changed_since: None,
             changed_only: false,
             summary: false,
+            ci_profile: None,
             report: None,
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -117,6 +117,7 @@ pub(super) fn review_observation_initial_metadata(
         "changed_since": args.changed_since,
         "changed_only": args.changed_only,
         "summary": args.summary,
+        "ci_profile": args.ci_profile,
         "report": args.report,
         "changed_file_count": changed_file_count,
         "observation_status": "running",
@@ -129,6 +130,15 @@ pub(super) fn review_observation_finish_metadata(
     exit_code: i32,
     error: Option<&str>,
 ) -> serde_json::Value {
+    let mut stages = vec![
+        stage_observation(&output.audit),
+        stage_observation(&output.lint),
+        stage_observation(&output.test),
+    ];
+    if let Some(ref stage) = output.ci_profile {
+        stages.push(stage_observation(stage));
+    }
+
     merge_metadata(
         initial_metadata,
         serde_json::json!({
@@ -140,11 +150,7 @@ pub(super) fn review_observation_finish_metadata(
             "changed_file_count": output.summary.changed_file_count,
             "hints": output.summary.hints,
             "artifact": output.artifact,
-            "stages": [
-                stage_observation(&output.audit),
-                stage_observation(&output.lint),
-                stage_observation(&output.test),
-            ],
+            "stages": stages,
             "error": error,
         }),
     )
@@ -183,6 +189,7 @@ mod tests {
             changed_since: Some("origin/main".to_string()),
             changed_only: false,
             summary: true,
+            ci_profile: None,
             report: Some("pr-comment".to_string()),
             banner: Vec::new(),
             baseline_args: BaselineArgs::default(),
@@ -275,6 +282,7 @@ mod tests {
             audit,
             lint,
             test,
+            ci_profile: None,
         };
 
         let metadata = review_observation_finish_metadata(initial, &output, 1, None);

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -9,7 +9,7 @@
 //! 1. Optional caller-supplied banners for action-level signals.
 //! 2. Scope banner: `:zap:` for changed-since/changed-only, `:information_source:` for full.
 //! 3. Total findings line.
-//! 4. Three stage blocks in fixed order — audit, lint, test. Each stage:
+//! 4. Stage blocks in fixed order — audit, lint, test, optional ci. Each stage:
 //!    - icon + name header (`:white_check_mark:`, `:x:`, `:fast_forward:`)
 //!    - up to 10 finding bullets (top categories / sniff codes / failure summary)
 //!    - blockquote with the deep-dive hint
@@ -17,6 +17,7 @@
 
 use std::fmt::Write as _;
 
+use homeboy::core::ci_profile::CiRunOutput;
 use homeboy::core::code_audit::{AuditCommandOutput, AuditFinding, Severity};
 use homeboy::core::extension::lint::LintCommandOutput;
 use homeboy::core::extension::test::{FailedTest, TestCommandOutput};
@@ -50,6 +51,10 @@ pub fn render_pr_comment_with_banners(
     render_lint_stage(&mut out, &output.lint);
     out.push('\n');
     render_test_stage(&mut out, &output.test);
+    if let Some(ref stage) = output.ci_profile {
+        out.push('\n');
+        render_ci_stage(&mut out, stage);
+    }
 
     out
 }
@@ -93,10 +98,15 @@ fn render_scope_banner(out: &mut String, output: &ReviewCommandOutput) {
 }
 
 fn render_total_findings(out: &mut String, output: &ReviewCommandOutput) {
-    let ran = [&output.audit.ran, &output.lint.ran, &output.test.ran]
-        .iter()
-        .filter(|r| ***r)
-        .count();
+    let ran = [output.audit.ran, output.lint.ran, output.test.ran]
+        .into_iter()
+        .filter(|ran| *ran)
+        .count()
+        + output
+            .ci_profile
+            .as_ref()
+            .map(|stage| usize::from(stage.ran))
+            .unwrap_or(0);
     let _ = writeln!(
         out,
         "**{}** finding(s) across {} stage(s)",
@@ -163,6 +173,14 @@ fn render_test_stage(out: &mut String, stage: &ReviewStage<TestCommandOutput>) {
     render_stage_header(out, stage);
     if let Some(ref output) = stage.output {
         render_test_body(out, output);
+    }
+    render_stage_hint(out, stage);
+}
+
+fn render_ci_stage(out: &mut String, stage: &ReviewStage<CiRunOutput>) {
+    render_stage_header(out, stage);
+    if let Some(ref output) = stage.output {
+        render_ci_body(out, output);
     }
     render_stage_hint(out, stage);
 }
@@ -334,10 +352,18 @@ fn render_failed_tests(out: &mut String, failed_tests: &[FailedTest]) {
     }
 }
 
+fn render_ci_body(out: &mut String, output: &CiRunOutput) {
+    for job in &output.jobs {
+        let marker = if job.success { "passed" } else { "failed" };
+        let _ = writeln!(out, "- `{}` — {} (exit {})", job.id, marker, job.exit_code);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use homeboy::core::ci_profile::{CiJobRunOutput, CiRunOutput, CiRunSelection};
     use homeboy::core::code_audit::{
         AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity,
     };
@@ -367,6 +393,7 @@ mod tests {
             audit: stage_audit_passing(),
             lint: stage_lint_passing(),
             test: stage_test_passing(0),
+            ci_profile: None,
         }
     }
 
@@ -406,6 +433,38 @@ mod tests {
             hint: "Deep dive: homeboy test my-comp".to_string(),
             skipped_reason: None,
             output: Some(test_with_counts(passed, 0, 0)),
+        }
+    }
+
+    fn stage_ci_with_jobs(jobs: Vec<CiJobRunOutput>) -> ReviewStage<CiRunOutput> {
+        let passed = jobs.iter().all(|job| job.success);
+        ReviewStage {
+            stage: "ci".to_string(),
+            ran: true,
+            passed,
+            exit_code: if passed { 0 } else { 1 },
+            finding_count: jobs.iter().filter(|job| !job.success).count(),
+            hint: "Deep dive: homeboy ci run my-comp --profile pr".to_string(),
+            skipped_reason: None,
+            output: Some(CiRunOutput {
+                extension_id: "test".to_string(),
+                selection: CiRunSelection::Profile("pr".to_string()),
+                jobs,
+                success: passed,
+                exit_code: if passed { 0 } else { 1 },
+            }),
+        }
+    }
+
+    fn ci_job(id: &str, success: bool, exit_code: i32) -> CiJobRunOutput {
+        CiJobRunOutput {
+            id: id.to_string(),
+            command: "sh".to_string(),
+            args: Vec::new(),
+            success,
+            exit_code,
+            stdout: String::new(),
+            stderr: String::new(),
         }
     }
 
@@ -622,6 +681,23 @@ mod tests {
     }
 
     #[test]
+    fn renders_optional_ci_stage() {
+        let mut env = passing_envelope();
+        env.summary.total_findings = 1;
+        env.ci_profile = Some(stage_ci_with_jobs(vec![
+            ci_job("lint", true, 0),
+            ci_job("unit", false, 1),
+        ]));
+
+        let md = render_pr_comment(&env);
+
+        assert!(md.contains("**1** finding(s) across 4 stage(s)"));
+        assert!(md.contains(":x: **ci**"));
+        assert!(md.contains("- `lint` — passed (exit 0)"));
+        assert!(md.contains("- `unit` — failed (exit 1)"));
+    }
+
+    #[test]
     fn renders_all_stages_skipped() {
         let env = ReviewCommandOutput {
             command: "review".to_string(),
@@ -644,6 +720,7 @@ mod tests {
             audit: stage_skipped("audit", "no files changed"),
             lint: stage_skipped("lint", "no files changed"),
             test: stage_skipped("test", "no files changed"),
+            ci_profile: None,
         };
         let md = render_pr_comment(&env);
         assert!(


### PR DESCRIPTION
## Summary
- Adds `homeboy review --ci-profile <ID>` as an optional fourth review gate after audit, lint, and test.
- Reuses explicit extension-declared CI profiles/jobs through the existing `homeboy ci run --profile` contract.
- Includes CI stage output in JSON, PR-comment rendering, artifacts, and observation metadata.

## Verification
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-review-ci-profile --changed-since origin/main`
- `cargo fmt --check`
- `cargo check --release`
- `cargo test --no-run`
- `git diff --check`

Refs #1977

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, docs, tests, and local verification commands for Chris to review.