### PR TITLE
feat: run CI profiles through bench

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -74,11 +74,21 @@ the other capabilities.
   be repeated. Homeboy validates selected ids against discovery before
   execution and forwards the comma-separated selector to runners via
   `$HOMEBOY_BENCH_SCENARIOS`.
+- `--ci-profile <ID>`: Run using env and passthrough args from a single
+  extension-declared CI profile whose only job declares `command: "bench"`.
+  This keeps bench parity on the normal Homeboy bench workflow instead of
+  parsing arbitrary provider YAML into runnable commands.
 - `--ignore-default-baseline`: Skip automatic single-rig expansion when
   the rig declares `bench.default_baseline_rig`.
 
 Arguments after `--` are passed verbatim to the extension's bench runner
 script.
+
+When `--ci-profile <ID>` is used, args declared on that profile's bench job
+are forwarded before explicit CLI passthrough arguments, and job env is passed
+to the bench runner. Profiles with zero jobs, multiple jobs, or a non-`bench`
+job are rejected for command-native bench reproduction; use `homeboy ci run
+--profile <ID>` when you need to execute a multi-job CI profile directly.
 
 `homeboy bench` is resource-policy aware. If the current machine is already warm
 or hot according to `homeboy doctor resources`, Homeboy prints a stderr warning

--- a/docs/commands/ci.md
+++ b/docs/commands/ci.md
@@ -32,7 +32,7 @@ homeboy ci run --path /path/to/repo --extension nodejs --profile pr
 
 `ci run` executes only jobs declared under the extension manifest's `ci.jobs` contract. It does not parse arbitrary provider YAML into runnable local commands. Commands run from the component root with the declared `args` and `env`; the command's exit code is captured in JSON and the overall command exits non-zero when any selected job fails.
 
-For command-native reproduction, `homeboy lint --ci-job <ID>` and `homeboy test --ci-job <ID>` select a single declared job whose `command` is `lint` or `test` respectively, then run through the normal Homeboy lint/test workflow with the job's declared local context applied.
+For command-native reproduction, `homeboy lint --ci-job <ID>` and `homeboy test --ci-job <ID>` select a single declared job whose `command` is `lint` or `test` respectively, then run through the normal Homeboy lint/test workflow with the job's declared local context applied. `homeboy bench --ci-profile <ID>` selects a single-job profile whose job declares `command: "bench"` and runs it through the normal bench workflow.
 
 ## Manifest Shape
 
