### PR TITLE
feat: add CI context to command outputs

### DIFF
--- a/docs/commands/ci.md
+++ b/docs/commands/ci.md
@@ -67,6 +67,22 @@ Supported fidelity values are `local-equivalent`, `local-partial`, `remote-only`
 
 The JSON output uses command `ci.list` and includes an `inventory` object with `profiles`, `jobs`, and `discovered_jobs`.
 
-`ci run` uses command `ci.run` and includes the selected job/profile, per-job command output, per-job exit codes, and an aggregate `success` / `exit_code`.
+`ci run` uses command `ci.run` and includes the selected job/profile, per-job command output, per-job `ci_context`, per-job exit codes, and an aggregate `success` / `exit_code`.
+
+Command-native CI reproduction also includes `ci_context` when a CI selector is used. `homeboy lint --ci-job <ID>`, `homeboy test --ci-job <ID>`, and `homeboy bench --ci-profile <ID>` preserve the normal command output shape and add the selected job's mapping metadata:
+
+```json
+{
+  "ci_context": {
+    "profile": "pr",
+    "job_id": "unit",
+    "check_names": ["test-unit-jspi"],
+    "provider": "github-actions",
+    "workflow": "ci.yml",
+    "fidelity": "local-partial",
+    "limitations": ["CI matrix shards are not reproduced locally"]
+  }
+}
+```
 
 Refs: [#1977](https://github.com/Extra-Chill/homeboy/issues/1977)

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -380,6 +380,7 @@ pub(super) fn run_single_rig(
                 .iter()
                 .flat_map(|output| output.diagnostics.clone())
                 .collect(),
+            ci_context: None,
         },
         exit_code,
     ))
@@ -527,10 +528,20 @@ fn run_component_with_rig_context(
         }
     };
 
-    Ok(extension_bench::from_main_workflow_with_rig(
-        workflow,
-        rig_snapshot,
-    ))
+    let ci_context =
+        ci_profile::ci_context_for_job(ci_profile_job.as_ref(), args.ci_profile.as_deref());
+    if ci_context.is_some() {
+        Ok(extension_bench::from_main_workflow_with_rig_and_ci_context(
+            workflow,
+            rig_snapshot,
+            ci_context,
+        ))
+    } else {
+        Ok(extension_bench::from_main_workflow_with_rig(
+            workflow,
+            rig_snapshot,
+        ))
+    }
 }
 
 fn resolve_ci_profile_job(
@@ -909,6 +920,7 @@ mod tests {
             rig_state: None,
             failure: None,
             diagnostics: Vec::new(),
+            ci_context: None,
         }
     }
 

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1454,6 +1454,7 @@ fn bench_output_single_serializes_without_wrapper_key() {
         rig_state: None,
         failure: None,
         diagnostics: Vec::new(),
+        ci_context: None,
     };
     let value = serde_json::to_value(BenchOutput::Single(single)).unwrap();
     assert!(value.get("comparison").is_none());

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -198,7 +198,10 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     resource_run.write_to_run_dir(&run_dir)?;
     let workflow = finish_lint_workflow(observation, workflow)?;
 