@@ -59,7 +59,7 @@ Extensions can declare CI profiles with a `ci` block:
 }
 ```
 
-For `homeboy test --ci-job`, job `args` are forwarded as test-runner passthrough arguments before any explicit CLI passthrough arguments. For `homeboy lint --ci-job`, job `env` is applied to the lint runner; use extension settings or env-backed runner behavior for lint-specific variants.
+For `homeboy test --ci-job` and `homeboy bench --ci-profile`, job `args` are forwarded as runner passthrough arguments before any explicit CLI passthrough arguments. For `homeboy lint --ci-job`, job `env` is applied to the lint runner; use extension settings or env-backed runner behavior for lint-specific variants.
 
 Supported fidelity values are `local-equivalent`, `local-partial`, `remote-only`, and `unknown`.
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -240,6 +240,10 @@ pub struct BenchRunArgs {
     #[arg(long, value_name = "PROFILE")]
     profile: Option<String>,
 
+    /// Run using env and passthrough args from a single extension-declared CI bench profile.
+    #[arg(long, value_name = "ID", conflicts_with = "profile")]
+    ci_profile: Option<String>,
+
     /// Skip auto-upgrading single-rig runs into a comparison even when
     /// the rig spec declares `bench.default_baseline_rig`. Use with
     /// `--baseline` / `--ratchet` against a rig that normally

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use homeboy::core::ci_profile::{self, CiResolvedJob};
 use homeboy::core::component::Component;
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::invocation::InvocationRequirements;
@@ -439,6 +440,8 @@ fn run_component_with_rig_context(
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
+    let ci_profile_job =
+        resolve_ci_profile_job(args.ci_profile.as_deref(), ctx.extension_id.as_deref())?;
 
     if let Some(snapshot) = rig_snapshot.as_mut() {
         let effective_path = ctx.source_path.to_string_lossy().into_owned();
@@ -494,7 +497,8 @@ fn run_component_with_rig_context(
             },
             regression_threshold_percent: args.regression_threshold,
             json_summary: args.json_summary,
-            passthrough_args: passthrough_args.to_vec(),
+            ci_env: ci_profile::ci_job_env(ci_profile_job.as_ref()),
+            passthrough_args: bench_passthrough_args(ci_profile_job.as_ref(), passthrough_args),
             scenario_ids: selected_scenarios,
             rig_id: rig_id.clone(),
             shared_state: shared_state_override.or_else(|| args.shared_state.clone()),
@@ -527,6 +531,29 @@ fn run_component_with_rig_context(
         workflow,
         rig_snapshot,
     ))
+}
+
+fn resolve_ci_profile_job(
+    profile_id: Option<&str>,
+    extension_id: Option<&str>,
+) -> homeboy::core::Result<Option<CiResolvedJob>> {
+    let Some(profile_id) = profile_id else {
+        return Ok(None);
+    };
+    let Some(extension_id) = extension_id else {
+        return Err(homeboy::core::Error::validation_missing_argument(vec![
+            "--extension <ID> or component bench extension".to_string(),
+        ]));
+    };
+    let jobs = ci_profile::resolve_profile_jobs_for_extension(extension_id, profile_id)?;
+    ci_profile::validate_single_profile_command(profile_id, &jobs, "bench")?;
+    Ok(jobs.into_iter().next())
+}
+
+fn bench_passthrough_args(job: Option<&CiResolvedJob>, cli_args: &[String]) -> Vec<String> {
+    let mut args = job.map(|job| job.spec.args.clone()).unwrap_or_default();
+    args.extend(cli_args.iter().cloned());
+    args
 }
 
 fn rig_workload_runtime_inputs(
@@ -663,6 +690,7 @@ mod tests {
             rig_concurrency: 1,
             scenario_ids: Vec::new(),
             profile: None,
+            ci_profile: None,
             ignore_default_baseline: false,
         };
 

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -469,6 +469,7 @@ mod tests {
             rig_concurrency: 1,
             scenario_ids: Vec::new(),
             profile: None,
+            ci_profile: None,
             ignore_default_baseline: false,
         }
     }

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -284,6 +284,7 @@ fn run_args(component: Option<&str>, rig: Vec<String>, scenario_ids: Vec<String>
             rig_concurrency: 1,
             scenario_ids,
             profile: None,
+            ci_profile: None,
             ignore_default_baseline: false,
         },
     }
@@ -293,6 +294,14 @@ fn run_args_with_profile(component: Option<&str>, rig: Vec<String>, profile: &st
     let mut args = run_args(component, rig, Vec::new());
     args.run.profile = Some(profile.to_string());
     args
+}
+
+#[test]
+fn parses_ci_profile_flag() {
+    let cli = TestCli::try_parse_from(["bench", "homeboy", "--ci-profile", "perf"])
+        .expect("bench should parse --ci-profile");
+
+    assert_eq!(cli.bench.run.ci_profile.as_deref(), Some("perf"));
 }
 
 #[test]

--- a/src/core/ci_profile.rs
+++ b/src/core/ci_profile.rs
@@ -167,6 +167,69 @@ pub fn resolve_job_for_extension(extension_id: &str, job_id: &str) -> Result<CiR
     })
 }
 
+pub fn resolve_profile_jobs_for_extension(
+    extension_id: &str,
+    profile_id: &str,
+) -> Result<Vec<CiResolvedJob>> {
+    let extension = extension::load_extension(extension_id)?;
+    let ci = extension.ci.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "extension",
+            format!("extension '{extension_id}' does not declare CI jobs"),
+            Some(extension_id.to_string()),
+            None,
+        )
+    })?;
+    let profile = ci.profiles.get(profile_id).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "profile",
+            format!("CI profile '{profile_id}' is not declared by extension '{extension_id}'"),
+            Some(profile_id.to_string()),
+            Some(ci.profiles.keys().cloned().collect()),
+        )
+    })?;
+
+    profile
+        .jobs
+        .iter()
+        .map(|job_id| {
+            let spec = ci.jobs.get(job_id).ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "job",
+                    format!("CI job '{job_id}' is not declared by extension '{extension_id}'"),
+                    Some(job_id.clone()),
+                    Some(ci.jobs.keys().cloned().collect()),
+                )
+            })?;
+            Ok(CiResolvedJob {
+                extension_id: extension_id.to_string(),
+                id: job_id.clone(),
+                spec: spec.clone(),
+            })
+        })
+        .collect()
+}
+
+pub fn validate_single_profile_command(
+    profile_id: &str,
+    jobs: &[CiResolvedJob],
+    expected_command: &str,
+) -> Result<()> {
+    if jobs.len() != 1 {
+        return Err(Error::validation_invalid_argument(
+            "ci-profile",
+            format!(
+                "CI profile '{profile_id}' declares {} jobs; this command requires exactly one '{expected_command}' job",
+                jobs.len()
+            ),
+            Some(profile_id.to_string()),
+            None,
+        ));
+    }
+
+    validate_job_command(&jobs[0], expected_command)
+}
+
 pub fn validate_job_command(job: &CiResolvedJob, expected_command: &str) -> Result<()> {
     if job.spec.command == expected_command {
         return Ok(());
@@ -557,6 +620,50 @@ mod tests {
             assert_eq!(job.spec.args, vec!["--unit"]);
             assert_eq!(job.spec.env.get("CI").map(String::as_str), Some("1"));
         });
+    }
+
+    #[test]
+    fn test_resolve_profile_jobs_for_extension() {
+        crate::test_support::with_isolated_home(|_home| {
+            let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "id": "test",
+                "name": "Test",
+                "version": "1.0.0",
+                "ci": {
+                    "profiles": {
+                        "perf": { "jobs": ["bench"] }
+                    },
+                    "jobs": {
+                        "bench": { "command": "bench", "args": ["--fast"] }
+                    }
+                }
+            }))
+            .expect("parse manifest");
+            crate::core::extension::save_manifest(&manifest).expect("save extension");
+
+            let jobs = resolve_profile_jobs_for_extension("test", "perf")
+                .expect("resolve CI profile jobs");
+
+            assert_eq!(jobs.len(), 1);
+            assert_eq!(jobs[0].id, "bench");
+            assert_eq!(jobs[0].spec.args, vec!["--fast"]);
+        });
+    }
+
+    #[test]
+    fn test_validate_single_profile_command() {
+        let job = CiResolvedJob {
+            extension_id: "test".to_string(),
+            id: "bench".to_string(),
+            spec: CiJobSpec {
+                command: "bench".to_string(),
+                ..CiJobSpec::default()
+            },
+        };
+
+        assert!(validate_single_profile_command("perf", &[job.clone()], "bench").is_ok());
+        assert!(validate_single_profile_command("perf", &[job], "test").is_err());
+        assert!(validate_single_profile_command("perf", &[], "bench").is_err());
     }
 
     #[test]

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -140,6 +140,7 @@ mod tests {
             },
             regression_threshold_percent: 5.0,
             json_summary: false,
+            ci_env: Vec::new(),
             passthrough_args: Vec::new(),
             scenario_ids: vec!["studio-agent-site-build".to_string()],
             rig_id: Some("studio-bfb".to_string()),

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -44,6 +44,7 @@ pub struct BenchRunWorkflowArgs {
     pub baseline_flags: BaselineFlags,
     pub regression_threshold_percent: f64,
     pub json_summary: bool,
+    pub ci_env: Vec<(String, String)>,
     pub passthrough_args: Vec<String>,
     /// Exact scenario ids selected by the CLI. Empty means run every
     /// discovered scenario.
@@ -175,6 +176,7 @@ pub fn run_bench_list_workflow(
             },
             regression_threshold_percent: 0.0,
             json_summary: false,
+            ci_env: Vec::new(),
             passthrough_args: args.passthrough_args,
             scenario_ids: Vec::new(),
             rig_id: None,
@@ -482,20 +484,7 @@ pub fn run_main_bench_workflow(
                 source_path,
                 run_dir,
                 true,
-                &[
-                    (
-                        "HOMEBOY_BENCH_ITERATIONS".to_string(),
-                        args.iterations.to_string(),
-                    ),
-                    (
-                        "HOMEBOY_BENCH_WARMUP_ITERATIONS".to_string(),
-                        args.warmup_iterations.unwrap_or(0).to_string(),
-                    ),
-                    (
-                        "HOMEBOY_BENCH_SCENARIOS".to_string(),
-                        args.scenario_ids.join(","),
-                    ),
-                ],
+                &bench_component_script_env(&args),
                 &args.passthrough_args,
             )?;
         let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
@@ -732,6 +721,25 @@ pub fn run_main_bench_workflow(
         failure,
         diagnostics,
     })
+}
+
+fn bench_component_script_env(args: &BenchRunWorkflowArgs) -> Vec<(String, String)> {
+    let mut env = vec![
+        (
+            "HOMEBOY_BENCH_ITERATIONS".to_string(),
+            args.iterations.to_string(),
+        ),
+        (
+            "HOMEBOY_BENCH_WARMUP_ITERATIONS".to_string(),
+            args.warmup_iterations.unwrap_or(0).to_string(),
+        ),
+        (
+            "HOMEBOY_BENCH_SCENARIOS".to_string(),
+            args.scenario_ids.join(","),
+        ),
+    ];
+    env.extend(args.ci_env.iter().cloned());
+    env
 }
 
 fn format_diagnostic_hint(diagnostic: &BenchDiagnostic) -> String {
@@ -1021,6 +1029,10 @@ fn build_runner(
     .passthrough(false)
     .stderr_passthrough(bench_progress_enabled());
 
+    for (key, value) in &args.ci_env {
+        runner = runner.env(key, value);
+    }
+
     if let Some(warmup_iterations) = args.warmup_iterations {
         runner = runner.env(
             "HOMEBOY_BENCH_WARMUP_ITERATIONS",
@@ -1303,6 +1315,7 @@ mod tests {
                 },
                 regression_threshold_percent: 5.0,
                 json_summary: false,
+                ci_env: Vec::new(),
                 passthrough_args: Vec::new(),
                 scenario_ids: Vec::new(),
                 rig_id: None,
@@ -1358,6 +1371,7 @@ mod tests {
             },
             regression_threshold_percent: 5.0,
             json_summary: false,
+            ci_env: Vec::new(),
             passthrough_args: Vec::new(),
             scenario_ids: vec!["boot".to_string()],
             rig_id: Some("studio".to_string()),

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -61,6 +61,7 @@ fn make_args(
             rig_concurrency: 1,
             scenario_ids: Vec::new(),
             profile: None,
+            ci_profile: None,
             ignore_default_baseline,
         },
     }


### PR DESCRIPTION
## Summary
- Add `homeboy bench --ci-profile <ID>` for extension-declared single-job bench CI profiles.
- Reuse the normal bench workflow while applying the selected CI job's env and prepending its runner args.
- Document the command-native bench CI profile behavior and validation rules.

Refs #1977.

## Testing
- `cargo check --release`
- `cargo test commands::bench::tests::parses_ci_profile_flag --lib`
- `cargo test ci_profile --lib`
- `cargo test command_surface --test command_surface_test`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-bench-ci-profile --changed-since origin/main`
- `cargo test --no-run`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and local verification steps for Chris to review.