-    Ok(report::from_main_workflow(workflow))
+    Ok(report::from_main_workflow_with_ci_context(
+        workflow,
+        ci_profile::ci_context_for_job(ci_job.as_ref(), None),
+    ))
 }
 
 fn resolve_ci_job(

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -363,12 +363,13 @@ fn render_ci_body(out: &mut String, output: &CiRunOutput) {
 mod tests {
     use super::*;
 
-    use homeboy::core::ci_profile::{CiJobRunOutput, CiRunOutput, CiRunSelection};
+    use homeboy::core::ci_profile::{CiContext, CiJobRunOutput, CiRunOutput, CiRunSelection};
     use homeboy::core::code_audit::{
         AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity,
     };
     use homeboy::core::extension::lint::{LintCommandOutput, LintFinding};
     use homeboy::core::extension::test::{FailedTest, TestCommandOutput, TestCounts};
+    use homeboy::core::extension::CiJobMapping;
     use homeboy::core::extension::{PhaseReport, PhaseStatus, VerificationPhase};
     use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
 
@@ -459,6 +460,12 @@ mod tests {
     fn ci_job(id: &str, success: bool, exit_code: i32) -> CiJobRunOutput {
         CiJobRunOutput {
             id: id.to_string(),
+            ci_context: CiContext {
+                profile: Some("pr".to_string()),
+                job_id: id.to_string(),
+                mapping: CiJobMapping::default(),
+                local_context: Default::default(),
+            },
             command: "sh".to_string(),
             args: Vec::new(),
             success,
@@ -553,6 +560,7 @@ mod tests {
             baseline_comparison: None,
             lint_findings: Some(findings),
             summary: None,
+            ci_context: None,
         }
     }
 
@@ -583,6 +591,7 @@ mod tests {
             test_scope: None,
             summary: None,
             raw_output: None,
+            ci_context: None,
         }
     }
 

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -204,7 +204,10 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     resource_run.write_to_run_dir(&run_dir)?;
     let workflow = finish_test_workflow_observation(observation, workflow)?;
 
-    Ok(report::from_main_workflow(workflow))
+    Ok(report::from_main_workflow_with_ci_context(
+        workflow,
+        ci_profile::ci_context_for_job(ci_job.as_ref(), None),
+    ))
 }
 
 fn resolve_ci_job(

--- a/src/core/ci_profile.rs
+++ b/src/core/ci_profile.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use crate::core::error::{Error, Result};
 use crate::core::extension::{
-    self, CiJobFidelity, CiJobSpec, CiLocalContext, CiProfileSpec, ExtensionManifest,
+    self, CiJobFidelity, CiJobMapping, CiJobSpec, CiLocalContext, CiProfileSpec, ExtensionManifest,
 };
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -28,8 +28,8 @@ pub struct CiProfileSummary {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CiJobSummary {
     pub id: String,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub check_names: Vec<String>,
+    #[serde(flatten)]
+    pub mapping: CiJobMapping,
     pub command: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
@@ -37,10 +37,6 @@ pub struct CiJobSummary {
     pub env: BTreeMap<String, String>,
     #[serde(flatten)]
     pub local_context: CiLocalContext,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workflow: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -73,6 +69,7 @@ pub struct CiRunOutput {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CiJobRunOutput {
     pub id: String,
+    pub ci_context: CiContext,
     pub command: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
@@ -89,6 +86,17 @@ pub struct CiResolvedJob {
     pub extension_id: String,
     pub id: String,
     pub spec: CiJobSpec,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CiContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    pub job_id: String,
+    #[serde(flatten)]
+    pub mapping: CiJobMapping,
+    #[serde(flatten)]
+    pub local_context: CiLocalContext,
 }
 
 pub fn list_for_extension(source_path: &Path, extension_id: &str) -> Result<CiInventory> {
@@ -257,6 +265,10 @@ pub fn ci_job_env(job: Option<&CiResolvedJob>) -> Vec<(String, String)> {
     .unwrap_or_default()
 }
 
+pub fn ci_context_for_job(job: Option<&CiResolvedJob>, profile: Option<&str>) -> Option<CiContext> {
+    job.map(|job| ci_context(&job.id, &job.spec, profile))
+}
+
 pub fn run_from_manifest(
     source_path: &Path,
     extension_id: &str,
@@ -271,6 +283,11 @@ pub fn run_from_manifest(
             None,
         )
     })?;
+
+    let profile_id = match &selection {
+        CiRunSelection::Profile(profile_id) => Some(profile_id.clone()),
+        CiRunSelection::Job(_) => None,
+    };
 
     let job_ids = match &selection {
         CiRunSelection::Job(job_id) => vec![job_id.clone()],
@@ -312,7 +329,7 @@ pub fn run_from_manifest(
                 Some(ci.jobs.keys().cloned().collect()),
             )
         })?;
-        jobs.push(run_job(source_path, &job_id, job)?);
+        jobs.push(run_job(source_path, &job_id, job, profile_id.as_deref())?);
     }
 
     let success = jobs.iter().all(|job| job.success);
@@ -325,7 +342,12 @@ pub fn run_from_manifest(
     })
 }
 
-fn run_job(source_path: &Path, job_id: &str, job: &CiJobSpec) -> Result<CiJobRunOutput> {
+fn run_job(
+    source_path: &Path,
+    job_id: &str,
+    job: &CiJobSpec,
+    profile: Option<&str>,
+) -> Result<CiJobRunOutput> {
     let output = Command::new(&job.command)
         .args(&job.args)
         .envs(&job.env)
@@ -340,6 +362,7 @@ fn run_job(source_path: &Path, job_id: &str, job: &CiJobSpec) -> Result<CiJobRun
 
     Ok(CiJobRunOutput {
         id: job_id.to_string(),
+        ci_context: ci_context(job_id, job, profile),
         command: job.command.clone(),
         args: job.args.clone(),
         success: output.status.success(),
@@ -347,6 +370,15 @@ fn run_job(source_path: &Path, job_id: &str, job: &CiJobSpec) -> Result<CiJobRun
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
     })
+}
+
+fn ci_context(job_id: &str, job: &CiJobSpec, profile: Option<&str>) -> CiContext {
+    CiContext {
+        profile: profile.map(ToString::to_string),
+        job_id: job_id.to_string(),
+        mapping: job.mapping.clone(),
+        local_context: job.local_context.clone(),
+    }
 }
 
 fn profile_summaries(profiles: &BTreeMap<String, CiProfileSpec>) -> Vec<CiProfileSummary> {
@@ -364,13 +396,11 @@ fn job_summaries(jobs: &BTreeMap<String, CiJobSpec>) -> Vec<CiJobSummary> {
     jobs.iter()
         .map(|(id, job)| CiJobSummary {
             id: id.clone(),
-            check_names: job.check_names.clone(),
+            mapping: job.mapping.clone(),
             command: job.command.clone(),
             args: job.args.clone(),
             env: job.env.clone(),
             local_context: job.local_context.clone(),
-            provider: job.provider.clone(),
-            workflow: job.workflow.clone(),
         })
         .collect()
 }
@@ -701,6 +731,37 @@ mod tests {
     }
 
     #[test]
+    fn test_ci_context_for_job() {
+        let job = CiResolvedJob {
+            extension_id: "test".to_string(),
+            id: "unit".to_string(),
+            spec: CiJobSpec {
+                mapping: CiJobMapping {
+                    check_names: vec!["Unit tests".to_string()],
+                    provider: Some("github-actions".to_string()),
+                    workflow: Some("ci.yml".to_string()),
+                },
+                command: "test".to_string(),
+                local_context: CiLocalContext {
+                    fidelity: CiJobFidelity::LocalPartial,
+                    limitations: vec!["matrix shard not reproduced".to_string()],
+                },
+                ..CiJobSpec::default()
+            },
+        };
+
+        let context = ci_context_for_job(Some(&job), Some("pr")).expect("context");
+
+        assert_eq!(context.profile.as_deref(), Some("pr"));
+        assert_eq!(context.job_id, "unit");
+        assert_eq!(context.mapping.check_names, vec!["Unit tests"]);
+        assert_eq!(context.mapping.provider.as_deref(), Some("github-actions"));
+        assert_eq!(context.mapping.workflow.as_deref(), Some("ci.yml"));
+        assert_eq!(context.local_context.fidelity, CiJobFidelity::LocalPartial);
+        assert_eq!(context.local_context.limitations.len(), 1);
+    }
+
+    #[test]
     fn run_from_manifest_executes_profile_jobs() {
         let tmp = TempDir::new().expect("temp dir");
         let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
@@ -728,6 +789,8 @@ mod tests {
 
         assert!(output.success);
         assert_eq!(output.jobs.len(), 2);
+        assert_eq!(output.jobs[0].ci_context.profile.as_deref(), Some("pr"));
+        assert_eq!(output.jobs[0].ci_context.job_id, "first");
         assert_eq!(output.jobs[0].stdout, "first");
         assert_eq!(output.jobs[1].stdout, "second");
     }

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -52,9 +52,10 @@ pub use parsing::{
 };
 pub use report::{
     aggregate_comparison, aggregate_comparison_with_axes, from_main_workflow,
-    from_main_workflow_with_rig, BenchArtifactRef, BenchCommandOutput, BenchComparisonDiff,
-    BenchComparisonOutput, BenchComparisonRigSummary, BenchComparisonSummaryOutput,
-    BenchDefaultBaselineExpansion, MetricDelta as ReportMetricDelta, RigBenchEntry,
+    from_main_workflow_with_rig, from_main_workflow_with_rig_and_ci_context, BenchArtifactRef,
+    BenchCommandOutput, BenchComparisonDiff, BenchComparisonOutput, BenchComparisonRigSummary,
+    BenchComparisonSummaryOutput, BenchDefaultBaselineExpansion, MetricDelta as ReportMetricDelta,
+    RigBenchEntry,
 };
 pub use run::{
     run_bench_list_workflow, run_main_bench_workflow, BenchListWorkflowArgs,

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -11,6 +11,7 @@ use super::distribution::BenchRunDistribution;
 use super::parsing::{BenchMetricPhase, BenchResults, BenchScenario};
 use super::run::{BenchRunFailure, BenchRunWorkflowResult};
 use crate::core::budget::BudgetFinding;
+use crate::core::ci_profile::CiContext;
 use crate::core::rig::RigStateSnapshot;
 
 #[derive(Serialize)]
@@ -42,6 +43,8 @@ pub struct BenchCommandOutput {
     pub failure: Option<BenchRunFailure>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<BenchDiagnostic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_context: Option<CiContext>,
 }
 
 pub fn from_main_workflow(result: BenchRunWorkflowResult) -> (BenchCommandOutput, i32) {
@@ -55,6 +58,14 @@ pub fn from_main_workflow(result: BenchRunWorkflowResult) -> (BenchCommandOutput
 pub fn from_main_workflow_with_rig(
     result: BenchRunWorkflowResult,
     rig_state: Option<RigStateSnapshot>,
+) -> (BenchCommandOutput, i32) {
+    from_main_workflow_with_rig_and_ci_context(result, rig_state, None)
+}
+
+pub fn from_main_workflow_with_rig_and_ci_context(
+    result: BenchRunWorkflowResult,
+    rig_state: Option<RigStateSnapshot>,
+    ci_context: Option<CiContext>,
 ) -> (BenchCommandOutput, i32) {
     let exit_code = result.exit_code;
     let budget_findings = result
@@ -82,6 +93,7 @@ pub fn from_main_workflow_with_rig(
             rig_state,
             failure: result.failure,
             diagnostics: result.diagnostics,
+            ci_context,
         },
         exit_code,
     )

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -3,6 +3,7 @@
 //! Mirrors `core/extension/test/report.rs` — the command layer calls a single
 //! builder function to convert a workflow result into the command output tuple.
 
+use crate::core::ci_profile::CiContext;
 use crate::core::extension::lint::baseline::{BaselineComparison, LintFinding};
 use crate::core::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
@@ -37,10 +38,19 @@ pub struct LintCommandOutput {
     pub lint_findings: Option<Vec<LintFinding>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<LintSummaryOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_context: Option<CiContext>,
 }
 
 /// Build output from a main lint workflow result.
 pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, i32) {
+    from_main_workflow_with_ci_context(result, None)
+}
+
+pub fn from_main_workflow_with_ci_context(
+    result: LintRunWorkflowResult,
+    ci_context: Option<CiContext>,
+) -> (LintCommandOutput, i32) {
     // Exit code should reflect the computed status, not just the extension's
     // shell exit code. When findings exist but the extension exited 0, the
     // process must still exit non-zero so CI treats it as a failure (#696).
@@ -79,6 +89,7 @@ pub fn from_main_workflow(result: LintRunWorkflowResult) -> (LintCommandOutput, 
                 result.lint_findings
             },
             summary: result.summary,
+            ci_context,
         },
         exit_code,
     )
@@ -161,6 +172,7 @@ pub fn from_lint_fix(component_label: String, run: RefactorSourceRun) -> (LintCo
             baseline_comparison: None,
             lint_findings: None,
             summary: None,
+            ci_context: None,
         },
         exit_code,
     )

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -263,8 +263,8 @@ impl Default for CiJobFidelity {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct CiJobSpec {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub check_names: Vec<String>,
+    #[serde(flatten)]
+    pub mapping: CiJobMapping,
     pub command: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
@@ -272,6 +272,12 @@ pub struct CiJobSpec {
     pub env: BTreeMap<String, String>,
     #[serde(flatten)]
     pub local_context: CiLocalContext,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CiJobMapping {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub check_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -58,15 +58,16 @@ pub use lifecycle::{
 pub use maintenance::{exec_tool, update_all};
 pub use manifest::{
     ActionConfig, ActionType, AuditCapability, AutofixVerifyConfig, BenchConfig, BuildConfig,
-    CiCapability, CiJobFidelity, CiJobSpec, CiLocalContext, CiProfileSpec, CliAutoFlag,
-    CliAutoFlagCondition, CliConfig, CliHelpConfig, ComponentEnvConfig, DatabaseCliConfig,
-    DatabaseConfig, DeployCapability, DeployOverride, DeployVerification, DiscoveryConfig,
-    DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionManifest, FeatureContextRule,
-    FileContainsCondition, HttpMethod, InputConfig, LintChangedFileRoute, LintConfig, OutputConfig,
-    OutputSchema, PlatformCapability, ProvidesConfig, RemotePathInferenceRule, RemotePathRootRule,
-    RequirementsConfig, RuntimeConfig, RuntimeRequirementsConfig, ScriptsConfig, SelectOption,
-    SettingConfig, SinceTagConfig, StructuredSidecarDeclaration, TestConfig, TestDriftConfig,
-    TestMappingConfig, TraceConfig, VersionPatternConfig,
+    CiCapability, CiJobFidelity, CiJobMapping, CiJobSpec, CiLocalContext, CiProfileSpec,
+    CliAutoFlag, CliAutoFlagCondition, CliConfig, CliHelpConfig, ComponentEnvConfig,
+    DatabaseCliConfig, DatabaseConfig, DeployCapability, DeployOverride, DeployVerification,
+    DiscoveryConfig, DiscoveryMarkerConfig, DocTarget, ExecutableCapability, ExtensionManifest,
+    FeatureContextRule, FileContainsCondition, HttpMethod, InputConfig, LintChangedFileRoute,
+    LintConfig, OutputConfig, OutputSchema, PlatformCapability, ProvidesConfig,
+    RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig, RuntimeConfig,
+    RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
+    StructuredSidecarDeclaration, TestConfig, TestDriftConfig, TestMappingConfig, TraceConfig,
+    VersionPatternConfig,
 };
 pub use refactor_protocol::{
     run_refactor_script, AdjustedItem, ParsedItem, RelatedTests, ResolvedImports, RewrittenImport,

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -4,6 +4,7 @@
 //! produce domain-specific result types. This module provides the unified output
 //! envelope and builder functions that assemble results into command-ready output.
 
+use crate::core::ci_profile::CiContext;
 use crate::core::extension::test::{
     CoverageOutput, DriftReport, TestAnalysis, TestBaselineComparison, TestCounts, TestScopeOutput,
     TestSummaryOutput,
@@ -68,10 +69,19 @@ pub struct TestCommandOutput {
     /// users see the actual PHPUnit/cargo output. (#1143)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raw_output: Option<RawTestOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_context: Option<CiContext>,
 }
 
 /// Build output from a main test workflow result.
 pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, i32) {
+    from_main_workflow_with_ci_context(result, None)
+}
+
+pub fn from_main_workflow_with_ci_context(
+    result: TestRunWorkflowResult,
+    ci_context: Option<CiContext>,
+) -> (TestCommandOutput, i32) {
     let exit_code = result.exit_code;
     let phase = Some(test_phase_report(
         &result.status,
@@ -104,6 +114,7 @@ pub fn from_main_workflow(result: TestRunWorkflowResult) -> (TestCommandOutput, 
             test_scope: result.test_scope,
             summary: result.summary,
             raw_output: result.raw_output,
+            ci_context,
         },
         exit_code,
     )
@@ -132,6 +143,7 @@ pub fn from_drift_workflow(result: DriftWorkflowResult) -> (TestCommandOutput, i
             test_scope: None,
             summary: None,
             raw_output: None,
+            ci_context: None,
         },
         exit_code,
     )
@@ -172,6 +184,7 @@ pub fn from_auto_fix_drift_workflow(
             test_scope: None,
             summary: None,
             raw_output: None,
+            ci_context: None,
         },
         0,
     )


### PR DESCRIPTION
## Summary
- Add a shared `ci_context` payload that maps local CI reproduction runs back to declared profile/job/check metadata.
- Include `ci_context` in `homeboy ci run` job results and command-native `lint --ci-job`, `test --ci-job`, and `bench --ci-profile` outputs.
- Reuse a shared CI job mapping struct for manifest specs, inventory summaries, and runtime context metadata.

Refs #1977.

## Testing
- `cargo fmt --check`
- `cargo test ci_profile --lib`
- `cargo test command_surface --test command_surface_test`
- `git diff --check`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@feat-ci-context-output --changed-since origin/main`
- `cargo check --release`
- `cargo test --no-run`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the CI context output implementation, tests, docs, and local verification steps for Chris to review.